### PR TITLE
fix(ci): render blog CTA footer links on separate rows

### DIFF
--- a/.github/workflows/feature-blog.yml
+++ b/.github/workflows/feature-blog.yml
@@ -456,7 +456,9 @@ jobs:
             fi
 
             if [ -n "$post" ]; then
-              printf '\n---\n\n**Enjoying Omnigent?** If this is useful to you, [give us a star on GitHub ⭐](https://github.com/omnigent-ai/omnigent). Come say hi on [Discord](https://discord.gg/omnigent), or [download the latest release](https://omnigent.ai/download).\n' \
+              # Each line is its own paragraph (blank line between), so the CTA
+              # links render on separate rows rather than collapsing into one.
+              printf '\n---\n\n**Enjoying Omnigent?** If this is useful to you, [give us a star on GitHub ⭐](https://github.com/omnigent-ai/omnigent).\n\n[Come say hi on Discord.](https://discord.gg/omnigent)\n\n[Download the latest release.](https://omnigent.ai/download)\n' \
                 >> "${SITE}/${post}"
             fi
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

The drafted post's CTA footer rendered all three links (star · Discord · download) on a **single row** — because it was written as one markdown paragraph, and markdown collapses a paragraph's newlines into one flowing line.

Split the footer into separate paragraphs (blank line between each) so the star ask, Discord, and download each render on their own row.

## Test Plan

- `check-yaml` (pre-commit) passes; `bash -n` passes on the `draftposts` step.
- End-to-end: a `dry_run: false` dispatch produces a post whose footer links stack on separate rows.

## Demo

N/A — CI-only change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified statically (YAML parse, `bash -n`). Rendering is confirmed by a `dry_run=false` dispatch.

## Changelog

<!-- CI-only fix; not user-facing. -->

This pull request and its description were written by Isaac.
