### PR TITLE
fix(sandbox): grant the private scratch tmpdir before the spawn-time wrap

### DIFF
--- a/omnigent/inner/sandbox.py
+++ b/omnigent/inner/sandbox.py
@@ -34,6 +34,14 @@ _SANDBOX_STRACE_ENV = "OMNIGENT_SANDBOX_STRACE"
 # and inherited by the wrapped process.
 _LAUNCHER_WRAPPED_ENV = "OMNIGENT_LAUNCHER_SPAWN_WRAPPED"
 
+# Hand-off marker for the spawn-time re-exec: the host pass mints the
+# private scratch tmpdir, grants it in the profile, and names it here
+# so the in-wrap pass adopts that exact dir (instead of minting a
+# second, un-granted one) and owns its cleanup on exit. Names the one
+# dir the host pass created, so cleanup can never touch a spec-supplied
+# write root that merely happens to sit under the system tempdir.
+_LAUNCHER_PRIVATE_TMPDIR_ENV = "OMNIGENT_LAUNCHER_SPAWN_PRIVATE_TMPDIR"
+
 # Backends that need a spawn-time wrap (parent-side ``bwrap`` /
 # ``sandbox-exec`` invocation) in addition to whatever in-process
 # work ``activate_sandbox`` does. ``none`` is a no-op backend so it
