### PR TITLE
fix(pi-native): fail loudly when no provider can serve the selected model

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -248,32 +248,43 @@ class PiProviderConfig:
     # an OpenAI Completions provider for GPT models on the Databricks gateway).
     # Keys are provider ids; values are complete Pi provider config dicts.
     additional_providers: dict[str, _PiProviderPayload] = field(default_factory=dict, hash=False)
+    # Set by the two Databricks builders: their primary is the AI Gateway's
+    # Claude-only ``/ai-gateway/anthropic`` surface. Never inferred from
+    # ``api``: a proxy can speak anthropic-messages for arbitrary models.
+    primary_claude_only: bool = False
+
+    def _model_suits_primary(self) -> bool:
+        """Return whether the primary provider can serve the selected model."""
+        if not self.primary_claude_only:
+            return True
+        return "claude" in self.model.lower()
 
     def to_models_config(self) -> _PiModelsConfig:
         """Render this provider as a Pi ``models.json`` mapping."""
-        models: list[_PiModelEntry]
-        if self.extra_models:
-            # Include all known models, ensuring the selected model is present.
-            # The selected model may be a newer id not yet in the static list.
-            models = list(self.extra_models)
-            # Only append to this (Anthropic) provider when the model is absent
-            # from ALL providers. Non-Claude models (GLM, GPT…) live in
-            # additional_providers (openai-completions); appending them here
-            # too would register them under the wrong wire protocol.
-            in_additional = any(
-                any(model_entry["id"] == self.model for model_entry in provider["models"])
-                for provider in self.additional_providers.values()
-            )
-            # Skip models excluded from Pi entirely (e.g. Gemini — no Responses API
-            # models) — don't register them under the Anthropic provider either.
-            if (
-                not any(m.get("id") == self.model for m in models)
-                and not in_additional
-                and not unsupported_in_pi(self.model.lower())
-            ):
-                models.append({"id": self.model, "input": ["text", "image"]})
-        else:
-            models = [{"id": self.model}]
+        in_additional = any(
+            any(model_entry["id"] == self.model for model_entry in provider["models"])
+            for provider in self.additional_providers.values()
+        )
+        models: list[_PiModelEntry] = list(self.extra_models)
+        if not in_additional and not any(m.get("id") == self.model for m in models):
+            if self._model_suits_primary():
+                models.append(
+                    {"id": self.model, "input": ["text", "image"]}
+                    if self.extra_models
+                    else {"id": self.model}
+                )
+            else:
+                # Self-registering here would put a non-Claude model on the
+                # gateway's Claude-only Anthropic surface — the #2575 hang.
+                # Leave it unregistered so Pi fails fast with an unknown model.
+                _LOGGER.error(
+                    "pi-native: %r is not a Claude model and the Databricks workspace model "
+                    "catalog did not list it, so no provider can serve it and Pi will not be "
+                    "able to select it. The catalog fetch may have failed (expired credentials "
+                    "or an unreachable workspace), or the endpoint may not be listed by the "
+                    "model-services API.",
+                    self.model,
+                )
         provider: _PiProviderPayload = {
             "baseUrl": self.base_url,
             "api": self.api,
@@ -364,6 +375,7 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         extra_models=claude_models,
         additional_providers=additional,
         credential_warning=credential_warning,
+        primary_claude_only=True,
     )
 
 
@@ -758,6 +770,7 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         auth_header=True,
         extra_models=claude_models,
         additional_providers=additional,
+        primary_claude_only=True,
     )
 
 

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import stat
 from pathlib import Path
 from types import SimpleNamespace
@@ -1153,3 +1154,162 @@ def test_fetch_pi_model_lists_falls_back_on_http_error() -> None:
     assert gpt == []
     assert completions == []
     assert gemini == []
