### PR TITLE
fix(ci): make feature-blog drafts read user-facing, not machine-generated

### DIFF
--- a/.github/agents/feature-blog-drafter/config.yaml
+++ b/.github/agents/feature-blog-drafter/config.yaml
@@ -17,9 +17,9 @@ name: feature-blog-drafter
 description: >-
   Drafts a single feature-blog post on omnigent-site for a scout-selected
   feature. Inspects the live site to match conventions, confirms facts against
-  the omnigent code, writes a short one-screen post following the 5-part
-  skeleton, and marks the mandatory demo for a human. Writes blog prose only —
-  never product code — and never commits or pushes (the workflow does that).
+  the omnigent code, and writes a short one-screen user-facing post, marking the
+  mandatory demo for a human. Writes blog prose only (never product code) and
+  never commits or pushes (the workflow does that).
 
 executor:
   type: omnigent
@@ -103,32 +103,59 @@ prompt: |
   it.
 
   ## Step 3 — Write the post (short, one-screen, in-style)
-  Create `app/blog/<SLUG>/page.mdx` — this is the ONLY file you write. Follow
-  this 5-part skeleton — keep the whole post to roughly one screen; it is a
-  changelog-blog entry, NOT a long-form article:
+  Create `app/blog/<SLUG>/page.mdx` — this is the ONLY file you write. Keep the
+  whole post to roughly one screen; it is a changelog-blog entry, NOT a long-form
+  article.
 
