### PR TITLE
fix(codex,claude): resolve CLI binary beyond the daemon's frozen PATH

### DIFF
--- a/omnigent/_platform.py
+++ b/omnigent/_platform.py
@@ -16,9 +16,99 @@ from __future__ import annotations
 
 import getpass
 import hashlib
+import logging
 import os
+import shutil
 import sys
+from contextlib import suppress
 from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+
+# Common global install dirs for npm/homebrew CLIs, probed when a binary isn't
+# on ``PATH``. The host daemon snapshots ``PATH`` at spawn and never refreshes
+# it, so a CLI installed into an nvm/npm/homebrew bin dir that only interactive
+# shell init puts on ``PATH`` is invisible to ``shutil.which``.
+def _cli_fallback_dirs() -> tuple[Path, ...]:
+    """Return the global install dirs to probe when a CLI isn't on ``PATH``.
+
+    Includes nvm's version-specific bin dirs (``~/.nvm/versions/node/*/bin``),
+    where npm global installs land under nvm — the common driver of a CLI that
+    a foreground shell sees but the daemon's frozen ``PATH`` doesn't.
+    """
+    home = Path.home()
+    dirs = [
+        home / ".local" / "bin",
+        Path("/usr/local/bin"),
+        Path("/opt/homebrew/bin"),
+        home / ".npm-global" / "bin",
+    ]
+    # nvm keeps global bins per Node version; newest first so a current install
+    # wins over a stale one. Sort by parsed numeric version (so v10 > v9, not
+    # the lexicographic order in which "v10" < "v9").
+    nvm_versions = home / ".nvm" / "versions" / "node"
+    with suppress(OSError):
+        version_dirs = [p for p in nvm_versions.iterdir() if p.is_dir()]
+        version_dirs.sort(key=lambda p: _parse_node_version(p.name), reverse=True)
+        dirs.extend(p / "bin" for p in version_dirs)
+    return tuple(dirs)
+
+
+def _parse_node_version(name: str) -> tuple[int, ...]:
+    """Parse an nvm version dir name (e.g. ``"v20.5.0"``) into a sortable tuple.
+
+    Non-numeric or malformed names sort lowest (empty tuple) so real versions
+    win over anything unparseable.
+    """
+    parts = name.lstrip("v").split(".")
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError:
+        return ()
+
+
+def resolve_cli_binary(name: str, *, env_var: str | None = None) -> str | None:
+    """Resolve a CLI binary that may live off the process ``PATH``.
+
+    Checks an optional ``env_var`` override first (an explicit path or a name
+    on ``PATH``), then ``PATH`` via :func:`shutil.which`, then a ladder of
+    common global install dirs (:func:`_cli_fallback_dirs`). This survives the
+    host daemon's frozen ``PATH``, which omits nvm/npm/homebrew bin dirs that
+    only interactive shell init adds. Returns ``None`` when none resolve; the
+    caller decides whether that's fatal.
+
+    :param name: The binary name, e.g. ``"codex"`` or ``"claude"``.
+    :param env_var: Optional env var holding an override path/name, e.g.
+        ``"OMNIGENT_CODEX_PATH"``.
+    :returns: An absolute path to the executable, or ``None``.
+    """
+    if env_var:
+        override = os.environ.get(env_var, "").strip()
+        if override:
+            resolved = shutil.which(override)
+            if resolved:
+                return resolved
+            if os.access(override, os.X_OK) and os.path.isfile(override):
+                return override
+            # A set-but-unresolvable override (typo, moved/non-executable
+            # binary) silently falling through to PATH would launch a
+            # *different* binary than intended — warn so the misconfig surfaces.
+            _logger.warning(
+                "%s=%r does not resolve to an executable file; falling back to PATH for %r.",
+                env_var,
+                override,
+                name,
+            )
+    on_path = shutil.which(name)
+    if on_path is not None:
+        return on_path
+    for directory in _cli_fallback_dirs():
+        candidate = directory / name
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
 
 #: True on native Windows (cmd/PowerShell), i.e. ``os.name == "nt"``. This is
 #: *not* true under WSL, where Python reports a Linux platform.

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -37,6 +37,7 @@ from omnigent.claude_native_bridge import url_component
 from omnigent.codex_native_app_server import (
     CodexAppServerClient,
     CodexNativeAppServer,
+    _find_codex_cli,
     build_codex_native_server,
     build_codex_remote_args,
     client_for_transport,
@@ -212,7 +213,7 @@ def _codex_auth_unavailable_reason() -> str | None:
         Token *validity* (revoked/expired refresh, an unreachable gateway) is
         not judged locally — it surfaces at the first turn via the executor.
     """
-    if shutil.which(_DEFAULT_CODEX_COMMAND) is None:
+    if _find_codex_cli() is None:
         return _CODEX_AUTH_UNAVAILABLE_BINARY_MISSING
     # ponytail: resolve_native_codex_launch runs once per codex spelling
     # (codex / codex-native / native-codex → 3×) per hello frame; on a host with

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1111,7 +1111,11 @@ def build_codex_native_server(
     """
     resolved_codex = codex_path or _find_codex_cli()
     if not resolved_codex:
-        raise ImportError("Native Codex requires the 'codex' CLI on PATH.")
+        raise ImportError(
+            "Native Codex requires the 'codex' CLI on PATH. If codex is "
+            "installed on a PATH the host daemon didn't inherit (e.g. an "
+            "nvm-managed bin dir), set OMNIGENT_CODEX_PATH=/path/to/codex."
+        )
     env = _clean_codex_env()
     config_overrides: list[str] = []
     if profile is not None:

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -33,7 +33,6 @@ import json
 import logging
 import os
 import pathlib
-import shutil
 import sys
 import tempfile
 import time
@@ -43,7 +42,7 @@ from dataclasses import dataclass
 from types import ModuleType
 from typing import Any, Protocol, TypeAlias, cast
 
-from omnigent._platform import stable_user_id
+from omnigent._platform import resolve_cli_binary, stable_user_id
 from omnigent.inner import _proc
 from omnigent.inner.bundle_skills import ensure_bundle_plugin_manifest
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
@@ -471,6 +470,11 @@ async def _multimodal_message_iter(
 # connect hang is sandbox-related vs. inside the binary itself.
 _NO_SANDBOX_ENV = "OMNIGENT_CLAUDE_SDK_NO_SANDBOX"
 
+# Env override for an explicit claude binary, mirroring codex's
+# OMNIGENT_CODEX_PATH. Set this when claude lives on a PATH the host
+# daemon doesn't inherit (e.g. an nvm-managed global bin dir).
+_CLAUDE_PATH_ENV = "OMNIGENT_CLAUDE_PATH"
+
 
 def _sandbox_disabled_by_env() -> bool:
     """``True`` when the diagnostic bypass env var is set to a truthy
@@ -708,13 +712,16 @@ def _augment_system_prompt_for_omnigent_mcp_tools(
 
 
 def _find_system_claude() -> str | None:
-    """Find a system-installed ``claude`` CLI binary on PATH.
+    """Find a system-installed ``claude`` CLI binary.
 
-    Returns the absolute path, or None if not found.  Prefers the system
-    install over the SDK's bundled CLI because the bundled version may be
-    older and send beta flags the Databricks gateway doesn't support.
+    Resolves via the ``OMNIGENT_CLAUDE_PATH`` override, then ``PATH``, then
+    common global install dirs — so an nvm/npm-installed claude off the host
+    daemon's frozen ``PATH`` is still found. Prefers the system install over
+    the SDK's bundled CLI because the bundled version may be older and send
+    beta flags the Databricks gateway doesn't support. Returns the absolute
+    path, or ``None`` if not found.
     """
-    return shutil.which("claude")
+    return resolve_cli_binary("claude", env_var=_CLAUDE_PATH_ENV)
 
 
 def _resolve_gateway_env(

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, TypeAlias
 
+from omnigent._platform import resolve_cli_binary
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.reasoning_effort import CODEX_EFFORTS, validate_effort
 from omnigent.runner.identity import OMNIGENT_SESSION_ENV_VAR
@@ -280,8 +281,15 @@ def _kill_process_tree(process: _Process | None) -> None:
     _proc.kill_tree(process)
 
 
+# Env override for an explicit codex binary, mirroring goose's
+# OMNIGENT_GOOSE_PATH. Set this when codex lives on a PATH the host
+# daemon doesn't inherit (e.g. an nvm-managed global bin dir).
+_CODEX_PATH_ENV = "OMNIGENT_CODEX_PATH"
+
+
 def _find_codex_cli() -> str | None:
-    return shutil.which("codex")
+    """Resolve the ``codex`` CLI binary (override → ``PATH`` → global dirs)."""
+    return resolve_cli_binary("codex", env_var=_CODEX_PATH_ENV)
 
 
 async def _codex_cli_version(codex_path: str) -> tuple[int, int, int] | None:
@@ -2139,7 +2147,11 @@ class CodexExecutor(Executor):
         self._skills_filter = skills_filter
         resolved_codex = codex_path or _find_codex_cli()
         if not resolved_codex:
-            raise ImportError("CodexExecutor requires the 'codex' CLI on PATH.")
+            raise ImportError(
+                "CodexExecutor requires the 'codex' CLI on PATH. If codex is "
+                "installed on a PATH the host daemon didn't inherit (e.g. an "
+                f"nvm-managed bin dir), set {_CODEX_PATH_ENV}=/path/to/codex."
+            )
         self._codex_path = resolved_codex
         self._env = _clean_codex_env(_declared_passthrough(self._os_env_spec))
         # Retry policy → OpenAI SDK env vars (Codex uses the OpenAI

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -4018,3 +4018,22 @@ def test_no_precompact_no_compaction_event() -> None:
         assert len(compaction_events) == 0
 
     _run(_t())
+
+
+def test_find_system_claude_delegates_to_shared_resolver(monkeypatch) -> None:
+    """``_find_system_claude`` resolves claude via the shared resolver with the
+    OMNIGENT_CLAUDE_PATH override, so an nvm/npm-installed claude off the host
+    daemon's frozen PATH is still found. (The resolver's PATH/override/fallback
+    behavior is covered in tests/inner/test_proc_and_platform.py.)"""
+    from omnigent.inner import claude_sdk_executor as cse
+
+    captured = {}
+
+    def fake_resolve(name, *, env_var=None):
+        captured["name"] = name
+        captured["env_var"] = env_var
+        return "/opt/homebrew/bin/claude"
+
+    monkeypatch.setattr(cse, "resolve_cli_binary", fake_resolve)
+    assert cse._find_system_claude() == "/opt/homebrew/bin/claude"
+    assert captured == {"name": "claude", "env_var": "OMNIGENT_CLAUDE_PATH"}

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -2819,6 +2819,24 @@ def test_declared_passthrough_reads_sandbox_env_passthrough():
     assert _declared_passthrough(OSEnvSpec(sandbox=OSEnvSandboxSpec(type="none"))) == ()
 
 
+def test_find_codex_cli_delegates_to_shared_resolver(monkeypatch):
+    """``_find_codex_cli`` resolves codex via the shared resolver with the
+    OMNIGENT_CODEX_PATH override. (The resolver's own PATH/override/fallback
+    behavior is covered in tests/inner/test_proc_and_platform.py.)"""
+    from omnigent.inner import codex_executor as ce
+
+    captured = {}
+
+    def fake_resolve(name, *, env_var=None):
+        captured["name"] = name
+        captured["env_var"] = env_var
+        return "/opt/homebrew/bin/codex"
+
+    monkeypatch.setattr(ce, "resolve_cli_binary", fake_resolve)
+    assert ce._find_codex_cli() == "/opt/homebrew/bin/codex"
+    assert captured == {"name": "codex", "env_var": "OMNIGENT_CODEX_PATH"}
+
+
 class TestCodexAppServerSessionReadOnlyCwd(unittest.TestCase):
     """Regression tests for .codex-tmp fallback on read-only cwd."""
 

--- a/tests/inner/test_proc_and_platform.py
+++ b/tests/inner/test_proc_and_platform.py
@@ -342,3 +342,100 @@ def test_host_runner_env_lets_child_import_asyncio_and_resolve_home() -> None:
         text=True,
     )
     assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# resolve_cli_binary — CLIs that may live off the daemon's frozen PATH
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_cli_binary_prefers_path(monkeypatch):
+    monkeypatch.delenv("OMNIGENT_TESTCLI_PATH", raising=False)
+    monkeypatch.setattr(
+        _platform.shutil, "which", lambda name: "/usr/bin/tool" if name == "tool" else None
+    )
+    monkeypatch.setattr(_platform, "_cli_fallback_dirs", lambda: ())
+    assert _platform.resolve_cli_binary("tool", env_var="OMNIGENT_TESTCLI_PATH") == "/usr/bin/tool"
+
+
+def test_resolve_cli_binary_env_override_wins(monkeypatch, tmp_path):
+    override = tmp_path / "tool"
+    override.write_text("#!/bin/sh\n")
+    override.chmod(0o755)
+    monkeypatch.setenv("OMNIGENT_TESTCLI_PATH", str(override))
+    # PATH would resolve elsewhere, but the override takes precedence.
+    monkeypatch.setattr(
+        _platform.shutil, "which", lambda name: "/usr/bin/tool" if name == "tool" else None
+    )
+    assert _platform.resolve_cli_binary("tool", env_var="OMNIGENT_TESTCLI_PATH") == str(override)
+
+
+def test_resolve_cli_binary_falls_back_to_global_dir(monkeypatch, tmp_path):
+    """A binary off PATH is still found in a common global install dir.
+
+    This is the nvm case: the host daemon's frozen PATH omits the bin dir,
+    but the binary is present on disk.
+    """
+    fallback_dir = tmp_path / "bin"
+    fallback_dir.mkdir()
+    tool = fallback_dir / "tool"
+    tool.write_text("#!/bin/sh\n")
+    tool.chmod(0o755)
+    monkeypatch.delenv("OMNIGENT_TESTCLI_PATH", raising=False)
+    monkeypatch.setattr(_platform.shutil, "which", lambda name: None)
+    monkeypatch.setattr(_platform, "_cli_fallback_dirs", lambda: (fallback_dir,))
+    assert _platform.resolve_cli_binary("tool", env_var="OMNIGENT_TESTCLI_PATH") == str(tool)
+
+
+def test_resolve_cli_binary_returns_none_when_absent(monkeypatch, tmp_path):
+    monkeypatch.delenv("OMNIGENT_TESTCLI_PATH", raising=False)
+    monkeypatch.setattr(_platform.shutil, "which", lambda name: None)
+    monkeypatch.setattr(_platform, "_cli_fallback_dirs", lambda: (tmp_path / "empty",))
+    assert _platform.resolve_cli_binary("tool", env_var="OMNIGENT_TESTCLI_PATH") is None
+
+
+def test_resolve_cli_binary_warns_on_bad_override(monkeypatch, tmp_path, caplog):
+    """A set-but-unresolvable override warns (so a misconfig surfaces) and then
+    falls back to PATH rather than launching nothing."""
+    monkeypatch.setenv("OMNIGENT_TESTCLI_PATH", str(tmp_path / "does-not-exist"))
+    monkeypatch.setattr(
+        _platform.shutil, "which", lambda name: "/usr/bin/tool" if name == "tool" else None
+    )
+    monkeypatch.setattr(_platform, "_cli_fallback_dirs", lambda: ())
+    with caplog.at_level("WARNING"):
+        resolved = _platform.resolve_cli_binary("tool", env_var="OMNIGENT_TESTCLI_PATH")
+    assert resolved == "/usr/bin/tool"
+    assert "OMNIGENT_TESTCLI_PATH" in caplog.text
+
+
+def test_resolve_cli_binary_no_env_var(monkeypatch):
+    """Without an env_var, resolution is PATH then fallback dirs only."""
+    monkeypatch.setattr(_platform.shutil, "which", lambda name: "/usr/bin/tool")
+    assert _platform.resolve_cli_binary("tool") == "/usr/bin/tool"
+
+
+def test_cli_fallback_dirs_includes_nvm_version_bins(monkeypatch, tmp_path):
+    """nvm keeps global bins under ~/.nvm/versions/node/<ver>/bin; the ladder
+    must include those (newest first) since that's the reported nvm case.
+
+    Ordering is by parsed numeric version, so double-digit majors (v10) beat
+    single-digit ones (v9) — a lexicographic sort would get this backwards.
+    """
+    nvm = tmp_path / ".nvm" / "versions" / "node"
+    for ver in ("v9.11.0", "v10.2.0", "v20.5.0"):
+        (nvm / ver / "bin").mkdir(parents=True)
+    monkeypatch.setattr(_platform.Path, "home", staticmethod(lambda: tmp_path))
+    dirs = _platform._cli_fallback_dirs()
+    for ver in ("v9.11.0", "v10.2.0", "v20.5.0"):
+        assert nvm / ver / "bin" in dirs
+    # newest → oldest, numerically: v20 > v10 > v9 (not the lexicographic
+    # order where "v9" would sort after "v10"/"v20").
+    order = [dirs.index(nvm / v / "bin") for v in ("v20.5.0", "v10.2.0", "v9.11.0")]
+    assert order == sorted(order)
+
+
+def test_cli_fallback_dirs_no_nvm_dir_is_safe(monkeypatch, tmp_path):
+    """Absent ~/.nvm, the ladder still returns the static dirs without error."""
+    monkeypatch.setattr(_platform.Path, "home", staticmethod(lambda: tmp_path))
+    dirs = _platform._cli_fallback_dirs()
+    assert tmp_path / ".local" / "bin" in dirs

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -29,6 +29,14 @@ def _isolate_cursor_credential(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     monkeypatch.delenv("CURSOR_API_KEY", raising=False)
     for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
         monkeypatch.delenv(var, raising=False)
+    # Codex readiness resolves the binary via resolve_cli_binary, which honors
+    # an OMNIGENT_CODEX_PATH override and probes on-disk global install dirs.
+    # Clear the override and stub the fallback dirs so a developer's real codex
+    # install can't flip the binary-missing verdict these tests assert.
+    import omnigent._platform as platform
+
+    monkeypatch.delenv("OMNIGENT_CODEX_PATH", raising=False)
+    monkeypatch.setattr(platform, "_cli_fallback_dirs", lambda: ())
 
 
 def _all_clis_installed(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -480,7 +480,7 @@ describe("harnessUnconfiguredOnHost", () => {
     );
     expect(harnessWarningBadgeText("binary-missing")).toBe("binary missing");
     expect(harnessWarningMessageText("Codex", "laptop", "binary-missing")).toBe(
-      "Codex is missing the Codex binary on laptop — run omnigent setup on that machine.",
+      "Codex can't find the Codex binary on laptop — if codex is installed, restart the host with omnigent host so it picks up your PATH, or set OMNIGENT_CODEX_PATH. Otherwise run omnigent setup.",
     );
   });
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -588,7 +588,7 @@ export function harnessWarningMessageText(
     return `${agentName} needs Codex authentication on ${hostName} — run codex login on that machine.`;
   }
   if (reason === "binary-missing") {
-    return `${agentName} is missing the Codex binary on ${hostName} — run omnigent setup on that machine.`;
+    return `${agentName} can't find the Codex binary on ${hostName} — if codex is installed, restart the host with omnigent host so it picks up your PATH, or set OMNIGENT_CODEX_PATH. Otherwise run omnigent setup.`;
   }
   return `${agentName} isn't configured on ${hostName} — run omnigent setup on that machine.`;
 }
@@ -618,8 +618,9 @@ function harnessWarningMessage(
   if (reason === "binary-missing") {
     return (
       <>
-        {agentName} is missing the Codex binary on {hostName} — run <code>omnigent setup</code> on
-        that machine.
+        {agentName} can&apos;t find the Codex binary on {hostName} — if codex is installed, restart
+        the host with <code>omnigent host</code> so it picks up your PATH, or set{" "}
+        <code>OMNIGENT_CODEX_PATH</code>. Otherwise run <code>omnigent setup</code>.
       </>
     );
   }


### PR DESCRIPTION
## Related issue

N/A

## Summary

The host daemon snapshots `PATH` at spawn and never refreshes it, so a `codex` or `claude` CLI installed into an nvm/npm-managed global bin dir (only added to `PATH` by interactive shell init) is invisible to `shutil.which`. Native Codex readiness then reports `binary-missing` and hides codex in the UI, and the claude-sdk executor can't find its system CLI — even though a foreground launch works, because that runs in the interactive shell's PATH.

- Add a shared `resolve_cli_binary(name, env_var)` in `omnigent/_platform.py`: override env var → `PATH` (`shutil.which`) → a ladder of common global install dirs (`~/.local/bin`, `/usr/local/bin`, `/opt/homebrew/bin`, `~/.npm-global/bin`). Returns `None` when none resolve; the caller decides whether that's fatal.
- Route `_find_codex_cli` (`OMNIGENT_CODEX_PATH`) and `_find_system_claude` (`OMNIGENT_CLAUDE_PATH`) through it, plus the codex readiness gate (`codex_native._codex_auth_unavailable_reason`) — so the readiness verdict and the actual launch can't disagree.
- Update the codex `binary-missing` UI message and the two `ImportError`s to point at the real fix (restart the host with `omnigent host` to re-snapshot PATH, or set the override) instead of `omnigent setup`, which doesn't address a stale PATH snapshot.

## Test Plan

- `pytest tests/inner/test_proc_and_platform.py` — new `resolve_cli_binary` tests (PATH-preferred, override-wins, fallback-dir hit, none-when-absent, no-env-var).
- `pytest tests/inner/test_codex_executor.py tests/inner/test_claude_sdk_executor.py` — 200 passed; each has a delegation test asserting it calls the shared resolver with the right name + override var.
- `pytest tests/onboarding/test_harness_readiness.py tests/test_codex_native.py tests/test_codex_native_app_server.py` — passing (readiness fixture repointed to stub `_platform._cli_fallback_dirs` so a dev's real codex install can't flip the `binary-missing` assertions).
- `web` `NewChatDialog.test.tsx` — 134 passed.
- `ruff check` + `ruff format` clean; prettier (pinned 3.8.4) clean.

## Demo

N/A — copy tweak to an existing warning message; no new UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: confirmed `shutil.which("codex")` returns `None` under a daemon PATH lacking the nvm bin dir while the binary is present on disk; the shared resolver finds it via the fallback ladder and the `OMNIGENT_CODEX_PATH` / `OMNIGENT_CLAUDE_PATH` overrides.

## Changelog

Native Codex and Claude now resolve their CLI from common global install dirs and an `OMNIGENT_CODEX_PATH` / `OMNIGENT_CLAUDE_PATH` override when it isn't on the host daemon's PATH

This pull request and its description were written by Isaac.
