### PR TITLE
feat(db): encrypt conversation-item payloads at rest via an optional column encryptor

### DIFF
--- a/omnigent/db/compression.py
+++ b/omnigent/db/compression.py
@@ -1,12 +1,19 @@
-"""Transparent client-side compression for opaque text columns.
+"""Transparent client-side compression (and optional encryption) for opaque
+text columns.
 
 A handful of columns hold machine-generated JSON or free text that is never
 queried in SQL or read by hand — per-conversation ``session_state`` /
-``session_usage``, native ``terminal_launch_args``, comment bodies/anchors, and
-agent descriptions. Compressing them on the client gives a uniform on-disk size
-across every backend: MySQL's InnoDB does not compress ``TEXT``/``BLOB`` by
-default and SQLite never does, so relying on per-backend storage compression
-would leave those two uncompressed while PostgreSQL (TOAST) compresses.
+``session_usage``, native ``terminal_launch_args``, comment bodies/anchors,
+agent descriptions, and conversation-item ``data``. Compressing them on the
+client gives a uniform on-disk size across every backend: MySQL's InnoDB does
+not compress ``TEXT``/``BLOB`` by default and SQLite never does, so relying on
+per-backend storage compression would leave those two uncompressed while
+PostgreSQL (TOAST) compresses.
+
+Columns typed :class:`EncryptedText` are additionally encrypted at rest when a
+deployment installs a :class:`ColumnEncryptor` via :func:`set_column_encryptor`
+(e.g. for customer-managed-key encryption). OSS installs none, so those columns
+are only compressed and behave exactly like :class:`CompressedText`.
 
 Stored layout (bytes), chosen so post-migration and legacy rows coexist without
 a backfill:
@@ -20,9 +27,14 @@ a backfill:
   ``TEXT``). They are detected by the absent sentinel — or, under SQLite's
   dynamic typing, by arriving as ``str`` — and returned unchanged. Each such
   row re-frames itself the next time it is written.
+
+Reads dispatch on the codec id, so a single column may hold a mix of legacy,
+plain-zstd, and encrypted rows and each decodes correctly.
 """
 
 from __future__ import annotations
+
+from typing import Protocol
 
 import zstandard
 from sqlalchemy import LargeBinary
@@ -34,6 +46,7 @@ _SENTINEL = 0x00
 # Codec ids, stored as the byte after the sentinel.
 _CODEC_RAW = 0x00  # payload stored uncompressed (below the size threshold)
 _CODEC_ZSTD = 0x01  # payload compressed with zstd
+_CODEC_ZSTD_ENCRYPTED = 0x02  # inner frame (raw/zstd) encrypted by the ColumnEncryptor
 
 # Below this many UTF-8 bytes, zstd's frame overhead outweighs the gain, so the
 # payload is framed but left uncompressed.
@@ -43,10 +56,52 @@ _MIN_COMPRESS_BYTES = 64
 _LEVEL = 19
 
 
-def encode(text: str | None) -> bytes | None:
-    """Frame *text* for storage.
+class ColumnEncryptor(Protocol):
+    """Encrypts/decrypts opaque column bytes at rest.
+
+    OSS ships without one, so :class:`EncryptedText` columns are only
+    compressed. A deployment needing at-rest encryption (e.g. customer-managed
+    keys) installs an implementation via :func:`set_column_encryptor`. The bytes
+    handed to :meth:`encrypt` are already compressed, and the ciphertext it
+    returns is stored verbatim; this module treats both directions as opaque
+    ``bytes -> bytes`` and leaves all key management to the implementation.
+    """
+
+    def encrypt(self, plaintext: bytes) -> bytes: ...
+
+    def decrypt(self, ciphertext: bytes) -> bytes: ...
+
+
+# Process-wide encryptor for EncryptedText columns. ``None`` (the OSS default)
+# means EncryptedText only compresses. TypeDecorator instances are created at
+# import time inside the models, so a module-level seam is the only place a
+# deployment can inject encryption after the fact — mirroring the
+# ``set_lakebase_token_provider`` pattern in ``omnigent/db/utils.py``.
+_column_encryptor: ColumnEncryptor | None = None
+
+
+def set_column_encryptor(encryptor: ColumnEncryptor | None) -> None:
+    """Install (or clear) the process-wide encryptor for :class:`EncryptedText`.
+
+    OSS leaves this unset, so ``EncryptedText`` behaves exactly like
+    ``CompressedText``. A deployment needing at-rest encryption installs one at
+    startup; every subsequent ``EncryptedText`` write then encrypts the
+    compressed bytes and reads decrypt transparently. Pass ``None`` to clear it.
+
+    :param encryptor: The encryptor to install, or ``None`` to remove it.
+    """
+    global _column_encryptor
+    _column_encryptor = encryptor
+
+
+def encode(text: str | None, *, encrypt: bool = False) -> bytes | None:
+    """Frame *text* for storage, optionally encrypting it.
 
     :param text: The plaintext to store, or ``None``.
+    :param encrypt: When ``True`` *and* an encryptor is installed via
+        :func:`set_column_encryptor`, encrypt the compressed payload. With no
+        encryptor installed this flag is a no-op, so the result is byte-for-byte
+        the compress-only form.
     :returns: ``sentinel + codec + payload`` bytes, or ``None`` when *text* is
         ``None``.
     """
