### PR TITLE
fix(harness): resolve CLI binaries off the daemon's frozen PATH in readiness gates

### DIFF
--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -433,26 +433,27 @@ def install_harness_cli(key: str) -> bool:
         subprocess.run(cmd, check=False, timeout=300)
     except (OSError, subprocess.TimeoutExpired):
         return False
+    # harness_install_command would have raised for a spec-less key, so spec is
+    # non-None past this point.
+    assert spec is not None
     # This is the setup flow's own process: check bare ``PATH`` (not the
     # resolve_cli_binary ladder), because the point of the ~/.local/bin refresh
     # below is to make the binary reachable via ``PATH`` for this process — the
     # subsequent harness_login/harness_cli_logged_in shell out with the bare
     # binary name and rely on the inherited ``PATH``.
-    if spec is not None and shutil.which(spec.binary) is not None:
+    if shutil.which(spec.binary) is not None:
         return True
 
     # uv-based vendor installers commonly place entry points here and update
     # shell startup files, which cannot change this already-running process.
-    if spec is not None:
-        user_bin = Path.home() / ".local" / "bin"
-        candidate = user_bin / spec.binary
-        if candidate.is_file() and os.access(candidate, os.X_OK):
-            current_path = os.environ.get("PATH", "")
-            path_entries = current_path.split(os.pathsep) if current_path else []
-            if str(user_bin) not in path_entries:
-                os.environ["PATH"] = os.pathsep.join([str(user_bin), *path_entries])
-        return shutil.which(spec.binary) is not None
-    return False
+    user_bin = Path.home() / ".local" / "bin"
+    candidate = user_bin / spec.binary
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        current_path = os.environ.get("PATH", "")
+        path_entries = current_path.split(os.pathsep) if current_path else []
+        if str(user_bin) not in path_entries:
+            os.environ["PATH"] = os.pathsep.join([str(user_bin), *path_entries])
+    return shutil.which(spec.binary) is not None
 
 
 def harness_cli_logged_in(key: str) -> bool:

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -42,6 +42,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from omnigent._platform import resolve_cli_binary
 from omnigent.harness_install_spec import HarnessInstallSpec
 from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, GEMINI_FAMILY, OPENAI_FAMILY
 
@@ -298,14 +299,15 @@ def required_cli_for_harness(harness: str) -> HarnessInstallSpec | None:
 
 
 def missing_harness_cli(harness: str) -> HarnessInstallSpec | None:
-    """Return a harness's required CLI spec when that CLI is absent from ``PATH``.
+    """Return a harness's required CLI spec when that CLI can't be resolved.
 
     Combines :func:`required_cli_for_harness` with the same
-    ``shutil.which`` probe :func:`harness_cli_installed` uses, so the
-    verdict matches what the harness's own launch will see (both read the
-    process ``PATH``). Used by sub-agent dispatch to fail loud *before*
-    spawning a worker whose harness can never boot here, instead of letting
-    the missing binary surface as a lazy, generic turn failure.
+    :func:`resolve_cli_binary` probe :func:`harness_cli_installed` uses, so the
+    verdict matches what the harness's own launch will see (both check ``PATH``
+    plus the common global install dirs the host daemon's frozen ``PATH`` may
+    omit). Used by sub-agent dispatch to fail loud *before* spawning a worker
+    whose harness can never boot here, instead of letting the missing binary
+    surface as a lazy, generic turn failure.
 
     :param harness: An executor harness identifier, e.g. ``"pi"`` or
         ``"claude-native"``.
@@ -316,7 +318,7 @@ def missing_harness_cli(harness: str) -> HarnessInstallSpec | None:
     spec = required_cli_for_harness(harness)
     if spec is None:
         return None
-    if shutil.which(spec.binary) is not None:
+    if resolve_cli_binary(spec.binary) is not None:
         return None
     return spec
 
@@ -364,21 +366,23 @@ def harness_install_spec(key: str) -> HarnessInstallSpec | None:
 
 
 def harness_cli_installed(key: str) -> bool:
-    """Return whether the harness's CLI binary is on ``PATH``.
+    """Return whether the harness's CLI binary can be resolved.
 
