### PR TITLE
feat(benchmarks): track server CPU and memory usage in nightly benchmark

### DIFF
--- a/dev/benchmarks/omnigent/environment.py
+++ b/dev/benchmarks/omnigent/environment.py
@@ -29,6 +29,7 @@ import socket
 import subprocess
 import sys
 import tarfile
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -161,6 +162,9 @@ class BenchEnvironment:
         self._runner_base_env: dict[str, str] = {}
         self._log_handles: list[IO[bytes]] = []
         self._agent_cache: dict[str, str] = {}
+        self._resource_samples: list[dict[str, float]] = []
+        self._sampler_stop: threading.Event = threading.Event()
+        self._sampler_thread: threading.Thread | None = None
 
     # ── lifecycle ────────────────────────────────────────────
 
@@ -171,6 +175,9 @@ class BenchEnvironment:
             timeout=300.0,
             headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
         )
+        # Start background resource sampler (server CPU + memory).
+        self._sampler_thread = threading.Thread(target=self._sample_resources, daemon=True)
+        self._sampler_thread.start()
         if self.with_runner:
             # ALLOW fallback so a server-side classifier call resolves against
             # the mock (never api.openai.com) and returns a valid verdict.
@@ -182,6 +189,9 @@ class BenchEnvironment:
     async def __aexit__(self, *exc: object) -> None:
         if self.client is not None:
             await self.client.aclose()
+        self._sampler_stop.set()
+        if self._sampler_thread is not None:
+            self._sampler_thread.join(timeout=5)
         await asyncio.to_thread(self._stop)
 
     def _start(self) -> None:
@@ -246,6 +256,63 @@ class BenchEnvironment:
         import shutil
 
         shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _sample_resources(self, interval: float = 1.0) -> None:
+        """Sample the server process's CPU and RSS memory at *interval*-second intervals.
+
+        Runs in a daemon thread; exits when ``_sampler_stop`` is set or the
+        process terminates. The first ``cpu_percent`` call always returns 0.0
+        (psutil baseline) — we discard it so only real measurements accumulate.
+        """
+        try:
+            import psutil
+        except ImportError:
+            return
+        if self._server_proc is None:
+            return
+        try:
+            proc = psutil.Process(self._server_proc.pid)
+            proc.cpu_percent()  # baseline; discard
+        except psutil.NoSuchProcess:
+            return
+        while not self._sampler_stop.is_set():
+            try:
+                cpu = proc.cpu_percent()
+                mem = proc.memory_info().rss
+                self._resource_samples.append({"cpu_pct": cpu, "rss_bytes": mem})
+            except psutil.NoSuchProcess:
+                break
+            self._sampler_stop.wait(timeout=interval)
+
+    @property
+    def resource_usage(self) -> dict[str, object]:
+        """Summarise sampled CPU% and RSS across the benchmark run.
+
+        :returns: A dict with ``cpu_pct`` and ``rss_bytes`` sub-dicts each
+            containing ``mean``, ``min``, ``max``, ``samples``. Empty dicts
+            when no samples were collected (psutil unavailable or server never
+            started).
+        """
+        if not self._resource_samples:
+            return {"cpu_pct": {}, "rss_bytes": {}}
+        cpu = [s["cpu_pct"] for s in self._resource_samples]
+        rss = [s["rss_bytes"] for s in self._resource_samples]
+        import statistics as _stats
+
+        return {
+            "cpu_pct": {
+                "mean": _stats.mean(cpu),
+                "min": min(cpu),
+                "max": max(cpu),
+                "samples": len(cpu),
+            },
+            "rss_bytes": {
+                "mean": _stats.mean(rss),
+                "min": min(rss),
+                "max": max(rss),
+                "samples": len(rss),
+            },
+        }
 
     # ── spawns ───────────────────────────────────────────────
 

--- a/dev/benchmarks/omnigent/run.py
+++ b/dev/benchmarks/omnigent/run.py
@@ -154,6 +154,7 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[dict[str, object], bo
                 max_p99_ms=args.max_p99_ms,
             ):
                 passed = False
+        resource_usage = env.resource_usage
 
     config = {
         "iterations": args.iterations,
@@ -170,6 +171,7 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[dict[str, object], bo
         generated_at=generated_at,
         config=config,
         harness=harness,
+        resource_usage=resource_usage,
     )
     return report, passed
 

--- a/dev/benchmarks/omnigent/schema.py
+++ b/dev/benchmarks/omnigent/schema.py
@@ -13,7 +13,7 @@ import platform
 import subprocess
 
 # Incremented on any breaking change to the report document shape below.
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 
 def _git(*args: str) -> str:
@@ -63,6 +63,7 @@ def build_report(
     generated_at: str,
     config: dict[str, object],
     harness: str,
+    resource_usage: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Assemble the full benchmark report document.
 
@@ -75,6 +76,8 @@ def build_report(
         mock_llm) for provenance.
     :param harness: Harness driving full-turn journeys, e.g.
         ``"openai-agents"``.
+    :param resource_usage: Optional server-process CPU/memory stats collected
+        during the run (see :meth:`BenchEnvironment.resource_usage`).
     :returns: The JSON-serializable report document.
     """
     return {
@@ -85,5 +88,6 @@ def build_report(
         "host": host_info(),
         "harness": harness,
         "config": config,
+        "resource_usage": resource_usage or {},
         "journeys": journey_results,
     }


### PR DESCRIPTION
## Related issue

N/A

## Summary

The nightly benchmark already tracks latency and throughput per journey, but gives no visibility into how much CPU or memory the omnigent server consumes over the run. This makes it hard to spot regressions where a change keeps latency flat but silently inflates memory use or CPU overhead.

- Adds a 1-second background sampler thread (`BenchEnvironment._sample_resources`) that polls the server process via `psutil` for CPU% and RSS memory throughout the benchmark.
- Exposes `BenchEnvironment.resource_usage` — a `mean/min/max/samples` summary for both metrics — captured just before teardown and included in the JSON report under a new top-level `resource_usage` key.
- Bumps `SCHEMA_VERSION` from 2 → 3 so the workspace ETL can branch on the new shape.
- No workflow changes needed: the existing artifact upload already captures the full report.

## Test Plan

- The sampler gracefully no-ops when `psutil` is unavailable (bare `ImportError` guard) or the process exits early (`NoSuchProcess`).
- Ran `uv run --no-sync ruff format --check` and `ruff check` over the changed files — all passed.
- The existing benchmark smoke test (`tests/benchmarks/test_benchmark_smoke.py`) continues to cover the measurement and report-building path; no new tests added since the sampler is a thin wrapper around psutil with error handling.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

The sampler is a thin psutil wrapper with explicit error guards for both `ImportError` and `NoSuchProcess`. The report shape change (new `resource_usage` key) is additive and covered by the schema version bump. Existing smoke tests exercise the report-building path.

## Changelog

Nightly benchmark report now includes server CPU% and RSS memory usage (mean/min/max) alongside latency metrics.