### PR TITLE
feat(server): add atomic event admission

### DIFF
--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -8,6 +8,10 @@ Policies are declarative gates that enforce rules on agent behavior. They evalua
 
 Policies compose: multiple policies can be active at once. The engine evaluates them in declaration order. A DENY from any policy short-circuits the rest.
 
+Server embedders that need the runner's atomic turn-versus-buffer decision in a
+REQUEST policy can use the opt-in
+[session-event admission extension](SESSION_EVENT_ADMISSION.md).
+
 ## Who configures policies
 
 Policies are set at three levels. Each level serves a different persona:

--- a/docs/SESSION_EVENT_ADMISSION.md
+++ b/docs/SESSION_EVENT_ADMISSION.md
@@ -1,0 +1,75 @@
+# Experimental session-event admission
+
+Omnigent exposes an opt-in Python extension seam for integrations that need an
+atomic answer to this question before a user message is persisted: does the
+message start a turn, steer the active turn, or wait for the next turn?
+
+The seam is experimental. Applications that do not configure it retain the
+stock event path.
+
+## Configure an admitter
+
+Pass a `SessionEventAdmitter` to the public `create_app(...)` factory. The
+admitter selects sessions; returning `False` makes no reservation call and
+leaves the acknowledgement unchanged.
+
+```python
+from omnigent.admission import AdmissionInfo, SessionInfo
+from omnigent.server.app import create_app
+
+
+class RoutedSessions:
+    async def wants(self, session: SessionInfo) -> bool:
+        return session.labels.get("routing.mode") == "external"
+
+
+async def record_admission(
+    session_id: str,
+    item_id: str | None,
+    admission: AdmissionInfo,
+) -> None:
+    print(session_id, item_id, admission.lineage_id)
+
+
+app = create_app(
+    agent_store,
+    file_store,
+    conversation_store,
+    artifact_store,
+    agent_cache,
+    session_event_admitter=RoutedSessions(),
+    on_event_admitted=record_admission,
+)
+```
+
+For a selected user message, Omnigent reserves the runner's FIFO admission
+slot before REQUEST policy evaluation. `EvaluationContext.admission` then
+contains:
+
+- `admission_id`: one-shot reservation identifier;
+- `input_seq`: monotonic input sequence for the session;
+- `disposition`: `new_turn`, `active_steer`, or `next_turn_buffer`;
+- `lineage_id`: stable identifier for the model-call lineage;
+- `active_response_id`: active response identifier, when one exists.
+
+An allowed message consumes the reservation exactly once. A denied, declined,
+timed-out, or disconnected request cancels it. Unconsumed reservations expire
+after the runner's configured TTL (30 seconds by default). Reuse, expiry,
+foreign-session use, and post-restart use return named errors rather than
+silently admitting the message again.
+
+The handled event acknowledgement gains an additive `admission` object, and
+the optional `on_event_admitted` callback receives the same correlation after
+persistence. If reservation fails for a selected session, the request fails
+closed with `admission_unavailable`; it never falls through to an uncorrelated
+event path.
+
+## Compatibility contract
+
+- `session_event_admitter=None` is the default and makes no new runner calls.
+- Unselected sessions receive no new fields and no admission callback.
+- `EvaluationContext.admission` is optional and defaults to `None`.
+- Admission state is transient runner state; no database migration is needed.
+- The extension observes and correlates Omnigent's turn decision. It does not
+  change model routing, buffering, steering, or turn ordering.
+

--- a/omnigent/admission.py
+++ b/omnigent/admission.py
@@ -1,0 +1,99 @@
+"""Public contracts for opt-in session-event admission.
+
+The admission seam lets an integration observe the runner's atomic
+turn-versus-buffer decision before a user message is persisted.  It is
+deliberately narrow: Omnigent still owns turn sequencing and the integration
+only decides whether a session should use the correlated path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Literal, Protocol, TypeAlias
+
+AdmissionDisposition: TypeAlias = Literal[
+    "new_turn",
+    "active_steer",
+    "next_turn_buffer",
+]
+
+
+@dataclass(frozen=True)
+class AdmissionInfo:
+    """Atomic runner decision associated with one user input."""
+
+    admission_id: str
+    input_seq: int
+    disposition: AdmissionDisposition
+    lineage_id: str
+    active_response_id: str | None = None
+
+    @classmethod
+    def from_runner_payload(cls, payload: Mapping[str, object]) -> AdmissionInfo:
+        """Parse the runner reservation response, failing on malformed data."""
+        admission_id = payload.get("admissionId")
+        input_seq = payload.get("inputSeq")
+        disposition = payload.get("disposition")
+        lineage_id = payload.get("lineageId")
+        active_response_id = payload.get("activeResponseId")
+        if not isinstance(admission_id, str) or not admission_id:
+            raise ValueError("runner admission response has no admissionId")
+        if not isinstance(input_seq, int) or isinstance(input_seq, bool) or input_seq < 0:
+            raise ValueError("runner admission response has an invalid inputSeq")
+        if disposition not in ("new_turn", "active_steer", "next_turn_buffer"):
+            raise ValueError("runner admission response has an invalid disposition")
+        if not isinstance(lineage_id, str) or not lineage_id:
+            raise ValueError("runner admission response has no lineageId")
+        if active_response_id is not None and not isinstance(active_response_id, str):
+            raise ValueError("runner admission response has an invalid activeResponseId")
+        return cls(
+            admission_id=admission_id,
+            input_seq=input_seq,
+            disposition=disposition,
+            lineage_id=lineage_id,
+            active_response_id=active_response_id,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the stable snake-case shape used by policies and acks."""
+        return {
+            "admission_id": self.admission_id,
+            "input_seq": self.input_seq,
+            "disposition": self.disposition,
+            "lineage_id": self.lineage_id,
+            "active_response_id": self.active_response_id,
+        }
+
+
+@dataclass(frozen=True)
+class SessionInfo:
+    """Public session snapshot passed to :meth:`SessionEventAdmitter.wants`."""
+
+    id: str
+    agent_id: str | None
+    harness: str | None
+    labels: Mapping[str, str]
+    parent_session_id: str | None = None
+
+
+class SessionEventAdmitter(Protocol):
+    """Select sessions whose user messages require atomic admission."""
+
+    async def wants(self, session: SessionInfo) -> bool:
+        """Return ``True`` to use reserve-policy-consume for *session*."""
+
+
+EventAdmittedCallback: TypeAlias = Callable[
+    [str, str | None, AdmissionInfo],
+    Awaitable[None] | None,
+]
+
+
+__all__ = [
+    "AdmissionDisposition",
+    "AdmissionInfo",
+    "EventAdmittedCallback",
+    "SessionEventAdmitter",
+    "SessionInfo",
+]

--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -60,6 +60,11 @@ class ErrorCode:
     # Keep the string equal to frames.HARNESS_NOT_CONFIGURED_ERROR_CODE —
     # the host's wire error code passes through as the API error code.
     HARNESS_NOT_CONFIGURED = "harness_not_configured"
+    ADMISSION_UNAVAILABLE = "admission_unavailable"
+    ADMISSION_NOT_FOUND = "admission_not_found"
+    ADMISSION_EXPIRED = "admission_expired"
+    ADMISSION_ALREADY_CONSUMED = "admission_already_consumed"
+    ADMISSION_SESSION_MISMATCH = "admission_session_mismatch"
 
 
 # Single source of truth for error code → HTTP status.
@@ -81,6 +86,11 @@ _CODE_TO_HTTP_STATUS: dict[str, int] = {
     # can't satisfy it until the user runs `omnigent setup` there —
     # neither a 400 (input is fine) nor a 503 (a retry won't help).
     ErrorCode.HARNESS_NOT_CONFIGURED: 412,
+    ErrorCode.ADMISSION_UNAVAILABLE: 503,
+    ErrorCode.ADMISSION_NOT_FOUND: 404,
+    ErrorCode.ADMISSION_EXPIRED: 410,
+    ErrorCode.ADMISSION_ALREADY_CONSUMED: 409,
+    ErrorCode.ADMISSION_SESSION_MISMATCH: 409,
 }
 
 

--- a/omnigent/policies/__init__.py
+++ b/omnigent/policies/__init__.py
@@ -24,6 +24,7 @@ artifacts, not declarations that appear in a spec.
 
 from __future__ import annotations
 