+
+
+def _mock_databricks_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the Databricks profile path at a fake workspace with fake creds."""
+    from omnigent.inner import databricks_executor
+    from omnigent.runtime.credentials import databricks as db_creds_mod
+
+    monkeypatch.setattr(
+        databricks_executor,
+        "_read_databrickscfg_host",
+        lambda profile: "https://wkspc.example.com/",
+    )
+    monkeypatch.setattr(
+        creds,
+        "resolve_databricks_workspace",
+        lambda profile: db_creds_mod.WorkspaceCreds(host="https://wkspc.example.com", token="tok"),
+    )
+
+
+def test_non_claude_model_not_registered_on_anthropic_surface(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A non-Claude model the catalog didn't place must not land on Anthropic.
+
+    The live model-services fetch is best-effort (expired token, network blip,
+    a workspace listing nothing). Registering the selected model on the primary
+    provider regardless put GLM/Gemini/DeepSeek on ``anthropic-messages``,
+    where the gateway answers "API type 'anthropic/v1/messages' is not
+    supported" — the #2575 hang. Leaving it unregistered makes Pi fail fast
+    instead, and the log says why.
+    """
+    _mock_databricks_profile(monkeypatch)
+
+    def _boom(*_args: object) -> None:
+        raise RuntimeError("network blip")
+
+    monkeypatch.setattr(creds, "_fetch_pi_model_lists", _boom)
+
+    with caplog.at_level(logging.ERROR, logger=creds._LOGGER.name):
+        provider = creds.resolve_pi_native_provider(
+            model="databricks-glm-5-2", config_loader=_databricks_config
+        )
+    assert provider is not None
+
+    cfg = provider.to_models_config()
+    assert list(cfg["providers"]) == ["omnigent"]
+    assert cfg["providers"]["omnigent"]["api"] == "anthropic-messages"
+    assert cfg["providers"]["omnigent"]["models"] == []
+    assert any(
+        "databricks-glm-5-2" in record.message and "workspace model catalog" in record.message
+        for record in caplog.records
+    ), "the refusal must be logged with the model id"
+
+
+def test_claude_model_registered_when_catalog_fetch_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Claude model still self-registers: the primary surface can serve it."""
+    _mock_databricks_profile(monkeypatch)
+    monkeypatch.setattr(creds, "_fetch_pi_model_lists", lambda *_: ([], [], [], []))
+
+    provider = creds.resolve_pi_native_provider(
+        model="databricks-claude-sonnet-4-6", config_loader=_databricks_config
+    )
+    assert provider is not None
+
+    cfg = provider.to_models_config()
+    assert [m["id"] for m in cfg["providers"]["omnigent"]["models"]] == [
+        "databricks-claude-sonnet-4-6"
+    ]
+
+
+def test_non_claude_model_in_catalog_is_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The guard only fires when nothing claimed the model.
+
+    A catalog that placed the model under a secondary provider keeps working —
+    the model is served there, and the primary must not offer it as well.
+    """
+    _mock_databricks_profile(monkeypatch)
+    live_claude = [{"id": "databricks-claude-sonnet-4-6", "input": ["text", "image"]}]
+    live_completions = [{"id": "databricks-llama-4", "input": ["text", "image"]}]
+    monkeypatch.setattr(
+        creds, "_fetch_pi_model_lists", lambda *_: (live_claude, [], live_completions, [])
+    )
+
+    provider = creds.resolve_pi_native_provider(
+        model="databricks-llama-4", config_loader=_databricks_config
+    )
+    assert provider is not None
+
+    cfg = provider.to_models_config()
+    assert [m["id"] for m in cfg["providers"]["omnigent-completions"]["models"]] == [
+        "databricks-llama-4"
+    ]
+    assert [m["id"] for m in cfg["providers"]["omnigent"]["models"]] == [
+        "databricks-claude-sonnet-4-6"
+    ]
+
+
+def test_inline_family_provider_still_self_registers() -> None:
+    """Non-Databricks primaries pick their api from the family, so any id fits.
+
+    ``_inline_family_pi_provider`` sets ``api`` to match the model's family, so
+    the Anthropic-surface guard must not strand an OpenAI key provider's model.
+    """
+    config = {
+        "providers": {
+            "openai": {
+                "kind": "key",
+                "default": True,
+                "openai": {"base_url": "https://api.openai.com/v1", "api_key": "sk-test"},
+            }
+        }
+    }
+    provider = creds.resolve_pi_native_provider(model="gpt-5-5", config_loader=lambda: config)
+    assert provider is not None
+    assert provider.api != "anthropic-messages"
+
+    cfg = provider.to_models_config()
+    assert [m["id"] for m in cfg["providers"][provider.provider_id]["models"]] == ["gpt-5-5"]
+
+
+def test_anthropic_protocol_proxy_serves_non_claude_model() -> None:
+    """An Anthropic-protocol proxy may serve non-Claude ids — don't refuse it.
+
+    ``anthropic-messages`` on its own does NOT imply "Claude only": a gateway
+    or LiteLLM-style proxy can speak the Anthropic protocol for arbitrary
+    models. Only the Databricks AI Gateway's ``/ai-gateway/anthropic`` surface
+    is Claude-only, and its builders say so via ``primary_claude_only``.
+    """
+    config = {
+        "providers": {
+            "proxy": {
+                "kind": "gateway",
+                "default": True,
+                "anthropic": {
+                    "base_url": "https://litellm.internal.example.com/anthropic",
+                    "api_key": "sk-proxy",
+                },
+            }
+        }
+    }
+    provider = creds.resolve_pi_native_provider(
+        model="zai-org/GLM-4.7", config_loader=lambda: config
+    )
+    assert provider is not None
+    assert provider.api == "anthropic-messages"
+    assert provider.primary_claude_only is False
+
+    cfg = provider.to_models_config()
+    assert [m["id"] for m in cfg["providers"]["omnigent"]["models"]] == ["zai-org/GLM-4.7"]
+
+
+def test_databricks_builders_declare_claude_only_primary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Databricks profile path marks its primary Claude-only."""
+    _mock_databricks_profile(monkeypatch)
+    monkeypatch.setattr(creds, "_fetch_pi_model_lists", lambda *_: ([], [], [], []))
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+    assert provider is not None
+    assert provider.primary_claude_only is True


### PR DESCRIPTION
Fixes #2575

## Problem

`main` already routes non-Claude Databricks-gateway models to the correct Pi surfaces: `_fetch_pi_model_lists` fetches the live Unity Catalog model-services list and `PiProviderConfig.additional_providers` splits families across `/serving-endpoints` (`openai-completions`), `/ai-gateway/codex/v1` (`openai-responses`) and `/ai-gateway/mlflow/v1`. **That only holds when the fetch succeeds.**

The fetch is best-effort by design — an expired OAuth token, a network blip, or a workspace whose model-services API lists nothing all return empty lists. `to_models_config` then registered the selected model on the *primary* provider regardless, and for the Databricks gateway that primary is the Claude-only `/ai-gateway/anthropic` surface. So a non-Claude session model still reproduces the original failure whenever the catalog is unavailable:

> API type 'anthropic/v1/messages' is not supported by 'databricks-glm-5-2'. Supported API types: [mlflow/v1/chat/completions]

`pi_native_provider_launch` also selected the primary in that case, so the `--thinking off` mitigation that keeps the gateway from 400-ing on `reasoning_effort` was skipped too.

Same run, same model (`glm-5-2`), before this change:

```
catalog fetch OK      → --provider omnigent-completions --model glm-5-2 --thinking off
                        omnigent             anthropic-messages  [claude-sonnet-4-6]
                        omnigent-completions openai-completions  [glm-5-2]

catalog fetch FAILED  → --provider omnigent --model glm-5-2
                        omnigent             anthropic-messages  [glm-5-2]   ← hangs
```

## Change

Registering the model under a surface guessed from its id would trade a hang for a silent guess, so this refuses instead.

**`PiProviderConfig.primary_claude_only`** is set by the two Databricks builders — the only places that know their primary is the gateway's Claude-only Anthropic surface. It is deliberately *not* inferred from `api == "anthropic-messages"`: an inline gateway or LiteLLM-style proxy speaks that protocol for arbitrary models, and inferring would strand those (there's a regression test for exactly that config).

**Refuse and say why.** When no provider claimed the model and the primary can't serve it, the model is left unregistered and an error is logged naming the model and the two reasons the catalog might lack it. Pi then fails fast with an unknown model instead of hanging on a rejected API type:

```
catalog fetch FAILED  → omnigent  anthropic-messages  []
ERROR pi-native: 'glm-5-2' is not a Claude model and the Databricks workspace model
      catalog did not list it, so no provider can serve it and Pi will not be able to
      select it. The catalog fetch may have failed (expired credentials or an
      unreachable workspace), or the endpoint may not be listed by the model-services API.
```

**`to_models_config` loses its `extra_models`-empty special case.** The "is this model already registered anywhere" check now runs on every path — previously it was computed inside the catalog branch, which is precisely how the degraded path slipped through. The bare `{"id": ...}` entry shape is preserved for catalog-less inline providers so no capability is asserted that can't be checked, and the `unsupported_in_pi` skip is subsumed (those ids aren't Claude ids, so the guard already refuses them).

`pi_native_provider_launch` needs no change: it already picks the provider containing the model and appends `--thinking off` for non-primary providers.

36 added / 23 removed lines in one production file.

## Scope / follow-ups

- A non-Claude serving endpoint the model-services API doesn't enumerate (custom or provisioned-throughput endpoints, or ones the token can't see) now refuses to launch instead of hanging. That's a loud failure replacing a silent one, not a fix for that case. If maintainers would rather route those by family than refuse, say so and I'll add the classifier that needs — I had it written and removed it, since guessing a surface from a model id is exactly what the live catalog exists to avoid.
- No end-to-end capture: I don't have a workspace to launch a real GLM session against. The routing and launch argv above are captured from real runs of the resolution path. Happy to attach a script that prints both scenarios and hands back a ready `PI_CODING_AGENT_DIR=... pi --provider ... --model ...` command if someone with gateway access wants to record the session itself.
- This branch previously carried a static-catalog implementation of the family routing that `main` has since superseded; rebasing it produced an empty commit, so the branch was re-scoped to the gap above. Details in the thread.

## Testing

- `tests/test_pi_native_credentials.py`: 60 passed (54 pre-existing — no regressions — plus 6 new covering the catalog-failure refusal and its log line, a Claude model still self-registering, a model the catalog *did* place staying untouched, an OpenAI key provider and an Anthropic-protocol proxy proving non-Databricks primaries are unaffected, and the `primary_claude_only` flag on the Databricks builders).
- `143 passed` across all `tests/test_pi*.py`.
- `ruff check`, `ruff format --check` and `mypy` clean on both files.
- Two of the new tests fail on `main` (verified by reverting the source change), so they pin the fix rather than the implementation.