### PR TITLE
fix(codex-native): surface launch routing in the thread-startup-timeout error (#2745)

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1262,11 +1262,16 @@ class NativeCodexLaunch:
     :param profile: Databricks profile for the ucode path, or ``None`` (a
         generic provider routes via *config_overrides*; CLI login uses
         neither).
+    :param summary: Human-readable one-line description of the routing
+        outcome (provider / profile / model, or the login-fallback state),
+        set at resolution time and surfaced in the startup-timeout error so
+        hosted users can diagnose without runner-log access (see #2745).
     """
 
     config_overrides: list[str]
     model: str | None
     profile: str | None
+    summary: str = ""
 
 
 def codex_session_meta_model_provider(launch: NativeCodexLaunch) -> str:
@@ -1345,7 +1350,12 @@ def _codex_provider_launch(entry: ProviderEntry, model: str | None) -> NativeCod
     )
 
     if entry.kind == DATABRICKS_KIND:
-        return NativeCodexLaunch(config_overrides=[], model=model, profile=entry.profile)
+        return NativeCodexLaunch(
+            config_overrides=[],
+            model=model,
+            profile=entry.profile,
+            summary=f"Databricks ucode profile {entry.profile!r}",
+        )
     if entry.kind == CLI_CONFIG_KIND:
         # Pin the config.toml-defined provider by name; its table (and
         # credential) ride along via the bridged config.toml. json.dumps
@@ -1354,6 +1364,10 @@ def _codex_provider_launch(entry: ProviderEntry, model: str | None) -> NativeCod
             config_overrides=[f"model_provider={json.dumps(entry.model_provider)}"],
             model=model,
             profile=None,
+            summary=(
+                f"provider {entry.name!r} via cli-config "
+                f"(model_provider={entry.model_provider!r})"
+            ),
         )
     if entry.kind not in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
         return None
@@ -1380,7 +1394,12 @@ def _codex_provider_launch(entry: ProviderEntry, model: str | None) -> NativeCod
         auth_command=auth_command,
         wire_api=family.wire_api or "responses",
     )
-    return NativeCodexLaunch(config_overrides=overrides, model=pinned, profile=None)
+    return NativeCodexLaunch(
+        config_overrides=overrides,
+        model=pinned,
+        profile=None,
+        summary=f"provider {entry.name!r} (model={pinned})",
+    )
 
 
 def _first_routable_codex_provider(
@@ -1476,7 +1495,10 @@ def _resolve_subscription_launch(
             entry.name,
         )
         return NativeCodexLaunch(
-            config_overrides=subscription_overrides, model=model, profile=None
+            config_overrides=subscription_overrides,
+            model=model,
+            profile=None,
+            summary=f"Codex CLI login (subscription provider {entry.name!r}; Codex is logged in)",
         )
     fallback = _first_routable_codex_provider(explicit, exclude=entry.name, model=model)
     if fallback is not None:
@@ -1486,7 +1508,16 @@ def _resolve_subscription_launch(
         "Codex login and no alternative provider is configured)",
         entry.name,
     )
-    return NativeCodexLaunch(config_overrides=subscription_overrides, model=model, profile=None)
+    return NativeCodexLaunch(
+        config_overrides=subscription_overrides,
+        model=model,
+        profile=None,
+        summary=(
+            f"Codex CLI login (subscription provider {entry.name!r} has no usable Codex "
+            "login and no alternative provider is configured) — the TUI likely renders "
+            "the sign-in screen and never starts a thread"
+        ),
+    )
 
 
 def resolve_native_codex_launch(*, model: str | None) -> NativeCodexLaunch:
@@ -1545,9 +1576,19 @@ def resolve_native_codex_launch(*, model: str | None) -> NativeCodexLaunch:
         # (parity with _resolve_provider_for_build).
         global_auth = _load_global_auth()
         if isinstance(global_auth, DatabricksAuth):
-            return NativeCodexLaunch(config_overrides=[], model=model, profile=global_auth.profile)
+            return NativeCodexLaunch(
+                config_overrides=[],
+                model=model,
+                profile=global_auth.profile,
+                summary=f"Databricks ucode profile {global_auth.profile!r} (global auth block)",
+            )
         if global_auth is not None:
-            return NativeCodexLaunch(config_overrides=[], model=model, profile=None)
+            return NativeCodexLaunch(
+                config_overrides=[],
+                model=model,
+                profile=None,
+                summary="Codex CLI login (global auth block, non-Databricks; no provider routing)",
+            )
         entry = default_provider_for_harness(effective_config_with_detected(explicit), "codex")
 
     if entry is None:
@@ -1556,7 +1597,17 @@ def resolve_native_codex_launch(*, model: str | None) -> NativeCodexLaunch:
             "harness, no Databricks profile). Run `omnigent setup --no-internal-beta` to route "
             "through a provider."
         )
-        return NativeCodexLaunch(config_overrides=no_provider_overrides, model=model, profile=None)
+        return NativeCodexLaunch(
+            config_overrides=no_provider_overrides,
+            model=model,
+            profile=None,
+            summary=(
+                "Codex CLI login (no provider configured for the codex harness, no "
+                "Databricks profile) — the TUI likely renders the ChatGPT sign-in "
+                "screen and never starts a thread; run `omnigent setup` to route through "
+                "a provider"
+            ),
+        )
     if entry.kind == SUBSCRIPTION_KIND:
         return _resolve_subscription_launch(entry, model, explicit)
 
@@ -1574,7 +1625,16 @@ def resolve_native_codex_launch(*, model: str | None) -> NativeCodexLaunch:
         "credential — falling back to Codex's own login.",
         entry.name,
     )
-    return NativeCodexLaunch(config_overrides=no_provider_overrides, model=model, profile=None)
+    return NativeCodexLaunch(
+        config_overrides=no_provider_overrides,
+        model=model,
+        profile=None,
+        summary=(
+            f"Codex CLI login (provider {entry.name!r} is the codex default but has no "
+            "usable openai credential) — the TUI likely renders the sign-in screen "
+            "and never starts a thread"
+        ),
+    )
 
 
 def client_for_transport(

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1365,8 +1365,7 @@ def _codex_provider_launch(entry: ProviderEntry, model: str | None) -> NativeCod
             model=model,
             profile=None,
             summary=(
-                f"provider {entry.name!r} via cli-config "
-                f"(model_provider={entry.model_provider!r})"
+                f"provider {entry.name!r} via cli-config (model_provider={entry.model_provider!r})"
             ),
         )
     if entry.kind not in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3713,6 +3713,7 @@ async def _auto_create_codex_terminal(
                 codex_ws_url=codex_ws_url,
                 codex_home=codex_home,
                 event_client=event_client,
+                routing_summary=_codex_launch.summary,
             )
             if launch_config.external_session_id is None
             else _codex_forward_known_thread(
@@ -3748,6 +3749,7 @@ async def _codex_discover_thread_and_forward(
     codex_ws_url: str,
     codex_home: Path,
     event_client: CodexAppServerClient,
+    routing_summary: str,
 ) -> None:
     """
     Adopt the fresh Codex TUI's thread, then mirror it into the Omnigent session.
@@ -3768,6 +3770,10 @@ async def _codex_discover_thread_and_forward(
     :param codex_home: Per-session private ``CODEX_HOME`` path.
     :param event_client: Connected app-server listener that will observe the
         TUI's ``thread/started``; reused to subscribe the forwarder.
+    :param routing_summary: One-line description of the resolved launch
+        routing (provider / profile / model, or the login-fallback state),
+        threaded into the startup-timeout error so hosted users can diagnose
+        without runner-log access (see #2745).
     """
     from omnigent.codex_native_bridge import (
         CodexNativeBridgeState,
@@ -3804,8 +3810,8 @@ async def _codex_discover_thread_and_forward(
             write_bridge_startup_error(
                 bridge_dir,
                 f"Codex app-server never started a thread ({cause}: "
-                f"{type(exc).__name__}). See the runner log near 'native-codex "
-                "routing' for the resolved provider/model.",
+                f"{type(exc).__name__}). Launch routing: {routing_summary}. "
+                "(The runner log has the same near 'native-codex routing'.)",
             )
             return
 

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -2703,6 +2703,7 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
             codex_ws_url="ws://127.0.0.1:1",
             codex_home=tmp_path / "codex-home",
             event_client=_Client(),  # type: ignore[arg-type]
+            routing_summary="provider 'test' (model=gpt-test)",
         )
     finally:
         _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
@@ -2765,6 +2766,7 @@ async def test_codex_discover_thread_and_forward_records_accurate_startup_error(
             codex_ws_url="ws://127.0.0.1:1",
             codex_home=tmp_path / "codex-home",
             event_client=_Client(),  # type: ignore[arg-type]
+            routing_summary="provider 'test' (model=gpt-test)",
         )
     finally:
         _AUTO_CODEX_APP_SERVERS.pop(session_id, None)

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -9956,9 +9956,7 @@ def test_resolve_native_codex_launch_no_provider_sets_login_fallback_summary(
     monkeypatch.setattr(provider_config, "load_config", dict)
     monkeypatch.setattr(detected, "codex_config_provider_dismissed", lambda cfg: False)
     monkeypatch.setattr(detected, "effective_config_with_detected", lambda cfg: {})
-    monkeypatch.setattr(
-        provider_config, "default_provider_for_harness", lambda cfg, harness: None
-    )
+    monkeypatch.setattr(provider_config, "default_provider_for_harness", lambda cfg, harness: None)
     monkeypatch.setattr(workflow, "_load_global_auth", lambda: None)
 
     launch = codex_native_app_server.resolve_native_codex_launch(model=None)

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -9933,3 +9933,92 @@ def test_rollout_records_without_compaction_item_has_no_compacted_entry() -> Non
     )
     types = [r["type"] for r in records]
     assert "compacted" not in types
+
+
+# --- #2745: routing summary surfaced in the startup-timeout error ---
+
+
+def test_native_codex_launch_summary_defaults_empty() -> None:
+    """The new summary field defaults to empty so existing call sites stay valid."""
+    launch = codex_native_app_server.NativeCodexLaunch(
+        config_overrides=[], model=None, profile=None
+    )
+    assert launch.summary == ""
+
+
+def test_resolve_native_codex_launch_no_provider_sets_login_fallback_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No configured provider -> summary names the login fallback (#2745)."""
+    from omnigent.onboarding import detected, provider_config
+    from omnigent.runtime import workflow
+
+    monkeypatch.setattr(provider_config, "load_config", dict)
+    monkeypatch.setattr(detected, "codex_config_provider_dismissed", lambda cfg: False)
+    monkeypatch.setattr(detected, "effective_config_with_detected", lambda cfg: {})
+    monkeypatch.setattr(
+        provider_config, "default_provider_for_harness", lambda cfg, harness: None
+    )
+    monkeypatch.setattr(workflow, "_load_global_auth", lambda: None)
+
+    launch = codex_native_app_server.resolve_native_codex_launch(model=None)
+
+    assert launch.profile is None
+    assert "no provider configured" in launch.summary
+    assert "sign-in" in launch.summary
+
+
+def test_resolve_native_codex_launch_databricks_provider_sets_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Databricks provider default -> summary names the ucode profile (#2745)."""
+    from omnigent.onboarding import detected, provider_config
+
+    entry = SimpleNamespace(kind=provider_config.DATABRICKS_KIND, profile="my-profile")
+    monkeypatch.setattr(provider_config, "load_config", dict)
+    monkeypatch.setattr(detected, "codex_config_provider_dismissed", lambda cfg: False)
+    monkeypatch.setattr(
+        provider_config, "default_provider_for_harness", lambda cfg, harness: entry
+    )
+
+    launch = codex_native_app_server.resolve_native_codex_launch(model="gpt-5.5")
+
+    assert launch.profile == "my-profile"
+    assert launch.summary == "Databricks ucode profile 'my-profile'"
+
+
+def test_codex_discover_thread_and_forward_writes_routing_summary_on_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A startup timeout records the launch routing summary in the bridge error (#2745)."""
+    from omnigent import codex_native_forwarder as _fwd
+    from omnigent.codex_native_bridge import read_bridge_startup_error
+    from omnigent.runner.native import orchestration as native_orch
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    async def _timeout(_client: object) -> str:
+        raise TimeoutError("no thread event")
+
+    monkeypatch.setattr(_fwd, "wait_for_thread_started", _timeout)
+
+    class _FakeClient:
+        async def close(self) -> None:
+            return None
+
+    asyncio.run(
+        native_orch._codex_discover_thread_and_forward(
+            session_id="conv_test",
+            bridge_dir=bridge_dir,
+            codex_ws_url="ws://127.0.0.1:9999",
+            codex_home=tmp_path / "codex-home",
+            event_client=_FakeClient(),
+            routing_summary="Codex CLI login (no provider configured) -- SENTINEL",
+        )
+    )
+
+    err = read_bridge_startup_error(bridge_dir)
+    assert err is not None
+    assert "Launch routing: Codex CLI login (no provider configured) -- SENTINEL" in err
+    assert "startup timed out" in err


### PR DESCRIPTION
## Related issue

Closes #2745

## Summary

When a codex-native session fails to start its app-server thread, the error tells the user to "See the runner log near 'native-codex routing'." On hosted/remote runners those logs aren't reachable, so it's a dead end. The most common cause is a routing fallback: when no provider resolves, the `codex --remote` TUI defaults to Codex's built-in OpenAI provider and blocks at the sign-in screen, so it never creates a thread and `wait_for_thread_started` times out.

This threads the resolved launch routing into the error text instead of pointing at logs. The routing decision is already computed at launch — it was just being discarded before the error was written.

- `codex_native_app_server.py`: add a `summary: str = ""` field to `NativeCodexLaunch`, populated at every branch of `resolve_native_codex_launch` / `_resolve_subscription_launch` / `_codex_provider_launch` (mirrors the existing `native-codex routing:` log lines; captures the login-fallback state the provider id alone can't).
- `runner/native/orchestration.py`: pass `_codex_launch.summary` into `_codex_discover_thread_and_forward` and fold it into `write_bridge_startup_error`. The executor already surfaces this bridge error into the web chat, so it reaches hosted users. The runner-log pointer is kept as a secondary hint. No behavior change to routing itself.

**ELI5:** The app-server is up and fine; the terminal (TUI) is stuck at a login screen and never opens a thread. We already know at launch *why* it would be stuck (which provider it routed to), but we were throwing that away and telling people to read a log they can't open. Now we just print the reason.

## Test Plan

- `pytest tests/test_codex_native.py` — 199 passed (4 new).
- `ruff check` clean on the three changed files.
- New tests: summary field default; no-provider → login-fallback summary; Databricks-provider summary; timeout writes the summary into the bridge error file.

## Demo

N/A (non-visual — error-message text change).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The startup-timeout path is covered end-to-end by `test_codex_discover_thread_and_forward_writes_routing_summary_on_timeout` (monkeypatches `wait_for_thread_started` to raise and asserts the summary lands in the bridge error). The per-branch summaries are asserted directly against `resolve_native_codex_launch`.

## Changelog

codex-native startup-timeout errors now name the resolved provider/model routing (and the login-fallback case) instead of pointing at the runner log