### PR TITLE
refactor(ci): reuse run-omnigent-agent action in feature-blog workflow

### DIFF
--- a/.github/workflows/feature-blog.yml
+++ b/.github/workflows/feature-blog.yml
@@ -174,52 +174,6 @@ jobs:
           [ -n "${BASE:-}" ] && args+=(--base "$BASE")
           python3 .github/scripts/changelog/generate.py "${args[@]}"
 
-      - name: Set up uv
-        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: true
-
-      - name: Cache virtualenv
-        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
-
-      - name: Install dependencies
-        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
-        run: uv sync --extra all --extra dev
-
-      - name: Install Claude Code CLI
-        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
-        env:
-          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
-        run: |
-          mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
-          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.170
-          node node_modules/@anthropic-ai/claude-code/install.cjs
-          echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
-
-      - name: Write Omnigent provider config
-        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
-        env:
-          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
-        run: |
-          mkdir -p "$HOME/.omnigent"
-          python3 -c "
-          import pathlib, os, json
-          gw = os.environ['GATEWAY_BASE_URL']
-          cfg = {'providers': {'databricks-gateway': {
-              'kind': 'gateway', 'default': ['anthropic'],
-              'anthropic': {
-                  'base_url': gw + '/anthropic',
-                  'api_key_ref': 'env:LLM_API_KEY',
-                  'models': {'default': 'databricks-claude-opus-4-8'},
-              }}}}
-          pathlib.Path.home().joinpath('.omnigent', 'config.yaml').write_text(json.dumps(cfg, indent=2))
-          "
-
       # --- 1) Scout: which features (if any) are blog-worthy? ---
       - name: Build scout prompt
         if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
@@ -251,30 +205,22 @@ jobs:
           pathlib.Path("/tmp/scout_prompt.txt").write_text(prompt)
           PYEOF
 
+      # Sets up uv + Claude CLI + the gateway provider config, runs the tools-less
+      # scout on the prompt file, and secret-scans its stdout — the same runner
+      # scaffold draft-release-notes.yml / publish-changelog.yml share. The env it
+      # sets up (PATH, ~/.omnigent, .venv) persists into the drafter loop below, so
+      # only the scout needs to invoke the action.
       - name: Run feature-blog scout
         id: scout
         if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
-        env:
-          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-        run: |
-          set -euo pipefail
-          prompt="$(cat /tmp/scout_prompt.txt)"
-          uv run --project "${GITHUB_WORKSPACE}" omnigent run \
-            "${GITHUB_WORKSPACE}/.github/agents/feature-blog-scout" \
-            -p "$prompt" --no-session \
-            2>scout-stderr.log | tee /tmp/scout_out.txt \
-            || { echo "::warning::scout exited non-zero — treating as no candidates"; cat scout-stderr.log; }
-
-      - name: Scan scout output for secrets
-        if: steps.scout.outcome == 'success'
-        env:
-          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -n "${LLM_API_KEY:-}" ] && grep -qF "$LLM_API_KEY" /tmp/scout_out.txt 2>/dev/null; then
-            echo "::error::Scout output contains LLM_API_KEY — aborting."
-            exit 1
-          fi
+        uses: ./.github/actions/run-omnigent-agent
+        with:
+          agent: feature-blog-scout
+          prompt-file: /tmp/scout_prompt.txt
+          output-file: /tmp/scout_out.txt
+          stderr-file: ${{ github.workspace }}/scout-stderr.log
+          gateway-base-url: ${{ secrets.GATEWAY_BASE_URL }}
+          llm-api-key: ${{ secrets.LLM_API_KEY }}
 
       - name: Parse candidates
         id: candidates


### PR DESCRIPTION
## Related issue

N/A

## Summary

Follow-up to #2682 and #2764. PR #2764 extracted the shared LLM-runner scaffold — uv + Claude Code CLI + gateway provider config + agent run + stdout secret-scan — into the composite action `.github/actions/run-omnigent-agent`, and pointed `draft-release-notes.yml` / `publish-changelog.yml` at it. `feature-blog.yml` (landed in #2682, just before #2764 merged) still inlined the whole thing.

This reuses the action:

- Removes the five inlined setup steps (`Set up uv`, `Cache virtualenv`, `Install dependencies`, `Install Claude Code CLI`, `Write Omnigent provider config`) plus the scout's own run + secret-scan steps.
- The tools-less **scout** now runs via one `uses: ./.github/actions/run-omnigent-agent` step (agent + prompt-file + output-file + gateway/key inputs), getting the same setup and fail-closed secret-scan as the other two workflows.
- Net **−54 lines**, and the runner scaffold now lives in exactly one place across all three release-automation workflows.

The per-candidate **drafter** loop still calls `omnigent run` directly on purpose: it interleaves `git switch` / `reset` / `commit` between invocations, which the single-shot action can't model. It reuses the environment (PATH, `~/.omnigent`, `.venv`) the action provisions when the scout runs, and keeps its own `LLM_API_KEY` in step env plus its existing drafter-output + drafted-file secret scans.

## Test Plan

- `check-yaml` (pre-commit) passes.
- Both shell blocks (`candidates`, `draftposts`, `Open draft PRs`) pass `bash -n`.
- Behavior-preserving: the scout consumes the same prompt file and produces the same `/tmp/scout_out.txt` the downstream `Parse candidates` step reads; the action's secret-scan replaces the removed inline one. Best validated the same way as #2682 — `workflow_dispatch` with `tag: v0.5.0`, `dry_run: true`.

## Demo

N/A — CI-only refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behavior-preserving refactor verified statically (YAML parse, `bash -n`) and by tracing input/output file contracts against the shared action, which is already exercised by `draft-release-notes.yml` and `publish-changelog.yml`. End-to-end path is exercised via `workflow_dispatch` + `dry_run: true` against a past release.

## Changelog

<!-- CI-only refactor; not user-facing. -->

This pull request and its description were written by Isaac.