@@ -54,9 +109,16 @@ def encode(text: str | None) -> bytes | None:
         return None
     raw = text.encode("utf-8")
     if len(raw) < _MIN_COMPRESS_BYTES:
-        return bytes((_SENTINEL, _CODEC_RAW)) + raw
-    packed = zstandard.ZstdCompressor(level=_LEVEL).compress(raw)
-    return bytes((_SENTINEL, _CODEC_ZSTD)) + packed
+        inner_codec, payload = _CODEC_RAW, raw
+    else:
+        inner_codec = _CODEC_ZSTD
+        payload = zstandard.ZstdCompressor(level=_LEVEL).compress(raw)
+    if encrypt and _column_encryptor is not None:
+        # Encrypt the inner frame (codec byte + payload) so decode can recover
+        # the compression codec after decrypting.
+        sealed = _column_encryptor.encrypt(bytes((inner_codec,)) + payload)
+        return bytes((_SENTINEL, _CODEC_ZSTD_ENCRYPTED)) + sealed
+    return bytes((_SENTINEL, inner_codec)) + payload
 
 
 def decode(value: bytes | str | memoryview | None) -> str | None:
@@ -66,6 +128,8 @@ def decode(value: bytes | str | memoryview | None) -> str | None:
         a legacy ``str`` (SQLite dynamic typing), a ``memoryview`` (some
         drivers), or ``None``.
     :returns: The decoded plaintext, or ``None`` when *value* is ``None``.
