### PR TITLE
fix(web): hide "Create custom agent" on a managed sandbox

### DIFF
--- a/tests/e2e_ui/start_session/test_create_custom_agent.py
+++ b/tests/e2e_ui/start_session/test_create_custom_agent.py
@@ -402,20 +402,20 @@ async def _drive_cancel(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
-def test_create_agent_disabled_on_sandbox(
+def test_create_agent_hidden_on_sandbox(
     seeded_session: tuple[str, str],
 ) -> None:
-    """On a managed sandbox target, "Create custom agent" is disabled and inert.
+    """On a managed sandbox target, "Create custom agent" is hidden.
 
     A sandbox provisions its runner from a baked image with no create path for
-    an uploaded bundle, so the affordance is shown disabled (with a tooltip)
-    rather than opening the dialog. Switching to a connected host re-enables it.
+    an uploaded bundle, so the affordance is omitted from the picker. Switching
+    to a connected host brings it back.
     """
     base_url, session_id = seeded_session
-    _run_in_fresh_loop(_drive_disabled_on_sandbox(base_url, session_id))
+    _run_in_fresh_loop(_drive_hidden_on_sandbox(base_url, session_id))
 
 
-async def _drive_disabled_on_sandbox(base_url: str, session_id: str) -> None:
+async def _drive_hidden_on_sandbox(base_url: str, session_id: str) -> None:
     async with async_playwright() as pw:
         browser = await pw.chromium.launch()
         page = await browser.new_page()
@@ -440,16 +440,11 @@ async def _drive_disabled_on_sandbox(base_url: str, session_id: str) -> None:
                 "Databricks Sandbox"
             )
 
-            # On the sandbox, the create item is disabled and does not open the
-            # dialog when activated.
+            # On the sandbox, the create item is omitted from the picker.
             await page.get_by_test_id("new-chat-landing-agent-select").click()
-            create_item = page.get_by_test_id("new-chat-landing-create-agent")
-            await expect(create_item).to_be_visible()
-            await expect(create_item).to_have_attribute("aria-disabled", "true")
-            await create_item.click()
-            await expect(page.get_by_test_id("create-agent-dialog")).to_have_count(0)
+            await expect(page.get_by_test_id("new-chat-landing-create-agent")).to_have_count(0)
 
-            # Switch to the connected host: the item becomes enabled and opens.
+            # Switch to the connected host: the item reappears and opens.
             await page.keyboard.press("Escape")
             await page.get_by_test_id("new-chat-landing-host-chip").click()
             await page.get_by_test_id(f"new-chat-landing-host-{_HOST_ID}").click()
@@ -457,9 +452,9 @@ async def _drive_disabled_on_sandbox(base_url: str, session_id: str) -> None:
                 "Databricks Sandbox"
             )
             await page.get_by_test_id("new-chat-landing-agent-select").click()
-            enabled_item = page.get_by_test_id("new-chat-landing-create-agent")
-            await expect(enabled_item).not_to_have_attribute("aria-disabled", "true")
-            await enabled_item.click()
+            create_item = page.get_by_test_id("new-chat-landing-create-agent")
+            await expect(create_item).to_be_visible()
+            await create_item.click()
             await expect(page.get_by_test_id("create-agent-dialog")).to_be_visible(timeout=5_000)
         finally:
             await browser.close()

--- a/tests/e2e_ui/start_session/test_create_custom_agent.py
+++ b/tests/e2e_ui/start_session/test_create_custom_agent.py
@@ -87,13 +87,39 @@ def _hosts_body() -> str:
     )
 
 
+def _managed_info_body() -> str:
+    """Stub body for ``GET /v1/info``: a managed deployment offering a sandbox.
+
+    ``managed_sandboxes_enabled: true`` + ``sandbox_provider: "lakebox"`` makes
+    the picker offer (and default to) the "Databricks Sandbox" target, which is
+    the shape that gates the "Create custom agent" affordance.
+    """
+    return json.dumps(
+        {
+            "accounts_enabled": False,
+            "login_url": None,
+            "needs_setup": False,
+            "databricks_features": True,
+            "managed_sandboxes_enabled": True,
+            "sandbox_provider": "lakebox",
+            "server_version": "0.0.0-e2e",
+            "smart_routing_enabled": False,
+        }
+    )
+
+
 async def _register_routes(
     page,
     *,
     created_session_id: str,
     create_requests: list[dict[str, Any]],
+    managed: bool = False,
 ) -> None:
-    """Install stubs for hosts, agents, session create, and events."""
+    """Install stubs for hosts, agents, session create, and events.
+
+    When ``managed`` is set, also stub ``GET /v1/info`` so the picker enters
+    managed mode and offers the sandbox target.
+    """
 
     async def handle_hosts(route: Route) -> None:
         await route.fulfill(status=200, content_type="application/json", body=_hosts_body())
@@ -125,6 +151,15 @@ async def _register_routes(
             )
         else:
             await route.continue_()
+
+    if managed:
+
+        async def handle_info(route: Route) -> None:
+            await route.fulfill(
+                status=200, content_type="application/json", body=_managed_info_body()
+            )
+
+        await page.route("**/v1/info", handle_info)
 
     await page.route("**/v1/hosts", handle_hosts)
     await page.route("**/v1/agents", handle_agents)
@@ -363,5 +398,68 @@ async def _drive_cancel(base_url: str, session_id: str) -> None:
             await expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
                 "Claude Code"
             )
+        finally:
+            await browser.close()
+
+
+def test_create_agent_disabled_on_sandbox(
+    seeded_session: tuple[str, str],
+) -> None:
+    """On a managed sandbox target, "Create custom agent" is disabled and inert.
+
+    A sandbox provisions its runner from a baked image with no create path for
+    an uploaded bundle, so the affordance is shown disabled (with a tooltip)
+    rather than opening the dialog. Switching to a connected host re-enables it.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_disabled_on_sandbox(base_url, session_id))
+
+
+async def _drive_disabled_on_sandbox(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_requests: list[dict[str, Any]] = []
+            # Managed mode: the picker defaults to the "Databricks Sandbox"
+            # target, alongside the one connected host.
+            await _register_routes(
+                page,
+                created_session_id=session_id,
+                create_requests=create_requests,
+                managed=True,
+            )
+            await _seed_workspace(page)
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            # Sanity: the sandbox is the default managed target.
+            await expect(page.get_by_test_id("new-chat-landing-host-chip")).to_contain_text(
+                "Databricks Sandbox"
+            )
+
+            # On the sandbox, the create item is disabled and does not open the
+            # dialog when activated.
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            create_item = page.get_by_test_id("new-chat-landing-create-agent")
+            await expect(create_item).to_be_visible()
+            await expect(create_item).to_have_attribute("aria-disabled", "true")
+            await create_item.click()
+            await expect(page.get_by_test_id("create-agent-dialog")).to_have_count(0)
+
+            # Switch to the connected host: the item becomes enabled and opens.
+            await page.keyboard.press("Escape")
+            await page.get_by_test_id("new-chat-landing-host-chip").click()
+            await page.get_by_test_id(f"new-chat-landing-host-{_HOST_ID}").click()
+            await expect(page.get_by_test_id("new-chat-landing-host-chip")).not_to_contain_text(
+                "Databricks Sandbox"
+            )
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            enabled_item = page.get_by_test_id("new-chat-landing-create-agent")
+            await expect(enabled_item).not_to_have_attribute("aria-disabled", "true")
+            await enabled_item.click()
+            await expect(page.get_by_test_id("create-agent-dialog")).to_be_visible(timeout=5_000)
         finally:
             await browser.close()

--- a/tests/e2e_ui/start_session/test_create_custom_agent.py
+++ b/tests/e2e_ui/start_session/test_create_custom_agent.py
@@ -458,3 +458,63 @@ async def _drive_hidden_on_sandbox(base_url: str, session_id: str) -> None:
             await expect(page.get_by_test_id("create-agent-dialog")).to_be_visible(timeout=5_000)
         finally:
             await browser.close()
+
+
+def test_pending_agent_dropped_when_switching_to_sandbox(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A pending custom agent picked on a host is dropped on switch to sandbox.
+
+    Creating a custom agent selects it as the pending pick. Since a pending
+    bundle can't run on a managed sandbox, switching the target to the sandbox
+    must fall the selection back to a real agent and drop the pending row.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_pending_dropped_on_sandbox(base_url, session_id))
+
+
+async def _drive_pending_dropped_on_sandbox(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_requests: list[dict[str, Any]] = []
+            await _register_routes(
+                page,
+                created_session_id=session_id,
+                create_requests=create_requests,
+                managed=True,
+            )
+            await _seed_workspace(page)
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Switch to the connected host, then create + submit a pending agent.
+            await page.get_by_test_id("new-chat-landing-host-chip").click()
+            await page.get_by_test_id(f"new-chat-landing-host-{_HOST_ID}").click()
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            await page.get_by_test_id("new-chat-landing-create-agent").click()
+            await expect(page.get_by_test_id("create-agent-dialog")).to_be_visible(timeout=5_000)
+            await page.get_by_test_id("create-agent-name").fill("pending-agent")
+            await page.get_by_test_id("create-agent-model").fill("claude-sonnet-4-20250514")
+            await page.get_by_test_id("create-agent-submit").click()
+            await expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
+                "pending-agent"
+            )
+
+            # Switch the target back to the sandbox: the pending pick is dropped.
+            await page.get_by_test_id("new-chat-landing-host-chip").click()
+            await page.get_by_test_id("new-chat-landing-sandbox-option").click()
+            await expect(page.get_by_test_id("new-chat-landing-host-chip")).to_contain_text(
+                "Databricks Sandbox"
+            )
+            await expect(page.get_by_test_id("new-chat-landing-agent-select")).not_to_contain_text(
+                "pending-agent"
+            )
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            await expect(page.get_by_test_id("new-chat-landing-agent-pending")).to_have_count(0)
+        finally:
+            await browser.close()

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2312,3 +2312,57 @@ describe("NewChatLandingScreen agent picker (mobile)", () => {
     expect(screen.queryByTestId("new-chat-landing-agent-config-page")).toBeNull();
   });
 });
