### PR TITLE
fix(server): size the SQLite connection pool above the default 15

### DIFF
--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -231,6 +231,18 @@ def _create_engine(db_uri: str) -> Engine:
         engine = create_engine(
             db_uri,
             connect_args={"check_same_thread": False, "timeout": 20.0},
+            # Give SQLite a modest pool above SQLAlchemy's default
+            # QueuePool(5, 10) = 15, which the /health sidebar poll exhausts
+            # under load (surfacing as "QueuePool ... timeout" 500s).
+            # Deliberately NOT sized to the 200-token AnyIO thread limiter
+            # like the Postgres branch below: SQLite serializes at the file
+            # level, so handing out ~200 connections just lets that many
+            # worker threads thrash SQLite's page-cache mutex and burn CPU
+            # instead of queuing cheaply on the pool. ~40 total clears the
+            # exhaustion without inviting lock contention.
+            pool_size=15,
+            max_overflow=25,
+            pool_timeout=10,
         )
 
         # Apply WAL + busy_timeout on every fresh DBAPI connection


### PR DESCRIPTION
## Related issue

Closes #2767

## Summary

- On the default local **SQLite** backend, `_create_engine` in `omnigent/db/utils.py` sets only `connect_args` — no pool sizing — so SQLite inherits SQLAlchemy's default `QueuePool(pool_size=5, max_overflow=10)` = **15 connections**, while `server/app.py:_lifespan` raises the AnyIO thread limiter to **200**.
- Under multi-session use the `/health` sidebar poll (every 1-2s, batched over every visible session id → `_bulk_session_liveness` → `get_session_connectivity`) exhausts the 15 slots and the next checkout hits `pool_timeout`, returning HTTP 500 with `QueuePool limit of size 5 overflow 10 reached, timeout 30.00`.
- This PR gives SQLite a **modest** pool (`pool_size=15, max_overflow=25` ≈ 40 total, `pool_timeout=10`) that clears the exhaustion.

### Why not mirror the Postgres branch (pool_size=200)?

The Postgres branch is sized to the 200-token thread limiter because a real DB server handles that concurrency. **SQLite must not** — it serializes at the file level, so handing out ~200 connections just lets that many worker threads pile into SQLite's internal page-cache mutex and burn CPU on lock contention instead of queuing cheaply on the pool. An earlier revision of this PR used `50/200` and reproduced exactly that: `/health` stopped 500ing, but the server pegged multiple cores under sidebar polling against a large `chat.db`. `~40` total is the sweet spot: comfortably above the 15-connection ceiling that caused the timeouts, low enough to avoid file-lock thrash.

```
_lifespan: AnyIO thread limiter = 200
  Postgres branch: pool_size=200   ← safe (server-side concurrency)
  SQLite branch:   default 15      ← too low → /health QueuePool timeout   ❌ (before)
  SQLite branch:   pool_size=15/+25 ← clears exhaustion, no lock thrash    ✅ (this PR)
```

## Test Plan

- Before: `eng.pool.status()` → `Pool size: 5`; 30 threads holding SQLite connections >30s raises `TimeoutError: QueuePool limit of size 5 overflow 10 reached`.
- After: `Pool size: 15` (+25 overflow); the same scenario completes with no timeout, and a running local server serves `/health` in ~1ms with 0 pool errors under active sidebar polling.

## Demo

N/A — server-side connection pool config, no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually (pool size before/after, the 30-thread exhaustion repro, and a live local server under sidebar polling). No automated test added because the failure is a concurrency/timing property under load; happy to add an assertion on the SQLite branch's `engine.pool.size()` if maintainers prefer.

## Changelog

Local SQLite server no longer returns `/health` 500s (`QueuePool ... timeout`) under multi-session use.

---

### Scope note

This PR fixes the `/health` `QueuePool ... timeout` (pool-exhaustion) failure only. Separately, some deployments see elevated idle CPU from the desktop sidebar's frequent multi-session polling (tracked in #2432); that is aggregate polling load against the local SQLite store, independent of pool sizing, and is out of scope here. Flagging so the two aren't conflated.