+from omnigent.admission import AdmissionInfo
 from omnigent.policies.base import Policy
 from omnigent.policies.function import (
     FunctionPolicy,
@@ -44,6 +45,7 @@ from omnigent.policies.types import (
 )
 
 __all__ = [
+    "AdmissionInfo",
     "ElicitationRequest",
     "EvaluationContext",
     "FunctionPolicy",

--- a/omnigent/policies/function.py
+++ b/omnigent/policies/function.py
@@ -250,6 +250,8 @@ def _build_event(ctx: EvaluationContext) -> dict[str, Any]:
         # the server has no ``llm:`` config.
         "llm_client": ctx.llm_client,
     }
+    if ctx.admission is not None:
+        event["context"]["admission"] = ctx.admission.to_dict()
     if ctx.request_data is not None:
         event["request_data"] = ctx.request_data
     return event

--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -32,6 +32,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from omnigent.admission import AdmissionInfo
 from omnigent.spec.types import Phase, PolicyAction, StateUpdate
 
 if TYPE_CHECKING:
@@ -185,6 +186,9 @@ class EvaluationContext:
         ``llm:`` config. The client is shared across all policies
         in one engine; each call should pass ``model`` and
         ``connection_params`` from the engine's resolved config.
+    :param admission: Atomic session-event admission decision for a
+        REQUEST policy. ``None`` on every stock path and on phases that do
+        not start or join a turn.
     """
 
     phase: Phase
@@ -201,6 +205,7 @@ class EvaluationContext:
     harness: str | None = None
     labels: dict[str, str] | None = None
     llm_client: Any = None  # PolicyLLMClient | None — Any to avoid import cycle
+    admission: AdmissionInfo | None = None
 
 
 @dataclass(frozen=True)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7833,6 +7833,20 @@ class _BodyRequest:
         return self._body
 
 
+@dataclasses.dataclass
+class _AdmissionReservation:
+    """One transient FIFO slot reserved before AP policy evaluation."""
+
+    admission_id: str
+    session_id: str
+    input_seq: int
+    disposition: str
+    lineage_id: str
+    active_response_id: str | None
+    expires_at_ms: int
+    expiry_task: asyncio.Task[None] | None = None
+
+
 def create_runner_app(
     *,
     process_manager: HarnessProcessManager | None = None,
@@ -7844,6 +7858,7 @@ def create_runner_app(
     per_session_workspace: bool = True,
     mcp_manager: Any | None = None,
     auth_token: str | None = None,
+    admission_reservation_ttl_seconds: float = 30.0,
 ) -> FastAPI:
     """Build a fresh runner FastAPI app.
 
@@ -7876,8 +7891,14 @@ def create_runner_app(
         request except ``GET /health`` is rejected with 401 if
         the token is missing or wrong.  ``None``
         disables auth (in-process / test path).
+    :param admission_reservation_ttl_seconds: Lifetime of an unconsumed
+        admission reservation. Expiry releases its FIFO slot and later
+        consumption fails with ``admission_expired``.
     """
     import hmac
+
+    if admission_reservation_ttl_seconds <= 0:
+        raise ValueError("admission_reservation_ttl_seconds must be positive")
 
     app = FastAPI(title="omnigent-runner")
 
@@ -8016,6 +8037,15 @@ def create_runner_app(
     _ingest_next_seq: dict[str, int] = {}
     _ingest_now_serving: dict[str, int] = {}
     _ingest_cond: dict[str, asyncio.Condition] = {}
+    # Opt-in admission reservations occupy an ingest sequence until the AP
+    # consumes, cancels, or lets them expire. Only the configured path creates
+    # entries; stock sessions never touch these maps.
+    _admission_reservations: dict[str, _AdmissionReservation] = {}
+    _admission_by_session: dict[str, str] = {}
+    _admission_tombstones: dict[str, tuple[str, str, float]] = {}
+    _session_lineage_ids: dict[str, str] = {}
+    app.state.admission_reservations = _admission_reservations
+    app.state.session_lineage_ids = _session_lineage_ids
     # Closure-local (one per app instance — a module global would leak stale
     # interrupt flags between distinct create_runner_app() instances in the
     # same process). Exposed on app.state below for test inspection.
@@ -8089,6 +8119,10 @@ def create_runner_app(
         :param session_id: Session/conversation identifier.
         :param event: The SSE event dict to enqueue.
         """
+        lineage_id = _session_lineage_ids.get(session_id)
+        if lineage_id is not None and str(event.get("type", "")).startswith("response."):
+            event = dict(event)
+            event.setdefault("lineage_id", lineage_id)
         queue = _session_event_queues.get(session_id)
         if queue is None:
             queue = asyncio.Queue()
@@ -9867,6 +9901,12 @@ def create_runner_app(
         _ingest_next_seq.pop(session_id, None)
         _ingest_now_serving.pop(session_id, None)
         _ingest_cond.pop(session_id, None)
+        admission_id = _admission_by_session.pop(session_id, None)
+        if admission_id is not None:
+            reservation = _admission_reservations.pop(admission_id, None)
+            if reservation is not None and reservation.expiry_task is not None:
+                reservation.expiry_task.cancel()
+        _session_lineage_ids.pop(session_id, None)
         _codex_terminal_ensure_locks.pop(session_id, None)
         _claude_terminal_ensure_locks.pop(session_id, None)
         _pi_terminal_ensure_locks.pop(session_id, None)
@@ -12931,7 +12971,9 @@ def create_runner_app(
         # publishes "running" microseconds later, and the in-between idle
         # otherwise hides the Working indicator on the client.
         # `failed` is always published so a real error is never swallowed.
-        has_buffered = bool(_session_message_buffers.get(conv_id))
+        has_buffered = bool(_session_message_buffers.get(conv_id)) or (
+            _has_pending_continuation_admission(conv_id)
+        )
         was_interrupted = conv_id in _interrupted_sessions
         if was_interrupted:
             _interrupted_sessions.discard(conv_id)
@@ -14856,6 +14898,225 @@ def create_runner_app(
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
 
+    def _purge_admission_tombstones() -> None:
+        """Drop old one-shot outcomes used only for named retry errors."""
+        now = time.monotonic()
+        for admission_id, (_outcome, _session_id, expires_at) in list(
+            _admission_tombstones.items()
+        ):
+            if expires_at <= now:
+                _admission_tombstones.pop(admission_id, None)
+
+    def _admission_error(code: str, detail: str, status_code: int) -> JSONResponse:
+        """Build a runner error response with a stable machine-readable code."""
+        return JSONResponse(
+            status_code=status_code,
+            content={"error": code, "detail": detail},
+        )
+
+    async def _release_admission(
+        reservation: _AdmissionReservation,
+        *,
+        outcome: str,
+    ) -> bool:
+        """Release a reservation's FIFO slot exactly once."""
+        current = _admission_reservations.get(reservation.admission_id)
+        if current is not reservation:
+            return False
+        _admission_reservations.pop(reservation.admission_id, None)
+        if _admission_by_session.get(reservation.session_id) == reservation.admission_id:
+            _admission_by_session.pop(reservation.session_id, None)
+        expiry_task = reservation.expiry_task
+        if expiry_task is not None and expiry_task is not asyncio.current_task():
+            expiry_task.cancel()
+        _purge_admission_tombstones()
+        _admission_tombstones[reservation.admission_id] = (
+            outcome,
+            reservation.session_id,
+            time.monotonic() + max(60.0, admission_reservation_ttl_seconds * 2),
+        )
+        cond = _ingest_cond.get(reservation.session_id)
+        if cond is not None:
+            async with cond:
+                if _ingest_now_serving.get(reservation.session_id, 0) == reservation.input_seq:
+                    _ingest_now_serving[reservation.session_id] = reservation.input_seq + 1
+                    cond.notify_all()
+        if (
+            outcome in {"cancelled", "expired"}
+            and reservation.disposition != "new_turn"
+            and reservation.session_id not in _active_turns
+            and not _session_message_buffers.get(reservation.session_id)
+        ):
+            # The turn may have ended while AP policy held a continuation
+            # reservation. Its stream-end path deliberately suppressed idle
+            # and sub-agent completion because the reservation promised a
+            # follow-up. If that promise is cancelled or expires, replay the
+            # terminal bookkeeping now that no continuation remains.
+            _on_proxy_stream_end(reservation.session_id)
+        return True
+
+    async def _expire_admission(reservation: _AdmissionReservation) -> None:
+        """Expire one reservation and wake the next FIFO waiter."""
+        delay = max(0.0, (reservation.expires_at_ms - int(time.time() * 1000)) / 1000)
+        await asyncio.sleep(delay)
+        await _release_admission(reservation, outcome="expired")
+
+    def _admission_retry_error(
+        conversation_id: str,
+        admission_id: str,
+    ) -> JSONResponse:
+        """Return the named error for a missing or already-finished id."""
+        active = _admission_reservations.get(admission_id)
+        if active is not None and active.session_id != conversation_id:
+            return _admission_error(
+                "admission_session_mismatch",
+                "Admission reservation belongs to a different session.",
+                409,
+            )
+        _purge_admission_tombstones()
+        tombstone = _admission_tombstones.get(admission_id)
+        if tombstone is None:
+            return _admission_error(
+                "admission_not_found",
+                "Admission reservation was not found on this runner.",
+                404,
+            )
+        outcome, owner_session_id, _expires_at = tombstone
+        if owner_session_id != conversation_id:
+            return _admission_error(
+                "admission_session_mismatch",
+                "Admission reservation belongs to a different session.",
+                409,
+            )
+        if outcome == "consumed":
+            return _admission_error(
+                "admission_already_consumed",
+                "Admission reservation has already been consumed.",
+                409,
+            )
+        if outcome == "expired":
+            return _admission_error(
+                "admission_expired",
+                "Admission reservation has expired.",
+                410,
+            )
+        return _admission_error(
+            "admission_not_found",
+            "Admission reservation has been cancelled.",
+            404,
+        )
+
+    def _has_pending_continuation_admission(conversation_id: str) -> bool:
+        """Whether turn completion must wait for a reserved continuation."""
+        admission_id = _admission_by_session.get(conversation_id)
+        reservation = (
+            _admission_reservations.get(admission_id) if admission_id is not None else None
+        )
+        return reservation is not None and reservation.disposition != "new_turn"
+
+    @app.post(
+        "/v1/sessions/{conversation_id}/admission-reservations",
+        status_code=201,
+    )
+    async def reserve_session_admission(
+        conversation_id: str,
+        request: Request,
+    ) -> JSONResponse:
+        """Reserve the next message's atomic turn-versus-buffer decision."""
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            body = None
+        if (
+            not isinstance(body, dict)
+            or body.get("source") != "ap"
+            or body.get("kind") != "user_message"
+        ):
+            return _admission_error(
+                "invalid_request",
+                "Admission reservations require source='ap' and kind='user_message'.",
+                400,
+            )
+
+        seq = _ingest_next_seq.get(conversation_id, 0)
+        _ingest_next_seq[conversation_id] = seq + 1
+        cond = _ingest_cond.get(conversation_id)
+        if cond is None:
+            cond = asyncio.Condition()
+            _ingest_cond[conversation_id] = cond
+        async with cond:
+            while _ingest_now_serving.get(conversation_id, 0) != seq:
+                await cond.wait()
+
+        active_turn = conversation_id in _active_turns
+        active_turn = active_turn or bool(_session_message_buffers.get(conversation_id))
+        if _is_native_harness(conversation_id):
+            active_turn = active_turn or _native_pane_status.get(conversation_id) == "running"
+        if process_manager is not None:
+            active_turn = active_turn or process_manager.has_active_turn(conversation_id)
+
+        if active_turn:
+            can_steer = (
+                not _is_native_harness(conversation_id)
+                and not pending_approvals.has_pending(conversation_id)
+                and conversation_id in _live_response_id
+            )
+            disposition = "active_steer" if can_steer else "next_turn_buffer"
+            lineage_id = _session_lineage_ids.get(conversation_id)
+            if lineage_id is None:
+                lineage_id = f"lin_{uuid.uuid4().hex}"
+                _session_lineage_ids[conversation_id] = lineage_id
+        else:
+            disposition = "new_turn"
+            lineage_id = f"lin_{uuid.uuid4().hex}"
+            _session_lineage_ids[conversation_id] = lineage_id
+
+        admission_id = f"adm_{uuid.uuid4().hex}"
+        expires_at_ms = int(time.time() * 1000 + admission_reservation_ttl_seconds * 1000)
+        reservation = _AdmissionReservation(
+            admission_id=admission_id,
+            session_id=conversation_id,
+            input_seq=seq,
+            disposition=disposition,
+            lineage_id=lineage_id,
+            active_response_id=_live_response_id.get(conversation_id),
+            expires_at_ms=expires_at_ms,
+        )
+        _admission_reservations[admission_id] = reservation
+        _admission_by_session[conversation_id] = admission_id
+        reservation.expiry_task = asyncio.create_task(
+            _expire_admission(reservation),
+            name=f"admission-expiry-{admission_id}",
+        )
+        return JSONResponse(
+            status_code=201,
+            content={
+                "admissionId": admission_id,
+                "inputSeq": seq,
+                "disposition": disposition,
+                "lineageId": lineage_id,
+                "activeResponseId": reservation.active_response_id,
+                "expiresAt": expires_at_ms,
+            },
+        )
+
+    @app.delete(
+        "/v1/sessions/{conversation_id}/admission-reservations/{admission_id}",
+        status_code=204,
+    )
+    async def cancel_session_admission(
+        conversation_id: str,
+        admission_id: str,
+    ) -> Response:
+        """Cancel an unconsumed reservation and release its FIFO slot."""
+        reservation = _admission_reservations.get(admission_id)
+        if reservation is None:
+            return _admission_retry_error(conversation_id, admission_id)
+        if reservation.session_id != conversation_id:
+            return _admission_retry_error(conversation_id, admission_id)
+        await _release_admission(reservation, outcome="cancelled")
+        return Response(status_code=204)
+
     @app.post("/v1/sessions/{conversation_id}/events")
     async def post_session_events(
         conversation_id: str,
@@ -14911,6 +15172,33 @@ def create_runner_app(
 
         body = await request.json()
         body_type = body.get("type") if isinstance(body, dict) else None
+        admission_id = body.get("admissionId") if isinstance(body, dict) else None
+        reservation: _AdmissionReservation | None = None
+        if admission_id is not None:
+            if not isinstance(admission_id, str) or not admission_id:
+                return _admission_error(
+                    "invalid_request",
+                    "admissionId must be a non-empty string.",
+                    400,
+                )
+            reservation = _admission_reservations.get(admission_id)
+            if reservation is None or reservation.session_id != conversation_id:
+                return _admission_retry_error(conversation_id, admission_id)
+            if reservation.expires_at_ms <= int(time.time() * 1000):
+                await _release_admission(reservation, outcome="expired")
+                return _admission_retry_error(conversation_id, admission_id)
+            if body_type not in ("message", None):
+                return _admission_error(
+                    "invalid_request",
+                    "Admission reservations can only be consumed by message events.",
+                    400,
+                )
+            # Crossing this point consumes before TTL even if later event
+            # processing awaits harness setup. Without cancelling now, the
+            # expiry task could release the FIFO slot mid-consume.
+            if reservation.expiry_task is not None:
+                reservation.expiry_task.cancel()
+                reservation.expiry_task = None
         _logger.info(
             "post_session_events: conv=%s type=%s active=%s buffer_len=%d content_types=%s",
             conversation_id,
@@ -14950,15 +15238,22 @@ def create_runner_app(
             # read-incremented synchronously here, before any await, so it
             # reflects arrival order. Content resolution + the decision then
             # run inside the served slot, serialized per conversation.
-            _seq = _ingest_next_seq.get(conversation_id, 0)
-            _ingest_next_seq[conversation_id] = _seq + 1
-            _cond = _ingest_cond.get(conversation_id)
-            if _cond is None:
-                _cond = asyncio.Condition()
-                _ingest_cond[conversation_id] = _cond
-            async with _cond:
-                while _ingest_now_serving.get(conversation_id, 0) != _seq:
-                    await _cond.wait()
+            if reservation is None:
+                _seq = _ingest_next_seq.get(conversation_id, 0)
+                _ingest_next_seq[conversation_id] = _seq + 1
+                _cond = _ingest_cond.get(conversation_id)
+                if _cond is None:
+                    _cond = asyncio.Condition()
+                    _ingest_cond[conversation_id] = _cond
+                async with _cond:
+                    while _ingest_now_serving.get(conversation_id, 0) != _seq:
+                        await _cond.wait()
+            else:
+                _seq = reservation.input_seq
+                _cond = _ingest_cond[conversation_id]
+                async with _cond:
+                    if _ingest_now_serving.get(conversation_id, 0) != _seq:
+                        return _admission_retry_error(conversation_id, admission_id)
             try:
                 _raw_content = message_body.get("content")
                 if isinstance(_raw_content, list):
@@ -14969,7 +15264,10 @@ def create_runner_app(
                     )
 
                 # Turn sequencing gate (invariant I2: single active turn).
-                if conversation_id in _active_turns:
+                reserved_continuation = (
+                    reservation is not None and reservation.disposition != "new_turn"
+                )
+                if conversation_id in _active_turns or reserved_continuation:
                     _native = _is_native_harness(conversation_id)
                     # A turn parked on a human approval must not be steered
                     # past its gate by an incoming message. The non-native
@@ -15000,9 +15298,11 @@ def create_runner_app(
                     # streaming; otherwise it would start a rogue turn (→ 204).
                     # The buffered copy still drives the post-turn continuation.
                     _can_forward = (
-                        not _native
+                        conversation_id in _active_turns
+                        and not _native
                         and not _awaiting_approval
                         and conversation_id in _live_response_id
+                        and (reservation is None or reservation.disposition == "active_steer")
                     )
                     if _can_forward:
                         message_body["injection_id"] = f"inj_{uuid.uuid4().hex[:16]}"
@@ -15065,12 +15365,20 @@ def create_runner_app(
                                 conversation_id,
                                 exc_info=True,
                             )
+                    buffered_content: dict[str, Any] = {
+                        "status": "buffered",
+                        "detail": ("Message buffered; active turn will process it."),
+                    }
+                    if reservation is not None:
+                        buffered_content.update(
+                            {
+                                "admissionId": reservation.admission_id,
+                                "lineageId": reservation.lineage_id,
+                            }
+                        )
                     return JSONResponse(
                         status_code=202,
-                        content={
-                            "status": "buffered",
-                            "detail": ("Message buffered; active turn will process it."),
-                        },
+                        content=buffered_content,
                     )
 
                 # Make the new user message visible to the turn. On the
@@ -15151,20 +15459,31 @@ def create_runner_app(
                 )
                 _background_tasks.add(_turn_task)
 
+                accepted_content: dict[str, Any] = {
+                    "status": "accepted",
+                    "detail": "Turn started.",
+                }
+                if reservation is not None:
+                    accepted_content.update(
+                        {
+                            "admissionId": reservation.admission_id,
+                            "lineageId": reservation.lineage_id,
+                        }
+                    )
                 return JSONResponse(
                     status_code=202,
-                    content={
-                        "status": "accepted",
-                        "detail": "Turn started.",
-                    },
+                    content=accepted_content,
                 )
             finally:
                 # Advance the gate so the next-arriving message for this
                 # conversation proceeds — even if this one raised, so a
                 # failed resolve/decision can't stall later messages.
-                async with _cond:
-                    _ingest_now_serving[conversation_id] = _seq + 1
-                    _cond.notify_all()
+                if reservation is not None:
+                    await _release_admission(reservation, outcome="consumed")
+                else:
+                    async with _cond:
+                        _ingest_now_serving[conversation_id] = _seq + 1
+                        _cond.notify_all()
 
         if body_type == "interrupt":
             # Native harnesses get a key sent to their TUI pane — a forwarded

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -23,6 +23,7 @@ from starlette.routing import Mount, Route
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from omnigent._platform import resolve_repo_symlink
+from omnigent.admission import EventAdmittedCallback, SessionEventAdmitter
 from omnigent.db.db_models import InvalidUuidError
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_plugins import (
@@ -1102,6 +1103,8 @@ def create_app(
     sharing_mode: SharingMode | Callable[[], SharingMode] | None = None,
     public_sharing: bool | Callable[[], bool] | None = None,
     server_config: dict[str, Any] | None = None,
+    session_event_admitter: SessionEventAdmitter | None = None,
+    on_event_admitted: EventAdmittedCallback | None = None,
 ) -> FastAPI:
     """
     Build and return the FastAPI application with all routes mounted.
@@ -1192,6 +1195,11 @@ def create_app(
         falsy — ``0``/``false``/``no``/``off``), failing open to enabled
         when unset. Reported by ``GET /v1/info`` as
         ``public_sharing_enabled``.
+    :param session_event_admitter: Optional experimental admission selector.
+        Sessions for which ``wants()`` returns ``True`` use the runner's
+        atomic reserve-policy-consume path; ``None`` preserves the stock path.
+    :param on_event_admitted: Optional callback invoked after a handled event
+        is forwarded, with its AP item id and atomic admission information.
     :returns: A fully configured :class:`FastAPI` application.
     :raises ValueError: If ``permission_store`` is provided
         without an ``auth_provider``.
@@ -2126,6 +2134,8 @@ def create_app(
             # workspace over the host tunnel when the runner is offline
             # (the file panel stays live without waking the agent).
             host_registry=host_registry,
+            session_event_admitter=session_event_admitter,
+            on_event_admitted=on_event_admitted,
         ),
         prefix="/v1",
         tags=["sessions"],

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import json
 import logging
 import mimetypes
@@ -57,6 +58,12 @@ from pydantic import TypeAdapter, ValidationError
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
+from omnigent.admission import (
+    AdmissionInfo,
+    EventAdmittedCallback,
+    SessionEventAdmitter,
+    SessionInfo,
+)
 from omnigent.codex_native_elicitation import codex_elicitation_id
 from omnigent.cost_plan import (
     COST_CONTROL_LABEL_NAMESPACE,
@@ -6200,6 +6207,146 @@ async def _get_runner_client(
     return cast("httpx.AsyncClient | None", get_runner_client())
 
 
+async def _admitter_wants_session(
+    admitter: SessionEventAdmitter,
+    conv: Conversation,
+) -> bool:
+    """Evaluate the public admission selector without exposing store internals."""
+    session = SessionInfo(
+        id=conv.id,
+        agent_id=conv.agent_id,
+        harness=_resolve_harness(conv),
+        labels=dict(conv.labels),
+        parent_session_id=conv.parent_conversation_id,
+    )
+    try:
+        result = await admitter.wants(session)
+    except Exception as exc:
+        _logger.warning("Session event admitter failed for %s", conv.id, exc_info=True)
+        raise OmnigentError(
+            "Session admission selector is unavailable.",
+            code=ErrorCode.ADMISSION_UNAVAILABLE,
+        ) from exc
+    return bool(result)
+
+
+async def _reserve_event_admission(
+    runner_client: httpx.AsyncClient,
+    session_id: str,
+) -> AdmissionInfo:
+    """Reserve the runner's next FIFO slot and validate its public shape."""
+    try:
+        response = await runner_client.post(
+            f"/v1/sessions/{session_id}/admission-reservations",
+            json={"source": "ap", "kind": "user_message"},
+            timeout=5.0,
+        )
+    except (httpx.HTTPError, ConnectionError, asyncio.TimeoutError) as exc:
+        raise OmnigentError(
+            "Runner admission reservation is unavailable.",
+            code=ErrorCode.ADMISSION_UNAVAILABLE,
+        ) from exc
+    if response.status_code != 201:
+        raise OmnigentError(
+            "Runner admission reservation was rejected.",
+            code=ErrorCode.ADMISSION_UNAVAILABLE,
+        )
+    try:
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError("reservation response must be an object")
+        return AdmissionInfo.from_runner_payload(payload)
+    except (ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise OmnigentError(
+            "Runner returned an invalid admission reservation.",
+            code=ErrorCode.ADMISSION_UNAVAILABLE,
+        ) from exc
+
+
+async def _cancel_event_admission(
+    runner_client: httpx.AsyncClient,
+    session_id: str,
+    admission: AdmissionInfo,
+    *,
+    raise_on_failure: bool = True,
+) -> None:
+    """Cancel one unconsumed reservation, optionally surfacing failure."""
+    try:
+        response = await runner_client.delete(
+            f"/v1/sessions/{session_id}/admission-reservations/{admission.admission_id}",
+            timeout=5.0,
+        )
+        # Expired/already-finished reservations no longer occupy a FIFO slot,
+        # so cancellation has achieved its only required effect.
+        if response.status_code in {204, 404, 409, 410}:
+            return
+        raise httpx.HTTPStatusError(
+            "admission cancellation rejected",
+            request=response.request,
+            response=response,
+        )
+    except (httpx.HTTPError, ConnectionError, asyncio.TimeoutError) as exc:
+        _logger.warning(
+            "Admission cancellation failed for session=%s admission=%s",
+            session_id,
+            admission.admission_id,
+            exc_info=True,
+        )
+        if raise_on_failure:
+            raise OmnigentError(
+                "Runner admission cancellation is unavailable.",
+                code=ErrorCode.ADMISSION_UNAVAILABLE,
+            ) from exc
+
+
+_ADMISSION_CONSUME_ERROR_CODES = frozenset(
+    {
+        ErrorCode.ADMISSION_NOT_FOUND,
+        ErrorCode.ADMISSION_EXPIRED,
+        ErrorCode.ADMISSION_ALREADY_CONSUMED,
+        ErrorCode.ADMISSION_SESSION_MISMATCH,
+    }
+)
+
+
+def _raise_for_admission_consume_response(response: httpx.Response) -> None:
+    """Surface a runner reservation-consume failure as a named AP error."""
+    if response.status_code < 400:
+        return
+    try:
+        payload = response.json()
+    except (ValueError, json.JSONDecodeError):
+        payload = {}
+    code = payload.get("error") if isinstance(payload, dict) else None
+    raise OmnigentError(
+        "Runner rejected the event admission reservation.",
+        code=(
+            code
+            if isinstance(code, str) and code in _ADMISSION_CONSUME_ERROR_CODES
+            else ErrorCode.ADMISSION_UNAVAILABLE
+        ),
+    )
+
+
+async def _notify_event_admitted(
+    callback: EventAdmittedCallback,
+    session_id: str,
+    item_id: str | None,
+    admission: AdmissionInfo,
+) -> None:
+    """Invoke the optional correlation callback without replaying a turn."""
+    try:
+        result = callback(session_id, item_id, admission)
+        if inspect.isawaitable(result):
+            await result
+    except Exception:
+        _logger.exception(
+            "on_event_admitted callback failed for session=%s admission=%s",
+            session_id,
+            admission.admission_id,
+        )
+
+
 async def _query_host_runner_status(
     host_conn: HostConnection,
     host_registry: HostRegistry,
@@ -8274,6 +8421,7 @@ async def _forward_native_terminal_message(
     body: SessionEventInput,
     file_store: FileStore | None = None,
     artifact_store: ArtifactStore | None = None,
+    admission_id: str | None = None,
 ) -> None:
     """
     Forward one Omnigent web-chat message to the native terminal harness.
@@ -8293,12 +8441,15 @@ async def _forward_native_terminal_message(
         content blocks.
     :param artifact_store: Optional binary content store for
         fetching file bytes during resolution.
+    :param admission_id: Optional one-shot runner reservation to consume.
     :returns: None.
     :raises HTTPException: 502 when the runner or harness rejects
         the injection request.
     """
     display_name, _, _ = _native_terminal_runtime(conv)
     event = _build_native_terminal_message_event(conv, body)
+    if admission_id is not None:
+        event["admissionId"] = admission_id
     _logger.info(
         "%s terminal message forward starting: session=%s block_types=%s",
         display_name,
@@ -8357,6 +8508,8 @@ async def _forward_native_terminal_message(
             detail=f"{display_name} terminal message delivery failed",
         ) from exc
     if resp.status_code >= 400:
+        if admission_id is not None:
+            _raise_for_admission_consume_response(resp)
         _logger.warning(
             "%s terminal message forward rejected for session=%s status=%s body=%s",
             display_name,
@@ -9223,6 +9376,7 @@ async def _forward_event_to_runner(
     artifact_store: ArtifactStore | None = None,
     has_mcp_servers: bool = False,
     created_by: str | None = None,
+    admission_id: str | None = None,
 ) -> str:
     """
     Persist a user event and forward it to the runner.
@@ -9251,6 +9405,7 @@ async def _forward_event_to_runner(
         this turn. ``False`` by default (agents without MCP servers).
     :param created_by: Authenticated identity of the posting actor,
         recorded on the persisted item for attribution.
+    :param admission_id: Optional one-shot runner reservation to consume.
     :returns: The store-assigned id of the persisted item.
     """
     import uuid
@@ -9416,16 +9571,20 @@ async def _forward_event_to_runner(
     # per-event value exists; the persisted column is the source.
     if conv.harness_override is not None:
         runner_body["harness_override"] = conv.harness_override
+    if admission_id is not None:
+        runner_body["admissionId"] = admission_id
 
     # The runner's sessions-native POST returns 202 immediately
     # and starts the turn as a background task. No streaming
     # response to drain — events flow through GET /stream.
     try:
-        await runner_client.post(
+        runner_response = await runner_client.post(
             f"/v1/sessions/{session_id}/events",
             json=runner_body,
             timeout=_RUNNER_FORWARD_TIMEOUT,
         )
+        if admission_id is not None:
+            _raise_for_admission_consume_response(runner_response)
         # Publish input.consumed AFTER the forward succeeds —
         # the runner has the message and will start the turn.
         _publish_input_consumed(session_id, persisted_items[0])
@@ -9498,6 +9657,7 @@ async def _dispatch_session_event_to_runner(
     has_mcp_servers: bool = False,
     created_by: str | None = None,
     runner_router: RunnerRouter | None = None,
+    admission_id: str | None = None,
 ) -> _SessionEventDispatchResult:
     """
     Forward an item-event to the runner with harness-aware dispatch.
@@ -9563,6 +9723,7 @@ async def _dispatch_session_event_to_runner(
         native-terminal parent-wake forward when a sub-agent fails to
         boot (see :func:`_persist_native_terminal_failure`). ``None``
         in in-process / test setups where the global client is used.
+    :param admission_id: Optional one-shot runner reservation to consume.
     :returns: A :class:`_SessionEventDispatchResult` carrying the
         persisted item id (non-native) or the pending-input id
         (claude-native message bypass).
@@ -9578,6 +9739,11 @@ async def _dispatch_session_event_to_runner(
             conv,
         )
         if ensure_outcome.error is not None:
+            if admission_id is not None:
+                raise OmnigentError(
+                    "Native terminal is unavailable for admitted event delivery.",
+                    code=ErrorCode.ADMISSION_UNAVAILABLE,
+                )
             item_id = await _persist_native_terminal_failure(
                 session_id,
                 conv,
@@ -9678,6 +9844,7 @@ async def _dispatch_session_event_to_runner(
                 body,
                 file_store=file_store,
                 artifact_store=artifact_store,
+                admission_id=admission_id,
             )
             forwarded = True
         finally:
@@ -9713,6 +9880,7 @@ async def _dispatch_session_event_to_runner(
         artifact_store=artifact_store,
         has_mcp_servers=has_mcp_servers,
         created_by=created_by,
+        admission_id=admission_id,
     )
     return _SessionEventDispatchResult(item_id=item_id, pending_id=None)
 
@@ -11599,6 +11767,7 @@ async def _evaluate_input_policy(
     _runner_router: RunnerRouter | None,
     *,
     actor: dict[str, str] | None = None,
+    admission: AdmissionInfo | None = None,
 ) -> dict[str, Any] | None:
     """
     Evaluate a user message against REQUEST (input) phase policy rules.
@@ -11628,6 +11797,8 @@ async def _evaluate_input_policy(
     :param actor: Authenticated principal, e.g.
         ``{"run_as": "alice@example.com"}``. ``None`` when
         identity is unknown.
+    :param admission: Atomic runner decision for an opted-in request.
+        ``None`` on the stock path.
     :returns: ``None`` on ALLOW or an approved ASK (fall through to the
         forward path). A verdict dict ``{"verdict": "deny", "reason":
         ...}`` on DENY or a declined / timed-out ASK.
@@ -11658,6 +11829,7 @@ async def _evaluate_input_policy(
         content=user_text,
         tool_name=None,
         actor=actor,
+        admission=admission,
     )
     result = await engine.evaluate(ctx)
 
@@ -14560,6 +14732,8 @@ def create_sessions_router(
     runner_tunnel_tokens: frozenset[str] | None = None,
     runner_exit_reports: RunnerExitReports | None = None,
     host_registry: HostRegistry | None = None,
+    session_event_admitter: SessionEventAdmitter | None = None,
+    on_event_admitted: EventAdmittedCallback | None = None,
 ) -> APIRouter:
     """
     Factory that builds the sessions router.
@@ -14620,6 +14794,10 @@ def create_sessions_router(
         the runner is offline, so the file panel stays live without
         waking the agent. ``None`` disables the fallback (the endpoints
         then 503 on an offline runner, as before).
+    :param session_event_admitter: Optional selector for atomic event
+        admission. ``None`` leaves the stock route untouched.
+    :param on_event_admitted: Optional post-forward correlation callback
+        for events handled by ``session_event_admitter``.
     :returns: A configured :class:`APIRouter` exposing the
         ``/sessions`` endpoints.
     """
@@ -19698,7 +19876,7 @@ def create_sessions_router(
         request: Request,
         session_id: str,
         body: SessionEventInput,
-    ) -> dict[str, bool | str]:
+    ) -> dict[str, object]:
         """
         Submit a session event (input message, tool output,
         approval, or interrupt).
@@ -19868,6 +20046,24 @@ def create_sessions_router(
                 "Session is closed. Start a new sub-agent session to continue.",
                 code=ErrorCode.CONFLICT,
             )
+        _admission_info: AdmissionInfo | None = None
+        _admission_runner_client: httpx.AsyncClient | None = None
+        if (
+            body.type == "message"
+            and body.data.get("role") == "user"
+            and session_event_admitter is not None
+            and await _admitter_wants_session(session_event_admitter, conv)
+        ):
+            _admission_runner_client = await _get_runner_client(session_id, runner_router)
+            if _admission_runner_client is None:
+                raise OmnigentError(
+                    "No runner is available for atomic session admission.",
+                    code=ErrorCode.ADMISSION_UNAVAILABLE,
+                )
+            _admission_info = await _reserve_event_admission(
+                _admission_runner_client,
+                session_id,
+            )
         if (
             body.type == "message"
             and body.data.get("role") == "user"
@@ -19883,6 +20079,7 @@ def create_sessions_router(
                     agent_store,
                     runner_router,
                     actor=_actor,
+                    admission=_admission_info,
                 )
             except Exception as _policy_exc:  # noqa: BLE001 — fail-safe for misconfigured policies
                 # Policy evaluation crashed (e.g. factory misconfigured).
@@ -19904,6 +20101,13 @@ def create_sessions_router(
                 # DENY or ASK — don't forward to runner. Publish a
                 # deny sentinel on the session stream so the
                 # client/REPL sees feedback.
+                if _admission_info is not None and _admission_runner_client is not None:
+                    await _cancel_event_admission(
+                        _admission_runner_client,
+                        session_id,
+                        _admission_info,
+                    )
+                    _admission_info = None
                 reason = _input_verdict.get("reason", "Denied by policy")
                 _publish_status(session_id, "running")
                 _publish_policy_deny(session_id, reason)
@@ -20795,19 +20999,32 @@ def create_sessions_router(
                 created_by=_attribution_user(user_id),
             )
             return {"queued": True, "item_id": item_id}
-        dispatch = await _dispatch_session_event_to_runner(
-            session_id,
-            conv,
-            body,
-            conversation_store,
-            runner_client,
-            agent_name=_agent.name if _agent else None,
-            file_store=file_store,
-            artifact_store=artifact_store,
-            has_mcp_servers=_has_mcp_servers,
-            created_by=_attribution_user(user_id),
-            runner_router=runner_router,
-        )
+        try:
+            dispatch = await _dispatch_session_event_to_runner(
+                session_id,
+                conv,
+                body,
+                conversation_store,
+                runner_client,
+                agent_name=_agent.name if _agent else None,
+                file_store=file_store,
+                artifact_store=artifact_store,
+                has_mcp_servers=_has_mcp_servers,
+                created_by=_attribution_user(user_id),
+                runner_router=runner_router,
+                admission_id=(
+                    _admission_info.admission_id if _admission_info is not None else None
+                ),
+            )
+        except BaseException:
+            if _admission_info is not None and _admission_runner_client is not None:
+                await _cancel_event_admission(
+                    _admission_runner_client,
+                    session_id,
+                    _admission_info,
+                    raise_on_failure=False,
+                )
+            raise
         response: dict[str, Any] = {"queued": True}
         if dispatch.item_id is not None:
             response["item_id"] = dispatch.item_id
@@ -20819,6 +21036,15 @@ def create_sessions_router(
         # stability) and relies on stableKey + FIFO instead.
         if dispatch.pending_id is not None:
             response["pending_id"] = dispatch.pending_id
+        if _admission_info is not None:
+            response["admission"] = _admission_info.to_dict()
+            if on_event_admitted is not None:
+                await _notify_event_admitted(
+                    on_event_admitted,
+                    session_id,
+                    dispatch.item_id,
+                    _admission_info,
+                )
         return response
 
     # ── GET /sessions/{session_id}/stream ────────────────────────

--- a/tests/policies/test_admission_context.py
+++ b/tests/policies/test_admission_context.py
@@ -1,0 +1,60 @@
+"""Tests for admission data exposed through the public function-policy seam."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from omnigent.admission import AdmissionInfo
+from omnigent.policies.function import FunctionPolicy
+from omnigent.policies.types import EvaluationContext
+from omnigent.spec.types import (
+    FunctionPolicySpec,
+    Phase,
+    PhaseSelector,
+    PolicyAction,
+)
+
+
+@pytest.mark.asyncio
+async def test_function_policy_receives_admission_only_when_present() -> None:
+    """The opt-in hook is visible without changing stock policy events."""
+    observed: list[dict[str, Any]] = []
+
+    async def capture(event: dict[str, Any]) -> dict[str, str]:
+        observed.append(event)
+        return {"result": "ALLOW"}
+
+    policy = FunctionPolicy(
+        FunctionPolicySpec(
+            name="capture-admission",
+            on=[PhaseSelector(phase=Phase.REQUEST)],
+        ),
+        capture,
+    )
+
+    stock_result = await policy.evaluate(
+        EvaluationContext(phase=Phase.REQUEST, content="stock"),
+        {},
+    )
+    admission = AdmissionInfo(
+        admission_id="admission-1",
+        input_seq=7,
+        disposition="next_turn_buffer",
+        lineage_id="lineage-1",
+        active_response_id="response-1",
+    )
+    admitted_result = await policy.evaluate(
+        EvaluationContext(
+            phase=Phase.REQUEST,
+            content="admitted",
+            admission=admission,
+        ),
+        {},
+    )
+
+    assert stock_result.action == PolicyAction.ALLOW
+    assert admitted_result.action == PolicyAction.ALLOW
+    assert "admission" not in observed[0]["context"]
+    assert observed[1]["context"]["admission"] == admission.to_dict()

--- a/tests/runner/test_admission_reservations.py
+++ b/tests/runner/test_admission_reservations.py
@@ -1,0 +1,359 @@
+"""Race and lifecycle coverage for atomic session-event admission."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from omnigent.runner import create_runner_app
+from tests.runner.helpers import NullServerClient
+
+
+class _BlockingHarnessClient:
+    """Harness stream that remains live until the test releases it."""
+
+    def __init__(self) -> None:
+        self.allow_created = asyncio.Event()
+        self.allow_created.set()
+        self.release = asyncio.Event()
+        self.started = asyncio.Event()
+        self.turn_bodies: list[dict[str, Any]] = []
+        self.injected_bodies: list[dict[str, Any]] = []
+
+    def stream(self, method: str, url: str, *, json: dict[str, Any], timeout: Any) -> Any:
+        """Capture the turn and return a controllable SSE stream."""
+        del method, url, timeout
+        self.turn_bodies.append(json)
+        outer = self
+        response_id = f"resp_{len(self.turn_bodies)}"
+
+        class _StreamContext:
+            async def __aenter__(self) -> _BlockingHarnessClient._StreamHandle:
+                return _BlockingHarnessClient._StreamHandle(outer, response_id)
+
+            async def __aexit__(self, *_args: Any) -> None:
+                return None
+
+        return _StreamContext()
+
+    class _StreamHandle:
+        status_code = 200
+
+        def __init__(self, owner: _BlockingHarnessClient, response_id: str) -> None:
+            self._owner = owner
+            self._response_id = response_id
+
+        async def aiter_text(self) -> AsyncIterator[str]:
+            await self._owner.allow_created.wait()
+            self._owner.started.set()
+            yield _sse(
+                {
+                    "type": "response.created",
+                    "response": {"id": self._response_id},
+                }
+            )
+            await self._owner.release.wait()
+            yield _sse(
+                {
+                    "type": "response.completed",
+                    "response": {"id": self._response_id},
+                }
+            )
+
+    async def post(self, url: str, *, json: dict[str, Any], timeout: Any = None) -> Any:
+        """Record a live injection and acknowledge it."""
+        del url, timeout
+        self.injected_bodies.append(json)
+        return httpx.Response(200, json={"ok": True})
+
+
+class _FakeProcessManager:
+    """Small process-manager surface used by the runner turn path."""
+
+    handles_tool_dispatch = True
+
+    def __init__(self, client: _BlockingHarnessClient) -> None:
+        self.client = client
+        self.in_flight: set[str] = set()
+
+    async def get_client(
+        self,
+        conversation_id: str,
+        harness: str,
+        env: Any = None,
+    ) -> _BlockingHarnessClient:
+        del conversation_id, harness, env
+        return self.client
+
+    def has_active_turn(self, conversation_id: str) -> bool:
+        return conversation_id in self.in_flight
+
+    def mark_in_flight(self, conversation_id: str, response_id: str) -> None:
+        del response_id
+        self.in_flight.add(conversation_id)
+
+    def clear_in_flight(self, conversation_id: str) -> None:
+        self.in_flight.discard(conversation_id)
+
+    async def forward_cancel(self, conversation_id: str) -> bool:
+        self.in_flight.discard(conversation_id)
+        return True
+
+    async def release(self, conversation_id: str) -> None:
+        self.in_flight.discard(conversation_id)
+
+
+def _sse(event: dict[str, Any]) -> str:
+    return f"data: {json.dumps(event)}\n\n"
+
+
+def _build_app(
+    *,
+    ttl_seconds: float = 30.0,
+) -> tuple[FastAPI, _BlockingHarnessClient]:
+    harness = _BlockingHarnessClient()
+    manager = _FakeProcessManager(harness)
+    app = create_runner_app(
+        process_manager=manager,  # type: ignore[arg-type]
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        admission_reservation_ttl_seconds=ttl_seconds,
+    )
+    return app, harness
+
+
+@contextlib.asynccontextmanager
+async def _client(app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://runner") as client:
+        yield client
+
+
+async def _reserve(client: httpx.AsyncClient, session_id: str) -> httpx.Response:
+    return await client.post(
+        f"/v1/sessions/{session_id}/admission-reservations",
+        json={"source": "ap", "kind": "user_message"},
+    )
+
+
+async def _consume(
+    client: httpx.AsyncClient,
+    session_id: str,
+    admission_id: str,
+    text: str,
+) -> httpx.Response:
+    return await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": text}],
+            "admissionId": admission_id,
+        },
+    )
+
+
+async def _cancel(
+    client: httpx.AsyncClient,
+    session_id: str,
+    admission_id: str,
+) -> httpx.Response:
+    return await client.delete(f"/v1/sessions/{session_id}/admission-reservations/{admission_id}")
+
+
+@pytest.mark.asyncio
+async def test_s7_1_concurrent_idle_posts_get_one_new_turn_and_fifo() -> None:
+    app, harness = _build_app()
+    async with _client(app) as client:
+        first = (await _reserve(client, "conv_race")).json()
+        second_task = asyncio.create_task(_reserve(client, "conv_race"))
+        await asyncio.sleep(0)
+        assert not second_task.done()
+
+        accepted = await _consume(client, "conv_race", first["admissionId"], "first")
+        second_response = await asyncio.wait_for(second_task, timeout=1)
+        second = second_response.json()
+
+        assert accepted.json()["status"] == "accepted"
+        assert first["disposition"] == "new_turn"
+        assert second["disposition"] in {"active_steer", "next_turn_buffer"}
+        assert [first["inputSeq"], second["inputSeq"]] == [0, 1]
+        assert second["lineageId"] == first["lineageId"]
+        buffered = await _consume(client, "conv_race", second["admissionId"], "second")
+        assert buffered.json()["status"] == "buffered"
+        duplicate = await _consume(client, "conv_race", second["admissionId"], "duplicate")
+        assert duplicate.status_code == 409
+        assert duplicate.json()["error"] == "admission_already_consumed"
+        harness.release.set()
+
+
+@pytest.mark.asyncio
+async def test_s7_2_live_tool_loop_steer_keeps_active_lineage() -> None:
+    app, harness = _build_app()
+    async with _client(app) as client:
+        first = (await _reserve(client, "conv_tool_loop")).json()
+        await _consume(client, "conv_tool_loop", first["admissionId"], "start")
+        await asyncio.wait_for(harness.started.wait(), timeout=1)
+
+        steer = (await _reserve(client, "conv_tool_loop")).json()
+        assert steer["disposition"] == "active_steer"
+        assert steer["lineageId"] == first["lineageId"]
+        assert steer["activeResponseId"] == "resp_1"
+        response = await _consume(client, "conv_tool_loop", steer["admissionId"], "steer")
+        assert response.json()["status"] == "buffered"
+        assert harness.injected_bodies[-1]["content"][0]["text"] == "steer"
+        harness.release.set()
+
+
+@pytest.mark.asyncio
+async def test_s7_3_reserved_buffered_continuation_keeps_sequence_and_lineage() -> None:
+    app, harness = _build_app()
+    harness.allow_created.clear()
+    async with _client(app) as client:
+        first = (await _reserve(client, "conv_buffered")).json()
+        await _consume(client, "conv_buffered", first["admissionId"], "first")
+        continuation = (await _reserve(client, "conv_buffered")).json()
+        assert continuation["disposition"] == "next_turn_buffer"
+        assert continuation["lineageId"] == first["lineageId"]
+        assert continuation["inputSeq"] == first["inputSeq"] + 1
+        buffered = await _consume(
+            client,
+            "conv_buffered",
+            continuation["admissionId"],
+            "continued",
+        )
+        assert buffered.json()["status"] == "buffered"
+        harness.allow_created.set()
+        harness.release.set()
+        for _ in range(50):
+            if len(harness.turn_bodies) >= 2:
+                break
+            await asyncio.sleep(0.01)
+        assert len(harness.turn_bodies) == 2
+
+
+@pytest.mark.asyncio
+async def test_s7_4_cancel_releases_slot_and_next_decision_is_truthful() -> None:
+    app, _harness = _build_app()
+    async with _client(app) as client:
+        denied = (await _reserve(client, "conv_cancel")).json()
+        assert (await _cancel(client, "conv_cancel", denied["admissionId"])).status_code == 204
+        next_admission = (await _reserve(client, "conv_cancel")).json()
+        assert next_admission["inputSeq"] == denied["inputSeq"] + 1
+        assert next_admission["disposition"] == "new_turn"
+        await _cancel(client, "conv_cancel", next_admission["admissionId"])
+
+
+@pytest.mark.asyncio
+async def test_s7_5_park_consumes_before_ttl_and_fails_after_ttl() -> None:
+    app, harness = _build_app(ttl_seconds=0.05)
+    async with _client(app) as client:
+        approved = (await _reserve(client, "conv_ask_ok")).json()
+        await asyncio.sleep(0.01)
+        assert (
+            await _consume(client, "conv_ask_ok", approved["admissionId"], "approved")
+        ).status_code == 202
+        harness.release.set()
+        await asyncio.sleep(0.08)
+        consumed_again = await _consume(
+            client,
+            "conv_ask_ok",
+            approved["admissionId"],
+            "approved again",
+        )
+        assert consumed_again.status_code == 409
+        assert consumed_again.json()["error"] == "admission_already_consumed"
+
+        expired = (await _reserve(client, "conv_ask_expired")).json()
+        await asyncio.sleep(0.08)
+        response = await _consume(
+            client,
+            "conv_ask_expired",
+            expired["admissionId"],
+            "late approval",
+        )
+        assert response.status_code == 410
+        assert response.json()["error"] == "admission_expired"
+
+
+@pytest.mark.asyncio
+async def test_s7_6_ttl_expiry_under_load_preserves_fifo_order() -> None:
+    app, _harness = _build_app(ttl_seconds=0.03)
+    async with _client(app) as client:
+        tasks = [asyncio.create_task(_reserve(client, "conv_load")) for _ in range(4)]
+        responses = await asyncio.wait_for(asyncio.gather(*tasks), timeout=1)
+        payloads = [response.json() for response in responses]
+        assert [payload["inputSeq"] for payload in payloads] == [0, 1, 2, 3]
+        assert all(payload["disposition"] == "new_turn" for payload in payloads)
+        await _cancel(client, "conv_load", payloads[-1]["admissionId"])
+
+
+@pytest.mark.asyncio
+async def test_s7_7_double_foreign_and_restart_consumes_are_named_errors() -> None:
+    app, harness = _build_app()
+    async with _client(app) as client:
+        admission = (await _reserve(client, "conv_owner")).json()
+        foreign = await _consume(client, "conv_foreign", admission["admissionId"], "foreign")
+        assert foreign.status_code == 409
+        assert foreign.json()["error"] == "admission_session_mismatch"
+        await _consume(client, "conv_owner", admission["admissionId"], "owner")
+        consumed_foreign = await _consume(
+            client,
+            "conv_foreign",
+            admission["admissionId"],
+            "foreign after consume",
+        )
+        assert consumed_foreign.status_code == 409
+        assert consumed_foreign.json()["error"] == "admission_session_mismatch"
+        double = await _consume(client, "conv_owner", admission["admissionId"], "again")
+        assert double.status_code == 409
+        assert double.json()["error"] == "admission_already_consumed"
+        harness.release.set()
+
+    restarted_app, _ = _build_app()
+    async with _client(restarted_app) as restarted_client:
+        missing = await _consume(
+            restarted_client,
+            "conv_owner",
+            admission["admissionId"],
+            "after restart",
+        )
+        assert missing.status_code == 404
+        assert missing.json()["error"] == "admission_not_found"
+
+
+@pytest.mark.asyncio
+async def test_s7_8_fork_session_reservation_is_isolated_from_source() -> None:
+    app, _harness = _build_app()
+    async with _client(app) as client:
+        source = (await _reserve(client, "conv_source")).json()
+        fork = (await _reserve(client, "conv_fork")).json()
+        assert source["disposition"] == fork["disposition"] == "new_turn"
+        assert source["inputSeq"] == fork["inputSeq"] == 0
+        assert source["lineageId"] != fork["lineageId"]
+        assert set(app.state.admission_reservations) == {
+            source["admissionId"],
+            fork["admissionId"],
+        }
+        await _cancel(client, "conv_source", source["admissionId"])
+        await _cancel(client, "conv_fork", fork["admissionId"])
+
+
+@pytest.mark.asyncio
+async def test_s7_9_first_input_after_resume_gets_fresh_truthful_lineage() -> None:
+    app, harness = _build_app()
+    async with _client(app) as client:
+        before = (await _reserve(client, "conv_resume")).json()
+        await _consume(client, "conv_resume", before["admissionId"], "before resume")
+        harness.release.set()
+        await asyncio.sleep(0.05)
+        resumed = (await _reserve(client, "conv_resume")).json()
+        assert resumed["disposition"] == "new_turn"
+        assert resumed["lineageId"] != before["lineageId"]
+        await _cancel(client, "conv_resume", resumed["admissionId"])

--- a/tests/server/routes/test_session_event_admission.py
+++ b/tests/server/routes/test_session_event_admission.py
@@ -1,0 +1,406 @@
+"""Public AP seam coverage for opt-in session-event admission."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from omnigent.admission import AdmissionInfo, SessionInfo
+from omnigent.entities import Agent, Conversation, ConversationItem, NewConversationItem
+from omnigent.errors import OmnigentError
+from omnigent.runtime import set_runner_client
+from omnigent.server.routes.sessions import create_sessions_router
+
+
+class _AgentStore:
+    def __init__(self, agent: Agent) -> None:
+        self.agent = agent
+
+    def get(self, agent_id: str) -> Agent | None:
+        return self.agent if agent_id == self.agent.id else None
+
+
+class _ConversationStore:
+    def __init__(self, conversation: Conversation) -> None:
+        self.conversation = conversation
+        self.items: list[ConversationItem] = []
+
+    def get_conversation(self, session_id: str) -> Conversation | None:
+        return self.conversation if session_id == self.conversation.id else None
+
+    def append(
+        self,
+        session_id: str,
+        items: list[NewConversationItem],
+    ) -> list[ConversationItem]:
+        if session_id != self.conversation.id:
+            return []
+        persisted: list[ConversationItem] = []
+        for item in items:
+            stored = ConversationItem(
+                id=f"item_{len(self.items) + 1}",
+                type=item.type,
+                status="completed",
+                response_id=item.response_id,
+                created_at=len(self.items) + 1,
+                data=item.data,
+                created_by=item.created_by,
+            )
+            self.items.append(stored)
+            persisted.append(stored)
+        return persisted
+
+    def update_conversation(self, session_id: str, **updates: Any) -> Conversation | None:
+        if session_id != self.conversation.id:
+            return None
+        for key, value in updates.items():
+            setattr(self.conversation, key, value)
+        return self.conversation
+
+
+class _Admitter:
+    def __init__(self, wanted: bool) -> None:
+        self.wanted = wanted
+        self.sessions: list[SessionInfo] = []
+
+    async def wants(self, session: SessionInfo) -> bool:
+        self.sessions.append(session)
+        return self.wanted
+
+
+class _RunnerClient:
+    """Capture reserve, consume, and cancel calls with httpx responses."""
+
+    def __init__(self, *, reservation_status: int = 201) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
+        self.reservation_status = reservation_status
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, Any],
+        timeout: float,
+    ) -> httpx.Response:
+        del timeout
+        self.calls.append(("POST", url, json))
+        request = httpx.Request("POST", f"http://runner{url}")
+        if url.endswith("/admission-reservations"):
+            if self.reservation_status != 201:
+                return httpx.Response(
+                    self.reservation_status,
+                    json={"error": "unavailable"},
+                    request=request,
+                )
+            return httpx.Response(
+                201,
+                json={
+                    "admissionId": "adm_public",
+                    "inputSeq": 41,
+                    "disposition": "new_turn",
+                    "lineageId": "lin_public",
+                    "activeResponseId": None,
+                    "expiresAt": 9_999_999_999_999,
+                },
+                request=request,
+            )
+        return httpx.Response(
+            202,
+            json={"status": "accepted"},
+            request=request,
+        )
+
+    async def delete(self, url: str, *, timeout: float) -> httpx.Response:
+        del timeout
+        self.calls.append(("DELETE", url, None))
+        return httpx.Response(
+            204,
+            request=httpx.Request("DELETE", f"http://runner{url}"),
+        )
+
+
+@pytest.fixture
+def route_factory() -> Any:
+    """Return a factory for isolated admission-enabled route clients."""
+
+    def _build(
+        *,
+        admitter: _Admitter | None,
+        runner: _RunnerClient,
+        callback: Any = None,
+    ) -> tuple[FastAPI, str]:
+        agent_id = "087b7cb7ac30abf4debfaa578d052ec6"
+        conv = Conversation(
+            id="conv_admission",
+            created_at=1,
+            updated_at=1,
+            root_conversation_id="conv_admission",
+            title="admission session",
+            agent_id=agent_id,
+        )
+        conversation_store = _ConversationStore(conv)
+        agent_store = _AgentStore(
+            Agent(
+                id=agent_id,
+                created_at=1,
+                name="test-agent",
+                bundle_location=f"{agent_id}/bundle",
+            )
+        )
+        app = FastAPI()
+
+        @app.exception_handler(OmnigentError)
+        async def _handle_omnigent_error(
+            request: Request,
+            exc: OmnigentError,
+        ) -> JSONResponse:
+            del request
+            return JSONResponse(
+                status_code=exc.http_status,
+                content={"error": {"code": exc.code, "message": exc.message}},
+            )
+
+        app.include_router(
+            create_sessions_router(
+                conversation_store=conversation_store,
+                agent_store=agent_store,
+                session_event_admitter=admitter,
+                on_event_admitted=callback,
+            ),
+            prefix="/v1",
+        )
+        set_runner_client(runner)  # type: ignore[arg-type]
+        return app, conv.id
+
+    return _build
+
+
+@pytest.fixture(autouse=True)
+def _reset_runner_client() -> Any:
+    async def _inline_to_thread(function: Any, *args: Any, **kwargs: Any) -> Any:
+        return function(*args, **kwargs)
+
+    route_asyncio = SimpleNamespace(**vars(asyncio))
+    route_asyncio.to_thread = _inline_to_thread
+    with (
+        patch("omnigent.server.routes.sessions.asyncio", route_asyncio),
+        patch("omnigent.server.routes._auth_helpers.asyncio", route_asyncio),
+    ):
+        yield
+    set_runner_client(None)
+
+
+@contextlib.asynccontextmanager
+async def _client(app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+        yield client
+
+
+def _event() -> dict[str, Any]:
+    return {
+        "type": "message",
+        "data": {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "hello"}],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_s7_10_wants_false_has_zero_admission_calls_or_ack_delta(
+    route_factory: Any,
+) -> None:
+    admitter = _Admitter(False)
+    runner = _RunnerClient()
+    app, session_id = route_factory(admitter=admitter, runner=runner)
+
+    async def _allow(*_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    admission_ids: list[str | None] = []
+
+    async def _dispatch(*_args: Any, **kwargs: Any) -> Any:
+        admission_ids.append(kwargs.get("admission_id"))
+        return type("Dispatch", (), {"item_id": "item_control", "pending_id": None})()
+
+    async with _client(app) as client:
+        with (
+            patch(
+                "omnigent.server.routes.sessions._evaluate_input_policy",
+                new=_allow,
+            ),
+            patch(
+                "omnigent.server.routes.sessions._dispatch_session_event_to_runner",
+                new=_dispatch,
+            ),
+        ):
+            response = await client.post(f"/v1/sessions/{session_id}/events", json=_event())
+
+    assert response.status_code == 202
+    assert set(response.json()) == {"queued", "item_id"}
+    assert response.json()["queued"] is True
+    assert runner.calls == []
+    assert admission_ids == [None]
+    assert [session.id for session in admitter.sessions] == [session_id]
+
+
+@pytest.mark.asyncio
+async def test_public_policy_ack_and_callback_share_one_admission(
+    route_factory: Any,
+) -> None:
+    admitter = _Admitter(True)
+    runner = _RunnerClient()
+    policy_admissions: list[AdmissionInfo | None] = []
+    dispatched_admission_ids: list[str | None] = []
+    callbacks: list[tuple[str, str | None, AdmissionInfo]] = []
+
+    async def _allow(*_args: Any, **kwargs: Any) -> None:
+        policy_admissions.append(kwargs.get("admission"))
+
+    async def _callback(
+        session_id: str,
+        item_id: str | None,
+        admission: AdmissionInfo,
+    ) -> None:
+        callbacks.append((session_id, item_id, admission))
+
+    async def _dispatch(*_args: Any, **kwargs: Any) -> Any:
+        dispatched_admission_ids.append(kwargs.get("admission_id"))
+        return type("Dispatch", (), {"item_id": "item_public", "pending_id": None})()
+
+    app, session_id = route_factory(
+        admitter=admitter,
+        runner=runner,
+        callback=_callback,
+    )
+    async with _client(app) as client:
+        with (
+            patch(
+                "omnigent.server.routes.sessions._evaluate_input_policy",
+                new=_allow,
+            ),
+            patch(
+                "omnigent.server.routes.sessions._dispatch_session_event_to_runner",
+                new=_dispatch,
+            ),
+        ):
+            response = await client.post(f"/v1/sessions/{session_id}/events", json=_event())
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["admission"] == {
+        "admission_id": "adm_public",
+        "input_seq": 41,
+        "disposition": "new_turn",
+        "lineage_id": "lin_public",
+        "active_response_id": None,
+    }
+    assert policy_admissions == [
+        AdmissionInfo.from_runner_payload(
+            {
+                "admissionId": "adm_public",
+                "inputSeq": 41,
+                "disposition": "new_turn",
+                "lineageId": "lin_public",
+                "activeResponseId": None,
+            }
+        )
+    ]
+    assert callbacks == [(session_id, payload["item_id"], policy_admissions[0])]
+    assert [call[0] for call in runner.calls] == ["POST"]
+    assert dispatched_admission_ids == ["adm_public"]
+
+
+@pytest.mark.parametrize("reason", ["not allowed", "approval declined"])
+@pytest.mark.asyncio
+async def test_policy_deny_or_ask_decline_cancels_reservation_before_return(
+    route_factory: Any,
+    reason: str,
+) -> None:
+    admitter = _Admitter(True)
+    runner = _RunnerClient()
+    app, session_id = route_factory(admitter=admitter, runner=runner)
+
+    async def _deny(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {"verdict": "deny", "reason": reason}
+
+    async with _client(app) as client:
+        with patch(
+            "omnigent.server.routes.sessions._evaluate_input_policy",
+            new=_deny,
+        ):
+            response = await client.post(f"/v1/sessions/{session_id}/events", json=_event())
+
+    assert response.status_code == 202
+    assert response.json() == {
+        "queued": False,
+        "denied": True,
+        "reason": reason,
+    }
+    assert [call[:2] for call in runner.calls] == [
+        ("POST", f"/v1/sessions/{session_id}/admission-reservations"),
+        (
+            "DELETE",
+            f"/v1/sessions/{session_id}/admission-reservations/adm_public",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_during_dispatch_cancels_reservation(
+    route_factory: Any,
+) -> None:
+    runner = _RunnerClient()
+    app, session_id = route_factory(admitter=_Admitter(True), runner=runner)
+
+    async def _allow(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    async def _disconnect(*_args: Any, **_kwargs: Any) -> Any:
+        raise asyncio.CancelledError
+
+    async with _client(app) as client:
+        with (
+            patch("omnigent.server.routes.sessions._evaluate_input_policy", new=_allow),
+            patch(
+                "omnigent.server.routes.sessions._dispatch_session_event_to_runner",
+                new=_disconnect,
+            ),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await client.post(f"/v1/sessions/{session_id}/events", json=_event())
+
+    assert [call[:2] for call in runner.calls] == [
+        ("POST", f"/v1/sessions/{session_id}/admission-reservations"),
+        (
+            "DELETE",
+            f"/v1/sessions/{session_id}/admission-reservations/adm_public",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_wanted_session_fails_closed_when_reservation_is_unavailable(
+    route_factory: Any,
+) -> None:
+    runner = _RunnerClient(reservation_status=503)
+    app, session_id = route_factory(admitter=_Admitter(True), runner=runner)
+
+    async with _client(app) as client:
+        response = await client.post(f"/v1/sessions/{session_id}/events", json=_event())
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "admission_unavailable"
+    assert [call[1] for call in runner.calls] == [
+        f"/v1/sessions/{session_id}/admission-reservations"
+    ]


### PR DESCRIPTION
## Related issue

Closes #2756

## Summary

- Add an experimental, opt-in session-event admitter to the public app factory.
- Reserve the runner's existing FIFO turn decision before REQUEST policy, then
  consume it exactly once on ALLOW or cancel it on rejection and interruption.
- Expose the same frozen correlation to function policies, the opt-in
  acknowledgement, and an optional post-persistence callback; the default path
  remains unchanged and requires no migration.

ELI5: the runner already knows whether a message starts, joins, or waits for a
turn. This change lets a selected integration reserve and observe that answer
before the message is saved, without moving the decision out of the runner.

```mermaid
sequenceDiagram
    participant Client
    participant Server
    participant Runner
    Client->>Server: POST session event
    Server->>Runner: reserve admission
    Runner-->>Server: disposition + lineage + admission ID
    Server->>Server: REQUEST policy
    alt allowed
        Server->>Runner: event + admission ID
        Runner-->>Server: consume once
        Server-->>Client: ack + admission + item ID
    else denied or interrupted
        Server->>Runner: cancel reservation
        Server-->>Client: named failure or denial
    end
```

Backward-compatibility guarantees:

- `session_event_admitter=None` makes no additional runner call and adds no
  response field or timing step;
- `EvaluationContext.admission` is optional and defaulted;
- acknowledgement correlation is additive and opt-in only;
- no database migration is required; and
- selected sessions fail closed on reservation or consume failure.

## Test Plan

- `pytest -q -p no:rerunfailures tests/policies/test_admission_context.py tests/runner/test_admission_reservations.py tests/server/routes/test_session_event_admission.py tests/runner/test_app_sessions_native.py::test_turn_sequencing_buffers_concurrent_message tests/runner/test_app_sessions_native.py::test_native_buffered_messages_each_delivered_once_in_order tests/runner/test_app_sessions_native.py::test_buffered_continuation_skips_transient_idle` — 19 passed.
- `ruff check` and `ruff format --check` on all changed Python files — passed.
- `dev/lint/lint_no_global_asyncio_patch.py` and
  `dev/lint/lint_no_skipped_tests.py` — passed.
- `pre-commit run --from-ref` on the full change set — all hooks passed (ruff format/check, asyncio-patch and skipped-test lints, whitespace/EOL/merge-conflict/large-file/case/line-ending checks).

## Demo

N/A — non-visual server extension.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified that the default path makes zero admission calls and preserves
the stock acknowledgement, that selected failures use named errors, and that no
private deployment terms or configuration appear in the patch.

## Changelog

Opt selected sessions into atomic turn admission and correlation before request
policy evaluation.
