### PR TITLE
fix(server): key HostRegistry by canonical host id so legacy host_<hex> lookups hit

### DIFF
--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -22,9 +22,35 @@ from typing import Any, Protocol
 
 from cachetools import TTLCache
 
+from omnigent.db.db_models import InvalidUuidError, uuid_to_bytes
 from omnigent.host.frames import HostHelloFrame
 
 _logger = logging.getLogger(__name__)
+
+
+def _canonical_host_id(host_id: str) -> str:
+    """Reduce a host id to the canonical bare-hex form used as the key.
+
+    Host ids reach the registry in every spelling ``uuid_to_bytes``
+    accepts: the bare 32-char hex the tunnel route registers under,
+    the legacy ``host_<hex>`` form that pre-migration clients still
+    send in REST paths, and the dashed uuid form. The DB layer
+    normalizes all of them (``Uuid16``), so the registry must key on
+    the same canonical form — otherwise a legacy-form lookup misses a
+    live tunnel and runner launches 409 "host is offline" while
+    ``GET /v1/hosts`` reports the host online. Ids that aren't
+    uuid-shaped at all are keyed verbatim so they simply miss.
+
+    :param host_id: A host id in any accepted spelling, e.g.
+        ``"host_a1b2..."``, ``"a1b2..."``, or the dashed uuid.
+    :returns: The bare-hex form, or *host_id* unchanged when it is
+        not uuid-shaped.
+    """
+    try:
+        return uuid_to_bytes(host_id).hex()
+    except InvalidUuidError:
+        return host_id
+
 
 # How long a runner exit report stays answerable, and how many are kept.
 # Reports only matter while a client is still waiting for the runner to
@@ -268,8 +294,10 @@ class HostRegistry:
         :param ws: The live WebSocket.
         :param hello: The hello frame from the host.
         :param owner: Authenticated user ID, or ``None``.
-        :returns: The new :class:`HostConnection`.
+        :returns: The new :class:`HostConnection`. Its ``host_id`` is
+            the canonical form (see :func:`_canonical_host_id`).
         """
+        host_id = _canonical_host_id(host_id)
         now = time.time()
         conn = HostConnection(
             host_id=host_id,
@@ -296,21 +324,22 @@ class HostRegistry:
 
         No-op if ``host_id`` is not registered.
 
-        :param host_id: Host identifier to remove.
+        :param host_id: Host identifier to remove, in any accepted
+            spelling (see :func:`_canonical_host_id`).
         """
         with self._lock:
-            self._hosts.pop(host_id, None)
+            self._hosts.pop(_canonical_host_id(host_id), None)
 
     def get(self, host_id: str) -> HostConnection | None:
         """Look up a live host connection.
 
-        :param host_id: Host identifier, e.g.
-            ``"host_a1b2c3d4..."``.
+        :param host_id: Host identifier, in any accepted spelling
+            (see :func:`_canonical_host_id`).
         :returns: The :class:`HostConnection` if online,
             otherwise ``None``.
         """
         with self._lock:
-            return self._hosts.get(host_id)
+            return self._hosts.get(_canonical_host_id(host_id))
 
     def online_host_ids(self) -> list[str]:
         """Return IDs of all currently connected hosts.

--- a/tests/server/test_host_registry.py
+++ b/tests/server/test_host_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import uuid
 from dataclasses import dataclass, field
 
 import pytest
@@ -256,3 +257,36 @@ def test_exit_reports_get_is_unscoped() -> None:
     assert reports.get("runner_abc") == "runner process exited with code 1"
     # Missing runner still reads None (snapshot then leaves last_task_error unset).
     assert reports.get("runner_unknown") is None
+
+
+def test_legacy_prefixed_id_resolves_to_bare_registration() -> None:
+    """
+    Every ``uuid_to_bytes``-accepted spelling of a host id must key
+    the same registry entry (regression: #2740).
+
+    The tunnel route registers under the bare-hex form, but
+    pre-migration clients still send ``host_<hex>`` in REST paths.
+    Before the fix, ``get`` was exact-string: launches 409'd "host
+    is offline" while ``GET /v1/hosts`` (DB-normalized) reported the
+    host online.
+    """
+    bare = "00112233445566778899aabbccddeeff"
+    prefixed = f"host_{bare}"
+    dashed = str(uuid.UUID(bare))
+
+    registry = HostRegistry()
+    conn = registry.register(bare, FakeWebSocket(), _make_hello(), owner="alice")
+
+    assert registry.get(prefixed) is conn
+    assert registry.get(dashed) is conn
+
+    # Registering under a legacy spelling replaces the same entry, and
+    # the stored connection carries the canonical id (send_text's
+    # replaced-connection check keys on conn.host_id).
+    replacement = registry.register(prefixed, FakeWebSocket(), _make_hello(), owner="alice")
+    assert replacement.host_id == bare
+    assert registry.get(bare) is replacement
+
+    # Deregistering by any spelling removes the entry.
+    registry.deregister(prefixed)
+    assert registry.get(bare) is None


### PR DESCRIPTION
Fixes #2740

## Root cause

Since #2228 the tunnel route registers hosts under the **bare-hex** id, while every DB path normalizes any spelling via `uuid_to_bytes` (which explicitly accepts the legacy `host_<hex>` form). The runner-launch path, however, looked up the in-memory registry with the **raw path param** (`_host_launch.py:126`), so a pre-migration client's `POST /v1/hosts/host_<hex>/runners` missed the live tunnel and 409'd `host is offline` — at the same moment `GET /v1/hosts/{id}` (DB-backed) reported the host `online`, and the tunnel's keepalives were flowing. `_workspace_validation.py:226` had the same exposure. Full evidence trail in #2740.

## Fix

Canonicalize the key inside `HostRegistry` itself — `register` / `get` / `deregister` all reduce the id via `uuid_to_bytes(...).hex()`, falling back to the verbatim string for ids that aren't uuid-shaped (they just miss, as before). One guard at the choke point covers both broken callers and any future ones, and keeps `HostConnection.host_id` equal to its storage key, which `send_text`'s replaced-connection check depends on.

## Tests

`tests/server/test_host_registry.py::test_legacy_prefixed_id_resolves_to_bare_registration` — registers bare, resolves via `host_<hex>` and dashed spellings; replacement via a legacy spelling lands on the same key with a canonical `conn.host_id`; deregister works from any spelling. (Fails on `main` with `get(prefixed) is None`.)

This pull request and its description were written by Isaac.