### PR TITLE
feat(codex): show plan/TODO updates in the Tasks panel

### DIFF
--- a/ap-web/src/lib/events.ts
+++ b/ap-web/src/lib/events.ts
@@ -512,12 +512,14 @@ export interface SessionAgentChangedEvent {
 }
 
 /**
- * `session.todos` — todo-list update from a claude-native session.
+ * `session.todos` — plan/TODO-list update from a native session.
  *
- * Emitted by the Omnigent server when the claude-native forwarder receives
- * a `PostToolUse`/`TodoWrite` hook event from Claude Code. Clients
- * should replace their cached todo list entirely on each event (the
- * payload is the full current list, not a diff).
+ * Emitted by the Omnigent server when a native forwarder posts
+ * `external_session_todos`: the claude-native forwarder on a
+ * `PostToolUse`/`TodoWrite` hook event, or the codex-native forwarder on a
+ * `turn/plan/updated` notification. Clients should replace their cached todo
+ * list entirely on each event (the payload is the full current list, not a
+ * diff).
  *
  * Each todo item has:
  * - `content`: the task description string

--- a/ap-web/src/lib/sessionCapabilities.ts
+++ b/ap-web/src/lib/sessionCapabilities.ts
@@ -16,3 +16,22 @@ export function supportsEffortControl(
   const wrapper = session?.labels?.["omnigent.wrapper"];
   return wrapper === CLAUDE_NATIVE_WRAPPER || wrapper === CODEX_NATIVE_WRAPPER;
 }
+
+/**
+ * Fail-closed gate for the Web UI Tasks (plan/TODO) panel.
+ *
+ * True only for harnesses that feed the panel via ``external_session_todos``:
+ * claude-native (TodoWrite/task hooks) and codex-native (structured
+ * ``turn/plan/updated`` plan steps). A narrow allowlist — other native
+ * wrappers (Cursor, Pi) don't emit todos.
+ *
+ * :param session: Session or sidebar row carrying labels. ``null`` or missing
+ *     labels fail closed.
+ * :returns: True only for native sessions that populate the Tasks panel.
+ */
+export function supportsTasksPanel(
+  session: { labels?: Record<string, string | null> | null } | null | undefined,
+): boolean {
+  const wrapper = session?.labels?.["omnigent.wrapper"];
+  return wrapper === CLAUDE_NATIVE_WRAPPER || wrapper === CODEX_NATIVE_WRAPPER;
+}

--- a/ap-web/src/shell/AppShell.tsx
+++ b/ap-web/src/shell/AppShell.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/hooks/useWorkspaceChangedFiles";
 import { cn } from "@/lib/utils";
 import { isNativeWrapper as isNativeWrapperLabel } from "@/lib/nativeCodingAgents";
+import { supportsTasksPanel as sessionSupportsTasksPanel } from "@/lib/sessionCapabilities";
 import { useChatStore } from "@/store/chatStore";
 import { livenessRowFromSession, useSessionLiveness } from "@/hooks/useSessionLiveness";
 import { useResizableInlinePanel } from "@/hooks/useResizableInlinePanel";
@@ -292,6 +293,9 @@ export function AppShell() {
   // (embedded Omnigent REPL terminal) have NO wrapper label and must
   // keep regular chat behavior. See TerminalFirstContext.tsx.
   const isNativeWrapper = isNativeWrapperLabel(sessionLabels["omnigent.wrapper"]);
+  // Gates the Tasks (plan/TODO) panel. Shares the native-wrapper allowlist with
+  // supportsEffortControl via sessionCapabilities.ts so the two stay in sync.
+  const supportsTasksPanel = sessionSupportsTasksPanel({ labels: sessionLabels });
   const todos = useChatStore((s) => s.todos);
   const todosCompleted = todos.filter((t) => t.status === "completed").length;
   // Used for the header "Back to parent" link, which is hidden on
@@ -431,14 +435,14 @@ export function AppShell() {
         // empty and ``agentSupportsShells`` starts false while the agent
         // loads, so native sessions don't flash the tab.
         terminals: !hideTerminalsTab && (railTerminals.length > 0 || agentSupportsShells),
-        todos: isClaudeNative && todos.length > 0,
+        todos: supportsTasksPanel && todos.length > 0,
       }) as const,
     [
       showFilesPanel,
       hideTerminalsTab,
       railTerminals.length,
       agentSupportsShells,
-      isClaudeNative,
+      supportsTasksPanel,
       todos.length,
     ],
   );