+
+describe("NewChatLandingScreen custom-agent sandbox gating", () => {
+  beforeEach(setupLandingMocks);
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  // Select the managed sandbox as the target. The default mocks give one
+  // online host (auto-selected), so we open the host chip and pick the
+  // sandbox option pinned at the top.
+  async function selectSandbox(): Promise<void> {
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("Sandbox"),
+    );
+  }
+
+  it("disables 'Create custom agent' on a sandbox and does not open the dialog", async () => {
+    renderLanding({ managed_sandboxes_enabled: true });
+    await selectSandbox();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    const createItem = screen.getByTestId("new-chat-landing-create-agent");
+    expect(createItem).toHaveAttribute("aria-disabled", "true");
+    // Activating the disabled row must not open the create-agent dialog.
+    fireEvent.click(createItem);
+    expect(screen.queryByTestId("create-agent-dialog")).toBeNull();
+  });
+
+  it("keeps 'Create custom agent' enabled on a host and opens the dialog", async () => {
+    renderLanding({ managed_sandboxes_enabled: true });
+    // The managed default is the sandbox even with a host present, so switch
+    // to the connected host (machine-1) first.
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("Sandbox"),
+    );
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    const hostItem = screen
+      .getAllByText("machine-1")
+      .find((el) => el.closest('[role="menuitem"]') !== null);
+    expect(hostItem).toBeTruthy();
+    fireEvent.click(hostItem!);
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("machine-1"),
+    );
+    // On a host, the create item is enabled and opens the dialog.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    const createItem = screen.getByTestId("new-chat-landing-create-agent");
+    expect(createItem).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(createItem);
+    await waitFor(() => expect(screen.getByTestId("create-agent-dialog")).toBeTruthy());
+  });
+});

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2361,4 +2361,48 @@ describe("NewChatLandingScreen custom-agent sandbox gating", () => {
     fireEvent.click(createItem);
     await waitFor(() => expect(screen.getByTestId("create-agent-dialog")).toBeTruthy());
   });
