### PR TITLE
fix: remove literal pipe from email regex and replace deprecated utcnow()

### DIFF
--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import enum
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal, TypeAlias
 
@@ -64,7 +64,7 @@ class Message:
 
     role: Literal["system", "user", "assistant", "tool_call", "tool_result"]
     content: MessageContent
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     source: str | None = None
     metadata: MessageMetadata = field(default_factory=dict)
 

--- a/omnigent/policies/builtins/safety.py
+++ b/omnigent/policies/builtins/safety.py
@@ -435,7 +435,7 @@ def enforce_sandbox(
 _PII_CATEGORY_PATTERNS: dict[str, _re.Pattern[str]] = {
     "ssn": _re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
     "credit_card": _re.compile(r"\b(?:\d[ -]*?){13,19}\b"),
-    "email": _re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),
+    "email": _re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
     # Phone: international (+cc ...) and common local formats
     # (US, UK, JP, DE, etc.) in a single pattern.
     "phone": _re.compile(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Fixed incorrect regex character class `[A-Z|a-z]` in the email PII detection pattern (`safety.py`). The pipe `|` inside `[]` is treated as a literal character, not alternation — changed to `[A-Za-z]`.
- Replaced deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)` in `datamodel.py`. `utcnow()` has been deprecated since Python 3.12 because it returns a naive datetime that can be misinterpreted as local time.

## Test Plan

- Verified the regex fix by confirming `[A-Za-z]` no longer matches a literal pipe character in TLD positions (e.g., `user@example.c|om` would have incorrectly matched before).
- Verified the datetime fix produces a timezone-aware UTC datetime, matching the semantics of the deprecated call.

## Demo

These are internal logic fixes with no user-visible UI change:

**Regex fix (safety.py):** Before the fix, the email regex `[A-Z|a-z]` treated `|` as a literal matchable character in TLD positions. After: `[A-Za-z]` correctly matches only letters.

```python
# Before (buggy): matches "user@example.c|om" as valid email
import re
old = r"[A-Z|a-z]"
print(bool(re.match(old, "|")))  # True — pipe matches

# After (fixed): pipe no longer matches
new = r"[A-Za-z]"
print(bool(re.match(new, "|")))  # False — correct
```

**datetime fix (datamodel.py):** `datetime.utcnow()` → `datetime.now(timezone.utc)` — produces timezone-aware UTC datetime, no behavioral change in output.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified that the regex change correctly excludes literal pipe from TLD matching and that the datetime replacement produces equivalent UTC timestamps with proper timezone awareness.