### PR TITLE
feat(android): floating server switcher pill with dropdown menu

### DIFF
--- a/web/android/.gitignore
+++ b/web/android/.gitignore
@@ -11,3 +11,7 @@
 *.aab
 *.keystore
 !debug.keystore
+*.jks
+keystore.properties
+# Google Play service-account key for Gradle Play Publisher — secret.
+play-credentials.json

--- a/web/android/README.md
+++ b/web/android/README.md
@@ -65,10 +65,60 @@ when the bridge methods are absent, so the Android shell omits them for now:
 
 ## Distribution
 
-Gradle assembles a release APK/AAB; `fastlane` (Android) automates signing and
-upload. Google Play restricts "WebView of a website" apps, so the initial
-channel is direct APK / F-Droid; a user-configured server client is a stronger
-Play case but review is unpredictable for this category.
+Gradle assembles a release APK/AAB. Google Play restricts "WebView of a
+website" apps, so the initial channel is direct APK / F-Droid; a
+user-configured server client is a stronger Play case but review is
+unpredictable for this category.
+
+### Release signing
+
+`bundleRelease` signs the artifact when signing credentials are available;
+without them the release build is left unsigned so debug builds still work.
+Credentials come from either a gitignored `keystore.properties` (copy
+`keystore.properties.example`) or, for CI, these environment variables:
+
+- `OMNIGENT_KEYSTORE_FILE` — path to the upload keystore
+- `OMNIGENT_KEYSTORE_PASSWORD`
+- `OMNIGENT_KEY_ALIAS`
+- `OMNIGENT_KEY_PASSWORD`
+
+Create the upload keystore once and back it up (Play App Signing then manages
+the app signing key):
+
+```sh
+keytool -genkeypair -v -keystore omnigent-upload.jks \
+  -keyalg RSA -keysize 2048 -validity 10000 -alias omnigent-upload
+```
+
+Build the Play-ready App Bundle (Play requires an `.aab`, not an APK); bump
+`versionCode` in `app/build.gradle.kts` before each upload:
+
+```sh
+./gradlew bundleRelease   # → app/build/outputs/bundle/release/app-release.aab
+```
+
+### Automated publishing (Gradle Play Publisher)
+
+After the first release is uploaded manually (Google blocks the Play API until
+an app has one human upload), `./gradlew publishReleaseBundle` builds the signed
+AAB and uploads it to the **internal** track. It needs a Google Play
+service-account key:
+
+1. In Google Cloud, create a service account and a JSON key.
+2. In Play Console → _Users & permissions_, invite that service account and
+   grant it release permissions.
+3. Point `PLAY_SERVICE_ACCOUNT_JSON` at the JSON, or drop it at
+   `web/android/play-credentials.json` (both gitignored).
+
+```sh
+export PLAY_SERVICE_ACCOUNT_JSON=/path/to/play-credentials.json
+./gradlew publishReleaseBundle   # signs + uploads to the internal track
+```
+
+The publish tasks are inert when no credentials file is present, so ordinary
+builds are unaffected. Bump `versionCode` before each publish (Play rejects a
+reused code). Change the target track via `track.set(...)` in
+`app/build.gradle.kts` (`internal` → `alpha` → `beta` → `production`).
 
 > Status: builds clean — `gradlew :app:assembleDebug :app:lintDebug` produces a
 > debug APK with 0 lint errors (JDK 17, Gradle 8.9 wrapper, `compileSdk 35`).

--- a/web/android/app/build.gradle.kts
+++ b/web/android/app/build.gradle.kts
@@ -1,7 +1,26 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.play.publisher)
 }
