### PR TITLE
fix(hermes): introspect state.db schema to survive cross-version column drift

### DIFF
--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -374,6 +374,22 @@ def _connect_ro(db_path: Path) -> sqlite3.Connection | None:
     return None
 
 
+def _table_columns(con: sqlite3.Connection, table: str) -> frozenset[str]:
+    """Return the set of column names on *table*, or empty on any error.
+
+    Hermes' ``state.db`` schema drifts across versions (e.g. schema_version 11
+    dropped ``sessions.cwd`` and ``messages.active`` / ``messages.compacted``
+    that older builds carried). The forwarder introspects the live schema and
+    adapts its SELECTs instead of assuming a fixed column set — otherwise a
+    single ``no such column`` error aborts discovery / mirroring and the chat
+    goes silent even though Hermes itself is working (visible in the terminal).
+    """
+    try:
+        return frozenset(str(r[1]) for r in con.execute(f"PRAGMA table_info({table})"))
+    except sqlite3.Error:
+        return frozenset()
+
+
 def _discover_session_id(
     db_path: Path,
     workspace: str,
@@ -401,11 +417,25 @@ def _discover_session_id(
     if con is None:
         return None
     floor_s = launch_epoch_s - _DISCOVERY_SKEW_S
+    # Newer Hermes (schema_version >= 11) no longer records ``sessions.cwd``.
+    # Select it only when present; otherwise treat every row as cwd-less and
+    # rely on the started_at-since-launch fallback below (the newest lone
+    # session started after this terminal launched is this terminal's session).
+    has_cwd = "cwd" in _table_columns(con, "sessions")
     try:
-        rows = con.execute(
-            "SELECT id, cwd FROM sessions WHERE started_at >= ? ORDER BY started_at DESC",
-            (floor_s,),
-        ).fetchall()
+        if has_cwd:
+            rows = con.execute(
+                "SELECT id, cwd FROM sessions WHERE started_at >= ? ORDER BY started_at DESC",
+                (floor_s,),
+            ).fetchall()
+        else:
+            rows = [
+                (sid, None)
+                for (sid,) in con.execute(
+                    "SELECT id FROM sessions WHERE started_at >= ? ORDER BY started_at DESC",
+                    (floor_s,),
+                ).fetchall()
+            ]
     except sqlite3.Error as exc:
         _warn_sqlite_once("session discovery", exc)
         return None
@@ -621,12 +651,24 @@ def _read_new_items(
     con = _connect_ro(db_path)
     if con is None:
         return []
+    # ``messages.active`` (compaction soft-delete flag) was dropped in newer
+    # Hermes schemas; only filter on it when present.
+    cols = _table_columns(con, "messages")
+    active_filter = " AND active = 1" if "active" in cols else ""
+    # ``reasoning_content`` / ``reasoning`` were added in newer schemas; SELECT
+    # them only when present so a v11 (or other older) DB does not raise
+    # ``no such column``.
+    reasoning_cols = ""
+    if "reasoning_content" in cols:
+        reasoning_cols += ", reasoning_content"
+    if "reasoning" in cols:
+        reasoning_cols += ", reasoning"
     try:
         rows = con.execute(
-            "SELECT id, role, content, tool_calls, tool_call_id, tool_name, "
-            "reasoning_content, reasoning "
+            "SELECT id, role, content, tool_calls, tool_call_id, tool_name "
+            f"{reasoning_cols} "
             "FROM messages "
-            "WHERE session_id = ? AND id > ? AND active = 1 ORDER BY id",
+            f"WHERE session_id = ? AND id > ?{active_filter} ORDER BY id",
             (hermes_session_id, last_id),
         ).fetchall()
     except sqlite3.Error as exc:
@@ -635,16 +677,12 @@ def _read_new_items(
     finally:
         con.close()
     items: list[_MirrorItem] = []
-    for (
-        msg_id,
-        role,
-        content,
-        tool_calls_json,
-        tool_call_id,
-        tool_name_val,
-        reasoning_content,
-        reasoning,
-    ) in rows:
+    for row in rows:
+        # The trailing reasoning_content / reasoning columns are present
+        # only when the live schema carries them; unpack positionally.
+        msg_id, role, content, tool_calls_json, tool_call_id, tool_name_val = row[:6]
+        reasoning_content = row[6] if len(row) > 6 and "reasoning_content" in cols else None
+        reasoning = row[-1] if len(row) > 6 and "reasoning" in cols else None
         converted = _message_to_items(
             msg_id,
             role,
@@ -887,6 +925,11 @@ def _has_new_compaction(db_path: Path, hermes_session_id: str) -> bool:
     con = _connect_ro(db_path)
     if con is None:
         return False
+    # ``messages.compacted`` was dropped in newer Hermes schemas; without it we
+    # cannot detect a compaction boundary here (safe: no boundary item posted).
+    if "compacted" not in _table_columns(con, "messages"):
+        con.close()
+        return False
     try:
         row = con.execute(
             "SELECT 1 FROM messages WHERE session_id = ? AND compacted = 1 LIMIT 1",
@@ -918,10 +961,10 @@ async def _persist_hermes_compaction_item(
     compacted_messages = None
     con = _connect_ro(db_path)
     if con is not None:
+        _active = " AND active = 1" if "active" in _table_columns(con, "messages") else ""
         try:
             rows = con.execute(
-                "SELECT role, content FROM messages "
-                "WHERE session_id = ? AND active = 1 ORDER BY id",
+                f"SELECT role, content FROM messages WHERE session_id = ?{_active} ORDER BY id",
                 (hermes_session_id,),
             ).fetchall()
             msgs = []

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -126,6 +126,81 @@ def test_discover_child_session_returns_newest_child(tmp_path: Path) -> None:
     assert f._discover_child_session(db, "child_new") is None
 
 
+# Newer Hermes (schema_version >= 11) dropped ``sessions.cwd`` and
+# ``messages.active`` / ``messages.compacted``. The forwarder must introspect
+# the live schema and adapt its SELECTs rather than raising ``no such column``
+# (which silently aborts discovery/mirroring — the exact "hermes doesn't work"
+# symptom on the shared CoDA host).
+_SCHEMA_V11 = """
+CREATE TABLE schema_version (version INTEGER NOT NULL);
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    started_at REAL NOT NULL,
+    parent_session_id TEXT
+);
+CREATE TABLE messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT,
+    tool_call_id TEXT,
+    tool_calls TEXT,
+    tool_name TEXT
+);
+"""
+
+
+def _seed_db_v11(path: Path, *, started_at: float, session_id: str = "20260710_1") -> None:
+    """Seed a schema-11 Hermes DB (no cwd / active / compacted columns)."""
+    con = sqlite3.connect(path)
+    con.executescript(_SCHEMA_V11)
+    con.execute("INSERT INTO schema_version(version) VALUES (11)")
+    con.execute(
+        "INSERT INTO sessions(id, source, started_at) VALUES (?,?,?)",
+        (session_id, "cli", started_at),
+    )
+    con.executemany(
+        "INSERT INTO messages(session_id, role, content, tool_call_id, tool_calls, tool_name)"
+        " VALUES (?,?,?,?,?,?)",
+        [
+            (session_id, "user", "ping", None, None, None),
+            (session_id, "assistant", "PONG_4242", None, None, None),
+        ],
+    )
+    con.commit()
+    con.close()
+
+
+def test_discover_session_id_v11_no_cwd_binds_lone_session(tmp_path: Path) -> None:
+    """Schema-11 DB has no cwd column; discovery binds the lone since-launch row."""
+    db = tmp_path / "state.db"
+    _seed_db_v11(db, started_at=1000.0)
+    # cwd is unknown/irrelevant on this schema; any workspace resolves the lone row.
+    assert f._discover_session_id(db, str(tmp_path), 1000.0) == "20260710_1"
+    # Floor still applies: a session started before launch is not bound.
+    assert f._discover_session_id(db, str(tmp_path), 2000.0) is None
+
+
+def test_read_new_items_v11_no_active_column(tmp_path: Path) -> None:
+    """Message read must not require the dropped ``active`` column (schema 11)."""
+    db = tmp_path / "state.db"
+    _seed_db_v11(db, started_at=1000.0)
+    items = f._read_new_items(db, "20260710_1", 0, "hermes-native-ui")
+    posted = [i for i in items if i.item_type]
+    assert len(posted) == 2
+    assert posted[0].item_data["role"] == "user"
+    assert posted[1].item_data["role"] == "assistant"
+    assert posted[1].item_data["content"] == [{"type": "output_text", "text": "PONG_4242"}]
+
+
+def test_has_new_compaction_v11_no_compacted_column(tmp_path: Path) -> None:
+    """Compaction detection returns False (no boundary) when the column is gone."""
+    db = tmp_path / "state.db"
+    _seed_db_v11(db, started_at=1000.0)
+    assert f._has_new_compaction(db, "20260710_1") is False
+
+
 def test_read_new_items_maps_roles_and_strips_attachments(tmp_path: Path) -> None:
     db = tmp_path / "state.db"
     _seed_db(db, cwd=str(tmp_path), started_at=1000.0)


### PR DESCRIPTION
## Related issue

N/A

## Summary

Hermes' `state.db` schema drifts across versions (e.g. schema_version 11 dropped `sessions.cwd` and `messages.active`/`messages.compacted`). The forwarder assumed a fixed column set, so a schema change would abort discovery/mirroring with `no such column` and the chat would go silent even though Hermes itself was working. Now introspects the live schema (`_table_columns`) and adapts its SELECTs.

## Test Plan

- `ruff check` + `ruff format` clean; byte-compile clean.
- `tests/test_hermes_native_forwarder.py` updated and passing — covers the schema introspection and adaptive SELECT behavior.

## Demo

N/A — non-visual fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`tests/test_hermes_native_forwarder.py` covers the column introspection and the adapted query path. The fix is defensive: if a column is absent, the SELECT omits it rather than failing.

## Changelog

Hermes forwarder introspects state.db columns to survive cross-version schema drift
