### PR TITLE
fix(runner): recover cold-resume context when server GET returns null external_session_id

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -2408,11 +2408,22 @@ async def _maybe_mirror_external_session_id(
         # overwrite conflict or schema validation). Retrying won't
         # help; latch off and let the operator see the log.
         if 400 <= exc.response.status_code < 500:
+            # The server rejected overwriting an existing binding.
+            # Fetch the real bound value so operators can identify
+            # which session still holds the context.
+            _bound_sid: str | None = None
+            try:
+                _snap = await _fetch_session_snapshot(client=client, session_id=session_id)
+                _bound_sid = _snap.get("external_session_id") if isinstance(_snap, dict) else None
+            except Exception:  # noqa: BLE001
+                pass
             _logger.warning(
-                "AP rejected external_session_id PATCH (%s); session=%s claude_sid=%s",
+                "AP rejected external_session_id PATCH (%s); session=%s "
+                "rejected_claude_sid=%s server_bound_claude_sid=%s",
                 exc.response.status_code,
                 session_id,
                 claude_sid,
+                _bound_sid,
             )
             return True
         _logger.warning(

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -2408,22 +2408,11 @@ async def _maybe_mirror_external_session_id(
         # overwrite conflict or schema validation). Retrying won't
         # help; latch off and let the operator see the log.
         if 400 <= exc.response.status_code < 500:
-            # The server rejected overwriting an existing binding.
-            # Fetch the real bound value so operators can identify
-            # which session still holds the context.
-            _bound_sid: str | None = None
-            try:
-                _snap = await _fetch_session_snapshot(client=client, session_id=session_id)
-                _bound_sid = _snap.get("external_session_id") if isinstance(_snap, dict) else None
-            except Exception:  # noqa: BLE001
-                pass
             _logger.warning(
-                "AP rejected external_session_id PATCH (%s); session=%s "
-                "rejected_claude_sid=%s server_bound_claude_sid=%s",
+                "AP rejected external_session_id PATCH (%s); session=%s claude_sid=%s",
                 exc.response.status_code,
                 session_id,
                 claude_sid,
-                _bound_sid,
             )
             return True
         _logger.warning(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5445,6 +5445,19 @@ async def _auto_create_claude_terminal(
             "Could not set bridge_id label for %s; relay may target wrong dir",
             session_id,
         )
+    # Capture the previous claude_session_id from the bridge state file BEFORE
+    # prepare_bridge_dir unlinks it. read_claude_session_id reads _STATE_FILE,
+    # which prepare_bridge_dir removes as part of its refresh; reading it here
+    # lets the cold-resume fallback below use it when the server GET missed the
+    # external_session_id binding (e.g. workspace-scope ContextVar not set).
+    from omnigent.claude_native_bridge import (
+        bridge_dir_for_bridge_id as _bridge_dir_for_bridge_id,
+    )
+    from omnigent.claude_native_bridge import (
+        read_claude_session_id as _read_csid_pre_wipe,
+    )
+
+    _pre_wipe_claude_sid = _read_csid_pre_wipe(_bridge_dir_for_bridge_id(bridge_id))
     bridge_dir = prepare_bridge_dir(session_id, bridge_id=bridge_id, workspace=Path(workspace))
     # Cancel any surviving forwarder BEFORE wiping its cursor/seen state, else it
     # re-posts with fresh dedup state alongside the forwarder spawned below.
@@ -5565,22 +5578,16 @@ async def _auto_create_claude_terminal(
 
     # The server GET may miss the external_session_id binding when the
     # reconnect request arrives without a workspace-scoped context (the
-    # ContextVar defaults to 0 on fresh tasks). If the previous launch on
-    # this host recorded a claude_session_id in the bridge state, use it
-    # as a resume hint — the PATCH will confirm or conflict, which is still
-    # better than silently discarding the user's session context.
-    if session_external_id is None:
-        from omnigent.claude_native_bridge import read_claude_session_id as _read_csid
-
-        _local_sid = _read_csid(bridge_dir)
-        if _local_sid is not None:
-            session_external_id = _local_sid
-            _logger.info(
-                "cold-resume fallback: server snapshot missing external_session_id, "
-                "using local bridge hint: session=%s local_claude_sid=%s",
-                session_id,
-                _local_sid,
-            )
+    # ContextVar defaults to 0 on fresh tasks). Fall back to the claude_session_id
+    # captured from the bridge state file before prepare_bridge_dir wiped it.
+    if session_external_id is None and _pre_wipe_claude_sid is not None:
+        session_external_id = _pre_wipe_claude_sid
+        _logger.info(
+            "cold-resume fallback: server snapshot missing external_session_id, "
+            "using local bridge hint: session=%s local_claude_sid=%s",
+            session_id,
+            _pre_wipe_claude_sid,
+        )
 
     # Cold resume: when this session wraps a prior Claude session,
     # synthesize the local ``~/.claude/projects/<workspace>/<sid>.jsonl``

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5563,6 +5563,25 @@ async def _auto_create_claude_terminal(
                 session_id,
             )
 
+    # The server GET may miss the external_session_id binding when the
+    # reconnect request arrives without a workspace-scoped context (the
+    # ContextVar defaults to 0 on fresh tasks). If the previous launch on
+    # this host recorded a claude_session_id in the bridge state, use it
+    # as a resume hint — the PATCH will confirm or conflict, which is still
+    # better than silently discarding the user's session context.
+    if session_external_id is None:
+        from omnigent.claude_native_bridge import read_claude_session_id as _read_csid
+
+        _local_sid = _read_csid(bridge_dir)
+        if _local_sid is not None:
+            session_external_id = _local_sid
+            _logger.info(
+                "cold-resume fallback: server snapshot missing external_session_id, "
+                "using local bridge hint: session=%s local_claude_sid=%s",
+                session_id,
+                _local_sid,
+            )
+
     # Cold resume: when this session wraps a prior Claude session,
     # synthesize the local ``~/.claude/projects/<workspace>/<sid>.jsonl``
     # transcript that Claude's ``--resume`` reads, then pass ``--resume``.

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -15377,6 +15377,129 @@ async def test_auto_create_claude_terminal_forwarder_skips_replayed_transcript_o
         assert synth_calls == [snapshot_external_id]
 
 
+@pytest.mark.asyncio
+async def test_auto_create_claude_terminal_cold_resume_fallback_uses_pre_wipe_bridge_sid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fallback fires when server GET omits external_session_id but local bridge has it.
+
+    Simulates the workspace-scope miss (ES-2065116): the server snapshot
+    returns no external_session_id, but the bridge state.json from the
+    previous launch holds a claude_session_id. The runner must read it
+    *before* prepare_bridge_dir wipes the file and use it as the resume
+    hint, so _ensure_local_claude_resume_transcript is called with the
+    local sid and --resume is passed.
+    """
+    monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+    # Write the previous claude_session_id into the bridge state.json *before*
+    # auto-create runs so the pre-wipe read can find it.
+    import json
+
+    session_id = "5cdbea97a2fb0c659bc09605401e2bb2"
+    prior_claude_sid = "3d10247d-c3c0-4689-8cbd-862d7453bf70"
+    pre_bridge_dir = bridge_dir_for_bridge_id(session_id)
+    pre_bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    (pre_bridge_dir / "state.json").write_text(
+        json.dumps({"claude_session_id": prior_claude_sid}), encoding="utf-8"
+    )
+
+    synth_calls: list[str] = []
+
+    async def _fake_synth(
+        client: Any,
+        *,
+        session_id: str,
+        external_session_id: str,
+        workspace: Path,
+    ) -> Path:
+        del client, session_id, workspace
+        synth_calls.append(external_session_id)
+        return tmp_path / f"{external_session_id}.jsonl"
+
+    monkeypatch.setattr(
+        "omnigent.claude_native._ensure_local_claude_resume_transcript",
+        _fake_synth,
+    )
+
+    forwarder_kwargs: dict[str, Any] = {}
+
+    async def _capture_forwarder(**kwargs: Any) -> None:
+        forwarder_kwargs.update(kwargs)
+
+    monkeypatch.setattr(
+        "omnigent.claude_native_forwarder.supervise_forwarder",
+        _capture_forwarder,
+    )
+
+    class _NullBindingServerClient(NullServerClient):
+        """Server client whose session snapshot omits external_session_id."""
+
+        async def get(self, url: str, **kwargs: Any) -> NullServerClient._Response:
+            del kwargs
+            if url.endswith("/labels"):
+
+                class _LabelsResponse(NullServerClient._Response):
+                    def json(self) -> dict[str, Any]:
+                        return {"labels": {}}
+
+                return _LabelsResponse()
+
+            # Session snapshot has no external_session_id (workspace-scope miss).
+            class _SnapResponse(NullServerClient._Response):
+                def json(self) -> dict[str, Any]:
+                    return {}
+
+            return _SnapResponse()
+
+    class _FakeResourceRegistry:
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            resource_role: str | None = None,
+            parent_os_env: Any = None,
+        ) -> SessionResourceView:
+            del terminal_name, session_key, spec
+            return SessionResourceView(
+                id="terminal_claude_main",
+                type="terminal",
+                session_id=session_id,
+                name="claude:main",
+                metadata={"terminal_name": "claude", "session_key": "main", "running": True},
+            )
+
+    await _auto_create_claude_terminal(
+        session_id,
+        _FakeResourceRegistry(),
+        lambda _sid, _evt: None,
+        server_client=_NullBindingServerClient(),  # type: ignore[arg-type]
+    )
+
+    await asyncio.sleep(0)
+
+    # The fallback must have fired: synthesis is called with the local bridge
+    # sid, not skipped (which would leave the user with no context).
+    assert synth_calls == [prior_claude_sid], (
+        f"Expected synthesis with prior claude sid {prior_claude_sid!r}; "
+        f"got {synth_calls!r}. The fallback may be reading the bridge dir "
+        "after prepare_bridge_dir already wiped state.json."
+    )
+    # The forwarder must start past the replayed transcript (same as a
+    # normal cold resume where the server returned the binding directly).
+    assert forwarder_kwargs.get("start_at_end") is True
+
+
 def _drain_session_event_queue(queue: asyncio.Queue[Any] | None) -> list[dict[str, Any]]:
     """
     Drain and return every dict item currently on a runner session queue.


### PR DESCRIPTION
## Summary

On runner reconnect, the GET /v1/sessions/{id} may return `external_session_id=null` because the workspace-scope ContextVar defaults to 0 on fresh async tasks (the server reconnect path doesn't run inside `workspace_scope()`). The runner then launches a fresh Claude session, silently discarding all conversation context and reverting permission mode to default.

Two changes:

- **`runner/app.py`** — after the GET block in `_auto_create_claude_terminal`, fall back to `read_claude_session_id(bridge_dir)` when `session_external_id` is still None. The local bridge state file survives `reset_transcript_forward_state` and holds the previous `claude_session_id`. Using it as the resume hint feeds into the existing `_ensure_local_claude_resume_transcript` path so `--resume` is passed correctly instead of launching fresh.

- **`claude_native_forwarder.py`** — on 400 from the `external_session_id` PATCH (overwrite conflict), fetch the session snapshot and log both the rejected sid and the server-bound sid. Previously the warning gave no indication of which session still held the real context.

The server-side root cause (workspace ContextVar not bound on the reconnect request) needs a separate fix — this makes the runner resilient to it.

## Test Plan

- Manual: trigger cold-resume by restarting a runner with an active bound session; confirm log shows fallback fires and `--resume` is passed; confirm session context is preserved.
- Unit test coverage for the fallback trigger (server returning null binding) requires a mock server; the `_ensure_local_claude_resume_transcript` path it delegates to already has unit tests.

## Demo

N/A — no UI change.

## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed

## Coverage notes

The fallback reads local bridge state and delegates to `_ensure_local_claude_resume_transcript`, which has existing unit tests. The new trigger condition (server returns null binding on reconnect) requires a live hosted-runner restart to repro.