### PR TITLE
chore(ci): update area owners in areas.json

### DIFF
--- a/.github/areas.json
+++ b/.github/areas.json
@@ -58,8 +58,7 @@
       ],
       "owners": [
         "serena-ruan",
-        "daniellok-db",
-        "hzub"
+        "daniellok-db"
       ]
     },
     {


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Updates the reviewer/assignee owner list for the `web` area in `.github/areas.json`.

## Test Plan

- `.github/areas.json` remains valid JSON and each area still has 2+ owners, so the invariants enforced by `areas.test.js` (owners in `.github/MAINTAINER`, valid `comp:*` label, 2+ owners, path resolution) continue to hold.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Config-only change to the ownership map. Verified the file is still valid JSON and the affected area retains 2+ owners, so `areas.test.js` invariants are satisfied.

This pull request and its description were written by Isaac.