### PR TITLE
fix: preserve Codex gateway provider config

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -2029,6 +2029,7 @@ class CodexExecutor(Executor):
         base_url_override: str | None = None,
         gateway_auth_command: str | None = None,
         gateway_auth_refresh_interval_ms: str | None = None,
+        wire_api: str | None = None,
         enable_web_search: bool = True,
         disable_native_tools: bool = False,
         retry_policy: RetryPolicy | None = None,
@@ -2079,6 +2080,8 @@ class CodexExecutor(Executor):
         :param gateway_auth_refresh_interval_ms: Refresh cadence as a string,
             e.g. ``"900000"``. Set from
             ``HARNESS_CODEX_GATEWAY_AUTH_REFRESH_INTERVAL_MS``.
+        :param wire_api: Wire protocol for a directly supplied generic gateway.
+            Set from ``HARNESS_CODEX_WIRE_API``; defaults to ``"responses"``.
         :param enable_web_search: Leave Codex's built-in ``web_search`` tool
             enabled.  Set ``False`` to force the model to use only
             Omnigent-bridged tools.
@@ -2219,14 +2222,21 @@ class CodexExecutor(Executor):
             # token`` fallback auth command; harmless for a generic gateway
             # whose auth command is a static ``printf %s <key>``.
             self._env["DATABRICKS_HOST"] = host
-            self._codex_config_overrides.extend(
-                _databricks_codex_config_overrides(
+            if self._gateway_uses_databricks_profile:
+                overrides = _databricks_codex_config_overrides(
                     model=effective_model,
                     base_url=base_url,
                     auth_command=auth_command,
                     auth_refresh_interval_ms=self._gateway_auth_refresh_interval_ms,
                 )
-            )
+            else:
+                overrides = _provider_codex_config_overrides(
+                    model=effective_model,
+                    base_url=base_url,
+                    auth_command=auth_command,
+                    wire_api=wire_api or "responses",
+                )
+            self._codex_config_overrides.extend(overrides)
         if not enable_web_search:
             # Disable Codex's built-in web_search tool so the model can only reach
             # tools exposed by Omnigent as dynamicTools. The top-level web_search

--- a/omnigent/inner/codex_harness.py
+++ b/omnigent/inner/codex_harness.py
@@ -120,6 +120,7 @@ _ENV_AGENT_NAME = "HARNESS_CODEX_AGENT_NAME"
 _ENV_GATEWAY_BASE_URL = "HARNESS_CODEX_GATEWAY_BASE_URL"
 _ENV_GATEWAY_AUTH_COMMAND = "HARNESS_CODEX_GATEWAY_AUTH_COMMAND"
 _ENV_GATEWAY_AUTH_REFRESH_INTERVAL_MS = "HARNESS_CODEX_GATEWAY_AUTH_REFRESH_INTERVAL_MS"
+_ENV_WIRE_API = "HARNESS_CODEX_WIRE_API"
 
 # Truthy strings the wrap accepts for boolean env vars. Must
 # match the claude-sdk wrap's parser for consistency — operators
@@ -303,6 +304,7 @@ def _build_codex_executor() -> Executor:
         gateway_auth_command=os.environ.get(_ENV_GATEWAY_AUTH_COMMAND) or None,
         gateway_auth_refresh_interval_ms=os.environ.get(_ENV_GATEWAY_AUTH_REFRESH_INTERVAL_MS)
         or None,
+        wire_api=os.environ.get(_ENV_WIRE_API) or None,
         retry_policy=_resolve_retry_policy(),
         bundle_dir=bundle_dir,
         agent_name=agent_name,

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -279,6 +279,13 @@ class TestCodexExecutor(unittest.TestCase):
                 "databricks auth token --host" in item for item in executor._codex_config_overrides
             )
         )
+        self.assertIn('model_provider="omnigent_provider"', executor._codex_config_overrides)
+        self.assertTrue(
+            any('wire_api="responses"' in item for item in executor._codex_config_overrides)
+        )
+        self.assertFalse(
+            any("omnigent_databricks" in item for item in executor._codex_config_overrides)
+        )
 
     def test_constructor_databricks_flag_with_host_override_requires_base_url(self):
         with (

--- a/tests/inner/test_codex_harness.py
+++ b/tests/inner/test_codex_harness.py
@@ -72,6 +72,7 @@ def test_executor_factory_reads_env_vars(
     )
     monkeypatch.setenv("HARNESS_CODEX_GATEWAY_AUTH_COMMAND", "printf token")
     monkeypatch.setenv("HARNESS_CODEX_GATEWAY_AUTH_REFRESH_INTERVAL_MS", "900000")
+    monkeypatch.setenv("HARNESS_CODEX_WIRE_API", "chat")
     monkeypatch.setenv("HARNESS_CODEX_CWD", "/tmp/test-cwd")
     monkeypatch.setenv("HARNESS_CODEX_PATH", "/usr/local/bin/codex")
     monkeypatch.setenv("HARNESS_CODEX_ENABLE_WEB_SEARCH", "false")
@@ -92,6 +93,7 @@ def test_executor_factory_reads_env_vars(
         base_url_override: str | None,
         gateway_auth_command: str | None,
         gateway_auth_refresh_interval_ms: str | None,
+        wire_api: str | None,
         enable_web_search: bool,
         disable_native_tools: bool,
         **_kwargs: Any,
@@ -106,6 +108,7 @@ def test_executor_factory_reads_env_vars(
         captured["base_url_override"] = base_url_override
         captured["gateway_auth_command"] = gateway_auth_command
         captured["gateway_auth_refresh_interval_ms"] = gateway_auth_refresh_interval_ms
+        captured["wire_api"] = wire_api
         captured["enable_web_search"] = enable_web_search
         captured["disable_native_tools"] = disable_native_tools
 
@@ -124,6 +127,7 @@ def test_executor_factory_reads_env_vars(
     assert captured["base_url_override"] == "https://example.databricks.com/ai-gateway/codex/v1"
     assert captured["gateway_auth_command"] == "printf token"
     assert captured["gateway_auth_refresh_interval_ms"] == "900000"
+    assert captured["wire_api"] == "chat"
     assert captured["cwd"] == "/tmp/test-cwd"
     assert captured["codex_path"] == "/usr/local/bin/codex"
     # Inverted defaults verify the truthy parser is consulted


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Thread `HARNESS_CODEX_WIRE_API` from the in-process harness into `CodexExecutor`.
- Use the generic `omnigent_provider` config for explicitly supplied gateways while preserving profile-derived Databricks behavior.
- ELI5: Codex now keeps the selected provider route instead of relabeling every gateway as Databricks.

`workflow env -> Codex harness -> CodexExecutor -> provider-specific config`

## Test Plan

- `pytest -q tests/inner/test_codex_harness.py tests/inner/test_codex_executor.py`
- `pytest -q tests/runtime/test_provider_spawn_env.py::test_codex_uses_openai_global_default`
- `git diff --check -- omnigent/inner/codex_harness.py omnigent/inner/codex_executor.py tests/inner/test_codex_harness.py tests/inner/test_codex_executor.py`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The harness factory regression verifies the wire API reaches the executor constructor; executor tests verify generic provider identity and wire configuration while retaining the Databricks profile path.

## Changelog

Codex gateway runs now preserve the configured provider identity and compatible wire API.