### PR TITLE
fix(relay): make tool dispatch timeout configurable

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -32,6 +32,7 @@ import contextlib
 import hashlib
 import json
 import logging
+import math
 import os
 import queue
 import re
@@ -114,7 +115,16 @@ _TOOLS_CHANGED_READY_TIMEOUT_S = 30.0
 _TOOLS_CHANGED_POST_TIMEOUT_S = 10.0
 # Ceiling the relay HTTP handler (``_run_relay_tool``) waits for a single
 # tool dispatch to complete on the harness event loop.
-_TOOL_CALL_TIMEOUT_S = 300.0
+_TOOL_CALL_TIMEOUT_ENV = "HARNESS_TOOL_RELAY_TIMEOUT_S"
+# Parsing is import-time and fail-loud so a malformed value aborts the child.
+try:
+    _TOOL_CALL_TIMEOUT_S = float(os.environ.get(_TOOL_CALL_TIMEOUT_ENV, "300"))
+except ValueError as exc:
+    raise ValueError(
+        f"{_TOOL_CALL_TIMEOUT_ENV} must be a positive finite number of seconds"
+    ) from exc
+if not math.isfinite(_TOOL_CALL_TIMEOUT_S) or _TOOL_CALL_TIMEOUT_S <= 0:
+    raise ValueError(f"{_TOOL_CALL_TIMEOUT_ENV} must be a positive finite number of seconds")
 # Timeout for the bridge's POST to the active-turn relay server
 # (``_call_relay_tool``). This is the OUTER hop: it waits for the relay
 # handler's entire ``_TOOL_CALL_TIMEOUT_S`` dispatch, which itself fans out
@@ -1292,6 +1302,10 @@ def build_mcp_config(bridge_dir: Path, *, python_executable: str | None = None) 
     :returns: JSON-serializable Claude MCP config.
     """
     python = python_executable or sys.executable
+    mcp_env = {"PYTHONUNBUFFERED": "1"}
+    # MCP launchers may filter ambient env, so carry an explicit resolved override.
+    if _TOOL_CALL_TIMEOUT_ENV in os.environ:
+        mcp_env[_TOOL_CALL_TIMEOUT_ENV] = str(_TOOL_CALL_TIMEOUT_S)
     return {
         "mcpServers": {
             _MCP_SERVER_NAME: {
@@ -1304,9 +1318,7 @@ def build_mcp_config(bridge_dir: Path, *, python_executable: str | None = None) 
                     "--bridge-dir",
                     str(bridge_dir),
                 ],
-                "env": {
-                    "PYTHONUNBUFFERED": "1",
-                },
+                "env": mcp_env,
             }
         }
     }

--- a/tests/test_claude_native_bridge_timeout_config.py
+++ b/tests/test_claude_native_bridge_timeout_config.py
@@ -1,0 +1,99 @@
+"""Tests for native tool-relay timeout configuration."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+_TIMEOUT_ENV = "HARNESS_TOOL_RELAY_TIMEOUT_S"
+_PRINT_TIMEOUTS = (
+    "from omnigent.claude_native_bridge import "
+    "_TOOL_CALL_TIMEOUT_S, _TOOL_RELAY_POST_TIMEOUT_S; "
+    "print(_TOOL_CALL_TIMEOUT_S, _TOOL_RELAY_POST_TIMEOUT_S)"
+)
+_PRINT_CHILD_TIMEOUT = (
+    "from pathlib import Path; "
+    "from omnigent.claude_native_bridge import build_mcp_config; "
+    "server = build_mcp_config(Path('/tmp/bridge'))['mcpServers']['omnigent']; "
+    f"print(server['env'].get('{_TIMEOUT_ENV}', '<missing>'))"
+)
+
+
+def _subprocess_env(value: str | None) -> dict[str, str]:
+    env = os.environ.copy()
+    if value is None:
+        env.pop(_TIMEOUT_ENV, None)
+    else:
+        env[_TIMEOUT_ENV] = value
+    return env
+
+
+def test_tool_relay_timeout_defaults_and_override() -> None:
+    assert (
+        subprocess.check_output(
+            [sys.executable, "-c", _PRINT_TIMEOUTS],
+            env=_subprocess_env(None),
+            text=True,
+        ).strip()
+        == "300.0 330.0"
+    )
+    assert (
+        subprocess.check_output(
+            [sys.executable, "-c", _PRINT_TIMEOUTS],
+            env=_subprocess_env("7200"),
+            text=True,
+        ).strip()
+        == "7200.0 7230.0"
+    )
+
+
+def test_tool_relay_timeout_malformed_value_fails_loud() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _PRINT_TIMEOUTS],
+        env=_subprocess_env("not-a-number"),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert _TIMEOUT_ENV in result.stderr.strip().splitlines()[-1]
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "nan", "inf"])
+def test_tool_relay_timeout_rejects_non_positive_or_non_finite_values(value: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _PRINT_TIMEOUTS],
+        env=_subprocess_env(value),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert _TIMEOUT_ENV in result.stderr.strip().splitlines()[-1]
+
+
+def test_serve_mcp_entry_carries_explicit_resolved_timeout() -> None:
+    assert (
+        subprocess.check_output(
+            [sys.executable, "-c", _PRINT_CHILD_TIMEOUT],
+            env=_subprocess_env("028800"),
+            text=True,
+        ).strip()
+        == "28800.0"
+    )
+
+
+def test_serve_mcp_entry_omits_timeout_without_override() -> None:
+    assert (
+        subprocess.check_output(
+            [sys.executable, "-c", _PRINT_CHILD_TIMEOUT],
+            env=_subprocess_env(None),
+            text=True,
+        ).strip()
+        == "<missing>"
+    )


