### PR TITLE
feat(policies): show config-file policies in admin policy page

### DIFF
--- a/omnigent/server/routes/default_policies.py
+++ b/omnigent/server/routes/default_policies.py
@@ -25,6 +25,7 @@ from sqlalchemy.exc import IntegrityError
 from omnigent.entities import Policy
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.policies.registry import is_registered_handler, validate_factory_params
+from omnigent.runtime import get_caps
 from omnigent.runtime.policies.builder import invalidate_default_policy_specs_cache
 from omnigent.server.auth import AuthProvider
 from omnigent.server.routes._auth_helpers import get_user_id
@@ -33,6 +34,7 @@ from omnigent.server.schemas import (
     CreateDefaultPolicyRequest,
     UpdateDefaultPolicyRequest,
 )
+from omnigent.spec.types import FunctionPolicySpec
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.policy_store import PolicyStore
 
@@ -65,6 +67,41 @@ def _entity_to_response(policy: Policy) -> dict[str, Any]:
     }
     if policy.factory_params is not None:
         result["factory_params"] = policy.factory_params
+    return result
+
+
+def _config_policies_to_response() -> list[dict[str, Any]]:
+    """Return config-file policies from :class:`RuntimeCaps` as response dicts.
+
+    These are YAML-loaded policies that are applied server-wide but not stored
+    in the database. They appear in the list as read-only entries (``source:
+    "config"``) so operators can see what the server config contributes.
+
+    Only :class:`~omnigent.spec.types.FunctionPolicySpec` entries are included
+    — those are the only type the admin UI knows how to display.
+
+    :returns: List of response dicts, one per config-file policy.
+    """
+    caps = get_caps()
+    result = []
+    for spec in caps.default_policies:
+        if not isinstance(spec, FunctionPolicySpec) or spec.function is None:
+            continue
+        entry: dict[str, Any] = {
+            "id": None,
+            "object": "default_policy",
+            "source": "config",
+            "name": spec.name,
+            "type": "python",
+            "handler": spec.function.path,
+            "enabled": True,
+            "created_at": None,
+            "updated_at": None,
+            "created_by": None,
+        }
+        if spec.function.arguments:
+            entry["factory_params"] = spec.function.arguments
+        result.append(entry)
     return result
 
 
@@ -208,7 +245,9 @@ def create_default_policies_router(
                 code=ErrorCode.UNAUTHORIZED,
             )
         policies = store.list_defaults()
