### PR TITLE
Generate concise titles for new sessions

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3240,12 +3240,14 @@ def server(
 
     server_llm = parse_server_llm(cfg.get("llm"))
 
-    # Build the default LLM-based routing client when BOTH the server
-    # has an ``llm:`` config AND the feature is explicitly enabled via
-    # OMNIGENT_SMART_ROUTING=1.  Hidden by default — managed deployments
-    # override RuntimeCaps.routing_client with their own implementation.
+    # A configured server LLM generates session titles by default. Operators
+    # can explicitly restore deterministic prompt-derived naming with
+    # ``OMNIGENT_SESSION_TITLES=0``. Smart routing remains opt-in.
+    title_generation_enabled = os.environ.get("OMNIGENT_SESSION_TITLES", "1") == "1"
+    smart_routing_enabled = os.environ.get("OMNIGENT_SMART_ROUTING") == "1"
     routing_client = None
-    if server_llm is not None and os.environ.get("OMNIGENT_SMART_ROUTING") == "1":
+    session_title_generator = None
+    if server_llm is not None and (title_generation_enabled or smart_routing_enabled):
         from omnigent.runtime.policies.builder import (
             _build_policy_llm_client,
             _resolve_server_llm_connection,
@@ -3254,15 +3256,21 @@ def server(
         _conn = _resolve_server_llm_connection(server_llm)
         _policy_client = _build_policy_llm_client(server_llm, _conn)
         if _policy_client is not None:
-            from omnigent.server.smart_routing import LLMRoutingClient
+            if title_generation_enabled:
+                from omnigent.server.session_titles import LLMSessionTitleGenerator
 
-            routing_client = LLMRoutingClient(_policy_client)
+                session_title_generator = LLMSessionTitleGenerator(_policy_client)
+            if smart_routing_enabled:
+                from omnigent.server.smart_routing import LLMRoutingClient
+
+                routing_client = LLMRoutingClient(_policy_client)
 
     caps = RuntimeCaps(
         execution_timeout=int(effective_timeout),
         default_policies=parse_default_policies(cfg.get("policies")),
         llm=server_llm,
         routing_client=routing_client,
+        session_title_generator=session_title_generator,
     )
     init_runtime(
         conversation_store=conversation_store,

--- a/omnigent/runtime/caps.py
+++ b/omnigent/runtime/caps.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from omnigent.server.session_titles import SessionTitleGenerator
     from omnigent.server.smart_routing import RoutingClient
     from omnigent.spec.types import LLMConfig, PolicySpec
 
@@ -53,6 +54,11 @@ class RuntimeCaps:
         LLM call is billed to the request caller rather than a
         static service-level credential. ``None`` falls back to the
         ``llm``-config-resolved connection.
+    :param session_title_generator: Optional generator that asynchronously
+        fills an initially empty session title from its first user request.
+        A configured generator retries briefly, then uses deterministic naming
+        if generation does not return a title.
+        ``None`` uses the deterministic prompt-derived title directly.
     """
 
     execution_timeout: int = 7200
@@ -75,3 +81,6 @@ class RuntimeCaps:
     # Managed deployments can supply a different implementation (e.g.
     # a rules engine or remote service).  ``None`` disables routing.
     routing_client: RoutingClient | None = None
+    # Optional LLM-backed session naming. Kept pluggable so managed deployments
+    # can provide their own implementation without coupling routes to a provider.
+    session_title_generator: SessionTitleGenerator | None = None

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1423,8 +1423,12 @@ def create_app(
             # slow provision doesn't outlive the ASGI shutdown (the
             # sandbox itself, if already provisioned, is reaped by the
             # provider lifetime cap — see the hook's docstring).
-            from omnigent.server.routes.sessions import cancel_managed_launch_tasks
+            from omnigent.server.routes.sessions import (
+                cancel_managed_launch_tasks,
+                cancel_session_title_tasks,
+            )
 
+            await cancel_session_title_tasks()
             await cancel_managed_launch_tasks()
             _uninstall_subagent_block_notifier()
             set_resource_registry(None)

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -123,7 +123,9 @@ from omnigent.runner.routing import RunnerRouter
 from omnigent.runner.transports.ws_tunnel.registry import TunnelRegistry
 from omnigent.runtime import (
     get_agent_cache,
+    get_artifact_store,
     get_caps,
+    get_file_store,
     get_policy_store,
     inflight_text,
     pending_elicitations,
@@ -943,6 +945,32 @@ _SERVER_STREAM_EVENT_ADAPTER: TypeAdapter[ServerStreamEvent] = TypeAdapter(Serve
 # it finishes (the well-known RUF006 / Python ``asyncio`` footgun).
 # Entries are evicted by a done-callback on the task itself.
 _WATCHER_TASKS: set[asyncio.Task[None]] = set()
+
+# Strong references and bounded in-flight guards for asynchronous title
+# generation. First-turn dispatch does not wait for history lookup or the model.
+_session_title_tasks: set[asyncio.Task[None]] = set()
+_session_title_inflight_ids: set[str] = set()
+_SESSION_TITLE_GENERATION_ATTEMPTS = 3
+_SESSION_TITLE_RETRY_DELAY_SECONDS = 1.0
+# Do not impose a runtime deadline on background title generation. This bound
+# applies only while the server itself is shutting down.
+_SESSION_TITLE_SHUTDOWN_TIMEOUT_SECONDS = 6.0
+
+
+async def cancel_session_title_tasks() -> None:
+    """Give title refinements bounded time to persist before cancellation."""
+    tasks = list(_session_title_tasks)
+    if not tasks:
+        return
+    _, pending = await asyncio.wait(
+        tasks,
+        timeout=_SESSION_TITLE_SHUTDOWN_TIMEOUT_SECONDS,
+    )
+    for task in pending:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+    await asyncio.sleep(0)
+
 
 # Per-session status cache updated by the runner SSE relay.
 # Used by _get_session_snapshot.
@@ -5341,12 +5369,17 @@ async def _persist_external_conversation_item(
     for skipped in skipped_kiro_pending:
         await _persist_skipped_kiro_pending_input(
             session_id,
+            conv,
             skipped,
             conversation_store,
         )
     persisted_items = await asyncio.to_thread(conversation_store.append, session_id, [item])
-    await _seed_missing_title_from_user_message(conv, item, conversation_store)
     persisted = persisted_items[0]
+    await _seed_missing_title_from_user_message(
+        conv,
+        item,
+        conversation_store,
+    )
     _publish_external_conversation_item(
         session_id, persisted, cleared_pending_id=cleared_pending_id
     )
@@ -5361,6 +5394,7 @@ def _is_kiro_native_session(conv: Conversation) -> bool:
 
 async def _persist_skipped_kiro_pending_input(
     session_id: str,
+    conv: Conversation,
     skipped: pending_inputs.DrainedInput,
     conversation_store: ConversationStore,
 ) -> None:
@@ -5387,6 +5421,11 @@ async def _persist_skipped_kiro_pending_input(
             user_item,
             NewConversationItem(type="error", response_id=turn_id, data=error),
         ],
+    )
+    await _seed_missing_title_from_user_message(
+        conv,
+        user_item,
+        conversation_store,
     )
     _publish_input_consumed(
         session_id,
@@ -8223,7 +8262,11 @@ async def _persist_host_launch_failure_turn(
         session_id,
         [user_item],
     )
-    await _seed_missing_title_from_user_message(conv, user_item, conversation_store)
+    await _seed_missing_title_from_user_message(
+        conv,
+        user_item,
+        conversation_store,
+    )
     error_persist_result = await _relay_persist_error_once(
         conversation_store,
         session_id,
@@ -9052,10 +9095,8 @@ async def _dispatch_skill_slash_command_to_runner(
     # otherwise keep a NULL title and the sidebar falls back to the
     # conversation id. Titled from the typed command ("/debate kafka…"),
     # NOT the hidden meta item — that's the full SKILL.md instruction blob.
-    command_text = f"/{skill_name} {arguments}" if arguments else f"/{skill_name}"
     await _seed_missing_title(
         conv,
-        [{"type": "input_text", "text": command_text}],
         conversation_store,
     )
 
@@ -9104,7 +9145,9 @@ async def _dispatch_skill_slash_command_to_runner(
     return visible.id
 
 
-def _title_content_from_item(item: NewConversationItem) -> list[dict[str, Any]]:
+def _title_content_from_item(
+    item: NewConversationItem | ConversationItem,
+) -> list[dict[str, Any]]:
     """
     Extract title candidate content blocks from a session item.
 
@@ -9137,41 +9180,229 @@ def _title_content_from_item(item: NewConversationItem) -> list[dict[str, Any]]:
         return []
     if not isinstance(item.data, MessageData):
         return []
-    if item.data.role != "user":
+    if item.data.role != "user" or item.data.is_meta:
         return []
     return item.data.content
 
 
+def _is_title_source_item(item: NewConversationItem | ConversationItem) -> bool:
+    """Return whether an item counts as the session's first user request."""
+    if item.type == _SLASH_COMMAND_TYPE:
+        return isinstance(item.data, SlashCommandData) and item.data.kind == "skill"
+    return (
+        item.type == "message"
+        and isinstance(item.data, MessageData)
+        and item.data.role == "user"
+        and not item.data.is_meta
+    )
+
+
+@dataclass(frozen=True)
+class _TitleCandidate:
+    """Resolved inputs for one title-generation attempt."""
+
+    prompt: str | None
+    fallback_title: str | None
+    attachments: tuple[dict[str, Any], ...]
+
+
+def _title_attachments(
+    content: list[dict[str, Any]],
+    conversation_id: str,
+    file_store: FileStore | None,
+    artifact_store: ArtifactStore | None,
+) -> tuple[dict[str, Any], ...]:
+    """Resolve title-candidate attachment blocks for the title model."""
+    from omnigent.runtime.content_resolver import _resolve_message_content
+
+    attachments: list[dict[str, Any]] = []
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") not in {
+            "input_image",
+            "input_file",
+        }:
+            continue
+        resolved = block
+        if "file_id" in block:
+            if file_store is None or artifact_store is None:
+                continue
+            try:
+                resolved = _resolve_message_content(
+                    [block],
+                    file_store,
+                    artifact_store,
+                    session_id=conversation_id,
+                )[0]
+            except (KeyError, ValueError):
+                _logger.warning(
+                    "Session title image resolution failed for session=%s",
+                    conversation_id,
+                    exc_info=True,
+                )
+                continue
+        if resolved.get("type") == "input_image":
+            image_url = resolved.get("image_url")
+            if isinstance(image_url, str) and image_url:
+                attachments.append(resolved)
+        else:
+            file_data = resolved.get("file_data")
+            if isinstance(file_data, str) and file_data:
+                attachments.append(resolved)
+    return tuple(attachments)
+
+
+def _first_title_candidate(
+    conversation_store: ConversationStore,
+    conversation_id: str,
+    *,
+    include_images: bool,
+) -> _TitleCandidate | None:
+    """Return the oldest persisted request usable by the title strategy."""
+    after: str | None = None
+    file_store = get_file_store() if include_images else None
+    artifact_store = get_artifact_store() if include_images else None
+    while True:
+        page = conversation_store.list_items(
+            conversation_id,
+            limit=100,
+            after=after,
+            order="asc",
+        )
+        for item in page.data:
+            if not _is_title_source_item(item):
+                continue
+            content = _title_content_from_item(item)
+            prompt = synthesize_conversation_title(content, limit=4000)
+            fallback_title = synthesize_conversation_title(content)
+            attachments = (
+                _title_attachments(
+                    content,
+                    conversation_id,
+                    file_store,
+                    artifact_store,
+                )
+                if include_images
+                else ()
+            )
+            if prompt is not None or attachments:
+                return _TitleCandidate(
+                    prompt=prompt,
+                    fallback_title=fallback_title,
+                    attachments=attachments,
+                )
+        if not page.has_more or page.last_id is None:
+            return None
+        after = page.last_id
+
+
 async def _seed_missing_title(
     conv: Conversation,
-    content: list[dict[str, Any]],
     conversation_store: ConversationStore,
 ) -> None:
     """
-    Set an untitled conversation's title from message content blocks.
+    Name an untitled conversation from its oldest persisted user request.
 
-    No-op when the conversation already has a title or the blocks
-    yield no usable text. Mutates ``conv.title`` in place on success
-    so callers holding the row see the persisted value.
+    Without a configured generator, the original prompt-derived title is
+    persisted before returning. With a generator, refinement runs in the
+    background and the session stays untitled until the model returns a valid
+    title. Generation is attempted a few times before falling back to the
+    original prompt-derived title. Any title is set only if the conversation is
+    still untitled.
 
     :param conv: The conversation row for the session.
-    :param content: Title-candidate blocks, e.g.
-        ``[{"type": "input_text", "text": "/debate kafka vs sqs"}]``.
     :param conversation_store: Store used to persist the title.
     :returns: None.
     """
     if conv.title is not None:
         return
-    title = synthesize_conversation_title(content)
-    if title is None:
+    generator = get_caps().session_title_generator
+
+    if generator is None:
+        try:
+            candidate = await asyncio.to_thread(
+                _first_title_candidate,
+                conversation_store,
+                conv.id,
+                include_images=False,
+            )
+            if candidate is None:
+                return
+            fallback_title = candidate.fallback_title
+            if fallback_title is None:
+                return
+            title_set = await asyncio.to_thread(
+                conversation_store.set_title_if_missing,
+                conv.id,
+                fallback_title,
+            )
+            if title_set:
+                conv.title = fallback_title
+        except Exception:  # noqa: BLE001 -- title persistence is best-effort
+            _logger.warning("Session fallback title persistence failed", exc_info=True)
         return
-    updated = await asyncio.to_thread(
-        conversation_store.update_conversation,
-        conv.id,
-        title=title,
+
+    if conv.id in _session_title_inflight_ids:
+        return
+    _session_title_inflight_ids.add(conv.id)
+
+    async def _refine_title() -> None:
+        try:
+            candidate = await asyncio.to_thread(
+                _first_title_candidate,
+                conversation_store,
+                conv.id,
+                include_images=True,
+            )
+            if candidate is None:
+                return
+            generated_title: str | None = None
+            for attempt in range(_SESSION_TITLE_GENERATION_ATTEMPTS):
+                persisted_conv = await asyncio.to_thread(
+                    conversation_store.get_conversation,
+                    conv.id,
+                )
+                if persisted_conv is None or persisted_conv.title is not None:
+                    return
+                try:
+                    generated_title = await generator.generate(
+                        candidate.prompt,
+                        candidate.attachments,
+                    )
+                except Exception:  # noqa: BLE001 -- naming is best-effort
+                    _logger.warning(
+                        "Session title generation attempt %d failed",
+                        attempt + 1,
+                        exc_info=True,
+                    )
+                if generated_title is not None:
+                    break
+                if attempt + 1 < _SESSION_TITLE_GENERATION_ATTEMPTS:
+                    await asyncio.sleep(_SESSION_TITLE_RETRY_DELAY_SECONDS)
+
+            title = generated_title or candidate.fallback_title
+            if title is None:
+                return
+            title_set = await asyncio.to_thread(
+                conversation_store.set_title_if_missing,
+                conv.id,
+                title,
+            )
+            if title_set:
+                conv.title = title
+        except Exception:  # noqa: BLE001 -- title refinement is best-effort
+            _logger.warning("Session title persistence failed", exc_info=True)
+
+    task = asyncio.create_task(
+        _refine_title(),
+        name=f"session-title-{conv.id}",
     )
-    if updated is not None:
-        conv.title = updated.title
+    _session_title_tasks.add(task)
+
+    def _title_task_done(done: asyncio.Task[None]) -> None:
+        _session_title_tasks.discard(done)
+        _session_title_inflight_ids.discard(conv.id)
+
+    task.add_done_callback(_title_task_done)
 
 
 async def _seed_missing_title_from_user_message(
@@ -9193,7 +9424,8 @@ async def _seed_missing_title_from_user_message(
     :param conversation_store: Store used to persist the title.
     :returns: None.
     """
-    await _seed_missing_title(conv, _title_content_from_item(item), conversation_store)
+    if _is_title_source_item(item):
+        await _seed_missing_title(conv, conversation_store)
 
 
 async def _persist_session_event(
@@ -13263,6 +13495,7 @@ async def _create_session_from_existing_agent(
                 for item in body.initial_items
             ]
             await asyncio.to_thread(conversation_store.append, conv.id, new_items)
+            await _seed_missing_title(conv, conversation_store)
         else:
             await _ensure_runner_relay_ready(
                 conv.id,

--- a/omnigent/server/session_titles.py
+++ b/omnigent/server/session_titles.py
@@ -1,0 +1,121 @@
+"""Optional LLM-backed titles for user-created sessions."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Sequence
+from typing import Any, Protocol
+
+_logger = logging.getLogger(__name__)
+
+TITLE_MAX_LENGTH = 60
+TITLE_PROMPT_MAX_LENGTH = 4000
+
+_TITLE_INSTRUCTIONS = """\
+Create a short title for the user's task.
+
+The title must be specific, use 3 to 8 words when practical, and be at most
+60 characters. Do not answer the request. Do not add quotes, markdown,
+punctuation at the end, or generic prefixes such as "Task" or "Help with".
+Use only information present in the request.
+
+Return strict JSON matching the supplied schema.
+"""
+
+_TITLE_SCHEMA: dict[str, object] = {
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string",
+            "maxLength": TITLE_MAX_LENGTH,
+        }
+    },
+    "required": ["title"],
+    "additionalProperties": False,
+}
+
+
+class SessionTitleGenerator(Protocol):
+    """Generate a human-readable title from a user's request."""
+
+    async def generate(
+        self,
+        prompt: str | None,
+        attachments: Sequence[dict[str, Any]] = (),
+    ) -> str | None:
+        """Return a generated title, or ``None`` to request caller fallback."""
+
+
+class LLMSessionTitleGenerator:
+    """Generate session titles with a server-configured policy LLM client."""
+
+    def __init__(self, llm_client: Any) -> None:
+        self._llm = llm_client
+
+    async def generate(
+        self,
+        prompt: str | None,
+        attachments: Sequence[dict[str, Any]] = (),
+    ) -> str | None:
+        """Generate and validate a title, returning ``None`` on rejection."""
+        try:
+            content: list[dict[str, Any]] = [
+                {
+                    "type": "input_text",
+                    "text": (
+                        prompt[:TITLE_PROMPT_MAX_LENGTH]
+                        if prompt
+                        else "The user provided an attachment without additional text."
+                    ),
+                }
+            ]
+            content.extend(dict(attachment) for attachment in attachments)
+            response = await self._llm.create(
+                instructions=_TITLE_INSTRUCTIONS,
+                input=[
+                    {
+                        "role": "user",
+                        "content": content,
+                    }
+                ],
+                text={
+                    "format": {
+                        "type": "json_schema",
+                        "name": "session_title",
+                        "strict": True,
+                        "schema": _TITLE_SCHEMA,
+                    }
+                },
+            )
+            payload = json.loads(_response_text(response))
+            title = payload.get("title")
+            return _normalize_generated_title(title)
+        except Exception:  # noqa: BLE001 -- title generation must never block a turn
+            _logger.warning(
+                "Session title generation failed; requesting caller fallback",
+                exc_info=True,
+            )
+            return None
+
+
+def _response_text(response: Any) -> str:
+    """Extract the first text block from a Responses-style result."""
+    for item in getattr(response, "output", []):
+        for block in getattr(item, "content", []):
+            text = getattr(block, "text", None)
+            if isinstance(text, str):
+                return text
+    return ""
+
+
+def _normalize_generated_title(value: Any) -> str | None:
+    """Collapse whitespace and enforce the persisted title length limit."""
+    if not isinstance(value, str):
+        return None
+    title = " ".join(value.split()).strip("\"'` ")
+    if not title:
+        return None
+    if len(title) > TITLE_MAX_LENGTH:
+        title = title[: TITLE_MAX_LENGTH - 1].rstrip() + "…"
+    return title

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -746,6 +746,21 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def set_title_if_missing(
+        self,
+        conversation_id: str,
+        title: str,
+    ) -> bool:
+        """
+        Atomically set a conversation title when it is still untitled.
+
+        :param conversation_id: Unique conversation identifier.
+        :param title: Initial title.
+        :returns: ``True`` when the title was set, otherwise ``False``.
+        """
+        ...
+
+    @abstractmethod
     def set_labels(
         self,
         conversation_id: str,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2567,6 +2567,24 @@ class SqlAlchemyConversationStore(ConversationStore):
                 meta.terminal_launch_args = json.dumps(terminal_launch_args)
         return self.get_conversation(conversation_id)
 
+    def set_title_if_missing(
+        self,
+        conversation_id: str,
+        title: str,
+    ) -> bool:
+        """Atomically set the title only while the conversation is untitled."""
+        with self._conv_session() as session:
+            result = session.execute(
+                update(SqlConversation)
+                .where(
+                    SqlConversation.workspace_id == current_workspace_id(),
+                    SqlConversation.id == conversation_id,
+                    SqlConversation.title == "",
+                )
+                .values(title=title, updated_at=now_epoch())
+            )
+            return int(getattr(result, "rowcount", 0)) == 1
+
     def set_runner_id(self, conversation_id: str, runner_id: str) -> bool:
         """
         Pin a conversation to a runner via atomic

--- a/tests/e2e_ui/sessions/test_generated_session_title.py
+++ b/tests/e2e_ui/sessions/test_generated_session_title.py
@@ -1,0 +1,32 @@
+"""Browser coverage for the untitled-to-generated sidebar transition."""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+from playwright.sync_api import Page, expect
+
+
+def test_new_chat_placeholder_is_replaced_by_generated_title(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """An untitled row stays usable until its background title arrives."""
+    base_url, session_id = seeded_session
+    row = page.locator(f'a[href="/c/{session_id}"]')
+    generated_title = f"Generated title {uuid.uuid4().hex[:8]}"
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(row).to_be_visible()
+    expect(row).to_contain_text("New Chat")
+
+    response = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": generated_title},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+
+    expect(row).to_contain_text(generated_title, timeout=20_000)
+    expect(row).not_to_contain_text("New Chat")

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -23,6 +23,7 @@ import pytest
 
 from omnigent.llms.context_window import ModelPricing
 from omnigent.runtime.tool_output import MAX_TOOL_OUTPUT_BYTES
+from omnigent.server.routes import sessions as sessions_module
 from omnigent.spec.types import SkillSpec
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
@@ -137,6 +138,26 @@ async def test_create_session_without_title_returns_none(
     agent = await create_test_agent(client)
     session = await _create_session(client, agent["id"])
     assert session["title"] is None
+
+
+async def test_history_only_initial_item_seeds_title(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unbound history seed receives the deterministic initial title."""
+
+    async def _no_runner(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    monkeypatch.setattr(sessions_module, "_get_runner_client", _no_runner)
+    agent = await create_test_agent(client)
+    session = await _create_session(
+        client,
+        agent["id"],
+        initial_message="Review the deployment architecture",
+    )
+
+    assert session["title"] == "Review the deployment architecture"
 
 
 # ── GET /v1/sessions (list) ──────────────────────────────
@@ -1069,13 +1090,8 @@ async def test_skill_slash_command_persists_visible_item_and_hidden_meta_message
     assert published[0][1]["item"]["type"] == "slash_command"
     assert published[0][1]["item"]["id"] == visible["id"]
 
-    # The dispatch also seeds the sidebar title from the typed command,
-    # mirroring the plain-message path. Without it, a session whose FIRST
-    # message is a skill invocation (web landing composer, REPL) keeps a
-    # NULL title and the UI falls back to the conversation id. The title
-    # must come from the visible "/name args" text — the hidden meta
-    # item's SKILL.md blob leaking here would show skill instructions in
-    # the sidebar.
+    # Without a configured title model, the visible command supplies the
+    # original deterministic fallback title.
     session_resp = await client.get(f"/v1/sessions/{session['id']}")
     assert session_resp.status_code == 200, session_resp.text
     assert session_resp.json()["title"] == "/grill-me review this rollout"
@@ -6236,22 +6252,15 @@ async def test_post_external_conversation_item_auto_assigns_response_id(
     assert published[0][1]["type"] == "session.input.consumed"
 
 
-async def test_external_user_message_seeds_title_on_claude_native_session(
+async def test_external_user_message_uses_fallback_without_title_generator(
     client: httpx.AsyncClient,
 ) -> None:
     """
-    First forwarded user message seeds the title on a claude-native session.
+    A forwarded user message uses deterministic naming without a generator.
 
     With the placeholder carve-out removed, ``omnigent claude``
-    creates sessions without a title — same shape as every other
-    untitled session. The transcript forwarder's first
-    ``external_conversation_item`` user-message POST must trigger
-    the generic ``_seed_missing_title_from_user_message`` path and
-    populate the title with the standard first-60-char synthesis.
-    This pins the integration of that helper with the external-
-    conversation-item route for the claude-native label combination,
-    so a future refactor of either side can't silently break the
-    sidebar's first-message title for these sessions.
+    creates sessions without a title. Its first prompt must restore the original
+    prompt-derived naming behavior without making an LLM call.
     """
     agent = await create_test_agent(client)
     session = await _create_session(
@@ -6289,13 +6298,7 @@ async def test_external_user_message_seeds_title_on_claude_native_session(
 
     snap = await client.get(f"/v1/sessions/{session['id']}")
     assert snap.status_code == 200
-    # The synthesized title equals the first message when it already fits
-    # the first-60-char budget. If this is empty or unchanged from None,
-    # the generic seed path didn't fire on the external_conversation_item
-    # route for claude-native labels.
-    assert snap.json()["title"] == first_message, (
-        f"first user message did not seed the title; title={snap.json()['title']!r}"
-    )
+    assert snap.json()["title"] == first_message
 
 
 async def test_interrupt_on_claude_native_session_skips_idle_publish_on_runner_failure(

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -13,11 +13,19 @@ import pytest
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from omnigent.entities import DEFAULT_ENVIRONMENT_ID, Conversation, ConversationItem, PagedList
+from omnigent.entities import (
+    DEFAULT_ENVIRONMENT_ID,
+    Conversation,
+    ConversationItem,
+    MessageData,
+    NewConversationItem,
+    PagedList,
+)
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.runtime import _globals, session_stream, set_runner_client, set_runner_router
 from omnigent.server.routes.sessions import _ancestor_session_ids, create_sessions_router
 from omnigent.server.schemas import SessionEventInput
+from omnigent.stores.conversation_store import ConversationStore
 
 
 class _ConversationStore:
@@ -3656,12 +3664,29 @@ async def test_kiro_native_dispatch_clears_pending_when_injection_fails() -> Non
 
 
 @pytest.mark.asyncio
-async def test_kiro_external_prompt_matches_pending_and_reports_skipped_input() -> None:
+async def test_kiro_external_prompt_matches_pending_and_reports_skipped_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A failed Kiro prompt must not make the next prompt clear the wrong pending input."""
     from omnigent.runtime import pending_inputs
     from omnigent.server.routes.sessions import _persist_external_conversation_item
 
     pending_inputs.reset_for_tests()
+    seeded_prompts: list[str] = []
+
+    async def _record_title_seed(
+        conv: Conversation,
+        item: NewConversationItem,
+        conversation_store: ConversationStore,
+    ) -> None:
+        del conv, conversation_store
+        if isinstance(item.data, MessageData):
+            seeded_prompts.append(item.data.content[0]["text"])
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._seed_missing_title_from_user_message",
+        _record_title_seed,
+    )
     store = _ConversationStore()
     conv = store.get_conversation("823dbd1aab969b5a813fac59bb977a77")
     assert conv is not None
@@ -3706,6 +3731,7 @@ async def test_kiro_external_prompt_matches_pending_and_reports_skipped_input() 
         assert matched_user.data.role == "user"
         assert matched_user.data.content == [{"type": "input_text", "text": "tell me a joke"}]
         assert matched_user.created_by == "alice@example.com"
+        assert seeded_prompts == ["!!!! XOXOX !!!!", "tell me a joke"]
         assert first != second
     finally:
         pending_inputs.reset_for_tests()

--- a/tests/server/test_session_titles.py
+++ b/tests/server/test_session_titles.py
@@ -1,0 +1,625 @@
+"""Tests for optional LLM-generated session titles."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from omnigent.entities import Conversation, MessageData
+from omnigent.server.routes import sessions as sessions_module
+from omnigent.server.session_titles import LLMSessionTitleGenerator
+from omnigent.stores.conversation_store import ConversationStore
+
+
+class _FakeLLM:
+    def __init__(self, result: str | Exception) -> None:
+        self.result = result
+        self.calls: list[dict[str, object]] = []
+
+    async def create(self, **kwargs: object) -> object:
+        self.calls.append(kwargs)
+        if isinstance(self.result, Exception):
+            raise self.result
+        return SimpleNamespace(
+            output=[SimpleNamespace(content=[SimpleNamespace(text=self.result)])]
+        )
+
+
+class _FakeTitleGenerator:
+    def __init__(self, title: str | None) -> None:
+        self.title = title
+        self.prompts: list[str] = []
+        self.attachments: list[tuple[dict[str, object], ...]] = []
+
+    async def generate(
+        self,
+        prompt: str | None,
+        attachments: Sequence[dict[str, object]] = (),
+    ) -> str | None:
+        if prompt is not None:
+            self.prompts.append(prompt)
+        self.attachments.append(tuple(attachments))
+        return self.title
+
+
+class _FakeConversationStore:
+    def __init__(self, items: list[tuple[str, str]] | None = None) -> None:
+        self.saved_title: str | None = None
+        self.items = [
+            SimpleNamespace(
+                id=item_id,
+                type="message",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": prompt}],
+                ),
+            )
+            for item_id, prompt in (items or [("item_1", "Initial prompt")])
+        ]
+
+    def list_items(
+        self,
+        conversation_id: str,
+        limit: int = 100,
+        after: str | None = None,
+        before: str | None = None,
+        order: str = "asc",
+        type: str | None = None,
+    ) -> object:
+        assert conversation_id == "session_1"
+        del before, order, type
+        start = 0
+        if after is not None:
+            start = next(i + 1 for i, item in enumerate(self.items) if item.id == after)
+        data = self.items[start : start + limit]
+        return SimpleNamespace(
+            data=data,
+            last_id=data[-1].id if data else None,
+            has_more=start + limit < len(self.items),
+        )
+
+    def set_title_if_missing(
+        self,
+        conversation_id: str,
+        title: str,
+    ) -> bool:
+        assert conversation_id == "session_1"
+        if self.saved_title is not None:
+            return False
+        self.saved_title = title
+        return True
+
+    def get_conversation(self, conversation_id: str) -> object:
+        assert conversation_id == "session_1"
+        return SimpleNamespace(title=self.saved_title)
+
+
+class _BlockingTitleGenerator(_FakeTitleGenerator):
+    def __init__(self, title: str | None) -> None:
+        super().__init__(title)
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def generate(
+        self,
+        prompt: str | None,
+        attachments: Sequence[dict[str, object]] = (),
+    ) -> str | None:
+        if prompt is not None:
+            self.prompts.append(prompt)
+        self.attachments.append(tuple(attachments))
+        self.started.set()
+        await self.release.wait()
+        return self.title
+
+
+class _SequencedTitleGenerator(_FakeTitleGenerator):
+    def __init__(self, results: list[str | None | Exception]) -> None:
+        super().__init__(None)
+        self.results = results
+        self.attempt_finished = asyncio.Event()
+
+    async def generate(
+        self,
+        prompt: str | None,
+        attachments: Sequence[dict[str, object]] = (),
+    ) -> str | None:
+        if prompt is not None:
+            self.prompts.append(prompt)
+        self.attachments.append(tuple(attachments))
+        result = self.results[len(self.attachments) - 1]
+        self.attempt_finished.set()
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+async def _finish_title_tasks() -> None:
+    tasks = list(sessions_module._session_title_tasks)
+    if tasks:
+        await asyncio.gather(*tasks)
+
+
+@pytest.fixture(autouse=True)
+def _reset_title_inflight() -> None:
+    sessions_module._session_title_inflight_ids.clear()
+
+
+@pytest.mark.asyncio
+async def test_llm_title_generator_requests_structured_concise_title() -> None:
+    llm = _FakeLLM('{"title":"Diagnose OAuth Callback Failure"}')
+    generator = LLMSessionTitleGenerator(llm)
+
+    title = await generator.generate(
+        "Our OAuth callback fails after login. Please inspect the redirect handling."
+    )
+
+    assert title == "Diagnose OAuth Callback Failure"
+    call = llm.calls[0]
+    assert call["input"][0]["content"][0]["text"].startswith("Our OAuth")  # type: ignore[index]
+    assert call["text"]["format"]["schema"]["properties"]["title"]["maxLength"] == 60  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "result",
+    [
+        RuntimeError("provider unavailable"),
+        "not json",
+        '{"title":"   "}',
+        '{"unexpected":"value"}',
+    ],
+)
+async def test_llm_title_generator_fails_open(result: str | Exception) -> None:
+    generator = LLMSessionTitleGenerator(_FakeLLM(result))
+
+    assert await generator.generate("A user request") is None
+
+
+@pytest.mark.asyncio
+async def test_llm_title_generator_normalizes_and_limits_output() -> None:
+    generator = LLMSessionTitleGenerator(_FakeLLM('{"title":"  `A   better   title`  "}'))
+    assert await generator.generate("request") == "A better title"
+
+    long_title = "x" * 80
+    generator = LLMSessionTitleGenerator(_FakeLLM(f'{{"title":"{long_title}"}}'))
+    title = await generator.generate("request")
+    assert title == "x" * 59 + "…"
+
+
+@pytest.mark.asyncio
+async def test_llm_title_generator_sends_images_to_the_model() -> None:
+    llm = _FakeLLM('{"title":"Golden Retriever at Beach"}')
+    generator = LLMSessionTitleGenerator(llm)
+
+    title = await generator.generate(
+        None,
+        [{"type": "input_image", "image_url": "data:image/png;base64,aW1hZ2U="}],
+    )
+
+    assert title == "Golden Retriever at Beach"
+    content = llm.calls[0]["input"][0]["content"]  # type: ignore[index]
+    assert content[1] == {  # type: ignore[index]
+        "type": "input_image",
+        "image_url": "data:image/png;base64,aW1hZ2U=",
+    }
+
+
+@pytest.mark.asyncio
+async def test_title_seed_stays_untitled_until_generator_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = _BlockingTitleGenerator("Repair OAuth Redirect Handling")
+    monkeypatch.setattr(
+        sessions_module,
+        "get_caps",
+        lambda: SimpleNamespace(session_title_generator=generated),
+    )
+    conv = cast(Conversation, SimpleNamespace(id="session_1", title=None))
+    prompt = "Investigate the OAuth redirect failure " + "with detailed context " * 10
+    raw_store = _FakeConversationStore([("item_1", prompt)])
+    store = cast(ConversationStore, raw_store)
+
+    await sessions_module._seed_missing_title(
+        conv,
+        store,
+    )
+
+    await generated.started.wait()
+    assert len(generated.prompts[0]) > 60
+    assert raw_store.saved_title is None
+    assert conv.title is None
+
+    generated.release.set()
+    await _finish_title_tasks()
+    assert raw_store.saved_title == "Repair OAuth Redirect Handling"
+
+
+@pytest.mark.asyncio
+async def test_generated_title_does_not_overwrite_manual_rename(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = _BlockingTitleGenerator("Generated title")
+    monkeypatch.setattr(
+        sessions_module,
+        "get_caps",
+        lambda: SimpleNamespace(session_title_generator=generated),
+    )
+    conv = cast(Conversation, SimpleNamespace(id="session_1", title=None))
+    raw_store = _FakeConversationStore()
+
+    await sessions_module._seed_missing_title(
+        conv,
+        cast(ConversationStore, raw_store),
+    )
+    await generated.started.wait()
+
+    raw_store.saved_title = "My manual title"
+    generated.release.set()
+    await _finish_title_tasks()
+
+    assert raw_store.saved_title == "My manual title"
+
+
+@pytest.mark.asyncio
+async def test_rejected_generation_retries_then_uses_original_title(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = _FakeTitleGenerator(None)
+    monkeypatch.setattr(
+        sessions_module,
+        "get_caps",
+        lambda: SimpleNamespace(session_title_generator=generated),
+    )
+    monkeypatch.setattr(sessions_module, "_SESSION_TITLE_RETRY_DELAY_SECONDS", 0)
+    conv = cast(Conversation, SimpleNamespace(id="session_1", title=None))
+    raw_store = _FakeConversationStore(
+        [("item_1", "Keep this deterministic"), ("item_2", "A later prompt")]
+    )
+    store = cast(ConversationStore, raw_store)
+
+    await sessions_module._seed_missing_title(
+        conv,
+        store,
+    )
+
+    await _finish_title_tasks()
+    assert raw_store.saved_title == "Keep this deterministic"
+    assert generated.prompts == ["Keep this deterministic"] * 3
+
+
+@pytest.mark.asyncio
+async def test_title_generation_retries_exception_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = _SequencedTitleGenerator(
+        [RuntimeError("temporary provider failure"), "Recovered generated title"]
+    )
+    monkeypatch.setattr(
+        sessions_module,
+        "get_caps",
+        lambda: SimpleNamespace(session_title_generator=generated),
+    )
+    monkeypatch.setattr(sessions_module, "_SESSION_TITLE_RETRY_DELAY_SECONDS", 0)
+    conv = cast(Conversation, SimpleNamespace(id="session_1", title=None))
+    raw_store = _FakeConversationStore([("item_1", "Investigate retry behavior")])
+
+    await sessions_module._seed_missing_title(
+        conv,
+        cast(ConversationStore, raw_store),
+    )
+    await _finish_title_tasks()
+
+    assert generated.prompts == ["Investigate retry behavior"] * 2
+    assert raw_store.saved_title == "Recovered generated title"
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_during_retry_prevents_generation_and_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = _SequencedTitleGenerator([None, "Must not be used"])
+    monkeypatch.setattr(
+        sessions_module,
+        "get_caps",
+        lambda: SimpleNamespace(session_title_generator=generated),
+    )
+    monkeypatch.setattr(sessions_module, "_SESSION_TITLE_RETRY_DELAY_SECONDS", 0.05)
+    conv = cast(Conversation, SimpleNamespace(id="session_1", title=None))
+    raw_store = _FakeConversationStore([("item_1", "Investigate manual renaming")])
+
+    await sessions_module._seed_missing_title(
+        conv,
+        cast(ConversationStore, raw_store),
+    )
+    await generated.attempt_finished.wait()
+    raw_store.saved_title = "My manual title"
+    await _finish_title_tasks()
+
+    assert generated.prompts == ["Investigate manual renaming"]
+    assert raw_store.saved_title == "My manual title"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_seed_requests_use_oldest_persisted_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = _FakeTitleGenerator("Oldest request title")
+    monkeypatch.setattr(
+        sessions_module,
+        "get_caps",
+        lambda: SimpleNamespace(session_title_generator=generated),
+    )
+    conv = cast(Conversation, SimpleNamespace(id="session_1", title=None))
+    raw_store = _FakeConversationStore(
+        [("item_1", "Oldest persisted request"), ("item_2", "Later request")]
+    )
+    store = cast(ConversationStore, raw_store)
+
+    await asyncio.gather(
+        sessions_module._seed_missing_title(conv, store),
+        sessions_module._seed_missing_title(conv, store),
+    )
+    await _finish_title_tasks()
+
+    assert generated.prompts == ["Oldest persisted request"]
+    assert raw_store.saved_title == "Oldest request title"
+
+
+@pytest.mark.asyncio
+async def test_image_only_request_is_titled_from_resolved_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = _FakeTitleGenerator("Golden Retriever at Beach")
+    monkeypatch.setattr(
+        sessions_module,
+        "get_caps",
+        lambda: SimpleNamespace(session_title_generator=generated),
+    )
+    monkeypatch.setattr(
+        sessions_module,
+        "get_file_store",
+        lambda: SimpleNamespace(
+            get=lambda file_id: SimpleNamespace(
+                id=file_id,
+                session_id="session_1",
+                content_type="image/png",
+                filename="dog.png",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        sessions_module,
+        "get_artifact_store",
+        lambda: SimpleNamespace(get=lambda file_id: b"image"),
+    )
+    conv = cast(Conversation, SimpleNamespace(id="session_1", title=None))
+    raw_store = _FakeConversationStore()
+    raw_store.items = [
+        SimpleNamespace(
+            id="item_1",
+            type="message",
+            data=MessageData(
+                role="user",
+                content=[{"type": "input_image", "file_id": "file_1", "filename": "dog.png"}],
+            ),
+        )
+    ]
+
+    await sessions_module._seed_missing_title(
+        conv,
+        cast(ConversationStore, raw_store),
+    )
+    await _finish_title_tasks()
+
+    assert raw_store.saved_title == "Golden Retriever at Beach"
+    assert generated.prompts == []
+    assert generated.attachments == [
+        (
+            {
+                "type": "input_image",
+                "filename": "dog.png",
+                "image_url": "data:image/png;base64,aW1hZ2U=",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_text_and_pdf_are_both_sent_to_title_generator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = _FakeTitleGenerator("Hutchinson Farms Case Study")
+    monkeypatch.setattr(
+        sessions_module,
+        "get_caps",
+        lambda: SimpleNamespace(session_title_generator=generated),
+    )
+    monkeypatch.setattr(
+        sessions_module,
+        "get_file_store",
+        lambda: SimpleNamespace(
+            get=lambda file_id: SimpleNamespace(
+                id=file_id,
+                session_id="session_1",
+                content_type="application/pdf",
+                filename="case-study.pdf",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        sessions_module,
+        "get_artifact_store",
+        lambda: SimpleNamespace(get=lambda file_id: b"%PDF"),
+    )
+    conv = cast(Conversation, SimpleNamespace(id="session_1", title=None))
+    raw_store = _FakeConversationStore()
+    raw_store.items = [
+        SimpleNamespace(
+            id="item_1",
+            type="message",
+            data=MessageData(
+                role="user",
+                content=[
+                    {"type": "input_text", "text": "a"},
+                    {
+                        "type": "input_file",
+                        "file_id": "file_1",
+                        "filename": "case-study.pdf",
+                    },
+                ],
+            ),
+        )
+    ]
+
+    await sessions_module._seed_missing_title(
+        conv,
+        cast(ConversationStore, raw_store),
+    )
+    await _finish_title_tasks()
+
+    assert raw_store.saved_title == "Hutchinson Farms Case Study"
+    assert generated.prompts == ["a"]
+    assert generated.attachments == [
+        (
+            {
+                "type": "input_file",
+                "filename": "case-study.pdf",
+                "file_data": "data:application/pdf;base64,JVBERg==",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_without_generator_image_only_request_does_not_block_later_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sessions_module,
+        "get_caps",
+        lambda: SimpleNamespace(session_title_generator=None),
+    )
+    conv = cast(Conversation, SimpleNamespace(id="session_1", title=None))
+    raw_store = _FakeConversationStore()
+    raw_store.items = [
+        SimpleNamespace(
+            id="item_1",
+            type="message",
+            data=MessageData(
+                role="user",
+                content=[{"type": "input_image", "file_id": "file_1"}],
+            ),
+        ),
+        SimpleNamespace(
+            id="item_2",
+            type="message",
+            data=MessageData(
+                role="user",
+                content=[{"type": "input_text", "text": "Explain this architecture"}],
+            ),
+        ),
+    ]
+
+    await sessions_module._seed_missing_title(
+        conv,
+        cast(ConversationStore, raw_store),
+    )
+
+    assert raw_store.saved_title == "Explain this architecture"
+
+
+@pytest.mark.asyncio
+async def test_title_seed_uses_original_title_without_generator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sessions_module,
+        "get_caps",
+        lambda: SimpleNamespace(session_title_generator=None),
+    )
+    conv = cast(Conversation, SimpleNamespace(id="session_1", title=None))
+    prompt = "Explain how to migrate this application without downtime " * 3
+    raw_store = _FakeConversationStore([("item_1", prompt)])
+
+    await sessions_module._seed_missing_title(
+        conv,
+        cast(ConversationStore, raw_store),
+    )
+    await _finish_title_tasks()
+
+    assert raw_store.saved_title == prompt[:59].rstrip() + "…"
+    assert conv.title == raw_store.saved_title
+
+
+@pytest.mark.asyncio
+async def test_stale_untitled_entity_does_not_trigger_duplicate_llm_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = _FakeTitleGenerator("Duplicate title")
+    monkeypatch.setattr(
+        sessions_module,
+        "get_caps",
+        lambda: SimpleNamespace(session_title_generator=generated),
+    )
+    conv = cast(Conversation, SimpleNamespace(id="session_1", title=None))
+    raw_store = _FakeConversationStore()
+    raw_store.saved_title = "Already generated"
+
+    await sessions_module._seed_missing_title(
+        conv,
+        cast(ConversationStore, raw_store),
+    )
+    await _finish_title_tasks()
+
+    assert generated.prompts == []
+    assert raw_store.saved_title == "Already generated"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_allows_generated_title_to_finish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = _BlockingTitleGenerator("Finished during shutdown")
+    monkeypatch.setattr(
+        sessions_module,
+        "get_caps",
+        lambda: SimpleNamespace(session_title_generator=generated),
+    )
+    monkeypatch.setattr(sessions_module, "_SESSION_TITLE_SHUTDOWN_TIMEOUT_SECONDS", 0.1)
+    conv = cast(Conversation, SimpleNamespace(id="session_1", title=None))
+    raw_store = _FakeConversationStore([("item_1", "Keep deterministic fallback")])
+
+    await sessions_module._seed_missing_title(
+        conv,
+        cast(ConversationStore, raw_store),
+    )
+    await generated.started.wait()
+
+    async def _release_generator() -> None:
+        await asyncio.sleep(0.01)
+        generated.release.set()
+
+    release_task = asyncio.create_task(_release_generator())
+    await sessions_module.cancel_session_title_tasks()
+    await release_task
+
+    assert raw_store.saved_title == "Finished during shutdown"
+    assert not sessions_module._session_title_tasks
+
+
+def test_hidden_meta_message_is_not_a_title_candidate() -> None:
+    item = SimpleNamespace(
+        type="message",
+        data=MessageData(
+            role="user",
+            content=[{"type": "input_text", "text": "Internal skill instructions"}],
+            is_meta=True,
+        ),
+    )
+
+    assert sessions_module._title_content_from_item(item) == []

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -287,6 +287,16 @@ def test_update_title(conversation_store: SqlAlchemyConversationStore) -> None:
     )
 
 
+def test_set_title_if_missing(conversation_store: SqlAlchemyConversationStore) -> None:
+    conv = conversation_store.create_conversation()
+
+    assert conversation_store.set_title_if_missing(conv.id, "Generated title")
+    assert conversation_store.get_conversation(conv.id).title == "Generated title"
+
+    assert not conversation_store.set_title_if_missing(conv.id, "Late generated title")
+    assert conversation_store.get_conversation(conv.id).title == "Generated title"
+
+
 def test_update_archived_round_trip(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:

--- a/web/src/shell/AnimatedSessionTitle.test.tsx
+++ b/web/src/shell/AnimatedSessionTitle.test.tsx
@@ -1,0 +1,49 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AnimatedSessionTitle } from "./AnimatedSessionTitle";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("AnimatedSessionTitle", () => {
+  it("renders New Chat while the session is untitled", () => {
+    render(<AnimatedSessionTitle title={null} fallback="New Chat" />);
+    expect(screen.getByText("New Chat")).toBeInTheDocument();
+  });
+
+  it("reveals the first generated title character by character", () => {
+    vi.useFakeTimers();
+    const { rerender } = render(<AnimatedSessionTitle title={null} fallback="New session" />);
+    expect(screen.getByText("New session")).toBeInTheDocument();
+
+    rerender(<AnimatedSessionTitle title="OAuth Fix" fallback="New session" />);
+    act(() => vi.advanceTimersByTime(48));
+    expect(screen.getByText("O")).toBeInTheDocument();
+
+    act(() => vi.runAllTimers());
+    expect(screen.getByText("OAuth Fix")).toBeInTheDocument();
+  });
+
+  it("treats an absent streamed title as untitled", () => {
+    vi.useFakeTimers();
+    const { rerender } = render(<AnimatedSessionTitle title={undefined} fallback="New session" />);
+    rerender(<AnimatedSessionTitle title="Generated" fallback="New session" />);
+
+    act(() => vi.advanceTimersByTime(48));
+    expect(screen.getByText("G")).toBeInTheDocument();
+  });
+
+  it("shows an existing title immediately on initial render", () => {
+    render(<AnimatedSessionTitle title="Existing title" fallback="New session" />);
+    expect(screen.getByText("Existing title")).toBeInTheDocument();
+  });
+
+  it("applies later manual renames immediately", () => {
+    const { rerender } = render(
+      <AnimatedSessionTitle title="Generated title" fallback="New session" />,
+    );
+    rerender(<AnimatedSessionTitle title="Manual title" fallback="New session" />);
+    expect(screen.getByText("Manual title")).toBeInTheDocument();
+  });
+});

--- a/web/src/shell/AnimatedSessionTitle.tsx
+++ b/web/src/shell/AnimatedSessionTitle.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from "react";
+
+const MAX_REVEAL_MS = 1_200;
+const MIN_CHARACTER_MS = 32;
+const MAX_CHARACTER_MS = 48;
+
+export function AnimatedSessionTitle({
+  title,
+  fallback,
+}: {
+  title: string | null | undefined;
+  fallback: string;
+}) {
+  const previousTitle = useRef(title);
+  const [displayedTitle, setDisplayedTitle] = useState(title ?? fallback);
+  const [animating, setAnimating] = useState(false);
+
+  useEffect(() => {
+    const previous = previousTitle.current;
+    previousTitle.current = title;
+
+    if (title == null) {
+      setDisplayedTitle(fallback);
+      setAnimating(false);
+      return;
+    }
+
+    const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+    if (previous != null || reduceMotion) {
+      setDisplayedTitle(title);
+      setAnimating(false);
+      return;
+    }
+
+    let characterCount = 0;
+    const characterMs = Math.max(
+      MIN_CHARACTER_MS,
+      Math.min(MAX_CHARACTER_MS, Math.floor(MAX_REVEAL_MS / title.length)),
+    );
+    setDisplayedTitle("");
+    setAnimating(true);
+    const timer = window.setInterval(() => {
+      characterCount += 1;
+      setDisplayedTitle(title.slice(0, characterCount));
+      if (characterCount >= title.length) {
+        window.clearInterval(timer);
+        setAnimating(false);
+      }
+    }, characterMs);
+    return () => window.clearInterval(timer);
+  }, [fallback, title]);
+
+  return (
+    <span aria-label={title ?? fallback}>
+      <span aria-hidden="true">{displayedTitle}</span>
+      {animating && (
+        <span aria-hidden="true" className="ml-px animate-pulse text-muted-foreground">
+          ▍
+        </span>
+      )}
+    </span>
+  );
+}

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -61,6 +61,7 @@ import {
   useSensors,
 } from "@dnd-kit/core";
 import { Link, useLocation, useNavigate, useParams } from "@/lib/routing";
+import { AnimatedSessionTitle } from "./AnimatedSessionTitle";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -142,7 +143,6 @@ import {
   type ActiveChatOverride,
   COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY,
   computeNextActiveOverride,
-  conversationDisplayLabel,
   dedupeConversationsById,
   EXPANDED_PROJECT_SECTIONS_STORAGE_KEY,
   migratePinnedConversationIds,
@@ -2474,7 +2474,7 @@ function ConversationRow({
   // native `title` tooltip.
   const projectFlyoutName = !isMobile && isPinned ? currentProject : null;
 
-  const label = conversationDisplayLabel(conversation);
+  const label = conversation.title || "New Chat";
   // Recompute unseen state the moment the last-seen map changes (e.g. the
   // user picks "Mark as unread" on this row) rather than waiting for the
   // next conversations poll.
@@ -2681,6 +2681,7 @@ function ConversationRow({
   const rowLink = (
     <Link
       to={selectionMode ? "#" : `/c/${conversation.id}`}
+      aria-label={`${label}${hasUnseenMessages ? " (unread)" : ""}`}
       className={cn(
         "relative flex w-full flex-col gap-0.5 rounded-md px-2 py-2 text-left text-sm hover:bg-muted",
         !selectionMode && (sessionState?.kind === "awaiting" ? "pr-48 md:pr-29" : "pr-28 md:pr-16"),
@@ -2710,7 +2711,7 @@ function ConversationRow({
       }}
       // The rich project flyout replaces the native tooltip on pinned,
       // project-owned rows so the two don't stack; other rows keep it.
-      title={projectFlyoutName ? undefined : (conversation.title ?? conversation.id)}
+      title={projectFlyoutName ? undefined : label}
     >
       {/* Row 1: the session name. Status markers (working, needs-approval,
           unseen) render in the trailing time-marker slot below, replacing
@@ -2718,8 +2719,8 @@ function ConversationRow({
           shared) were removed to keep rows text-clean; pinned rows still
           group under "Pinned". */}
       <div className="flex w-full items-center gap-1.5">
-        <span className="relative min-w-0 truncate">
-          {label}
+        <span className="relative flex h-5 min-w-0 flex-1 items-center truncate">
+          <AnimatedSessionTitle title={conversation.title} fallback="New Chat" />
           {hasUnseenMessages && <span className="sr-only"> (unread)</span>}
         </span>
       </div>


### PR DESCRIPTION
## Related issue

Closes #2737

## Summary

New sessions now start as **New Chat** and receive a concise title from the server's configured LLM after the first user request is persisted. Title generation runs in a background task, so it does not delay forwarding the request to the agent.

The implementation deliberately keeps session naming separate from the agent turn:

- The oldest persisted user request is the source of truth, including resolved image and file attachments when available.
- A title is written with a single atomic "only if still untitled" update. If someone renames the session while generation is running, their title wins.
- Generation gets three attempts. If the model errors or returns an unusable result, the existing prompt-derived naming convention is used instead.
- Servers without an `llm:` configuration keep the existing deterministic behavior. Operators can also opt out with `OMNIGENT_SESSION_TITLES=0`.
- The sidebar reserves the final title's space, shows **New Chat** while waiting, and types in the persisted title without changing the row size or dropping the unread state from its accessible name.

In short: the chat starts immediately, naming happens beside it, and the generated result is only accepted while the title is still empty.

```mermaid
flowchart LR
    A[Persist first user request] --> B[Forward request to agent]
    A --> C[Generate concise title]
    C --> D{Valid title returned?}
    D -->|Yes| E[Set only if still untitled]
    D -->|No after 3 attempts| F[Use original prompt title]
    F --> E
    E --> G[Sidebar animates persisted title]
```

## Test Plan

- `.venv/bin/python -m pytest -q tests/server/test_session_titles.py tests/stores/test_conversation_store.py` — 187 passed
- Focused session endpoint tests for history seeds, Skill-first sessions, and native forwarded prompts — 3 passed
- Kiro skipped-input regression test — passed
- `.venv/bin/python -m pytest -q tests/e2e_ui/sessions/test_generated_session_title.py` — Chromium E2E passed
- `npm --prefix web test -- --run src/shell/AnimatedSessionTitle.test.tsx` — 5 passed
- `.venv/bin/pre-commit run` — passed for all staged files
- `npm --prefix web run build` — passed
- `git diff --check` — passed

The repository-wide web lint command still reports pre-existing errors in unrelated files on `main`; the staged-file checks report no errors in this change.

## Demo

Verified in Chromium against a real local server: an untitled sidebar row renders as **New Chat**, then changes in place to the persisted generated title without a reload. The browser E2E test covers the same transition end to end.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified text prompts, an image with a short prompt, fallback behavior, and the **New Chat** to generated-title transition on the local server. Automated coverage also exercises concurrent first messages, delayed generation, retries, rejection, shutdown, attachment resolution, deterministic fallback, and a manual rename while generation is still running.

## Changelog

New chats receive concise generated titles without delaying the first message or overwriting manual names.
