### PR TITLE
fix(cli): drop the OpenRouter example from the Gateway setup option

### DIFF
--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -459,8 +459,8 @@ def add_menu_options() -> list[AddOption]:
         ),
         # Cross-vendor extras, alphabetical (Gateway before OpenRouter).
         _opt(
-            "Gateway — custom base URL + key (e.g. OpenRouter)",
-            "An OpenAI/Anthropic-compatible proxy: LiteLLM, Ollama, OpenRouter, vLLM, …",
+            "Gateway — custom base URL + key",
+            "An OpenAI/Anthropic-compatible proxy: LiteLLM, Ollama, vLLM, …",
             GATEWAY_KIND,
         ),
         _opt(

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -546,7 +546,7 @@ def test_add_menu_options_ordering() -> None:
         "Gemini — API key",
         "ChatGPT — subscription",
         "Claude — subscription (Pro/Max)",
-        "Gateway — custom base URL + key (e.g. OpenRouter)",
+        "Gateway — custom base URL + key",
         "OpenRouter — API key",
         "Databricks — workspace",
         "Other provider — API key",
@@ -560,7 +560,7 @@ def test_add_menu_options_ordering() -> None:
     assert codex == [
         "OpenAI — API key",
         "ChatGPT — subscription",
-        "Gateway — custom base URL + key (e.g. OpenRouter)",
+        "Gateway — custom base URL + key",
         "OpenRouter — API key",
         "Databricks — workspace",
         "Other provider — API key",
@@ -573,7 +573,7 @@ def test_add_menu_options_ordering() -> None:
     assert claude == [
         "Anthropic — API key",
         "Claude — subscription (Pro/Max)",
-        "Gateway — custom base URL + key (e.g. OpenRouter)",
+        "Gateway — custom base URL + key",
         "Databricks — workspace",
         "AWS Bedrock — API key",
     ]


### PR DESCRIPTION
## Related issue

N/A — user feedback from Slack: the setup menu offering both "Gateway … (e.g. OpenRouter)" and a standalone "OpenRouter" option read as two ways to do the same thing.

## Summary

- Drop the "(e.g. OpenRouter)" example from the **Gateway** option in the model-setup add menu, and drop OpenRouter from its description line, since OpenRouter has its own dedicated menu entry directly below.
- Users who want OpenRouter should pick the standalone "OpenRouter — API key" option; the Gateway option remains for other OpenAI/Anthropic-compatible proxies (LiteLLM, Ollama, vLLM, …).

## Test Plan

- Updated the label assertions in `tests/cli/test_configure_models.py`; `pytest tests/cli/test_configure_models.py` passes (5 pre-existing Databricks-gating failures in my env are unrelated and fail identically on `main`).
- Rendered the add menu to confirm the new copy (see Demo).

## Demo

Before:

```
🌐 Gateway — custom base URL + key (e.g. OpenRouter)   An OpenAI/Anthropic-compatible proxy: LiteLLM, Ollama, OpenRouter, vLLM, …
🔑 OpenRouter — API key                                One key, many models (openrouter.ai).
```

After:

```
🌐 Gateway — custom base URL + key            An OpenAI/Anthropic-compatible proxy: LiteLLM, Ollama, vLLM, …
🔑 OpenRouter — API key                       One key, many models (openrouter.ai).
```

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The menu labels and ordering are asserted directly in `tests/cli/test_configure_models.py`.

## Changelog

Changed: the Gateway option in model setup no longer cites OpenRouter as an example — use the dedicated OpenRouter option instead

This pull request and its description were written by Isaac.
