### PR TITLE
feat(ci): let feature-blog dispatch pick how many posts to draft

### DIFF
--- a/.github/agents/feature-blog-scout/config.yaml
+++ b/.github/agents/feature-blog-scout/config.yaml
@@ -22,7 +22,8 @@ spec_version: 1
 name: feature-blog-scout
 description: >-
   Selects which features from a release's merged PRs (if any) are big enough to
-  warrant a feature-blog post. Applies a signal-based bar, caps at the top 2–3,
+  warrant a feature-blog post. Applies a signal-based bar, caps at the requested
+  limit (default top 2–3),
   and emits a ranked BLOG_CANDIDATES JSON block (often empty). No tools, no
   sub-agents — a pure selection turn.
 
@@ -72,8 +73,9 @@ prompt: |
     thin to show.
   - Collapse related PRs into ONE feature (as release notes do) — a feature is a
     theme, not a PR.
-  - **Cap: the top 2–3, ranked strongest-first.** Even if more clear the bar,
-    return at most 3.
+  - **Cap: rank strongest-first and return at most the number of features the
+    run asks for** (the run prompt states the limit; default is the top 2–3).
+    Even if more clear the bar, never exceed that limit.
   - **Final self-check per candidate — drop it if it fails:** can you picture the
     15–30s demo, and does a benefit headline beat naming the mechanism? (Signal 3
     and this check are the same demo test — apply it as a filter and as a veto.)

--- a/.github/workflows/feature-blog.yml
+++ b/.github/workflows/feature-blog.yml
@@ -52,6 +52,13 @@ on:
         type: choice
         options: [auto, "true", "false"]
         default: auto
+      max_posts:
+        description: >-
+          Maximum number of blog posts to draft (the scout still only picks
+          features that clear the bar, so it may pick fewer). Default 3.
+        required: false
+        type: string
+        default: "3"
 
 permissions:
   contents: read
@@ -86,11 +93,20 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
           INPUT_BASE: ${{ inputs.base }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          INPUT_MAX_POSTS: ${{ inputs.max_posts }}
         run: |
           set -euo pipefail
           tag="${INPUT_TAG:-$RUN_BRANCH}"
           base="${INPUT_BASE:-}"
           proceed=false; dry_run=false
+
+          # How many posts to draft at most. Only settable via manual dispatch;
+          # a real release cut (workflow_run) uses the default. Must be a positive
+          # integer, else fall back to the default.
+          max_posts="${INPUT_MAX_POSTS:-3}"
+          case "$max_posts" in
+            ""|*[!0-9]*|0) max_posts=3 ;;
+          esac
 
           # Does the tag look like a final release (vX.Y.Z, not rc/dev/alpha/beta)?
           is_version=true
@@ -122,7 +138,8 @@ jobs:
           echo "base=${base}" >> "$GITHUB_OUTPUT"
           echo "proceed=${proceed}" >> "$GITHUB_OUTPUT"
           echo "dry_run=${dry_run}" >> "$GITHUB_OUTPUT"
-          echo "Resolved tag=${tag} base=${base:-<none>} proceed=${proceed} dry_run=${dry_run}" \
+          echo "max_posts=${max_posts}" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=${tag} base=${base:-<none>} proceed=${proceed} dry_run=${dry_run} max_posts=${max_posts}" \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
       # Trusted default branch, full history + tags for the range computation.
@@ -179,11 +196,13 @@ jobs:
         if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
         env:
           TAG: ${{ steps.guard.outputs.tag }}
+          MAX_POSTS: ${{ steps.guard.outputs.max_posts }}
         run: |
           set -euo pipefail
           python3 -u <<'PYEOF'
           import os, pathlib
           tag = os.environ["TAG"]
+          max_posts = int(os.environ.get("MAX_POSTS", "3"))
           # `omnigent run -p` passes the whole prompt as one argv string, capped at
           # ~128 KiB on Linux. Cap the PR list well under that.
           MAX = 100_000
@@ -194,6 +213,8 @@ jobs:
           note = ("\n> NOTE: the PR list was truncated — select from what's visible.\n"
                   if truncated else "")
           prompt = f"""Select the blog-worthy features (if any) from {tag}.
+          Return AT MOST {max_posts} feature(s), ranked strongest-first — pick fewer
+          if fewer clear the bar. This overrides any other cap in your instructions.
           {note}
           ## Merged PRs (number, title, and author changelog entries)
           {pr_list}
@@ -225,6 +246,8 @@ jobs:
       - name: Parse candidates
         id: candidates
         if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
+        env:
+          MAX_POSTS: ${{ steps.guard.outputs.max_posts }}
         run: |
           set -euo pipefail
           python3 -u <<'PYEOF'
@@ -272,8 +295,9 @@ jobs:
               c["pr_refs"] = refs
               cands.append(c)
 
-          # Cap at 3 defensively (the scout is instructed to, but enforce it here).
-          cands = cands[:3]
+          # Enforce the post cap defensively (the scout is told the limit too).
+          max_posts = int(os.environ.get("MAX_POSTS", "3"))
+          cands = cands[:max_posts]
           pathlib.Path("/tmp/candidates.json").write_text(json.dumps(cands))
           out = os.environ["GITHUB_OUTPUT"]
           with open(out, "a") as f:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds a `max_posts` input to the feature-blog `workflow_dispatch` so a manual run can control how many blog posts get drafted. Default is 3 (unchanged behavior); a real release cut (`workflow_run`) always uses the default.

The value flows through the whole pipeline:
- **Guard step** sanitizes it — empty / non-numeric / `0` fall back to 3 — and exposes it as an output.
- **Scout prompt** now tells the scout to "return AT MOST N features, ranked strongest-first, pick fewer if fewer clear the bar," overriding its built-in top-2–3 cap.
- **Parse step** enforces it defensively (`cands[:max_posts]`, replacing the hardcoded `3`).
- **Scout config** cap wording now defers to the run-supplied limit instead of hardcoding "at most 3".

The bar is unchanged — `max_posts` is a ceiling, not a quota, so the scout still only picks features that clear the signal bar and can produce zero.

## Test Plan

- `check-yaml` (pre-commit) passes on both files.
- `bash -n` passes on the guard, Build-scout-prompt, and Parse-candidates steps.
- Unit-tested the guard sanitization: `""`, `abc`, `2x`, `0` → 3; `5` → 5; `10` → 10.
- End-to-end: `workflow_dispatch` on `tag: v0.5.0`, `dry_run: true`, `max_posts: 1` should yield a single ranked candidate.

## Demo

N/A — CI-only change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified statically (YAML parse, `bash -n`) and by unit-testing the guard's integer sanitization in isolation. The end-to-end cap is exercised via a `workflow_dispatch` + `dry_run: true` run with an explicit `max_posts`; there is no hermetic harness for a release-cut workflow driving a live LLM agent.

## Changelog

<!-- CI-only enhancement; not user-facing. -->

This pull request and its description were written by Isaac.
