### PR TITLE
fix(sandbox): grant exec-chain symlink hops + launcher target in seatbelt

### DIFF
--- a/omnigent/inner/seatbelt_sandbox.py
+++ b/omnigent/inner/seatbelt_sandbox.py
@@ -504,6 +504,16 @@ class SeatbeltSandboxBackend(SandboxBackend):
         :param chdir: Ignored. Present for interface parity with
             :class:`SandboxBackend.wrap_launcher_argv`; the helper
             chdirs itself from its JSON config.
+        :param target: Absolute path to the binary the launcher will
+            exec as its final target after the re-exec (e.g. the
+            ``claude`` CLI). When set and not already covered by the
+            default subtrees / cwd / read roots, narrow read grants
+            are added for its symlink chain and its resolved parent
+            directory so the in-sandbox exec can read it — the same
+            treatment the bwrap backend gives its ``target``. This
+            lane never raises; un-grantable layouts degrade to
+            literal grants plus a WARNING
+            (see :func:`_target_visibility_grants`).
         :returns: A complete ``sandbox-exec`` argv ready for
             ``subprocess.Popen`` — never an empty list.
         :raises OSError: When the cwd-scan cap is hit and overflow is
@@ -513,15 +523,34 @@ class SeatbeltSandboxBackend(SandboxBackend):
             unsafe ancestor (see :func:`_ensure_executable_visible`).
         """
         del chdir  # See docstring — Seatbelt has no --chdir analog.
-        del target  # SBPL profile grants read access by subpath rules; the
-        # run_launcher target binary is typically covered by the cwd or default
-        # subpath allows.  A targeted seatbelt fix is tracked separately.
         cwd_resolved = cwd.resolve(strict=False)
         extra_read_paths = _ensure_executable_visible(
             argv, cwd_resolved, policy_read_roots=policy.read_roots or []
         )
+        covered_prefixes: list[Path] = [Path(p) for p in _DEFAULT_READ_SUBPATHS]
+        covered_prefixes.append(cwd_resolved)
+        covered_prefixes.extend(policy.read_roots or [])
+        # Symlink hops in the exec chain need explicit literal reads:
+        # execve reads each symlink at its literal path, and subpath
+        # rules match only the kernel-canonical path. Without these,
+        # uv's version-floating ``cpython-3.12 -> cpython-3.12.13``
+        # dir symlink EPERMs the helper interpreter's execvp even
+        # though the resolved install root has a subpath grant.
+        extra_read_literals: list[Path] = (
+            _symlink_hop_literals(Path(argv[0]), covered_prefixes) if argv else []
+        )
+        if target is not None:
+            target_subpaths, target_literals = _target_visibility_grants(
+                target, covered_prefixes, extra_read_paths
+            )
+            extra_read_paths.extend(target_subpaths)
+            extra_read_literals.extend(p for p in target_literals if p not in extra_read_literals)
         profile = _build_profile(
-            policy, cwd_resolved, extra_read_paths=extra_read_paths, argv=argv
+            policy,
+            cwd_resolved,
+            extra_read_paths=extra_read_paths,
+            extra_read_literals=extra_read_literals,
+            argv=argv,
         )
         if len(profile.encode("utf-8")) > _MAX_PROFILE_BYTES:
             raise OSError(
@@ -597,6 +626,7 @@ def _build_profile(
     cwd: Path,
     *,
     extra_read_paths: list[Path] | None = None,
+    extra_read_literals: list[Path] | None = None,
     argv: Sequence[str] | None = None,
 ) -> str:
     """
@@ -641,6 +671,14 @@ def _build_profile(
         the explicit HOME deny would otherwise block). Emitted as
         ``(allow file-read* (subpath ...))`` AFTER the HOME deny so
         last-match-wins re-allows the interpreter.
+    :param extra_read_literals: Individual paths — symlink hops in
+        the exec chain and, for un-grantable layouts, the launcher
+        target binary itself — emitted as
+        ``(allow file-read* (literal ...))``. Symlinks are read by
+        the kernel at their literal path during execve resolution,
+        which subpath rules (matched against canonical paths) never
+        cover. Also fed to the ancestor-traversal walker so
+        ``realpath()`` walks through their parent chains succeed.
     :returns: The SBPL profile text, ready to pass to
         ``sandbox-exec -p``. Always a non-empty string starting with
         ``(version 1)``.
