### PR TITLE
feat(hosts): share hosts with permissions + external-host runner auth

### DIFF
--- a/deploy/databricks/src/app.py
+++ b/deploy/databricks/src/app.py
@@ -148,6 +148,9 @@ try:
         SqlAlchemyConversationStore,
     )
     from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+    from omnigent.stores.host_permission_store.sqlalchemy_store import (
+        SqlAlchemyHostPermissionStore,
+    )
     from omnigent.stores.host_store import HostStore
     from omnigent.stores.permission_store.sqlalchemy_store import (
         SqlAlchemyPermissionStore,
@@ -202,6 +205,11 @@ try:
     # provider always wins over the enable switch).
     os.environ.setdefault("OMNIGENT_AUTH_PROVIDER", "header")
     auth_provider = create_auth_provider()
+    # Declarative admin roster: identities here are promoted to
+    # users.is_admin on their next login (additive, never demotes) —
+    # the same `admins:` knob the OSS server config exposes. Set per
+    # deploy via `deploy.py --admins ...` → the OMNIGENT_ADMINS env var.
+    admins = [a.strip() for a in os.environ.get("OMNIGENT_ADMINS", "").split(",") if a.strip()]
     app = create_app(
         agent_store=agent_store,
         file_store=file_store,
@@ -212,7 +220,9 @@ try:
         permission_store=permission_store,
         policy_store=policy_store,
         host_store=host_store,
+        host_permission_store=SqlAlchemyHostPermissionStore(DB_URI),
         auth_provider=auth_provider,
+        admins=admins,
     )
 
     if __name__ == "__main__":

--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -285,6 +285,9 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         SqlAlchemyConversationStore,
     )
     from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+    from omnigent.stores.host_permission_store.sqlalchemy_store import (
+        SqlAlchemyHostPermissionStore,
+    )
     from omnigent.stores.host_store import HostStore
     from omnigent.stores.permission_store.sqlalchemy_store import (
         SqlAlchemyPermissionStore,
@@ -344,6 +347,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         comment_store=comment_store,
         permission_store=permission_store,
         host_store=host_store,
+        host_permission_store=SqlAlchemyHostPermissionStore(database_url),
         auth_provider=auth_provider,
         account_store=account_store,
         # Non-secret auth settings from the config file (admins are the

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3268,9 +3268,13 @@ def server(
             agent_cache,
         )
 
+    from omnigent.stores.host_permission_store.sqlalchemy_store import (
+        SqlAlchemyHostPermissionStore,
+    )
     from omnigent.stores.host_store import HostStore
 
     host_store = HostStore(db_uri)
+    host_permission_store = SqlAlchemyHostPermissionStore(db_uri)
 
     # Managed sandbox hosts (host_type="managed" sessions): parse the
     # config's `sandbox:` section up front so an operator typo stops
@@ -3341,6 +3345,7 @@ def server(
         permission_store=permission_store,
         auth_provider=auth_provider,
         host_store=host_store,
+        host_permission_store=host_permission_store,
         account_store=account_store,
         policy_modules=cfg.get("policy_modules"),
         admins=config_str_list(cfg.get("admins")),

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1158,6 +1158,53 @@ class SqlHost(OmnigentBase):
     )
 
 
+class SqlHostPermission(OmnigentBase):
+    """
+    SQLAlchemy model for the ``host_permissions`` table.
+
+    Junction table mapping ``(user_id, host_id)`` to a numeric
+    permission level, sharing a host the user does not own with them.
+    PK is ``(user_id, host_id)`` — optimized for the hot path ("list
+    hosts I can access" = prefix scan on ``user_id``). The host owner
+    (``hosts.owner``) and admins need no row — owner/admin access is
+    resolved by :func:`omnigent.server.host_permissions.check_host_access`,
+    not stored here.
+
+    The FK targets the durable ``hosts.host_id`` UNIQUE column (not the
+    ``(owner, name)`` primary key), so a grant survives an ``(owner,
+    name)`` change across host identity rotation / re-owning. Unlike
+    ``session_permissions`` there is no ``"__public__"`` sentinel: host
+    sharing is explicit per-user opt-in (see ``spec`` SR-007).
+
+    :param user_id: The grantee, e.g. ``"alice@example.com"``.
+    :param host_id: The host being shared, e.g. ``"host_a1b2c3d4..."``.
+    :param level: Numeric permission level: ``1`` = view, ``2`` = use,
+        ``3`` = manage. Each level subsumes the ones below it
+        (comparison is ``>=``).
+    :param created_at: Unix epoch seconds the grant was created.
+    :param updated_at: Unix epoch seconds the grant was last changed.
+    :param created_by: User ID that created the grant (admin or a
+        manage-level grantee), or ``None`` when unattributed.
+    """
+
+    __tablename__ = "host_permissions"
+
+    # No DB foreign keys (Rule R032): the application owns referential
+    # cleanup — HostStore.delete_host removes a host's grants, mirroring
+    # how it nulls conversations.host_id.
+    user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    host_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    level: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[int] = mapped_column(Integer, nullable=False)
+    updated_at: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint("level IN (1, 2, 3)", name="ck_host_permissions_level"),
+        Index("ix_host_permissions_host_id", "host_id"),
+    )
+
+
 class SqlUserDailyCost(OmnigentBase):
     """
     SQLAlchemy model for the ``user_daily_cost`` table.

--- a/omnigent/db/migrations/versions/r1a2b3c4d5e6_add_workspace_id_to_all_tables.py
+++ b/omnigent/db/migrations/versions/r1a2b3c4d5e6_add_workspace_id_to_all_tables.py
@@ -63,6 +63,30 @@ def _existing_pk_name(table: str) -> str | None:
     return sa.inspect(op.get_bind()).get_pk_constraint(table).get("name")
 
 
+def _drop_fks_referencing(tables: list[str]) -> None:
+    """Drop every FK that references any of ``tables`` (PostgreSQL).
+
+    The PK of a table cannot be dropped while another table's FK still
+    references it. Migration ``p1a2b3c4d5e6`` was meant to strip all FKs, but
+    it predates tables added later (e.g. ``host_permissions``), so surviving
+    FKs like ``host_permissions_user_id_fkey`` still block the PK rebuild here.
+    Drop whatever FKs actually reference these tables, by their real reflected
+    name, so the widening below is the "purely local" op the module assumes.
+    """
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT con.conname, con.conrelid::regclass::text AS child "
+            "FROM pg_constraint con "
+            "WHERE con.contype = 'f' "
+            "AND con.confrelid::regclass::text = ANY(:tables)"
+        ),
+        {"tables": tables},
+    ).fetchall()
+    for conname, child in rows:
+        op.execute(sa.text(f'ALTER TABLE "{child}" DROP CONSTRAINT "{conname}"'))
+
+
 @contextlib.contextmanager
 def _quiet_pk_override() -> Iterator[None]:
     """
@@ -86,6 +110,10 @@ def upgrade() -> None:
         op.execute(sa.text("PRAGMA foreign_keys = OFF"))
 
     is_mysql = op.get_bind().dialect.name == "mysql"
+    # PostgreSQL blocks dropping a PK while any FK still references it. Strip
+    # surviving FKs (incl. ones from tables added after p1a2b3c4d5e6) first.
+    if not sqlite and not is_mysql:
+        _drop_fks_referencing(list(_TABLE_PKS.keys()))
     for table, pk_cols in _TABLE_PKS.items():
         if is_mysql:
             # Use raw DDL on MySQL to avoid batch_alter_table reading ORM