-        return {"object": "list", "data": [_entity_to_response(p) for p in policies]}
+        data = [_entity_to_response(p) for p in policies]
+        data.extend(_config_policies_to_response())
+        return {"object": "list", "data": data}
 
     @router.get("/policies/{policy_id}")
     async def get_policy(

--- a/tests/server/routes/test_default_policies.py
+++ b/tests/server/routes/test_default_policies.py
@@ -15,8 +15,10 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 
+from omnigent.runtime import get_caps
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server.app import create_app
+from omnigent.spec.types import FunctionPolicySpec, FunctionRef
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.artifact_store.local import LocalArtifactStore
 from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
@@ -216,3 +218,86 @@ async def test_delete_default_policy_idempotent(policy_client: httpx.AsyncClient
     resp = await policy_client.delete("/v1/policies/087a5ba1a5c50583fc5bd2e3f035d3df")
     assert resp.status_code == 200
     assert resp.json()["deleted"] is True
+
+
+# ── Config-file policies (RuntimeCaps.default_policies) ──────────────
+
+
+async def test_list_includes_config_policies(
+    policy_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Config-file policies appear in GET /v1/policies with source='config'."""
+    spec = FunctionPolicySpec(
+        name="yaml_audit",
+        on=None,
+        function=FunctionRef(path=_REGISTERED_HANDLER),
+    )
+    monkeypatch.setattr(get_caps(), "default_policies", [spec])
+
+    resp = await policy_client.get("/v1/policies")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    config_entries = [p for p in data if p.get("source") == "config"]
+    assert len(config_entries) == 1
+    entry = config_entries[0]
+    assert entry["name"] == "yaml_audit"
+    assert entry["handler"] == _REGISTERED_HANDLER
+    assert entry["id"] is None
+    assert entry["enabled"] is True
+
+
+async def test_list_config_policy_with_factory_params(
+    policy_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """factory_params from FunctionRef.arguments appear in the config entry."""
+    spec = FunctionPolicySpec(
+        name="yaml_rate_limit",
+        on=None,
+        function=FunctionRef(path=_REGISTERED_HANDLER, arguments={"limit": 5}),
+    )
+    monkeypatch.setattr(get_caps(), "default_policies", [spec])
+
+    resp = await policy_client.get("/v1/policies")
+    data = resp.json()["data"]
+    entry = next(p for p in data if p.get("source") == "config")
+    assert entry["factory_params"] == {"limit": 5}
+
+
+async def test_list_config_and_db_policies_together(
+    policy_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DB-managed and config-file policies both appear in the list."""
+    # Create a DB policy.
+    create_resp = await policy_client.post("/v1/policies", json=_policy_payload(name="db_policy"))
+    db_id = create_resp.json()["id"]
+
+    # Add a config policy via RuntimeCaps.
+    spec = FunctionPolicySpec(
+        name="config_policy",
+        on=None,
+        function=FunctionRef(path=_REGISTERED_HANDLER),
+    )
+    monkeypatch.setattr(get_caps(), "default_policies", [spec])
+
+    resp = await policy_client.get("/v1/policies")
+    data = resp.json()["data"]
+    ids = [p["id"] for p in data]
+    names = [p["name"] for p in data]
+    assert db_id in ids
+    assert "config_policy" in names
+    config_entries = [p for p in data if p.get("source") == "config"]
+    assert len(config_entries) == 1
+
+
+async def test_list_no_config_policies_when_caps_empty(
+    policy_client: httpx.AsyncClient,
+) -> None:
+    """No config entries appear when RuntimeCaps.default_policies is empty."""
+    # runtime_init sets default_policies=[] by default.
+    resp = await policy_client.get("/v1/policies")
+    data = resp.json()["data"]
+    config_entries = [p for p in data if p.get("source") == "config"]
+    assert config_entries == []

--- a/web/src/hooks/useDefaultPolicies.ts
+++ b/web/src/hooks/useDefaultPolicies.ts
@@ -3,14 +3,16 @@ import { authenticatedFetch } from "@/lib/identity";
 
 /** A server-wide default policy returned by the admin CRUD API. */
 export interface DefaultPolicy {
-  id: string;
+  id: string | null;
   object: "default_policy";
+  /** Config-file policies have ``source: "config"`` and are read-only. */
+  source?: "config";
   name: string;
   type: string;
   handler: string;
   factory_params?: Record<string, unknown> | null;
   enabled: boolean;
-  created_at: number;
+  created_at: number | null;
   updated_at: number | null;
   created_by: string | null;
 }

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -477,7 +477,7 @@ export function PoliciesPage() {
   }
 
   async function onConfirmDelete() {
-    if (deleteCandidate === null) return;
+    if (deleteCandidate === null || deleteCandidate.id === null) return;
     setPendingAction(true);
     setActionError(null);
     deletePolicy.mutate(deleteCandidate.id, {
@@ -513,14 +513,22 @@ export function PoliciesPage() {
             const params = p.factory_params;
             const hasParams = params != null && Object.keys(params).length > 0;
             return (
-              <div key={p.id} className="rounded-lg border border-border bg-background p-4">
+              <div
+                key={p.id ?? p.name}
+                className="rounded-lg border border-border bg-background p-4"
+              >
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex items-start gap-2.5 min-w-0">
                     <ShieldCheckIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <span className="text-sm font-medium">{p.name}</span>
-                        {!p.enabled && (
+                        {p.source === "config" && (
+                          <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                            Config
+                          </span>
+                        )}
+                        {!p.enabled && p.source !== "config" && (
                           <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
                             Disabled
                           </span>
@@ -537,26 +545,30 @@ export function PoliciesPage() {
                     </div>
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
-                    <Switch
-                      checked={p.enabled}
-                      onCheckedChange={(checked) =>
-                        updatePolicy.mutate({
-                          policyId: p.id,
-                          enabled: checked,
-                        })
-                      }
-                      aria-label={`Toggle ${p.name}`}
-                    />
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-8 text-muted-foreground hover:text-destructive"
-                      title="Remove policy"
-                      onClick={() => setDeleteCandidate(p)}
-                      disabled={pendingAction}
-                    >
-                      <TrashIcon className="size-3.5" />
-                    </Button>
+                    {p.source !== "config" ? (
+                      <>
+                        <Switch
+                          checked={p.enabled}
+                          onCheckedChange={(checked) =>
+                            updatePolicy.mutate({
+                              policyId: p.id!,
+                              enabled: checked,
+                            })
+                          }
+                          aria-label={`Toggle ${p.name}`}
+                        />
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-8 text-muted-foreground hover:text-destructive"
+                          title="Remove policy"
+                          onClick={() => setDeleteCandidate(p)}
+                          disabled={pendingAction}
+                        >
+                          <TrashIcon className="size-3.5" />
+                        </Button>
+                      </>
+                    ) : null}
                   </div>
                 </div>
                 {hasParams && (


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Policies declared in the server `--config` YAML (`policies:` key) were evaluated on every session but not visible in the admin UI — the UI only read from the database.
- `GET /v1/policies` now appends config-file policies from `RuntimeCaps.default_policies` as extra entries tagged with `source: "config"`.
- The frontend renders them with a **Config** badge and omits the enable toggle and delete button, since they are managed via the config file, not the UI.

## Test Plan

1. Start a server with `omni server -c config.yaml` where `config.yaml` has a `policies:` block.
2. Open `/settings/policies` in the admin UI.
3. Verify the YAML-defined policies appear with a "Config" badge and no toggle/delete controls.
4. Verify DB-managed policies still show toggle and delete as before.

## Demo

<img width="454" height="569" alt="image" src="https://github.com/user-attachments/assets/7ee0666a-8646-4d0a-9cc2-55f59f709def" />


## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change

## Test coverage

- [x] Manual verification completed

## Coverage notes

The behavior can be verified by running a local server with a config YAML that declares policies and checking the admin UI. No automated test added — the `GET /v1/policies` logic is a straightforward append from an in-memory list.

## Changelog

Config-file policies (declared via `omni server -c`) now appear in the admin Global Policies page as read-only entries labeled "Config".