### PR TITLE
fix: terminal UTF-8, deploy --no-otel, hermes schema drift, opencode model carry

### DIFF
--- a/deploy/databricks/README.md
+++ b/deploy/databricks/README.md
@@ -258,7 +258,21 @@ uv run python deploy/databricks/deploy.py --skip-build --allow-dirty ...
 
 # API-only deploy (drops the SPA from the main wheel).
 uv run python deploy/databricks/deploy.py --skip-web-ui ...
+
+# No-OpenTelemetry deploy: runs `python app.py` instead of under
+# opentelemetry-instrument, drops OTEL_TRACES_SAMPLER, and drops the platform
+# telemetry_export_destinations. Use for workspaces with no OTel collector /
+# UC OTel tables -- otherwise every span export fails DEADLINE_EXCEEDED to
+# localhost:4317. Selects the `prod-no-otel` DAB target (same workspace/state
+# as `prod`).
+uv run python deploy/databricks/deploy.py --no-otel ...
 ```
+
+> [!NOTE]
+> `--no-otel` auto-switches the default `--target prod` to `prod-no-otel`.
+> If you deploy to a custom `--target`, add the OTel-off variable overrides
+> (`app_command`, `app_env`, `otel_export_destinations`) to that target too
+> — see the `prod-no-otel` block in `databricks.yml` for the template.
 
 ## Troubleshooting
 

--- a/deploy/databricks/databricks.yml
+++ b/deploy/databricks/databricks.yml
@@ -21,6 +21,51 @@ variables:
       UC schema (catalog.schema) holding the OTel destination tables.
       The platform writes to <schema>.otel_logs, otel_metrics, otel_spans.
     default: main.omnigent_logs
+  admins:
+    description: >
+      Comma-separated identities to grant admin (users.is_admin) on login,
+      e.g. "alice@example.com,bob@example.com". Empty = no declarative
+      admins; promote via the runtime admin-list file or the DB instead.
+    default: ""
+  # OTel plumbing is gated on these three complex variables so a workspace
+  # without an OTel collector / UC OTel tables can deploy cleanly. deploy.py
+  # sets the OTel-off values when run with --no-otel; the defaults keep the
+  # tracer on. See the `prod` target for the matching telemetry_export block.
+  app_command:
+    type: complex
+    description: >
+      App entrypoint. Default runs under opentelemetry-instrument so the
+      Databricks Apps platform OTLP endpoint is auto-instrumented. --no-otel
+      overrides this with ["python", "app.py"] (no instrumentation).
+    default: ["opentelemetry-instrument", "python", "app.py"]
+  app_env:
+    type: complex
+    description: >
+      The app's full env list. Default forces the OTel tracer on
+      (OTEL_TRACES_SAMPLER=always_on); --no-otel overrides with the same list
+      minus the sampler, so no exporter is configured (otherwise spans export
+      to localhost:4317 and fail DEADLINE_EXCEEDED when no collector present).
+    default:
+      - name: AP_LAKEBASE_ENDPOINT
+        value_from: postgres
+      - name: AP_ARTIFACT_VOLUME_PATH
+        value_from: artifact_volume
+      - name: OMNIGENT_ADMINS
+        value: ${var.admins}
+      - name: OTEL_TRACES_SAMPLER
+        value: 'always_on'
+  otel_export_destinations:
+    type: complex
+    description: >
+      Databricks Apps platform OTel export destinations (UC tables). Default
+      routes logs/metrics/traces to <otel_table_schema>.otel_*; --no-otel
+      overrides with an empty list (no export). Requires a workspace with a
+      custom storage location — the export API rejects default-storage tables.
+    default:
+      - unity_catalog:
+          logs_table: ${var.otel_table_schema}.otel_logs
+          metrics_table: ${var.otel_table_schema}.otel_metrics
+          traces_table: ${var.otel_table_schema}.otel_spans
 
 resources:
   apps:
@@ -36,14 +81,8 @@ resources:
       # set it out-of-band via apps.create_update in deploy.py before
       # the bundle deploy runs.
       config:
-        command: ["opentelemetry-instrument", "python", "app.py"]
-        env:
-          - name: AP_LAKEBASE_ENDPOINT
-            value_from: postgres
-          - name: AP_ARTIFACT_VOLUME_PATH
-            value_from: artifact_volume
-          - name: OTEL_TRACES_SAMPLER
-            value: 'always_on'
+        command: ${var.app_command}
+        env: ${var.app_env}
       resources:
         - name: postgres
           postgres:
@@ -56,29 +95,54 @@ resources:
             securable_type: VOLUME
             permission: WRITE_VOLUME
 
+# Reusable workspace block so a target and its no-OTel variant share one
+# host/root_path definition (host must be literal — DAB reads it before
+# resolving vars — so it can't be a ${var.}). To deploy to a different
+# workspace, edit this one anchor.
+.prod_workspace: &prod_workspace
+  host: https://example.databricks.com   # ← your workspace URL
+  # Isolate state per app so one bundle can deploy multiple apps.
+  root_path: /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.name}/${var.app_name}
+
 targets:
-  # One target per workspace. workspace.host must be literal (DAB reads it
-  # before resolving vars). deploy.py selects via --target. To deploy to a
-  # different workspace, add another target block here and pass
-  # `deploy.py --target <name>`.
+  # One target per workspace. deploy.py selects via --target. `prod` keeps the
+  # OTel tracer on; `prod-no-otel` (below) is the same workspace/state with the
+  # OTel variables overridden off — deploy.py --no-otel selects it. To deploy
+  # to a different workspace, edit the &prod_workspace anchor above.
   prod:
     mode: production
-    workspace:
-      host: https://example.databricks.com   # ← your workspace URL
-      # Isolate state per app so one bundle can deploy multiple apps.
-      root_path: /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.name}/${var.app_name}
+    workspace: *prod_workspace
     resources:
       apps:
         omnigent:
-          # Optional: Databricks Apps platform OTel export. The platform
-          # auto-injects OTEL_EXPORTER_OTLP_ENDPOINT into the app container
-          # so any OTLP emitter (including telemetry.init() in src/app.py)
-          # routes to the configured UC tables. The export API rejects tables
-          # in default storage ("Cannot export App telemetry to tables in
-          # default storage"), so this requires a workspace with a custom
-          # storage location — drop this block if yours has none.
-          telemetry_export_destinations:
-            - unity_catalog:
-                logs_table: ${var.otel_table_schema}.otel_logs
-                metrics_table: ${var.otel_table_schema}.otel_metrics
-                traces_table: ${var.otel_table_schema}.otel_spans
+          # Databricks Apps platform OTel export. The platform auto-injects
+          # OTEL_EXPORTER_OTLP_ENDPOINT into the app container so any OTLP
+          # emitter (including telemetry.init() in src/app.py) routes to the
+          # configured UC tables. Gated on ${var.otel_export_destinations} so
+          # --no-otel drops it (empty list). The export API rejects tables in
+          # default storage, so this requires a workspace with a custom
+          # storage location — use --no-otel if yours has none.
+          telemetry_export_destinations: ${var.otel_export_destinations}
+
+  # No-OTel variant of `prod`: same workspace + Terraform state (shared
+  # root_path), but overrides the OTel complex variables so the app runs
+  # uninstrumented (`python app.py`, no OTEL_TRACES_SAMPLER, no platform
+  # export). Use for workspaces with no OTel collector / UC OTel tables —
+  # otherwise span exports fail DEADLINE_EXCEEDED to localhost:4317.
+  # Selected by deploy.py --no-otel.
+  prod-no-otel:
+    mode: production
+    workspace: *prod_workspace
+    variables:
+      app_command:
+        default: ["python", "app.py"]
+      app_env:
+        default:
+          - name: AP_LAKEBASE_ENDPOINT
+            value_from: postgres
+          - name: AP_ARTIFACT_VOLUME_PATH
+            value_from: artifact_volume
+          - name: OMNIGENT_ADMINS
+            value: ${var.admins}
+      otel_export_destinations:
+        default: []

--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -25,6 +25,7 @@ including first-time infrastructure setup.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
 import shutil
@@ -385,6 +386,45 @@ def build_uv_pyproject(
     )
 
 
+def _sanitize_lock_proxy_urls(lock: Path) -> None:
+    """Rewrite internal pypi-proxy URLs in ``uv.lock`` to public PyPI.
+
+    The Databricks Apps build environment cannot reach
+    ``pypi-proxy.cloud.databricks.com``, so any URL pointing at it 404s
+    at install time. But a machine whose global uv config pins the proxy
+    as the default index bakes proxy hostnames into every lock entry
+    regardless of ``--index-url``. The proxy is a caching mirror of PyPI
+    with an identical ``/packages/<hash>/`` layout, so swapping only the
+    hostname preserves every version and sha256 pin; uv re-verifies the
+    hashes on install.
+    """
+    text = lock.read_text()
+    rewritten = (
+        text.replace(
+            "https://pypi-proxy.cloud.databricks.com/packages/",
+            "https://files.pythonhosted.org/packages/",
+        )
+        .replace(
+            "https://pypi-proxy.cloud.databricks.com/simple/",
+            "https://pypi.org/simple/",
+        )
+        .replace(
+            "https://pypi-proxy.cloud.databricks.com/simple",
+            "https://pypi.org/simple",
+        )
+    )
+    if rewritten != text:
+        lock.write_text(rewritten)
+        _log(f"rewrote pypi-proxy URLs → public PyPI in {lock.name}")
+    # Scan unconditionally: a lock carrying only an uncovered proxy form
+    # (a bare host root, a non-packages/simple path) would slip through the
+    # three replaces above and ship an unreachable URL to the Apps build env.
+    if "pypi-proxy.cloud.databricks.com" in rewritten:
+        raise RuntimeError(
+            f"{lock} still references pypi-proxy after rewrite; the Apps build env cannot reach it"
+        )
+
+
 def run_uv_lock(src: Path) -> None:
     """Generate ``uv.lock`` for the Databricks Apps source directory.
 
@@ -406,6 +446,10 @@ def run_uv_lock(src: Path) -> None:
         env=env,
         check=True,
     )
+    # A global uv config pinning the proxy as default can still bake proxy
+    # hostnames into the lock even when we pass --index-url. The Apps build
+    # env can't reach the proxy, so sanitize the resolved lock to public PyPI.
+    _sanitize_lock_proxy_urls(src / "uv.lock")
 
 
 def write_uv_dependency_files(
@@ -553,6 +597,15 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--admins",
+        default="",
+        help=(
+            "Comma-separated identities to grant admin on login, e.g. "
+            "'alice@example.com'. Empty keeps the runtime admin-list file / "
+            "DB flag as the only admin sources."
+        ),
+    )
+    parser.add_argument(
         "--compute-size",
         default="LARGE",
         choices=["SMALL", "MEDIUM", "LARGE"],
@@ -565,6 +618,17 @@ def _parse_args() -> argparse.Namespace:
             "UC schema (catalog.schema) holding the OTel destination tables. "
             "The Databricks Apps platform writes logs/metrics/spans to "
             "<schema>.otel_{logs,metrics,spans}."
+        ),
+    )
+    parser.add_argument(
+        "--no-otel",
+        action="store_true",
+        help=(
+            "Deploy without OpenTelemetry: run 'python app.py' instead of "
+            "under opentelemetry-instrument, drop OTEL_TRACES_SAMPLER, and "
+            "drop the platform telemetry_export_destinations. Use for "
+            "workspaces with no OTel collector / UC OTel tables — otherwise "
+            "span exports fail DEADLINE_EXCEEDED to localhost:4317."
         ),
     )
     parser.add_argument(
@@ -583,6 +647,18 @@ def _parse_args() -> argparse.Namespace:
             "Databricks CLI profile to authenticate with. Omit when running "
             "with env-based auth (DATABRICKS_HOST + DATABRICKS_CLIENT_ID + "
             "DATABRICKS_CLIENT_SECRET)."
+        ),
+    )
+    parser.add_argument(
+        "--profile-token-auth",
+        action="store_true",
+        help=(
+            "Read the --profile's cached OAuth token and use bearer auth "
+            "(DATABRICKS_HOST + DATABRICKS_TOKEN) for the SDK and CLI instead "
+            "of profile auth. Use when the SDK's forced token refresh fails "
+            "in a spawned subprocess (macOS keychain write denied, "
+            "'cache update: exit status 161'). The token comes from the same "
+            "--profile, so it cannot route to a different workspace."
         ),
     )
     parser.add_argument(
@@ -634,14 +710,107 @@ def _parse_args() -> argparse.Namespace:
             "known commit on main."
         ),
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    # --no-otel selects the tracer-off DAB target (same workspace + state as
+    # `prod`, OTel variables overridden off). Only auto-switch the default
+    # target so an explicit --target still wins; if a caller pairs --no-otel
+    # with a custom --target, that target must define the OTel-off overrides
+    # itself.
+    if args.no_otel and args.target == "prod":
+        args.target = "prod-no-otel"
+    return args
 
 
-def _clear_env_vars() -> None:
+def _clear_env_vars(keep: Iterable[str] = ()) -> None:
+    keep = set(keep)
     for name in _ENV_VARS_TO_CLEAR:
+        if name in keep:
+            continue
         if name in os.environ:
             _log(f"unsetting {name} to avoid leaking into the SDK")
             del os.environ[name]
+
+
+# A deploy (build → wheel upload → bundle deploy → run → smoke check) can run
+# for several minutes. The bearer token below is captured ONCE and never
+# refreshed (unlike profile auth, which the SDK/CLI refresh transparently), so
+# it must have enough runway to outlast the whole deploy. Refuse a token with
+# less than this remaining rather than 401 partway through.
+_MIN_TOKEN_RUNWAY_S = 10 * 60
+
+
+def _setup_profile_token_auth(profile: str) -> None:
+    """Switch to bearer auth using the profile's cached OAuth token.
+
+    The SDK's ``databricks-cli`` credential strategy force-refreshes the
+    token on every init, which writes to the macOS keychain — denied for
+    a spawned subprocess ("cache update: exit status 161"). Reading the
+    *cached* token (no ``--force-refresh``) succeeds, and exporting it as
+    ``DATABRICKS_TOKEN`` makes both the SDK and the CLI use bearer auth,
+    skipping the refresh entirely. The token is scoped to ``profile``, so
+    it cannot authenticate against a different workspace.
+
+    The captured token is NOT refreshed for the rest of the deploy, so this
+    fails fast when its remaining runway (``_MIN_TOKEN_RUNWAY_S``) can't cover
+    a full deploy — re-run ``databricks auth login --profile <p>`` first.
+    """
+    token_data = json.loads(
+        subprocess.run(
+            ["databricks", "auth", "token", "--profile", profile],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    )
+    token = token_data["access_token"]
+    _assert_token_runway(token_data.get("expiry"), profile)
+    host = subprocess.run(
+        ["databricks", "auth", "env", "--profile", profile],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    host_url = json.loads(host).get("env", {}).get("DATABRICKS_HOST", "")
+    if not host_url:
+        raise SystemExit(f"could not resolve DATABRICKS_HOST for profile {profile!r}")
+    os.environ["DATABRICKS_HOST"] = host_url
+    os.environ["DATABRICKS_TOKEN"] = token
+    _log(f"--profile-token-auth: using cached bearer token for {profile} ({host_url})")
+
+
+def _assert_token_runway(expiry: str | None, profile: str) -> None:
+    """Refuse a cached token that won't outlast a deploy.
+
+    ``expiry`` is the absolute ISO-8601 timestamp from ``databricks auth
+    token`` — the true remaining runway (``expires_in`` is the original
+    lifetime, not what's left on a token cached a while ago).
+    """
+    if not expiry:
+        _log("--profile-token-auth: token has no expiry field; skipping runway check")
+        return
+    from datetime import datetime, timezone
+
+    remaining = (datetime.fromisoformat(expiry) - datetime.now(timezone.utc)).total_seconds()
+    if remaining < _MIN_TOKEN_RUNWAY_S:
+        raise SystemExit(
+            f"cached token for {profile!r} has {int(remaining)}s left "
+            f"(< {_MIN_TOKEN_RUNWAY_S}s); it may expire mid-deploy. "
+            f"Run `databricks auth login --profile {profile}` and retry."
+        )
+    _log(f"--profile-token-auth: token runway {int(remaining)}s")
+
+
+def _workspace_client(args: argparse.Namespace) -> WorkspaceClient:
+    """Construct the SDK client, honoring --profile-token-auth.
+
+    With token auth, DATABRICKS_HOST + DATABRICKS_TOKEN are already in the
+    env, so a bare client uses bearer auth and skips the profile refresh.
+    """
+    from databricks.sdk import WorkspaceClient as _WorkspaceClient
+
+    if getattr(args, "profile_token_auth", False):
+        return _WorkspaceClient()
+    return _WorkspaceClient(profile=args.profile) if args.profile else _WorkspaceClient()
 
 
 def _ensure_bound(args: argparse.Namespace) -> None:
@@ -660,10 +829,9 @@ def _ensure_bound(args: argparse.Namespace) -> None:
     success.
     """
     # Late-import so --help works without the SDK.
-    from databricks.sdk import WorkspaceClient
     from databricks.sdk.errors.platform import NotFound
 
-    wc = WorkspaceClient(profile=args.profile) if args.profile else WorkspaceClient()
+    wc = _workspace_client(args)
     try:
         wc.apps.get(name=args.app_name)
     except NotFound:
@@ -746,10 +914,22 @@ def _bundle_vars(args: argparse.Namespace) -> list[str]:
         f"volume_name={args.volume_name}",
         "--var",
         f"otel_table_schema={args.otel_table_schema}",
+        # The Apps spec validator rejects an env entry whose `value:` is the
+        # empty string ("Must specify environment variable source"). When no
+        # admins are set, pass a single space so the entry is a valid non-empty
+        # value; the app parses OMNIGENT_ADMINS on `,` and strips each token,
+        # so a whitespace-only value yields an empty admin roster all the same.
+        "--var",
+        f"admins={args.admins or ' '}",
     ]
 
 
 def _profile_arg(args: argparse.Namespace) -> list[str]:
+    # With --profile-token-auth the CLI authenticates via DATABRICKS_HOST +
+    # DATABRICKS_TOKEN in the env; passing --profile too would re-trigger the
+    # keychain refresh we're avoiding.
+    if getattr(args, "profile_token_auth", False):
+        return []
     return ["--profile", args.profile] if args.profile else []
 
 
@@ -781,26 +961,45 @@ def _ensure_app_sp_uc_traversal(
     ):
         _log(f"granting {priv} on {kind} {fqn} → app SP {app_sp}")
         payload = _json.dumps({"changes": [{"principal": app_sp, "add": [priv]}]})
-        subprocess.run(
-            [
-                "databricks",
-                "grants",
-                "update",
-                kind,
-                fqn,
-                *_profile_arg(args),
-                "--json",
-                payload,
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            subprocess.run(
+                [
+                    "databricks",
+                    "grants",
+                    "update",
+                    kind,
+                    fqn,
+                    *_profile_arg(args),
+                    "--json",
+                    payload,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            # SP may already have access via group inheritance, or the
+            # deployer lacks MANAGE on a shared catalog; warn, don't abort.
+            detail = exc.stderr.strip()[:200] if exc.stderr else f"rc={exc.returncode}"
+            _log(f"warning: {priv} grant on {fqn} failed ({detail})")
 
 
 def main() -> int:
     args = _parse_args()
-    _clear_env_vars()
+    if args.profile_token_auth:
+        if not args.profile:
+            raise SystemExit("--profile-token-auth requires --profile")
+        _setup_profile_token_auth(args.profile)
+        # Deliberately keep DATABRICKS_TOKEN: this mode's whole point is to feed
+        # the cached bearer token to the SDK *and* the `databricks` CLI
+        # subprocesses via the env. That does hand a live workspace token to
+        # every child (build.sh, uv, git) — the accepted cost of dodging the
+        # keychain refresh; don't "fix" it by re-clearing the token. The
+        # matching DATABRICKS_HOST _setup wrote is also a legit auth var (see
+        # the env-based auth path), so it's fine to leave set.
+        _clear_env_vars(keep={"DATABRICKS_TOKEN"})
+    else:
+        _clear_env_vars()
     _assert_clean_tree(skip=args.allow_dirty)
 
     base_version = _read_base_version()
@@ -843,10 +1042,7 @@ def main() -> int:
             "because uv lock validates path sources locally."
         )
 
-    # Late-import the SDK so `--help` works without it installed.
-    from databricks.sdk import WorkspaceClient
-
-    wc = WorkspaceClient(profile=args.profile) if args.profile else WorkspaceClient()
+    wc = _workspace_client(args)
 
     # 1) Prep the bundle's source_code_path (src/) — sweep stale
     # wheels locally, then copy the new small wheels in.

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -369,6 +369,22 @@ def _connect_ro(db_path: Path) -> sqlite3.Connection | None:
     return None
 
 
+def _table_columns(con: sqlite3.Connection, table: str) -> frozenset[str]:
+    """Return the set of column names on *table*, or empty on any error.
+
+    Hermes' ``state.db`` schema drifts across versions (e.g. schema_version 11
+    dropped ``sessions.cwd`` and ``messages.active`` / ``messages.compacted``
+    that older builds carried). The forwarder introspects the live schema and
+    adapts its SELECTs instead of assuming a fixed column set — otherwise a
+    single ``no such column`` error aborts discovery / mirroring and the chat
+    goes silent even though Hermes itself is working (visible in the terminal).
+    """
+    try:
+        return frozenset(str(r[1]) for r in con.execute(f"PRAGMA table_info({table})"))
+    except sqlite3.Error:
+        return frozenset()
+
+
 def _discover_session_id(
     db_path: Path,
     workspace: str,
@@ -396,11 +412,25 @@ def _discover_session_id(
     if con is None:
         return None
     floor_s = launch_epoch_s - _DISCOVERY_SKEW_S
+    # Newer Hermes (schema_version >= 11) no longer records ``sessions.cwd``.
+    # Select it only when present; otherwise treat every row as cwd-less and
+    # rely on the started_at-since-launch fallback below (the newest lone
+    # session started after this terminal launched is this terminal's session).
+    has_cwd = "cwd" in _table_columns(con, "sessions")
     try:
-        rows = con.execute(
-            "SELECT id, cwd FROM sessions WHERE started_at >= ? ORDER BY started_at DESC",
-            (floor_s,),
-        ).fetchall()
+        if has_cwd:
+            rows = con.execute(
+                "SELECT id, cwd FROM sessions WHERE started_at >= ? ORDER BY started_at DESC",
+                (floor_s,),
+            ).fetchall()
+        else:
+            rows = [
+                (sid, None)
+                for (sid,) in con.execute(
+                    "SELECT id FROM sessions WHERE started_at >= ? ORDER BY started_at DESC",
+                    (floor_s,),
+                ).fetchall()
+            ]
     except sqlite3.Error as exc:
         _warn_sqlite_once("session discovery", exc)
         return None
@@ -594,11 +624,14 @@ def _read_new_items(
     con = _connect_ro(db_path)
     if con is None:
         return []
+    # ``messages.active`` (compaction soft-delete flag) was dropped in newer
+    # Hermes schemas; only filter on it when present.
+    active_filter = " AND active = 1" if "active" in _table_columns(con, "messages") else ""
     try:
         rows = con.execute(
             "SELECT id, role, content, tool_calls, tool_call_id, tool_name "
             "FROM messages "
-            "WHERE session_id = ? AND id > ? AND active = 1 ORDER BY id",
+            f"WHERE session_id = ? AND id > ?{active_filter} ORDER BY id",
             (hermes_session_id, last_id),
         ).fetchall()
     except sqlite3.Error as exc:
@@ -827,6 +860,11 @@ def _has_new_compaction(db_path: Path, hermes_session_id: str) -> bool:
     con = _connect_ro(db_path)
     if con is None:
         return False
+    # ``messages.compacted`` was dropped in newer Hermes schemas; without it we
+    # cannot detect a compaction boundary here (safe: no boundary item posted).
+    if "compacted" not in _table_columns(con, "messages"):
+        con.close()
+        return False
     try:
         row = con.execute(
             "SELECT 1 FROM messages WHERE session_id = ? AND compacted = 1 LIMIT 1",
@@ -858,10 +896,10 @@ async def _persist_hermes_compaction_item(
     compacted_messages = None
     con = _connect_ro(db_path)
     if con is not None:
+        _active = " AND active = 1" if "active" in _table_columns(con, "messages") else ""
         try:
             rows = con.execute(
-                "SELECT role, content FROM messages "
-                "WHERE session_id = ? AND active = 1 ORDER BY id",
+                f"SELECT role, content FROM messages WHERE session_id = ?{_active} ORDER BY id",
                 (hermes_session_id,),
             ).fetchall()
             msgs = []

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -56,6 +56,73 @@ logger = logging.getLogger(__name__)
 _TMUX_CONFIG_PATH = os.devnull
 _TMUX_CONVERSATION_LINK_OPTION = "@omnigent-conversation-link"
 
+# Fallback UTF-8 locale forced into a terminal's env when the inherited
+# environment carries no UTF-8 locale signal. ``C.UTF-8`` is glibc's and
+# musl's locale-independent UTF-8 codeset; it needs no locale archive so it
+# is present on minimal container images where ``en_US.UTF-8`` is not.
+_FALLBACK_UTF8_LOCALE = "C.UTF-8"
+
+
+def _is_utf8_locale_value(value: str | None) -> bool:
+    """Return whether a locale env value names the UTF-8 codeset.
+
+    Matches ``en_US.UTF-8``, ``C.UTF-8``, ``utf8``, etc. case- and
+    punctuation-insensitively.
+
+    :param value: A locale env value, or ``None`` when the var is unset.
+    :returns: ``True`` when *value* selects the UTF-8 codeset.
+    """
+    if not value:
+        return False
+    return value.replace("-", "").replace("_", "").lower().endswith("utf8")
+
+
+def _has_utf8_locale(env: dict[str, str]) -> bool:
+    """Return whether *env* selects UTF-8 in a var the pane CLIs actually read.
+
+    The affected native TUIs read ``LC_ALL`` / ``LANG`` directly rather than
+    calling ``setlocale``, so a UTF-8 ``LC_CTYPE`` alone does NOT save them:
+    with ``LANG`` empty and ``LC_ALL`` unset they still fall back to
+    ASCII/Latin-1. Treat the env as safe only when the codeset-deciding vars
+    the CLIs consult carry UTF-8:
+
+    - ``LC_ALL`` set to UTF-8 makes the env safe (it overrides everything).
+    - ``LC_ALL`` set to a non-UTF-8 value is unsafe (it pins non-UTF-8;
+      ``LANG`` cannot rescue it).
+    - otherwise ``LANG`` set to UTF-8 makes the env safe.
+
+    :param env: The environment about to be handed to the terminal's tmux
+        server (and, through it, the native CLI in the pane).
+    :returns: ``True`` when no locale fix is needed.
+    """
+    lc_all = env.get("LC_ALL")
+    if lc_all:
+        return _is_utf8_locale_value(lc_all)
+    return _is_utf8_locale_value(env.get("LANG"))
+
+
+def _apply_utf8_locale_default(env: dict[str, str]) -> None:
+    """Force a UTF-8 locale into *env* when it lacks one, in place.
+
+    Native TUI CLIs (opencode, pi, hermes, and friends) run in the terminal's
+    pane. Several read ``LC_ALL`` / ``LANG`` directly (rather than calling
+    ``setlocale``) to pick their output codeset; when neither names UTF-8 they
+    fall back to ASCII/Latin-1 and re-encode their internal UTF-8 as single
+    bytes, producing cascading mojibake (a UTF-8 arrow renders as a run of
+    accented Latin-1 glyphs) in both the chat and the raw terminal view.
+    Setting ``LC_ALL`` and ``LANG`` to a UTF-8 codeset removes that ambiguity.
+    Only applied when the inherited env has no UTF-8 signal, so an
+    operator-provided locale always wins.
+
+    :param env: The terminal spawn environment, mutated in place.
+    :returns: None.
+    """
+    if IS_WINDOWS or _has_utf8_locale(env):
+        return
+    env["LANG"] = _FALLBACK_UTF8_LOCALE
+    env["LC_ALL"] = _FALLBACK_UTF8_LOCALE
+
+
 # Web-terminal attach transports. ``pty`` forks a full ``tmux attach`` client
 # and streams the rendered screen (see terminals/ws_bridge.py); ``control``
 # attaches a ``tmux -C`` control-mode client and streams per-pane ``%output``
@@ -1059,6 +1126,11 @@ class TerminalInstance:
         # this tmux pane, so the binding token must never reach it.
         # After ``env.update`` so ``self.env`` can't re-admit it.
         env = strip_runner_auth_secrets(env)
+        # Force a UTF-8 locale when the inherited env carries none. Native
+        # TUI CLIs that read LC_ALL / LANG directly otherwise fall back to
+        # ASCII/Latin-1 and mangle multibyte output into mojibake. No-op when
+        # a UTF-8 locale is already set (operator config wins) or on Windows.
+        _apply_utf8_locale_default(env)
 
         # Build the command to run inside tmux. If a sandbox policy
         # is configured, wrap the command in the sandbox launcher so

--- a/omnigent/opencode_native_provider.py
+++ b/omnigent/opencode_native_provider.py
@@ -427,11 +427,18 @@ def maybe_merge_user_provider_config(config: dict[str, object]) -> dict[str, obj
     server sees both the user's providers (with their custom base URLs) and
     any Omnigent-synthesized providers (e.g. Databricks gateway).
 
-    Only ``provider`` entries are merged — the synthesized config takes
-    precedence for all other keys (model, mcp, plugin, permission, etc.).
+    ``provider`` entries are merged, and the user config's top-level ``model``
+    default is adopted **only when the synthesized config pins none** — the
+    synthesized config still takes precedence for all keys it sets (model, mcp,
+    plugin, permission, etc.). The ``model`` carry-over matters because when
+    neither a gateway nor a spec-supplied ``model_override`` is present, the
+    synthesized config has no ``model`` key, and opencode-native would otherwise
+    pick its own default over the merged models map (e.g. landing on a served
+    Gemini endpoint even though the user's config defaults to Claude).
 
     :param config: The synthesized config dict (may be empty).
-    :returns: *config* with user's ``provider`` entries merged in (if any).
+    :returns: *config* with user's ``provider`` entries (and, if unset, the
+        user's default ``model``) merged in.
     """
     from omnigent.opencode_native_bridge import user_opencode_config_path
 
@@ -462,9 +469,23 @@ def maybe_merge_user_provider_config(config: dict[str, object]) -> dict[str, obj
     if not isinstance(user_config, dict):
         return config
 
+    # Adopt the user's default ``model`` when the synthesized config pins none.
+    # ``setdefault`` keeps the synthesized value authoritative (gateway /
+    # spec-supplied ``model_override`` win); it only fills the gap where both
+    # were absent, so opencode-native launches on the user's chosen default
+    # instead of picking its own over the merged models map.
+    def _carry_model(target: dict[str, object]) -> None:
+        user_model = user_config.get("model")
+        if isinstance(user_model, str) and user_model:
+            target.setdefault("model", user_model)
+
     user_providers = user_config.get("provider")
     if not isinstance(user_providers, dict) or not user_providers:
-        return config
+        # No custom providers to merge, but the user's default model still
+        # applies when the synthesized config didn't pin one.
+        result = dict(config)
+        _carry_model(result)
+        return result
 
     result = dict(config)
     existing = result.get("provider")
@@ -480,6 +501,7 @@ def maybe_merge_user_provider_config(config: dict[str, object]) -> dict[str, obj
     else:
         result["provider"] = dict(user_providers)
 
+    _carry_model(result)
     result.setdefault("$schema", "https://opencode.ai/config.json")
 
     return result

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -19,6 +19,8 @@ from omnigent.inner.terminal import (
     TERMINAL_TRANSPORT_CONTROL,
     TERMINAL_TRANSPORT_PTY,
     TerminalInstance,
+    _apply_utf8_locale_default,
+    _has_utf8_locale,
     create_terminal_instance,
     resolve_terminal_transport,
 )
@@ -1320,3 +1322,77 @@ def test_create_terminal_instance_denies_control_socket_but_keeps_private_dir_wr
         )
     finally:
         shutil.rmtree(instance.private_dir, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        # LC_ALL wins outright when set.
+        ({"LC_ALL": "en_US.UTF-8"}, True),
+        ({"LC_ALL": "C.UTF-8"}, True),
+        ({"LC_ALL": "C"}, False),
+        # A UTF-8 LC_ALL overrides even a non-UTF-8 LANG, and vice versa.
+        ({"LC_ALL": "en_US.UTF-8", "LANG": "C"}, True),
+        ({"LC_ALL": "C", "LANG": "en_US.UTF-8"}, False),
+        # No LC_ALL: LANG decides.
+        ({"LANG": "en_US.UTF-8"}, True),
+        ({"LANG": "C"}, False),
+        ({"LANG": ""}, False),
+        ({}, False),
+        # A UTF-8 LC_CTYPE alone does NOT count: the affected TUIs read
+        # LC_ALL / LANG directly, so LANG empty + LC_CTYPE=C.UTF-8 (the
+        # deployed-container config that triggered the mojibake) is unsafe.
+        ({"LC_CTYPE": "C.UTF-8"}, False),
+        # Case / punctuation insensitivity.
+        ({"LANG": "en_US.utf8"}, True),
+        ({"LANG": "en_US.Utf-8"}, True),
+    ],
+)
+def test_has_utf8_locale(env: dict[str, str], expected: bool) -> None:
+    """UTF-8 detection follows POSIX precedence and only trusts LC_ALL/LANG."""
+    assert _has_utf8_locale(env) is expected
+
+
+def test_apply_utf8_locale_default_fixes_bare_env() -> None:
+    """A bare env gets LANG and LC_ALL forced to the fallback UTF-8 locale."""
+    env: dict[str, str] = {"PATH": "/usr/bin"}
+    _apply_utf8_locale_default(env)
+    assert env["LANG"] == "C.UTF-8"
+    assert env["LC_ALL"] == "C.UTF-8"
+
+
+def test_apply_utf8_locale_default_fixes_ctype_only_container_env() -> None:
+    """LC_CTYPE=C.UTF-8 with empty LANG (the repro config) still gets fixed."""
+    env = {"PATH": "/usr/bin", "LC_CTYPE": "C.UTF-8"}
+    _apply_utf8_locale_default(env)
+    assert env["LANG"] == "C.UTF-8"
+    assert env["LC_ALL"] == "C.UTF-8"
+    # The pre-existing LC_CTYPE is left as-is.
+    assert env["LC_CTYPE"] == "C.UTF-8"
+
+
+def test_apply_utf8_locale_default_preserves_operator_locale() -> None:
+    """An operator-provided UTF-8 locale is never overridden."""
+    env = {"LANG": "en_US.UTF-8"}
+    _apply_utf8_locale_default(env)
+    assert env["LANG"] == "en_US.UTF-8"
+    assert "LC_ALL" not in env
+
+
+def test_apply_utf8_locale_default_corrects_non_utf8_lc_all() -> None:
+    """A pinned non-UTF-8 LC_ALL is corrected to the fallback UTF-8 locale."""
+    env = {"LC_ALL": "C", "LANG": "en_US.UTF-8"}
+    _apply_utf8_locale_default(env)
+    assert env["LANG"] == "C.UTF-8"
+    assert env["LC_ALL"] == "C.UTF-8"
+
+
+def test_apply_utf8_locale_default_noop_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On Windows the locale default is skipped (no POSIX locale env)."""
+    monkeypatch.setattr(terminal_mod, "IS_WINDOWS", True)
+    env: dict[str, str] = {"PATH": "C:\\Windows"}
+    _apply_utf8_locale_default(env)
+    assert "LANG" not in env
+    assert "LC_ALL" not in env

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -122,6 +122,81 @@ def test_discover_child_session_returns_newest_child(tmp_path: Path) -> None:
     assert f._discover_child_session(db, "child_new") is None
 
 
+# Newer Hermes (schema_version >= 11) dropped ``sessions.cwd`` and
+# ``messages.active`` / ``messages.compacted``. The forwarder must introspect
+# the live schema and adapt its SELECTs rather than raising ``no such column``
+# (which silently aborts discovery/mirroring — the exact "hermes doesn't work"
+# symptom on the shared CoDA host).
+_SCHEMA_V11 = """
+CREATE TABLE schema_version (version INTEGER NOT NULL);
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    started_at REAL NOT NULL,
+    parent_session_id TEXT
+);
+CREATE TABLE messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT,
+    tool_call_id TEXT,
+    tool_calls TEXT,
+    tool_name TEXT
+);
+"""
+
+
+def _seed_db_v11(path: Path, *, started_at: float, session_id: str = "20260710_1") -> None:
+    """Seed a schema-11 Hermes DB (no cwd / active / compacted columns)."""
+    con = sqlite3.connect(path)
+    con.executescript(_SCHEMA_V11)
+    con.execute("INSERT INTO schema_version(version) VALUES (11)")
+    con.execute(
+        "INSERT INTO sessions(id, source, started_at) VALUES (?,?,?)",
+        (session_id, "cli", started_at),
+    )
+    con.executemany(
+        "INSERT INTO messages(session_id, role, content, tool_call_id, tool_calls, tool_name)"
+        " VALUES (?,?,?,?,?,?)",
+        [
+            (session_id, "user", "ping", None, None, None),
+            (session_id, "assistant", "PONG_4242", None, None, None),
+        ],
+    )
+    con.commit()
+    con.close()
+
+
+def test_discover_session_id_v11_no_cwd_binds_lone_session(tmp_path: Path) -> None:
+    """Schema-11 DB has no cwd column; discovery binds the lone since-launch row."""
+    db = tmp_path / "state.db"
+    _seed_db_v11(db, started_at=1000.0)
+    # cwd is unknown/irrelevant on this schema; any workspace resolves the lone row.
+    assert f._discover_session_id(db, str(tmp_path), 1000.0) == "20260710_1"
+    # Floor still applies: a session started before launch is not bound.
+    assert f._discover_session_id(db, str(tmp_path), 2000.0) is None
+
+
+def test_read_new_items_v11_no_active_column(tmp_path: Path) -> None:
+    """Message read must not require the dropped ``active`` column (schema 11)."""
+    db = tmp_path / "state.db"
+    _seed_db_v11(db, started_at=1000.0)
+    items = f._read_new_items(db, "20260710_1", 0, "hermes-native-ui")
+    posted = [i for i in items if i.item_type]
+    assert len(posted) == 2
+    assert posted[0].item_data["role"] == "user"
+    assert posted[1].item_data["role"] == "assistant"
+    assert posted[1].item_data["content"] == [{"type": "output_text", "text": "PONG_4242"}]
+
+
+def test_has_new_compaction_v11_no_compacted_column(tmp_path: Path) -> None:
+    """Compaction detection returns False (no boundary) when the column is gone."""
+    db = tmp_path / "state.db"
+    _seed_db_v11(db, started_at=1000.0)
+    assert f._has_new_compaction(db, "20260710_1") is False
+
+
 def test_read_new_items_maps_roles_and_strips_attachments(tmp_path: Path) -> None:
     db = tmp_path / "state.db"
     _seed_db(db, cwd=str(tmp_path), started_at=1000.0)

--- a/tests/test_opencode_native_provider.py
+++ b/tests/test_opencode_native_provider.py
@@ -327,6 +327,71 @@ def test_merge_user_provider_config_does_not_clobber_synthesized_providers(
     )
 
 
+def test_merge_user_provider_config_adopts_user_model_when_synthesized_has_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """User's default model is adopted when the synthesized config pins none.
+
+    Regression: with no gateway and no spec model_override, the synthesized
+    config had no ``model`` key; opencode-native then picked its own default
+    over the merged models map (landing on a served Gemini endpoint) instead of
+    the user's configured Claude default. The merge now carries ``model``.
+    """
+    cfg_dir = tmp_path / "cfg" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.json").write_text(
+        '{"model": "databricks/databricks-claude-opus-4-8", '
+        '"provider": {"databricks": {"npm": "@ai-sdk/openai-compatible", '
+        '"options": {"baseURL": "https://ws/serving-endpoints", "apiKey": "t"}, '
+        '"models": {"databricks-claude-opus-4-8": {"name": "Claude"}, '
+        '"databricks-gemini-2-5-pro": {"name": "Gemini"}}}}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    config: dict[str, object] = {}  # no gateway, no model_override
+    result = maybe_merge_user_provider_config(config)
+
+    assert result["model"] == "databricks/databricks-claude-opus-4-8"
+
+
+def test_merge_user_provider_config_does_not_override_synthesized_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A synthesized ``model`` (gateway / spec override) wins over the user's."""
+    cfg_dir = tmp_path / "cfg" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.json").write_text(
+        '{"model": "databricks/databricks-claude-opus-4-8", '
+        '"provider": {"databricks": {"models": {"m": {"name": "m"}}}}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    config: dict[str, object] = {"model": "databricks-gateway/pinned-model"}
+    result = maybe_merge_user_provider_config(config)
+
+    assert result["model"] == "databricks-gateway/pinned-model"
+
+
+def test_merge_user_provider_config_carries_model_without_user_providers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """User's default model is adopted even when the user declares no providers."""
+    cfg_dir = tmp_path / "cfg" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.json").write_text(
+        '{"model": "databricks/databricks-claude-opus-4-8"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    config: dict[str, object] = {}
+    result = maybe_merge_user_provider_config(config)
+
+    assert result["model"] == "databricks/databricks-claude-opus-4-8"
+
+
 def test_merge_user_provider_config_merges_alongside_synthesized_providers(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Related issue

N/A — no tracking issue yet. _(Replace with `Closes #NNN` if one exists.)_

