### PR TITLE
[host] Refresh harness readiness without reconnect

### DIFF
--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -61,6 +61,11 @@ from omnigent.codex_native_forwarder import supervise_forwarder
 from omnigent.codex_native_state import read_launch_state, write_launch_state
 from omnigent.conversation_browser import conversation_url, open_conversation_link_if_enabled
 from omnigent.entities.session_resources import terminal_resource_id
+from omnigent.harness_availability import (
+    HARNESS_BINARY_MISSING,
+    HARNESS_NEEDS_AUTH,
+    HarnessUnavailableReason,
+)
 from omnigent.host.daemon_launch import (
     error_text,
     launch_or_reuse_daemon_runner,
@@ -107,8 +112,6 @@ _UNBOUND_RUNNER_MESSAGE_FRAGMENT = "not bound to a runner"
 # hex + hyphens keeps it safe to interpolate into a rollout filename and a
 # ``codex resume`` argument (no path separators / traversal).
 _CODEX_THREAD_ID_RE = re.compile(r"^[0-9a-fA-F-]+$")
-_CODEX_AUTH_UNAVAILABLE_BINARY_MISSING = "binary-missing"
-_CODEX_AUTH_UNAVAILABLE_NEEDS_AUTH = "needs-auth"
 
 
 @dataclass(frozen=True)
@@ -185,7 +188,7 @@ def _codex_auth_json_has_available_credential(auth_path: Path) -> bool:
     return False
 
 
-def _codex_auth_unavailable_reason() -> str | None:
+def _codex_auth_unavailable_reason() -> HarnessUnavailableReason | None:
     """
     Return why local Codex is unavailable, or ``None`` when available.
 
@@ -214,13 +217,9 @@ def _codex_auth_unavailable_reason() -> str | None:
         not judged locally — it surfaces at the first turn via the executor.
     """
     if _find_codex_cli() is None:
-        return _CODEX_AUTH_UNAVAILABLE_BINARY_MISSING
-    # ponytail: resolve_native_codex_launch runs once per codex spelling
-    # (codex / codex-native / native-codex → 3×) per hello frame; on a host with
-    # NO configured provider it also runs ambient detection (a localhost ollama
-    # probe + a `claude auth status` subprocess). It's off the event loop and
-    # only bites unconfigured hosts — memoize the launch across the map build in
-    # configured_harness_map if that cost ever shows up.
+        return HARNESS_BINARY_MISSING
+    # On a host with no configured provider this may run ambient detection.
+    # configured_harness_map shares one probe across all Codex aliases.
     try:
         launch = resolve_native_codex_launch(model=None)
         routes_through_provider = (
@@ -233,7 +232,7 @@ def _codex_auth_unavailable_reason() -> str | None:
         return None
     source = _resolve_codex_auth_source()
     if not _codex_auth_json_has_available_credential(source.auth_path):
-        return _CODEX_AUTH_UNAVAILABLE_NEEDS_AUTH
+        return HARNESS_NEEDS_AUTH
     return None
 
 

--- a/omnigent/harness_availability.py
+++ b/omnigent/harness_availability.py
@@ -1,0 +1,21 @@
+"""Shared harness-readiness states and harness-family identifiers."""
+
+from __future__ import annotations
+
+from typing import Final, Literal, TypeGuard
+
+HARNESS_BINARY_MISSING: Final[Literal["binary-missing"]] = "binary-missing"
+HARNESS_NEEDS_AUTH: Final[Literal["needs-auth"]] = "needs-auth"
+
+HarnessUnavailableReason = Literal["binary-missing", "needs-auth"]
+HarnessAvailability = Literal[True, False, "binary-missing", "needs-auth"]
+
+# Readiness and model-family checks must agree on every Codex spelling.
+CODEX_CANONICAL_HARNESSES: Final[frozenset[str]] = frozenset(
+    {"codex", "codex-native", "native-codex"}
+)
+
+
+def is_harness_availability(value: object) -> TypeGuard[HarnessAvailability]:
+    """Return whether a decoded value is a supported readiness state."""
+    return isinstance(value, bool) or value in (HARNESS_BINARY_MISSING, HARNESS_NEEDS_AUTH)

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -24,6 +24,7 @@ from websockets.exceptions import InvalidStatus, InvalidURI
 
 from omnigent._platform import WINDOWS_ENV_PASSTHROUGH
 from omnigent.env_credentials import env_names_with_omnigent_prefix
+from omnigent.harness_availability import HARNESS_BINARY_MISSING, HarnessAvailability
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
     HostCreateDirFrame,
@@ -94,16 +95,18 @@ from omnigent.version import VERSION
 
 _logger = logging.getLogger(__name__)
 
+# Binary appearance is cheap to probe, so new CLI installs surface quickly.
 HARNESS_READINESS_REFRESH_INTERVAL_S = 5.0
+# Auth changes and removals need the full, potentially expensive readiness map.
 HARNESS_READINESS_FULL_REFRESH_INTERVAL_S = 60.0
 
 
 def _unavailable_harness_became_ready(
-    previous: Mapping[str, bool | str],
+    previous: Mapping[str, HarnessAvailability],
 ) -> bool:
-    """Return whether a previously missing CLI-backed harness is now ready."""
+    """Detect newly available binaries; auth changes wait for the full refresh."""
     return any(
-        (availability is False or availability == "binary-missing")
+        (availability is False or availability == HARNESS_BINARY_MISSING)
         and harness_is_configured(harness)
         for harness, availability in previous.items()
     )

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -32,6 +32,7 @@ from omnigent.host.frames import (
     HostCreateWorktreeResultFrame,
     HostFsRequestFrame,
     HostFsResultFrame,
+    HostHarnessReadinessFrame,
     HostHelloFrame,
     HostLaunchRunnerFrame,
     HostLaunchRunnerResultFrame,
@@ -92,6 +93,20 @@ from omnigent.runner.transports.ws_tunnel.limits import (
 from omnigent.version import VERSION
 
 _logger = logging.getLogger(__name__)
+
+HARNESS_READINESS_REFRESH_INTERVAL_S = 5.0
+HARNESS_READINESS_FULL_REFRESH_INTERVAL_S = 60.0
+
+
+def _unavailable_harness_became_ready(
+    previous: Mapping[str, bool | str],
+) -> bool:
+    """Return whether a previously missing CLI-backed harness is now ready."""
+    return any(
+        (availability is False or availability == "binary-missing")
+        and harness_is_configured(harness)
+        for harness, availability in previous.items()
+    )
 
 
 def _runner_log_dir() -> Path:
@@ -2001,16 +2016,15 @@ class HostProcess:
                 _tel_install_id = _get_install_id()
         except Exception:  # noqa: BLE001
             pass
+        configured_harnesses = await asyncio.to_thread(configured_harness_map)
         hello = HostHelloFrame(
             version=VERSION,
             frame_protocol_version=1,
             name=self._identity.name,
             runners=self._alive_runner_ids(),
-            # Off the event loop: probes PATH (shutil.which) and reads
-            # ~/.omnigent/config.yaml. Recomputed on every (re)connect, so
-            # the server's view refreshes whenever the tunnel does; the
-            # launch-time check above stays the authoritative gate.
-            configured_harnesses=await asyncio.to_thread(configured_harness_map),
+            # Off the event loop: probes PATH and reads local config.
+            # The loop below refreshes changes; launch remains authoritative.
+            configured_harnesses=configured_harnesses,
             telemetry_opt_out=_tel_opt_out,
             installation_id=_tel_install_id,
         )
@@ -2033,11 +2047,42 @@ class HostProcess:
             flush=True,
         )
 
+        loop = asyncio.get_running_loop()
+        next_quick_refresh = loop.time() + HARNESS_READINESS_REFRESH_INTERVAL_S
+        next_full_refresh = loop.time() + HARNESS_READINESS_FULL_REFRESH_INTERVAL_S
         while True:
-            try:
-                raw = await asyncio.wait_for(ws.recv(), timeout=60.0)
-            except asyncio.TimeoutError:
-                continue
+            raw: object | None = None
+            with contextlib.suppress(asyncio.TimeoutError):
+                raw = await asyncio.wait_for(
+                    ws.recv(),
+                    timeout=max(
+                        0.0,
+                        min(next_quick_refresh, next_full_refresh) - loop.time(),
+                    ),
+                )
+
+            now = loop.time()
+            refresh_full_map = now >= next_full_refresh
+            if now >= next_quick_refresh:
+                next_quick_refresh = now + HARNESS_READINESS_REFRESH_INTERVAL_S
+                if not refresh_full_map:
+                    refresh_full_map = await asyncio.to_thread(
+                        _unavailable_harness_became_ready,
+                        configured_harnesses,
+                    )
+
+            if refresh_full_map:
+                latest_harnesses = await asyncio.to_thread(configured_harness_map)
+                next_full_refresh = now + HARNESS_READINESS_FULL_REFRESH_INTERVAL_S
+                if latest_harnesses != configured_harnesses:
+                    await ws.send(
+                        encode_host_frame(
+                            HostHarnessReadinessFrame(
+                                configured_harnesses=latest_harnesses,
+                            )
+                        )
+                    )
+                    configured_harnesses = latest_harnesses
             if isinstance(raw, str):
                 await self._handle_raw_message(ws, raw)
 

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
-HarnessAvailability = bool | str
+from omnigent.harness_availability import HarnessAvailability, is_harness_availability
 
 # Structured error code carried in ``HostLaunchRunnerResultFrame.error_code``
 # when the host refuses a launch because the session's harness is not
@@ -82,8 +82,9 @@ class HostHelloFrame:
         (see ``omnigent.onboarding.harness_readiness``). Keys
         cover every accepted harness spelling. ``None`` means
         unknown (an older host that doesn't report it) — never
-        treat ``None`` as "nothing is configured". Refreshed while
-        connected; the launch-time check is authoritative.
+        treat ``None`` as "nothing is configured". Changes arrive in
+        :class:`HostHarnessReadinessFrame`; launch-time checks remain
+        authoritative.
     """
 
     version: str
@@ -1056,6 +1057,11 @@ def _decode_harness_readiness(msg: dict[str, Any]) -> HostHarnessReadinessFrame:
     configured_harnesses = _optional_str_availability_map(msg, "configured_harnesses")
     if configured_harnesses is None:
         raise ValueError("harness readiness frame requires a configured_harnesses object")
+    raw = msg["configured_harnesses"]
+    if len(configured_harnesses) != len(raw):
+        raise ValueError("harness readiness frame contains an unsupported availability state")
+    if not configured_harnesses:
+        raise ValueError("harness readiness frame requires a non-empty configured_harnesses map")
     return HostHarnessReadinessFrame(configured_harnesses=configured_harnesses)
 
 
@@ -1484,7 +1490,7 @@ def _optional_str_availability_map(
     Tolerant by design: absent, null, or non-mapping values all decode
     to ``None`` ("unknown") rather than raising, so an older or newer
     peer's hello never breaks the tunnel handshake. Entries with a
-    non-string key or non-bool/string value are dropped for the same reason.
+    non-string key or unsupported readiness value are dropped for the same reason.
 
     :param msg: Decoded frame object.
     :param key: Field name, e.g. ``"configured_harnesses"``.
@@ -1494,7 +1500,7 @@ def _optional_str_availability_map(
     val = msg.get(key)
     if not isinstance(val, dict):
         return None
-    return {k: v for k, v in val.items() if isinstance(k, str) and isinstance(v, (bool, str))}
+    return {k: v for k, v in val.items() if isinstance(k, str) and is_harness_availability(v)}
 
 
 def _optional_nullable_str(msg: dict[str, Any], key: str) -> str | None:

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -38,6 +38,7 @@ class HostFrameKind(str, Enum):
     """All host frame kinds; the value is the JSON wire string."""
 
     HELLO = "host.hello"
+    HARNESS_READINESS = "host.harness_readiness"
     LAUNCH_RUNNER = "host.launch_runner"
     LAUNCH_RUNNER_RESULT = "host.launch_runner_result"
     STOP_RUNNER = "host.stop_runner"
@@ -81,8 +82,8 @@ class HostHelloFrame:
         (see ``omnigent.onboarding.harness_readiness``). Keys
         cover every accepted harness spelling. ``None`` means
         unknown (an older host that doesn't report it) — never
-        treat ``None`` as "nothing is configured". Recomputed on
-        each (re)connect; the launch-time check is authoritative.
+        treat ``None`` as "nothing is configured". Refreshed while
+        connected; the launch-time check is authoritative.
     """
 
     version: str
@@ -92,6 +93,17 @@ class HostHelloFrame:
     configured_harnesses: dict[str, HarnessAvailability] | None = None
     telemetry_opt_out: bool = False
     installation_id: str | None = None
+
+
+@dataclass
+class HostHarnessReadinessFrame:
+    """Host's refreshed per-harness readiness while the tunnel stays open.
+
+    :param configured_harnesses: Current launch readiness keyed by every
+        accepted harness spelling. Sent only when the map changes.
+    """
+
+    configured_harnesses: dict[str, HarnessAvailability]
 
 
 @dataclass
@@ -621,6 +633,7 @@ class HostFsResultFrame:
 
 HostFrame = (
     HostHelloFrame
+    | HostHarnessReadinessFrame
     | HostLaunchRunnerFrame
     | HostLaunchRunnerResultFrame
     | HostStopRunnerFrame
@@ -690,6 +703,13 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "configured_harnesses": frame.configured_harnesses,
                 "telemetry_opt_out": frame.telemetry_opt_out,
                 "installation_id": frame.installation_id,
+            }
+        )
+    if isinstance(frame, HostHarnessReadinessFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.HARNESS_READINESS.value,
+                "configured_harnesses": frame.configured_harnesses,
             }
         )
     if isinstance(frame, HostLaunchRunnerFrame):
@@ -967,6 +987,8 @@ def _decode_known_host_frame(
     match kind:
         case HostFrameKind.HELLO:
             return _decode_host_hello(msg)
+        case HostFrameKind.HARNESS_READINESS:
+            return _decode_harness_readiness(msg)
         case HostFrameKind.LAUNCH_RUNNER:
             return _decode_launch_runner(msg)
         case HostFrameKind.LAUNCH_RUNNER_RESULT:
@@ -1027,6 +1049,14 @@ def _decode_host_hello(msg: dict[str, Any]) -> HostHelloFrame:
         telemetry_opt_out=bool(msg.get("telemetry_opt_out", False)),
         installation_id=_optional_nullable_str(msg, "installation_id"),
     )
+
+
+def _decode_harness_readiness(msg: dict[str, Any]) -> HostHarnessReadinessFrame:
+    """Decode a live harness-readiness refresh frame."""
+    configured_harnesses = _optional_str_availability_map(msg, "configured_harnesses")
+    if configured_harnesses is None:
+        raise ValueError("harness readiness frame requires a configured_harnesses object")
+    return HostHarnessReadinessFrame(configured_harnesses=configured_harnesses)
 
 
 def _decode_launch_runner(msg: dict[str, Any]) -> HostLaunchRunnerFrame:

--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import re
 
 from omnigent.harness_aliases import canonicalize_harness, is_native_harness
+from omnigent.harness_availability import CODEX_CANONICAL_HARNESSES
 from omnigent.harness_plugins import model_env_keys
 
 # Generous-but-safe upper bound; real ids ("databricks-claude-opus-4-8",
@@ -74,15 +75,14 @@ def validate_model_override(value: str) -> str:
 _CLAUDE_FAMILY_HARNESSES: frozenset[str] = frozenset(
     {"claude-native", "native-claude", "claude-sdk", "claude_sdk"}
 )
-# codex stays single-vendor (GPT-only): the Databricks gateway only serves
+# CODEX_CANONICAL_HARNESSES stays single-vendor (GPT-only): the gateway serves
 # codex over the Anthropic-incompatible Responses wire, and codex >= 0.137
 # dropped the chat/completions wire that was the only path to Claude — so a
 # codex x Claude dispatch is genuinely broken and must fail loud here.
 # openai-agents (and its "openai-agents-sdk" / "agents_sdk" spellings) is
-# intentionally NOT in this set: a live SDK probe completed a Claude
+# intentionally not included: a live SDK probe completed a Claude
 # tool-calling turn on the gateway over the chat wire, so the harness is
 # multi-model like pi and accepts any validated id (no family rejection).
-_CODEX_FAMILY_HARNESSES: frozenset[str] = frozenset({"codex", "codex-native", "native-codex"})
 # antigravity is Gemini-native: it authenticates a direct Gemini API key /
 # Vertex AI and has no Databricks/gateway path (see _build_antigravity_spawn_env
 # in omnigent/runtime/workflow.py). So unlike the single-vendor harnesses above,
@@ -139,7 +139,7 @@ def model_family_mismatch(harness: str, model: str) -> str | None:
             f"'claude'); got {model!r}. Use the codex worker for GPT models "
             "or the pi / openai-agents worker for any other gateway model."
         )
-    if canon in _CODEX_FAMILY_HARNESSES and not is_gpt:
+    if canon in CODEX_CANONICAL_HARNESSES and not is_gpt:
         return (
             f"harness {canon!r} only runs GPT models (id containing 'gpt' "
             f"or 'codex'); got {model!r}. Use the claude_code worker for "

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -1,9 +1,9 @@
 """Harness readiness checks used by the host daemon.
 
-The daemon reports a per-harness readiness map in its hello frame (so the
-web agent picker can warn) and re-checks the session's harness before
-spawning a runner (so an unconfigured launch fails with a clear,
-actionable error instead of dying inside the executor).
+The daemon reports a per-harness readiness map in its hello frame, refreshes
+it while connected (so the web agent picker can warn accurately), and
+re-checks the session's harness before spawning a runner (so an unconfigured
+launch fails clearly instead of dying inside the executor).
 
 "Configured" here is deliberately narrow: the **only** thing the daemon
 can reliably determine locally is whether a harness's wrapped CLI binary
@@ -331,6 +331,16 @@ def configured_harness_map() -> dict[str, HarnessAvailability]:
     spellings.add(GOOSE_KEY)  # headless Goose (``goose acp``) gates on the goose binary
     spellings.add(HERMES_KEY)  # Hermes Agent wraps the ``hermes`` CLI
     spellings.add(COPILOT_KEY)
-    return {
-        spelling: _harness_availability(_canonical_harness(spelling)) for spelling in spellings
-    }
+    availability_cache: dict[tuple[str, ...], HarnessAvailability] = {}
+    result: dict[str, HarnessAvailability] = {}
+    for spelling in spellings:
+        canonical = _canonical_harness(spelling)
+        cache_key = (
+            ("codex",)
+            if canonical in {"codex", "codex-native", "native-codex"}
+            else ("harness", canonical)
+        )
+        if cache_key not in availability_cache:
+            availability_cache[cache_key] = _harness_availability(canonical)
+        result[spelling] = availability_cache[cache_key]
+    return result

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -30,6 +30,10 @@ from collections.abc import Callable
 
 import omnigent.onboarding.gemini_auth as _gemini_auth
 from omnigent.harness_aliases import HARNESS_ALIASES, canonicalize_harness
+from omnigent.harness_availability import (
+    CODEX_CANONICAL_HARNESSES,
+    HarnessAvailability,
+)
 from omnigent.harness_plugins import harness_install_keys, valid_harnesses
 from omnigent.onboarding.harness_install import (
     COPILOT_KEY,
@@ -51,8 +55,6 @@ from omnigent.onboarding.provider_config import (
     OPENAI_FAMILY,
     PI_SURFACE,
 )
-
-HarnessAvailability = bool | str
 
 # In-process SDK harnesses: no CLI binary, credentials resolved at runtime
 # from ambient/spec sources the daemon can't see. Never gated. Includes both
@@ -289,14 +291,18 @@ def harness_is_configured(harness: str) -> bool:
 
 def _harness_availability(canonical: str) -> HarnessAvailability:
     """Return picker-facing availability for one canonical harness spelling."""
-    if (
-        canonical in {"codex", "codex-native", "native-codex"}
-        and _HARNESS_FAMILY.get(canonical) == OPENAI_FAMILY
-    ):
+    if _is_codex_family_harness(canonical):
         from omnigent.codex_native import _codex_auth_unavailable_reason
 
         return _codex_auth_unavailable_reason() or True
     return harness_is_configured(canonical)
+
+
+def _is_codex_family_harness(canonical: str) -> bool:
+    """Return whether a canonical harness uses Codex readiness semantics."""
+    return (
+        canonical in CODEX_CANONICAL_HARNESSES and _HARNESS_FAMILY.get(canonical) == OPENAI_FAMILY
+    )
 
 
 def configured_harness_map() -> dict[str, HarnessAvailability]:
@@ -335,11 +341,7 @@ def configured_harness_map() -> dict[str, HarnessAvailability]:
     result: dict[str, HarnessAvailability] = {}
     for spelling in spellings:
         canonical = _canonical_harness(spelling)
-        cache_key = (
-            ("codex",)
-            if canonical in {"codex", "codex-native", "native-codex"}
-            else ("harness", canonical)
-        )
+        cache_key = ("codex",) if _is_codex_family_harness(canonical) else ("harness", canonical)
         if cache_key not in availability_cache:
             availability_cache[cache_key] = _harness_availability(canonical)
         result[spelling] = availability_cache[cache_key]

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2503,10 +2503,7 @@ def create_app(
         from omnigent.server.routes.host_tunnel import create_host_tunnel_router
         from omnigent.server.routes.hosts import create_hosts_router
 
-        async def _on_host_connect(_host_id: str, owner: str | None) -> None:
-            announce_hosts_changed(owner)
-
-        async def _on_host_disconnect(_host_id: str, owner: str | None) -> None:
+        async def _on_hosts_changed(_host_id: str, owner: str | None) -> None:
             announce_hosts_changed(owner)
 
         app.include_router(
@@ -2516,8 +2513,9 @@ def create_app(
                 auth_provider=auth_provider,
                 runner_exit_reports=runner_exit_reports,
                 on_runner_exited=_on_runner_exited,
-                on_host_connect=_on_host_connect,
-                on_host_disconnect=_on_host_disconnect,
+                on_host_connect=_on_hosts_changed,
+                on_host_disconnect=_on_hosts_changed,
+                on_host_update=_on_hosts_changed,
             ),
             prefix="/v1",
             tags=["hosts"],

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -5,11 +5,10 @@ outbound WebSocket. The server sends control frames
 (launch/stop runner) over the tunnel; the host process spawns
 or terminates runner subprocesses accordingly.
 
-Per ``designs/DAEMON_API.md``, the host sends a ``host.hello``
-frame on connect advertising its version, name, and live runner
-IDs, then reports readiness changes while connected. The server
-validates ``frame_protocol_version`` for version-skew enforcement
-(strict-major).
+The host sends a ``host.hello`` frame on connect advertising its
+version, name, live runner IDs, and harness readiness, then reports
+readiness changes while connected. The server validates
+``frame_protocol_version`` for version-skew enforcement (strict-major).
 
 The endpoint registers the host in the :class:`HostRegistry`
 (in-memory, per-replica) and upserts the host in the ``hosts``
@@ -106,7 +105,7 @@ def create_host_tunnel_router(
     :param on_host_disconnect: Optional async callback fired when
         a host's tunnel closes. Receives the ``host_id``.
     :param on_host_update: Optional async callback fired when a connected
-        host reports changed harness readiness. Receives the ``host_id``.
+        host reports changed harness readiness. Receives ``host_id`` and owner.
     :param local_single_user: When ``True``, allow a host to re-own a
         ``host_id`` already registered under a different owner — needed
         only for the single-user loopback local server, where the owner

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -7,8 +7,9 @@ or terminates runner subprocesses accordingly.
 
 Per ``designs/DAEMON_API.md``, the host sends a ``host.hello``
 frame on connect advertising its version, name, and live runner
-IDs. The server validates ``frame_protocol_version`` for
-version-skew enforcement (strict-major).
+IDs, then reports readiness changes while connected. The server
+validates ``frame_protocol_version`` for version-skew enforcement
+(strict-major).
 
 The endpoint registers the host in the :class:`HostRegistry`
 (in-memory, per-replica) and upserts the host in the ``hosts``
@@ -30,6 +31,7 @@ from omnigent.host.frames import (
     HostCreateDirResultFrame,
     HostCreateWorktreeResultFrame,
     HostFsResultFrame,
+    HostHarnessReadinessFrame,
     HostHelloFrame,
     HostLaunchRunnerResultFrame,
     HostListDirResultFrame,
@@ -70,6 +72,7 @@ def create_host_tunnel_router(
     auth_provider: AuthProvider | None = None,
     on_host_connect: Callable[[str, str | None], Awaitable[None]] | None = None,
     on_host_disconnect: Callable[[str, str | None], Awaitable[None]] | None = None,
+    on_host_update: Callable[[str, str | None], Awaitable[None]] | None = None,
     on_runner_exited: Callable[[str, str], Awaitable[None]] | None = None,
     local_single_user: bool | None = None,
     runner_exit_reports: RunnerExitReports | None = None,
@@ -102,6 +105,8 @@ def create_host_tunnel_router(
         runner-tunnel ``on_runner_disconnect`` path never fires).
     :param on_host_disconnect: Optional async callback fired when
         a host's tunnel closes. Receives the ``host_id``.
+    :param on_host_update: Optional async callback fired when a connected
+        host reports changed harness readiness. Receives the ``host_id``.
     :param local_single_user: When ``True``, allow a host to re-own a
         ``host_id`` already registered under a different owner — needed
         only for the single-user loopback local server, where the owner
@@ -268,7 +273,15 @@ def create_host_tunnel_router(
                 name=f"host-ping:{host_id}",
             )
             receive_task = asyncio.create_task(
-                _receive_loop(ws, conn, host_id, runner_exit_reports, on_runner_exited),
+                _receive_loop(
+                    ws,
+                    conn,
+                    host_id,
+                    host_store,
+                    runner_exit_reports,
+                    on_runner_exited,
+                    on_host_update,
+                ),
                 name=f"host-receive:{host_id}",
             )
 
@@ -384,18 +397,23 @@ async def _receive_loop(
     ws: WebSocket,
     conn: HostConnection,
     host_id: str,
+    host_store: HostStore,
     runner_exit_reports: RunnerExitReports | None,
     on_runner_exited: Callable[[str, str], Awaitable[None]] | None,
+    on_host_update: Callable[[str, str | None], Awaitable[None]] | None,
 ) -> None:
     """Receive host frames and route results to pending futures.
 
     :param ws: Accepted Starlette WebSocket.
     :param conn: Host connection for resolving pending requests.
     :param host_id: Host id for logging.
+    :param host_store: Persistent store receiving live readiness updates.
     :param runner_exit_reports: Store for ``host.runner_exited``
         reports; ``None`` drops them.
     :param on_runner_exited: Callback fired with ``(runner_id, error)``
         when a ``host.runner_exited`` frame arrives; ``None`` skips it.
+    :param on_host_update: Callback fired after readiness changes persist;
+        ``None`` skips it.
     """
     while True:
         message = await ws.receive()
@@ -442,6 +460,20 @@ async def _receive_loop(
                 host_id,
                 type(runner_frame).__name__,
             )
+            continue
+
+        if isinstance(frame, HostHarnessReadinessFrame):
+            await asyncio.to_thread(
+                host_store.update_harness_readiness,
+                host_id,
+                frame.configured_harnesses,
+            )
+            conn.hello.configured_harnesses = dict(frame.configured_harnesses)
+            if on_host_update is not None:
+                try:
+                    await on_host_update(host_id, conn.owner)
+                except Exception:
+                    _logger.exception("on_host_update callback failed for %s", host_id)
             continue
 
         if isinstance(frame, HostLaunchRunnerResultFrame):

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -28,6 +28,7 @@ from omnigent.db.db_models import (
 )
 from omnigent.db.enum_codecs import decode_host_status, encode_host_status
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker, now_epoch
+from omnigent.harness_availability import HarnessAvailability, is_harness_availability
 
 # A host is considered live only if its row was touched (connect or
 # heartbeat) within this window. The host tunnel's ping loop writes a
@@ -39,7 +40,6 @@ from omnigent.db.utils import get_or_create_engine, make_managed_session_maker, 
 # (PING_INTERVAL_S * PING_MISS_THRESHOLD) so a healthy host that is
 # still heart-beating is never falsely aged out.
 HOST_LIVENESS_TTL_S = 90
-HarnessAvailability = bool | str
 
 
 @dataclass
@@ -114,7 +114,7 @@ def _parse_configured_harnesses(raw: str | None) -> dict[str, HarnessAvailabilit
     Tolerant: ``NULL``, malformed JSON, or a non-object payload all
     map to ``None`` ("unknown") — a corrupt column value must degrade
     to no-warning in the UI, never break host listing. Entries with a
-    non-bool/string value are dropped for the same reason.
+    unsupported readiness value are dropped for the same reason.
 
     :param raw: The raw column value, e.g.
         ``'{"claude-sdk": true, "codex": false}'`` or ``None``.
@@ -129,7 +129,7 @@ def _parse_configured_harnesses(raw: str | None) -> dict[str, HarnessAvailabilit
         return None
     if not isinstance(parsed, dict):
         return None
-    return {k: v for k, v in parsed.items() if isinstance(k, str) and isinstance(v, (bool, str))}
+    return {k: v for k, v in parsed.items() if isinstance(k, str) and is_harness_availability(v)}
 
 
 def _row_to_host(row: SqlHost) -> Host:

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -491,6 +491,29 @@ class HostStore:
                 row.status = encode_host_status("offline")
                 row.updated_at = now_epoch()
 
+    def update_harness_readiness(
+        self,
+        host_id: str,
+        configured_harnesses: dict[str, HarnessAvailability],
+    ) -> None:
+        """Replace a connected host's live per-harness readiness map.
+
+        :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
+        :param configured_harnesses: Current readiness keyed by harness spelling.
+        """
+        with self._session() as session:
+            session.execute(
+                update(SqlHost)
+                .where(
+                    SqlHost.workspace_id == current_workspace_id(),
+                    SqlHost.host_id == host_id,
+                )
+                .values(
+                    configured_harnesses=json.dumps(configured_harnesses),
+                    updated_at=now_epoch(),
+                )
+            )
+
     def heartbeat(self, host_id: str) -> None:
         """
         Refresh a host's last-seen timestamp while its tunnel is alive.

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -513,6 +513,54 @@ async def test_live_host_refreshes_harness_readiness_without_reconnect(
     assert refresh.configured_harnesses == {"pi": True}
 
 
+async def test_live_host_full_refresh_detects_auth_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full-refresh fallback catches readiness changes beyond binary installs."""
+    readiness = iter(({"codex": "needs-auth"}, {"codex": True}))
+    monkeypatch.setattr(
+        "omnigent.host.connect.configured_harness_map",
+        lambda: next(readiness),
+    )
+    monkeypatch.setattr(
+        "omnigent.host.connect.HARNESS_READINESS_FULL_REFRESH_INTERVAL_S",
+        0.01,
+    )
+    host = _make_host_process()
+    tunnel = _ReadinessChangingTunnel()
+
+    with pytest.raises(ConnectionError, match="test disconnect"):
+        await host._serve_frames(tunnel)  # type: ignore[arg-type] — duck-typed ws
+
+    assert len(tunnel.sent) == 2
+    refresh = decode_host_frame(tunnel.sent[1])
+    assert isinstance(refresh, HostHarnessReadinessFrame)
+    assert refresh.configured_harnesses == {"codex": True}
+
+
+async def test_live_host_does_not_repeat_unchanged_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A periodic full refresh sends nothing when the readiness map is unchanged."""
+    readiness = iter(({"codex": "needs-auth"}, {"codex": "needs-auth"}))
+    monkeypatch.setattr(
+        "omnigent.host.connect.configured_harness_map",
+        lambda: next(readiness),
+    )
+    monkeypatch.setattr(
+        "omnigent.host.connect.HARNESS_READINESS_FULL_REFRESH_INTERVAL_S",
+        0.01,
+    )
+    host = _make_host_process()
+    tunnel = _ReadinessChangingTunnel()
+
+    with pytest.raises(ConnectionError, match="test disconnect"):
+        await host._serve_frames(tunnel)  # type: ignore[arg-type] — duck-typed ws
+
+    assert len(tunnel.sent) == 1
+    assert isinstance(decode_host_frame(tunnel.sent[0]), HostHelloFrame)
+
+
 async def test_handle_launch_immediate_exit_reports_exit_code_and_log_tail(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -25,6 +25,7 @@ from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
     HostCreateDirFrame,
     HostCreateDirResultFrame,
+    HostHarnessReadinessFrame,
     HostHelloFrame,
     HostLaunchRunnerFrame,
     HostLaunchRunnerResultFrame,
@@ -462,6 +463,54 @@ class _FakeTunnel:
         :raises ConnectionError: Always — ends the serve loop.
         """
         raise ConnectionError("test disconnect")
+
+
+class _ReadinessChangingTunnel(_FakeTunnel):
+    """Trigger one idle refresh before disconnecting the fake tunnel."""
+
+    def __init__(self) -> None:
+        """Initialize the frame log and receive counter."""
+        super().__init__()
+        self.recv_count = 0
+
+    async def recv(self) -> str:
+        """Simulate one idle interval followed by a disconnect."""
+        self.recv_count += 1
+        if self.recv_count == 1:
+            await asyncio.Future()
+        raise ConnectionError("test disconnect")
+
+
+async def test_live_host_refreshes_harness_readiness_without_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A setup completed after connect must replace the advertised readiness."""
+    readiness = iter(({"pi": False}, {"pi": True}))
+    monkeypatch.setattr(
+        "omnigent.host.connect.configured_harness_map",
+        lambda: next(readiness),
+    )
+    monkeypatch.setattr(
+        "omnigent.host.connect.harness_is_configured",
+        lambda harness: harness == "pi",
+    )
+    monkeypatch.setattr(
+        "omnigent.host.connect.HARNESS_READINESS_REFRESH_INTERVAL_S",
+        0.01,
+    )
+    host = _make_host_process()
+    tunnel = _ReadinessChangingTunnel()
+
+    with pytest.raises(ConnectionError, match="test disconnect"):
+        await host._serve_frames(tunnel)  # type: ignore[arg-type] — duck-typed ws
+
+    assert len(tunnel.sent) == 2
+    hello = decode_host_frame(tunnel.sent[0])
+    refresh = decode_host_frame(tunnel.sent[1])
+    assert isinstance(hello, HostHelloFrame)
+    assert hello.configured_harnesses == {"pi": False}
+    assert isinstance(refresh, HostHarnessReadinessFrame)
+    assert refresh.configured_harnesses == {"pi": True}
 
 
 async def test_handle_launch_immediate_exit_reports_exit_code_and_log_tail(

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -14,6 +14,7 @@ from omnigent.host.frames import (
     HostCreateWorktreeResultFrame,
     HostFsRequestFrame,
     HostFsResultFrame,
+    HostHarnessReadinessFrame,
     HostHelloFrame,
     HostLaunchRunnerFrame,
     HostLaunchRunnerResultFrame,
@@ -194,6 +195,16 @@ def test_hello_frame_configured_harnesses_round_trip() -> None:
     # Exact map equality: both the True and the False must survive —
     # False is the actionable "warn the user" value.
     assert decoded.configured_harnesses == {"claude-sdk": True, "codex": "needs-auth"}
+
+
+def test_harness_readiness_frame_round_trip() -> None:
+    """Verify a live readiness refresh survives encode and decode."""
+    original = HostHarnessReadinessFrame(
+        configured_harnesses={"pi": True, "codex": "needs-auth"},
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostHarnessReadinessFrame)
+    assert decoded.configured_harnesses == {"pi": True, "codex": "needs-auth"}
 
 
 def test_hello_frame_legacy_payload_decodes_unknown_harnesses() -> None:

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -207,6 +207,48 @@ def test_harness_readiness_frame_round_trip() -> None:
     assert decoded.configured_harnesses == {"pi": True, "codex": "needs-auth"}
 
 
+def test_harness_readiness_frame_rejects_unknown_availability() -> None:
+    """Unknown readiness states cannot partially replace the live map."""
+    encoded = json.dumps(
+        {
+            "kind": "host.harness_readiness",
+            "configured_harnesses": {
+                "pi": "future-state",
+                "codex": "needs-auth",
+            },
+        }
+    )
+
+    with pytest.raises(ValueError, match="unsupported availability state"):
+        decode_host_frame(encoded)
+
+
+def test_harness_readiness_frame_requires_object_map() -> None:
+    """A malformed live refresh is rejected instead of clearing known readiness."""
+    encoded = json.dumps(
+        {
+            "kind": "host.harness_readiness",
+            "configured_harnesses": ["pi"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="requires a configured_harnesses object"):
+        decode_host_frame(encoded)
+
+
+def test_harness_readiness_frame_rejects_empty_map() -> None:
+    """An empty refresh cannot erase the host's last complete readiness map."""
+    encoded = json.dumps(
+        {
+            "kind": "host.harness_readiness",
+            "configured_harnesses": {},
+        }
+    )
+
+    with pytest.raises(ValueError, match="requires a non-empty configured_harnesses map"):
+        decode_host_frame(encoded)
+
+
 def test_hello_frame_legacy_payload_decodes_unknown_harnesses() -> None:
     """
     Verify a hello payload from an OLDER host (no configured_harnesses

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -284,6 +284,30 @@ def test_configured_harness_map_all_true_with_clis(
     assert all(result.values())
 
 
+def test_configured_harness_map_probes_codex_readiness_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex aliases share one potentially expensive readiness probe."""
+    calls = 0
+
+    def _codex_reason() -> str:
+        nonlocal calls
+        calls += 1
+        return "needs-auth"
+
+    monkeypatch.setattr(
+        "omnigent.codex_native._codex_auth_unavailable_reason",
+        _codex_reason,
+    )
+
+    result = configured_harness_map()
+
+    assert calls == 1
+    assert result["codex"] == "needs-auth"
+    assert result["codex-native"] == "needs-auth"
+    assert result["native-codex"] == "needs-auth"
+
+
 def test_kimi_readiness_keys_off_binary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/server/integration/test_host_tunnel_route.py
+++ b/tests/server/integration/test_host_tunnel_route.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from omnigent.db.db_models import SqlHost
 from omnigent.db.utils import get_or_create_engine, now_epoch
 from omnigent.host.frames import (
+    HostHarnessReadinessFrame,
     HostHelloFrame,
     HostLaunchRunnerResultFrame,
     encode_host_frame,
@@ -302,6 +303,66 @@ async def test_host_tunnel_upserts_db_on_connect(
     assert host is not None, "Host row should exist in DB after tunnel connect"
     assert host.name == "test-laptop"
     assert host.status == "online"
+
+
+async def test_host_tunnel_refreshes_harness_readiness_without_reconnect(
+    db_uri: str,
+) -> None:
+    """A live host readiness update must replace the stale setup warning state."""
+    registry = HostRegistry()
+    store = HostStore(db_uri)
+    updates: list[str] = []
+
+    async def _on_host_update(host_id: str, _owner: str | None) -> None:
+        updates.append(host_id)
+
+    app = FastAPI()
+    app.include_router(
+        create_host_tunnel_router(
+            registry,
+            store,
+            on_host_update=_on_host_update,
+        ),
+        prefix="/v1",
+    )
+    comm = await _connect_route(app, _TUNNEL_PATH)
+    await comm.send_input(
+        {
+            "type": "websocket.receive",
+            "text": encode_host_frame(
+                HostHelloFrame(
+                    version="0.1.0-test",
+                    frame_protocol_version=1,
+                    name="test-laptop",
+                    configured_harnesses={"pi": False},
+                )
+            ),
+        }
+    )
+    await asyncio.wait_for(_wait_registered(registry, _HOST_ID), timeout=2.0)
+
+    await comm.send_input(
+        {
+            "type": "websocket.receive",
+            "text": encode_host_frame(
+                HostHarnessReadinessFrame(configured_harnesses={"pi": True})
+            ),
+        }
+    )
+
+    async def _wait_until_ready() -> None:
+        while True:
+            host = store.get_host(_HOST_ID)
+            if host is not None and host.configured_harnesses == {"pi": True}:
+                return
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(_wait_until_ready(), timeout=0.5)
+
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+    assert conn.hello.configured_harnesses == {"pi": True}
+    assert updates == [_HOST_ID]
 
 
 async def test_host_tunnel_sets_offline_on_disconnect(

--- a/tests/stores/test_host_store.py
+++ b/tests/stores/test_host_store.py
@@ -162,6 +162,24 @@ def test_upsert_reconnect_overwrites_and_nulls_configured_harnesses(
     assert fetched.configured_harnesses is None
 
 
+def test_update_harness_readiness_replaces_live_map(host_store: HostStore) -> None:
+    """A live tunnel refresh replaces readiness without reconnecting."""
+    host_id = "6d86ee544f1d5b7068ac56f5927a5b5c"
+    host_store.upsert_on_connect(
+        host_id=host_id,
+        name="laptop-live",
+        owner="alice@example.com",
+        configured_harnesses={"pi": False},
+    )
+
+    host_store.update_harness_readiness(host_id, {"pi": True})
+
+    fetched = host_store.get_host(host_id)
+    assert fetched is not None
+    assert fetched.configured_harnesses == {"pi": True}
+    assert fetched.status == "online"
+
+
 def test_malformed_configured_harnesses_column_reads_as_none(
     host_store: HostStore,
     db_uri: str,

--- a/tests/stores/test_host_store.py
+++ b/tests/stores/test_host_store.py
@@ -211,6 +211,33 @@ def test_malformed_configured_harnesses_column_reads_as_none(
     assert fetched.configured_harnesses is None
 
 
+def test_host_store_drops_unknown_harness_availability(
+    host_store: HostStore,
+    db_uri: str,
+) -> None:
+    """Persisted readiness maps retain only states supported by the wire contract."""
+    host_id = "7c1e25b5bfa49cb0cfb4fb1ed86333fb"
+    host_store.upsert_on_connect(
+        host_id=host_id,
+        name="laptop-readiness",
+        owner="alice@example.com",
+        configured_harnesses={"codex": "needs-auth"},
+    )
+    engine = get_or_create_engine(db_uri)
+    with Session(engine) as session:
+        session.execute(
+            update(SqlHost)
+            .where(SqlHost.host_id == host_id)
+            .values(configured_harnesses='{"codex":"needs-auth","pi":"future-state"}')
+        )
+        session.commit()
+
+    fetched = host_store.get_host(host_id)
+
+    assert fetched is not None
+    assert fetched.configured_harnesses == {"codex": "needs-auth"}
+
+
 def test_reconnect_with_rotated_host_id_repoints_bound_conversations(
     host_store: HostStore,
     db_uri: str,

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -60,9 +60,9 @@ def _point_codex_auth_check_at(
         lambda: codex_native._CodexAuthSource(auth_path=auth_path),
     )
     monkeypatch.setattr(
-        codex_native.shutil,
-        "which",
-        lambda name: f"/tmp/{name}" if binary_present else None,
+        codex_native,
+        "_find_codex_cli",
+        lambda: "/tmp/codex" if binary_present else None,
     )
 
 

--- a/tests/test_harness_capabilities.py
+++ b/tests/test_harness_capabilities.py
@@ -10,6 +10,7 @@ drift.
 from __future__ import annotations
 
 from omnigent import harness_plugins as hp
+from omnigent.harness_availability import CODEX_CANONICAL_HARNESSES
 from omnigent.harness_capabilities import (
     AuthModel,
     EffortFamily,
@@ -29,7 +30,6 @@ from omnigent.harness_plugins import (
 from omnigent.model_override import (
     _ANTIGRAVITY_FAMILY_HARNESSES,
     _CLAUDE_FAMILY_HARNESSES,
-    _CODEX_FAMILY_HARNESSES,
 )
 
 _NATIVE_MODES = frozenset({IntegrationMode.NATIVE_TUI, IntegrationMode.NATIVE_SERVER})
@@ -61,7 +61,7 @@ def test_model_family_matches_model_override_sets() -> None:
         family = capability.model_family
         if harness in _CLAUDE_FAMILY_HARNESSES:
             assert family is ModelFamily.CLAUDE, harness
-        elif harness in _CODEX_FAMILY_HARNESSES:
+        elif harness in CODEX_CANONICAL_HARNESSES:
             assert family is ModelFamily.GPT, harness
         elif harness in _ANTIGRAVITY_FAMILY_HARNESSES:
             assert family is ModelFamily.GEMINI, harness


### PR DESCRIPTION
## Related issue

N/A

## Summary

Harness readiness was captured only when a host tunnel connected, so installing or configuring Pi while the daemon stayed online left both the web UI and desktop app showing a stale “isn't configured” warning. This keeps the launch-time check authoritative while adding lightweight, change-only readiness refreshes over the existing host tunnel.

- Recheck previously unavailable CLI-backed harnesses every five seconds and perform a full refresh only after a detected change or once per minute.
- Persist live readiness updates on the server and publish `hosts_changed` so both clients invalidate their shared host query immediately.
- Centralize the closed readiness states and Codex aliases, reject unsupported or empty live maps, and share the potentially expensive Codex probe across aliases.

**ELI5:** The host used to tell the UI which tools were installed only when it first connected. It now sends another note when that answer changes, so the warning disappears without restarting anything.

```text
omnigent setup
      |
      v
host detects readiness change
      |
      v
host.harness_readiness -> server store -> hosts_changed
                                           |
                                           v
                                  web + desktop refresh
```

## Test Plan

- [x] Added regression coverage for Pi changing from unavailable to ready without reconnecting the host tunnel.
- [x] Ran 217 tests across host connection/frames, readiness, host tunnel integration, and host store modules.
- [x] Ran 9 Codex readiness tests and 124 model/capability/plugin tests.
- [x] Ran 7 server app integration tests, including host route wiring.
- [x] Ran Ruff formatting/lint, repository test-quality lint, and `git diff --check` on the changed files.

## Demo

N/A — this is a host/server state propagation fix with no visual layout change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage exercises the readiness transition from daemon emission through server persistence and client invalidation callback wiring.

## Changelog

Harness setup warnings now clear automatically without reconnecting the host.