+
+  // Switch the target to the connected host, then create + submit a pending
+  // custom agent from the dialog so it becomes the selected agent.
+  async function createAndSelectPendingAgentOnHost(): Promise<void> {
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("Sandbox"),
+    );
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    const hostItem = screen
+      .getAllByText("machine-1")
+      .find((el) => el.closest('[role="menuitem"]') !== null);
+    fireEvent.click(hostItem!);
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("machine-1"),
+    );
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-create-agent"));
+    await waitFor(() => expect(screen.getByTestId("create-agent-dialog")).toBeTruthy());
+    fireEvent.change(screen.getByTestId("create-agent-name"), { target: { value: "my-agent" } });
+    fireEvent.change(screen.getByTestId("create-agent-model"), {
+      target: { value: "claude-sonnet-4-20250514" },
+    });
+    fireEvent.click(screen.getByTestId("create-agent-submit"));
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain("my-agent"),
+    );
+  }
+
+  it("drops a selected pending custom agent when the target switches to a sandbox", async () => {
+    renderLanding({ managed_sandboxes_enabled: true });
+    await createAndSelectPendingAgentOnHost();
+    // Switch back to the sandbox: the pending pick can't run there, so the
+    // selection falls back to a real agent and the pending row disappears.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("Sandbox"),
+    );
+    expect(screen.getByTestId("new-chat-landing-agent-select").textContent).not.toContain(
+      "my-agent",
+    );
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    expect(screen.queryByTestId("new-chat-landing-agent-pending")).toBeNull();
+  });
 });

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2331,18 +2331,15 @@ describe("NewChatLandingScreen custom-agent sandbox gating", () => {
     );
   }
 
