### PR TITLE
docs: establish project health workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,6 +37,15 @@ recording, or paste a link. Expected for UI / frontend changes (check the
 use `N/A` for non-visual changes.
 -->
 
+## Project health
+
+<!--
+For substantial or cross-cutting work, name the architecture/diagram, glossary,
+invariant, contract, or runbook updates included in this PR. Note any files over
+the guideposts in docs/PROJECT_HEALTH.md and explain the boundary decision. Use
+N/A for small/local changes with no durable project-health impact.
+-->
+
 ## Type of change
 
 - [ ] Bug fix

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,14 @@
 Guidance for AI agents (Claude Code, Copilot, Cursor, etc.) working in this
 repository. See `CONTRIBUTING.md` for the full contributor workflow.
 
+## Before project work
+
+Read [`docs/PROJECT_HEALTH.md`](docs/PROJECT_HEALTH.md) before planning a
+substantial change or exploring an unfamiliar subsystem. It defines the
+required workflow for context-efficient large-file reads and for locating or
+maintaining architecture, glossary, invariant, graph, and operational
+artifacts. Include applicable project-health work in the plan before editing.
+
 ## Committing
 
 Run the `pre-commit` hook before committing (`pre-commit run --all-files`, or
@@ -21,6 +29,8 @@ filename). Keep every section and checkbox row so reviewers can skim them.
   PRs for UI / frontend changes (check the "UI / frontend change" box under
   *Type of change*) so reviewers can see the new behaviour without checking out
   the branch. Use `N/A` for non-visual changes.
+- **Project health** — name applicable health-artifact updates and large-file
+  decisions, or use `N/A` for small/local changes.
 - **Type of change** / **Test coverage** — check all that apply (at least one
   each).
 - **Coverage notes** — required if you checked "Manual verification completed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,15 @@ welcome. For larger changes, open an issue first so we can discuss the approach.
 Please don't include secrets, internal URLs, customer data, or private
 configuration in issues, tests, examples, or logs.
 
+## Planning sustainable changes
+
+Before planning a substantial change or working in an unfamiliar subsystem,
+follow the [project-health workflow](docs/PROJECT_HEALTH.md). It explains how to
+map a project without repeatedly reading large files, when architecture
+diagrams or dependency graphs are expected, and how project-local glossaries
+and invariants become required planning inputs. Update those artifacts in the
+same pull request when a change makes them incomplete or inaccurate.
+
 ## Development setup
 
 This is a Python package with an optional frontend under `web/`. Use

--- a/docs/PROJECT_HEALTH.md
+++ b/docs/PROJECT_HEALTH.md
@@ -1,0 +1,105 @@
+# Project health
+
+Use this policy when starting a substantial project, reading an unfamiliar area,
+or planning a change that crosses module boundaries. Its purpose is to keep the
+repository understandable without repeatedly loading large source files or
+reconstructing architectural knowledge from code.
+
+Small, local changes do not need new documentation. Apply the requirements below
+when the information is durable, affects multiple contributors or agents, or
+would otherwise have to be rediscovered.
+
+## Project-local artifacts
+
+Keep health artifacts beside the project they describe. A top-level subsystem
+can use its own directory (for example, `web/`); a cross-cutting project can use
+an existing file under `designs/` or `docs/`. Link all applicable artifacts from
+the project's README or design/plan so there is one obvious starting point.
+
+For a substantial project, the starting document must identify:
+
+- **Architecture:** link an `ARCHITECTURE.md`, a design document, or an
+  equivalent section that names boundaries, dependencies, data/control flow,
+  and ownership. Include a Mermaid, ASCII, or maintained image diagram when the
+  system has several interacting components or a sequence is difficult to
+  explain linearly.
+- **Glossary:** link `GLOSSARY.md` or an equivalent section defining
+  project-specific terms, acronyms, and names that could be confused. Treat the
+  glossary as required planning input when terminology is part of the design.
+- **Invariants:** link `INVARIANTS.md` or an equivalent section listing
+  properties that must remain true across components, state transitions, or
+  failure paths. Each invariant should point to its enforcement or test where
+  one exists.
+- **Operational knowledge:** link relevant runbooks, generated schemas, API
+  contracts, migration notes, or dependency graphs instead of duplicating them.
+
+A single project README or design document may contain all of these sections;
+separate files are useful only when the material is large or independently
+maintained. Do not create empty placeholder documents.
+
+## File size and context budget
+
+Large files cost review time and model context. Before reading a file in full,
+inspect its size and structure (`wc -l`, symbol search, headings, or a targeted
+range), then load only the relevant sections. Search for callers, tests,
+contracts, and project-health artifacts before expanding the read. Prefer
+repository search and narrow slices over repeated full-file reads.
+
+There is no universal line limit, but a source file approaching **500 lines** or
+a document approaching **1,000 lines** requires an explicit choice in the plan:
+read it selectively, split it along a real boundary, or record why keeping it
+whole is clearer. Generated and vendored files are exempt from splitting, but
+must be identified so contributors do not spend context analyzing them as
+hand-maintained source.
+
+When a changed file grows past these guideposts, reviewers should expect the PR
+to explain the boundary decision. Avoid mechanical splitting that hides a
+cohesive concept or creates circular dependencies.
+
+## Sustainable workflow
+
+### Before planning or coding
+
+1. Read the nearest `AGENTS.md`, README, design/plan, glossary, and invariants.
+2. Map the affected modules, entry points, callers, tests, contracts, and
+   generated files with search before opening large files in full.
+3. Record the architecture boundary and invariants the change must preserve.
+4. Decide whether a diagram, glossary entry, invariant, or large-file boundary
+   must be created or updated as part of the change.
+5. Put those documentation updates and their verification in the implementation
+   plan, not in a follow-up backlog.
+
+### While changing the project
+
+- Keep terminology consistent with the glossary and update it when introducing
+  a durable new term.
+- Turn new cross-cutting assumptions into explicit invariants and, where
+  practical, tests or validation.
+- Update diagrams and dependency/data-flow descriptions in the same change that
+  makes them inaccurate.
+- Re-check file growth and dependency direction before adding another concern
+  to an already large module.
+
+### Before review
+
+- Confirm links and diagrams render and referenced files exist.
+- Verify documented commands, tests, schemas, and generated artifacts as
+  applicable.
+- In the PR, state which health artifacts changed, or why none were needed.
+- Call out deliberate exceptions to the size guideposts and the reasoning.
+
+## Planning checklist
+
+Copy this into a design or implementation plan when the project is substantial:
+
+```markdown
+## Project health
+
+- [ ] Starting document and ownership identified
+- [ ] Architecture boundaries and diagram/graph needs assessed
+- [ ] Glossary read and updated if terminology changes
+- [ ] Invariants read, preserved, and linked to enforcement/tests where possible
+- [ ] Large files identified; selective-read or split decisions recorded
+- [ ] Contracts, schemas, runbooks, and generated artifacts identified
+- [ ] Health artifacts included in implementation and verification scope
+```


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a central project-health policy for context-efficient repository reading and sustainable project maintenance.
- Require substantial project plans to identify architecture, glossary, invariants, graphs, operational artifacts, and large-file decisions.
- Wire the policy into contributor/agent entry points and the PR review workflow.

ELI5: contributors now have one checklist for finding the map, vocabulary, and rules of a project before changing it, so they do not have to reconstruct that knowledge from large source files every time.

```mermaid
flowchart LR
    A[Start project work] --> B[Read project-health policy]
    B --> C[Map architecture, terms, invariants, and large files]
    C --> D[Include health artifacts in the plan]
    D --> E[Report updates or N/A in the PR]
```

## Test Plan

- `git diff --cached --check`
- Applicable pre-commit file-hygiene hooks: merge conflicts, added large files, case conflicts, and mixed line endings
- Full `pre-commit run --all-files` was attempted; Python hooks could not run because this worktree has no `.venv/bin/python`. The broad web Prettier hook touched unrelated pre-existing formatting, and those formatter-only edits were reverted.

## Demo

N/A — documentation/policy-only change.

## Project health

Adds `docs/PROJECT_HEALTH.md` as the canonical health artifact and links it from `AGENTS.md` and `CONTRIBUTING.md`. The new document defines architecture/graph, glossary, invariant, operational-artifact, and large-file planning requirements. No changed file exceeds its guideposts.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

This change only updates Markdown policy and contribution guidance. I manually checked the staged diff, links to repository-local files, PR-template completeness, whitespace, conflict markers, filename case conflicts, line endings, and added-file size.

## Changelog

Document project-health expectations for architecture, glossaries, invariants, and context-efficient large-file work.
