### PR TITLE
feat(ci): feature-blog drafter emits BlogPostHeader instead of a plain H1

### DIFF
--- a/.github/agents/feature-blog-drafter/config.yaml
+++ b/.github/agents/feature-blog-drafter/config.yaml
@@ -100,7 +100,10 @@ prompt: |
   structure. Posts are auto-discovered by `lib/blog.js`, so you do NOT register
   the post anywhere — matching the existing post shape is all that's needed. Read
   `lib/blog.js` only to confirm which frontmatter fields it expects; do not edit
-  it.
+  it. Every post's title + author + date + reading-time header is rendered by the
+  `<BlogPostHeader slug="SLUG" />` component (registered globally in
+  `mdx-components.js`, so no import is needed) — use it as the first thing in the
+  body and never hand-write a `# H1` title (item 1 below).
 
   ## Step 3 — Write the post (short, one-screen, in-style)
   Create `app/blog/<SLUG>/page.mdx` — this is the ONLY file you write. Keep the
@@ -110,15 +113,22 @@ prompt: |
   The five items below are the SHAPE of the post, in order — they are NOT section
   headings and NOT sentence lead-ins. Write flowing prose. Do NOT emit label text
   like "Who it's for:", "The problem it solves", "How to use", or "What's next" —
-  neither as headings nor at the start of a sentence. The only heading in the
-  post is the H1 title.
+  neither as headings nor at the start of a sentence. Do NOT write a Markdown
+  `# H1` title at all — the title and byline are rendered by the header component
+  (see item 1); a `#` heading would duplicate it. Use `##` for any in-body
+  subheadings only if genuinely needed (usually none for a one-screen post).
 
-  1. Open with the benefit `HEADLINE` as the H1 title, then a short opening
-     paragraph. Say who it helps and what they can now do as a natural sentence
-     ("If you drive long agent runs in the web UI, you can now line up your next
-     few messages instead of waiting for each turn to finish."), NOT as a
-     "Who it's for:" label. Frontmatter carries `date: DATE`, `category: CATEGORY`,
-     and `author: "omnigent"` (default; a human may overwrite it during review).
+  1. Frontmatter first: after the `import { pageMeta } from "@/lib/og";` line and
+     the exported `metadata`, export a `meta` object carrying
+     `title: "<the benefit HEADLINE>"`, `date: "DATE"`, `category: "CATEGORY"`,
+     `author: "omnigent"` (default; a human may overwrite it during review), and
+     `heroArt: ""`. Then, as the FIRST thing in the body, render the header:
+     `<BlogPostHeader slug="SLUG" />` (use the exact SLUG you were given). This
+     component draws the title + author + date + reading-time byline, so do not
+     repeat the title as text. Follow it with a short opening paragraph that says
+     who it helps and what they can now do as a natural sentence ("If you drive
+     long agent runs in the web UI, you can now line up your next few messages
+     instead of waiting for each turn to finish."), NOT as a "Who it's for:" label.
   2. In 2–3 sentences, describe the problem this removes and the outcome, in the
      user's terms. Lead with what the user gets, then just enough of how it works
      to be concrete. Let the "orchestration layer over many agents, any device,


### PR DESCRIPTION
## Related issue

N/A

## Summary

Follow-up to omnigent-site#340, which adds a `<BlogPostHeader slug="..." />` component rendering each blog post's title + author avatar + date + reading time. Update the feature-blog drafter so generated posts use it:

- Export the `meta` object (`title`, `date`, `category`, `author: "omnigent"`, `heroArt: ""`).
- Render `<BlogPostHeader slug="SLUG" />` as the first element in the body (it's registered globally in `mdx-components.js`, so no import is needed).
- Never hand-write a `# H1` title — the component draws the title, so an H1 would duplicate it.

Depends on omnigent-site#340 being merged (the component must exist on the site's `main` before a drafted post referencing it will build).

## Test Plan

- `check-yaml` (pre-commit) passes on the drafter config.
- End-to-end: after omnigent-site#340 merges, `workflow_dispatch` on `tag: v0.5.0`, `dry_run: true` and confirm the drafted MDX exports `meta` and opens with `<BlogPostHeader slug=... />` and no `# H1`.

## Demo

N/A — agent-config change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Prompt-only change to an agent config, verified statically (YAML parse). The rendered output is confirmed by a `dry_run` dispatch once the site component lands.

## Changelog

<!-- CI/agent-config change; not user-facing. -->

This pull request and its description were written by Isaac.
