### PR TITLE
feat(harness): add omp (Oh My Pi) as an ACP-backed agent

### DIFF
--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -526,6 +526,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
             "kimi",
             "kimi-native",
             "kiro-native",
+            "omp",
             "open-responses",
             "openai-agents",
             "opencode-native",
@@ -553,6 +554,10 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "kimi": "omnigent.inner.kimi_harness",
         "kimi-native": "omnigent.inner.kimi_native_harness",
         "kiro-native": "omnigent.inner.kiro_native_harness",
+        # omp (Oh My Pi) is driven over ACP (``omp acp``) — same wrap as the
+        # generic ``acp`` harness, but with the command pinned by its spawn-env
+        # builder so the built-in omp agent works with no user ``acp:`` config.
+        "omp": "omnigent.inner.acp_harness",
         "openai-agents": "omnigent.inner.openai_agents_sdk_harness",
         "opencode-native": "omnigent.inner.opencode_native_harness",
         "pi": "omnigent.inner.pi_harness",
@@ -640,6 +645,12 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         # stays a valid harness for YAML specs (and the credential-free
         # integration mock LLM), but is no longer offered as a UI pick.
         "pi": "Pi",
+        "omp": "Oh My Pi",
+    },
+    spawn_env_builders={
+        # omp's ACP command is pinned here (not resolved from the user's ``acp:``
+        # config block like the generic ``acp`` harness).
+        "omp": "omnigent.runtime.workflow._build_omp_spawn_env",
     },
     capabilities=_BUILTIN_CAPABILITIES,
 )

