### PR TITLE
fix(fs): forward per-file line counts on the host-served changed-files list

### DIFF
--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -393,6 +393,8 @@ class WorkspaceReader:
                 "status": rec["status"],
                 "bytes": rec.get("bytes"),
                 "modified_at": rec.get("modified_at"),
+                "lines_added": rec.get("lines_added"),
+                "lines_removed": rec.get("lines_removed"),
             }
             for rec in raw_changes
         ]

--- a/tests/test_workspace_fs.py
+++ b/tests/test_workspace_fs.py
@@ -293,6 +293,13 @@ def test_changes_lists_git_working_tree_modifications(tmp_path: Path) -> None:
     by_path = {e["path"]: e for e in result["data"]}
     assert by_path["committed.txt"]["status"] == "modified"
     assert by_path["new.txt"]["status"] == "created"
+    # Line counts come from numstat (git diff HEAD), so the host-served
+    # list surfaces them just like the runner endpoint. The tracked edit
+    # rewrote one line; the untracked file isn't in numstat → no counts.
+    assert by_path["committed.txt"]["lines_added"] == 1
+    assert by_path["committed.txt"]["lines_removed"] == 1
+    assert by_path["new.txt"]["lines_added"] is None
+    assert by_path["new.txt"]["lines_removed"] is None
 
 
 def test_diff_returns_before_and_after_for_modified_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Follow-up to #2526, which added per-file `+N −M` line counts to the changed-files panel and threaded `lines_added` / `lines_removed` from the filesystem registry through the **runner** endpoint to the web UI.
- The changed-files list has a *second* server-side builder: when a session's runner is offline but the host holding the workspace on disk is still connected, the list is served over the fs tunnel by `WorkspaceReader.changes()` (`omnigent/workspace_fs.py`). That builder shaped its own entry dict and **dropped** the new fields — so the per-file counts silently vanished whenever the list was host-served.
- Forward `lines_added` / `lines_removed` there too, matching the runner endpoint exactly. The underlying registry already populates them (host and runner share `create_filesystem_registry`), so this is purely payload parity — no frontend change needed, since the UI can't tell which side answered.

## Test Plan

- `pytest tests/test_workspace_fs.py` — **18 passed**. Extended `test_changes_lists_git_working_tree_modifications` to assert a tracked edit surfaces `+1 −1` and an untracked file (absent from numstat) surfaces `None` / `None`, matching the runner-side coverage.
- `ruff check` / `ruff format --check` clean on touched files; pre-commit hooks green.

## Demo

N/A — no visual change; restores counts that already render in the panel when the list happens to be host-served.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the unit test above.

## Changelog

The changed-files panel now shows per-file line-change counts even when the list is served by the host (runner offline).

---

This pull request and its description were written by Isaac.