--- a/omnigent/db/migrations/versions/z6a2b3c4d5e6_add_host_permissions.py
+++ b/omnigent/db/migrations/versions/z6a2b3c4d5e6_add_host_permissions.py
@@ -1,0 +1,65 @@
+"""add host permissions
+
+Revision ID: z6a2b3c4d5e6
+Revises: z5a2b3c4d5e6
+Create Date: 2026-07-07 00:00:00.000000
+
+Adds the ``host_permissions`` table: a junction table mapping
+``(user_id, host_id)`` to a numeric level (1=view, 2=use, 3=manage)
+that shares a host with users who do not own it.
+
+The FK targets the durable ``hosts.host_id`` UNIQUE column (not the
+``(owner, name)`` primary key) so a grant survives an owner change
+across host identity rotation / re-owning.
+
+NO backfill: existing hosts stay private after migration. Owner and
+admin access is resolved in code, not stored as grants, so there are
+no rows to seed — a non-owner gains access only when an explicit
+grant is created.
+
+See ``specs/admin-host-management-spec.md``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "z6a2b3c4d5e6"
+down_revision: str | None = "z5a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the host_permissions table. No backfill — hosts stay private."""
+    # Idempotent: some databases already have this table (created out-of-band
+    # from the same model), so skip creation when present. The definition below
+    # is the source of truth for a fresh DB.
+    if sa.inspect(op.get_bind()).has_table("host_permissions"):
+        return
+    # No DB foreign keys (Rule R032): the application owns referential
+    # cleanup — HostStore.delete_host removes a host's grants.
+    op.create_table(
+        "host_permissions",
+        sa.Column("user_id", sa.String(128), primary_key=True),
+        sa.Column("host_id", sa.String(64), primary_key=True),
+        sa.Column("level", sa.Integer, nullable=False),
+        sa.Column("created_at", sa.Integer, nullable=False),
+        sa.Column("updated_at", sa.Integer, nullable=False),
+        sa.Column("created_by", sa.String(128), nullable=True),
+        sa.CheckConstraint("level IN (1, 2, 3)", name="ck_host_permissions_level"),
+    )
+    op.create_index(
+        "ix_host_permissions_host_id",
+        "host_permissions",
+        ["host_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the host_permissions table."""
+    op.drop_index("ix_host_permissions_host_id", table_name="host_permissions")
+    op.drop_table("host_permissions")

--- a/omnigent/entities/__init__.py
+++ b/omnigent/entities/__init__.py
@@ -25,7 +25,7 @@ from omnigent.entities.conversation import (
 )
 from omnigent.entities.file import StoredFile
 from omnigent.entities.pagination import PagedList
-from omnigent.entities.permission import ResolvedAccess, SessionPermission
+from omnigent.entities.permission import HostPermission, ResolvedAccess, SessionPermission
 from omnigent.entities.policy import Policy
 from omnigent.entities.scheduled_task import ScheduledTask, ScheduledTaskRun
 from omnigent.entities.session_resources import (
@@ -50,6 +50,7 @@ __all__ = [
     "ErrorData",
     "FunctionCallData",
     "FunctionCallOutputData",
+    "HostPermission",
     "ItemData",
     "LoadedAgent",
     "MessageData",

--- a/omnigent/entities/permission.py
+++ b/omnigent/entities/permission.py
@@ -22,6 +22,32 @@ class SessionPermission:
     level: int
 
 
+@dataclasses.dataclass
+class HostPermission:
+    """A single permission grant on a host.
+
+    Shares a host the grantee does not own with them. The host owner
+    and admins need no grant — their access is resolved by
+    :func:`omnigent.server.host_permissions.check_host_access`.
+
+    :param user_id: The grantee, e.g. ``"alice@example.com"``.
+    :param host_id: The host this grant applies to, e.g.
+        ``"host_a1b2c3d4..."``.
+    :param level: Numeric permission level: ``1`` = view, ``2`` = use,
+        ``3`` = manage. Comparison is ``>=``.
+    :param created_at: Unix epoch seconds the grant was created.
+    :param updated_at: Unix epoch seconds the grant was last changed.
+    :param created_by: User ID that created the grant, or ``None``.
+    """
+
+    user_id: str
+    host_id: str
+    level: int
+    created_at: int
+    updated_at: int
+    created_by: str | None = None
+
+
 @dataclasses.dataclass(frozen=True)
 class ResolvedAccess:
     """The raw permission inputs for one ``(user, conversation)`` pair.

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -26,6 +26,7 @@ from omnigent._platform import WINDOWS_ENV_PASSTHROUGH
 from omnigent.env_credentials import env_names_with_omnigent_prefix
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
+    HOST_AT_CAPACITY_ERROR_CODE,
     HostCreateDirFrame,
     HostCreateDirResultFrame,
     HostCreateWorktreeFrame,
@@ -43,6 +44,7 @@ from omnigent.host.frames import (
     HostRemoveWorktreeFrame,
     HostRemoveWorktreeResultFrame,
     HostRunnerExitedFrame,
+    HostShutdownFrame,
     HostStatFrame,
     HostStatResultFrame,
     HostStopRunnerFrame,
@@ -73,6 +75,7 @@ from omnigent.process_logging import (
 from omnigent.runner.identity import (
     RUNNER_ID_ENV_VAR,
     RUNNER_PARENT_PID_ENV_VAR,
+    RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR,
     RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR,
     RUNNER_WORKSPACE_ENV_VAR,
     token_bound_runner_id,
@@ -144,6 +147,33 @@ _RUNNER_WATCH_INTERVAL_S = 0.5
 # ~900 zombies and OOM'd the box (#1782). A ``WNOHANG`` sweep is a cheap
 # syscall, so 2s keeps zombie lifetime short at negligible cost.
 _ORPHAN_REAP_INTERVAL_S = 2.0
+
+
+def _max_concurrent_runners() -> int | None:
+    """Max concurrent runners this host will spawn, or ``None`` for unlimited.
+
+    Read from ``OMNIGENT_HOST_MAX_RUNNERS`` at call time (not import) so a
+    redeploy can change it without a code change. On a fixed-resource host
+    (e.g. a Databricks App container: 4 vCPU / 12 GB) each runner is a full
+    agent process using 0.5-1.5 GB, so an unbounded fan-out of
+    ``host.launch_runner`` frames can OOM the box and take down every session
+    on it (cf. the zombie-OOM incident, #1782). A positive value caps the
+    fan-out; ``0`` / unset / non-numeric means unlimited (unchanged behavior).
+
+    :returns: The positive cap, or ``None`` when unlimited.
+    """
+    raw = os.environ.get("OMNIGENT_HOST_MAX_RUNNERS", "").strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        _logger.warning(
+            "OMNIGENT_HOST_MAX_RUNNERS=%r is not an integer — ignoring (unlimited)",
+            raw,
+        )
+        return None
+    return value if value > 0 else None
 
 
 def _install_child_subreaper() -> bool:
@@ -498,6 +528,16 @@ class HostConnectError(Exception):
     """
 
 
+class HostShutdownRequested(Exception):
+    """The server ordered this host to shut down (``host.shutdown``).
+
+    Raised out of the frame dispatch so the reconnect loop in
+    :meth:`HostProcess.run` exits cleanly instead of treating the
+    ensuing disconnect as transient and reconnecting. The message is
+    the server-provided reason, if any.
+    """
+
+
 def _build_runner_env(
     base_env: Mapping[str, str],
     *,
@@ -506,6 +546,7 @@ def _build_runner_env(
     binding_token: str,
     workspace: str,
     parent_pid: int,
+    prefer_binding_token_mint: bool = False,
 ) -> dict[str, str]:
     """
     Build the environment for a spawned runner subprocess.
@@ -529,6 +570,12 @@ def _build_runner_env(
     :param workspace: Absolute runner cwd on the host, e.g.
         ``"/Users/alice/proj"``.
     :param parent_pid: Host process pid, for orphan detection.
+    :param prefer_binding_token_mint: When ``True``, set the env flag that
+        tells the runner to authenticate its server callbacks via the
+        binding-token mint (session-owner identity) instead of the
+        inherited host-owner credential. Set by the server on the
+        ``host.launch_runner`` frame only when the session owner differs
+        from the host owner.
     :returns: The runner subprocess environment.
     """
     extra_names = {
@@ -549,6 +596,8 @@ def _build_runner_env(
     env[RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR] = binding_token
     env[RUNNER_WORKSPACE_ENV_VAR] = workspace
     env[RUNNER_PARENT_PID_ENV_VAR] = str(parent_pid)
+    if prefer_binding_token_mint:
+        env[RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR] = "1"
     return env
 
 
@@ -1045,6 +1094,34 @@ class HostProcess:
             ``"harness_not_configured"`` when the harness check
             refuses the launch.
         """
+        # Backpressure: refuse to spawn past this host's configured runner cap.
+        # On a fixed-resource host each runner is a full agent process, so an
+        # unbounded fan-out of launch frames can OOM the box and kill every
+        # session on it. ``_alive_runner_ids`` prunes dead entries first, so the
+        # count reflects only runners actually still consuming resources.
+        # ``None`` (unset/0) preserves the original unlimited behavior.
+        max_runners = _max_concurrent_runners()
+        if max_runners is not None:
+            live = len(self._alive_runner_ids())
+            if live >= max_runners:
+                _logger.warning(
+                    "Refusing launch_runner: host %r at capacity "
+                    "(%d/%d live runners, OMNIGENT_HOST_MAX_RUNNERS)",
+                    self._identity.name,
+                    live,
+                    max_runners,
+                )
+                return HostLaunchRunnerResultFrame(
+                    request_id=frame.request_id,
+                    status="failed",
+                    error=(
+                        f"host {self._identity.name!r} is at capacity "
+                        f"({live}/{max_runners} runners) — close a session or "
+                        f"raise OMNIGENT_HOST_MAX_RUNNERS"
+                    ),
+                    error_code=HOST_AT_CAPACITY_ERROR_CODE,
+                )
+
         # Refuse to spawn for a harness this machine can't actually run —
         # otherwise the runner starts, the session looks alive, and the
         # first turn dies confusingly inside the executor. ``None`` (an
@@ -1077,6 +1154,7 @@ class HostProcess:
             binding_token=frame.binding_token,
             workspace=str(workspace),
             parent_pid=os.getpid(),
+            prefer_binding_token_mint=frame.prefer_binding_token_mint,
         )
 
         try:
@@ -1751,6 +1829,12 @@ class HostProcess:
                     backoff = _RECONNECT_BASE_S
                 except (KeyboardInterrupt, asyncio.CancelledError):
                     break
+                except HostShutdownRequested as exc:
+                    # Server-ordered stop: exit the loop instead of
+                    # reconnecting — that's the whole difference between
+                    # a shutdown and an ordinary tunnel drop.
+                    print(f"Host shut down by server: {exc}", flush=True)
+                    break
                 except HostConnectError:
                     # Permanent failure (auth / authorization / outdated
                     # server). Do NOT back off and retry — propagate so
@@ -2080,6 +2164,15 @@ class HostProcess:
             await ws.send(encode_host_frame(await self._handle_remove_worktree(frame)))
         elif isinstance(frame, HostListWorktreesFrame):
             await ws.send(encode_host_frame(await self._handle_list_worktrees(frame)))
+        elif isinstance(frame, HostShutdownFrame):
+            # Server-ordered shutdown (owner/admin action). Terminate the
+            # runners here so they die even if process teardown is
+            # interrupted, then raise the control signal — run()'s finally
+            # re-runs cleanup, which is a no-op on the emptied map.
+            reason = frame.reason or "shut down by server request"
+            _logger.info("Received host.shutdown: %s", reason)
+            self._cleanup_runners()
+            raise HostShutdownRequested(reason)
         elif isinstance(frame, HostFsRequestFrame):
             # Git status and directory walks can block, so run the read
             # off the event loop and reply when it completes.

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -33,6 +33,14 @@ HarnessAvailability = bool | str
 # ``ErrorCode.HARNESS_NOT_CONFIGURED``), and tests.
 HARNESS_NOT_CONFIGURED_ERROR_CODE = "harness_not_configured"
 
+# Structured error code carried in ``HostLaunchRunnerResultFrame.error_code``
+# when the host refuses a launch because it is already at its configured
+# maximum number of concurrent runners (``OMNIGENT_HOST_MAX_RUNNERS``). Lets
+# the server distinguish a capacity backpressure signal (retryable / queue
+# elsewhere) from a hard failure. Shared by the daemon (producer), server, and
+# tests.
+HOST_AT_CAPACITY_ERROR_CODE = "host_at_capacity"
+
 
 class HostFrameKind(str, Enum):
     """All host frame kinds; the value is the JSON wire string."""
@@ -55,6 +63,7 @@ class HostFrameKind(str, Enum):
     LIST_WORKTREES_RESULT = "host.list_worktrees_result"
     CREATE_DIR = "host.create_dir"
     CREATE_DIR_RESULT = "host.create_dir_result"
+    SHUTDOWN = "host.shutdown"
     FS_REQUEST = "host.fs_request"
     FS_RESULT = "host.fs_result"
 
@@ -113,6 +122,15 @@ class HostLaunchRunnerFrame:
         :data:`HARNESS_NOT_CONFIGURED_ERROR_CODE` when not.
         ``None`` (older server, or no resolvable harness) skips
         the check — fail open.
+    :param prefer_binding_token_mint: When ``True``, the runner should
+        authenticate its server callbacks with the binding-token owner
+        mint (acting as the SESSION owner) instead of the inherited
+        host-owner credential. The server sets this only when the
+        session owner differs from the host owner — the shared /
+        externally-owned-host case (e.g. a service-principal-owned host
+        serving another user's session), where the host-owner credential
+        cannot read the guest session's spec. ``False`` (the default, and
+        what an older server omits) keeps the host-owner credential path.
     """
 
     request_id: str
@@ -120,6 +138,7 @@ class HostLaunchRunnerFrame:
     workspace: str
     session_id: str | None = None
     harness: str | None = None
+    prefer_binding_token_mint: bool = False
 
 
 @dataclass
@@ -177,6 +196,26 @@ class HostStopRunnerResultFrame:
     request_id: str
     status: str
     error: str | None = None
+
+
+@dataclass
+class HostShutdownFrame:
+    """Server → host: terminate all runners and exit the host process.
+
+    Sent by the owner/admin-triggered ``POST /v1/hosts/{id}/shutdown``.
+    Unlike a plain tunnel close — which the daemon treats as transient
+    and reconnects from — this tells the daemon to stop for good: it
+    terminates its runners and exits instead of re-entering the
+    reconnect loop. Older hosts that don't know the kind ignore it
+    (the dispatch drops unrecognized frames), so shutdown degrades to
+    a no-op rather than an error against them.
+
+    :param reason: Optional human-readable cause for the daemon's
+        log, e.g. ``"shut down by admin"``. ``None`` logs a generic
+        message.
+    """
+
+    reason: str | None = None
 
 
 @dataclass
@@ -594,6 +633,7 @@ HostFrame = (
     | HostListWorktreesResultFrame
     | HostCreateDirFrame
     | HostCreateDirResultFrame
+    | HostShutdownFrame
     | HostFsRequestFrame
     | HostFsResultFrame
 )
@@ -655,6 +695,7 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "workspace": frame.workspace,
                 "session_id": frame.session_id,
                 "harness": frame.harness,
+                "prefer_binding_token_mint": frame.prefer_binding_token_mint,
             }
         )
     if isinstance(frame, HostLaunchRunnerResultFrame):
@@ -683,6 +724,13 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "request_id": frame.request_id,
                 "status": frame.status,
                 "error": frame.error,
+            }
+        )
+    if isinstance(frame, HostShutdownFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.SHUTDOWN.value,
+                "reason": frame.reason,
             }
         )
     if isinstance(frame, HostRunnerExitedFrame):
@@ -939,6 +987,8 @@ def _decode_known_host_frame(
             return _decode_create_dir(msg)
         case HostFrameKind.CREATE_DIR_RESULT:
             return _decode_create_dir_result(msg)
+        case HostFrameKind.SHUTDOWN:
+            return _decode_shutdown(msg)
         case HostFrameKind.FS_REQUEST:
             return _decode_fs_request(msg)
         case HostFrameKind.FS_RESULT:
@@ -975,6 +1025,7 @@ def _decode_launch_runner(msg: dict[str, Any]) -> HostLaunchRunnerFrame:
         workspace=_required_str(msg, "workspace"),
         session_id=_optional_nullable_str(msg, "session_id"),
         harness=_optional_nullable_str(msg, "harness"),
+        prefer_binding_token_mint=_optional_bool(msg, "prefer_binding_token_mint"),
     )
 
 
@@ -1019,6 +1070,17 @@ def _decode_stop_runner_result(
         request_id=_required_str(msg, "request_id"),
         status=_required_str(msg, "status"),
         error=_optional_nullable_str(msg, "error"),
+    )
+
+
+def _decode_shutdown(msg: dict[str, Any]) -> HostShutdownFrame:
+    """Decode a host.shutdown frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.shutdown frame.
+    """
+    return HostShutdownFrame(
+        reason=_optional_nullable_str(msg, "reason"),
     )
 
 
@@ -1337,6 +1399,26 @@ def _required_bool(msg: dict[str, Any], key: str) -> bool:
     val = msg.get(key)
     if not isinstance(val, bool):
         raise ValueError(f"frame missing required bool field: {key!r}")
+    return val
+
+
+def _optional_bool(msg: dict[str, Any], key: str, default: bool = False) -> bool:
+    """Return an optional boolean field, defaulting when absent.
+
+    Absent is the wire-compat case (a frame from an older peer that
+    predates the field), so it must default rather than raise.
+
+    :param msg: Decoded frame object.
+    :param key: Field name, e.g. ``"prefer_binding_token_mint"``.
+    :param default: Value when the key is absent.
+    :returns: The boolean value, or *default* when absent.
+    :raises ValueError: If the field is present but not a bool.
+    """
+    if key not in msg:
+        return default
+    val = msg[key]
+    if not isinstance(val, bool):
+        raise ValueError(f"frame field must be a bool: {key!r}")
     return val
 
 

--- a/omnigent/inner/pi_native_executor.py
+++ b/omnigent/inner/pi_native_executor.py
@@ -130,6 +130,10 @@ class PiNativeExecutor(Executor):
                 # per-turn refresh preserves the workspace / deployment routing
                 # selectors baked at launch (see runner/app.py). A bearer-only
                 # refresh would drop them and re-break routing after the first turn.
+                # refresh_config_auth_headers MERGES over the existing authHeaders,
+                # so the guest-on-shared-host X-Omnigent-Runner-Tunnel-Token written
+                # at launch also survives (this worker's env has the token scrubbed,
+                # so we can't re-supply it â the merge keeps the chat-mirror grant).
                 refresh_config_auth_headers(
                     self._bridge_dir,
                     databricks_request_headers(

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -121,6 +121,30 @@ def policy_hook_wrapper_script(server_url: str, session_id: str, hook_script_pat
     factory = _make_auth_token_factory(server_url=server_url)
     token = factory() if factory is not None else None
     auth_headers = databricks_request_headers(server_url, bearer_token=token)
+    # Guest-on-shared-host: when the server flagged this runner as serving a
+    # session whose host it doesn't own (a shared/externally-owned host such as
+    # a CoDA Databricks App), the baked SP bearer clears the ingress but has no
+    # user grant on the guest's conversation, so the hook's POST to
+    # /v1/sessions/{id}/policies/evaluate 404s. post_evaluate_with_retry then
+    # returns no response and the hook FAILS CLOSED — blocking every tool call
+    # ("tools don't work in Hermes"). Attach the tunnel binding token so the
+    # server's runner self-access check matches the token-derived runner id
+    # against the session's runner_id and authorizes the evaluate. Gated on the
+    # same flag the transcript forwarder uses, so it isn't sent on own-host runs.
+    # Mirrors the pi-/claude-/hermes-native forwarder auth.
+    try:
+        from omnigent.runner._entry import _runner_tunnel_binding_token_from_env
+        from omnigent.runner.identity import (
+            RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR,
+            RUNNER_TUNNEL_TOKEN_HEADER,
+        )
+
+        if os.environ.get(RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR):
+            _binding_token = _runner_tunnel_binding_token_from_env()
+            if _binding_token:
+                auth_headers[RUNNER_TUNNEL_TOKEN_HEADER] = _binding_token
+    except Exception:  # noqa: BLE001 — best effort; own-host / import failure = no header
+        pass
     return (
         "#!/bin/sh\n"
         f"export _OMNIGENT_SERVER_URL={shlex.quote(server_url)}\n"

--- a/omnigent/pi_native_bridge.py
+++ b/omnigent/pi_native_bridge.py
@@ -295,17 +295,19 @@ def refresh_config_auth_headers(bridge_dir: Path, auth_headers: dict[str, str]) 
     Best-effort and behavior-preserving: it touches only ``authHeaders``,
     leaving ``serverUrl`` / ``tools`` / etc. intact.
 
-    Headers are **merged** (fresh values win on collision) rather than replaced,
-    so launch-written headers such as ``X-Omnigent-Runner-Tunnel-Token`` — set
-    when the binding token was available in the runner-main process env and
-    needed for guest-on-shared-host self-access — survive every bearer rotation.
+    The fresh headers are **merged over** the existing ``authHeaders`` rather
+    than replacing them, so a header the launch established but the refresh
+    caller cannot re-derive — notably the guest-on-shared-host
+    ``X-Omnigent-Runner-Tunnel-Token`` (the binding token is scrubbed from the
+    harness-worker env that drives the per-turn refresh) — survives the bearer
+    rotation instead of being clobbered.
 
     :param bridge_dir: Native Pi bridge directory.
     :param auth_headers: Fresh outbound auth headers to merge in, e.g.
         ``{"Authorization": "Bearer <token>"}``.
     :returns: ``True`` when the config was rewritten; ``False`` when
         *auth_headers* is empty (local/unauthenticated), the config is
-        missing/unreadable, or the merged result is unchanged.
+        missing/unreadable, or the merged headers already match.
     """
     if not auth_headers:
         return False
@@ -316,8 +318,8 @@ def refresh_config_auth_headers(bridge_dir: Path, auth_headers: dict[str, str]) 
         return False
     if not isinstance(payload, dict):
         return False
-    existing = payload.get("authHeaders") or {}
-    merged = {**existing, **auth_headers}
+    existing = payload.get("authHeaders")
+    merged = {**existing, **auth_headers} if isinstance(existing, dict) else dict(auth_headers)
     if merged == existing:
         return False
     payload["authHeaders"] = merged

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -396,6 +396,24 @@ def _make_auth_token_factory(
                 return oidc_token
         return _sdk_token()
 
+    # Guest-on-shared-host: the server set OMNIGENT_RUNNER_PREFER_BINDING_TOKEN_MINT
+    # because this session's owner differs from the host owner. Prefer the
+    # binding-token mint (acting as the SESSION owner) OVER the inherited
+    # host-owner credential — the host-owner credential can't read the guest
+    # session's spec, so its callbacks 404. This is the only case where the
+    # mint is chosen ahead of an available user credential; every other path
+    # keeps the historical order (user credential first, mint as fallback).
+    # Falls through to that order if the binding token is somehow absent
+    # (safe degrade — never abort the launch here).
+    # NOTE: the prefer-flag does NOT force the owner-JWT mint here. In header
+    # mode the mint endpoint 302s/400s (no cookie secret), which would break
+    # the tunnel bearer this factory also feeds → runner_failed_to_start. The
+    # flag instead drives the binding-token HEADER on the callback client (see
+    # create_app's server_client), which the server matches to conv.runner_id
+    # to grant read — no minted credential, no auth-mode dependency. The tunnel
+    # keeps authenticating with the host owner's credential (below), which the
+    # server accepts for the tunnel.
+
     # Probe once to check if a user credential is available.
     try:
         if _factory() is not None:
@@ -577,22 +595,40 @@ def _mint_managed_owner_token(
     return payload["token"], float(payload["expires_at"])
 
 
+# Captured at first read (runner startup, before any scrub). The binding
+# token is popped from os.environ at every child-spawn / sandbox boundary
+# (strip_runner_auth_secrets / sandbox launcher), so a later reader —
+# e.g. _auto_create_pi_terminal building the pi extension config after a
+# terminal launch scrubbed the env — would otherwise see None. Caching it
+# in the runner's own process memory keeps it available to all in-process
+# callbacks without re-exposing it to any child environment (the scrub
+# boundary is child process env, not in-process memory).
+_CAPTURED_BINDING_TOKEN: str | None = None
+
+
 def _runner_tunnel_binding_token_from_env() -> str | None:
-    """Return the optional tunnel binding token from the environment.
+    """Return the optional tunnel binding token.
+
+    Reads the env var on first call (runner startup, before the env is
+    scrubbed) and caches it, so later callers still get it after the
+    sandbox / child-spawn scrubbers pop it from ``os.environ``.
 
     :returns: Secret token used to bind the WebSocket tunnel to its
         runner id, or ``None`` when the runner was started without
         per-tunnel binding.
     :raises RuntimeError: If the token env var is set but empty.
     """
+    global _CAPTURED_BINDING_TOKEN
     from omnigent.runner.identity import RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR
 
     token = os.environ.get(RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR)
     if token is None:
-        return None
+        # Env was scrubbed after startup; fall back to the captured value.
+        return _CAPTURED_BINDING_TOKEN
     if not token.strip():
         raise RuntimeError(f"{RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR} must not be empty")
-    return token.strip()
+    _CAPTURED_BINDING_TOKEN = token.strip()
+    return _CAPTURED_BINDING_TOKEN
 
 
 def _runner_parent_pid_from_env() -> int | None:
@@ -904,6 +940,25 @@ def create_app(
     # token cache); otherwise build our own.
     if auth_token_factory is None:
         auth_token_factory = _make_auth_token_factory()
+    _callback_headers = {
+        "Origin": OMNIGENT_INTERNAL_WS_ORIGIN,
+        **databricks_request_headers(server_url),
+    }
+    # Guest-on-shared-host: when the server flagged this runner as serving a
+    # session it doesn't own the host of, attach the tunnel binding token so the
+    # server can grant read on THIS session by matching the token-derived runner
+    # id against the session's runner_id. Works in header/proxy auth mode, where
+    # no owner token can be minted. Gated by the flag so the token isn't sent on
+    # ordinary own-host runs.
+    from omnigent.runner.identity import (
+        RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR,
+        RUNNER_TUNNEL_TOKEN_HEADER,
+    )
+
+    if os.environ.get(RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR):
+        _binding_token = _runner_tunnel_binding_token_from_env()
+        if _binding_token:
+            _callback_headers[RUNNER_TUNNEL_TOKEN_HEADER] = _binding_token
     server_client = httpx.AsyncClient(
         base_url=server_url,
         auth=_RunnerDatabricksAuth(auth_token_factory),
@@ -916,7 +971,7 @@ def create_app(
         #
         # The workspace-routing header (empty unless a ?o= selector was
         # recorded for this server) routes these callbacks to the workspace.
-        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN, **databricks_request_headers(server_url)},
+        headers=_callback_headers,
         timeout=httpx.Timeout(5.0, read=None),
         # NOTE: ``follow_redirects`` deliberately stays False.
         # ``_RunnerDatabricksAuth.auth_flow`` needs to *see* the

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1938,6 +1938,22 @@ async def _auto_create_pi_terminal(
     from omnigent.cli_auth import databricks_request_headers
 
     auth_headers = databricks_request_headers(launch_config.server_url, bearer_token=auth_token)
+    # Guest-on-shared-host: attach the tunnel binding token so the extension's
+    # POST /events (chat mirror) is authorized against THIS session by matching
+    # the token-derived runner id against the session's runner_id. Without it the
+    # SP bearer clears the ingress but has no user grant on the human's conv, so
+    # the server 404-masks the mirror. Gated on the same flag the transcript
+    # forwarder uses (see the guest-on-shared-host block below), so it isn't sent
+    # on ordinary own-host runs.
+    from omnigent.runner._entry import _runner_tunnel_binding_token_from_env
+    from omnigent.runner.identity import (
+        RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR,
+        RUNNER_TUNNEL_TOKEN_HEADER,
+    )
+
+    _pi_binding_token = _runner_tunnel_binding_token_from_env()
+    if os.environ.get(RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR) and _pi_binding_token:
+        auth_headers[RUNNER_TUNNEL_TOKEN_HEADER] = _pi_binding_token
     # Build the Omnigent tool surface (sys_* tools) the Pi extension registers
     # via pi.registerTool. Reuses the same schema set the claude-native /
     # codex-native relay advertises, gated by the session's spec. Each tool's
@@ -2528,7 +2544,7 @@ async def _auto_create_hermes_terminal(
     :returns: Created terminal resource view.
     """
     from omnigent.hermes_native import resolve_hermes_executable
-    from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
+    from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
 
     # Tear down any forwarder left from a prior terminal for this session before
     # re-creating, so old and new tasks can't both mirror (double-posting), and
@@ -2647,7 +2663,21 @@ async def _auto_create_hermes_terminal(
         session_key="main",
         resource_role=HERMES_NATIVE_TERMINAL_ROLE,
         spec=TerminalEnvSpec(
-            os_env=OSEnvSpec(type="caller_process", cwd=workspace),
+            # Explicit sandbox=none: an OSEnvSpec with sandbox=None resolves to
+            # the platform default (linux_bwrap on Linux) in resolve_sandbox(),
+            # which needs the `bwrap` binary — absent on hosts like a CoDA
+            # Databricks App container, so the Hermes TUI terminal 500s with
+            # "linux_bwrap sandbox requires the 'bwrap' binary on PATH" and the
+            # whole session fails to start. The hermes-native wrapper agent spec
+            # (see omnigent.hermes_native._materialize_hermes_agent_spec) already
+            # declares sandbox: none; thread the same here so the runner-owned
+            # terminal matches it. Mirrors the caller_process + sandbox=none the
+            # headless `hermes` harness uses.
+            os_env=OSEnvSpec(
+                type="caller_process",
+                cwd=workspace,
+                sandbox=OSEnvSandboxSpec(type="none"),
+            ),
             command=hermes_command,
             args=hermes_args,
             env=_hermes_terminal_env,
@@ -2684,6 +2714,28 @@ async def _auto_create_hermes_terminal(
     server_url = _required_runner_env("RUNNER_SERVER_URL")
     _runner_auth = _RunnerDatabricksAuth(_make_auth_token_factory())
 
+    # Guest-on-shared-host: when the server flagged this runner as serving a
+    # session whose host it doesn't own (a shared/externally-owned host such as
+    # a CoDA Databricks App), the refresh-capable SP bearer clears the ingress
+    # but has no user grant on the human's conversation, so the forwarder's and
+    # approval mirror's POST /v1/sessions/{id}/events would be 404-masked and the
+    # Hermes transcript / dangerous-command prompts would never reach Chat.
+    # Attach the tunnel binding token so the server's runner self-access check
+    # matches the token-derived runner id against the session's runner_id and
+    # grants LEVEL_EDIT. The flag gates the header so it isn't sent on ordinary
+    # own-host runs. Mirrors the pi-/claude-native paths.
+    from omnigent.runner._entry import _runner_tunnel_binding_token_from_env
+    from omnigent.runner.identity import (
+        RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR,
+        RUNNER_TUNNEL_TOKEN_HEADER,
+    )
+
+    _hermes_forward_headers: dict[str, str] = {}
+    if os.environ.get(RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR):
+        _hermes_binding_token = _runner_tunnel_binding_token_from_env()
+        if _hermes_binding_token:
+            _hermes_forward_headers[RUNNER_TUNNEL_TOKEN_HEADER] = _hermes_binding_token
+
     from omnigent.hermes_native_bridge import read_hermes_home
     from omnigent.hermes_native_forwarder import supervise_hermes_forwarder
     from omnigent.hermes_native_permissions import supervise_hermes_approval_mirror
@@ -2712,7 +2764,7 @@ async def _auto_create_hermes_terminal(
         await asyncio.gather(
             supervise_hermes_forwarder(
                 base_url=server_url,
-                headers={},
+                headers=dict(_hermes_forward_headers),
                 session_id=session_id,
                 bridge_dir=bridge_dir,
                 agent_name="hermes-native-ui",
@@ -2723,7 +2775,7 @@ async def _auto_create_hermes_terminal(
             ),
             supervise_hermes_approval_mirror(
                 base_url=server_url,
-                headers={},
+                headers=dict(_hermes_forward_headers),
                 session_id=session_id,
                 bridge_dir=bridge_dir,
                 auth=_runner_auth,
@@ -5487,6 +5539,23 @@ async def _auto_create_claude_terminal(
     from omnigent.cli_auth import databricks_request_headers
 
     _runner_headers = databricks_request_headers(server_url, bearer_token=_auth_token)
+    # Guest-on-shared-host: when the server flagged this runner as serving a
+    # session it doesn't own the host of, attach the tunnel binding token so the
+    # transcript forwarder's POST /events is authorized against THIS session by
+    # matching the token-derived runner id against the session's runner_id.
+    # Header/proxy auth mode has no owner token to mint; the flag gates the
+    # header so it isn't sent on ordinary own-host runs. Mirrors _entry.py's
+    # server_client and the spec-callback GET routes.
+    from omnigent.runner._entry import _runner_tunnel_binding_token_from_env
+    from omnigent.runner.identity import (
+        RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR,
+        RUNNER_TUNNEL_TOKEN_HEADER,
+    )
+
+    if os.environ.get(RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR):
+        _binding_token = _runner_tunnel_binding_token_from_env()
+        if _binding_token:
+            _runner_headers[RUNNER_TUNNEL_TOKEN_HEADER] = _binding_token
     _runner_auth = _RunnerDatabricksAuth(_auth_factory)
 
     from omnigent.claude_launcher import resolve_claude_launch

--- a/omnigent/runner/identity.py
+++ b/omnigent/runner/identity.py
@@ -34,6 +34,16 @@ OMNIGENT_INTERNAL_WS_ORIGIN = "omnigent://internal"
 # CLI flows leave it unset (agent sees the project root directly).
 RUNNER_ISOLATE_SESSION_ENV_VAR = "OMNIGENT_RUNNER_ISOLATE_SESSION"
 
+# "1" tells a host-launched runner to authenticate its server callbacks
+# with the binding-token owner mint (acting as the SESSION owner) instead
+# of the inherited host-owner credential. Set by the server (via the
+# host.launch_runner frame → host runner env) only when the session owner
+# differs from the host owner — the shared / externally-owned-host case
+# (e.g. a Databricks App host serving another user's session). Unset keeps
+# the default order (inherited credential first, mint as fallback). Not a
+# secret — a plain flag — so it is NOT in RUNNER_AUTH_SECRET_ENV_VARS.
+RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR = "OMNIGENT_RUNNER_PREFER_BINDING_TOKEN_MINT"
+
 # Marker env var stamped into every agent-facing environment so any
 # process launched inside an Omnigent agent session can detect it is
 # running under Omnigent. This is the analog of Claude Code's

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -86,6 +86,7 @@ from omnigent.stores import (
 )
 from omnigent.stores.comment_store import CommentStore
 from omnigent.stores.conversation_store import SessionConnectivity
+from omnigent.stores.host_permission_store import HostPermissionStore
 from omnigent.stores.host_store import HostStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.policy_store import PolicyStore
@@ -1093,6 +1094,7 @@ def create_app(
     scheduled_task_store: ScheduledTaskStore | None = None,
     auth_provider: AuthProvider | None = None,
     host_store: HostStore | None = None,
+    host_permission_store: HostPermissionStore | None = None,
     account_store: Any | None = None,  # SqlAlchemyAccountStore — accounts mode only
     extra_routers: list[tuple[Any, str, list[str]]] | None = None,
     policy_modules: list[str] | None = None,
@@ -1144,6 +1146,10 @@ def create_app(
     :param host_store: Store for host registrations. ``None``
         disables host connectivity features (list hosts, launch
         runners on remote hosts).
+    :param host_permission_store: Store for host-sharing grants.
+        Required when ``host_store`` is provided — the host routes
+        resolve owned-or-shared visibility and per-host access through
+        it. ``None`` is allowed only when host support is disabled.
     :param policy_modules: Additional dotted module paths to
         scan for ``POLICY_REGISTRY`` lists at startup, e.g.
         ``["myorg.policies.safety"]``. Sourced from the server
@@ -1443,6 +1449,8 @@ def create_app(
     app.state.runner_router = runner_router
     app.state.host_registry = host_registry
     app.state.host_store = host_store
+    app.state.host_permission_store = host_permission_store
+    app.state.permission_store = permission_store
     app.state.sandbox_config = sandbox_config
     # Admin roster: the config ``admins:`` list (canonical) union'd with the
     # runtime-editable ``<data_dir>/admins`` file. Built once here so BOTH the
@@ -2460,6 +2468,13 @@ def create_app(
     # except (a hidden failure). No host_store = host support is simply
     # not enabled (host connects get 404), rather than silently broken.
     if host_store is not None:
+        if host_permission_store is None:
+            # Host routes resolve owned-or-shared visibility and per-host
+            # access through the host permission store; mounting them
+            # without it would 500 on every host request. Fail loud at
+            # wiring time instead.
+            raise ValueError("host_permission_store is required when host_store is provided")
+
         from omnigent.server.routes.host_tunnel import create_host_tunnel_router
         from omnigent.server.routes.hosts import create_hosts_router
 
@@ -2487,10 +2502,14 @@ def create_app(
                 host_registry,
                 host_store,
                 conversation_store,
+                host_permission_store=host_permission_store,
                 auth_provider=auth_provider,
                 permission_store=permission_store,
                 agent_store=agent_store,
                 agent_cache=agent_cache,
+                # Same roster /v1/me consults, so the admin fleet view
+                # authorizes exactly the users the SPA shows it to.
+                admin_list=admin_list,
             ),
             prefix="/v1",
             tags=["hosts"],

--- a/omnigent/server/audit.py
+++ b/omnigent/server/audit.py
@@ -1,0 +1,39 @@
+"""Structured audit trail for operator-relevant host mutations.
+
+Host shutdowns and permission grant/revoke changes are security-relevant
+actions taken by one principal against a resource that affects others,
+so they are recorded with actor + target on a dedicated logger
+(``omnigent.audit``) as single-line JSON. Operators grep the server log
+for ``audit:`` (or filter the logger name) to reconstruct who did what,
+when — no new storage, works on every deploy target.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from omnigent.db.utils import now_epoch
+
+_audit_logger = logging.getLogger("omnigent.audit")
+
+
+def audit_event(action: str, *, actor: str | None, target: str, **fields: object) -> None:
+    """Record one audit entry.
+
+    :param action: What happened, e.g. ``"host.shutdown"``,
+        ``"host.permission.grant"``.
+    :param actor: The authenticated principal that performed it, or
+        ``None`` when auth is disabled (recorded as ``"local"``).
+    :param target: The resource acted on, e.g. ``"host_a1b2c3d4..."``.
+    :param fields: Extra action-specific context, e.g.
+        ``principal="bob@example.com", level="use"``.
+    """
+    entry: dict[str, object] = {
+        "action": action,
+        "actor": actor if actor is not None else "local",
+        "target": target,
+        "ts": now_epoch(),
+        **fields,
+    }
+    _audit_logger.info("audit: %s", json.dumps(entry, sort_keys=True, default=str))

--- a/omnigent/server/host_permissions.py
+++ b/omnigent/server/host_permissions.py
@@ -1,0 +1,115 @@
+"""Host access checks for route handlers.
+
+Provides :func:`check_host_access`, the single resolver every host
+read/use path routes through. Mirrors
+:func:`omnigent.server.permissions.check_session_access` but for hosts:
+
+1. auth disabled (``user_id is None``) → allow (single-user/local)
+2. admin → allow (reuses the global ``users.is_admin`` flag)
+3. host owner → allow (no grant row needed)
+4. otherwise → delegate to the host permission grant check
+
+See ``specs/admin-host-management-spec.md``.
+"""
+
+from __future__ import annotations
+
+from omnigent.stores.host_permission_store import HostPermissionStore
+from omnigent.stores.host_store import HostStore
+from omnigent.stores.permission_store import PermissionStore
+
+# Host permission levels. Host-local on purpose — they share the
+# session model's integers (so the DB CHECK and any shared comparison
+# stay aligned) but carry host-meaningful names: "use" is not "edit".
+HOST_LEVEL_VIEW = 1
+HOST_LEVEL_USE = 2
+HOST_LEVEL_MANAGE = 3
+# Effective-only: the owner/admin display level. Never stored as a grant
+# (the CHECK constraint forbids 4); returned by get_host_permission_level
+# so the UI can label owner/admin access.
+HOST_LEVEL_OWNER = 4
+
+
+def check_host_access(
+    user_id: str | None,
+    host_id: str,
+    required_level: int,
+    host_permission_store: HostPermissionStore,
+    host_store: HostStore,
+    permission_store: PermissionStore | None = None,
+) -> bool:
+    """Check whether *user_id* may act on a host at *required_level*.
+
+    Resolution order:
+
+    1. ``user_id is None`` (auth disabled) → allow, consistent with the
+       single-user/local behavior the host routes already use.
+    2. Admin → allow (when *permission_store* is supplied; the admin
+       flag is global, stored on ``users.is_admin``).
+    3. Host owner → allow at every level (owner needs no grant row).
+    4. Otherwise → the user's host grant must be ``>= required_level``.
+
+    A missing host resolves to no access for non-owners (the grant
+    lookup misses); callers that must distinguish 404 from 403 look the
+    host up themselves first.
+
+    :param user_id: The authenticated caller, e.g. ``"alice@example.com"``,
+        or ``None`` when auth is disabled.
+    :param host_id: The host to check, e.g. ``"host_a1b2c3d4..."``.
+    :param required_level: Minimum numeric level needed
+        (1=view, 2=use, 3=manage).
+    :param host_permission_store: Store for host grant lookups.
+    :param host_store: Store for host owner lookup.
+    :param permission_store: Session permission store, consulted only
+        for the global admin flag. ``None`` skips the admin bypass.
+    :returns: ``True`` if access is allowed, ``False`` otherwise.
+    """
+    if user_id is None:
+        return True
+
+    if permission_store is not None and permission_store.is_admin(user_id):
+        return True
+
+    host = host_store.get_host(host_id)
+    if host is not None and host.owner == user_id:
+        return True
+
+    return host_permission_store.check_access(user_id, host_id, required_level)
+
+
+def get_host_permission_level(
+    user_id: str | None,
+    host_id: str,
+    host_permission_store: HostPermissionStore,
+    host_store: HostStore,
+    permission_store: PermissionStore | None = None,  # noqa: ARG001 — kept for call-site parity with check_host_access
+) -> int | None:
+    """Return the caller's effective host permission level for UI display.
+
+    This is a *display* value paired with ``owned_by_current_user`` in
+    host responses, so it must stay coherent with ownership: only an
+    actual owner (or the auth-disabled local caller) resolves to
+    :data:`HOST_LEVEL_OWNER`. An admin is an access *override*, not an
+    ownership claim — an admin viewing a host they do not own shows their
+    real grant level (``view``/``use``/``manage``) or ``None`` if they
+    have no grant, never a spurious ``owner``. (Admin access still works:
+    :func:`check_host_access` applies the admin bypass for the access
+    decision; this function only governs the label.)
+
+    :param user_id: The authenticated caller, or ``None``.
+    :param host_id: The host to check.
+    :param host_permission_store: Store for host grant lookups.
+    :param host_store: Store for host owner lookup.
+    :param permission_store: Unused; kept for signature parity with
+        :func:`check_host_access` so call sites pass the same args.
+    :returns: Numeric level (1/2/3/4), or ``None`` when no grant and not
+        the owner.
+    """
+    if user_id is None:
+        return HOST_LEVEL_OWNER
+
+    host = host_store.get_host(host_id)
+    if host is not None and host.owner == user_id:
+        return HOST_LEVEL_OWNER
+
+    return host_permission_store.get_permission_level(user_id, host_id)

--- a/omnigent/server/routes/_auth_helpers.py
+++ b/omnigent/server/routes/_auth_helpers.py
@@ -25,7 +25,9 @@ from fastapi import Request
 
 from omnigent.entities import Conversation
 from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.runner.identity import token_bound_runner_id
 from omnigent.server.auth import (
+    LEVEL_EDIT,
     LEVEL_OWNER,
     RESERVED_USER_LOCAL,
     AuthProvider,
@@ -256,6 +258,7 @@ def _require_access_and_level_sync(
     required_level: int,
     permission_store: PermissionStore | None,
     conversation_store: ConversationStore,
+    runner_binding_token: str | None = None,
 ) -> SessionAccess:
     """Synchronous core of :func:`require_access_and_level`.
 
@@ -284,6 +287,27 @@ def _require_access_and_level_sync(
     """
     if permission_store is None:
         return SessionAccess(level=None, conversation=None)
+
+    # Runner self-access: a runner may read AND write (post events/results) on
+    # its OWN bound session by presenting its tunnel binding token, verified by
+    # matching the token-derived runner id against the session's recorded
+    # runner_id. This needs no auth-mode secret (unlike the cookie-mode
+    # owner-JWT mint), so it works in header/proxy mode where a
+    # guest-on-shared-host runner has no readable user identity. A runner's job
+    # is to read its spec (LEVEL_READ) and post the agent's events/usage back
+    # (LEVEL_EDIT) — so the grant caps at LEVEL_EDIT: it can never satisfy
+    # manage/owner (delete the session, change its sharing). Scoped to this one
+    # session (token↔runner_id match), never yields a user_id; a non-match or a
+    # higher required level falls through to the normal checks (fail closed).
+    if runner_binding_token and required_level <= LEVEL_EDIT:
+        conv = conversation_store.get_conversation(conversation_id)
+        if (
+            conv is not None
+            and conv.runner_id is not None
+            and token_bound_runner_id(runner_binding_token.strip()) == conv.runner_id
+        ):
+            return SessionAccess(level=LEVEL_EDIT, conversation=conv)
+
     if user_id is None:
         raise OmnigentError(
             "Authentication required",
@@ -354,6 +378,7 @@ async def require_access_and_level(
     required_level: int,
     permission_store: PermissionStore | None,
     conversation_store: ConversationStore,
+    runner_binding_token: str | None = None,
 ) -> SessionAccess:
     """Authorize a caller and resolve their display level in one threaded pass.
 
@@ -381,6 +406,7 @@ async def require_access_and_level(
         required_level,
         permission_store,
         conversation_store,
+        runner_binding_token,
     )
 
 

--- a/omnigent/server/routes/_host_launch.py
+++ b/omnigent/server/routes/_host_launch.py
@@ -24,9 +24,11 @@ from fastapi import HTTPException
 
 from omnigent.entities import Conversation
 from omnigent.server.auth import LEVEL_OWNER
+from omnigent.server.host_permissions import HOST_LEVEL_USE, check_host_access
 from omnigent.server.host_registry import HostConnection, HostRegistry
 from omnigent.server.permissions import check_session_access
 from omnigent.stores import ConversationStore
+from omnigent.stores.host_permission_store import HostPermissionStore
 from omnigent.stores.host_store import Host, HostStore
 from omnigent.stores.permission_store import PermissionStore
 
@@ -46,35 +48,56 @@ class HostLaunchTarget:
     conv: Conversation
 
 
-def resolve_host_owner(
+def resolve_host_access(
     *,
     user_id: str | None,
     host_id: str,
     host_store: HostStore,
+    host_permission_store: HostPermissionStore,
+    permission_store: PermissionStore | None,
+    required_level: int = HOST_LEVEL_USE,
 ) -> Host:
     """
-    Authorize that the caller owns a known host.
+    Authorize that the caller may reach a host at *required_level*.
 
     Every route that reaches a host on the caller's behalf must pass
-    this first so the owner check can't drift between them: the runner
+    this first so the access check can't drift between them: the runner
     launch (via :func:`resolve_host_launch`) AND the session-create
     workspace probe, which sends a ``host.stat`` to the host. The
     original bug had that probe contacting another user's host before
-    any ownership check. When ``user_id`` is ``None`` (auth disabled)
-    the check is skipped, consistent with single-user/local behavior.
+    any ownership check.
+
+    Access is owner OR a sufficient host grant OR admin (see
+    :func:`omnigent.server.host_permissions.check_host_access`). Both
+    callers need ``use`` (the default): the workspace probe browses the
+    host filesystem and the launch runs code on it. When ``user_id`` is
+    ``None`` (auth disabled) the check is skipped, consistent with
+    single-user/local behavior.
 
     :param user_id: Authenticated caller, e.g. ``"alice@example.com"``,
         or ``None`` when auth is disabled.
     :param host_id: Target host id, e.g. ``"host_a1b2c3d4..."``.
     :param host_store: Persistent host registrations.
-    :returns: The host record owned by the caller.
-    :raises HTTPException: 404 if the host is unknown; 403 if it is
-        owned by a different user.
+    :param host_permission_store: Host grant store for the access check.
+    :param permission_store: Session permission store, for the admin
+        bypass. ``None`` skips it.
+    :param required_level: Minimum host level needed; defaults to
+        ``use``.
+    :returns: The host record the caller may reach.
+    :raises HTTPException: 404 if the host is unknown; 403 if the caller
+        lacks sufficient access.
     """
     host = host_store.get_host(host_id)
     if host is None:
         raise HTTPException(status_code=404, detail="host not found")
-    if user_id is not None and host.owner != user_id:
+    if not check_host_access(
+        user_id,
+        host_id,
+        required_level,
+        host_permission_store,
+        host_store,
+        permission_store,
+    ):
         raise HTTPException(status_code=403, detail="not your host")
     return host
 
@@ -88,6 +111,7 @@ def resolve_host_launch(
     host_registry: HostRegistry,
     conversation_store: ConversationStore,
     permission_store: PermissionStore | None,
+    host_permission_store: HostPermissionStore,
 ) -> HostLaunchTarget:
     """
     Resolve and authorize a host runner launch.
@@ -109,18 +133,28 @@ def resolve_host_launch(
     :param conversation_store: Conversation lookups (also used by the
         session-access check for sub-agent parent delegation).
     :param permission_store: Session permission store, or ``None`` to
-        skip the session-owner check (auth disabled).
+        skip the session-owner check (auth disabled). Also consulted for
+        the admin bypass in the host access check.
+    :param host_permission_store: Host grant store for the host access
+        check (owner / ``use`` grant / admin).
     :returns: A :class:`HostLaunchTarget` with the validated host,
         connection, and conversation.
     :raises HTTPException: 404 if the host or session is missing (or the
         session is not owned by the caller — 404, not 403, so other
-        users' sessions aren't enumerable); 403 if the host is owned by
-        a different user; 409 if the host is offline.
+        users' sessions aren't enumerable); 403 if the caller lacks
+        ``use`` on the host; 409 if the host is offline.
     """
-    host = resolve_host_owner(
+    # Host side: owner OR a `use` grant OR admin. A host grant alone is
+    # never enough to launch — the session-owner check below still gates
+    # which session the runner binds to (sharing a host must not widen
+    # session reach).
+    host = resolve_host_access(
         user_id=user_id,
         host_id=host_id,
         host_store=host_store,
+        host_permission_store=host_permission_store,
+        permission_store=permission_store,
+        required_level=HOST_LEVEL_USE,
     )
 
     conn = host_registry.get(host_id)

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -33,16 +33,27 @@ from omnigent.host.frames import (
     HostCreateDirFrame,
     HostLaunchRunnerFrame,
     HostListDirFrame,
+    HostShutdownFrame,
     encode_host_frame,
 )
 from omnigent.runner.identity import token_bound_runner_id
 from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.admin_list import AdminList
+from omnigent.server.audit import audit_event
 from omnigent.server.auth import AuthProvider
+from omnigent.server.host_permissions import (
+    HOST_LEVEL_MANAGE,
+    HOST_LEVEL_USE,
+    HOST_LEVEL_VIEW,
+    check_host_access,
+    get_host_permission_level,
+)
 from omnigent.server.host_registry import HostConnection, HostRegistry
 from omnigent.server.routes._auth_helpers import require_user
 from omnigent.server.routes._host_launch import resolve_host_launch
 from omnigent.server.schemas import SessionGitOptions
 from omnigent.stores import AgentStore, ConversationStore
+from omnigent.stores.host_permission_store import HostPermissionStore
 from omnigent.stores.host_store import HostStore, host_is_live
 from omnigent.stores.permission_store import PermissionStore
 
@@ -59,6 +70,24 @@ _LIST_DIR_MAX_LIMIT = 1000
 # fast syscall on the host side; 5s matches list_dir and is generous
 # for transient network slowness without making the picker feel hung.
 _CREATE_DIR_TIMEOUT_S = 5.0
+
+# Host permission level → API string. Owner/admin resolve to "owner".
+_HOST_LEVEL_NAMES = {
+    HOST_LEVEL_VIEW: "view",
+    HOST_LEVEL_USE: "use",
+    HOST_LEVEL_MANAGE: "manage",
+    4: "owner",  # HOST_LEVEL_OWNER, effective-only (never stored)
+}
+
+
+def _permission_level_name(level: int | None) -> str | None:
+    """Map a numeric host level to its API string, or ``None``.
+
+    :param level: Numeric host level (1/2/3/4), or ``None`` for no access.
+    :returns: ``"view"`` / ``"use"`` / ``"manage"`` / ``"owner"``, or
+        ``None``.
+    """
+    return _HOST_LEVEL_NAMES.get(level) if level is not None else None
 
 
 async def _proxy_list_dir(
@@ -231,6 +260,25 @@ class LaunchRunnerRequest(BaseModel):
     git: SessionGitOptions | None = None
 
 
+class SetHostPermissionRequest(BaseModel):
+    """Request body for ``PUT /v1/hosts/{host_id}/permissions/{user_id}``.
+
+    :param level: Grant level to set: ``"view"``, ``"use"``, or
+        ``"manage"``. ``"owner"`` is not grantable — ownership comes
+        from the host tunnel identity, not a grant.
+    """
+
+    level: str
+
+
+# Grantable host levels (owner is effective-only, never written).
+_HOST_GRANT_LEVELS = {
+    "view": HOST_LEVEL_VIEW,
+    "use": HOST_LEVEL_USE,
+    "manage": HOST_LEVEL_MANAGE,
+}
+
+
 async def _resolve_agent_spec_cwd(
     conv: Conversation,
     agent_store: AgentStore,
@@ -290,10 +338,12 @@ def create_hosts_router(
     host_store: HostStore,
     conversation_store: ConversationStore,
     *,
+    host_permission_store: HostPermissionStore,
     auth_provider: AuthProvider | None = None,
     permission_store: PermissionStore | None = None,
     agent_store: AgentStore | None = None,
     agent_cache: AgentCache | None = None,
+    admin_list: AdminList | None = None,
 ) -> APIRouter:
     """Build the router for host REST endpoints.
 
@@ -304,10 +354,16 @@ def create_hosts_router(
     :param host_store: Persistent store for host registrations.
     :param conversation_store: Conversation store for reading and
         updating session rows (runner_id, host_id).
+    :param host_permission_store: Host grant store backing shared-host
+        visibility and access checks.
     :param auth_provider: Optional auth provider for user identity.
     :param permission_store: Session permission store, used to verify
         the caller owns the session a runner is launched for. ``None``
         disables the session-owner check (single-user/local).
+    :param admin_list: File/config admin roster, unioned with the
+        ``users.is_admin`` flag for the admin fleet view — the same
+        union ``/v1/me`` reports, so the UI's admin chrome and this
+        gate never disagree. ``None`` checks the DB flag only.
     :param agent_store: Agent store used to resolve a session's agent
         for workspace-boundary validation on runner launch (W6). When
         ``None`` (non-production wiring), the boundary check is skipped;
@@ -318,30 +374,100 @@ def create_hosts_router(
     """
     router = APIRouter()
 
-    @router.get("/hosts")
-    async def list_hosts(request: Request) -> dict[str, list[dict[str, Any]]]:
-        """List all hosts owned by the authenticated user.
+    def _is_admin_caller(user_id: str | None) -> bool:
+        """Whether the caller may use admin-scoped host reads/actions.
 
-        Returns both online and offline hosts, with live runner
-        information for online hosts.
+        Mirrors ``/v1/me``'s admin computation — the DB ``users.is_admin``
+        flag unioned with the admin-list file/config roster — so the gate
+        here never under-reports relative to the admin chrome the SPA
+        shows. Single-user mode (no permission store) is always allowed:
+        every host on such a server belongs to the sole local user.
+
+        :param user_id: The authenticated caller, or ``None`` when auth
+            is disabled (single-user).
+        :returns: ``True`` when admin-scoped access is allowed.
+        """
+        if permission_store is None:
+            return True
+        if user_id is None:
+            return False
+        if permission_store.is_admin(user_id):
+            return True
+        return admin_list is not None and admin_list.is_admin(user_id)
+
+    @router.get("/hosts")
+    async def list_hosts(
+        request: Request,
+        all: bool = Query(default=False),
+    ) -> dict[str, list[dict[str, Any]]]:
+        """List hosts the authenticated user owns or has been shared.
+
+        Returns both online and offline hosts, owned plus any with at
+        least a ``view`` grant. Each host carries the caller's effective
+        ``permission_level`` and an ``owned_by_current_user`` flag so the
+        UI can label shared hosts without parsing the opaque ``owner``.
+
+        With ``?all=true`` (admin only) the owner filter is dropped and
+        every registered host is returned, each with the extra fleet
+        fields ``created_at``, ``last_seen``, and ``session_count`` —
+        the admin Hosts page's data source.
 
         :param request: The incoming request (for auth).
+        :param all: When ``True``, return every host across all owners
+            (requires admin).
         :returns: ``{"hosts": [...]}`` with host details.
+        :raises HTTPException: 401 unauthenticated; 403 when ``all=true``
+            and the caller is not an admin.
         """
         # require_user: unauthenticated callers 401. user_id is None
         # only when auth is disabled entirely — there the single-user
         # server's hosts are owned by the reserved "local" user.
         user_id = require_user(request, auth_provider)
-        if user_id is None:
-            hosts = await asyncio.to_thread(host_store.list_hosts, "local")
+        viewer = user_id if user_id is not None else "local"
+        if all:
+            # Fail closed: the unfiltered fleet view exposes every
+            # owner's hosts, so a non-admin gets 403 rather than a
+            # silently owner-filtered response they might mistake for
+            # the full fleet.
+            if not await asyncio.to_thread(_is_admin_caller, user_id):
+                raise HTTPException(status_code=403, detail="admin privileges required")
+            hosts = await asyncio.to_thread(host_store.list_all_hosts)
+            # Enumerating every owner's hosts (owner emails, names, load)
+            # is a security-relevant read, not just a mutation — audit it
+            # so an admin sweeping the fleet leaves a trail. Target is the
+            # fleet itself; count lets a reviewer size the disclosure.
+            audit_event("host.fleet.list", actor=user_id, target="*", host_count=len(hosts))
         else:
-            hosts = await asyncio.to_thread(host_store.list_hosts, user_id)
+            hosts = await asyncio.to_thread(host_store.list_hosts_for, viewer)
+
+        # Sessions bound per host — the "what would a shutdown affect"
+        # signal on the admin page. Only computed for the fleet view;
+        # the picker payload stays unchanged (additive/opt-in).
+        session_counts: dict[str, int] = {}
+        if all:
+
+            def _count_sessions() -> dict[str, int]:
+                return {
+                    h.host_id: conversation_store.count_conversations_by_host_id(h.host_id)
+                    for h in hosts
+                }
+
+            session_counts = await asyncio.to_thread(_count_sessions)
 
         # One clock for the whole batch so every host is classified
         # against a consistent "now" (host_is_live's documented idiom).
         now = now_epoch()
         result: list[dict[str, Any]] = []
         for host in hosts:
+            owned = host.owner == viewer
+            level = await asyncio.to_thread(
+                get_host_permission_level,
+                user_id,
+                host.host_id,
+                host_permission_store,
+                host_store,
+                permission_store,
+            )
             # Status comes from the DB, not host_registry. The registry
             # is per-replica; if a host is connected to replica B and
             # this request lands on replica A, A's registry won't know
@@ -351,21 +477,31 @@ def create_hosts_router(
             # A stored "online" is only trusted if the host was seen
             # recently: a crashed host never runs set_offline and would
             # otherwise show as online forever in the picker.
-            result.append(
-                {
-                    "host_id": host.host_id,
-                    "name": host.name,
-                    "owner": host.owner,
-                    "status": "online" if host_is_live(host, now=now) else "offline",
-                    # Non-None marks a server-managed sandbox host (e.g.
-                    # "modal"). Clients use it to hide sandbox-backed
-                    # hosts from manual host pickers — they are launch
-                    # targets the server creates on demand, not
-                    # user-connectable machines.
-                    "sandbox_provider": host.sandbox_provider,
-                    "configured_harnesses": host.configured_harnesses,
-                }
-            )
+            entry: dict[str, Any] = {
+                "host_id": host.host_id,
+                "name": host.name,
+                "owner": host.owner,
+                "status": "online" if host_is_live(host, now=now) else "offline",
+                # Non-None marks a server-managed sandbox host (e.g.
+                # "modal"). Clients use it to hide sandbox-backed
+                # hosts from manual host pickers — they are launch
+                # targets the server creates on demand, not
+                # user-connectable machines.
+                "sandbox_provider": host.sandbox_provider,
+                "configured_harnesses": host.configured_harnesses,
+                # Shared-host fields: the UI labels a row "Shared"
+                # when not owned, and disables view-only rows as
+                # launch targets (a launch needs `use`).
+                "owned_by_current_user": owned,
+                "permission_level": _permission_level_name(level),
+            }
+            if all:
+                # updated_at doubles as last-seen: written on connect,
+                # disconnect, and every tunnel heartbeat tick.
+                entry["created_at"] = host.created_at
+                entry["last_seen"] = host.updated_at
+                entry["session_count"] = session_counts.get(host.host_id, 0)
+            result.append(entry)
         return {"hosts": result}
 
     @router.get("/hosts/{host_id}")
@@ -387,9 +523,28 @@ def create_hosts_router(
         host = await asyncio.to_thread(host_store.get_host, host_id)
         if host is None:
             raise HTTPException(status_code=404, detail="host not found")
-        if user_id is not None and host.owner != user_id:
+        # Reading host metadata requires at least `view` — owner, a
+        # `view`+ grantee, or admin. 403 (not 404) for a known host the
+        # caller can't see matches the prior behavior for owned hosts.
+        if not await asyncio.to_thread(
+            check_host_access,
+            user_id,
+            host_id,
+            HOST_LEVEL_VIEW,
+            host_permission_store,
+            host_store,
+            permission_store,
+        ):
             raise HTTPException(status_code=403, detail="not your host")
 
+        level = await asyncio.to_thread(
+            get_host_permission_level,
+            user_id,
+            host_id,
+            host_permission_store,
+            host_store,
+            permission_store,
+        )
         # Status comes from the DB so the answer is consistent across
         # replicas, gated on the liveness freshness window — see
         # list_hosts above for the full rationale.
@@ -402,6 +557,8 @@ def create_hosts_router(
             # server-managed sandbox host (e.g. "modal").
             "sandbox_provider": host.sandbox_provider,
             "configured_harnesses": host.configured_harnesses,
+            "owned_by_current_user": host.owner == (user_id if user_id is not None else "local"),
+            "permission_level": _permission_level_name(level),
             "runners": [],
         }
 
@@ -423,10 +580,10 @@ def create_hosts_router(
             ``workspace``.
         :returns: ``{"runner_id": ..., "status": "launching"}``.
         :raises HTTPException: 404 if host not found, 409 if host
-            offline, 403 if caller doesn't own the host, 400 if
+            offline, 403 if caller lacks `use` on the host, 400 if
             session already has a runner.
         """
-        # require_user: resolve_host_launch skips its ownership checks
+        # require_user: resolve_host_launch skips its access checks
         # for user_id=None (the auth-disabled single-user case), so an
         # unauthenticated caller slipping through as None could launch
         # a runner on another user's host. 401 instead.
@@ -443,6 +600,7 @@ def create_hosts_router(
             host_registry=host_registry,
             conversation_store=conversation_store,
             permission_store=permission_store,
+            host_permission_store=host_permission_store,
         )
         conn = target.conn
 
@@ -629,6 +787,16 @@ def create_hosts_router(
         harness: str | None = None
         if agent_store is not None and agent_cache is not None:
             harness = await _resolve_agent_harness(target.conv, agent_store, agent_cache)
+        # When the launching user (the session owner) is not the host owner —
+        # a shared / externally-owned host, e.g. a service-principal-owned
+        # Databricks App host serving another user's session — tell the runner
+        # to authenticate its server callbacks with its tunnel binding token
+        # (matched against the session's runner_id) instead of the host-owner
+        # credential, which can't read a guest session's spec (404). Equal
+        # owners (own-host, the common case) leave this False → unchanged.
+        prefer_binding_token_mint = (
+            user_id is not None and conn.owner is not None and user_id != conn.owner
+        )
         launch_frame = encode_host_frame(
             HostLaunchRunnerFrame(
                 request_id=request_id,
@@ -636,6 +804,7 @@ def create_hosts_router(
                 workspace=workspace,
                 session_id=body.session_id,
                 harness=harness,
+                prefer_binding_token_mint=prefer_binding_token_mint,
             )
         )
         try:
@@ -681,6 +850,69 @@ def create_hosts_router(
             "runner_id": runner_id,
             "status": "launching",
         }
+
+    @router.post("/hosts/{host_id}/shutdown")
+    async def shutdown_host(request: Request, host_id: str) -> dict[str, str]:
+        """Shut down a host: terminate its runners and exit the daemon.
+
+        Owner-or-admin gated. Sends ``host.shutdown`` over the tunnel;
+        the daemon terminates its runners and exits instead of
+        reconnecting, and the tunnel's existing disconnect path then
+        deregisters the connection and marks the host offline in the DB.
+        Fire-and-forget: the offline flip lands via that disconnect
+        path, so callers observe it on their next poll.
+
+        :param request: The incoming request (for auth).
+        :param host_id: Host to shut down, e.g. ``"host_a1b2c3d4..."``.
+        :returns: ``{"status": "shutting_down"}``.
+        :raises HTTPException: 404 unknown host, 403 when the caller is
+            neither the owner nor an admin, 400 for server-managed
+            sandbox hosts, 409 when the host has no live connection.
+        """
+        # require_user: unauthenticated callers 401 instead of slipping
+        # past the owner/admin check below as None.
+        user_id = require_user(request, auth_provider)
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            raise HTTPException(status_code=404, detail="host not found")
+        if (
+            user_id is not None
+            and host.owner != user_id
+            and not await asyncio.to_thread(_is_admin_caller, user_id)
+        ):
+            raise HTTPException(status_code=403, detail="not your host")
+        # Managed sandbox hosts are created/terminated by the server's
+        # own lifecycle (provider API, not the tunnel); routing them
+        # through a daemon-exit frame would leave the provider-side
+        # sandbox running. Out of scope here.
+        if host.sandbox_provider is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="managed sandbox hosts are terminated by the server automatically",
+            )
+
+        conn = host_registry.get(host_id)
+        if conn is None:
+            raise HTTPException(status_code=409, detail="host is offline")
+
+        actor_label = user_id if user_id is not None else "server operator"
+        frame = encode_host_frame(HostShutdownFrame(reason=f"shut down by {actor_label}"))
+        try:
+            host_registry.send_text(conn, frame)
+        except ConnectionError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail="host connection was replaced",
+            ) from exc
+
+        audit_event(
+            "host.shutdown",
+            actor=user_id,
+            target=host_id,
+            host_name=host.name,
+            host_owner=host.owner,
+        )
+        return {"status": "shutting_down"}
 
     @router.get("/hosts/{host_id}/filesystem")
     async def list_host_filesystem_root(
@@ -795,16 +1027,26 @@ def create_hosts_router(
         :raises HTTPException: See per-route docstrings for codes.
         """
         # require_user: unauthenticated callers 401 instead of slipping
-        # past the owner check below as None (see get_host above).
+        # past the access check below as None (see get_host above).
         user_id = require_user(request, auth_provider)
 
-        # Owner check: load the host record, fail with 404 if it
-        # doesn't exist (don't leak existence to non-owners), fail
-        # with 403 only when an authenticated caller doesn't own it.
+        # Access check: load the host record, fail with 404 if it
+        # doesn't exist (don't leak existence to non-owners), fail with
+        # 403 unless the caller has `use` — browsing the filesystem
+        # exposes the host process user's files, so `view` is not enough
+        # (a `view` grantee can see the host but not its contents).
         host = await asyncio.to_thread(host_store.get_host, host_id)
         if host is None:
             raise HTTPException(status_code=404, detail="host not found")
-        if user_id is not None and host.owner != user_id:
+        if not await asyncio.to_thread(
+            check_host_access,
+            user_id,
+            host_id,
+            HOST_LEVEL_USE,
+            host_permission_store,
+            host_store,
+            permission_store,
+        ):
             raise HTTPException(status_code=403, detail="not your host")
 
         if "\x00" in path:
@@ -861,31 +1103,40 @@ def create_hosts_router(
 
         Backs the Web UI workspace picker's "New folder" action so a
         user can make a fresh directory to start a session in without
-        dropping to a terminal. Owner-scoped exactly like the
+        dropping to a terminal. Access-scoped exactly like the
         filesystem browse endpoints (``GET /v1/hosts/{id}/filesystem``):
-        only the host owner can create directories, and — like browse —
-        this is NOT scoped to a session. The workspace-boundary check
-        still runs at session-create time, so creating a directory here
-        does not by itself grant an agent access to it.
+        creating a directory mutates the host filesystem, so it needs
+        ``use`` (owner, admin, or a ``use``+ grantee), and — like
+        browse — this is NOT scoped to a session. The workspace-boundary
+        check still runs at session-create time, so creating a directory
+        here does not by itself grant an agent access to it.
 
         :param request: FastAPI request (for auth).
         :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
         :param body: Request body carrying the absolute (or
             tilde-prefixed) ``path`` to create.
         :returns: ``{"object": "directory", "path": "<created abs path>"}``.
-        :raises HTTPException: 404 if host not found, 403 if not owned
-            by caller, 409 if host is offline or the directory could not
-            be created (already exists / permission denied), 400 on path
-            validation, 504 on host timeout, 502 on host I/O failure.
+        :raises HTTPException: 404 if host not found, 403 if the caller
+            lacks ``use``, 409 if host is offline or the directory could
+            not be created (already exists / permission denied), 400 on
+            path validation, 504 on host timeout, 502 on host I/O failure.
         """
         # require_user: unauthenticated callers 401 instead of slipping
-        # past the owner check below as None.
+        # past the access check below as None.
         user_id = require_user(request, auth_provider)
 
         host = await asyncio.to_thread(host_store.get_host, host_id)
         if host is None:
             raise HTTPException(status_code=404, detail="host not found")
-        if user_id is not None and host.owner != user_id:
+        if not await asyncio.to_thread(
+            check_host_access,
+            user_id,
+            host_id,
+            HOST_LEVEL_USE,
+            host_permission_store,
+            host_store,
+            permission_store,
+        ):
             raise HTTPException(status_code=403, detail="not your host")
 
         path = body.path
@@ -998,5 +1249,164 @@ def create_hosts_router(
             raise HTTPException(status_code=400, detail=exc.message) from exc
 
         return {"object": "list", "data": worktrees}
+
+    # ── Host sharing (permissions) ────────────────────────────────
+    # Owner / admin / a `manage` grantee may view and mutate grants. An
+    # app-SP-owned CoDA host can't use the UI, so its first grant is
+    # bootstrapped by an admin (whose is_admin flag bypasses the manage
+    # check). A `manage` grant created that way then lets a human
+    # administer further grants without admin involvement (FR-016a).
+
+    async def _require_host_manage(request: Request, host_id: str) -> str | None:
+        """Authorize a host-permission mutation/read; return the caller id.
+
+        Requires owner / admin / ``manage`` on the host. 404 when the
+        host is unknown (don't leak existence), 403 when known but the
+        caller lacks ``manage``.
+
+        :param request: The incoming request (for auth).
+        :param host_id: Target host id.
+        :returns: The authenticated caller's user id (or ``None`` when
+            auth is disabled).
+        :raises HTTPException: 404 host unknown, 403 insufficient access.
+        """
+        user_id = require_user(request, auth_provider)
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            raise HTTPException(status_code=404, detail="host not found")
+        # Admin first, via the same roster union every other admin gate
+        # on this router uses (_is_admin_caller). check_host_access's own
+        # admin bypass reads only the DB flag, which the admin-list file
+        # can't flip in header mode (no login event runs the promotion).
+        if await asyncio.to_thread(_is_admin_caller, user_id):
+            return user_id
+        if not await asyncio.to_thread(
+            check_host_access,
+            user_id,
+            host_id,
+            HOST_LEVEL_MANAGE,
+            host_permission_store,
+            host_store,
+            permission_store,
+        ):
+            raise HTTPException(status_code=403, detail="not your host")
+        return user_id
+
+    @router.get("/hosts/{host_id}/permissions")
+    async def list_host_permissions(
+        request: Request,
+        host_id: str,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """List the grants on a host.
+
+        Requires owner / admin / ``manage`` access.
+
+        :param request: The incoming request (for auth).
+        :param host_id: Host identifier.
+        :returns: ``{"permissions": [{"user_id", "level"}, ...]}``.
+        :raises HTTPException: 404 unknown host, 403 insufficient access.
+        """
+        await _require_host_manage(request, host_id)
+        grants = await asyncio.to_thread(host_permission_store.list_for_host, host_id)
+        return {
+            "permissions": [
+                {
+                    "user_id": g.user_id,
+                    "level": _permission_level_name(g.level),
+                    "created_at": g.created_at,
+                    "updated_at": g.updated_at,
+                    "created_by": g.created_by,
+                }
+                for g in grants
+            ]
+        }
+
+    @router.put("/hosts/{host_id}/permissions/{user_id}")
+    async def set_host_permission(
+        request: Request,
+        host_id: str,
+        user_id: str,
+        body: SetHostPermissionRequest,
+    ) -> dict[str, Any]:
+        """Grant or update a user's access to a host.
+
+        Requires owner / admin / ``manage`` access. The grantee gets the
+        requested ``view`` / ``use`` / ``manage`` level (an existing
+        grant is upgraded or downgraded in place).
+
+        :param request: The incoming request (for auth).
+        :param host_id: Host identifier.
+        :param user_id: The grantee to set access for.
+        :param body: The level to set.
+        :returns: ``{"user_id", "host_id", "level"}`` for the grant.
+        :raises HTTPException: 404 unknown host, 403 insufficient access,
+            400 invalid level or granting to the host owner.
+        """
+        actor = await _require_host_manage(request, host_id)
+        level = _HOST_GRANT_LEVELS.get(body.level)
+        if level is None:
+            raise HTTPException(
+                status_code=400,
+                detail="level must be one of: view, use, manage",
+            )
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        # host is non-None (the manage check 404s otherwise), but the
+        # owner can't be a grantee — ownership already grants everything.
+        if host is not None and host.owner == user_id:
+            raise HTTPException(
+                status_code=400,
+                detail="host owner already has full access; cannot grant",
+            )
+        # The grantee must exist as a user row for the FK to hold. The
+        # session permission store owns the users table; ensure the row.
+        if permission_store is not None:
+            await asyncio.to_thread(permission_store.ensure_user, user_id)
+        grant = await asyncio.to_thread(
+            host_permission_store.grant,
+            user_id,
+            host_id,
+            level,
+            created_by=actor,
+        )
+        audit_event(
+            "host.permission.grant",
+            actor=actor,
+            target=host_id,
+            principal=user_id,
+            level=_permission_level_name(level),
+        )
+        return {
+            "user_id": grant.user_id,
+            "host_id": grant.host_id,
+            "level": _permission_level_name(grant.level),
+        }
+
+    @router.delete("/hosts/{host_id}/permissions/{user_id}")
+    async def delete_host_permission(
+        request: Request,
+        host_id: str,
+        user_id: str,
+    ) -> dict[str, bool]:
+        """Revoke a user's access to a host.
+
+        Requires owner / admin / ``manage`` access. Idempotent: revoking
+        a non-existent grant returns ``{"revoked": false}``.
+
+        :param request: The incoming request (for auth).
+        :param host_id: Host identifier.
+        :param user_id: The grantee to revoke.
+        :returns: ``{"revoked": bool}``.
+        :raises HTTPException: 404 unknown host, 403 insufficient access.
+        """
+        actor = await _require_host_manage(request, host_id)
+        revoked = await asyncio.to_thread(host_permission_store.revoke, user_id, host_id)
+        if revoked:
+            audit_event(
+                "host.permission.revoke",
+                actor=actor,
+                target=host_id,
+                principal=user_id,
+            )
+        return {"revoked": revoked}
 
     return router

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -149,6 +149,7 @@ from omnigent.server._elicitation_registry import (
     _ParkedHarnessElicitation,
     _PreResolvedHarnessElicitation,
 )
+from omnigent.server.audit import audit_event
 from omnigent.server.auth import (
     LEVEL_EDIT,
     LEVEL_MANAGE,
@@ -6249,9 +6250,9 @@ async def _validate_session_workspace(
     See ``designs/SESSION_WORKSPACE_SELECTION.md`` for the full
     semantic spec.
 
-    The caller's host ownership is checked BEFORE the ``host.stat``
-    round-trip the validation performs, so a non-owner never reaches
-    another user's host (raises 403/404 via ``resolve_host_owner``).
+    The caller's host access is checked BEFORE the ``host.stat``
+    round-trip the validation performs, so a caller without ``use``
+    never reaches the host (raises 403/404 via ``resolve_host_access``).
 
     :param user_id: Authenticated caller, e.g.
         ``"alice@example.com"``, or ``None`` when auth is disabled.
@@ -6307,21 +6308,27 @@ async def _validate_session_workspace(
             code=ErrorCode.INTERNAL_ERROR,
         )
 
-    # Authorize host ownership FIRST — before loading the agent spec or
-    # the host.stat round-trip below. A non-owner must be rejected
-    # (403/404 via the shared resolve_host_owner) before we touch the
-    # host or even read the agent bundle (cross-user host probe). The
-    # returned host also gives the display name for error messages.
-    from omnigent.server.routes._host_launch import resolve_host_owner
+    # Authorize host access FIRST — before loading the agent spec or
+    # the host.stat round-trip below. A caller without `use` must be
+    # rejected (403/404 via the shared resolve_host_access) before we
+    # touch the host or even read the agent bundle (cross-user host
+    # probe). Browsing the host filesystem requires `use` — the same
+    # privilege as launching on it. The returned host also gives the
+    # display name for error messages.
+    from omnigent.server.routes._host_launch import resolve_host_access
 
     host_name: str | None = None
     host_store_inst = getattr(request.app.state, "host_store", None)
-    if host_store_inst is not None:
+    host_permission_store_inst = getattr(request.app.state, "host_permission_store", None)
+    permission_store_inst = getattr(request.app.state, "permission_store", None)
+    if host_store_inst is not None and host_permission_store_inst is not None:
         host = await asyncio.to_thread(
-            resolve_host_owner,
+            resolve_host_access,
             user_id=user_id,
             host_id=host_id,
             host_store=host_store_inst,
+            host_permission_store=host_permission_store_inst,
+            permission_store=permission_store_inst,
         )
         host_name = host.name
 
@@ -6389,6 +6396,7 @@ async def _launch_runner_on_host(
     conversation_store: ConversationStore,
     host_registry: HostRegistry,
     host_conn: HostConnection,
+    permission_store: PermissionStore | None = None,
 ) -> _HostLaunchAttempt:
     """
     Ask a host to spawn a runner for a session and capture the result.
@@ -6406,6 +6414,12 @@ async def _launch_runner_on_host(
     :param conversation_store: Store for updating ``runner_id``.
     :param host_registry: In-memory ``HostRegistry``.
     :param host_conn: The live ``HostConnection`` for the host.
+    :param permission_store: Permission store, used to resolve the session
+        owner so the frame can tell the runner to authenticate its
+        callbacks as the session owner when that owner differs from the
+        host owner (the shared / externally-owned-host case). ``None``
+        skips the resolution → the flag stays ``False`` (today's
+        host-owner-credential behavior).
     :returns: The :class:`_HostLaunchAttempt` — the new runner id plus any
         structured refusal from the host.
     """
@@ -6435,6 +6449,18 @@ async def _launch_runner_on_host(
         )
         return _HostLaunchAttempt(runner_id=new_runner_id)
     request_id = secrets.token_hex(8)
+    # When the session owner differs from the host owner (a shared /
+    # externally-owned host, e.g. a service-principal-owned Databricks App
+    # host serving another user's session), tell the runner to authenticate
+    # its server callbacks as the SESSION owner via the binding-token mint —
+    # the host-owner credential can't read a guest session's spec, so its
+    # spec callbacks 404 and the native terminal fails to start. Equal owners
+    # (the common own-host case) leave this False → today's behavior.
+    session_owner = _get_session_owner_id(conv.id, permission_store)
+    host_owner = host_conn.owner
+    prefer_binding_token_mint = (
+        session_owner is not None and host_owner is not None and session_owner != host_owner
+    )
     launch_future: asyncio.Future[dict[str, str | None]] = (
         asyncio.get_running_loop().create_future()
     )
@@ -6449,6 +6475,7 @@ async def _launch_runner_on_host(
             # same configuration check it does at create-time launch. None
             # (agent not resolvable) skips the host-side check — fail open.
             harness=_resolve_harness(conv),
+            prefer_binding_token_mint=prefer_binding_token_mint,
         )
     )
     try:
@@ -14664,7 +14691,12 @@ def create_sessions_router(
         if launch_host_id is not None and resp.runner_id is None:
             host_registry = getattr(request.app.state, "host_registry", None)
             host_store_inst = getattr(request.app.state, "host_store", None)
-            if host_registry is not None and host_store_inst is not None:
+            host_permission_store_inst = getattr(request.app.state, "host_permission_store", None)
+            if (
+                host_registry is not None
+                and host_store_inst is not None
+                and host_permission_store_inst is not None
+            ):
                 from omnigent.host.frames import (
                     HostLaunchRunnerFrame,
                     encode_host_frame,
@@ -14681,6 +14713,7 @@ def create_sessions_router(
                     host_registry=host_registry,
                     conversation_store=conversation_store,
                     permission_store=permission_store,
+                    host_permission_store=host_permission_store_inst,
                 )
                 conn = target.conn
                 binding_token = secrets.token_urlsafe(32)
@@ -14711,6 +14744,15 @@ def create_sessions_router(
                         "schema constraint should have prevented this",
                         code=ErrorCode.INTERNAL_ERROR,
                     )
+                # Guest on a shared / externally-owned host (session owner !=
+                # host owner): tell the runner to authenticate its server
+                # callbacks with its binding token (matched to the session's
+                # runner_id) instead of the host-owner credential, which can't
+                # read a guest session's spec (404). Equal owners (own-host)
+                # leave this False → unchanged.
+                prefer_binding_token_mint = (
+                    user_id is not None and conn.owner is not None and user_id != conn.owner
+                )
                 launch_frame = encode_host_frame(
                     HostLaunchRunnerFrame(
                         request_id=request_id,
@@ -14722,6 +14764,7 @@ def create_sessions_router(
                         # spawning. None (agent not resolvable) skips the
                         # host-side check.
                         harness=resp.harness,
+                        prefer_binding_token_mint=prefer_binding_token_mint,
                     )
                 )
                 host_registry.send_text(conn, launch_frame)
@@ -14953,7 +14996,12 @@ def create_sessions_router(
         # require_access + get_permission_level + snapshot-get_conversation
         # sequence, which made ~5-6 separate store round-trips.
         access = await _require_access_and_level(
-            user_id, session_id, LEVEL_READ, permission_store, conversation_store
+            user_id,
+            session_id,
+            LEVEL_READ,
+            permission_store,
+            conversation_store,
+            runner_binding_token=request.headers.get(RUNNER_TUNNEL_TOKEN_HEADER),
         )
         return await _get_session_snapshot(
             conversation_store,
@@ -15032,6 +15080,7 @@ def create_sessions_router(
         include_archived: bool = Query(default=False),
         kind: str = Query(default="default", pattern="^(default|sub_agent|any)$"),
         project: str | None = Query(default=None),
+        all: bool = Query(default=False),
     ) -> PaginatedList:
         """
         List sessions with cursor-based pagination.
@@ -15039,6 +15088,16 @@ def create_sessions_router(
         Sessions are conversations with a non-``None`` ``agent_id``
         — i.e. those created via ``POST /v1/sessions``.
         Conversations without an agent binding are excluded.
+
+        With ``?all=true`` (admin only) the per-user ACL filter is
+        dropped and sessions across **every** owner are returned — the
+        admin fleet view, mirroring ``GET /v1/hosts?all=true``. Each item
+        already carries ``host_id``, ``runner_id``, and ``owner`` so an
+        admin can see which host/owner every session belongs to. Fails
+        closed: a non-admin passing ``all=true`` gets 403 rather than a
+        silently owner-filtered response they might mistake for the fleet.
+        The read is audited (``session.fleet.list``) since it discloses
+        every owner's sessions.
 
         :param limit: Maximum number of sessions to return
             (1-1000, default 20).
@@ -15075,8 +15134,13 @@ def create_sessions_router(
             this lets the new-session agent picker discover agents
             that are only bound to sub-agent sessions (e.g. ones
             uploaded via ``sys_session_create``).
+        :param all: When ``True``, return sessions across every owner
+            (requires admin) — the admin fleet view. ``False`` (default)
+            scopes to the caller's own/shared sessions.
         :returns: A :class:`PaginatedList` of
             :class:`SessionListItem`.
+        :raises HTTPException: 403 when ``all=true`` and the caller is
+            not an admin.
         """
         # Empty-string normalization — the UI sends
         # ``?search_query=`` when the search box is cleared and
@@ -15091,12 +15155,26 @@ def create_sessions_router(
         # disabled entirely — no auth_provider).
         user_id = _require_user(request, auth_provider)
         normalized_query = search_query if search_query else None
+        # Admin fleet view: drop the ACL filter so every owner's sessions
+        # are returned. Fail closed — a non-admin asking for all=true gets
+        # 403, never a silently owner-scoped list. Audit the disclosure.
+        fleet_view = False
+        if all:
+            is_admin = (
+                await asyncio.to_thread(permission_store.is_admin, user_id)
+                if permission_store is not None and user_id is not None
+                else False
+            )
+            if not is_admin:
+                raise HTTPException(status_code=403, detail="admin privileges required")
+            fleet_view = True
+            audit_event("session.fleet.list", actor=user_id, target="*")
         # A specific project folder ("My sessions"-only) must show only the
         # viewer's own sessions — a session shared with them but filed under a
         # like-named project belongs on "Shared with me", not in this folder.
         # The flat list (project=None) and Unfiled (project="") stay unscoped so
         # shared sessions still surface for the "Shared with me" tab.
-        owned_by = user_id if project else None
+        owned_by = None if fleet_view else (user_id if project else None)
         page = await asyncio.to_thread(
             conversation_store.list_conversations,
             limit=limit,
@@ -15104,7 +15182,7 @@ def create_sessions_router(
             before=before,
             agent_id=agent_id,
             agent_name=agent_name,
-            accessible_by=user_id,
+            accessible_by=None if fleet_view else user_id,
             owned_by=owned_by,
             has_agent_id=True,
             # The store treats ``None`` as "no kind filter"; the API
@@ -16451,8 +16529,17 @@ def create_sessions_router(
             ``tool_name``.
         """
         user_id = _get_user_id(request, auth_provider)
-        await _require_access(
-            user_id, session_id, LEVEL_READ, permission_store, conversation_store
+        # Use the level-aware helper so the runner's tunnel binding token can
+        # authorize a guest approval prompt on a shared externally-owned host
+        # (header auth mode has no mintable owner identity). The resolved level
+        # is unused here; this route only needs READ.
+        await _require_access_and_level(
+            user_id,
+            session_id,
+            LEVEL_READ,
+            permission_store,
+            conversation_store,
+            runner_binding_token=request.headers.get(RUNNER_TUNNEL_TOKEN_HEADER),
         )
         try:
             payload = await request.json()
@@ -16778,7 +16865,12 @@ def create_sessions_router(
         """
         user_id = _get_user_id(request, auth_provider)
         access = await _require_access_and_level(
-            user_id, session_id, LEVEL_READ, permission_store, conversation_store
+            user_id,
+            session_id,
+            LEVEL_READ,
+            permission_store,
+            conversation_store,
+            runner_binding_token=request.headers.get(RUNNER_TUNNEL_TOKEN_HEADER),
         )
         is_read_only = access.level is not None and access.level < LEVEL_EDIT
         try:
@@ -19596,7 +19688,12 @@ def create_sessions_router(
         """
         user_id = _get_user_id(request, auth_provider)
         access = await _require_access_and_level(
-            user_id, session_id, LEVEL_EDIT, permission_store, conversation_store
+            user_id,
+            session_id,
+            LEVEL_EDIT,
+            permission_store,
+            conversation_store,
+            runner_binding_token=request.headers.get(RUNNER_TUNNEL_TOKEN_HEADER),
         )
         conv = access.conversation
         if conv is None:
@@ -20402,6 +20499,7 @@ def create_sessions_router(
                         conversation_store,
                         _host_reg,
                         _host_conn,
+                        permission_store=getattr(request.app.state, "permission_store", None),
                     )
                     if launch_attempt.error_code == _HARNESS_NOT_CONFIGURED_ERROR_CODE:
                         # The host refused: the agent's harness isn't
@@ -21346,7 +21444,12 @@ def create_sessions_router(
         """
         user_id = _require_user(request, auth_provider)
         access = await _require_access_and_level(
-            user_id, session_id, LEVEL_READ, permission_store, conversation_store
+            user_id,
+            session_id,
+            LEVEL_READ,
+            permission_store,
+            conversation_store,
+            runner_binding_token=request.headers.get(RUNNER_TUNNEL_TOKEN_HEADER),
         )
         conv = access.conversation
         if conv is None:
@@ -21397,7 +21500,12 @@ def create_sessions_router(
         """
         user_id = _require_user(request, auth_provider)
         access = await _require_access_and_level(
-            user_id, session_id, LEVEL_READ, permission_store, conversation_store
+            user_id,
+            session_id,
+            LEVEL_READ,
+            permission_store,
+            conversation_store,
+            runner_binding_token=request.headers.get(RUNNER_TUNNEL_TOKEN_HEADER),
         )
         conv = access.conversation
         if conv is None:

--- a/omnigent/stores/__init__.py
+++ b/omnigent/stores/__init__.py
@@ -4,6 +4,7 @@ from omnigent.stores.agent_store import AgentStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.conversation_store import ConversationStore
 from omnigent.stores.file_store import FileStore
+from omnigent.stores.host_permission_store import HostPermissionStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.scheduled_task_store import ScheduledTaskStore
 
@@ -12,6 +13,7 @@ __all__ = [
     "ArtifactStore",
     "ConversationStore",
     "FileStore",
+    "HostPermissionStore",
     "PermissionStore",
     "ScheduledTaskStore",
 ]

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1092,6 +1092,21 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def count_conversations_by_host_id(self, host_id: str) -> int:
+        """
+        Return the number of conversations bound to the given ``host_id``.
+
+        Backs the admin fleet view's per-host session count
+        (``GET /v1/hosts?all=true``). A count rather than a list: the
+        caller only needs the size, so implementations should avoid
+        materializing rows.
+
+        :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
+        :returns: Count of conversations whose ``host_id`` matches.
+        """
+        ...
+
+    @abstractmethod
     def set_host_id(
         self,
         conversation_id: str,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2734,6 +2734,26 @@ class SqlAlchemyConversationStore(ConversationStore):
             for r in ap_rows
         ]
 
+    def count_conversations_by_host_id(self, host_id: str) -> int:
+        """
+        Return the number of conversations bound to the given ``host_id``.
+
+        Counts in SQL rather than materializing rows — the admin fleet
+        view only needs the size per host.
+
+        :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
+        :returns: Count of conversations whose ``host_id`` matches.
+        """
+        with self._session() as session:
+            return (
+                session.query(SqlConversation)
+                .filter(
+                    SqlConversation.workspace_id == current_workspace_id(),
+                    SqlConversation.host_id == host_id,
+                )
+                .count()
+            )
+
     def set_host_id(
         self,
         conversation_id: str,

--- a/omnigent/stores/host_permission_store/__init__.py
+++ b/omnigent/stores/host_permission_store/__init__.py
@@ -1,0 +1,138 @@
+"""Host permission store — manages host-level access grants.
+
+Each grant is a ``(user_id, host_id, level)`` triple where level is an
+integer: 1=view, 2=use, 3=manage. Unlike the session permission store
+there is no ``"__public__"`` sentinel — host sharing is explicit
+per-user opt-in (see the feature spec, SR-007).
+
+The host owner (``hosts.owner``) and admins are NOT stored here; their
+access is resolved in :func:`omnigent.server.host_permissions.check_host_access`.
+"""
+
+from abc import ABC, abstractmethod
+
+from omnigent.entities import HostPermission
+
+
+class HostPermissionStore(ABC):
+    """Abstract base for host permission persistence.
+
+    Manages grants between users and hosts they do not own. A separate
+    store from :class:`~omnigent.stores.permission_store.PermissionStore`
+    because session permissions are keyed by ``conversation_id`` and
+    carry ``"__public__"`` semantics that must not transfer to hosts.
+    """
+
+    def __init__(self, storage_location: str) -> None:
+        """Initialize the host permission store.
+
+        :param storage_location: Backend-specific storage URI,
+            e.g. ``"sqlite:///omnigent.db"``.
+        """
+        self.storage_location = storage_location
+
+    @abstractmethod
+    def grant(
+        self,
+        user_id: str,
+        host_id: str,
+        level: int,
+        *,
+        created_by: str | None = None,
+    ) -> HostPermission:
+        """Upsert a host permission grant.
+
+        If the user already has a grant on this host, the level is
+        overwritten (upgrade or downgrade); ``created_at`` and the
+        original ``created_by`` are preserved. The caller is responsible
+        for authorization (only owner/admin/manage may grant).
+
+        :param user_id: The grantee, e.g. ``"alice@example.com"``.
+        :param host_id: The host to grant access to, e.g.
+            ``"host_a1b2c3d4..."``.
+        :param level: Numeric permission level (1=view, 2=use, 3=manage).
+        :param created_by: User ID recording who created the grant, set
+            only on first insert.
+        :returns: The resulting :class:`HostPermission`.
+        """
+        ...
+
+    @abstractmethod
+    def revoke(self, user_id: str, host_id: str) -> bool:
+        """Remove a host permission grant.
+
+        No-op if the grant does not exist (returns ``False``).
+
+        :param user_id: The grantee to revoke.
+        :param host_id: The host to revoke access from.
+        :returns: ``True`` if a row was deleted, ``False`` otherwise.
+        """
+        ...
+
+    @abstractmethod
+    def get(self, user_id: str, host_id: str) -> HostPermission | None:
+        """Look up a single host permission grant.
+
+        :param user_id: The grantee.
+        :param host_id: The host.
+        :returns: The :class:`HostPermission` if found, else ``None``.
+        """
+        ...
+
+    @abstractmethod
+    def list_for_host(self, host_id: str) -> list[HostPermission]:
+        """Return all grants on a host.
+
+        :param host_id: The host to query, e.g. ``"host_a1b2c3d4..."``.
+        :returns: List of :class:`HostPermission` objects.
+        """
+        ...
+
+    @abstractmethod
+    def list_for_user(self, user_id: str) -> list[HostPermission]:
+        """Return all grants for a user.
+
+        The hot path backing "list hosts I can access".
+
+        :param user_id: The user to query, e.g. ``"alice@example.com"``.
+        :returns: List of :class:`HostPermission` objects.
+        """
+        ...
+
+    @abstractmethod
+    def check_access(
+        self,
+        user_id: str | None,
+        host_id: str,
+        required_level: int,
+    ) -> bool:
+        """Check whether *user_id* has a grant at *required_level* or above.
+
+        Considers only the user's direct grant. Does NOT handle owner
+        short-circuit or admin bypass — those are resolution policy in
+        :func:`omnigent.server.host_permissions.check_host_access`.
+
+        :param user_id: The authenticated user, or ``None``.
+        :param host_id: The host to check.
+        :param required_level: Minimum numeric level needed.
+        :returns: ``True`` if a sufficient grant exists, ``False`` otherwise.
+        """
+        ...
+
+    @abstractmethod
+    def get_permission_level(
+        self,
+        user_id: str | None,
+        host_id: str,
+    ) -> int | None:
+        """Return the user's effective grant level for UI display.
+
+        Returns the user's direct grant level, or ``None`` when they have
+        no grant. Does NOT apply owner/admin resolution — callers layer
+        that on (owner/admin display as ``owner``).
+
+        :param user_id: The authenticated user, or ``None``.
+        :param host_id: The host to check.
+        :returns: Numeric level (1/2/3), or ``None``.
+        """
+        ...

--- a/omnigent/stores/host_permission_store/sqlalchemy_store.py
+++ b/omnigent/stores/host_permission_store/sqlalchemy_store.py
@@ -1,0 +1,149 @@
+"""SQLAlchemy-backed host permission store."""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from omnigent.db.db_models import SqlHostPermission
+from omnigent.db.utils import get_or_create_engine, make_managed_session_maker, now_epoch
+from omnigent.entities import HostPermission
+from omnigent.stores.host_permission_store import HostPermissionStore
+
+
+def _to_entity(row: SqlHostPermission) -> HostPermission:
+    """Convert a :class:`SqlHostPermission` ORM row to a domain entity.
+
+    :param row: The SQLAlchemy ORM row to convert.
+    :returns: A :class:`HostPermission` dataclass instance.
+    """
+    return HostPermission(
+        user_id=row.user_id,
+        host_id=row.host_id,
+        level=row.level,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        created_by=row.created_by,
+    )
+
+
+class SqlAlchemyHostPermissionStore(HostPermissionStore):
+    """SQLAlchemy-backed implementation of :class:`HostPermissionStore`.
+
+    Persists host permissions in a relational database via SQLAlchemy
+    ORM. Uses dialect-aware upsert for grants (SQLite
+    ``ON CONFLICT DO UPDATE``, PostgreSQL ``ON CONFLICT ... DO UPDATE``),
+    preserving ``created_at`` / ``created_by`` on conflict.
+    """
+
+    def __init__(self, storage_location: str) -> None:
+        """Initialize the SQLAlchemy host permission store.
+
+        :param storage_location: SQLAlchemy database URI,
+            e.g. ``"sqlite:///omnigent.db"``.
+        """
+        super().__init__(storage_location)
+        self._engine = get_or_create_engine(storage_location)
+        self._session = make_managed_session_maker(self._engine)
+
+    def grant(
+        self,
+        user_id: str,
+        host_id: str,
+        level: int,
+        *,
+        created_by: str | None = None,
+    ) -> HostPermission:
+        """Upsert a host permission grant. See base class for contract."""
+        now = now_epoch()
+        with self._session() as session:
+            is_sqlite = self._engine.dialect.name == "sqlite"
+            insert = sqlite_insert if is_sqlite else pg_insert
+            stmt = (
+                insert(SqlHostPermission)
+                .values(
+                    user_id=user_id,
+                    host_id=host_id,
+                    level=level,
+                    created_at=now,
+                    updated_at=now,
+                    created_by=created_by,
+                )
+                .on_conflict_do_update(
+                    index_elements=["user_id", "host_id"],
+                    # Only the level and updated_at change on re-grant;
+                    # created_at / created_by stay as first written.
+                    set_={"level": level, "updated_at": now},
+                )
+            )
+            session.execute(stmt)
+            session.flush()
+            row = session.get(SqlHostPermission, (user_id, host_id))
+            # row is non-None: we just upserted it.
+            assert row is not None
+            return _to_entity(row)
+
+    def revoke(self, user_id: str, host_id: str) -> bool:
+        """Remove a host permission grant. See base class for contract."""
+        with self._session() as session:
+            result = session.execute(
+                delete(SqlHostPermission).where(
+                    SqlHostPermission.user_id == user_id,
+                    SqlHostPermission.host_id == host_id,
+                )
+            )
+            return result.rowcount > 0
+
+    def get(self, user_id: str, host_id: str) -> HostPermission | None:
+        """Look up a single grant. See base class for contract."""
+        with self._session() as session:
+            row = session.get(SqlHostPermission, (user_id, host_id))
+            return _to_entity(row) if row is not None else None
+
+    def list_for_host(self, host_id: str) -> list[HostPermission]:
+        """Return all grants on a host. See base class for contract."""
+        with self._session() as session:
+            rows = (
+                session.execute(
+                    select(SqlHostPermission).where(SqlHostPermission.host_id == host_id)
+                )
+                .scalars()
+                .all()
+            )
+            return [_to_entity(r) for r in rows]
+
+    def list_for_user(self, user_id: str) -> list[HostPermission]:
+        """Return all grants for a user. See base class for contract."""
+        with self._session() as session:
+            rows = (
+                session.execute(
+                    select(SqlHostPermission).where(SqlHostPermission.user_id == user_id)
+                )
+                .scalars()
+                .all()
+            )
+            return [_to_entity(r) for r in rows]
+
+    def check_access(
+        self,
+        user_id: str | None,
+        host_id: str,
+        required_level: int,
+    ) -> bool:
+        """Check grant-level access. See base class for contract."""
+        if user_id is None:
+            return False
+        grant = self.get(user_id, host_id)
+        return grant is not None and grant.level >= required_level
+
+    def get_permission_level(
+        self,
+        user_id: str | None,
+        host_id: str,
+    ) -> int | None:
+        """Return the user's effective grant level. See base class for contract."""
+        if user_id is None:
+            return None
+        grant = self.get(user_id, host_id)
+        return grant.level if grant is not None else None

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 from omnigent.db.db_models import (
     SqlConversationMetadata,
     SqlHost,
+    SqlHostPermission,
     current_workspace_id,
 )
 from omnigent.db.enum_codecs import decode_host_status, encode_host_status
@@ -597,6 +598,51 @@ class HostStore:
             )
             return [_row_to_host(row) for row in rows]
 
+    def list_all_hosts(self) -> list[Host]:
+        """
+        List every registered host across all owners.
+
+        Backs the admin fleet view (``GET /v1/hosts?all=true``) — the
+        caller is responsible for admin-gating; this read has no
+        authorization of its own. Ordered like :meth:`list_hosts`
+        (``updated_at`` descending, most recently active first).
+
+        :returns: List of :class:`Host` entities for every owner.
+        """
+        with self._session() as session:
+            rows = session.query(SqlHost).order_by(SqlHost.updated_at.desc()).all()
+            return [_row_to_host(row) for row in rows]
+
+    def list_hosts_for(self, user_id: str) -> list[Host]:
+        """
+        List hosts the user owns OR has been granted access to.
+
+        Returns owned hosts plus every host with a row in
+        ``host_permissions`` for *user_id* (any level — the lowest,
+        ``view``, already grants visibility). One query: an owner match
+        OR a ``host_id`` in the user's grant set. Ordered by
+        ``updated_at`` descending, same as :meth:`list_hosts`. Admin
+        visibility is NOT expanded here — an admin sees their own hosts
+        in the picker; admin bypass applies to per-host access checks,
+        not to enumerating every user's host (the fleet view,
+        :meth:`list_all_hosts`, is the explicit admin read).
+
+        :param user_id: The viewing user, e.g.
+            ``"alice@example.com"``.
+        :returns: List of :class:`Host` entities the user may see.
+        """
+        with self._session() as session:
+            granted_host_ids = select(SqlHostPermission.host_id).where(
+                SqlHostPermission.user_id == user_id
+            )
+            rows = (
+                session.query(SqlHost)
+                .filter((SqlHost.owner == user_id) | (SqlHost.host_id.in_(granted_host_ids)))
+                .order_by(SqlHost.updated_at.desc())
+                .all()
+            )
+            return [_row_to_host(row) for row in rows]
+
     def get_host(self, host_id: str) -> Host | None:
         """
         Fetch a single host by ID.
@@ -740,9 +786,10 @@ class HostStore:
         Managed-host teardown: removes the host from the picker AND
         revokes its launch token in one operation (the row IS the
         credential). Explicitly nulls ``conversations.host_id`` for any
-        sessions still bound to this host — the DB no longer cascades
-        this via FK. No-op when the row does not exist — deletion is
-        invoked from best-effort cleanup paths that may race.
+        sessions still bound to this host and deletes the host's sharing
+        grants — the DB no longer cascades either via FK. No-op when the
+        row does not exist — deletion is invoked from best-effort cleanup
+        paths that may race.
 
         :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
         """
@@ -754,6 +801,11 @@ class HostStore:
                     SqlConversationMetadata.host_id == host_id,
                 )
                 .values(host_id=None)
+            )
+            session.execute(
+                sql_delete(SqlHostPermission).where(
+                    SqlHostPermission.host_id == host_id,
+                )
             )
             session.execute(
                 sql_delete(SqlHost).where(

--- a/openapi.json
+++ b/openapi.json
@@ -5511,6 +5511,21 @@
         "title": "SetCodexGoalRequest",
         "type": "object"
       },
+      "SetHostPermissionRequest": {
+        "description": "Request body for `PUT /v1/hosts/{host_id}/permissions/{user_id}`.",
+        "properties": {
+          "level": {
+            "description": "Grant level to set: `\"view\"`, `\"use\"`, or `\"manage\"`. `\"owner\"` is not grantable \u2014 ownership comes from the host tunnel identity, not a grant.",
+            "title": "Level",
+            "type": "string"
+          }
+        },
+        "required": [
+          "level"
+        ],
+        "title": "SetHostPermissionRequest",
+        "type": "object"
+      },
       "SetSharingRequest": {
         "description": "Body for `PUT /v1/sharing`.\n\nBoth fields are optional so an admin can update either setting\nindependently; at least one must be present.",
         "properties": {
@@ -6529,8 +6544,21 @@
     },
     "/v1/hosts": {
       "get": {
-        "description": "List all hosts owned by the authenticated user.\n\nReturns both online and offline hosts, with live runner\ninformation for online hosts.\n\n**Returns:** `{\"hosts\": [...]}` with host details.",
+        "description": "List hosts the authenticated user owns or has been shared.\n\nReturns both online and offline hosts, owned plus any with at\nleast a `view` grant. Each host carries the caller's effective\n`permission_level` and an `owned_by_current_user` flag so the\nUI can label shared hosts without parsing the opaque `owner`.\n\nWith `?all=true` (admin only) the owner filter is dropped and\nevery registered host is returned, each with the extra fleet\nfields `created_at`, `last_seen`, and `session_count` \u2014\nthe admin Hosts page's data source.\n\n**Returns:** `{\"hosts\": [...]}` with host details.\n\n**Raises**\n\n- `HTTPException` \u2014 401 unauthenticated; 403 when `all=true` and the caller is not an admin.",
         "operationId": "list_hosts_v1_hosts_get",
+        "parameters": [
+          {
+            "description": "When `True`, return every host across all owners (requires admin).",
+            "in": "query",
+            "name": "all",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "All",
+              "type": "boolean"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -6549,6 +6577,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "List Hosts",
@@ -6605,7 +6643,7 @@
     },
     "/v1/hosts/{host_id}/directories": {
       "post": {
-        "description": "Create a new directory on a host.\n\nBacks the Web UI workspace picker's \"New folder\" action so a\nuser can make a fresh directory to start a session in without\ndropping to a terminal. Owner-scoped exactly like the\nfilesystem browse endpoints (`GET /v1/hosts/{id}/filesystem`):\nonly the host owner can create directories, and \u2014 like browse \u2014\nthis is NOT scoped to a session. The workspace-boundary check\nstill runs at session-create time, so creating a directory here\ndoes not by itself grant an agent access to it.\n\n**Parameters**\n\n- `body` \u2014 Request body carrying the absolute (or tilde-prefixed) `path` to create.\n\n**Returns:** `{\"object\": \"directory\", \"path\": \"<created abs path>\"}`.\n\n**Raises**\n\n- `HTTPException` \u2014 404 if host not found, 403 if not owned by caller, 409 if host is offline or the directory could not be created (already exists / permission denied), 400 on path validation, 504 on host timeout, 502 on host I/O failure.",
+        "description": "Create a new directory on a host.\n\nBacks the Web UI workspace picker's \"New folder\" action so a\nuser can make a fresh directory to start a session in without\ndropping to a terminal. Access-scoped exactly like the\nfilesystem browse endpoints (`GET /v1/hosts/{id}/filesystem`):\ncreating a directory mutates the host filesystem, so it needs\n`use` (owner, admin, or a `use`+ grantee), and \u2014 like\nbrowse \u2014 this is NOT scoped to a session. The workspace-boundary\ncheck still runs at session-create time, so creating a directory\nhere does not by itself grant an agent access to it.\n\n**Parameters**\n\n- `body` \u2014 Request body carrying the absolute (or tilde-prefixed) `path` to create.\n\n**Returns:** `{\"object\": \"directory\", \"path\": \"<created abs path>\"}`.\n\n**Raises**\n\n- `HTTPException` \u2014 404 if host not found, 403 if the caller lacks `use`, 409 if host is offline or the directory could not be created (already exists / permission denied), 400 on path validation, 504 on host timeout, 502 on host I/O failure.",
         "operationId": "create_host_directory_v1_hosts__host_id__directories_post",
         "parameters": [
           {
@@ -6855,9 +6893,183 @@
         ]
       }
     },
+    "/v1/hosts/{host_id}/permissions": {
+      "get": {
+        "description": "List the grants on a host.\n\nRequires owner / admin / `manage` access.\n\n**Returns:** `{\"permissions\": [{\"user_id\", \"level\"}, ...]}`.\n\n**Raises**\n\n- `HTTPException` \u2014 404 unknown host, 403 insufficient access.",
+        "operationId": "list_host_permissions_v1_hosts__host_id__permissions_get",
+        "parameters": [
+          {
+            "description": "Host identifier.",
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "title": "Host Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "additionalProperties": true,
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response List Host Permissions V1 Hosts  Host Id  Permissions Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Host Permissions",
+        "tags": [
+          "hosts"
+        ]
+      }
+    },
+    "/v1/hosts/{host_id}/permissions/{user_id}": {
+      "delete": {
+        "description": "Revoke a user's access to a host.\n\nRequires owner / admin / `manage` access. Idempotent: revoking\na non-existent grant returns `{\"revoked\": false}`.\n\n**Returns:** `{\"revoked\": bool}`.\n\n**Raises**\n\n- `HTTPException` \u2014 404 unknown host, 403 insufficient access.",
+        "operationId": "delete_host_permission_v1_hosts__host_id__permissions__user_id__delete",
+        "parameters": [
+          {
+            "description": "Host identifier.",
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "title": "Host Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The grantee to revoke.",
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Delete Host Permission V1 Hosts  Host Id  Permissions  User Id  Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Host Permission",
+        "tags": [
+          "hosts"
+        ]
+      },
+      "put": {
+        "description": "Grant or update a user's access to a host.\n\nRequires owner / admin / `manage` access. The grantee gets the\nrequested `view` / `use` / `manage` level (an existing\ngrant is upgraded or downgraded in place).\n\n**Parameters**\n\n- `body` \u2014 The level to set.\n\n**Returns:** `{\"user_id\", \"host_id\", \"level\"}` for the grant.\n\n**Raises**\n\n- `HTTPException` \u2014 404 unknown host, 403 insufficient access, 400 invalid level or granting to the host owner.",
+        "operationId": "set_host_permission_v1_hosts__host_id__permissions__user_id__put",
+        "parameters": [
+          {
+            "description": "Host identifier.",
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "title": "Host Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The grantee to set access for.",
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetHostPermissionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Set Host Permission V1 Hosts  Host Id  Permissions  User Id  Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Set Host Permission",
+        "tags": [
+          "hosts"
+        ]
+      }
+    },
     "/v1/hosts/{host_id}/runners": {
       "post": {
-        "description": "Launch a runner on a host for a session.\n\nGenerates a binding token, writes the expected runner_id\nto the session row, sends the launch command to the host,\nand waits for the host's acknowledgement.\n\n**Parameters**\n\n- `body` \u2014 Launch request with `session_id` and `workspace`.\n\n**Returns:** `{\"runner_id\": ..., \"status\": \"launching\"}`.\n\n**Raises**\n\n- `HTTPException` \u2014 404 if host not found, 409 if host offline, 403 if caller doesn't own the host, 400 if session already has a runner.",
+        "description": "Launch a runner on a host for a session.\n\nGenerates a binding token, writes the expected runner_id\nto the session row, sends the launch command to the host,\nand waits for the host's acknowledgement.\n\n**Parameters**\n\n- `body` \u2014 Launch request with `session_id` and `workspace`.\n\n**Returns:** `{\"runner_id\": ..., \"status\": \"launching\"}`.\n\n**Raises**\n\n- `HTTPException` \u2014 404 if host not found, 409 if host offline, 403 if caller lacks `use` on the host, 400 if session already has a runner.",
         "operationId": "launch_runner_v1_hosts__host_id__runners_post",
         "parameters": [
           {
@@ -6906,6 +7118,54 @@
           }
         },
         "summary": "Launch Runner",
+        "tags": [
+          "hosts"
+        ]
+      }
+    },
+    "/v1/hosts/{host_id}/shutdown": {
+      "post": {
+        "description": "Shut down a host: terminate its runners and exit the daemon.\n\nOwner-or-admin gated. Sends `host.shutdown` over the tunnel;\nthe daemon terminates its runners and exits instead of\nreconnecting, and the tunnel's existing disconnect path then\nderegisters the connection and marks the host offline in the DB.\nFire-and-forget: the offline flip lands via that disconnect\npath, so callers observe it on their next poll.\n\n**Returns:** `{\"status\": \"shutting_down\"}`.\n\n**Raises**\n\n- `HTTPException` \u2014 404 unknown host, 403 when the caller is neither the owner nor an admin, 400 for server-managed sandbox hosts, 409 when the host has no live connection.",
+        "operationId": "shutdown_host_v1_hosts__host_id__shutdown_post",
+        "parameters": [
+          {
+            "description": "Host to shut down, e.g. `\"host_a1b2c3d4...\"`.",
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "title": "Host Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Shutdown Host V1 Hosts  Host Id  Shutdown Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Shutdown Host",
         "tags": [
           "hosts"
         ]
@@ -7441,7 +7701,7 @@
     },
     "/v1/sessions": {
       "get": {
-        "description": "List sessions with cursor-based pagination.\n\nSessions are conversations with a non-`None` `agent_id`\n\u2014 i.e. those created via `POST /v1/sessions`.\nConversations without an agent binding are excluded.\n\n**Returns:** A `PaginatedList` of `SessionListItem`.",
+        "description": "List sessions with cursor-based pagination.\n\nSessions are conversations with a non-`None` `agent_id`\n\u2014 i.e. those created via `POST /v1/sessions`.\nConversations without an agent binding are excluded.\n\nWith `?all=true` (admin only) the per-user ACL filter is\ndropped and sessions across **every** owner are returned \u2014 the\nadmin fleet view, mirroring `GET /v1/hosts?all=true`. Each item\nalready carries `host_id`, `runner_id`, and `owner` so an\nadmin can see which host/owner every session belongs to. Fails\nclosed: a non-admin passing `all=true` gets 403 rather than a\nsilently owner-filtered response they might mistake for the fleet.\nThe read is audited (`session.fleet.list`) since it discloses\nevery owner's sessions.\n\n**Returns:** A `PaginatedList` of `SessionListItem`.\n\n**Raises**\n\n- `HTTPException` \u2014 403 when `all=true` and the caller is not an admin.",
         "operationId": "list_sessions_v1_sessions_get",
         "parameters": [
           {
@@ -7603,6 +7863,17 @@
                 }
               ],
               "title": "Project"
+            }
+          },
+          {
+            "description": "When `True`, return sessions across every owner (requires admin) \u2014 the admin fleet view. `False` (default) scopes to the caller's own/shared sessions.",
+            "in": "query",
+            "name": "all",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "All",
+              "type": "boolean"
             }
           }
         ],

--- a/scripts/dump_openapi.py
+++ b/scripts/dump_openapi.py
@@ -327,6 +327,9 @@ def _build_app_with_stub_stores() -> Any:
         SqlAlchemyConversationStore,
     )
     from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+    from omnigent.stores.host_permission_store.sqlalchemy_store import (
+        SqlAlchemyHostPermissionStore,
+    )
     from omnigent.stores.host_store import HostStore
     from omnigent.stores.policy_store.sqlalchemy_store import SqlAlchemyPolicyStore
 
@@ -348,6 +351,7 @@ def _build_app_with_stub_stores() -> Any:
         ),
         # Pass stores so conditionally-mounted routes stay in the spec.
         host_store=HostStore(db_uri),
+        host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
         policy_store=SqlAlchemyPolicyStore(db_uri),
     )
 

--- a/tests/e2e/omnigent/test_repl_session_lifecycle.py
+++ b/tests/e2e/omnigent/test_repl_session_lifecycle.py
@@ -510,6 +510,7 @@ from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStor
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
 from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
 from omnigent.stores.host_store import HostStore
+from omnigent.stores.host_permission_store.sqlalchemy_store import SqlAlchemyHostPermissionStore
 db_uri = os.environ["OMNIGENT_E2E_DB_URI"]
 artifact_location = Path(os.environ["OMNIGENT_E2E_ARTIFACT_LOCATION"])
 port = int(os.environ["OMNIGENT_E2E_PORT"])
@@ -541,6 +542,7 @@ app = create_app(
     agent_cache=agent_cache,
     runner_tunnel_tokens=None,
     host_store=host_store,
+    host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
 )
 uvicorn.run(app, host="127.0.0.1", port=port)
 """

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -23,6 +23,7 @@ from omnigent.host.connect import (
 )
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
+    HOST_AT_CAPACITY_ERROR_CODE,
     HostCreateDirFrame,
     HostCreateDirResultFrame,
     HostHelloFrame,
@@ -41,6 +42,7 @@ from omnigent.host.identity import HostIdentity
 from omnigent.runner.identity import (
     RUNNER_ID_ENV_VAR,
     RUNNER_PARENT_PID_ENV_VAR,
+    RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR,
     RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR,
     RUNNER_WORKSPACE_ENV_VAR,
     token_bound_runner_id,
@@ -223,6 +225,143 @@ async def test_handle_launch_refuses_unconfigured_harness(
     assert result.runner_id is None
     # No runner subprocess may exist after a refusal.
     assert host._runners == {}
+
+
+async def test_handle_launch_refuses_when_at_capacity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    With OMNIGENT_HOST_MAX_RUNNERS set, a launch past the cap is refused
+    with the structured host_at_capacity code and no runner is spawned.
+
+    If this regresses, an unbounded fan-out of launch frames spawns a full
+    agent process each, which can OOM a fixed-resource host and kill every
+    session on it — the exact backpressure this cap exists to provide.
+    """
+    monkeypatch.setenv("OMNIGENT_HOST_MAX_RUNNERS", "1")
+    host = _make_host_process()
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    # One live runner already occupies the single slot.
+    alive_proc = subprocess.Popen(
+        ["sleep", "60"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    host._runners["runner_existing"] = _RunnerHandle(
+        proc=alive_proc, log_path=tmp_path / "runner-existing.log"
+    )
+    # Harness check would pass — isolate the capacity refusal.
+    monkeypatch.setattr(
+        "omnigent.host.connect.harness_is_configured",
+        lambda harness: True,
+    )
+
+    frame = HostLaunchRunnerFrame(
+        request_id="req_capacity",
+        binding_token="token_over",
+        workspace=str(workspace),
+        harness="codex",
+    )
+    try:
+        result = await host._handle_launch(frame)
+
+        assert isinstance(result, HostLaunchRunnerResultFrame)
+        assert result.status == "failed"
+        assert result.error_code == HOST_AT_CAPACITY_ERROR_CODE
+        assert "capacity" in (result.error or "").lower()
+        assert result.runner_id is None
+        # No NEW runner spawned; only the pre-existing one remains.
+        assert set(host._runners) == {"runner_existing"}
+    finally:
+        alive_proc.terminate()
+        alive_proc.wait()
+        _cleanup_host(host)
+
+
+async def test_handle_launch_unlimited_when_cap_unset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    With OMNIGENT_HOST_MAX_RUNNERS unset, the capacity gate is a no-op:
+    a launch proceeds to the harness check (original behavior preserved).
+    """
+    monkeypatch.delenv("OMNIGENT_HOST_MAX_RUNNERS", raising=False)
+    host = _make_host_process()
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    # Pre-load several live runners; without a cap none of them block a launch.
+    procs = []
+    for name in ("r_a", "r_b", "r_c"):
+        p = subprocess.Popen(["sleep", "60"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        host._runners[name] = _RunnerHandle(proc=p, log_path=tmp_path / f"{name}.log")
+        procs.append(p)
+    # Fail the harness check so we prove the launch got PAST the capacity gate
+    # (a capacity refusal would carry a different error_code) without spawning.
+    monkeypatch.setattr(
+        "omnigent.host.connect.harness_is_configured",
+        lambda harness: False,
+    )
+
+    frame = HostLaunchRunnerFrame(
+        request_id="req_unlimited",
+        binding_token="token_ok",
+        workspace=str(workspace),
+        harness="codex",
+    )
+    try:
+        result = await host._handle_launch(frame)
+        # Reached the harness check — not stopped by capacity.
+        assert result.status == "failed"
+        assert result.error_code == HARNESS_NOT_CONFIGURED_ERROR_CODE
+    finally:
+        for p in procs:
+            p.terminate()
+            p.wait()
+        _cleanup_host(host)
+
+
+async def test_handle_launch_capacity_counts_only_live_runners(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The cap counts only LIVE runners: a dead handle occupying the dict must
+    not consume a slot (``_alive_runner_ids`` prunes it first), so a launch
+    under a cap of 1 with only a dead runner present proceeds.
+    """
+    monkeypatch.setenv("OMNIGENT_HOST_MAX_RUNNERS", "1")
+    host = _make_host_process()
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    dead_proc = subprocess.Popen(["true"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    dead_proc.wait()
+    host._runners["runner_dead"] = _RunnerHandle(
+        proc=dead_proc, log_path=tmp_path / "runner-dead.log"
+    )
+    # Harness check fails so the launch stops cleanly right after the capacity
+    # gate without spawning a real runner — proving the gate did NOT refuse.
+    monkeypatch.setattr(
+        "omnigent.host.connect.harness_is_configured",
+        lambda harness: False,
+    )
+
+    frame = HostLaunchRunnerFrame(
+        request_id="req_dead_slot",
+        binding_token="token_x",
+        workspace=str(workspace),
+        harness="codex",
+    )
+    try:
+        result = await host._handle_launch(frame)
+        # Not a capacity refusal (dead runner was pruned, slot free).
+        assert result.error_code == HARNESS_NOT_CONFIGURED_ERROR_CODE
+        # And the dead handle was cleaned up as a side effect of the count.
+        assert "runner_dead" not in host._runners
+    finally:
+        _cleanup_host(host)
 
 
 async def test_handle_launch_native_cursor_message_points_at_cursor_installer(
@@ -1304,6 +1443,40 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     assert env[RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR] == "tok"
     assert env[RUNNER_WORKSPACE_ENV_VAR] == "/ws"
     assert env[RUNNER_PARENT_PID_ENV_VAR] == "42"
+    # The prefer-mint flag is NOT set unless explicitly requested.
+    assert RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR not in env
+
+
+def test_build_runner_env_sets_prefer_mint_flag_when_requested() -> None:
+    """
+    ``prefer_binding_token_mint=True`` stamps the runner env flag so the
+    runner authenticates its server callbacks as the session owner (the
+    guest-on-shared-host case); ``False`` (the default) leaves it unset so
+    the runner keeps today's inherited-credential behavior.
+    """
+    base = {"PATH": "/usr/bin", "HOME": "/home/alice"}
+
+    on = _build_runner_env(
+        base,
+        server_url="http://server",
+        runner_id="runner_abc",
+        binding_token="tok",
+        workspace="/ws",
+        parent_pid=42,
+        prefer_binding_token_mint=True,
+    )
+    assert on[RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR] == "1"
+
+    off = _build_runner_env(
+        base,
+        server_url="http://server",
+        runner_id="runner_abc",
+        binding_token="tok",
+        workspace="/ws",
+        parent_pid=42,
+        prefer_binding_token_mint=False,
+    )
+    assert RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR not in off
 
 
 def test_build_runner_env_forwards_harness_credentials_and_endpoints() -> None:
@@ -2382,3 +2555,27 @@ def test_run_host_process_announces_session_log_dir_on_start(
     out = capsys.readouterr().out
     assert "Session logs: ~/.omnigent/logs/runner/" in out
     assert "This host's log: ~/.omnigent/logs/host/host-" in out
+
+
+async def test_dispatch_shutdown_terminates_runners_and_raises(tmp_path: Path) -> None:
+    """
+    Verify a host.shutdown frame terminates every tracked runner and
+    raises HostShutdownRequested so the reconnect loop exits instead
+    of treating the disconnect as transient.
+    """
+    from omnigent.host.connect import HostShutdownRequested
+    from omnigent.host.frames import HostShutdownFrame
+
+    host = _make_host_process()
+    proc = subprocess.Popen(
+        ["sleep", "60"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    host._runners["runner_shut"] = _RunnerHandle(proc=proc, log_path=tmp_path / "runner-s.log")
+
+    with pytest.raises(HostShutdownRequested, match="maintenance"):
+        await host._dispatch_host_frame(object(), HostShutdownFrame(reason="maintenance"))
+
+    assert proc.poll() is not None, "Runner must be terminated on shutdown"
+    assert host._runners == {}

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -128,6 +128,51 @@ def test_launch_runner_frame_round_trip() -> None:
     assert decoded.binding_token == "secret_token_xyz"
     assert decoded.workspace == "/Users/corey/projects/frontend"
     assert decoded.session_id == "conv_abc123"
+    # Default when unset — today's behavior.
+    assert decoded.prefer_binding_token_mint is False
+
+
+def test_launch_runner_frame_prefer_binding_token_mint_round_trip() -> None:
+    """
+    Verify prefer_binding_token_mint=True survives encode → decode.
+
+    This flag steers a guest-on-shared-host runner to authenticate as
+    the session owner; if it were dropped on the wire, the guest
+    session's spec callbacks would 404 as they do today.
+    """
+    original = HostLaunchRunnerFrame(
+        request_id="req_002",
+        binding_token="tok",
+        workspace="/ws",
+        prefer_binding_token_mint=True,
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostLaunchRunnerFrame)
+    assert decoded.prefer_binding_token_mint is True
+
+
+def test_launch_runner_frame_missing_prefer_flag_defaults_false() -> None:
+    """
+    Verify a frame from an OLD server (field absent) decodes to False.
+
+    Wire compatibility (FR-004 / SC-005): a new host receiving a
+    launch frame produced before this field existed must degrade to
+    today's host-owner-credential behavior, not error.
+    """
+    from omnigent.host.frames import HostFrameKind
+
+    old_frame = json.dumps(
+        {
+            "kind": HostFrameKind.LAUNCH_RUNNER.value,
+            "request_id": "req_003",
+            "binding_token": "tok",
+            "workspace": "/ws",
+            "harness": None,
+        }
+    )
+    decoded = decode_host_frame(old_frame)
+    assert isinstance(decoded, HostLaunchRunnerFrame)
+    assert decoded.prefer_binding_token_mint is False
 
 
 def test_launch_runner_result_frame_success_round_trip() -> None:
@@ -988,6 +1033,19 @@ def test_create_dir_result_error_round_trip() -> None:
     assert decoded.status == "ok"
     assert decoded.path is None
     assert decoded.error == "directory already exists"
+
+
+def test_shutdown_frame_round_trip() -> None:
+    """host.shutdown encodes and decodes with its optional reason."""
+    from omnigent.host.frames import HostShutdownFrame
+
+    decoded = decode_host_frame(encode_host_frame(HostShutdownFrame(reason="shut down by admin")))
+    assert isinstance(decoded, HostShutdownFrame)
+    assert decoded.reason == "shut down by admin"
+
+    bare = decode_host_frame(encode_host_frame(HostShutdownFrame()))
+    assert isinstance(bare, HostShutdownFrame)
+    assert bare.reason is None
 
 
 def test_fs_request_round_trip() -> None:

--- a/tests/inner/test_pi_native_executor.py
+++ b/tests/inner/test_pi_native_executor.py
@@ -131,6 +131,32 @@ async def test_turn_refreshes_baked_bearer(tmp_path: Path, monkeypatch) -> None:
     assert refreshed == [{"Authorization": "Bearer tok"}, {"Authorization": "Bearer tok"}]
 
 
+async def test_turn_refresh_supplies_only_bearer(tmp_path: Path, monkeypatch) -> None:
+    """The per-turn refresh rotates ONLY the bearer.
+
+    The guest-on-shared-host X-Omnigent-Runner-Tunnel-Token is written at launch
+    (runner-main process, which has the binding token). The refresh runs in a
+    harness worker whose env has the token scrubbed, so it can only supply the
+    bearer — and it must, so ``refresh_config_auth_headers`` MERGES it over the
+    existing headers and the launch-written tunnel token survives (covered by
+    ``test_refresh_config_auth_headers_preserves_launch_headers``).
+    """
+    import omnigent.runner._entry as entry
+
+    monkeypatch.setattr(entry, "_make_auth_token_factory", lambda *a, **k: lambda: "tok")
+    monkeypatch.setattr(pne, "enqueue_user_message", lambda *a: "msg")
+    refreshed: list[dict[str, str]] = []
+    monkeypatch.setattr(
+        pne,
+        "refresh_config_auth_headers",
+        lambda bridge_dir, headers: bool(refreshed.append(headers)),
+    )
+    ex = pne.PiNativeExecutor(bridge_dir=tmp_path)
+
+    [_ async for _ in ex.run_turn([{"role": "user", "content": "hi"}], [], "")]
+    assert refreshed == [{"Authorization": "Bearer tok"}]
+
+
 async def test_turn_refresh_is_best_effort(tmp_path: Path, monkeypatch) -> None:
     """A mint failure never blocks the turn (best-effort refresh)."""
     import omnigent.runner._entry as entry

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -59,6 +59,7 @@ from omnigent.runner.app import (
     _auto_create_claude_terminal,
     _auto_create_codex_terminal,
     _auto_create_cursor_terminal,
+    _auto_create_hermes_terminal,
     _auto_create_kiro_terminal,
     _auto_create_pi_terminal,
     _auto_create_repl_terminal,
@@ -18375,3 +18376,150 @@ async def test_events_stop_session_on_kiro_native_503_when_kill_fails(
         f"No session.status: idle should be enqueued when kill_session failed; "
         f"got {status_idle!r}."
     )
+
+
+@pytest.mark.parametrize(
+    ("prefer_binding_mint", "binding_token", "expect_tunnel_header"),
+    [
+        # Guest-on-shared-host: flag set + token present -> attach the header so
+        # the forwarder's POST /events is authorized against THIS session.
+        (True, "tok-binding-123", True),
+        # Own-host run: flag unset -> no tunnel header (SP bearer suffices).
+        (False, "tok-binding-123", False),
+        # Flag set but no binding token (e.g. header/proxy auth) -> nothing to attach.
+        (True, None, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_auto_create_hermes_terminal_attaches_tunnel_token_on_shared_host(
+    prefer_binding_mint: bool,
+    binding_token: str | None,
+    expect_tunnel_header: bool,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Hermes transcript forwarder + approval mirror get the tunnel binding
+    token as ``X-Omnigent-Runner-Tunnel-Token`` when the server flags the runner
+    guest-on-shared-host, and NOT on ordinary own-host runs.
+
+    Without the header, a shared/externally-owned host (e.g. a CoDA Databricks
+    App serving another user's session) sends only the SP bearer, which has no
+    user grant on the human's conversation, so the POST /v1/sessions/{id}/events
+    is 404-masked and the Hermes transcript never reaches Chat.
+    """
+    import omnigent.hermes_native as hermes_native_mod
+    import omnigent.hermes_native_bridge as hermes_bridge_mod
+    import omnigent.hermes_native_forwarder as hermes_forwarder_mod
+    import omnigent.hermes_native_permissions as hermes_perms_mod
+    import omnigent.runner._entry as entry_mod
+    import omnigent.runner.app as runner_app_mod
+    from omnigent.runner.identity import (
+        RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR,
+        RUNNER_TUNNEL_TOKEN_HEADER,
+    )
+    from omnigent.runner.resource_registry import HERMES_NATIVE_TERMINAL_ROLE
+
+    session_id = "conv_hermes_shared_host"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    bridge_dir = tmp_path / "hermes-bridge"
+    bridge_dir.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+    if prefer_binding_mint:
+        monkeypatch.setenv(RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR, "1")
+    else:
+        monkeypatch.delenv(RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR, raising=False)
+
+    # Stub the bridge/native helpers the auto-create path imports at runtime.
+    monkeypatch.setattr(hermes_bridge_mod, "bridge_dir_for_session_id", lambda _sid: bridge_dir)
+    monkeypatch.setattr(hermes_bridge_mod, "write_policy_hook_config", lambda *a, **k: None)
+    monkeypatch.setattr(hermes_bridge_mod, "read_hermes_home", lambda _bd: hermes_home)
+    monkeypatch.setattr(hermes_bridge_mod, "write_tmux_target", lambda *a, **k: None)
+    monkeypatch.setattr(hermes_forwarder_mod, "clear_hermes_bridge_state", lambda _bd: None)
+    monkeypatch.setattr(
+        runner_app_mod, "clear_hermes_status_state", lambda _bd: None, raising=False
+    )
+    import omnigent.hermes_native_status as hermes_status_mod
+
+    monkeypatch.setattr(hermes_status_mod, "clear_hermes_status_state", lambda _bd: None)
+    monkeypatch.setattr(hermes_native_mod, "resolve_hermes_executable", lambda: "/bin/hermes")
+
+    # Resolve the binding token from the (cached) runner entry helper.
+    monkeypatch.setattr(entry_mod, "_runner_tunnel_binding_token_from_env", lambda: binding_token)
+    monkeypatch.setattr(entry_mod, "_make_auth_token_factory", lambda *a, **k: None)
+
+    # Session snapshot (workspace + no fork).
+    async def _fake_launch_config(**_kwargs: Any) -> _PiNativeLaunchConfig:
+        return _PiNativeLaunchConfig(
+            workspace=workspace,
+            server_url="http://ap.example",
+            terminal_launch_args=[],
+            external_session_id=None,
+        )
+
+    monkeypatch.setattr(runner_app_mod, "_pi_native_launch_config", _fake_launch_config)
+
+    # Capture the headers passed to both runner-owned supervisors.
+    captured: dict[str, dict[str, str]] = {}
+
+    async def _fake_forwarder(*, headers: dict[str, str], **_k: Any) -> None:
+        captured["forwarder"] = headers
+
+    async def _fake_approval(*, headers: dict[str, str], **_k: Any) -> None:
+        captured["approval"] = headers
+
+    monkeypatch.setattr(hermes_forwarder_mod, "supervise_hermes_forwarder", _fake_forwarder)
+    monkeypatch.setattr(hermes_perms_mod, "supervise_hermes_approval_mirror", _fake_approval)
+
+    class _FakeResourceRegistry:
+        """Resource registry that records the required-terminal launch."""
+
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            *,
+            resource_role: str | None = None,
+            **_kwargs: Any,
+        ) -> SessionResourceView:
+            assert terminal_name == "hermes"
+            assert session_key == "main"
+            assert resource_role == HERMES_NATIVE_TERMINAL_ROLE
+            return SessionResourceView(
+                id="terminal_hermes_main",
+                type="terminal",
+                session_id=session_id,
+                name="Hermes",
+            )
+
+    try:
+        await _auto_create_hermes_terminal(
+            session_id,
+            cast(SessionResourceRegistry, _FakeResourceRegistry()),
+            lambda _sid, _event: None,
+            server_client=cast(httpx.AsyncClient, NullServerClient()),
+        )
+        # Let the supervisor task run so it captures the headers.
+        for _ in range(10):
+            await asyncio.sleep(0)
+            if "forwarder" in captured and "approval" in captured:
+                break
+    finally:
+        await runner_app_mod._cancel_auto_forwarder_task(session_id)
+
+    assert "forwarder" in captured, "forwarder supervisor was not started"
+    assert "approval" in captured, "approval mirror supervisor was not started"
+
+    if expect_tunnel_header:
+        assert captured["forwarder"].get(RUNNER_TUNNEL_TOKEN_HEADER) == binding_token
+        assert captured["approval"].get(RUNNER_TUNNEL_TOKEN_HEADER) == binding_token
+    else:
+        assert RUNNER_TUNNEL_TOKEN_HEADER not in captured["forwarder"]
+        assert RUNNER_TUNNEL_TOKEN_HEADER not in captured["approval"]

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -44,6 +44,20 @@ from omnigent.runner.transports.ws_tunnel.serve import RUNNER_TUNNEL_REJECTION_P
 importlib.import_module("mcp.client.streamable_http")
 
 
+@pytest.fixture(autouse=True)
+def _reset_captured_binding_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear the process-global binding-token cache before each test.
+
+    ``_runner_tunnel_binding_token_from_env`` caches the token on first read so
+    it survives the post-startup env scrub. That cache is module-global, so a
+    test that sets a token would otherwise leak it into a later test asserting
+    "no token". Reset it per test for isolation.
+    """
+    import omnigent.runner._entry as _entry
+
+    monkeypatch.setattr(_entry, "_CAPTURED_BINDING_TOKEN", None)
+
+
 class _TrackingTerminalRegistry:
     """TerminalRegistry stand-in that records shutdown calls."""
 
@@ -220,6 +234,109 @@ def test_make_auth_token_factory_uses_managed_mint_when_only_binding_token(
 
     assert factory is not None
     assert factory() == "managed-jwt"
+
+
+def test_make_auth_token_factory_flag_does_not_force_mint_over_user_cred(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag set does NOT force the owner-JWT mint for the tunnel/callback bearer.
+
+    The prefer flag drives the binding-token HEADER on the callback client
+    (feature 002), NOT a token mint here. Forcing the mint would break the
+    tunnel bearer in header mode (the mint 302s/400s → runner_failed_to_start).
+    So even with the flag set, an available inherited credential still wins in
+    _make_auth_token_factory; the header path grants read separately.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :returns: None.
+    """
+    from omnigent.inner.databricks_executor import _DatabricksBearerAuth
+
+    class _Cfg:
+        def authenticate(self) -> dict[str, str]:
+            return {"Authorization": "Bearer inherited-host-owner-token"}
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://omnigent.example.com")
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "binding-token")
+    monkeypatch.setenv("OMNIGENT_RUNNER_PREFER_BINDING_TOKEN_MINT", "1")
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr(
+        "omnigent.inner.databricks_executor._resolve_databricks_auth",
+        lambda profile=None: (_DatabricksBearerAuth(_Cfg(), profile_name=None), "https://ex.test"),
+    )
+
+    factory = _make_auth_token_factory()
+
+    assert factory is not None
+    # Inherited credential still wins — the flag did NOT force a mint.
+    assert factory() == "inherited-host-owner-token"
+
+
+def test_make_auth_token_factory_flag_unset_keeps_user_cred_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag UNSET keeps today's order (user credential first), even with a token.
+
+    Owner-on-own-host (US2 regression guard): the server never sets the
+    flag when session owner == host owner, so the runner must use its
+    inherited credential exactly as before — not mint.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :returns: None.
+    """
+    from omnigent.inner.databricks_executor import _DatabricksBearerAuth
+
+    class _Cfg:
+        def authenticate(self) -> dict[str, str]:
+            return {"Authorization": "Bearer inherited-token"}
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://omnigent.example.com")
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "binding-token")
+    monkeypatch.delenv("OMNIGENT_RUNNER_PREFER_BINDING_TOKEN_MINT", raising=False)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr(
+        "omnigent.inner.databricks_executor._resolve_databricks_auth",
+        lambda profile=None: (_DatabricksBearerAuth(_Cfg(), profile_name=None), "https://ex.test"),
+    )
+
+    factory = _make_auth_token_factory()
+
+    assert factory is not None
+    assert factory() == "inherited-token"
+
+
+def test_make_auth_token_factory_flag_set_no_binding_token_safe_degrade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag set but NO binding token → fall through, do not crash (FR-007).
+
+    Safe degrade: if the runner is told to prefer the mint but has no
+    binding token to mint against, it must fall back to the normal order
+    (here, the inherited credential) rather than raising and aborting the
+    launch.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :returns: None.
+    """
+    from omnigent.inner.databricks_executor import _DatabricksBearerAuth
+
+    class _Cfg:
+        def authenticate(self) -> dict[str, str]:
+            return {"Authorization": "Bearer fallback-token"}
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://omnigent.example.com")
+    monkeypatch.delenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", raising=False)
+    monkeypatch.setenv("OMNIGENT_RUNNER_PREFER_BINDING_TOKEN_MINT", "1")
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr(
+        "omnigent.inner.databricks_executor._resolve_databricks_auth",
+        lambda profile=None: (_DatabricksBearerAuth(_Cfg(), profile_name=None), "https://ex.test"),
+    )
+
+    factory = _make_auth_token_factory()
+
+    assert factory is not None
+    assert factory() == "fallback-token"
 
 
 def test_make_auth_token_factory_none_without_creds_or_binding_token(
@@ -798,6 +915,9 @@ def test_runner_tunnel_binding_token_from_env_returns_none_without_token(
     :param monkeypatch: Pytest environment patch fixture.
     :returns: None.
     """
+    import omnigent.runner._entry as _entry
+
+    monkeypatch.setattr(_entry, "_CAPTURED_BINDING_TOKEN", None)
     monkeypatch.delenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", raising=False)
 
     assert _runner_tunnel_binding_token_from_env() is None
@@ -811,6 +931,9 @@ def test_runner_tunnel_binding_token_from_env_rejects_empty_token(
     :param monkeypatch: Pytest environment patch fixture.
     :returns: None.
     """
+    import omnigent.runner._entry as _entry
+
+    monkeypatch.setattr(_entry, "_CAPTURED_BINDING_TOKEN", None)
     monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "  ")
 
     with pytest.raises(RuntimeError, match="must not be empty"):
@@ -825,8 +948,32 @@ def test_runner_tunnel_binding_token_from_env_strips_value(
     :param monkeypatch: Pytest environment patch fixture.
     :returns: None.
     """
+    import omnigent.runner._entry as _entry
+
+    monkeypatch.setattr(_entry, "_CAPTURED_BINDING_TOKEN", None)
     monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", " bind-token ")
 
+    assert _runner_tunnel_binding_token_from_env() == "bind-token"
+
+
+def test_runner_tunnel_binding_token_survives_env_scrub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The token, captured on first read, survives a later os.environ scrub.
+
+    The sandbox launcher / child-spawn scrubbers pop the binding token from
+    ``os.environ`` after startup. A later in-process reader (e.g. the pi
+    terminal auto-create building the extension config) must still get it from
+    the captured value, or the extension's POST /events self-access 404-masks.
+    """
+    import omnigent.runner._entry as _entry
+
+    monkeypatch.setattr(_entry, "_CAPTURED_BINDING_TOKEN", None)
+    # First read at startup, before any scrub — populates the cache.
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "bind-token")
+    assert _runner_tunnel_binding_token_from_env() == "bind-token"
+    # Env scrubbed (token popped) — the reader must fall back to the capture.
+    monkeypatch.delenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", raising=False)
     assert _runner_tunnel_binding_token_from_env() == "bind-token"
 
 
@@ -1641,3 +1788,75 @@ def test_agent_cache_dest_normal_id_round_trips(tmp_path: Path) -> None:
     dest = _agent_cache_dest(cache_root, "ag_abc123", "3")
 
     assert dest == cache_root / "ag_abc123-v3"
+
+
+def _run_create_app_capturing_client_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, str]:
+    """Drive create_app() with fakes and return the server_client headers.
+
+    Monkeypatches httpx.AsyncClient to capture the headers kwarg the runner's
+    callback client is built with, plus the minimal set of runner dependencies
+    so create_app() constructs without real I/O.
+    """
+    import omnigent.runner._entry as entry_mod
+
+    captured: dict[str, dict[str, str]] = {}
+
+    class _CapturingAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            del args
+            captured["headers"] = dict(kwargs.get("headers") or {})
+
+        async def aclose(self) -> None:
+            pass
+
+    class _FakePM:
+        def __init__(self) -> None: ...
+        async def start(self) -> None: ...
+        async def shutdown(self) -> None: ...
+
+    def _tr_factory(*, conversation_link_base_url: str | None = None) -> _TrackingTerminalRegistry:
+        return _TrackingTerminalRegistry(conversation_link_base_url=conversation_link_base_url)
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://runner.test")
+    monkeypatch.setattr(entry_mod.httpx, "AsyncClient", _CapturingAsyncClient)
+    monkeypatch.setattr(entry_mod.httpx, "Client", _TrackingSyncClient)
+    monkeypatch.setattr(entry_mod, "_make_auth_token_factory", lambda: None)
+    monkeypatch.setattr(
+        "omnigent.runtime.harnesses.process_manager.HarnessProcessManager", _FakePM
+    )
+    monkeypatch.setattr("omnigent.terminals.TerminalRegistry", _tr_factory)
+    monkeypatch.setattr("omnigent.runner.identity.get_stable_runner_id", lambda: "runner-test-id")
+    entry_mod.create_app()
+    return captured["headers"]
+
+
+def test_server_client_attaches_binding_token_when_prefer_flag_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the prefer flag + a binding token, the callback client sends the
+    tunnel-token header (feature 002 — header-mode guest access)."""
+    from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER
+
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "bind-tok-123")
+    monkeypatch.setenv("OMNIGENT_RUNNER_PREFER_BINDING_TOKEN_MINT", "1")
+
+    headers = _run_create_app_capturing_client_headers(monkeypatch)
+
+    assert headers.get(RUNNER_TUNNEL_TOKEN_HEADER) == "bind-tok-123"
+
+
+def test_server_client_omits_binding_token_without_prefer_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the prefer flag, the callback client does NOT send the tunnel
+    token (own-host / ordinary runs are unchanged)."""
+    from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER
+
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "bind-tok-123")
+    monkeypatch.delenv("OMNIGENT_RUNNER_PREFER_BINDING_TOKEN_MINT", raising=False)
+
+    headers = _run_create_app_capturing_client_headers(monkeypatch)
+
+    assert RUNNER_TUNNEL_TOKEN_HEADER not in headers

--- a/tests/server/integration/test_accounts_auth_e2e.py
+++ b/tests/server/integration/test_accounts_auth_e2e.py
@@ -25,6 +25,9 @@ import pytest_asyncio
 from fastapi import FastAPI
 
 from omnigent.server.auth import create_auth_provider
+from omnigent.stores.host_permission_store.sqlalchemy_store import (
+    SqlAlchemyHostPermissionStore,
+)
 from omnigent.stores.permission_store.sqlalchemy_store import (
     SqlAlchemyPermissionStore,
 )
@@ -116,6 +119,7 @@ def _build_app(
         comment_store=comment_store,
         permission_store=permission_store,
         host_store=host_store,
+        host_permission_store=SqlAlchemyHostPermissionStore(db_url),
         auth_provider=auth_provider,
         account_store=account_store,
     )

--- a/tests/server/integration/test_app.py
+++ b/tests/server/integration/test_app.py
@@ -15,6 +15,7 @@ from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.host_permission_store.sqlalchemy_store import SqlAlchemyHostPermissionStore
 from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
 
 pytestmark = pytest.mark.asyncio
@@ -211,6 +212,7 @@ async def test_host_routes_mounted_with_host_store(
             cache_dir=tmp_path / "cache",
         ),
         host_store=HostStore(db_uri),
+        host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
     )
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/server/integration/test_host_liveness_staleness_e2e.py
+++ b/tests/server/integration/test_host_liveness_staleness_e2e.py
@@ -52,6 +52,7 @@ from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.host_permission_store.sqlalchemy_store import SqlAlchemyHostPermissionStore
 from omnigent.stores.host_store import HOST_LIVENESS_TTL_S, HostStore
 from tests.server.helpers import create_test_agent
 
@@ -91,6 +92,7 @@ async def host_aware_client(
         ),
         comment_store=SqlAlchemyCommentStore(db_uri),
         host_store=HostStore(db_uri),
+        host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
     )
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),

--- a/tests/server/integration/test_host_runner_launch_worktree.py
+++ b/tests/server/integration/test_host_runner_launch_worktree.py
@@ -46,6 +46,7 @@ from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.host_permission_store.sqlalchemy_store import SqlAlchemyHostPermissionStore
 from omnigent.stores.host_store import HostStore
 from tests.server.helpers import create_test_agent
 
@@ -81,6 +82,7 @@ def app(runtime_init: None, db_uri: str, tmp_path: Path) -> FastAPI:
         ),
         comment_store=SqlAlchemyCommentStore(db_uri),
         host_store=HostStore(db_uri),
+        host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
     )
 
 

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -42,6 +42,9 @@ from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.host_permission_store.sqlalchemy_store import (
+    SqlAlchemyHostPermissionStore,
+)
 from omnigent.stores.host_store import HostStore
 from tests.server.helpers import (
     FakeSandboxLauncher,
@@ -107,13 +110,19 @@ def binding_app(
     registry = HostRegistry()
     host_store = HostStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
+    host_permission_store = SqlAlchemyHostPermissionStore(db_uri)
     app = FastAPI()
     app.include_router(
         create_host_tunnel_router(registry, host_store),
         prefix="/v1",
     )
     app.include_router(
-        create_hosts_router(registry, host_store, conv_store),
+        create_hosts_router(
+            registry,
+            host_store,
+            conv_store,
+            host_permission_store=host_permission_store,
+        ),
         prefix="/v1",
     )
     return app, registry, host_store, conv_store
@@ -269,6 +278,7 @@ async def managed_session_env(
         ),
         comment_store=SqlAlchemyCommentStore(db_uri),
         host_store=host_store,
+        host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
         # The production YAML parse path: its modal factory resolves
         # ModalSandboxLauncher at call time, which the test substitutes
         # via install_fake_modal_launcher.
@@ -606,6 +616,7 @@ async def test_managed_session_create_without_config_fails_clearly(
         ),
         comment_store=SqlAlchemyCommentStore(db_uri),
         host_store=HostStore(db_uri),
+        host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
     )
     async with AsyncClient(
         transport=ASGITransport(app=app),

--- a/tests/server/integration/test_hosts_api.py
+++ b/tests/server/integration/test_hosts_api.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from httpx import ASGITransport, AsyncClient
 
+from omnigent.db.utils import now_epoch
 from omnigent.host.frames import (
     HostHelloFrame,
     HostLaunchRunnerResultFrame,
@@ -25,6 +26,9 @@ from omnigent.server.routes.host_tunnel import create_host_tunnel_router
 from omnigent.server.routes.hosts import create_hosts_router
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
+)
+from omnigent.stores.host_permission_store.sqlalchemy_store import (
+    SqlAlchemyHostPermissionStore,
 )
 from omnigent.stores.host_store import HostStore
 from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
@@ -88,13 +92,20 @@ def host_api_app(
     registry = HostRegistry()
     host_store = HostStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
+    host_permission_store = SqlAlchemyHostPermissionStore(db_uri)
     app = FastAPI()
+    app.state.host_permission_store = host_permission_store
     app.include_router(
         create_host_tunnel_router(registry, host_store),
         prefix="/v1",
     )
     app.include_router(
-        create_hosts_router(registry, host_store, conv_store),
+        create_hosts_router(
+            registry,
+            host_store,
+            conv_store,
+            host_permission_store=host_permission_store,
+        ),
         prefix="/v1",
     )
     return app, registry, host_store, conv_store
@@ -335,9 +346,15 @@ async def test_list_and_get_host_report_online_from_other_replica(
     registry_a = HostRegistry()
     host_store_a = HostStore(db_uri)
     conv_store_a = SqlAlchemyConversationStore(db_uri)
+    host_permission_store_a = SqlAlchemyHostPermissionStore(db_uri)
     app_a = FastAPI()
     app_a.include_router(
-        create_hosts_router(registry_a, host_store_a, conv_store_a),
+        create_hosts_router(
+            registry_a,
+            host_store_a,
+            conv_store_a,
+            host_permission_store=host_permission_store_a,
+        ),
         prefix="/v1",
     )
     assert registry_a.get(_HOST_ID) is None, (
@@ -661,10 +678,32 @@ def multi_user_app(
     host_store = HostStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
     permission_store = SqlAlchemyPermissionStore(db_uri)
+    host_permission_store = SqlAlchemyHostPermissionStore(db_uri)
     auth = _StubAuthProvider()
     app = FastAPI()
-    # Stash the permission store so tests can set up session grants.
+    # Stash the stores so tests can set up session and host grants.
     app.state.permission_store = permission_store
+    app.state.host_permission_store = host_permission_store
+
+    # Same OmnigentError → JSON handler create_app installs, so auth
+    # failures (require_user raises OmnigentError, not HTTPException)
+    # surface as 401 responses instead of raising through the client.
+    from omnigent.errors import OmnigentError
+
+    @app.exception_handler(OmnigentError)
+    async def _handle_omnigent_error(request: object, exc: OmnigentError) -> JSONResponse:
+        """Convert OmnigentError to the production JSON error shape.
+
+        :param request: The incoming request (unused).
+        :param exc: The application error raised by the route.
+        :returns: The same JSON body create_app's handler produces.
+        """
+        del request
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
     app.include_router(
         # local_single_user=False: this fixture models a deployed
         # multi-user server, so host_id re-own must be refused (the
@@ -683,6 +722,7 @@ def multi_user_app(
             conv_store,
             auth_provider=auth,
             permission_store=permission_store,
+            host_permission_store=host_permission_store,
         ),
         prefix="/v1",
     )
@@ -823,6 +863,7 @@ async def test_launch_runner_validates_workspace_boundary(
     registry = HostRegistry()
     host_store = HostStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
+    host_permission_store = SqlAlchemyHostPermissionStore(db_uri)
     agent_store = SqlAlchemyAgentStore(db_uri)
     artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
     agent_cache = AgentCache(artifact_store=artifact_store, cache_dir=tmp_path / "cache")
@@ -835,6 +876,7 @@ async def test_launch_runner_validates_workspace_boundary(
             registry,
             host_store,
             conv_store,
+            host_permission_store=host_permission_store,
             agent_store=agent_store,
             agent_cache=agent_cache,
         ),
@@ -986,6 +1028,7 @@ async def test_resolve_host_launch_enforces_host_and_session_ownership(
     host_store = HostStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
     perm = SqlAlchemyPermissionStore(db_uri)
+    host_perm = SqlAlchemyHostPermissionStore(db_uri)
 
     # Alice owns an online host and a session.
     host_store.upsert_on_connect(
@@ -1001,6 +1044,7 @@ async def test_resolve_host_launch_enforces_host_and_session_ownership(
         "host_registry": registry,
         "conversation_store": conv_store,
         "permission_store": perm,
+        "host_permission_store": host_perm,
     }
 
     # Happy path: Alice owns both → returns the resolved target.
@@ -1255,3 +1299,581 @@ async def test_runner_exited_invokes_callback_with_runner_and_error(
 
     # The callback got the exact runner id and error string off the frame.
     assert received == [("runner_x", "exited with code 1")]
+
+
+# ── Admin fleet view (?all=true) ────────────────────────
+
+
+async def test_list_all_hosts_admin_sees_every_owner(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    Verify GET /v1/hosts?all=true returns every owner's hosts to an
+    admin, with the fleet-only fields (created_at, last_seen,
+    session_count) present.
+    """
+    app, _reg, host_store, conv_store = multi_user_app
+    perm_store: SqlAlchemyPermissionStore = app.state.permission_store
+    perm_store.ensure_user("admin@test.com", is_admin=True)
+    host_store.upsert_on_connect("host_fleet_a", "alice-laptop", "alice@test.com")
+    host_store.upsert_on_connect("host_fleet_b", "bob-laptop", "bob@test.com")
+    # Two sessions bound to alice's host so session_count has signal.
+    for _ in range(2):
+        conv = conv_store.create_conversation(agent_id=None)
+        conv_store.set_host_id(conv.id, "host_fleet_a", "/tmp/ws")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            "/v1/hosts",
+            params={"all": "true"},
+            headers={"x-test-user": "admin@test.com"},
+        )
+    assert resp.status_code == 200
+    hosts = {h["host_id"]: h for h in resp.json()["hosts"]}
+    assert {"host_fleet_a", "host_fleet_b"} <= set(hosts), (
+        f"Admin should see every owner's hosts, got {set(hosts)}."
+    )
+    fleet_a = hosts["host_fleet_a"]
+    assert fleet_a["owner"] == "alice@test.com"
+    assert fleet_a["session_count"] == 2
+    assert isinstance(fleet_a["created_at"], int)
+    assert isinstance(fleet_a["last_seen"], int)
+
+
+async def test_list_all_hosts_403_non_admin(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    Verify GET /v1/hosts?all=true fails closed (403) for a non-admin —
+    NOT a silently owner-filtered 200 they could mistake for the fleet.
+    """
+    app, _reg, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_fleet_c", "alice-laptop", "alice@test.com")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            "/v1/hosts",
+            params={"all": "true"},
+            headers={"x-test-user": "bob@test.com"},
+        )
+    assert resp.status_code == 403, (
+        f"Expected 403 for non-admin ?all=true, got {resp.status_code}. "
+        "The admin fleet view must fail closed."
+    )
+
+
+async def test_list_all_hosts_plain_list_unchanged_for_admin(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    Verify the default (no ?all) listing stays owner-scoped even for
+    an admin, and carries none of the fleet-only fields — the picker
+    payload is unchanged by the admin feature (additive/opt-in).
+    """
+    app, _reg, host_store, _cs = multi_user_app
+    perm_store: SqlAlchemyPermissionStore = app.state.permission_store
+    perm_store.ensure_user("admin@test.com", is_admin=True)
+    host_store.upsert_on_connect("host_fleet_d", "alice-laptop", "alice@test.com")
+    host_store.upsert_on_connect("host_fleet_e", "admin-laptop", "admin@test.com")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            "/v1/hosts",
+            headers={"x-test-user": "admin@test.com"},
+        )
+    assert resp.status_code == 200
+    hosts = resp.json()["hosts"]
+    assert {h["host_id"] for h in hosts} == {"host_fleet_e"}
+    assert "session_count" not in hosts[0]
+    assert "last_seen" not in hosts[0]
+
+
+# ── Host shutdown (POST /v1/hosts/{id}/shutdown) ────────────────────────
+
+
+def _register_live_conn(registry: HostRegistry, host_id: str, owner: str) -> object:
+    """Register a fake live connection so send_text enqueues frames.
+
+    :param registry: The registry under test.
+    :param host_id: Host identifier to register.
+    :param owner: Owner identity for the connection.
+    :returns: The registered HostConnection (queue readable by tests).
+    """
+    hello = HostHelloFrame(version="0", frame_protocol_version=1, name=host_id)
+    return registry.register(host_id, ws=object(), hello=hello, owner=owner)
+
+
+async def test_shutdown_host_owner_sends_frame(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    Verify the owner can shut their host down: 200, and a
+    host.shutdown frame is enqueued on the host's tunnel.
+    """
+    import json as _json
+
+    app, registry, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_shut_a", "alice-laptop", "alice@test.com")
+    conn = _register_live_conn(registry, "host_shut_a", "alice@test.com")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/hosts/host_shut_a/shutdown",
+            headers={"x-test-user": "alice@test.com"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "shutting_down"}
+    frame = _json.loads(conn.outbound_queue.get_nowait())
+    assert frame["kind"] == "host.shutdown"
+    assert "alice@test.com" in frame["reason"]
+
+
+async def test_shutdown_host_admin_non_owner_allowed(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    Verify an admin who does NOT own the host can still shut it down
+    (the operator reclaim path).
+    """
+    app, registry, host_store, _cs = multi_user_app
+    perm_store: SqlAlchemyPermissionStore = app.state.permission_store
+    perm_store.ensure_user("admin@test.com", is_admin=True)
+    host_store.upsert_on_connect("host_shut_b", "alice-laptop", "alice@test.com")
+    _register_live_conn(registry, "host_shut_b", "alice@test.com")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/hosts/host_shut_b/shutdown",
+            headers={"x-test-user": "admin@test.com"},
+        )
+    assert resp.status_code == 200
+
+
+async def test_shutdown_host_403_non_owner_non_admin(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    Verify shutdown fails closed for a caller who is neither the owner
+    nor an admin — and no frame reaches the host.
+    """
+    app, registry, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_shut_c", "alice-laptop", "alice@test.com")
+    conn = _register_live_conn(registry, "host_shut_c", "alice@test.com")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/hosts/host_shut_c/shutdown",
+            headers={"x-test-user": "bob@test.com"},
+        )
+    assert resp.status_code == 403
+    assert conn.outbound_queue.empty(), "No shutdown frame may be sent on a refused request"
+
+
+async def test_shutdown_host_409_offline(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    Verify shutdown returns 409 when the host has no live tunnel —
+    there is nothing to signal.
+    """
+    app, _reg, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_shut_d", "alice-laptop", "alice@test.com")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/hosts/host_shut_d/shutdown",
+            headers={"x-test-user": "alice@test.com"},
+        )
+    assert resp.status_code == 409
+
+
+async def test_shutdown_host_404_unknown(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """Verify shutdown returns 404 for an unknown host id."""
+    app, _reg, _hs, _cs = multi_user_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/hosts/host_nonexistent/shutdown",
+            headers={"x-test-user": "alice@test.com"},
+        )
+    assert resp.status_code == 404
+
+
+async def test_shutdown_host_400_managed_sandbox(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    Verify shutdown refuses managed sandbox hosts (400) — they are
+    torn down via the provider API, not a daemon-exit frame.
+    """
+    app, registry, host_store, _cs = multi_user_app
+    host_store.register_managed_host(
+        host_id="host_shut_e",
+        name="sandbox-e",
+        owner="alice@test.com",
+        token="tok-shut-e",
+        provider="modal",
+        sandbox_id="sb-1",
+        token_expires_at=now_epoch() + 3600,
+    )
+    _register_live_conn(registry, "host_shut_e", "alice@test.com")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/hosts/host_shut_e/shutdown",
+            headers={"x-test-user": "alice@test.com"},
+        )
+    assert resp.status_code == 400
+
+
+# ── Host sharing (shared visibility for SP-owned hosts) ───────────
+# Covers the feature spec acceptance criteria AC-002..AC-007: shared
+# hosts appear in /v1/hosts, a `view` grantee can read but not browse
+# or launch, a `use` grantee can, non-granted users are blocked, and
+# only owner/admin/manage can mutate grants.
+
+
+def _grant_host(app: FastAPI, user_id: str, host_id: str, level: int) -> None:
+    """Seed a host grant directly via the app's host permission store.
+
+    :param app: The multi_user_app FastAPI instance.
+    :param user_id: Grantee user id.
+    :param host_id: Host to share.
+    :param level: Host level (1=view, 2=use, 3=manage).
+    """
+    # The grantee must exist as a users row for the FK to hold.
+    app.state.permission_store.ensure_user(user_id)
+    app.state.host_permission_store.grant(user_id, host_id, level)
+
+
+async def test_shared_host_appears_in_list_for_grantee(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """AC-002: /v1/hosts returns owned + shared, excludes unshared third-party.
+
+    Alice owns one host and is granted `use` on the SP-owned host; she
+    sees both. Bob's unrelated host stays hidden from her.
+    """
+    app, _reg, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_alice", "alice-laptop", "alice@test.com")
+    host_store.upsert_on_connect("host_sp", "coda-app", "app-sp@example")
+    host_store.upsert_on_connect("host_bob", "bob-laptop", "bob@test.com")
+    _grant_host(app, "alice@test.com", "host_sp", 2)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/v1/hosts", headers={"x-test-user": "alice@test.com"})
+    assert resp.status_code == 200
+    hosts = {h["host_id"]: h for h in resp.json()["hosts"]}
+    assert set(hosts) == {"host_alice", "host_sp"}, (
+        f"Alice should see her host plus the shared SP host, got {set(hosts)}."
+    )
+    # The owned host is flagged owned; the shared host is flagged shared
+    # with a `use` level so the UI can label and gate it.
+    assert hosts["host_alice"]["owned_by_current_user"] is True
+    assert hosts["host_alice"]["permission_level"] == "owner"
+    assert hosts["host_sp"]["owned_by_current_user"] is False
+    assert hosts["host_sp"]["permission_level"] == "use"
+
+
+async def test_view_grantee_can_read_host(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """AC-003: GET /v1/hosts/{id} allows a `view` grantee."""
+    app, _reg, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_sp", "coda-app", "app-sp@example")
+    _grant_host(app, "alice@test.com", "host_sp", 1)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/v1/hosts/host_sp", headers={"x-test-user": "alice@test.com"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["host_id"] == "host_sp"
+    assert body["owned_by_current_user"] is False
+    assert body["permission_level"] == "view"
+
+
+async def test_filesystem_rejects_view_allows_use(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """AC-004: filesystem browsing rejects `view`, allows `use`.
+
+    A `view` grantee is 403 on the filesystem endpoint. A `use`
+    grantee gets past the access check (the host is offline here, so
+    the call then 409s — proving auth passed, not the browse itself).
+    """
+    app, _reg, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_sp", "coda-app", "app-sp@example")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # view grantee → 403
+        _grant_host(app, "viewer@test.com", "host_sp", 1)
+        resp = await client.get(
+            "/v1/hosts/host_sp/filesystem", headers={"x-test-user": "viewer@test.com"}
+        )
+        assert resp.status_code == 403, (
+            "A view-only grantee must not browse the host filesystem (SR-002)."
+        )
+
+        # use grantee → passes the access check; host offline → 409.
+        _grant_host(app, "user@test.com", "host_sp", 2)
+        resp = await client.get(
+            "/v1/hosts/host_sp/filesystem", headers={"x-test-user": "user@test.com"}
+        )
+        assert resp.status_code == 409, (
+            f"A use grantee should pass auth and hit 'host offline' (409); got {resp.status_code}."
+        )
+
+
+async def test_nongranted_user_blocked_everywhere(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """AC-006: a non-granted user cannot list, read, or browse another's host."""
+    app, _reg, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_sp", "coda-app", "app-sp@example")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # Not in the list.
+        resp = await client.get("/v1/hosts", headers={"x-test-user": "stranger@test.com"})
+        assert resp.json()["hosts"] == []
+        # Read → 403.
+        resp = await client.get("/v1/hosts/host_sp", headers={"x-test-user": "stranger@test.com"})
+        assert resp.status_code == 403
+        # Browse → 403.
+        resp = await client.get(
+            "/v1/hosts/host_sp/filesystem", headers={"x-test-user": "stranger@test.com"}
+        )
+        assert resp.status_code == 403
+
+
+async def test_only_owner_or_manage_can_grant(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """AC-007: only owner/admin/manage may grant or revoke host access."""
+    app, _reg, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_sp", "coda-app", "app-sp@example")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # A `use` grantee cannot grant to others.
+        _grant_host(app, "user@test.com", "host_sp", 2)
+        resp = await client.put(
+            "/v1/hosts/host_sp/permissions/victim@test.com",
+            json={"level": "view"},
+            headers={"x-test-user": "user@test.com"},
+        )
+        assert resp.status_code == 403, "A `use` grantee must not be able to grant."
+
+        # The owner can grant.
+        resp = await client.put(
+            "/v1/hosts/host_sp/permissions/alice@test.com",
+            json={"level": "manage"},
+            headers={"x-test-user": "app-sp@example"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["level"] == "manage"
+
+        # The `manage` grantee can now grant further (FR-016a chain).
+        resp = await client.put(
+            "/v1/hosts/host_sp/permissions/bob@test.com",
+            json={"level": "use"},
+            headers={"x-test-user": "alice@test.com"},
+        )
+        assert resp.status_code == 200
+
+        # The grant is visible in the permissions listing.
+        resp = await client.get(
+            "/v1/hosts/host_sp/permissions", headers={"x-test-user": "app-sp@example"}
+        )
+        assert resp.status_code == 200
+        levels = {p["user_id"]: p["level"] for p in resp.json()["permissions"]}
+        # user@test.com was seeded `use` at the top of the test; alice and
+        # bob were granted above. All three legitimate grants are listed.
+        assert levels == {
+            "user@test.com": "use",
+            "alice@test.com": "manage",
+            "bob@test.com": "use",
+        }
+
+        # Revoke works and is reflected.
+        resp = await client.delete(
+            "/v1/hosts/host_sp/permissions/bob@test.com",
+            headers={"x-test-user": "app-sp@example"},
+        )
+        assert resp.status_code == 200 and resp.json()["revoked"] is True
+
+
+async def test_cannot_grant_to_owner_or_unknown_level(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """Granting to the owner, or an invalid level, is a 400."""
+    app, _reg, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_sp", "coda-app", "app-sp@example")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.put(
+            "/v1/hosts/host_sp/permissions/app-sp@example",
+            json={"level": "view"},
+            headers={"x-test-user": "app-sp@example"},
+        )
+        assert resp.status_code == 400, "Granting to the host owner is meaningless."
+
+        resp = await client.put(
+            "/v1/hosts/host_sp/permissions/alice@test.com",
+            json={"level": "owner"},
+            headers={"x-test-user": "app-sp@example"},
+        )
+        assert resp.status_code == 400, "`owner` is not a grantable level."
+
+
+async def test_private_hosts_stay_private_with_no_grants(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """AC-001 semantics: with no grants, each user sees only their own host."""
+    app, _reg, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_alice", "alice-laptop", "alice@test.com")
+    host_store.upsert_on_connect("host_bob", "bob-laptop", "bob@test.com")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/v1/hosts", headers={"x-test-user": "alice@test.com"})
+        assert {h["host_id"] for h in resp.json()["hosts"]} == {"host_alice"}
+
+
+# ── M6 hardening: unauthenticated fail-closed + audit trail ─────────
+
+
+async def test_new_endpoints_401_unauthenticated(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    Every new endpoint fails closed with 401 when the caller presents
+    no identity at all (auth provider configured, header absent) — an
+    anonymous caller must never fall through to the single-user path.
+    """
+    app, registry, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_hard_a", "alice-laptop", "alice@test.com")
+    _register_live_conn(registry, "host_hard_a", "alice@test.com")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        for method, url, kwargs in [
+            ("GET", "/v1/hosts?all=true", {}),
+            ("POST", "/v1/hosts/host_hard_a/shutdown", {}),
+            ("GET", "/v1/hosts/host_hard_a/permissions", {}),
+            ("PUT", "/v1/hosts/host_hard_a/permissions/bob@test.com", {"json": {"level": "use"}}),
+            ("DELETE", "/v1/hosts/host_hard_a/permissions/bob@test.com", {}),
+        ]:
+            resp = await client.request(method, url, **kwargs)
+            assert resp.status_code == 401, (
+                f"{method} {url} must 401 for an unauthenticated caller, got {resp.status_code}"
+            )
+
+
+async def test_stranger_cannot_read_grant_list(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    GET /v1/hosts/{id}/permissions fails closed (403) for a caller with
+    no manage-level access — the grant list names principals and must
+    not be enumerable by a mere `use` grantee or a stranger.
+    """
+    app, _reg, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_hard_b", "alice-laptop", "alice@test.com")
+    _grant_host(app, "user@test.com", "host_hard_b", 2)  # use, not manage
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        for caller in ("stranger@test.com", "user@test.com"):
+            resp = await client.get(
+                "/v1/hosts/host_hard_b/permissions",
+                headers={"x-test-user": caller},
+            )
+            assert resp.status_code == 403, f"{caller} must not read the grant list"
+
+
+async def test_audit_trail_for_shutdown_grant_revoke(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Shutdown, grant, and revoke each emit an omnigent.audit entry
+    carrying actor + target (C-N3), so an operator can reconstruct who
+    did what from the server log alone.
+    """
+    import json as _json
+
+    app, registry, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_hard_c", "alice-laptop", "alice@test.com")
+    _register_live_conn(registry, "host_hard_c", "alice@test.com")
+
+    with caplog.at_level("INFO", logger="omnigent.audit"):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            await client.put(
+                "/v1/hosts/host_hard_c/permissions/bob@test.com",
+                json={"level": "use"},
+                headers={"x-test-user": "alice@test.com"},
+            )
+            await client.delete(
+                "/v1/hosts/host_hard_c/permissions/bob@test.com",
+                headers={"x-test-user": "alice@test.com"},
+            )
+            await client.post(
+                "/v1/hosts/host_hard_c/shutdown",
+                headers={"x-test-user": "alice@test.com"},
+            )
+
+    entries = [
+        _json.loads(r.message.removeprefix("audit: "))
+        for r in caplog.records
+        if r.name == "omnigent.audit"
+    ]
+    by_action = {e["action"]: e for e in entries}
+    assert set(by_action) == {
+        "host.permission.grant",
+        "host.permission.revoke",
+        "host.shutdown",
+    }
+    for entry in entries:
+        assert entry["actor"] == "alice@test.com"
+        assert entry["target"] == "host_hard_c"
+    assert by_action["host.permission.grant"]["principal"] == "bob@test.com"
+    assert by_action["host.permission.grant"]["level"] == "use"
+    assert by_action["host.permission.revoke"]["principal"] == "bob@test.com"
+
+
+async def test_audit_trail_for_fleet_view(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    The admin fleet enumeration (?all=true) is a security-relevant read
+    across every owner, so it emits an omnigent.audit entry with the
+    actor and a host count — an owner-scoped listing does NOT.
+    """
+    import json as _json
+
+    app, _reg, host_store, _cs = multi_user_app
+    perm_store: SqlAlchemyPermissionStore = app.state.permission_store
+    perm_store.ensure_user("admin@test.com", is_admin=True)
+    host_store.upsert_on_connect("host_fleet_audit_a", "alice-laptop", "alice@test.com")
+    host_store.upsert_on_connect("host_fleet_audit_b", "bob-laptop", "bob@test.com")
+
+    with caplog.at_level("INFO", logger="omnigent.audit"):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            # Owner-scoped read: no audit.
+            await client.get("/v1/hosts", headers={"x-test-user": "alice@test.com"})
+            # Fleet read: audited.
+            await client.get(
+                "/v1/hosts",
+                params={"all": "true"},
+                headers={"x-test-user": "admin@test.com"},
+            )
+
+    entries = [
+        _json.loads(r.message.removeprefix("audit: "))
+        for r in caplog.records
+        if r.name == "omnigent.audit"
+    ]
+    fleet_entries = [e for e in entries if e["action"] == "host.fleet.list"]
+    assert len(fleet_entries) == 1, (
+        f"expected exactly one fleet-list audit entry, got {[e['action'] for e in entries]}"
+    )
+    assert fleet_entries[0]["actor"] == "admin@test.com"
+    assert fleet_entries[0]["host_count"] >= 2

--- a/tests/server/integration/test_hosts_create_directory.py
+++ b/tests/server/integration/test_hosts_create_directory.py
@@ -32,6 +32,9 @@ from omnigent.server.routes.hosts import create_hosts_router
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
+from omnigent.stores.host_permission_store.sqlalchemy_store import (
+    SqlAlchemyHostPermissionStore,
+)
 from omnigent.stores.host_store import HostStore
 
 # Same liveness-race flake guard as test_hosts_filesystem.py: the mock
@@ -100,7 +103,12 @@ def mkdir_app(
         prefix="/v1",
     )
     app.include_router(
-        create_hosts_router(registry, host_store, conv_store),
+        create_hosts_router(
+            registry,
+            host_store,
+            conv_store,
+            host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
+        ),
         prefix="/v1",
     )
     return app, registry, host_store, conv_store

--- a/tests/server/integration/test_hosts_filesystem.py
+++ b/tests/server/integration/test_hosts_filesystem.py
@@ -35,6 +35,9 @@ from omnigent.server.routes.hosts import create_hosts_router
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
+from omnigent.stores.host_permission_store.sqlalchemy_store import (
+    SqlAlchemyHostPermissionStore,
+)
 from omnigent.stores.host_store import HostStore
 
 # Interim: any test using the ``fs_setup`` mock host tunnel can flake
@@ -99,13 +102,19 @@ def fs_app(
     registry = HostRegistry()
     host_store = HostStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
+    host_permission_store = SqlAlchemyHostPermissionStore(db_uri)
     app = FastAPI()
     app.include_router(
         create_host_tunnel_router(registry, host_store),
         prefix="/v1",
     )
     app.include_router(
-        create_hosts_router(registry, host_store, conv_store),
+        create_hosts_router(
+            registry,
+            host_store,
+            conv_store,
+            host_permission_store=host_permission_store,
+        ),
         prefix="/v1",
     )
     return app, registry, host_store, conv_store
@@ -469,6 +478,7 @@ async def test_list_filesystem_nul_byte_in_path_returns_400(
 
 async def test_list_filesystem_owner_check_blocks_other_users(
     fs_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+    db_uri: str,
 ) -> None:
     """
     Verify the owner check returns 403 when an authenticated caller
@@ -503,6 +513,7 @@ async def test_list_filesystem_owner_check_blocks_other_users(
     auth = _Stub()
     auth_app = FastAPI()
     registry = HostRegistry()
+    host_permission_store = SqlAlchemyHostPermissionStore(db_uri)
     auth_app.include_router(
         create_host_tunnel_router(registry, host_store, auth_provider=auth),
         prefix="/v1",
@@ -513,6 +524,7 @@ async def test_list_filesystem_owner_check_blocks_other_users(
             host_store,
             conv_store,
             auth_provider=auth,
+            host_permission_store=host_permission_store,
         ),
         prefix="/v1",
     )

--- a/tests/server/integration/test_hosts_management_e2e.py
+++ b/tests/server/integration/test_hosts_management_e2e.py
@@ -28,6 +28,9 @@ from omnigent.server.routes.runner_tunnel import create_runner_tunnel_router
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
+from omnigent.stores.host_permission_store.sqlalchemy_store import (
+    SqlAlchemyHostPermissionStore,
+)
 from omnigent.stores.host_store import HostStore
 
 pytestmark = pytest.mark.asyncio
@@ -49,7 +52,12 @@ def management_app(
     reports = RunnerExitReports()
     app = FastAPI()
     app.include_router(
-        create_hosts_router(host_registry, host_store, conv_store),
+        create_hosts_router(
+            host_registry,
+            host_store,
+            conv_store,
+            host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
+        ),
         prefix="/v1",
     )
     app.include_router(

--- a/tests/server/integration/test_session_host_launch.py
+++ b/tests/server/integration/test_session_host_launch.py
@@ -48,6 +48,7 @@ from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.host_permission_store.sqlalchemy_store import SqlAlchemyHostPermissionStore
 from omnigent.stores.host_store import HostStore
 from tests.server.helpers import create_test_agent
 
@@ -55,6 +56,93 @@ pytestmark = pytest.mark.asyncio
 
 _HOST_ID = "c2d81b1a6812ae1cf32221c5a2a70ba0"
 _WORKSPACE = "/work/repo"
+
+
+async def _capture_launch_frame_flag(*, session_owner: str | None, host_owner: str | None) -> bool:
+    """Call ``_launch_runner_on_host`` with stubbed owners; return the
+    ``prefer_binding_token_mint`` flag on the frame it builds.
+
+    Stubs the host registry's ``send_text`` to raise ``ConnectionError``,
+    which makes ``_launch_runner_on_host`` return early *after* it has
+    built and attempted to send the launch frame — so the flag decision
+    is captured without needing a launch-result future.
+    """
+    from types import SimpleNamespace
+
+    from omnigent.host.frames import HostLaunchRunnerFrame, decode_host_frame
+    from omnigent.server.auth import LEVEL_OWNER
+    from omnigent.server.routes.sessions import _launch_runner_on_host
+    from omnigent.stores.permission_store import SessionPermission
+
+    # _launch_runner_on_host reads conv.id / host_id / workspace, and
+    # _resolve_harness(conv) reads harness_override + agent_id (None →
+    # fail-open, no harness in the frame).
+    conv = SimpleNamespace(
+        id="conv_flag_test",
+        host_id=_HOST_ID,
+        workspace=_WORKSPACE,
+        harness_override=None,
+        agent_id=None,
+    )
+    conversation_store = SimpleNamespace(replace_runner_id=lambda *a, **k: None)
+    permission_store = SimpleNamespace(
+        list_for_session=lambda _cid: (
+            [
+                SessionPermission(
+                    user_id=session_owner, conversation_id="conv_flag_test", level=LEVEL_OWNER
+                )
+            ]
+            if session_owner is not None
+            else []
+        )
+    )
+    host_conn = SimpleNamespace(owner=host_owner, pending_launches={})
+
+    captured: dict[str, bool] = {}
+
+    def _send_text(_conn: object, text: str) -> None:
+        frame = decode_host_frame(text)
+        assert isinstance(frame, HostLaunchRunnerFrame)
+        captured["flag"] = frame.prefer_binding_token_mint
+        raise ConnectionError("stub: capture then early-return")
+
+    host_registry = SimpleNamespace(send_text=_send_text)
+
+    await _launch_runner_on_host(
+        conv,  # type: ignore[arg-type]
+        conversation_store,  # type: ignore[arg-type]
+        host_registry,  # type: ignore[arg-type]
+        host_conn,  # type: ignore[arg-type]
+        permission_store=permission_store,  # type: ignore[arg-type]
+    )
+    return captured["flag"]
+
+
+async def test_launch_frame_prefers_mint_when_session_owner_differs() -> None:
+    """Guest-on-shared-host (US1): session owner != host owner → flag True.
+
+    A service-principal-owned host serving another user's session must
+    tell the runner to authenticate as the session owner; otherwise the
+    host-owner credential can't read the guest session's spec (404).
+    """
+    flag = await _capture_launch_frame_flag(
+        session_owner="guest@example.com",
+        host_owner="sp-host-owner@example.com",
+    )
+    assert flag is True
+
+
+async def test_launch_frame_no_mint_when_owner_equals_host() -> None:
+    """Owner-on-own-host (US2 regression): equal owners → flag False.
+
+    The common case (a user's own host serving their own session) must
+    keep today's inherited-credential behavior — no mint preference.
+    """
+    flag = await _capture_launch_frame_flag(
+        session_owner="alice@example.com",
+        host_owner="alice@example.com",
+    )
+    assert flag is False
 
 
 class _NoopRunnerWS:
@@ -115,6 +203,7 @@ def app(runtime_init: None, db_uri: str, tmp_path) -> FastAPI:
         ),
         comment_store=SqlAlchemyCommentStore(db_uri),
         host_store=HostStore(db_uri),
+        host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
     )
 
 
@@ -1440,6 +1529,7 @@ async def test_health_reports_online_for_host_on_other_replica(
         ),
         comment_store=SqlAlchemyCommentStore(db_uri),
         host_store=HostStore(db_uri),
+        host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
     )
     assert app_b.state.host_registry.get(_HOST_ID) is None, (
         "test setup is broken: replica B's host registry should be empty."

--- a/tests/server/integration/test_sessions_permissions.py
+++ b/tests/server/integration/test_sessions_permissions.py
@@ -37,6 +37,9 @@ from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.host_permission_store.sqlalchemy_store import (
+    SqlAlchemyHostPermissionStore,
+)
 from omnigent.stores.host_store import HostStore
 from omnigent.stores.permission_store.sqlalchemy_store import (
     SqlAlchemyPermissionStore,
@@ -208,6 +211,7 @@ def host_perm_app(
         permission_store=SqlAlchemyPermissionStore(db_uri),
         auth_provider=create_auth_provider(),
         host_store=HostStore(db_uri),
+        host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
     )
 
 
@@ -1116,6 +1120,69 @@ async def test_admin_user_bypasses_permission_checks(
     )
     assert resp.status_code == 200, (
         f"admin user should be able to list permissions, got {resp.status_code}."
+    )
+
+
+# ── Admin fleet view: GET /v1/sessions?all=true ──────────────────
+
+
+async def test_fleet_view_admin_sees_all_owners_sessions(
+    auth_client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """``?all=true`` as admin returns sessions across every owner.
+
+    Without the fleet view an admin's plain list is still ACL-scoped to
+    their own/shared sessions; this proves the flag drops that filter so
+    the admin sees the whole fleet, with each item carrying its owner.
+    """
+    agent = await create_test_agent(auth_client, user="bryan")
+    # Two sessions owned by two different, unrelated users.
+    await _create_session_as(auth_client, agent["id"], "user-a", title="a-session")
+    await _create_session_as(auth_client, agent["id"], "user-b", title="b-session")
+
+    perm_store = SqlAlchemyPermissionStore(db_uri)
+    perm_store.ensure_user("admin-user", is_admin=True)
+
+    # Plain list as admin-user: no grants, so it sees none of the two.
+    scoped = await _list_sessions_as(auth_client, "admin-user")
+    scoped_titles = {s.get("title") for s in scoped}
+    assert "a-session" not in scoped_titles
+    assert "b-session" not in scoped_titles
+
+    # Fleet view: both owners' sessions appear.
+    resp = await auth_client.get(
+        "/v1/sessions?all=true",
+        headers={"X-Forwarded-Email": "admin-user"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+    titles = {s.get("title") for s in data}
+    assert "a-session" in titles
+    assert "b-session" in titles
+    # Owner is surfaced so an admin can attribute each session.
+    owners = {s.get("owner") for s in data}
+    assert "user-a" in owners
+    assert "user-b" in owners
+
+
+async def test_fleet_view_non_admin_forbidden(
+    auth_client: httpx.AsyncClient,
+) -> None:
+    """``?all=true`` from a non-admin fails closed with 403.
+
+    A regression here would silently return an owner-scoped list the
+    caller might mistake for the full fleet.
+    """
+    agent = await create_test_agent(auth_client, user="bryan")
+    await _create_session_as(auth_client, agent["id"], "user-a")
+
+    resp = await auth_client.get(
+        "/v1/sessions?all=true",
+        headers={"X-Forwarded-Email": "user-a"},
+    )
+    assert resp.status_code == 403, (
+        f"non-admin all=true must be 403, got {resp.status_code}: {resp.text}"
     )
 
 

--- a/tests/server/routes/test_auth_helpers.py
+++ b/tests/server/routes/test_auth_helpers.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import pytest
 
 from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.runner.identity import token_bound_runner_id
 from omnigent.server.auth import (
     LEVEL_EDIT,
     LEVEL_OWNER,
@@ -228,3 +229,138 @@ async def test_missing_conversation_raises_404(
         )
 
     assert exc.value.code == ErrorCode.NOT_FOUND
+
+
+# --- Runner binding-token session access (header-mode, feature 002) ---
+
+_BINDING_TOKEN = "test-binding-token-xyz"
+
+
+@pytest.mark.asyncio
+async def test_binding_token_grants_read_on_own_session_without_user(
+    perm_store: SqlAlchemyPermissionStore, conv_store: SqlAlchemyConversationStore
+) -> None:
+    """A runner reads AND posts events on its OWN bound session, no user_id.
+
+    The header-mode case (US1): user_id is None (no readable identity), but the
+    token's derived runner id matches conv.runner_id → the runner gets its
+    self-access level (EDIT: read the spec + post events/usage back).
+    """
+    conv = conv_store.create_conversation()
+    conv_store.replace_runner_id(conv.id, token_bound_runner_id(_BINDING_TOKEN))
+
+    # A read requirement (spec fetch) is satisfied ...
+    access = await require_access_and_level(
+        None,
+        conv.id,
+        LEVEL_READ,
+        perm_store,
+        conv_store,
+        runner_binding_token=_BINDING_TOKEN,
+    )
+    assert access.level == LEVEL_EDIT
+    assert access.conversation is not None
+    assert access.conversation.id == conv.id
+
+    # ... and so is an edit requirement (POST /events, the transcript/usage
+    # forwarder), so the agent's responses reach the web transcript.
+    access_edit = await require_access_and_level(
+        None,
+        conv.id,
+        LEVEL_EDIT,
+        perm_store,
+        conv_store,
+        runner_binding_token=_BINDING_TOKEN,
+    )
+    assert access_edit.level == LEVEL_EDIT
+
+
+@pytest.mark.asyncio
+async def test_binding_token_does_not_grant_other_session(
+    perm_store: SqlAlchemyPermissionStore, conv_store: SqlAlchemyConversationStore
+) -> None:
+    """A token bound to session X grants nothing on session Y (US2 security).
+
+    Y is bound to a DIFFERENT runner, so presenting X's token for Y falls
+    through to the normal deny (404, no user identity).
+    """
+    conv_y = conv_store.create_conversation()
+    conv_store.replace_runner_id(conv_y.id, token_bound_runner_id("some-other-token"))
+
+    with pytest.raises(OmnigentError) as exc:
+        await require_access_and_level(
+            None,
+            conv_y.id,
+            LEVEL_READ,
+            perm_store,
+            conv_store,
+            runner_binding_token=_BINDING_TOKEN,
+        )
+    # No user identity + no matching binding → 401 (unauthenticated), never a grant.
+    assert exc.value.code == ErrorCode.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_binding_token_cannot_satisfy_above_edit(
+    perm_store: SqlAlchemyPermissionStore, conv_store: SqlAlchemyConversationStore
+) -> None:
+    """A matching binding token does NOT satisfy a > LEVEL_EDIT requirement (US2).
+
+    The grant caps at EDIT (read spec + post events on its own session); a
+    manage/owner requirement (delete the session, change its sharing) falls
+    through to the normal deny — the runner can't escalate on its own session.
+    """
+    conv = conv_store.create_conversation()
+    conv_store.replace_runner_id(conv.id, token_bound_runner_id(_BINDING_TOKEN))
+
+    with pytest.raises(OmnigentError) as exc:
+        await require_access_and_level(
+            None,
+            conv.id,
+            LEVEL_OWNER,
+            perm_store,
+            conv_store,
+            runner_binding_token=_BINDING_TOKEN,
+        )
+    assert exc.value.code == ErrorCode.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_absent_binding_token_unchanged(
+    perm_store: SqlAlchemyPermissionStore, conv_store: SqlAlchemyConversationStore
+) -> None:
+    """No binding token → resolution is exactly as before (US3 regression).
+
+    A runner-bound session with no token + no user identity still 401s.
+    """
+    conv = conv_store.create_conversation()
+    conv_store.replace_runner_id(conv.id, token_bound_runner_id(_BINDING_TOKEN))
+
+    with pytest.raises(OmnigentError) as exc:
+        await require_access_and_level(None, conv.id, LEVEL_READ, perm_store, conv_store)
+    assert exc.value.code == ErrorCode.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_binding_token_owner_access_unaffected(
+    perm_store: SqlAlchemyPermissionStore, conv_store: SqlAlchemyConversationStore
+) -> None:
+    """A real owner still gets their owner level even if a (bogus) token is passed.
+
+    The binding-token branch only ADDS read on a match; it never downgrades or
+    overrides a user's own access.
+    """
+    conv = conv_store.create_conversation()
+    conv_store.replace_runner_id(conv.id, token_bound_runner_id(_BINDING_TOKEN))
+    perm_store.ensure_user(ALICE)
+    perm_store.grant(ALICE, conv.id, LEVEL_OWNER)
+
+    access = await require_access_and_level(
+        ALICE,
+        conv.id,
+        LEVEL_READ,
+        perm_store,
+        conv_store,
+        runner_binding_token="unrelated-token",
+    )
+    assert access.level == LEVEL_OWNER

--- a/tests/server/routes/test_host_launch.py
+++ b/tests/server/routes/test_host_launch.py
@@ -1,6 +1,6 @@
 """Tests for the host launch authorization helpers.
 
-Tests ``resolve_host_owner`` and ``resolve_host_launch`` directly
+Tests ``resolve_host_access`` and ``resolve_host_launch`` directly
 (pure function tests, no HTTP).
 """
 
@@ -12,9 +12,10 @@ import pytest
 from fastapi import HTTPException
 
 from omnigent.entities import Conversation
+from omnigent.server.host_permissions import HOST_LEVEL_USE, HOST_LEVEL_VIEW
 from omnigent.server.routes._host_launch import (
+    resolve_host_access,
     resolve_host_launch,
-    resolve_host_owner,
 )
 
 
@@ -34,6 +35,24 @@ class _FakeHostStore:
 
 
 @dataclass
+class _FakeHostPermissionStore:
+    """Grant lookup keyed on (user_id, host_id) → level."""
+
+    grants: dict[tuple[str, str], int] = field(default_factory=dict)
+
+    def check_access(self, user_id: str | None, host_id: str, required_level: int) -> bool:
+        if user_id is None:
+            return False
+        level = self.grants.get((user_id, host_id))
+        return level is not None and level >= required_level
+
+    def get_permission_level(self, user_id: str | None, host_id: str) -> int | None:
+        if user_id is None:
+            return None
+        return self.grants.get((user_id, host_id))
+
+
+@dataclass
 class _FakeHostRegistry:
     conns: dict[str, object] = field(default_factory=dict)
 
@@ -49,33 +68,86 @@ class _FakeConversationStore:
         return self.convs.get(conversation_id)
 
 
-# ── resolve_host_owner ───────────────────────────────────────────────
+# ── resolve_host_access ──────────────────────────────────────────────
 
 
-class TestResolveHostOwner:
+class TestResolveHostAccess:
     def test_unknown_host_404(self) -> None:
         store = _FakeHostStore()
         with pytest.raises(HTTPException) as exc_info:
-            resolve_host_owner(user_id="alice", host_id="host_x", host_store=store)
+            resolve_host_access(
+                user_id="alice",
+                host_id="host_x",
+                host_store=store,
+                host_permission_store=_FakeHostPermissionStore(),
+                permission_store=None,
+            )
         assert exc_info.value.status_code == 404
 
-    def test_wrong_owner_403(self) -> None:
+    def test_wrong_owner_no_grant_403(self) -> None:
         host = _FakeHost(host_id="host_1", owner="bob")
         store = _FakeHostStore(hosts={"host_1": host})
         with pytest.raises(HTTPException) as exc_info:
-            resolve_host_owner(user_id="alice", host_id="host_1", host_store=store)
+            resolve_host_access(
+                user_id="alice",
+                host_id="host_1",
+                host_store=store,
+                host_permission_store=_FakeHostPermissionStore(),
+                permission_store=None,
+            )
         assert exc_info.value.status_code == 403
 
     def test_correct_owner(self) -> None:
         host = _FakeHost(host_id="host_1", owner="alice")
         store = _FakeHostStore(hosts={"host_1": host})
-        result = resolve_host_owner(user_id="alice", host_id="host_1", host_store=store)
+        result = resolve_host_access(
+            user_id="alice",
+            host_id="host_1",
+            host_store=store,
+            host_permission_store=_FakeHostPermissionStore(),
+            permission_store=None,
+        )
         assert result.host_id == "host_1"
 
-    def test_no_auth_skips_owner_check(self) -> None:
+    def test_use_grantee_allowed(self) -> None:
         host = _FakeHost(host_id="host_1", owner="bob")
         store = _FakeHostStore(hosts={"host_1": host})
-        result = resolve_host_owner(user_id=None, host_id="host_1", host_store=store)
+        grants = _FakeHostPermissionStore(grants={("alice", "host_1"): HOST_LEVEL_USE})
+        result = resolve_host_access(
+            user_id="alice",
+            host_id="host_1",
+            host_store=store,
+            host_permission_store=grants,
+            permission_store=None,
+        )
+        assert result.host_id == "host_1"
+
+    def test_view_grantee_403_at_use_level(self) -> None:
+        # `view` shows the host in listings but must not authorize the
+        # default `use`-level access (browse/launch).
+        host = _FakeHost(host_id="host_1", owner="bob")
+        store = _FakeHostStore(hosts={"host_1": host})
+        grants = _FakeHostPermissionStore(grants={("alice", "host_1"): HOST_LEVEL_VIEW})
+        with pytest.raises(HTTPException) as exc_info:
+            resolve_host_access(
+                user_id="alice",
+                host_id="host_1",
+                host_store=store,
+                host_permission_store=grants,
+                permission_store=None,
+            )
+        assert exc_info.value.status_code == 403
+
+    def test_no_auth_skips_access_check(self) -> None:
+        host = _FakeHost(host_id="host_1", owner="bob")
+        store = _FakeHostStore(hosts={"host_1": host})
+        result = resolve_host_access(
+            user_id=None,
+            host_id="host_1",
+            host_store=store,
+            host_permission_store=_FakeHostPermissionStore(),
+            permission_store=None,
+        )
         assert result.host_id == "host_1"
 
 
@@ -97,6 +169,7 @@ class TestResolveHostLaunch:
                 host_registry=registry,
                 conversation_store=conv_store,
                 permission_store=None,
+                host_permission_store=_FakeHostPermissionStore(),
             )
         assert exc_info.value.status_code == 409
 
@@ -115,6 +188,7 @@ class TestResolveHostLaunch:
                 host_registry=registry,
                 conversation_store=conv_store,
                 permission_store=None,
+                host_permission_store=_FakeHostPermissionStore(),
             )
         assert exc_info.value.status_code == 404
 
@@ -139,6 +213,7 @@ class TestResolveHostLaunch:
             host_registry=registry,
             conversation_store=conv_store,
             permission_store=None,
+            host_permission_store=_FakeHostPermissionStore(),
         )
         assert result.host.host_id == "host_1"
         assert result.conv.id == "s1"

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -48,6 +48,9 @@ from omnigent.server.passwords import (
     needs_rehash,
     verify_password,
 )
+from omnigent.stores.host_permission_store.sqlalchemy_store import (
+    SqlAlchemyHostPermissionStore,
+)
 from omnigent.stores.permission_store.sqlalchemy_store import (
     SqlAlchemyPermissionStore,
 )
@@ -1076,6 +1079,7 @@ def _build_accounts_app(
         comment_store=comment_store,
         permission_store=permission_store,
         host_store=host_store,
+        host_permission_store=SqlAlchemyHostPermissionStore(db_url),
         auth_provider=auth_provider,
         account_store=account_store,
     )
@@ -1167,6 +1171,7 @@ def header_mode_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator
         comment_store=comment_store,
         permission_store=permission_store,
         host_store=host_store,
+        host_permission_store=SqlAlchemyHostPermissionStore(db_url),
         auth_provider=auth_provider,
         account_store=None,
     )

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -20,6 +20,7 @@ from omnigent.server import app as server_app
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.artifact_store.local import LocalArtifactStore
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from omnigent.stores.host_permission_store.sqlalchemy_store import SqlAlchemyHostPermissionStore
 
 
 @pytest.mark.asyncio
@@ -158,6 +159,7 @@ def _build_liveness_app(
         conversation_store=conversation_store,
         artifact_store=artifact_store,
         host_store=host_store,
+        host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
         agent_cache=AgentCache(
             artifact_store=artifact_store,
             cache_dir=tmp_path / "cache",
@@ -454,6 +456,7 @@ async def test_health_unbound_fork_of_coding_session_reads_offline(
         conversation_store=conversation_store,
         artifact_store=artifact_store,
         host_store=host_store,
+        host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
         agent_cache=AgentCache(
             artifact_store=artifact_store,
             cache_dir=tmp_path / "cache",
@@ -1017,6 +1020,7 @@ def _build_api_only_app(db_uri: str, tmp_path: Path, monkeypatch: pytest.MonkeyP
         conversation_store=SqlAlchemyConversationStore(db_uri),
         artifact_store=artifact_store,
         host_store=HostStore(db_uri),
+        host_permission_store=SqlAlchemyHostPermissionStore(db_uri),
         agent_cache=AgentCache(artifact_store=artifact_store, cache_dir=tmp_path / "cache"),
     )
 

--- a/tests/server/test_host_permissions.py
+++ b/tests/server/test_host_permissions.py
@@ -1,0 +1,157 @@
+"""Unit tests for the host access resolver.
+
+Covers :func:`omnigent.server.host_permissions.check_host_access` and
+:func:`omnigent.server.host_permissions.get_host_permission_level`
+against every resolution branch:
+
+1. auth disabled (user_id=None) -> allow
+2. admin -> allow
+3. host owner -> allow at any level (no grant row)
+4. sufficient grant -> allow; insufficient -> deny
+5. no grant, not owner, not admin -> deny
+
+Uses real SQLite-backed stores so owner lookup and the admin flag
+behave exactly as in production.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.server.host_permissions import (
+    HOST_LEVEL_MANAGE,
+    HOST_LEVEL_OWNER,
+    HOST_LEVEL_USE,
+    HOST_LEVEL_VIEW,
+    check_host_access,
+    get_host_permission_level,
+)
+from omnigent.stores.host_permission_store.sqlalchemy_store import (
+    SqlAlchemyHostPermissionStore,
+)
+from omnigent.stores.host_store import HostStore
+from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+
+
+@pytest.fixture()
+def stores(
+    db_uri: str,
+) -> tuple[HostStore, SqlAlchemyHostPermissionStore, SqlAlchemyPermissionStore]:
+    """Host, host-permission, and session-permission stores on one DB.
+
+    :param db_uri: SQLite URI from the shared fixture.
+    :returns: ``(host_store, host_permission_store, permission_store)``.
+    """
+    host_store = HostStore(db_uri)
+    host_perm = SqlAlchemyHostPermissionStore(db_uri)
+    perm = SqlAlchemyPermissionStore(db_uri)
+    # A host owned by the service principal (the CoDA case).
+    host_store.upsert_on_connect("host_sp", "coda-app", "app-sp@example")
+    # Grantee user rows must exist for the grant FK (users.id) to hold —
+    # the route ensures these; the unit test seeds them up front.
+    for user in ("viewer@example", "user@example"):
+        perm.ensure_user(user)
+    return host_store, host_perm, perm
+
+
+def test_auth_disabled_allows(
+    stores: tuple[HostStore, SqlAlchemyHostPermissionStore, SqlAlchemyPermissionStore],
+) -> None:
+    """user_id=None (auth disabled) is allowed at any level.
+
+    Mirrors the single-user/local escape hatch the host routes use;
+    breaking it would 403 every local launch.
+    """
+    host_store, host_perm, perm = stores
+    assert check_host_access(None, "host_sp", HOST_LEVEL_MANAGE, host_perm, host_store, perm)
+    assert get_host_permission_level(None, "host_sp", host_perm, host_store, perm) == (
+        HOST_LEVEL_OWNER
+    )
+
+
+def test_owner_allowed_without_grant(
+    stores: tuple[HostStore, SqlAlchemyHostPermissionStore, SqlAlchemyPermissionStore],
+) -> None:
+    """The host owner has full access with no grant row (FR-004)."""
+    host_store, host_perm, perm = stores
+    assert check_host_access(
+        "app-sp@example", "host_sp", HOST_LEVEL_MANAGE, host_perm, host_store, perm
+    )
+    assert (
+        get_host_permission_level("app-sp@example", "host_sp", host_perm, host_store, perm)
+        == HOST_LEVEL_OWNER
+    )
+
+
+def test_admin_allowed_without_grant(
+    stores: tuple[HostStore, SqlAlchemyHostPermissionStore, SqlAlchemyPermissionStore],
+) -> None:
+    """An admin bypasses the per-host ACCESS check (FR-005).
+
+    Access is granted, but the DISPLAY level is not spuriously "owner":
+    an admin who neither owns nor was granted the host shows ``None``
+    (no grant), so ``(owned_by_current_user=False, permission_level)``
+    stays coherent in the UI. Admin is an access override, not an
+    ownership claim.
+    """
+    host_store, host_perm, perm = stores
+    perm.ensure_user("admin@example", is_admin=True)
+    # Access: yes, at every level.
+    assert check_host_access(
+        "admin@example", "host_sp", HOST_LEVEL_MANAGE, host_perm, host_store, perm
+    )
+    # Display: not "owner" — the admin neither owns nor has a grant here.
+    assert (
+        get_host_permission_level("admin@example", "host_sp", host_perm, host_store, perm) is None
+    )
+
+    # With an explicit grant, the admin's displayed level is that grant.
+    host_perm.grant("admin@example", "host_sp", HOST_LEVEL_USE)
+    assert (
+        get_host_permission_level("admin@example", "host_sp", host_perm, host_store, perm)
+        == HOST_LEVEL_USE
+    )
+
+
+def test_grant_level_ordering(
+    stores: tuple[HostStore, SqlAlchemyHostPermissionStore, SqlAlchemyPermissionStore],
+) -> None:
+    """A grantee is allowed up to their level and no higher.
+
+    A ``view`` grantee sees the host but cannot use it; a ``use``
+    grantee can use but not manage.
+    """
+    host_store, host_perm, perm = stores
+    host_perm.grant("viewer@example", "host_sp", HOST_LEVEL_VIEW)
+    host_perm.grant("user@example", "host_sp", HOST_LEVEL_USE)
+
+    assert check_host_access(
+        "viewer@example", "host_sp", HOST_LEVEL_VIEW, host_perm, host_store, perm
+    )
+    assert not check_host_access(
+        "viewer@example", "host_sp", HOST_LEVEL_USE, host_perm, host_store, perm
+    )
+
+    assert check_host_access(
+        "user@example", "host_sp", HOST_LEVEL_USE, host_perm, host_store, perm
+    )
+    assert not check_host_access(
+        "user@example", "host_sp", HOST_LEVEL_MANAGE, host_perm, host_store, perm
+    )
+
+    assert get_host_permission_level("viewer@example", "host_sp", host_perm, host_store, perm) == 1
+    assert get_host_permission_level("user@example", "host_sp", host_perm, host_store, perm) == 2
+
+
+def test_no_grant_denied(
+    stores: tuple[HostStore, SqlAlchemyHostPermissionStore, SqlAlchemyPermissionStore],
+) -> None:
+    """A non-owner, non-admin, non-grantee is denied and has no level."""
+    host_store, host_perm, perm = stores
+    assert not check_host_access(
+        "stranger@example", "host_sp", HOST_LEVEL_VIEW, host_perm, host_store, perm
+    )
+    assert (
+        get_host_permission_level("stranger@example", "host_sp", host_perm, host_store, perm)
+        is None
+    )

--- a/tests/stores/test_host_permission_store.py
+++ b/tests/stores/test_host_permission_store.py
@@ -1,0 +1,128 @@
+"""Tests for the host permission store (host-sharing grants)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.stores.host_permission_store.sqlalchemy_store import (
+    SqlAlchemyHostPermissionStore,
+)
+from omnigent.stores.host_store import HostStore
+from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+
+
+@pytest.fixture()
+def store(db_uri: str) -> SqlAlchemyHostPermissionStore:
+    """Host permission store backed by the per-test SQLite database.
+
+    Seeds the ``users`` and ``hosts`` rows the grant FKs reference
+    (``host_permissions.user_id`` → ``users.id`` and ``.host_id`` →
+    ``hosts.host_id``), so a grant in these tests behaves like one made
+    through the route (which ensures the user and requires the host).
+
+    :param db_uri: SQLite URI from the shared ``db_uri`` fixture.
+    :returns: A :class:`SqlAlchemyHostPermissionStore` instance.
+    """
+    perm = SqlAlchemyPermissionStore(db_uri)
+    for user in ("alice@test.com", "bob@test.com"):
+        perm.ensure_user(user)
+    host_store = HostStore(db_uri)
+    for host_id in ("host_x", "host_y"):
+        host_store.upsert_on_connect(host_id, host_id, "owner@test.com")
+    return SqlAlchemyHostPermissionStore(db_uri)
+
+
+def test_grant_then_get_roundtrips(store: SqlAlchemyHostPermissionStore) -> None:
+    """A granted level reads back exactly, with timestamps and creator.
+
+    If get returns None or a different level, the upsert or the
+    entity mapping is broken.
+    """
+    grant = store.grant("alice@test.com", "host_x", 2, created_by="admin@test.com")
+    assert grant.user_id == "alice@test.com"
+    assert grant.host_id == "host_x"
+    assert grant.level == 2
+    assert grant.created_by == "admin@test.com"
+    assert grant.created_at > 0
+    assert grant.updated_at == grant.created_at
+
+    fetched = store.get("alice@test.com", "host_x")
+    assert fetched is not None
+    assert fetched.level == 2
+    assert fetched.created_by == "admin@test.com"
+
+
+def test_grant_upsert_overwrites_level_preserving_created(
+    store: SqlAlchemyHostPermissionStore,
+) -> None:
+    """Re-granting changes the level but keeps created_at / created_by.
+
+    The created metadata records who first shared and when; a level
+    change (upgrade/downgrade) must not rewrite it.
+    """
+    first = store.grant("alice@test.com", "host_x", 1, created_by="admin@test.com")
+    second = store.grant("alice@test.com", "host_x", 3, created_by="someone-else")
+
+    assert second.level == 3
+    # created_at and created_by come from the first insert.
+    assert second.created_at == first.created_at
+    assert second.created_by == "admin@test.com"
+    # updated_at advanced (or at least did not go backwards).
+    assert second.updated_at >= first.updated_at
+
+
+def test_revoke_removes_grant(store: SqlAlchemyHostPermissionStore) -> None:
+    """Revoke deletes the row and is idempotent.
+
+    A revoked grant must not authorize subsequent access (SR-004).
+    """
+    store.grant("alice@test.com", "host_x", 2)
+    assert store.revoke("alice@test.com", "host_x") is True
+    assert store.get("alice@test.com", "host_x") is None
+    # Second revoke is a no-op.
+    assert store.revoke("alice@test.com", "host_x") is False
+
+
+def test_check_access_respects_level_ordering(
+    store: SqlAlchemyHostPermissionStore,
+) -> None:
+    """check_access is satisfied by an equal-or-higher grant only.
+
+    A ``use`` (2) grant must satisfy a ``view`` (1) requirement but
+    not a ``manage`` (3) requirement.
+    """
+    store.grant("alice@test.com", "host_x", 2)
+    assert store.check_access("alice@test.com", "host_x", 1) is True
+    assert store.check_access("alice@test.com", "host_x", 2) is True
+    assert store.check_access("alice@test.com", "host_x", 3) is False
+    # Unknown user / host → no access.
+    assert store.check_access("bob@test.com", "host_x", 1) is False
+    assert store.check_access(None, "host_x", 1) is False
+
+
+def test_list_for_host_and_user(store: SqlAlchemyHostPermissionStore) -> None:
+    """list_for_host / list_for_user return the matching grants.
+
+    Backs the permissions API and the "hosts I can access" query.
+    """
+    store.grant("alice@test.com", "host_x", 2)
+    store.grant("bob@test.com", "host_x", 1)
+    store.grant("alice@test.com", "host_y", 3)
+
+    by_host = {g.user_id for g in store.list_for_host("host_x")}
+    assert by_host == {"alice@test.com", "bob@test.com"}
+
+    by_user = {g.host_id for g in store.list_for_user("alice@test.com")}
+    assert by_user == {"host_x", "host_y"}
+
+
+def test_get_permission_level(store: SqlAlchemyHostPermissionStore) -> None:
+    """get_permission_level returns the user's own grant level or None.
+
+    Owner/admin resolution is layered on in the access helper, not
+    here — this store only knows about stored grants.
+    """
+    store.grant("alice@test.com", "host_x", 2)
+    assert store.get_permission_level("alice@test.com", "host_x") == 2
+    assert store.get_permission_level("bob@test.com", "host_x") is None
+    assert store.get_permission_level(None, "host_x") is None

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -670,6 +670,68 @@ def test_policy_hook_wrapper_script_bakes_auth_and_routing(
     assert "X-Databricks-Org-Id" in line and "org123" in line
 
 
+def test_policy_hook_wrapper_bakes_tunnel_token_on_guest_shared_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guest-on-shared-host: the baked headers carry the tunnel binding token.
+
+    On a shared/externally-owned host the SP bearer has no user grant on the
+    guest's conversation, so the hook's POST to
+    ``/v1/sessions/{id}/policies/evaluate`` 404s and the hook FAILS CLOSED —
+    blocking every tool call. Attaching X-Omnigent-Runner-Tunnel-Token (gated
+    on RUNNER_PREFER_BINDING_TOKEN_MINT) lets the server's runner self-access
+    check authorize the evaluate. The evaluate route already reads this header
+    (see sessions.py evaluate_policy).
+    """
+    import omnigent.cli_auth as cli_auth
+    import omnigent.runner._entry as entry
+    from omnigent.runner.identity import (
+        RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR,
+        RUNNER_TUNNEL_TOKEN_HEADER,
+    )
+
+    monkeypatch.setattr(
+        entry, "_make_auth_token_factory", lambda *, server_url=None: lambda: "tok"
+    )
+    monkeypatch.setattr(cli_auth, "load_databricks_org_id", lambda _url: None)
+    monkeypatch.setattr(entry, "_runner_tunnel_binding_token_from_env", lambda: "bind-xyz")
+    monkeypatch.setenv(RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR, "1")
+
+    script = native_policy_hook.policy_hook_wrapper_script(
+        "https://acme.databricks.com", "conv_guest", "/path/hook.py"
+    )
+    line = next(
+        ln for ln in script.splitlines() if ln.startswith("export _OMNIGENT_AUTH_HEADERS=")
+    )
+    assert RUNNER_TUNNEL_TOKEN_HEADER in line
+    assert "bind-xyz" in line
+    assert "Bearer tok" in line  # SP bearer still present alongside
+
+
+def test_policy_hook_wrapper_no_tunnel_token_on_own_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Own-host (flag unset): no tunnel token baked — SP bearer suffices."""
+    import omnigent.cli_auth as cli_auth
+    import omnigent.runner._entry as entry
+    from omnigent.runner.identity import (
+        RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR,
+        RUNNER_TUNNEL_TOKEN_HEADER,
+    )
+
+    monkeypatch.setattr(
+        entry, "_make_auth_token_factory", lambda *, server_url=None: lambda: "tok"
+    )
+    monkeypatch.setattr(cli_auth, "load_databricks_org_id", lambda _url: None)
+    monkeypatch.setattr(entry, "_runner_tunnel_binding_token_from_env", lambda: "bind-xyz")
+    monkeypatch.delenv(RUNNER_PREFER_BINDING_TOKEN_MINT_ENV_VAR, raising=False)
+
+    script = native_policy_hook.policy_hook_wrapper_script(
+        "https://acme.databricks.com", "conv_own", "/path/hook.py"
+    )
+    assert RUNNER_TUNNEL_TOKEN_HEADER not in script
+
+
 def test_policy_hook_wrapper_script_omits_auth_when_unauthenticated(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_pi_native_bridge.py
+++ b/tests/test_pi_native_bridge.py
@@ -275,6 +275,41 @@ def test_refresh_config_auth_headers_replaces_only_auth(tmp_path: Path) -> None:
     assert payload["tools"] == [{"name": "t"}]
 
 
+def test_refresh_config_auth_headers_preserves_launch_headers(tmp_path: Path) -> None:
+    """A bearer refresh must NOT clobber other launch-time headers.
+
+    The guest-on-shared-host X-Omnigent-Runner-Tunnel-Token is written at
+    launch (in the runner-main process, which has the binding token) but the
+    per-turn refresh runs in a harness worker whose env has the token scrubbed,
+    so it can only supply the bearer. The refresh must merge the fresh bearer
+    over the existing headers, keeping the tunnel token — otherwise the
+    extension's POST /events chat-mirror loses self-access and 404-masks.
+    """
+    bridge_dir = tmp_path / "bridge"
+    pi_native_bridge.write_extension_files(
+        bridge_dir,
+        session_id="conv_abc",
+        server_url="http://omnigent.test",
+        conversation_url="http://omnigent.test/c/conv_abc",
+        auth_headers={
+            "Authorization": "Bearer stale",
+            "X-Omnigent-Runner-Tunnel-Token": "bind-token",
+        },
+    )
+
+    # Refresh supplies ONLY the rotated bearer (worker can't re-derive the token).
+    assert (
+        pi_native_bridge.refresh_config_auth_headers(bridge_dir, {"Authorization": "Bearer fresh"})
+        is True
+    )
+    payload = json.loads(pi_native_bridge.config_path(bridge_dir).read_text(encoding="utf-8"))
+    # Bearer rotated AND the tunnel token preserved via the merge.
+    assert payload["authHeaders"] == {
+        "Authorization": "Bearer fresh",
+        "X-Omnigent-Runner-Tunnel-Token": "bind-token",
+    }
+
+
 def test_refresh_config_auth_headers_noops(tmp_path: Path) -> None:
     """No-op (returns False) on empty headers, a missing config, or no change."""
     bridge_dir = tmp_path / "bridge"


### PR DESCRIPTION
## Related issue

Closes #2704  <!-- replace NNN with the issue number once #<issue> is created; search existing issues first to avoid a duplicate close -->

## Summary

Multi-user host sharing, backend only (UI follows in a separate PR):

- **Host permissions** — an owner/admin can grant another user `view` / `launch` (`use`) / `manage` access to a host. New `HostPermission` entity, `host_permissions` table + Alembic migration, `HostPermissionStore`, and `host_permissions` service (`check_host_access`, `get_host_permission_level`).
- **Shared-host visibility & launch** — `GET /v1/hosts` returns owned + shared hosts, each with the caller's `permission_level` and an `owned_by_current_user` flag. A grantee can launch a session on a shared host.
- **External-host runner auth** — a session launched on a *shared* host authenticates to that host's runner over the tunnel as a guest (tunnel binding token), so the runner accepts the cross-user session.
- **Admin fleet view** — `GET /v1/hosts?all=true` (admin only) returns every host with `created_at`, `last_seen`, and `session_count` (new `count_conversations_by_host_id`), restoring the admin Hosts page's per-host count.
- **Shutdown over the tunnel** — owners/admins can shut down a host's runner over the tunnel (`HostShutdownFrame` / `HostShutdownRequested`).

### ELI5

Right now every host belongs to one user and only they can use it. This lets a host's owner say "user B may use my host too." B then sees the host in their list and can start a session on it; that session logs into *the owner's* runner over the secure tunnel (as a guest) instead of needing its own. The owner (or an admin) can also stop that runner remotely.

### Diagram

```
  Owner A                  Server                    User B (grantee)
    │                        │                            │
    │  PUT /hosts/{h}/perms  │                            │
    │  {user:B, level:launch}│                            │
    │───────────────────────▶│  stores HostPermission      │
    │                        │                            │
    │                        │  GET /v1/hosts              │
    │                        │◀───────────────────────────│  sees A's host
    │                        │  (permission_level=launch) │    (shared)
    │                        │                            │
    │                        │  POST /v1/sessions (on h)   │
    │                        │◀───────────────────────────│
    │                        │ resolve_host_access(B,h) ──▶│ ok (launch)
    │                        │                            │
    │  runner tunnel token    │                            │
    │  (guest, scoped to h)   │  session runner ──────────▶│  auths to A's
    │◀───────────────────────│                            │  host runner
    │                        │                            │  over tunnel
    │  shutdown frame        │                            │
    │◀───────────────────────│  (owner/admin stops runner) │
```

## Test Plan

- **Lint/types**: `ruff check` + `ruff format` clean on all changed Python; `tsc -b` clean; `uv lock --locked` passes; `openapi.json` regenerated via `scripts/dump_openapi.py`.
- **New unit/store tests**: `tests/server/test_host_permissions.py`, `tests/stores/test_host_permission_store.py`.
- **New/updated integration tests** (host API, permissions, shared-host launch, session binding, runner launch worktree, accounts auth, app wiring): `tests/server/integration/test_hosts_api.py`, `test_hosts_management_e2e.py`, `test_session_host_launch.py`, `test_sessions_permissions.py`, `test_host_session_binding.py`, `test_host_runner_launch_worktree.py`, `test_accounts_auth_e2e.py`, `test_app.py`, and routes tests `test_host_launch.py`, `test_auth_helpers.py`.
- **Merge-affected areas re-verified locally (passing)**: `tests/host/test_connect.py`, `tests/host/test_frames.py` (shutdown frame round-trip), `tests/test_pi_native_bridge.py` (18/18), runner shutdown (`test_dispatch_shutdown_terminates_runners_and_raises`, `test_run_host_process_announces_session_log_dir_on_start`), `tests/inner/test_pi_native_executor.py`, `tests/test_native_policy_hook.py`.
- Full suite left to CI (a representative subset was run locally; the environment can't run the complete suite offline).

## Demo

N/A — backend/API only (no UI in this PR). A UI demo (admin Hosts/Sessions pages, share dialog, launching a shared host) will accompany the follow-up UI PR. Optionally, exercise the API with `curl`: `PUT /v1/hosts/{id}/permissions/{user}` then `GET /v1/hosts?all=true` as an admin.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit + store tests cover the permission service and store; new/updated integration tests cover the host permission endpoints, shared-host launch, session binding, and admin fleet listing. Merge-affected areas (host connect/frames, pi native bridge, runner shutdown, native policy hook) are covered by existing tests that were re-run and pass locally. The end-to-end UI flow is intentionally out of scope here (deferred to the UI PR) — reviewers may want to sanity-check the API via curl before that lands.

**Note for reviewers:** `create_app` now requires a `host_permission_store` whenever a `host_store` is provided (raises `ValueError` otherwise). All internal callers (`cli.py`, `deploy/databricks/src/app.py`, `deploy/docker/entrypoint.py`) are updated to construct it. Flagged in case any out-of-tree caller constructs the app directly.

## Changelog

Hosts can be shared with other users via view/launch/manage permissions; shared hosts are visible and launchable, with runner auth over the tunnel