--- a/omnigent/omp_agent.py
+++ b/omnigent/omp_agent.py
@@ -1,0 +1,55 @@
+"""Built-in omp (Oh My Pi) agent spec.
+
+omp is driven over the Agent Client Protocol (``omp acp``) through the ``omp``
+harness (see :mod:`omnigent.inner.acp_harness` +
+``omnigent.runtime.workflow._build_omp_spawn_env``, which pins the command).
+This module materializes the thin launcher spec the server seeds as a built-in
+so "Oh My Pi" appears in the New Chat picker with no user ``acp:`` config.
+
+omp owns its own file/shell tools and authenticates with its own ``~/.omp``
+credentials, so the spec declares neither an ``os_env`` block nor
+``executor.auth`` — mirroring the other self-authenticating ACP agents.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# The built-in agent name (the New Chat picker label and the stable builtin id).
+OMP_AGENT_NAME = "omp"
+
+_PROMPT = (
+    "You are Oh My Pi (omp), running over ACP inside Omnigent. Help the user "
+    "with software engineering and system-debugging tasks — read and edit "
+    "files, run shell commands, and reach local network resources when asked. "
+    "Keep responses concise and prefer showing diffs and commands over prose."
+)
+
+
+def _omp_agent_spec() -> dict[str, Any]:
+    """Return the built-in omp agent spec as a plain dict."""
+    return {
+        "name": OMP_AGENT_NAME,
+        "description": (
+            "Oh My Pi (omp) coding agent, driven over the Agent Client Protocol "
+            "via `omp acp`. Runs its own file/shell tools and authenticates with "
+            "its own ~/.omp credentials (e.g. Ollama Cloud)."
+        ),
+        "executor": {"harness": "omp"},
+        "prompt": _PROMPT,
+    }
+
+
+def materialize_omp_agent_spec(tmpdir: Path) -> Path:
+    """
+    Write the built-in omp agent spec YAML into *tmpdir*.
+
+    :param tmpdir: Temporary directory for the generated YAML file.
+    :returns: Path to the generated ``omp.yaml`` spec.
+    """
+    yaml_path = tmpdir / "omp.yaml"
+    yaml_path.write_text(yaml.safe_dump(_omp_agent_spec(), sort_keys=False), encoding="utf-8")
+    return yaml_path

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -67,6 +67,12 @@ KIMI_KEY = "kimi"
 # installer, not an npm package managed by ``omnigent setup``.
 KIRO_KEY = "kiro"
 
+# omp ("Oh My Pi") is driven over ACP (``omp acp``). A compiled single binary
+# (not npm), so — like cursor/kimi/kiro — it declares no install package and is
+# gated purely on the ``omp`` binary being on PATH. omp self-authenticates via
+# its own ``~/.omp`` state, so there is no Omnigent-side credential.
+OMP_KEY = "omp"
+
 # OpenCode native harness CLI (``opencode serve`` / ``opencode attach``),
 # installed via the ``opencode-ai`` npm package. No login/logout/status argv
 # is wired yet — readiness is binary-only until an auth check exists.
@@ -166,6 +172,13 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         package=None,
         install_hint="curl -fsSL https://cli.kiro.dev/install | bash",
     ),
+    OMP_KEY: HarnessInstallSpec(
+        "Oh My Pi",
+        "omp",
+        package=None,
+        install_hint="install the omp (Oh My Pi) CLI and add it to your PATH",
+        auth_hint="run `omp` once to sign in (writes provider state to ~/.omp)",
+    ),
     # The native Antigravity (agy) TUI bridge wraps the ``agy`` CLI. ``agy`` has
     # no ``login`` / ``logout`` subcommand — the user authenticates via browser
     # OAuth by launching ``agy`` with no arguments on first run — so login_args /
@@ -232,6 +245,8 @@ _HARNESS_NAME_TO_KEY: dict[str, str] = {
     "cursor-native": CURSOR_KEY,
     "native-cursor": CURSOR_KEY,
     "kiro-native": KIRO_KEY,
+    # omp is binary-gated: the ACP harness can't launch without the ``omp`` CLI.
+    OMP_KEY: OMP_KEY,
     "native-kiro": KIRO_KEY,
     # The native agy TUI bridge wraps the ``agy`` CLI; both spellings map to
     # the Gemini family's install spec. (The in-process ``antigravity`` SDK

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1544,6 +1544,43 @@ def _build_acp_spawn_env(
     return env
 
 
+def _build_omp_spawn_env(
+    spec: AgentSpec,
+    *,
+    cwd: Path | None = None,
+    workdir: Path | None = None,
+) -> dict[str, str]:
+    """Build the env-var dict for the built-in omp (Oh My Pi) ACP harness.
+
+    omp is driven over ACP via ``omp acp``. Unlike the generic ``acp`` harness —
+    which resolves its command from the user's ``acp:`` config block — the ``omp``
+    harness pins the command so the seeded omp agent works out of the box with no
+    setup. Like Goose, omp owns its own auth (``~/.omp``), so this wires no
+    provider/gateway credential; a ``databricks-*`` model is dropped and omp's own
+    configured model applies. The knobs match ``_build_acp_spawn_env`` /
+    ``omnigent/inner/acp_harness.py``.
+
+    :param spec: The agent spec.
+    :param cwd: Session workspace (selected working folder), or ``None``.
+    :param workdir: Accepted for builder-signature parity; unused.
+    :returns: A dict of ``HARNESS_ACP_*`` env-var overrides for the spawn.
+    """
+    env: dict[str, str] = {
+        "HARNESS_ACP_COMMAND": "omp acp",
+        "HARNESS_ACP_NAME": "Oh My Pi",
+        "HARNESS_ACP_SESSION_ID_MODE": "server",
+    }
+    model = _resolve_spec_model(spec)
+    if model is not None and not model.startswith(("databricks-", "databricks/")):
+        env["HARNESS_ACP_MODEL"] = model
+    if cwd is not None:
+        env["HARNESS_ACP_CWD"] = str(cwd)
+    os_env_payload = _serialize_os_env(spec.os_env)
+    if os_env_payload is not None:
+        env["HARNESS_ACP_OS_ENV"] = os_env_payload
+    return env
+
+
 def _load_global_auth() -> ApiKeyAuth | DatabricksAuth | None:
     """
     Load the ``auth:`` block from ``~/.omnigent/config.yaml``.

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -444,6 +444,7 @@ def _ensure_default_agents(
     _ensure_default_claude_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_codex_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_pi_agent(agent_store, artifact_store, agent_cache)
+    _ensure_default_omp_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_opencode_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_cursor_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_kiro_agent(agent_store, artifact_store, agent_cache)
@@ -610,6 +611,49 @@ def _ensure_default_codex_agent(
         agent_cache,
         name=_CODEX_NATIVE_AGENT_NAME,
         bundle_bytes=_build_codex_native_bundle(),
+    )
+
+
+def _build_omp_bundle() -> bytes:
+    """
+    Build a gzipped tarball of the built-in omp (Oh My Pi) agent spec.
+
+    :returns: Gzipped tarball bytes suitable for the artifact store.
+    """
+    import tempfile
+
+    from omnigent.omp_agent import materialize_omp_agent_spec
+    from omnigent.spec import materialize_bundle
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        spec_path = materialize_omp_agent_spec(Path(tmpdir))
+        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
+        return _tar_gz_dir(bundle_dir)
+
+
+def _ensure_default_omp_agent(
+    agent_store: AgentStore,
+    artifact_store: ArtifactStore,
+    agent_cache: Any,
+) -> None:
+    """
+    Register or refresh the built-in omp (Oh My Pi) agent.
+
+    Called during server lifespan startup so the Web UI can offer Oh My Pi as a
+    built-in ACP-backed agent. Content-aware via :func:`_ensure_builtin_agent`.
+
+    :param agent_store: Store for agent metadata.
+    :param artifact_store: Store for agent bundles.
+    :param agent_cache: Cache for loaded agent specs.
+    """
+    from omnigent.omp_agent import OMP_AGENT_NAME
+
+    _ensure_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_cache,
+        name=OMP_AGENT_NAME,
+        bundle_bytes=_build_omp_bundle(),
     )
 
 