@@ -614,11 +622,18 @@ def _prune_environ_to_spawn_allowlist(sandbox: SandboxPolicy) -> None:
     :param sandbox: The decoded launcher policy. No-op when its
         ``spawn_env_allowlist`` is ``None``. The internal launcher
         markers (:data:`_LAUNCHER_WRAPPED_ENV`,
-        :data:`_SANDBOX_STRACE_ENV`) are always retained.
+        :data:`_SANDBOX_STRACE_ENV`,
+        :data:`_LAUNCHER_PRIVATE_TMPDIR_ENV`) are always retained —
+        dropping the tmpdir marker would make the in-wrap pass mint a
+        second scratch dir the profile never granted.
     """
     if sandbox.spawn_env_allowlist is None:
         return
-    allowed = set(sandbox.spawn_env_allowlist) | {_LAUNCHER_WRAPPED_ENV, _SANDBOX_STRACE_ENV}
+    allowed = set(sandbox.spawn_env_allowlist) | {
+        _LAUNCHER_WRAPPED_ENV,
+        _SANDBOX_STRACE_ENV,
+        _LAUNCHER_PRIVATE_TMPDIR_ENV,
+    }
     for name in list(os.environ):
         if name not in allowed:
             del os.environ[name]
@@ -699,50 +714,88 @@ def run_launcher(encoded_sandbox: str, target_path: str, argv: list[str]) -> int
         and os.environ.get(_LAUNCHER_WRAPPED_ENV) != "1"
     ):
         backend = get_backend(sandbox.backend_type)
-        # Re-invoke run_launcher via an INLINE python -c script
-        # rather than re-running the launcher tempfile. Reason:
-        # bwrap mounts ``/tmp`` as a fresh tmpfs, so the host's
-        # ``/tmp/omnigent-sandbox-*.py`` written by
-        # ``create_exec_launcher`` is invisible inside the wrap.
-        # ``python -c '<inline>'`` doesn't need a script file in
-        # the sandbox view — the inline string travels through
-        # argv. Bwrap's ``_ensure_executable_visible`` already
-        # ensures ``sys.executable`` is reachable. The project
-        # root is added to sys.path inside the inline so
-        # ``omnigent.inner.sandbox`` imports succeed even when
-        # the cwd is outside the project tree (terminal case).
-        project_root = repr(str(_project_root()))
-        inline = (
-            "import sys; "
-            f"sys.path.insert(0, {project_root}); "
-            "from omnigent.inner.sandbox import run_launcher; "
-            f"raise SystemExit(run_launcher({encoded_sandbox!r}, "
-            f"{target_path!r}, sys.argv[1:]))"
-        )
-        launcher_argv = [sys.executable, "-c", inline, *argv]
-        wrapped = list(
-            backend.wrap_launcher_argv(
-                launcher_argv,
-                sandbox,
-                Path(os.getcwd()),
-                target=target_path,
+        # Mint the private scratch tmpdir HERE, on the host, before the
+        # wrap is built — the reference pattern from
+        # ``_HelperProcessClient._start_locked``. The wrap bakes the
+        # sandbox profile (seatbelt SBPL / bwrap binds) from ``sandbox``
+        # right now, so the scratch dir has to be a write root *before*
+        # that snapshot or the profile never grants it. Deferring the
+        # ``create_private_tmpdir`` to the in-wrap pass (as before) left
+        # the in-jail ``mkdtemp`` targeting ``$TMPDIR`` = the system
+        # tempdir root, which the profile only granted a subpath of —
+        # ``FileNotFoundError: No usable temporary directory`` on
+        # seatbelt (bwrap masked it via its ``--tmpfs /tmp`` fallback).
+        tmpdir = create_private_tmpdir()
+        try:
+            sandbox = with_additional_write_roots(sandbox, [tmpdir])
+            set_temp_env(os.environ, tmpdir)
+            encoded_sandbox = _encode_json_arg(sandbox.to_jsonable())
+            # Name the dir for the in-wrap pass: it adopts this exact
+            # path (no second mint) and owns the cleanup on exit.
+            os.environ[_LAUNCHER_PRIVATE_TMPDIR_ENV] = str(tmpdir)
+            # Re-invoke run_launcher via an INLINE python -c script
+            # rather than re-running the launcher tempfile. Reason:
+            # bwrap mounts ``/tmp`` as a fresh tmpfs, so the host's
+            # ``/tmp/omnigent-sandbox-*.py`` written by
+            # ``create_exec_launcher`` is invisible inside the wrap.
+            # ``python -c '<inline>'`` doesn't need a script file in
+            # the sandbox view — the inline string travels through
+            # argv. Bwrap's ``_ensure_executable_visible`` already
+            # ensures ``sys.executable`` is reachable. The project
+            # root is added to sys.path inside the inline so
+            # ``omnigent.inner.sandbox`` imports succeed even when
+            # the cwd is outside the project tree (terminal case).
+            # The inline carries the RE-ENCODED policy so the in-wrap
+            # pass decodes the same granted scratch root the profile
+            # was built from.
+            project_root = repr(str(_project_root()))
+            inline = (
+                "import sys; "
+                f"sys.path.insert(0, {project_root}); "
+                "from omnigent.inner.sandbox import run_launcher; "
+                f"raise SystemExit(run_launcher({encoded_sandbox!r}, "
+                f"{target_path!r}, sys.argv[1:]))"
             )
-        )
-        os.environ[_LAUNCHER_WRAPPED_ENV] = "1"
-        logger.info(
-            "[omnigent-sandbox] spawn-time wrap re-exec backend=%s wrap_head=%s",
-            sandbox.backend_type,
-            wrapped[:3],
-        )
-        # ``os.execvp`` replaces the process; nothing after this
-        # line runs unless the exec fails (which raises).
-        os.execvp(wrapped[0], wrapped)
+            launcher_argv = [sys.executable, "-c", inline, *argv]
+            wrapped = list(
+                backend.wrap_launcher_argv(
+                    launcher_argv,
+                    sandbox,
+                    Path(os.getcwd()),
+                    target=target_path,
+                )
+            )
+            os.environ[_LAUNCHER_WRAPPED_ENV] = "1"
+            logger.info(
+                "[omnigent-sandbox] spawn-time wrap re-exec backend=%s wrap_head=%s",
+                sandbox.backend_type,
+                wrapped[:3],
+            )
+            # ``os.execvp`` replaces the process; nothing after this
+            # line runs unless the exec fails (which raises). On success
+            # the in-wrap pass adopts ``tmpdir`` and cleans it up; this
+            # ``except`` only fires if the wrap/exec never handed off.
+            os.execvp(wrapped[0], wrapped)
+        except BaseException:
+            cleanup_private_tmpdir(tmpdir)
+            raise
 
     tmpdir: Path | None = None
     if sandbox.active:
-        tmpdir = create_private_tmpdir()
-        sandbox = with_additional_write_roots(sandbox, [tmpdir])
-        set_temp_env(os.environ, tmpdir)
+        inherited = os.environ.get(_LAUNCHER_PRIVATE_TMPDIR_ENV)
+        if inherited:
+            # In-wrap pass of a spawn-time-wrap backend: adopt the dir
+            # the host pass minted and granted. Re-assert ``$TMPDIR`` in
+            # case the env prune stripped it; do NOT mint a second dir
+            # (that one wouldn't be in the baked profile).
+            tmpdir = Path(inherited)
+            set_temp_env(os.environ, tmpdir)
+        else:
+            # Single-pass active backends (no spawn-time re-exec, e.g.
+            # ``windows_jobobject``): mint + grant + surface here.
+            tmpdir = create_private_tmpdir()
+            sandbox = with_additional_write_roots(sandbox, [tmpdir])
+            set_temp_env(os.environ, tmpdir)
     # Checkpoints around activate + spawn so a hang in either step is
     # visible in the wrapper's stderr (the wrapper template enables INFO).
     logger.info(

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -1478,3 +1478,73 @@ def _argv_mentions(argv: list[str], path: str, *, after_token: str) -> bool:
         if i + 2 < len(argv) and argv[i] == after_token and argv[i + 2] == path:
             return True
     return False
+
+
+@pytestmark_bwrap
+def test_run_launcher_spawn_wrap_private_tmpdir_boots_under_bwrap(tmp_path: Path) -> None:
+    """
+    End-to-end: the ``create_exec_launcher`` -> ``run_launcher``
+    two-pass re-exec grants its private scratch tmpdir on bwrap.
+
+    The macOS-seatbelt counterpart of this test
+    (``test_seatbelt_sandbox.py``) guards the reported
+    ``FileNotFoundError: No usable temporary directory`` — the in-wrap
+    ``mkdtemp`` targeting an un-granted ``$TMPDIR``. bwrap masked that
+    via its ``--tmpfs /tmp`` fallback, so it never regressed; this test
+    exists so the shared fix (mint + grant the scratch dir on the host
+    before the wrap, then adopt it in-wrap) is guarded on the bwrap lane
+    too. Forces ``TMPDIR`` to the system tempdir root to match the
+    seatbelt reproduction exactly.
+    """
+    import tempfile
+
+    from omnigent.inner.sandbox import _project_root, create_exec_launcher
+
+    cwd = tmp_path
+    target = cwd / "tmp_probe.py"
+    target.write_text(
+        "import tempfile, pathlib\n"
+        "d = tempfile.mkdtemp()\n"
+        "p = pathlib.Path(d) / 'scratch.txt'\n"
+        "p.write_text('ok')\n"
+        "assert p.read_text() == 'ok'\n"
+        "print('TMPOK', d)\n"
+    )
+
+    # cwd READ-ONLY (the default) so tempfile can't fall back to it and
+    # mask the bug — the in-wrap mkdtemp must succeed via the granted
+    # private scratch tmpdir. read_roots grants the project root so the
+    # inline re-exec can import ``omnigent.inner``.
+    policy = _make_policy(
+        cwd,
+        read_roots=[_project_root()],
+        cwd_hidden_scan_overflow="warn",
+    )
+    launcher = create_exec_launcher(os.path.realpath(sys.executable), policy)
+    try:
+        env = dict(os.environ)
+        env["TMPDIR"] = tempfile.gettempdir()
+        completed = subprocess.run(
+            [launcher, str(target)],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+            check=False,
+        )
+    finally:
+        os.unlink(launcher)
+
+    assert "No usable temporary directory" not in completed.stderr, (
+        "in-wrap mkdtemp could not find a writable $TMPDIR — the private "
+        f"scratch tmpdir was not granted. rc={completed.returncode} "
+        f"stderr={completed.stderr[-400:]!r}"
+    )
+    assert completed.returncode == 0, (
+        f"wrapped launcher exited {completed.returncode}. "
+        f"stdout={completed.stdout!r} stderr={completed.stderr[-400:]!r}"
+    )
+    assert "TMPOK" in completed.stdout, (
+        f"target did not reach the scratch-write marker. stdout={completed.stdout!r}"
+    )

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -1517,6 +1517,7 @@ def test_run_launcher_spawn_wrap_private_tmpdir_boots_under_bwrap(tmp_path: Path
     # inline re-exec can import ``omnigent.inner``.
     policy = _make_policy(
         cwd,
+        allow_hidden=[".venv"],
         read_roots=[_project_root()],
         cwd_hidden_scan_overflow="warn",
     )

--- a/tests/inner/test_seatbelt_sandbox.py
+++ b/tests/inner/test_seatbelt_sandbox.py
@@ -2287,3 +2287,115 @@ def test_symlink_hop_literals_survives_cycles(tmp_path: Path) -> None:
         f"Cycle members should each be collected once; got {literals!r}."
     )
     assert len(literals) == 2, f"Cycle must not duplicate entries or spin; got {literals!r}."
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="darwin_seatbelt requires macOS")
+def test_run_launcher_spawn_wrap_private_tmpdir_boots_under_seatbelt(
+    tmp_path: Path,
+) -> None:
+    """
+    End-to-end regression for the spawn-time-wrap private-tmpdir grant.
+
+    Drives the FULL ``create_exec_launcher`` -> ``run_launcher``
+    two-pass re-exec (the host pass builds the ``sandbox-exec`` wrap and
+    ``execvp``s into it; the in-wrap pass activates and runs the target).
+    This is the path claude-sdk / terminals / the other spawn-wrap
+    harnesses use — distinct from the direct ``wrap_launcher_argv``
+    calls the rest of this file exercises.
+
+    Reproduces the reported failure: inside the wrap, the launcher mints
+    a private scratch tmpdir via ``tempfile.mkdtemp()``, which targets
+    ``$TMPDIR``. On macOS ``$TMPDIR`` is the system tempdir *root*
+    (``/var/folders/.../T``), and the seatbelt profile — baked before
+    the re-exec — only grants a *subpath* of it, so the in-wrap
+    ``mkdtemp`` died with ``FileNotFoundError: No usable temporary
+    directory``. (bwrap masked this via its ``--tmpfs /tmp`` fallback,
+    so Linux CI never saw it.) The fix mints + grants the scratch dir on
+    the host BEFORE the wrap and hands it to the in-wrap pass, so
+    ``mkdtemp`` lands in a profile-granted, writable location.
+
+    The target is a tiny script that calls ``tempfile.mkdtemp()`` and
+    writes a file into it — the exact operation that failed. We force
+    ``TMPDIR`` to the system tempdir root to reproduce the macOS
+    condition deterministically. Pre-fix: the in-wrap launcher exits
+    non-zero with the ``FileNotFoundError`` before the target ever runs.
+    Post-fix: the target runs and prints ``TMPOK``.
+    """
+    import os
+    import shutil as _shutil
+    import subprocess
+    import tempfile
+
+    from omnigent.inner.sandbox import _project_root, create_exec_launcher
+
+    if _shutil.which("sandbox-exec") is None:
+        pytest.skip("sandbox-exec not on PATH")
+
+    cwd = tmp_path
+    # A target that exercises the scratch tmpdir the way real helpers do:
+    # mkdtemp() (honours $TMPDIR) then write into it. This is what raised
+    # FileNotFoundError inside the wrap pre-fix.
+    target = cwd / "tmp_probe.py"
+    target.write_text(
+        "import tempfile, pathlib\n"
+        "d = tempfile.mkdtemp()\n"
+        "p = pathlib.Path(d) / 'scratch.txt'\n"
+        "p.write_text('ok')\n"
+        "assert p.read_text() == 'ok'\n"
+        "print('TMPOK', d)\n"
+    )
+
+    # cwd is READ-ONLY — the seatbelt default, and the condition that
+    # makes this a real reproduction: with no writable cwd, Python's
+    # tempfile fallback chain ($TMPDIR -> /tmp -> ... -> os.getcwd())
+    # has NO writable entry, so a private-tmpdir mkdtemp that targets an
+    # un-granted $TMPDIR fails outright. (If cwd were writable, mkdtemp
+    # would silently fall back to it and mask the bug.) ``.venv`` allowed
+    # so the dotfile mask doesn't fight the interpreter symlink
+    # convention. The project root is a read root so the inline re-exec
+    # can import ``omnigent.inner`` — in production that import is
+    # covered by the interpreter install-root grant or by cwd; here cwd
+    # is pytest's tmp_path, so grant it explicitly.
+    policy = _make_policy(
+        cwd.resolve(strict=False),
+        allow_hidden=[".venv"],
+        read_roots=[_project_root()],
+    )
+
+    # The launcher script re-execs run_launcher under sandbox-exec. Its
+    # shebang is ``sys.executable``; run it as a plain argv so the
+    # two-pass flow (host -> execvp sandbox-exec -> in-wrap) happens for
+    # real. ``target`` is the interpreter here, exec'd inside the jail.
+    launcher = create_exec_launcher(str(Path(sys.executable).resolve(strict=True)), policy)
+    try:
+        env = dict(os.environ)
+        # Reproduce the macOS failure condition explicitly: $TMPDIR is
+        # the system tempdir ROOT, which the profile only grants a
+        # subpath of. Pre-fix this is exactly what broke the in-wrap
+        # mkdtemp.
+        env["TMPDIR"] = tempfile.gettempdir()
+        result = subprocess.run(
+            [launcher, str(target)],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+    finally:
+        os.unlink(launcher)
+
+    assert "No usable temporary directory" not in result.stderr, (
+        "In-wrap mkdtemp could not find a writable $TMPDIR — the private "
+        "scratch tmpdir was not granted in the baked seatbelt profile. "
+        f"rc={result.returncode}\nstdout={result.stdout!r}\n"
+        f"stderr={result.stderr!r}"
+    )
+    assert result.returncode == 0, (
+        f"Wrapped launcher exited {result.returncode}.\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "TMPOK" in result.stdout, (
+        "Target ran but didn't reach the scratch-write marker; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )


### PR DESCRIPTION
## Related issue

N/A — follow-up to the macOS-seatbelt cluster (#2743 / #2749, both merged). Surfaced while smoke-testing that cluster on a real Mac; no separate issue was filed.

## Summary

- A `darwin_seatbelt` claude-sdk seat booted the `sandbox-exec` wrap fine but then died with `FileNotFoundError: [Errno 2] No usable temporary directory found in ['/var/folders/.../T', ...]`.
- `run_launcher` runs **twice** for spawn-wrap backends: the host pass builds the wrap (baking the seatbelt SBPL profile / bwrap binds) and `execvp`s into it; the in-wrap pass activates and runs the target. The private scratch tmpdir was minted only in the **in-wrap** pass — via `mkdtemp()` against `$TMPDIR` = the system tempdir **root**, which the already-baked profile only granted a *subpath* of. bwrap masked this via its `--tmpfs /tmp` fallback, so only seatbelt (no tmpfs; `$TMPDIR` always set on macOS) hit it, and Linux CI never saw it.
- Fix: mint + grant the scratch dir on the **host, before** the wrap (the pattern `_HelperProcessClient._start_locked` already uses), re-encode the policy so both the profile and the in-wrap pass see the granted root, and hand the path to the in-wrap pass via a marker env var so it adopts that exact dir and owns cleanup.

**ELI5:** the sandbox handed the jailed process a locked room and told it "make your scratch folder in the building lobby" — but only the room was unlocked, not the lobby. Now we make the scratch folder *before* locking up, inside the room, and tell the process where it is.

```
BEFORE                                   AFTER
host pass:  build wrap ── execvp ─┐      host pass:  mkdtemp() + grant + $TMPDIR + marker
                                  │                  build wrap ── execvp ─┐
in-wrap:    mkdtemp($TMPDIR=/T)   ▼                                        ▼
            └─ /T root NOT granted → EPERM   in-wrap:  adopt marker dir (granted) ✓ → boots
```

Cleanup uses the marker (the one dir the host pass minted), not `_scratch_tmpdir` re-derivation — kimi/acp add `/tmp` to `write_roots`, so re-derivation could `rmtree("/tmp")`. The marker is retained through the spawn-env prune (five harnesses set `spawn_env_allowlist`; dropping it would make them mint a second, un-granted dir in-jail).

## Test Plan

Verified end-to-end on a real Mac (macOS 26.5.1, arm64, `/usr/bin/sandbox-exec`):

- **Reproduced pre-fix / gone post-fix**: the new seatbelt E2E test fails with the exact `FileNotFoundError` when the fix is stashed, passes with it applied.
- **Real boot**: `omnigent run` of a `claude-sdk` + `darwin_seatbelt` agent now boots through the sandbox all the way to provider auth — zero `FileNotFoundError` / `execvp` / `realpath` EPERM in the launcher stderr (previously died at the tmpdir stage).
- **Suites green** on macOS: `tests/inner/test_seatbelt_sandbox.py` (incl. the new test + the ~10 macOS-gated cases CI skips) and `tests/inner/test_claude_sdk_executor.py`.
- New E2E tests drive the **full `create_exec_launcher` → `run_launcher` two-pass re-exec** (the path claude-sdk / terminals / the other spawn-wrap harnesses use), forcing `TMPDIR` to the system tempdir root to reproduce the macOS condition. The bwrap counterpart is `bwrap`-gated so CI validates the non-regression on Linux (I can't run bwrap on macOS).
- `ruff check` / `ruff format --check` clean on all three files.

## Demo

N/A (non-visual sandbox/launcher change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added macOS-gated (`test_seatbelt_sandbox.py`) and Linux-gated (`test_bwrap_sandbox.py`) end-to-end regression tests that drive the real two-pass re-exec through `create_exec_launcher` → `run_launcher` (the rest of those files only call `wrap_launcher_argv` directly, which never exercises the broken in-wrap path). Manual verification = the real `omnigent run` seatbelt boot described in the Test Plan, on a physical Mac (`sandbox-exec` is unavailable in Linux CI, so the seatbelt lane can only be smoke-tested by hand).

## Changelog

Sandboxed (`darwin_seatbelt`) agents no longer die at startup with "No usable temporary directory" — the private scratch tmpdir is now granted in the sandbox profile before the process is jailed.