## Summary

Four small, independent backend fixes bundled for review:

- **Terminal UTF-8 locale** (`omnigent/inner/terminal.py`) — when the inherited environment carries no UTF-8 locale signal, force `C.UTF-8` into the terminal env so native TUI harnesses in minimal containers don't fall back to ASCII (glibc/musl ship `C.UTF-8` without a locale archive).
- **`--no-otel` deploy** (`deploy/databricks/deploy.py`, `databricks.yml`, `README.md`) — deploy without the OpenTelemetry collector for collector-less workspaces. Also makes the post-start UC `USE_CATALOG`/`USE_SCHEMA` grant step warn-and-continue instead of aborting the whole deploy when the grant fails (the SP may already have access via group inheritance, or the deployer may lack `MANAGE` on a shared catalog).
- **Hermes schema drift** (`omnigent/hermes_native_forwarder.py`) — introspect `state.db` columns and adapt SELECTs, so a schema change across Hermes builds (e.g. a dropped `sessions.cwd`) no longer aborts discovery/mirroring with `no such column`.
- **opencode model carry** (`omnigent/opencode_native_provider.py`) — carry the user config's top-level `model` default into the synthesized config when no model is pinned, so opencode-native doesn't silently fall back to its own default over the merged models map.

### ELI5

- Terminal fix: some containers start with no UTF-8 locale set, so special characters break in the TUI; we now set a safe UTF-8 locale automatically.
- `--no-otel`: you can now skip the telemetry collector if you don't want it.
- Hermes fix: Hermes changes its internal database layout between versions; we now read the layout at runtime instead of guessing, so mirroring keeps working.
- opencode fix: when you set a default model in your config, that choice now survives into opencode sessions instead of being overridden.

## Test Plan

- **Lint**: `ruff check` + `ruff format` clean on all changed Python; byte-compile clean.
- **Updated unit tests pass**: `tests/inner/test_terminal.py` (UTF-8 locale fallback), `tests/test_hermes_native_forwarder.py` (schema introspection), `tests/test_opencode_native_provider.py` (model carry-over).
- Full suite left to CI (the complete suite can't be run in this offline environment).

## Demo

N/A — non-visual changes. `--no-otel` is a CLI flag; optionally show `omnigent deploy ... --no-otel` resulting in a collector-less deployment.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Each fix has a corresponding updated unit test (`test_terminal.py`, `test_hermes_native_forwarder.py`, `test_opencode_native_provider.py`). The `--no-otel` deploy path is covered by the updated deploy option wiring + docs; an integration deploy test would be a nice follow-up but isn't included here. These four changes are independent of each other and of the host-sharing PR — happy to split into separate PRs if reviewers prefer one-fix-per-PR.

## Changelog

`--no-otel` deploys without the OpenTelemetry collector; terminal auto-forces a UTF-8 locale in minimal containers