@@ -1059,7 +1063,7 @@ export function AppShell() {
                     todosPanelOpen,
                     hideTerminalsTab,
                     terminalsLength: railTerminals.length,
-                    isClaudeNative,
+                    supportsTasksPanel,
                     todosCompleted,
                     todosTotal: todos.length,
                     debugMode,
@@ -1106,7 +1110,7 @@ export function AppShell() {
                       terminalsLength={railTerminals.length}
                       subagentsWorking={subagentsWorking}
                       agentCount={agentCount}
-                      isClaudeNative={isClaudeNative}
+                      supportsTasksPanel={supportsTasksPanel}
                       todosCompleted={todosCompleted}
                       todosTotal={todos.length}
                       rootSessionId={rootSessionId}

--- a/ap-web/src/shell/ChatHeader.test.tsx
+++ b/ap-web/src/shell/ChatHeader.test.tsx
@@ -18,7 +18,7 @@ const mobileMenu = {
   todosPanelOpen: false,
   hideTerminalsTab: false,
   terminalsLength: 0,
-  isClaudeNative: false,
+  supportsTasksPanel: false,
   todosCompleted: 0,
   todosTotal: 0,
   debugMode: false,

--- a/ap-web/src/shell/ChatHeader.tsx
+++ b/ap-web/src/shell/ChatHeader.tsx
@@ -52,8 +52,8 @@ interface MobileSessionMenuProps {
   hideTerminalsTab: boolean;
   /** Number of open terminals (entry badge + visibility). */
   terminalsLength: number;
-  /** Whether this is a claude-native session (gates the Tasks entry). */
-  isClaudeNative: boolean;
+  /** Whether this session's harness feeds the Tasks panel (gates the Tasks entry). */
+  supportsTasksPanel: boolean;
   /** Completed todo count (Tasks entry badge numerator). */
   todosCompleted: number;
   /** Total todo count (Tasks entry badge denominator + visibility). */
@@ -427,7 +427,7 @@ export function ChatHeader({
                     </span>
                   </DropdownMenuItem>
                 )}
-                {mobileMenu.isClaudeNative && mobileMenu.todosTotal > 0 && (
+                {mobileMenu.supportsTasksPanel && mobileMenu.todosTotal > 0 && (
                   <DropdownMenuItem
                     onSelect={mobileMenu.onOpenTodos}
                     className="gap-2.5 px-2.5 py-2 text-base"

--- a/ap-web/src/shell/TodoPanel.tsx
+++ b/ap-web/src/shell/TodoPanel.tsx
@@ -23,16 +23,18 @@ function TodoIcon({ status }: { status: TodoItem["status"] }) {
 }
 
 /**
- * Displays Claude Code's active todo list for `omnigent claude` sessions.
+ * Displays the active plan/TODO list for native sessions that feed it —
+ * claude-native (Claude Code's TodoWrite/task hooks) and codex-native
+ * (Codex's `turn/plan/updated` plan steps).
  *
  * Reads from `useChatStore.todos` which is populated by:
  * - the session snapshot on bind (from `_session_todos_cache` on the server)
- * - `session.todos` SSE events emitted whenever the forwarder detects a
- *   change in Claude's `~/.claude/todos/{session_id}-agent-{session_id}.json`
+ * - `session.todos` SSE events emitted whenever a forwarder posts an
+ *   `external_session_todos` update
  *
  * Renders nothing when the todo list is empty, so the panel occupies no
- * space for sessions that have never had todos (non-claude-native, or
- * claude-native before the first turn creates any todos).
+ * space for sessions that have never had todos (unsupported harness, or a
+ * supported one before its first plan/todo update).
  */
 export function TodoPanel({ frameless = false }: TodoPanelProps) {
   const todos = useChatStore((s) => s.todos);

--- a/ap-web/src/shell/WorkspacePanel.test.tsx
+++ b/ap-web/src/shell/WorkspacePanel.test.tsx
@@ -40,6 +40,9 @@ function renderWorkspace(
     rightRailTab?: RightRailTab;
     selectedFilePath?: string | null;
     openFiles?: string[];
+    supportsTasksPanel?: boolean;
+    todosTotal?: number;
+    todosCompleted?: number;
   } = {},
 ) {
   const openFileViewer = vi.fn();
@@ -58,9 +61,9 @@ function renderWorkspace(
       terminalsLength={0}
       subagentsWorking={0}
       agentCount={1}
-      isClaudeNative={false}
-      todosCompleted={0}
-      todosTotal={0}
+      supportsTasksPanel={overrides.supportsTasksPanel ?? false}
+      todosCompleted={overrides.todosCompleted ?? 0}
+      todosTotal={overrides.todosTotal ?? 0}
       rootSessionId={null}
       selectedFilePath={overrides.selectedFilePath ?? null}
       openFiles={overrides.openFiles ?? []}
@@ -177,5 +180,31 @@ describe("WorkspacePanel content area", () => {
     // slot and the viewer is unmounted.
     expect(screen.getByTestId("files-panel-stub")).toBeInTheDocument();
     expect(screen.queryByTestId("file-viewer-stub")).toBeNull();
+  });
+});
+
+describe("WorkspacePanel Tasks tab", () => {
+  it("shows the Tasks tab + panel for a tasks-capable session (e.g. codex-native) with todos", () => {
+    // A Codex session reaches WorkspacePanel with supportsTasksPanel=true, the
+    // same value AppShell now derives for both claude- and codex-native
+    // wrappers. With ≥1 todo the trigger and (on the todos tab) the panel show.
+    renderWorkspace({ supportsTasksPanel: true, todosTotal: 2, todosCompleted: 1 });
+    expect(screen.getByRole("tab", { name: /tasks/i })).toBeInTheDocument();
+
+    cleanup();
+    renderWorkspace({
+      rightRailTab: "todos",
+      supportsTasksPanel: true,
+      todosTotal: 2,
+      todosCompleted: 1,
+    });
+    expect(screen.getByTestId("todos-stub")).toBeInTheDocument();
+  });
+
+  it("hides the Tasks tab for a non-capable session even when todos exist", () => {
+    // Guards the harness gate: a session that doesn't feed the panel
+    // (supportsTasksPanel=false) must not surface the Tasks tab.
+    renderWorkspace({ supportsTasksPanel: false, todosTotal: 2 });
+    expect(screen.queryByRole("tab", { name: /tasks/i })).toBeNull();
   });
 });

--- a/ap-web/src/shell/WorkspacePanel.tsx
+++ b/ap-web/src/shell/WorkspacePanel.tsx
@@ -160,8 +160,8 @@ interface WorkspacePanelProps {
    * badge denominator) — starts at 1 for a lone agent.
    */
   agentCount: number;
-  /** Whether this is a claude-native session (gates the Tasks tab). */
-  isClaudeNative: boolean;
+  /** Whether this session's harness feeds the Tasks panel (gates the Tasks tab). */
+  supportsTasksPanel: boolean;
   /** Number of completed todos (Tasks tab badge numerator). */
   todosCompleted: number;
   /** Total todo count (Tasks tab badge denominator + visibility gate). */
@@ -231,7 +231,7 @@ export function WorkspacePanel({
   terminalsLength,
   subagentsWorking,
   agentCount,
-  isClaudeNative,
+  supportsTasksPanel,
   todosCompleted,
   todosTotal,
   rootSessionId,
@@ -352,7 +352,7 @@ export function WorkspacePanel({
                 )}
               </TabsTrigger>
             )}
-            {isClaudeNative && todosTotal > 0 && (
+            {supportsTasksPanel && todosTotal > 0 && (
               <TabsTrigger
                 value="todos"
                 className="h-[32px] gap-[6px] rounded-[8px] px-[12px] text-[13px] leading-5"
@@ -418,7 +418,7 @@ export function WorkspacePanel({
           />
         ) : rightRailTab === "subagents" && rootSessionId ? (
           <SubagentsPanel conversationId={conversationId} rootSessionId={rootSessionId} />
-        ) : rightRailTab === "todos" && isClaudeNative ? (
+        ) : rightRailTab === "todos" && supportsTasksPanel ? (
           <TodoPanel frameless />
         ) : rightRailTab === "terminals" && showShellsTab ? (
           <InlineTerminalsSection conversationId={conversationId} onExpand={openTerminalsPanel} />

--- a/ap-web/src/store/chatStore.ts
+++ b/ap-web/src/store/chatStore.ts
@@ -370,10 +370,11 @@ export interface ChatState {
    */
   gitBranch: string | null;
   /**
-   * Current Claude Code todo list for `omnigent claude` sessions.
-   * Populated from the session snapshot on bind and updated by
-   * `session.todos` SSE events. Empty array for non-claude-native
-   * sessions or before the first poll tick from the forwarder.
+   * Current plan/TODO list for native sessions that feed the Tasks panel
+   * (claude-native TodoWrite/task hooks; codex-native `turn/plan/updated`
+   * plan steps). Populated from the session snapshot on bind and updated by
+   * `session.todos` SSE events. Empty array for unsupported sessions or
+   * before the forwarder posts the first update.
    */
   todos: Array<{
     content: string;

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -2609,32 +2609,30 @@ async def _handle_turn_plan_updated(
     params: dict[str, Any],
 ) -> None:
     """
-    Mirror a Codex plan update as a visible assistant message.
+    Mirror a Codex plan update into the Omnigent Tasks panel.
 
-    Codex emits plan changes as app-server notifications rather than
-    ordinary assistant text. Omnigent web currently renders persisted message
-    items, not a dedicated plan item type, so the native bridge converts
-    the structured plan into a compact assistant message.
+    Codex emits structured plan changes (``params["plan"]`` is a list of
+    ``{step, status}`` entries) as app-server notifications. These are
+    normalized into the same ``external_session_todos`` events the
+    claude-native forwarder posts, so the web Tasks panel renders Codex
+    plan progress the same way it renders Claude todos — rather than
+    appending repeated Markdown messages to the chat transcript.
 
     :param client: HTTP client for Omnigent event posts.
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
     :param params: Codex ``turn/plan/updated`` params.
     :returns: None.
     """
-    text = _plan_text_from_update(params)
-    if not text:
+    todos = _plan_todos_from_update(params)
+    if todos is None:
         return
-    await _post_external_item(
+    response = await _post_session_event(
         client,
         session_id,
-        item_type="message",
-        item_data={
-            "role": "assistant",
-            "agent": _AGENT_NAME,
-            "content": [{"type": "output_text", "text": text}],
-        },
-        response_id=_response_id(params),
+        event_type="external_session_todos",
+        data={"todos": todos},
     )
+    _log_failed_session_event_post("external_session_todos", response)
 
 
 def _is_codex_elicitation_request(event: CodexMessage) -> bool:
@@ -5239,49 +5237,53 @@ def _json_string(value: dict[str, Any]) -> str | None:
         return None
 
 
-def _plan_text_from_update(params: dict[str, Any]) -> str | None:
+def _plan_todos_from_update(params: dict[str, Any]) -> list[dict[str, Any]] | None:
     """
-    Render a Codex ``turn/plan/updated`` payload as Markdown text.
+    Map a Codex ``turn/plan/updated`` payload to ``external_session_todos`` items.
 
-    :param params: Codex plan update params.
-    :returns: Markdown plan text, or ``None`` when no valid plan steps
-        are present.
+    Each Codex plan entry (``{step, status}``) becomes a todo item in the
+    shape the Sessions API expects (``{content, status, activeForm}``).
+    Codex has no gerund/active form, so ``step`` is reused for both
+    ``content`` and ``activeForm`` (the same approach the claude-native
+    forwarder uses for native task hooks). Statuses are normalized to the
+    snake_case vocabulary the server accepts.
+
+    :param params: Codex ``turn/plan/updated`` params.
+    :returns: Todo items for the ``external_session_todos`` event, or
+        ``None`` when the payload carries no valid plan steps.
     """
     plan = params.get("plan")
     if not isinstance(plan, list) or not plan:
         return None
-    lines: list[str] = []
-    explanation = params.get("explanation")
-    if isinstance(explanation, str) and explanation:
-        lines.append(explanation)
-        lines.append("")
-    lines.append("Plan:")
+    todos: list[dict[str, Any]] = []
     for entry in plan:
         if not isinstance(entry, dict):
             continue
         step = entry.get("step")
         if not isinstance(step, str) or not step:
             continue
-        status = entry.get("status")
-        marker = _plan_status_marker(status)
-        lines.append(f"{marker} {step}")
-    if len(lines) == 1 or (len(lines) == 3 and lines[-1] == "Plan:"):
-        return None
-    return "\n".join(lines)
+        todos.append(
+            {
+                "content": step,
+                "status": _normalize_plan_status(entry.get("status")),
+                "activeForm": step,
+            }
+        )
+    return todos or None
 
 
-def _plan_status_marker(status: Any) -> str:
+def _normalize_plan_status(status: Any) -> str:
     """
-    Return a readable Markdown marker for a Codex plan step status.
+    Normalize a Codex plan step status to the Sessions API todo vocabulary.
 
-    :param status: Codex step status value.
-    :returns: Markdown list marker.
+    :param status: Codex step status value, e.g. ``"inProgress"``.
+    :returns: One of ``"pending"``, ``"in_progress"``, ``"completed"``.
     """
     if status == "completed":
-        return "- [x]"
+        return "completed"
     if status in {"inProgress", "in_progress"}:
-        return "- [~]"
-    return "- [ ]"
+        return "in_progress"
+    return "pending"
 
 
 def _response_id(params: dict[str, Any]) -> str:

--- a/tests/e2e_ui/chat/test_codex_tasks_panel.py
+++ b/tests/e2e_ui/chat/test_codex_tasks_panel.py
@@ -1,0 +1,99 @@
+"""E2E: codex-native sessions render plan/TODO progress in the Tasks panel."""
+
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# Todos the patched snapshot advertises. Mirrors the ``external_session_todos``
+# payload the codex-native forwarder now emits from ``turn/plan/updated``
+# (``step`` → ``content``/``activeForm``, camelCase status normalized to
+# snake_case). The Tasks panel renders ``content`` per row.
+_CODEX_TODOS = [
+    {
+        "content": "Investigate the failing test",
+        "status": "completed",
+        "activeForm": "Investigating",
+    },
+    {"content": "Apply the fix", "status": "in_progress", "activeForm": "Applying the fix"},
+    {"content": "Run the suite", "status": "pending", "activeForm": "Running the suite"},
+]
+
+
+def _patch_session_as_codex_native_with_todos(page: Page, session_id: str) -> None:
+    """Patch the browser's session snapshot into a codex-native + todos response.
+
+    The server fixture seeds a normal ``hello_world`` session so the page can
+    boot against the real app/server. This route patch changes only the
+    ``GET /v1/sessions/{session_id}`` response as seen by the browser, stamping
+    the ``codex-native-ui`` wrapper label (so the Tasks panel's harness gate
+    admits the session) and a ``todos`` list (what the server snapshot builder
+    would return from ``_session_todos_cache`` after the forwarder posted a
+    plan). No real Codex CLI is needed to exercise the web behavior.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Session id to patch, e.g. ``"conv_abc123"``.
+    :returns: None.
+    """
+
+    def _handle(route: Route) -> None:
+        request = route.request
+        if urlparse(request.url).path != f"/v1/sessions/{session_id}" or request.method != "GET":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        payload["labels"] = {
+            **payload.get("labels", {}),
+            "omnigent.wrapper": "codex-native-ui",
+        }
+        payload["harness"] = "codex"
+        payload["todos"] = _CODEX_TODOS
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route("**/v1/sessions/**", _handle)
+
+
+def test_codex_native_session_shows_plan_in_tasks_panel(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A codex-native session surfaces its plan steps in the Tasks panel.
+
+    Covers the harness-gate widening: the Tasks tab (previously claude-native
+    only) now admits ``codex-native-ui``, and the shared TodoPanel renders the
+    plan steps the forwarder mapped into ``external_session_todos``.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser snapshot is patched to codex-native with todos.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _patch_session_as_codex_native_with_todos(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # Scope every lookup to the desktop "Workspace" rail so it never matches the
+    # hidden mobile drawer that mirrors the same labels.
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+
+    tasks_tab = rail.get_by_role("tab", name=re.compile("^Tasks"))
+    expect(tasks_tab).to_be_visible(timeout=30_000)
+    # Badge shows completed/total (1 of 3 todos completed).
+    expect(tasks_tab).to_contain_text("1/3")
+
+    tasks_tab.click()
+    # The panel renders each plan step's content.
+    for todo in _CODEX_TODOS:
+        expect(rail.get_by_text(todo["content"], exact=False)).to_be_visible(timeout=30_000)

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -4881,12 +4881,15 @@ def test_forwarder_skips_user_recovery_when_user_seen_live(tmp_path: Path) -> No
 
 def test_forwarder_posts_codex_turn_plan_update(tmp_path: Path) -> None:
     """
-    Codex ``turn/plan/updated`` notifications are visible in Omnigent web.
+    Codex ``turn/plan/updated`` notifications feed the Omnigent Tasks panel.
 
     Plan mode emits plan state through a dedicated app-server
-    notification rather than assistant text. If the forwarder ignores
-    it, the terminal shows the plan while the web transcript appears to
-    skip straight to the final prompt.
+    notification rather than assistant text. The forwarder normalizes it
+    into an ``external_session_todos`` event (the same pipeline the
+    claude-native forwarder uses) so the web Tasks panel renders live plan
+    progress, rather than appending Markdown to the chat transcript. This
+    exercises the full ``_handle_event`` dispatch path; the direct-call and
+    mapping unit tests live in ``test_codex_native_forwarder.py``.
     """
     posted: list[dict[str, Any]] = []
 
@@ -4934,24 +4937,23 @@ def test_forwarder_posts_codex_turn_plan_update(tmp_path: Path) -> None:
     asyncio.run(run())
 
     assert len(posted) == 1
-    assert posted[0]["type"] == "external_conversation_item"
-    data = posted[0]["data"]
-    assert data["item_type"] == "message"
-    assert data["response_id"] == "codex_turn_123"
-    assert data["item_data"] == {
-        "role": "assistant",
-        "agent": "codex-native-ui",
-        "content": [
+    assert posted[0]["type"] == "external_session_todos"
+    # ``inProgress`` normalizes to ``in_progress``; ``step`` fills both
+    # ``content`` and ``activeForm`` (Codex has no gerund form).
+    assert posted[0]["data"] == {
+        "todos": [
             {
-                "type": "output_text",
-                "text": (
-                    "Plan:\n"
-                    "- [x] Inspect Codex plan events\n"
-                    "- [~] Mirror plans to web\n"
-                    "- [ ] Run checks"
-                ),
-            }
-        ],
+                "content": "Inspect Codex plan events",
+                "status": "completed",
+                "activeForm": "Inspect Codex plan events",
+            },
+            {
+                "content": "Mirror plans to web",
+                "status": "in_progress",
+                "activeForm": "Mirror plans to web",
+            },
+            {"content": "Run checks", "status": "pending", "activeForm": "Run checks"},
+        ]
     }
 
 

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -667,3 +667,113 @@ async def test_elicitation_post_returns_none_when_budget_exhausted(
     # 1 = the deadline check stopped the loop before a second attempt
     # (backoff 1.0s > 0.5s budget); more means the budget is ignored.
     assert len(client.posts) == 1
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("completed", "completed"),
+        ("inProgress", "in_progress"),
+        ("in_progress", "in_progress"),
+        ("pending", "pending"),
+        (None, "pending"),
+        ("something-else", "pending"),
+    ],
+)
+def test_normalize_plan_status(status: object, expected: str) -> None:
+    """Codex step statuses map onto the server's snake_case todo vocabulary.
+
+    ``inProgress`` (camelCase, Codex's wire form) must become ``in_progress``
+    or the server's todo filter silently drops the item; anything unknown
+    falls back to ``pending``.
+    """
+    assert fwd._normalize_plan_status(status) == expected
+
+
+def test_plan_todos_from_update_maps_steps() -> None:
+    """A structured plan maps to well-formed external_session_todos items.
+
+    ``step`` fills both ``content`` and ``activeForm`` (Codex has no gerund
+    form, matching the claude-native native-task fallback), and statuses are
+    normalized so every item survives the server/web todo filter.
+    """
+    params = {
+        "plan": [
+            {"step": "Read the code", "status": "completed"},
+            {"step": "Write the fix", "status": "inProgress"},
+            {"step": "Run tests", "status": "pending"},
+        ]
+    }
+
+    assert fwd._plan_todos_from_update(params) == [
+        {"content": "Read the code", "status": "completed", "activeForm": "Read the code"},
+        {"content": "Write the fix", "status": "in_progress", "activeForm": "Write the fix"},
+        {"content": "Run tests", "status": "pending", "activeForm": "Run tests"},
+    ]
+
+
+def test_plan_todos_from_update_skips_malformed_and_empty() -> None:
+    """Non-dict entries and blank/missing steps are dropped; empties → None."""
+    assert fwd._plan_todos_from_update({"plan": []}) is None
+    assert fwd._plan_todos_from_update({}) is None
+    assert fwd._plan_todos_from_update({"plan": "nope"}) is None
+    # Only the valid entry survives the filter.
+    plan = [
+        "bogus",
+        {"status": "pending"},
+        {"step": "", "status": "pending"},
+        {"step": "Ship it"},
+    ]
+    assert fwd._plan_todos_from_update({"plan": plan}) == [
+        {"content": "Ship it", "status": "pending", "activeForm": "Ship it"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handle_turn_plan_updated_posts_todos_not_chat() -> None:
+    """turn/plan/updated feeds the Tasks panel, not the chat transcript.
+
+    The forwarder must post a single ``external_session_todos`` event with the
+    normalized plan, and must NOT post an ``external_conversation_item``
+    (chat message) — the regression guard for the panel-only behavior.
+    """
+    client = _RecordingClient()
+    params = {
+        "turnId": "turn_1",
+        "plan": [
+            {"step": "Investigate", "status": "inProgress"},
+            {"step": "Fix", "status": "pending"},
+        ],
+    }
+
+    await fwd._handle_turn_plan_updated(client, "conv_x", params)  # type: ignore[arg-type]
+
+    assert client.posts == [
+        (
+            "/v1/sessions/conv_x/events",
+            {
+                "type": "external_session_todos",
+                "data": {
+                    "todos": [
+                        {
+                            "content": "Investigate",
+                            "status": "in_progress",
+                            "activeForm": "Investigate",
+                        },
+                        {"content": "Fix", "status": "pending", "activeForm": "Fix"},
+                    ]
+                },
+            },
+        )
+    ]
+    assert all(body["type"] != "external_conversation_item" for _url, body in client.posts)
+
+
+@pytest.mark.asyncio
+async def test_handle_turn_plan_updated_empty_plan_posts_nothing() -> None:
+    """An empty/absent plan produces no post (matches Claude, which skips empties)."""
+    client = _RecordingClient()
+
+    await fwd._handle_turn_plan_updated(client, "conv_x", {"plan": []})  # type: ignore[arg-type]
+
+    assert client.posts == []


### PR DESCRIPTION
## Summary

Codex emits plan progress through `turn/plan/updated` app-server
notifications. Previously the forwarder flattened each one to Markdown and
appended it to the chat transcript, producing repeated plan messages and no
live panel.

- **Forwarder** (`omnigent/codex_native_forwarder.py`): normalize
  `turn/plan/updated` steps into `external_session_todos` events (`step` →
  `content`/`activeForm`; `inProgress`/`in_progress` → `in_progress`). This is
  the same pipeline the claude-native forwarder already uses, so the server
  needs no changes. Live plan updates now go to the **Tasks panel only**; the
  plan-mode *proposal document* still posts to chat via a separate event
  (`item/completed` type `plan`), unchanged.
- **Web**: widen the Tasks-panel harness gate to include `codex-native-ui`,
  via a shared `supportsTasksPanel()` capability helper in
  `sessionCapabilities.ts` (kept in sync with `supportsEffortControl`).

**ELI5:** Codex writes a to-do list as it works. We were pasting that list
into the chat over and over; now it shows up in the side "Tasks" panel and
updates in place — exactly like Claude Code's task list.

**Flow:**

```mermaid
flowchart LR
  A["Codex app-server<br/>turn/plan/updated"] --> B["codex forwarder<br/>_handle_turn_plan_updated"]
  B -->|external_session_todos| C["server<br/>_session_todos_cache + SSE"]
  C -->|session.todos| D["web Tasks panel"]
```

**Trade-off (durability):** the panel reads from the server's in-memory
`_session_todos_cache`, which is lost on server restart (it re-seeds from the
next `turn/plan/updated`). The old chat message was durable in the transcript.
This matches the existing claude-native behavior and is an intentional choice —
a structured, in-place panel over durable-but-noisy chat messages.

## Demo

Codex plan/TODO progress rendered live in the Tasks panel (Codex harness, Plan
mode):

<img width="1717" height="911" alt="Screenshot 2026-07-16 at 12 44 50 PM" src="https://github.com/user-attachments/assets/41262e99-55c5-4208-8ead-b0c432a1cf24" />

--  full plan appears in the Tasks panel (0/6) at the start of the turn._


<img width="1905" height="941" alt="Screenshot 2026-07-16 at 1 00 54 PM" src="https://github.com/user-attachments/assets/955c155d-411a-49d7-a270-1892a8426979" />

— steps update in place: 2/6 complete, completed steps struck through, current step in progress._

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Commands run locally (all green):

- `ruff check` on the changed Python.
- `pytest tests/test_codex_native_forwarder.py` (status normalization, plan →
  todos mapping, and a regression guard that `turn/plan/updated` posts
  `external_session_todos` and **not** a chat message) and the updated
  `tests/test_codex_native.py::test_forwarder_posts_codex_turn_plan_update`
  (asserts the new shape through the full `_handle_event` dispatch).
- `ap-web` `tsc -b` type-check + `vitest` for `WorkspacePanel.test.tsx` /
  `ChatHeader.test.tsx` (Tasks tab renders for a `codex-native-ui` session,
  hidden when unsupported).
- New Playwright e2e `tests/e2e_ui/chat/test_codex_tasks_panel.py` (patches a
  codex-native snapshot with todos, asserts the Tasks tab + step content
  render) — satisfies the `web/**` e2e_ui gate.
- Manual: drove a real codex-native session against a live server end-to-end;
  verified the plan appears in the panel, updates in place, and no longer
  duplicates into chat.