### PR TITLE
fix(fork): narrow launch-arg drop to genuine cross-CLI switches

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -10915,6 +10915,54 @@ def _agent_provider_family(agent: Agent) -> str | None:
     return provider_family_for_harness(spec.executor.harness_kind)
 
 
+def _agent_canonical_harness(agent: Agent) -> str | None:
+    """Return the canonical harness id of an agent, or ``None``.
+
+    Loads the agent's spec to read its ``harness_kind`` and canonicalizes it
+    (so the reversed native spellings — ``native-claude`` vs ``claude-native``
+    — compare equal). Returns ``None`` when the bundle can't be loaded, which
+    callers treat as "can't confirm".
+
+    :param agent: The agent whose harness to resolve.
+    :returns: The canonical harness id, e.g. ``"claude-native"``, else ``None``.
+    """
+    from omnigent.harness_aliases import canonicalize_harness
+
+    try:
+        spec = (
+            get_agent_cache()
+            .load(agent.id, agent.bundle_location, expand_env=agent.session_id is None)
+            .spec
+        )
+    except Exception:  # noqa: BLE001 — unloadable bundle → unknown harness
+        return None
+    harness = spec.executor.harness_kind
+    return canonicalize_harness(harness) or harness
+
+
+def _same_cli_harness(a: Agent, b: Agent) -> bool:
+    """Return whether two agents run the same (known) CLI harness.
+
+    ``terminal_launch_args`` are the argv handed to a native CLI in its
+    terminal (e.g. Claude Code's ``--permission-mode``); they only make sense
+    for the exact CLI that defined them. This is stricter than
+    :func:`_same_provider_family`: claude-native and claude-SDK share the
+    ``anthropic`` family but are different harnesses — the SDK target has no
+    terminal, and a different native CLI (pi, codex) rejects the source's
+    flags outright (pi exits at launch on an unknown ``--permission-mode``).
+
+    ``False`` when either harness is undeterminable, so a fork that can't
+    confirm both agents run the same CLI drops the launch args and lets the
+    target reapply its own defaults.
+
+    :param a: First agent (e.g. the fork source's agent).
+    :param b: Second agent (e.g. the switch target).
+    :returns: ``True`` when both resolve to the same non-``None`` harness.
+    """
+    harness_a = _agent_canonical_harness(a)
+    return harness_a is not None and harness_a == _agent_canonical_harness(b)
+
+
 def _same_provider_family(a: Agent, b: Agent) -> bool:
     """Return whether two agents share a (known) provider family.
 
@@ -16302,6 +16350,20 @@ def create_sessions_router(
                 _same_provider_family, source_agent, base_agent
             )
 
+        # ``terminal_launch_args`` are the argv for a native CLI's terminal and
+        # only make sense for the exact CLI that defined them. A same-agent fork
+        # always keeps them; a switch keeps them only when the target runs the
+        # SAME CLI harness (e.g. claude-native → another claude-native agent).
+        # A switch to a different CLI drops them: a different native CLI rejects
+        # the source's flags (pi exits at launch on an unknown
+        # ``--permission-mode`` → ``required_terminal_exited``), and an SDK
+        # target has no terminal to apply them to.
+        copy_terminal_launch_args = True
+        if switching_agent:
+            copy_terminal_launch_args = await asyncio.to_thread(
+                _same_cli_harness, source_agent, base_agent
+            )
+
         # When the fork binds a NATIVE target, the native CLI won't replay
         # the copied Omnigent transcript on its own — mark the fork so the
         # runner carries history into the native harness. Same-family: clone
@@ -16354,12 +16416,7 @@ def create_sessions_router(
                 cloned_agent_bundle_location=base_agent.bundle_location,
                 cloned_agent_description=base_agent.description,
                 copy_model_settings=copy_model_settings,
-                # Launch flags are CLI-specific. On an agent switch the fork may
-                # bind a different CLI (e.g. claude-code → pi), whose flag set
-                # differs — Claude Code's ``--permission-mode`` makes pi exit at
-                # launch (unknown option → ``required_terminal_exited``). Only
-                # carry the source's launch args on a same-agent fork.
-                copy_terminal_launch_args=not switching_agent,
+                copy_terminal_launch_args=copy_terminal_launch_args,
                 carry_history_into_native=carry_history_into_native,
                 resume_source_native_session=resume_source_native_session,
                 presentation_labels=presentation_labels,
@@ -16531,6 +16588,14 @@ def create_sessions_router(
         carry_history_into_native = await asyncio.to_thread(
             _agent_carries_native_fork_history, target_agent
         )
+        # ``terminal_launch_args`` are the leaving CLI's argv. Keep them only
+        # when the switch stays on the SAME CLI harness; a switch to a different
+        # CLI (or an SDK target with no terminal) leaves them stale and — for a
+        # different native CLI — invalid (pi rejects Claude Code's
+        # ``--permission-mode`` and exits at launch), so clear them.
+        keep_terminal_launch_args = await asyncio.to_thread(
+            _same_cli_harness, current_agent, target_agent
+        )
         presentation_labels = await asyncio.to_thread(_presentation_labels_for_agent, target_agent)
 
         # Resolve the built-in the session is leaving so the UI can offer a
@@ -16563,6 +16628,7 @@ def create_sessions_router(
                 new_agent_bundle_location=target_agent.bundle_location,
                 new_agent_description=target_agent.description,
                 copy_model_settings=copy_model_settings,
+                clear_terminal_launch_args=not keep_terminal_launch_args,
                 carry_history_into_native=carry_history_into_native,
                 presentation_labels=presentation_labels,
                 previous_builtin_id=previous_builtin_id,

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1372,7 +1372,8 @@ class ConversationStore(ABC):
             an agent in a different provider family, where the source's
             model id is meaningless (a model is provider-bound).
         :param copy_terminal_launch_args: When ``True`` (default), copy the
-            source's ``terminal_launch_args``. When ``False``, the fork starts
+            source's ``terminal_launch_args`` (kept for a same-agent fork or a
+            switch onto the same CLI harness). When ``False``, the fork starts
             with none — used when the fork switches to a different CLI, where
             the source's flags are meaningless or rejected (e.g. Claude Code's
             ``--permission-mode`` would make ``pi`` exit at launch).
@@ -1424,6 +1425,7 @@ class ConversationStore(ABC):
         new_agent_bundle_location: str,
         new_agent_description: str | None,
         copy_model_settings: bool,
+        clear_terminal_launch_args: bool = True,
         carry_history_into_native: bool,
         presentation_labels: dict[str, str],
         previous_builtin_id: str | None,
@@ -1460,6 +1462,13 @@ class ConversationStore(ABC):
             switch stays in the same provider family). When ``False``,
             both are reset to ``None`` so the new agent's defaults
             apply (a cross-family switch — a model id is provider-bound).
+        :param clear_terminal_launch_args: When ``True`` (default), reset
+            ``terminal_launch_args`` to ``None`` so the target CLI launches
+            with its own defaults. Set ``False`` by the route when the switch
+            stays on the SAME CLI harness, where the source's launch flags are
+            still valid; a switch to a different CLI leaves them stale or
+            invalid (e.g. Claude Code's ``--permission-mode`` makes pi exit at
+            launch), and an SDK target has no terminal for them.
         :param carry_history_into_native: When ``True``, stamp
             :data:`FORK_CARRY_HISTORY_LABEL_KEY` so a native target
             rebuilds its transcript from this session's own AP items on

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3345,12 +3345,13 @@ class SqlAlchemyConversationStore(ConversationStore):
             }
             source_workspace = source_meta_ref.workspace if source_meta_ref else None
             source_ext_session = source_meta_ref.external_session_id if source_meta_ref else None
-            # ``terminal_launch_args`` are CLI-specific launch flags. A fork
-            # that switches CLI family (e.g. claude-code → pi) must NOT inherit
-            # them: the source's flags are meaningless or rejected by the new
-            # CLI — Claude Code's ``--permission-mode auto`` makes ``pi`` exit 1
-            # at launch (unknown option), which surfaces as
-            # ``required_terminal_exited``. Drop them on a switching fork.
+            # ``terminal_launch_args`` are a native CLI's argv. The caller
+            # gates whether they carry over (``copy_terminal_launch_args``):
+            # kept for a same-agent fork or a switch onto the SAME CLI harness,
+            # dropped when the fork switches to a different CLI — the source's
+            # flags are then meaningless or rejected (Claude Code's
+            # ``--permission-mode auto`` makes ``pi`` exit 1 at launch, which
+            # surfaces as ``required_terminal_exited``).
             source_terminal_args = (
                 source_meta_ref.terminal_launch_args
                 if source_meta_ref and copy_terminal_launch_args
@@ -3425,6 +3426,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         new_agent_bundle_location: str,
         new_agent_description: str | None,
         copy_model_settings: bool,
+        clear_terminal_launch_args: bool = True,
         carry_history_into_native: bool,
         presentation_labels: dict[str, str],
         previous_builtin_id: str | None,
@@ -3527,11 +3529,12 @@ class SqlAlchemyConversationStore(ConversationStore):
             meta = session.get(SqlConversationMetadata, (current_workspace_id(), conversation_id))
             if meta is not None:
                 meta.external_session_id = None
-                # Launch flags are CLI-specific: a switch to a different CLI
-                # (e.g. claude-code → pi) leaves the prior CLI's flags stale —
-                # Claude Code's ``--permission-mode`` makes pi exit 1 at launch.
-                # Clear them so the new CLI launches with its own defaults.
-                meta.terminal_launch_args = None
+                # Launch flags are the leaving CLI's argv. A switch to a
+                # different CLI (e.g. claude-code → pi) leaves them stale —
+                # Claude Code's ``--permission-mode`` makes pi exit 1 at launch —
+                # so the route clears them; a same-CLI switch keeps them valid.
+                if clear_terminal_launch_args:
+                    meta.terminal_launch_args = None
 
         conv = self.get_conversation(conversation_id)
         if conv is None:

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -951,6 +951,50 @@ async def test_fork_switch_model_and_carry_gating(
 
 
 @pytest.mark.asyncio
+async def test_fork_switch_same_cli_keeps_launch_args(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A switch onto the SAME CLI harness keeps the source's launch args.
+
+    Switching to a different claude-native agent stays on the ``claude``
+    CLI, so the source's ``terminal_launch_args`` (e.g. ``--permission-mode``)
+    are still valid and must carry over — only a cross-CLI switch drops them.
+    """
+    conv = _make_conversation()
+    conv_store = _ConversationStore(
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={
+            "e9f8f58523cec9a57d3bdf93be543e8c": [
+                _make_item("9980c8a9248139f14f4165e5d53088aa", "Hi")
+            ]
+        },
+    )
+    agent_store = _switch_agent_store()
+    # Source and target both report claude-native → same CLI harness.
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.get_agent_cache",
+        lambda: _StubAgentCache(
+            {
+                "087b7cb7ac30abf4debfaa578d052ec6": "claude-native",
+                "280d725b404d2915f9e9d6cccce91303": "claude-native",
+            }
+        ),
+    )
+    client = TestClient(_build_app(conv_store, agent_store=agent_store))
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"agent_id": "280d725b404d2915f9e9d6cccce91303"},
+    )
+
+    assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
+    fork_call = conv_store.fork_calls[0]
+    assert fork_call["copy_terminal_launch_args"] is True, (
+        "A switch onto the SAME CLI harness must keep the source's launch args."
+    )
+
+
+@pytest.mark.asyncio
 async def test_fork_no_switch_native_source_carries_history(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/server/routes/test_sessions_switch_agent.py
+++ b/tests/server/routes/test_sessions_switch_agent.py
@@ -84,6 +84,7 @@ class _ConversationStore:
         new_agent_bundle_location: str,
         new_agent_description: str | None,
         copy_model_settings: bool,
+        clear_terminal_launch_args: bool = True,
         carry_history_into_native: bool,
         presentation_labels: dict[str, str],
         previous_builtin_id: str | None,
@@ -96,6 +97,8 @@ class _ConversationStore:
         :param new_agent_bundle_location: Target bundle to clone.
         :param new_agent_description: Target description.
         :param copy_model_settings: Same-family flag from the route.
+        :param clear_terminal_launch_args: Whether to reset the leaving CLI's
+            launch args (route passes ``False`` only for a same-CLI switch).
         :param carry_history_into_native: Native-rebuild flag.
         :param presentation_labels: Target-harness ui/wrapper labels.
         :param previous_builtin_id: Built-in switched away from.
@@ -110,6 +113,7 @@ class _ConversationStore:
                 "new_agent_bundle_location": new_agent_bundle_location,
                 "new_agent_description": new_agent_description,
                 "copy_model_settings": copy_model_settings,
+                "clear_terminal_launch_args": clear_terminal_launch_args,
                 "carry_history_into_native": carry_history_into_native,
                 "presentation_labels": presentation_labels,
                 "previous_builtin_id": previous_builtin_id,

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -4081,6 +4081,44 @@ def test_switch_conversation_agent_same_family_keeps_model_settings(
     assert SWITCH_PREVIOUS_BUILTIN_LABEL_KEY not in updated.labels
 
 
+def test_switch_conversation_agent_clears_or_keeps_terminal_launch_args(
+    conversation_store: SqlAlchemyConversationStore,
+    agent_store: SqlAlchemyAgentStore,
+) -> None:
+    """The switch honors ``clear_terminal_launch_args``.
+
+    Launch args are the leaving CLI's argv: a cross-CLI switch clears them
+    (default) so the new CLI applies its own defaults; a same-CLI switch keeps
+    them (``clear_terminal_launch_args=False``) since they stay valid.
+    """
+    cases = (
+        (True, None, "1a2b3c4d5e6f708192a3b4c5d6e7f809"),
+        (False, ["--permission-mode", "auto"], "90fedcba9876543210abcdef01234567"),
+    )
+    for clear, expected, new_agent_id in cases:
+        created = conversation_store.create_conversation(
+            terminal_launch_args=["--permission-mode", "auto"],
+        )
+        conv_id = created.id
+        conversation_store.switch_conversation_agent(
+            conv_id,
+            new_agent_id=new_agent_id,
+            new_agent_name="target (switch)",
+            new_agent_bundle_location="06efca8dd5c2e87b8cfed1aae99cc239/hash",
+            new_agent_description=None,
+            copy_model_settings=True,
+            clear_terminal_launch_args=clear,
+            carry_history_into_native=False,
+            presentation_labels={},
+            previous_builtin_id=None,
+        )
+        fetched = conversation_store.get_conversation(conv_id)
+        assert fetched is not None
+        assert fetched.terminal_launch_args == expected, (
+            f"clear_terminal_launch_args={clear} should yield {expected!r}"
+        )
+
+
 def test_get_session_connectivity_batches_runner_and_host(
     conversation_store: SqlAlchemyConversationStore,
     db_uri: str,


### PR DESCRIPTION
## Related issue

N/A — follow-up to #2780 (review feedback).

## Summary

#2780 dropped `terminal_launch_args` on **any** agent switch, but its inline
comments described the drop as cross-CLI-specific. As noted in review, a
**same-CLI** switch (e.g. claude-native → a different claude-native agent) also
discarded still-valid flags like `--permission-mode` — a minor UX regression,
and the code didn't match its comments.

This narrows the drop to genuine cross-CLI switches:

- New `_same_cli_harness(a, b)` compares canonical `harness_kind`. This is
  stricter than `_same_provider_family` on purpose: claude-native and
  claude-SDK share the `anthropic` family but are different CLIs — the SDK
  target has no terminal, and a different native CLI rejects the source's flags.
- **Fork route** copies launch args when *not switching* **or** switching onto
  the same CLI harness.
- **Switch route** passes `clear_terminal_launch_args=not same_cli` to the
  store, which now gates the clear instead of clearing unconditionally.

`terminal_launch_args` only exist for native CLI harnesses, so the preserved
case is precisely "same native CLI → same native CLI"; SDK sessions have no
launch args to carry.

## Test Plan

- New `test_fork_switch_same_cli_keeps_launch_args` (claude-native → claude-native
  keeps args); existing cross-CLI switch-gating test still asserts drop.
- New store test `test_switch_conversation_agent_clears_or_keeps_terminal_launch_args`
  (switch honors the flag both ways).
- Route-test fakes updated with the new `clear_terminal_launch_args` param.
- `uv run --extra databricks --extra dev python -m pytest tests/server/routes/test_sessions_fork.py tests/server/routes/test_sessions_switch_agent.py` → 43 passed.
- Store fork/switch/terminal_launch tests → 37 passed. `ruff check` clean.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover all four branches: same-agent fork (keep), same-CLI switch
(keep), cross-CLI switch (drop) on both the fork and in-place switch paths.

## Changelog

Switching a session to a different agent on the same CLI no longer discards valid terminal launch flags like --permission-mode

This pull request and its description were written by Isaac.
