### PR TITLE
[cli] Install Hermes from setup flow

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10875,20 +10875,21 @@ def _manage_acp_agent(slug: str) -> None:
 
 
 def _manage_hermes_harness() -> None:
-    """Run the level-2 loop for Hermes: ensure the CLI is installed.
+    """Run the level-2 loop for Hermes: install the CLI, then configure it.
 
     Hermes owns its own auth via ``hermes model`` (interactive provider/model
     picker) and is installed via a curl script from Nous Research — Omnigent
-    stores no Hermes credential. A missing CLI gates the drill-in; when
-    installed, the drill-in offers to launch ``hermes model`` for provider
-    configuration.
+    stores no Hermes credential. A missing CLI offers to run the vendor
+    installer; when installed, the drill-in offers to launch ``hermes model``
+    for provider configuration.
 
-    :returns: None. Side effects: may launch ``hermes model``.
+    :returns: None. Side effects: may install Hermes or launch ``hermes model``.
     """
     from omnigent.onboarding.harness_install import (
         HERMES_KEY,
         harness_cli_installed,
         harness_install_spec,
+        install_harness_cli,
     )
     from omnigent.onboarding.interactive import console, select
 
@@ -10899,11 +10900,36 @@ def _manage_hermes_harness() -> None:
             if spec and spec.install_hint
             else "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash"
         )
-        console.print(
-            f"  Hermes isn't installed. Install it with:\n    [bold]{hint}[/bold]\n"
-            "  then re-open this menu."
+        choice = select(
+            "Hermes isn't installed. Install it now?",
+            [
+                f"Yes — install ({hint})",
+                "No — back to harnesses",
+                "I'll run it myself (show the command)",
+            ],
+            descriptions=[
+                f"Runs `{hint}`.",
+                "Return to the harness picker without installing.",
+                "Print the command so you can install it yourself, then return.",
+            ],
+            default=0,
+            clear_on_exit=True,
         )
-        return
+        if choice == 0:
+            console.print(f"  [dim]Installing Hermes — running `{hint}`…[/dim]")
+            if install_harness_cli(HERMES_KEY):
+                console.print("  [green]✓ Hermes installed[/green]")
+            else:
+                console.print(
+                    f"  [red]Install failed.[/red] Run it manually, then re-open: "
+                    f"[bold]{hint}[/bold]"
+                )
+                return
+        elif choice == 2:
+            console.print(f"  Install Hermes with:\n    [bold]{hint}[/bold]")
+            return
+        else:
+            return
 
     status: str | None = None
     while True:

--- a/omnigent/harness_install_spec.py
+++ b/omnigent/harness_install_spec.py
@@ -23,3 +23,4 @@ class HarnessInstallSpec:
     install_hint: str | None = None
     login_status_key: str | None = None
     auth_hint: str | None = None
+    install_command: tuple[str, ...] | None = None

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -40,6 +40,7 @@ import os
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 from omnigent.harness_install_spec import HarnessInstallSpec
 from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, GEMINI_FAMILY, OPENAI_FAMILY
@@ -88,6 +89,8 @@ COPILOT_KEY = "copilot"
 # authenticates through its own ``hermes model`` interactive flow (no
 # Omnigent-managed credentials). The ``hermes`` binary must be on PATH.
 HERMES_KEY = "hermes"
+
+_HERMES_INSTALL_HINT = "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash"
 
 
 # Keyed by harness family (Claude=anthropic, Codex=openai) plus the pi
@@ -194,7 +197,8 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         "Hermes",
         "hermes",
         package=None,
-        install_hint="curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash",
+        install_hint=_HERMES_INSTALL_HINT,
+        install_command=("bash", "-c", _HERMES_INSTALL_HINT),
     ),
 }
 
@@ -378,11 +382,12 @@ def harness_cli_installed(key: str) -> bool:
 
 
 def harness_install_command(key: str) -> list[str]:
-    """Return the argv that installs the harness CLI, e.g. ``npm install -g …``.
+    """Return the argv that installs the harness CLI.
 
     :param key: A harness family or :data:`PI_KEY`.
-    :returns: The install command, e.g.
-        ``["npm", "install", "-g", "@anthropic-ai/claude-code"]``.
+    :returns: The install command, e.g. ``["npm", "install", "-g",
+        "@anthropic-ai/claude-code"]`` or an explicitly configured vendor
+        installer command.
     :raises KeyError: If *key* has no install spec (caller should gate on
         :func:`harness_install_spec`).
     :raises ValueError: If *key* has a spec but no npm ``package`` (a CLI
@@ -391,6 +396,8 @@ def harness_install_command(key: str) -> list[str]:
     spec = harness_install_spec(key)
     if spec is None:
         raise KeyError(key)
+    if spec.install_command is not None:
+        return list(spec.install_command)
     package = spec.package
     if package is None:
         raise ValueError(f"{key!r} has no npm package; show its install_hint instead")
@@ -398,11 +405,12 @@ def harness_install_command(key: str) -> list[str]:
 
 
 def install_harness_cli(key: str) -> bool:
-    """Install the harness CLI via npm; return whether it landed on ``PATH``.
+    """Install the harness CLI; return whether it landed on ``PATH``.
 
     Shells out to :func:`harness_install_command` and re-checks
-    :func:`harness_cli_installed`. Surfaces npm's own output (no capture) so a
-    failing install is visible. Requires ``npm`` on ``PATH``.
+    :func:`harness_cli_installed`. Surfaces the installer's own output (no
+    capture) so a failing install is visible. Harnesses without an npm package
+    or explicit installer command remain manual-only.
 
     :param key: A harness family or :data:`PI_KEY`.
     :returns: ``True`` when the CLI is on ``PATH`` after the install attempt
@@ -411,16 +419,29 @@ def install_harness_cli(key: str) -> bool:
     :raises KeyError: If *key* has no install spec.
     """
     spec = harness_install_spec(key)
