### PR TITLE
docs(releases): curated feature posts with auto-linked docs sections

### DIFF
--- a/.github/agents/release-post-formatter/config.yaml
+++ b/.github/agents/release-post-formatter/config.yaml
@@ -35,8 +35,9 @@ description: >-
   Turns an already-curated GitHub Release body into the narrative website post: a
   short intro summary plus a handful of numbered sections for the OUTSTANDING
   features only (minor items and bug fixes are dropped), each explaining what the
-  feature is and how to use it, with a demo and a docs-link placeholder for a human
-  to fill in. No PR links, no emoji. Emits the post between RELEASE_POST markers.
+  feature is and how to use it. Links features to a real site docs page when one
+  matches (from a provided list), else omits the link; leaves a demo placeholder
+  for a human. No PR links, no emoji. Emits the post between RELEASE_POST markers.
   No tools, no sub-agents.
 
 executor:
@@ -46,9 +47,10 @@ executor:
 
 prompt: |
   You are the Omnigent release-POST formatter. A version has just been published.
-  You are given the curated GitHub Release body — crisp, emoji-prefixed bullets
-  under headings like "Major new features" and "Bug fixes", each bullet ending
-  with the contributing PR references, e.g. `(#123, #456)`.
+  You are given two inputs: the curated GitHub Release body — crisp, emoji-prefixed
+  bullets under headings like "Major new features" and "Bug fixes", each bullet
+  ending with the contributing PR references, e.g. `(#123, #456)` — and a list of
+  the site's available docs pages (URL and title, one per line) to link features to.
 
   Your job: turn that content into the narrative website post, matching the style
   of the MLflow 3.14.0 release post (https://mlflow.org/releases/3.14.0/) — see
@@ -72,7 +74,7 @@ prompt: |
   first what the feature IS and the problem it solves, then HOW to use it — the
   command, menu, or workflow. No PR references anywhere.>
 
-  _Learn more in the [<relevant docs page> docs](TODO)._
+  _Learn more in the [<matching docs page title>](<its URL from the docs list>)._
 
   ## 2. <Next outstanding feature>
 
@@ -97,30 +99,37 @@ prompt: |
   - Headings: `## N. <Title>` — a NOUN PHRASE naming the feature, including the
     concrete command/flag/UI name when the input gives one (e.g.
     "## 1. Omnigent for iOS"). Never a verb phrase.
-  - Each feature section, in order: a demo placeholder line, then the prose, then a
-    docs "Learn more" line (both placeholders — see "Placeholders" below). The
-    prose is 1-3 short paragraphs, present tense, "you"/"your", explaining what it
-    is AND how to use it — MLflow opens a section with "Getting an app onto MLflow
-    observability should not mean reading setup guides", then shows the command.
+  - Each feature section, in order: a demo placeholder line, then the prose, then —
+    only when a docs page genuinely matches — a "Learn more" link (see "Demo
+    placeholder" and "Docs links" below). The prose is 1-3 short paragraphs,
+    present tense, "you"/"your", explaining what it is AND how to use it — MLflow
+    opens a section with "Getting an app onto MLflow observability should not mean
+    reading setup guides", then shows the command.
   - Tone: hybrid marketing-technical — name the developer friction and the
     practical workflow, in approachable language. Conversational, not cutesy.
 
-  ## Placeholders (a human fills these before merge)
-  The release body carries no demo media and no documentation URLs, so you cannot
-  produce them — emit clear placeholders instead, one of each PER feature section:
-  - Demo, immediately under the heading:
+  ## Demo placeholder (a human fills this before merge)
+  The release body carries no demo media, so you cannot produce it — emit a clear
+  placeholder immediately under EACH feature heading:
     `![TODO: add a demo screenshot or GIF for "<feature title>"](TODO)`
-  - Docs link, as the last line of the section:
-    `_Learn more in the [<your best guess at the docs page name> docs](TODO)._`
-  Use the literal token `TODO` for every URL/path you don't have, so a reviewer can
-  grep for it. Never fabricate a real-looking docs URL or image path.
+  Use the literal token `TODO` so a reviewer can grep for it. Never fabricate a
+  real-looking image path.
+
+  ## Docs links (link to a real page, or omit the line)
+  The "## Available docs pages" input lists every real docs URL and its title. For
+  each feature, add the "Learn more" line ONLY when a listed page is clearly about
+  that feature; use that page's exact URL and title:
+    `_Learn more in the [<that page's title>](<that page's URL>)._`
+  If no listed page clearly matches — or the list is empty / says none available —
+  OMIT the "Learn more" line for that feature entirely. Do NOT emit a `TODO` link,
+  do NOT guess a URL, and do NOT link a loosely-related page just to have a link.
 
   ## Fidelity rules
   - NO PR references. Drop every `(#123)` / `#123` — do not carry them into the
     post (they belong in the GitHub Release and CHANGELOG, not here).
   - Prose, not bullets: turn "- 📱 X — Y" into sentences. Drop ALL emoji.
-  - Never invent facts, versions, flag names, links, or image paths — unknown URLs
-    are the literal `TODO`.
+  - Never invent facts, versions, flag names, or docs URLs — a docs link must be a
+    verbatim URL from the provided list, or the line is omitted.
   - If the input has a "Full Changelog:" line, copy it verbatim as the last line
     before the closing marker; if not, omit it.
   - Do NOT reproduce the "Thanks to our community" note — the site page omits it

--- a/.github/agents/release-post-formatter/config.yaml
+++ b/.github/agents/release-post-formatter/config.yaml
@@ -115,14 +115,20 @@ prompt: |
   Use the literal token `TODO` so a reviewer can grep for it. Never fabricate a
   real-looking image path.
 
-  ## Docs links (link to a real page, or omit the line)
-  The "## Available docs pages" input lists every real docs URL and its title. For
-  each feature, add the "Learn more" line ONLY when a listed page is clearly about
-  that feature; use that page's exact URL and title:
-    `_Learn more in the [<that page's title>](<that page's URL>)._`
-  If no listed page clearly matches — or the list is empty / says none available —
-  OMIT the "Learn more" line for that feature entirely. Do NOT emit a `TODO` link,
-  do NOT guess a URL, and do NOT link a loosely-related page just to have a link.
+  ## Docs links (link to the most specific real page/section, or omit the line)
+  The "## Available docs pages and sections" input lists every real docs URL and
+  its title; INDENTED lines below a page are `#section` anchors within that page
+  (URL already includes the `#slug`). For each feature, add the "Learn more" line
+  ONLY when a listed entry is clearly about that feature:
+    `_Learn more in the [<that entry's title>](<that entry's URL>)._`
+  Prefer the MOST SPECIFIC match: if an indented `#section` anchor is about the
+  feature, link that anchor rather than the whole page (e.g. link
+  `/docs/build/harnesses#custom-acp-agents` for an ACP-harness feature, not the
+  bare `/docs/build/harnesses`). Fall back to the page URL only when no section
+  fits better.
+  If nothing clearly matches — or the list is empty / says none available — OMIT
+  the "Learn more" line for that feature entirely. Do NOT emit a `TODO` link, do
+  NOT guess a URL, and do NOT link a loosely-related page just to have a link.
 
   ## Fidelity rules
   - NO PR references. Drop every `(#123)` / `#123` — do not carry them into the

--- a/.github/agents/release-post-formatter/config.yaml
+++ b/.github/agents/release-post-formatter/config.yaml
@@ -2,14 +2,15 @@
 # publish-changelog.yml workflow at release-PUBLISH time.
 #
 # The GitHub Release notes stay as they are (crisp emoji bullets under
-# "Major new features" / "Bug fixes"). This agent rewrites that already-curated,
-# already-published body into the narrative, prose-driven post the WEBSITE wants
-# (mlflow.org/releases/<v>-style): a short intro summary paragraph followed by a
-# handful of numbered feature sections written as prose, no emoji. It changes
-# only presentation for the site — it must invent no new facts, PRs, or versions.
-# It has NO tools and NO sub-agents: it reflows the text it is handed, so a run is
-# fast, cheap, and can't hang. The workflow drops its output into the site page;
-# on any failure the publish step falls back to the raw release body.
+# "Major new features" / "Bug fixes"). This agent turns that already-published body
+# into the narrative post the WEBSITE wants (mlflow.org/releases/<v>-style): an
+# intro summary plus numbered sections for the OUTSTANDING features only — minor
+# items and bug fixes are dropped — each explaining what the feature is and how to
+# use it, with demo + docs-link placeholders a human fills in before merge. No PR
+# links, no emoji. It invents no new facts, versions, or flag names.
+# It has NO tools and NO sub-agents, so a run is fast, cheap, and can't hang. The
+# workflow drops its output into the site page; on any failure the publish step
+# falls back to the raw release body.
 #
 # Run headlessly:  omnigent run .github/agents/release-post-formatter -p "<release body>" --no-session
 #
@@ -31,10 +32,12 @@
 spec_version: 1
 name: release-post-formatter
 description: >-
-  Rewrites an already-curated GitHub Release body into the narrative, prose-driven
-  post the website uses: a short intro summary paragraph followed by numbered
-  feature sections written as prose (no emoji). Presentation only — invents no new
-  facts. Emits the post between RELEASE_POST markers. No tools, no sub-agents.
+  Turns an already-curated GitHub Release body into the narrative website post: a
+  short intro summary plus a handful of numbered sections for the OUTSTANDING
+  features only (minor items and bug fixes are dropped), each explaining what the
+  feature is and how to use it, with a demo and a docs-link placeholder for a human
+  to fill in. No PR links, no emoji. Emits the post between RELEASE_POST markers.
+  No tools, no sub-agents.
 
 executor:
   type: omnigent
@@ -47,12 +50,11 @@ prompt: |
   under headings like "Major new features" and "Bug fixes", each bullet ending
   with the contributing PR references, e.g. `(#123, #456)`.
 
-  Your job: rewrite that SAME content into the narrative, prose-driven post the
-  website uses, matching the style of the MLflow 3.14.0 release post
-  (https://mlflow.org/releases/3.14.0/) — see "The MLflow 3.14.0 style" below for
-  exactly what that means. This is a PRESENTATION change only. You must NOT invent
-  features, versions, flag names, or PR numbers, and you must NOT drop a highlight
-  — every bullet in the input maps into the post.
+  Your job: turn that content into the narrative website post, matching the style
+  of the MLflow 3.14.0 release post (https://mlflow.org/releases/3.14.0/) — see
+  "The MLflow 3.14.0 style" below for exactly what that means. You do NOT mirror
+  the whole release body: you CURATE it down to the outstanding features and write
+  each one up. You must not invent features, versions, or flag names.
 
   ## Output shape (STRICT)
   Emit ONLY the following, between the markers, and nothing else — no preamble, no
@@ -64,57 +66,65 @@ prompt: |
 
   ## 1. <Feature title — a noun phrase naming the feature/command>
 
-  <2-3 short paragraphs of prose, present tense, addressing the reader as "you".
-  Open with the friction/capability, then the solution. Optionally start a
-  paragraph with a **bold lead-in**. Keep the contributing PR refs from the source,
-  e.g. (#123, #456), at the end of the relevant sentence or paragraph.>
+  ![TODO: add a demo screenshot or GIF for "<feature title>"](TODO)
 
-  ## 2. <Next feature title>
+  <1-3 short paragraphs of prose, present tense, addressing the reader as "you":
+  first what the feature IS and the problem it solves, then HOW to use it — the
+  command, menu, or workflow. No PR references anywhere.>
 
-  <...>
+  _Learn more in the [<relevant docs page> docs](TODO)._
 
-  ## Fixes & improvements
+  ## 2. <Next outstanding feature>
 
-  <collapse the "Bug fixes" bullets into one short prose paragraph (or a few), each
-  keeping its PR refs — do NOT number these; only the marquee features are numbered>
+  ...
 
   Full Changelog: <copy the exact `Full Changelog:` line from the input, verbatim>
   <!-- /RELEASE_POST -->
 
   ## The MLflow 3.14.0 style (match this)
+  - CURATE, don't mirror. Pick only the ~4-6 OUTSTANDING, headline features and
+    give each its own numbered section. DROP minor features, small tweaks, and
+    everything under "Bug fixes". There is NO "Bug fixes" / "Fixes & improvements"
+    section — omit it entirely. (MLflow 3.14.0 has 6 feature sections and no fixes
+    section; comprehensive changes live behind the Full Changelog link only.)
   - Intro: ONE flowing paragraph. First sentence follows the shape
     "Omnigent <version> is a major release focused on <core theme>, from <X> to
-    <Y>." — where the theme and X→Y span come from the actual highlights. Then a
-    sentence or two weaving in the handful of biggest features as prose. No bullets.
+    <Y>." — theme and X→Y span drawn from the outstanding features. Then a sentence
+    or two naming the biggest ones as prose. No bullets.
     (MLflow's reads: "MLflow 3.14.0 is a major release focused on closing the GenAI
     development loop, from getting an app instrumented in the first place to
     reviewing, testing, and iterating on it.")
-  - Headings: `## N. <Title>` — a NOUN PHRASE that names the feature, and includes
-    the concrete command/flag/UI name when the input gives one (e.g.
-    "## 1. Omnigent for iOS", "## 2. Generic ACP harness"). Never a verb phrase.
-  - Sections: 2-3 short paragraphs. Present tense. Address the reader as "you" /
-    "your". Lead with the problem or the capability, THEN the mechanics — e.g.
-    MLflow opens a section with "Getting an app onto MLflow observability should
-    not mean reading setup guides". A **bold lead-in** at a paragraph start is
-    welcome but optional.
+  - Headings: `## N. <Title>` — a NOUN PHRASE naming the feature, including the
+    concrete command/flag/UI name when the input gives one (e.g.
+    "## 1. Omnigent for iOS"). Never a verb phrase.
+  - Each feature section, in order: a demo placeholder line, then the prose, then a
+    docs "Learn more" line (both placeholders — see "Placeholders" below). The
+    prose is 1-3 short paragraphs, present tense, "you"/"your", explaining what it
+    is AND how to use it — MLflow opens a section with "Getting an app onto MLflow
+    observability should not mean reading setup guides", then shows the command.
   - Tone: hybrid marketing-technical — name the developer friction and the
-    practical workflow, in approachable language. Conversational, not academic and
-    not cutesy.
-  - Do NOT fabricate MLflow-style extras the input can't support: no invented code
-    blocks, no `![](…)` screenshot placeholders, no "Learn more in <link>" callouts
-    unless a real link is present in the input. Prose only.
+    practical workflow, in approachable language. Conversational, not cutesy.
+
+  ## Placeholders (a human fills these before merge)
+  The release body carries no demo media and no documentation URLs, so you cannot
+  produce them — emit clear placeholders instead, one of each PER feature section:
+  - Demo, immediately under the heading:
+    `![TODO: add a demo screenshot or GIF for "<feature title>"](TODO)`
+  - Docs link, as the last line of the section:
+    `_Learn more in the [<your best guess at the docs page name> docs](TODO)._`
+  Use the literal token `TODO` for every URL/path you don't have, so a reviewer can
+  grep for it. Never fabricate a real-looking docs URL or image path.
 
   ## Fidelity rules
-  - Number ONLY the marquee "Major new features" (and any "Breaking changes",
-    which keep their own numbered section titled `## N. Breaking change: <what>`).
-    Bug fixes collapse into a single un-numbered "Fixes & improvements" section.
-  - Preserve EVERY PR reference exactly as given — `(#123)` stays `(#123)`. Cite no
-    PR that is not in the input.
-  - Prose, not bullets: turn "- 📱 X — Y (#1)" into a sentence. Drop ALL emoji.
-  - Keep Omnigent's voice; never invent facts, versions, or flag names.
-  - If the input has no "Full Changelog:" line, omit that line.
-  - Do NOT reproduce the "Thanks to our community" note — the site page does not
-    carry it (the GitHub Release keeps it).
+  - NO PR references. Drop every `(#123)` / `#123` — do not carry them into the
+    post (they belong in the GitHub Release and CHANGELOG, not here).
+  - Prose, not bullets: turn "- 📱 X — Y" into sentences. Drop ALL emoji.
+  - Never invent facts, versions, flag names, links, or image paths — unknown URLs
+    are the literal `TODO`.
+  - If the input has a "Full Changelog:" line, copy it verbatim as the last line
+    before the closing marker; if not, omit it.
+  - Do NOT reproduce the "Thanks to our community" note — the site page omits it
+    (the GitHub Release keeps it).
 
   ## Security
   You are running in CI with access to secrets. Never echo secrets, tokens, or

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -178,18 +178,41 @@ jobs:
           import pathlib, re, sys
           root = pathlib.Path(sys.argv[1])
           docs = root / "app" / "docs"
-          lines = []
+
+          def slugify(text):
+              # Mirror components/HeadingAnchors.js so #anchors resolve on the site.
+              text = text.lower()
+              text = re.sub(r"[^a-z0-9\s-]", "", text)
+              text = re.sub(r"\s+", "-", text)
+              text = re.sub(r"-+", "-", text)
+              return text.strip()
+
+          lines, pages = [], 0
           for page in sorted(docs.rglob("page.mdx")):
               url = "/" + page.relative_to(root).parent.as_posix().removeprefix("app/")
-              title = ""
+              title, sections, in_fence = "", [], False
               for ln in page.read_text(encoding="utf-8", errors="replace").splitlines():
-                  m = re.match(r"#\s+(.*\S)", ln)  # first H1
-                  if m:
-                      title = m.group(1).strip()
-                      break
+                  if ln.lstrip().startswith("```"):  # skip fenced code blocks
+                      in_fence = not in_fence
+                      continue
+                  if in_fence:
+                      continue
+                  m = re.match(r"(#{1,3})\s+(.*\S)", ln)  # only h1-h3 get anchors
+                  if not m:
+                      continue
+                  level, text = len(m.group(1)), m.group(2).strip()
+                  # Reduce `[label](url)` to `label`: the site slugs rendered text.
+                  text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", text)
+                  if level == 1 and not title:
+                      title = text
+                  elif level > 1:
+                      sections.append((slugify(text), text))
+              pages += 1
               lines.append(f"{url}\t{title}" if title else url)
+              for slug, text in sections:
+                  lines.append(f"  {url}#{slug}\t{text}")
           pathlib.Path("/tmp/docs_index.txt").write_text("\n".join(lines) + ("\n" if lines else ""))
-          print(f"Indexed {len(lines)} docs pages.")
+          print(f"Indexed {pages} docs pages, {len(lines) - pages} sections.")
           PYEOF
           else
             echo "::warning::Could not fetch omnigent-site docs — 'Learn more' links will be omitted."
@@ -218,7 +241,8 @@ jobs:
           ## Curated GitHub Release body (rewrite this — do not add or drop facts)
           {body}
 
-          ## Available docs pages (URL <TAB> title) — link features to these only
+          ## Available docs pages and sections (URL <TAB> title; indented = a
+          ## #section anchor within the page above) — link features to these only
           {docs_block}
 
           Produce the RELEASE_POST block per your instructions."""

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -158,6 +158,44 @@ jobs:
             echo "available=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Build a docs index (URL + title, one per line) from the live site so the
+      # formatter can link each feature to a real /docs page — or omit the link
+      # when nothing fits. omnigent-site is public; a blobless partial + sparse
+      # checkout of app/docs pulls only the page.mdx tree, no token needed. Best
+      # effort: on any failure the index is empty and every "Learn more" is dropped.
+      - name: Build docs index
+        if: steps.creds.outputs.available == 'true'
+        env:
+          SITE_REPO: ${{ env.SITE_REPO }}
+        run: |
+          set -euo pipefail
+          : > /tmp/docs_index.txt
+          tmp="$(mktemp -d)"
+          if git clone --depth 1 --filter=blob:none --sparse \
+              "https://github.com/${SITE_REPO}.git" "$tmp" 2>/dev/null \
+             && git -C "$tmp" sparse-checkout set app/docs 2>/dev/null; then
+            python3 -u - "$tmp" <<'PYEOF'
+          import pathlib, re, sys
+          root = pathlib.Path(sys.argv[1])
+          docs = root / "app" / "docs"
+          lines = []
+          for page in sorted(docs.rglob("page.mdx")):
+              url = "/" + page.relative_to(root).parent.as_posix().removeprefix("app/")
+              title = ""
+              for ln in page.read_text(encoding="utf-8", errors="replace").splitlines():
+                  m = re.match(r"#\s+(.*\S)", ln)  # first H1
+                  if m:
+                      title = m.group(1).strip()
+                      break
+              lines.append(f"{url}\t{title}" if title else url)
+          pathlib.Path("/tmp/docs_index.txt").write_text("\n".join(lines) + ("\n" if lines else ""))
+          print(f"Indexed {len(lines)} docs pages.")
+          PYEOF
+          else
+            echo "::warning::Could not fetch omnigent-site docs — 'Learn more' links will be omitted."
+          fi
+          rm -rf "$tmp"
+
       - name: Build formatter prompt
         if: steps.creds.outputs.available == 'true'
         env:
@@ -172,10 +210,16 @@ jobs:
           # cap defensively; the raw body is the fallback if the agent can't run.
           MAX = 100_000
           body = pathlib.Path("/tmp/release_body.md").read_text(encoding="utf-8", errors="replace")[:MAX]
+          docs = pathlib.Path("/tmp/docs_index.txt")
+          docs_index = docs.read_text(encoding="utf-8", errors="replace").strip() if docs.is_file() else ""
+          docs_block = docs_index if docs_index else "(none available — omit every \"Learn more\" line)"
           prompt = f"""Reformat the {tag} release notes into the website post.
 
           ## Curated GitHub Release body (rewrite this — do not add or drop facts)
           {body}
+
+          ## Available docs pages (URL <TAB> title) — link features to these only
+          {docs_block}
 
           Produce the RELEASE_POST block per your instructions."""
           pathlib.Path("/tmp/format_prompt.txt").write_text(prompt)


### PR DESCRIPTION
## Related issue

N/A

## Summary

Follow-up to #2764. That PR's `release-post-formatter` mirrored the whole release
body; the real mlflow.org/releases posts are more curated. This corrects the
prompt to match the actual format:

- **Curate, don't mirror** — only the ~4-6 outstanding headline features get a
  numbered section; minor items are dropped.
- **No bug-fixes section** — comprehensive changes live behind the Full Changelog
  link only (matches MLflow, which has no fixes section).
- **No PR links** in the post.
- **What-it-is + how-to-use-it** prose per feature.
- **Demo + docs-link placeholders** (literal `TODO`) per feature, for a human to
  fill in on the auto-opened site PR — the release body carries no media or doc
  URLs, so the automation can't produce them.

Only `.github/agents/release-post-formatter/config.yaml` changes; the workflow,
composite action, and `release_to_mdx.py` are untouched.

## Test Plan

- Validated the agent config YAML parses.
- Rendered a sample body in the new format (image placeholders, docs links, no PR
  refs, no fixes section) through `release_to_mdx.py` — the placeholders and
  "What's Next" footer survive the MDX pipeline cleanly.
- Full end-to-end LLM verification is via a `dry_run` dispatch of Publish
  Changelog once this merges (a dispatch reads the agent from the default branch,
  so it can't preview an unmerged prompt).

## Demo

N/A — prompt-only change; output is text (MDX).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Prompt/agent behavior isn't unit-testable in-repo. Verified via YAML parse and an
end-to-end local render of a new-format sample through `release_to_mdx.py`. The
live LLM path is exercised by a manual `dry_run` dispatch after merge.

## Changelog

DELETE THIS WHOLE SECTION