### PR DESCRIPTION
## Related issue

Part of #2815

## Summary

The native MCP relay currently stops a tool dispatch after 300 seconds even when the tool is still making legitimate progress. This adds `HARNESS_TOOL_RELAY_TIMEOUT_S` as a positive, finite timeout override while preserving 300 seconds as the default.

The resolved timeout drives both the inner tool dispatch and the outer relay POST, which keeps its existing 30-second margin. An explicitly configured value is also copied into the generated `serve-mcp` environment instead of relying on ambient inheritance. The same bounded configuration shape merged for the ACP prompt deadline in #2817.

ELI5: a slow but healthy tool call can receive a longer clock, and every relay process uses the same clock.

```text
HARNESS_TOOL_RELAY_TIMEOUT_S
        |-> tool dispatch timeout
        |-> relay POST timeout = configured value + 30 seconds
        \-> generated serve-mcp environment
```

## Test Plan

Revert-check on pristine `901aa8d12a2c7e51764d6d14269fc4576ec77c07`, keeping the PR tests but removing the production change:

```text
../pr2816-rescue/.venv/bin/python -m pytest tests/test_claude_native_bridge_timeout_config.py -q
7 failed, 1 passed in 0.86s
```

The failures show that the override remains at 300 seconds, malformed and non-positive values are accepted, and the generated child lacks the configured timeout.

Corrected focused run:

```text
uv run --no-sync pytest tests/test_claude_native_bridge_timeout_config.py -q
8 passed in 0.79s
```

Corrected native bridge suites:

```text
uv run --no-sync pytest tests/test_claude_native_bridge.py tests/test_claude_native_bridge_timeout_config.py -q
240 passed in 39.38s
```

Static checks:

```text
uv run --no-sync pre-commit run --files omnigent/claude_native_bridge.py tests/test_claude_native_bridge_timeout_config.py
Passed

uv run --no-sync pyrefly check
0 errors (414 suppressed, 195 warnings not shown)
```

The repository-wide Ruff command reports the same three pre-existing notebook-fixture errors on this branch and pristine main. The all-files pre-commit run likewise reaches the same pre-existing `vscode-tsc` failure on both trees; every other hook passes.

## Demo

![Recorded relay timeout configuration output](https://raw.githubusercontent.com/dosenr/omnigent/9804833a76f13c04e249260c1bf62c710d79f66d/2816-final.png)

The recorded local command output shows the default, a 7200 second override, the derived 30 second outer margin, explicit child propagation, and rejection of malformed, non-positive, and non-finite values.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Subprocess isolation verifies the import-time default and override behavior, the 30-second outer margin, and explicit child propagation. It also verifies that malformed, zero, negative, `nan`, and infinite values fail during import and name `HARNESS_TOOL_RELAY_TIMEOUT_S` in the error.

## Changelog

Allow slow native tool relay calls to use a configurable deadline without changing the default.