+    :raises RuntimeError: If the value is encrypted but no encryptor is
+        installed to decrypt it.
     """
     if value is None:
         return None
@@ -79,6 +143,15 @@ def decode(value: bytes | str | memoryview | None) -> str | None:
         # Empty, or legacy UTF-8 text (no sentinel — cannot start with NUL).
         return value.decode("utf-8")
     codec, payload = value[1], value[2:]
+    if codec == _CODEC_ZSTD_ENCRYPTED:
+        if _column_encryptor is None:
+            raise RuntimeError(
+                "encountered an encrypted column value but no column encryptor is "
+                "installed; call set_column_encryptor() before reading encrypted columns"
+            )
+        # Decrypt back to the inner frame, then fall through on its codec byte.
+        inner = _column_encryptor.decrypt(payload)
+        codec, payload = inner[0], inner[1:]
     if codec == _CODEC_ZSTD:
         return zstandard.ZstdDecompressor().decompress(payload).decode("utf-8")
     return payload.decode("utf-8")
@@ -108,3 +181,22 @@ class CompressedText(TypeDecorator):
     ) -> str | None:
         """Decompress on the way out of the database."""
         return decode(value)
+
+
+class EncryptedText(CompressedText):
+    """A :class:`CompressedText` column that is also encrypted at rest when a
+    :class:`ColumnEncryptor` is installed via :func:`set_column_encryptor`.
+
+    With no encryptor installed (the OSS default) this is byte-for-byte
+    identical to :class:`CompressedText` — the encryption seam stays inert until
+    a deployment opts in. Reads are codec-driven (:func:`decode`), so a column
+    may hold a mix of legacy, plain-zstd, and encrypted rows and each decodes
+    correctly. Same constraint as ``CompressedText``: the stored bytes are
+    opaque, so never filter, order, or pattern-match this column in SQL.
+    """
+
+    cache_ok = True
+
+    def process_bind_param(self, value: str | None, _dialect: object) -> bytes | None:
+        """Compress, then encrypt (if an encryptor is installed), on the way in."""
+        return encode(value, encrypt=True)

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -29,7 +29,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.mysql import BINARY as MySQLBinary
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-from omnigent.db.compression import CompressedText
+from omnigent.db.compression import CompressedText, EncryptedText
 
 # 32-byte sha256 digest column. LargeBinary → BYTEA (Postgres) / BLOB (SQLite),
 # but MySQL cannot index a BLOB without a key-prefix length, so use fixed-length
@@ -623,8 +623,9 @@ class SqlConversationMetadata(OmnigentBase):
     external_session_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     session_state: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
     session_usage: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
-    # JSON-encoded list of strings. NULL for non-native sessions.
-    terminal_launch_args: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
+    # JSON-encoded list of strings. NULL for non-native sessions. Compressed,
+    # and encrypted at rest when a column encryptor is installed.
+    terminal_launch_args: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)
     # Required when host_id is set; enforced by check constraint below.
     workspace: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     git_branch: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -863,7 +864,9 @@ class SqlConversationItem(ConversationBase):
     # ITEM_TYPE). The store converts to/from the string name at the
     # row↔entity boundary.
     type: Mapped[int] = mapped_column(SmallInteger)
-    data: Mapped[str] = mapped_column(Text)
+    # Item payload: compressed, and encrypted at rest when a column encryptor is
+    # installed. Opaque bytes to the database — content search uses search_text.
+    data: Mapped[str] = mapped_column(EncryptedText)
     search_text: Mapped[str] = mapped_column(Text)
     created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
@@ -1021,7 +1024,8 @@ class SqlComment(OmnigentBase):
     status: Mapped[int] = mapped_column(SmallInteger)
     created_at: Mapped[int] = mapped_column(Integer)
     updated_at: Mapped[int] = mapped_column(BigInteger)
-    anchor_content: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
+    # Compressed, and encrypted at rest when a column encryptor is installed.
+    anchor_content: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)
     created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     __table_args__ = (

--- a/omnigent/db/migrations/versions/c4d5e6f7a8b9_conversation_items_data_binary.py
+++ b/omnigent/db/migrations/versions/c4d5e6f7a8b9_conversation_items_data_binary.py
@@ -1,0 +1,130 @@
+"""Store conversation_items.data as a compressed/encrypted BLOB.
+
+Revision ID: c4d5e6f7a8b9
+Revises: d1e2f3a4b5c6
+Create Date: 2026-07-17 00:00:00.000000
+
+Switches ``conversation_items.data`` from ``TEXT`` to a binary column so the
+application layer can store it zstd-compressed — and, when a column encryptor is
+installed, encrypted at rest (``omnigent/db/compression.py``, ``EncryptedText``).
+This matches the treatment of the other opaque columns and lets a deployment
+that needs customer-managed-key encryption protect conversation-item payloads
+without a schema change of its own.
+
+``data`` is never pattern-matched in SQL: the content-search fallback matches
+``search_text`` (the same plain-text column the FTS path uses), so making
+``data`` opaque does not regress search.
+
+Existing rows need no backfill on upgrade: they become their raw UTF-8 bytes,
+and the codec recognises unframed values and reads them back unchanged,
+re-framing each on its next write. Downgrade decompresses every row back to
+plaintext before restoring the ``TEXT`` type; a value that was encrypted cannot
+be downgraded without the encryptor and raises — encrypted rows only exist where
+a deployment installed one, never in an OSS/Alembic-managed database.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import zstandard
+from alembic import op
+
+revision: str = "c4d5e6f7a8b9"
+down_revision: str | None = "d1e2f3a4b5c6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _alter_type(to_binary: bool) -> None:
+    """Change ``conversation_items.data``'s SQL type in both directions.
+
+    Uses batch mode on every dialect: SQLite cannot alter a column type in
+    place (``recreate="always"`` rebuilds the table), and routing all dialects
+    through ``batch_op`` keeps the change off the bare ``op`` proxy, which the
+    SQLite-safety guard forbids for ``alter_column``.
+
+    :param to_binary: ``True`` for ``TEXT`` → ``LargeBinary`` (upgrade),
+        ``False`` for the reverse (downgrade).
+    """
+    sqlite = op.get_bind().dialect.name == "sqlite"
+    old_type = sa.Text() if to_binary else sa.LargeBinary()
+    new_type = sa.LargeBinary() if to_binary else sa.Text()
+    # PostgreSQL cannot implicitly cast between text and bytea, so spell the
+    # conversion out. Ignored by other dialects.
+    cast = "convert_to(data, 'UTF8')" if to_binary else "convert_from(data, 'UTF8')"
+    with op.batch_alter_table(
+        "conversation_items", recreate="always" if sqlite else "auto"
+    ) as batch:
+        batch.alter_column(
+            "data",
+            existing_type=old_type,
+            type_=new_type,
+            existing_nullable=False,
+            postgresql_using=cast,
+        )
+
+
+def upgrade() -> None:
+    """``TEXT`` → ``LargeBinary``. Existing rows keep their raw UTF-8 bytes."""
+    _alter_type(to_binary=True)
+
+
+def _decode(value: object) -> str:
+    """Reverse the compression frame written by ``omnigent/db/compression.py``.
+
+    Inlined so the downgrade stays correct against this migration's on-disk
+    format regardless of later codec changes.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, memoryview):
+        value = value.tobytes()
+    data = bytes(value)
+    if not data or data[0] != 0x00:
+        return data.decode("utf-8")  # legacy unframed text
+    codec, payload = data[1], data[2:]
+    if codec == 0x02:  # encrypted
+        raise RuntimeError(
+            "cannot downgrade an encrypted conversation_items.data value without the "
+            "column encryptor; encrypted rows are not present in an OSS/Alembic database"
+        )
+    if codec == 0x01:  # zstd
+        return zstandard.ZstdDecompressor().decompress(payload).decode("utf-8")
+    return payload.decode("utf-8")  # framed, uncompressed
+
+
+def downgrade() -> None:
+    """Decompress every value, then restore the ``TEXT`` type."""
+    bind = op.get_bind()
+    on_sqlite = bind.dialect.name == "sqlite"
+    # Rewrite each value as raw UTF-8 plaintext (bytes on PostgreSQL/MySQL, str
+    # on dynamically-typed SQLite) so the binary → text conversion sees valid
+    # UTF-8. Untyped text() SQL bypasses the column's binary type processor.
+    # id / conversation_id are 16 raw bytes; SELECT returns them in that form
+    # and the UPDATE binds them back verbatim, so the PK match is byte-exact.
+    select_sql = (
+        "SELECT workspace_id, conversation_id, id, created_at, data AS v FROM conversation_items"
+    )
+    update_sql = (
+        "UPDATE conversation_items SET data = :v "
+        "WHERE workspace_id = :ws AND conversation_id = :cid "
+        "AND id = :id AND created_at = :created_at"
+    )
+    for workspace_id, conversation_id, row_id, created_at, value in bind.execute(
+        sa.text(select_sql)
+    ).fetchall():
+        plain = _decode(value)
+        stored = plain if on_sqlite else plain.encode("utf-8")
+        bind.execute(
+            sa.text(update_sql),
+            {
+                "v": stored,
+                "ws": workspace_id,
+                "cid": conversation_id,
+                "id": row_id,
+                "created_at": created_at,
+            },
+        )
+    _alter_type(to_binary=False)

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -1662,31 +1662,26 @@ class SqlAlchemyConversationStore(ConversationStore):
                         "ORDER BY rank LIMIT :limit"
                     )
             else:
-                # Non-SQLite fallback: LIKE/ILIKE on the data column.
-                # PostgreSQL: cast MEDIUMBLOB/JSONB to text and use ILIKE.
-                # MySQL: CONVERT(data USING utf8mb4) + LIKE (case-insensitive
-                #        by default with utf8mb4_unicode_ci collation).
+                # Non-SQLite fallback: LIKE/ILIKE on search_text — the same
+                # plain-text column the FTS path searches. The data column is a
+                # compressed (and optionally encrypted) BLOB, so it can't be
+                # pattern-matched as text. MySQL LIKE is case-insensitive under
+                # the default utf8mb4 collation; PostgreSQL needs ILIKE.
                 like_pattern = f"%{query}%"
-                is_mysql = self._conv_engine.dialect.name == "mysql"
-                if is_mysql:
-                    data_expr = "CONVERT(ci.data USING utf8mb4)"
-                    like_op = "LIKE"
-                else:
-                    data_expr = "ci.data::text"
-                    like_op = "ILIKE"
+                like_op = "LIKE" if self._conv_engine.dialect.name == "mysql" else "ILIKE"
                 if conversation_id is not None:
                     stmt = text(
                         f"SELECT ci.id FROM conversation_items ci "
                         f"WHERE ci.workspace_id = :ws "
                         f"AND ci.conversation_id = :cid "
-                        f"AND {data_expr} {like_op} :query "
+                        f"AND ci.search_text {like_op} :query "
                         f"ORDER BY ci.created_at DESC LIMIT :limit"
                     )
                 else:
                     stmt = text(
                         f"SELECT ci.id FROM conversation_items ci "
                         f"WHERE ci.workspace_id = :ws "
-                        f"AND {data_expr} {like_op} :query "
+                        f"AND ci.search_text {like_op} :query "
                         f"ORDER BY ci.created_at DESC LIMIT :limit"
                     )
                 query = like_pattern

--- a/tests/db/test_compression.py
+++ b/tests/db/test_compression.py
@@ -11,7 +11,14 @@ import json
 
 import pytest
 
-from omnigent.db.compression import _MIN_COMPRESS_BYTES, decode, encode
+from omnigent.db.compression import (
+    _MIN_COMPRESS_BYTES,
+    CompressedText,
+    EncryptedText,
+    decode,
+    encode,
+    set_column_encryptor,
+)
 
 
 def test_none_round_trips() -> None:
@@ -77,3 +84,103 @@ def test_memoryview_is_accepted() -> None:
 def test_empty_bytes_decode_to_empty_string() -> None:
     """A legacy empty ``TEXT`` value (empty bytes) decodes to ``''``."""
     assert decode(b"") == ""
+
+
+# --- Encryption seam (EncryptedText / set_column_encryptor) -------------------
+
+_ENCRYPTED_CODEC = 0x02
+
+
+class _ReversibleEncryptor:
+    """Test column encryptor: a marker prefix + XOR, so the ciphertext is
+    distinct from the compressed input yet round-trips exactly."""
+
+    _MARKER = b"ENC:"
+    _KEY = 0x5A
+
+    def encrypt(self, plaintext: bytes) -> bytes:
+        return self._MARKER + bytes(b ^ self._KEY for b in plaintext)
+
+    def decrypt(self, ciphertext: bytes) -> bytes:
+        assert ciphertext.startswith(self._MARKER), "ciphertext not produced by this encryptor"
+        return bytes(b ^ self._KEY for b in ciphertext[len(self._MARKER) :])
+
+
+@pytest.fixture
+def column_encryptor() -> object:
+    """Install the reversible test encryptor for the test, then clear it.
+
+    The seam is process-wide, so always restore it to keep tests isolated.
+    """
+    encryptor = _ReversibleEncryptor()
+    set_column_encryptor(encryptor)
+    try:
+        yield encryptor
+    finally:
+        set_column_encryptor(None)
+
+
+def test_encrypt_flag_is_noop_without_encryptor() -> None:
+    """With no encryptor installed, ``encrypt=True`` is byte-for-byte the plain path."""
+    value = json.dumps({"k": "v" * 200})
+    assert encode(value, encrypt=True) == encode(value, encrypt=False)
+
+
+def test_encrypted_text_matches_compressed_without_encryptor() -> None:
+    """``EncryptedText`` is inert (== ``CompressedText``) until an encryptor is installed."""
+    value = "y" * 200
+    assert EncryptedText().process_bind_param(value, None) == CompressedText().process_bind_param(
+        value, None
+    )
+
+
+def test_encrypted_round_trip(column_encryptor: object) -> None:
+    """A large value is compressed, then encrypted, and decodes back exactly."""
+    value = json.dumps({"history": [{"turn": i, "note": f"entry {i}"} for i in range(300)]})
+    blob = encode(value, encrypt=True)
+    assert blob is not None
+    assert blob[0] == 0x00 and blob[1] == _ENCRYPTED_CODEC  # sentinel + encrypted codec
+    assert b"ENC:" in blob, "the installed encryptor should have run"
+    assert decode(blob) == value
+
+
+def test_small_value_is_encrypted_too(column_encryptor: object) -> None:
+    """Sub-threshold payloads are framed raw internally, then encrypted."""
+    blob = encode("hi", encrypt=True)
+    assert blob is not None and blob[1] == _ENCRYPTED_CODEC
+    assert decode(blob) == "hi"
+
+
+def test_encrypted_text_decorator_round_trips(column_encryptor: object) -> None:
+    """The ``EncryptedText`` decorator encrypts on bind and decrypts on result."""
+    column = EncryptedText()
+    value = json.dumps({"secret": "value", "n": 1})
+    stored = column.process_bind_param(value, None)
+    assert stored is not None and stored[1] == _ENCRYPTED_CODEC
+    assert column.process_result_value(stored, None) == value
+
+
+def test_encrypted_value_needs_encryptor_to_decode(column_encryptor: object) -> None:
+    """An encrypted value can't be read once the encryptor is gone."""
+    blob = encode("secret payload " * 10, encrypt=True)
+    assert blob is not None
+    set_column_encryptor(None)
+    with pytest.raises(RuntimeError, match="no column encryptor"):
+        decode(blob)
+
+
+def test_clearing_encryptor_restores_plain_path(column_encryptor: object) -> None:
+    """``set_column_encryptor(None)`` makes ``encrypt=True`` a no-op again."""
+    set_column_encryptor(None)
+    value = "x" * 200
+    assert encode(value, encrypt=True) == encode(value, encrypt=False)
+
+
+def test_plain_encrypted_and_legacy_rows_coexist(column_encryptor: object) -> None:
+    """decode dispatches on the codec, so mixed row formats in one column all read."""
+    plain = encode("legacy compressed " * 20, encrypt=False)
+    encrypted = encode("newly encrypted " * 20, encrypt=True)
+    legacy = b'{"unframed":"text"}'
+    assert decode(plain) == "legacy compressed " * 20
+    assert decode(encrypted) == "newly encrypted " * 20
+    assert decode(legacy) == '{"unframed":"text"}'

