### PR TITLE
✨ feat(cli): add `omni usage` cost report

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5027,14 +5027,20 @@ def import_session_command(
 
 def _render_usage(report: dict[str, Any], limit: int) -> None:  # type: ignore[explicit-any]
     """
-    Print the usage report: a rolling-window cost summary plus a per-session table.
+    Print the usage report: a daily-rollup cost summary plus per-session detail.
 
     Styling routes through :mod:`omnigent.inner.ui` — the CLI palette SOT —
     so headers/borders use the brand semantic tokens (``omni.accent`` /
     ``omni.muted``) and adapt to light / dark terminals (no hard-coded colors).
 
+    The per-session block mirrors the web session sidebar: an authoritative
+    session total, then each model's recorded cost indented beneath. The
+    per-model costs are shown faithfully and may not sum to the session total
+    (native harnesses report one cumulative figure attributed to the active
+    model — see :class:`omnigent.server.schemas.SessionUsage`).
+
     :param report: The decoded ``GET /v1/usage`` JSON body.
-    :param limit: Maximum number of sessions to show in the table.
+    :param limit: Maximum number of sessions to show.
     """
     from rich.markup import escape
     from rich.style import Style
@@ -5050,16 +5056,6 @@ def _render_usage(report: dict[str, Any], limit: int) -> None:  # type: ignore[e
     def money(value: float) -> str:
         return f"${value:,.2f}"
 
-    def model_cell(model: str | None) -> str:
-        # Base model in the default fg, the "+N" (extra distinct models) in
-        # accent. Escaped in case a raw model id carries markup characters.
-        if not model:
-            return "[omni.muted]—[/omni.muted]"
-        base, sep, extra = model.partition(" +")
-        if sep:
-            return f"{escape(base)} [omni.accent]+{escape(extra)}[/omni.accent]"
-        return escape(model)
-
     ui.console.print()
     ui.console.print(
         "[omni.muted]Costs are best-effort estimates; consult your provider for "
@@ -5067,9 +5063,10 @@ def _render_usage(report: dict[str, Any], limit: int) -> None:  # type: ignore[e
     )
     ui.console.print()
     ui.console.print(Text("Summary", style=accent_bold))
-    ui.kv("  Last 24h", money(report.get("cost_last_24h", 0.0)), label_width=12)
-    ui.kv("  Last 7d", money(report.get("cost_last_7d", 0.0)), label_width=12)
-    ui.kv("  Last 30d", money(report.get("cost_last_30d", 0.0)), label_width=12)
+    ui.kv("  Today", money(report.get("cost_today", 0.0)), label_width=15)
+    ui.kv("  Last 7 days", money(report.get("cost_last_7d", 0.0)), label_width=15)
+    ui.kv("  Last 30 days", money(report.get("cost_last_30d", 0.0)), label_width=15)
+    ui.kv("  All time", money(report.get("total_cost_usd", 0.0)), label_width=15)
     ui.console.print()
 
     all_sessions = report.get("sessions", [])
@@ -5079,8 +5076,15 @@ def _render_usage(report: dict[str, Any], limit: int) -> None:  # type: ignore[e
     header.append("Per session", style=accent_bold)
     header.append(f" (last {len(shown)})", style="omni.muted")
     ui.console.print(header)
-    # Bold default-fg headers (accent is reserved for the section headers);
-    # the border uses the shared muted token so it adapts to light / dark.
+    if not all_sessions:
+        ui.console.print("  [omni.muted]No usage recorded yet.[/omni.muted]")
+        return
+
+    # Three columns: Session ID · Model · Cost. A single-model session fits on
+    # one line; a multi-model session leaves the Model column blank on the
+    # session line (id + bold authoritative total) and lists each model on its
+    # own row beneath, cost muted to mark it as breakdown detail. The border
+    # uses the shared muted token so it adapts to light / dark.
     tbl = Table(
         box=box.SIMPLE_HEAVY,
         show_edge=False,
@@ -5091,14 +5095,22 @@ def _render_usage(report: dict[str, Any], limit: int) -> None:  # type: ignore[e
     tbl.add_column("Model", no_wrap=True)
     tbl.add_column("Cost", justify="right", no_wrap=True)
     for s in shown:
-        tbl.add_row(
-            str(s.get("id", "")),
-            model_cell(s.get("model")),
-            f"[bold]{money(s.get('cost_usd', 0.0))}[/bold]",
-        )
+        sid = escape(str(s.get("id", "")))
+        total = f"[bold]{money(s.get('cost_usd', 0.0))}[/bold]"
+        # Dominant model first, so the biggest spend leads (cost desc).
+        models = sorted((s.get("models") or {}).items(), key=lambda kv: kv[1], reverse=True)
+        if len(models) <= 1:
+            model_cell = escape(str(models[0][0])) if models else "[omni.muted]—[/omni.muted]"
+            tbl.add_row(sid, model_cell, total)
+        else:
+            tbl.add_row(sid, "", total)
+            for name, cost in models:
+                tbl.add_row(
+                    "",
+                    escape(str(name)),
+                    f"[omni.muted]{money(float(cost))}[/omni.muted]",
+                )
     ui.console.print(tbl)
-    if not all_sessions:
-        ui.console.print("  [omni.muted]No usage recorded yet.[/omni.muted]")
 
 
 @cli.command("usage")
@@ -5124,18 +5136,20 @@ def _render_usage(report: dict[str, Any], limit: int) -> None:  # type: ignore[e
     help="Emit the raw usage report as JSON instead of the table.",
 )
 def usage(limit: int, server: str | None, as_json: bool) -> None:
-    """Show your Omnigent LLM cost over the last 24h / 7 days / 30 days.
+    """Show your Omnigent LLM cost for today / the last 7 / 30 days.
 
-    Sums spend across all your sessions (each rolled up over its
-    sub-agents) into rolling 24h / 7d / 30d cost totals, then lists a
-    per-session breakdown of model and cost.
+    The summary is sourced from the per-user daily cost rollup, which
+    attributes spend to the UTC calendar day it occurred on — so the
+    windows reflect when spend actually happened, not just a session's
+    last-activity time. Below it, the most-recent sessions are listed with
+    each session's total and its per-model cost breakdown.
 
     \b
-    A session is counted in a window when its last-activity time falls
-    inside it. Because a session carries one cumulative usage total with a
-    single timestamp, a session active across a window edge is attributed
-    wholly to the window its last activity falls in — approximate at the
-    edges.
+    Per-model costs are shown as recorded and may not sum to the session
+    total: native harnesses report one cumulative session figure attributed
+    to the active model, so a session that switched models mid-run shows a
+    snapshot per model rather than each model's own spend (the same
+    convention as the web session sidebar).
 
     \b
     Examples:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1519,6 +1519,7 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
         "uninstall",
         "update",
         "upgrade",
+        "usage",
         "version",
     }
 )
