### PR TITLE
feat(kiro): discover model options dynamically

### DIFF
--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import shutil
+import subprocess
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -45,44 +46,123 @@ _DEFAULT_KIRO_COMMAND = "kiro-cli"
 _KIRO_PATH_ENV = "OMNIGENT_KIRO_PATH"
 _AGENT_NAME = "kiro-native-ui"
 
-# Curated kiro-cli base models for the Web UI picker. Static (like cursor-native,
-# the other launch-only-model vendor) rather than runner-discovered: the list is
-# global and fixed, not account-scoped. ids match what ``kiro-cli --model`` accepts
-# (and ``--list-models`` reports); ``auto`` is kiro's default and a real literal id.
-# Refresh by hand from ``kiro-cli chat --list-models --format json`` if Kiro
-# ships/renames a model.
-_KIRO_BASE_MODELS: list[dict[str, Any]] = [
-    {"id": "auto", "displayName": "Auto", "isDefault": True},
-    {"id": "claude-sonnet-4.5", "displayName": "Claude Sonnet 4.5"},
-    {"id": "claude-sonnet-4", "displayName": "Claude Sonnet 4"},
-    {"id": "claude-haiku-4.5", "displayName": "Claude Haiku 4.5"},
-    {"id": "deepseek-3.2", "displayName": "DeepSeek V3.2"},
-    {"id": "minimax-m2.5", "displayName": "MiniMax M2.5"},
-    {"id": "minimax-m2.1", "displayName": "MiniMax M2.1"},
-    {"id": "glm-5", "displayName": "GLM-5"},
-    {"id": "qwen3-coder-next", "displayName": "Qwen3 Coder Next"},
-]
+_KIRO_MODEL_DISCOVERY_TIMEOUT_S = 10.0
 
 
-def kiro_base_model_options() -> list[dict[str, Any]]:
-    """Return the curated kiro base-model options for the Web UI picker.
+def normalize_kiro_model_options(payload: Any) -> list[dict[str, Any]]:
+    """Normalize ``kiro-cli chat --list-models --format json`` output.
 
-    Mirrors :func:`omnigent.cursor_native.cursor_base_model_options`: each option
-    carries ``id`` (the value ``kiro-cli --model`` accepts), ``displayName``, and
-    ``isDefault``/``isCurrent`` flags. kiro applies the model only at launch, so
-    the picked id is persisted as ``model_override`` and consumed by the runner.
+    Accept a top-level array or an object containing ``models`` so minor CLI
+    envelope changes do not blank the picker. Model entries may be strings or
+    objects. Preserve CLI order, discard duplicate ids, and fail loudly on
+    malformed or empty catalogs so callers never cache a partial list.
 
-    :returns: Fresh option dicts (callers may mutate); base order preserved.
+    :param payload: Decoded JSON emitted by Kiro.
+    :returns: Web-picker options with ``id``, ``displayName``, and ``isDefault``.
+    :raises ValueError: If the catalog shape or an entry is invalid or empty.
     """
-    return [
-        {
-            "id": m["id"],
-            "displayName": m["displayName"],
-            "isDefault": bool(m.get("isDefault", False)),
-            "isCurrent": False,
-        }
-        for m in _KIRO_BASE_MODELS
-    ]
+    raw_models = payload.get("models") if isinstance(payload, dict) else payload
+    if not isinstance(raw_models, list):
+        raise ValueError("Kiro model catalog must be a list or an object containing models")
+    catalog_default = (
+        next(
+            (
+                value.strip()
+                for key in ("defaultModel", "default_model", "defaultModelId", "default_model_id")
+                if isinstance((value := payload.get(key)), str) and value.strip()
+            ),
+            None,
+        )
+        if isinstance(payload, dict)
+        else None
+    )
+
+    options: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in raw_models:
+        if isinstance(raw, str):
+            model_id = raw.strip()
+            display_name = model_id
+            supplied_default = False
+        elif isinstance(raw, dict):
+            model_id = next(
+                (
+                    value.strip()
+                    for key in ("id", "modelId", "model_id", "model")
+                    if isinstance((value := raw.get(key)), str) and value.strip()
+                ),
+                "",
+            )
+            display_name = next(
+                (
+                    value.strip()
+                    for key in ("displayName", "display_name", "name")
+                    if isinstance((value := raw.get(key)), str) and value.strip()
+                ),
+                model_id,
+            )
+            supplied_default = any(
+                raw.get(key) is True for key in ("isDefault", "is_default", "default")
+            )
+        else:
+            raise ValueError("Kiro model catalog entries must be strings or objects")
+        if not model_id:
+            raise ValueError("Kiro model catalog entry is missing an id")
+        if model_id in seen:
+            continue
+        seen.add(model_id)
+        options.append(
+            {
+                "id": model_id,
+                "displayName": display_name,
+                "isDefault": supplied_default
+                or model_id == catalog_default
+                or (catalog_default is None and model_id == "auto"),
+            }
+        )
+    if not options:
+        raise ValueError("Kiro model catalog is empty")
+    return options
+
+
+def discover_kiro_model_options(
+    executable: str,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    timeout_s: float = _KIRO_MODEL_DISCOVERY_TIMEOUT_S,
+) -> list[dict[str, Any]]:
+    """Run Kiro's machine-readable model discovery command.
+
+    :param executable: Resolved ``kiro-cli`` executable path.
+    :param cwd: Session workspace, matching the live Kiro terminal.
+    :param env: Sanitized Kiro child environment.
+    :param timeout_s: Maximum discovery runtime in seconds.
+    :returns: Normalized Web-picker model options.
+    :raises RuntimeError: If Kiro cannot run, times out, exits non-zero, or emits
+        invalid JSON/catalog data.
+    """
+    argv = [executable, "chat", "--list-models", "--format", "json"]
+    try:
+        completed = subprocess.run(
+            argv,
+            cwd=cwd,
+            env=dict(env),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError(f"Kiro model discovery failed: {exc}") from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
+        raise RuntimeError(f"Kiro model discovery exited {completed.returncode}: {detail}")
+    try:
+        payload = json.loads(completed.stdout)
+        return normalize_kiro_model_options(payload)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise RuntimeError(f"Kiro model discovery returned invalid JSON: {exc}") from exc
 
 
 _TERMINAL_NAME = "kiro"

--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -7,6 +7,7 @@ import json
 import os
 import shutil
 import subprocess
+import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -49,6 +50,14 @@ _AGENT_NAME = "kiro-native-ui"
 _KIRO_MODEL_DISCOVERY_TIMEOUT_S = 10.0
 
 
+class KiroModelDiscoveryUnavailable(RuntimeError):
+    """Kiro model discovery should pause before a later retry."""
+
+
+class KiroModelDiscoveryNotReady(RuntimeError):
+    """Kiro model discovery may succeed when retried shortly."""
+
+
 def normalize_kiro_model_options(payload: Any) -> list[dict[str, Any]]:
     """Normalize ``kiro-cli chat --list-models --format json`` output.
 
@@ -79,6 +88,7 @@ def normalize_kiro_model_options(payload: Any) -> list[dict[str, Any]]:
 
     options: list[dict[str, Any]] = []
     seen: set[str] = set()
+    supplied_default_ids: list[str] = []
     for raw in raw_models:
         if isinstance(raw, str):
             model_id = raw.strip()
@@ -108,6 +118,8 @@ def normalize_kiro_model_options(payload: Any) -> list[dict[str, Any]]:
             raise ValueError("Kiro model catalog entries must be strings or objects")
         if not model_id:
             raise ValueError("Kiro model catalog entry is missing an id")
+        if supplied_default and model_id not in supplied_default_ids:
+            supplied_default_ids.append(model_id)
         if model_id in seen:
             continue
         seen.add(model_id)
@@ -115,13 +127,20 @@ def normalize_kiro_model_options(payload: Any) -> list[dict[str, Any]]:
             {
                 "id": model_id,
                 "displayName": display_name,
-                "isDefault": supplied_default
-                or model_id == catalog_default
-                or (catalog_default is None and model_id == "auto"),
+                "isDefault": False,
             }
         )
     if not options:
         raise ValueError("Kiro model catalog is empty")
+    default_id = catalog_default if catalog_default in seen else None
+    if default_id is None:
+        default_id = next(
+            (model_id for model_id in supplied_default_ids if model_id in seen), None
+        )
+    if default_id is None and "auto" in seen:
+        default_id = "auto"
+    for option in options:
+        option["isDefault"] = option["id"] == default_id
     return options
 
 
