### PR TITLE
fix(claude-sdk): degrade instead of crashing when the CLI wrap is infeasible

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -71,6 +71,7 @@ from .executor import (
 )
 from .sandbox import (
     create_exec_launcher,
+    get_backend,
     resolve_sandbox,
     with_additional_read_roots,
     with_additional_write_files,
@@ -920,6 +921,15 @@ def prepare_claude_cli_path(
 ) -> PreparedClaudeCli:
     """Wrap the Claude CLI in the agent's configured sandbox when possible.
 
+    Degrades instead of crashing: when the sandbox can't be resolved or
+    the wrap can't be built (unsupported platform, un-grantable
+    interpreter layout, profile-size overflow), the CLI is returned
+    unwrapped with native tools disabled — the same confinement story
+    as ``OMNIGENT_CLAUDE_SDK_NO_SANDBOX``: file/shell access still goes
+    through the independently sandboxed ``sys_os_*`` helpers (which
+    fail closed on their own), and only the CLI supervisor process
+    runs unwrapped.
+
     :param real_cli_path: Absolute path to the system-installed Claude CLI
         binary, or ``None`` when no CLI is available.
     :param spec: The agent's ``os_env`` spec.  Only ``caller_process`` specs
@@ -939,7 +949,17 @@ def prepare_claude_cli_path(
         return PreparedClaudeCli(cli_path=real_cli_path, enable_native_tools=True)
 
     cwd = _resolve_sandbox_cwd(spec.cwd)
-    sandbox = resolve_sandbox(spec, cwd)
+    try:
+        sandbox = resolve_sandbox(spec, cwd)
+    except (OSError, NotImplementedError) as exc:
+        logger.warning(
+            "Cannot resolve the configured sandbox for the Claude CLI wrap; "
+            "running the CLI unwrapped with native tools disabled "
+            "(file/shell access stays confined to the sandboxed sys_os_* "
+            "tools): %s",
+            exc,
+        )
+        return PreparedClaudeCli(cli_path=real_cli_path, enable_native_tools=False)
     if not sandbox.active:
         return PreparedClaudeCli(cli_path=real_cli_path, enable_native_tools=False)
     if not sandbox.allow_network:
@@ -950,6 +970,26 @@ def prepare_claude_cli_path(
     sandbox = with_additional_read_roots(sandbox, _claude_internal_write_roots())
     sandbox = with_additional_write_roots(sandbox, _claude_internal_write_roots())
     sandbox = with_additional_write_files(sandbox, _claude_internal_write_files())
+    # Dry-run the spawn-time wrap now, while degrading is still possible.
+    # The real wrap happens later inside run_launcher, where an OSError
+    # (un-grantable interpreter layout, profile-size cap, cwd-scan
+    # overflow) kills the launcher and surfaces as an opaque connect
+    # timeout. By run time native tools are already enabled, so this is
+    # the last point where "skip the wrap" is still safe.
+    try:
+        get_backend(sandbox.backend_type).wrap_launcher_argv(
+            [sys.executable, "-c", "pass"], sandbox, cwd, target=real_cli_path
+        )
+    except OSError as exc:
+        logger.warning(
+            "The configured sandbox cannot wrap the Claude CLI at %s; "
+            "running it unwrapped with native tools disabled (file/shell "
+            "access stays confined to the sandboxed sys_os_* tools). "
+            "Remediation hints in the underlying error: %s",
+            real_cli_path,
+            exc,
+        )
+        return PreparedClaudeCli(cli_path=real_cli_path, enable_native_tools=False)
     return PreparedClaudeCli(
         cli_path=create_exec_launcher(real_cli_path, sandbox),
         enable_native_tools=True,

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -2602,6 +2602,144 @@ def test_prepare_tight_cli_process_path_bypasses_wrapper_when_env_set(monkeypatc
     assert prepare_tight_cli_process_path("/usr/bin/claude") == "/usr/bin/claude"
 
 
+def _wrap_probe_spec():
+    from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+
+    return OSEnvSpec(
+        type="caller_process",
+        cwd="/tmp/work",
+        sandbox=OSEnvSandboxSpec(
+            type="linux_bwrap",
+            read_paths=["."],
+            write_paths=["."],
+            allow_network=True,
+        ),
+    )
+
+
+def _active_policy():
+    from omnigent.inner.sandbox import SandboxPolicy
+
+    return SandboxPolicy(
+        backend_type="linux_bwrap",
+        active=True,
+        read_roots=[Path("/tmp/work")],
+        write_roots=[Path("/tmp/work")],
+        write_files=[],
+        allow_network=True,
+    )
+
+
+def test_prepare_claude_cli_path_degrades_when_resolve_sandbox_fails(monkeypatch, caplog) -> None:
+    """
+    A ``resolve_sandbox`` failure (e.g. ``sandbox-exec`` missing on the
+    host) must NOT crash the seat at connect time. The prepare degrades
+    to the raw CLI with native tools disabled — the same confinement
+    shape as the ``OMNIGENT_CLAUDE_SDK_NO_SANDBOX`` bypass — and warns.
+    """
+    from omnigent.inner.claude_sdk_executor import prepare_claude_cli_path
+
+    def _raise_resolve(*args, **kwargs):
+        raise OSError("darwin_seatbelt requires sandbox-exec on PATH")
+
+    monkeypatch.setattr("omnigent.inner.claude_sdk_executor.resolve_sandbox", _raise_resolve)
+
+    def _fail_if_called(*args, **kwargs) -> str:
+        raise AssertionError("create_exec_launcher must not run when resolve failed")
+
+    monkeypatch.setattr("omnigent.inner.claude_sdk_executor.create_exec_launcher", _fail_if_called)
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.inner.claude_sdk_executor"):
+        prepared = prepare_claude_cli_path("/usr/bin/claude", _wrap_probe_spec())
+
+    assert prepared.cli_path == "/usr/bin/claude"
+    assert prepared.enable_native_tools is False
+    assert any(
+        "Cannot resolve the configured sandbox" in record.getMessage() for record in caplog.records
+    ), [r.getMessage() for r in caplog.records]
+
+
+def test_prepare_claude_cli_path_degrades_when_wrap_probe_fails(monkeypatch, caplog) -> None:
+    """
+    When the backend can resolve but the spawn-time wrap can't be built
+    (un-grantable interpreter layout, profile-size cap, cwd-scan
+    overflow), the OSError previously fired inside ``run_launcher`` and
+    killed the CLI spawn with an opaque connect timeout. The prepare-
+    time probe must catch it and degrade — unwrapped CLI, native tools
+    OFF, loud warning — never raise.
+    """
+    from omnigent.inner.claude_sdk_executor import prepare_claude_cli_path
+
+    monkeypatch.setattr(
+        "omnigent.inner.claude_sdk_executor.resolve_sandbox",
+        lambda *a, **k: _active_policy(),
+    )
+
+    class _RefusingBackend:
+        def wrap_launcher_argv(self, *args, **kwargs):
+            raise OSError("would require widening the sandbox read view")
+
+    monkeypatch.setattr(
+        "omnigent.inner.claude_sdk_executor.get_backend",
+        lambda name: _RefusingBackend(),
+    )
+
+    def _fail_if_called(*args, **kwargs) -> str:
+        raise AssertionError("create_exec_launcher must not run when the wrap probe failed")
+
+    monkeypatch.setattr("omnigent.inner.claude_sdk_executor.create_exec_launcher", _fail_if_called)
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.inner.claude_sdk_executor"):
+        prepared = prepare_claude_cli_path("/usr/bin/claude", _wrap_probe_spec())
+
+    assert prepared.cli_path == "/usr/bin/claude"
+    assert prepared.enable_native_tools is False
+    assert any("cannot wrap the Claude CLI" in record.getMessage() for record in caplog.records), [
+        r.getMessage() for r in caplog.records
+    ]
+
+
+def test_prepare_claude_cli_path_probe_passes_target_and_still_wraps(
+    monkeypatch,
+) -> None:
+    """
+    The happy path is unchanged by the probe: the wrap still happens,
+    native tools stay ON, and the probe exercises the same lane the
+    launcher will (``target=<real CLI>``), so a probe pass means the
+    run-time wrap can build the same grants.
+    """
+    from omnigent.inner.claude_sdk_executor import prepare_claude_cli_path
+
+    monkeypatch.setattr(
+        "omnigent.inner.claude_sdk_executor.resolve_sandbox",
+        lambda *a, **k: _active_policy(),
+    )
+
+    seen: dict[str, object] = {}
+
+    class _OkBackend:
+        def wrap_launcher_argv(self, argv, policy, cwd, chdir=None, target=None):
+            seen["target"] = target
+            return ["bwrap", "--", *argv]
+
+    monkeypatch.setattr(
+        "omnigent.inner.claude_sdk_executor.get_backend",
+        lambda name: _OkBackend(),
+    )
+    monkeypatch.setattr(
+        "omnigent.inner.claude_sdk_executor.create_exec_launcher",
+        lambda path, sandbox: "/tmp/launcher",
+    )
+
+    prepared = prepare_claude_cli_path("/usr/bin/claude", _wrap_probe_spec())
+
+    assert prepared.cli_path == "/tmp/launcher"
+    assert prepared.enable_native_tools is True
+    assert seen["target"] == "/usr/bin/claude", (
+        "The probe must exercise the target lane run_launcher will use."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Tests: _to_anthropic_content_blocks
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

Closes #517

Last piece of the three-part issue: the reported crash (CLI install tree unreadable) was fixed by #2743, and the `OMNIGENT_CLAUDE_SDK_NO_SANDBOX` env-allowlist half already landed on main (`omnigent/host/connect.py`). This PR adds the behaviour the issue actually asked for: **degrade instead of crash** when the wrap is infeasible.

## Summary

Two crash paths survived #2743, both killing the seat at connect time for unusual layouts:

- `prepare_claude_cli_path` called `resolve_sandbox` with no error handling (its sibling `prepare_tight_cli_process_path` already catches and warns) — e.g. a macOS host without `sandbox-exec` crashed at prepare.
- Wrap-time `OSError`s (un-grantable interpreter layout, >64 KB profile cap, `cwd_hidden_scan_overflow: "error"`) fired inside `run_launcher`, where they surface as an opaque exit-71 / 60 s connect timeout.

Fix: catch the resolve failure, and **dry-run the wrap at prepare time** (`wrap_launcher_argv` probe with `target=<real CLI>` — the exact lane `run_launcher` uses). On failure, return the CLI unwrapped with `enable_native_tools=False` plus a loud WARNING — byte-identical contract to the `OMNIGENT_CLAUDE_SDK_NO_SANDBOX` diagnostic path.

**ELI5:** if the straitjacket doesn't fit, we no longer cancel the show — the supervisor walks on stage without it, but its hands (file/shell tools) stay tied: those run through the `sys_os_*` helpers, which wear their own straitjacket and refuse to work without it.

Why prepare time and not inside `run_launcher`: by run time native tools are already enabled, so degrading there would run Claude's Bash/file tools unsandboxed. The prepare-time probe is the last point where "skip the wrap" is still safe, and `run_launcher` stays fail-closed for every other lane (terminals, os_env helpers).

## Test Plan

- 3 new tests beside the existing NO_SANDBOX bypass tests: resolve failure degrades (raw path, tools off, warning), wrap-probe failure degrades (and `create_exec_launcher` provably never runs), and the happy path still wraps with the probe exercising `target=<real CLI>`.
- Full `test_claude_sdk_executor.py` (107) and `test_claude_sdk_harness.py` (23) suites green locally — including the pre-existing prepare test, which now exercises a real bwrap probe un-mocked.
- `ruff check` / `ruff format` / `pre-commit run` clean.

## Demo

N/A (non-visual failure-handling change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Changelog

A sandboxed claude-sdk agent no longer dies at connect time when its sandbox can't wrap the Claude CLI — it starts with native tools disabled (file/shell access stays sandboxed via the `sys_os_*` tools) and logs why.

This pull request and its description were written by Isaac.