--- a/tests/e2e_ui/chat/test_omp_agent_tile.py
+++ b/tests/e2e_ui/chat/test_omp_agent_tile.py
@@ -1,0 +1,144 @@
+"""E2E: the built-in omp (Oh My Pi) agent renders in the New Chat picker.
+
+Covers the UI change that adds the ACP-backed ``omp`` harness. omp is not a
+native coding-agent tile (it renders in the web composer, not a terminal), so
+its picker label comes from ``DISPLAY_NAMES`` in
+``web/src/hooks/useAvailableAgents.ts`` (``displayNameForAgent`` maps the ``omp``
+agent name to "Oh My Pi") and its glyph from the ``omp`` branch of
+``AgentCard.iconForAgent``. This drives the rendered picker end to end: on a host
+that reports ``omp`` configured, the "Oh My Pi" tile is listed and selectable.
+
+The ``page.route`` stubbing and async-in-a-fresh-thread shape mirror
+``chat/test_hide_unconfigured_harnesses.py``: the e2e harness's runner tunnels
+into the server and registers no *host*, so faking ``/v1/hosts`` (with
+``configured_harnesses``) and ``/v1/agents`` is the established way to drive the
+landing picker, and once a pytest-playwright *sync* test has run in the session,
+pytest-asyncio can't start a loop on the main thread, so each async body runs in
+its own thread via :func:`asyncio.run`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+from collections.abc import Coroutine
+from typing import Any
+
+from playwright.async_api import Route, async_playwright, expect
+
+_HOST_ID = "host_e2e"
+_HOST_NAME = "e2e-host"
+_OMP_AGENT_ID = "ag_omp_e2e"
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* in a dedicated thread with its own event loop (see module docstring)."""
+    captured: dict[str, Exception] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except Exception as exc:  # noqa: BLE001 — re-raised on the calling thread below
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+def _hosts_body() -> str:
+    """Stub ``GET /v1/hosts``: one online host that reports ``omp`` configured."""
+    return json.dumps(
+        {
+            "hosts": [
+                {
+                    "host_id": _HOST_ID,
+                    "name": _HOST_NAME,
+                    "owner": "e2e",
+                    "status": "online",
+                    "configured_harnesses": {"omp": True},
+                }
+            ]
+        }
+    )
+
+
+def _agents_body() -> str:
+    """Stub ``GET /v1/agents``: the built-in omp (Oh My Pi) agent.
+
+    The server returns the raw ``name``/``harness``; the web recomputes the
+    display label via ``displayNameForAgent`` (so ``display_name`` here is
+    intentionally the un-prettified name, proving the "Oh My Pi" mapping is the
+    frontend's doing, not the stub's).
+    """
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": _OMP_AGENT_ID,
+                    "name": "omp",
+                    "display_name": "omp",
+                    "description": "Oh My Pi (omp) coding agent, driven over ACP.",
+                    "harness": "omp",
+                    "skills": [],
+                }
+            ]
+        }
+    )
+
+
+async def _register_routes(page) -> None:
+    """Stub the host/agent endpoints and neutralize session-scan discovery."""
+
+    async def handle_hosts(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_hosts_body())
+
+    async def handle_agents(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_agents_body())
+
+    async def handle_agent_scan(route: Route) -> None:
+        await route.fulfill(
+            status=200, content_type="application/json", body=json.dumps({"data": []})
+        )
+
+    await page.route("**/v1/hosts", handle_hosts)
+    await page.route("**/v1/agents", handle_agents)
+    await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+
+def test_omp_agent_tile_renders_in_picker(seeded_session: tuple[str, str]) -> None:
+    """The omp built-in shows as an "Oh My Pi" tile in the New Chat picker."""
+    base_url, session_id = seeded_session
+    del session_id  # this flow only reads the picker; it never creates a session
+    _run_in_fresh_loop(_drive(base_url))
+
+
+async def _drive(base_url: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await _register_routes(page)
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+
+            tile = page.get_by_test_id(f"new-chat-landing-agent-{_OMP_AGENT_ID}")
+            await expect(tile).to_be_visible(timeout=30_000)
+            # The label is the frontend-computed "Oh My Pi" (DISPLAY_NAMES["omp"]),
+            # not the raw agent name the stub returned.
+            await expect(tile).to_contain_text("Oh My Pi")
+        finally:
+            await browser.close()

--- a/tests/test_harness_plugins.py
+++ b/tests/test_harness_plugins.py
@@ -212,3 +212,26 @@ def test_community_namespace_imports_external_harness_package(
 
     module = importlib.import_module("omnigent.community.harness.foo")
     assert module.VALUE == "ok"
+
+
+def test_omp_builtin_harness_is_acp_backed() -> None:
+    """The built-in ``omp`` harness is ACP-backed with a pinned command builder."""
+    assert "omp" in hp.valid_harnesses()
+    assert hp.harness_modules()["omp"] == "omnigent.inner.acp_harness"
+    assert (
+        hp.spawn_env_builders()["omp"] == "omnigent.runtime.workflow._build_omp_spawn_env"
+    )
+    assert hp.harness_labels().get("omp") == "Oh My Pi"
+
+
+def test_omp_spawn_env_pins_the_acp_command() -> None:
+    """``_build_omp_spawn_env`` pins ``omp acp`` so the built-in needs no config."""
+    from types import SimpleNamespace
+
+    from omnigent.runtime.workflow import _build_omp_spawn_env
+
+    spec = SimpleNamespace(executor=SimpleNamespace(model=None), os_env=None)
+    env = _build_omp_spawn_env(spec)
+    assert env["HARNESS_ACP_COMMAND"] == "omp acp"
+    assert env["HARNESS_ACP_NAME"] == "Oh My Pi"
+    assert env["HARNESS_ACP_SESSION_ID_MODE"] == "server"

--- a/tests/test_harness_readiness.py
+++ b/tests/test_harness_readiness.py
@@ -74,3 +74,18 @@ def test_configured_harness_map_exposes_kiro_native(monkeypatch: pytest.MonkeyPa
     cmap = hr.configured_harness_map()
     assert cmap.get("kiro-native") is False
     assert cmap.get("native-kiro") is False
+
+
+def test_omp_harness_gates_on_omp_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ACP-backed ``omp`` harness is gated on the ``omp`` binary on PATH."""
+    monkeypatch.setattr(hr.shutil, "which", lambda _b: None)
+    assert hr.harness_is_configured("omp") is False
+
+    monkeypatch.setattr(hr.shutil, "which", lambda _b: "/usr/local/bin/omp")
+    assert hr.harness_is_configured("omp") is True
+
+
+def test_configured_harness_map_exposes_omp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The readiness map carries an ``omp`` key for the web picker lookup."""
+    monkeypatch.setattr(hr.shutil, "which", lambda _b: None)
+    assert hr.configured_harness_map().get("omp") is False

--- a/web/src/components/AgentCard.tsx
+++ b/web/src/components/AgentCard.tsx
@@ -9,6 +9,7 @@ import { KimiIcon } from "@/components/icons/KimiIcon";
 import { KiroIcon } from "@/components/icons/KiroIcon";
 import { NessieIcon } from "@/components/icons/NessieIcon";
 import { OpenCodeIcon } from "@/components/icons/OpenCodeIcon";
+import { OmpIcon } from "@/components/icons/OmpIcon";
 import { PiIcon } from "@/components/icons/PiIcon";
 import type { ComponentType, SVGProps } from "react";
 import type { AvailableAgent } from "@/hooks/useAvailableAgents";
@@ -54,6 +55,8 @@ function iconForAgent(agent: AvailableAgent): ComponentType<SVGProps<SVGSVGEleme
   // qwen falls back to generic BotIcon for now; see docs/QWEN_FOLLOWUPS.md
   // Exact match — a substring check would false-match e.g. "openapi".
   if (agent.harness === "pi") return PiIcon;
+  // omp (Oh My Pi) is an ACP-backed harness; exact match avoids false hits.
+  if (agent.harness === "omp") return OmpIcon;
   // Both the native (`antigravity-native`) and SDK (`antigravity`) harnesses
   // share the Antigravity glyph.
   if (agent.harness?.includes("antigravity")) return AntigravityIcon;

--- a/web/src/components/icons/OmpIcon.tsx
+++ b/web/src/components/icons/OmpIcon.tsx
@@ -1,0 +1,26 @@
+import type { SVGProps } from "react";
+
+// omp (Oh My Pi) mark: a stylized omega (ω) — a nod to "Oh My" — kept visually
+// distinct from the Pi glyph. Uses currentColor so it follows the app theme
+// like its sibling brand icons.
+export function OmpIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" {...props}>
+      <path
+        d="M4 19c0-1.6 1-2.8 2.3-4.2C7.8 13.2 8.8 11.9 8.8 10a3.2 3.2 0 0 0-6.4 0M20 19c0-1.6-1-2.8-2.3-4.2-1.5-1.6-2.5-2.9-2.5-4.8a3.2 3.2 0 0 1 6.4 0"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M8.5 12a3.5 3.5 0 0 0 7 0"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M2 19h4M18 19h4" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -50,6 +50,9 @@ const DISPLAY_NAMES: Record<string, string> = {
   nessie: "Nessie",
   polly: "Polly",
   debby: "Debby",
+  // omp is the built-in ACP-backed "Oh My Pi" agent (not a native coding-agent
+  // tile), so its picker label is mapped here rather than in NATIVE_CODING_AGENTS.
+  omp: "Oh My Pi",
 };
 
 function displayNameForAgent(name: string, harness?: string | null): string {

--- a/web/src/lib/agentLabels.ts
+++ b/web/src/lib/agentLabels.ts
@@ -23,6 +23,7 @@ export const BRAIN_HARNESS_LABELS: Record<string, string> = {
   codex: "Codex",
   cursor: "Cursor",
   pi: "Pi",
+  omp: "Oh My Pi",
   antigravity: "Antigravity",
   copilot: "Copilot",
 };


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds **"Oh My Pi" (`omp`)** as a first-class New Chat picker tile, backed by omp's **ACP mode** (`omp acp`).

- A dedicated **`omp` harness** reuses the generic ACP wrap (`omnigent.inner.acp_harness`) but **pins the launch command** via a spawn-env builder (`_build_omp_spawn_env` → `HARNESS_ACP_COMMAND="omp acp"`), so the seeded built-in works with **no user `acp:` config**.
- omp **self-authenticates** via its own `~/.omp` state (e.g. Ollama Cloud), so no Omnigent-side credential is wired; **readiness gates on the `omp` binary**.
- A **server-seeded built-in `omp` agent** makes the tile appear in `/v1/agents` out of the box, with a "Oh My Pi" label + omega icon in the web UI.

<details><summary>Why ACP, not a native TUI harness</summary>

An earlier revision tried a native-TUI harness by cloning `pi-native`'s bridge extension (omp is Pi-family). A live end-to-end test proved that path **non-viable**: omp's plugin/extension API is a `setup()`-based npm-package system, **incompatible** with pi's single-file `module.exports = function(pi)` + `pi.on(...)` contract. omp loaded the extension file but **never invoked its entry point**, so the inbox poller never started and no turns mirrored. ACP (`omp acp`) is omp's supported integration surface and works cleanly, so the harness was re-based onto it.
</details>

## Test Plan

Environment: fork run via `uv sync` (workspace resolves the circular `omnigent`↔`omnigent-client` editable path deps; plain `pip install -e .` can't).

- **Live E2E (real omp, isolated local server+runner):** `omnigent run --harness omp` → server → runner → `omp acp` → **real inference round-trip confirmed** (`PONG`). Server startup seeds the built-in `omp` agent; `GET /v1/agents` returns `omp` alongside the other tiles.
- **Unit tests (pass):** `test_omp_builtin_harness_is_acp_backed` (harness→acp module, pinned spawn builder, label), `test_omp_spawn_env_pins_the_acp_command`, `test_omp_harness_gates_on_omp_binary`, `test_configured_harness_map_exposes_omp`.
- **Lint/type:** `ruff check` clean on all changed Python; web `tsc -b` type-check clean.

## Demo

A new **"Oh My Pi"** tile appears in New Chat (omega icon), backed by `omp acp`. _(UI is a one-line label+icon addition; the substantive change is backend. Screenshot pending a UI run if reviewers want one.)_

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the omp harness registration, the pinned `omp acp` spawn command, and the binary readiness gate. Manual verification covered the full live round-trip (`omnigent run --harness omp` → real reply), the server seed + `/v1/agents` listing, ruff, and the web type-check. Not yet automated: a UI-driven picker→session E2E (the ACP session machinery it rides on is already covered by the generic ACP path).
