### PR TITLE
fix(benchmark-pr): continue-on-error for PR comment step on fork PRs

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -152,6 +152,9 @@ jobs:
           } > comment_body.md
 
       - name: Post PR comment
+        # Fork PRs have a read-only GITHUB_TOKEN so the comment may fail —
+        # that's acceptable; results are still available in the artifact.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Related issue

N/A

## Summary

The benchmark PR job was failing on fork PRs (e.g. #2574) because `GITHUB_TOKEN` is read-only for fork `pull_request` events — GitHub's security model prevents forks from writing back to the base repo. The `gh pr comment` step was failing with a 403, which failed the whole job even when the benchmark itself passed.

Added `continue-on-error: true` to the "Post PR comment" step. Results are still available in the uploaded artifact; the comment is best-effort.

## Test Plan

- Reproduced by checking the failed job at https://github.com/omnigent-ai/omnigent/actions/runs/29524857966/job/87710652426 — the only failing step was "Post PR comment", and "Fail on regression" was correctly skipped (no regression).
- One-line fix with no logic change.

## Demo

N/A

## Type of change

- [x] Bug fix
- [x] Test / CI

## Test coverage

- [x] Not applicable

## Coverage notes

CI-only fix; no application logic changed.