### PR TITLE
fix(electron): use public npm registry in lockfile to fix Windows CI

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -59,6 +59,18 @@ jobs:
           node-version: "22"
           cache-dependency-path: web/electron/package-lock.json
 
+      - name: Verify lockfile uses public registry
+        # Fail fast (in seconds, not minutes) if any package-lock.json
+        # resolved URL points at an internal proxy that public CI runners
+        # can't reach — e.g. npm-proxy.cloud.databricks.com. Without this
+        # guard, npm ci silently times out mid-install on Windows/Linux.
+        # Uses the shared normalize_package_lock_registry.py script (same
+        # one wired into pre-commit) so CI and local checks stay in sync.
+        working-directory: web/electron
+        shell: bash
+        run: |
+          python3 ../../scripts/normalize_package_lock_registry.py --check package-lock.json
+
       - name: Install dependencies
         working-directory: web/electron
         run: npm ci --no-audit --no-fund
@@ -74,15 +86,34 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: npm run ${{ matrix.build-script }} -- --publish never
 
-      - name: Upload installers
+      # Each distributable gets its own artifact so consumers can download just
+      # the AppImage or just the .deb without pulling down everything else.
+      # Ship only the distributables, not electron-builder's unpacked
+      # intermediates (dist/linux-unpacked, dist/win-unpacked, blockmaps).
+
+      - name: Upload Linux AppImage
+        if: matrix.platform == 'linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: omnigent-desktop-${{ matrix.platform }}
-          # Ship only the distributables, not electron-builder's unpacked
-          # intermediates (dist/linux-unpacked, dist/win-unpacked, blockmaps).
-          path: |
-            web/electron/dist/*.AppImage
-            web/electron/dist/*.deb
-            web/electron/dist/*.exe
+          name: omnigent-desktop-linux-appimage
+          path: web/electron/dist/*.AppImage
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload Linux deb
+        if: matrix.platform == 'linux'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: omnigent-desktop-linux-deb
+          path: web/electron/dist/*.deb
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload Windows installer
+        if: matrix.platform == 'win'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: omnigent-desktop-win
+          path: web/electron/dist/*.exe
           if-no-files-found: error
           retention-days: 14

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,6 +105,20 @@ repos:
         files: ^uv\.lock$
         pass_filenames: true
 
+      # Local `npm install` rewrites every `resolved` URL in
+      # package-lock.json to whatever registry is configured on the
+      # developer's machine (e.g. the Databricks npm proxy via a global
+      # ~/.npmrc). This OSS repo must always commit the public npm registry
+      # (registry.npmjs.org), so normalize it back before it lands — a
+      # proxy URL would make `npm ci` time out on public CI runners. Fixer:
+      # re-stage if it changes. Mirrors normalize-uv-lock-registry above.
+      - id: normalize-package-lock-registry
+        name: normalize package-lock.json registry to npmjs.org
+        language: system
+        entry: .venv/bin/python scripts/normalize_package_lock_registry.py
+        files: ^(web|web/electron|editors/vscode)/package-lock\.json$
+        pass_filenames: true
+
       # Fail if routing.proto changed without regenerating the committed
       # bindings (or vice versa). Verify-only, not a fixer: regen needs
       # grpcio-tools, so CI's `uv sync --extra dev` enforces it (like ktlint).

--- a/scripts/normalize_package_lock_registry.py
+++ b/scripts/normalize_package_lock_registry.py
@@ -1,0 +1,121 @@
+"""Normalize the registry in npm ``package-lock.json`` files to the public npm registry.
+
+Local ``npm install`` runs resolve against whatever registry is configured
+on the developer's machine (e.g. the Databricks npm proxy via a global
+``~/.npmrc``), and npm rewrites every ``"resolved"`` URL in
+``package-lock.json`` to that registry.  For this OSS repo the committed
+lockfile must always point at the public npm registry
+(``https://registry.npmjs.org``) so the lock is reproducible for
+contributors who don't have the proxy — CI runners can't reach the
+internal proxy, so ``npm ci`` would time out fetching from it.
+
+This is a pre-commit *fixer*: it rewrites the registry host in every
+``"resolved"`` URL in place and exits non-zero when it changed anything,
+so the commit aborts and the developer re-stages the normalized lockfile
+(mirroring ``end-of-file-fixer`` and friends).  Only the ``resolved``
+host is touched; the path and ``integrity`` fields are identical between
+the proxy and the canonical host, so the tarball content is unchanged.
+
+Pass ``--check`` to validate without writing: it exits non-zero (and
+names the offending URLs) when a file is *not* already canonical, but
+leaves it untouched.  CI can run this mode against the committed
+lockfile before ``npm ci`` to fail fast instead of timing out mid-install.
+
+Usage::
+
+    python scripts/normalize_package_lock_registry.py web/electron/package-lock.json
+    python scripts/normalize_package_lock_registry.py --check web/electron/package-lock.json
+
+Multiple files may be passed; pre-commit passes the changed files.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# The canonical public registry the committed lockfile must always use.
+_CANONICAL_REGISTRY = "https://registry.npmjs.org"
+
+# Matches a "resolved" URL with a non-canonical host, capturing the path
+# suffix so only the host is replaced, e.g.
+#   "resolved": "https://npm-proxy.cloud.databricks.com/electron-updater/-/electron-updater-6.8.9.tgz"
+# becomes
+#   "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz"
+_NON_CANONICAL_RESOLVED_RE = re.compile(
+    r'("resolved":\s*")(https?://(?!registry\.npmjs\.org)[^"]+)(")'
+)
+
+
+def non_canonical_urls(text: str) -> list[str]:
+    """Return the ``resolved`` URLs in *text* that are not on the canonical registry.
+
+    :param text: Full contents of a ``package-lock.json`` file.
+    :returns: Each non-canonical URL, in order, with duplicates preserved.
+    """
+    return [m.group(2) for m in _NON_CANONICAL_RESOLVED_RE.finditer(text)]
+
+
+def normalize_text(text: str) -> str:
+    """Return *text* with every non-canonical ``resolved`` URL rewritten to the canonical registry.
+
+    The path component (everything after the host) is identical between a
+    proxy and the canonical registry, so only the host is swapped.
+
+    :param text: Full contents of a ``package-lock.json`` file.
+    :returns: The normalized text.
+    """
+    return _NON_CANONICAL_RESOLVED_RE.sub(rf"\g<1>{_CANONICAL_REGISTRY}\g<3>", text)
+
+
+def main(argv: list[str]) -> int:
+    """Normalize (or, with ``--check``, validate) each given lockfile.
+
+    :param argv: Filenames to process, optionally preceded/followed by the
+        ``--check`` flag (passed by pre-commit or CI).
+    :returns: In fix mode, ``1`` when a file was modified (so the commit
+        aborts and the change is re-staged) else ``0``.  In ``--check``
+        mode, ``1`` when any file is not already canonical (printing the
+        offending URLs) else ``0``; no file is written.
+    """
+    check = "--check" in argv
+    files = [a for a in argv if a != "--check"]
+
+    if check:
+        ok = True
+        for name in files:
+            offenders = non_canonical_urls(Path(name).read_text())
+            if offenders:
+                ok = False
+                unique = sorted(set(offenders))
+                print(
+                    f"{name}: {len(offenders)} non-canonical resolved URL(s) "
+                    f"(expected {_CANONICAL_REGISTRY}):"
+                )
+                for url in unique:
+                    print(f"  {url}")
+                print(
+                    "Fix with: python scripts/normalize_package_lock_registry.py "
+                    f"{' '.join(files)} && git add {' '.join(files)}"
+                )
+        return 0 if ok else 1
+
+    changed = False
+    for name in files:
+        path = Path(name)
+        original = path.read_text()
+        normalized = normalize_text(original)
+        if normalized != original:
+            # Validate that the result is still valid JSON before writing.
+            json.loads(normalized)
+            path.write_text(normalized)
+            count = len(non_canonical_urls(original))
+            print(f"{name}: normalized {count} resolved URL(s) to {_CANONICAL_REGISTRY}")
+            changed = True
+    return 1 if changed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/web/electron/.npmrc
+++ b/web/electron/.npmrc
@@ -1,0 +1,6 @@
+# Pin the public npm registry for this package so lockfile `resolved` URLs
+# always point to registry.npmjs.org — never an internal proxy (e.g.
+# npm-proxy.cloud.databricks.com) that would be unreachable from public CI
+# runners. Developers behind a corporate proxy can override this in their
+# global ~/.npmrc without affecting the committed lockfile.
+registry=https://registry.npmjs.org/

--- a/web/electron/package-lock.json
+++ b/web/electron/package-lock.json
@@ -1531,7 +1531,7 @@
     },
     "node_modules/electron-updater": {
       "version": "6.8.9",
-      "resolved": "https://npm-proxy.cloud.databricks.com/electron-updater/-/electron-updater-6.8.9.tgz",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
       "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
       "license": "MIT",
       "dependencies": {
@@ -1547,7 +1547,7 @@
     },
     "node_modules/electron-updater/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
@@ -2412,13 +2412,13 @@
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "license": "MIT"
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
@@ -3413,7 +3413,7 @@
     },
     "node_modules/tiny-typed-emitter": {
       "version": "2.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
     },


### PR DESCRIPTION
## Problem

The Electron Build workflow's Windows job failed at `npm ci` with `ETIMEDOUT`:

```
npm error code ETIMEDOUT
npm error network request to https://npm-proxy.cloud.databricks.com/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz failed
```

5 packages in `web/electron/package-lock.json` had `resolved` URLs pointing at `npm-proxy.cloud.databricks.com` — an internal Databricks npm proxy unreachable from public GitHub Actions runners. `npm ci` uses the `resolved` URLs directly from the lockfile, so it timed out trying to fetch from the internal proxy. (Linux survived because its npm cache was already warm from a prior run.)

## Fix

1. **`web/electron/package-lock.json`** — Rewrote all 5 internal proxy `resolved` URLs to `https://registry.npmjs.org/`\u2026`. These are public packages (electron-updater, semver, lodash.escaperegexp, lodash.isequal, tiny-typed-emitter) — the internal proxy is just a caching layer, so the tarballs and integrity hashes are identical.

2. **`web/electron/.npmrc`** (new) — Pins the npm registry to `https://registry.npmjs.org/` for this package so future `npm install` runs don't reintroduce internal proxy URLs into the committed lockfile. Developers behind a corporate proxy can override in their global `~/.npmrc` without affecting the lockfile.

3. **`.github/workflows/electron-build.yml`** — Added a "Verify lockfile uses public registry" step that runs before `npm ci` and fails fast (seconds, not minutes) if internal registry URLs are detected.

Also splits the Linux AppImage and `.deb` into separate downloadable artifacts instead of bundling them into one.