### PR TITLE
test(runtime): add coverage for the model-change respawn happy path

### DIFF
--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -460,6 +460,58 @@ async def test_get_client_respawns_on_harness_change(
         _HARNESS_MODULES.pop("test2", None)
 
 
+async def test_get_client_respawns_on_model_change(
+    manager: HarnessProcessManager,
+) -> None:
+    """A different model for the same conversation respawns the subprocess.
+
+    Mirrors the harness-change branch above: the model is baked into the
+    subprocess env at spawn time, so a later turn with a different model
+    must respawn, or the cached process keeps serving the old one. Covers
+    the real ``/model`` switch path via ``post_responses`` in production,
+    previously untested. Also checks the inverse: same model, no respawn.
+    """
+    await manager.start()
+    try:
+        client_first = await manager.get_client(
+            "conv_a",
+            _TEST_HARNESS_NAME,
+            env={"HARNESS_TEST_MODEL": "model-a"},
+        )
+        pid_first = (await client_first.get("/pid")).json()["pid"]
+
+        # Same conversation, SAME model → must reuse the cached subprocess.
+        client_same = await manager.get_client(
+            "conv_a",
+            _TEST_HARNESS_NAME,
+            env={"HARNESS_TEST_MODEL": "model-a"},
+        )
+        pid_same = (await client_same.get("/pid")).json()["pid"]
+        assert pid_same == pid_first
+
+        # Same conversation, DIFFERENT model → must respawn.
+        client_second = await manager.get_client(
+            "conv_a",
+            _TEST_HARNESS_NAME,
+            env={"HARNESS_TEST_MODEL": "model-b"},
+        )
+        pid_second = (await client_second.get("/pid")).json()["pid"]
+
+        # Different PID proves the model-change branch tore down the old
+        # subprocess and spawned a new one. Same PID would mean the model
+        # switch kept serving the old model (the bug this branch guards).
+        assert pid_second != pid_first
+        assert _pid_alive(pid_second)
+        # The original subprocess was terminated by the respawn's close.
+        for _ in range(40):
+            if not _pid_alive(pid_first):
+                break
+            await asyncio.sleep(0.05)
+        assert not _pid_alive(pid_first)
+    finally:
+        await manager.shutdown()
+
+
 async def test_get_client_any_harness_sentinel_reuses_subprocess(
     manager: HarnessProcessManager,
 ) -> None:


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

N/A - This is a follow-up to the review discussion on #2226 and is not tied to its own issue.

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->
- `get_client`'s model-change respawn branch (a concrete harness receiving a different model for the same conversation) had no direct test coverage, despite being a real path reachable in production via `post_responses`.
- Adds `test_get_client_respawns_on_model_change`, covering both directions: a different model triggers a respawn (new subprocess, old one torn down), and the same model reuses the cached subprocess (no spurious respawn).
- Suggested by @fanzeyi when closing #2226: the "any"-sentinel fix in that PR turned out to be a no-op for every existing caller, but the review surfaced that this adjacent happy path had zero coverage.

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->
- `uv run pytest tests/runtime/harnesses/test_process_manager.py::test_get_client_respawns_on_model_change`, passes.
- `uv run pytest tests/runtime/harnesses/test_process_manager.py` -> full suite, 39/39 pass, no regressions.
- Verified the test is meaningful: temporarily disabled the model-change respawn branch in `process_manager.py` and confirmed the new test fails, then restored the source (no source changes in this PR, test-only).
- `uv run ruff check` / `ruff format --check` / `pre-commit run --files` on the changed file, all tests pass clean.

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->
`N/A`, backend test only, no surface UI changes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [X] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->
This PR adds coverage rather than fixing a bug. The model-change respawn behavior already worked correctly on `main`; this test proves it and guards against future regressions on that path.


