### PR TITLE
Show agent info panel on hover, not just click (#2736)

### DIFF
--- a/web/src/components/AgentInfo.test.tsx
+++ b/web/src/components/AgentInfo.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Agent } from "@/hooks/useAgents";
@@ -177,6 +177,83 @@ describe("AgentInfoButton", () => {
     fireEvent.click(screen.getByTestId("agent-info-trigger"));
     expect(screen.getByText("Claude")).toBeInTheDocument();
     expect(screen.queryByText("claude-native-ui")).toBeNull();
+  });
+});
+
+describe("AgentInfoButton hover behavior", () => {
+  // The panel now reveals on hover of the info icon (no click needed) and
+  // dismisses shortly after the pointer leaves both the icon and the panel.
+
+  function popoverContent(): HTMLElement | null {
+    // The rendered agent name only lives inside the popover body.
+    return (
+      screen.queryByText("Databricks_coding_agent")?.closest("[data-slot='popover-content']") ??
+      null
+    );
+  }
+
+  it("opens on hover over the info icon and dismisses after the pointer leaves", () => {
+    vi.useFakeTimers();
+    try {
+      renderButton(AGENT_WITH_BOTH);
+      const trigger = screen.getByTestId("agent-info-trigger");
+      // Closed: nothing rendered until hover.
+      expect(popoverContent()).toBeNull();
+
+      fireEvent.mouseEnter(trigger);
+      expect(popoverContent()).not.toBeNull();
+
+      fireEvent.mouseLeave(trigger);
+      // A short grace period keeps it up so the pointer can reach the panel.
+      expect(popoverContent()).not.toBeNull();
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(popoverContent()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stays open while the pointer moves from the icon onto the panel", () => {
+    vi.useFakeTimers();
+    try {
+      renderButton(AGENT_WITH_BOTH);
+      const trigger = screen.getByTestId("agent-info-trigger");
+      fireEvent.mouseEnter(trigger);
+      const panel = popoverContent();
+      expect(panel).not.toBeNull();
+
+      // Leaving the icon starts the dismiss timer; entering the panel cancels it.
+      fireEvent.mouseLeave(trigger);
+      fireEvent.mouseEnter(panel!);
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(popoverContent()).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a clicked (pinned) panel open after the pointer leaves", () => {
+    vi.useFakeTimers();
+    try {
+      renderButton(AGENT_WITH_BOTH);
+      const trigger = screen.getByTestId("agent-info-trigger");
+      // Open via hover, then pin with a click.
+      fireEvent.mouseEnter(trigger);
+      fireEvent.click(trigger);
+
+      fireEvent.mouseLeave(trigger);
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      // Pinned: a mouse-leave no longer dismisses it.
+      expect(popoverContent()).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -46,7 +46,6 @@ import {
 } from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ModelValueCombobox } from "@/components/ModelValueCombobox";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { capitalizeAgentName } from "@/lib/agentLabels";
 import { coercePolicyParams } from "@/lib/policyParams";
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
@@ -1313,33 +1312,90 @@ export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
 /**
  * Header info icon revealing the active agent's tools & policies.
  *
+ * The panel opens on hover of the icon and stays open while the pointer is
+ * over the icon or the panel, so a quick peek (e.g. the session cost) needs
+ * no click. A deliberate click — or any click inside the panel — "pins" it
+ * open so the interactive tools/policies controls stay usable without the
+ * panel dismissing on mouse-leave; an outside click or Escape unpins it.
+ *
  * Desktop-only: on mobile (`< md`) the same content is reached via the
  * header's three-dot menu, which opens {@link AgentInfoContent} in a
  * dialog. Self-hides when the agent has neither tools nor policies.
  */
 export function AgentInfoButton({ agent, sessionId }: AgentInfoProps) {
+  const [open, setOpen] = useState(false);
+  // A click pins the panel open; hover-leave only dismisses an unpinned
+  // (hover-opened) panel. Outside click / Escape clears the pin via onOpenChange.
+  const pinnedRef = useRef(false);
+  const closeTimerRef = useRef<number | null>(null);
+
+  const cancelClose = () => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  };
+  // Short grace period so moving the pointer across the gap between the icon
+  // and the panel doesn't dismiss it mid-travel.
+  const scheduleClose = () => {
+    if (pinnedRef.current) return;
+    cancelClose();
+    closeTimerRef.current = window.setTimeout(() => setOpen(false), 150);
+  };
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current);
+    };
+  }, []);
+
   if (!agentHasInfo(agent, sessionId)) return null;
 
   return (
-    <Popover>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <PopoverTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label="Agent tools and policies"
-              data-testid="agent-info-trigger"
-              className="hidden text-muted-foreground hover:text-foreground md:inline-flex"
-            >
-              <InfoIcon className="size-4" />
-            </Button>
-          </PopoverTrigger>
-        </TooltipTrigger>
-        <TooltipContent>Agent tools &amp; policies</TooltipContent>
-      </Tooltip>
-      <PopoverContent align="end" className="w-80">
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        cancelClose();
+        if (!next) pinnedRef.current = false;
+        setOpen(next);
+      }}
+    >
+      <PopoverTrigger
+        asChild
+        onClick={(e) => {
+          // Pin on click. When already open (via hover) suppress Radix's
+          // default toggle so the click keeps the panel open instead of closing it.
+          if (open) e.preventDefault();
+          pinnedRef.current = true;
+          setOpen(true);
+        }}
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Agent tools and policies"
+          data-testid="agent-info-trigger"
+          className="hidden text-muted-foreground hover:text-foreground md:inline-flex"
+          onMouseEnter={() => {
+            cancelClose();
+            setOpen(true);
+          }}
+          onMouseLeave={scheduleClose}
+        >
+          <InfoIcon className="size-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-80"
+        // Hover-opened: don't yank focus into the panel on a mere peek.
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onMouseEnter={cancelClose}
+        onMouseLeave={scheduleClose}
+        onPointerDownCapture={() => {
+          pinnedRef.current = true;
+        }}
+      >
         <AgentInfoContent agent={agent} sessionId={sessionId} />
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
## Related issue

Closes #2736

## Summary

- The header **(i)** info button previously required a *click* to reveal the agent info panel (session cost, token usage, tools, policies). It now reveals on **hover** of the icon, so a quick peek — e.g. checking the session cost — needs no click.
- The panel **stays open while the pointer is over the icon or the panel**, with a short (150 ms) grace period bridging the gap between them so travelling onto the panel doesn't dismiss it mid-move.
- A **click** — or any click inside the panel — **pins** it open, so the interactive controls (add/remove MCP servers & policies, copy session ID) stay usable without the panel dismissing on mouse-leave. An outside click or `Escape` unpins and closes it.
- The now-redundant hover tooltip ("Agent tools & policies") is removed, since the panel itself appears on hover.

Kept as a `Popover` (rather than switching to `HoverCard`) on purpose: the panel holds genuinely interactive controls, and Radix advises against `HoverCard` for interactive/keyboard content. Layering hover-to-open onto the existing `Popover` preserves click-to-open, nested popovers, dialogs, keyboard, and touch.

### ELI5

The little **ⓘ** next to the agent shows your cost and tools. You used to have to click it. Now you just *point* at it and it pops up — and it stays put while your mouse is on it. If you click it (or click something inside), it "sticks" open so you can fiddle with the tools without it vanishing.

```
hover ⓘ ─▶ panel opens ──▶ move onto panel (stays) ──▶ move away ──▶ closes (150ms)
click ⓘ ─▶ panel PINNED open ──────────────────────▶ outside-click / Esc ──▶ closes
```

## Test Plan

From `web/`:

- `npx vitest run src/components/AgentInfo.test.tsx` → **42 passed** (3 new hover tests: opens on hover, stays open when the pointer moves onto the panel, and a pinned/clicked panel survives mouse-leave; all pre-existing click/cost/owner/usage tests still pass).
- `npx tsc -b` → clean.
- `npx oxlint src/components/AgentInfo.tsx src/components/AgentInfo.test.tsx` → no new findings.
- `npx prettier --check` + `pre-commit run --files …` → pass.

## Demo

_UI behaviour change; interaction (hover-to-open / stays-open / click-to-pin) is described above and covered by the new jsdom hover tests. The panel's contents are unchanged from the issue screenshot (#2736) — only the trigger changes from click to hover._

```
Before:  click ⓘ  →  panel opens
After:   hover ⓘ  →  panel opens, stays open while the pointer is on it;
                     click to pin it open for the tools/policies controls
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests in `AgentInfo.test.tsx` exercise the hover open/close timing (with fake timers), the pointer-moves-onto-panel keep-open path, and the click-to-pin path. All existing tests for the panel's contents (cost, session id, owner, per-model usage, MCP/policy management) continue to pass unchanged, since the panel body is untouched.

## Changelog

The agent info panel (session cost, tools, policies) now appears on hover of the header ⓘ button, not only on click
