### PR TITLE
fix(ci): emit MDX comment for demo marker, guard against HTML comments

### DIFF
--- a/.github/agents/feature-blog-drafter/config.yaml
+++ b/.github/agents/feature-blog-drafter/config.yaml
@@ -116,8 +116,10 @@ prompt: |
      (Omnigent is the orchestration layer over many agents, any device, with
      governance) — imply it, don't sloganeer.
   3. **Demo** — you CANNOT produce the screenshot/recording. Emit EXACTLY this
-     marker where the demo belongs, with a one-line suggestion of what to show:
-     `<!-- DEMO REQUIRED: 15–30s recording or light/dark screenshot pair, realistic data. No sanitized mockups. Suggested: <what to show> -->`
+     marker where the demo belongs, with a one-line suggestion of what to show.
+     It MUST be an MDX comment (`{/* ... */}`), NOT an HTML comment (`<!-- ... -->`)
+     — HTML comments are invalid in MDX and break the site build:
+     `{/* DEMO REQUIRED: 15–30s recording or light/dark screenshot pair, realistic data. No sanitized mockups. Suggested: <what to show> */}`
   4. **How to use** — a copy-pasteable fenced command block (only commands/flags
      grounded in `MATERIAL_FILE`) and a link to the relevant docs page.
   5. **What's next** — an optional one-line forward look ONLY if the material
@@ -139,7 +141,7 @@ prompt: |
   - `## Post drafted` — the path of the single post file you created
     (`app/blog/<SLUG>/page.mdx`). You should not have edited any other file.
   - `## Manual review needed` — a checklist: `- [ ] <item> — <why>`. Always
-    include the mandatory demo line (the `<!-- DEMO REQUIRED -->` marker you left)
+    include the mandatory demo line (the `{/* DEMO REQUIRED */}` marker you left)
     and the hero art + author byline as items a human must complete before merge.
     Add any fact you had to omit for lack of grounding.
   Then STOP. Do NOT `git commit`, push, or open a PR — the workflow does that.

--- a/.github/workflows/feature-blog.yml
+++ b/.github/workflows/feature-blog.yml
@@ -444,6 +444,15 @@ jobs:
             # can't see untracked paths). Porcelain lines are "XY path"; take the
             # path field of the first added/modified page.mdx.
             post="$(git -C "$SITE" status --porcelain | grep -m1 'page.mdx' | awk '{print $NF}' || true)"
+
+            # Fail fast on HTML comments in the MDX: `<!-- ... -->` is invalid in
+            # MDX (only `{/* ... */}` works) and would break the site's `next build`
+            # only after the PR is opened. Catch it here so we never ship a red PR.
+            if [ -n "$post" ] && grep -qF '<!--' "${SITE}/${post}"; then
+              echo "::error::Drafted ${post} contains an HTML comment (<!-- -->); MDX requires {/* */}. Aborting."
+              exit 1
+            fi
+
             if [ -n "$post" ]; then
               printf '\n---\n\n**Enjoying Omnigent?** If this is useful to you, [give us a star on GitHub ⭐](https://github.com/omnigent-ai/omnigent). Come say hi on [Discord](https://discord.gg/omnigent), or [download the latest release](https://omnigent.ai/download).\n' \
                 >> "${SITE}/${post}"


### PR DESCRIPTION
## Related issue

N/A

## Summary

The generated blog PR (omnigent-site#337) failed CI at `next build`:

```
./app/blog/queue-and-steer-agents/page.mdx
page.mdx:36:2: Unexpected character `!` (U+0021) before name …
(note: to create a comment in MDX, use {/* text */})
> Build failed because of webpack errors
```

Root cause: the drafter's demo placeholder was an **HTML comment** (`<!-- DEMO REQUIRED … -->`). HTML comments are invalid in MDX (only `{/* … */}` compiles). It slips past `fmt:check` (prettier accepts it) but breaks `next build`, so every generated post PR failed.

Fix:
- Change the drafter's demo marker to an MDX comment `{/* DEMO REQUIRED … */}`, with an explicit note in the prompt that HTML comments break the build. Update the summary-contract reference to match.
- Add a **fail-fast guard** in the workflow: if the drafted `page.mdx` contains any `<!--`, abort before opening the PR — so a stray HTML comment can never ship a build-red PR again.

## Test Plan

- `check-yaml` (pre-commit) passes on both files; `bash -n` passes on the `draftposts` step.
- End-to-end: `workflow_dispatch` on `tag: v0.5.0`, `dry_run: false` — the new post should now compile under `next build` on omnigent-site, and any regression would abort in the guard rather than open a red PR.

## Demo

N/A — CI/agent-config change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Prompt + workflow-guard change verified statically (YAML parse, `bash -n`). The compile behavior is confirmed by a `dry_run=false` dispatch producing a post that passes omnigent-site's `next build`; there is no hermetic harness for a cross-repo drafting workflow.

## Changelog

<!-- CI-only fix; not user-facing. -->

This pull request and its description were written by Isaac.
