### PR TITLE
fix(fork): drop CLI-specific launch args when a fork switches harness

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -16354,6 +16354,12 @@ def create_sessions_router(
                 cloned_agent_bundle_location=base_agent.bundle_location,
                 cloned_agent_description=base_agent.description,
                 copy_model_settings=copy_model_settings,
+                # Launch flags are CLI-specific. On an agent switch the fork may
+                # bind a different CLI (e.g. claude-code → pi), whose flag set
+                # differs — Claude Code's ``--permission-mode`` makes pi exit at
+                # launch (unknown option → ``required_terminal_exited``). Only
+                # carry the source's launch args on a same-agent fork.
+                copy_terminal_launch_args=not switching_agent,
                 carry_history_into_native=carry_history_into_native,
                 resume_source_native_session=resume_source_native_session,
                 presentation_labels=presentation_labels,

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1327,6 +1327,7 @@ class ConversationStore(ABC):
         cloned_agent_bundle_location: str | None = None,
         cloned_agent_description: str | None = None,
         copy_model_settings: bool = True,
+        copy_terminal_launch_args: bool = True,
         carry_history_into_native: bool = False,
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
@@ -1370,6 +1371,11 @@ class ConversationStore(ABC):
             the bound agent's defaults — used when the fork switches to
             an agent in a different provider family, where the source's
             model id is meaningless (a model is provider-bound).
+        :param copy_terminal_launch_args: When ``True`` (default), copy the
+            source's ``terminal_launch_args``. When ``False``, the fork starts
+            with none — used when the fork switches to a different CLI, where
+            the source's flags are meaningless or rejected (e.g. Claude Code's
+            ``--permission-mode`` would make ``pi`` exit at launch).
         :param carry_history_into_native: When ``True``, stamp
             :data:`FORK_CARRY_HISTORY_LABEL_KEY` on the fork so a native
             target harness rebuilds its transcript (clone the source's

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3084,6 +3084,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         cloned_agent_bundle_location: str | None = None,
         cloned_agent_description: str | None = None,
         copy_model_settings: bool = True,
+        copy_terminal_launch_args: bool = True,
         carry_history_into_native: bool = False,
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
@@ -3344,8 +3345,16 @@ class SqlAlchemyConversationStore(ConversationStore):
             }
             source_workspace = source_meta_ref.workspace if source_meta_ref else None
             source_ext_session = source_meta_ref.external_session_id if source_meta_ref else None
+            # ``terminal_launch_args`` are CLI-specific launch flags. A fork
+            # that switches CLI family (e.g. claude-code → pi) must NOT inherit
+            # them: the source's flags are meaningless or rejected by the new
+            # CLI — Claude Code's ``--permission-mode auto`` makes ``pi`` exit 1
+            # at launch (unknown option), which surfaces as
+            # ``required_terminal_exited``. Drop them on a switching fork.
             source_terminal_args = (
-                source_meta_ref.terminal_launch_args if source_meta_ref else None
+                source_meta_ref.terminal_launch_args
+                if source_meta_ref and copy_terminal_launch_args
+                else None
             )
             if source_workspace is not None:
                 fork_labels[FORK_SOURCE_LABEL_KEY] = source_conversation_id
@@ -3518,6 +3527,11 @@ class SqlAlchemyConversationStore(ConversationStore):
             meta = session.get(SqlConversationMetadata, (current_workspace_id(), conversation_id))
             if meta is not None:
                 meta.external_session_id = None
+                # Launch flags are CLI-specific: a switch to a different CLI
+                # (e.g. claude-code → pi) leaves the prior CLI's flags stale —
+                # Claude Code's ``--permission-mode`` makes pi exit 1 at launch.
+                # Clear them so the new CLI launches with its own defaults.
+                meta.terminal_launch_args = None
 
         conv = self.get_conversation(conversation_id)
         if conv is None:

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -130,6 +130,7 @@ class _ConversationStore:
         cloned_agent_bundle_location: str | None = None,
         cloned_agent_description: str | None = None,
         copy_model_settings: bool = True,
+        copy_terminal_launch_args: bool = True,
         carry_history_into_native: bool = False,
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
@@ -149,6 +150,9 @@ class _ConversationStore:
         :param cloned_agent_description: Optional clone description.
         :param copy_model_settings: Whether the source's model settings
             carry over (route passes ``False`` on a cross-family switch).
+        :param copy_terminal_launch_args: Whether the source's launch args
+            carry over (route passes ``False`` on any agent switch — launch
+            flags are CLI-specific and would break a different target CLI).
         :param carry_history_into_native: Whether to mark the fork for
             native transcript rebuild (route passes ``True`` for any
             native target, regardless of family).
@@ -175,6 +179,7 @@ class _ConversationStore:
                 "cloned_agent_bundle_location": cloned_agent_bundle_location,
                 "cloned_agent_description": cloned_agent_description,
                 "copy_model_settings": copy_model_settings,
