### PR TITLE
fix(acp): make prompt timeout configurable

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -49,6 +49,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import math
 import os
 import secrets
 import shlex
@@ -106,7 +107,15 @@ _TOOL_STATUS_COMPLETED = "completed"
 _TOOL_STATUS_FAILED = "failed"
 
 # Idle (time-without-progress) timeouts in seconds.
-_PROMPT_TIMEOUT_SECONDS = 300.0
+# Some ACP agents may remain silent while an external interaction is pending.
+# Parsing is import-time and fail-loud so a malformed value aborts the child.
+_PROMPT_TIMEOUT_ENV = "HARNESS_ACP_PROMPT_TIMEOUT_S"
+try:
+    _PROMPT_TIMEOUT_SECONDS = float(os.environ.get(_PROMPT_TIMEOUT_ENV, "300"))
+except ValueError as exc:
+    raise ValueError(f"{_PROMPT_TIMEOUT_ENV} must be a positive finite number of seconds") from exc
+if not math.isfinite(_PROMPT_TIMEOUT_SECONDS) or _PROMPT_TIMEOUT_SECONDS <= 0:
+    raise ValueError(f"{_PROMPT_TIMEOUT_ENV} must be a positive finite number of seconds")
 _INIT_TIMEOUT_SECONDS = 30.0
 
 # ACP protocol version this executor targets (matches Goose 1.38 / Qwen).

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -106,16 +106,20 @@ _UPDATE_USAGE = "usage_update"
 _TOOL_STATUS_COMPLETED = "completed"
 _TOOL_STATUS_FAILED = "failed"
 
-# Idle (time-without-progress) timeouts in seconds.
-# Some ACP agents may remain silent while an external interaction is pending.
-# Parsing is import-time and fail-loud so a malformed value aborts the child.
+# Idle (time-without-progress) timeout for a prompt turn, in seconds.
+# Some ACP agents stay silent while an external interaction is pending, so
+# this is configurable. Parsing is import-time and fail-loud: a malformed,
+# non-positive, or non-finite value aborts the ACP child at startup.
 _PROMPT_TIMEOUT_ENV = "HARNESS_ACP_PROMPT_TIMEOUT_S"
+_PROMPT_TIMEOUT_ERR = f"{_PROMPT_TIMEOUT_ENV} must be a positive finite number of seconds"
 try:
     _PROMPT_TIMEOUT_SECONDS = float(os.environ.get(_PROMPT_TIMEOUT_ENV, "300"))
 except ValueError as exc:
-    raise ValueError(f"{_PROMPT_TIMEOUT_ENV} must be a positive finite number of seconds") from exc
+    raise ValueError(_PROMPT_TIMEOUT_ERR) from exc
 if not math.isfinite(_PROMPT_TIMEOUT_SECONDS) or _PROMPT_TIMEOUT_SECONDS <= 0:
-    raise ValueError(f"{_PROMPT_TIMEOUT_ENV} must be a positive finite number of seconds")
+    raise ValueError(_PROMPT_TIMEOUT_ERR)
+
+# Idle timeout for the initial ACP handshake (initialize / session setup).
 _INIT_TIMEOUT_SECONDS = 30.0
 
 # ACP protocol version this executor targets (matches Goose 1.38 / Qwen).

--- a/omnigent/inner/acp_harness.py
+++ b/omnigent/inner/acp_harness.py
@@ -26,6 +26,8 @@ Env vars read at startup:
 - ``HARNESS_ACP_SEND_MODEL``: ``"1"`` to send the model in ``session/new``.
 - ``HARNESS_ACP_OS_ENV``: JSON-encoded :class:`OSEnvSpec`. When unset, falls
   back to ``caller_process`` + ``sandbox=none``.
