### PR TITLE
fix(sandbox): detach managed BoxLite boxes

### DIFF
--- a/omnigent/onboarding/sandboxes/boxlite.py
+++ b/omnigent/onboarding/sandboxes/boxlite.py
@@ -372,8 +372,9 @@ class BoxliteSandboxLauncher(SandboxLauncher):
         """
         Create a new BoxLite box from the host image.
 
-        The box is persistent (``auto_remove=False``); the managed-session
-        machinery owns its teardown (session delete / relaunch → ``terminate``).
+        The box is detached and persistent (``detach=True``,
+        ``auto_remove=False``); the managed-session machinery owns its teardown
+        (session delete / relaunch → ``terminate``).
         Network defaults to full egress (boxlite ``NetworkSpec`` default
         ``Enabled``) so the in-box host can reach ``server_url``.
 
@@ -398,6 +399,7 @@ class BoxliteSandboxLauncher(SandboxLauncher):
                 memory_mib=_SANDBOX_MEMORY_MIB,
                 env=env,
                 auto_remove=False,
+                detach=True,
             )
             box = await runtime.create(options, name=name)
             return str(box.id)

--- a/tests/onboarding/sandboxes/test_boxlite.py
+++ b/tests/onboarding/sandboxes/test_boxlite.py
@@ -151,6 +151,7 @@ class _FakeBoxOptions:
         memory_mib: int | None = None,
         env: object = None,
         auto_remove: bool | None = None,
+        detach: bool | None = None,
         **kwargs: object,
     ) -> None:
         self.image = image
@@ -158,6 +159,7 @@ class _FakeBoxOptions:
         self.memory_mib = memory_mib
         self.env = env if env is not None else []
         self.auto_remove = auto_remove
+        self.detach = detach
         self.extra = kwargs
 
 
@@ -357,9 +359,9 @@ def test_provision_defaults_official_image_and_persists(
     fake_boxlite: _FakeBoxliteState,
 ) -> None:
     """
-    A bare provision uses the official host image, is persistent
-    (auto_remove=False so the managed machinery owns teardown), injects
-    no env, sizes like Modal/Daytona, and runs LOCAL by default.
+    A bare provision uses the official host image, stays alive after the SDK
+    handle is dropped, lets managed machinery own teardown, injects no env,
+    sizes like Modal/Daytona, and runs LOCAL by default.
     """
     box_id = BoxliteSandboxLauncher().provision("managed-abc")
 
@@ -367,6 +369,7 @@ def test_provision_defaults_official_image_and_persists(
     [create] = fake_boxlite.create_calls
     assert create.options.image == DEFAULT_HOST_IMAGE
     assert create.options.auto_remove is False
+    assert create.options.detach is True
     assert create.options.cpus == 2
     assert create.options.memory_mib == 4096
     assert create.options.env == []


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Provision managed BoxLite boxes with `detach=True` so they remain running after the temporary SDK handle is dropped.
- Keep `auto_remove=False` so Omnigent's managed-session lifecycle remains responsible for teardown.
- Add a focused regression assertion for the detached lifecycle option.

Without detachment, the BoxLite SDK stops the VM when the provision-time `Box` handle is released.
Omnigent stores only the box ID and reacquires the box for later commands, so those commands fail with a gRPC transport error after the VM has already stopped.

## Test Plan

- `uv run --frozen --extra dev pytest tests/onboarding/sandboxes/test_boxlite.py -q`
- `uv run --frozen --extra dev pre-commit run --all-files`
- Manually verified a managed BoxLite sandbox could launch Claude Code and return `sandbox works` after provisioning released the original handle.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The updated launcher test verifies `BoxOptions.detach` is enabled alongside the existing persistent-lifecycle assertions.
Manual verification exercised the full managed-sandbox path with BoxLite 0.9.7 and confirmed a command could run after the provision-time SDK handle was released.

## Changelog

Managed BoxLite sandboxes remain available after provisioning so agent launches can execute commands reliably.