@@ -5022,6 +5023,149 @@ def import_session_command(
         click.echo(f"Failed: {failed_count}")
         if failed_count:
             raise click.ClickException(f"{failed_count} session(s) failed to import")
+
+
+def _render_usage(report: dict[str, Any], limit: int) -> None:  # type: ignore[explicit-any]
+    """
+    Print the usage report: a rolling-window cost summary plus a per-session table.
+
+    Styling routes through :mod:`omnigent.inner.ui` — the CLI palette SOT —
+    so headers/borders use the brand semantic tokens (``omni.accent`` /
+    ``omni.muted``) and adapt to light / dark terminals (no hard-coded colors).
+
+    :param report: The decoded ``GET /v1/usage`` JSON body.
+    :param limit: Maximum number of sessions to show in the table.
+    """
+    from rich.markup import escape
+    from rich.style import Style
+    from rich.text import Text
+
+    from omnigent.inner import ui
+
+    # rich resolves a theme token combined with an attribute only via a Style
+    # object or inline single-token markup, not a "bold omni.accent" style
+    # string — so build the accent header style explicitly.
+    accent_bold = ui.console.get_style("omni.accent") + Style(bold=True)
+
+    def money(value: float) -> str:
+        return f"${value:,.2f}"
+
+    def model_cell(model: str | None) -> str:
+        # Base model in the default fg, the "+N" (extra distinct models) in
+        # accent. Escaped in case a raw model id carries markup characters.
+        if not model:
+            return "[omni.muted]—[/omni.muted]"
+        base, sep, extra = model.partition(" +")
+        if sep:
+            return f"{escape(base)} [omni.accent]+{escape(extra)}[/omni.accent]"
+        return escape(model)
+
+    ui.console.print()
+    ui.console.print(
+        "[omni.muted]Costs are best-effort estimates; consult your provider for "
+        "actual billing.[/omni.muted]"
+    )
+    ui.console.print()
+    ui.console.print(Text("Summary", style=accent_bold))
+    ui.kv("  Last 24h", money(report.get("cost_last_24h", 0.0)), label_width=12)
+    ui.kv("  Last 7d", money(report.get("cost_last_7d", 0.0)), label_width=12)
+    ui.kv("  Last 30d", money(report.get("cost_last_30d", 0.0)), label_width=12)
+    ui.console.print()
+
+    all_sessions = report.get("sessions", [])
+    shown = all_sessions[:limit]
+    # Empty base Text so the muted count hint doesn't inherit the accent.
+    header = Text()
+    header.append("Per session", style=accent_bold)
+    header.append(f" (last {len(shown)})", style="omni.muted")
+    ui.console.print(header)
+    # Bold default-fg headers (accent is reserved for the section headers);
+    # the border uses the shared muted token so it adapts to light / dark.
+    tbl = Table(
+        box=box.SIMPLE_HEAVY,
+        show_edge=False,
+        header_style="bold",
+        border_style="omni.muted",
+    )
+    tbl.add_column("Session ID", style="omni.muted", no_wrap=True)
+    tbl.add_column("Model", no_wrap=True)
+    tbl.add_column("Cost", justify="right", no_wrap=True)
+    for s in shown:
+        tbl.add_row(
+            str(s.get("id", "")),
+            model_cell(s.get("model")),
+            f"[bold]{money(s.get('cost_usd', 0.0))}[/bold]",
+        )
+    ui.console.print(tbl)
+    if not all_sessions:
+        ui.console.print("  [omni.muted]No usage recorded yet.[/omni.muted]")
+
+
+@cli.command("usage")
+@click.option(
+    "--limit",
+    default=10,
+    show_default=True,
+    help="Number of most-recent sessions to show in the per-session table.",
+)
+@click.option(
+    "--server",
+    default=None,
+    help=(
+        "Omnigent server URL. "
+        "Defaults to the configured server, or a local server already running."
+    ),
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit the raw usage report as JSON instead of the table.",
+)
+def usage(limit: int, server: str | None, as_json: bool) -> None:
+    """Show your Omnigent LLM cost over the last 24h / 7 days / 30 days.
+
+    Sums spend across all your sessions (each rolled up over its
+    sub-agents) into rolling 24h / 7d / 30d cost totals, then lists a
+    per-session breakdown of model and cost.
+
+    \b
+    A session is counted in a window when its last-activity time falls
+    inside it. Because a session carries one cumulative usage total with a
+    single timestamp, a session active across a window edge is attributed
+    wholly to the window its last activity falls in — approximate at the
+    edges.
+
+    \b
+    Examples:
+      omnigent usage
+      omnigent usage --limit 25
+      omnigent usage --json
+    """
+    import httpx
+
+    from omnigent.chat import _remote_headers
+
+    cfg = _load_effective_config()
+    base_url = _resolve_attach_server(server, cfg.get("server"))
+    if base_url is None:
+        startup = ensure_local_omnigent_server()
+        base_url = startup.url
+    base_url = base_url.rstrip("/")
+
+    with httpx.Client(
+        base_url=base_url, headers=_remote_headers(server_url=base_url), timeout=60.0
+    ) as client:
+        resp = client.get("/v1/usage")
+        resp.raise_for_status()
+        report = resp.json()
+
+    if as_json:
+        click.echo(json.dumps(report, indent=2))
+        return
+
+    _render_usage(report, limit)
 
 
 @cli.group("session", invoke_without_command=True)

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -87,6 +87,7 @@ from omnigent.server.routes.sessions import (
 )
 from omnigent.server.routes.sharing import create_sharing_router
 from omnigent.server.routes.terminal_attach import create_terminal_attach_router
+from omnigent.server.routes.usage import create_usage_router
 from omnigent.server.runner_session_init import RunnerSessionInitializer
 from omnigent.server.scheduled import ScheduledTaskScheduler
 from omnigent.server.ws_origin import WebSocketOriginMiddleware
@@ -2295,6 +2296,16 @@ def create_app(
         ),
         prefix="/v1",
         tags=["imports"],
+    )
+    # Per-user LLM cost report (omni usage). User-scoped, not session-scoped,
+    # so it gets its own router rather than living under /sessions.
+    app.include_router(
+        create_usage_router(
+            conversation_store,
+            auth_provider=auth_provider,
+        ),
+        prefix="/v1",
+        tags=["usage"],
     )
     # Read-only built-in agent discovery (designs/BUILTIN_AGENTS.md).
     # Successor to the removed GET /api/agents list; lists only

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -287,6 +287,8 @@ from omnigent.server.schemas import (
     SkillSummary,
     ToolOutputDeltaEvent,
     UpdateSessionRequest,
+    UsageReport,
+    UsageSession,
 )
 from omnigent.session_lifecycle import (
     is_session_closed,
@@ -3223,6 +3225,124 @@ def _record_daily_cost(
     from omnigent.db.utils import now_epoch
 
     conversation_store.add_daily_cost(owner, _utc_day(now_epoch()), delta_usd)
+
+
+def _usage_window_starts(now_epoch_s: int) -> tuple[int, int, int]:
+    """
+    Return the rolling window start boundaries for the usage report.
+
+    :param now_epoch_s: Current time as Unix epoch seconds.
+    :returns: ``(since_24h, since_7d, since_30d)`` as Unix epoch seconds —
+        24 hours, 7 days, and 30 days before now.
+    """
+    day = 86_400
+    return now_epoch_s - day, now_epoch_s - 7 * day, now_epoch_s - 30 * day
+
+
+def _primary_model(by_model: object) -> str | None:
+    """
+    Pick a session's primary model id from its ``by_model`` map.
+
+    Returns the full id of the highest-cost model, verbatim. Some native
+    harnesses record the same spend under several aliases (identical
+    buckets), so buckets with identical contents collapse to one entry and
+    a single-model session isn't mislabeled ``" +N"``. When genuinely
+    distinct models were used, the primary is suffixed ``" +N"``.
+
+    :param by_model: The ``session_usage["by_model"]`` value (expected to
+        be a ``dict`` keyed by model id); anything else yields ``None``.
+    :returns: The primary model id, optionally ``" +N"`` suffixed, or
+        ``None`` when no model was recorded.
+    """
+    if not isinstance(by_model, dict) or not by_model:
+        return None
+    # Group by bucket contents so aliases (the same spend under several
+    # names) collapse; the representative is the shortest of the duplicate
+    # ids, picked verbatim — no prefix/suffix rewriting.
+    reps: dict[tuple[tuple[str, float], ...], tuple[str, float]] = {}
+    for name, bucket in by_model.items():
+        if not isinstance(bucket, dict):
+            continue
+        sig = tuple(sorted((str(k), float(v)) for k, v in bucket.items()))
+        cost = float(bucket.get("total_cost_usd") or 0.0)
+        current = reps.get(sig)
+        if current is None or len(str(name)) < len(current[0]):
+            reps[sig] = (str(name), cost)
+    if not reps:
+        return None
+    ordered = [n for n, _ in sorted(reps.values(), key=lambda nc: nc[1], reverse=True)]
+    if len(ordered) == 1:
+        return ordered[0]
+    return f"{ordered[0]} +{len(ordered) - 1}"
+
+
+def _build_usage_report(
+    conversation_store: ConversationStore,
+    user_id: str | None,
+) -> UsageReport:
+    """
+    Aggregate a user's LLM spend across all their top-level sessions.
+
+    Walks the caller's ``kind="default"`` sessions (newest activity first)
+    and rolls each one's subtree usage in via :func:`load_session_usage`, so
+    a session's cost includes its sub-agents. Sub-agent sessions are never
+    iterated directly, so their spend is counted once, through their parent.
+    Cost is bucketed by each session's ``updated_at`` against rolling
+    24h / 7d / 30d windows.
+
+    :param conversation_store: Store to read sessions and usage from.
+    :param user_id: The caller, used as the ACL scope (``accessible_by``);
+        ``None`` in single-user / local mode returns every local session.
+    :returns: The populated :class:`UsageReport`.
+    """
+    from omnigent.db.utils import now_epoch
+
+    since_24h, since_7d, since_30d = _usage_window_starts(now_epoch())
+    sessions: list[UsageSession] = []
+    cost_24h = cost_7d = cost_30d = total = 0.0
+    after: str | None = None
+    while True:
+        page = conversation_store.list_conversations(
+            limit=200,
+            after=after,
+            accessible_by=user_id,
+            has_agent_id=True,
+            kind="default",
+            order="desc",
+            sort_by="updated_at",
+        )
+        for conv in page.data:
+            if conv.agent_id is None:
+                continue
+            usage = load_session_usage(conv.id, conversation_store)
+            cost = _priced_cost_for_display(usage) or 0.0
+            sessions.append(
+                UsageSession(
+                    id=conv.id,
+                    created_at=conv.created_at,
+                    updated_at=conv.updated_at,
+                    title=conv.title,
+                    model=_primary_model(usage.get("by_model")),
+                    cost_usd=cost,
+                )
+            )
+            total += cost
+            if conv.updated_at >= since_30d:
+                cost_30d += cost
+            if conv.updated_at >= since_7d:
+                cost_7d += cost
+            if conv.updated_at >= since_24h:
+                cost_24h += cost
+        if not page.has_more:
+            break
+        after = page.last_id
+    return UsageReport(
+        cost_last_24h=cost_24h,
+        cost_last_7d=cost_7d,
+        cost_last_30d=cost_30d,
+        total_cost_usd=total,
+        sessions=sessions,
+    )
 
 
 def _priced_cost_for_display(usage: dict[str, Any]) -> float | None:
@@ -15508,6 +15628,30 @@ def create_sessions_router(
             id=conv.id,
             labels=labels_with_closed_status(conv.labels, conv.title),
         )
+
+    # ── GET /usage ───────────────────────────────────────────────
+
+    @router.get(
+        "/usage",
+        response_model=UsageReport,
+    )
+    async def get_usage(request: Request) -> UsageReport:
+        """
+        Aggregate the calling user's LLM spend across their sessions.
+
+        Sums the ``session_usage`` of every top-level session the user can
+        access (each rolled up over its sub-agent subtree) into rolling
+        24h / 7d / 30d and all-time cost totals plus a per-session breakdown.
+        Powers the ``omni usage`` CLI command.
+
+        require_user, not get_user_id: the aggregation scopes to
+        ``accessible_by=user_id``, so a request slipping through as ``None``
+        would sum EVERY user's spend. Fail closed with 401 instead
+        (``user_id`` is ``None`` only when auth is disabled — the
+        single-user / local case).
+        """
+        user_id = _require_user(request, auth_provider)
+        return await asyncio.to_thread(_build_usage_report, conversation_store, user_id)
 
     # ── GET /sessions ───────────────────────────────────────────
 

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -287,8 +287,6 @@ from omnigent.server.schemas import (
     SkillSummary,
     ToolOutputDeltaEvent,
     UpdateSessionRequest,
-    UsageReport,
-    UsageSession,
 )
 from omnigent.session_lifecycle import (
     is_session_closed,
@@ -3225,124 +3223,6 @@ def _record_daily_cost(
     from omnigent.db.utils import now_epoch
 
     conversation_store.add_daily_cost(owner, _utc_day(now_epoch()), delta_usd)
-
-
-def _usage_window_starts(now_epoch_s: int) -> tuple[int, int, int]:
-    """
-    Return the rolling window start boundaries for the usage report.
-
-    :param now_epoch_s: Current time as Unix epoch seconds.
-    :returns: ``(since_24h, since_7d, since_30d)`` as Unix epoch seconds —
-        24 hours, 7 days, and 30 days before now.
-    """
-    day = 86_400
-    return now_epoch_s - day, now_epoch_s - 7 * day, now_epoch_s - 30 * day
-
-
-def _primary_model(by_model: object) -> str | None:
-    """
-    Pick a session's primary model id from its ``by_model`` map.
-
-    Returns the full id of the highest-cost model, verbatim. Some native
-    harnesses record the same spend under several aliases (identical
-    buckets), so buckets with identical contents collapse to one entry and
-    a single-model session isn't mislabeled ``" +N"``. When genuinely
-    distinct models were used, the primary is suffixed ``" +N"``.
-
-    :param by_model: The ``session_usage["by_model"]`` value (expected to
-        be a ``dict`` keyed by model id); anything else yields ``None``.
-    :returns: The primary model id, optionally ``" +N"`` suffixed, or
-        ``None`` when no model was recorded.
-    """
-    if not isinstance(by_model, dict) or not by_model:
-        return None
-    # Group by bucket contents so aliases (the same spend under several
-    # names) collapse; the representative is the shortest of the duplicate
-    # ids, picked verbatim — no prefix/suffix rewriting.
-    reps: dict[tuple[tuple[str, float], ...], tuple[str, float]] = {}
-    for name, bucket in by_model.items():
-        if not isinstance(bucket, dict):
-            continue
-        sig = tuple(sorted((str(k), float(v)) for k, v in bucket.items()))
-        cost = float(bucket.get("total_cost_usd") or 0.0)
-        current = reps.get(sig)
-        if current is None or len(str(name)) < len(current[0]):
-            reps[sig] = (str(name), cost)
-    if not reps:
-        return None
-    ordered = [n for n, _ in sorted(reps.values(), key=lambda nc: nc[1], reverse=True)]
-    if len(ordered) == 1:
-        return ordered[0]
-    return f"{ordered[0]} +{len(ordered) - 1}"
-
-
-def _build_usage_report(
-    conversation_store: ConversationStore,
-    user_id: str | None,
-) -> UsageReport:
-    """
-    Aggregate a user's LLM spend across all their top-level sessions.
-
-    Walks the caller's ``kind="default"`` sessions (newest activity first)
-    and rolls each one's subtree usage in via :func:`load_session_usage`, so
-    a session's cost includes its sub-agents. Sub-agent sessions are never
-    iterated directly, so their spend is counted once, through their parent.
-    Cost is bucketed by each session's ``updated_at`` against rolling
-    24h / 7d / 30d windows.
-
-    :param conversation_store: Store to read sessions and usage from.
-    :param user_id: The caller, used as the ACL scope (``accessible_by``);
-        ``None`` in single-user / local mode returns every local session.
-    :returns: The populated :class:`UsageReport`.
-    """
-    from omnigent.db.utils import now_epoch
-
-    since_24h, since_7d, since_30d = _usage_window_starts(now_epoch())
-    sessions: list[UsageSession] = []
-    cost_24h = cost_7d = cost_30d = total = 0.0
-    after: str | None = None
-    while True:
-        page = conversation_store.list_conversations(
-            limit=200,
-            after=after,
-            accessible_by=user_id,
-            has_agent_id=True,
-            kind="default",
-            order="desc",
-            sort_by="updated_at",
-        )
-        for conv in page.data:
-            if conv.agent_id is None:
-                continue
-            usage = load_session_usage(conv.id, conversation_store)
-            cost = _priced_cost_for_display(usage) or 0.0
-            sessions.append(
-                UsageSession(
-                    id=conv.id,
-                    created_at=conv.created_at,
-                    updated_at=conv.updated_at,
-                    title=conv.title,
-                    model=_primary_model(usage.get("by_model")),
-                    cost_usd=cost,
-                )
-            )
-            total += cost
-            if conv.updated_at >= since_30d:
-                cost_30d += cost
-            if conv.updated_at >= since_7d:
-                cost_7d += cost
-            if conv.updated_at >= since_24h:
-                cost_24h += cost
-        if not page.has_more:
-            break
-        after = page.last_id
-    return UsageReport(
-        cost_last_24h=cost_24h,
-        cost_last_7d=cost_7d,
-        cost_last_30d=cost_30d,
-        total_cost_usd=total,
-        sessions=sessions,
-    )
 
 
 def _priced_cost_for_display(usage: dict[str, Any]) -> float | None:
@@ -15628,30 +15508,6 @@ def create_sessions_router(
             id=conv.id,
             labels=labels_with_closed_status(conv.labels, conv.title),
         )
-
-    # ── GET /usage ───────────────────────────────────────────────
-
-    @router.get(
-        "/usage",
-        response_model=UsageReport,
-    )
-    async def get_usage(request: Request) -> UsageReport:
-        """
-        Aggregate the calling user's LLM spend across their sessions.
-
-        Sums the ``session_usage`` of every top-level session the user can
-        access (each rolled up over its sub-agent subtree) into rolling
-        24h / 7d / 30d and all-time cost totals plus a per-session breakdown.
-        Powers the ``omni usage`` CLI command.
-
-        require_user, not get_user_id: the aggregation scopes to
-        ``accessible_by=user_id``, so a request slipping through as ``None``
-        would sum EVERY user's spend. Fail closed with 401 instead
-        (``user_id`` is ``None`` only when auth is disabled — the
-        single-user / local case).
-        """
-        user_id = _require_user(request, auth_provider)
-        return await asyncio.to_thread(_build_usage_report, conversation_store, user_id)
 
     # ── GET /sessions ───────────────────────────────────────────
 

--- a/omnigent/server/routes/usage.py
+++ b/omnigent/server/routes/usage.py
@@ -1,0 +1,180 @@
+"""API route for the per-user LLM cost report (``omni usage``)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from omnigent.runtime.policies.builder import load_session_usage
+from omnigent.server.auth import RESERVED_USER_LOCAL, AuthProvider
+from omnigent.server.routes._auth_helpers import require_user
+from omnigent.server.schemas import SessionUsage, UsageReport
+from omnigent.stores import ConversationStore
+
+# The daily rollup floor for an "all-time" sum: earlier than any real row, so
+# ``sum_daily_cost`` with this lower bound totals every recorded day.
+_EPOCH_DAY = "0000-00-00"
+
+
+def _utc_today() -> str:
+    """Return the current UTC calendar day as ``"YYYY-MM-DD"``."""
+    from omnigent.db.utils import now_epoch
+
+    return datetime.fromtimestamp(now_epoch(), tz=timezone.utc).date().isoformat()
+
+
+def _day_offset(day_utc: str, *, days: int) -> str:
+    """Return the UTC day *days* before *day_utc*, as ``"YYYY-MM-DD"``."""
+    base = datetime.strptime(day_utc, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    return (base - timedelta(days=days)).date().isoformat()
+
+
+def _session_models(usage: dict[str, Any]) -> dict[str, float]:
+    """
+    Project a session's ``by_model`` map into a ``{model_id: cost_usd}`` dict.
+
+    Mirrors the web session sidebar's per-model list: each model's recorded
+    cost, keyed by the raw harness model id, shown faithfully. Models with no
+    recorded cost are omitted. NOT guaranteed to sum to the session's
+    ``total_cost_usd`` — see :class:`SessionUsage`.
+
+    :param usage: A subtree-summed ``session_usage`` dict.
+    :returns: Per-model cost map (empty when no per-model cost was recorded).
+    """
+    by_model = usage.get("by_model")
+    if not isinstance(by_model, dict):
+        return {}
+    models: dict[str, float] = {}
+    for name, bucket in by_model.items():
+        if not isinstance(bucket, dict) or "total_cost_usd" not in bucket:
+            continue
+        try:
+            models[str(name)] = float(bucket["total_cost_usd"])
+        except (TypeError, ValueError):
+            continue
+    return models
+
+
+def _session_cost(usage: dict[str, Any]) -> float:
+    """
+    Read a session's authoritative cumulative cost, or ``0.0`` when unpriced.
+
+    ``total_cost_usd`` is present only on priced sessions (the "priced ⟺ key
+    present" contract); an absent or malformed value reads as ``0.0``.
+    """
+    if "total_cost_usd" not in usage:
+        return 0.0
+    try:
+        return float(usage["total_cost_usd"])
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _build_usage_report(
+    conversation_store: ConversationStore,
+    user_id: str | None,
+) -> UsageReport:
+    """
+    Build the usage report: a daily-rollup cost summary plus session detail.
+
+    The summary (today / last 7 days / last 30 days / all-time) is summed
+    from the per-user daily-cost rollup (``user_daily_cost``), which
+    attributes spend to the UTC day it occurred on — so the windows reflect
+    when spend actually happened, not merely a session's last-activity time.
+
+    The per-session detail is a separate view over each top-level session's
+    cumulative ``session_usage`` (rolled up across its sub-agent subtree via
+    :func:`load_session_usage`), newest activity first, carrying the
+    authoritative session cost and the per-model breakdown.
+
+    :param conversation_store: Store to read the rollup and sessions from.
+    :param user_id: The caller / ACL scope. ``None`` in single-user mode maps
+        to the reserved local owner the daily rollup and grants are keyed by.
+    :returns: The populated :class:`UsageReport`.
+    """
+    # The daily rollup and session-permission grants key spend by the resolved
+    # owner, which is the reserved local sentinel in single-user mode (where
+    # require_user yields None). Map None -> "local" so the summary reads the
+    # same rows the write path recorded.
+    rollup_user = user_id if user_id is not None else RESERVED_USER_LOCAL
+
+    today = _utc_today()
+    cost_today = conversation_store.sum_daily_cost(rollup_user, today)
+    cost_7d = conversation_store.sum_daily_cost(rollup_user, _day_offset(today, days=6))
+    cost_30d = conversation_store.sum_daily_cost(rollup_user, _day_offset(today, days=29))
+    total = conversation_store.sum_daily_cost(rollup_user, _EPOCH_DAY)
+
+    sessions: list[SessionUsage] = []
+    after: str | None = None
+    while True:
+        page = conversation_store.list_conversations(
+            limit=200,
+            after=after,
+            accessible_by=user_id,
+            has_agent_id=True,
+            kind="default",
+            order="desc",
+            sort_by="updated_at",
+        )
+        for conv in page.data:
+            if conv.agent_id is None:
+                continue
+            usage = load_session_usage(conv.id, conversation_store)
+            sessions.append(
+                SessionUsage(
+                    id=conv.id,
+                    created_at=conv.created_at,
+                    updated_at=conv.updated_at,
+                    title=conv.title,
+                    cost_usd=_session_cost(usage),
+                    models=_session_models(usage),
+                )
+            )
+        if not page.has_more:
+            break
+        after = page.last_id
+
+    return UsageReport(
+        cost_today=cost_today,
+        cost_last_7d=cost_7d,
+        cost_last_30d=cost_30d,
+        total_cost_usd=total,
+        sessions=sessions,
+    )
+
+
+def create_usage_router(
+    conversation_store: ConversationStore,
+    *,
+    auth_provider: AuthProvider | None = None,
+) -> APIRouter:
+    """
+    Create the per-user usage-report router.
+
+    The report is user-scoped, not session-scoped, so it lives in its own
+    router rather than under the sessions router.
+
+    :param conversation_store: Store for the daily rollup and session reads.
+    :param auth_provider: Auth provider for user identity. ``None`` disables
+        auth (single-user / local mode).
+    :returns: The configured router (mounted under ``/v1``).
+    """
+    router = APIRouter()
+
+    @router.get("/usage", response_model=UsageReport)
+    async def get_usage(request: Request) -> UsageReport:
+        """
+        Aggregate the calling user's LLM spend across their sessions.
+
+        require_user, not get_user_id: the aggregation scopes to the caller,
+        so a request slipping through as ``None`` in multi-user mode would
+        read another scope. Fail closed with 401 instead (``user_id`` is
+        ``None`` only when auth is disabled — the single-user / local case).
+        """
+        user_id = require_user(request, auth_provider)
+        return await asyncio.to_thread(_build_usage_report, conversation_store, user_id)
+
+    return router

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2298,57 +2298,75 @@ class ChildSessionList(BaseModel):
     has_more: bool = False
 
 
-class UsageSession(BaseModel):
+class SessionUsage(BaseModel):
     """
     One session's rolled-up LLM spend for the ``GET /v1/usage`` report.
 
     ``cost_usd`` is the subtree total — the session plus every sub-agent it
     spawned — read from ``session_usage`` via
-    :func:`omnigent.runtime.policies.builder.load_session_usage`.
+    :func:`omnigent.runtime.policies.builder.load_session_usage`. It is the
+    authoritative session figure (the same value the web session sidebar
+    shows as "Session cost" and the daily rollup records).
+
+    ``models`` is the per-model cost breakdown, mirroring the web session
+    sidebar's per-model list. Deliberately **not guaranteed to sum to
+    ``cost_usd``**: native harnesses report a single cumulative session
+    total and the server attributes it to the currently-active model, so on
+    a session that switched models mid-run each model's bucket is a snapshot
+    of the running total rather than that model's own spend. The header
+    ``cost_usd`` stays authoritative; the per-model values are shown
+    faithfully as recorded (same convention as the web UI).
 
     :param id: Session/conversation identifier, e.g. ``"conv_abc123"``.
     :param created_at: Unix epoch seconds of creation.
-    :param updated_at: Unix epoch seconds of last activity; the timestamp the
-        report buckets this session's cost by.
+    :param updated_at: Unix epoch seconds of last activity.
     :param title: Optional human-readable title.
-    :param model: Primary model id (the highest-cost model, verbatim),
-        suffixed ``" +N"`` when the subtree spanned several distinct models.
-        ``None`` when no model was recorded.
-    :param cost_usd: Cumulative USD spend for this session's subtree.
+    :param cost_usd: Authoritative cumulative USD spend for this session's
+        subtree.
+    :param models: Per-model recorded cost, keyed by the raw harness model
+        id (e.g. ``{"claude-opus-4-8": 14.03}``). Empty when no per-model
+        cost was recorded. May not sum to ``cost_usd`` (see above).
     """
 
     id: str
     created_at: int
     updated_at: int
     title: str | None = None
-    model: str | None = None
     cost_usd: float = 0.0
+    models: dict[str, float] = Field(default_factory=dict)
 
 
 class UsageReport(BaseModel):
     """
     Aggregated LLM usage for the calling user, powering ``omni usage``.
 
-    Cost buckets are rolling trailing windows measured back from now:
-    ``cost_last_24h`` / ``cost_last_7d`` / ``cost_last_30d``. A session is
-    counted in a window when its ``updated_at`` (last activity) falls inside
-    it. Because a session carries a single cumulative ``session_usage`` blob
-    (no per-turn timestamps), one whose activity straddled a window edge is
-    attributed wholly to the window its last activity falls in.
+    The cost summary is sourced from the per-user daily-cost rollup
+    (``user_daily_cost``), which attributes spend to the UTC calendar day it
+    occurred on. Windows are therefore calendar-day buckets summed back from
+    today — ``cost_today`` / ``cost_last_7d`` / ``cost_last_30d`` — not
+    rolling wall-clock hours, so a weeks-old session touched today is not
+    counted wholly in "today".
 
-    :param cost_last_24h: Total spend for sessions active in the last 24h.
-    :param cost_last_7d: Total spend for sessions active in the last 7 days.
-    :param cost_last_30d: Total spend for sessions active in the last 30 days.
-    :param total_cost_usd: All-time total spend across the user's sessions.
-    :param sessions: Per-session breakdown, newest activity first.
+    The ``sessions`` list is a separate detail view built from each session's
+    cumulative ``session_usage`` (newest activity first), so the summary and
+    the per-session list come from different sources and are not guaranteed
+    to tie out to the cent (the summary counts every priced turn ever
+    recorded for the user; the list only covers the user's currently-listed
+    top-level sessions).
+
+    :param cost_today: Total spend on the current UTC day.
+    :param cost_last_7d: Total spend over the last 7 UTC days (incl. today).
+    :param cost_last_30d: Total spend over the last 30 UTC days (incl. today).
+    :param total_cost_usd: All-time total spend from the daily rollup.
+    :param sessions: Per-session detail, newest activity first.
     """
 
     object: Literal["usage_report"] = "usage_report"
-    cost_last_24h: float = 0.0
+    cost_today: float = 0.0
     cost_last_7d: float = 0.0
     cost_last_30d: float = 0.0
     total_cost_usd: float = 0.0
-    sessions: list[UsageSession] = Field(default_factory=list)
+    sessions: list[SessionUsage] = Field(default_factory=list)
 
 
 # ── Permissions ────────────────────────────────────────────────────

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2298,6 +2298,59 @@ class ChildSessionList(BaseModel):
     has_more: bool = False
 
 
+class UsageSession(BaseModel):
+    """
+    One session's rolled-up LLM spend for the ``GET /v1/usage`` report.
+
+    ``cost_usd`` is the subtree total — the session plus every sub-agent it
+    spawned — read from ``session_usage`` via
+    :func:`omnigent.runtime.policies.builder.load_session_usage`.
+
+    :param id: Session/conversation identifier, e.g. ``"conv_abc123"``.
+    :param created_at: Unix epoch seconds of creation.
+    :param updated_at: Unix epoch seconds of last activity; the timestamp the
+        report buckets this session's cost by.
+    :param title: Optional human-readable title.
+    :param model: Primary model id (the highest-cost model, verbatim),
+        suffixed ``" +N"`` when the subtree spanned several distinct models.
+        ``None`` when no model was recorded.
+    :param cost_usd: Cumulative USD spend for this session's subtree.
+    """
+
+    id: str
+    created_at: int
+    updated_at: int
+    title: str | None = None
+    model: str | None = None
+    cost_usd: float = 0.0
+
+
+class UsageReport(BaseModel):
+    """
+    Aggregated LLM usage for the calling user, powering ``omni usage``.
+
+    Cost buckets are rolling trailing windows measured back from now:
+    ``cost_last_24h`` / ``cost_last_7d`` / ``cost_last_30d``. A session is
+    counted in a window when its ``updated_at`` (last activity) falls inside
+    it. Because a session carries a single cumulative ``session_usage`` blob
+    (no per-turn timestamps), one whose activity straddled a window edge is
+    attributed wholly to the window its last activity falls in.
+
+    :param cost_last_24h: Total spend for sessions active in the last 24h.
+    :param cost_last_7d: Total spend for sessions active in the last 7 days.
+    :param cost_last_30d: Total spend for sessions active in the last 30 days.
+    :param total_cost_usd: All-time total spend across the user's sessions.
+    :param sessions: Per-session breakdown, newest activity first.
+    """
+
+    object: Literal["usage_report"] = "usage_report"
+    cost_last_24h: float = 0.0
+    cost_last_7d: float = 0.0
+    cost_last_30d: float = 0.0
+    total_cost_usd: float = 0.0
+    sessions: list[UsageSession] = Field(default_factory=list)
+
+
 # ── Permissions ────────────────────────────────────────────────────
 
 

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1003,6 +1003,27 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def sum_daily_cost(self, user_id: str, since_day_utc: str) -> float:
+        """
+        Sum a user's LLM spend over all UTC days ``>= since_day_utc``.
+
+        Backs the ``omni usage`` rolling-window summary: the daily rollup
+        is time-attributed per calendar day, so summing the days in a
+        window gives spend that actually happened in that window (a
+        weeks-old session touched today no longer dumps its whole cost
+        into "today"). Day strings sort lexicographically because they are
+        zero-padded ``"YYYY-MM-DD"``, so the ``>=`` range works as a plain
+        string comparison.
+
+        :param user_id: The user to read, e.g. ``"alice@example.com"``.
+        :param since_day_utc: Inclusive lower-bound UTC day as an ISO date
+            string ``"YYYY-MM-DD"``, e.g. ``"2026-06-05"``.
+        :returns: The summed ``cost_usd`` across matching days, or ``0.0``
+            when no rows fall in the range.
+        """
+        ...
+
+    @abstractmethod
     def get_daily_cost_state(self, user_id: str, day_utc: str) -> dict[str, float]:
         """
         Return a user's daily cost rollup state for one UTC day.

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -1490,6 +1490,24 @@ class SqlAlchemyConversationStore(ConversationStore):
             row = session.get(SqlUserDailyCost, (current_workspace_id(), user_id, day_utc))
             return float(row.cost_usd) if row is not None else 0.0
 
+    def sum_daily_cost(self, user_id: str, since_day_utc: str) -> float:
+        """
+        Sum a user's LLM spend over all UTC days ``>= since_day_utc``.
+
+        See :meth:`ConversationStore.sum_daily_cost`. Day strings compare
+        lexicographically (zero-padded ``"YYYY-MM-DD"``), so the range is
+        a plain ``>=`` on the string column; ``SUM`` returns ``NULL`` for
+        an empty range, coalesced to ``0.0``.
+        """
+        with self._session() as session:
+            total = session.execute(
+                select(func.coalesce(func.sum(SqlUserDailyCost.cost_usd), 0.0))
+                .where(SqlUserDailyCost.workspace_id == current_workspace_id())
+                .where(SqlUserDailyCost.user_id == user_id)
+                .where(SqlUserDailyCost.day_utc >= since_day_utc)
+            ).scalar_one()
+            return float(total or 0.0)
+
     def get_daily_cost_state(self, user_id: str, day_utc: str) -> dict[str, float]:
         """
         Return a user's daily cost rollup state for one UTC day.

--- a/openapi.json
+++ b/openapi.json
@@ -6445,6 +6445,108 @@
         "title": "UsageDetails",
         "type": "object"
       },
+      "UsageReport": {
+        "description": "Aggregated LLM usage for the calling user, powering `omni usage`.\n\nCost buckets are rolling trailing windows measured back from now:\n`cost_last_24h` / `cost_last_7d` / `cost_last_30d`. A session is\ncounted in a window when its `updated_at` (last activity) falls inside\nit. Because a session carries a single cumulative `session_usage` blob\n(no per-turn timestamps), one whose activity straddled a window edge is\nattributed wholly to the window its last activity falls in.",
+        "properties": {
+          "cost_last_24h": {
+            "default": 0.0,
+            "description": "Total spend for sessions active in the last 24h.",
+            "title": "Cost Last 24H",
+            "type": "number"
+          },
+          "cost_last_30d": {
+            "default": 0.0,
+            "description": "Total spend for sessions active in the last 30 days.",
+            "title": "Cost Last 30D",
+            "type": "number"
+          },
+          "cost_last_7d": {
+            "default": 0.0,
+            "description": "Total spend for sessions active in the last 7 days.",
+            "title": "Cost Last 7D",
+            "type": "number"
+          },
+          "object": {
+            "const": "usage_report",
+            "default": "usage_report",
+            "title": "Object",
+            "type": "string"
+          },
+          "sessions": {
+            "description": "Per-session breakdown, newest activity first.",
+            "items": {
+              "$ref": "#/components/schemas/UsageSession"
+            },
+            "title": "Sessions",
+            "type": "array"
+          },
+          "total_cost_usd": {
+            "default": 0.0,
+            "description": "All-time total spend across the user's sessions.",
+            "title": "Total Cost Usd",
+            "type": "number"
+          }
+        },
+        "title": "UsageReport",
+        "type": "object"
+      },
+      "UsageSession": {
+        "description": "One session's rolled-up LLM spend for the `GET /v1/usage` report.\n\n`cost_usd` is the subtree total \u2014 the session plus every sub-agent it\nspawned \u2014 read from `session_usage` via\n`omnigent.runtime.policies.builder.load_session_usage`.",
+        "properties": {
+          "cost_usd": {
+            "default": 0.0,
+            "description": "Cumulative USD spend for this session's subtree.",
+            "title": "Cost Usd",
+            "type": "number"
+          },
+          "created_at": {
+            "description": "Unix epoch seconds of creation.",
+            "title": "Created At",
+            "type": "integer"
+          },
+          "id": {
+            "description": "Session/conversation identifier, e.g. `\"conv_abc123\"`.",
+            "title": "Id",
+            "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Primary model id (the highest-cost model, verbatim), suffixed `\" +N\"` when the subtree spanned several distinct models. `None` when no model was recorded.",
+            "title": "Model"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional human-readable title.",
+            "title": "Title"
+          },
+          "updated_at": {
+            "description": "Unix epoch seconds of last activity; the timestamp the report buckets this session's cost by.",
+            "title": "Updated At",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "UsageSession",
+        "type": "object"
+      },
       "ValidationError": {
         "properties": {
           "ctx": {
@@ -11665,6 +11767,28 @@
         "summary": "Set Sharing",
         "tags": [
           "sharing"
+        ]
+      }
+    },
+    "/v1/usage": {
+      "get": {
+        "description": "Aggregate the calling user's LLM spend across their sessions.\n\nSums the `session_usage` of every top-level session the user can\naccess (each rolled up over its sub-agent subtree) into rolling\n24h / 7d / 30d and all-time cost totals plus a per-session breakdown.\nPowers the `omni usage` CLI command.\n\nrequire_user, not get_user_id: the aggregation scopes to\n`accessible_by=user_id`, so a request slipping through as `None`\nwould sum EVERY user's spend. Fail closed with 401 instead\n(`user_id` is `None` only when auth is disabled \u2014 the\nsingle-user / local case).",
+        "operationId": "get_usage_v1_usage_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsageReport"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Usage",
+        "tags": [
+          "sessions"
         ]
       }
     }

--- a/openapi.json
+++ b/openapi.json
@@ -5488,6 +5488,59 @@
         "title": "SessionTodosEvent",
         "type": "object"
       },
+      "SessionUsage": {
+        "description": "One session's rolled-up LLM spend for the `GET /v1/usage` report.\n\n`cost_usd` is the subtree total \u2014 the session plus every sub-agent it\nspawned \u2014 read from `session_usage` via\n`omnigent.runtime.policies.builder.load_session_usage`. It is the\nauthoritative session figure (the same value the web session sidebar\nshows as \"Session cost\" and the daily rollup records).\n\n`models` is the per-model cost breakdown, mirroring the web session\nsidebar's per-model list. Deliberately **not guaranteed to sum to\n`cost_usd`**: native harnesses report a single cumulative session\ntotal and the server attributes it to the currently-active model, so on\na session that switched models mid-run each model's bucket is a snapshot\nof the running total rather than that model's own spend. The header\n`cost_usd` stays authoritative; the per-model values are shown\nfaithfully as recorded (same convention as the web UI).",
+        "properties": {
+          "cost_usd": {
+            "default": 0.0,
+            "description": "Authoritative cumulative USD spend for this session's subtree.",
+            "title": "Cost Usd",
+            "type": "number"
+          },
+          "created_at": {
+            "description": "Unix epoch seconds of creation.",
+            "title": "Created At",
+            "type": "integer"
+          },
+          "id": {
+            "description": "Session/conversation identifier, e.g. `\"conv_abc123\"`.",
+            "title": "Id",
+            "type": "string"
+          },
+          "models": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "description": "Per-model recorded cost, keyed by the raw harness model id (e.g. `{\"claude-opus-4-8\": 14.03}`). Empty when no per-model cost was recorded. May not sum to `cost_usd` (see above).",
+            "title": "Models",
+            "type": "object"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional human-readable title.",
+            "title": "Title"
+          },
+          "updated_at": {
+            "description": "Unix epoch seconds of last activity.",
+            "title": "Updated At",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "SessionUsage",
+        "type": "object"
+      },
       "SessionUsageEvent": {
         "description": "Token-usage update from a terminal-backed integration.\n\nEmitted after an `external_session_usage` POST from an\nout-of-AP runtime (e.g. the `omnigent claude` transcript\nforwarder). Either field may be absent; clients should leave\ncached values untouched for missing fields.",
         "properties": {
@@ -6446,24 +6499,24 @@
         "type": "object"
       },
       "UsageReport": {
-        "description": "Aggregated LLM usage for the calling user, powering `omni usage`.\n\nCost buckets are rolling trailing windows measured back from now:\n`cost_last_24h` / `cost_last_7d` / `cost_last_30d`. A session is\ncounted in a window when its `updated_at` (last activity) falls inside\nit. Because a session carries a single cumulative `session_usage` blob\n(no per-turn timestamps), one whose activity straddled a window edge is\nattributed wholly to the window its last activity falls in.",
+        "description": "Aggregated LLM usage for the calling user, powering `omni usage`.\n\nThe cost summary is sourced from the per-user daily-cost rollup\n(`user_daily_cost`), which attributes spend to the UTC calendar day it\noccurred on. Windows are therefore calendar-day buckets summed back from\ntoday \u2014 `cost_today` / `cost_last_7d` / `cost_last_30d` \u2014 not\nrolling wall-clock hours, so a weeks-old session touched today is not\ncounted wholly in \"today\".\n\nThe `sessions` list is a separate detail view built from each session's\ncumulative `session_usage` (newest activity first), so the summary and\nthe per-session list come from different sources and are not guaranteed\nto tie out to the cent (the summary counts every priced turn ever\nrecorded for the user; the list only covers the user's currently-listed\ntop-level sessions).",
         "properties": {
-          "cost_last_24h": {
-            "default": 0.0,
-            "description": "Total spend for sessions active in the last 24h.",
-            "title": "Cost Last 24H",
-            "type": "number"
-          },
           "cost_last_30d": {
             "default": 0.0,
-            "description": "Total spend for sessions active in the last 30 days.",
+            "description": "Total spend over the last 30 UTC days (incl. today).",
             "title": "Cost Last 30D",
             "type": "number"
           },
           "cost_last_7d": {
             "default": 0.0,
-            "description": "Total spend for sessions active in the last 7 days.",
+            "description": "Total spend over the last 7 UTC days (incl. today).",
             "title": "Cost Last 7D",
+            "type": "number"
+          },
+          "cost_today": {
+            "default": 0.0,
+            "description": "Total spend on the current UTC day.",
+            "title": "Cost Today",
             "type": "number"
           },
           "object": {
@@ -6473,78 +6526,21 @@
             "type": "string"
           },
           "sessions": {
-            "description": "Per-session breakdown, newest activity first.",
+            "description": "Per-session detail, newest activity first.",
             "items": {
-              "$ref": "#/components/schemas/UsageSession"
+              "$ref": "#/components/schemas/SessionUsage"
             },
             "title": "Sessions",
             "type": "array"
           },
           "total_cost_usd": {
             "default": 0.0,
-            "description": "All-time total spend across the user's sessions.",
+            "description": "All-time total spend from the daily rollup.",
             "title": "Total Cost Usd",
             "type": "number"
           }
         },
         "title": "UsageReport",
-        "type": "object"
-      },
-      "UsageSession": {
-        "description": "One session's rolled-up LLM spend for the `GET /v1/usage` report.\n\n`cost_usd` is the subtree total \u2014 the session plus every sub-agent it\nspawned \u2014 read from `session_usage` via\n`omnigent.runtime.policies.builder.load_session_usage`.",
-        "properties": {
-          "cost_usd": {
-            "default": 0.0,
-            "description": "Cumulative USD spend for this session's subtree.",
-            "title": "Cost Usd",
-            "type": "number"
-          },
-          "created_at": {
-            "description": "Unix epoch seconds of creation.",
-            "title": "Created At",
-            "type": "integer"
-          },
-          "id": {
-            "description": "Session/conversation identifier, e.g. `\"conv_abc123\"`.",
-            "title": "Id",
-            "type": "string"
-          },
-          "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Primary model id (the highest-cost model, verbatim), suffixed `\" +N\"` when the subtree spanned several distinct models. `None` when no model was recorded.",
-            "title": "Model"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Optional human-readable title.",
-            "title": "Title"
-          },
-          "updated_at": {
-            "description": "Unix epoch seconds of last activity; the timestamp the report buckets this session's cost by.",
-            "title": "Updated At",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id",
-          "created_at",
-          "updated_at"
-        ],
-        "title": "UsageSession",
         "type": "object"
       },
       "ValidationError": {
@@ -11772,7 +11768,7 @@
     },
     "/v1/usage": {
       "get": {
-        "description": "Aggregate the calling user's LLM spend across their sessions.\n\nSums the `session_usage` of every top-level session the user can\naccess (each rolled up over its sub-agent subtree) into rolling\n24h / 7d / 30d and all-time cost totals plus a per-session breakdown.\nPowers the `omni usage` CLI command.\n\nrequire_user, not get_user_id: the aggregation scopes to\n`accessible_by=user_id`, so a request slipping through as `None`\nwould sum EVERY user's spend. Fail closed with 401 instead\n(`user_id` is `None` only when auth is disabled \u2014 the\nsingle-user / local case).",
+        "description": "Aggregate the calling user's LLM spend across their sessions.\n\nrequire_user, not get_user_id: the aggregation scopes to the caller,\nso a request slipping through as `None` in multi-user mode would\nread another scope. Fail closed with 401 instead (`user_id` is\n`None` only when auth is disabled \u2014 the single-user / local case).",
         "operationId": "get_usage_v1_usage_get",
         "responses": {
           "200": {
@@ -11788,7 +11784,7 @@
         },
         "summary": "Get Usage",
         "tags": [
-          "sessions"
+          "usage"
         ]
       }
     }

--- a/tests/cli/test_usage.py
+++ b/tests/cli/test_usage.py
@@ -1,0 +1,117 @@
+"""Tests for the ``omnigent usage`` command and its renderer."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from omnigent.cli import _render_usage, cli
+
+_REPORT: dict[str, Any] = {
+    "cost_last_24h": 1.5,
+    "cost_last_7d": 3.0,
+    "cost_last_30d": 9.0,
+    "total_cost_usd": 9.0,
+    "sessions": [
+        {"id": "conv_abc", "model": "claude-opus-4-8", "cost_usd": 1.5},
+        {"id": "conv_def", "model": "claude-opus-4-8 +2", "cost_usd": 7.5},
+    ],
+}
+
+
+def test_render_usage_table(capsys: pytest.CaptureFixture[str]) -> None:
+    _render_usage(_REPORT, limit=10)
+    out = capsys.readouterr().out
+    assert "best-effort estimates" in out
+    assert "Summary" in out
+    assert "Last 24h" in out and "$1.50" in out
+    assert "Last 30d" in out and "$9.00" in out
+    assert "Per session" in out and "(last 2)" in out
+    assert "conv_abc" in out
+    assert "claude-opus-4-8" in out
+    assert "+2" in out
+
+
+def test_render_usage_limit_caps_rows(capsys: pytest.CaptureFixture[str]) -> None:
+    _render_usage(_REPORT, limit=1)
+    out = capsys.readouterr().out
+    assert "(last 1)" in out
+    assert "conv_abc" in out
+    assert "conv_def" not in out
+
+
+def test_render_usage_shows_full_id(capsys: pytest.CaptureFixture[str]) -> None:
+    full_id = "conv_" + "0123456789abcdef" * 2
+    _render_usage(
+        {"sessions": [{"id": full_id, "model": "opus", "cost_usd": 1.0}]},
+        limit=10,
+    )
+    out = capsys.readouterr().out
+    assert full_id in out
+    assert "…" not in out
+
+
+def test_render_usage_empty(capsys: pytest.CaptureFixture[str]) -> None:
+    _render_usage({"sessions": []}, limit=10)
+    out = capsys.readouterr().out
+    assert "Summary" in out
+    assert "No usage recorded yet." in out
+
+
+def test_usage_command_help() -> None:
+    result = CliRunner().invoke(cli, ["usage", "--help"])
+    assert result.exit_code == 0
+    assert "--limit" in result.output
+    assert "--json" in result.output
+
+
+class _FakeResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return _REPORT
+
+
+class _FakeClient:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def __enter__(self) -> _FakeClient:
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def get(self, path: str) -> _FakeResponse:
+        assert path == "/v1/usage"
+        return _FakeResponse()
+
+
+@pytest.fixture()
+def _stub_usage_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("omnigent.cli._load_effective_config", dict)
+    monkeypatch.setattr("omnigent.cli._resolve_attach_server", lambda *a, **k: "http://x")
+    monkeypatch.setattr("omnigent.chat._remote_headers", lambda **k: {})
+    monkeypatch.setattr(httpx, "Client", _FakeClient)
+
+
+@pytest.mark.usefixtures("_stub_usage_fetch")
+def test_usage_command_renders_table() -> None:
+    result = CliRunner().invoke(cli, ["usage", "--server", "http://x"])
+    assert result.exit_code == 0, result.output
+    assert "Summary" in result.output
+    assert "conv_abc" in result.output
+
+
+@pytest.mark.usefixtures("_stub_usage_fetch")
+def test_usage_command_json() -> None:
+    result = CliRunner().invoke(cli, ["usage", "--json", "--server", "http://x"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["cost_last_24h"] == 1.5
+    assert payload["sessions"][0]["model"] == "claude-opus-4-8"

--- a/tests/cli/test_usage.py
+++ b/tests/cli/test_usage.py
@@ -12,28 +12,44 @@ from click.testing import CliRunner
 from omnigent.cli import _render_usage, cli
 
 _REPORT: dict[str, Any] = {
-    "cost_last_24h": 1.5,
+    "cost_today": 1.5,
     "cost_last_7d": 3.0,
     "cost_last_30d": 9.0,
     "total_cost_usd": 9.0,
     "sessions": [
-        {"id": "conv_abc", "model": "claude-opus-4-8", "cost_usd": 1.5},
-        {"id": "conv_def", "model": "claude-opus-4-8 +2", "cost_usd": 7.5},
+        {
+            "id": "conv_abc",
+            "cost_usd": 1.5,
+            "models": {"claude-opus-4-8": 1.5},
+        },
+        {
+            "id": "conv_def",
+            "cost_usd": 6.02,
+            # Multi-model: costs deliberately don't sum to cost_usd (faithful).
+            "models": {
+                "claude-opus-4-8": 6.02,
+                "system.ai.claude-opus-4-8[1m]": 13.58,
+            },
+        },
     ],
 }
 
 
-def test_render_usage_table(capsys: pytest.CaptureFixture[str]) -> None:
+def test_render_usage_summary_and_sessions(capsys: pytest.CaptureFixture[str]) -> None:
     _render_usage(_REPORT, limit=10)
     out = capsys.readouterr().out
     assert "best-effort estimates" in out
     assert "Summary" in out
-    assert "Last 24h" in out and "$1.50" in out
-    assert "Last 30d" in out and "$9.00" in out
+    assert "Today" in out and "$1.50" in out
+    assert "Last 7 days" in out and "$3.00" in out
+    assert "Last 30 days" in out
+    assert "All time" in out and "$9.00" in out
     assert "Per session" in out and "(last 2)" in out
     assert "conv_abc" in out
+    # Both models of the multi-model session are listed verbatim (no collapse).
     assert "claude-opus-4-8" in out
-    assert "+2" in out
+    assert "system.ai.claude-opus-4-8[1m]" in out
+    assert "$13.58" in out
 
 
 def test_render_usage_limit_caps_rows(capsys: pytest.CaptureFixture[str]) -> None:
@@ -47,7 +63,7 @@ def test_render_usage_limit_caps_rows(capsys: pytest.CaptureFixture[str]) -> Non
 def test_render_usage_shows_full_id(capsys: pytest.CaptureFixture[str]) -> None:
     full_id = "conv_" + "0123456789abcdef" * 2
     _render_usage(
-        {"sessions": [{"id": full_id, "model": "opus", "cost_usd": 1.0}]},
+        {"sessions": [{"id": full_id, "cost_usd": 1.0, "models": {}}]},
         limit=10,
     )
     out = capsys.readouterr().out
@@ -113,5 +129,5 @@ def test_usage_command_json() -> None:
     result = CliRunner().invoke(cli, ["usage", "--json", "--server", "http://x"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
-    assert payload["cost_last_24h"] == 1.5
-    assert payload["sessions"][0]["model"] == "claude-opus-4-8"
+    assert payload["cost_today"] == 1.5
+    assert payload["sessions"][0]["models"] == {"claude-opus-4-8": 1.5}

--- a/tests/e2e/test_usage_e2e.py
+++ b/tests/e2e/test_usage_e2e.py
@@ -1,0 +1,79 @@
+"""E2E happy-path test for the ``GET /v1/usage`` report (powers ``omni usage``).
+
+Pure HTTP — boots the live server and calls the route directly without
+starting an LLM turn. Like the comments e2e, the server always runs with
+``permission_store`` active, so the test creates a *real* session via
+``POST /v1/sessions`` and sends ``X-Forwarded-Email`` so the server can
+resolve the caller and scope the report to their sessions.
+
+Usage::
+
+    pytest tests/e2e/test_usage_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+
+import httpx
+import yaml
+
+_OWNER_EMAIL = "usage-owner@e2e.test"
+_AGENT_NAME = "e2e-usage-test"
+
+
+def _build_minimal_agent_bundle() -> bytes:
+    """Build a minimal agent bundle as an in-memory tar.gz for session create."""
+    config = yaml.dump(
+        {
+            "spec_version": 1,
+            "name": _AGENT_NAME,
+            "executor": {"type": "omnigent", "config": {"harness": "openai-agents"}},
+            "llm": {"model": _AGENT_NAME, "connection": {"api_key": "test-key"}},
+        }
+    ).encode()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name="config.yaml")
+        info.size = len(config)
+        tf.addfile(info, io.BytesIO(config))
+    return buf.getvalue()
+
+
+def _create_session(client: httpx.Client, *, email: str) -> str:
+    """Create a real session as *email* (granted LEVEL_OWNER) and return its id."""
+    resp = client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", _build_minimal_agent_bundle(), "application/gzip")},
+        headers={"X-Forwarded-Email": email},
+    )
+    assert resp.status_code == 201, f"Session creation failed: {resp.status_code} {resp.text}"
+    return resp.json()["session_id"]
+
+
+def test_usage_report_happy_path(http_client: httpx.Client) -> None:
+    """The report is well-formed, windows are monotonic, and it lists the caller's session."""
+    session_id = _create_session(http_client, email=_OWNER_EMAIL)
+
+    resp = http_client.get("/v1/usage", headers={"X-Forwarded-Email": _OWNER_EMAIL})
+    assert resp.status_code == 200, f"{resp.status_code} {resp.text}"
+    report = resp.json()
+
+    assert report["object"] == "usage_report"
+    windows = [
+        report["cost_last_24h"],
+        report["cost_last_7d"],
+        report["cost_last_30d"],
+        report["total_cost_usd"],
+    ]
+    assert all(isinstance(v, (int, float)) for v in windows)
+    # Rolling windows nest, so each is <= the next and <= the all-time total.
+    assert windows == sorted(windows)
+
+    by_id = {s["id"]: s for s in report["sessions"]}
+    assert session_id in by_id, "created session missing from the usage report"
+    # No turn ran, so the fresh session is priced at zero.
+    assert by_id[session_id]["cost_usd"] == 0.0

--- a/tests/e2e/test_usage_e2e.py
+++ b/tests/e2e/test_usage_e2e.py
@@ -64,16 +64,17 @@ def test_usage_report_happy_path(http_client: httpx.Client) -> None:
 
     assert report["object"] == "usage_report"
     windows = [
-        report["cost_last_24h"],
+        report["cost_today"],
         report["cost_last_7d"],
         report["cost_last_30d"],
         report["total_cost_usd"],
     ]
     assert all(isinstance(v, (int, float)) for v in windows)
-    # Rolling windows nest, so each is <= the next and <= the all-time total.
+    # Windows nest (today ⊆ 7d ⊆ 30d ⊆ all-time), so each is <= the next.
     assert windows == sorted(windows)
 
     by_id = {s["id"]: s for s in report["sessions"]}
     assert session_id in by_id, "created session missing from the usage report"
-    # No turn ran, so the fresh session is priced at zero.
+    # No turn ran, so the fresh session is priced at zero with no per-model cost.
     assert by_id[session_id]["cost_usd"] == 0.0
+    assert by_id[session_id]["models"] == {}

--- a/tests/server/routes/test_usage_report.py
+++ b/tests/server/routes/test_usage_report.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from omnigent.server.routes.sessions import (
+from omnigent.server.auth import RESERVED_USER_LOCAL
+from omnigent.server.routes.usage import (
     _build_usage_report,
-    _primary_model,
-    _usage_window_starts,
+    _day_offset,
+    _session_cost,
+    _session_models,
 )
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
@@ -18,46 +20,55 @@ _DAY = 86_400
 _AGENT_ID = "0123456789abcdef0123456789abcdef"
 
 
-def test_usage_window_starts() -> None:
-    now = 1_700_000_000
-    since_24h, since_7d, since_30d = _usage_window_starts(now)
-    assert since_24h == now - _DAY
-    assert since_7d == now - 7 * _DAY
-    assert since_30d == now - 30 * _DAY
+def test_day_offset() -> None:
+    # Inclusive windows: today + the 6 prior days = a 7-day window.
+    assert _day_offset("2026-07-22", days=6) == "2026-07-16"
+    assert _day_offset("2026-07-22", days=29) == "2026-06-23"
+    # Crosses a month boundary correctly.
+    assert _day_offset("2026-07-01", days=1) == "2026-06-30"
 
 
-def test_primary_model_single() -> None:
-    by_model = {"claude-opus-4-8": {"total_cost_usd": 1.0}}
-    assert _primary_model(by_model) == "claude-opus-4-8"
+def test_session_cost_priced() -> None:
+    assert _session_cost({"total_cost_usd": 2.5}) == 2.5
 
 
-def test_primary_model_keeps_full_id() -> None:
-    # The full model id is shown verbatim — no prefix/suffix rewriting.
-    by_model = {"provider.foo-4[1m]": {"total_cost_usd": 1.0}}
-    assert _primary_model(by_model) == "provider.foo-4[1m]"
+def test_session_cost_unpriced_or_malformed() -> None:
+    # Absent key (unpriced) and malformed values both read as 0.0.
+    assert _session_cost({}) == 0.0
+    assert _session_cost({"total_cost_usd": "oops"}) == 0.0
 
 
-def test_primary_model_collapses_identical_alias_buckets() -> None:
-    # The same spend recorded under two names is one model: collapse to the
-    # shortest id (picked verbatim) with no spurious "+N".
-    by_model = {
-        "system.ai.claude-opus-4-8[1m]": {"total_cost_usd": 2.0},
-        "claude-opus-4-8": {"total_cost_usd": 2.0},
+def test_session_models_faithful_no_collapse() -> None:
+    # Per-model costs are projected verbatim — no alias collapsing, no
+    # requirement that they sum to the session total (matches the web UI).
+    usage = {
+        "total_cost_usd": 14.03,
+        "by_model": {
+            "system.ai.claude-opus-4-8[1m]": {"total_cost_usd": 14.03},
+            "system.ai.claude-sonnet-4-6[1m]": {"total_cost_usd": 12.36},
+        },
     }
-    assert _primary_model(by_model) == "claude-opus-4-8"
-
-
-def test_primary_model_multiple_ranks_by_cost() -> None:
-    by_model = {
-        "claude-sonnet-5": {"total_cost_usd": 1.0},
-        "claude-opus-4-8": {"total_cost_usd": 3.0},
+    assert _session_models(usage) == {
+        "system.ai.claude-opus-4-8[1m]": 14.03,
+        "system.ai.claude-sonnet-4-6[1m]": 12.36,
     }
-    assert _primary_model(by_model) == "claude-opus-4-8 +1"
+
+
+def test_session_models_omits_unpriced_and_malformed() -> None:
+    usage = {
+        "by_model": {
+            "claude-opus-4-8": {"total_cost_usd": 1.0},
+            "unpriced-model": {"input_tokens": 100},  # no cost key -> omitted
+            "bad-model": {"total_cost_usd": "nan-ish"},  # malformed -> omitted
+        }
+    }
+    assert _session_models(usage) == {"claude-opus-4-8": 1.0}
 
 
 @pytest.mark.parametrize("value", [None, {}, "not-a-dict", 5])
-def test_primary_model_missing(value: object) -> None:
-    assert _primary_model(value) is None
+def test_session_models_missing(value: object) -> None:
+    assert _session_models({"by_model": value}) == {}
+    assert _session_models({}) == {}
 
 
 def _add_session(
@@ -69,8 +80,8 @@ def _add_session(
     by_model: dict[str, dict[str, float]],
     title: str,
 ) -> str:
-    # create_conversation stamps updated_at from now_epoch; pin it to place the
-    # session in a specific window. set_session_usage does not touch updated_at.
+    # create_conversation stamps updated_at from now_epoch; pin it so the
+    # session lands at a specific time. set_session_usage does not touch it.
     monkeypatch.setattr(
         "omnigent.stores.conversation_store.sqlalchemy_store.now_epoch",
         lambda: ts,
@@ -80,7 +91,31 @@ def _add_session(
     return conv.id
 
 
-def test_build_usage_report_windows_and_totals(
+def test_build_usage_report_summary_from_daily_rollup(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    # The summary windows are sourced from the per-user daily rollup, NOT from
+    # each session's last-activity time — so record spend directly on the
+    # rollup, attributed to calendar days relative to "today".
+    store.add_daily_cost(RESERVED_USER_LOCAL, "2026-07-22", 1.0)  # today
+    store.add_daily_cost(RESERVED_USER_LOCAL, "2026-07-18", 2.0)  # within 7d
+    store.add_daily_cost(RESERVED_USER_LOCAL, "2026-07-01", 4.0)  # within 30d
+    store.add_daily_cost(RESERVED_USER_LOCAL, "2026-05-01", 8.0)  # older, all-time only
+
+    # 1_784_678_400 == 2026-07-22T00:00:00Z. usage._utc_today reads now_epoch
+    # from omnigent.db.utils, so patch it there.
+    monkeypatch.setattr("omnigent.db.utils.now_epoch", lambda: 1_784_678_400)
+    report = _build_usage_report(store, None)
+
+    assert report.cost_today == 1.0
+    assert report.cost_last_7d == 3.0  # today + 2026-07-18
+    assert report.cost_last_30d == 7.0  # + 2026-07-01
+    assert report.total_cost_usd == 15.0  # + 2026-05-01
+
+
+def test_build_usage_report_sessions_detail(
     db_uri: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -95,49 +130,38 @@ def test_build_usage_report_windows_and_totals(
         by_model={"claude-opus-4-8": {"total_cost_usd": 1.0}},
         title="recent",
     )
-    week = _add_session(
+    older = _add_session(
         store,
         monkeypatch,
         ts=now - 3 * _DAY,
-        cost=2.0,
-        by_model={"gpt-5.5": {"total_cost_usd": 2.0}},
-        title="week",
-    )
-    old = _add_session(
-        store,
-        monkeypatch,
-        ts=now - 40 * _DAY,
-        cost=4.0,
+        cost=6.02,
+        # Multi-model session whose per-model costs deliberately do NOT sum to
+        # the session total (native cumulative attribution) — shown faithfully.
         by_model={
-            "claude-opus-4-8": {"total_cost_usd": 3.0},
-            "claude-sonnet-5": {"total_cost_usd": 1.0},
+            "claude-opus-4-8": {"total_cost_usd": 6.02},
+            "system.ai.claude-opus-4-8[1m]": {"total_cost_usd": 13.58},
         },
-        title="old",
+        title="older",
     )
 
     monkeypatch.setattr("omnigent.db.utils.now_epoch", lambda: now)
     report = _build_usage_report(store, None)
 
-    assert report.cost_last_24h == 1.0
-    assert report.cost_last_7d == 3.0
-    assert report.cost_last_30d == 3.0
-    assert report.total_cost_usd == 7.0
-
-    # Newest activity first, subtree cost + primary model per session.
-    assert [s.id for s in report.sessions] == [recent, week, old]
-    assert [s.cost_usd for s in report.sessions] == [1.0, 2.0, 4.0]
-    assert [s.model for s in report.sessions] == [
-        "claude-opus-4-8",
-        "gpt-5.5",
-        "claude-opus-4-8 +1",
-    ]
+    # Newest activity first; authoritative session cost + faithful per-model map.
+    assert [s.id for s in report.sessions] == [recent, older]
+    assert [s.cost_usd for s in report.sessions] == [1.0, 6.02]
+    assert report.sessions[0].models == {"claude-opus-4-8": 1.0}
+    assert report.sessions[1].models == {
+        "claude-opus-4-8": 6.02,
+        "system.ai.claude-opus-4-8[1m]": 13.58,
+    }
 
 
 def test_build_usage_report_empty(db_uri: str) -> None:
     store = SqlAlchemyConversationStore(db_uri)
     report = _build_usage_report(store, None)
     assert report.sessions == []
-    assert report.cost_last_24h == 0.0
+    assert report.cost_today == 0.0
     assert report.cost_last_7d == 0.0
     assert report.cost_last_30d == 0.0
     assert report.total_cost_usd == 0.0
@@ -153,7 +177,7 @@ def test_build_usage_report_unpriced_session(
         "omnigent.stores.conversation_store.sqlalchemy_store.now_epoch",
         lambda: now,
     )
-    # A session with no recorded usage: cost falls back to 0.0, model None.
+    # A session with no recorded usage: cost falls back to 0.0, no models.
     conv = store.create_conversation(title="bare", agent_id=_AGENT_ID)
 
     monkeypatch.setattr("omnigent.db.utils.now_epoch", lambda: now)
@@ -161,4 +185,17 @@ def test_build_usage_report_unpriced_session(
 
     bare = next(s for s in report.sessions if s.id == conv.id)
     assert bare.cost_usd == 0.0
-    assert bare.model is None
+    assert bare.models == {}
+
+
+def test_sum_daily_cost_range(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    store.add_daily_cost("alice", "2026-07-01", 1.0)
+    store.add_daily_cost("alice", "2026-07-10", 2.0)
+    store.add_daily_cost("alice", "2026-07-20", 4.0)
+    store.add_daily_cost("bob", "2026-07-20", 100.0)  # other user, excluded
+
+    assert store.sum_daily_cost("alice", "2026-07-10") == 6.0  # 10th + 20th
+    assert store.sum_daily_cost("alice", "0000-00-00") == 7.0  # all-time
+    assert store.sum_daily_cost("alice", "2026-08-01") == 0.0  # nothing in range
+    assert store.sum_daily_cost("nobody", "0000-00-00") == 0.0

--- a/tests/server/routes/test_usage_report.py
+++ b/tests/server/routes/test_usage_report.py
@@ -1,0 +1,164 @@
+"""Tests for the ``GET /v1/usage`` report builder and its helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.server.routes.sessions import (
+    _build_usage_report,
+    _primary_model,
+    _usage_window_starts,
+)
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+
+_DAY = 86_400
+# Agent ids are stored as 16-byte uuids, so tests use a valid 32-char hex id.
+_AGENT_ID = "0123456789abcdef0123456789abcdef"
+
+
+def test_usage_window_starts() -> None:
+    now = 1_700_000_000
+    since_24h, since_7d, since_30d = _usage_window_starts(now)
+    assert since_24h == now - _DAY
+    assert since_7d == now - 7 * _DAY
+    assert since_30d == now - 30 * _DAY
+
+
+def test_primary_model_single() -> None:
+    by_model = {"claude-opus-4-8": {"total_cost_usd": 1.0}}
+    assert _primary_model(by_model) == "claude-opus-4-8"
+
+
+def test_primary_model_keeps_full_id() -> None:
+    # The full model id is shown verbatim — no prefix/suffix rewriting.
+    by_model = {"provider.foo-4[1m]": {"total_cost_usd": 1.0}}
+    assert _primary_model(by_model) == "provider.foo-4[1m]"
+
+
+def test_primary_model_collapses_identical_alias_buckets() -> None:
+    # The same spend recorded under two names is one model: collapse to the
+    # shortest id (picked verbatim) with no spurious "+N".
+    by_model = {
+        "system.ai.claude-opus-4-8[1m]": {"total_cost_usd": 2.0},
+        "claude-opus-4-8": {"total_cost_usd": 2.0},
+    }
+    assert _primary_model(by_model) == "claude-opus-4-8"
+
+
+def test_primary_model_multiple_ranks_by_cost() -> None:
+    by_model = {
+        "claude-sonnet-5": {"total_cost_usd": 1.0},
+        "claude-opus-4-8": {"total_cost_usd": 3.0},
+    }
+    assert _primary_model(by_model) == "claude-opus-4-8 +1"
+
+
+@pytest.mark.parametrize("value", [None, {}, "not-a-dict", 5])
+def test_primary_model_missing(value: object) -> None:
+    assert _primary_model(value) is None
+
+
+def _add_session(
+    store: SqlAlchemyConversationStore,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    ts: int,
+    cost: float,
+    by_model: dict[str, dict[str, float]],
+    title: str,
+) -> str:
+    # create_conversation stamps updated_at from now_epoch; pin it to place the
+    # session in a specific window. set_session_usage does not touch updated_at.
+    monkeypatch.setattr(
+        "omnigent.stores.conversation_store.sqlalchemy_store.now_epoch",
+        lambda: ts,
+    )
+    conv = store.create_conversation(title=title, agent_id=_AGENT_ID)
+    store.set_session_usage(conv.id, {"total_cost_usd": cost, "by_model": by_model})
+    return conv.id
+
+
+def test_build_usage_report_windows_and_totals(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    now = 1_700_000_000
+
+    recent = _add_session(
+        store,
+        monkeypatch,
+        ts=now - 3600,
+        cost=1.0,
+        by_model={"claude-opus-4-8": {"total_cost_usd": 1.0}},
+        title="recent",
+    )
+    week = _add_session(
+        store,
+        monkeypatch,
+        ts=now - 3 * _DAY,
+        cost=2.0,
+        by_model={"gpt-5.5": {"total_cost_usd": 2.0}},
+        title="week",
+    )
+    old = _add_session(
+        store,
+        monkeypatch,
+        ts=now - 40 * _DAY,
+        cost=4.0,
+        by_model={
+            "claude-opus-4-8": {"total_cost_usd": 3.0},
+            "claude-sonnet-5": {"total_cost_usd": 1.0},
+        },
+        title="old",
+    )
+
+    monkeypatch.setattr("omnigent.db.utils.now_epoch", lambda: now)
+    report = _build_usage_report(store, None)
+
+    assert report.cost_last_24h == 1.0
+    assert report.cost_last_7d == 3.0
+    assert report.cost_last_30d == 3.0
+    assert report.total_cost_usd == 7.0
+
+    # Newest activity first, subtree cost + primary model per session.
+    assert [s.id for s in report.sessions] == [recent, week, old]
+    assert [s.cost_usd for s in report.sessions] == [1.0, 2.0, 4.0]
+    assert [s.model for s in report.sessions] == [
+        "claude-opus-4-8",
+        "gpt-5.5",
+        "claude-opus-4-8 +1",
+    ]
+
+
+def test_build_usage_report_empty(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    report = _build_usage_report(store, None)
+    assert report.sessions == []
+    assert report.cost_last_24h == 0.0
+    assert report.cost_last_7d == 0.0
+    assert report.cost_last_30d == 0.0
+    assert report.total_cost_usd == 0.0
+
+
+def test_build_usage_report_unpriced_session(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    now = 1_700_000_000
+    monkeypatch.setattr(
+        "omnigent.stores.conversation_store.sqlalchemy_store.now_epoch",
+        lambda: now,
+    )
+    # A session with no recorded usage: cost falls back to 0.0, model None.
+    conv = store.create_conversation(title="bare", agent_id=_AGENT_ID)
+
+    monkeypatch.setattr("omnigent.db.utils.now_epoch", lambda: now)
+    report = _build_usage_report(store, None)
+
+    bare = next(s for s in report.sessions if s.id == conv.id)
+    assert bare.cost_usd == 0.0
+    assert bare.model is None


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds an `omni usage` command that reports your LLM spend across all your
sessions.

- **Server** — a new user-scoped router (`omnigent/server/routes/usage.py`)
  serves `GET /v1/usage`. The **cost summary** (Today / Last 7 days / Last 30
  days / All time) is sourced from the per-user daily-cost rollup
  (`user_daily_cost`) via a new `sum_daily_cost` range read, so each window
  reflects when spend actually happened — a weeks-old session touched today no
  longer dumps its whole cost into "today". The windows are calendar-day
  buckets (relabeled truthfully) rather than rolling wall-clock hours. The
  **per-session detail** reads each top-level session's cumulative
  `session_usage` (rolled up over its sub-agents via `load_session_usage`),
  newest activity first, carrying the authoritative session total and a
  per-model cost breakdown.
- **CLI** — `omni usage` (`--limit`, `--server`, `--json`) renders the report
  through the shared `omnigent.inner.ui` palette (adapts to light/dark
  terminals): the summary, then a per-session table. A single-model session
  shows `Session ID · Model · Cost` on one line; a multi-model session shows
  the authoritative total on the id line and lists each model's recorded cost
  in rows beneath — mirroring the web session sidebar's convention (shown
  faithfully; per-model costs are not forced to sum to the session total).

_Note: the summary and the per-session list come from different sources (the
daily rollup vs. `session_usage`), so they are not guaranteed to tie out to
the cent — the summary counts every priced turn recorded for the user, while
the list only covers the user's currently-listed top-level sessions._

## Test Plan

- `tests/server/routes/test_usage_report.py` — `_build_usage_report`
  end-to-end against a real SQLite `SqlAlchemyConversationStore`: summary
  windows sourced from the daily rollup (today / 7d / 30d / all-time), the
  `sum_daily_cost` range read, per-session detail (order, authoritative cost,
  faithful per-model map that deliberately does **not** sum), empty, and
  no-usage sessions; plus `_day_offset` / `_session_cost` / `_session_models`
  helpers.
- `tests/cli/test_usage.py` — `_render_usage` (summary + labels, the
  multi-model breakdown rows, `--limit` cap, full-id rendering, empty),
  `usage --help`, and the command's table + `--json` paths with a stubbed
  fetch.
- `tests/e2e/test_usage_e2e.py` — pure-HTTP happy path: boots the live server,
  creates a real session, and asserts `GET /v1/usage` returns a well-formed
  report with monotonic (nested) windows and lists the caller's session with
  `cost_usd == 0.0` and an empty `models` map.
- Also exercised end-to-end against a local server pointed at a fresh copy of
  real session data.

## Demo

<img width="1122" height="866" alt="image" src="https://github.com/user-attachments/assets/2cd2887d-0f42-4ec4-a3cb-28ff2b35d3aa" />

_Note: multi-model sessions show each model's recorded cost, which may not sum
to the session total. This is an existing data-quality limitation of the
native cumulative usage write path (also visible in the web session sidebar),
not introduced by this PR; a fix to per-model attribution is tracked as a
separate follow-up._

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the server report builder + helpers, the new `sum_daily_cost`
store method, and the CLI renderer / command wiring. Manually verified by
running `omni usage` (table and `--json`) against a local server backed by a
fresh copy of real session data, confirming the summary windows nest
(`today ≤ 7d ≤ 30d ≤ all-time`) and that multi-model sessions render the
per-model breakdown beneath the session total.

## Changelog

`omni usage` reports your LLM cost for today / the last 7 / 30 days, with a per-session per-model cost breakdown
