### PR TITLE
fix(native): keep serve-mcp responsive during slow calls

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -115,6 +115,8 @@ _TOOL_CALL_TIMEOUT_S = 300.0
 # below the real round-trip latency under load, so slow-but-healthy calls
 # (session history reads, shell) tripped it and crashed the bridge.
 _TOOL_RELAY_POST_TIMEOUT_S = _TOOL_CALL_TIMEOUT_S + 30.0
+# Backstop per-request threads above any expected client tool-call fan-out.
+_MAX_CONCURRENT_MCP_REQUESTS = 64
 # Web-UI → Claude input now flows through tmux send-keys, not
 # Claude's experimental Channels MCP capability. The runner writes
 # ``tmux.json`` after the Claude terminal launches; the harness
@@ -3756,6 +3758,7 @@ def _stdio_jsonrpc_loop(
     :returns: None when stdin reaches EOF.
     """
     use_content_length = False
+    request_slots = threading.BoundedSemaphore(_MAX_CONCURRENT_MCP_REQUESTS)
     while True:
         raw_line = sys.stdin.buffer.readline()
         if raw_line == b"":
@@ -3790,20 +3793,37 @@ def _stdio_jsonrpc_loop(
         method = message.get("method")
         if request_id is None or not isinstance(method, str):
             continue
-        threading.Thread(
-            target=_handle_and_write_mcp_request,
-            args=(
-                request_id,
-                method,
-                message.get("params"),
-                tools,
-                bridge_dir,
-                stdout_lock,
-                use_content_length,
-            ),
-            name="claude-native-mcp-request",
-            daemon=True,
-        ).start()
+        if request_slots.acquire(blocking=False):
+            request_thread = threading.Thread(
+                target=_handle_and_write_mcp_request,
+                args=(
+                    request_id,
+                    method,
+                    message.get("params"),
+                    tools,
+                    bridge_dir,
+                    stdout_lock,
+                    use_content_length,
+                    request_slots,
+                ),
+                name="claude-native-mcp-request",
+                daemon=True,
+            )
+            try:
+                request_thread.start()
+            except RuntimeError:
+                request_slots.release()
+            else:
+                continue
+        _write_jsonrpc(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32000, "message": "server busy"},
+            },
+            stdout_lock,
+            framed=use_content_length,
+        )
 
 
 def _handle_and_write_mcp_request(
@@ -3814,6 +3834,7 @@ def _handle_and_write_mcp_request(
     bridge_dir: Path,
     stdout_lock: threading.Lock,
     framed: bool,
+    request_slots: threading.BoundedSemaphore,
 ) -> None:
     """
     Handle one request without blocking the stdio reader.
@@ -3825,6 +3846,7 @@ def _handle_and_write_mcp_request(
     :param bridge_dir: Bridge directory used to resolve the active relay.
     :param stdout_lock: Lock serializing responses and notifications.
     :param framed: Whether to emit a Content-Length framed response.
+    :param request_slots: Concurrency slot released after the response.
     :returns: None after the response is written.
     """
     # A request failure must not tear down the long-lived MCP server.
@@ -3841,7 +3863,10 @@ def _handle_and_write_mcp_request(
             "id": request_id,
             "error": {"code": -32603, "message": f"internal error: {exc}"},
         }
-    _write_jsonrpc(response, stdout_lock, framed=framed)
+    try:
+        _write_jsonrpc(response, stdout_lock, framed=framed)
+    finally:
+        request_slots.release()
 
 
 def _handle_mcp_request(

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -3790,29 +3790,58 @@ def _stdio_jsonrpc_loop(
         method = message.get("method")
         if request_id is None or not isinstance(method, str):
             continue
-        # Per-request guard: a failure handling ONE request must never tear
-        # down the long-lived MCP server (which would surface to Claude Code
-        # as ``-32000: Connection closed`` and drop every tool until respawn).
-        # Convert any handler exception into a JSON-RPC error response so the
-        # offending call fails cleanly and the stdio loop keeps serving. The
-        # individual handlers already return ``_mcp_error`` content for
-        # expected failures; this catches the unexpected (e.g. a bug in a
-        # tool, or an OSError that slipped a narrower except).
-        try:
-            result = _handle_mcp_request(method, message.get("params"), tools, bridge_dir)
-            response: _JsonObject = {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "result": result,
-            }
-        except Exception as exc:  # noqa: BLE001 - top-level loop guard keeps the server alive.
-            response = {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                # -32603 is the JSON-RPC 2.0 "Internal error" code.
-                "error": {"code": -32603, "message": f"internal error: {exc}"},
-            }
-        _write_jsonrpc(response, stdout_lock, framed=use_content_length)
+        threading.Thread(
+            target=_handle_and_write_mcp_request,
+            args=(
+                request_id,
+                method,
+                message.get("params"),
+                tools,
+                bridge_dir,
+                stdout_lock,
+                use_content_length,
+            ),
+            name="claude-native-mcp-request",
+            daemon=True,
+        ).start()
+
+
+def _handle_and_write_mcp_request(
+    request_id: object,
+    method: str,
+    params: object,
+    tools: dict[str, Tool],
+    bridge_dir: Path,
+    stdout_lock: threading.Lock,
+    framed: bool,
+) -> None:
+    """
+    Handle one request without blocking the stdio reader.
+
+    :param request_id: JSON-RPC request identifier returned to the client.
+    :param method: JSON-RPC method name.
+    :param params: Method parameters from the request.
+    :param tools: Omnigent tools exposed over MCP.
+    :param bridge_dir: Bridge directory used to resolve the active relay.
+    :param stdout_lock: Lock serializing responses and notifications.
+    :param framed: Whether to emit a Content-Length framed response.
+    :returns: None after the response is written.
+    """
+    # A request failure must not tear down the long-lived MCP server.
+    try:
+        result = _handle_mcp_request(method, params, tools, bridge_dir)
+        response: _JsonObject = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": result,
+        }
+    except Exception as exc:  # noqa: BLE001 - request failure must not stop the server.
+        response = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32603, "message": f"internal error: {exc}"},
+        }
+    _write_jsonrpc(response, stdout_lock, framed=framed)
 
 
 def _handle_mcp_request(

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -4005,6 +4005,147 @@ def test_serve_mcp_answers_while_relay_call_is_blocked(
         server_thread.join(timeout=5.0)
 
 
+def test_serve_mcp_rejects_at_concurrency_cap_and_keeps_serving(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A saturated request cap rejects work without stopping the server."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    blocked_call_started = threading.Event()
+    release_blocked_call = threading.Event()
+    requests: queue.Queue[bytes] = queue.Queue()
+    responses: queue.Queue[dict[str, Any]] = queue.Queue()
+
+    class _QueuedStdin:
+        """Minimal binary stdin stream driven by a queue."""
+
+        buffer: _QueuedStdin
+
+        def __init__(self) -> None:
+            self.buffer = self
+
+        def readline(self) -> bytes:
+            return requests.get(timeout=5.0)
+
+    def _write_request(request_id: int) -> None:
+        requests.put(
+            (json.dumps({"jsonrpc": "2.0", "id": request_id, "method": "ping"}) + "\n").encode()
+        )
+
+    def _handle_mcp_request(
+        method: str,
+        params: object,
+        tools: dict[str, object],
+        request_bridge_dir: Path,
+    ) -> dict[str, object]:
+        del method, params, tools, request_bridge_dir
+        if not blocked_call_started.is_set():
+            blocked_call_started.set()
+            release_blocked_call.wait(timeout=10.0)
+        return {}
+
+    monkeypatch.setattr(claude_native_bridge, "_MAX_CONCURRENT_MCP_REQUESTS", 1)
+    monkeypatch.setattr(claude_native_bridge.sys, "stdin", _QueuedStdin())
+    monkeypatch.setattr(claude_native_bridge, "_handle_mcp_request", _handle_mcp_request)
+    monkeypatch.setattr(
+        claude_native_bridge,
+        "_write_jsonrpc",
+        lambda payload, _lock, **_kwargs: responses.put(payload),
+    )
+    server_thread = threading.Thread(
+        target=claude_native_bridge._stdio_jsonrpc_loop,
+        args=({}, threading.Lock(), bridge_dir),
+        daemon=True,
+    )
+    server_thread.start()
+    try:
+        _write_request(1)
+        assert blocked_call_started.wait(timeout=5.0)
+
+        _write_request(2)
+        rejected = responses.get(timeout=1.0)
+        assert rejected == {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "error": {"code": -32000, "message": "server busy"},
+        }
+
+        release_blocked_call.set()
+        assert responses.get(timeout=5.0)["id"] == 1
+        for request_thread in threading.enumerate():
+            if request_thread.name == "claude-native-mcp-request":
+                request_thread.join(timeout=5.0)
+                assert not request_thread.is_alive()
+        _write_request(3)
+        assert responses.get(timeout=5.0) == {"jsonrpc": "2.0", "id": 3, "result": {}}
+    finally:
+        release_blocked_call.set()
+        requests.put(b"")
+        server_thread.join(timeout=5.0)
+
+
+def test_serve_mcp_rejects_when_request_thread_cannot_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A request-thread start failure rejects calls without stopping the server."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    requests: queue.Queue[bytes] = queue.Queue()
+    responses: queue.Queue[dict[str, Any]] = queue.Queue()
+
+    class _QueuedStdin:
+        """Minimal binary stdin stream driven by a queue."""
+
+        buffer: _QueuedStdin
+
+        def __init__(self) -> None:
+            self.buffer = self
+
+        def readline(self) -> bytes:
+            return requests.get(timeout=5.0)
+
+    real_thread = threading.Thread
+
+    class _FailingThread(real_thread):
+        """Request thread whose start simulates OS resource exhaustion."""
+
+        def start(self) -> None:
+            raise RuntimeError("can't start new thread")
+
+    def _write_request(request_id: int) -> None:
+        requests.put(
+            (json.dumps({"jsonrpc": "2.0", "id": request_id, "method": "ping"}) + "\n").encode()
+        )
+
+    monkeypatch.setattr(claude_native_bridge, "_MAX_CONCURRENT_MCP_REQUESTS", 1)
+    monkeypatch.setattr(claude_native_bridge.sys, "stdin", _QueuedStdin())
+    monkeypatch.setattr(claude_native_bridge.threading, "Thread", _FailingThread)
+    monkeypatch.setattr(
+        claude_native_bridge,
+        "_write_jsonrpc",
+        lambda payload, _lock, **_kwargs: responses.put(payload),
+    )
+    server_thread = real_thread(
+        target=claude_native_bridge._stdio_jsonrpc_loop,
+        args=({}, threading.Lock(), bridge_dir),
+        daemon=True,
+    )
+    server_thread.start()
+    try:
+        for request_id in (1, 2):
+            _write_request(request_id)
+            assert responses.get(timeout=5.0) == {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32000, "message": "server busy"},
+            }
+    finally:
+        requests.put(b"")
+        server_thread.join(timeout=5.0)
+
+
 @pytest.mark.asyncio
 async def test_start_tool_relay_accepts_pi_native_bridge_root(
     tmp_path: Path,

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import queue
 import select
 import shlex
 import subprocess
@@ -3903,6 +3904,105 @@ async def test_serve_mcp_survives_handler_exception_and_keeps_serving(
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=5.0)
+
+
+@pytest.mark.parametrize("concurrent_method", ["ping", "tools/call"])
+def test_serve_mcp_answers_while_relay_call_is_blocked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    concurrent_method: str,
+) -> None:
+    """A slow relay call must not stop the stdio server from serving peers."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    blocked_call_started = threading.Event()
+    release_blocked_call = threading.Event()
+    requests: queue.Queue[bytes] = queue.Queue()
+    responses: queue.Queue[dict[str, Any]] = queue.Queue()
+
+    class _QueuedStdin:
+        """Minimal binary stdin stream driven by a queue."""
+
+        buffer: _QueuedStdin
+
+        def __init__(self) -> None:
+            self.buffer = self
+
+        def readline(self) -> bytes:
+            return requests.get(timeout=5.0)
+
+    def _write_request(payload: dict[str, object]) -> None:
+        requests.put((json.dumps(payload) + "\n").encode("utf-8"))
+
+    def _call_relay_tool(
+        bridge_dir: Path,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        del bridge_dir, arguments
+        if name == "sys_slow":
+            blocked_call_started.set()
+            release_blocked_call.wait(timeout=10.0)
+            return {"content": [{"type": "text", "text": "slow-done"}]}
+        return {"content": [{"type": "text", "text": "fast-done"}]}
+
+    monkeypatch.setattr(claude_native_bridge.sys, "stdin", _QueuedStdin())
+    monkeypatch.setattr(
+        claude_native_bridge, "_read_relay_tool_names", lambda _path: {"sys_slow", "sys_fast"}
+    )
+    monkeypatch.setattr(claude_native_bridge, "_call_relay_tool", _call_relay_tool)
+    monkeypatch.setattr(
+        claude_native_bridge,
+        "_write_jsonrpc",
+        lambda payload, _lock, **_kwargs: responses.put(payload),
+    )
+    server_thread = threading.Thread(
+        target=claude_native_bridge._stdio_jsonrpc_loop,
+        args=({}, threading.Lock(), bridge_dir),
+        daemon=True,
+    )
+    server_thread.start()
+    try:
+        _write_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "sys_slow", "arguments": {}},
+            }
+        )
+        assert blocked_call_started.wait(timeout=5.0)
+
+        if concurrent_method == "ping":
+            concurrent_request: dict[str, object] = {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "ping",
+                "params": {},
+            }
+        else:
+            concurrent_request = {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "sys_fast", "arguments": {}},
+            }
+        _write_request(concurrent_request)
+
+        concurrent_response = responses.get(timeout=1.0)
+        assert concurrent_response["id"] == 2
+        if concurrent_method == "ping":
+            assert concurrent_response["result"] == {}
+        else:
+            assert concurrent_response["result"]["content"][0]["text"] == "fast-done"
+
+        release_blocked_call.set()
+        blocked_response = responses.get(timeout=5.0)
+        assert blocked_response["id"] == 1
+    finally:
+        release_blocked_call.set()
+        requests.put(b"")
+        server_thread.join(timeout=5.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Closes #2812

Related: #2815

## Summary

- Dispatch each `serve-mcp` stdio request on its own worker so the reader can accept pings and additional calls during a slow relay request.
- Keep stdout writes serialized and retain a per-request error boundary.
- Add focused tests for a ping and a second tool call while the first tool call is blocked.

ELI5: one slow package no longer stops the front desk from answering the bell or accepting another package.

```text
stdin reader -> request worker -> relay call
           \-> request worker -> ping response
           \-> request worker -> second relay call
all responses -> stdout lock -> stdout
```

## Test Plan

Failing first on pristine `764afb6ed405f7e85d182c672b6a0fa678f7a867`:

```text
uv run --extra dev pytest tests/test_claude_native_bridge.py -q -k 'serve_mcp_answers_while_relay_call_is_blocked'
2 failed in 2.31s
```

Patched focused run:

```text
uv run --extra dev pytest tests/test_claude_native_bridge.py -q -k 'serve_mcp_answers_while_relay_call_is_blocked'
2 passed in 0.06s
```

Patched file suite:

```text
uv run --extra dev pytest tests/test_claude_native_bridge.py -q
3 failed, 168 passed in 21.54s
```

The same three macOS subprocess startup tests fail on the pristine base (`3 failed, 166 passed in 21.61s`):

- `test_mcp_server_initialize_omits_blocked_channel_capability`
- `test_channel_server_relays_active_omnigent_tools`
- `test_serve_mcp_survives_handler_exception_and_keeps_serving`

After installing the locked web dependencies with `npm ci --legacy-peer-deps`:

```text
pre-commit run --all-files
Passed
```

## Demo

Both captures drive the real `serve-mcp` entry point over stdio JSON-RPC. Each run starts a
20-second `sys_slow` relay call, then sends a `ping` and a second `tools/call` one second later.

### Before

![Before: ping and second tool call wait behind the slow relay call](https://raw.githubusercontent.com/dosenr/omnigent/a67205c4db04461ecb018df7c4a99f6577d6f669/before.png)

The ping and second tool call wait 19.01s and 19.02s for the slow relay call to finish.

### After

![After: ping and second tool call complete while the slow relay call continues](https://raw.githubusercontent.com/dosenr/omnigent/a67205c4db04461ecb018df7c4a99f6577d6f669/after.png)

The ping and second tool call return in under 10 milliseconds. The original slow call remains in
flight and completes normally at 20 seconds.

The captures print the tested commit and a SHA-256 prefix of the loaded module. Demo scripts and
raw terminal captures: https://github.com/dosenr/omnigent/tree/assets/2813-serve-mcp-demo

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused tests exercise the real stdio loop with a blocked relay call. They verify that a ping and a second tool call complete before the first call is released.

## Changelog

Keep `serve-mcp` responsive to pings and additional requests during slow tool calls.