@@ -137,32 +156,54 @@ def discover_kiro_model_options(
     :param executable: Resolved ``kiro-cli`` executable path.
     :param cwd: Session workspace, matching the live Kiro terminal.
     :param env: Sanitized Kiro child environment.
-    :param timeout_s: Maximum discovery runtime in seconds.
+    :param timeout_s: Maximum combined runtime for authentication and discovery.
     :returns: Normalized Web-picker model options.
-    :raises RuntimeError: If Kiro cannot run, times out, exits non-zero, or emits
-        invalid JSON/catalog data.
+    :raises KiroModelDiscoveryUnavailable: If Kiro is unauthenticated, cannot
+        run, exits non-zero, or emits invalid JSON/catalog data.
+    :raises KiroModelDiscoveryNotReady: If a bounded CLI check times out.
     """
-    argv = [executable, "chat", "--list-models", "--format", "json"]
-    try:
-        completed = subprocess.run(
-            argv,
-            cwd=cwd,
-            env=dict(env),
-            capture_output=True,
-            text=True,
-            timeout=timeout_s,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        raise RuntimeError(f"Kiro model discovery failed: {exc}") from exc
-    if completed.returncode != 0:
-        detail = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
-        raise RuntimeError(f"Kiro model discovery exited {completed.returncode}: {detail}")
+
+    deadline = time.monotonic() + timeout_s
+
+    def _run(argv: list[str], *, action: str) -> subprocess.CompletedProcess[str]:
+        remaining_s = deadline - time.monotonic()
+        if remaining_s <= 0:
+            raise KiroModelDiscoveryNotReady(f"Kiro {action} timed out")
+        try:
+            completed = subprocess.run(
+                argv,
+                cwd=cwd,
+                env=dict(env),
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                timeout=remaining_s,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise KiroModelDiscoveryNotReady(f"Kiro {action} timed out") from exc
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise KiroModelDiscoveryUnavailable(f"Kiro {action} failed: {exc}") from exc
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
+            raise KiroModelDiscoveryUnavailable(
+                f"Kiro {action} exited {completed.returncode}: {detail}"
+            )
+        return completed
+
+    _run([executable, "whoami", "--format", "json"], action="authentication check")
+
+    completed = _run(
+        [executable, "chat", "--list-models", "--format", "json"],
+        action="model discovery",
+    )
     try:
         payload = json.loads(completed.stdout)
         return normalize_kiro_model_options(payload)
     except (json.JSONDecodeError, ValueError) as exc:
-        raise RuntimeError(f"Kiro model discovery returned invalid JSON: {exc}") from exc
+        raise KiroModelDiscoveryUnavailable(
+            f"Kiro model discovery returned invalid JSON: {exc}"
+        ) from exc
 
 
 _TERMINAL_NAME = "kiro"

--- a/omnigent/kiro_native_bridge.py
+++ b/omnigent/kiro_native_bridge.py
@@ -215,12 +215,20 @@ def build_kiro_native_terminal_env(
     source_env: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Build the allowlisted child environment for ``kiro-cli``."""
-    env = os.environ if source_env is None else source_env
-    child = {key: env[key] for key in _CHILD_ENV_ALLOWLIST if env.get(key)}
+    child = build_kiro_native_discovery_env(source_env=source_env)
     bridge_dir = prepare_bridge_dir(session_id)
     child[KIRO_NATIVE_BRIDGE_DIR_ENV_VAR] = str(bridge_dir)
     child[KIRO_ACP_RECORD_PATH_ENV_VAR] = str(acp_record_path(bridge_dir))
     return child
+
+
+def build_kiro_native_discovery_env(
+    *,
+    source_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build Kiro's allowlisted environment without live-session bridge state."""
+    env = os.environ if source_env is None else source_env
+    return {key: env[key] for key in _CHILD_ENV_ALLOWLIST if env.get(key)}
 
 
 def write_tmux_target(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -630,6 +630,10 @@ def _kiro_session_workspace(session_workspace: str | None) -> Path:
     return Path(raw.strip()).expanduser().resolve()
 
 
+_KIRO_MODEL_OPTIONS_TOTAL_TIMEOUT_S = 20.0
+_KIRO_MODEL_OPTIONS_SUBPROCESS_MARGIN_S = 0.5
+
+
 async def _kiro_native_launch_config(
     *,
     session_id: str,
@@ -11125,21 +11129,36 @@ def create_runner_app(
             build_kiro_native_discovery_env,
         )
 
-        launch_config = await _kiro_native_launch_config(
-            session_id=conv_id,
-            server_client=server_client,
-        )
-        env = build_kiro_native_discovery_env()
-        for key in KIRO_NATIVE_ENV_UNSET:
-            env.pop(key, None)
-        env["KIRO_LOG_NO_COLOR"] = "true"
-        executable = resolve_kiro_executable()
-        return await asyncio.to_thread(
-            discover_kiro_model_options,
-            executable,
-            cwd=launch_config.workspace,
-            env=env,
-        )
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _KIRO_MODEL_OPTIONS_TOTAL_TIMEOUT_S
+        worker_deadline = time.monotonic() + _KIRO_MODEL_OPTIONS_TOTAL_TIMEOUT_S
+        async with asyncio.timeout_at(deadline):
+            launch_config = await _kiro_native_launch_config(
+                session_id=conv_id,
+                server_client=server_client,
+            )
+            env = build_kiro_native_discovery_env()
+            for key in KIRO_NATIVE_ENV_UNSET:
+                env.pop(key, None)
+            env["KIRO_LOG_NO_COLOR"] = "true"
+            executable = resolve_kiro_executable()
+
+            def _discover_before_deadline() -> list[dict[str, Any]]:
+                remaining_s = (
+                    worker_deadline - time.monotonic() - _KIRO_MODEL_OPTIONS_SUBPROCESS_MARGIN_S
+                )
+                if remaining_s <= 0:
+                    raise TimeoutError("Kiro model-options deadline exhausted before discovery")
+                return discover_kiro_model_options(
+                    executable,
+                    cwd=launch_config.workspace,
+                    env=env,
+                    timeout_s=min(10.0, remaining_s),
+                )
+
+            return await asyncio.to_thread(
+                _discover_before_deadline,
+            )
 
     async def _handle_pi_native_interrupt(conv_id: str) -> Response:
         """
@@ -17822,8 +17841,11 @@ def create_runner_app(
         :param session_id: Session/conversation identifier, e.g.
             ``"conv_abc123"``.
         :returns: JSON ``{"models": [...]}``. Wrong-harness sessions return an
-            empty list; discovery failures return retryable HTTP 503.
+            empty list. Failures requiring a retry cooldown return HTTP 424;
+            transient not-ready failures return HTTP 503.
         """
+        from omnigent.kiro_native import KiroModelDiscoveryUnavailable
+
         if _session_harness_name(session_id) != "kiro-native":
             return JSONResponse(status_code=200, content={"models": []})
         try:
@@ -17831,7 +17853,16 @@ def create_runner_app(
                 status_code=200,
                 content={"models": await _kiro_native_model_options(session_id)},
             )
-        except Exception as exc:  # noqa: BLE001 - surface runner-local CLI failures to AP.
+        except KiroModelDiscoveryUnavailable as exc:
+            _logger.info("Kiro model discovery unavailable for session=%s", session_id)
+            return JSONResponse(
+                status_code=424,
+                content={
+                    "error": "kiro_native_model_options_unavailable",
+                    "detail": _client_safe_error_detail(exc, context="kiro-native model options"),
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 - surface transient runner failures to AP.
             _logger.warning(
                 "Kiro model discovery failed for session=%s",
                 session_id,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -11105,6 +11105,42 @@ def create_runner_app(
                 await codex_client.close()
         return options
 
+    async def _kiro_native_model_options(conv_id: str) -> list[dict[str, Any]]:
+        """Discover model options from the Kiro CLI installed on this runner.
+
+        The runner owns both the Kiro binary and its authenticated credential
+        home. Use the same workspace and sanitized environment as the live TUI
+        so remote runners report their own available catalog, not the AP host's.
+
+        :param conv_id: Session/conversation identifier, e.g. ``"conv_abc123"``.
+        :returns: Normalized Web-picker model objects.
+        :raises RuntimeError: If launch config or Kiro discovery fails.
+        """
+        from omnigent.kiro_native import (
+            discover_kiro_model_options,
+            resolve_kiro_executable,
+        )
+        from omnigent.kiro_native_bridge import (
+            KIRO_NATIVE_ENV_UNSET,
+            build_kiro_native_discovery_env,
+        )
+
+        launch_config = await _kiro_native_launch_config(
+            session_id=conv_id,
+            server_client=server_client,
+        )
+        env = build_kiro_native_discovery_env()
+        for key in KIRO_NATIVE_ENV_UNSET:
+            env.pop(key, None)
+        env["KIRO_LOG_NO_COLOR"] = "true"
+        executable = resolve_kiro_executable()
+        return await asyncio.to_thread(
+            discover_kiro_model_options,
+            executable,
+            cwd=launch_config.workspace,
+            env=env,
+        )
+
     async def _handle_pi_native_interrupt(conv_id: str) -> Response:
         """
         Stop a pi-native turn by asking the resident Pi extension to abort.
@@ -17776,6 +17812,36 @@ def create_runner_app(
                 content={
                     "error": "codex_native_model_options_failed",
                     "detail": _client_safe_error_detail(exc, context="codex-native model options"),
+                },
+            )
+
+    @app.get("/v1/sessions/{session_id}/kiro-model-options")
+    async def get_session_kiro_model_options(session_id: str) -> JSONResponse:
+        """Return the live Kiro CLI model catalog for a kiro-native session.
+
+        :param session_id: Session/conversation identifier, e.g.
+            ``"conv_abc123"``.
+        :returns: JSON ``{"models": [...]}``. Wrong-harness sessions return an
+            empty list; discovery failures return retryable HTTP 503.
+        """
+        if _session_harness_name(session_id) != "kiro-native":
+            return JSONResponse(status_code=200, content={"models": []})
+        try:
+            return JSONResponse(
+                status_code=200,
+                content={"models": await _kiro_native_model_options(session_id)},
+            )
+        except Exception as exc:  # noqa: BLE001 - surface runner-local CLI failures to AP.
+            _logger.warning(
+                "Kiro model discovery failed for session=%s",
+                session_id,
+                exc_info=True,
+            )
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "kiro_native_model_options_failed",
+                    "detail": _client_safe_error_detail(exc, context="kiro-native model options"),
                 },
             )
 

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -1166,15 +1166,19 @@ _session_mcp_startup_cache: dict[str, dict[str, McpServerStartup]] = {}
 # poll can't pin the runner's event loop and wedge a turn.
 _runner_skills_cache: dict[str, list[SkillSummary]] = {}
 _runner_skills_inflight: dict[str, asyncio.Task[None]] = {}
+_runner_skills_generation: dict[str, object] = {}
 # Per-session runner-owned native model catalog cache + in-flight fetch.
 # The snapshot warms this from the bound runner off the hot path, same shape as
 # runner skills. Codex queries app-server ``model/list``; Kiro invokes its CLI.
 _model_options_cache: dict[str, list[dict[str, Any]]] = {}
 _model_options_inflight: dict[str, asyncio.Task[None]] = {}
+_model_options_generation: dict[str, object] = {}
+_model_options_retry_after: dict[str, float] = {}
 _MODEL_OPTIONS_RETRY_DELAYS_S = (0.25, 0.5, 1.0, 2.0, 2.0)
-# Kiro discovery includes a session-workspace read plus a CLI call bounded at
-# 10s. Keep the AP→runner request budget above both bounds so a valid discovery
-# is not cancelled by the outer request first.
+_MODEL_OPTIONS_UNAVAILABLE_COOLDOWN_S = 30.0
+_MODEL_OPTIONS_UNAVAILABLE_MAX_ATTEMPTS = 3
+# Kiro discovery includes a 10s workspace read plus a 10s combined CLI budget.
+# Keep the AP→runner request budget above both bounds.
 _MODEL_OPTIONS_REQUEST_TIMEOUT_S = 25.0
 # Per-session model catalog PUSHED by a native harness's extension
 # (``external_model_options``), as opposed to the runner-fetched
@@ -6092,8 +6096,8 @@ def _invalidate_runner_backed_snapshot_state(
     These fields are discovered from the bound runner (skills and native model
     catalogs), so browser reloads can ask the
     next snapshot to refresh them from the live session instead of serving
-    stale AP-process memory. Runner teardown additionally cancels any
-    in-flight fetch so a dead runner cannot land a late stale value.
+    stale AP-process memory. Generation fencing rejects late stale results;
+    runner teardown additionally cancels its task.
 
     :param session_id: Session/conversation identifier,
         e.g. ``"conv_abc123"``.
@@ -6102,15 +6106,21 @@ def _invalidate_runner_backed_snapshot_state(
         refreshes so concurrent page-load callers do not cancel each other.
     """
     _runner_skills_cache.pop(session_id, None)
-    if cancel_inflight:
-        inflight = _runner_skills_inflight.pop(session_id, None)
-        if inflight is not None:
-            inflight.cancel()
+    _runner_skills_generation[session_id] = object()
+    skills_inflight = _runner_skills_inflight.pop(session_id, None)
+    if skills_inflight is not None and cancel_inflight:
+        skills_inflight.cancel()
     _model_options_cache.pop(session_id, None)
+    _model_options_retry_after.pop(session_id, None)
+    # Identity tokens avoid ABA when delete/rebind removes state while a
+    # cancellation-resistant stale fetch still owns its former token.
+    _model_options_generation[session_id] = object()
+    model_options_inflight = _model_options_inflight.pop(session_id, None)
+    if model_options_inflight is not None and cancel_inflight:
+        model_options_inflight.cancel()
     if cancel_inflight:
-        model_options_inflight = _model_options_inflight.pop(session_id, None)
-        if model_options_inflight is not None:
-            model_options_inflight.cancel()
+        _runner_skills_generation.pop(session_id, None)
+        _model_options_generation.pop(session_id, None)
 
 
 def _publish_changed_files_invalidated(session_id: str, environment_id: str = "default") -> None:
@@ -10681,10 +10691,11 @@ async def _relay_runner_stream(
         # mid-turn, or a rebind cancellation) can't strand it forever.
         # Normal turn-ends already clear via record_publish.
         inflight_text.discard(session_id)
-        # Relay ended (runner dropped/rebound): re-discover runner-backed
-        # snapshot overlays next time. Cancel in-flight fetches so they can't
-        # land stale values from the dead runner after this pop.
-        _invalidate_runner_backed_snapshot_state(session_id, cancel_inflight=True)
+        # Only active binding owns session-wide teardown. A cancelled old
+        # relay may finish after replacement already started runner fetches.
+        current_relay = _runner_relay_tasks.get(session_id)
+        if current_relay is not None and current_relay.task is asyncio.current_task():
+            _invalidate_runner_backed_snapshot_state(session_id, cancel_inflight=True)
 
 
 def _ensure_runner_relay(
@@ -10734,6 +10745,10 @@ def _ensure_runner_relay(
         )
         if not existing.task.done():
             existing.task.cancel()  # stale binding; replace
+        # Runner-derived overlays belong to the old binding. Fence and drop
+        # them before publishing the new relay handle so stale fetches cannot
+        # repopulate state for the replacement runner.
+        _invalidate_runner_backed_snapshot_state(session_id, cancel_inflight=True)
     else:
         _logger.info("Relay: creating new for session=%s runner=%s", session_id, runner_id)
     ready = asyncio.Event()
@@ -21189,6 +21204,9 @@ def create_sessions_router(
         # for reload visibility while the session exists, so a session
         # whose MCP startup never settled clean would leak its entry.
         _session_mcp_startup_cache.pop(session_id, None)
+        # Runner-backed catalogs may be waiting in a retry cooldown indefinitely;
+        # deleting their session must cancel the task and drop every overlay.
+        _invalidate_runner_backed_snapshot_state(session_id, cancel_inflight=True)
         # Same for the extension-pushed model catalog: kept across reloads
         # while the session exists (the extension only pushes on start), so a
         # deleted session would otherwise leak its entry for the process life.
@@ -21962,15 +21980,30 @@ async def _fetch_runner_skills(
     # event loop and wedges the turn. Kick one background fetch (single-
     # flight) and return ``[]``; a later poll serves the cached result.
     if session_id not in _runner_skills_inflight:
-        task = asyncio.create_task(_load_runner_skills(runner_client, session_id))
+        generation = _runner_skills_generation.setdefault(session_id, object())
+        task = asyncio.create_task(
+            _load_runner_skills(runner_client, session_id, generation=generation)
+        )
         _runner_skills_inflight[session_id] = task
-        task.add_done_callback(lambda _t, sid=session_id: _runner_skills_inflight.pop(sid, None))
+
+        def _clear_inflight(
+            _task: asyncio.Task[None],
+            *,
+            sid: str = session_id,
+            expected: asyncio.Task[None] = task,
+        ) -> None:
+            if _runner_skills_inflight.get(sid) is expected:
+                _runner_skills_inflight.pop(sid, None)
+
+        task.add_done_callback(_clear_inflight)
     return []
 
 
 async def _load_runner_skills(
     runner_client: httpx.AsyncClient,
     session_id: str,
+    *,
+    generation: object,
 ) -> None:
     """Background single-flight fetch of a session's runner-owned skills.
 
@@ -21982,6 +22015,7 @@ async def _load_runner_skills(
 
     :param runner_client: HTTP client pointed at the bound runner.
     :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
+    :param generation: Session cache identity token captured when fetch started.
     """
     try:
         resp = await runner_client.get(
@@ -21999,10 +22033,11 @@ async def _load_runner_skills(
     except (ValueError, AttributeError, KeyError, TypeError):
         _logger.debug("Runner skills payload malformed for %s", session_id)
         return
-    _runner_skills_cache[session_id] = skills
-    # Nudge any subscribed client to re-read the (now-warm) snapshot so
-    # its slash-command menu fills without waiting for the next bind.
-    _publish_runner_skills(session_id)
+    if _runner_skills_generation.get(session_id) is generation:
+        _runner_skills_cache[session_id] = skills
+        # Nudge any subscribed client to re-read the (now-warm) snapshot so
+        # its slash-command menu fills without waiting for the next bind.
+        _publish_runner_skills(session_id)
 
 
 def _model_options_from_wire(raw_models: Any) -> list[dict[str, Any]]:
@@ -22096,11 +22131,29 @@ async def _fetch_model_options(
     cached = _model_options_cache.get(session_id)
     if cached is not None:
         return cached
+    retry_after = _model_options_retry_after.get(session_id)
+    if retry_after is not None:
+        if retry_after > time.monotonic():
+            return []
+        _model_options_retry_after.pop(session_id, None)
     if session_id not in _model_options_inflight:
         path = f"/v1/sessions/{session_id}/{endpoint}"
-        task = asyncio.create_task(_load_model_options(runner_client, session_id, path))
+        generation = _model_options_generation.setdefault(session_id, object())
+        task = asyncio.create_task(
+            _load_model_options(runner_client, session_id, path, generation=generation)
+        )
         _model_options_inflight[session_id] = task
-        task.add_done_callback(lambda _t, sid=session_id: _model_options_inflight.pop(sid, None))
+
+        def _clear_inflight(
+            _task: asyncio.Task[None],
+            *,
+            sid: str = session_id,
+            expected: asyncio.Task[None] = task,
+        ) -> None:
+            if _model_options_inflight.get(sid) is expected:
+                _model_options_inflight.pop(sid, None)
+
+        task.add_done_callback(_clear_inflight)
     return []
 
 
@@ -22108,6 +22161,8 @@ async def _load_model_options(
     runner_client: httpx.AsyncClient,
     session_id: str,
     path: str,
+    *,
+    generation: object,
 ) -> None:
     """
     Background single-flight fetch of a session's native model catalog.
@@ -22116,19 +22171,40 @@ async def _load_model_options(
     :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
     :param path: Runner route to query, e.g.
         ``"/v1/sessions/conv_abc/kiro-model-options"``.
+    :param generation: Session cache identity token captured when fetch started.
     """
-    for attempt in range(len(_MODEL_OPTIONS_RETRY_DELAYS_S) + 1):
+    transient_attempt = 0
+    unavailable_attempt = 0
+    while True:
         try:
             resp = await runner_client.get(path, timeout=_MODEL_OPTIONS_REQUEST_TIMEOUT_S)
         except (httpx.HTTPError, ConnectionError):
             _logger.debug("Runner model-options query failed for %s", session_id)
             return
         if resp.status_code != 200:
+            if resp.status_code == status.HTTP_424_FAILED_DEPENDENCY:
+                # Avoid a subprocess storm while still recovering automatically
+                # after login or a temporary Kiro service failure.
+                unavailable_attempt += 1
+                if _model_options_generation.get(session_id) is generation:
+                    if unavailable_attempt >= _MODEL_OPTIONS_UNAVAILABLE_MAX_ATTEMPTS:
+                        _model_options_retry_after.pop(session_id, None)
+                        return
+                    retry_at = time.monotonic() + _MODEL_OPTIONS_UNAVAILABLE_COOLDOWN_S
+                    _model_options_retry_after[session_id] = retry_at
+                    await asyncio.sleep(_MODEL_OPTIONS_UNAVAILABLE_COOLDOWN_S)
+                    if _model_options_generation.get(session_id) is not generation:
+                        return
+                    _model_options_retry_after.pop(session_id, None)
+                    transient_attempt = 0
+                    continue
+                return
             # 503 means native model discovery is temporarily unavailable.
             # Keep the background single-flight alive so the web picker fills
             # without a second manual refresh.
-            if resp.status_code == 503 and attempt < len(_MODEL_OPTIONS_RETRY_DELAYS_S):
-                await asyncio.sleep(_MODEL_OPTIONS_RETRY_DELAYS_S[attempt])
+            if resp.status_code == 503 and transient_attempt < len(_MODEL_OPTIONS_RETRY_DELAYS_S):
+                await asyncio.sleep(_MODEL_OPTIONS_RETRY_DELAYS_S[transient_attempt])
+                transient_attempt += 1
                 continue
             return
         try:
@@ -22140,12 +22216,15 @@ async def _load_model_options(
             # Older runners returned 200 + [] for the same not-ready window.
             # Do not cache that empty catalog; retry, then leave the cache
             # cold so a later snapshot can try again.
-            if attempt < len(_MODEL_OPTIONS_RETRY_DELAYS_S):
-                await asyncio.sleep(_MODEL_OPTIONS_RETRY_DELAYS_S[attempt])
+            if transient_attempt < len(_MODEL_OPTIONS_RETRY_DELAYS_S):
+                await asyncio.sleep(_MODEL_OPTIONS_RETRY_DELAYS_S[transient_attempt])
+                transient_attempt += 1
                 continue
             return
-        _model_options_cache[session_id] = options
-        _publish_model_options(session_id)
+        if _model_options_generation.get(session_id) is generation:
+            _model_options_retry_after.pop(session_id, None)
+            _model_options_cache[session_id] = options
+            _publish_model_options(session_id)
         return
 
 

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -1166,12 +1166,16 @@ _session_mcp_startup_cache: dict[str, dict[str, McpServerStartup]] = {}
 # poll can't pin the runner's event loop and wedge a turn.
 _runner_skills_cache: dict[str, list[SkillSummary]] = {}
 _runner_skills_inflight: dict[str, asyncio.Task[None]] = {}
-# Per-session codex-native model catalog cache + in-flight fetch.
-# The snapshot warms this from the bound runner's live Codex app-server
-# (``model/list``) off the hot path, same shape as runner skills.
+# Per-session runner-owned native model catalog cache + in-flight fetch.
+# The snapshot warms this from the bound runner off the hot path, same shape as
+# runner skills. Codex queries app-server ``model/list``; Kiro invokes its CLI.
 _model_options_cache: dict[str, list[dict[str, Any]]] = {}
 _model_options_inflight: dict[str, asyncio.Task[None]] = {}
-_CODEX_MODEL_OPTIONS_RETRY_DELAYS_S = (0.25, 0.5, 1.0, 2.0, 2.0)
+_MODEL_OPTIONS_RETRY_DELAYS_S = (0.25, 0.5, 1.0, 2.0, 2.0)
+# Kiro discovery includes a session-workspace read plus a CLI call bounded at
+# 10s. Keep the AP→runner request budget above both bounds so a valid discovery
+# is not cancelled by the outer request first.
+_MODEL_OPTIONS_REQUEST_TIMEOUT_S = 25.0
 # Per-session model catalog PUSHED by a native harness's extension
 # (``external_model_options``), as opposed to the runner-fetched
 # ``_model_options_cache`` above. Kept in a separate cache that a browser
@@ -6063,9 +6067,9 @@ def _publish_model_options(session_id: str) -> None:
     """
     Publish a typed :class:`SessionModelOptionsEvent` to the live stream.
 
-    Fired when the background Codex ``model/list`` fetch populates the
-    per-session model-options cache. Connected clients re-read the session
-    snapshot and apply its cache-backed ``model_options`` field.
+    Fired when a background runner fetch populates the per-session
+    model-options cache. Connected clients re-read the session snapshot and
+    apply its cache-backed ``model_options`` field.
 
     :param session_id: Session/conversation identifier,
         e.g. ``"conv_abc123"``.
@@ -6085,8 +6089,8 @@ def _invalidate_runner_backed_snapshot_state(
     """
     Drop runner-derived session snapshot overlays for one session.
 
-    These fields are discovered from the bound runner (skills and the
-    codex-native ``model/list`` catalog), so browser reloads can ask the
+    These fields are discovered from the bound runner (skills and native model
+    catalogs), so browser reloads can ask the
     next snapshot to refresh them from the live session instead of serving
     stale AP-process memory. Runner teardown additionally cancels any
     in-flight fetch so a dead runner cannot land a late stale value.
@@ -6104,9 +6108,9 @@ def _invalidate_runner_backed_snapshot_state(
             inflight.cancel()
     _model_options_cache.pop(session_id, None)
     if cancel_inflight:
-        codex_inflight = _model_options_inflight.pop(session_id, None)
-        if codex_inflight is not None:
-            codex_inflight.cancel()
+        model_options_inflight = _model_options_inflight.pop(session_id, None)
+        if model_options_inflight is not None:
+            model_options_inflight.cancel()
 
 
 def _publish_changed_files_invalidated(session_id: str, environment_id: str = "default") -> None:
@@ -22003,28 +22007,29 @@ async def _load_runner_skills(
 
 def _model_options_from_wire(raw_models: Any) -> list[dict[str, Any]]:
     """
-    Validate runner-returned raw Codex ``model/list`` data.
+    Validate runner-returned native model-option data.
 
     :param raw_models: JSON value from the runner's
-        ``{"models": [...]}`` response, e.g. a list of Codex model dicts.
+        ``{"models": [...]}`` response, e.g. Codex or Kiro model dicts.
     :returns: Raw model options for the session snapshot.
     :raises ValueError: If the payload is not the expected list/dict
         shape.
     """
     if not isinstance(raw_models, list):
-        raise ValueError("Codex model options payload must be a list")
+        raise ValueError("Native model options payload must be a list")
     options: list[dict[str, Any]] = []
     for raw_model in raw_models:
         if not isinstance(raw_model, dict):
-            raise ValueError("Codex model option must be an object")
+            raise ValueError("Native model option must be an object")
         options.append(raw_model)
     return options
 
 
 # Native harnesses whose model picker is populated from a *live*, runner-owned
 # model-options endpoint, keyed by wrapper label -> the runner route segment.
-# Codex queries its live app-server ``model/list`` (account/session-scoped, so
-# it must come from the bound runner). Cursor is deliberately NOT here: its
+# Codex queries its live app-server ``model/list``; Kiro invokes its
+# account-scoped CLI discovery command. Both must run on the bound runner.
+# Cursor is deliberately NOT here: its
 # catalog is a curated *static* base list served directly (see
 # ``_fetch_model_options``), which keeps it off the runner-backed cache that
 # ``refresh_state`` invalidates — otherwise an effort/model change would blank
@@ -22032,6 +22037,7 @@ def _model_options_from_wire(raw_models: Any) -> list[dict[str, Any]]:
 _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER: dict[str, str] = {
     _CODEX_NATIVE_WRAPPER_LABEL_VALUE: "codex-model-options",
     _OPENCODE_NATIVE_WRAPPER_LABEL_VALUE: "codex-model-options",
+    _KIRO_NATIVE_WRAPPER_LABEL_VALUE: "kiro-model-options",
     # pi-native is deliberately NOT here: its catalog is PUSHED by the resident
     # extension (``external_model_options`` → ``_pushed_model_options_cache``),
     # not fetched from a runner route, so the picker works in every auth path
@@ -22055,10 +22061,11 @@ async def _fetch_model_options(
       cache below: the catalog never changes per session, and routing it
       through that cache would let a ``refresh_state`` snapshot (which pops the
       cache) blank the picker on an effort/model change.
-    * **codex-native** — a *live*, account-scoped catalog only the bound runner
-      can read (its app-server ``model/list``). Like skills, this stays off the
-      snapshot hot path: the first snapshot kicks a background fetch and returns
-      ``[]``; subsequent snapshots serve the cache.
+    * **codex-native / kiro-native** — a *live*, account-scoped catalog only the
+      bound runner can read (Codex app-server ``model/list`` or Kiro CLI model
+      discovery). Like skills, this stays off the snapshot hot path: the first
+      snapshot kicks a background fetch and returns ``[]``; subsequent snapshots
+      serve the cache.
 
     :param runner_client: HTTP client pointed at the bound runner, or
         ``None`` when no runner is bound.
@@ -22066,17 +22073,13 @@ async def _fetch_model_options(
         e.g. ``"conv_abc123"``.
     :param conv: Conversation row whose labels identify the wrapper.
     :returns: Model options, or ``[]`` when the session has no model picker or
-        the (codex) options are not yet available.
+        runner-owned options are not yet available.
     """
     wrapper = conv.labels.get(_CLAUDE_NATIVE_WRAPPER_LABEL_KEY)
     if wrapper == _CURSOR_NATIVE_WRAPPER_LABEL_VALUE:
         from omnigent.cursor_native import cursor_base_model_options
 
         return cursor_base_model_options()
-    if wrapper == _KIRO_NATIVE_WRAPPER_LABEL_VALUE:
-        from omnigent.kiro_native import kiro_base_model_options
-
-        return kiro_base_model_options()
     if wrapper == _PI_NATIVE_WRAPPER_LABEL_VALUE:
         # pi-native's catalog is PUSHED by its extension (its live
         # ``ctx.modelRegistry``), not fetched: that reflects the models pi
@@ -22112,20 +22115,20 @@ async def _load_model_options(
     :param runner_client: HTTP client pointed at the bound runner.
     :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
     :param path: Runner route to query, e.g.
-        ``"/v1/sessions/conv_abc/cursor-model-options"``.
+        ``"/v1/sessions/conv_abc/kiro-model-options"``.
     """
-    for attempt in range(len(_CODEX_MODEL_OPTIONS_RETRY_DELAYS_S) + 1):
+    for attempt in range(len(_MODEL_OPTIONS_RETRY_DELAYS_S) + 1):
         try:
-            resp = await runner_client.get(path, timeout=5.0)
+            resp = await runner_client.get(path, timeout=_MODEL_OPTIONS_REQUEST_TIMEOUT_S)
         except (httpx.HTTPError, ConnectionError):
             _logger.debug("Runner model-options query failed for %s", session_id)
             return
         if resp.status_code != 200:
-            # 503 means the native backend (Codex app-server bridge / cursor
-            # login) is still booting. Keep the background single-flight alive
-            # so the web picker fills without a second manual refresh.
-            if resp.status_code == 503 and attempt < len(_CODEX_MODEL_OPTIONS_RETRY_DELAYS_S):
-                await asyncio.sleep(_CODEX_MODEL_OPTIONS_RETRY_DELAYS_S[attempt])
+            # 503 means native model discovery is temporarily unavailable.
+            # Keep the background single-flight alive so the web picker fills
+            # without a second manual refresh.
+            if resp.status_code == 503 and attempt < len(_MODEL_OPTIONS_RETRY_DELAYS_S):
+                await asyncio.sleep(_MODEL_OPTIONS_RETRY_DELAYS_S[attempt])
                 continue
             return
         try:
@@ -22137,8 +22140,8 @@ async def _load_model_options(
             # Older runners returned 200 + [] for the same not-ready window.
             # Do not cache that empty catalog; retry, then leave the cache
             # cold so a later snapshot can try again.
-            if attempt < len(_CODEX_MODEL_OPTIONS_RETRY_DELAYS_S):
-                await asyncio.sleep(_CODEX_MODEL_OPTIONS_RETRY_DELAYS_S[attempt])
+            if attempt < len(_MODEL_OPTIONS_RETRY_DELAYS_S):
+                await asyncio.sleep(_MODEL_OPTIONS_RETRY_DELAYS_S[attempt])
                 continue
             return
         _model_options_cache[session_id] = options
@@ -22359,10 +22362,10 @@ async def _get_session_snapshot(
     # server only overlays the result; best-effort, empty when no runner
     # is bound or it can't be reached.
     skills = await _fetch_runner_skills(runner_client, session_id)
-    # Codex model options are also runner-owned: they come from the
-    # session's live Codex app-server ``model/list`` response. Best-effort
-    # and cache-backed like skills so a snapshot poll cannot wedge the
-    # runner while a turn is active.
+    # Native model options can also be runner-owned: Codex reads app-server
+    # ``model/list`` and Kiro invokes its authenticated CLI discovery command.
+    # Best-effort and cache-backed like skills so a snapshot poll cannot wedge
+    # the runner while a turn is active.
     model_options = await _fetch_model_options(runner_client, session_id, conv)
     # Dynamic override from the forwarder (real Claude Code window).
     # Only present after the first statusLine tick; before that the

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1751,10 +1751,9 @@ class SessionResponse(BaseModel):
         runner at startup. Empty list when the agent spec
         cannot be loaded, or when bundled + host discovery
         yields nothing.
-    :param model_options: Codex app-server ``model/list`` options
-        for codex-native sessions, including each model's supported
-        reasoning efforts. Empty for non-codex-native sessions or while
-        the bound runner / Codex app-server cannot answer yet.
+    :param model_options: Native model-picker options. Codex entries may include
+        supported reasoning efforts; Kiro entries come from CLI discovery.
+        Empty for sessions without a picker or while the runner cannot answer.
     :param terminal_pending: ``True`` while the runner is auto-creating
         a terminal-first session's terminal (claude-native /
         codex-native), so the Web UI shows a spinner on the Terminal

--- a/tests/e2e_ui/chat/test_kiro_model_metadata.py
+++ b/tests/e2e_ui/chat/test_kiro_model_metadata.py
@@ -14,8 +14,7 @@ def _patch_session_as_kiro_native(page: Page, session_id: str) -> list[dict]:
     The server fixture seeds a normal session so the page boots against the real
     app/server. This route patch rewrites only ``GET``/``PATCH
     /v1/sessions/{session_id}`` as seen by the browser into a kiro-native
-    snapshot carrying the curated kiro ``model_options`` (the shape
-    :func:`omnigent.kiro_native.kiro_base_model_options` serves) and a persisted
+    snapshot carrying runner-discovered Kiro ``model_options`` and a persisted
     ``model_override``.
 
     :param page: Playwright page before navigation.
@@ -54,16 +53,15 @@ def _patch_session_as_kiro_native(page: Page, session_id: str) -> list[dict]:
         }
         payload["harness"] = "kiro-native"
         payload["model_options"] = [
-            {"id": "auto", "displayName": "Auto", "isDefault": True, "isCurrent": False},
+            {"id": "auto", "displayName": "Auto", "isDefault": True},
             {
-                "id": "claude-haiku-4.5",
-                "displayName": "Claude Haiku 4.5",
+                "id": "claude-opus-4.8",
+                "displayName": "Claude Opus 4.8",
                 "isDefault": False,
-                "isCurrent": False,
             },
-            {"id": "glm-5", "displayName": "GLM-5", "isDefault": False, "isCurrent": False},
+            {"id": "sonnet-5", "displayName": "Sonnet 5", "isDefault": False},
         ]
-        payload.setdefault("model_override", "claude-haiku-4.5")
+        payload.setdefault("model_override", "claude-opus-4.8")
         latest_payload = dict(payload)
         route.fulfill(status=200, headers=headers, body=json.dumps(payload))
 
@@ -75,7 +73,7 @@ def test_kiro_native_picker_lists_models_and_persists_pick(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """The kiro-native picker renders the curated catalog and persists a pick.
+    """The kiro-native picker renders the dynamic catalog and persists a pick.
 
     kiro applies the chosen model as ``--model`` at launch, so the picker writes
     the selection to ``model_override`` (no in-session mirror). This covers the
@@ -95,12 +93,12 @@ def test_kiro_native_picker_lists_models_and_persists_pick(
     expect(trigger).to_be_visible(timeout=15_000)
     trigger.click()
 
-    # The curated kiro catalog renders with its display names.
-    haiku_row = page.locator('[data-testid="model-picker-item"][data-model-id="claude-haiku-4.5"]')
-    expect(haiku_row).to_be_visible()
-    expect(haiku_row).to_contain_text("Claude Haiku 4.5")
+    # Runner-discovered models render with their display names.
+    opus_row = page.locator('[data-testid="model-picker-item"][data-model-id="claude-opus-4.8"]')
+    expect(opus_row).to_be_visible()
+    expect(opus_row).to_contain_text("Claude Opus 4.8")
     expect(
-        page.locator('[data-testid="model-picker-item"][data-model-id="glm-5"]')
+        page.locator('[data-testid="model-picker-item"][data-model-id="sonnet-5"]')
     ).to_be_visible()
 
     # Picking a model PATCHes model_override (consumed at launch via --model).
@@ -111,6 +109,6 @@ def test_kiro_native_picker_lists_models_and_persists_pick(
             and response.status == 200
         )
     ):
-        page.locator('[data-testid="model-picker-item"][data-model-id="glm-5"]').click()
+        page.locator('[data-testid="model-picker-item"][data-model-id="sonnet-5"]').click()
 
-    assert patch_bodies[-1] == {"model_override": "glm-5"}
+    assert patch_bodies[-1] == {"model_override": "sonnet-5"}

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -9732,6 +9732,183 @@ async def test_codex_native_model_options_query_model_list(
 
 
 @pytest.mark.asyncio
+async def test_kiro_native_model_options_discovers_on_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Kiro endpoint discovers models with session workspace and terminal env."""
+    from omnigent import kiro_native
+
+    conv_id = "conv_kiro_native_model_options"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro-home"))
+    monkeypatch.setenv("KIRO_CONFIG_HOME", str(tmp_path / "kiro-config"))
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "must-not-leak")
+    recorded: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        kiro_native,
+        "resolve_kiro_executable",
+        lambda: "/opt/kiro-cli",
+    )
+
+    def _discover(
+        executable: str,
+        *,
+        cwd: Path,
+        env: dict[str, str],
+    ) -> list[dict[str, object]]:
+        recorded.update(executable=executable, cwd=cwd, env=env)
+        return [
+            {"id": "auto", "displayName": "Auto", "isDefault": True},
+            {"id": "claude-opus-4.8", "displayName": "Claude Opus 4.8"},
+        ]
+
+    monkeypatch.setattr(kiro_native, "discover_kiro_model_options", _discover)
+
+    class _SnapshotClient(NullServerClient):
+        async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+            del kwargs
+            if url == f"/v1/sessions/{conv_id}":
+                return httpx.Response(
+                    200,
+                    json={"workspace": str(workspace)},
+                    request=httpx.Request("GET", url),
+                )
+            return await super().get(url)
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "kiro-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=_SnapshotClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        resp = await client.get(f"/v1/sessions/{conv_id}/kiro-model-options")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "models": [
+            {"id": "auto", "displayName": "Auto", "isDefault": True},
+            {"id": "claude-opus-4.8", "displayName": "Claude Opus 4.8"},
+        ]
+    }
+    assert recorded["executable"] == "/opt/kiro-cli"
+    assert recorded["cwd"] == workspace.resolve()
+    env = cast(dict[str, str], recorded["env"])
+    assert env["HOME"] == str(tmp_path / "home")
+    assert env["KIRO_HOME"] == str(tmp_path / "kiro-home")
+    assert env["KIRO_CONFIG_HOME"] == str(tmp_path / "kiro-config")
+    assert env["KIRO_LOG_NO_COLOR"] == "true"
+    assert "AWS_ACCESS_KEY_ID" not in env
+    assert kiro_native_bridge.KIRO_NATIVE_BRIDGE_DIR_ENV_VAR not in env
+    assert kiro_native_bridge.KIRO_ACP_RECORD_PATH_ENV_VAR not in env
+
+
+@pytest.mark.asyncio
+async def test_kiro_native_model_options_failure_is_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runner returns 503 when Kiro discovery fails, preventing empty caching."""
+    from omnigent import kiro_native
+
+    conv_id = "conv_kiro_native_model_options_failed"
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(Path.cwd()))
+    monkeypatch.setattr(kiro_native, "resolve_kiro_executable", lambda: "kiro-cli")
+    monkeypatch.setattr(
+        kiro_native,
+        "discover_kiro_model_options",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("not logged in")),
+    )
+    spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "kiro-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        resp = await client.get(f"/v1/sessions/{conv_id}/kiro-model-options")
+
+    assert resp.status_code == 503, resp.text
+    assert resp.json() == {
+        "error": "kiro_native_model_options_failed",
+        "detail": "Request failed on the runner; see runner logs for details.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_kiro_model_options_wrong_harness_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Kiro discovery cannot be invoked through another harness session."""
+    from omnigent import kiro_native
+
+    monkeypatch.setattr(
+        kiro_native,
+        "discover_kiro_model_options",
+        lambda *args, **kwargs: pytest.fail("discovery must not run"),
+    )
+    spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "codex-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": "conv_not_kiro", "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        resp = await client.get("/v1/sessions/conv_not_kiro/kiro-model-options")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"models": []}
+
+
+@pytest.mark.asyncio
 async def test_events_codex_native_plan_mode_requires_loaded_bridge(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -17,7 +17,7 @@ import shutil
 import sys
 import threading
 import uuid
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -9759,8 +9759,9 @@ async def test_kiro_native_model_options_discovers_on_runner(
         *,
         cwd: Path,
         env: dict[str, str],
+        timeout_s: float,
     ) -> list[dict[str, object]]:
-        recorded.update(executable=executable, cwd=cwd, env=env)
+        recorded.update(executable=executable, cwd=cwd, env=env, timeout_s=timeout_s)
         return [
             {"id": "auto", "displayName": "Auto", "isDefault": True},
             {"id": "claude-opus-4.8", "displayName": "Claude Opus 4.8"},
@@ -9812,6 +9813,7 @@ async def test_kiro_native_model_options_discovers_on_runner(
     }
     assert recorded["executable"] == "/opt/kiro-cli"
     assert recorded["cwd"] == workspace.resolve()
+    assert 0 < cast(float, recorded["timeout_s"]) <= 10.0
     env = cast(dict[str, str], recorded["env"])
     assert env["HOME"] == str(tmp_path / "home")
     assert env["KIRO_HOME"] == str(tmp_path / "kiro-home")
@@ -9823,19 +9825,164 @@ async def test_kiro_native_model_options_discovers_on_runner(
 
 
 @pytest.mark.asyncio
-async def test_kiro_native_model_options_failure_is_retryable(
+async def test_kiro_native_model_options_has_runner_side_total_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Runner returns 503 when Kiro discovery fails, preventing empty caching."""
+    """Runner bounds workspace lookup and discovery under one deadline."""
+    from omnigent import kiro_native
+
+    conv_id = "conv_kiro_model_options_deadline"
+    monkeypatch.setattr("omnigent.runner.app._KIRO_MODEL_OPTIONS_TOTAL_TIMEOUT_S", 0.02)
+    monkeypatch.setattr("omnigent.runner.app._KIRO_MODEL_OPTIONS_SUBPROCESS_MARGIN_S", 0.005)
+    monkeypatch.setattr(
+        kiro_native,
+        "discover_kiro_model_options",
+        lambda *args, **kwargs: pytest.fail("discovery must not start after workspace timeout"),
+    )
+
+    class _SlowSnapshotClient(NullServerClient):
+        async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+            del kwargs
+            if url == f"/v1/sessions/{conv_id}":
+                await asyncio.sleep(1.0)
+            return await super().get(url)
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "kiro-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=_SlowSnapshotClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        assert (
+            await client.post(
+                "/v1/sessions",
+                json={"session_id": conv_id, "agent_id": "ag_1"},
+            )
+        ).status_code == 201
+        resp = await client.get(f"/v1/sessions/{conv_id}/kiro-model-options")
+
+    assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_kiro_native_model_options_rechecks_deadline_inside_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A queued worker cannot start Kiro after the request deadline."""
+    from omnigent import kiro_native
+
+    conv_id = "conv_kiro_model_options_queued_worker"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    discovery_called = False
+
+    monkeypatch.setattr("omnigent.runner.app._KIRO_MODEL_OPTIONS_TOTAL_TIMEOUT_S", 0.02)
+    monkeypatch.setattr("omnigent.runner.app._KIRO_MODEL_OPTIONS_SUBPROCESS_MARGIN_S", 0.005)
+    monkeypatch.setattr(kiro_native, "resolve_kiro_executable", lambda: "/opt/kiro-cli")
+
+    def _discover(*args: Any, **kwargs: Any) -> list[dict[str, object]]:
+        nonlocal discovery_called
+        discovery_called = True
+        return []
+
+    monkeypatch.setattr(kiro_native, "discover_kiro_model_options", _discover)
+
+    async def _queued_to_thread(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.sleep(1.0)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", _queued_to_thread)
+
+    class _SnapshotClient(NullServerClient):
+        async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+            del kwargs
+            if url == f"/v1/sessions/{conv_id}":
+                return httpx.Response(
+                    200,
+                    json={"workspace": str(workspace)},
+                    request=httpx.Request("GET", url),
+                )
+            return await super().get(url)
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "kiro-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=_SnapshotClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        assert (
+            await client.post(
+                "/v1/sessions",
+                json={"session_id": conv_id, "agent_id": "ag_1"},
+            )
+        ).status_code == 201
+        resp = await client.get(f"/v1/sessions/{conv_id}/kiro-model-options")
+
+    assert resp.status_code == 503
+    assert not discovery_called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "expected_status", "expected_error"),
+    [
+        (
+            "unavailable",
+            424,
+            "kiro_native_model_options_unavailable",
+        ),
+        (
+            "transient",
+            503,
+            "kiro_native_model_options_failed",
+        ),
+    ],
+)
+async def test_kiro_native_model_options_classifies_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+    expected_status: int,
+    expected_error: str,
+) -> None:
+    """Runner distinguishes cooldown-worthy Kiro failure from not-ready."""
     from omnigent import kiro_native
 
     conv_id = "conv_kiro_native_model_options_failed"
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(Path.cwd()))
     monkeypatch.setattr(kiro_native, "resolve_kiro_executable", lambda: "kiro-cli")
+    error = (
+        kiro_native.KiroModelDiscoveryUnavailable("not logged in")
+        if failure == "unavailable"
+        else kiro_native.KiroModelDiscoveryNotReady("timed out")
+    )
     monkeypatch.setattr(
         kiro_native,
         "discover_kiro_model_options",
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("not logged in")),
+        lambda *args, **kwargs: (_ for _ in ()).throw(error),
     )
     spec = AgentSpec(
         spec_version=1,
@@ -9861,9 +10008,9 @@ async def test_kiro_native_model_options_failure_is_retryable(
         assert create_resp.status_code == 201, create_resp.text
         resp = await client.get(f"/v1/sessions/{conv_id}/kiro-model-options")
 
-    assert resp.status_code == 503, resp.text
+    assert resp.status_code == expected_status, resp.text
     assert resp.json() == {
-        "error": "kiro_native_model_options_failed",
+        "error": expected_error,
         "detail": "Request failed on the runner; see runner logs for details.",
     }
 

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -8,9 +8,11 @@ the stores.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import httpx
+import pytest
 import pytest_asyncio
 
 from omnigent.db.utils import generate_agent_id
@@ -106,6 +108,46 @@ async def test_delete_session(
     assert resp.status_code == 200
     body = resp.json()
     assert body["deleted"] is True
+
+
+async def test_delete_session_cancels_model_options_recovery(
+    client: httpx.AsyncClient,
+    session_id: str,
+) -> None:
+    """Deleting a session cancels and clears runner-backed model discovery."""
+    started = asyncio.Event()
+
+    async def _wait_for_retry() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_wait_for_retry())
+    await started.wait()
+    sessions_module._model_options_cache[session_id] = [{"id": "auto"}]
+    sessions_module._model_options_retry_after[session_id] = 123.0
+    sessions_module._model_options_generation[session_id] = 7
+    sessions_module._model_options_inflight[session_id] = task
+    sessions_module._pushed_model_options_cache[session_id] = [{"id": "pi-model"}]
+
+    try:
+        resp = await client.delete(f"/v1/sessions/{session_id}")
+
+        assert resp.status_code == 200
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert session_id not in sessions_module._model_options_cache
+        assert session_id not in sessions_module._model_options_retry_after
+        assert session_id not in sessions_module._model_options_generation
+        assert session_id not in sessions_module._model_options_inflight
+        assert session_id not in sessions_module._pushed_model_options_cache
+    finally:
+        sessions_module._model_options_cache.pop(session_id, None)
+        sessions_module._model_options_retry_after.pop(session_id, None)
+        sessions_module._model_options_generation.pop(session_id, None)
+        sessions_module._model_options_inflight.pop(session_id, None)
+        sessions_module._pushed_model_options_cache.pop(session_id, None)
+        if not task.done():
+            task.cancel()
 
 
 async def test_delete_session_not_found(client: httpx.AsyncClient) -> None:

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -106,6 +106,34 @@ class _HeartbeatRunnerClient:
         return _HeartbeatStreamResponse(self._release)
 
 
+class _CatalogResponse:
+    """Minimal response for runner-backed snapshot catalogs."""
+
+    status_code = 200
+
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def json(self) -> dict[str, object]:
+        """Return configured JSON payload."""
+        return self._payload
+
+
+class _CatalogHeartbeatRunnerClient(_HeartbeatRunnerClient):
+    """Heartbeat runner that also serves replacement-runner catalogs."""
+
+    async def get(self, path: str, *, timeout: float) -> _CatalogResponse:
+        """Serve skills and model options discovered on replacement runner."""
+        del timeout
+        if path.endswith("/skills"):
+            return _CatalogResponse(
+                {"skills": [{"name": "new-skill", "description": "From new runner."}]}
+            )
+        if path.endswith("/kiro-model-options"):
+            return _CatalogResponse({"models": [{"id": "new-model", "displayName": "New Model"}]})
+        raise AssertionError(f"Unexpected path: {path}")
+
+
 @pytest.mark.asyncio
 async def test_runner_relay_ready_waits_for_runner_heartbeat() -> None:
     """
@@ -144,6 +172,94 @@ async def test_runner_relay_ready_waits_for_runner_heartbeat() -> None:
         if handle is not None:
             await asyncio.wait_for(handle.task, timeout=1.0)
         sessions_module._runner_relay_tasks.clear()
+
+
+@pytest.mark.asyncio
+async def test_replaced_relay_cannot_invalidate_new_runner_fetch() -> None:
+    """Rebind drops old catalogs; old finalizer cannot drop new catalogs."""
+    from omnigent.server.routes import sessions as sessions_module
+
+    sessions_module._runner_relay_tasks.clear()
+    sessions_module._runner_skills_cache.clear()
+    sessions_module._runner_skills_inflight.clear()
+    sessions_module._runner_skills_generation.clear()
+    sessions_module._model_options_cache.clear()
+    sessions_module._model_options_inflight.clear()
+    sessions_module._model_options_generation.clear()
+    old_release = asyncio.Event()
+    new_release = asyncio.Event()
+    session_id = "conv_relay_rebind_models"
+
+    old_handle = sessions_module._ensure_runner_relay(
+        session_id,
+        "runner_old",
+        _HeartbeatRunnerClient(old_release),  # type: ignore[arg-type]
+    )
+    assert old_handle is not None
+    await old_handle.ready.wait()
+
+    old_skills_fetch = asyncio.create_task(asyncio.Event().wait())
+    old_model_fetch = asyncio.create_task(asyncio.Event().wait())
+    sessions_module._runner_skills_cache[session_id] = [
+        sessions_module.SkillSummary(name="old-skill", description="From old runner.")
+    ]
+    sessions_module._runner_skills_inflight[session_id] = old_skills_fetch  # type: ignore[assignment]
+    sessions_module._model_options_cache[session_id] = [{"id": "old-model"}]
+    sessions_module._model_options_inflight[session_id] = old_model_fetch  # type: ignore[assignment]
+
+    new_runner = _CatalogHeartbeatRunnerClient(new_release)
+    new_handle = sessions_module._ensure_runner_relay(
+        session_id,
+        "runner_new",
+        new_runner,  # type: ignore[arg-type]
+    )
+    assert new_handle is not None
+    assert session_id not in sessions_module._runner_skills_cache
+    assert session_id not in sessions_module._runner_skills_inflight
+    assert session_id not in sessions_module._model_options_cache
+    assert session_id not in sessions_module._model_options_inflight
+
+    conv = SimpleNamespace(
+        labels={
+            sessions_module._CLAUDE_NATIVE_WRAPPER_LABEL_KEY: (
+                sessions_module._KIRO_NATIVE_WRAPPER_LABEL_VALUE
+            )
+        }
+    )
+    assert await sessions_module._fetch_runner_skills(new_runner, session_id) == []  # type: ignore[arg-type]
+    assert (
+        await sessions_module._fetch_model_options(  # type: ignore[arg-type]
+            new_runner,
+            session_id,
+            conv,
+        )
+        == []
+    )
+    await asyncio.gather(
+        sessions_module._runner_skills_inflight[session_id],
+        sessions_module._model_options_inflight[session_id],
+    )
+
+    with contextlib.suppress(asyncio.CancelledError):
+        await old_handle.task
+
+    assert [skill.name for skill in sessions_module._runner_skills_cache[session_id]] == [
+        "new-skill"
+    ]
+    assert sessions_module._model_options_cache[session_id] == [
+        {"id": "new-model", "displayName": "New Model"}
+    ]
+
+    new_release.set()
+    with contextlib.suppress(asyncio.CancelledError):
+        await new_handle.task
+    sessions_module._runner_relay_tasks.clear()
+    sessions_module._runner_skills_cache.clear()
+    sessions_module._runner_skills_inflight.clear()
+    sessions_module._runner_skills_generation.clear()
+    sessions_module._model_options_cache.clear()
+    sessions_module._model_options_inflight.clear()
+    sessions_module._model_options_generation.clear()
 
 
 class _ScriptedStreamResponse:

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -45,6 +45,14 @@ async def _drain_model_options(session_id: str) -> None:
         await asyncio.sleep(0)
 
 
+async def _drain_model_options_inflight(session_id: str) -> None:
+    """Pump the loop until a model-options background fetch finishes."""
+    for _ in range(100):
+        if session_id not in _sessions_mod._model_options_inflight:
+            return
+        await asyncio.sleep(0)
+
+
 class _ConversationStore:
     """Minimal store that records ``list_items`` calls.
 
@@ -925,6 +933,208 @@ async def test_session_snapshot_fetches_dynamic_kiro_model_options(
     ]
     assert snapshot.model_options[1]["displayName"] == "Claude Opus 4.8"
     assert published == ["conv_kiro_options"]
+
+
+@pytest.mark.asyncio
+async def test_kiro_unavailable_model_failure_uses_retry_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unavailable Kiro discovery retries automatically after its cooldown."""
+    from omnigent.server.routes import sessions as _mod
+
+    _mod._model_options_cache.clear()
+    _mod._model_options_inflight.clear()
+    _mod._model_options_generation.clear()
+    _mod._model_options_retry_after.clear()
+
+    class _FakeResponse:
+        def __init__(self, status_code: int, payload: dict[str, object] | None = None) -> None:
+            self.status_code = status_code
+            self._payload = payload or {}
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+    class _FakeRunnerClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def get(self, url: str, timeout: float) -> _FakeResponse:
+            del url, timeout
+            self.calls += 1
+            if self.calls == 1:
+                return _FakeResponse(424)
+            return _FakeResponse(
+                200,
+                {"models": [{"id": "auto", "displayName": "Auto", "isDefault": True}]},
+            )
+
+    client = _FakeRunnerClient()
+    session_id = "conv_kiro_unavailable"
+    path = f"/v1/sessions/{session_id}/kiro-model-options"
+    generation = object()
+    _mod._model_options_generation[session_id] = generation
+
+    monkeypatch.setattr(_mod, "_MODEL_OPTIONS_UNAVAILABLE_COOLDOWN_S", 0.0)
+    await _mod._load_model_options(  # type: ignore[arg-type]
+        client,
+        session_id,
+        path,
+        generation=generation,
+    )
+
+    assert client.calls == 2
+    assert [model["id"] for model in _mod._model_options_cache[session_id]] == ["auto"]
+    assert session_id not in _mod._model_options_retry_after
+
+
+@pytest.mark.asyncio
+async def test_model_options_refresh_fences_stale_inflight_failure() -> None:
+    """A pre-refresh failure cannot restore cooldown state afterward."""
+    from omnigent.server.routes import sessions as _mod
+
+    _mod._model_options_cache.clear()
+    _mod._model_options_inflight.clear()
+    _mod._model_options_generation.clear()
+    _mod._model_options_retry_after.clear()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class _PermanentFailure:
+        status_code = 424
+
+    class _SlowRunnerClient:
+        async def get(self, url: str, timeout: float) -> _PermanentFailure:
+            del url, timeout
+            started.set()
+            await release.wait()
+            return _PermanentFailure()
+
+    session_id = "conv_kiro_stale_failure"
+    generation = object()
+    _mod._model_options_generation[session_id] = generation
+    task = asyncio.create_task(
+        _mod._load_model_options(  # type: ignore[arg-type]
+            _SlowRunnerClient(),
+            session_id,
+            f"/v1/sessions/{session_id}/kiro-model-options",
+            generation=generation,
+        )
+    )
+    _mod._model_options_inflight[session_id] = task
+    await started.wait()
+
+    _mod._invalidate_runner_backed_snapshot_state(session_id, cancel_inflight=False)
+    release.set()
+    await task
+
+    assert session_id not in _mod._model_options_inflight
+    assert session_id not in _mod._model_options_retry_after
+
+    _mod._invalidate_runner_backed_snapshot_state(session_id, cancel_inflight=True)
+    assert session_id not in _mod._model_options_generation
+
+
+@pytest.mark.asyncio
+async def test_kiro_unavailable_model_failure_has_bounded_retry_lifetime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated 424 responses stop, leaving next snapshot free to retry."""
+    from omnigent.server.routes import sessions as _mod
+
+    _mod._model_options_cache.clear()
+    _mod._model_options_inflight.clear()
+    _mod._model_options_generation.clear()
+    _mod._model_options_retry_after.clear()
+
+    class _Unavailable:
+        status_code = 424
+
+    class _RunnerClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def get(self, url: str, timeout: float) -> _Unavailable:
+            del url, timeout
+            self.calls += 1
+            return _Unavailable()
+
+    client = _RunnerClient()
+    session_id = "conv_kiro_bounded_unavailable"
+    generation = object()
+    _mod._model_options_generation[session_id] = generation
+    monkeypatch.setattr(_mod, "_MODEL_OPTIONS_UNAVAILABLE_COOLDOWN_S", 0.0)
+    monkeypatch.setattr(_mod, "_MODEL_OPTIONS_UNAVAILABLE_MAX_ATTEMPTS", 3)
+
+    await _mod._load_model_options(  # type: ignore[arg-type]
+        client,
+        session_id,
+        f"/v1/sessions/{session_id}/kiro-model-options",
+        generation=generation,
+    )
+
+    assert client.calls == 3
+    assert session_id not in _mod._model_options_cache
+    assert session_id not in _mod._model_options_retry_after
+
+
+@pytest.mark.asyncio
+async def test_cancelled_stale_model_fetch_cannot_overwrite_rebound_runner() -> None:
+    """Cancellation-resistant old fetch cannot win after delete/rebind."""
+    from omnigent.server.routes import sessions as _mod
+
+    _mod._model_options_cache.clear()
+    _mod._model_options_inflight.clear()
+    _mod._model_options_generation.clear()
+    old_started = asyncio.Event()
+    release_old = asyncio.Event()
+
+    class _Response:
+        status_code = 200
+
+        def __init__(self, model_id: str) -> None:
+            self.model_id = model_id
+
+        def json(self) -> dict[str, object]:
+            return {"models": [{"id": self.model_id, "displayName": self.model_id}]}
+
+    class _OldRunner:
+        async def get(self, url: str, timeout: float) -> _Response:
+            del url, timeout
+            old_started.set()
+            try:
+                await release_old.wait()
+            except asyncio.CancelledError:
+                await release_old.wait()
+            return _Response("stale")
+
+    class _NewRunner:
+        async def get(self, url: str, timeout: float) -> _Response:
+            del url, timeout
+            return _Response("fresh")
+
+    session_id = "conv_model_rebind_aba"
+    path = f"/v1/sessions/{session_id}/kiro-model-options"
+    old_generation = object()
+    _mod._model_options_generation[session_id] = old_generation
+    old_task = asyncio.create_task(
+        _mod._load_model_options(  # type: ignore[arg-type]
+            _OldRunner(), session_id, path, generation=old_generation
+        )
+    )
+    _mod._model_options_inflight[session_id] = old_task
+    await old_started.wait()
+
+    _mod._invalidate_runner_backed_snapshot_state(session_id, cancel_inflight=True)
+    new_generation = object()
+    _mod._model_options_generation[session_id] = new_generation
+    await _mod._load_model_options(  # type: ignore[arg-type]
+        _NewRunner(), session_id, path, generation=new_generation
+    )
+    release_old.set()
+    await old_task
+
+    assert [model["id"] for model in _mod._model_options_cache[session_id]] == ["fresh"]
 
 
 @pytest.mark.asyncio

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -33,9 +33,9 @@ async def _drain_runner_skills(session_id: str) -> None:
 
 
 async def _drain_model_options(session_id: str) -> None:
-    """Pump the loop until the background Codex model-options fetch lands.
+    """Pump the loop until the background native model-options fetch lands.
 
-    Codex model options are eventual-consistent like skills: the first
+    Runner-owned model options are eventual-consistent like skills: the first
     snapshot returns ``[]`` and starts the runner query; a later snapshot
     serves the cache.
     """
@@ -842,6 +842,92 @@ async def test_session_snapshot_serves_static_cursor_model_options(
 
 
 @pytest.mark.asyncio
+async def test_session_snapshot_fetches_dynamic_kiro_model_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Kiro options arrive from runner CLI discovery, not a static catalog."""
+    from omnigent.server.routes import sessions as _mod
+
+    _mod._session_status_cache.clear()
+    _mod._runner_skills_cache.clear()
+    _mod._runner_skills_inflight.clear()
+    _mod._model_options_cache.clear()
+    _mod._model_options_inflight.clear()
+    published: list[str] = []
+    monkeypatch.setattr(_mod, "_publish_model_options", published.append)
+
+    class _FakeResponse:
+        status_code = 200
+
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+    class _FakeRunnerClient:
+        def __init__(self) -> None:
+            self.get_calls: list[str] = []
+
+        async def get(self, url: str, timeout: float = 5.0) -> _FakeResponse:
+            del timeout
+            self.get_calls.append(url)
+            if url.endswith("/skills"):
+                return _FakeResponse({"skills": []})
+            if url.endswith("/kiro-model-options"):
+                return _FakeResponse(
+                    {
+                        "models": [
+                            {"id": "auto", "displayName": "Auto", "isDefault": True},
+                            {"id": "claude-opus-4.8", "displayName": "Claude Opus 4.8"},
+                            {"id": "sonnet-5", "displayName": "Sonnet 5"},
+                        ]
+                    }
+                )
+            return _FakeResponse({"status": "idle"})
+
+    fake_client = _FakeRunnerClient()
+    monkeypatch.setattr("omnigent.runtime.get_runner_client", lambda: fake_client)
+    monkeypatch.setattr("omnigent.runtime.get_runner_router", lambda: None)
+
+    conv = Conversation(
+        id="conv_kiro_options",
+        created_at=1,
+        updated_at=1,
+        root_conversation_id="conv_kiro_options",
+        agent_id="ag_test",
+        labels={
+            _mod._CLAUDE_NATIVE_WRAPPER_LABEL_KEY: _mod._KIRO_NATIVE_WRAPPER_LABEL_VALUE,
+        },
+    )
+    conv_store = _ConversationStore(
+        [_message_item("item_1", "hi")],
+        conversations={"conv_kiro_options": conv},
+    )
+
+    first = await _get_session_snapshot(
+        conv_store,  # type: ignore[arg-type]
+        "conv_kiro_options",
+    )
+    assert first.model_options == []
+    await _drain_model_options("conv_kiro_options")
+
+    snapshot = await _get_session_snapshot(
+        conv_store,  # type: ignore[arg-type]
+        "conv_kiro_options",
+    )
+
+    assert "/v1/sessions/conv_kiro_options/kiro-model-options" in fake_client.get_calls
+    assert [m["id"] for m in snapshot.model_options] == [
+        "auto",
+        "claude-opus-4.8",
+        "sonnet-5",
+    ]
+    assert snapshot.model_options[1]["displayName"] == "Claude Opus 4.8"
+    assert published == ["conv_kiro_options"]
+
+
+@pytest.mark.asyncio
 async def test_session_snapshot_refresh_state_reloads_model_options(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -967,7 +1053,7 @@ async def test_session_snapshot_retries_empty_model_options(
     _mod._runner_skills_inflight.clear()
     _mod._model_options_cache.clear()
     _mod._model_options_inflight.clear()
-    monkeypatch.setattr(_mod, "_CODEX_MODEL_OPTIONS_RETRY_DELAYS_S", (0.0,))
+    monkeypatch.setattr(_mod, "_MODEL_OPTIONS_RETRY_DELAYS_S", (0.0,))
 
     class _FakeResponse:
         def __init__(self, payload: dict[str, object]) -> None:
@@ -1068,7 +1154,7 @@ async def test_session_snapshot_retries_503_model_options(
     _mod._runner_skills_inflight.clear()
     _mod._model_options_cache.clear()
     _mod._model_options_inflight.clear()
-    monkeypatch.setattr(_mod, "_CODEX_MODEL_OPTIONS_RETRY_DELAYS_S", (0.0,))
+    monkeypatch.setattr(_mod, "_MODEL_OPTIONS_RETRY_DELAYS_S", (0.0,))
 
     class _FakeResponse:
         def __init__(

--- a/tests/test_kiro_native.py
+++ b/tests/test_kiro_native.py
@@ -30,8 +30,9 @@ from omnigent.kiro_native import (
     _update_startup_progress,
     _wait_for_kiro_terminal_ready,
     build_kiro_launch,
-    kiro_base_model_options,
+    discover_kiro_model_options,
     kiro_terminal_resource_id,
+    normalize_kiro_model_options,
     resolve_kiro_executable,
     run_kiro_native,
 )
@@ -546,16 +547,115 @@ async def test_wait_for_kiro_terminal_ready_times_out() -> None:
         await _wait_for_kiro_terminal_ready(client, "conv", timeout_s=0.05)
 
 
-def test_kiro_base_model_options_shape_and_default() -> None:
-    """The curated kiro catalog exposes picker option dicts with one default."""
-    options = kiro_base_model_options()
-    ids = [o["id"] for o in options]
+def test_normalize_kiro_model_options_preserves_order_and_metadata() -> None:
+    """Kiro JSON becomes deduplicated Web-picker options in CLI order."""
+    options = normalize_kiro_model_options(
+        {
+            "defaultModel": "sonnet-5",
+            "models": [
+                {"id": "auto", "displayName": "Auto"},
+                {"modelId": "claude-opus-4.8", "name": "Claude Opus 4.8"},
+                {"model_id": "sonnet-5", "display_name": "Sonnet 5"},
+                {"id": "claude-opus-4.8", "displayName": "duplicate"},
+                "qwen3-coder-next",
+            ],
+        }
+    )
 
-    # Canonical ids confirmed against ``kiro-cli --list-models`` (2.10.0).
-    assert ids[0] == "auto"
-    assert "claude-haiku-4.5" in ids and "glm-5" in ids
-    # Exactly one default, and every option carries the picker fields.
-    assert [o["id"] for o in options if o["isDefault"]] == ["auto"]
-    for option in options:
-        assert set(option) == {"id", "displayName", "isDefault", "isCurrent"}
-        assert option["isCurrent"] is False
+    assert options == [
+        {"id": "auto", "displayName": "Auto", "isDefault": False},
+        {
+            "id": "claude-opus-4.8",
+            "displayName": "Claude Opus 4.8",
+            "isDefault": False,
+        },
+        {"id": "sonnet-5", "displayName": "Sonnet 5", "isDefault": True},
+        {
+            "id": "qwen3-coder-next",
+            "displayName": "qwen3-coder-next",
+            "isDefault": False,
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [None, {}, {"models": "not-a-list"}, {"models": []}, {"models": [{}]}, [123]],
+)
+def test_normalize_kiro_model_options_rejects_malformed_catalog(payload: object) -> None:
+    """Malformed or empty discovery output is never cached as a catalog."""
+    with pytest.raises(ValueError, match="Kiro model catalog"):
+        normalize_kiro_model_options(payload)
+
+
+def test_discover_kiro_model_options_runs_machine_readable_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Discovery runs Kiro in the session workspace with the supplied environment."""
+    recorded: dict[str, object] = {}
+
+    def _run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        recorded.update({"argv": argv, **kwargs})
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout='[{"id":"auto","displayName":"Auto"}]',
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    options = discover_kiro_model_options(
+        "/opt/kiro-cli",
+        cwd=tmp_path,
+        env={"HOME": "/home/test", "KIRO_HOME": "/kiro"},
+        timeout_s=3.0,
+    )
+
+    assert options == [{"id": "auto", "displayName": "Auto", "isDefault": True}]
+    assert recorded == {
+        "argv": ["/opt/kiro-cli", "chat", "--list-models", "--format", "json"],
+        "cwd": tmp_path,
+        "env": {"HOME": "/home/test", "KIRO_HOME": "/kiro"},
+        "capture_output": True,
+        "text": True,
+        "timeout": 3.0,
+        "check": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("completed", "message"),
+    [
+        (subprocess.CompletedProcess([], 2, stdout="", stderr="not logged in"), "exited 2"),
+        (subprocess.CompletedProcess([], 0, stdout="not-json", stderr=""), "invalid JSON"),
+        (subprocess.CompletedProcess([], 0, stdout='{"models":[]}', stderr=""), "invalid JSON"),
+    ],
+)
+def test_discover_kiro_model_options_rejects_command_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    completed: subprocess.CompletedProcess[str],
+    message: str,
+) -> None:
+    """Non-zero, invalid, and empty discovery results surface as failures."""
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: completed)
+
+    with pytest.raises(RuntimeError, match=message):
+        discover_kiro_model_options("kiro-cli", cwd=tmp_path, env={})
+
+
+def test_discover_kiro_model_options_wraps_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A wedged discovery process is bounded and reported to the runner route."""
+
+    def _timeout(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired("kiro-cli", 10)
+
+    monkeypatch.setattr(subprocess, "run", _timeout)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        discover_kiro_model_options("kiro-cli", cwd=tmp_path, env={})

--- a/tests/test_kiro_native.py
+++ b/tests/test_kiro_native.py
@@ -14,6 +14,7 @@ from click import ClickException
 from omnigent._wrapper_labels import KIRO_NATIVE_WRAPPER_VALUE, WRAPPER_LABEL_KEY
 from omnigent.kiro_native import (
     _KIRO_PATH_ENV,
+    KiroModelDiscoveryUnavailable,
     LaunchedKiroTerminal,
     PreparedKiroTerminal,
     _attach_terminal_resource,
@@ -578,6 +579,20 @@ def test_normalize_kiro_model_options_preserves_order_and_metadata() -> None:
     ]
 
 
+def test_normalize_kiro_model_options_selects_one_item_default() -> None:
+    """An explicit item default wins over Auto, including on a duplicate."""
+    assert normalize_kiro_model_options(
+        [
+            {"id": "auto", "displayName": "Auto"},
+            {"id": "sonnet-5", "displayName": "Sonnet 5"},
+            {"id": "sonnet-5", "isDefault": True},
+        ]
+    ) == [
+        {"id": "auto", "displayName": "Auto", "isDefault": False},
+        {"id": "sonnet-5", "displayName": "Sonnet 5", "isDefault": True},
+    ]
+
+
 @pytest.mark.parametrize(
     "payload",
     [None, {}, {"models": "not-a-list"}, {"models": []}, {"models": [{}]}, [123]],
@@ -593,14 +608,15 @@ def test_discover_kiro_model_options_runs_machine_readable_command(
     tmp_path: Path,
 ) -> None:
     """Discovery runs Kiro in the session workspace with the supplied environment."""
-    recorded: dict[str, object] = {}
+    recorded: list[dict[str, object]] = []
 
     def _run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        recorded.update({"argv": argv, **kwargs})
+        recorded.append({"argv": argv, **kwargs})
+        stdout = "logged in" if argv[1] == "whoami" else '[{"id":"auto","displayName":"Auto"}]'
         return subprocess.CompletedProcess(
             argv,
             0,
-            stdout='[{"id":"auto","displayName":"Auto"}]',
+            stdout=stdout,
             stderr="",
         )
 
@@ -614,15 +630,45 @@ def test_discover_kiro_model_options_runs_machine_readable_command(
     )
 
     assert options == [{"id": "auto", "displayName": "Auto", "isDefault": True}]
-    assert recorded == {
-        "argv": ["/opt/kiro-cli", "chat", "--list-models", "--format", "json"],
+    assert len(recorded) == 2
+    first_timeout = recorded[0].pop("timeout")
+    second_timeout = recorded[1].pop("timeout")
+    assert isinstance(first_timeout, float) and 0 < first_timeout <= 3.0
+    assert isinstance(second_timeout, float) and 0 < second_timeout <= first_timeout
+    common = {
         "cwd": tmp_path,
         "env": {"HOME": "/home/test", "KIRO_HOME": "/kiro"},
+        "stdin": subprocess.DEVNULL,
         "capture_output": True,
         "text": True,
-        "timeout": 3.0,
         "check": False,
     }
+    assert recorded == [
+        {"argv": ["/opt/kiro-cli", "whoami", "--format", "json"], **common},
+        {
+            "argv": ["/opt/kiro-cli", "chat", "--list-models", "--format", "json"],
+            **common,
+        },
+    ]
+
+
+def test_discover_kiro_model_options_stops_after_unauthenticated_check(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Unauthenticated discovery is non-interactive and never launches chat."""
+    calls: list[tuple[list[str], object]] = []
+
+    def _run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((argv, kwargs.get("stdin")))
+        return subprocess.CompletedProcess(argv, 2, stdout="", stderr="not logged in")
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    with pytest.raises(KiroModelDiscoveryUnavailable, match="authentication check exited 2"):
+        discover_kiro_model_options("kiro-cli", cwd=tmp_path, env={})
+
+    assert calls == [(["kiro-cli", "whoami", "--format", "json"], subprocess.DEVNULL)]
 
 
 @pytest.mark.parametrize(
@@ -640,7 +686,13 @@ def test_discover_kiro_model_options_rejects_command_failures(
     message: str,
 ) -> None:
     """Non-zero, invalid, and empty discovery results surface as failures."""
-    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: completed)
+    responses = iter(
+        [
+            subprocess.CompletedProcess([], 0, stdout="logged in", stderr=""),
+            completed,
+        ]
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: next(responses))
 
     with pytest.raises(RuntimeError, match=message):
         discover_kiro_model_options("kiro-cli", cwd=tmp_path, env={})

--- a/tests/test_kiro_native_bridge.py
+++ b/tests/test_kiro_native_bridge.py
@@ -16,6 +16,7 @@ from omnigent.kiro_native_bridge import (
     KIRO_ACP_RECORD_PATH_ENV_VAR,
     KIRO_NATIVE_BRIDGE_DIR_ENV_VAR,
     acp_record_path,
+    build_kiro_native_discovery_env,
     build_kiro_native_terminal_env,
     inject_user_message,
     send_kiro_permission_verdict,
@@ -110,6 +111,28 @@ def test_build_terminal_env_adds_bridge_dir_and_acp_record_path(
     assert env[KIRO_NATIVE_BRIDGE_DIR_ENV_VAR] == str(bridge_dir)
     assert env[KIRO_ACP_RECORD_PATH_ENV_VAR] == str(acp_record_path(bridge_dir))
     assert env["PATH"] == "/usr/bin"
+
+
+def test_build_discovery_env_omits_bridge_state_and_credentials() -> None:
+    """Standalone model discovery inherits Kiro homes but no session recorder."""
+    env = build_kiro_native_discovery_env(
+        source_env={
+            "HOME": "/home/test",
+            "KIRO_HOME": "/kiro",
+            "KIRO_CONFIG_HOME": "/kiro-config",
+            "PATH": "/usr/bin",
+            "AWS_ACCESS_KEY_ID": "secret",
+            KIRO_NATIVE_BRIDGE_DIR_ENV_VAR: "/tmp/bridge",
+            KIRO_ACP_RECORD_PATH_ENV_VAR: "/tmp/record.jsonl",
+        }
+    )
+
+    assert env == {
+        "HOME": "/home/test",
+        "KIRO_HOME": "/kiro",
+        "KIRO_CONFIG_HOME": "/kiro-config",
+        "PATH": "/usr/bin",
+    }
 
 
 def test_send_kiro_permission_verdict_accepts_default_option(

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -787,9 +787,9 @@ export interface SessionSkillsEvent {
 }
 
 /**
- * `session.model_options` — the Codex app-server model catalog just
- * resolved for a session. Consumers refetch the session snapshot and apply
- * its now-populated `codexModelOptions`.
+ * `session.model_options` — a native model catalog just resolved for a
+ * session. Consumers refetch the session snapshot and apply its now-populated
+ * `codexModelOptions` compatibility field.
  */
 export interface SessionModelOptionsEvent {
   type: "session_model_options";

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -410,10 +410,9 @@ export interface Session {
    */
   skills?: SkillSummary[];
   /**
-   * Codex app-server model options for codex-native sessions. Each option
-   * comes from Codex ``model/list`` and carries the model-specific reasoning
-   * efforts the picker should offer. Empty for non-codex-native sessions or
-   * while the runner has not answered yet.
+   * Server-provided native model options. Codex entries may carry
+   * model-specific reasoning efforts; Cursor, Kiro, and Pi use the common
+   * id/display metadata. Empty while the runner has not answered yet.
    */
   codexModelOptions?: CodexModelOption[];
   /**

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1341,7 +1341,7 @@ interface MainAgentSurfaceProps {
   showModels: boolean;
   /** Native model picker family, when present. */
   modelPickerKind: NativeModelPickerKind | null;
-  /** Codex app-server model options for codex-native sessions. */
+  /** Server-provided model options for native sessions. */
   codexModelOptions: readonly CodexModelOption[];
   /** Show the Codex Plan-mode toggle. */
   showCodexPlanMode: boolean;
@@ -3333,7 +3333,7 @@ interface ComposerProps {
   showModels: boolean;
   /** Native model picker family, when present. */
   modelPickerKind: NativeModelPickerKind | null;
-  /** Codex app-server model options for codex-native sessions. */
+  /** Server-provided model options for native sessions. */
   codexModelOptions: readonly CodexModelOption[];
   /** Show the Codex Plan-mode toggle. */
   showCodexPlanMode: boolean;
@@ -5322,7 +5322,7 @@ interface AgentPickerProps {
   showEffort: boolean;
   /** Native model picker family, when present. */
   modelPickerKind: NativeModelPickerKind | null;
-  /** Codex app-server model options for codex-native sessions. */
+  /** Server-provided model options for native sessions. */
   codexModelOptions: readonly CodexModelOption[];
   /**
    * Disables the picker trigger. The picker is purely a write

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -488,7 +488,7 @@ export interface ChatState {
    */
   skills: SkillSummary[];
   /**
-   * Codex app-server model options for the active codex-native session.
+   * Server-provided model options for the active native session.
    * Populated from the session snapshot and updated when the server's
    * background Codex ``model/list`` fetch lands.
    */
@@ -3844,7 +3844,7 @@ interface RefetchRunnerBackedSessionStateOptions {
 /**
  * Refetch runner-backed session state and apply it to the store.
  *
- * Skills and codex-native model options are runner-owned. When a session
+ * Skills and native model options are runner-owned. When a session
  * binds before those background fetches land, the snapshot carries empty
  * lists. The server later sends a bare nudge; refetching the snapshot is
  * how the store pulls the cache-warmed fields without clobbering live chat
@@ -4535,9 +4535,9 @@ export function handleSessionEvent(event: StreamEvent): void {
       void refetchRunnerBackedSessionState(event.conversationId);
       return;
     case "session_model_options":
-      // Codex app-server `model/list` just resolved. Refetch the
-      // cache-warmed snapshot and apply `codexModelOptions`; the picker
-      // derives both model rows and effort levels from that catalog.
+      // A runner-owned native model catalog just resolved. Refetch the
+      // cache-warmed snapshot and apply `codexModelOptions`; model rows use
+      // it for every supported native picker, while Codex also derives effort.
       void refetchRunnerBackedSessionState(event.conversationId);
       return;
     case "tool_result":


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace Kiro's hand-maintained model list with live discovery through `kiro-cli chat --list-models --format json` on the bound runner.
- Reuse the existing server-cached `model_options` snapshot and SSE path, keeping the public API and existing web model picker unchanged.
- Add bounded, non-interactive discovery with authentication preflight, retry/cooldown handling, stale-result fencing, runner-rebind cleanup, and regression coverage for timeout and lifecycle races.

ELI5: the Kiro picker now asks the Kiro installation that is actually running the session which models are available, instead of shipping a copied list that becomes stale.

```text
Web picker <- session snapshot/SSE <- AP cache <- runner <- kiro-cli model discovery
```

## Test Plan

- `uv run pytest tests/test_kiro_native.py tests/test_kiro_native_bridge.py tests/runner/test_app_sessions_native.py tests/server/routes/test_sessions_snapshot.py tests/server/routes/test_sessions_crud.py tests/server/routes/test_sessions_runner_relay.py -k 'kiro or model_options or replaced_relay or delete_session_cancels' -q`
  - 109 passed, 1 skipped after rebasing onto current `main`.
- `uv run pre-commit run --files <all 16 changed files>`
  - All hooks passed.
- `git diff --check`
  - Passed.
- Updated the existing Kiro model-picker Playwright scenario to use dynamically supplied models. It was not rerun locally because the Playwright Chromium binary is not installed in this environment.

## Demo

N/A — this changes the model catalog source and lifecycle handling; the existing model-picker UI and wire protocol are unchanged.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Coverage includes JSON normalization/default selection, subprocess arguments and environment isolation, runner routes, AP caching and SSE publication, bounded retries, timeouts, stale task fencing, deletion, and runner rebind behavior. A live Kiro CLI smoke test was not possible because `kiro-cli` is not installed on this machine.

## Changelog

Kiro model choices now come from the authenticated CLI on the session's runner, so the model picker stays current without a hard-coded catalog.