--- a/tests/db/test_migration_conversation_items_data_binary.py
+++ b/tests/db/test_migration_conversation_items_data_binary.py
@@ -1,0 +1,103 @@
+"""Tests for the conversation_items.data TEXT -> BLOB migration (c4d5e6f7a8b9).
+
+The migration makes ``data`` a binary column so the app layer can store it
+zstd-compressed (and, where a column encryptor is installed, encrypted). These
+tests pin the type change, that item payloads still round-trip through the
+opaque column, and that the downgrade decompresses every value back to
+plaintext before restoring ``TEXT``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+from omnigent.entities.conversation import MessageData, NewConversationItem
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+_TABLE = "conversation_items"
+_PRIOR_REVISION = "d1e2f3a4b5c6"  # the migration before this one
+
+
+def _data_column(engine: Engine) -> dict[str, Any]:
+    columns = sa.inspect(engine).get_columns(_TABLE)
+    return next(col for col in columns if col["name"] == "data")
+
+
+def _message(text: str, response_id: str = "resp_1") -> NewConversationItem:
+    return NewConversationItem(
+        type="message",
+        response_id=response_id,
+        data=MessageData(role="user", content=[{"type": "input_text", "text": text}]),
+    )
+
+
+def test_head_data_column_is_binary(tmp_path: Path) -> None:
+    """At head ``data`` is a binary column, not text."""
+    uri = f"sqlite:///{tmp_path / 'head.db'}"
+    engine = get_or_create_engine(uri)
+    try:
+        assert isinstance(_data_column(engine)["type"], sa.LargeBinary)
+    finally:
+        engine.dispose()
+        clear_engine_cache()
+
+
+def test_item_payload_round_trips_and_is_framed(tmp_path: Path) -> None:
+    """A large item payload round-trips and is stored as framed (compressed) bytes."""
+    uri = f"sqlite:///{tmp_path / 'roundtrip.db'}"
+    engine = get_or_create_engine(uri)
+    try:
+        store = SqlAlchemyConversationStore(str(engine.url))
+        conv = store.create_conversation()
+        long_text = "the quick brown fox " * 50  # well over the compression threshold
+        store.append(conv.id, [_message(long_text)])
+
+        items = store.list_items(conv.id).data
+        assert len(items) == 1
+        assert items[0].data.content[0]["text"] == long_text
+
+        # The on-disk bytes are framed and zstd-compressed (sentinel + codec).
+        with engine.connect() as conn:
+            raw = conn.execute(sa.text("SELECT data FROM conversation_items")).scalar_one()
+        raw = raw.tobytes() if isinstance(raw, memoryview) else bytes(raw)
+        assert raw[0] == 0x00 and raw[1] == 0x01  # NUL sentinel + zstd codec
+    finally:
+        engine.dispose()
+        clear_engine_cache()
+
+
+def test_downgrade_restores_text_and_plaintext(tmp_path: Path) -> None:
+    """Downgrading one step restores TEXT and decompresses every value to plaintext."""
+    uri = f"sqlite:///{tmp_path / 'downgrade.db'}"
+    engine = get_or_create_engine(uri)
+    try:
+        store = SqlAlchemyConversationStore(str(engine.url))
+        conv = store.create_conversation()
+        long_text = "downgrade me back to plaintext " * 20
+        store.append(conv.id, [_message(long_text)])
+
+        config = _build_alembic_config(uri)
+        with engine.begin() as conn:
+            config.attributes["connection"] = conn
+            command.downgrade(config, _PRIOR_REVISION)
+
+        # Column is text again, and the stored value is readable plaintext JSON
+        # (the downgrade decompressed the framed bytes).
+        assert isinstance(_data_column(engine)["type"], sa.Text)
+        with engine.connect() as conn:
+            stored = conn.execute(sa.text("SELECT data FROM conversation_items")).scalar_one()
+        assert isinstance(stored, str)
+        assert long_text in stored
+    finally:
+        engine.dispose()
+        clear_engine_cache()


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds an optional **column-encryptor seam** to the opaque-column codec so a deployment can encrypt these columns at rest (e.g. under a customer-managed key) while OSS stays encryption-free and dependency-free.
- `EncryptedText` compresses exactly like `CompressedText` and, when a `ColumnEncryptor` is installed via `set_column_encryptor()`, also encrypts the compressed bytes. With none installed (the OSS default) it is **byte-for-byte `CompressedText`** — mirroring the existing `set_lakebase_token_provider` injection seam.
- A new `zstd+encrypted` codec (`0x02`) frames encrypted values, and `decode()` dispatches on the codec, so **legacy, plain-zstd, and encrypted rows coexist in one column with no backfill**. Reads fail closed if an encrypted value is seen with no encryptor installed.
- Applies `EncryptedText` to `conversation_items.data`, `comments.anchor_content`, and `conversations.terminal_launch_args`.
- `conversation_items.data` moves `TEXT` → binary (migration `c4d5e6f7a8b9`) so it can hold compressed/encrypted bytes. Since `data` is now opaque, the non-FTS content-search fallback matches `search_text` (the same plain-text column the FTS path already uses) instead of `data`.

ELI5: several columns hold machine-generated JSON we already compress. This lets a deployment additionally encrypt them at rest, with all key handling injected from outside — OSS itself never encrypts and gains no new dependency.

## Test Plan

- `uv run pytest tests/db/test_compression.py` — 21 pass (8 new: encrypt round-trip, `EncryptedText` inert without an encryptor, mixed legacy/plain/encrypted coexistence, fail-closed decode when the encryptor is gone).
- `uv run pytest tests/db/test_migration_conversation_items_data_binary.py` — 3 pass (`data` is binary at head, item payload round-trips and is stored framed, downgrade restores `TEXT` and decompresses every value to plaintext).
- `uv run pytest tests/stores/test_conversation_store_split_db.py` — 25 pass (item write/read through the new column with the migration applied to head).
- `ruff check` / `ruff format` clean; all `pre-commit` hooks pass.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The encryption path is exercised with a reversible in-test `ColumnEncryptor`; no real KMS is contacted. The default (no encryptor installed) is covered by the existing compression and conversation-store suites, which pass unchanged.
