### PR TITLE
feat(setup): offer clickable Hermes CLI install like OpenCode

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10890,16 +10890,19 @@ def _manage_hermes_harness() -> None:
 
     Hermes owns its own auth via ``hermes model`` (interactive provider/model
     picker) and is installed via a curl script from Nous Research — Omnigent
-    stores no Hermes credential. A missing CLI gates the drill-in; when
-    installed, the drill-in offers to launch ``hermes model`` for provider
+    stores no Hermes credential. A missing CLI gates the drill-in with the same
+    three-choice install offer OpenCode uses (run now / back / show command);
+    when installed, the drill-in offers to launch ``hermes model`` for provider
     configuration.
 
-    :returns: None. Side effects: may launch ``hermes model``.
+    :returns: None. Side effects: may run the Hermes curl installer and/or
+        launch ``hermes model``.
     """
     from omnigent.onboarding.harness_install import (
         HERMES_KEY,
         harness_cli_installed,
         harness_install_spec,
+        install_harness_cli,
     )
     from omnigent.onboarding.interactive import console, select
 
@@ -10910,11 +10913,36 @@ def _manage_hermes_harness() -> None:
             if spec and spec.install_hint
             else "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash"
         )
-        console.print(
-            f"  Hermes isn't installed. Install it with:\n    [bold]{hint}[/bold]\n"
-            "  then re-open this menu."
+        choice = select(
+            "Hermes's CLI isn't installed. Install it now?",
+            [
+                f"Yes — install ({hint})",
+                "No — back to harnesses",
+                "I'll run it myself (show the command)",
+            ],
+            descriptions=[
+                f"Runs `{hint}`.",
+                "Return to the harness picker without installing.",
+                "Print the command so you can install it yourself, then return.",
+            ],
+            default=0,
+            clear_on_exit=True,
         )
-        return
+        if choice == 0:
+            console.print(f"  [dim]Installing Hermes — running `{hint}`…[/dim]")
+            if install_harness_cli(HERMES_KEY):
+                console.print("  [green]✓ Hermes installed[/green]")
+            else:
+                console.print(
+                    f"  [red]Install failed.[/red] Run it manually, then re-open: "
+                    f"[bold]{hint}[/bold]"
+                )
+                return
+        elif choice == 2:  # run it yourself
+            console.print(f"  Install Hermes with:\n    [bold]{hint}[/bold]")
+            return
+        else:
+            return
 
     status: str | None = None
     while True:

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -10,8 +10,10 @@ A coding harness is "ready" along two independent axes:
   npm packages it installs.
 
 ``omnigent setup --no-internal-beta`` uses this to mark an uninstalled harness and
-offer to ``npm install`` it; the first-run ``omnigent run`` flow uses the
-same map so the two surfaces never disagree about what the machine can launch.
+offer to install it (``npm install -g …`` for npm CLIs, or the vendor
+``install_hint`` curl/brew command for Hermes and friends); the first-run
+``omnigent run`` flow uses the same map so the two surfaces never disagree
+about what the machine can launch.
 
 This module also owns the per-harness **CLI binary name**, so it is the natural
 home for driving each harness's own *subscription login/logout* commands
@@ -174,8 +176,8 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
     # CLI instead of guessing from a credential file. (The readiness layer still
     # uses the subprocess-free file check ``gemini_login_detected`` for its fast
     # path.) ``agy`` ships via a shell installer rather than npm, so ``package``
-    # is ``None`` and the manual command lives in ``install_hint`` (shown as
-    # guidance; ``install_harness_cli`` refuses to auto-run it).
+    # is ``None`` and the vendor command lives in ``install_hint`` (run by
+    # ``install_harness_cli`` when the setup menu offers "install now").
     GEMINI_FAMILY: HarnessInstallSpec(
         "Antigravity",
         "agy",
@@ -397,23 +399,53 @@ def harness_install_command(key: str) -> list[str]:
     return ["npm", "install", "-g", package]
 
 
+def _ensure_local_bin_on_path() -> None:
+    """Prepend ``~/.local/bin`` to this process's ``PATH`` when missing.
+
+    Vendor curl installers (Hermes, Cursor, Kiro, …) commonly drop the binary
+    there and only amend *shell* config — so without this, a successful install
+    still looks missing until the user restarts the terminal.
+    """
+    local_bin = os.path.join(os.path.expanduser("~"), ".local", "bin")
+    path = os.environ.get("PATH", "")
+    parts = path.split(os.pathsep) if path else []
+    if local_bin not in parts:
+        os.environ["PATH"] = local_bin + (os.pathsep + path if path else "")
+
+
 def install_harness_cli(key: str) -> bool:
-    """Install the harness CLI via npm; return whether it landed on ``PATH``.
+    """Install the harness CLI; return whether it landed on ``PATH``.
 
-    Shells out to :func:`harness_install_command` and re-checks
-    :func:`harness_cli_installed`. Surfaces npm's own output (no capture) so a
-    failing install is visible. Requires ``npm`` on ``PATH``.
+    npm-packaged harnesses shell :func:`harness_install_command`
+    (``npm install -g …``). Curl-/brew-installed harnesses (``package is None``
+    with an ``install_hint``) run that vendor command via ``bash -c`` instead —
+    so setup menus can offer "install now" for Hermes the same way they do for
+    OpenCode. Surfaces the installer's own output (no capture) so a failing
+    install is visible.
 
-    :param key: A harness family or :data:`PI_KEY`.
+    :param key: A harness family or :data:`PI_KEY` / :data:`HERMES_KEY` / ….
     :returns: ``True`` when the CLI is on ``PATH`` after the install attempt
-        (including the no-op case where npm reports success but the binary is
-        present), ``False`` if npm is missing or the install failed.
+        (including the no-op case where the installer reports success but the
+        binary is present), ``False`` if the installer can't run (npm missing
+        for an npm package, no ``install_hint`` for a non-npm CLI) or the
+        install failed.
     :raises KeyError: If *key* has no install spec.
     """
     spec = harness_install_spec(key)
