### PR TITLE
fix(web): wrap loose inline image runs so markdown files with bare images open (#2320 residual)

### DIFF
--- a/web/src/shell/MarkdownRichTextViewer.integration.test.tsx
+++ b/web/src/shell/MarkdownRichTextViewer.integration.test.tsx
@@ -89,7 +89,10 @@ vi.mock("@tiptap/extension-table", () => ({
 }));
 vi.mock("./TipTapGitHubAlert", () => ({ GitHubAlertBlockquote: {} }));
 vi.mock("./TipTapHtmlPassthrough", () => ({ HtmlPassthrough: {} }));
-vi.mock("./tiptapMarkdownPatches", () => ({ installMarkdownSerializerPatch: vi.fn() }));
+vi.mock("./tiptapMarkdownPatches", () => ({
+  installMarkdownSerializerPatch: vi.fn(),
+  installMarkdownParserPatch: vi.fn(),
+}));
 vi.mock("./TipTapWorkspaceImage", () => ({
   createWorkspaceImageExtension: vi.fn().mockReturnValue({}),
   ImageAwareLink: { configure: vi.fn().mockReturnValue({}) },

--- a/web/src/shell/MarkdownRichTextViewer.looseImageCrash.test.ts
+++ b/web/src/shell/MarkdownRichTextViewer.looseImageCrash.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression test: opening a markdown file that contains a bare inline image
+ * not wrapped in a paragraph used to crash the whole editor panel — the
+ * "known residual" documented in #2320 (which fixed block-first list items
+ * via SafeListItem = `block+` but explicitly did not cover loose inline
+ * images, because an inline node can't sit directly in a `block+` container).
+ *
+ * The workspace image node is an inline atom (`inline: true` in
+ * TipTapWorkspaceImage), and `@tiptap/markdown` (beta) can hand back a bare
+ * image with no wrapping paragraph at the document level (an image as a
+ * loose child after a thematic break or heading) and at the list-item level
+ * (`1. ![x](y)`). Both the top-level `doc` and SafeListItem have a `block+`
+ * content model, which cannot hold a bare inline node, so the parsed doc is
+ * schema-invalid. ProseMirror builds the initial doc via `nodeFromJSON`
+ * (which does NOT validate), so it loads silently — then the first
+ * transaction (a user edit, or StarterKit's TrailingNode appendTransaction
+ * on load) calls `contentMatchAt` and throws ("Called contentMatchAt on a
+ * node with invalid content"). The viewer's panel boundary catches the throw
+ * and the whole file view crashes ("Page failed to load"). Same failure
+ * family as #2559 / #2004 / #2320.
+ *
+ * Fix: SafeInlineWrap generalizes #2004's `toBlockContent` (previously
+ * blockquote-only) to every `block+` parent, wrapping loose inline runs in a
+ * paragraph after parse. These tests use the EXACT extension stack from
+ * MarkdownRichTextViewer so a regression fails here.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { Table, TableRow, TableCell, TableHeader } from "@tiptap/extension-table";
+import { ListItem, TaskItem, TaskList } from "@tiptap/extension-list";
+import { Markdown } from "@tiptap/markdown";
+import { createWorkspaceImageExtension, ImageAwareLink } from "./TipTapWorkspaceImage";
+import { GitHubAlertBlockquote } from "./TipTapGitHubAlert";
+import { HtmlPassthrough } from "./TipTapHtmlPassthrough";
+import { installMarkdownParserPatch } from "./tiptapMarkdownPatches";
+
+// The fix under test — installed at module load, as MarkdownRichTextViewer does.
+installMarkdownParserPatch();
+
+// Must match MarkdownRichTextViewer's SafeListItem (the #2320 fix).
+const SafeListItem = ListItem.extend({ content: "block+" });
+
+vi.mock("@/hooks/useFileContent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks/useFileContent")>();
+  return { ...actual, fetchFileContent: vi.fn().mockResolvedValue(undefined) };
+});
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+beforeEach(() => {
+  URL.createObjectURL = vi.fn(() => "blob:mock");
+  URL.revokeObjectURL = vi.fn();
+});
+
+let editor: Editor | null = null;
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+  vi.clearAllMocks();
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
+function makeEditor(markdown: string): Editor {
+  return new Editor({
+    element: document.createElement("div"),
+    extensions: [
+      StarterKit.configure({ link: false, blockquote: false, listItem: false }),
+      SafeListItem,
+      TaskList,
+      TaskItem.configure({ nested: true }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableCell,
+      TableHeader,
+      ImageAwareLink.configure({ openOnClick: false, autolink: false }),
+      GitHubAlertBlockquote,
+      HtmlPassthrough,
+      Markdown,
+      createWorkspaceImageExtension("conv_test", "README.md"),
+    ],
+    content: markdown,
+    contentType: "markdown",
+  });
+}
+
+/** Dispatch an edit at the document start — the transaction that trips the crash. */
+function typeAtStart(ed: Editor): void {
+  ed.view.dispatch(ed.state.tr.insertText("a", 1));
+}
+
+describe("loose inline image crash (residual of #2320)", () => {
+  // Each input makes @tiptap/markdown emit a bare inline image (or other
+  // loose inline run) directly under a block+ parent — the document or a
+  // list item — with no wrapping paragraph.
+  const CRASHERS = [
+    "![x](y.png)", // document-level, only content
+    "Intro paragraph.\n\n![x](y.png)\n\n## Next", // document-level, normal block flow
+    "---\n\n![x](y.png)", // document-level, after thematic break
+    "1. ![x](y.png)", // ordered-list item
+    "- ![x](y.png)", // bullet-list item
+    "- [![badge](b.png)](https://example.com)", // linked image in a list item
+  ];
+
+  it.each(CRASHERS)("parses %j into a schema-valid document", (md) => {
+    editor = makeEditor(md);
+    // Node.check() recurses the whole tree and throws on invalid content;
+    // before the fix this threw for the bare inline image.
+    expect(() => editor!.state.doc.check()).not.toThrow();
+  });
+
+  it.each(CRASHERS)("survives an edit transaction without crashing: %j", (md) => {
+    editor = makeEditor(md);
+    expect(() => typeAtStart(editor!)).not.toThrow();
+  });
+
+  it("wraps a document-level lone image in a paragraph", () => {
+    editor = makeEditor("![x](y.png)");
+    const first = editor.state.doc.child(0);
+    expect(first.type.name).toBe("paragraph");
+    expect(first.child(0).type.name).toBe("image");
+  });
+
+  it("wraps a list-item lone image in a paragraph", () => {
+    editor = makeEditor("- ![x](y.png)");
+    const item = editor.state.doc.child(0).child(0); // bulletList > listItem
+    expect(item.type.name).toBe("listItem");
+    expect(item.child(0).type.name).toBe("paragraph");
+    expect(item.child(0).child(0).type.name).toBe("image");
+  });
+
+  it("round-trips a document-level lone image back to markdown", () => {
+    editor = makeEditor("Intro.\n\n![x](y.png)\n\n## Next");
+    const md = editor.getMarkdown();
+    expect(md).toContain("![x](y.png)");
+    expect(md).toContain("## Next");
+  });
+});

--- a/web/src/shell/MarkdownRichTextViewer.teardown.test.tsx
+++ b/web/src/shell/MarkdownRichTextViewer.teardown.test.tsx
@@ -112,7 +112,10 @@ vi.mock("@tiptap/extension-table", () => ({
 }));
 vi.mock("./TipTapGitHubAlert", () => ({ GitHubAlertBlockquote: {} }));
 vi.mock("./TipTapHtmlPassthrough", () => ({ HtmlPassthrough: {} }));
-vi.mock("./tiptapMarkdownPatches", () => ({ installMarkdownSerializerPatch: vi.fn() }));
+vi.mock("./tiptapMarkdownPatches", () => ({
+  installMarkdownSerializerPatch: vi.fn(),
+  installMarkdownParserPatch: vi.fn(),
+}));
 vi.mock("./TipTapWorkspaceImage", () => ({
   createWorkspaceImageExtension: vi.fn().mockReturnValue({}),
   ImageAwareLink: { configure: vi.fn().mockReturnValue({}) },

--- a/web/src/shell/MarkdownRichTextViewer.test.tsx
+++ b/web/src/shell/MarkdownRichTextViewer.test.tsx
@@ -38,7 +38,10 @@ vi.mock("@tiptap/extension-list", () => ({
 }));
 vi.mock("./TipTapGitHubAlert", () => ({ GitHubAlertBlockquote: {} }));
 vi.mock("./TipTapHtmlPassthrough", () => ({ HtmlPassthrough: {} }));
-vi.mock("./tiptapMarkdownPatches", () => ({ installMarkdownSerializerPatch: vi.fn() }));
+vi.mock("./tiptapMarkdownPatches", () => ({
+  installMarkdownSerializerPatch: vi.fn(),
+  installMarkdownParserPatch: vi.fn(),
+}));
 vi.mock("./TipTapWorkspaceImage", () => ({
   createWorkspaceImageExtension: vi.fn().mockReturnValue({}),
   ImageAwareLink: { configure: vi.fn().mockReturnValue({}) },

--- a/web/src/shell/MarkdownRichTextViewer.tsx
+++ b/web/src/shell/MarkdownRichTextViewer.tsx
@@ -44,11 +44,20 @@ import {
 import { createWorkspaceImageExtension, ImageAwareLink } from "./TipTapWorkspaceImage";
 import { GitHubAlertBlockquote } from "./TipTapGitHubAlert";
 import { HtmlPassthrough } from "./TipTapHtmlPassthrough";
-import { installMarkdownSerializerPatch } from "./tiptapMarkdownPatches";
+import {
+  installMarkdownParserPatch,
+  installMarkdownSerializerPatch,
+} from "./tiptapMarkdownPatches";
 
 // Minimal-escaping serialiser override (see tiptapMarkdownPatches.ts) —
 // installed once at module load, before any editor instance is created.
 installMarkdownSerializerPatch();
+
+// Post-parse normalisation wrapping loose inline runs (a standalone image in
+// document flow, `1. ![x](y)`) in a paragraph so block+ containers never get
+// a bare inline child — the crash residual #2320 documented (see
+// tiptapMarkdownPatches.ts).
+installMarkdownParserPatch();
 
 // @tiptap/markdown parses a list item whose first child is a non-paragraph
 // block — a nested list, a fenced code block, a blockquote, a heading, or a

--- a/web/src/shell/tiptapMarkdownPatches.ts
+++ b/web/src/shell/tiptapMarkdownPatches.ts
@@ -22,6 +22,8 @@
 import { MarkdownManager } from "@tiptap/markdown";
 import type { JSONContent } from "@tiptap/core";
 
+import { toBlockContent } from "./TipTapGitHubAlert";
+
 /** Ampersands that would parse as an entity reference on the way back in. */
 const ENTITY_AMP = /&(?=[a-zA-Z][a-zA-Z0-9]{1,31};|#\d{1,7};|#[xX][0-9a-fA-F]{1,6};)/g;
 /** `<` that could open an HTML tag, closing tag, comment, or declaration. */
@@ -64,5 +66,67 @@ export function installMarkdownSerializerPatch(): void {
       .replace(ENTITY_AMP, "&amp;")
       .replace(TAG_OPEN, "&lt;")
       .replace(LINE_START_QUOTE, "$1\\>");
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Parser patch — wrap loose inline runs so block+ parents stay schema-valid
+// ---------------------------------------------------------------------------
+
+/**
+ * Node types whose content expression is block-level (`block+` or
+ * `paragraph block*`) in the editor schema. A bare inline child under any of
+ * these makes the parsed document schema-invalid.
+ */
+const BLOCK_CONTAINER_TYPES = new Set([
+  "doc",
+  "blockquote",
+  "listItem",
+  "taskItem",
+  "tableCell",
+  "tableHeader",
+]);
+
+/**
+ * Recursively coerce every block container's children into valid block
+ * content, wrapping runs of loose inline nodes in a paragraph (see
+ * `toBlockContent`). Leaves inline parents (paragraph, heading, …) untouched.
+ */
+function wrapLooseInlineRuns(node: JSONContent): JSONContent {
+  if (node.content == null) return node;
+  const content = node.content.map(wrapLooseInlineRuns);
+  return {
+    ...node,
+    content:
+      node.type != null && BLOCK_CONTAINER_TYPES.has(node.type) ? toBlockContent(content) : content,
+  };
+}
+
+let parserPatchInstalled = false;
+
+/**
+ * Install a post-parse normalisation on `MarkdownManager.parse`. Idempotent.
+ *
+ * `@tiptap/markdown` (beta) can hand back a bare inline node directly under a
+ * `block+` container — a standalone image in document flow (`\n\n![x](y)\n\n`,
+ * or after `---`), or an image-first list item (`1. ![x](y)`). #2320 relaxed
+ * `listItem` to `block+` for block-first children, but an INLINE first child
+ * can't be fixed by any content expression on the parent — the parsed doc is
+ * schema-invalid either way. ProseMirror loads it silently via `nodeFromJSON`
+ * (no validation); the first transaction (a user edit, or StarterKit's
+ * TrailingNode on load) calls `contentMatchAt` and throws ("Called
+ * contentMatchAt on a node with invalid content"), crashing the whole file
+ * panel. This is the "known residual" follow-up documented in #2320,
+ * generalising #2004's blockquote-only `toBlockContent` guard to every block
+ * container. The wrap is round-trip-safe: the serialiser emits a paragraph
+ * holding a lone image as `![x](y)`, byte-identical to the source.
+ */
+export function installMarkdownParserPatch(): void {
+  if (parserPatchInstalled) return;
+  parserPatchInstalled = true;
+  const proto = MarkdownManager.prototype;
+  const originalParse = proto.parse;
+  proto.parse = function (this: MarkdownManager, markdown: string): JSONContent {
+    return wrapLooseInlineRuns(originalParse.call(this, markdown));
   };
 }


### PR DESCRIPTION
## Summary

Fixes the remaining "conversation bricked opening a markdown file" crash — the **known residual documented in #2320**: a bare inline image not wrapped in a paragraph. Same crash family as #2559 / #2004 / #2320 (`Called contentMatchAt on a node with invalid content` → route-level PanelBoundary → "Page failed to load", changed-files panel shows "0 changes", session stays bricked until stopped).

## Root cause (verified empirically, see below)

`@tiptap/markdown` (beta) can hand back a **bare inline image with no wrapping paragraph**:

- a standalone image in document flow (`Intro.\n\n![x](y)\n\n## Next`, or lone `![x](y)`, or after `---`), and
- an image-first ordered-list item (`1. ![x](y)`).

The workspace image node is an inline atom (`inline: true` in `TipTapWorkspaceImage.ts`). Both the top-level `doc` and `SafeListItem` (#2320) have a `block+` content model, which cannot hold a bare inline node — #2320's `block+` relaxation fixed block-*first* children but, as its own residual note says, no content expression on the parent can admit a bare *inline* child. `nodeFromJSON` loads the invalid doc without validating; the first transaction (a user edit, or StarterKit's TrailingNode `appendTransaction` on load) calls `contentMatchAt` and throws, crashing the whole panel.

## Fix

Exactly the follow-up #2320 prescribed: generalize #2004's `toBlockContent` guard from blockquote-only to **every block container**. Implemented as a post-parse normalization on `MarkdownManager.parse` (`installMarkdownParserPatch` in `tiptapMarkdownPatches.ts`, the same runtime-patch pattern as the existing serializer patch): walk the parsed JSON and wrap loose inline runs under `doc` / `listItem` / `taskItem` / `blockquote` / `tableCell` / `tableHeader` in a paragraph. Round-trip-safe — the serializer emits a paragraph holding a lone image as `![x](y)`, byte-identical to the source.

## Verification — red then green

New regression test `web/src/shell/MarkdownRichTextViewer.looseImageCrash.test.ts`, a sibling of `MarkdownRichTextViewer.listItemCrash.test.ts` using the **exact viewer extension stack**.

```bash
cd web
# RED — on main (without this PR's src changes):
npx vitest run src/shell/MarkdownRichTextViewer.looseImageCrash.test.ts
#   → 8 failures: "Called contentMatchAt on a node with invalid content"
# GREEN — with this PR:
npx vitest run src/shell/MarkdownRichTextViewer.looseImageCrash.test.ts
#   → 15 passed
```

Empirical red set on current `main` (useful boundary data):

| input | on main |
|---|---|
| `![x](y.png)` (lone, doc level) | ❌ crashes |
| `Intro.\n\n![x](y.png)\n\n## Next` (block flow — the real file's shape) | ❌ crashes |
| `---\n\n![x](y.png)` | ❌ crashes |
| `1. ![x](y.png)` | ❌ schema-invalid |
| `- ![x](y.png)` | ✅ parser already wraps it |
| `- [![badge](b.png)](url)` | ✅ parser already wraps it |

I also ran the **actual triggering file** (`docs/web/docs/agents/agent-framework/load-test-agent-app.md` from databricks-eng/universe — the file behind the internal bricked conversation) through the same stack:

- **Pre-fix**: the only doc-level schema violation is the standalone image (line 19). Its `:::list-table` nested lists are already schema-legal under #2320 — confirming this repro is the residual, not a #2320 regression. An edit transaction throws the exact production error.
- **Post-fix**: the file loads, survives edits at both ends of the document, and serializes back to markdown.

## Out of scope (noting for completeness)

Strict `doc.check()` on that real file also surfaces a separate, non-crashing latent violation: `` [`uv`](https://docs.astral.sh/uv/) `` parses to a text node carrying both `link` and `code` marks, which the Code mark's exclusion rejects. It does not affect load, edits, or serialization (the crash reported here is purely the content-model one), so it's left for a follow-up.

## Test plan

tested locally:
off main:
<img width="1312" height="740" alt="image" src="https://github.com/user-attachments/assets/7a8c43bc-125b-4dbb-bd47-d93a4709a15c" />

with fixes: 

<img width="1286" height="785" alt="image" src="https://github.com/user-attachments/assets/ea45bccf-9a0e-40bf-acbc-010dcd666874" />


- [x] New `looseImageCrash` test: red on main (8 failures with the production error), green with the fix (15 passed)
- [x] Real triggering file: crashes pre-fix, opens/edits/round-trips post-fix
- [x] Full web suite: 4202 passed (3 expected-fail, 2 skipped), no regressions
- [x] `oxlint`, `tsc --noEmit`, `prettier --check` clean on changed files

Related: #2559, #2320, #2004

🤖 Generated with [Claude Code](https://claude.com/claude-code)
