### PR TITLE
fix(ci): prettier-format drafted blog files before committing

### DIFF
--- a/.github/workflows/feature-blog.yml
+++ b/.github/workflows/feature-blog.yml
@@ -425,6 +425,18 @@ jobs:
                 >> "${SITE}/${post}"
             fi
 
+            # Prettier the drafter's changed files so they pass the site's
+            # `fmt:check` gate — LLM-generated MDX/JS (and the CTA footer appended
+            # above) are rarely prettier-clean. Run from inside $SITE so prettier
+            # discovers the site's .prettierrc.json + .prettierignore, and pin the
+            # site's major version. Formatting failures are non-fatal: a human
+            # reviews the draft PR and CI still reports any residual issue.
+            mapfile -t changed < <(git -C "$SITE" status --porcelain | awk '{print $NF}')
+            if [ "${#changed[@]}" -gt 0 ]; then
+              ( cd "$SITE" && npx --yes prettier@3 --write --ignore-unknown "${changed[@]}" ) \
+                || echo "::warning::prettier --write failed for ${slug}; committing unformatted (CI will flag)"
+            fi
+
             title=$(sed -n 's/^BLOG_PR_TITLE:[[:space:]]*//p' "/tmp/drafter_out_${i}.txt" | head -n1)
             [ -z "$title" ] && title="add feature blog: ${headline}"
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Follow-up to #2682 / #2782. When a real (`dry_run=false`) run drafts posts into `omnigent-site`, the resulting PRs fail the site's `Check formatting` CI job (`prettier --check .`) — see [omnigent-site run](https://github.com/omnigent-ai/omnigent-site/actions/runs/29564401576). LLM-generated MDX/JS, plus the CTA footer the workflow appends after the drafter runs, are essentially never prettier-clean, so every draft PR arrives red.

Fix in the workflow: after the drafter writes its files (and the CTA footer is appended), run `prettier --write` on the changed files **from inside the site checkout** — so prettier discovers the site's `.prettierrc.json` and `.prettierignore` — before staging and committing.

- Pinned to `prettier@3` (the site pins `^3.8.4`); invoked via `npx --yes` (Node is already on PATH from the Claude CLI install).
- `--ignore-unknown` so non-formattable files are skipped safely.
- Non-fatal: a prettier failure logs a `::warning::` and commits anyway — these are human-reviewed draft PRs, and the site CI still reports any residual formatting issue.

## Test Plan

- `check-yaml` (pre-commit) passes; `bash -n` passes on the `draftposts` step.
- End-to-end: re-run `workflow_dispatch` with `tag: v0.5.0`, `dry_run: false` and confirm the new draft PRs pass `fmt:check` on omnigent-site. (The three existing test PRs #334–#336 predate this fix.)

## Demo

N/A — CI-only change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified statically (YAML parse, `bash -n`). The formatting behavior is best confirmed by a `dry_run=false` dispatch producing PRs that pass omnigent-site's `fmt:check`; there is no hermetic harness for a cross-repo drafting workflow.

## Changelog

<!-- CI-only fix; not user-facing. -->

This pull request and its description were written by Isaac.
