### PR TITLE
docs: add finishing-task and deprecation guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,20 @@ Generate the description from the actual diff and this session's context — lea
 with the motivation, then the change. Don't pass a `--body` that skips these
 sections.
 
+## Finishing a task
+
+When you finish a task, print instructions to the user on how to test it: the
+commands to run, the inputs to provide, or the steps to reproduce so they can
+verify the result themselves. Don't leave the user guessing how to confirm the
+work — tell them exactly what to do.
+
+## Deprecating features
+
+When deprecating a feature, note the version in which it is expected to be
+removed so we can clean it up when that version ships. Call out the deprecation
+version in code (e.g. a `@deprecated` tag or comment naming the target release)
+and in the PR/commit description, so there's a clear marker to act on later.
+
 ## Code comments
 
 Keep comments short and focused on the code, not on the change history.


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds two new sections to `AGENTS.md` to guide AI agents working in this repo:

- **Finishing a task** — agents should print explicit testing instructions (commands to run, inputs to provide, or reproduction steps) when completing a task, so the user can verify the work without guessing.
- **Deprecating features** — when deprecating a feature, note the version in which it is expected to be removed (in code via a `@deprecated` tag/comment naming the target release, and in the PR/commit description), so we can clean it up when that version ships.

## Test Plan

- Reviewed the rendered `AGENTS.md` for consistent tone, heading level, and placement (between "Pull requests" and "Code comments").
- Ran the repo's `pre-commit` hook against `AGENTS.md`; all checks passed.

## Demo

N/A — docs-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Docs-only change to `AGENTS.md`; no executable code is affected, so automated test coverage is not applicable.