@@ -797,6 +835,18 @@ def _build_profile(
             lines.append(f"(allow file-read* (subpath {_quote(str(path))}))")
 
     # ----------------------------------------------------------------
+    # Exec-chain symlink hops + launcher target. Literal (not subpath)
+    # because the kernel reads a symlink at its literal path during
+    # execve resolution while subpath rules match canonical paths; a
+    # literal on a symlink exposes only its target string.
+    # ----------------------------------------------------------------
+    if extra_read_literals:
+        lines.append("")
+        lines.append(";; Exec-chain symlink hops + launcher target (literal reads)")
+        for path in extra_read_literals:
+            lines.append(f"(allow file-read* (literal {_quote(str(path))}))")
+
+    # ----------------------------------------------------------------
     # Scratch tmpdir — always RW; surfaced via $TMPDIR for the helper.
     #
     # L2 (security): canonicalise the scratch path before emission so
@@ -883,7 +933,7 @@ def _build_profile(
         allowed_paths=_collect_allowed_paths(
             cwd=cwd,
             scratch=scratch,
-            extra_read_paths=extra_read_paths or [],
+            extra_read_paths=[*(extra_read_paths or []), *(extra_read_literals or [])],
             policy=policy,
             dyld_cache=dyld_cache,
         ),
@@ -1267,6 +1317,145 @@ def _ensure_executable_visible(
     if exe_resolved != exe_literal:
         _add_topmost(exe_resolved)
     return extras
+
+
+def _symlink_hop_literals(start: Path, covered_prefixes: Sequence[Path]) -> list[Path]:
+    """
+    Collect the symlinks ``execve`` will read while resolving *start*.
+
+    Mirrors the hop-by-hop walk in
+    :func:`omnigent.inner.bwrap_sandbox._ensure_executable_visible`:
+    follow the final component's symlink chain (40-hop cap, matching
+    MAXSYMLINKS), and at every hop collect each path component — the
+    hop itself and any intermediate directory — that is a symlink.
+    The kernel reads each such symlink at its LITERAL path during
+    path resolution, and SBPL subpath rules match only the
+    kernel-canonical path, so every uncovered symlink needs an
+    ``(allow file-read* (literal ...))`` grant. Reading a symlink
+    exposes only its target string, so these grants never widen the
+    sandbox beyond the exec chain itself.
+
+    The canonical failure this closes: uv installs a version-floating
+    dir symlink (``cpython-3.12 -> cpython-3.12.13``) between a tool
+    venv's ``bin/python`` and the real interpreter. The resolved
+    install root gets a subpath grant, but the literal hop through
+    the versionless dir was denied — so ``sandbox-exec``'s execvp of
+    the helper interpreter failed with EPERM and every jailed helper
+    spawn died at boot.
+
+    :param start: The literal path execve will be called with
+        (``argv[0]`` or the launcher target).
+    :param covered_prefixes: Roots whose subtrees are already
+        readable at their literal paths (default RO subtrees + cwd +
+        spec read roots); symlinks under them need no extra grant.
+    :returns: De-duplicated literal symlink paths, in walk order.
+    """
+    literals: list[Path] = []
+    seen: set[Path] = set()
+
+    def _collect_component_symlinks(path: Path) -> None:
+        for prefix in (*reversed(path.parents), path):
+            if str(prefix) in ("/", ""):
+                continue
+            if prefix in seen:
+                continue
+            try:
+                if not prefix.is_symlink():
+                    continue
+            except OSError:
+                continue
+            seen.add(prefix)
+            if any(_is_within_literal(prefix, root) for root in covered_prefixes):
+                continue
+            literals.append(prefix)
+
+    visited: set[Path] = set()
+    current = Path(os.path.abspath(str(start)))
+    for _ in range(40):  # MAXSYMLINKS parity with the bwrap walk
+        if current in visited:
+            break
+        visited.add(current)
+        _collect_component_symlinks(current)
+        try:
+            if not current.is_symlink():
+                break
+            link = os.readlink(str(current))
+        except OSError:
+            break
+        if link.startswith("/"):
+            current = Path(link)
+        else:
+            current = Path(os.path.normpath(str(current.parent / link)))
+    return literals
+
+
+def _target_visibility_grants(
+    target: str,
+    covered_prefixes: Sequence[Path],
+    already_granted: Sequence[Path],
+) -> tuple[list[Path], list[Path]]:
+    """
+    Compute read grants so the launcher's final *target* binary is
+    exec-able inside the sandbox.
+
+    Parity with the bwrap backend, which bind-mounts the target's
+    directory chain when given (its ``wrap_launcher_argv`` calls
+    ``_ensure_executable_visible([target], ...)``). For seatbelt the
+    equivalent is: literal reads for the symlink chain to the binary
+    (:func:`_symlink_hop_literals`) plus a subpath grant on the
+    RESOLVED binary's parent directory — exec of a resolved binary
+    empirically requires a ``subpath`` rule on a parent, and the
+    binary's own directory is the narrowest one that works (e.g. the
+    claude CLI's ``~/.local/share/claude/versions/<v>/``).
+
+    Unlike the interpreter lane, this never raises: the target is
+    harness-supplied (a CLI being wrapped), so an un-grantable layout
+    degrades to a literal grant on the resolved binary plus an audit
+    WARNING instead of failing the spawn. The parent-dir subpath is
+    refused when it would be sandbox-defeating: ``/``, an entry of
+    :data:`_UNSAFE_WIDEN_ANCESTORS`, ``$HOME``, or an ancestor of
+    ``$HOME``.
+
+    :param target: Absolute path to the final exec target.
+    :param covered_prefixes: Literal-coverage roots (default RO
+        subtrees + cwd + spec read roots).
+    :param already_granted: Subpath grants already computed for the
+        helper interpreter; a target inside one of them adds nothing.
+    :returns: ``(subpaths, literals)`` to merge into the profile's
+        extra read grants.
+    """
+    literals = _symlink_hop_literals(Path(target), covered_prefixes)
+    resolved = Path(target).resolve(strict=False)
+    covered = [*covered_prefixes, *already_granted]
+    if any(_is_within_literal(resolved, root) for root in covered):
+        return [], literals
+    parent = resolved.parent
+    home: Path | None
+    try:
+        home = Path(os.path.expanduser("~")).resolve(strict=False)
+        if not home.is_absolute() or str(home) in ("", "/"):
+            home = None
+    except (OSError, RuntimeError):
+        home = None
+    parent_too_broad = (
+        str(parent) == "/"
+        or str(parent) in _UNSAFE_WIDEN_ANCESTORS
+        or (home is not None and _is_within_literal(home, parent))
+    )
+    if parent_too_broad:
+        _LOGGER.warning(
+            "darwin_seatbelt: launcher target %r resolves to %r whose parent "
+            "directory %r is too broad to grant (subpath) on. Granting a "
+            "literal read on the binary only; if the exec still fails with "
+            "EPERM, add a narrow read_paths entry covering the install tree.",
+            target,
+            str(resolved),
+            str(parent),
+        )
+        if resolved not in literals:
+            literals.append(resolved)
+        return [], literals
+    return [parent], literals
 
 
 def _interpreter_install_root(exe: Path) -> Path | None:

--- a/tests/inner/test_seatbelt_sandbox.py
+++ b/tests/inner/test_seatbelt_sandbox.py
@@ -48,6 +48,7 @@ from omnigent.inner.seatbelt_sandbox import (
     _per_user_dyld_cache_subpath,
     _quote,
     _resolve_root,
+    _symlink_hop_literals,
 )
 
 # ---------------------------------------------------------------------------
@@ -2080,3 +2081,209 @@ def test_s5_read_paths_dedup_skips_paths_under_cwd(tmp_path: Path) -> None:
         ".env masked more than once — the dedup that skips "
         "read_paths roots at-or-under cwd regressed."
     )
+
+
+# ---------------------------------------------------------------------------
+# Exec-chain symlink hops + launcher target visibility (bwrap parity)
+# ---------------------------------------------------------------------------
+
+
+def _uv_style_layout(base: Path) -> tuple[Path, Path, Path]:
+    """
+    Stage uv's tool-venv → versionless-hop → real-install layout.
+
+    Mirrors what ``uv tool install omnigent`` produces: the tool
+    venv's ``bin/python`` symlinks to a path that traverses the
+    version-floating ``cpython-3.12`` directory symlink before
+    landing on the real ``cpython-3.12.13`` install. Both roots get
+    the venv/install shape (``bin/`` + ``lib/python3.12``) so the
+    narrow install-root fallback matches them.
+
+    :param base: Directory to stage the fake ``$HOME`` layout under.
+    :returns: ``(tool_exe, versionless_dir, real_install_root)``.
+    """
+    real_root = base / ".local" / "share" / "uv" / "python" / "cpython-3.12.13-macos"
+    (real_root / "bin").mkdir(parents=True)
+    (real_root / "lib" / "python3.12").mkdir(parents=True)
+    real_exe = real_root / "bin" / "python3.12"
+    real_exe.write_text("#!fake\n")
+    real_exe.chmod(0o755)
+    versionless = base / ".local" / "share" / "uv" / "python" / "cpython-3.12-macos"
+    versionless.symlink_to("cpython-3.12.13-macos")
+    tool_root = base / ".local" / "share" / "uv" / "tools" / "omnigent"
+    (tool_root / "bin").mkdir(parents=True)
+    (tool_root / "lib" / "python3.12").mkdir(parents=True)
+    tool_exe = tool_root / "bin" / "python"
+    tool_exe.symlink_to(versionless / "bin" / "python3.12")
+    return tool_exe, versionless, real_root
+
+
+def test_wrap_launcher_argv_grants_uv_versionless_hop_literal(tmp_path: Path) -> None:
+    """
+    The uv boot regression: the helper interpreter is reached through
+    uv's version-floating directory symlink
+    (``cpython-3.12 -> cpython-3.12.13``). The profile grants a
+    subpath on the RESOLVED install root, but execve reads the
+    versionless symlink at its LITERAL path — without a literal
+    grant for the hop, ``sandbox-exec``'s execvp of the helper dies
+    with EPERM and every jailed helper spawn fails at boot.
+    """
+    tool_exe, versionless, real_root = _uv_style_layout(tmp_path / "fake-home")
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+
+    backend = _make_backend()
+    policy = _make_policy(cwd, allow_hidden=[".venv"])
+    argv = backend.wrap_launcher_argv(
+        [str(tool_exe), "-m", "omnigent.inner.os_env", "helper", "X"], policy, cwd
+    )
+    profile = Path(argv[2]).read_text()
+
+    hop_literal = f"(allow file-read* (literal {_quote(str(versionless))}))"
+    assert hop_literal in profile, (
+        f"Missing literal read grant for the versionless symlink hop "
+        f"{str(versionless)!r}. Subpath rules match only canonical "
+        "paths, so without this literal the kernel denies reading the "
+        "symlink during execve resolution and the helper interpreter "
+        "never boots (execvp EPERM)."
+    )
+    resolved_subpath = (
+        f"(allow file-read* (subpath {_quote(str(real_root.resolve(strict=False)))}))"
+    )
+    assert resolved_subpath in profile, (
+        "The resolved install root must keep its narrow subpath grant "
+        "— the hop literal complements it, never replaces it."
+    )
+
+
+def test_wrap_launcher_argv_target_grants_claude_cli_install(tmp_path: Path) -> None:
+    """
+    The launcher target (e.g. the claude CLI wrapped by
+    ``prepare_claude_cli_path``) must be readable inside the sandbox:
+    the standalone installer puts a symlink at ``~/.local/bin/claude``
+    pointing into ``~/.local/share/claude/versions/<v>/``. The wrap
+    must grant a literal read on the symlink and a subpath on the
+    version directory — and nothing wider — instead of discarding
+    ``target`` (which crashed the whole native-tool wrap with
+    ``PermissionError`` at connect time).
+    """
+    fake_home = tmp_path / "fake-home"
+    version_dir = fake_home / ".local" / "share" / "claude" / "versions" / "1.0.61"
+    version_dir.mkdir(parents=True)
+    cli_real = version_dir / "claude"
+    cli_real.write_bytes(b"\x00fakebun")
+    cli_real.chmod(0o755)
+    bin_dir = fake_home / ".local" / "bin"
+    bin_dir.mkdir(parents=True)
+    cli_link = bin_dir / "claude"
+    cli_link.symlink_to(cli_real)
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+
+    backend = _make_backend()
+    policy = _make_policy(cwd, allow_hidden=[".venv"])
+    argv = backend.wrap_launcher_argv(_safe_helper_argv(cwd), policy, cwd, target=str(cli_link))
+    profile = Path(argv[2]).read_text()
+
+    assert f"(allow file-read* (literal {_quote(str(cli_link))}))" in profile, (
+        "The target symlink needs a literal read grant — the kernel "
+        "reads it at its literal path when the launcher execs the CLI."
+    )
+    assert f"(allow file-read* (subpath {_quote(str(version_dir))}))" in profile, (
+        "The resolved CLI's own directory needs a subpath grant so the "
+        "in-sandbox exec can read the binary."
+    )
+    dotlocal = fake_home / ".local"
+    assert f"(allow file-read* (subpath {_quote(str(dotlocal))}))" not in profile, (
+        "The grant must stay scoped to the CLI install — widening to "
+        "~/.local would expose sibling tool state."
+    )
+    assert f"(allow file-read-metadata (literal {_quote(str(bin_dir))}))" in profile, (
+        "The literal grant's ancestors need stat-only traversal allows "
+        "or realpath() walks to the CLI EPERM under deny-default."
+    )
+
+
+def test_wrap_launcher_argv_target_under_cwd_changes_nothing(tmp_path: Path) -> None:
+    """
+    A target already covered by the cwd subpath must not change the
+    profile — no redundant grants, profile contents byte-identical to
+    the no-target wrap (mirrors the bwrap no-op-target behaviour).
+    """
+    backend = _make_backend()
+    policy = _make_policy(tmp_path, allow_hidden=[".venv"])
+    tool = tmp_path / "tools" / "cli"
+    tool.parent.mkdir()
+    tool.write_text("#!fake\n")
+    tool.chmod(0o755)
+    helper_argv = _safe_helper_argv(tmp_path)
+
+    argv_no_target = backend.wrap_launcher_argv(helper_argv, policy, tmp_path)
+    argv_with_target = backend.wrap_launcher_argv(helper_argv, policy, tmp_path, target=str(tool))
+    assert Path(argv_no_target[2]).read_text() == Path(argv_with_target[2]).read_text(), (
+        "A cwd-covered target must be a no-op for the profile; extra "
+        "grants here mean the coverage check regressed."
+    )
+
+
+def test_wrap_launcher_argv_target_with_unsafe_parent_degrades_not_raises(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    The target lane must NEVER raise (parity with the crash-instead-
+    of-degrade complaint): when the resolved target's parent directory
+    is too broad to grant — an unsafe ancestor, ``$HOME``, or above —
+    the wrap degrades to a literal read on the binary plus an audit
+    WARNING instead of failing the spawn.
+    """
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir()
+    binary = fake_home / "claude"
+    binary.write_bytes(b"\x00fakebun")
+    binary.chmod(0o755)
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+
+    backend = _make_backend()
+    policy = _make_policy(cwd, allow_hidden=[".venv"])
+    with patch(
+        "omnigent.inner.seatbelt_sandbox._UNSAFE_WIDEN_ANCESTORS",
+        frozenset({str(fake_home)}),
+    ):
+        with caplog.at_level("WARNING", logger="omnigent.inner.seatbelt_sandbox"):
+            argv = backend.wrap_launcher_argv(
+                _safe_helper_argv(cwd), policy, cwd, target=str(binary)
+            )
+    profile = Path(argv[2]).read_text()
+
+    assert f"(allow file-read* (literal {_quote(str(binary))}))" in profile, (
+        "The degraded path must still grant a literal read on the "
+        "binary itself — best effort beats a guaranteed crash."
+    )
+    assert f"(allow file-read* (subpath {_quote(str(fake_home))}))" not in profile, (
+        "The refused parent must NOT get a subpath grant — that's the "
+        "sandbox-defeating widening the guard exists to prevent."
+    )
+    assert any("too broad" in record.message for record in caplog.records), (
+        "The degrade must be auditable via a WARNING naming the refused parent."
+    )
+
+
+def test_symlink_hop_literals_survives_cycles(tmp_path: Path) -> None:
+    """
+    A symlink cycle (``a -> b -> a``) must terminate via the
+    visited-set (same contract as the bwrap walk) and still report
+    the symlinks it saw.
+    """
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.symlink_to(b)
+    b.symlink_to(a)
+
+    literals = _symlink_hop_literals(a, [])
+
+    assert a in literals and b in literals, (
+        f"Cycle members should each be collected once; got {literals!r}."
+    )
+    assert len(literals) == 2, f"Cycle must not duplicate entries or spin; got {literals!r}."


### PR DESCRIPTION
## Related issue

Closes #2049

Also fixes the wrap-crash surface of #517 (the `PermissionError` on the CLI the launcher wraps). #517 stays open for its crash-instead-of-degrade half — the interpreter lane still raises on un-grantable layouts by design (H1/H2/H3).

## Summary

The seatbelt backend never got two visibility behaviours bwrap has had for a while, and together they killed every jailed `claude-sdk` seat on macOS:

- **No symlink hop-walk.** `_ensure_executable_visible` granted only `argv[0]`'s literal and fully-resolved paths. uv reaches the interpreter through a version-floating dir symlink (`cpython-3.12 → cpython-3.12.13`); execve reads that symlink at its **literal** path, SBPL subpath rules match only **canonical** paths, so the hop was denied and `sandbox-exec`'s execvp died with EPERM (#2049).
- **`del target`.** `wrap_launcher_argv` discarded the launcher's final target binary (bwrap bind-mounts it). The wrapped claude CLI (`~/.local/bin/claude → ~/.local/share/claude/versions/<v>/claude`) was unreadable inside the profile, crashing the native-tool wrap at connect time (#517's first half).

**ELI5:** the sandbox knew where the program *really* lives and where the shortcut *starts*, but not the shortcuts *in between* — and it threw away the address of the app it was supposed to launch. Now it reads the whole chain of shortcuts and grants each one, plus the app's own folder.

```
argv[0]  ~/.local/share/uv/tools/omnigent/bin/python      ── subpath (install-root, existing)
              │ symlink
              ▼
         …/uv/python/cpython-3.12-macos/bin/python3.12
                        └─ dir symlink ──────────────────── literal  (NEW: hop grant)
              ▼
         …/uv/python/cpython-3.12.13-macos/…              ── subpath (existing)

target   ~/.local/bin/claude ───────────────────────────── literal  (NEW: hop grant)
              │ symlink
              ▼
         ~/.local/share/claude/versions/1.0.61/           ── subpath (NEW: parent-dir grant)
```

Mechanics: `_symlink_hop_literals` mirrors bwrap's 40-hop walk and collects every uncovered symlink component; they're emitted as `(allow file-read* (literal …))` (a symlink read exposes only its target string) and fed to the ancestor-traversal walker for stat-only realpath coverage. The target lane (`_target_visibility_grants`) additionally grants a subpath on the resolved binary's **own directory** — never `$HOME`, `/`, or an `_UNSAFE_WIDEN_ANCESTORS` entry; those degrade to a literal grant plus an audit WARNING instead of raising, so the target lane can't create new spawn crashes.

## Test Plan

- 5 new regression tests in `tests/inner/test_seatbelt_sandbox.py`: the uv versionless-hop profile grant, the claude-CLI target layout (literal + version-dir subpath, nothing wider, ancestors stat-covered), cwd-covered target is a byte-identical no-op, unsafe-parent target degrades with a WARNING instead of raising, and symlink-cycle termination.
- Full suites green locally: `test_seatbelt_sandbox.py` 56 passed / 11 skipped (macOS-gated), `test_bwrap_sandbox.py` + `tests/inner/sandbox/` 51 passed / 26 skipped.
- Live-layout probe: generated a profile against a real `uv tool` install (venv python → versionless `cpython-3.12-linux-x86_64-gnu` hop → real install) and confirmed the emitted grants are exactly the ones issue #2049's reporter validated by hand-editing their profile.
- `pre-commit run` clean on both files.

**Not verified on macOS** (developed on Linux; `sandbox-exec` unavailable). Profile generation is platform-independent and the new grant shape is the one empirically validated in #2049's repro, but a maintainer smoke on a Mac is the real proof:

```bash
# on macOS, with omnigent installed via `uv tool install`:
omnigent run <any claude-sdk agent with os_env.sandbox.type: darwin_seatbelt>
# pre-fix: sandbox-exec execvp EPERM at boot; post-fix: helper boots
```

## Demo

N/A (non-visual sandbox/profile change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = the live-layout profile probe on Linux described above (real uv symlink chain, generated profile inspected for the exact grants). The end-to-end `sandbox-exec` boot needs a macOS box — called out in the Test Plan with a one-line smoke recipe.

## Changelog

Sandboxed (`darwin_seatbelt`) agents now boot when the helper interpreter or the wrapped CLI is reached through symlinks — uv-installed Pythons and the standalone Claude CLI no longer die with `Operation not permitted`.

This pull request and its description were written by Isaac.