-  it("disables 'Create custom agent' on a sandbox and does not open the dialog", async () => {
+  it("hides 'Create custom agent' on a sandbox", async () => {
     renderLanding({ managed_sandboxes_enabled: true });
     await selectSandbox();
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    const createItem = screen.getByTestId("new-chat-landing-create-agent");
-    expect(createItem).toHaveAttribute("aria-disabled", "true");
-    // Activating the disabled row must not open the create-agent dialog.
-    fireEvent.click(createItem);
-    expect(screen.queryByTestId("create-agent-dialog")).toBeNull();
+    // The item is omitted entirely on a sandbox target.
+    expect(screen.queryByTestId("new-chat-landing-create-agent")).toBeNull();
   });
 
-  it("keeps 'Create custom agent' enabled on a host and opens the dialog", async () => {
+  it("shows 'Create custom agent' on a host and opens the dialog", async () => {
     renderLanding({ managed_sandboxes_enabled: true });
     // The managed default is the sandbox even with a host present, so switch
     // to the connected host (machine-1) first.
@@ -2358,10 +2355,9 @@ describe("NewChatLandingScreen custom-agent sandbox gating", () => {
     await waitFor(() =>
       expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("machine-1"),
     );
-    // On a host, the create item is enabled and opens the dialog.
+    // On a host, the create item is present and opens the dialog.
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
     const createItem = screen.getByTestId("new-chat-landing-create-agent");
-    expect(createItem).not.toHaveAttribute("aria-disabled", "true");
     fireEvent.click(createItem);
     await waitFor(() => expect(screen.getByTestId("create-agent-dialog")).toBeTruthy());
   });

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2242,8 +2242,13 @@ export function NewChatLandingScreen() {
   // A pick only wins while it exists in the list — a persisted id whose
   // agent has since been unregistered (or hidden) falls back to the default.
   // The pending custom agent sentinel also wins when set.
+  // A pending (just-created, not-yet-submitted) custom agent can't run on a
+  // managed sandbox — the sandbox create path doesn't provision a runner for a
+  // bundled agent. So a pending pick made before switching to a sandbox is
+  // dropped there, falling back to a real agent; off the sandbox it's kept.
+  const pendingAgentAllowedOnTarget = !sandboxSelected;
   const effectiveAgentId =
-    pickedAgentId === PENDING_AGENT_ID
+    pickedAgentId === PENDING_AGENT_ID && pendingAgentAllowedOnTarget
       ? PENDING_AGENT_ID
       : ((agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ??
         null);
@@ -3297,7 +3302,11 @@ export function NewChatLandingScreen() {
                   hasAgents={agentList.length > 0}
                   host={harnessWarningHost}
                   onSelectAgent={handleSelectAgent}
-                  pendingAgent={pendingAgent}
+                  // Hide the pending (just-created, unsubmitted) custom agent
+                  // row on a sandbox — it can't run there, so it would linger
+                  // as an unselectable entry. Pending state is in-memory only,
+                  // so it's cleared on reload regardless.
+                  pendingAgent={pendingAgentAllowedOnTarget ? pendingAgent : null}
                   pendingAgentId={PENDING_AGENT_ID}
                   onSelectPending={handleSelectPending}
                   onCreateCustomAgent={() => setCreateAgentOpen(true)}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -3302,10 +3302,6 @@ export function NewChatLandingScreen() {
                   hasAgents={agentList.length > 0}
                   host={harnessWarningHost}
                   onSelectAgent={handleSelectAgent}
-                  // Hide the pending (just-created, unsubmitted) custom agent
-                  // row on a sandbox — it can't run there, so it would linger
-                  // as an unselectable entry. Pending state is in-memory only,
-                  // so it's cleared on reload regardless.
                   pendingAgent={pendingAgentAllowedOnTarget ? pendingAgent : null}
                   pendingAgentId={PENDING_AGENT_ID}
                   onSelectPending={handleSelectPending}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1327,9 +1327,6 @@ function AgentHarnessPicker({
   pendingAgentId: string;
   onSelectPending: () => void;
   onCreateCustomAgent: () => void;
-  // When a managed sandbox is the target, custom-agent creation isn't
-  // available (the sandbox create path doesn't provision a runner for a
-  // bundled agent), so the "Create custom agent" item is hidden.
   sandboxSelected: boolean;
   permissionMode: string;
   approvalMode: string;

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1299,6 +1299,7 @@ function AgentHarnessPicker({
   pendingAgentId,
   onSelectPending,
   onCreateCustomAgent,
+  sandboxSelected,
   permissionMode,
   approvalMode,
   cursorExecMode,
@@ -1326,6 +1327,11 @@ function AgentHarnessPicker({
   pendingAgentId: string;
   onSelectPending: () => void;
   onCreateCustomAgent: () => void;
+  // When a managed sandbox is the target, custom-agent creation is disabled:
+  // the sandbox create path doesn't provision a runner for a bundled agent, so
+  // the "Create custom agent" item is shown disabled with an explanatory
+  // tooltip rather than opening the dialog.
+  sandboxSelected: boolean;
   permissionMode: string;
   approvalMode: string;
   cursorExecMode: string;
@@ -1727,14 +1733,52 @@ function AgentHarnessPicker({
                 </div>
               </DropdownMenuItem>
             )}
-            <DropdownMenuItem
-              data-testid="new-chat-landing-create-agent"
-              onSelect={onCreateCustomAgent}
-              className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
-            >
-              <PlusIcon className="size-3.5" />
-              Create custom agent
-            </DropdownMenuItem>
+            {sandboxSelected ? (
+              // A managed sandbox provisions its runner from a baked image and
+              // has no create path for an uploaded bundle, so custom-agent
+              // creation isn't offered there. Keep the row visible but disabled
+              // (with a why-tooltip) rather than hiding it, so the affordance
+              // stays discoverable — mirrors the disabled New-Sandbox row.
+              <DropdownMenuItem
+                data-testid="new-chat-landing-create-agent"
+                aria-disabled="true"
+                onSelect={(e) => e.preventDefault()}
+                className="flex items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground opacity-60"
+              >
+                <span className="flex items-center gap-2">
+                  <PlusIcon className="size-3.5" />
+                  Create custom agent
+                </span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground/80 hover:text-foreground"
+                      aria-label="Why custom agents are unavailable on a sandbox"
+                      onClick={(e) => e.stopPropagation()}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") e.stopPropagation();
+                      }}
+                    >
+                      <CircleHelpIcon className="size-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-64">
+                    Custom agents aren&apos;t available on a sandbox. Select a connected host to
+                    create one.
+                  </TooltipContent>
+                </Tooltip>
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem
+                data-testid="new-chat-landing-create-agent"
+                onSelect={onCreateCustomAgent}
+                className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
+              >
+                <PlusIcon className="size-3.5" />
+                Create custom agent
+              </DropdownMenuItem>
+            )}
           </>
         )}
       </DropdownMenuContent>
@@ -3294,6 +3338,7 @@ export function NewChatLandingScreen() {
                   pendingAgentId={PENDING_AGENT_ID}
                   onSelectPending={handleSelectPending}
                   onCreateCustomAgent={() => setCreateAgentOpen(true)}
+                  sandboxSelected={sandboxSelected}
                   permissionMode={permissionMode}
                   approvalMode={approvalMode}
                   cursorExecMode={cursorExecMode}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1327,10 +1327,9 @@ function AgentHarnessPicker({
   pendingAgentId: string;
   onSelectPending: () => void;
   onCreateCustomAgent: () => void;
-  // When a managed sandbox is the target, custom-agent creation is disabled:
-  // the sandbox create path doesn't provision a runner for a bundled agent, so
-  // the "Create custom agent" item is shown disabled with an explanatory
-  // tooltip rather than opening the dialog.
+  // When a managed sandbox is the target, custom-agent creation isn't
+  // available (the sandbox create path doesn't provision a runner for a
+  // bundled agent), so the "Create custom agent" item is hidden.
   sandboxSelected: boolean;
   permissionMode: string;
   approvalMode: string;
@@ -1733,43 +1732,10 @@ function AgentHarnessPicker({
                 </div>
               </DropdownMenuItem>
             )}
-            {sandboxSelected ? (
-              // A managed sandbox provisions its runner from a baked image and
-              // has no create path for an uploaded bundle, so custom-agent
-              // creation isn't offered there. Keep the row visible but disabled
-              // (with a why-tooltip) rather than hiding it, so the affordance
-              // stays discoverable — mirrors the disabled New-Sandbox row.
-              <DropdownMenuItem
-                data-testid="new-chat-landing-create-agent"
-                aria-disabled="true"
-                onSelect={(e) => e.preventDefault()}
-                className="flex items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground opacity-60"
-              >
-                <span className="flex items-center gap-2">
-                  <PlusIcon className="size-3.5" />
-                  Create custom agent
-                </span>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground/80 hover:text-foreground"
-                      aria-label="Why custom agents are unavailable on a sandbox"
-                      onClick={(e) => e.stopPropagation()}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") e.stopPropagation();
-                      }}
-                    >
-                      <CircleHelpIcon className="size-3.5" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-64">
-                    Custom agents aren&apos;t available on a sandbox. Select a connected host to
-                    create one.
-                  </TooltipContent>
-                </Tooltip>
-              </DropdownMenuItem>
-            ) : (
+            {/* A managed sandbox provisions its runner from a baked image and
+            has no create path for an uploaded bundle, so custom-agent creation
+            isn't offered there — the item is omitted on a sandbox target. */}
+            {!sandboxSelected && (
               <DropdownMenuItem
                 data-testid="new-chat-landing-create-agent"
                 onSelect={onCreateCustomAgent}


### PR DESCRIPTION
## Why

A **pending** custom agent — one just built in the "Create custom agent" dialog, not yet registered — has to be created via the **multipart bundle upload** path (`createBundledSession` → multipart `POST /v1/sessions`). That path can't also provision a managed host: `host_type: "managed"` lives only on the JSON create body, and the multipart metadata schema (`SessionCreateMetadata`) has no `host_type` field, so `_create_bundled_session_from_multipart` never schedules a managed launch.

So "upload a new bundle" and "start a managed sandbox" can't happen in the same create request. On a sandbox target the pending-agent create therefore produces a session with no host and no runner, and the first message fails with `RUNNER_UNAVAILABLE` ("The runner didn't come online in time"). (An **already-registered** agent — custom or built-in — is unaffected: it goes through the JSON create path, which does support `host_type: "managed"`.)

This may or may not be fixed in the future depending on customer demand.

## Change

Gate the pending custom-agent affordance on `!sandboxSelected` in `AgentHarnessPicker` / `NewChatLandingScreen`:

- **Hide "Create custom agent"** in the picker when a sandbox is selected, so a new pending agent can't be created for a sandbox target.
- **Drop a pending pick on switch to a sandbox**: `effectiveAgentId` falls back to a real agent and the pending row is hidden, so a pending agent selected before switching to a sandbox can't be submitted through the unsupported multipart path.

Off a sandbox (connected host) both behaviors are unchanged — the item shows and pending agents work as before.

## Tests

- **Vitest** (`web/src/shell/NewChatDialog.test.tsx`): item hidden on a sandbox / shown + opens the dialog on a host / a pending pick is dropped when the target switches to a sandbox.
- **Playwright e2e** (`tests/e2e_ui/start_session/test_create_custom_agent.py`): create item absent on the sandbox default and back on the host; a pending agent created on a host is dropped after switching to the sandbox.

Verified locally: vitest 137/137 pass, `tsc` clean on the changed file, e2e collects, ruff clean.