+- ``HARNESS_ACP_PROMPT_TIMEOUT_S``: optional idle (time-without-progress) deadline in
+  seconds for a prompt turn (default 300); must be positive and finite or the child aborts.
 """
 
 from __future__ import annotations

--- a/tests/inner/test_acp_executor_timeout_config.py
+++ b/tests/inner/test_acp_executor_timeout_config.py
@@ -1,0 +1,70 @@
+"""Tests for ACP executor timeout configuration."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+_TIMEOUT_ENV = "HARNESS_ACP_PROMPT_TIMEOUT_S"
+_PRINT_TIMEOUT = (
+    "from omnigent.inner.acp_executor import _PROMPT_TIMEOUT_SECONDS; "
+    "print(_PROMPT_TIMEOUT_SECONDS)"
+)
+
+
+def _subprocess_env(value: str | None) -> dict[str, str]:
+    env = os.environ.copy()
+    if value is None:
+        env.pop(_TIMEOUT_ENV, None)
+    else:
+        env[_TIMEOUT_ENV] = value
+    return env
+
+
+def test_prompt_timeout_defaults_and_override() -> None:
+    assert (
+        subprocess.check_output(
+            [sys.executable, "-c", _PRINT_TIMEOUT],
+            env=_subprocess_env(None),
+            text=True,
+        ).strip()
+        == "300.0"
+    )
+    assert (
+        subprocess.check_output(
+            [sys.executable, "-c", _PRINT_TIMEOUT],
+            env=_subprocess_env("7200"),
+            text=True,
+        ).strip()
+        == "7200.0"
+    )
+
+
+def test_prompt_timeout_malformed_value_fails_loud() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _PRINT_TIMEOUT],
+        env=_subprocess_env("not-a-number"),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert _TIMEOUT_ENV in result.stderr.strip().splitlines()[-1]
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "nan", "inf"])
+def test_prompt_timeout_rejects_non_positive_or_non_finite_values(value: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _PRINT_TIMEOUT],
+        env=_subprocess_env(value),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert _TIMEOUT_ENV in result.stderr.strip().splitlines()[-1]


### PR DESCRIPTION
## Related issue

Refs #2815

## Summary

- Add `HARNESS_ACP_PROMPT_TIMEOUT_S` for the ACP executor prompt deadline.
- Preserve 300 seconds as the default.
- Reject malformed, non-positive, and non-finite values during executor import with an error that names the variable.

ELI5: deployments that expect a prompt to wait longer can extend that clock without changing the default for everyone else.

```text
HARNESS_ACP_PROMPT_TIMEOUT_S
              |
              v
        ACP prompt deadline
        default: 300 seconds
```

## Test Plan

Initial failing-first proof on pristine `764afb6ed405f7e85d182c672b6a0fa678f7a867`:

```text
uv run --extra dev pytest tests/inner/test_acp_executor_timeout_config.py -q
2 failed in 0.70s
```

The corrected diagnostic and validation cases fail on published head `0017e357835a40bbce2a4e8ae31a78e5af4b3cf7`:

```text
uv run --extra dev pytest tests/inner/test_acp_executor_timeout_config.py -q
5 failed, 1 passed in 1.35s
```

Corrected focused run:

```text
uv run --extra dev pytest tests/inner/test_acp_executor_timeout_config.py -q
6 passed in 1.35s
```

Corrected ACP executor suites:

```text
uv run --extra dev pytest tests/inner/test_acp_executor.py tests/inner/test_acp_executor_timeout_config.py -q
40 passed in 4.10s
```

```text
uv run pre-commit run --files omnigent/inner/acp_executor.py tests/inner/test_acp_executor_timeout_config.py
Passed
```

## Demo

![Recorded ACP prompt timeout configuration output](https://raw.githubusercontent.com/dosenr/omnigent/d7157b8fd05a869ca3b31ba2c4a2dabe5eb3d5b3/2817-final.png)

The recorded local command output shows the default, a 7200 second override, and rejection of malformed, non-positive, and non-finite values.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Subprocess isolation verifies import-time default and override behavior. It also verifies that malformed, zero, negative, `nan`, and infinite values fail during import and name `HARNESS_ACP_PROMPT_TIMEOUT_S` on the final error line. The existing ACP executor suite covers prompt and tool-call behavior around the configured constant.

## Changelog

Allow the ACP prompt deadline to be configured without changing its default.
