### PR TITLE
test(terminals): de-flake control-bridge burst-then-exit tail test

### DIFF
--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -312,6 +312,8 @@ async def bridge_tmux_control_to_websocket(
     tmux_target: str,
     read_only: bool,
     on_client_interaction: Callable[[], None] | None = None,
+    reader_done: asyncio.Event | None = None,
+    forward_done: asyncio.Event | None = None,
 ) -> None:
     """Bridge a tmux control-mode client to an already-accepted *websocket*.
 
@@ -330,6 +332,13 @@ async def bridge_tmux_control_to_websocket(
         interaction (connect, disconnect, each input/resize frame) so the
         idle watcher can discount client-driven repaints. See the PTY bridge
         for the full rationale.
+    :param reader_done: Optional test-only event set once the reader has queued
+        the full backlog and the ``None`` EOF sentinel, letting a test await the
+        reader draining tmux instead of sleeping. Inert (never awaited) when
+        ``None``, which is the only case real callers hit.
+    :param forward_done: Optional test-only event set once the forwarder task
+        returns (normal completion or cancellation), letting a test await the
+        backlog fully flushing to the browser. Inert when ``None``.
     """
     # Attaching reflows the pane to this client's size — stamp it as a client
     # interaction so the idle watcher discounts the resulting repaint.
@@ -455,6 +464,8 @@ async def bridge_tmux_control_to_websocket(
                         return
         finally:
             output_chunks.put_nowait(None)
+            if reader_done is not None:
+                reader_done.set()
 
     async def _ws_to_control() -> None:
         """Read browser frames; resize via refresh-client -C, input via -H hex."""
@@ -508,6 +519,8 @@ async def bridge_tmux_control_to_websocket(
         ),
         name="tmux-control-forward",
     )
+    if forward_done is not None:
+        forward_task.add_done_callback(lambda _task: forward_done.set())
     ws_task = asyncio.create_task(_ws_to_control(), name="tmux-ws-to-control")
     # "Control side ended" == the reader finished (session gone / %exit /
     # window-close) — the signal the close-code logic keys on. The forwarder

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -279,14 +279,23 @@ async def test_control_bridge_burst_then_exit_delivers_full_tail() -> None:
     await asyncio.sleep(0.2)
 
     ws = _FakeWebSocket(inbound=[], send_delay_s=0.005)
+    reader_done = asyncio.Event()
+    forward_done = asyncio.Event()
     task = asyncio.create_task(
         bridge_tmux_control_to_websocket(
-            ws, socket_path=str(sock), tmux_target=target, read_only=False
+            ws,
+            socket_path=str(sock),
+            tmux_target=target,
+            read_only=False,
+            reader_done=reader_done,
+            forward_done=forward_done,
         )
     )
-    # Wait past attach + burst + the bounded drain (coalesced to ~100 frames of
-    # ~20 KB, so ~0.5 s of 5 ms sends; generous margin below).
-    await asyncio.sleep(10.0)
+    # Deterministically wait until the reader has queued the whole backlog plus
+    # the EOF sentinel, then until the forwarder has fully drained it — no
+    # arbitrary wall-clock sleep. Timeouts are generous backstops, not timing.
+    await asyncio.wait_for(reader_done.wait(), timeout=20.0)
+    await asyncio.wait_for(forward_done.wait(), timeout=20.0)
 
     total_y = sum(f.count(b"Y") for f in ws.sent)
     assert total_y >= payload_len, (


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `test_control_bridge_burst_then_exit_delivers_full_tail` was flaky and slow: it relied on a fixed `sleep(10.0)` to give the reader time to drain the tmux control stream, which was both wasteful and still racy under load.
- Add two inert, default-`None` `asyncio.Event` hooks (`reader_done` / `forward_done`) to `bridge_tmux_control_to_websocket` that fire when the reader and forwarder tasks finish, and switch the test to wait on those events instead of a wall-clock sleep.
- The hooks default to `None`, so the hot path is unchanged for real callers — only the test opts in.

## Test Plan

- Target test `test_control_bridge_burst_then_exit_delivers_full_tail`: now ~2s (was ~10s).
- Stress run: 20/20 passed.
- Full file: 11 passed.
- `pre-commit run --files ...` clean on both changed files.

## Demo

N/A (non-visual change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the target test (~2s, was ~10s), a 20-iteration stress loop (20/20 passed), and the full `test_control_bridge.py` file (11 passed). The change is test-plumbing plus two default-None hooks that no production caller sets, so behavior for real callers is unchanged.