+
+// Release signing credentials come from a gitignored keystore.properties (local
+// dev) or, failing that, environment variables (CI). Absent both, the release
+// signing config is skipped so debug builds still work without the keystore.
+val keystorePropsFile = rootProject.file("keystore.properties")
+val keystoreProps =
+    Properties().apply {
+        if (keystorePropsFile.exists()) keystorePropsFile.inputStream().use { load(it) }
+    }
+
+fun signingValue(
+    propKey: String,
+    envKey: String,
+): String? = keystoreProps.getProperty(propKey) ?: System.getenv(envKey)
+
+val storeFilePath = signingValue("storeFile", "OMNIGENT_KEYSTORE_FILE")
 
 android {
     namespace = "ai.omnigent.android"
@@ -11,12 +30,24 @@ android {
         applicationId = "ai.omnigent.android"
         minSdk = 28
         targetSdk = 35
-        versionCode = 1
+        versionCode = 2
         versionName = "0.1.0"
+    }
+
+    signingConfigs {
+        if (storeFilePath != null) {
+            create("release") {
+                storeFile = file(storeFilePath)
+                storePassword = signingValue("storePassword", "OMNIGENT_KEYSTORE_PASSWORD")
+                keyAlias = signingValue("keyAlias", "OMNIGENT_KEY_ALIAS")
+                keyPassword = signingValue("keyPassword", "OMNIGENT_KEY_PASSWORD")
+            }
+        }
     }
 
     buildTypes {
         release {
+            signingConfig = signingConfigs.findByName("release")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -44,6 +75,27 @@ android {
             isIncludeAndroidResources = true
         }
     }
+}
+
+// Gradle Play Publisher: `./gradlew publishReleaseBundle` builds the signed AAB
+// and uploads it to the internal track. The service-account JSON is a secret —
+// point PLAY_SERVICE_ACCOUNT_JSON at it, or drop it at web/android/
+// play-credentials.json (both gitignored). Publish tasks only run when the file
+// is present; without it the config is inert so ordinary builds are unaffected.
+val playCredentialsFile =
+    (System.getenv("PLAY_SERVICE_ACCOUNT_JSON")?.let { file(it) })
+        ?: rootProject.file("play-credentials.json")
+
+play {
+    enabled.set(playCredentialsFile.exists())
+    if (playCredentialsFile.exists()) {
+        serviceAccountCredentials.set(playCredentialsFile)
+    }
+    track.set("internal")
+    defaultToAppBundles.set(true)
+    // First upload of any new version code must clear review; fail fast rather
+    // than hang if Google hasn't finished processing a prior upload.
+    releaseStatus.set(com.github.triplet.gradle.androidpublisher.ReleaseStatus.COMPLETED)
 }
 
 dependencies {

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -9,6 +9,8 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
+import android.view.Gravity
+import android.view.View
 import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.MimeTypeMap
@@ -16,12 +18,16 @@ import android.webkit.PermissionRequest
 import android.webkit.URLUtil
 import android.webkit.ValueCallback
 import android.webkit.WebView
+import android.widget.FrameLayout
+import android.widget.PopupMenu
+import android.widget.TextView
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.graphics.Insets
+import androidx.core.view.MenuCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -50,6 +56,11 @@ class MainActivity : ComponentActivity() {
     private var pageLoaded = false
     private var loginAttempts = 0 // capped browser-login retries; reset in onPageReady
     private var historyCleared = false // drop pre-auth/login-redirect history once
+
+    // Floating server switcher — mirrors the iOS `ServerSwitcher`. Always
+    // visible so it's always available as a recovery path (backward compatible
+    // with older web builds). Theme-aware via brand colors (light/dark XML).
+    private lateinit var switchButton: View
 
     // WebChromeClient affordances that need Activity-scoped result launchers.
     // Transient by design: rotation is covered by configChanges (no recreation),
@@ -135,7 +146,38 @@ class MainActivity : ComponentActivity() {
                     downloadFile(downloadUrl, contentDisposition, mimeType)
                 }
             }
-        setContentView(webView)
+        // Wrap the WebView in a FrameLayout so the floating server-switcher
+        // pill can sit on top of it. The pill uses the app's brand palette
+        // (values/values-night colors.xml) so it adapts to light/dark mode.
+        val container = FrameLayout(this)
+        container.addView(webView)
+        val dp = resources.displayMetrics.density
+        switchButton =
+            TextView(this).apply {
+                text = hostLabelOf(serverUrl)
+                background =
+                    ContextCompat.getDrawable(this@MainActivity, R.drawable.bg_floating_switch)
+                setTextColor(ContextCompat.getColor(this@MainActivity, R.color.brand_foreground))
+                textSize = 12f
+                setPadding((12 * dp).toInt(), (6 * dp).toInt(), (12 * dp).toInt(), (6 * dp).toInt())
+                elevation = 6 * dp
+                isClickable = true
+                isFocusable = true
+                setOnClickListener { showServerSwitcherMenu(it) }
+            }
+        switchButton.layoutParams =
+            FrameLayout
+                .LayoutParams(
+                    FrameLayout.LayoutParams.WRAP_CONTENT,
+                    FrameLayout.LayoutParams.WRAP_CONTENT,
+                    Gravity.TOP or Gravity.CENTER_HORIZONTAL,
+                ).apply {
+                    // Initial position below the status bar; corrected by the
+                    // insets listener once system bar insets are measured.
+                    topMargin = (8 * dp).toInt()
+                }
+        container.addView(switchButton)
+        setContentView(container)
         installBridge()
 
         // Measure the OS safe area and push it into the page as CSS custom
@@ -171,6 +213,12 @@ class MainActivity : ComponentActivity() {
             // keyboard covers the nav bar). Top/left/right are IME-independent.
             val bottom = if (ime.bottom > 0) 0 else bars.bottom
             lastInsets = Insets.of(bars.left, bars.top, bars.right, bottom)
+            // Push the floating switch button below the status bar so it doesn't
+            // disappear under the notch/status icons on edge-to-edge layouts.
+            (switchButton.layoutParams as? FrameLayout.LayoutParams)?.let { lp ->
+                lp.topMargin = bars.top + (8 * dp).toInt()
+                switchButton.layoutParams = lp
+            }
             emitInsets()
             insets
         }
@@ -239,7 +287,10 @@ class MainActivity : ComponentActivity() {
                 webView,
                 OmnigentBridgeListener.JS_OBJECT_NAME,
                 setOf(origin),
-                OmnigentBridgeListener(notifications, blobSaver),
+                OmnigentBridgeListener(
+                    notifications = notifications,
+                    blobSaver = blobSaver,
+                ),
             )
         } catch (_: IllegalArgumentException) {
             // Malformed origin rule — leave the bridge absent; the web layer falls back.
@@ -360,6 +411,26 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    /**
+     * Extract a short host[:port] label from a URL for the server switcher pill.
+     * Mirrors the iOS `URL.omnigentHostLabel` in `URL+Omnigent.swift`.
+     */
+    private fun hostLabelOf(url: String): String {
+        val uri = Uri.parse(url)
+        val host = uri.host ?: return url
+        val port = uri.port
+        return if (port != -1 &&
+            !(
+                (uri.scheme?.lowercase() == "https" && port == 443) ||
+                    (uri.scheme?.lowercase() == "http" && port == 80)
+            )
+        ) {
+            "$host:$port"
+        } else {
+            host
+        }
+    }
+
     override fun onDestroy() {
         // Unblock a pending file input / mic request, then release WebView + worker.
         pendingFileCallback?.onReceiveValue(null)
@@ -375,10 +446,101 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+
+        // Detect a server change: ConnectActivity re-enters us via
+        // CLEAR_TOP|SINGLE_TOP after the user picks a different server. The
+        // bridge is origin-allowlisted, so a server switch without re-registering
+        // leaves the bridge dead for the new origin.
+        val store = ServerStore(this)
+        val newServerUrl = store.currentServerUrl()
+        val newOrigin = originOf(newServerUrl)
+        if (newOrigin != null && newOrigin != pinnedOrigin) {
+            reloadWithNewServer(newServerUrl, newOrigin)
+        }
+
         val path = navigatePathOf(intent) ?: return
         pendingNavigatePath = path
         // Replay now if the page is up; otherwise onPageReady will flush it.
         if (pageLoaded) flushPendingActivation()
+    }
+
+    /**
+     * Swap to a new pinned server: remove the old bridge (allowlisted to the
+     * old origin), update [pinnedOrigin], re-install the bridge for the new
+     * origin, reset page state, and reload. Called from [onNewIntent] when
+     * ConnectActivity returns with a different server.
+     */
+    private fun reloadWithNewServer(
+        serverUrl: String,
+        newOrigin: String,
+    ) {
+        try {
+            WebViewCompat.removeWebMessageListener(
+                webView,
+                OmnigentBridgeListener.JS_OBJECT_NAME,
+            )
+        } catch (_: Exception) {
+            // Not registered (feature unsupported, or already removed) — no-op.
+        }
+        pinnedOrigin = newOrigin
+        pageLoaded = false
+        historyCleared = false
+        loginAttempts = 0
+        (switchButton as? TextView)?.text = hostLabelOf(serverUrl)
+        installBridge()
+        webView.loadUrl(serverUrl)
+    }
+
+    /**
+     * Show the server-switcher dropdown menu, mirroring the iOS `ServerSwitcher`
+     * `Menu`. Lists the current server (disabled header), other recent servers,
+     * Reload, and Connect to New Server. Tapping a recent server switches
+     * directly without leaving the app; "Connect to New Server" opens
+     * [ConnectActivity] for manual URL entry.
+     */
+    private fun showServerSwitcherMenu(anchor: View) {
+        val store = ServerStore(this)
+        val currentUrl = store.currentServerUrl()
+        val otherServers = store.recentServers().filter { originOf(it) != pinnedOrigin }
+
+        val popup = PopupMenu(this, anchor, Gravity.TOP)
+        MenuCompat.setGroupDividerEnabled(popup.menu, true)
+        popup.menu.apply {
+            // Group 0: current server — disabled header.
+            add(0, 0, 0, hostLabelOf(currentUrl)).isEnabled = false
+            // Group 1: other recent servers (divider before this group).
+            otherServers.forEachIndexed { i, url ->
+                add(1, 100 + i, 0, hostLabelOf(url))
+            }
+            // Group 2: actions (divider before this group).
+            add(2, 3, 0, getString(R.string.menu_reload))
+            add(2, 4, 0, getString(R.string.menu_connect_new))
+        }
+        popup.setOnMenuItemClickListener { item ->
+            when (item.itemId) {
+                3 -> {
+                    webView.reload()
+                    true
+                }
+
+                4 -> {
+                    startActivity(Intent(this@MainActivity, ConnectActivity::class.java))
+                    true
+                }
+
+                in 100..Int.MAX_VALUE -> {
+                    val url = otherServers[item.itemId - 100]
+                    store.connect(url)
+                    originOf(url)?.let { reloadWithNewServer(url, it) }
+                    true
+                }
+
+                else -> {
+                    false
+                }
+            }
+        }
+        popup.show()
     }
 
     /** Run bridge-dependent work once a pinned-origin page has finished loading. */

--- a/web/android/app/src/main/res/drawable/bg_floating_switch.xml
+++ b/web/android/app/src/main/res/drawable/bg_floating_switch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Server-switcher pill — uses the app's brand palette so it adapts to
+     light/dark mode automatically, matching the Connect screen. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/brand_background" />
+    <stroke android:width="1dp" android:color="@color/brand_border" />
+    <corners android:radius="9dp" />
+</shape>

--- a/web/android/app/src/main/res/values/strings.xml
+++ b/web/android/app/src/main/res/values/strings.xml
@@ -15,4 +15,6 @@
     <string name="connect_action">Connect</string>
     <string name="connect_recents">Recent servers</string>
     <string name="connect_invalid">Enter a valid http(s) server URL</string>
+    <string name="menu_reload">Reload</string>
+    <string name="menu_connect_new">Connect to New Server</string>
 </resources>

--- a/web/android/gradle/libs.versions.toml
+++ b/web/android/gradle/libs.versions.toml
@@ -11,6 +11,9 @@ androidxWebkit = "1.12.1"
 junit = "4.13.2"
 robolectric = "4.14.1"
 androidxTestCore = "1.6.1"
+# Gradle Play Publisher. 3.x tracks the AGP 8.x / Gradle 8.9 toolchain pinned
+# above; 4.x targets the newer toolchain, so bump it with the rest, not alone.
+playPublisher = "3.12.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
@@ -23,3 +26,4 @@ androidx-test-core = { group = "androidx.test", name = "core", version.ref = "an
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+play-publisher = { id = "com.github.triplet.play", version.ref = "playPublisher" }

--- a/web/android/keystore.properties.example
+++ b/web/android/keystore.properties.example
@@ -1,0 +1,15 @@
+# Release signing credentials for `./gradlew bundleRelease`.
+#
+# Copy this file to `keystore.properties` (gitignored) and fill in real values,
+# OR export the equivalent env vars in CI:
+#   OMNIGENT_KEYSTORE_FILE, OMNIGENT_KEYSTORE_PASSWORD,
+#   OMNIGENT_KEY_ALIAS, OMNIGENT_KEY_PASSWORD
+#
+# When neither the file nor the env vars are present, the release signing
+# config is skipped and debug builds still work without a keystore.
+
+# Path to the upload keystore. Absolute, or relative to web/android/.
+storeFile=/absolute/path/to/omnigent-upload.jks
+storePassword=CHANGE_ME
+keyAlias=omnigent-upload
+keyPassword=CHANGE_ME

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -155,6 +155,11 @@
   --omnigent-native-bottom-bar: 0px; /* set by native bridge (px) */
   --omnigent-top-bar-visible: 0; /* web-owned 0|1 */
   --omnigent-bottom-bar-visible: 0; /* web-owned 0|1 */
+  /* Android floating server-switcher pill footprint (margin + height).
+     Used by the Android scroll-fade gradient so it starts at the pill
+     bottom. Set once; if the pill size changes, update both values. */
+  --omnigent-android-switcher-margin: 8px;
+  --omnigent-android-switcher-height: 25px;
   --omnigent-inset-top: var(--omnigent-safe-top);
   --omnigent-inset-bottom: calc(
     var(--omnigent-safe-bottom) + var(--omnigent-native-bottom-bar) *
@@ -581,6 +586,26 @@
       to bottom,
       transparent calc(48px + var(--omnigent-inset-top)),
       black calc(80px + var(--omnigent-inset-top))
+    );
+  }
+
+  /* Android: the floating server-switcher pill sits at the top. Start the
+     fade at the pill bottom (safe-top + margin + height) so content scrolls
+     smoothly into view below it. */
+  [data-android-native] .chat-scroll-fade {
+    --fade-start: calc(
+      var(--omnigent-safe-top) + var(--omnigent-android-switcher-margin) +
+        var(--omnigent-android-switcher-height)
+    );
+    mask-image: linear-gradient(
+      to bottom,
+      transparent var(--fade-start),
+      black calc(var(--fade-start) + 32px)
+    );
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      transparent var(--fade-start),
+      black calc(var(--fade-start) + 32px)
     );
   }
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a floating server-switcher pill to the Android WebView shell, mirroring the iOS `ServerSwitcher`. The pill is always visible at the top center of the screen, shows the current server's host, and opens a dropdown menu with recent servers, Reload, and Connect to New Server — giving users a universal recovery path when the server is unreachable or a non-Omnigent page loads.
- Add an Android-specific scroll-fade gradient so the chat transcript fades smoothly into the pill area, starting at the pill's bottom edge. The fade offsets are driven by CSS variables (`--omnigent-android-switcher-margin/height`) so they stay in sync with the pill dimensions.
- Theme-aware pill styling via the app's brand color resources (light/dark).

## Test Plan

- `./gradlew :app:assembleDebug :app:lintDebug` — 0 lint errors, build succeeds.
- Manual: installed on a Pixel 9a via `adb install`, verified the pill renders with correct theme colors, the dropdown menu opens with recent servers and actions, switching servers reloads the bridge for the new origin, and the scroll-fade gradient appears below the pill.
- Verified the pill stays visible across page loads (always-visible default, backward compatible with older web builds).

## Demo

N/A — tested on physical device; screenshots taken via `adb screencap` during development.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification on a Pixel 9a (API 35): confirmed pill rendering, theme-aware colors (light/dark), dropdown menu with group dividers, server switching via `reloadWithNewServer` (removes old bridge, re-registers for new origin), scroll-fade gradient position, and backward-compatible always-visible default. Existing Robolectric unit tests fail due to Maven Central network blocking (pre-existing, unrelated to this change).

## Changelog

Android app shows a floating server switcher pill with a dropdown menu for quick server switching