-    if spec is not None and spec.package is None:
-        # Non-npm CLI (e.g. cursor-agent): no auto-install; caller shows install_hint.
-        return False
+    if spec is None:
+        raise KeyError(key)
+    if spec.package is None:
+        hint = spec.install_hint
+        if not hint:
+            return False
+        try:
+            # install_hint is a hardcoded vendor command (e.g. curl | bash), not
+            # user input — bash -c is how the setup menu runs it in-process.
+            subprocess.run(["bash", "-c", hint], check=False, timeout=600)
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        _ensure_local_bin_on_path()
+        return harness_cli_installed(key)
     if shutil.which("npm") is None:
         return False
     cmd = harness_install_command(key)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -38,6 +38,7 @@ from omnigent.cli import (
     _is_run_shorthand,
     _load_global_config,
     _manage_goose_harness,
+    _manage_hermes_harness,
     _manage_kimi_harness,
     _manage_qwen_harness,
     _materialize_harness_launcher_file,
@@ -5324,6 +5325,81 @@ def test_manage_qwen_harness_back_does_not_launch(
     _manage_qwen_harness()
 
     launch.assert_not_called()
+
+
+# ── omnigent setup: Hermes drill-in (_manage_hermes_harness) ─────────────
+
+
+def test_manage_hermes_harness_offers_install_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing hermes CLI shows the OpenCode-style install picker.
+
+    Choosing "Yes — install" runs ``install_harness_cli``; declining returns
+    without reaching the ``hermes model`` menu.
+    """
+    import omnigent.onboarding.harness_install as hi
+    import omnigent.onboarding.interactive as it
+
+    monkeypatch.setattr(hi, "harness_cli_installed", lambda key: False)
+    console = Mock()
+    monkeypatch.setattr(it, "console", console)
+    install = Mock(return_value=False)
+    monkeypatch.setattr(hi, "install_harness_cli", install)
+    # Pick "I'll run it myself" (2) — print the command and return.
+    monkeypatch.setattr(it, "select", lambda *a, **k: 2)
+
+    _manage_hermes_harness()
+
+    install.assert_not_called()
+    printed = " ".join(str(c.args[0]) for c in console.print.call_args_list if c.args)
+    assert "hermes-agent.nousresearch.com/install.sh" in printed
+
+
+def test_manage_hermes_harness_install_now_runs_installer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Choosing "Yes — install" shells the Hermes curl installer."""
+    import omnigent.onboarding.harness_install as hi
+    import omnigent.onboarding.interactive as it
+
+    # Missing until install succeeds; then the post-install menu can open.
+    installed = {"ok": False}
+
+    def _cli_installed(key: str) -> bool:
+        return installed["ok"] if key == hi.HERMES_KEY else False
+
+    def _install(key: str) -> bool:
+        assert key == hi.HERMES_KEY
+        installed["ok"] = True
+        return True
+
+    monkeypatch.setattr(hi, "harness_cli_installed", _cli_installed)
+    monkeypatch.setattr(hi, "install_harness_cli", _install)
+    monkeypatch.setattr(it, "console", Mock())
+    # First select: install offer → Yes (0). Second: Hermes Agent menu → Back (1).
+    choices = iter([0, 1])
+    monkeypatch.setattr(it, "select", lambda *a, **k: next(choices))
+
+    _manage_hermes_harness()
+
+    assert installed["ok"] is True
+
+
+def test_manage_hermes_harness_back_does_not_launch_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the CLI installed, choosing "← Back" exits without ``hermes model``."""
+    import omnigent.onboarding.harness_install as hi
+    import omnigent.onboarding.interactive as it
+
+    monkeypatch.setattr(hi, "harness_cli_installed", lambda key: True)
+    monkeypatch.setattr(it, "console", Mock())
+    # rows = [Run hermes model, ← Back]; pick Back (1). If model were wrongly
+    # launched, the inline ``subprocess.run`` would escape the stubbed select.
+    monkeypatch.setattr(it, "select", lambda *a, **k: 1)
+
+    _manage_hermes_harness()
 
 
 # ── omnigent setup: Goose drill-in (_manage_goose_harness) ───────────────

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -152,20 +152,80 @@ def test_install_command_rejects_non_npm_harness() -> None:
         hi.harness_install_command(hi.KIRO_KEY)
 
 
-def test_install_harness_cli_noop_for_non_npm(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``install_harness_cli`` never shells npm for a non-npm CLI.
+def test_hermes_install_spec_is_curl_installer_no_npm() -> None:
+    """Hermes ships via Nous Research's curl installer (no npm package)."""
+    spec = hi.harness_install_spec(hi.HERMES_KEY)
+    assert spec is not None
+    assert spec.display == "Hermes"
+    assert spec.binary == "hermes"
+    assert spec.package is None
+    assert spec.install_hint == (
+        "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash"
+    )
 
-    It returns ``False`` without spawning anything, so the menu falls back to
-    the manual ``install_hint`` rather than running a bogus npm command.
+
+def test_install_harness_cli_runs_shell_hint_for_non_npm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-npm CLIs install via ``bash -c <install_hint>``, not ``npm``.
+
+    Setup menus (Hermes, …) offer "install now" the same way OpenCode does for
+    npm packages; this is the shared install path those menus call.
     """
-    monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
+    calls: list[list[str]] = []
+    state = {"installed": False}
+
+    def _which(name: str) -> str | None:
+        if name == "hermes":
+            return "/home/x/.local/bin/hermes" if state["installed"] else None
+        return None
+
+    def _run(argv: list[str], *, check: bool = False, timeout: float | None = None):
+        calls.append(argv)
+        state["installed"] = True
+        return subprocess.CompletedProcess(args=argv, returncode=0)
+
+    monkeypatch.setattr(hi.shutil, "which", _which)
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+
+    assert hi.install_harness_cli(hi.HERMES_KEY) is True
+    assert len(calls) == 1
+    assert calls[0][:2] == ["bash", "-c"]
+    assert "hermes-agent.nousresearch.com/install.sh" in calls[0][2]
+    # Never an npm argv for a curl-installed harness.
+    assert all(c[0] != "npm" for c in calls)
+
+
+def test_install_harness_cli_shell_hint_missing_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shell installer that leaves the binary off PATH reports failure."""
+    monkeypatch.setattr(hi.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        hi.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(args=a[0], returncode=0),
+    )
+    assert hi.install_harness_cli(hi.HERMES_KEY) is False
+
+
+def test_install_harness_cli_no_hint_returns_false_without_spawn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A package-less spec with no ``install_hint`` is a no-op (no spawn)."""
+    from omnigent.harness_install_spec import HarnessInstallSpec
+
+    monkeypatch.setitem(
+        hi._HARNESS_INSTALL,
+        "no-hint",
+        HarnessInstallSpec("NoHint", "nohint", package=None, install_hint=None),
+    )
 
     def _explode(*a: object, **k: object) -> None:
-        raise AssertionError("npm install spawned for a non-npm harness")
+        raise AssertionError("subprocess.run spawned despite no install_hint")
 
     monkeypatch.setattr(hi.subprocess, "run", _explode)
-    assert hi.install_harness_cli(hi.CURSOR_KEY) is False
-    assert hi.install_harness_cli(hi.KIRO_KEY) is False
+    assert hi.install_harness_cli("no-hint") is False
 
 
 def test_unknown_key_has_no_spec_and_is_not_installed() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Clicking Hermes in `omni setup` previously only printed a curl command and told you to re-open the menu — unlike OpenCode/Qwen, which offer a selectable "Yes — install" action. That made Hermes feel broken compared to the other harnesses.

This matches Hermes to the OpenCode install UX: a three-choice picker (install now / back / show command), and `install_harness_cli` now runs a non-npm harness's `install_hint` via `bash -c` (then prepends `~/.local/bin` to PATH so the new binary is visible without restarting the shell).

- Hermes drill-in offers the same install picker OpenCode uses when the CLI is missing
- Shared `install_harness_cli` supports vendor curl/brew installers, not only npm packages
- Unit coverage for the shell install path and the Hermes setup menu choices

## Test Plan

- [x] `uv run pytest` on the new/updated Hermes install + setup menu tests (9 passed)
- [x] `uv run ruff check` / `ruff format --check` on touched files
- [ ] Manual: `omni setup` → Harnesses → Hermes with `hermes` missing from PATH; confirm picker offers install, and "Yes — install" runs the curl installer

## Demo

N/A — CLI menu flow (non-visual web UI)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage stubs the installer and menu selections. Live curl install against Nous Research's script was not run in this environment.

## Changelog

`omni setup` can install the Hermes CLI from the menu instead of only printing the curl command