### PR TITLE
fix(codex-native): Hide unresolved citation markers

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import re
 from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -60,6 +61,7 @@ from omnigent.entities.session_resources import terminal_resource_id
 _logger = logging.getLogger(__name__)
 
 _AGENT_NAME = "codex-native-ui"
+_CODEX_CITATION_MARKER_RE = re.compile(r"[ \t]*citeturn\d+[a-z_]+\d+(?:turn\d+[a-z_]+\d+)*")
 _SUBSCRIBE_RETRY_DELAY_SECONDS = 0.2
 # How long to wait for a freshly launched Codex TUI to create its
 # app-server thread (emit ``thread/started``) before giving up. Generous
@@ -4212,6 +4214,9 @@ async def _post_interrupted_partial_agent_message(
     :param text: Partial assistant text, e.g. ``"The answer is"``.
     :returns: None.
     """
+    text = _strip_codex_citation_markers(text)
+    if not text:
+        return
     await _post_external_item(
         client,
         session_id,
@@ -4224,6 +4229,11 @@ async def _post_interrupted_partial_agent_message(
         },
         response_id=_response_id(params),
     )
+
+
+def _strip_codex_citation_markers(text: str) -> str:
+    """Remove Codex web-search citation tokens that Omnigent cannot resolve."""
+    return _CODEX_CITATION_MARKER_RE.sub("", text)
 
 
 async def _flush_turn_diff(
@@ -5032,6 +5042,9 @@ async def _post_agent_message(
     """
     text = item.get("text")
     if not isinstance(text, str) or not text:
+        return
+    text = _strip_codex_citation_markers(text)
+    if not text:
         return
     await _post_external_item(
         client,

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -1216,6 +1216,36 @@ async def test_completed_context_compaction_item_clears_spinner() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agent_message_strips_unresolvable_codex_citations() -> None:
+    """Codex citation control tokens do not leak into persisted chat text."""
+    client = _RecordingClient()
+
+    await fwd._post_agent_message(
+        client,
+        "conv_x",
+        {"turnId": "turn_1"},
+        {
+            "type": "agentMessage",
+            "id": "item_1",
+            "text": (
+                "Hooks can return additional model context. citeturn211492view0turn5search2"
+            ),
+        },
+    )
+
+    assert client.posts[0][1]["data"]["item_data"]["content"] == [
+        {"type": "output_text", "text": "Hooks can return additional model context."}
+    ]
+
+
+def test_strip_codex_citation_markers_preserves_non_citation_text() -> None:
+    """Only complete Codex citation markers are removed."""
+    text = "Keep turn12view3 and the literal word cite."
+
+    assert fwd._strip_codex_citation_markers(text) == text
+
+
+@pytest.mark.asyncio
 async def test_reasoning_delta_opens_block_then_continues() -> None:
     """
     Codex reasoning deltas mirror as external_output_reasoning_delta (#1254).


### PR DESCRIPTION
## Related issue

N/A

## Summary

Codex app-server returns web-search citations as opaque control tokens such as `citeturn211492view0`, without source URLs that Omnigent can resolve. Persisting those tokens verbatim exposes internal formatting in the chat transcript.

- Remove complete Codex citation markers before persisting completed assistant messages.
- Apply the same cleanup to interrupted partial responses.
- Preserve ordinary text containing words such as `cite` or citation-like identifiers that are not complete control tokens.

## Test Plan

- `uv run --extra dev pytest tests/test_codex_native_forwarder.py -q` — 76 passed.
- `uv run --extra dev ruff check omnigent/codex_native_forwarder.py tests/test_codex_native_forwarder.py`
- `uv run --extra dev ruff format --check omnigent/codex_native_forwarder.py tests/test_codex_native_forwarder.py`
- `.venv/bin/pre-commit run --all-files`

## Demo

N/A — backend transcript sanitization with no new UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The forwarder unit suite verifies that complete single and grouped Codex citation markers are removed while unrelated text remains unchanged.

## Changelog

Codex web-search replies no longer show internal citation markers in chat.
