### PR TITLE
fix(repl): reconcile to server-relaunched runner on stale bind

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -1800,10 +1800,15 @@ class _SessionsChatReplAdapter:
                     file=sys.stderr,
                     flush=True,
                 )
-            session = await self._client.sessions.bind_runner(
-                self._session_id,
-                runner_id=self._runner_id,
-            )
+            try:
+                session = await self._client.sessions.bind_runner(
+                    self._session_id,
+                    runner_id=self._runner_id,
+                )
+            except OmnigentError as exc:
+                session = await self._reconcile_runner_after_bind_failure(exc)
+                if session is None:
+                    raise
             self._hydrate_from_session_snapshot(session)
             self._clear_runner_recovery_error()
             if _dbg:
@@ -1812,6 +1817,36 @@ class _SessionsChatReplAdapter:
                     file=sys.stderr,
                     flush=True,
                 )
+
+    async def _reconcile_runner_after_bind_failure(self, exc: OmnigentError) -> Session | None:
+        """
+        Adopt the server's live runner after a stale-runner bind failure.
+
+        A dead runner that the server has relaunched under a new id leaves
+        the cached ``_runner_id`` stale, so the bind 400s forever. Re-read
+        the snapshot and rebind onto the runner the server now reports.
+
+        Only when the server owns relaunch (``runner_recover is None``); a
+        client-owned runner is driven by ``_recover_runner_if_needed``.
+
+        :param exc: The bind failure to recover from.
+        :returns: The rebind snapshot, or ``None`` to re-raise *exc*.
+        """
+        if self._runner_recover is not None:
+            return None
+        if not self._is_terminal_runner_recovery_error(exc):
+            return None
+        if self._session_id is None:
+            return None
+        snapshot = await self._client.sessions.get(self._session_id)
+        live_runner_id = snapshot.runner_id
+        if not live_runner_id or live_runner_id == self._runner_id:
+            return None
+        self._runner_id = live_runner_id
+        return await self._client.sessions.bind_runner(
+            self._session_id,
+            runner_id=live_runner_id,
+        )
 
     def _clear_runner_recovery_error(self) -> None:
         """

--- a/tests/repl/test_agent_switch_refresh.py
+++ b/tests/repl/test_agent_switch_refresh.py
@@ -18,6 +18,7 @@ is exercised — not a re-implementation of it.
 from __future__ import annotations
 
 import pytest
+from omnigent_client._errors import InvalidInputError
 from omnigent_client._sessions import Session as SessionSnapshot
 from omnigent_ui_sdk import RichBlockFormatter
 from rich.text import Text
@@ -409,3 +410,122 @@ async def test_refresh_preserves_client_owned_runner_id() -> None:
     )
 
     assert adapter._runner_id == "runner_token_client"
+
+
+class _StaleBindSessions:
+    """
+    ``client.sessions`` stub modelling a server-relaunched runner.
+
+    ``bind_runner`` 400s any runner but the live one; ``get`` reports the
+    live runner the session is now bound to.
+
+    :param live_runner_id: Runner the snapshot is bound to, e.g.
+        ``"runner_token_new"``.
+    """
+
+    def __init__(self, live_runner_id: str) -> None:
+        self._live_runner_id = live_runner_id
+        self.bind_calls: list[str] = []
+        self.get_calls: list[str] = []
+
+    async def bind_runner(self, session_id: str, *, runner_id: str) -> SessionSnapshot:
+        """
+        Accept the live runner; 400 any other id like the server does.
+
+        :param session_id: Session being bound (ignored).
+        :param runner_id: Runner id the adapter is binding.
+        :returns: Snapshot bound to *runner_id* when it is live.
+        :raises InvalidInputError: When *runner_id* is not the live runner.
+        """
+        self.bind_calls.append(runner_id)
+        if runner_id != self._live_runner_id:
+            raise InvalidInputError(
+                f"runner {runner_id!r} is not registered",
+                status_code=400,
+                code="invalid_input",
+            )
+        return _runner_snapshot(runner_id)
+
+    async def get(self, session_id: str) -> SessionSnapshot:
+        """
+        Serve the snapshot bound to the live runner.
+
+        :param session_id: Session id requested (ignored).
+        :returns: Snapshot bound to the live runner.
+        """
+        self.get_calls.append(session_id)
+        return _runner_snapshot(self._live_runner_id)
+
+
+class _StaleBindClient:
+    """Client stub whose sessions surface models a relaunched runner."""
+
+    def __init__(self, live_runner_id: str) -> None:
+        self.sessions = _StaleBindSessions(live_runner_id)
+
+
+@pytest.mark.asyncio
+async def test_bind_reconciles_to_relaunched_runner_on_not_registered() -> None:
+    """A "not registered" bind failure adopts the snapshot's live runner.
+
+    Regression for the stale-runner deadlock: the adapter is pinned to a
+    dead runner the server has relaunched under a new id, so the bind 400s
+    on every send. The bind path must re-read the snapshot, adopt the live
+    runner, and rebind.
+    """
+    client = _StaleBindClient("runner_token_new")
+    adapter = _make_adapter(client)
+    adapter._runner_id = "runner_token_old"
+    adapter._bound_runner_id = None
+
+    await adapter._bind_runner_if_needed()
+
+    assert adapter._runner_id == "runner_token_new"
+    assert adapter._bound_runner_id == "runner_token_new"
+    # First bind uses the stale id (fails), second uses the reconciled id.
+    assert client.sessions.bind_calls == ["runner_token_old", "runner_token_new"]
+    assert client.sessions.get_calls == ["conv_abc"]
+
+
+@pytest.mark.asyncio
+async def test_bind_reraises_when_snapshot_has_no_live_runner() -> None:
+    """A snapshot with no runner leaves nothing to adopt — re-raise.
+
+    With no bound runner to reconcile onto, the original error must
+    propagate so the REPL shows its recovery message instead of hanging.
+    """
+    client = _StaleBindClient("runner_token_new")
+    # Snapshot reports no live runner despite the bind rejection.
+    client.sessions._live_runner_id = None  # type: ignore[assignment]
+    adapter = _make_adapter(client)
+    adapter._runner_id = "runner_token_old"
+    adapter._bound_runner_id = None
+
+    with pytest.raises(InvalidInputError):
+        await adapter._bind_runner_if_needed()
+
+    assert adapter._runner_id == "runner_token_old"
+
+
+@pytest.mark.asyncio
+async def test_bind_does_not_reconcile_with_client_owned_runner() -> None:
+    """With a recovery callback set, the bind path leaves the runner alone.
+
+    A client-owned runner is driven by ``_recover_runner_if_needed``, so
+    reconciliation must not fetch the snapshot or override ``_runner_id``.
+    """
+    client = _StaleBindClient("runner_token_new")
+    adapter = _SessionsChatReplAdapter(
+        client,  # type: ignore[arg-type]
+        "nessie",
+        session_id="conv_abc",
+        runner_id="runner_token_client",
+        runner_recover=lambda: "runner_token_client",
+    )
+    adapter._bound_runner_id = None
+
+    with pytest.raises(InvalidInputError):
+        await adapter._bind_runner_if_needed()
+
+    assert adapter._runner_id == "runner_token_client"
+    assert client.sessions.get_calls == []


### PR DESCRIPTION


<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

NA

## Summary

When a run-spawned runner dies, the server relaunches and rebinds the session to a new runner, but the CLI stays pinned to the launch-time runner id. The bind then 400s with "runner ... is not registered" before any turn dispatches, so the turn-start metadata refresh that would adopt the live runner never fires and every send fails forever.

On a terminal runner-state bind failure, re-read the session snapshot, adopt the server's live runner, and rebind once. Guarded to the server-owned relaunch case (runner_recover is None); re-raises when the snapshot shows no live runner so the actionable error still surfaces.

## Test Plan

Added three unit tests in `tests/repl/test_agent_switch_refresh.py` driving the real `_SessionsChatReplAdapter._bind_runner_if_needed` against a stub `client.sessions` that models the server states from the incident (bind 400s the stale runner, snapshot reports the live relaunched runner):

- reconciles a "not registered" bind failure to the relaunched runner and rebinds
- re-raises when the snapshot has no live runner (genuinely needs a relaunch)
- does not reconcile when a client-owned runner_recover callback is set

Before/after check: reverting the production change makes `test_bind_reconciles_to_relaunched_runner_on_not_registered` fail with the exact incident error (InvalidInputError: runner '...' is not registered); restoring it passes.

Not covered: a live end-to-end repro (kill a real runner mid-session and assert send recovers). The unit tests encode the deadlock mechanism inferred from the CLI/runner logs and the code paths, not a full server replay.

## Demo

NA

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the unit tests above.

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

Recover automatically when a session's runner is relaunched server-side, instead of failing every message with "runner is not registered"
