### PR TITLE
chore(ci): stop the Reviewer SLA scheduled sweep

### DIFF
--- a/.github/workflows/review-sla.yml
+++ b/.github/workflows/review-sla.yml
@@ -1,18 +1,16 @@
 name: Reviewer SLA
 
-# Daily (weekday) sweep that enforces a 5-working-day reviewer SLA: any open PR
+# Manual-only sweep that enforces a 5-working-day reviewer SLA: any open PR
 # awaiting review from a maintainer -- or open issue awaiting a maintainer
 # assignee -- with no reply in 5 working days gets the assignee re-pinged in a
 # comment plus a second reviewer (PR) / second assignee (issue), then a one-shot
 # `review-sla-escalated` label so it's never nudged twice. All logic + safety
 # notes live in review-sla.js (offline unit test: review-sla.test.js).
 #
-# Scheduled -> runs on the trusted default branch with the repo GITHUB_TOKEN; it
-# reads no PR-authored code, only .github/ config + the issues/PRs API.
+# Runs on the trusted default branch with the repo GITHUB_TOKEN; it reads no
+# PR-authored code, only .github/ config + the issues/PRs API.
 
 on:
-  schedule:
-    - cron: "0 8 * * 1-5" # 08:00 UTC, Mon-Fri (weekday SLA -> no weekend pings)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Removes the daily weekday `cron` trigger (`0 8 * * 1-5`) from the **Reviewer SLA** workflow (`.github/workflows/review-sla.yml`), so it no longer runs automatically. This is the sweep that re-pings reviewers, adds a second reviewer/assignee, and applies the `review-sla-escalated` label to open PRs/issues awaiting review for 5+ working days.
- Keeps `workflow_dispatch` so the sweep can still be triggered manually from the Actions tab if ever needed.
- Updates the header comment to reflect the manual-only trigger.

No changes to `review-sla.js`, its tests, or permissions.

## Test Plan

- `git diff` confirms only the `schedule:` block (and the matching header wording) is removed; `on:` retains `workflow_dispatch`.
- YAML validated with `yaml.safe_load` (parses OK) and the pre-commit `check yaml syntax` hook passed.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually: the `schedule:` trigger is gone and `workflow_dispatch` remains, and the workflow YAML parses. The change only affects when the workflow runs (removing the cron), not its logic, so `review-sla.js` and its unit tests are unaffected.

This pull request and its description were written by Isaac.