### PR TITLE
[benchmarks] Add existing-session cold restart journey

### DIFF
--- a/dev/benchmarks/omnigent/README.md
+++ b/dev/benchmarks/omnigent/README.md
@@ -81,23 +81,21 @@ drift negligible (~2 ms/turn).
 
 | Journey | Operation timed |
 | --- | --- |
-| `session_cold_start` | Spawn a **fresh runner process**, wait for its tunnel, bind a session, and drive the first turn to `idle` — the full new-conversation cold path |
+| `session_cold_start` | Create a new host-bound session and time its fresh runner launch through the first token — the full new-conversation cold path |
+| `session_cold_restart` | With an existing session's runner stopped before the sample, post a user message and time the automatic runner relaunch to first token |
 | `warm_turn` | Drive a turn on an already-warm session — steady-state dispatch overhead |
 | `time_to_first_token` | Post a turn; time to the first streamed `output_text` delta |
 | `interrupt` | Interrupt a running (gated) turn; time to cancellation |
 | `read_runner_file` | `GET .../environments/default/filesystem/{path}` — server → runner filesystem read proxy |
 
-**`session_cold_start` spawns a real runner.** The env spawns one runner at
-boot, but the warm journeys reuse it — so `session_cold_start` instead spawns a
-*fresh* runner subprocess per iteration and waits for its reverse tunnel to
-register before binding and driving the turn. That captures the runner process
-start + tunnel handshake that a real new conversation always pays (and that a
-host-launched session pays on its first message), not just the sub-second
-executor-construction + first-turn overhead. Each iteration terminates its
-runner afterward, so at most one extra runner is ever live. Each spawned runner
-mints its own binding token and derives its `runner_id` from it (so tunnel,
-mint, and session binding all agree on one id) and registers over loopback,
-exactly like the boot runner — a fully independent runner.
+The two cold journeys use a real `omni host` daemon. `session_cold_start`
+creates a new host-bound session per sample, while `session_cold_restart`
+creates one session up front and sends `stop_session` before each sample. That
+control event preserves the conversation but stops its runner; the timed user
+message then follows the production auto-relaunch path. In both cases the host
+spawns a fresh runner with its own binding token and reverse tunnel, so the
+latency includes process startup, tunnel registration, and first-token
+dispatch. The daemon reaps any remaining runners when the benchmark exits.
 
 `read_runner_file` needs a runner but does **not** drive a turn or call the LLM:
 its setup plants a file via `PUT`, and the timed op is the proxied read (a

--- a/dev/benchmarks/omnigent/environment.py
+++ b/dev/benchmarks/omnigent/environment.py
@@ -55,10 +55,12 @@ _HEALTH_TIMEOUT_S = 90.0
 _MOCK_TIMEOUT_S = 15.0
 _POLL_INTERVAL_S = 0.2
 _TURN_TIMEOUT_S = 180.0
-# Budget for the host daemon (session_cold_start journey, with_host) to connect
-# its tunnel and register in the hosts table after being spawned. Covers
+# Budget for the host daemon (host-backed cold journeys) to connect its tunnel
+# and register in the hosts table after being spawned. Covers
 # interpreter start + imports + the reverse-tunnel handshake.
 _HOST_ONLINE_TIMEOUT_S = 60.0
+# Budget for a host-owned runner tunnel to disappear after ``stop_session``.
+_RUNNER_OFFLINE_TIMEOUT_S = 30.0
 
 # Terminal SSE events — if one arrives before any delta, the turn produced no
 # streamed text (a failure for the TTFT journey).
@@ -112,9 +114,8 @@ class BenchEnvironment:
     :param with_host: When ``True`` (implies ``with_runner``), additionally
         spawn a real ``omnigent host`` daemon. Additive over ``with_runner``:
         the boot runner still serves the warm journeys, while the daemon lets
-        the ``session_cold_start`` journey create host-bound sessions that fire
-        ``host.launch_runner`` and launch their OWN fresh runner — so the first
-        message races the runner's boot, reproducing the true UI cold path.
+        the cold-start and cold-restart journeys use host-bound sessions that
+        fire ``host.launch_runner`` and launch their own fresh runners.
     :param database_uri: SQLAlchemy URI the server boots against. ``None``
         (default) uses a fresh throwaway SQLite file in the temp dir — the
         empty-DB path. Pass a pre-seeded URI (e.g. a seeded SQLite file, or a
@@ -216,9 +217,8 @@ class BenchEnvironment:
             self._runner_proc = self._spawn_runner(base_env, binding_token)
         self._wait_ready()
         # The host daemon is ADDITIVE — the boot runner above still serves the
-        # warm journeys; the daemon exists so the cold-start journey can create
-        # host-bound sessions that launch their OWN fresh runners on demand
-        # (the race the cold path measures). The two never share a runner id.
+        # warm journeys; the daemon exists so host-backed cold journeys can
+        # launch their own runners on demand. The two never share a runner id.
         if self.with_host:
             self._host_proc = self._spawn_host(base_env)
             self._wait_host_online()
@@ -340,10 +340,8 @@ class BenchEnvironment:
     ) -> subprocess.Popen[bytes]:
         """Spawn one runner subprocess under *runner_id* + *binding_token*.
 
-        Factored out of :meth:`_spawn_runner` so the ``session_cold_start``
-        journey can spawn additional runners on demand, each under its own id,
-        binding token, and workspace. The caller must pair *runner_id* with the token
-        it derives from (``token_bound_runner_id(binding_token)``): the runner
+        The caller must pair *runner_id* with the token it derives from
+        (``token_bound_runner_id(binding_token)``): the runner
         derives its managed-mint URL from the token internally, so a mismatch
         would register the tunnel under one id but mint under another (→ 401).
         """
@@ -640,6 +638,33 @@ class BenchEnvironment:
         bound.raise_for_status()
         return session_id
 
+    async def stop_session_runner(
+        self, session_id: str, *, timeout: float = _RUNNER_OFFLINE_TIMEOUT_S
+    ) -> None:
+        """Stop a host-backed session's runner and wait until it is offline.
+
+        ``stop_session`` preserves the conversation and its host binding. The
+        next user message therefore exercises the production auto-relaunch
+        path instead of starting a new conversation.
+        """
+        assert self.client is not None
+        if not self.with_host:
+            raise RuntimeError("stop_session_runner requires with_host=True")
+        stopped = await self.client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={"type": "stop_session", "data": {}},
+        )
+        stopped.raise_for_status()
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            snap = await self.client.get(f"/v1/sessions/{session_id}")
+            snap.raise_for_status()
+            if snap.json().get("runner_online") is False:
+                return
+            await asyncio.sleep(_POLL_INTERVAL_S)
+        raise RuntimeError(f"runner did not stop within {timeout}s (session {session_id})")
+
     async def write_runner_file(self, session_id: str, relative_path: str, content: str) -> None:
         """Write a file into the runner's default environment over HTTP.
 
@@ -742,9 +767,9 @@ class BenchEnvironment:
 
         :param wait_idle_first: When ``True``, wait for the session to be ``idle``
             before subscribing so a prior turn's terminal event can't race this
-            turn's response (warm-session TTFT). ``False`` for a fresh session whose
-            first turn is the only one — the cold path, where the timed span must
-            include runner launch + connect, so we must NOT poll it warm first.
+            turn's response (warm-session TTFT). ``False`` for a fresh session or
+            a stopped existing session — cold paths where polling for ``idle``
+            would either warm the runner or wait forever on its disconnected state.
         :raises RuntimeError: If not in runner mode, or no response / a terminal
             event arrives within *timeout*.
         """
