### PR TITLE
fix(deps): prevent incompatible OpenAI Agents SDK resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ dependencies = [
     "omnigent-ui-sdk==0.6.0.dev0",
     # Merged from omnigent + omnigent.
     "pyyaml>=6.0,<7",
-    "openai>=1.0,<3",
+    # openai-agents<0.18.2 omits a field required by openai>=2.45.
+    # Keep this cap until the websockets<15 compatibility pin can be lifted.
+    "openai>=1.0,<2.45",
     # >=14: the `e2b` extra's SDK (>=2.26) needs rich>=14 (was >=13,<14).
     "rich>=14,<15",
     "prompt_toolkit>=3.0,<4",

--- a/tests/inner/test_openai_agents_sdk_dependency.py
+++ b/tests/inner/test_openai_agents_sdk_dependency.py
@@ -1,0 +1,9 @@
+"""Compatibility checks for the OpenAI Agents SDK dependency pair."""
+
+from agents.usage import Usage
+
+
+def test_default_usage_is_compatible_with_openai_models() -> None:
+    usage = Usage()
+
+    assert usage.input_tokens_details.cached_tokens == 0

--- a/uv.lock
+++ b/uv.lock
@@ -3022,7 +3022,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "omnigent-client", editable = "sdks/python-client" },
     { name = "omnigent-ui-sdk", editable = "sdks/ui" },
-    { name = "openai", specifier = ">=1.0,<3" },
+    { name = "openai", specifier = ">=1.0,<2.45" },
     { name = "openai-agents", specifier = ">=0.0.17" },
     { name = "openai-agents", marker = "extra == 'agents-sdk'", specifier = ">=0.1,<1" },
     { name = "openshell", marker = "extra == 'openshell'", specifier = ">=0.0.7,<1" },


### PR DESCRIPTION
## Related issue

Closes #2502

## Summary

- Cap `openai` below `2.45` while the baseline `openai-agents` release still constructs the older usage schema.
- Preserve the existing `websockets<15` compatibility constraint instead of forcing an `openai-agents` upgrade that conflicts with it.
- Add a smoke test that constructs the SDK's default `Usage` object, matching the reported crash path.

**ELI5:** prevent fresh installs from pairing an older Agents SDK with a newer OpenAI schema it cannot construct.

```text
openai-agents 0.13.x + openai >=2.45  -> validation crash
openai-agents 0.13.x + openai <2.45   -> compatible
```

## Test Plan

- `uv lock --check --default-index https://pypi.org/simple`
- `uv run --frozen pytest -q tests/inner/test_openai_agents_sdk_dependency.py tests/inner/test_openai_agents_sdk_executor.py` (`71 passed`)
- `pre-commit run --all-files`

## Demo

N/A — dependency and test-only change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit test exercises the third-party SDK constructor that fails under the incompatible dependency pairing.

## Changelog

Fresh installs no longer resolve an OpenAI SDK combination that crashes every OpenAI Agents harness turn.