+                "copy_terminal_launch_args": copy_terminal_launch_args,
                 "carry_history_into_native": carry_history_into_native,
                 "resume_source_native_session": resume_source_native_session,
                 "presentation_labels": presentation_labels,
@@ -925,6 +930,10 @@ async def test_fork_switch_model_and_carry_gating(
         f"{source_harness}->{target_harness}: copy_model_settings should be "
         f"{expect_copy_model} (model id is provider-bound)."
     )
+    assert fork_call["copy_terminal_launch_args"] is False, (
+        f"{source_harness}->{target_harness}: an agent switch must NOT carry the "
+        f"source's launch args (CLI-specific flags break a different target CLI)."
+    )
     assert fork_call["carry_history_into_native"] is expect_carry, (
         f"{source_harness}->{target_harness}: carry_history_into_native should "
         f"be {expect_carry} (only native harnesses with replayable fork history)."
@@ -972,6 +981,9 @@ async def test_fork_no_switch_native_source_carries_history(
     assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
     fork_call = conv_store.fork_calls[0]
     assert fork_call["copy_model_settings"] is True
+    assert fork_call["copy_terminal_launch_args"] is True, (
+        "A same-agent fork keeps the same CLI, so its launch args stay valid and must carry over."
+    )
     assert fork_call["carry_history_into_native"] is True, (
         "A same-agent fork of a native source must mark native carry so the "
         "runner rebuilds the transcript instead of resuming blank."

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3187,6 +3187,43 @@ def test_fork_conversation_copies_items(
         assert fork_item.data == src_item.data
 
 
+def test_fork_copies_terminal_launch_args_by_default(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A same-agent fork inherits the source's launch args.
+
+    A plain fork keeps the same CLI, so its launch flags stay valid and must
+    carry over (e.g. a Claude Code fork keeps ``--permission-mode``).
+    """
+    source = conversation_store.create_conversation(
+        terminal_launch_args=["--permission-mode", "auto"],
+    )
+    fork = conversation_store.fork_conversation(source.id)
+    fetched = conversation_store.get_conversation(fork.id)
+    assert fetched is not None
+    assert fetched.terminal_launch_args == ["--permission-mode", "auto"]
+
+
+def test_fork_drops_terminal_launch_args_when_switching_agent(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A CLI-switching fork must NOT inherit the source's launch args.
+
+    Forking a Claude Code session onto ``pi`` carried the source's
+    ``--permission-mode auto`` into the pi argv; pi rejects the unknown option
+    and exits 1 at launch, surfacing as ``required_terminal_exited``. With
+    ``copy_terminal_launch_args=False`` the fork starts with clean args so the
+    new CLI launches with its own defaults.
+    """
+    source = conversation_store.create_conversation(
+        terminal_launch_args=["--permission-mode", "auto"],
+    )
+    fork = conversation_store.fork_conversation(source.id, copy_terminal_launch_args=False)
+    fetched = conversation_store.get_conversation(fork.id)
+    assert fetched is not None
+    assert fetched.terminal_launch_args is None
+
+
 def test_fork_conversation_preserves_created_by(
     conversation_store: SqlAlchemyConversationStore,
     agent_store: SqlAlchemyAgentStore,


### PR DESCRIPTION
## Related issue

N/A

## Summary

Forking a **Claude Code** session onto **pi** failed to start with
`Error · required_terminal_exited`. The fork copied the source session's
`terminal_launch_args` verbatim, so Claude Code's `--permission-mode auto`
reached the pi argv. pi (0.73.1) rejects the unknown option and exits 1 at
launch — killing the required terminal and the session before any pane
snapshot. It was cross-CLI-fork-specific: fresh pi sessions and pi→pi forks
never carry that flag.

- `fork_conversation` gains `copy_terminal_launch_args` (default `True`); the
  fork route passes `not switching_agent`, so a same-agent fork still inherits
  launch flags but an agent switch starts with clean args.
- `switch_conversation_agent` (in-place claude→pi switch — same latent bug) now
  clears `terminal_launch_args` alongside the `external_session_id` it already
  cleared.

## Test Plan

- New store tests: `test_fork_copies_terminal_launch_args_by_default` (same-agent
  fork keeps flags) and `test_fork_drops_terminal_launch_args_when_switching_agent`
  (switching fork drops them).
- `uv run --extra databricks --extra dev python -m pytest tests/stores/test_conversation_store.py tests/stores/test_conversation_store_split_db.py -k "fork or switch"` → 30 passed.
- `ruff check` clean on all changed files.
- Verified live: forking a Claude Code session onto pi now launches instead of
  `required_terminal_exited`.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover both fork paths (same-agent keeps args, switching drops them).
Manual verification: forked a Claude Code session onto pi in the local web UI
and confirmed the pi terminal launches and takes a turn rather than exiting with
`required_terminal_exited`.

## Changelog

Forking a Claude Code session onto pi (or other CLIs) no longer fails to start with `required_terminal_exited`

This pull request and its description were written by Isaac.