@@ -843,6 +868,19 @@ class BenchEnvironment:
         """
         await self._post_and_await_first_delta(
             session_id, text, wait_idle_first=True, timeout=timeout
+        )
+
+    async def cold_restart_first_delta(
+        self, session_id: str, text: str, *, timeout: float = _TURN_TIMEOUT_S
+    ) -> None:
+        """Post to a stopped existing session and await its first response.
+
+        A stopped session is marked failed rather than idle, so this deliberately
+        skips the warm-session idle poll. The POST itself triggers the host runner
+        relaunch whose latency this path measures.
+        """
+        await self._post_and_await_first_delta(
+            session_id, text, wait_idle_first=False, timeout=timeout
         )
 
     async def cold_start_first_delta(

--- a/dev/benchmarks/omnigent/journeys.py
+++ b/dev/benchmarks/omnigent/journeys.py
@@ -27,6 +27,11 @@ SSE stream, sends the first message, and times to the first output-text delta �
 so the span includes the on-demand runner launch + reverse-tunnel handshake the
 UI's first message races, exactly as a real new chat pays it.
 
+``session_cold_restart`` reuses one existing host-bound session. Before every
+timed message it stops that session's runner outside the measured span; the
+message then exercises the server's automatic relaunch path and times to the
+first streamed response.
+
 The framework (``Journey`` + the two runners) is harness-agnostic and reused
 verbatim by phase-2 full-turn journeys.
 """
