### PR TITLE
ci(android): add version-code input to bundle workflow

### DIFF
--- a/.github/workflows/android-bundle.yml
+++ b/.github/workflows/android-bundle.yml
@@ -7,6 +7,10 @@ name: Android Bundle
 on:
   workflow_dispatch:
     inputs:
+      version-code:
+        description: "versionCode (must be higher than the last uploaded to Play; starts at 3)"
+        required: true
+        type: string
       version-note:
         description: "Optional note appended to the artifact filename (e.g. rc1)"
         required: false
@@ -43,7 +47,7 @@ jobs:
           cache-read-only: false
 
       - name: Build release AAB
-        run: ./gradlew bundleRelease --no-daemon --console=plain
+        run: ./gradlew bundleRelease --no-daemon --console=plain -PversionCode=${{ github.event.inputs.version-code }}
 
       - name: Verify artifact
         run: |

--- a/web/android/app/build.gradle.kts
+++ b/web/android/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
         applicationId = "ai.omnigent.android"
         minSdk = 28
         targetSdk = 35
-        versionCode = 2
+        versionCode = (project.findProperty("versionCode") as? String)?.toIntOrNull() ?: 2
         versionName = "0.1.0"
     }
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a required `version-code` input to the `workflow_dispatch` trigger in the Android Bundle workflow. The value is passed to Gradle via `-PversionCode=N` and read in `build.gradle.kts` so each CI-built AAB gets a unique, Play-compatible `versionCode` without manual edits to the build file.

## Test Plan

- Verified locally: `./gradlew -PversionCode=99 assembleDebug` produces an APK with `versionCode='99'`.
- Verified fallback: `./gradlew assembleDebug` (no property) still defaults to `versionCode=2`.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the Gradle property override produces the correct versionCode in the built APK via `aapt dump badging`.
