### PR TITLE
[cli] Import recent chats in bounded batches

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5960,9 +5960,17 @@ def resume(
 @click.option(
     "--session",
     "source_session_id",
-    required=True,
+    default=None,
     metavar="SESSION_ID",
-    help="Harness-native session ID to import.",
+    help="Harness-native session ID to import. Mutually exclusive with --last.",
+)
+@click.option(
+    "--last",
+    "recent_session_count",
+    type=click.IntRange(min=1, max=50),
+    default=None,
+    metavar="N",
+    help="Import the N most recently modified parent sessions (maximum 50).",
 )
 @click.option(
     "--server",
@@ -5974,18 +5982,21 @@ def resume(
 )
 def import_session_command(
     harness: str,
-    source_session_id: str,
+    source_session_id: str | None,
+    recent_session_count: int | None,
     server: str | None,
 ) -> None:
-    """Import one local Claude Code or Codex chat.
+    """Import local Claude Code or Codex chats.
 
     The source transcript is converted to ordinary Omnigent items and stored
-    as a normal session. A source session can only be imported once.
+    as a normal session. Use --session for one chat or --last for a bounded
+    batch. A source session can only be imported once.
 
     \b
     Examples:
       omnigent import --harness claude --session <session-id>
       omnigent import --harness codex --session <session-id>
+      omnigent import --harness claude --last 10
     """
     import httpx
 
@@ -5994,54 +6005,117 @@ def import_session_command(
         ImportSource,
         SessionImportNotFoundError,
     )
-    from omnigent.session_import.local import load_local_session
+    from omnigent.session_import.local import (
+        list_recent_local_session_ids,
+        load_local_session,
+    )
 
-    try:
-        imported = load_local_session(cast(ImportSource, harness.lower()), source_session_id)
-    except SessionImportNotFoundError as exc:
-        raise click.ClickException(str(exc)) from exc
+    if (source_session_id is None) == (recent_session_count is None):
+        raise click.UsageError("Provide exactly one of --session or --last.")
+
+    source = cast(ImportSource, harness.lower())
+    is_batch = recent_session_count is not None
+    if recent_session_count is not None:
+        recent_ids = list_recent_local_session_ids(source, limit=recent_session_count)
+        if not recent_ids:
+            raise click.ClickException(f"No local {source} parent sessions were found")
+        source_session_ids = tuple(reversed(recent_ids))
+    else:
+        assert source_session_id is not None
+        source_session_ids = (source_session_id,)
 
     cfg = _load_effective_config()
     base_url = _resolve_attach_server(server, cfg.get("server"))
     if base_url is None:
         base_url = ensure_local_omnigent_server().url
     base_url = base_url.rstrip("/")
-    payload = {
-        "source": imported.source,
-        "external_session_id": imported.external_session_id,
-        "workspace": imported.workspace,
-        "items": [
-            {
-                "type": item.type,
-                "response_id": item.response_id,
-                "data": item.data.model_dump(mode="json", exclude_none=True),
-            }
-            for item in imported.items
-        ],
-    }
-    try:
-        response = httpx.post(
-            f"{base_url}/v1/imports",
-            json=payload,
-            headers=_remote_headers(server_url=base_url),
-            timeout=120.0,
-        )
-    except httpx.RequestError as exc:
-        raise click.ClickException(f"Could not reach the Omnigent server: {exc}") from exc
-    if response.is_error:
+    imported_count = 0
+    already_imported_count = 0
+    failed_count = 0
+    for current_source_session_id in source_session_ids:
         try:
-            body = response.json()
-            detail = body.get("error", {}).get("message") or body.get("detail")
-        except (ValueError, AttributeError):
-            detail = None
-        raise click.ClickException(
-            f"Import failed ({response.status_code}): {detail or response.text}"
-        )
+            imported = load_local_session(source, current_source_session_id)
+        except SessionImportNotFoundError as exc:
+            if not is_batch:
+                raise click.ClickException(str(exc)) from exc
+            failed_count += 1
+            click.echo(f"Failed {current_source_session_id}: {exc}", err=True)
+            continue
+        except (OSError, TypeError, ValueError) as exc:
+            if not is_batch:
+                raise
+            failed_count += 1
+            click.echo(f"Failed {current_source_session_id}: {exc}", err=True)
+            continue
 
-    result = response.json()
-    session_id = result["session_id"]
-    item_count = result["item_count"]
-    click.echo(f"Imported {item_count} item(s) into {session_id}.")
+        payload = {
+            "source": imported.source,
+            "external_session_id": imported.external_session_id,
+            "workspace": imported.workspace,
+            "items": [
+                {
+                    "type": item.type,
+                    "response_id": item.response_id,
+                    "data": item.data.model_dump(mode="json", exclude_none=True),
+                }
+                for item in imported.items
+            ],
+        }
+        try:
+            response = httpx.post(
+                f"{base_url}/v1/imports",
+                json=payload,
+                headers=_remote_headers(server_url=base_url),
+                timeout=120.0,
+            )
+        except httpx.RequestError as exc:
+            raise click.ClickException(f"Could not reach the Omnigent server: {exc}") from exc
+
+        if response.status_code == 409 and is_batch:
+            already_imported_count += 1
+            click.echo(f"Already imported {current_source_session_id}; skipped.")
+            continue
+        if response.is_error:
+            try:
+                body = response.json()
+                detail = body.get("error", {}).get("message") or body.get("detail")
+            except (ValueError, AttributeError):
+                detail = None
+            message = f"Import failed ({response.status_code}): {detail or response.text}"
+            if not is_batch:
+                raise click.ClickException(message)
+            failed_count += 1
+            click.echo(f"Failed {current_source_session_id}: {message}", err=True)
+            continue
+
+        try:
+            result = response.json()
+            session_id = result["session_id"]
+            item_count = result["item_count"]
+        except (AttributeError, KeyError, TypeError, ValueError) as exc:
+            if not is_batch:
+                raise click.ClickException("Import returned an invalid server response") from exc
+            failed_count += 1
+            click.echo(
+                f"Failed {current_source_session_id}: import returned an invalid server response",
+                err=True,
+            )
+            continue
+        imported_count += 1
+        if is_batch:
+            click.echo(
+                f"Imported {item_count} item(s) from {current_source_session_id} "
+                f"into {session_id}."
+            )
+        else:
+            click.echo(f"Imported {item_count} item(s) into {session_id}.")
+
+    if is_batch:
+        click.echo(f"\nImported: {imported_count}")
+        click.echo(f"Already imported: {already_imported_count}")
+        click.echo(f"Failed: {failed_count}")
+        if failed_count:
+            raise click.ClickException(f"{failed_count} session(s) failed to import")
 
 
 @cli.group("session", invoke_without_command=True)

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 
 from omnigent.claude_native_bridge import read_transcript_items_from_offset
-from omnigent.codex_native import _find_codex_rollout
+from omnigent.codex_native import _CODEX_THREAD_ID_RE, _find_codex_rollout
 from omnigent.entities import NewConversationItem, parse_item_data
 from omnigent.session_import.models import (
     ImportSource,
@@ -24,6 +24,63 @@ def _find_transcript(root: Path, session_id: str) -> Path | None:
         if path.stem == session_id and "subagents" not in path.parts and path.is_file()
     ]
     return max(matches, key=lambda path: path.stat().st_mtime) if matches else None
+
+
+def _recent_unique_session_ids(
+    candidates: list[tuple[Path, str]],
+    *,
+    limit: int,
+) -> tuple[str, ...]:
+    """Return unique session ids ordered from newest transcript to oldest."""
+    newest_by_id: dict[str, float] = {}
+    for path, session_id in candidates:
+        try:
+            modified_at = path.stat().st_mtime
+        except OSError:
+            continue
+        newest_by_id[session_id] = max(newest_by_id.get(session_id, 0), modified_at)
+    ordered = sorted(
+        newest_by_id,
+        key=lambda session_id: (newest_by_id[session_id], session_id),
+        reverse=True,
+    )
+    return tuple(ordered[:limit])
+
+
+def list_recent_local_session_ids(
+    source: ImportSource,
+    *,
+    limit: int,
+) -> tuple[str, ...]:
+    """List recent parent session ids for one local harness."""
+    if source == "claude":
+        configured_home = os.environ.get("CLAUDE_CONFIG_DIR")
+        home = Path(configured_home).expanduser() if configured_home else Path.home() / ".claude"
+        root = home / "projects"
+        candidates = [
+            (path, path.stem)
+            for path in root.rglob("*.jsonl")
+            if "subagents" not in path.parts and path.is_file()
+        ]
+        return _recent_unique_session_ids(candidates, limit=limit)
+
+    configured_home = os.environ.get("CODEX_HOME")
+    home = Path(configured_home).expanduser() if configured_home else Path.home() / ".codex"
+    rollouts: list[Path] = []
+    sessions = home / "sessions"
+    archived_sessions = home / "archived_sessions"
+    if sessions.is_dir():
+        rollouts.extend(path for path in sessions.glob("**/rollout-*.jsonl") if path.is_file())
+    if archived_sessions.is_dir():
+        rollouts.extend(
+            path for path in archived_sessions.glob("rollout-*.jsonl") if path.is_file()
+        )
+    candidates = []
+    for path in rollouts:
+        session_id = path.stem[-36:]
+        if _CODEX_THREAD_ID_RE.fullmatch(session_id):
+            candidates.append((path, session_id))
+    return _recent_unique_session_ids(candidates, limit=limit)
 
 
 def _claude_workspace(transcript_path: Path) -> str | None:
@@ -259,6 +316,7 @@ def load_local_session(source: ImportSource, session_id: str) -> LocalSessionImp
 
 
 __all__ = [
+    "list_recent_local_session_ids",
     "load_claude_session",
     "load_codex_session",
     "load_local_session",

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -15,24 +16,39 @@ from omnigent.cli import _CLICK_SUBCOMMANDS, cli
 _BASE = "http://localhost:6767"
 
 
-@respx.mock
-def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path: Path) -> None:
-    """The CLI reads local history and submits only Omnigent item shapes."""
-    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
-    transcript = tmp_path / ".claude" / "projects" / "-repo" / f"{session_id}.jsonl"
-    transcript.parent.mkdir(parents=True)
+def _write_claude_transcript(
+    home: Path,
+    session_id: str,
+    *,
+    text: str,
+    modified_at: int | None = None,
+    uuid_value: str = "user-1",
+) -> Path:
+    """Create one minimal parent transcript under a fake Claude home."""
+    transcript = home / ".claude" / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
     transcript.write_text(
         json.dumps(
             {
                 "type": "user",
-                "uuid": "user-1",
+                "uuid": uuid_value,
                 "cwd": "/repo",
-                "message": {"role": "user", "content": "inspect TODO.md"},
+                "message": {"role": "user", "content": text},
             }
         )
         + "\n",
         encoding="utf-8",
     )
+    if modified_at is not None:
+        os.utime(transcript, (modified_at, modified_at))
+    return transcript
+
+
+@respx.mock
+def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path: Path) -> None:
+    """The CLI reads local history and submits only Omnigent item shapes."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    _write_claude_transcript(tmp_path, session_id, text="inspect TODO.md")
     route = respx.post(f"{_BASE}/v1/imports").mock(
         return_value=httpx.Response(
             201,
@@ -78,3 +94,112 @@ def test_import_command_rejects_cursor() -> None:
 
     assert result.exit_code == 2
     assert "Invalid value for '--harness'" in result.output
+
+
+@respx.mock
+def test_import_command_imports_last_sessions_oldest_first_and_skips_duplicates(
+    tmp_path: Path,
+) -> None:
+    """A batch preserves source recency and treats duplicate imports as skips."""
+    session_ids = (
+        "a1b2c3d4-1234-5678-9abc-def012345671",
+        "a1b2c3d4-1234-5678-9abc-def012345672",
+        "a1b2c3d4-1234-5678-9abc-def012345673",
+    )
+    for modified_at, session_id in enumerate(session_ids, start=1):
+        _write_claude_transcript(
+            tmp_path,
+            session_id,
+            text=f"prompt {modified_at}",
+            modified_at=modified_at,
+        )
+    route = respx.post(f"{_BASE}/v1/imports").mock(
+        side_effect=[
+            httpx.Response(
+                201,
+                json={"session_id": "imported-middle", "status": "imported", "item_count": 1},
+            ),
+            httpx.Response(
+                409,
+                json={"error": {"message": "already imported"}},
+            ),
+        ]
+    )
+
+    with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
+        result = CliRunner().invoke(
+            cli,
+            ["import", "--harness", "claude", "--last", "2"],
+            env={"HOME": str(tmp_path)},
+        )
+
+    assert result.exit_code == 0, result.output
+    payloads = [json.loads(call.request.content) for call in route.calls]
+    assert [payload["external_session_id"] for payload in payloads] == list(session_ids[1:])
+    assert "Imported: 1" in result.output
+    assert "Already imported: 1" in result.output
+    assert "Failed: 0" in result.output
+
+
+@respx.mock
+def test_import_command_continues_batch_after_session_failure(tmp_path: Path) -> None:
+    """One invalid server response does not prevent later sessions importing."""
+    session_ids = (
+        "a1b2c3d4-1234-5678-9abc-def012345674",
+        "a1b2c3d4-1234-5678-9abc-def012345675",
+    )
+    for modified_at, session_id in enumerate(session_ids, start=1):
+        _write_claude_transcript(
+            tmp_path,
+            session_id,
+            text=f"prompt {modified_at}",
+            modified_at=modified_at,
+        )
+    route = respx.post(f"{_BASE}/v1/imports").mock(
+        side_effect=[
+            httpx.Response(422, json={"error": {"message": "invalid transcript"}}),
+            httpx.Response(
+                201,
+                json={"session_id": "imported-new", "status": "imported", "item_count": 1},
+            ),
+        ]
+    )
+
+    with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
+        result = CliRunner().invoke(
+            cli,
+            ["import", "--harness", "claude", "--last", "2"],
+            env={"HOME": str(tmp_path)},
+        )
+
+    assert result.exit_code == 1
+    assert len(route.calls) == 2
+    assert "Imported: 1" in result.output
+    assert "Failed: 1" in result.output
+
+
+def test_import_command_requires_exactly_one_session_selector() -> None:
+    """Single and batch selectors cannot be omitted or combined."""
+    runner = CliRunner()
+
+    missing = runner.invoke(cli, ["import", "--harness", "claude"])
+    combined = runner.invoke(
+        cli,
+        ["import", "--harness", "claude", "--session", "session-id", "--last", "2"],
+    )
+
+    assert missing.exit_code == 2
+    assert combined.exit_code == 2
+    assert "Provide exactly one of --session or --last" in missing.output
+    assert "Provide exactly one of --session or --last" in combined.output
+
+
+def test_import_command_limits_batch_size() -> None:
+    """The CLI rejects batch sizes above the safety cap."""
+    result = CliRunner().invoke(
+        cli,
+        ["import", "--harness", "codex", "--last", "51"],
+    )
+
+    assert result.exit_code == 2
+    assert "51 is not in the range 1<=x<=50" in result.output

--- a/tests/e2e/test_chat_import_e2e.py
+++ b/tests/e2e/test_chat_import_e2e.py
@@ -87,3 +87,161 @@ def test_cli_imports_claude_chat_into_live_server(live_server: str, tmp_path: Pa
     items = httpx.get(f"{live_server}/v1/sessions/{session_id}/items", timeout=10)
     items.raise_for_status()
     assert [item["type"] for item in items.json()["data"]] == ["message", "message"]
+
+
+def test_cli_imports_recent_claude_chats_as_batch(live_server: str, tmp_path: Path) -> None:
+    """The real CLI imports a bounded recent batch from oldest to newest."""
+    source_session_ids = (
+        "a1b2c3d4-1234-5678-9abc-def012345671",
+        "a1b2c3d4-1234-5678-9abc-def012345672",
+        "a1b2c3d4-1234-5678-9abc-def012345673",
+    )
+    project = tmp_path / ".claude" / "projects" / "-repo"
+    project.mkdir(parents=True)
+    for modified_at, source_session_id in enumerate(source_session_ids, start=1):
+        transcript = project / f"{source_session_id}.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "type": "user",
+                    "uuid": f"user-{modified_at}",
+                    "cwd": "/repo",
+                    "message": {"role": "user", "content": f"prompt {modified_at}"},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.utime(transcript, (modified_at, modified_at))
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "OMNIGENT_CONFIG_HOME": str(tmp_path / "config"),
+            "OMNIGENT_DATA_DIR": str(tmp_path / "omnigent-data"),
+        }
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "import",
+            "--harness",
+            "claude",
+            "--last",
+            "2",
+            "--server",
+            live_server,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+    imported = re.findall(
+        r"Imported \d+ item\(s\) from (\S+) into (\S+)\.",
+        result.stdout,
+    )
+    assert [source_id for source_id, _ in imported] == list(source_session_ids[1:])
+    assert "Imported: 2" in result.stdout
+    assert "Already imported: 0" in result.stdout
+    assert "Failed: 0" in result.stdout
+    for source_id, session_id in imported:
+        session = httpx.get(
+            f"{live_server}/v1/sessions/{session_id}",
+            params={"include_items": "false", "include_liveness": "false"},
+            timeout=10,
+        )
+        session.raise_for_status()
+        assert session.json()["external_session_id"] == source_id
+
+
+def test_cli_imports_recent_codex_chats_as_batch(live_server: str, tmp_path: Path) -> None:
+    """The real CLI discovers and imports recent Codex rollout files."""
+    source_session_ids = (
+        "019f7777-0001-7000-8000-000000000001",
+        "019f7777-0001-7000-8000-000000000002",
+        "019f7777-0001-7000-8000-000000000003",
+    )
+    sessions = tmp_path / ".codex" / "sessions" / "2026" / "07" / "16"
+    sessions.mkdir(parents=True)
+    for modified_at, source_session_id in enumerate(source_session_ids, start=1):
+        rollout = sessions / f"rollout-2026-07-16T00-00-0{modified_at}-{source_session_id}.jsonl"
+        rollout.write_text(
+            "".join(
+                [
+                    json.dumps(
+                        {
+                            "type": "session_meta",
+                            "payload": {"id": source_session_id, "cwd": "/repo"},
+                        }
+                    ),
+                    "\n",
+                    json.dumps(
+                        {
+                            "type": "response_item",
+                            "payload": {
+                                "type": "message",
+                                "role": "user",
+                                "content": [
+                                    {
+                                        "type": "input_text",
+                                        "text": f"prompt {modified_at}",
+                                    }
+                                ],
+                            },
+                        }
+                    ),
+                    "\n",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        os.utime(rollout, (modified_at, modified_at))
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "OMNIGENT_CONFIG_HOME": str(tmp_path / "config"),
+            "OMNIGENT_DATA_DIR": str(tmp_path / "omnigent-data"),
+        }
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "import",
+            "--harness",
+            "codex",
+            "--last",
+            "2",
+            "--server",
+            live_server,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+    imported = re.findall(
+        r"Imported \d+ item\(s\) from (\S+) into (\S+)\.",
+        result.stdout,
+    )
+    assert [source_id for source_id, _ in imported] == list(source_session_ids[1:])
+    assert "Imported: 2" in result.stdout
+    for source_id, session_id in imported:
+        session = httpx.get(
+            f"{live_server}/v1/sessions/{session_id}",
+            params={"include_items": "false", "include_liveness": "false"},
+            timeout=10,
+        )
+        session.raise_for_status()
+        assert session.json()["external_session_id"] == source_id

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
 
 from omnigent.session_import.local import (
+    list_recent_local_session_ids,
     load_claude_session,
     load_codex_session,
 )
@@ -98,6 +100,32 @@ def test_load_claude_session_rejects_empty_history(tmp_path: Path) -> None:
 
     with pytest.raises(SessionImportNotFoundError, match="no importable history"):
         load_claude_session(session_id, claude_home=tmp_path)
+
+
+def test_list_recent_claude_sessions_orders_parents_and_applies_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Claude batch discovery returns only the newest parent transcripts."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    project = tmp_path / "projects" / "-repo"
+    project.mkdir(parents=True)
+    transcripts = [
+        (project / "old.jsonl", 1),
+        (project / "middle.jsonl", 2),
+        (project / "new.jsonl", 3),
+    ]
+    for path, modified_at in transcripts:
+        path.touch()
+        os.utime(path, (modified_at, modified_at))
+    subagent = project / "subagents" / "subagent.jsonl"
+    subagent.parent.mkdir()
+    subagent.touch()
+    os.utime(subagent, (4, 4))
+
+    recent = list_recent_local_session_ids("claude", limit=2)
+
+    assert recent == ("new", "middle")
 
 
 def test_load_codex_session_normalizes_response_items(tmp_path: Path) -> None:
@@ -283,3 +311,30 @@ def test_load_codex_session_rejects_empty_history(tmp_path: Path) -> None:
 
     with pytest.raises(SessionImportNotFoundError, match="no importable history"):
         load_codex_session(session_id, codex_home=tmp_path)
+
+
+def test_list_recent_codex_sessions_includes_archived_and_deduplicates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex batch discovery combines active and archived rollout identities."""
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    first_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    second_id = "019f680e-3edc-7fa3-9d50-1c4be395fa27"
+    active_dir = tmp_path / "sessions" / "2026" / "07" / "16"
+    archived_dir = tmp_path / "archived_sessions"
+    active_dir.mkdir(parents=True)
+    archived_dir.mkdir()
+    rollouts = [
+        (active_dir / f"rollout-old-{first_id}.jsonl", 1),
+        (active_dir / f"rollout-new-{second_id}.jsonl", 3),
+        (archived_dir / f"rollout-archived-{first_id}.jsonl", 4),
+        (active_dir / "rollout-malformed.jsonl", 5),
+    ]
+    for path, modified_at in rollouts:
+        path.touch()
+        os.utime(path, (modified_at, modified_at))
+
+    recent = list_recent_local_session_ids("codex", limit=10)
+
+    assert recent == (first_id, second_id)


### PR DESCRIPTION
## Related issue

N/A

## Summary

Importing local harness history one chat at a time is tedious when a user wants to bring their recent work into Omnigent. This adds a bounded batch mode to the existing import command while preserving the single-session flow and reusing the existing import API.

- Add `omni import --harness <claude|codex> --last N`, with `N` limited to 1–50 and mutually exclusive with `--session`.
- Discover parent transcripts by modification time, including active and archived Codex rollouts, then import the selected chats oldest-to-newest so the newest chat lands last.
- Keep imports sequential and non-atomic: duplicate `409` responses are skipped, individual parse/API failures do not stop later chats, transport failures abort, and genuine failures produce a nonzero exit with an imported/skipped/failed summary.
- Reuse the existing single-session endpoint and Omnigent item conversion; there are no database or API schema changes.

ELI5: Omnigent finds the newest local chat files, takes up to the requested limit, and feeds each one through the same doorway used by single-chat imports.

```text
Claude/Codex parent transcripts
            |
      newest N by mtime
            |
      oldest -> newest
            |
    existing POST /v1/imports
            |
    normal Omnigent sessions
```

Scope: session selection is mtime-based. Subagent transcripts, Cursor support, and import-and-continue remain out of scope.

## Test Plan

- [x] Unit and route coverage: `pytest -p no:rerunfailures -q tests/cli/test_import.py tests/test_session_import.py tests/server/routes/test_imports.py` (`16 passed`)
- [x] Real CLI/live-server coverage for single Claude plus batch Claude and Codex imports: `pytest -p no:rerunfailures -o addopts='' -q tests/e2e/test_chat_import_e2e.py` (`3 passed`)
- [x] Staged-file repository hooks: `pre-commit run`
- [x] Ruff and strict type checking on the changed import modules

## Demo

N/A — CLI-only change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The e2e tests invoke the real CLI against a live local server and verify that both Claude and Codex batches become ordinary readable Omnigent sessions.

## Changelog

`omni import --harness <claude|codex> --last N` can now import up to 50 recent local chats at once.