-  1. **What's new + who it's for** — the benefit `HEADLINE` as the title/H1, plus
-     a one-line "who it's for". Frontmatter carries `date: DATE`,
-     `category: CATEGORY`, and `author: "omnigent"` (default; a human may
-     overwrite it during review).
-  2. **The problem it solves** — 2–3 sentences. Benefit before mechanism: lead
-     with the user outcome, then the how. Keep our wedge as the through-line
-     (Omnigent is the orchestration layer over many agents, any device, with
-     governance) — imply it, don't sloganeer.
-  3. **Demo** — you CANNOT produce the screenshot/recording. Emit EXACTLY this
-     marker where the demo belongs, with a one-line suggestion of what to show.
-     It MUST be an MDX comment (`{/* ... */}`), NOT an HTML comment (`<!-- ... -->`)
-     — HTML comments are invalid in MDX and break the site build:
+  The five items below are the SHAPE of the post, in order — they are NOT section
+  headings and NOT sentence lead-ins. Write flowing prose. Do NOT emit label text
+  like "Who it's for:", "The problem it solves", "How to use", or "What's next" —
+  neither as headings nor at the start of a sentence. The only heading in the
+  post is the H1 title.
+
+  1. Open with the benefit `HEADLINE` as the H1 title, then a short opening
+     paragraph. Say who it helps and what they can now do as a natural sentence
+     ("If you drive long agent runs in the web UI, you can now line up your next
+     few messages instead of waiting for each turn to finish."), NOT as a
+     "Who it's for:" label. Frontmatter carries `date: DATE`, `category: CATEGORY`,
+     and `author: "omnigent"` (default; a human may overwrite it during review).
+  2. In 2–3 sentences, describe the problem this removes and the outcome, in the
+     user's terms. Lead with what the user gets, then just enough of how it works
+     to be concrete. Let the "orchestration layer over many agents, any device,
+     with governance" wedge show through the framing; never sloganeer it.
+  3. The demo. You CANNOT produce the screenshot/recording, so emit EXACTLY this
+     marker where it belongs, with a one-line suggestion of what to show. It MUST
+     be an MDX comment (`{/* ... */}`), NOT an HTML comment (`<!-- ... -->`);
+     HTML comments are invalid in MDX and break the site build:
      `{/* DEMO REQUIRED: 15–30s recording or light/dark screenshot pair, realistic data. No sanitized mockups. Suggested: <what to show> */}`
-  4. **How to use** — a copy-pasteable fenced command block (only commands/flags
-     grounded in `MATERIAL_FILE`) and a link to the relevant docs page.
-  5. **What's next** — an optional one-line forward look ONLY if the material
-     supports it; otherwise omit the line. Do NOT write the closing CTA / star
-     ask — the workflow appends a fixed footer.
+  4. Show how to use it: a short prose sentence plus, when the feature has one, a
+     copy-pasteable fenced command block (only commands/flags grounded in
+     `MATERIAL_FILE`), and a link to the relevant docs page. If it is a UI feature
+     with no command, describe the click path in one or two sentences instead.
+  5. Optionally close with one plain sentence on what is coming next, ONLY if the
+     material clearly supports it; otherwise stop. Do NOT write the closing CTA /
+     star ask — the workflow appends a fixed footer.
+
+  ## Voice and content rules (IMPORTANT — the last drafts failed these)
+  - **User-facing, not implementation.** Write about what the reader can now DO,
+    never about how it is built or verified. Do NOT list harness ids, internal
+    component names, per-harness verification status, PR numbers, flags, or
+    "verified for X, still being verified for Y" caveats. If a capability works
+    across harnesses, say "works with any agent you run in Omnigent" — not a list
+    of `claude-sdk, codex-sdk, ...`. When the material is full of engineering
+    detail, translate it into the one user outcome that matters and drop the rest.
+  - **Few dashes.** Do NOT use " — " (spaced em/en dashes) as a sentence
+    connector; it reads as AI-generated. Write separate sentences, or use a comma,
+    "and", parentheses, or a colon. At most ONE dash in the whole post, and only
+    if nothing else fits. Do not use "not X but Y" or "It's not just … it's …"
+    constructions.
+  - **Plain and concrete.** Short sentences, active voice, no marketing adjectives
+    ("powerful", "seamless", "effortless", "game-changing"), no hype. Prefer a
+    real example over an abstraction.
 
   Do not add a hero image — leave any `heroArt` frontmatter blank for a human.
-  Be accurate and concise — no marketing fluff. Ground every fact in the
-  material; if unsure, omit it and note it under "Manual review needed".
+  Ground every fact in the material; if unsure, omit it and note it under
+  "Manual review needed".
 
   ## Output contract (your final assistant text)
   On the line IMMEDIATELY BEFORE `<!-- BLOG_DRAFT_SUMMARY -->`, emit a single

--- a/.github/workflows/feature-blog.yml
+++ b/.github/workflows/feature-blog.yml
@@ -441,9 +441,11 @@ jobs:
 
             # Append the fixed CTA footer to the drafted post (LLM never writes it).
             # The post is a new, untracked file — find it via status (git diff
-            # can't see untracked paths). Porcelain lines are "XY path"; take the
-            # path field of the first added/modified page.mdx.
-            post="$(git -C "$SITE" status --porcelain | grep -m1 'page.mdx' | awk '{print $NF}' || true)"
+            # can't see untracked paths). Use -uall: plain porcelain collapses a
+            # brand-new directory to "app/blog/<slug>/" and never names the file
+            # inside it, so grep 'page.mdx' would miss it. Porcelain lines are
+            # "XY path"; take the path field of the first added/modified page.mdx.
+            post="$(git -C "$SITE" status --porcelain -uall | grep -m1 'page.mdx' | awk '{print $NF}' || true)"
 
             # Fail fast on HTML comments in the MDX: `<!-- ... -->` is invalid in
             # MDX (only `{/* ... */}` works) and would break the site's `next build`
@@ -464,7 +466,7 @@ jobs:
             # discovers the site's .prettierrc.json + .prettierignore, and pin the
             # site's major version. Formatting failures are non-fatal: a human
             # reviews the draft PR and CI still reports any residual issue.
-            mapfile -t changed < <(git -C "$SITE" status --porcelain | awk '{print $NF}')
+            mapfile -t changed < <(git -C "$SITE" status --porcelain -uall | awk '{print $NF}')
             if [ "${#changed[@]}" -gt 0 ]; then
               ( cd "$SITE" && npx --yes prettier@3 --write --ignore-unknown "${changed[@]}" ) \
                 || echo "::warning::prettier --write failed for ${slug}; committing unformatted (CI will flag)"

--- a/.github/workflows/feature-blog.yml
+++ b/.github/workflows/feature-blog.yml
@@ -470,6 +470,21 @@ jobs:
                 || echo "::warning::prettier --write failed for ${slug}; committing unformatted (CI will flag)"
             fi
 
+            # Surface the drafted post itself: copy it to /tmp (uploaded as an
+            # artifact) and, on a dry run, render it into the job summary so the
+            # post body can be reviewed without opening a PR.
+            if [ -n "$post" ] && [ -f "${SITE}/${post}" ]; then
+              cp "${SITE}/${post}" "/tmp/post_${i}.mdx"
+              {
+                echo "<details><summary>Drafted post: ${slug}</summary>"
+                echo
+                echo '```mdx'
+                cat "${SITE}/${post}"
+                echo '```'
+                echo "</details>"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+
             title=$(sed -n 's/^BLOG_PR_TITLE:[[:space:]]*//p' "/tmp/drafter_out_${i}.txt" | head -n1)
             [ -z "$title" ] && title="add feature blog: ${headline}"
 
@@ -556,6 +571,7 @@ jobs:
           files = ["scout-stderr.log", "drafter-stderr.log", "/tmp/scout_out.txt",
                    "/tmp/scout_prompt.txt"]
           files += glob.glob("/tmp/drafter_out_*.txt") + glob.glob("/tmp/material_*.txt")
+          files += glob.glob("/tmp/post_*.mdx")
           for f in files:
               p = pathlib.Path(f)
               if not p.is_file() or not key:
@@ -566,7 +582,7 @@ jobs:
                   print(f"redacted key from {f}")
           PYEOF
 
-      - name: Upload logs on failure
+      - name: Upload logs and drafted posts
         if: always() && steps.guard.outputs.proceed == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -577,5 +593,6 @@ jobs:
             /tmp/scout_out.txt
             /tmp/candidates.json
             /tmp/drafter_out_*.txt
+            /tmp/post_*.mdx
           retention-days: 7
           if-no-files-found: ignore


### PR DESCRIPTION
## Related issue

N/A

## Summary

The first drafted posts (e.g. the queue/edit/steer preview) read like machine output. Three concrete problems, all from the drafter prompt:

1. **Skeleton labels leaked as literal text.** The prompt's 5-part structure showed up verbatim in the post — `Who it's for: anyone driving a long-running agent turn…`, a `The problem it solves` heading, etc. Those are supposed to be the internal *shape*, not headings or sentence lead-ins.
2. **Too implementation-detailed, not user-driven.** e.g. *"Deterministic mid-turn steering is verified today for claude-sdk, codex-sdk, pi-sdk, codex-native, and claude-native; steering is enabled across the remaining native harnesses…"* — the reader only needs "works with any agent you run in Omnigent."
3. **Too many " — " dashes**, which reads as AI-generated.

Prompt changes:
- Reframe the 5 items as the post's **shape, in order — not headings or sentence lead-ins**. Only the H1 title is a heading; everything else is flowing prose. Explicitly ban the label phrases ("Who it's for:", "The problem it solves", "How to use", "What's next") as headings *or* sentence starts.
- Add a **"Voice and content rules"** section: write what the user can DO, never how it's built or verified; never list harness ids / internal component names / PR numbers / per-harness verification caveats (say "works with any agent you run in Omnigent"); at most **one** dash in the whole post; plain active voice, no marketing adjectives.

No behavior/plumbing change — prompt-only.

## Test Plan

- `check-yaml` (pre-commit) passes.
- End-to-end: `workflow_dispatch` on `tag: v0.5.0`, `dry_run: true` and inspect the drafted MDX in the artifact — expect prose with only the H1 heading, no `Label:` lead-ins, no harness-id lists, and ≤1 dash.

## Demo

N/A — agent-config change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Prompt-only change to an agent config; verified statically (YAML parse). Output quality is confirmed by inspecting a `dry_run: true` draft artifact; there is no hermetic harness for an LLM drafting agent.

## Changelog

<!-- CI/agent-config change; not user-facing. -->

This pull request and its description were written by Isaac.
