### PR TITLE
feat(routing): route via a remote routes:select endpoint

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3226,7 +3226,49 @@ def server(
     # OMNIGENT_SMART_ROUTING=1.  Hidden by default — managed deployments
     # override RuntimeCaps.routing_client with their own implementation.
     routing_client = None
-    if server_llm is not None and os.environ.get("OMNIGENT_SMART_ROUTING") == "1":
+    routing_cfg = cfg.get("routing") or {}
+    routing_endpoint = routing_cfg.get("endpoint")
+    if routing_endpoint:
+        # Resolve a bearer token from the server llm: connection/profile.
+        _routing_token = None
+        if server_llm is not None:
+            from omnigent.runtime.policies.builder import _resolve_server_llm_connection
+
+            _conn = _resolve_server_llm_connection(server_llm)
+            _routing_token = (_conn or {}).get("api_key")
+        from omnigent_client._routing import RouteOption as _RouteOption
+        from omnigent_client._routing import RoutingNamespace
+
+        from omnigent.server.smart_routing import RoutingResult
+
+        _router = routing_cfg.get("router", "task_v0")
+        _ns = RoutingNamespace(routing_endpoint, token=_routing_token)
+
+        class _RemoteRoutingClient:
+            async def route(
+                self,
+                message: str,
+                available_models: dict[str, list[str]],
+            ) -> RoutingResult | None:
+                options = [
+                    _RouteOption(model=m, harness=h)
+                    for h, models in available_models.items()
+                    for m in models
+                ]
+                try:
+                    sel = await _ns.select(message, options, router=_router)
+                except Exception:  # noqa: BLE001
+                    return None
+                if sel.route_option is None or not sel.route_option.model:
+                    return None
+                return RoutingResult(
+                    model=sel.route_option.model,
+                    rationale=sel.rationale,
+                    harness=sel.route_option.harness or None,
+                )
+
+        routing_client = _RemoteRoutingClient()
+    elif server_llm is not None and os.environ.get("OMNIGENT_SMART_ROUTING") == "1":
         from omnigent.runtime.policies.builder import (
             _build_policy_llm_client,
             _resolve_server_llm_connection,

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2052,8 +2052,8 @@ def create_app(
         # source as /api/version), surfaced so the web UI can show it in the
         # session info popover alongside the per-session host version.
         # smart_routing_enabled: true when the server can route — either
-        # a RoutingClient is explicitly configured (OMNIGENT_SMART_ROUTING=1
-        # + llm: config) or the managed deployment registered a
+        # a RoutingClient is explicitly configured (a routing.endpoint in
+        # the server config) or the managed deployment registered a
         # policy_llm_connection_factory (which means it has LLM capability
         # and will supply its own RoutingClient).
         try:

--- a/omnigent/tools/builtins/advise_models.py
+++ b/omnigent/tools/builtins/advise_models.py
@@ -10,7 +10,7 @@ before the MCP proxy ever reaches the runner.
 The tool is registered by ``ToolManager`` when:
 - ``tools.agents`` is declared in the spec, AND
 - ``RuntimeCaps.routing_client`` is configured
-  (``OMNIGENT_SMART_ROUTING=1`` + ``llm:`` config block).
+  (a ``routing.endpoint`` in the server config).
 """
 
 from __future__ import annotations
@@ -50,7 +50,7 @@ class SysAdviseModelsTool(Tool):
             "for, plus an optional model list to constrain the pick. "
             "Returns one {agent, model, rationale} entry per agent entry. "
             "Use the returned model as args.model in sys_session_send. "
-            "Advisory only. Available when OMNIGENT_SMART_ROUTING=1."
+            "Advisory only. Available when a routing endpoint is configured."
         )
 
     def get_schema(self) -> dict[str, Any]:

--- a/sdks/python-client/omnigent_client/__init__.py
+++ b/sdks/python-client/omnigent_client/__init__.py
@@ -55,6 +55,7 @@ from ._client import OmnigentClient
 from ._errors import OmnigentError, ToolCallDenied
 from ._events import MCP_ELICITATION_METHOD, ElicitationRequest
 from ._query import QueryResult, QueryStream
+from ._routing import RouteOption, RouteSelection, RoutingNamespace
 from ._server import LocalServer
 from ._session import Session
 from ._sessions import SessionsNamespace
@@ -100,6 +101,9 @@ __all__ = [
     "ResponseEndBlock",
     "ResponseStartBlock",
     "RetryBlock",
+    "RouteOption",
+    "RouteSelection",
+    "RoutingNamespace",
     "Session",
     "SessionToolCallInfo",
     "SessionsChat",

--- a/sdks/python-client/omnigent_client/_client.py
+++ b/sdks/python-client/omnigent_client/_client.py
@@ -12,6 +12,7 @@ from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
 from ._files import FilesNamespace
 from ._query import QueryResult, QueryStream
 from ._responses import ResponsesNamespace
+from ._routing import RoutingNamespace
 from ._session import Session
 from ._sessions import SessionsNamespace
 from ._sessions_chat import SessionsChat, ToolCallable
@@ -52,6 +53,13 @@ class OmnigentClient:
         request, allowing transparent token refresh for OAuth
         flows. ``None`` (default) relies on static ``headers``.
     :param timeout: Default timeout for HTTP requests in seconds.
+    :param routing_endpoint: Optional base URL for the ``routes:select``
+        routing endpoint, up to ``/v1`` (e.g.
+        ``"https://host/ai-gateway/routing/v1"``). When set,
+        ``client.routing`` is available.  ``None`` (default) leaves
+        ``client.routing`` as ``None``.
+    :param routing_token: Bearer token for the routing endpoint.
+        Only used when ``routing_endpoint`` is set.
     """
 
     def __init__(
@@ -67,6 +75,8 @@ class OmnigentClient:
         # (tool calls can legitimately hold the stream open for
         # minutes).
         timeout: float = 30.0,
+        routing_endpoint: str | None = None,
+        routing_token: str | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         # Long read timeout for SSE streams (tool execution can
@@ -95,6 +105,11 @@ class OmnigentClient:
         self.sessions = SessionsNamespace(self._http, self._base_url)
         self.files = FilesNamespace(self._http, self._base_url)
         self.responses = ResponsesNamespace(self._http, self._base_url)
+        self.routing: RoutingNamespace | None = (
+            RoutingNamespace(routing_endpoint, token=routing_token)
+            if routing_endpoint is not None
+            else None
+        )
 
     def session(
         self,

--- a/sdks/python-client/omnigent_client/_routing.py
+++ b/sdks/python-client/omnigent_client/_routing.py
@@ -1,0 +1,155 @@
+"""Routing namespace — select a route for a task via a remote routing endpoint."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from ._errors import OmnigentError, raise_for_status, response_body
+
+# Route name appended to the base endpoint. The base is everything up to and
+# including ``/v1`` (OpenAI-style), so we only append the resource verb.
+_SELECT_ROUTE = "routes:select"
+
+
+@dataclass(frozen=True)
+class RouteOption:
+    """A candidate destination the router may choose from.
+
+    :param model: Model identifier, e.g. ``"claude-opus-4-8"``.
+    :param harness: Harness driving the model, e.g. ``"claude"``.
+    """
+
+    model: str
+    harness: str
+
+
+@dataclass(frozen=True)
+class RouteSelection:
+    """The routing decision returned by the endpoint.
+
+    :param route_option: The chosen ``(model, harness)`` pair, or ``None``
+        when the endpoint returned no selection.
+    :param rationale: Human-readable explanation from the router, or ``""``
+        when absent.
+    :param raw: The full parsed response body for callers that need fields
+        beyond ``route_option`` and ``rationale``.
+    """
+
+    route_option: RouteOption | None
+    rationale: str
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+class RoutingNamespace:
+    """Client for the ``routes:select`` routing endpoint.
+
+    Sends a task and a list of candidate ``(model, harness)`` pairs to a
+    remote routing endpoint and returns the selected route.
+
+    Usage::
+
+        from omnigent_client import OmnigentClient
+
+        async with OmnigentClient(
+            base_url="http://localhost:8080",
+            routing_endpoint="https://host/ai-gateway/routing/v1",
+        ) as client:
+            selection = await client.routing.select(
+                prompt="Fix the NullPointerException in login",
+                route_options=[
+                    RouteOption(model="claude-opus-4-8", harness="claude"),
+                    RouteOption(model="gpt-5-5", harness="codex"),
+                ],
+            )
+            print(selection.route_option)   # RouteOption(model=..., harness=...)
+            print(selection.rationale)
+
+    :param base_url: Routing endpoint base URL up to ``/v1``, e.g.
+        ``"https://host/ai-gateway/routing/v1"``.  ``routes:select`` is
+        appended automatically.
+    :param token: Bearer token for the ``Authorization`` header.  ``None``
+        for an unauthenticated endpoint.
+    :param http: Optional shared ``httpx.AsyncClient``.  When ``None`` a
+        short-lived client is created per request.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: str | None = None,
+        http: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._url = f"{base_url.rstrip('/')}/{_SELECT_ROUTE}"
+        self._token = token
+        self._http = http
+
+    async def select(
+        self,
+        prompt: str,
+        route_options: list[RouteOption],
+        *,
+        router: str = "task_v0",
+        timeout: float = 10.0,
+    ) -> RouteSelection:
+        """Select a route for a task.
+
+        Sends ``route_options`` and the ``prompt`` to the routing endpoint
+        and returns the chosen ``(model, harness)`` pair plus a rationale.
+
+        :param prompt: The task prompt, e.g. ``"Fix the NPE in login"``.
+            Truncated to 4 000 characters before sending.
+        :param route_options: Candidate ``(model, harness)`` pairs for the
+            router to choose from.
+        :param router: Routing strategy name, e.g. ``"task_v0"``.
+        :param timeout: Per-request timeout in seconds.  Ignored when a
+            shared ``http`` client was passed to the constructor.
+        :returns: The selected route.
+        :raises OmnigentError: On a non-2xx response or an unexpected body.
+        """
+        body: dict[str, Any] = {
+            "route_options": [
+                {"model": opt.model, "harness": opt.harness} for opt in route_options
+            ],
+            "task": {"prompt": prompt[:4000]},
+            "route_selector": {"router": router},
+        }
+        headers = {"Content-Type": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+
+        if self._http is not None:
+            resp = await self._http.post(self._url, json=body, headers=headers)
+        else:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.post(self._url, json=body, headers=headers)
+
+        parsed = response_body(resp)
+        raise_for_status(resp.status_code, parsed)
+
+        if not isinstance(parsed, dict):
+            raise OmnigentError(
+                f"routes:select returned unexpected body: {str(parsed)[:200]}",
+                resp.status_code,
+            )
+
+        return _parse_selection(parsed)
+
+
+def _parse_selection(body: dict[str, Any]) -> RouteSelection:
+    """Parse a ``SelectRouteResponse`` body into a :class:`RouteSelection`."""
+    rationale = body.get("rationale") or ""
+    selections = body.get("routeSelection") or body.get("route_selection") or []
+    if not selections or not isinstance(selections, list):
+        return RouteSelection(route_option=None, rationale=str(rationale), raw=body)
+
+    first = selections[0]
+    option = first.get("routeOption") or first.get("route_option") or {}
+    model = option.get("model") or None
+    harness = option.get("harness") or None
+
+    route_option = RouteOption(model=model, harness=harness) if model else None
+    return RouteSelection(route_option=route_option, rationale=str(rationale), raw=body)


### PR DESCRIPTION
Move the server-side routing decision from an in-process LLM judge to a remote endpoint that speaks the omnigent.api.routing.v1 contract.

- cli: enable routing when the server config declares routing.endpoint; reuse the server llm: connection/profile for the bearer token, with an optional routing.router (default task_v0).
- smart_routing: rewrite LLMRoutingClient to POST route_options (model + harness), task, and route_selector.router to <endpoint>/routes:select, parse SelectRouteResponse, clamp unknown models to the cheapest offered, re-resolve harness by model ownership, and fail open. Drop the local-judge scaffolding.
- Propagate the routed harness: route_turn keys the live catalog by the session harness and returns it; both call sites persist harness_override (validated against OMNIGENT_HARNESSES, only switching when it differs).
- Update tests to drive the endpoint via httpx.MockTransport; refresh stale OMNIGENT_SMART_ROUTING docstrings.

Co-authored-by: Isaac

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Test Plan

```
# config.yaml
llm:
  model: databricks-claude-haiku-4-5
  profile: eng-ml-inference   # token source for the routing bearer

routing:
  endpoint: https://eng-ml-inference.staging.cloud.databricks.com/ai-gateway/routing/v1
  router: task_v0
```

```
from omnigent_client import OmnigentClient, RouteOption

async with OmnigentClient(
    base_url="http://localhost:8080",
    routing_endpoint="https://eng-ml-inference.staging.cloud.databricks.com/ai-gateway/routing/v1",
    routing_token="dapi...",
) as client:
    selection = await client.routing.select(
        prompt="Fix the NullPointerException in UserService.login",
        route_options=[
            RouteOption(model="claude-opus-4-8", harness="claude"),
            RouteOption(model="gpt-5-5", harness="codex"),
            RouteOption(model="gpt-5-4-mini", harness="codex"),
        ],
    )
    print(selection.route_option)  # RouteOption(model='claude-opus-4-8', harness='claude')
    print(selection.rationale)     # "complex multi-file reasoning task..."
```

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

<Add a line to describe the change, else delete this section>