-    if spec is not None and spec.package is None:
-        # Non-npm CLI (e.g. cursor-agent): no auto-install; caller shows install_hint.
-        return False
-    if shutil.which("npm") is None:
+    if spec is not None and spec.package is None and spec.install_command is None:
+        # Manual-only CLI (e.g. cursor-agent): caller shows install_hint.
         return False
     cmd = harness_install_command(key)
+    if shutil.which(cmd[0]) is None:
+        return False
     try:
         subprocess.run(cmd, check=False, timeout=300)
     except (OSError, subprocess.TimeoutExpired):
         return False
+    if harness_cli_installed(key):
+        return True
+
+    # uv-based vendor installers commonly place entry points here and update
+    # shell startup files, which cannot change this already-running process.
+    if spec is not None:
+        user_bin = Path.home() / ".local" / "bin"
+        candidate = user_bin / spec.binary
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            current_path = os.environ.get("PATH", "")
+            path_entries = current_path.split(os.pathsep) if current_path else []
+            if str(user_bin) not in path_entries:
+                os.environ["PATH"] = os.pathsep.join([str(user_bin), *path_entries])
     return harness_cli_installed(key)
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -38,6 +38,7 @@ from omnigent.cli import (
     _is_run_shorthand,
     _load_global_config,
     _manage_goose_harness,
+    _manage_hermes_harness,
     _manage_kimi_harness,
     _manage_qwen_harness,
     _materialize_harness_launcher_file,
@@ -5324,6 +5325,48 @@ def test_manage_qwen_harness_back_does_not_launch(
     _manage_qwen_harness()
 
     launch.assert_not_called()
+
+
+# ── omnigent setup: Hermes drill-in (_manage_hermes_harness) ─────────────
+
+
+def test_manage_hermes_harness_installs_then_opens_config_menu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accepting the Hermes install offer continues directly to configuration."""
+    import omnigent.onboarding.harness_install as hi
+    import omnigent.onboarding.interactive as it
+
+    monkeypatch.setattr(hi, "harness_cli_installed", lambda key: False)
+    install = Mock(return_value=True)
+    monkeypatch.setattr(hi, "install_harness_cli", install)
+    monkeypatch.setattr(it, "console", Mock())
+    select = Mock(side_effect=[0, 1])
+    monkeypatch.setattr(it, "select", select)
+
+    _manage_hermes_harness()
+
+    install.assert_called_once_with(hi.HERMES_KEY)
+    assert "Install it now?" in select.call_args_list[0].args[0]
+    assert select.call_args_list[1].args[0] == "Hermes Agent"
+
+
+def test_manage_hermes_harness_declines_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Declining the Hermes install offer returns without running the script."""
+    import omnigent.onboarding.harness_install as hi
+    import omnigent.onboarding.interactive as it
+
+    monkeypatch.setattr(hi, "harness_cli_installed", lambda key: False)
+    install = Mock()
+    monkeypatch.setattr(hi, "install_harness_cli", install)
+    monkeypatch.setattr(it, "console", Mock())
+    monkeypatch.setattr(it, "select", lambda *args, **kwargs: 1)
+
+    _manage_hermes_harness()
+
+    install.assert_not_called()
 
 
 # ── omnigent setup: Goose drill-in (_manage_goose_harness) ───────────────

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -106,6 +107,19 @@ def test_kiro_install_spec_is_manual_installer_no_npm() -> None:
     assert spec.binary == "kiro-cli"
     assert spec.package is None
     assert spec.install_hint == "curl -fsSL https://cli.kiro.dev/install | bash"
+
+
+def test_hermes_install_spec_has_actionable_vendor_installer() -> None:
+    """Hermes' trusted vendor installer can be launched from the setup menu."""
+    spec = hi.harness_install_spec(hi.HERMES_KEY)
+    assert spec is not None
+    assert spec.package is None
+    assert spec.install_hint is not None
+    assert hi.harness_install_command(hi.HERMES_KEY) == [
+        "bash",
+        "-c",
+        spec.install_hint,
+    ]
 
 
 def test_antigravity_install_spec_status_only_no_npm() -> None:
@@ -340,6 +354,65 @@ def test_install_harness_cli_runs_npm_then_rechecks(monkeypatch: pytest.MonkeyPa
 
     assert hi.install_harness_cli(OPENAI_FAMILY) is True
     assert calls == [["npm", "install", "-g", "@openai/codex"]]
+
+
+def test_install_harness_cli_runs_hermes_installer_then_rechecks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Hermes installer is interactive-menu actionable and PATH-verified."""
+    calls: list[list[str]] = []
+    state = {"installed": False}
+
+    def _which(name: str) -> str | None:
+        if name == "bash":
+            return "/bin/bash"
+        if name == "hermes" and state["installed"]:
+            return "/usr/local/bin/hermes"
+        return None
+
+    def _run(argv: list[str], *, check: bool = False, timeout: float | None = None):
+        calls.append(argv)
+        state["installed"] = True
+        return subprocess.CompletedProcess(args=argv, returncode=0)
+
+    monkeypatch.setattr(hi.shutil, "which", _which)
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+
+    assert hi.install_harness_cli(hi.HERMES_KEY) is True
+    spec = hi.harness_install_spec(hi.HERMES_KEY)
+    assert spec is not None
+    assert spec.install_hint is not None
+    assert calls == [["bash", "-c", spec.install_hint]]
+
+
+def test_install_harness_cli_refreshes_user_local_bin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A vendor install into ~/.local/bin is usable without restarting setup."""
+    user_bin = tmp_path / ".local" / "bin"
+    user_bin.mkdir(parents=True)
+    hermes = user_bin / "hermes"
+    hermes.write_text("#!/bin/sh\n")
+    hermes.chmod(0o755)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    def _which(name: str) -> str | None:
+        if name == "bash":
+            return "/bin/bash"
+        if name == "hermes" and str(user_bin) in hi.os.environ["PATH"].split(hi.os.pathsep):
+            return str(hermes)
+        return None
+
+    monkeypatch.setattr(hi.shutil, "which", _which)
+    monkeypatch.setattr(
+        hi.subprocess,
+        "run",
+        lambda argv, *, check=False, timeout=None: subprocess.CompletedProcess(argv, 0),
+    )
+
+    assert hi.install_harness_cli(hi.HERMES_KEY) is True
+    assert hi.os.environ["PATH"].split(hi.os.pathsep)[0] == str(user_bin)
 
 
 def test_harness_login_skips_when_already_logged_in(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Related issue

N/A — reported directly.

## Summary

Hermes setup currently stops at a copy-paste installer hint, unlike OpenCode's actionable install flow. This adds the same install/back/show-command choice to the Hermes drill-in and continues directly to provider configuration after a successful install.

- Declare the trusted Nous Research installer as explicit harness metadata while leaving other curl-only harnesses manual-only.
- Re-check the installed binary and expose `~/.local/bin` to the current process when the installer updates shell startup files, avoiding a setup restart.

## Test Plan

- [x] `pytest --noconftest tests/onboarding/test_harness_install.py tests/cli/test_configure_models.py -q -k 'harness_install or hermes'` (73 passed)
- [x] `pytest --noconftest tests/onboarding/test_harness_install.py tests/cli/test_cli.py -q -k 'hermes or install_harness_cli or install_command_rejects_non_npm_harness'` (12 passed)
- [x] `pre-commit run --files omnigent/cli.py omnigent/harness_install_spec.py omnigent/onboarding/harness_install.py tests/cli/test_cli.py tests/onboarding/test_harness_install.py`
- [x] `mypy omnigent/harness_install_spec.py omnigent/onboarding/harness_install.py`

## Demo

N/A — CLI-only change; the vendor installer subprocess is covered with unit-test fakes to avoid modifying the test machine.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The real vendor installer was not run because it downloads software and changes the developer machine. Tests cover accepting and declining the prompt, exact installer argv, post-install binary detection, `~/.local/bin` PATH refresh, and continuation into the Hermes configuration menu.

## Changelog

`omnigent setup` can now install Hermes directly before configuring its model provider.
