### PR TITLE
fix(web): stop double-prefixing the basename on query/hash paths

### DIFF
--- a/web/src/lib/routing.test.tsx
+++ b/web/src/lib/routing.test.tsx
@@ -43,6 +43,27 @@ describe("basenamedRouting Link rebasing", () => {
     // Same invariant for the object form's pathname.
     expect(renderRebasedLink("/mount", { pathname: "/mount/c/abc" })).toBe("/mount/c/abc");
   });
+
+  it("does not double-prefix the bare basename carrying a query", () => {
+    // Regression guard: the settings "Back to Omnigent" link targets the
+    // pre-settings location captured from `useLocation()`, which in the embed
+    // already includes the basename. On the home page that's the bare basename
+    // plus the host's `?o=<workspace>` search (e.g. `/mount?o=123`). The old
+    // guard only treated `=== basename` / `${basename}/` as "already under",
+    // so the `?`-boundary form fell through and was prefixed again, landing at
+    // `/mount/mount?o=123` — a 404 (the reported double-basename bug).
+    expect(renderRebasedLink("/mount", "/mount?o=123")).toBe("/mount?o=123");
+    expect(renderRebasedLink("/mount", { pathname: "/mount", search: "?o=123" })).toBe(
+      "/mount?o=123",
+    );
+  });
+
+  it("still rebases a distinct sibling segment that only shares the basename prefix", () => {
+    // The boundary check must not over-match: `/mounting` is NOT under `/mount`
+    // (no `/`, `?`, or `#` at the boundary), so it gets rebased like any other
+    // app-absolute path.
+    expect(renderRebasedLink("/mount", "/mounting")).toBe("/mount/mounting");
+  });
 });
 
 describe("rebasePath primitive", () => {
@@ -60,5 +81,14 @@ describe("rebasePath primitive", () => {
 
   it("does not double-prefix a path already under the basename", () => {
     expect(basenamedRouting("/mount").rebasePath("/mount/c/abc")).toBe("/mount/c/abc");
+    // The `?`/`#` boundary forms are equally "already under" the basename.
+    expect(basenamedRouting("/mount").rebasePath("/mount?o=123")).toBe("/mount?o=123");
+    expect(basenamedRouting("/mount").rebasePath("/mount#frag")).toBe("/mount#frag");
+  });
+
+  it("rebases a distinct sibling segment that only shares the basename prefix", () => {
+    // `/mounting` merely shares the `/mount` text prefix; it's a different path
+    // and must be rebased under the mount, not treated as already-under.
+    expect(basenamedRouting("/mount").rebasePath("/mounting")).toBe("/mount/mounting");
   });
 });

--- a/web/src/lib/routing.tsx
+++ b/web/src/lib/routing.tsx
@@ -77,8 +77,19 @@ export const reactRouterRouting: RoutingApi = {
  */
 function rebasePath(path: string, basename: string): string {
   if (!path.startsWith("/")) return path;
-  // Avoid double-prefixing if already under the basename.
-  if (path === basename || path.startsWith(`${basename}/`)) return path;
+  // Avoid double-prefixing if already under the basename. The basename ends at
+  // the first `/`, `?`, or `#` (or end of string) — so `/mount`, `/mount/c/x`,
+  // and `/mount?o=1` are all "already under `/mount`", but a distinct segment
+  // like `/mounting` is not. Checking only `=== basename` / `${basename}/`
+  // missed the query/hash forms: a mount-absolute path carrying a search (e.g.
+  // the settings "Back to Omnigent" target `/mount?o=123`, captured from
+  // `useLocation()` which already includes the basename) fell through and got
+  // prefixed again → `/mount/mount?o=123`, a 404.
+  if (path === basename) return path;
+  if (path.startsWith(basename)) {
+    const boundary = path[basename.length];
+    if (boundary === "/" || boundary === "?" || boundary === "#") return path;
+  }
   return `${basename}${path}`;
 }
 


### PR DESCRIPTION
## What

In an embedded mount (basename e.g. `/omnigent`) the app matches **absolute** paths, so `useLocation().pathname` already includes the basename. The settings sidebar (`SettingsSidebarBody` / `useTrackSettingsReturn`) captures that location as the **"Back to Omnigent"** return target. On the home page that's the bare basename plus the host's search — e.g. `/omnigent?o=<workspace>`. The link then routes it back through `rebasePath`, whose idempotency guard only treated `=== basename` and `` `${basename}/` `` as "already under the basename":

```ts
if (path === basename || path.startsWith(`${basename}/`)) return path;
```

`/omnigent?o=123` matches neither (the char after `/omnigent` is `?`, not `/`), so it gets prefixed a **second** time → `/omnigent/omnigent?o=123`, which 404s. A conversation return path (`/omnigent/c/abc`) escaped the bug only because it happens to start with `/omnigent/`.

## Fix

Treat `/`, `?`, `#`, and end-of-string as the basename boundary — matching the guard's own documented contract, *"does not double-prefix a path already under the basename"* — while still rebasing a distinct sibling segment like `/mounting` that merely shares the text prefix.

## Repro

1. Open the app under an embed mount (e.g. `/omnigent`) with a host query string (`?o=<workspace>`).
2. Go to Settings, then click **"Back to Omnigent"**.
3. Before: navigates to `/omnigent/omnigent?o=<workspace>` → 404. After: returns to `/omnigent?o=<workspace>`.

## Tests

`web/src/lib/routing.test.tsx` — added regression coverage (`vitest run src/lib/routing.test.tsx`, 9/9 pass):
- `basenamedRouting` `Link` rebasing: a bare-basename path carrying a query — `/mount?o=123` and the object form `{ pathname: "/mount", search: "?o=123" }` — resolves to `/mount?o=123`, not `/mount/mount?o=123` (fails on the old guard, passes on the new one).
- `rebasePath` primitive: the `?` and `#` boundary forms (`/mount?o=123`, `/mount#frag`) pass through untouched.
- Over-match guard: `/mounting` (shares only the text prefix, no boundary char) is still rebased to `/mount/mounting`.

manual test:
https://github.com/user-attachments/assets/2e69a7c0-8560-4fff-8502-2dc8a11ae1bc

