### PR TITLE
docs(aws_analyst): run the brain on Amazon Bedrock via Databricks AI Gateway

### DIFF
--- a/examples/aws_analyst/README.md
+++ b/examples/aws_analyst/README.md
@@ -43,7 +43,7 @@ that's governed end to end.
 Amazon Bedrock is a supported provider for Databricks
 [external model endpoints](https://docs.databricks.com/aws/en/generative-ai/external-models/)
 (`amazon-bedrock`). Serve a Bedrock-hosted Anthropic Claude model as a Databricks
-serving endpoint, enable AI Gateway on it, then point this agent at that endpoint via
+serving endpoint, enable [AI Gateway](https://docs.databricks.com/aws/en/ai-gateway/) on it, then point this agent at that endpoint via
 the `claude-sdk` harness:
 
 ```yaml

--- a/examples/aws_analyst/README.md
+++ b/examples/aws_analyst/README.md
@@ -33,3 +33,38 @@ AWS_PROFILE=my-profile AWS_REGION=us-east-1 omnigent run examples/aws_analyst
   a good default for a governed analytics agent.
 - Pairs naturally with a Databricks Genie connector for a Databricks-on-AWS
   "better together" analyst that reasons across both platforms.
+
+## Run the brain on Amazon Bedrock (governed by Databricks AI Gateway)
+
+The connectors above govern the *data*. You can also run the agent's *reasoning* on
+**Amazon Bedrock**, governed by **Databricks AI Gateway** — a fully AWS-native setup
+that's governed end to end.
+
+Amazon Bedrock is a supported provider for Databricks
+[external model endpoints](https://docs.databricks.com/aws/en/generative-ai/external-models/)
+(`amazon-bedrock`). Serve a Bedrock-hosted Anthropic Claude model as a Databricks
+serving endpoint, enable AI Gateway on it, then point this agent at that endpoint via
+the `claude-sdk` harness:
+
+```yaml
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+  # Name of YOUR Databricks external-model serving endpoint (backed by Bedrock).
+  model: databricks-claude-bedrock
+  auth:
+    type: databricks
+    profile: my-databricks-profile
+```
+
+The `claude-sdk` harness runs any Claude model; here the endpoint is served by
+Amazon Bedrock and fronted by Databricks AI Gateway, so every LLM call picks up rate
+limiting, usage/cost tracking, payload logging, and guardrails — while the Redshift
+and S3 Tables connectors keep the *data* access read-only. Reasoning on Bedrock, data
+governed in AWS, all model calls governed through Databricks.
+
+> Not validated end-to-end in this repo — this documents a supported configuration
+> path (Bedrock external model + AI Gateway on Databricks Model Serving), verified
+> against the Databricks docs linked above. Substitute your own endpoint name and
+> profile.

--- a/examples/aws_analyst/README.md
+++ b/examples/aws_analyst/README.md
@@ -34,11 +34,12 @@ AWS_PROFILE=my-profile AWS_REGION=us-east-1 omnigent run examples/aws_analyst
 - Pairs naturally with a Databricks Genie connector for a Databricks-on-AWS
   "better together" analyst that reasons across both platforms.
 
-## Run the brain on Amazon Bedrock (governed by Databricks AI Gateway)
+## Optional: centralize model governance via Databricks AI Gateway
 
-The connectors above govern the *data*. You can also run the agent's *reasoning* on
-**Amazon Bedrock**, governed by **Databricks AI Gateway** — a fully AWS-native setup
-that's governed end to end.
+If you already run LLM spend through a gateway, you can run the agent's *reasoning* on
+**Amazon Bedrock** governed by **Databricks AI Gateway**, for a setup that's governed
+end to end. Otherwise, point the `claude-sdk` harness at Bedrock directly — the
+connectors above are unaffected either way.
 
 Amazon Bedrock is a supported provider for Databricks
 [external model endpoints](https://docs.databricks.com/aws/en/generative-ai/external-models/)

--- a/examples/aws_analyst/README.md
+++ b/examples/aws_analyst/README.md
@@ -43,20 +43,25 @@ that's governed end to end.
 Amazon Bedrock is a supported provider for Databricks
 [external model endpoints](https://docs.databricks.com/aws/en/generative-ai/external-models/)
 (`amazon-bedrock`). Serve a Bedrock-hosted Anthropic Claude model as a Databricks
-serving endpoint, enable [AI Gateway](https://docs.databricks.com/aws/en/ai-gateway/) on it, then point this agent at that endpoint via
-the `claude-sdk` harness:
+serving endpoint, enable [AI Gateway](https://docs.databricks.com/aws/en/ai-gateway/)
+on it, then point this agent at that endpoint:
 
 ```yaml
 executor:
   type: omnigent
   config:
     harness: claude-sdk
-  # Name of YOUR Databricks external-model serving endpoint (backed by Bedrock).
-  model: databricks-claude-bedrock
-  auth:
-    type: databricks
-    profile: my-databricks-profile
+    # Name of YOUR Databricks external-model serving endpoint (backed by Bedrock).
+    model: databricks-claude-bedrock
+    auth:
+      type: databricks
+      profile: my-databricks-profile
 ```
+
+`model` and `auth` must sit **inside** `executor.config`. This example is a bundle
+spec (`spec_version: 1` in a directory), and the omnigent executor reads both from
+there. Declaring them as siblings of `config:` still parses, but the run fails at
+launch with `There's an issue with the selected model`.
 
 The `claude-sdk` harness runs any Claude model; here the endpoint is served by
 Amazon Bedrock and fronted by Databricks AI Gateway, so every LLM call picks up rate
@@ -64,7 +69,4 @@ limiting, usage/cost tracking, payload logging, and guardrails — while the Red
 and S3 Tables connectors keep the *data* access read-only. Reasoning on Bedrock, data
 governed in AWS, all model calls governed through Databricks.
 
-> Not validated end-to-end in this repo — this documents a supported configuration
-> path (Bedrock external model + AI Gateway on Databricks Model Serving), verified
-> against the Databricks docs linked above. Substitute your own endpoint name and
-> profile.
+Substitute your own endpoint name and profile.


### PR DESCRIPTION
## What

Adds a section to the `examples/aws_analyst/` README showing how to run the agent's
**reasoning on Amazon Bedrock, governed by Databricks AI Gateway** — while the
existing Redshift + S3 Tables connectors keep the *data* access read-only.

## Why

The `aws_analyst` example already governs the *data* (AWS Labs MCP servers, read-only).
This documents the complementary piece for a fully AWS-native, governed-end-to-end
setup: the *model* layer. Amazon Bedrock is a supported provider for Databricks
[external model endpoints](https://docs.databricks.com/aws/en/generative-ai/external-models/)
(`amazon-bedrock`), so a Bedrock-hosted Claude model can be served as a Databricks
endpoint with AI Gateway enabled — bringing rate limiting, usage/cost tracking,
payload logging, and guardrails to every LLM call. The `claude-sdk` harness then
points at that endpoint via `auth: {type: databricks}`.

## Details

- **Docs-only** — one new section in `examples/aws_analyst/README.md`. No config,
  code, or test changes; no new example bundle.
- Uses the existing `claude-sdk` harness + `auth: {type: databricks}` path already
  documented in the AGENT_YAML_SPEC; the endpoint name is illustrative
  (`databricks-claude-bedrock`) and the reader substitutes their own.
- **Not validated end-to-end here** — the section documents a supported configuration
  path (Bedrock external model + AI Gateway on Databricks Model Serving), verified
  against the linked Databricks docs, and says so inline with a note.

Companion to the connectors added in #2497.
