### PR TITLE
[ci] Require DCO in Merge Ready

### DIFF
--- a/.github/scripts/merge-ready/required.sh
+++ b/.github/scripts/merge-ready/required.sh
@@ -7,6 +7,7 @@
 # Generated file -- do not hand-edit; it is replaced wholesale on every sync.
 
 REQUIRED=(
+  "DCO"
   "Pre-commit checks"
   "Pytest (runtime-harnesses)"
   "Pytest (runtime-policies)"

--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -29,6 +29,8 @@ on:
   workflow_run:
     workflows: [PR Template, CI, Lint, E2E UI Tests, E2E Tests, Integration Tests]
     types: [completed]
+  check_run:
+    types: [completed]
   issue_comment:
     types: [created]
   # Programmatic / manual re-evaluation of a single PR.
@@ -48,7 +50,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: merge-ready-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr || github.event.workflow_run.head_sha }}
+  group: merge-ready-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr || github.event.workflow_run.head_sha || github.event.check_run.head_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -61,8 +63,9 @@ jobs:
       actions: read         # evaluate-checks.sh reads GET /actions/runs to classify missing checks
       statuses: write
     # Fire on automerge label adds, PR CI workflow_run completions (same-repo
-    # and fork), `/merge` comments, or a workflow_dispatch re-eval. Runs with no
-    # open PR (push to main, etc.) are dropped by the ctx step.
+    # and fork), DCO check_run completions, `/merge` comments, or a
+    # workflow_dispatch re-eval. Runs with no open PR (push to main, etc.) are
+    # dropped by the ctx step.
     if: >-
       (
         github.event_name == 'pull_request_target' &&
@@ -71,6 +74,11 @@ jobs:
       (
         github.event_name == 'workflow_run' &&
         github.event.workflow_run.event == 'pull_request'
+      ) ||
+      (
+        github.event_name == 'check_run' &&
+        github.event.check_run.name == 'DCO' &&
+        github.event.check_run.app.slug == 'dco'
       ) ||
       github.event_name == 'workflow_dispatch' ||
       (
@@ -102,6 +110,7 @@ jobs:
           # Via env, not interpolated: author-controlled, so direct
           # interpolation would be a shell-injection vector.
           WF_PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+          CHECK_RUN_SHA: ${{ github.event.check_run.head_sha }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           PR_INPUT: ${{ inputs.pr }}
           SHA_INPUT: ${{ inputs.sha }}
@@ -142,6 +151,14 @@ jobs:
             fi
             PR="${{ github.event.issue.number }}"
             SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+          elif [[ "${{ github.event_name }}" == "check_run" ]]; then
+            SHA="$CHECK_RUN_SHA"
+            PR=$(resolve_pr_from_sha "$SHA")
+            if [[ -z "$PR" ]]; then
+              echo "::notice::Skipped: DCO check_run has no associated open PR"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           else
             PR=$(echo "$WF_PRS" | jq -r '.[0].number // empty')
             SHA="${{ github.event.workflow_run.head_sha }}"


### PR DESCRIPTION
## Related issue

N/A

## Summary

DCO is installed again for the repo, but `Merge Ready` is the aggregate gate that branch protection trusts. This wires the DCO app check into that gate so unsigned commits block merge through the same path as the rest of CI.

- Re-evaluate `Merge Ready` when the DCO app completes its `DCO` check run.
- Resolve the affected PR from the DCO check run head SHA, matching the existing fork-safe SHA lookup pattern.
- Add `DCO` as a non-skippable required gate entry.

## Test Plan

- [x] Ran `pre-commit run --files .github/workflows/merge-ready.yml .github/scripts/merge-ready/required.sh`
- [x] Parsed `.github/workflows/merge-ready.yml` as YAML locally
- [x] Ran `bash -n .github/scripts/merge-ready/required.sh`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

This is GitHub Actions gate wiring. Validation covered YAML parsing, shell syntax, and the repo pre-commit checks for the touched workflow/script files.
