### PR TITLE
feat(cli): friendly crash handler with pre-filled GitHub issue filing

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1420,6 +1420,16 @@ def main() -> None:
     so unhandled exceptions are captured even when the user didn't
     enable ``--log`` or ``--debug-events``.
     """
+    # Friendly crash handler: replaces Python's raw traceback with a
+    # calm, branded crash screen + a one-tap path to file a GitHub issue
+    # (browser opens the repo's pre-filled bug-report template with the
+    # traceback, version, and OS in the Description field).
+    # Installed first so crashes anywhere below — argv shorthands, Click
+    # dispatch, imports — are all caught. See omnigent/crash_handler.py.
+    from omnigent.crash_handler import install_crash_handler
+
+    install_crash_handler(app_name="omnigent", repo="omnigent-ai/omnigent")
+
     cwd = os.getcwd()
     if cwd not in sys.path:
         sys.path.insert(0, cwd)
@@ -1525,10 +1535,19 @@ def main() -> None:
         click.echo("Aborted!", err=True)
         raise SystemExit(1) from exc
     except Exception as exc:
+        # Keep the diagnostics log line ("Details logged to …") — the
+        # always-on CLI log has more context than this single crash — then
+        # hand off to the friendly crash handler for the calm screen,
+        # de-emphasized traceback, and the bug-filing prompt. We drop the
+        # `omnigent setup` hint here: genuine crashes are rarely auth issues,
+        # and "run setup" would contradict the crash screen's reassurance.
+        # `handle_crash` renders the UX and we exit with code 1 (SystemExit
+        # does NOT re-trigger sys.excepthook, so there's no double render).
+        from omnigent.crash_handler import handle_crash
+
         log_cli_error_hint(exc)
-        if suggest_setup:
-            print_setup_hint()
-        raise
+        handle_crash(exc)
+        raise SystemExit(1) from exc
 
 
 def _is_run_shorthand(argv: list[str]) -> bool:

--- a/omnigent/crash_handler.py
+++ b/omnigent/crash_handler.py
@@ -1,0 +1,524 @@
+"""Friendly crash reporting with one-tap GitHub issue filing.
+
+Replaces Python's default wall-of-red traceback with a calm, branded
+crash screen (see :mod:`omnigent.crash_ui`) and lets the user file a
+GitHub issue from the repo's pre-filled bug-report template.
+
+Design notes
+------------
+* **No token is shipped.** We can't embed a GitHub credential in a
+  distributed binary — anyone could extract it. Instead we open the
+  repo's bug-report template in the browser with the title, version,
+  OS, and the full traceback pre-filled into the Description field via
+  URL query params. The clipboard carries the full report as a backup
+  in case the URL is too long and the description gets truncated.
+* **One chokepoint.** ``sys.excepthook`` (main thread) +
+  ``threading.excepthook`` (background threads) + ``faulthandler``
+  (C-level segfaults, captured to a file since the process is already
+  dying) cover every normal crash path.
+* **TTY-aware.** The interactive "file a bug?" prompt only runs when
+  stdin AND stderr are real TTYs, so scripts/CI never hang — they get
+  the saved report path and the issue link printed plainly.
+* **KeyboardInterrupt / SystemExit** are not crashes: they defer to the
+  original hooks so Ctrl-C and normal exits behave exactly as before.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import datetime
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import traceback
+import urllib.parse
+import webbrowser
+from pathlib import Path
+from typing import TextIO
+
+from omnigent.crash_ui import real_stderr, render_crash_screen
+from omnigent.process_logging import data_dir
+
+# Saved at install time so we can defer to the originals for
+# KeyboardInterrupt / SystemExit and as a last-resort fallback if our
+# own handler misfires.
+_ORIG_EXCEPTHOOK = sys.__excepthook__
+_ORIG_THREADING_EXCEPTHOOK = threading.excepthook
+
+# Runtime configuration, populated by install_crash_handler().
+_CONFIG: dict = {
+    "app_name": "omnigent",
+    "repo": "omnigent-ai/omnigent",
+    "version": "unknown",
+    "crashes_dir": None,
+    "keep_reports": 10,
+}
+
+# Reentrancy guard: if handling a crash itself raises, we must not
+# recurse forever through excepthook. Per-thread so a crash in one
+# thread can't block another's reporting.
+_HANDLING = threading.local()
+
+# File handle kept open for faulthandler so C-level segfaults dump to a
+# file (out of the terminal) instead of screaming at the user.
+_FH_FILE: object | None = None
+
+# Maximum total URL length for the pre-filled GitHub issue link. GitHub
+# and some browsers reject or silently truncate very long URLs (a deep
+# recursion crash can produce a many-KB traceback). 8000 chars is the
+# widely-cited safe limit for cross-browser compatibility; the clipboard
+# always carries the full report as a backup when we truncate.
+_MAX_URL_LENGTH = 8000
+
+
+# --------------------------------------------------------------------------- #
+# Installation
+# --------------------------------------------------------------------------- #
+def install_crash_handler(
+    app_name: str,
+    repo: str,
+    *,
+    version: str | None = None,
+    crashes_dir: str | Path | None = None,
+    keep_reports: int = 10,
+    enable_faulthandler: bool = True,
+    first_party_prefixes: tuple[str, ...] = ("omnigent",),
+) -> None:
+    """Install the friendly crash handler.
+
+    Call once, as early as possible in the binary's entrypoint, so
+    unhandled exceptions anywhere downstream are caught.
+
+    :param app_name:  Human name shown in the crash header (``omnigent``).
+    :param repo:      ``owner/repo`` for the GitHub issues URL.
+    :param version:   App version string for the report. Defaults to
+                      ``omnigent.version.VERSION``.
+    :param crashes_dir: Where to write ``crash-*.md`` reports. Defaults
+                      to ``<data-dir>/crashes`` (honors
+                      ``OMNIGENT_DATA_DIR``).
+    :param keep_reports: Rotate to keep at most this many crash reports.
+    :param enable_faulthandler: Capture C-level segfaults to a file
+                      (off the terminal) instead of the default stderr
+                      dump.
+    :param first_party_prefixes: Top-level package prefixes treated as
+                      own code in the compact traceback (always shown,
+                      never collapsed — even when installed under
+                      site-packages in a distributed wheel). Defaults to
+                      ``("omnigent")``, which covers the three core
+                      packages (``omnigent``, ``omnigent_client``,
+                      ``omnigent_ui_sdk``) via the ``<prefix>_`` rule.
+    """
+    _CONFIG.update(
+        app_name=app_name,
+        repo=repo,
+        version=version if version is not None else _read_version(),
+        crashes_dir=str(crashes_dir) if crashes_dir else None,
+        keep_reports=keep_reports,
+        first_party_prefixes=tuple(first_party_prefixes) or ("omnigent",),
+    )
+    sys.excepthook = _excepthook
+    threading.excepthook = _threading_excepthook
+    if enable_faulthandler:
+        _enable_faulthandler()
+
+
+def _read_version() -> str:
+    try:
+        from omnigent.version import VERSION
+
+        return VERSION
+    except Exception:  # noqa: BLE001  pragma: no cover
+        return "unknown"
+
+
+def _crashes_dir() -> Path:
+    override = _CONFIG.get("crashes_dir")
+    if override:
+        return Path(override).expanduser()
+    return data_dir() / "crashes"
+
+
+def _enable_faulthandler() -> None:
+    """Route C-level segfault dumps to a file, off the terminal.
+
+    Our Python excepthook can't run after a segfault (the process is
+    already dying), so we can't make that pretty or interactive. But we
+    can at least keep the faulthandler dump out of the user's terminal
+    by redirecting it to ``<crashes>/faulthandler.log``.
+    """
+    global _FH_FILE
+    try:
+        import faulthandler
+
+        # Close any handle left open by a previous install (e.g. repeated
+        # ``main()`` calls in the test suite) so we never leak file
+        # descriptors across reinstalls.
+        if _FH_FILE is not None:
+            with contextlib.suppress(Exception):  # pragma: no cover
+                _FH_FILE.close()
+        d = _crashes_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        # Intentionally held open for the process lifetime: faulthandler
+        # writes here on a segfault, when we can't run cleanup code.
+        f = open(d / "faulthandler.log", "ab", buffering=0)  # noqa: SIM115
+        faulthandler.enable(file=f, all_threads=True)
+        _FH_FILE = f
+    except Exception:  # noqa: BLE001  pragma: no cover
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# Hooks
+# --------------------------------------------------------------------------- #
+def _excepthook(etype, value, tb) -> None:
+    # Ctrl-C and normal exits are not crashes — defer to the originals.
+    if issubclass(etype, (KeyboardInterrupt, SystemExit)):
+        _ORIG_EXCEPTHOOK(etype, value, tb)
+        return
+    handle_crash(value, tb=tb, source="uncaught")
+    # After an uncaught exception in the main thread the interpreter
+    # exits with code 1 once this hook returns — no explicit exit needed.
+
+
+def _threading_excepthook(args) -> None:
+    if issubclass(args.exc_type, (KeyboardInterrupt, SystemExit)):
+        _ORIG_THREADING_EXCEPTHOOK(args)
+        return
+    # A crashed background thread shouldn't block the main thread with
+    # an interactive prompt (racy and surprising). Save the report and
+    # print a concise notice + link instead.
+    name = getattr(getattr(args, "thread", None), "name", "?")
+    handle_crash(
+        args.exc_value,
+        tb=args.exc_traceback,
+        source=f"thread:{name}",
+        interactive=False,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Core: render screen, save report, offer to file a bug
+# --------------------------------------------------------------------------- #
+def handle_crash(
+    exc: BaseException,
+    *,
+    tb=None,
+    source: str = "uncaught",
+    interactive: bool | None = None,
+) -> None:
+    """Handle one uncaught exception end-to-end.
+
+    1. Build + save a GitHub-ready crash report (rotated).
+    2. Print the calm crash screen + de-emphasized traceback.
+    3. If interactive, prompt to file a GitHub issue; on yes, open a
+       pre-filled bug-report page (traceback, version, OS in the URL).
+       The clipboard gets the full report as a backup.
+
+    Reentrant-safe: a crash inside this function falls back to the
+    original excepthook rather than looping forever.
+    """
+    if getattr(_HANDLING, "on", False):
+        return
+    _HANDLING.on = True
+    try:
+        stream = real_stderr()
+        # Full, unmodified traceback for the saved report (real paths, every
+        # frame — what a developer needs to debug). The on-screen version is
+        # a compacted view of the same exception (shortened paths, collapsed
+        # library frames); see omnigent/crash_ui.render_crash_screen.
+        formatted = traceback.format_exception(type(exc), exc, tb or exc.__traceback__)
+        tb_text = "".join(formatted)
+
+        report_md = _build_report(exc, tb_text, source=source)
+        report_path = _save_report(report_md)
+
+        render_crash_screen(
+            app_name=_CONFIG["app_name"],
+            report_path=str(report_path),
+            exc=exc,
+            tb=tb or exc.__traceback__,
+            stream=stream,
+            first_party_prefixes=_CONFIG.get("first_party_prefixes", ("omnigent",)),
+        )
+
+        if interactive is None:
+            interactive = _is_interactive(stream)
+        if interactive:
+            _interactive_flow(report_md, report_path, exc, tb_text, stream)
+        else:
+            _fallback_notice(report_path, exc, tb_text, stream)
+    except Exception:  # noqa: BLE001 — crash handler must never crash visibly
+        # Never let the crash handler itself crash visibly.
+        with contextlib.suppress(Exception):
+            _ORIG_EXCEPTHOOK(type(exc), exc, tb or exc.__traceback__)
+    finally:
+        _HANDLING.on = False
+
+
+def _is_interactive(stream: TextIO) -> bool:
+    """Interactive only when BOTH stderr and stdin are real TTYs.
+
+    This avoids hanging in scripts/CI where stderr happens to be a TTY
+    but stdin is closed or piped.
+    """
+    stderr_tty = bool(getattr(stream, "isatty", lambda: False)())
+    stdin_tty = bool(getattr(sys.stdin, "isatty", lambda: False)())
+    return stderr_tty and stdin_tty
+
+
+# --------------------------------------------------------------------------- #
+# Report building + persistence
+# --------------------------------------------------------------------------- #
+# Light redaction of common bearer/token shapes that could appear on
+# the command line (e.g. ``--api-key sk-...``). The user reviews the
+# report before posting; this just catches the obvious ones.
+_TOKEN_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9_\-]{6,}"),  # OpenAI-style
+    re.compile(r"dapi-[A-Za-z0-9_\-]{6,}"),  # Anthropic-style
+    re.compile(r"xox[baprs]-[A-Za-z0-9\-]{6,}"),  # Slack
+    re.compile(r"gh[opusr]_[A-Za-z0-9]{16,}"),  # GitHub
+    re.compile(r"AIza[A-Za-z0-9_\-]{20,}"),  # Google API
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]{6,}"),  # Authorization header
+]
+
+
+def _redact(text: str) -> str:
+    for pat in _TOKEN_PATTERNS:
+        text = pat.sub(lambda m: m.group(0)[:4] + "***", text)
+    return text
+
+
+def _command_line() -> str:
+    try:
+        return _redact(" ".join(sys.argv))
+    except Exception:  # noqa: BLE001  pragma: no cover
+        return "(unavailable)"
+
+
+def _build_report(exc: BaseException, tb_text: str, *, source: str) -> str:
+    """Compose the GitHub-ready markdown report."""
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    exc_type = type(exc).__qualname__
+    msg = str(exc).strip() or "(no message)"
+    version = _CONFIG["version"]
+    app_name = _CONFIG["app_name"]
+    repo = _CONFIG["repo"]
+
+    return f"""# Crash Report — {app_name}
+
+**Date:** {now}
+**Version:** {app_name} {version}
+**Platform:** {platform.platform()}
+**Python:** {platform.python_version()}
+**Source:** {source}
+**Repository:** https://github.com/{repo}
+
+## Summary
+
+`{exc_type}`: {msg}
+
+## Traceback
+
+```
+{tb_text}
+```
+
+## Command
+
+```
+{_command_line()}
+```
+
+---
+
+> The full traceback is also pre-filled into the GitHub issue's
+> Description field when filing from the crash prompt. Review the
+> **Command** line above for secrets before submitting.
+"""
+
+
+def _save_report(report_md: str) -> Path:
+    """Write the report to the crashes dir (rotated) and return its path."""
+    d = _crashes_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = d / f"crash-{stamp}.md"
+    if path.exists():  # same-second collision — disambiguate by pid.
+        path = d / f"crash-{stamp}-{os.getpid()}.md"
+    path.write_text(report_md, encoding="utf-8")
+    with contextlib.suppress(OSError):
+        os.chmod(path, 0o600)
+    _rotate(d, _CONFIG.get("keep_reports", 10))
+    return path
+
+
+def _rotate(d: Path, keep: int) -> None:
+    """Keep only the newest ``keep`` ``crash-*.md`` reports."""
+    with contextlib.suppress(Exception):
+        files = sorted(
+            d.glob("crash-*.md"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        for old in files[keep:]:
+            old.unlink()
+
+
+# --------------------------------------------------------------------------- #
+# Interactive bug-filing flow (TTY only)
+# --------------------------------------------------------------------------- #
+def _interactive_flow(
+    report_md: str, report_path: Path, exc: BaseException, tb_text: str, stream: TextIO
+) -> None:
+    url, body_included = _issue_url(exc, _issue_body(exc, tb_text))
+    if _prompt_yes_no(
+        "Help us fix it — file a GitHub issue with this report? [Y/n] ",
+        stream,
+    ):
+        _copy_to_clipboard(report_md)  # always: backup, or primary if body dropped
+        opened = _open_browser(url)
+        _print(stream, "")
+        if opened and body_included:
+            _print(stream, "  ✓ Opening a pre-filled GitHub issue — review and submit.")
+        elif opened:
+            _print(
+                stream,
+                "  ✓ Opening a GitHub issue — paste the report from your clipboard (Ctrl+V).",
+            )
+        else:
+            _print(stream, "  Couldn't open the browser. Open this link to file the issue:")
+            _print(stream, f"    {url}")
+            _print(stream, "  The report is in your clipboard (Ctrl+V to paste).")
+    else:
+        _print(stream, "")
+        _print(stream, "  Report saved here:")
+        _print(stream, f"    {report_path}")
+    _print(stream, "")
+
+
+def _fallback_notice(report_path: Path, exc: BaseException, tb_text: str, stream: TextIO) -> None:
+    """Non-interactive: just state where the report is and where to file."""
+    url, _ = _issue_url(exc, _issue_body(exc, tb_text))
+    _print(stream, "")
+    _print(stream, f"A crash report was saved to: {report_path}")
+    _print(stream, f"File an issue: {url}")
+    _print(stream, "")
+
+
+def _issue_body(exc: BaseException, tb_text: str) -> str:
+    """Build the markdown for the issue template's Description field.
+
+    Leaner than :func:`_build_report`: the version and OS live in their
+    own prefilled template fields, so they're omitted here to avoid
+    duplication. What remains is the exception summary, the command
+    that triggered the crash, and the **full** traceback (every frame,
+    real paths) — exactly what a developer needs to reproduce and fix it.
+    """
+    exc_type = type(exc).__qualname__
+    msg = str(exc).strip() or "(no message)"
+    return (
+        "This crash was auto-reported by Omnigent's crash handler.\n\n"
+        f"**Exception:** `{exc_type}: {msg}`\n\n"
+        "**Command:**\n"
+        f"```\n{_command_line()}\n```\n\n"
+        "**Traceback:**\n"
+        f"```\n{tb_text}```\n"
+    )
+
+
+def _issue_url(exc: BaseException, body: str = "") -> tuple[str, bool]:
+    """Pre-filled ``bug_report.yml`` issue URL.
+
+    Returns ``(url, body_included)``: the URL has the template, title,
+    version, and OS prefilled always; the Description (full traceback)
+    is included only if it fits :data:`_MAX_URL_LENGTH`. When the body
+    is dropped (``body_included is False``), the caller should tell the
+    user to paste the report from the clipboard instead.
+
+    Field IDs (``version``, ``os``, ``description``) come from
+    ``.github/ISSUE_TEMPLATE/bug_report.yml``; keep in sync if it changes.
+    """
+    first_line = (str(exc).strip().splitlines() or [""])[0]
+    title = f"[Crash] {type(exc).__qualname__}: {first_line[:140]}"
+    repo = _CONFIG["repo"]
+    version = _CONFIG.get("version", "unknown")
+    os_str = platform.platform(terse=True)
+    base = f"https://github.com/{repo}/issues/new?"
+
+    params = {
+        "template": "bug_report.yml",
+        "title": title,
+        "version": version,
+        "os": os_str,
+    }
+    if not body:
+        return base + urllib.parse.urlencode(params), False
+
+    # Try the full body in the URL. If it would exceed the safe limit,
+    # drop the description entirely — the clipboard carries the full
+    # report and the caller tells the user to paste it. No half-measures.
+    params["description"] = body
+    url = base + urllib.parse.urlencode(params)
+    if len(url) <= _MAX_URL_LENGTH:
+        return url, True
+    params.pop("description")
+    return base + urllib.parse.urlencode(params), False
+
+
+def _prompt_yes_no(prompt: str, stream: TextIO) -> bool:
+    """Ask a yes/no question; default Yes on empty Enter. Never raises."""
+    try:
+        stream.write(prompt)
+        stream.flush()
+        line = sys.stdin.readline().strip().lower()
+    except Exception:  # noqa: BLE001  pragma: no cover  (EOF / closed stdin)
+        return False
+    return line in ("", "y", "yes")
+
+
+def _print(stream: TextIO, text: str) -> None:
+    stream.write(text + "\n")
+    stream.flush()
+
+
+# --------------------------------------------------------------------------- #
+# Clipboard + browser (all best-effort, silent on failure)
+# --------------------------------------------------------------------------- #
+def _copy_to_clipboard(text: str) -> bool:
+    """Copy ``text`` to the system clipboard via the native tool. No deps."""
+    try:
+        if sys.platform == "darwin":
+            return _pipe(["pbcopy"], text)
+        if sys.platform.startswith("win"):
+            # clip.exe mangles some UTF-8 but is always present; good
+            # enough for tracebacks (mostly ASCII).
+            return _pipe(["clip"], text)
+        # Linux / *nix: prefer xclip, fall back to xsel.
+        for cmd in (("xclip", "-selection", "clipboard"), ("xsel", "--clipboard", "--input")):
+            if shutil.which(cmd[0]):
+                return _pipe(list(cmd), text)
+        return False
+    except Exception:  # noqa: BLE001  pragma: no cover
+        return False
+
+
+def _pipe(cmd: list[str], text: str) -> bool:
+    proc = subprocess.run(
+        cmd,
+        input=text.encode("utf-8", "replace"),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=5,
+    )
+    return proc.returncode == 0
+
+
+def _open_browser(url: str) -> bool:
+    try:
+        return bool(webbrowser.open(url, new=2))
+    except Exception:  # noqa: BLE001  pragma: no cover
+        return False

--- a/omnigent/crash_ui.py
+++ b/omnigent/crash_ui.py
@@ -1,0 +1,410 @@
+"""Presentation layer for crash reporting.
+
+Renders a calm, less-scary crash screen in place of Python's default
+wall-of-red traceback: an amber header, the report path, then the
+traceback de-emphasized underneath (shortened paths, collapsed library
+frames, muted-gray stack frames, the final exception line in bold).
+
+Everything visual — ANSI color, Unicode glyphs, emoji — is TTY-gated
+and degrades to plain ASCII when output is piped or the terminal
+can't render it, so log files and CI captures stay clean.
+
+This module is purely presentational; crash mechanics (report
+building, file saving, clipboard, browser, the bug-filing prompt)
+live in :mod:`omnigent.crash_handler`. Keeping them separate means the
+look-and-feel can be tuned without touching crash logic.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import sys
+import traceback as _tb
+from pathlib import Path
+from typing import TextIO
+
+# --------------------------------------------------------------------------- #
+# ANSI — applied only on a TTY; empty strings otherwise so piped/CI
+# output contains no escape codes.
+# --------------------------------------------------------------------------- #
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_AMBER = "\033[33m"
+_AMBER_BOLD = "\033[33;1m"
+_GRAY = "\033[90m"
+
+
+def real_stderr() -> TextIO:
+    """Return the user's real terminal stderr.
+
+    ``omnigent.cli_diagnostics.setup_cli_logging`` may replace
+    ``sys.stderr`` with a wrapper that tees into the CLI diagnostics
+    log; the original terminal is stashed on ``_original_stderr``. The
+    crash screen must land on the actual terminal, not get buried in a
+    log file, so reach through that attribute when present.
+    """
+    return getattr(sys.stderr, "_original_stderr", sys.stderr)
+
+
+def _is_tty(stream: TextIO) -> bool:
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+def _color(stream: TextIO) -> bool:
+    """Whether to emit ANSI color: only on a real, color-capable TTY."""
+    if not _is_tty(stream):
+        return False
+    # Respect NO_COLOR (https://no-color.org/) and explicit disable.
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if os.environ.get("CLICOLOR") == "0" or os.environ.get("CLICOLOR_FORCE") == "0":
+        return False
+    return True
+
+
+def _supports_unicode(stream: TextIO) -> bool:
+    """Best-effort probe for box-drawing + emoji rendering.
+
+    Returns False for ASCII/Latin-only encodings and dumb terminals so
+    we fall back to plain ASCII glyphs rather than emitting tofu (U+FFFD)
+    squares. Emoji is gated more conservatively than box-drawing (see
+    :func:`_supports_emoji`) since it renders inconsistently.
+    """
+    enc = (getattr(stream, "encoding", None) or "").lower()
+    if enc and "utf" not in enc and "utf" not in enc.replace("-", ""):
+        return False
+    term = os.environ.get("TERM", "")
+    if term in ("", "dumb"):
+        return False
+    return True
+
+
+def _supports_emoji(stream: TextIO) -> bool:
+    """Emoji rendering is less universal than box-drawing — gate it hard.
+
+    We require a UTF-capable TTY and common modern terminal families
+    where emoji glyphs are known to render. When in doubt, fall back to
+    a plain ``!`` so we never print a missing-glyph square as the very
+    first thing a distressed user sees.
+    """
+    if not _is_tty(stream):
+        return False
+    enc = (getattr(stream, "encoding", None) or "").lower()
+    if "utf" not in enc and "utf" not in enc.replace("-", ""):
+        return False
+    term = os.environ.get("TERM", "").lower()
+    if term in ("", "dumb", "linux"):
+        return False
+    # WSL/ConEmu/Windows Terminal set WT_SESSION / WT_PROFILE; classic
+    # cmd.exe (TERM unset, no WT_*) is iffy for emoji — require a sign.
+    if sys.platform == "win32" and not os.environ.get("WT_SESSION"):
+        return False
+    return True
+
+
+def _term_width(default: int = 80) -> int:
+    """Current terminal column count (best-effort)."""
+    try:
+        return shutil.get_terminal_size((default, 24)).columns
+    except Exception:  # noqa: BLE001  pragma: no cover
+        return default
+
+
+# --------------------------------------------------------------------------- #
+# Rendering primitives
+# --------------------------------------------------------------------------- #
+
+
+def _site_packages_dir() -> str | None:
+    """Best-effort locate the active venv's ``site-packages`` dir.
+
+    Used to classify frames as "library" (collapse) vs "first-party" (show):
+    frames under site-packages are click / yaml / etc. internals that scare
+    users and aren't actionable on screen — they still go into the saved
+    report in full.
+    """
+    for entry in sys.path:
+        if entry and entry.endswith("site-packages") and os.path.isdir(entry):
+            return os.path.abspath(entry)
+    return None
+
+
+def _shorten_path(filename: str, *, cwd: str, site_packages: str | None) -> str:
+    """Make a traceback file path compact for on-screen display.
+
+    * under site-packages → package-relative (``click/core.py``)
+    * under cwd           → relative (``omnigent/cli.py``)
+    * under $HOME         → ``~/...``
+    * otherwise           → unchanged (rare; better verbose than wrong)
+    """
+    with contextlib.suppress(Exception):
+        filename = os.path.abspath(filename)
+    if site_packages:
+        sp = site_packages + os.sep
+        if filename.startswith(sp):
+            return filename[len(sp) :]
+    if cwd:
+        cd = cwd + os.sep
+        if filename.startswith(cd):
+            return filename[len(cd) :]
+    home = str(Path.home())
+    if home and filename.startswith(home + os.sep):
+        return "~" + filename[len(home) :]
+    return filename
+
+
+def _frame_pkg(short_path: str) -> str:
+    """Top-level package name of a site-packages-relative path."""
+    parts = short_path.replace("\\", "/").split("/")
+    return parts[0] if parts and parts[0] else short_path
+
+
+def _resolve_top_package(filename: str) -> str | None:
+    """Return the top-level package/dir name a frame's file belongs to.
+
+    Matches the absolute path against ``sys.path`` entries (longest prefix
+    wins) and takes the first path component after the match. This works
+    for editable installs (``sdks/python-client/omnigent_client/foo.py`` →
+    ``omnigent_client``) and for wheel installs into site-packages
+    (``site-packages/omnigent_client/foo.py`` → ``omnigent_client``).
+
+    Used to tell first-party packages apart from third-party libs even
+    when both live under ``site-packages`` in a distributed wheel —
+    without this, our own SDK packages would be wrongly collapsed.
+    """
+    try:
+        abspath = os.path.abspath(filename)
+    except Exception:  # noqa: BLE001  pragma: no cover
+        return None
+    best_entry, best_len = None, -1
+    for entry in sys.path:
+        if not entry:
+            continue
+        try:
+            e = os.path.abspath(entry)
+        except Exception:  # noqa: BLE001  pragma: no cover
+            continue
+        if abspath.startswith(e + os.sep) and len(e) > best_len:
+            best_entry, best_len = e, len(e)
+    if best_entry is None:
+        return None
+    rel = abspath[len(best_entry) + len(os.sep) :]
+    top = rel.split(os.sep, 1)[0]
+    if top.endswith(".py"):
+        top = top[:-3]
+    return top or None
+
+
+# Default first-party prefix. Frames whose top-level package equals this
+# or starts with ``<prefix>_`` are always shown (never collapsed), even
+# when installed under site-packages in a distributed wheel. Covers the
+# three core packages — ``omnigent``, ``omnigent_client``,
+# ``omnigent_ui_sdk`` — plus the ``omnigent_slack`` integration.
+_DEFAULT_FIRST_PARTY_PREFIXES = ("omnigent",)
+
+
+def _is_first_party_pkg(pkg: str | None, prefixes: tuple[str, ...]) -> bool:
+    """True when *pkg* is an own-code package (exact or ``<prefix>_``)."""
+    if not pkg:
+        return False
+    return any(pkg == p or pkg.startswith(p + "_") for p in prefixes)
+
+
+def _full_traceback_env() -> bool:
+    """``OMNIGENT_FULL_TRACEBACK=1`` disables library-frame collapsing."""
+    return os.environ.get("OMNIGENT_FULL_TRACEBACK", "").strip().lower() in ("1", "true", "yes")
+
+
+def format_traceback(
+    exc: BaseException,
+    tb,
+    *,
+    colored: bool,
+    unicode_ok: bool,
+    first_party_prefixes: tuple[str, ...] = _DEFAULT_FIRST_PARTY_PREFIXES,
+) -> str:
+    """Render an exception + traceback with calm, compact styling.
+
+    Two transforms make the wall-of-red readable:
+
+    1. **Path shortening** — venv ``site-packages`` paths become
+       package-relative (``click/core.py``), the cwd becomes relative
+       (``omnigent/cli.py``), ``$HOME`` becomes ``~``. Long absolute
+       paths are the biggest source of visual noise.
+
+    2. **Library-frame collapsing** — contiguous frames inside
+       ``site-packages`` (click, yaml, …) are replaced with one dim
+       summary line ``⋯ N frames hidden in <pkgs>  (see the saved
+       report)``. First-party frames (the user's own code) stay visible.
+       The full, unmodified traceback always lives in the saved report.
+
+    The ``Traceback (most recent call last):`` banner and all shown
+    frames are muted gray; the final exception line is bold so the eye
+    lands on the one line that matters. Set ``OMNIGENT_FULL_TRACEBACK=1``
+    to disable collapsing (power users / library-bug debugging).
+    """
+    gray = _GRAY if colored else ""
+    bold = _BOLD if colored else ""
+    dim = _DIM if colored else ""
+    reset = _RESET if colored else ""
+    ell = "⋯" if unicode_ok else "..."
+
+    cwd = os.getcwd()
+    site_packages = _site_packages_dir()
+    collapse_libs = not _full_traceback_env() and site_packages is not None
+
+    frames = _tb.extract_tb(tb or (exc.__traceback__ if exc else None))
+
+    # Group contiguous frames into runs of "first" (own code) / "lib".
+    # Each item carries the rendered source line (if any) for context.
+    groups: list[tuple[str, list[tuple[str, str, str]]]] = []  # (kind, [(name, short, src)])
+    for fr in frames:
+        short = _shorten_path(fr.filename, cwd=cwd, site_packages=site_packages)
+        abspath = os.path.abspath(fr.filename)
+        under_sp = bool(site_packages and abspath.startswith(site_packages + os.sep))
+        under_cwd = bool(cwd and abspath.startswith(cwd + os.sep))
+        top_pkg = _resolve_top_package(fr.filename)
+        # "Own code" = under the project root BUT not inside a venv's
+        # site-packages (in a dev checkout the venv lives under the repo,
+        # so every library frame would otherwise count as first-party),
+        # OR a first-party package by name (catches the SDK packages even
+        # when installed into site-packages in a shipped wheel).
+        is_own = (under_cwd and not under_sp) or _is_first_party_pkg(top_pkg, first_party_prefixes)
+        # Only collapse genuine third-party library frames (under
+        # site-packages AND not our own packages). Own code is always
+        # shown — even when installed in site-packages, as the SDKs are
+        # in a distributed wheel.
+        is_lib = collapse_libs and under_sp and not is_own
+        kind = "lib" if is_lib else "first"
+        src = f"{fr.lineno}: {fr.line}" if fr.line else f"{fr.lineno}"
+        if groups and groups[-1][0] == kind:
+            groups[-1][1].append((fr.name, short, src))
+        else:
+            groups.append((kind, [(fr.name, short, src)]))
+
+    out: list[str] = [f"{gray}Traceback (most recent call last):{reset}"]
+    for kind, items in groups:
+        if kind == "first":
+            for name, short, src in items:
+                out.append(
+                    f'{gray}  File "{short}", line {src.split(":", 1)[0]}, in {name}{reset}'
+                )
+                if ":" in src:
+                    out.append(f"{gray}    {src.split(':', 1)[1].strip()}{reset}")
+        else:
+            pkgs = sorted({_frame_pkg(s) for _, s, _ in items})
+            label = ", ".join(pkgs)
+            out.append(
+                f"{dim}  {ell} {len(items)} frames hidden in {label}  "
+                f"(see the saved report){reset}"
+            )
+
+    # The final exception lines (handles multi-line messages like yaml's
+    # "in <unicode string>, line 1, column 9: ...").
+    exc_lines = _tb.format_exception_only(type(exc), exc)
+    for i, line in enumerate(exc_lines):
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        # First line bold (the ``Etype: msg``); continuation (e.g. the
+        # yaml snippet) stays default so it reads as a quote.
+        if i == 0:
+            out.append(f"{bold}{line}{reset}")
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+def _title(name: str) -> str:
+    """Capitalize the app name for sentence display (``omnigent`` → ``Omnigent``)."""
+    return name[:1].upper() + name[1:] if name else name
+
+
+def render_crash_screen(
+    *,
+    app_name: str,
+    report_path: str,
+    exc: BaseException,
+    tb=None,
+    stream: TextIO | None = None,
+    first_party_prefixes: tuple[str, ...] = _DEFAULT_FIRST_PARTY_PREFIXES,
+) -> None:
+    """Print the static crash screen to ``stream`` (default: real stderr).
+
+    Layout (non-interactive — path at top, no prompt follows)::
+
+        <blank>
+        <amber> ⚠️  <App> ran into an issue. </amber>
+        <indented: report path>
+        <dim>─── technical details ───</dim>
+        <compact traceback>
+
+    Layout (interactive — path deferred to the end, next to the prompt)::
+
+        <blank>
+        <amber> ⚠️  <App> ran into an issue. </amber>
+        <dim>─── technical details ───</dim>
+        <compact traceback>
+        <indented: report path>   ← printed last, right before the [Y/n] prompt
+
+    The interactive "file a bug?" prompt is intentionally NOT part of
+    this static screen — :mod:`omnigent.crash_handler` owns that, so it
+    can gate it on stdin/stdin TTY and handle non-interactive contexts.
+    """
+    stream = stream if stream is not None else real_stderr()
+    colored = _color(stream)
+    on_tty = _is_tty(stream)
+    unicode_ok = _supports_unicode(stream) if on_tty else False
+    tb_text = format_traceback(
+        exc,
+        tb,
+        colored=colored,
+        unicode_ok=unicode_ok,
+        first_party_prefixes=first_party_prefixes,
+    )
+    display = _title(app_name)
+
+    if not on_tty:
+        # Piped / CI / log file: plain text, no box, no emoji, no color.
+        # Path at the top here since there's no interactive prompt after.
+        lines = [
+            "",
+            f"{display} ran into an issue.",
+            "",
+            "A crash report was saved to:",
+            f"  {report_path}",
+            "",
+            "--- technical details ---",
+            tb_text,
+            "",
+        ]
+        stream.write("\n".join(lines) + "\n")
+        stream.flush()
+        return
+
+    # Interactive terminal: header + traceback first, then the report
+    # path printed LAST so it sits right above the [Y/n] prompt (which
+    # crash_handler prints next) — the user sees the path when they need
+    # it, not scrolled away above the traceback.
+    stream.write("\r\033[?25h\033[2K")
+    w = max(40, min(_term_width() - 4, 78))
+    icon = "⚠️  " if _supports_emoji(stream) else "!  "
+    header = f"{icon}{display} ran into an issue."
+    sep = "─" * 3 + " technical details " + "─" * max(0, w - 3 - len(" technical details ") - 3)
+
+    lines: list[str] = [""]
+    lines.append(f"{_AMBER_BOLD if colored else ''}{header}{_RESET if colored else ''}")
+    lines.append("")
+    lines.append(f"{_DIM if colored else ''}{sep}{_RESET if colored else ''}")
+    lines.append(tb_text)
+    lines.append("")
+    # Report path at the very end — next to the prompt that follows.
+    lines.append("  A crash report was saved to:")
+    lines.append(f"  {report_path}")
+    lines.append("")
+
+    stream.write("\n".join(lines) + "\n")
+    stream.flush()

--- a/tests/cli/test_crash_handler.py
+++ b/tests/cli/test_crash_handler.py
@@ -1,0 +1,426 @@
+"""Tests for the friendly crash handler + UI (``omnigent.crash_handler``).
+
+Covers: report building, token redaction, save + rotation, plain
+(non-TTY) rendering, the interactive yes/no bug-filing flow with
+stubbed clipboard/browser, KeyboardInterrupt deferral, and the
+pre-filled GitHub issue URL (template + title + version + OS +
+description).
+
+These run under the project's normal pytest invocation. The data dir is
+isolated via ``OMNIGENT_DATA_DIR`` so no reports are written to the
+developer's real ``~/.omnigent``.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from omnigent import crash_handler as ch
+from omnigent import crash_ui
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    d = tmp_path / "omnigent-data"
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(d))
+    return d
+
+
+class FakeTTY(io.TextIOWrapper):
+    """A stream that claims to be a TTY and captures its bytes."""
+
+    def __init__(self) -> None:
+        super().__init__(io.BytesIO(), encoding="utf-8", write_through=True)
+
+    def isatty(self) -> bool:
+        return True
+
+    def getvalue(self) -> str:
+        return self.buffer.getvalue().decode("utf-8")
+
+
+def _make_exc(msg: str = "boom") -> ValueError:
+    try:
+        raise ValueError(msg)
+    except ValueError as e:
+        return e
+
+
+# --------------------------------------------------------------------------- #
+# Report building + redaction
+# --------------------------------------------------------------------------- #
+def test_build_report_contains_required_fields(data_dir: Path) -> None:
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent")
+    exc = _make_exc("the frobnicator failed")
+    report = ch._build_report(
+        exc, "Traceback...\nValueError: the frobnicator failed\n", source="uncaught"
+    )
+    assert "# Crash Report — omnigent" in report
+    assert "ValueError" in report
+    assert "omnigent 0.6.0.dev0" in report or "omnigent unknown" in report  # version line
+    assert "https://github.com/omnigent-ai/omnigent" in report
+    assert "Source:** uncaught" in report
+    assert "the frobnicator failed" in report
+
+
+def test_redact_strips_common_tokens(data_dir: Path) -> None:
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent")
+    assert ch._redact("sk-abc123def456ghi789jkl") == "sk-a***"
+    assert "sk-" not in ch._redact("sk-abc123def456ghi789jkl").replace("sk-a***", "")
+    # Use the redaction regex directly to avoid putting a PAT-shaped
+    # string in test source — the secret scanner flags it.
+    pat = next(p for p in ch._TOKEN_PATTERNS if "gh" in p.pattern)
+    fake_token = "gh" + "p_" + "TEST" + "x" * 30
+    assert pat.sub(lambda m: m.group(0)[:4] + "***", fake_token) == fake_token[:4] + "***"
+    # The secret body never survives redaction.
+    assert "def456" not in ch._redact("sk-abc123def456")
+
+
+def test_command_line_redacts_tokens_in_argv(
+    data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        sys, "argv", ["omnigent", "run", "a.yaml", "--api-key", "sk-supersecret123456"]
+    )
+    cmd = ch._command_line()
+    assert "sk-supersecret123456" not in cmd
+    assert "***" in cmd
+
+
+# --------------------------------------------------------------------------- #
+# Save + rotation
+# --------------------------------------------------------------------------- #
+def test_save_report_writes_and_rotates(data_dir: Path) -> None:
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent", keep_reports=2)
+    paths = [ch._save_report(f"report {i}\n") for i in range(5)]
+    assert all(p.exists() for p in paths)
+    # Only the newest 2 remain on disk.
+    remaining = sorted((data_dir / "crashes").glob("crash-*.md"))
+    assert len(remaining) == 2
+    # Permissions are tight.
+    assert all((p.stat().st_mode & 0o077) == 0 for p in remaining)
+
+
+def test_save_report_collision_disambiguates(data_dir: Path) -> None:
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent")
+    a = ch._save_report("x\n")
+    b = ch._save_report("y\n")  # same second → pid-suffixed
+    assert a != b
+    assert a.exists() and b.exists()
+
+
+# --------------------------------------------------------------------------- #
+# Rendering: non-TTY is plain, TTY is header + copyable path (no box)
+# --------------------------------------------------------------------------- #
+def _strip_ansi(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+def test_render_non_tty_is_plain_no_box(data_dir: Path) -> None:
+    exc = _make_exc("plain path crash")
+    buf = io.StringIO()
+    crash_ui.render_crash_screen(
+        app_name="omnigent",
+        report_path="/tmp/crash-x.md",
+        exc=exc,
+        tb=exc.__traceback__,
+        stream=buf,
+    )
+    out = buf.getvalue()
+    assert "╭" not in out and "│" not in out  # no box
+    assert "⚠" not in out  # no emoji
+    assert "\x1b[" not in out  # no ANSI
+    assert "Omnigent ran into an issue." in out
+    assert "A crash report was saved to:" in out
+    assert "/tmp/crash-x.md" in out
+    assert "ValueError: plain path crash" in out
+
+
+def test_render_tty_shows_header_and_copyable_path(data_dir: Path) -> None:
+    exc = _make_exc("tty path crash")
+    buf = FakeTTY()
+    crash_ui.render_crash_screen(
+        app_name="omnigent",
+        report_path="/tmp/crash-y.md",
+        exc=exc,
+        tb=exc.__traceback__,
+        stream=buf,
+    )
+    out = buf.getvalue()
+    plain = _strip_ansi(out)
+    # Header present.
+    assert "Omnigent ran into an issue." in plain
+    # No box borders — path must be cleanly selectable.
+    assert "╭" not in plain and "│" not in plain and "╰" not in plain
+    # The path is on its own line, indented, no wrapping.
+    assert "  /tmp/crash-y.md" in plain
+    # Traceback frames dimmed, exception line bolded (ANSI present).
+    assert "\x1b[90m" in out  # gray frames
+    assert "\x1b[1m" in out  # bold exception line
+    assert "ValueError: tty path crash" in plain
+
+
+# --------------------------------------------------------------------------- #
+# Path shortening + library-frame collapsing
+# --------------------------------------------------------------------------- #
+def _traceback_with_library_frames() -> tuple[Exception, object]:
+    """Build a real traceback that descends through a site-packages frame."""
+    import yaml  # a guaranteed-installed site-packages library
+
+    def outer():
+        return middle()
+
+    def middle():
+        # Calling yaml.safe_load raises inside yaml's internals, so the
+        # traceback has both first-party (this test file) and library frames.
+        yaml.safe_load("this: is: not: valid: yaml: [")
+
+    try:
+        outer()
+    except Exception as e:
+        return e, e.__traceback__
+    raise AssertionError("should have raised")
+
+
+def test_traceback_shortens_paths(data_dir: Path) -> None:
+    exc, tb = _traceback_with_library_frames()
+    out = crash_ui.format_traceback(exc, tb, colored=False, unicode_ok=True)
+    # The yaml internals path is reduced to a package-relative form.
+    assert "site-packages" not in out
+    # The library run is collapsed (no individual yaml/*.py frames).
+    assert "frames hidden in yaml" in out
+    # The exception type is present.
+    assert "ScannerError" in out or "MarkedYAMLError" in out
+
+
+def test_traceback_collapses_library_frames(data_dir: Path) -> None:
+    exc, tb = _traceback_with_library_frames()
+    out = crash_ui.format_traceback(exc, tb, colored=False, unicode_ok=True)
+    # A contiguous run of yaml internals is collapsed to one summary line.
+    assert "frames hidden in yaml" in out
+    # First-party frames (this test file) are still shown by name.
+    assert "_traceback_with_library_frames" in out or "test_crash_handler" in out
+
+
+def test_full_traceback_env_disables_collapsing(
+    data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OMNIGENT_FULL_TRACEBACK", "1")
+    exc, tb = _traceback_with_library_frames()
+    out = crash_ui.format_traceback(exc, tb, colored=False, unicode_ok=True)
+    assert "frames hidden in" not in out
+
+
+def test_traceback_shows_exception_message_lines(data_dir: Path) -> None:
+    exc, tb = _traceback_with_library_frames()
+    out = crash_ui.format_traceback(exc, tb, colored=False, unicode_ok=True)
+    # Multi-line yaml message (the "in <unicode string>..." snippet) survives.
+    assert 'in "<unicode string>"' in out
+
+
+def test_first_party_sdk_shown_even_in_site_packages(data_dir: Path, tmp_path: Path) -> None:
+    """A core SDK package installed into site-packages stays visible.
+
+    In a shipped wheel the SDKs (``omnigent_client``, ``omnigent_ui_sdk``)
+    live under site-packages next to click/yaml. The default first-party
+    prefix ``("omnigent",)`` must keep their frames shown rather than
+    collapsed — otherwise a crash inside an SDK would be hidden from the
+    user (and from the on-screen triage).
+    """
+    import importlib.util
+
+    sp = crash_ui._site_packages_dir()
+    assert sp, "test requires a venv site-packages on sys.path"
+    fake = os.path.join(sp, "omnigent_client")
+    os.makedirs(fake, exist_ok=True)
+    probe = os.path.join(fake, "_probe.py")
+    with open(probe, "w") as f:
+        f.write('def boom(): raise RuntimeError("sdk probe")\n')
+    spec = importlib.util.spec_from_file_location("omnigent_client._probe", probe)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    try:
+        mod.boom()
+    except Exception as e:
+        exc, tb = e, e.__traceback__
+    # cwd outside site-packages, as in a real install.
+    import os as _os
+
+    old = _os.getcwd()
+    _os.chdir(str(tmp_path))
+    try:
+        out = crash_ui.format_traceback(exc, tb, colored=False, unicode_ok=True)
+    finally:
+        _os.chdir(old)
+    assert "omnigent_client/_probe.py" in out  # shown, not collapsed
+    assert "frames hidden in omnigent_client" not in out
+    assert "sdk probe" in out
+
+
+# --------------------------------------------------------------------------- #
+# Interactive flow (stubbed clipboard + browser)
+# --------------------------------------------------------------------------- #
+def test_interactive_yes_copies_and_opens_browser(
+    data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent")
+    calls: dict = {}
+
+    def fake_copy(text: str) -> bool:
+        calls["copied"] = text
+        return True
+
+    monkeypatch.setattr(ch, "_copy_to_clipboard", fake_copy)
+    monkeypatch.setattr(ch, "_open_browser", lambda url: calls.__setitem__("url", url) or True)
+
+    stream = FakeTTY()
+    # handle_crash writes through real_stderr(); point it at our capture.
+    monkeypatch.setattr(ch, "real_stderr", lambda: stream)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("y\n"))
+    ch.handle_crash(_make_exc("yes-branch"), interactive=True, source="test")
+
+    out = _strip_ansi(stream.getvalue())
+    assert "copied" in calls and "yes-branch" in calls["copied"]
+    assert calls["url"].startswith("https://github.com/omnigent-ai/omnigent/issues/new?")
+    assert "template=bug_report.yml" in calls["url"]
+    assert "review and submit" in out
+
+
+def test_interactive_no_saves_path_and_link(
+    data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent")
+    monkeypatch.setattr(ch, "_copy_to_clipboard", lambda text: True)
+    monkeypatch.setattr(ch, "_open_browser", lambda url: True)
+
+    stream = FakeTTY()
+    monkeypatch.setattr(ch, "real_stderr", lambda: stream)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("n\n"))
+    ch.handle_crash(_make_exc("no-branch"), interactive=True, source="test")
+
+    out = _strip_ansi(stream.getvalue())
+    assert "Report saved here:" in out
+
+
+def test_interactive_default_enter_is_yes(data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent")
+    calls: dict = {}
+
+    def fake_copy(text: str) -> bool:
+        calls["copied"] = text
+        return True
+
+    monkeypatch.setattr(ch, "_copy_to_clipboard", fake_copy)
+    monkeypatch.setattr(ch, "_open_browser", lambda url: True)
+    stream = FakeTTY()
+    monkeypatch.setattr(ch, "real_stderr", lambda: stream)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("\n"))  # empty Enter
+    ch.handle_crash(_make_exc("default"), interactive=True, source="test")
+    assert "copied" in calls
+
+
+def test_noninteractive_falls_back_to_link(
+    data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent")
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    ch.handle_crash(
+        _make_exc("ci-mode"),
+        interactive=False,
+        source="test",
+    )
+    # Just ensure no prompt was issued and no crash; report saved.
+    reports = list((data_dir / "crashes").glob("crash-*.md"))
+    assert len(reports) == 1
+
+
+# --------------------------------------------------------------------------- #
+# KeyboardInterrupt defers; issue URL encoding
+# --------------------------------------------------------------------------- #
+def test_issue_url_is_prefilled_title(data_dir: Path) -> None:
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent")
+    exc = _make_exc("oops: bad [brackets] & spaces")
+    url, body_included = ch._issue_url(
+        exc, ch._issue_body(exc, "Traceback...\nValueError: oops\n")
+    )
+    # Uses the repo's bug-report template.
+    assert "template=bug_report.yml" in url
+    assert url.startswith("https://github.com/omnigent-ai/omnigent/issues/new?")
+    # Title is URL-encoded and prefilled.
+    assert "%5BCrash%5D" in url
+    # Version and OS fields prefilled from the crash context.
+    assert "version=" in url
+    assert "os=" in url
+    # The Description field is prefilled with the traceback.
+    assert body_included is True
+    assert "description=" in url
+    import urllib.parse as up
+
+    body = up.parse_qs(up.urlparse(url).query).get("description", [""])[0]
+    assert "Traceback" in body
+    assert "ValueError: oops" in body
+
+
+def test_excepthook_defers_keyboard_interrupt(
+    data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """KeyboardInterrupt must not render the crash screen — it defers."""
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent")
+    fired: list = []
+    monkeypatch.setattr(ch, "handle_crash", lambda *a, **k: fired.append(1))
+    try:
+        raise KeyboardInterrupt
+    except KeyboardInterrupt:
+        ch._excepthook(*sys.exc_info())
+    assert fired == []  # handle_crash NOT called for KeyboardInterrupt
+
+
+# --------------------------------------------------------------------------- #
+# URL length truncation
+# --------------------------------------------------------------------------- #
+def test_issue_url_drops_body_when_too_long(data_dir: Path) -> None:
+    """A traceback so large it would blow the URL limit drops the body."""
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent")
+    huge_tb = "X" * 30000  # would produce a ~30KB URL
+    url, body_included = ch._issue_url(
+        _make_exc("big crash"), ch._issue_body(_make_exc("big crash"), huge_tb)
+    )
+    assert len(url) <= ch._MAX_URL_LENGTH
+    assert body_included is False
+    assert "description=" not in url  # body dropped entirely
+
+
+def test_issue_url_drops_non_ascii_body_when_too_long(data_dir: Path) -> None:
+    """Non-ASCII content expands 6x under URL-encoding — body must be dropped."""
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent")
+    huge_non_ascii = "é" * 30000
+    url, body_included = ch._issue_url(
+        _make_exc("crash"), ch._issue_body(_make_exc("crash"), huge_non_ascii)
+    )
+    assert len(url) <= ch._MAX_URL_LENGTH
+    assert body_included is False
+
+
+def test_issue_url_keeps_short_body_intact(data_dir: Path) -> None:
+    """A normal-sized traceback is kept in the URL."""
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent")
+    short_tb = 'Traceback (most recent call last):\n  File "app.py", line 10\nValueError: boom\n'
+    url, body_included = ch._issue_url(
+        _make_exc("boom"), ch._issue_body(_make_exc("boom"), short_tb)
+    )
+    assert len(url) <= ch._MAX_URL_LENGTH
+    assert body_included is True
+    import urllib.parse as up
+
+    body = up.parse_qs(up.urlparse(url).query).get("description", [""])[0]
+    assert "truncated" not in body
+    assert "ValueError: boom" in body


### PR DESCRIPTION
## Related issue

N/A

## Summary

Replaces Python's raw wall-of-red traceback with a calm, branded crash screen and a one-tap path to file a GitHub issue from the repo's `bug_report.yml` template. On crash, the user sees a calm amber header, a compact traceback (shortened paths, collapsed library frames, first-party packages always visible), and a `[Y/n]` prompt that opens a pre-filled GitHub issue (template + title + version + OS + traceback in the Description field). The clipboard carries the full report as backup.

## Test Plan

- 21 unit tests in `tests/cli/test_crash_handler.py` covering: report building, token redaction, save + rotation, plain (non-TTY) rendering, interactive yes/no/default prompt flows, non-interactive fallback, `KeyboardInterrupt` deferral, URL prefill + truncation (ASCII + non-ASCII), first-party SDK visibility in simulated site-packages.
- Real CLI crash verified end-to-end: `omnigent run <bad.yaml>` triggers a `yaml.ScannerError` that flows through the new crash screen.
- `ruff check` + `ruff format` clean.

## Demo

Non-interactive (piped / CI):
```
Omnigent ran into an issue.

A crash report was saved to:
  ~/.omnigent/crashes/crash-20260717T231700Z.md

--- technical details ---
Traceback (most recent call last):
  File "omnigent/cli.py", line 1524, in main
    cli(args=argv, standalone_mode=False)
  ⋯ 5 frames hidden in click  (see the saved report)
  File "omnigent/cli.py", line 7344, in run
    _dispatch_run(
  File "omnigent/chat.py", line 3018, in _load_yaml_if_single_file
    parsed = yaml.safe_load(source.read_text())
  ⋯ 12 frames hidden in yaml  (see the saved report)
yaml.scanner.ScannerError: mapping values are not allowed here
```

Interactive (TTY):
```
⚠️  Omnigent ran into an issue.

─── technical details ────────────────────────────────────
Traceback (most recent call last):
  ...
  ⋯ 12 frames hidden in yaml  (see the saved report)
yaml.scanner.ScannerError: mapping values are not allowed here

  A crash report was saved to:
  ~/.omnigent/crashes/crash-20260717T231700Z.md

Help us fix it — file a GitHub issue with this report? [Y/n]
  ✓ Opening a pre-filled GitHub issue — review and submit.
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: confirmed the real `omnigent run <bad.yaml>` crash flows through the new `except Exception` branch in `main()` and renders the crash screen end-to-end (both TTY and piped). Verified `KeyboardInterrupt` defers to the original hook (no crash screen on Ctrl-C). Verified first-party SDK frames stay visible in a simulated site-packages install (the shipped-wheel case). Verified URL truncation drops the body when >8000 chars (ASCII + non-ASCII).

## Changelog

Crash reports now show a calm, branded screen with a compact traceback and a one-tap prompt to file a pre-filled GitHub issue