@@ -70,6 +75,9 @@ class Journey:
         the environment and the setup context.
     :param setup: Optional coroutine run once before timing; its return value
         is passed to ``measure`` (and ``teardown``) as ``ctx``.
+    :param prepare: Optional coroutine run before every measured operation,
+        outside that operation's latency timer. Used when each sample needs a
+        repeatable precondition, such as an offline runner.
     :param teardown: Optional coroutine run once after timing, given ``ctx``.
     :param concurrency_safe: Whether many ``measure`` calls may run at once
         against a shared setup (true for read-only / independent-write HTTP
@@ -79,8 +87,7 @@ class Journey:
         HTTP/DB journeys leave this ``False``.
     :param needs_host: Whether this journey needs a real host daemon
         (``BenchEnvironment(with_host=True)``) so a host-bound session-create
-        fires ``host.launch_runner`` and the first message races the runner's
-        boot. Implies ``needs_runner``. Only ``session_cold_start`` sets this.
+        or restart can fire ``host.launch_runner``. Implies ``needs_runner``.
     :param max_iterations: Upper bound on latency iterations for this journey,
         clamping ``--iterations`` down (never up). Full-turn journeys cost ~1s+
         per op, so 100+ iterations would blow the CI time budget; they cap at a
@@ -93,6 +100,7 @@ class Journey:
     kind: JourneyKind
     measure: Callable[[BenchEnvironment, JourneyContext], Awaitable[None]]
     setup: Callable[[BenchEnvironment], Awaitable[JourneyContext]] | None = None
+    prepare: Callable[[BenchEnvironment, JourneyContext], Awaitable[None]] | None = None
     teardown: Callable[[BenchEnvironment, JourneyContext], Awaitable[None]] | None = None
     concurrency_safe: bool = False
     needs_runner: bool = False
@@ -102,6 +110,10 @@ class Journey:
 
     async def run_setup(self, env: BenchEnvironment) -> JourneyContext:
         return await self.setup(env) if self.setup is not None else None
+
+    async def run_prepare(self, env: BenchEnvironment, ctx: JourneyContext) -> None:
+        if self.prepare is not None:
+            await self.prepare(env, ctx)
 
     async def run_teardown(self, env: BenchEnvironment, ctx: JourneyContext) -> None:
         if self.teardown is not None:
@@ -141,10 +153,19 @@ async def run_latency(
     try:
         for _ in range(warmup):
             with contextlib.suppress(Exception):  # warmup errors are non-fatal
+                await journey.run_prepare(env, ctx)
                 await journey.measure(env, ctx)
         result = RunResult()
         wall_start = time.perf_counter()
         for _ in range(iterations):
+            try:
+                await journey.run_prepare(env, ctx)
+            except httpx.HTTPStatusError as exc:
+                result.record_failure(f"HTTP {exc.response.status_code}")
+                continue
+            except Exception as exc:  # noqa: BLE001 — preparation failure is a data point
+                result.record_failure(exc.__class__.__name__)
+                continue
             await _timed(journey, env, ctx, result)
         result.wall_time = time.perf_counter() - wall_start
         return result
@@ -173,9 +194,18 @@ async def run_throughput(
         async def _one(count_it: bool, result: RunResult) -> None:
             async with sem:
                 if count_it:
+                    try:
+                        await journey.run_prepare(env, ctx)
+                    except httpx.HTTPStatusError as exc:
+                        result.record_failure(f"HTTP {exc.response.status_code}")
+                        return
+                    except Exception as exc:  # noqa: BLE001 — preparation failure is a data point
+                        result.record_failure(exc.__class__.__name__)
+                        return
                     await _timed(journey, env, ctx, result)
                 else:
                     with contextlib.suppress(Exception):  # warmup errors are non-fatal
+                        await journey.run_prepare(env, ctx)
                         await journey.measure(env, ctx)
 
         if warmup:
@@ -385,6 +415,32 @@ async def _setup_cold_start_agent(env: BenchEnvironment) -> str:
     return await _setup_turn_agent(env, stream=True)
 
 
+async def _setup_cold_restart_session(env: BenchEnvironment) -> str:
+    """Create a host-backed session and complete its first turn.
+
+    This establishes the durable conversation and its runner binding before
+    the per-sample preparation stops the runner. Every measured message then
+    resumes this same existing session through the automatic relaunch path.
+    """
+    agent_id = await _setup_turn_agent(env, stream=True)
+    session_id = await env.create_hosted_session(agent_id)
+    await env.drive_turn(session_id, _TURN_PROMPT)
+    return session_id
+
+
+async def _prepare_cold_restart(env: BenchEnvironment, ctx: JourneyContext) -> None:
+    """Stop the existing session's runner before a cold-restart sample."""
+    session_id = cast(str, ctx)  # _setup_cold_restart_session
+    await env.stop_session_runner(session_id)
+
+
+async def _teardown_cold_restart(env: BenchEnvironment, ctx: JourneyContext) -> None:
+    """Stop the runner left online after the final first-token sample."""
+    session_id = cast(str, ctx)  # _setup_cold_restart_session
+    with contextlib.suppress(Exception):
+        await env.stop_session_runner(session_id)
+
+
 async def _setup_warm_session(env: BenchEnvironment) -> str:
     """Create+bind a session and drive one warm-up turn; return the session id.
 
@@ -445,6 +501,12 @@ async def _measure_session_cold_start(env: BenchEnvironment, ctx: JourneyContext
     """
     agent_id = cast(str, ctx)  # _setup_turn_agent (stream=True)
     await env.cold_start_first_delta(agent_id, _TURN_PROMPT)
+
+
+async def _measure_session_cold_restart(env: BenchEnvironment, ctx: JourneyContext) -> None:
+    """Post to an existing session with a dead runner; await first token."""
+    session_id = cast(str, ctx)  # _setup_cold_restart_session
+    await env.cold_restart_first_delta(session_id, _TURN_PROMPT)
 
 
 async def _measure_warm_turn(env: BenchEnvironment, ctx: JourneyContext) -> None:
@@ -551,6 +613,19 @@ ALL_JOURNEYS: dict[str, Journey] = {
             max_iterations=_RUNNER_MAX_ITERATIONS,
             description="Create a host-bound session (fires host.launch_runner) then "
             "time create → attach SSE → send → first token — the real UI cold path.",
+        ),
+        Journey(
+            name="session_cold_restart",
+            kind="latency",
+            measure=_measure_session_cold_restart,
+            setup=_setup_cold_restart_session,
+            prepare=_prepare_cold_restart,
+            teardown=_teardown_cold_restart,
+            needs_runner=True,
+            needs_host=True,
+            max_iterations=_RUNNER_MAX_ITERATIONS,
+            description="Stop the runner for an existing host-bound session, then time "
+            "POST message → automatic runner relaunch → first token.",
         ),
         Journey(
             name="warm_turn",

--- a/tests/benchmarks/test_benchmark_smoke.py
+++ b/tests/benchmarks/test_benchmark_smoke.py
@@ -17,7 +17,8 @@ from typing import cast
 import pytest
 
 from dev.benchmarks.omnigent import run as bench_run
-from dev.benchmarks.omnigent.journeys import ALL_JOURNEYS
+from dev.benchmarks.omnigent.environment import BenchEnvironment
+from dev.benchmarks.omnigent.journeys import ALL_JOURNEYS, Journey, run_latency
 from dev.benchmarks.omnigent.measure import RunResult, aggregate, check_thresholds
 from dev.benchmarks.omnigent.schema import SCHEMA_VERSION, build_report
 
@@ -149,6 +150,52 @@ def test_runner_journeys_are_capped() -> None:
             assert journey.max_iterations is None, journey.name
 
 
+@pytest.mark.asyncio
+async def test_latency_prepare_runs_before_warmup_and_timed_operations() -> None:
+    """Per-sample preparation is outside measure but runs for every sample."""
+    calls: list[str] = []
+
+    async def _setup(_env: BenchEnvironment) -> object:
+        calls.append("setup")
+        return object()
+
+    async def _prepare(_env: BenchEnvironment, _ctx: object) -> None:
+        calls.append("prepare")
+
+    async def _measure(_env: BenchEnvironment, _ctx: object) -> None:
+        calls.append("measure")
+
+    async def _teardown(_env: BenchEnvironment, _ctx: object) -> None:
+        calls.append("teardown")
+
+    journey = Journey(
+        name="prepared",
+        kind="latency",
+        setup=_setup,
+        prepare=_prepare,
+        measure=_measure,
+        teardown=_teardown,
+    )
+    result = await run_latency(
+        journey,
+        cast(BenchEnvironment, object()),
+        iterations=2,
+        warmup=1,
+    )
+
+    assert result.n_success == 2
+    assert calls == [
+        "setup",
+        "prepare",
+        "measure",
+        "prepare",
+        "measure",
+        "prepare",
+        "measure",
+        "teardown",
+    ]
+
+
 # ── end-to-end smoke (boots the server) ──────────────────────
 
 
@@ -192,6 +239,7 @@ async def test_benchmark_smoke_threshold_failure_exits_nonzero() -> None:
 
 _RUNNER_JOURNEYS = [
     "session_cold_start",
+    "session_cold_restart",
     "warm_turn",
     "time_to_first_token",
     "interrupt",
@@ -204,7 +252,7 @@ async def test_benchmark_smoke_runner_journeys() -> None:
     """Run each full-turn journey once through server + runner + mock LLM.
 
     First exercise of the ``with_runner=True`` path end-to-end. Tiny counts —
-    each cold-start iteration spawns a runner, so this is the slow smoke.
+    each cold-journey iteration spawns a runner, so this is the slow smoke.
     """
     report, passed = await bench_run.run_benchmark(
         _smoke_args(journeys=_RUNNER_JOURNEYS, iterations=1, warmup=1)


### PR DESCRIPTION
## Related issue

N/A

## Summary

The nightly benchmark measures starting a brand-new session, but it did not cover the distinct latency users experience when returning to an existing session whose runner has died. This adds a `session_cold_restart` journey so reports capture the automatic runner relaunch path from the user message through the first streamed response.

- Create and warm one host-backed session, then preserve and reuse that conversation for every sample.
- Stop the runner before each sample outside the latency timer; the timed POST exercises the production host relaunch path.
- Add per-sample benchmark preparation, lifecycle helpers, smoke coverage, and journey documentation.

**ELI5:** the benchmark now turns off an existing session's worker, sends the session another message, and measures how long it takes to see the first reply.

```mermaid
flowchart LR
    A["Existing session"] --> B["Untimed stop_session"]
    B --> C["Runner offline"]
    C --> D["Timed POST /events"]
    D --> E["Host launches replacement runner"]
    E --> F["First streamed response"]
```

## Test Plan

- [x] Ran `uv run --no-sync pre-commit run` on the staged files.
- [x] Ran `uv run --no-sync ruff format --check dev/benchmarks/omnigent/journeys.py dev/benchmarks/omnigent/environment.py tests/benchmarks/test_benchmark_smoke.py`.
- [x] Ran `uv run --no-sync ruff check dev/benchmarks/omnigent/journeys.py dev/benchmarks/omnigent/environment.py tests/benchmarks/test_benchmark_smoke.py`.
- [x] Ran `uv run --no-sync pytest -q tests/benchmarks/test_benchmark_smoke.py` (13 passed).
- [x] Ran `uv run --no-sync dev/benchmarks/omnigent/run.py --journeys session_cold_restart --iterations 2 --runs 1 --warmup 1`; both timed cold restarts succeeded with zero failures.

## Demo

N/A — non-visual benchmark change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification ran the new journey with one warmup and two consecutive timed relaunches against a real local server, host daemon, runner, and mock LLM. The generated report recorded two successes and zero failures.

## Changelog

Benchmark reports now measure cold restarts of existing sessions whose runner is offline.