-    "Installed" is deliberately the CLI binary (``shutil.which``), matching
-    ucode and the npm install-prompt UX — even though the SDK-based
-    ``claude-sdk`` harness can run without the ``claude`` CLI.
+    "Installed" is deliberately the CLI binary (:func:`resolve_cli_binary` —
+    ``PATH`` plus the common global install dirs the host daemon's frozen
+    ``PATH`` may omit), matching ucode and the npm install-prompt UX — even
+    though the SDK-based ``claude-sdk`` harness can run without the ``claude``
+    CLI.
 
     :param key: A harness family (``"anthropic"`` / ``"openai"``) or
         :data:`PI_KEY` / :data:`KIMI_KEY`.
-    :returns: ``True`` when the CLI is on ``PATH``; ``False`` when it isn't or
+    :returns: ``True`` when the CLI resolves; ``False`` when it doesn't or
         the key has no associated CLI.
     """
     spec = harness_install_spec(key)
     if spec is None:
         return False
-    return shutil.which(spec.binary) is not None
+    return resolve_cli_binary(spec.binary) is not None
 
 
 def harness_install_command(key: str) -> list[str]:
@@ -429,7 +433,12 @@ def install_harness_cli(key: str) -> bool:
         subprocess.run(cmd, check=False, timeout=300)
     except (OSError, subprocess.TimeoutExpired):
         return False
-    if harness_cli_installed(key):
+    # This is the setup flow's own process: check bare ``PATH`` (not the
+    # resolve_cli_binary ladder), because the point of the ~/.local/bin refresh
+    # below is to make the binary reachable via ``PATH`` for this process — the
+    # subsequent harness_login/harness_cli_logged_in shell out with the bare
+    # binary name and rely on the inherited ``PATH``.
+    if spec is not None and shutil.which(spec.binary) is not None:
         return True
 
     # uv-based vendor installers commonly place entry points here and update
@@ -442,7 +451,8 @@ def install_harness_cli(key: str) -> bool:
             path_entries = current_path.split(os.pathsep) if current_path else []
             if str(user_bin) not in path_entries:
                 os.environ["PATH"] = os.pathsep.join([str(user_bin), *path_entries])
-    return harness_cli_installed(key)
+        return shutil.which(spec.binary) is not None
+    return False
 
 
 def harness_cli_logged_in(key: str) -> bool:

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -25,10 +25,10 @@ that would actually work.
 from __future__ import annotations
 
 import os
-import shutil
 from collections.abc import Callable
 
 import omnigent.onboarding.gemini_auth as _gemini_auth
+from omnigent._platform import resolve_cli_binary
 from omnigent.harness_aliases import HARNESS_ALIASES, canonicalize_harness
 from omnigent.harness_plugins import harness_install_keys, valid_harnesses
 from omnigent.onboarding.harness_install import (
@@ -269,7 +269,7 @@ def harness_is_configured(harness: str) -> bool:
     ):
         required_cli = required_cli_for_harness(canonical) or required_cli_for_harness(harness)
         if required_cli is not None:
-            return shutil.which(required_cli.binary) is not None
+            return resolve_cli_binary(required_cli.binary) is not None
         # Unknown harness — the daemon has no install metadata for it, so
         # it can't assess readiness. Fail open (custom/newer harnesses,
         # version skew).

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -7,8 +7,23 @@ from pathlib import Path
 
 import pytest
 
+import omnigent._platform as _platform
 from omnigent.onboarding import harness_install as hi
 from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, GEMINI_FAMILY, OPENAI_FAMILY
+
+
+@pytest.fixture(autouse=True)
+def _stub_cli_fallback_dirs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reduce ``resolve_cli_binary`` to a pure ``PATH`` probe under test.
+
+    ``harness_cli_installed`` / ``missing_harness_cli`` resolve via
+    ``resolve_cli_binary``, which also probes on-disk global install dirs
+    (``~/.local/bin``, nvm, …). Tests here stub ``shutil.which`` to simulate a
+    binary's presence/absence; stub the fallback dirs to empty too so a
+    developer's real claude/codex install can't flip a ``which``-returns-None
+    assertion.
+    """
+    monkeypatch.setattr(_platform, "_cli_fallback_dirs", lambda: ())
 
 
 @pytest.mark.parametrize(
@@ -307,16 +322,37 @@ def test_missing_harness_cli_none_for_sdk_harness(monkeypatch: pytest.MonkeyPatc
 
 
 def test_cli_installed_reflects_which(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``harness_cli_installed`` is exactly ``shutil.which(binary) is not None``.
+    """``harness_cli_installed`` follows ``resolve_cli_binary``.
 
-    Present → True; absent → False — the signal the configure ✗ marker and the
-    run gating both read.
+    On ``PATH`` → True; unresolvable (the autouse fixture stubs the fallback
+    dirs empty) → False — the signal the configure ✗ marker and the run gating
+    both read.
     """
     monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
     assert hi.harness_cli_installed(ANTHROPIC_FAMILY) is True
 
     monkeypatch.setattr(hi.shutil, "which", lambda name: None)
     assert hi.harness_cli_installed(ANTHROPIC_FAMILY) is False
+
+
+def test_cli_installed_finds_binary_off_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A CLI in a global install dir but off ``PATH`` still reads installed.
+
+    This is the reported nvm case: the host daemon's frozen ``PATH`` omits the
+    bin dir, so bare ``shutil.which`` misses it, but ``resolve_cli_binary``'s
+    fallback ladder finds it on disk. Readiness must not report it missing.
+    """
+    fallback_dir = tmp_path / "bin"
+    fallback_dir.mkdir()
+    claude = fallback_dir / "claude"
+    claude.write_text("#!/bin/sh\n")
+    claude.chmod(0o755)
+    monkeypatch.setattr(hi.shutil, "which", lambda name: None)
+    monkeypatch.setattr(_platform, "_cli_fallback_dirs", lambda: (fallback_dir,))
+    assert hi.harness_cli_installed(ANTHROPIC_FAMILY) is True
+    assert hi.missing_harness_cli("claude-native") is None
 
 
 def test_install_harness_cli_requires_npm(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_harness_plugins.py
+++ b/tests/test_harness_plugins.py
@@ -182,13 +182,13 @@ def test_community_harness_readiness_uses_install_metadata(
 
     from omnigent.onboarding import harness_readiness as readiness
 
-    monkeypatch.setattr(readiness.shutil, "which", lambda _binary: None)
+    monkeypatch.setattr(readiness, "resolve_cli_binary", lambda _binary: None)
     assert readiness.harness_is_configured("foo") is False
     configured = readiness.configured_harness_map()
     assert configured["foo"] is False
     assert configured["foo-code"] is False
 
-    monkeypatch.setattr(readiness.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+    monkeypatch.setattr(readiness, "resolve_cli_binary", lambda binary: f"/usr/bin/{binary}")
     assert readiness.harness_is_configured("foo") is True
 
 


### PR DESCRIPTION
## Related issue

N/A — follow-up to #2788.

## Summary

#2788 fixed off-PATH resolution for the codex readiness gate and the codex/claude-sdk launch resolvers. But the *general* readiness gates still probed bare `shutil.which(spec.binary)`, so a `claude-native` / `cursor-native` / `kiro-native` / etc. CLI installed into an nvm/npm-managed global bin dir (only on `PATH` via interactive shell init) could still be reported "binary missing" by the host daemon — whose frozen `PATH` snapshot omits that dir. This is the same split #2788 closed for codex, just in the harness-agnostic gates.

- Route `harness_cli_installed`, `missing_harness_cli`, and the `harness_is_configured` fallback gate through the shared `resolve_cli_binary` (`PATH` → global-dir ladder) added in #2788, so the readiness verdict matches what the launch will see for every CLI harness.
- `install_harness_cli` deliberately keeps a bare `shutil.which` check: it runs in the setup flow's own process, where the `~/.local/bin` PATH refresh (and the subsequent bare-binary `harness_login` / `harness_cli_logged_in` shell-outs) depend on the binary being reachable via *this process's* `PATH`, not merely present on disk.

## Test Plan

- `pytest tests/onboarding/` (harness suites) — 124 passed. New `test_cli_installed_finds_binary_off_path` covers the nvm case (binary in a global dir, off `PATH`, still reads installed). Added an autouse fixture stubbing `_cli_fallback_dirs` empty so a dev's real claude/codex install can't flip the `which`-returns-None assertions.
- `pytest tests/runner/test_runner_dispatch.py` — 131 passed (exercises `missing_harness_cli` via sub-agent dispatch).
- `ruff check` + `ruff format` clean.

## Demo

N/A — non-visual; internal readiness-gate resolution.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: confirmed on this host that `claude`/`codex` live under `~/.nvm/versions/node/*/bin` (off the daemon's `PATH`); bare `shutil.which` misses them, while `resolve_cli_binary` finds them via the fallback ladder — so the readiness gate no longer false-negatives.

## Changelog

Harness readiness now finds CLIs installed in common global dirs (nvm/npm/homebrew) that aren't on the host daemon's PATH, matching what the launch resolves

This pull request and its description were written by Isaac.
