### PR TITLE
feat(harness): add Snowflake CoCo (coco-native) terminal harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Or launch a specific agent runtime:
 ```bash
 omnigent claude                      # Claude Code, in a session your team can join
 omnigent codex                       # Codex
+omnigent coco                        # Snowflake CoCo (Cortex Code)
 omnigent cursor                      # Cursor
 omnigent opencode                    # OpenCode
 omnigent hermes                      # Hermes Agent (Nous Research)
@@ -473,9 +474,10 @@ name: my_agent
 prompt: You are a helpful data analyst.
 
 executor:
-  harness: claude-sdk          # or: claude-native, codex, codex-native, cursor,
-                               # cursor-native, hermes, hermes-native, opencode,
-                               # pi, pi-native, openai-agents
+  harness: claude-sdk          # or: claude-native, coco-native, codex,
+                               # codex-native, cursor, cursor-native, hermes,
+                               # hermes-native, opencode, pi, pi-native,
+                               # openai-agents
 
 tools:
   # A local Python function (schema auto-generated from the signature)

--- a/docs/COCO_NATIVE_DESIGN.md
+++ b/docs/COCO_NATIVE_DESIGN.md
@@ -1,0 +1,161 @@
+# `coco-native` — Snowflake CoCo (Cortex Code) native TUI harness
+
+A terminal-native Snowflake CoCo harness (`harness: coco-native`, aliases
+`coco` / `cortex` / `native-coco`) that embeds the **live interactive `cortex`
+TUI** in the Omnigent web UI — the Snowflake analog of `goose-native`, with a
+hook-driven transcript mirror instead of a store tail.
+
+All protocol claims below were verified live against **CoCo CLI v1.1.1**
+(`Cortex Code v1.1.1`, macOS arm64).
+
+## Key insights (verified)
+
+1. **CoCo supports Claude-Code-compatible lifecycle hooks** — command hooks
+   receive a JSON payload on stdin carrying `hook_event_name`, `session_id`,
+   `transcript_path`, `cwd`, `permission_mode` (plus `prompt` on
+   `UserPromptSubmit`). As of v1.1.1 hooks load **only** from
+   `$SNOWFLAKE_HOME/cortex/hooks.json` — project `.cortex/settings.json`,
+   `.cortex/hooks.json`, `.cortex/hooks/hooks.json` and `--config` hooks were
+   all tested and do **not** fire.
+2. **`SNOWFLAKE_HOME` redirects the whole config tree** (auth
+   `connections.toml`, `cortex/` settings/MCP/skills/conversations). So a
+   per-session `SNOWFLAKE_HOME` that **symlinks every entry of the user's real
+   home** and replaces only `cortex/hooks.json` gives Omnigent its hook
+   without touching user config — the hermes `HERMES_HOME` pattern.
+3. **The TUI ignores `--session-id`** (v1.1.1; headless `-p` honors it). TUI
+   sessions mint their own id, so discovery flows through the hook events:
+   `SessionStart` announces the real id at boot, and the forwarder persists it
+   as `external_session_id` for cold resume (`cortex -r <id>`).
+4. **CoCo flushes its transcript before firing the `Stop` hook.** Without
+   hooks the `conversations/<id>.history.jsonl` write is lazy (observed
+   minutes late / at quit), so a goose-style store tail alone cannot mirror
+   live. With the Stop hook, the finished turn's rows are on disk at hook
+   time (verified: `hist_lines` grows exactly at Stop) — so the forwarder
+   mirrors per turn: `UserPromptSubmit` → `running` edge, `Stop` → read new
+   history rows → items → `idle` edge.
+5. **Escape interrupts; Ctrl+C is dangerous.** The TUI footer advertises
+   "esc to interrupt" mid-turn and a live check confirmed clean cancellation
+   ("Tool execution was interrupted by user"). Ctrl+C is bound to
+   cancel-or-exit (double-tap exits), so two rapid Stop clicks would kill the
+   TUI — the interrupt path sends Escape only.
+6. **Injection is goose-identical.** tmux bracketed paste
+   (`load-buffer`/`paste-buffer -p`) + one Enter submits through the normal
+   input path and renders as a normal user bubble; CoCo queues messages typed
+   mid-turn ("Type to queue message"), so mid-turn steering lands too.
+
+## History file format (verified)
+
+`~/.snowflake/cortex/conversations/<session_id>.history.jsonl` — one JSON
+object per line, Anthropic-style content blocks:
+
+```jsonc
+{"role":"user","content":[{"type":"text","text":"..."}],"id":"msg_<uuid>","user_sent_time":"..."}
+{"role":"assistant","content":[
+   {"type":"text","text":"..."},
+   {"type":"tool_use","tool_use":{"tool_use_id":"...","name":"BASH","input":{...}}}
+ ],"id":"msg_<uuid>","assistant_sent_time":"..."}
+{"role":"user","content":[{"type":"tool_result","tool_result":{"name":"BASH","tool_use_id":"...","content":[...],"status":"..."},"message_id":"..."}]}
+```
+
+The sibling `<session_id>.json` is the metadata file (`title`, `session_id`,
+`working_directory`, `history_length`, ...) — it is what the hook's
+`transcript_path` points at; the forwarder derives the `.history.jsonl`
+sibling. Message ids are UUIDs (not ordinal), so the mirror cursor is a line
+count, not an id high-water mark.
+
+## Architecture
+
+```
+web chat ──user turn──▶ CocoNativeExecutor ──tmux paste+Enter──▶ cortex TUI (tmux pane, embedded)
+                                                                    │
+   per-session SNOWFLAKE_HOME (bridge_dir/snowflake_home):          │ lifecycle hooks
+     connections.toml → symlink(user's)                             ▼
+     cortex/* → symlinks(user's, incl. conversations/)   coco_native_hook.py --bridge-dir …
+     cortex/hooks.json → Omnigent relay (merged w/ user's)          │ append JSON line
+                                                                    ▼
+   coco_native_forwarder ◀──tail── bridge_dir/hook_events.jsonl
+     SessionStart → adopt session id (cursor = current history length; persists
+                    external_session_id via runner PATCH)
+     UserPromptSubmit → running edge (coco:turn:<n>)
+     Stop → read conversations/<id>.history.jsonl past cursor → mirror
+            text/tool_use/tool_result as message/function_call/
+            function_call_output items → idle edge
+   Stop button ──▶ runner _handle_coco_native_interrupt ──Escape──▶ pane
+```
+
+Because both the hook event log and the line cursor are durable (bridge dir),
+a forwarder restart resumes exactly where it left off — unprocessed events are
+still in the file, so there is no open-turn replay pass (unlike goose).
+
+### Resume / fork
+
+- **Cold resume**: the persisted `external_session_id` + an on-disk recording
+  check gate `cortex -r <id>` (resume on an unknown id errors, so the guard is
+  the recording file — same convention as qwen-native). The conversations dir
+  is symlinked from the user's real home, so recordings survive bridge-dir
+  cleanup and stay visible to the user's own `cortex resume`.
+- **Adoption cursor**: on `SessionStart` the forwarder seeds its line cursor
+  to the history file's current length — a resumed session's prior rows (which
+  Omnigent already holds) are never re-mirrored; a fresh session starts at 0.
+- **Fork**: v1 starts the forked TUI fresh (goose parity — the copied Omnigent
+  items still show in web chat). CoCo has native `--fork-session -r <id>` /
+  `--resume-session-at`, so true fork-with-history is a natural follow-up.
+
+## Capability declaration
+
+`NATIVE_TUI / EL.NONE / WARM_REATTACH / EF.NONE / MF.MULTI / OWN_AUTH,
+subagents=False, interrupt=True, streaming=False`. `streaming=False` is by
+construction: the mirror posts whole finished turns at Stop; no delta path
+exists. Tool approvals stay in the vendor TUI (CoCo's three-tier confirm
+actions / plan / bypass modes, Shift+Tab), which renders in the embedded pane.
+
+## Hardening notes (adversarial-review driven)
+
+- **Status memo / reaper**: `COCO_NATIVE_TERMINAL_ROLE` is in the PTY
+  watcher's `emit_status` set (like goose/hermes) so a `/quit` before the
+  first turn classifies as a clean exit (not a `required_terminal_exited`
+  crash card) and the pane reaper's busy check sees activity.
+- **First run**: `write_coco_home` pre-creates the user-side
+  `~/.snowflake/cortex/conversations` skeleton before symlinking, so a fresh
+  machine's transcripts land in the durable user home (not the throwaway
+  bridge dir) and cold resume works; broken symlinks (deleted-then-recreated
+  user files) are healed on relaunch.
+- **Forwarder durability**: the open-turn flag (`turn_live`) persists with the
+  cursor, so a forwarder restart closes the original `coco:turn:<n>` instead
+  of orphaning its spinner or minting a duplicate id; a history file that
+  shrinks (CoCo compaction) snaps the cursor down instead of going silently
+  dead; the stalled-turn backstop keeps the turn id so late rows rejoin their
+  streaming group (goose parity).
+- **User bubbles**: CoCo bakes its injected context into the stored user
+  message as `<system-reminder>` text blocks (verified live); the mirror
+  strips them.
+
+## First-run UX notes
+
+- A workspace not previously trusted shows CoCo's "Do you trust this
+  project?" prompt in the embedded pane; the user answers there (same
+  surrender-to-vendor stance as the trust/auth wizards of other native
+  harnesses).
+- No `connections.toml` → CoCo's connection wizard runs in the pane.
+- Readiness gates only on the `cortex` binary
+  (`curl -LsS https://ai.snowflake.com/static/cc-scripts/install.sh | sh`).
+
+## Follow-ups (deliberately out of v1 — the qwen PR-1/PR-2 split)
+
+- **Web approval mirror / policy gating** via the `PermissionRequest` hook
+  (present in the binary's hook set) — would upgrade `EL.NONE` to a real
+  ASK-mirror like goose's cliclack mirror.
+- **Omnigent MCP relay** via `--mcp-config` (CoCo supports the flag; the
+  qwen-native launch shows the serve-mcp wiring). Needs a live check of CoCo's
+  MCP trust prompt for CLI-provided servers.
+- **Fork with history** via `--fork-session -r <src>` + first-Stop cursor
+  handling for the copied prefix.
+- **Cost tracking** from `~/.snowflake/cortex/stats/usage.json`.
+- **Piped `coco` harness**: `cortex acp serve` speaks ACP over stdio (the
+  goose/qwen ACP model, protocol-level cancel + permission routing), and the
+  CLI also has full headless stream-json (`-p` / `--input-format stream-json`
+  / `--output-format stream-json`, Claude-Code-shaped envelopes). Either gives
+  a chat-first counterpart to this terminal-first harness.
+- **Newer CoCo versions**: v1.1.41+ exists; re-verify `--session-id` TUI
+  behavior and hook sources on update (discovery-by-hook keeps working either
+  way).

--- a/omnigent/_wrapper_labels.py
+++ b/omnigent/_wrapper_labels.py
@@ -80,3 +80,7 @@ KIMI_NATIVE_WRAPPER_VALUE = "kimi-native-ui"
 # Value the ``omnigent hermes`` wrapper writes into
 # ``conversations.labels[WRAPPER_LABEL_KEY]``.
 HERMES_NATIVE_WRAPPER_VALUE = "hermes-native-ui"
+
+# Value the ``omnigent coco`` (Snowflake CoCo / Cortex Code) wrapper writes
+# into ``conversations.labels[WRAPPER_LABEL_KEY]``.
+COCO_NATIVE_WRAPPER_VALUE = "coco-native-ui"

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1323,6 +1323,7 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
         "antigravity",
         "attach",
         "claude",
+        "coco",
         "codex",
         "config",
         "cursor",
@@ -5488,6 +5489,69 @@ def goose(
     default=None,
     help=(
         "Remote omnigent URL. Ensures the host daemon, asks the "
+        "daemon-spawned runner to launch the Snowflake CoCo TUI, and attaches "
+        'this TTY. Pass --server "" to auto-spawn a persistent local server in '
+        "the background and use that instead of a remote one."
+    ),
+)
+@click.option(
+    "-r",
+    "--resume",
+    "resume",
+    is_flag=False,
+    flag_value=_RESUME_PICKER_SENTINEL,
+    default=None,
+    help=(
+        "Resume a prior Omnigent conversation. With a conversation id "
+        "(e.g. ``--resume conv_abc123``) attaches directly; with no value "
+        "opens an interactive picker scoped to coco-native sessions."
+    ),
+)
+@click.argument("coco_args", nargs=-1, type=click.UNPROCESSED)
+def coco(
+    server: str | None,
+    resume: str | None,
+    coco_args: tuple[str, ...],
+) -> None:
+    """Launch the Snowflake CoCo (Cortex Code) TUI in an Omnigent terminal.
+
+    \b
+    Examples:
+      omnigent coco
+      omnigent coco --resume conv_abc123
+      omnigent coco --resume                  # interactive picker
+    """
+    choice = _split_resume_value(resume)
+
+    from omnigent.coco_native import run_coco_native
+
+    cfg = _load_effective_config()
+    if server is None:
+        server = cfg.get("server")
+    auto_open_conversation = _resolve_auto_open_conversation_from_config(cfg)
+
+    server = _ensure_backend(server)
+
+    run_coco_native(
+        server=server,
+        session_id=choice.conversation_id,
+        resume_picker=choice.picker,
+        coco_args=coco_args,
+        auto_open_conversation=auto_open_conversation,
+    )
+
+
+@cli.command(
+    context_settings={
+        "ignore_unknown_options": True,
+        "allow_extra_args": True,
+    }
+)
+@click.option(
+    "--server",
+    default=None,
+    help=(
+        "Remote omnigent URL. Ensures the host daemon, asks the "
         "daemon-spawned runner to launch the Hermes TUI, and attaches this TTY. "
         'Pass --server "" to auto-spawn a persistent local server in the '
         "background and use that instead of a remote one."
@@ -6560,6 +6624,14 @@ _NATIVE_TERMINAL_DISPATCH_SPECS: dict[str, _NativeTerminalDispatchSpec] = {
         module="omnigent.hermes_native",
         function="run_hermes_native",
         args_param="hermes_args",
+        model_strategy="explicit_passthrough",
+    ),
+    # ``cortex`` accepts ``--model`` directly, so an explicit ``--model`` is
+    # forwarded as a passthrough arg; otherwise CoCo's own default applies.
+    "coco": _NativeTerminalDispatchSpec(
+        module="omnigent.coco_native",
+        function="run_coco_native",
+        args_param="coco_args",
         model_strategy="explicit_passthrough",
     ),
 }
@@ -10932,6 +11004,67 @@ def _manage_hermes_harness() -> None:
                 status = "✗ hermes binary not found"
 
 
+def _manage_coco_harness() -> None:
+    """Run the level-2 loop for Snowflake CoCo: ensure the CLI is installed.
+
+    CoCo owns its own auth via ``~/.snowflake/connections.toml`` (shared with
+    the Snowflake CLI; its connection wizard runs on first ``cortex`` launch)
+    and is installed via Snowflake's curl script — Omnigent stores no CoCo
+    credential. A missing CLI gates the drill-in; when installed, the drill-in
+    offers to list the configured Snowflake connections. Mirrors
+    :func:`_manage_hermes_harness`.
+
+    :returns: None. Side effects: may run ``cortex connections list``.
+    """
+    from omnigent.onboarding.harness_install import (
+        COCO_KEY,
+        harness_cli_installed,
+        harness_install_spec,
+    )
+    from omnigent.onboarding.interactive import console, select
+
+    if not harness_cli_installed(COCO_KEY):
+        spec = harness_install_spec(COCO_KEY)
+        hint = (
+            spec.install_hint
+            if spec and spec.install_hint
+            else "curl -LsS https://ai.snowflake.com/static/cc-scripts/install.sh | sh"
+        )
+        console.print(
+            f"  Snowflake CoCo isn't installed. Install it with:\n    [bold]{hint}[/bold]\n"
+            "  then re-open this menu."
+        )
+        return
+
+    status: str | None = None
+    while True:
+        rows: list[_HarnessMenuRow] = [
+            _HarnessMenuRow(
+                "Run cortex connections list (show Snowflake connections)", action="list"
+            ),
+            _HarnessMenuRow("← Back", action="back"),
+        ]
+        idx = select(
+            "Snowflake CoCo",
+            [r.label for r in rows],
+            clear_on_exit=True,
+            status=status,
+        )
+        if idx < 0:
+            return
+        action = rows[idx].action
+        if action == "back":
+            return
+        if action == "list":
+            import subprocess
+
+            try:
+                subprocess.run(["cortex", "connections", "list"], check=False)
+                status = "✓ connections listed (run `cortex` once to add one via its wizard)"
+            except FileNotFoundError:
+                status = "✗ cortex binary not found"
+
+
 def _manage_kiro_harness() -> None:
     """Run the level-2 loop for Kiro: ensure the CLI is installed and signed in.
 
@@ -11822,6 +11955,7 @@ def _run_configure_harnesses_interactive() -> None:
     from omnigent.onboarding.extra_install import extra_install_display
     from omnigent.onboarding.goose_auth import goose_config_summary
     from omnigent.onboarding.harness_install import (
+        COCO_KEY,
         COPILOT_KEY,
         CURSOR_KEY,
         GOOSE_KEY,
@@ -11882,6 +12016,10 @@ def _run_configure_harnesses_interactive() -> None:
     # Sentinel marking the Hermes row — like Goose it owns its own auth via
     # ``hermes model`` and is installed via a curl installer.
     _HERMES = "\x00hermes"
+    # Sentinel marking the Snowflake CoCo row — like Hermes it owns its own
+    # auth (``~/.snowflake/connections.toml`` via CoCo's wizard) and is
+    # installed via Snowflake's curl installer.
+    _COCO = "\x00coco"
     # Sentinel marking the Kiro row — like Goose/Hermes it owns its own auth (via
     # ``kiro-cli login``) and is installed via Kiro's curl installer, so it
     # dispatches to its own drill-in rather than a provider family.
@@ -12172,6 +12310,35 @@ def _run_configure_harnesses_interactive() -> None:
             kimi_hint = (kimi_spec.install_hint if kimi_spec else None) or "see Kimi Code docs"
             rows.append((_KIMI, "Kimi Code", "Not installed", "missing", _install_hint(kimi_hint)))
 
+        # Snowflake CoCo — curl-installed ``cortex`` binary; auth is the
+        # user's ``connections.toml`` (written by CoCo's own first-run
+        # wizard), so readiness is binary + that file's presence.
+        if not harness_cli_installed(COCO_KEY):
+            coco_spec = harness_install_spec(COCO_KEY)
+            coco_hint = (
+                coco_spec.install_hint
+                if coco_spec and coco_spec.install_hint
+                else "curl -LsS https://ai.snowflake.com/static/cc-scripts/install.sh | sh"
+            )
+            rows.append(
+                (_COCO, "Snowflake CoCo", "Not installed", "missing", _install_hint(coco_hint)),
+            )
+        elif (
+            Path(os.environ.get("SNOWFLAKE_HOME", "") or "~/.snowflake").expanduser()
+            / "connections.toml"
+        ).is_file():
+            rows.append((_COCO, "Snowflake CoCo", "connections.toml", "ready", ""))
+        else:
+            rows.append(
+                (
+                    _COCO,
+                    "Snowflake CoCo",
+                    "Not configured",
+                    "warn",
+                    "Run `cortex` once to set up a Snowflake connection.",
+                ),
+            )
+
         # Custom ACP agents — the generic `acp` harness driving any user-configured
         # ACP-agent command. Each configured agent gets its own overview row
         # (select → per-agent remove drill-in) so it sits alongside the built-in
@@ -12263,6 +12430,8 @@ def _run_configure_harnesses_interactive() -> None:
             _manage_acp_agent(target[len(_ACP_AGENT_PREFIX) :])
         elif target == _HERMES:
             _manage_hermes_harness()
+        elif target == _COCO:
+            _manage_coco_harness()
         elif target == _KIRO:
             _manage_kiro_harness()
         elif target == _KIMI:

--- a/omnigent/coco_native.py
+++ b/omnigent/coco_native.py
@@ -1,0 +1,617 @@
+"""Native Snowflake CoCo TUI wrapper for the Omnigent CLI.
+
+``omnigent coco`` launches Snowflake's CoCo (Cortex Code) CLI interactive TUI
+(the ``cortex`` binary) inside an Omnigent-runner-owned tmux terminal and
+attaches the local TTY — the CoCo analog of ``omnigent goose`` /
+``omnigent cursor``. The runner spawns the process (see
+:func:`omnigent.runner.app._auto_create_coco_terminal`); this module owns the
+CLI-side orchestration: session create/resume, daemon runner bind,
+terminal-ready poll, and the direct tmux attach.
+
+Auth is CoCo's own configuration (``~/.snowflake/connections.toml``, shared
+with the Snowflake CLI); no Omnigent-managed key is required. The runner
+launches ``cortex`` with a per-session ``SNOWFLAKE_HOME`` that symlinks the
+user's real config and adds the Omnigent lifecycle hook (see
+:mod:`omnigent.coco_native_bridge`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import click
+import httpx
+import yaml
+
+from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
+from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
+from omnigent._wrapper_labels import COCO_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE
+from omnigent._wrapper_labels import WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY
+from omnigent.conversation_browser import conversation_url, open_conversation_link_if_enabled
+from omnigent.entities.session_resources import terminal_resource_id
+from omnigent.host.daemon_launch import (
+    error_text,
+    launch_or_reuse_daemon_runner,
+    wait_for_host_online,
+    wait_for_runner_online,
+)
+from omnigent.native_coding_agents import native_shell_terminal_spec
+from omnigent.native_terminal import (
+    DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
+)
+from omnigent.native_terminal import (
+    DAEMON_RUNNER_ONLINE_TIMEOUT_S as _DAEMON_RUNNER_ONLINE_TIMEOUT_S,
+)
+from omnigent.native_terminal import (
+    DAEMON_TERMINAL_READY_TIMEOUT_S as _DAEMON_TERMINAL_READY_TIMEOUT_S,
+)
+from omnigent.native_terminal import bind_session_runner as _bind_session_runner
+from omnigent.native_terminal import url_component
+
+_DEFAULT_COCO_COMMAND = "cortex"
+_COCO_PATH_ENV = "OMNIGENT_CORTEX_PATH"
+_AGENT_NAME = "coco-native-ui"
+_TERMINAL_NAME = "coco"
+_TERMINAL_SESSION_KEY = "main"
+_SESSION_LABELS = {
+    "omnigent.ui": "terminal",
+    _WRAPPER_LABEL_KEY: _WRAPPER_LABEL_VALUE,
+}
+
+
+@dataclass(frozen=True)
+class NativeCocoLaunch:
+    """Resolved native CoCo process launch."""
+
+    executable: str
+    argv: list[str]
+
+
+@dataclass(frozen=True)
+class LaunchedCocoTerminal:
+    """Terminal resource returned by the Omnigent runner launch path."""
+
+    terminal_id: str
+    tmux_socket: Path | None
+    tmux_target: str | None
+
+
+@dataclass(frozen=True)
+class PreparedCocoTerminal:
+    """Prepared native CoCo terminal attachment details.
+
+    :param reattached: ``True`` when an existing, still-running session terminal
+        was reused (the live-reattach path: prior session intact).
+    :param cold_resumed: ``True`` when resuming an existing Omnigent session
+        whose terminal had already exited, so a *fresh* ``cortex`` TUI was
+        launched. Mirrors goose-native: ``cold_resumed`` and ``reattached`` are
+        mutually exclusive (the cold-resume path leaves ``reattached`` False).
+    """
+
+    session_id: str
+    terminal_id: str
+    tmux_socket: Path | None
+    tmux_target: str | None
+    reattached: bool
+    cold_resumed: bool = False
+
+
+def _configured_coco_command(env: Mapping[str, str]) -> str:
+    """Return the configured cortex executable name/path from *env*."""
+    value = env.get(_COCO_PATH_ENV, "").strip()
+    return value or _DEFAULT_COCO_COMMAND
+
+
+def resolve_coco_executable(
+    *,
+    env: Mapping[str, str] | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> str:
+    """
+    Resolve the native CoCo (``cortex``) executable.
+
+    :param env: Environment mapping to inspect. Defaults to ``os.environ``.
+    :param which: Resolver hook for tests; defaults to ``shutil.which``.
+    :returns: Absolute executable path.
+    :raises click.ClickException: If no cortex CLI is available.
+    """
+    env = os.environ if env is None else env
+    which = shutil.which if which is None else which
+    command = _configured_coco_command(env)
+    resolved = which(command)
+    if resolved is None:
+        raise click.ClickException(
+            "Native CoCo requires Snowflake's 'cortex' CLI on PATH. Install it with: "
+            "curl -LsS https://ai.snowflake.com/static/cc-scripts/install.sh | sh, "
+            "then run 'cortex' once to configure a Snowflake connection. "
+            f"You can also set {_COCO_PATH_ENV}=/path/to/cortex."
+        )
+    return resolved
+
+
+def build_coco_launch(
+    coco_args: Sequence[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> NativeCocoLaunch:
+    """Build the argv for a native CoCo process."""
+    executable = resolve_coco_executable(env=env, which=which)
+    return NativeCocoLaunch(executable=executable, argv=[executable, *coco_args])
+
+
+def run_coco_native(
+    *,
+    server: str | None,
+    session_id: str | None,
+    coco_args: tuple[str, ...],
+    resume_picker: bool = False,
+    auto_open_conversation: bool = False,
+) -> None:
+    """
+    Launch the CoCo TUI in an Omnigent terminal.
+
+    :param server: Resolved Omnigent server URL.
+    :param session_id: Optional existing Omnigent conversation id.
+    :param coco_args: Raw cortex CLI args to persist for the runner-owned TUI.
+    :param resume_picker: ``True`` runs the coco-native picker.
+    :param auto_open_conversation: When ``True``, open the browser conversation
+        URL after launch.
+    :returns: None after the terminal attach session ends.
+    """
+    _preflight_local_tools()
+    if server is None:
+        raise click.ClickException(
+            "CoCo requires a resolved Omnigent server URL. The CLI should call "
+            "_ensure_backend before run_coco_native."
+        )
+    with TemporaryDirectory(prefix="omnigent-coco-native-") as tmpdir:
+        spec_path = _materialize_coco_agent_spec(Path(tmpdir))
+        _run_with_remote_server(
+            server.rstrip("/"),
+            spec_path,
+            session_id=session_id,
+            resume_picker=resume_picker,
+            coco_args=coco_args,
+            auto_open_conversation=auto_open_conversation,
+        )
+
+
+def _materialize_coco_agent_spec(tmpdir: Path) -> Path:
+    """
+    Write the terminal-first agent spec used by ``omnigent coco``.
+
+    :param tmpdir: Temporary directory for the generated YAML file.
+    :returns: Path to the generated YAML spec.
+    """
+    yaml_path = tmpdir / "coco-native-ui.yaml"
+    raw: dict[str, Any] = {
+        "name": _AGENT_NAME,
+        "prompt": (
+            "Snowflake CoCo is running in the session terminal. The user drives "
+            "the cortex TUI directly."
+        ),
+        "executor": {"harness": "coco-native"},
+        "spawn": True,
+        "os_env": {
+            "type": "caller_process",
+            "cwd": ".",
+            "sandbox": {"type": "none"},
+        },
+        # Default shell terminal for the web-UI "+ New shell" affordance;
+        # its command follows the user's ``$SHELL`` (zsh/fish/bash).
+        "terminals": native_shell_terminal_spec(),
+    }
+    yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    return yaml_path
+
+
+def _run_with_remote_server(
+    base_url: str,
+    spec_path: Path,
+    *,
+    session_id: str | None,
+    resume_picker: bool,
+    coco_args: tuple[str, ...],
+    auto_open_conversation: bool = False,
+) -> None:
+    """
+    Launch CoCo on an Omnigent server via a daemon-spawned runner.
+
+    :param base_url: Omnigent server base URL.
+    :param spec_path: Generated CoCo wrapper agent spec.
+    :param session_id: Optional existing Omnigent session id.
+    :param resume_picker: When ``True``, run the coco-native picker.
+    :param coco_args: Raw cortex CLI args.
+    :param auto_open_conversation: Whether to open the web conversation URL.
+    """
+    from omnigent.chat import _bundle_agent, _remote_headers
+    from omnigent.cli import _ensure_host_daemon
+    from omnigent.host.identity import load_or_create_host_identity
+
+    headers = _remote_headers(server_url=base_url)
+    try:
+        resolved_session_id = _resolve_session_id_for_resume(
+            base_url=base_url,
+            headers=headers,
+            session_id=session_id,
+            resume_picker=resume_picker,
+        )
+        if resolved_session_id is None and resume_picker and session_id is None:
+            return
+
+        async def _drive() -> None:
+            with runner_startup_progress(initial_message="Preparing CoCo...") as progress:
+                _update_startup_progress(progress, "Connecting to local daemon...")
+                _ensure_host_daemon(base_url)
+                host_id = load_or_create_host_identity().host_id
+                bundle = None if resolved_session_id is not None else _bundle_agent(spec_path)
+                prepared = await _prepare_coco_terminal_via_daemon(
+                    base_url=base_url,
+                    headers=headers,
+                    session_id=resolved_session_id,
+                    session_bundle=bundle,
+                    coco_args=coco_args,
+                    host_id=host_id,
+                    workspace=str(Path.cwd().resolve()),
+                    startup_progress=progress,
+                )
+            click.echo(f"Web UI: {conversation_url(base_url, prepared.session_id)}", err=True)
+            open_conversation_link_if_enabled(
+                base_url=base_url,
+                conversation_id=prepared.session_id,
+                enabled=auto_open_conversation,
+                warn=lambda message: click.echo(message, err=True),
+            )
+            if prepared.cold_resumed:
+                echo_native_cold_resume_hint(agent_label="CoCo")
+            await _attach_terminal_resource(prepared)
+            if resolved_session_id is None:
+                echo_native_resume_hint(
+                    native_command="coco",
+                    session_id=prepared.session_id,
+                    server=base_url,
+                )
+
+        asyncio.run(_drive())
+    except httpx.ConnectError as exc:
+        raise click.ClickException(
+            f"Could not reach the omnigent server at {base_url}. "
+            "Confirm the server is running and reachable from here "
+            f"(e.g. `curl {base_url}/health`), and that --server is correct."
+        ) from exc
+
+
+async def _prepare_coco_terminal_via_daemon(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str | None,
+    session_bundle: bytes | None,
+    coco_args: tuple[str, ...],
+    host_id: str,
+    workspace: str,
+    startup_progress: RunnerStartupProgress | None = None,
+) -> PreparedCocoTerminal:
+    """
+    Create or resume a coco-native session through a daemon runner.
+
+    :returns: Prepared terminal details for attaching.
+    """
+    persist_args = list(coco_args)
+    timeout = httpx.Timeout(30.0, read=120.0)
+    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+        reattached = False
+        cold_resumed = False
+        if session_id is None:
+            if session_bundle is None:
+                raise click.ClickException("Creating a CoCo session requires a session bundle.")
+            _update_startup_progress(startup_progress, "Creating CoCo session...")
+            session_id = await _create_coco_session(
+                client,
+                session_bundle,
+                terminal_launch_args=persist_args or None,
+            )
+        else:
+            _update_startup_progress(startup_progress, "Loading CoCo session...")
+            payload = await _fetch_coco_session(client, session_id)
+            labels = payload.get("labels") if isinstance(payload, dict) else None
+            if (
+                not isinstance(labels, dict)
+                or labels.get(_WRAPPER_LABEL_KEY) != _WRAPPER_LABEL_VALUE
+            ):
+                raise click.ClickException(
+                    f"Conversation {session_id!r} is not a coco-native session."
+                )
+            existing_terminal = await _find_running_coco_terminal(client, session_id)
+            if existing_terminal is not None:
+                if persist_args:
+                    click.echo(
+                        "Ignoring CoCo launch args for an already-running terminal; "
+                        "restart the session terminal to apply them.",
+                        err=True,
+                    )
+                _update_startup_progress(startup_progress, "CoCo terminal ready.")
+                return PreparedCocoTerminal(
+                    session_id=session_id,
+                    terminal_id=existing_terminal.terminal_id,
+                    tmux_socket=existing_terminal.tmux_socket,
+                    tmux_target=existing_terminal.tmux_target,
+                    reattached=True,
+                )
+            # Session exists but its terminal exited: relaunch a fresh TUI.
+            cold_resumed = True
+            if persist_args:
+                _update_startup_progress(startup_progress, "Updating CoCo session...")
+                resp = await client.patch(
+                    f"/v1/sessions/{url_component(session_id)}",
+                    json={"terminal_launch_args": persist_args},
+                )
+                if resp.status_code >= 400:
+                    raise click.ClickException(
+                        f"CoCo session launch config update failed "
+                        f"({resp.status_code}): {error_text(resp)}"
+                    )
+
+        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        _update_startup_progress(startup_progress, "Starting runner...")
+        runner_id = await launch_or_reuse_daemon_runner(
+            client,
+            host_id=host_id,
+            session_id=session_id,
+            workspace=workspace,
+        )
+        _update_startup_progress(startup_progress, "Waiting for runner...")
+        await wait_for_runner_online(client, runner_id, timeout_s=_DAEMON_RUNNER_ONLINE_TIMEOUT_S)
+        await _bind_session_runner(client, session_id, runner_id)
+        _update_startup_progress(startup_progress, "Starting CoCo terminal...")
+        await _ensure_coco_terminal_on_runner(client, session_id)
+        terminal = await _wait_for_coco_terminal_ready(
+            client,
+            session_id,
+            timeout_s=_DAEMON_TERMINAL_READY_TIMEOUT_S,
+        )
+        _update_startup_progress(startup_progress, "CoCo terminal ready.")
+    return PreparedCocoTerminal(
+        session_id=session_id,
+        terminal_id=terminal.terminal_id,
+        tmux_socket=terminal.tmux_socket,
+        tmux_target=terminal.tmux_target,
+        reattached=reattached,
+        cold_resumed=cold_resumed,
+    )
+
+
+async def _create_coco_session(
+    client: httpx.AsyncClient,
+    bundle: bytes,
+    *,
+    terminal_launch_args: list[str] | None = None,
+) -> str:
+    """Create a bundled terminal-first coco-native session."""
+    metadata: dict[str, Any] = {"labels": dict(_SESSION_LABELS)}
+    if terminal_launch_args:
+        metadata["terminal_launch_args"] = terminal_launch_args
+    resp = await client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps(metadata)},
+        files={"bundle": ("coco-native-ui.tar.gz", bundle, "application/gzip")},
+        timeout=120.0,
+    )
+    if resp.status_code >= 400:
+        raise click.ClickException(
+            f"CoCo session creation failed ({resp.status_code}): {error_text(resp)}"
+        )
+    body = resp.json()
+    new_session_id = body.get("session_id")
+    if not isinstance(new_session_id, str) or not new_session_id:
+        raise click.ClickException("CoCo session creation response did not include session_id.")
+    return new_session_id
+
+
+async def _fetch_coco_session(client: httpx.AsyncClient, session_id: str) -> dict[str, Any]:
+    """Fetch an existing Omnigent session."""
+    resp = await client.get(f"/v1/sessions/{url_component(session_id)}")
+    if resp.status_code == 404:
+        raise click.ClickException(f"Conversation {session_id!r} not found on the server.")
+    if resp.status_code >= 400:
+        raise click.ClickException(
+            f"Failed to fetch conversation {session_id!r} ({resp.status_code}): {error_text(resp)}"
+        )
+    payload = resp.json()
+    if not isinstance(payload, dict):
+        raise click.ClickException("Conversation fetch returned non-object JSON.")
+    return payload
+
+
+async def _ensure_coco_terminal_on_runner(client: httpx.AsyncClient, session_id: str) -> None:
+    """Ask the bound runner to ensure the CoCo terminal exists."""
+    resp = await client.post(
+        f"/v1/sessions/{url_component(session_id)}/resources/terminals",
+        json={
+            "terminal": _TERMINAL_NAME,
+            "session_key": _TERMINAL_SESSION_KEY,
+            "ensure_native_terminal": True,
+        },
+        timeout=60.0,
+    )
+    if resp.status_code >= 400:
+        raise click.ClickException(
+            f"CoCo terminal ensure failed ({resp.status_code}): {error_text(resp)}"
+        )
+
+
+async def _wait_for_coco_terminal_ready(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    timeout_s: float,
+) -> LaunchedCocoTerminal:
+    """Wait until the runner exposes the CoCo terminal resource."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        terminal = await _find_running_coco_terminal(client, session_id)
+        if terminal is not None:
+            return terminal
+        await asyncio.sleep(0.2)
+    raise click.ClickException(
+        f"The runner did not create the CoCo terminal for {session_id!r} within {timeout_s:.0f}s."
+    )
+
+
+async def _find_running_coco_terminal(
+    client: httpx.AsyncClient,
+    session_id: str,
+) -> LaunchedCocoTerminal | None:
+    """Return the existing running CoCo terminal id if present."""
+    terminal_id = coco_terminal_resource_id()
+    resp = await client.get(
+        f"/v1/sessions/{url_component(session_id)}"
+        f"/resources/terminals/{url_component(terminal_id)}"
+    )
+    if resp.status_code == 404:
+        return None
+    if resp.status_code >= 400:
+        text = error_text(resp)
+        if resp.status_code in {409, 503} and (
+            "not bound to a runner" in text or "offline" in text
+        ):
+            return None
+        raise click.ClickException(f"Failed to fetch CoCo terminal ({resp.status_code}): {text}")
+    payload = resp.json()
+    metadata = payload.get("metadata") if isinstance(payload, dict) else None
+    if isinstance(metadata, dict) and metadata.get("running") is False:
+        return None
+    return _launched_coco_terminal_from_payload(payload)
+
+
+def _launched_coco_terminal_from_payload(payload: object) -> LaunchedCocoTerminal:
+    """Decode terminal launch metadata returned by the runner."""
+    if not isinstance(payload, dict):
+        raise click.ClickException("CoCo terminal launch returned non-object JSON.")
+    terminal_id = payload.get("id")
+    if not isinstance(terminal_id, str) or not terminal_id:
+        raise click.ClickException("CoCo terminal launch response did not include terminal id.")
+    metadata = payload.get("metadata")
+    tmux_socket: Path | None = None
+    tmux_target: str | None = None
+    if isinstance(metadata, dict):
+        raw_socket = metadata.get("tmux_socket")
+        raw_target = metadata.get("tmux_target")
+        if isinstance(raw_socket, str) and raw_socket:
+            tmux_socket = Path(raw_socket)
+        if isinstance(raw_target, str) and raw_target:
+            tmux_target = raw_target
+    return LaunchedCocoTerminal(
+        terminal_id=terminal_id,
+        tmux_socket=tmux_socket,
+        tmux_target=tmux_target,
+    )
+
+
+async def _attach_terminal_resource(prepared: PreparedCocoTerminal) -> None:
+    """Attach the current terminal to the prepared CoCo terminal resource."""
+    direct_tmux_error = _direct_tmux_unavailable_reason(prepared)
+    if direct_tmux_error is not None:
+        raise click.ClickException(
+            f"Runner-owned CoCo terminal requires direct tmux attach, but {direct_tmux_error}"
+        )
+    if prepared.tmux_socket is None or prepared.tmux_target is None:
+        raise click.ClickException("CoCo tmux attach metadata was incomplete.")
+    await _attach_direct_tmux(prepared.tmux_socket, prepared.tmux_target)
+
+
+async def _attach_direct_tmux(socket_path: Path, tmux_target: str) -> None:
+    """Attach the current terminal directly to the runner-owned tmux pane."""
+    # ``os.environ.copy()`` returns a plain-dict copy without tripping the
+    # exfil-scan wholesale-environ-dump shape; this only drops TMUX before
+    # handing the env to the local tmux attach subprocess.
+    env = os.environ.copy()
+    env.pop("TMUX", None)
+    process = await asyncio.create_subprocess_exec(
+        "tmux",
+        "-S",
+        str(socket_path),
+        "-f",
+        os.devnull,
+        "attach",
+        "-t",
+        tmux_target,
+        env=env,
+    )
+    await process.wait()
+
+
+def _direct_tmux_unavailable_reason(prepared: PreparedCocoTerminal) -> str | None:
+    """Explain why direct tmux attach is unavailable."""
+    if prepared.tmux_socket is None:
+        return "the terminal resource did not include a tmux socket path."
+    if prepared.tmux_target is None:
+        return "the terminal resource did not include a tmux target."
+    if not prepared.tmux_socket.exists():
+        return f"tmux socket {prepared.tmux_socket} is not reachable from this CLI process."
+    if shutil.which("tmux") is None:
+        return "tmux is not available on PATH."
+    return None
+
+
+def _resolve_session_id_for_resume(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str | None,
+    resume_picker: bool,
+) -> str | None:
+    """Translate resume inputs into a concrete coco-native session id."""
+    if session_id is not None:
+        return session_id
+    if not resume_picker:
+        return None
+    from omnigent_client import OmnigentClient
+
+    from omnigent.repl._resume_picker import pick_conversation_by_wrapper_label_from_sdk
+
+    async def _drive() -> str | None:
+        async with OmnigentClient(
+            base_url=base_url,
+            headers=headers if headers else None,
+        ) as client:
+            return await pick_conversation_by_wrapper_label_from_sdk(
+                client,
+                wrapper_value=_WRAPPER_LABEL_VALUE,
+                agent_name=_AGENT_NAME,
+            )
+
+    return asyncio.run(_drive())
+
+
+def _update_startup_progress(
+    startup_progress: RunnerStartupProgress | None,
+    message: str,
+) -> None:
+    """Show one concise CoCo startup milestone when a renderer is active."""
+    if startup_progress is not None:
+        startup_progress.update(message)
+
+
+def _preflight_local_tools() -> None:
+    """Verify local executables required by the native CoCo wrapper."""
+    if shutil.which("tmux") is None:
+        raise click.ClickException(
+            "tmux was not found on local PATH. The native CoCo wrapper "
+            "attaches to the runner-owned CoCo tmux terminal."
+        )
+
+
+def coco_terminal_resource_id() -> str:
+    """Return the deterministic terminal resource id for CoCo."""
+    return terminal_resource_id(_TERMINAL_NAME, _TERMINAL_SESSION_KEY)

--- a/omnigent/coco_native_bridge.py
+++ b/omnigent/coco_native_bridge.py
@@ -1,0 +1,497 @@
+"""Filesystem bridge + tmux injection for the coco-native terminal harness.
+
+The runner launches the Snowflake CoCo (Cortex Code) TUI — the ``cortex``
+binary — in a private tmux pane and records that pane's socket + target here
+via :func:`write_tmux_target`. The harness executor then delivers Omnigent
+web-UI messages into the *same* pane via :func:`inject_user_message` (tmux
+bracketed paste + a single Enter) — the CoCo analog of the goose-native tmux
+bridge.
+
+Unlike goose, CoCo supports lifecycle hooks, but (as of v1.1.1) loads them
+only from ``$SNOWFLAKE_HOME/cortex/hooks.json`` — there is no project-level or
+``--config`` hook source. So the bridge builds a **per-session
+``SNOWFLAKE_HOME``** (:func:`write_coco_home`): every entry of the user's real
+``~/.snowflake`` tree is symlinked in (auth ``connections.toml``, settings,
+MCP config, skills, and — importantly — the ``conversations`` store, so
+sessions stay resumable from the user's own ``cortex resume``), and only
+``cortex/hooks.json`` is replaced with a merged copy that adds the Omnigent
+lifecycle hook (:mod:`omnigent.coco_native_hook`). The hook appends
+``SessionStart`` / ``UserPromptSubmit`` / ``Stop`` events to
+``<bridge_dir>/hook_events.jsonl``, which the forwarder tails.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from omnigent._platform import stable_user_id
+
+#: Env var carrying the bridge dir into the harness executor process.
+BRIDGE_DIR_ENV_VAR = "HARNESS_COCO_NATIVE_BRIDGE_DIR"
+
+_BRIDGE_ROOT = Path(tempfile.gettempdir()) / f"omnigent-{stable_user_id()}" / "coco-native"
+_TMUX_FILE = "tmux.json"
+_SNOWFLAKE_HOME_SUBDIR = "snowflake_home"
+_TMUX_READY_TIMEOUT_S = 30.0
+_TMUX_SEND_TIMEOUT_S = 10.0
+_POLL_INTERVAL_S = 0.2
+_PASTE_SETTLE_S = 0.3
+_PASTE_BUFFER = "omnigent-coco-paste"
+# How long to wait for the pasted text to become visible in the pane before
+# sending Enter — submitting before the TUI commits the paste folds the Enter
+# into the paste as a newline and the message sits unsent.
+_PASTE_COMMIT_TIMEOUT_S = 5.0
+# CoCo emits no fixed ready-prompt sentinel; readiness is detected by the pane
+# settling (no byte changes across consecutive captures), like goose-native.
+_SETTLE_STABLE_POLLS = 3
+
+#: Hook events the bridge registers. SessionStart/UserPromptSubmit carry the
+#: CoCo session id (TUI-mode discovery); Stop marks the turn end at which CoCo
+#: has flushed the transcript (verified on v1.1.1).
+_HOOK_EVENTS = ("SessionStart", "UserPromptSubmit", "Stop")
+
+
+def bridge_dir_for_session_id(session_id: str) -> Path:
+    """Return the per-session bridge dir, e.g. ``/tmp/omnigent-<uid>/coco-native/<hash>``."""
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:32]
+    return _BRIDGE_ROOT / digest
+
+
+def bridge_root() -> Path:
+    """Return the configured coco-native bridge root."""
+    return _BRIDGE_ROOT
+
+
+def _ensure_dir(path: Path) -> None:
+    """Create *path* (and parents) with owner-only permissions."""
+    path.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError):
+        os.chmod(path, 0o700)
+
+
+def default_snowflake_home() -> Path:
+    """Return the user's real Snowflake home (``SNOWFLAKE_HOME`` or ``~/.snowflake``)."""
+    override = os.environ.get("SNOWFLAKE_HOME", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".snowflake"
+
+
+def coco_conversations_dir(snowflake_home: Path | None = None) -> Path:
+    """Return CoCo's conversations store under *snowflake_home*.
+
+    The per-session home symlinks this directory from the user's real home, so
+    session recordings resolve to the same files either way.
+    """
+    home = snowflake_home or default_snowflake_home()
+    return home / "cortex" / "conversations"
+
+
+def coco_session_recording_exists(coco_session_id: str) -> bool:
+    """Return whether a CoCo transcript exists for *coco_session_id*.
+
+    Guards cold resume: launch ``cortex -r <id>`` only when the recording is
+    present, else fall back to a fresh session (CoCo's resume errors on an
+    unknown id).
+    """
+    if not coco_session_id:
+        return False
+    history = coco_conversations_dir() / f"{coco_session_id}.history.jsonl"
+    return history.is_file()
+
+
+def _user_hooks_config(user_cortex_dir: Path) -> dict[str, Any]:
+    """Load the user's own ``hooks.json`` map, tolerating both accepted shapes.
+
+    CoCo's loader accepts ``{"hooks": {...}}`` or the bare event map; normalize
+    to the bare map so merging is uniform. Malformed content degrades to no
+    user hooks rather than failing the launch.
+    """
+    path = user_cortex_dir / "hooks.json"
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if isinstance(raw, dict):
+        hooks = raw.get("hooks", raw)
+        if isinstance(hooks, dict):
+            return hooks
+    return {}
+
+
+def _omnigent_hook_command(bridge_dir: Path) -> str:
+    """Shell command string CoCo runs for each registered lifecycle event."""
+    hook_script = Path(__file__).resolve().parent / "coco_native_hook.py"
+    return (
+        f"{shlex.quote(sys.executable)} {shlex.quote(str(hook_script))} "
+        f"--bridge-dir {shlex.quote(str(bridge_dir))}"
+    )
+
+
+def _symlink_children(source_dir: Path, target_dir: Path, *, skip: frozenset[str]) -> None:
+    """Symlink every child of *source_dir* into *target_dir* except *skip* names."""
+    if not source_dir.is_dir():
+        return
+    for entry in source_dir.iterdir():
+        if entry.name in skip:
+            continue
+        link = target_dir / entry.name
+        with contextlib.suppress(OSError):
+            # Heal a broken symlink (its target was deleted since the last
+            # launch): left in place it would hard-fail CoCo's own directory
+            # creation for that path.
+            if link.is_symlink() and not link.exists():
+                link.unlink()
+            if not link.exists() and not link.is_symlink():
+                link.symlink_to(entry)
+
+
+def write_coco_home(bridge_dir: Path) -> Path:
+    """Build the per-session ``SNOWFLAKE_HOME`` with the Omnigent lifecycle hook.
+
+    Mirrors the user's real Snowflake home by symlink — auth
+    (``connections.toml``), all of ``cortex/`` (settings, MCP, skills, agents,
+    the ``conversations`` store, ...) — and writes only ``cortex/hooks.json``
+    fresh, merging the user's own hook entries with the Omnigent event relay
+    so neither is lost. Idempotent: re-running refreshes the hook config and
+    fills in links that appeared in the user's home since the last launch.
+
+    :param bridge_dir: Per-session bridge dir (also the hook's append target).
+    :returns: The per-session ``SNOWFLAKE_HOME`` path.
+    """
+    _ensure_dir(bridge_dir)
+    home = bridge_dir / _SNOWFLAKE_HOME_SUBDIR
+    _ensure_dir(home)
+    cortex_dir = home / "cortex"
+    _ensure_dir(cortex_dir)
+
+    user_home = default_snowflake_home()
+    user_cortex = user_home / "cortex"
+    # Pre-create the user-side skeleton on a first run (no ~/.snowflake yet):
+    # the conversations store MUST be a symlink into the user's real home, or
+    # CoCo creates a real dir inside the throwaway bridge dir and transcripts
+    # (and cold resume) die with the session.
+    with contextlib.suppress(OSError):
+        (user_cortex / "conversations").mkdir(parents=True, exist_ok=True)
+    # Top level: connections.toml / config.toml etc. — everything but the
+    # cortex dir itself, which needs the hooks.json carve-out below.
+    _symlink_children(user_home, home, skip=frozenset({"cortex"}))
+    _symlink_children(user_cortex, cortex_dir, skip=frozenset({"hooks.json"}))
+
+    hooks: dict[str, Any] = {
+        event: list(groups) if isinstance(groups, list) else []
+        for event, groups in _user_hooks_config(user_cortex).items()
+    }
+    command = _omnigent_hook_command(bridge_dir)
+    for event in _HOOK_EVENTS:
+        groups = hooks.setdefault(event, [])
+        groups.append({"hooks": [{"type": "command", "command": command}]})
+    hooks_path = cortex_dir / "hooks.json"
+    hooks_path.write_text(json.dumps({"hooks": hooks}, indent=2) + "\n", encoding="utf-8")
+    with contextlib.suppress(OSError):
+        os.chmod(hooks_path, 0o600)
+    return home
+
+
+def read_coco_home(bridge_dir: Path) -> Path | None:
+    """Return the per-session ``SNOWFLAKE_HOME`` if it was written, else ``None``."""
+    home = bridge_dir / _SNOWFLAKE_HOME_SUBDIR
+    return home if home.is_dir() else None
+
+
+def build_coco_native_spawn_env(session_id: str) -> dict[str, str]:
+    """Build the ``HARNESS_COCO_NATIVE_*`` env the harness executor reads.
+
+    Publishes the per-session bridge dir so the
+    :class:`~omnigent.inner.coco_native_executor.CocoNativeExecutor` can find
+    the tmux target advertised by the runner.
+
+    :param session_id: The Omnigent session id (keys the bridge dir).
+    :returns: Env-var overrides for the harness executor spawn.
+    """
+    bridge_dir = bridge_dir_for_session_id(session_id)
+    _ensure_dir(bridge_dir)
+    return {BRIDGE_DIR_ENV_VAR: str(bridge_dir)}
+
+
+def write_tmux_target(
+    bridge_dir: Path,
+    *,
+    socket_path: Path,
+    tmux_target: str,
+    pid: int | None = None,
+) -> None:
+    """Advertise the tmux socket + target for the running CoCo terminal."""
+    _ensure_dir(bridge_dir)
+    payload: dict[str, Any] = {
+        "socket_path": str(socket_path),
+        "tmux_target": tmux_target,
+        "updated_at": time.time(),
+    }
+    if pid is not None:
+        payload["pid"] = pid
+    tmp = bridge_dir / (_TMUX_FILE + ".tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    os.replace(tmp, bridge_dir / _TMUX_FILE)
+
+
+def read_tmux_info(bridge_dir: Path) -> dict[str, str] | None:
+    """Return ``{socket_path, tmux_target}`` from ``tmux.json``, or ``None``."""
+    try:
+        raw = (bridge_dir / _TMUX_FILE).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    socket_path = data.get("socket_path")
+    tmux_target = data.get("tmux_target")
+    if (
+        isinstance(socket_path, str)
+        and socket_path
+        and isinstance(tmux_target, str)
+        and tmux_target
+    ):
+        return {"socket_path": socket_path, "tmux_target": tmux_target}
+    return None
+
+
+def _wait_for_tmux_info(bridge_dir: Path, *, timeout_s: float) -> dict[str, str]:
+    """Block until ``tmux.json`` is advertised, or raise on timeout."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        info = read_tmux_info(bridge_dir)
+        if info is not None:
+            return info
+        time.sleep(_POLL_INTERVAL_S)
+    raise RuntimeError(f"coco-native tmux target was not advertised within {timeout_s:.0f}s")
+
+
+def _run_tmux(socket_path: str, *args: str) -> None:
+    """Invoke ``tmux -S <socket> <args...>`` and raise on failure."""
+    try:
+        proc = subprocess.run(
+            ["tmux", "-S", socket_path, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_SEND_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"tmux command timed out after {_TMUX_SEND_TIMEOUT_S}s") from exc
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "<no output>"
+        raise RuntimeError(f"tmux command failed (rc={proc.returncode}): {detail}")
+
+
+def _capture_pane(socket_path: str, tmux_target: str) -> str:
+    """Capture the visible pane contents; ``""`` on any failure (treat as not-ready)."""
+    try:
+        proc = subprocess.run(
+            ["tmux", "-S", socket_path, "capture-pane", "-p", "-t", tmux_target],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_SEND_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    return proc.stdout if proc.returncode == 0 else ""
+
+
+def _paste_payload_bytes(text: str) -> bytes:
+    r"""Encode text for ``tmux load-buffer``: line breaks → CR, tabs kept, other
+    control bytes dropped (a stray ESC would close the bracketed-paste early)."""
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    body = bytearray()
+    for ch in normalized:
+        if ch == "\n":
+            body.append(0x0D)
+            continue
+        if ch == "\t":
+            body.append(0x09)
+            continue
+        if ord(ch) < 0x20:
+            continue
+        body.extend(ch.encode("utf-8"))
+    return bytes(body)
+
+
+def _session_alive(socket_path: str, tmux_target: str) -> bool:
+    """Return whether the tmux session/pane still exists (the TUI is running)."""
+    try:
+        proc = subprocess.run(
+            ["tmux", "-S", socket_path, "has-session", "-t", tmux_target],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_SEND_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return proc.returncode == 0
+
+
+def _submit_needle(content: str) -> str:
+    """A stable single-line substring used to confirm the paste rendered in the pane.
+
+    Anchored to the LAST qualifying line, not the first: the tail of a freshly
+    pasted message is far less likely to already be visible in the pane (a prior
+    turn's echo, scrollback) than its opening line, so matching it is a tighter
+    signal that *this* paste committed before we send Enter.
+    """
+    for line in reversed(content.splitlines()):
+        stripped = line.strip()
+        if len(stripped) >= 4:
+            return stripped[:24]
+    stripped = content.strip()
+    return stripped[:24] if len(stripped) >= 4 else ""
+
+
+def _settle_pane(socket_path: str, tmux_target: str, *, timeout_s: float) -> None:
+    """Best-effort wait until the CoCo input box is ready to receive a paste.
+
+    CoCo emits no fixed idle marker, so readiness is detected by the pane
+    settling: the captured contents stop changing for :data:`_SETTLE_STABLE_POLLS`
+    consecutive polls (no spinner churn, no streaming output). Falls through after
+    the timeout (mid-turn steering may never fully settle) rather than raising —
+    CoCo queues messages typed mid-turn, so a paste into a busy pane still lands.
+    """
+    deadline = time.monotonic() + timeout_s
+    previous = _capture_pane(socket_path, tmux_target)
+    stable = 0
+    while time.monotonic() < deadline:
+        time.sleep(_POLL_INTERVAL_S)
+        current = _capture_pane(socket_path, tmux_target)
+        if current and current == previous:
+            stable += 1
+            if stable >= _SETTLE_STABLE_POLLS:
+                return
+        else:
+            stable = 0
+        previous = current
+
+
+def inject_user_message(
+    bridge_dir: Path,
+    *,
+    content: str,
+    timeout_s: float = _TMUX_READY_TIMEOUT_S,
+) -> None:
+    """Deliver a web-UI user message into the CoCo TUI via a tmux bracketed paste.
+
+    Clears any leftover draft, pastes *content* (multi-line safe via
+    ``load-buffer``/``paste-buffer -p`` so interior newlines stay data, not
+    submits), settles, then submits with a *single* Enter. CoCo submits on
+    Enter and inserts a newline on Ctrl+J, so exactly one Enter is sent — a
+    second would submit twice.
+
+    :param bridge_dir: The coco-native bridge dir holding ``tmux.json``.
+    :param content: User text (non-empty).
+    :param timeout_s: Per-readiness-gate timeout.
+    :raises RuntimeError: If the tmux target is never advertised or a tmux
+        command fails.
+    """
+    if not content:
+        raise RuntimeError("coco-native injection requires non-empty content")
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    socket_path = info["socket_path"]
+    tmux_target = info["tmux_target"]
+    # Fast-fail if the TUI already exited: otherwise _settle_pane polls a dead
+    # pane for the full timeout and the web message is silently lost.
+    if not _session_alive(socket_path, tmux_target):
+        raise RuntimeError(
+            "CoCo terminal is no longer running (the TUI exited); restart the session"
+        )
+    _settle_pane(socket_path, tmux_target, timeout_s=timeout_s)
+    # Clear any leftover draft: Home (C-a) + kill-to-end (C-k).
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-a")
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-k")
+    with tempfile.NamedTemporaryFile(
+        dir=bridge_dir, prefix="paste_", suffix=".bin", delete=False
+    ) as paste_file:
+        # Trailing newline absorbs any trailing backslash so it can't escape Enter.
+        paste_file.write(_paste_payload_bytes(content + "\n"))
+        paste_path = paste_file.name
+    try:
+        _run_tmux(socket_path, "load-buffer", "-b", _PASTE_BUFFER, paste_path)
+        _run_tmux(
+            socket_path,
+            "paste-buffer",
+            "-p",  # bracketed-paste markers — the TUI keeps newlines as data
+            "-d",  # drop the buffer after pasting
+            "-b",
+            _PASTE_BUFFER,
+            "-t",
+            tmux_target,
+        )
+    finally:
+        with contextlib.suppress(OSError):
+            os.unlink(paste_path)
+    # Wait until the paste is visibly committed before Enter. Submitting mid-paste
+    # folds the Enter in as a newline (rapid stdin bursts coalesce), leaving the
+    # message unsent. Poll for the text, then submit; blind-submit if no needle.
+    needle = _submit_needle(content)
+    if needle:
+        deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if needle in _capture_pane(socket_path, tmux_target):
+                break
+            time.sleep(_POLL_INTERVAL_S)
+    time.sleep(_PASTE_SETTLE_S)
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
+
+
+def inject_interrupt(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S) -> None:
+    """Cancel the in-flight CoCo turn by sending ``Escape`` to the pane.
+
+    CoCo's own footer advertises "esc to interrupt" while a turn runs, and a
+    live check confirms Escape cancels tool execution cleanly ("Tool execution
+    was interrupted by user"). Ctrl+C is deliberately NOT used: CoCo binds it
+    to cancel-or-exit (double-tap exits), so two rapid Stop clicks would kill
+    the TUI outright.
+
+    :raises RuntimeError: If the tmux target is not advertised or send-keys fails.
+    """
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    # No ``-l``: tmux must interpret ``Escape`` as a key name.
+    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Escape")
+
+
+def kill_session(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S) -> None:
+    """Hard-stop the CoCo session by killing its tmux session.
+
+    Terminates ``cortex`` and the pane outright — the analog of the user
+    manually exiting the attached TUI, for the web UI's "Stop session"
+    affordance.
+
+    :raises RuntimeError: If the tmux target is not advertised or kill-session fails.
+    """
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    _run_tmux(info["socket_path"], "kill-session", "-t", info["tmux_target"])
+
+
+def capture_coco_pane(bridge_dir: Path) -> str | None:
+    """Return the visible CoCo pane text, or ``None`` if the TUI is not running.
+
+    ``None`` (no advertised tmux target, or a dead pane) is distinct from
+    ``""`` (a live but empty capture).
+    """
+    info = read_tmux_info(bridge_dir)
+    if info is None:
+        return None
+    socket_path, tmux_target = info["socket_path"], info["tmux_target"]
+    if not _session_alive(socket_path, tmux_target):
+        return None
+    return _capture_pane(socket_path, tmux_target)

--- a/omnigent/coco_native_forwarder.py
+++ b/omnigent/coco_native_forwarder.py
@@ -1,0 +1,681 @@
+"""TUI→web forwarder for the coco-native harness.
+
+The ``omnigent coco`` wrapper launches the real Snowflake CoCo (Cortex Code)
+TUI in a runner-owned tmux pane, and :mod:`omnigent.coco_native_bridge` injects
+web-UI messages into it. That covers the web→TUI direction; this module is the
+missing mirror back — the CoCo analog of
+:mod:`omnigent.goose_native_forwarder`.
+
+Unlike goose (live SQLite store) CoCo flushes its transcript lazily, so a bare
+store tail would sit empty for whole turns. Instead the bridge registers a
+lifecycle hook (:mod:`omnigent.coco_native_hook`) in the per-session
+``SNOWFLAKE_HOME`` and this forwarder tails the hook's
+``<bridge_dir>/hook_events.jsonl``:
+
+- ``SessionStart`` / ``UserPromptSubmit`` events carry the CoCo
+  ``session_id`` + ``transcript_path`` — the *only* reliable discovery in TUI
+  mode, where CoCo mints its own id and ignores ``--session-id`` (verified on
+  v1.1.1). The id is persisted so cold resume can launch ``cortex -r <id>``.
+- ``UserPromptSubmit`` opens a turn (``running`` status edge).
+- ``Stop`` closes a turn: CoCo has flushed
+  ``conversations/<session_id>.history.jsonl`` by the time the Stop hook fires
+  (verified on v1.1.1), so the finished turn is mirrored from that file past a
+  persisted line cursor. History rows carry Anthropic-style content blocks —
+  ``text`` / ``tool_use`` / ``tool_result`` — which map onto ``message`` /
+  ``function_call`` / ``function_call_output`` conversation items.
+
+Because both the event log and the line cursor are durable, a forwarder
+restart resumes exactly where it left off with no replay pass: unprocessed
+hook events are still in the file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from omnigent._native_post_delivery import post_external_session_status
+from omnigent.coco_native_hook import HOOK_EVENTS_FILE
+
+_logger = logging.getLogger(__name__)
+
+#: Seconds between hook-event polls. Events arrive only at turn boundaries
+#: (prompt submit / stop), so this is latency-to-notice, not a hot loop.
+_DEFAULT_POLL_INTERVAL_S = 0.4
+_POST_TIMEOUT_S = 30.0
+
+#: Seconds of inactivity after which an open turn's live card is closed.
+#: Backstop for turns that died without a ``Stop`` hook (TUI killed mid-turn,
+#: CoCo crash). Minutes, not seconds: a long tool call emits no hook events
+#: while it runs.
+_STALLED_TURN_IDLE_S = 300.0
+
+#: After a ``Stop`` event, how long to keep re-reading the transcript for the
+#: turn's rows before closing the turn anyway. CoCo flushes before firing the
+#: hook, so this only papers over a slow filesystem, not a design gap.
+_STOP_FLUSH_GRACE_S = 3.0
+
+# Supervisor backoff (mirrors goose_native_forwarder.supervise_goose_forwarder).
+_SUPERVISOR_INITIAL_BACKOFF_S = 1.0
+_SUPERVISOR_MAX_BACKOFF_S = 30.0
+_SUPERVISOR_HEALTHY_UPTIME_S = 60.0
+
+_STATE_FILE = "coco_forwarder.json"
+
+# The executor injects ``[Attached: <path>]`` markers for web-UI attachments
+# before pasting into the TUI; strip them from the mirrored bubble (the path is
+# an internal bridge detail).
+_ATTACHMENT_MARKER_RE = re.compile(r"\[Attached:[^\]]*\]")
+
+# CoCo prepends its injected context (skills, SQL rules, todo nags, ...) to the
+# stored user message as ``<system-reminder>...</system-reminder>`` text blocks
+# ahead of the user's own text (verified on v1.1.1). Strip them from the
+# mirrored user bubble — they are vendor-internal prompt plumbing.
+_SYSTEM_REMINDER_RE = re.compile(r"<system-reminder>.*?</system-reminder>\s*", re.DOTALL)
+
+
+@dataclass
+class _ForwardState:
+    """Durable forwarder cursor, persisted to ``bridge_dir/coco_forwarder.json``.
+
+    :param coco_session_id: The CoCo session id being mirrored (from the hook
+        events), or ``None`` before the first ``SessionStart`` arrives.
+    :param history_path: The resolved ``<session_id>.history.jsonl`` path.
+    :param last_line: Count of history lines already processed (mirrored or
+        skipped). Lines are append-ordered, so the count is sufficient dedup.
+    :param events_offset: Byte offset into ``hook_events.jsonl`` already
+        consumed. The event log is append-only, so no event is ever lost to a
+        forwarder restart.
+    :param turn_seq: Monotonic per-session turn counter minting the
+        ``coco:turn:<n>`` response ids that group one turn's items.
+    :param turn_live: Whether a ``running`` edge for ``coco:turn:<turn_seq>``
+        was posted and not yet closed. Persisted so a forwarder restart can
+        close (or keep stamping) the open turn instead of orphaning its
+        spinner or minting a duplicate turn id for the same prompt.
+    """
+
+    coco_session_id: str | None = None
+    history_path: str | None = None
+    last_line: int = 0
+    events_offset: int = 0
+    turn_seq: int = 0
+    turn_live: bool = False
+
+
+def _read_state(bridge_dir: Path) -> _ForwardState:
+    """Load the persisted forward cursor, or a cold default."""
+    try:
+        raw = (bridge_dir / _STATE_FILE).read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, ValueError):
+        return _ForwardState()
+    if not isinstance(data, dict):
+        return _ForwardState()
+    state = _ForwardState()
+    sid = data.get("coco_session_id")
+    state.coco_session_id = sid if isinstance(sid, str) else None
+    history_path = data.get("history_path")
+    state.history_path = history_path if isinstance(history_path, str) else None
+    for attr in ("last_line", "events_offset", "turn_seq"):
+        value = data.get(attr)
+        if isinstance(value, int) and value >= 0:
+            setattr(state, attr, value)
+    state.turn_live = data.get("turn_live") is True
+    return state
+
+
+def _write_state(bridge_dir: Path, state: _ForwardState) -> bool:
+    """Atomically persist the forward cursor (tmp write + rename)."""
+    try:
+        bridge_dir.mkdir(parents=True, exist_ok=True)
+        tmp = bridge_dir / (_STATE_FILE + ".tmp")
+        tmp.write_text(
+            json.dumps(
+                {
+                    "coco_session_id": state.coco_session_id,
+                    "history_path": state.history_path,
+                    "last_line": state.last_line,
+                    "events_offset": state.events_offset,
+                    "turn_seq": state.turn_seq,
+                    "turn_live": state.turn_live,
+                }
+            ),
+            encoding="utf-8",
+        )
+        os.replace(tmp, bridge_dir / _STATE_FILE)
+        return True
+    except OSError:
+        _logger.warning("coco forwarder could not persist state to %s", bridge_dir, exc_info=True)
+        return False
+
+
+def clear_coco_bridge_state(bridge_dir: Path) -> None:
+    """Drop the persisted cursor and event log so a re-created terminal starts clean."""
+    for name in (_STATE_FILE, HOOK_EVENTS_FILE):
+        with contextlib.suppress(OSError):
+            (bridge_dir / name).unlink()
+
+
+def _history_path_for_transcript(transcript_path: str) -> str | None:
+    """Derive the message-history JSONL path from a hook ``transcript_path``.
+
+    The hook payload points at the session's metadata file
+    (``<session_id>.json``); the messages live in the sibling
+    ``<session_id>.history.jsonl``.
+    """
+    if not transcript_path:
+        return None
+    if transcript_path.endswith(".history.jsonl"):
+        return transcript_path
+    if transcript_path.endswith(".json"):
+        return transcript_path[: -len(".json")] + ".history.jsonl"
+    return None
+
+
+def _read_new_events(events_path: Path, offset: int) -> tuple[list[dict[str, Any]], int]:
+    """Read whole JSONL events past *offset*; return them and the new offset.
+
+    A trailing partial line (hook mid-write) is left unconsumed so the next
+    poll re-reads it complete.
+    """
+    try:
+        with open(events_path, "rb") as fh:
+            fh.seek(offset)
+            chunk = fh.read()
+    except OSError:
+        return [], offset
+    if not chunk:
+        return [], offset
+    events: list[dict[str, Any]] = []
+    consumed = 0
+    for raw_line in chunk.splitlines(keepends=True):
+        if not raw_line.endswith(b"\n"):
+            break
+        consumed += len(raw_line)
+        try:
+            obj = json.loads(raw_line.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            continue
+        if isinstance(obj, dict):
+            events.append(obj)
+    return events, offset + consumed
+
+
+@dataclass
+class _MirrorItem:
+    """One conversation item ready to POST."""
+
+    item_type: str
+    item_data: dict[str, object]
+    response_id: str
+
+
+def _block_text(block: dict[str, Any]) -> str:
+    """Extract prose from a ``text`` content block."""
+    text = block.get("text")
+    return text if isinstance(text, str) else ""
+
+
+def _tool_result_text(inner: Any) -> str:
+    """Flatten a ``tool_result`` block's ``content`` into plain text."""
+    if isinstance(inner, str):
+        return inner
+    if isinstance(inner, dict):
+        content = inner.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for part in content:
+                if isinstance(part, str):
+                    parts.append(part)
+                elif isinstance(part, dict):
+                    text = part.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+            return "".join(parts)
+    return ""
+
+
+def _message_to_items(
+    line_no: int,
+    obj: dict[str, Any],
+    agent_name: str,
+    turn_response_id: str | None,
+) -> list[_MirrorItem]:
+    """Convert one history row to zero or more mirror items.
+
+    CoCo rows are ``{"role": "user"|"assistant", "content": [blocks], ...}``
+    with Anthropic-style blocks. ``role=user`` rows carry both real user turns
+    (``text`` blocks) and tool-result carrier messages (``tool_result``
+    blocks); each block maps independently.
+
+    :param turn_response_id: The open turn's response id, or ``None`` when no
+        turn is open (items then get a per-line fallback id).
+    """
+    role = obj.get("role")
+    content = obj.get("content")
+    if role not in ("user", "assistant") or not isinstance(content, list):
+        return []
+
+    per_line_id = f"coco:{line_no}"
+    rid = turn_response_id or per_line_id
+    items: list[_MirrorItem] = []
+    text_parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            text_parts.append(_block_text(block))
+        elif block_type == "tool_use" and role == "assistant":
+            inner = block.get("tool_use")
+            if not isinstance(inner, dict):
+                continue
+            call_id = inner.get("tool_use_id")
+            if not isinstance(call_id, str) or not call_id:
+                continue
+            name = inner.get("name")
+            raw_input = inner.get("input", {})
+            try:
+                args_json = json.dumps(raw_input) if not isinstance(raw_input, str) else raw_input
+            except (TypeError, ValueError):
+                args_json = "{}"
+            items.append(
+                _MirrorItem(
+                    item_type="function_call",
+                    item_data={
+                        "agent": agent_name,
+                        "name": name if isinstance(name, str) else str(name),
+                        "arguments": args_json,
+                        "call_id": call_id,
+                    },
+                    response_id=rid,
+                )
+            )
+        elif block_type == "tool_result":
+            inner = block.get("tool_result")
+            if not isinstance(inner, dict):
+                continue
+            call_id = inner.get("tool_use_id")
+            if not isinstance(call_id, str) or not call_id:
+                continue
+            items.append(
+                _MirrorItem(
+                    item_type="function_call_output",
+                    item_data={"call_id": call_id, "output": _tool_result_text(inner)},
+                    response_id=rid,
+                )
+            )
+
+    text = "".join(text_parts)
+    if role == "user":
+        text = _SYSTEM_REMINDER_RE.sub("", text)
+    text = _ATTACHMENT_MARKER_RE.sub("", text).strip()
+    if text:
+        if role == "user":
+            items.insert(
+                0,
+                _MirrorItem(
+                    item_type="message",
+                    item_data={"role": "user", "content": [{"type": "input_text", "text": text}]},
+                    # User bubbles are standalone, never part of the reply's
+                    # streaming group.
+                    response_id=per_line_id,
+                ),
+            )
+        else:
+            items.append(
+                _MirrorItem(
+                    item_type="message",
+                    item_data={
+                        "role": "assistant",
+                        "agent": agent_name,
+                        "content": [{"type": "output_text", "text": text}],
+                    },
+                    response_id=rid,
+                )
+            )
+    return items
+
+
+def _read_history_lines(history_path: str, last_line: int) -> list[tuple[int, dict[str, Any]]]:
+    """Read parsed history rows past the *last_line* cursor.
+
+    Returns ``(line_no, row)`` pairs with 1-based line numbers. A trailing
+    line that fails to parse is treated as mid-write and excluded (the next
+    read retries it); an interior unparsable line is skipped for good.
+    """
+    try:
+        with open(history_path, encoding="utf-8") as fh:
+            raw_lines = fh.readlines()
+    except OSError:
+        return []
+    rows: list[tuple[int, dict[str, Any]]] = []
+    for idx, raw in enumerate(raw_lines[last_line:], start=last_line + 1):
+        stripped = raw.strip()
+        if not stripped:
+            rows.append((idx, {}))
+            continue
+        try:
+            obj = json.loads(stripped)
+        except ValueError:
+            if idx == len(raw_lines) and not raw.endswith("\n"):
+                break
+            rows.append((idx, {}))
+            continue
+        rows.append((idx, obj if isinstance(obj, dict) else {}))
+    return rows
+
+
+def _count_history_lines(history_path: str) -> int:
+    """Return the current number of lines in *history_path* (0 when unreadable)."""
+    try:
+        with open(history_path, "rb") as fh:
+            return sum(1 for _ in fh)
+    except OSError:
+        return 0
+
+
+async def _post_conversation_item(
+    client: httpx.AsyncClient, *, session_id: str, item: _MirrorItem
+) -> None:
+    """POST one mirrored item as an ``external_conversation_item`` event."""
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": item.item_type,
+                "item_data": item.item_data,
+                "response_id": item.response_id,
+            },
+        },
+    )
+    resp.raise_for_status()
+
+
+class _TurnTracker:
+    """Live-card lifecycle for the turn currently being mirrored (in-memory).
+
+    Durable dedup lives in :class:`_ForwardState`; this only tracks whether a
+    ``running`` edge is open and when hook activity was last seen, for the
+    stalled-turn backstop.
+    """
+
+    def __init__(self) -> None:
+        self.response_id: str | None = None
+        self.live = False
+        self.last_activity_ts: float | None = None
+
+    def touch(self) -> None:
+        self.last_activity_ts = time.monotonic()
+
+    def reset(self) -> None:
+        self.response_id = None
+        self.live = False
+        self.last_activity_ts = None
+
+
+async def forward_coco_events_to_session(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    bridge_dir: Path,
+    agent_name: str,
+    on_coco_session_id: Any | None = None,
+    poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+    auth: httpx.Auth | None = None,
+) -> None:
+    """Tail the hook event log and mirror finished CoCo turns into the session.
+
+    :param base_url: Omnigent server base URL.
+    :param headers: Static HTTP headers (auth normally via ``auth``).
+    :param session_id: Omnigent session/conversation id.
+    :param bridge_dir: The coco-native bridge dir (event log + cursor).
+    :param agent_name: Agent label stamped on mirrored assistant items.
+    :param on_coco_session_id: Optional async callback invoked once per newly
+        discovered CoCo session id (used to persist ``external_session_id``
+        for resume).
+    :param poll_interval_s: Seconds between event-log polls.
+    :param auth: Optional refresh-capable httpx Auth for remote deployments.
+    :returns: Never normally returns; cancel the task to stop it.
+    """
+    events_path = bridge_dir / HOOK_EVENTS_FILE
+    state = _read_state(bridge_dir)
+    turn = _TurnTracker()
+    # Restore an open turn across a forwarder restart: without this the
+    # previous run's ``running`` edge could never be closed, and re-processing
+    # a not-yet-persisted UserPromptSubmit would mint a duplicate turn id.
+    if state.turn_live:
+        turn.response_id = f"coco:turn:{state.turn_seq}"
+        turn.live = True
+        turn.touch()
+    timeout = httpx.Timeout(_POST_TIMEOUT_S)
+
+    async def _mirror_new_rows(client: httpx.AsyncClient) -> int:
+        """Mirror history rows past the cursor; returns how many were posted."""
+        if state.history_path is None:
+            return 0
+        # CoCo can rewrite the history file shorter (compaction / summarize).
+        # Snap the cursor down so the mirror resumes from the rewritten tail
+        # instead of going silently dead for the rest of the session; the
+        # skipped span was already mirrored in its pre-rewrite form.
+        current_lines = await asyncio.to_thread(_count_history_lines, state.history_path)
+        if current_lines < state.last_line:
+            _logger.warning(
+                "coco history shrank (%d -> %d lines); resetting mirror cursor; session=%s",
+                state.last_line,
+                current_lines,
+                session_id,
+            )
+            state.last_line = current_lines
+            _write_state(bridge_dir, state)
+        rows = await asyncio.to_thread(_read_history_lines, state.history_path, state.last_line)
+        posted = 0
+        for line_no, obj in rows:
+            items = _message_to_items(line_no, obj, agent_name, turn.response_id)
+            for item in items:
+                await _post_conversation_item(client, session_id=session_id, item=item)
+                posted += 1
+            state.last_line = line_no
+            _write_state(bridge_dir, state)
+        return posted
+
+    async def _close_turn(client: httpx.AsyncClient) -> None:
+        if turn.live:
+            await post_external_session_status(
+                client, session_id=session_id, status="idle", response_id=turn.response_id
+            )
+        turn.reset()
+        if state.turn_live:
+            state.turn_live = False
+            _write_state(bridge_dir, state)
+
+    async def _adopt_session(client: httpx.AsyncClient, event: dict[str, Any]) -> None:
+        """Bind to the CoCo session a hook event announced, if new."""
+        coco_sid = event.get("session_id")
+        if not isinstance(coco_sid, str) or not coco_sid or coco_sid == state.coco_session_id:
+            return
+        history_path = _history_path_for_transcript(str(event.get("transcript_path") or ""))
+        if history_path is None:
+            return
+        # A turn left open by the previous CoCo session can never close now.
+        await _close_turn(client)
+        state.coco_session_id = coco_sid
+        state.history_path = history_path
+        # Resumed/forked sessions open with their prior history already in the
+        # transcript; Omnigent already holds those messages, so mirror only
+        # rows appended from here on. A fresh session's file has 0 lines (or
+        # does not exist yet), so this is also the correct fresh-start cursor.
+        state.last_line = await asyncio.to_thread(_count_history_lines, history_path)
+        _write_state(bridge_dir, state)
+        if on_coco_session_id is not None:
+            try:
+                await on_coco_session_id(coco_sid)
+            except Exception:  # noqa: BLE001 — persistence is best-effort; resume self-heals
+                _logger.warning(
+                    "coco forwarder external-session-id callback failed; session=%s",
+                    session_id,
+                    exc_info=True,
+                )
+
+    async with httpx.AsyncClient(
+        base_url=base_url, headers=headers, auth=auth, timeout=timeout
+    ) as client:
+        while True:
+            try:
+                events, new_offset = await asyncio.to_thread(
+                    _read_new_events, events_path, state.events_offset
+                )
+                for event in events:
+                    kind = event.get("hook_event_name")
+                    if kind in ("SessionStart", "UserPromptSubmit", "Stop"):
+                        await _adopt_session(client, event)
+                    if kind == "UserPromptSubmit":
+                        # Mirror the just-submitted user bubble (and any rows
+                        # CoCo flushed since the last turn) before opening the
+                        # new turn, so pre-turn rows keep standalone ids.
+                        await _mirror_new_rows(client)
+                        # A submit while a turn is live is mid-turn steering
+                        # (CoCo queues it); the open turn keeps running, so
+                        # only refresh activity — never close or re-mint.
+                        if not turn.live:
+                            state.turn_seq += 1
+                            state.turn_live = True
+                            turn.response_id = f"coco:turn:{state.turn_seq}"
+                            _write_state(bridge_dir, state)
+                            await post_external_session_status(
+                                client,
+                                session_id=session_id,
+                                status="running",
+                                response_id=turn.response_id,
+                            )
+                            turn.live = True
+                        turn.touch()
+                    elif kind == "Stop":
+                        # CoCo flushes the transcript before firing Stop;
+                        # retry briefly in case the write is still landing.
+                        deadline = time.monotonic() + _STOP_FLUSH_GRACE_S
+                        posted = await _mirror_new_rows(client)
+                        while posted == 0 and time.monotonic() < deadline:
+                            await asyncio.sleep(0.2)
+                            posted = await _mirror_new_rows(client)
+                        await _close_turn(client)
+                # Advance past malformed-only chunks too, or the same bytes
+                # would be re-read (and re-fail) on every poll forever.
+                if new_offset != state.events_offset:
+                    state.events_offset = new_offset
+                    _write_state(bridge_dir, state)
+
+                # Backstop: a turn that died without its Stop hook (killed
+                # pane, CoCo crash) must not leave a spinner forever. Hook
+                # events are the only mid-turn activity signal, so a
+                # legitimately long turn also trips this — like goose, keep
+                # ``response_id`` so the eventual Stop's rows rejoin the same
+                # streaming group even though the spinner closed early.
+                if (
+                    turn.live
+                    and turn.last_activity_ts is not None
+                    and time.monotonic() - turn.last_activity_ts > _STALLED_TURN_IDLE_S
+                ):
+                    await _mirror_new_rows(client)
+                    await post_external_session_status(
+                        client,
+                        session_id=session_id,
+                        status="idle",
+                        response_id=turn.response_id,
+                    )
+                    turn.live = False
+                    turn.last_activity_ts = None
+                    state.turn_live = False
+                    _write_state(bridge_dir, state)
+
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _logger.exception(
+                    "coco forwarder poll failed; session=%s coco_session=%s",
+                    session_id,
+                    state.coco_session_id,
+                )
+            await asyncio.sleep(poll_interval_s)
+
+
+def _supervisor_monotonic() -> float:
+    """Indirection so tests can stub the supervisor's clock."""
+    return time.monotonic()
+
+
+async def _supervisor_sleep(seconds: float) -> None:
+    """Indirection so tests can stub the supervisor's backoff sleep."""
+    await asyncio.sleep(seconds)
+
+
+async def supervise_coco_forwarder(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    bridge_dir: Path,
+    agent_name: str,
+    on_coco_session_id: Any | None = None,
+    poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+    auth: httpx.Auth | None = None,
+) -> None:
+    """Run :func:`forward_coco_events_to_session` under a restart supervisor.
+
+    Mirrors :func:`omnigent.goose_native_forwarder.supervise_goose_forwarder`:
+    bounded exponential backoff, :class:`asyncio.CancelledError` propagates for
+    clean teardown, and the persisted cursors mean restarts resume exactly
+    where they left off.
+
+    :returns: Never normally returns; cancel the task to stop it.
+    """
+    backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+    while True:
+        run_started_at = _supervisor_monotonic()
+        crash_exc: Exception | None = None
+        try:
+            await forward_coco_events_to_session(
+                base_url=base_url,
+                headers=headers,
+                session_id=session_id,
+                bridge_dir=bridge_dir,
+                agent_name=agent_name,
+                on_coco_session_id=on_coco_session_id,
+                poll_interval_s=poll_interval_s,
+                auth=auth,
+            )
+            _logger.warning(
+                "coco forwarder returned unexpectedly; restarting; session=%s bridge_dir=%s",
+                session_id,
+                bridge_dir,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — supervisor restarts on any Exception
+            crash_exc = exc
+        if _supervisor_monotonic() - run_started_at >= _SUPERVISOR_HEALTHY_UPTIME_S:
+            backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+        if crash_exc is not None:
+            _logger.error(
+                "coco forwarder crashed; restarting in %.1fs; session=%s bridge_dir=%s",
+                backoff_s,
+                session_id,
+                bridge_dir,
+                exc_info=crash_exc,
+            )
+        await _supervisor_sleep(backoff_s)
+        backoff_s = min(backoff_s * 2.0, _SUPERVISOR_MAX_BACKOFF_S)

--- a/omnigent/coco_native_hook.py
+++ b/omnigent/coco_native_hook.py
@@ -1,0 +1,77 @@
+"""
+Fast lifecycle-event hook for the native Omnigent CoCo (Cortex Code) wrapper.
+
+The coco-native bridge registers this script in the per-session
+``SNOWFLAKE_HOME``'s ``cortex/hooks.json`` for the ``SessionStart``,
+``UserPromptSubmit`` and ``Stop`` events. CoCo **blocks** on command hooks, so
+this module is deliberately tiny: it imports only the standard library and does
+nothing but append the hook's stdin JSON payload as one structured line to
+``<bridge_dir>/hook_events.jsonl``.
+
+The background transcript forwarder tails that file:
+
+- ``SessionStart`` / ``UserPromptSubmit`` carry ``session_id`` +
+  ``transcript_path`` — this is how Omnigent discovers which CoCo conversation
+  the TUI actually opened (CoCo mints its own session id in TUI mode and
+  ignores ``--session-id``, verified on v1.1.1).
+- ``UserPromptSubmit`` marks a turn opening (the ``running`` status edge).
+- ``Stop`` marks a turn ending; CoCo flushes the session's
+  ``<session_id>.history.jsonl`` transcript before firing it (verified on
+  v1.1.1), so the forwarder mirrors the finished turn from that file.
+
+Observed payload shape (CoCo v1.1.1, Claude-Code-compatible)::
+
+    {
+      "hook_event_name": "SessionStart" | "UserPromptSubmit" | "Stop",
+      "session_id": "<coco-session-uuid>",
+      "transcript_path": "/.../conversations/<session_id>.json",
+      "cwd": "/path/to/workspace",
+      "permission_mode": "default",
+      "prompt": "...",            # UserPromptSubmit only
+      "stop_hook_active": false   # Stop only
+    }
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+# Append-only events file written in the bridge directory. The forwarder
+# imports this constant so both sides agree on the path without the forwarder
+# paying this module's (stdlib-only) import cost on its hot path. Kept here
+# because this module is the writer.
+HOOK_EVENTS_FILE = "hook_events.jsonl"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Append the hook payload from stdin to the bridge events file.
+
+    Exits 0 unconditionally: a hook failure must never block or degrade the
+    user's CoCo TUI session (a non-zero exit could suppress the action the
+    hook observed).
+
+    :param argv: CLI args; ``None`` uses ``sys.argv[1:]``.
+    :returns: Process exit code (always 0).
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--bridge-dir", required=True)
+    try:
+        args, _ = parser.parse_known_args(argv)
+        raw = sys.stdin.read()
+        payload = json.loads(raw) if raw.strip() else {}
+        if not isinstance(payload, dict):
+            payload = {"malformed_payload": raw[:2000]}
+        line = json.dumps(payload, separators=(",", ":"))
+        path = os.path.join(args.bridge_dir, HOOK_EVENTS_FILE)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except Exception:  # noqa: BLE001 — never fail the TUI from a hook
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -16,6 +16,7 @@ from typing import Any
 from omnigent._wrapper_labels import (
     ANTIGRAVITY_NATIVE_WRAPPER_VALUE,
     CLAUDE_NATIVE_WRAPPER_VALUE,
+    COCO_NATIVE_WRAPPER_VALUE,
     CODEX_NATIVE_WRAPPER_VALUE,
     CURSOR_NATIVE_WRAPPER_VALUE,
     GOOSE_NATIVE_WRAPPER_VALUE,
@@ -198,6 +199,15 @@ HERMES_NATIVE_CODING_AGENT = NativeCodingAgent(
     terminal_name="hermes",
 )
 
+COCO_NATIVE_CODING_AGENT = NativeCodingAgent(
+    key="coco",
+    display_name="CoCo",
+    agent_name="coco-native-ui",
+    harness="coco-native",
+    wrapper_label=COCO_NATIVE_WRAPPER_VALUE,
+    terminal_name="coco",
+)
+
 
 # Declared capabilities for the built-in harnesses. Each value is backed by the
 # module that implements it; the derivable axes (model_family, subagents) are
@@ -348,6 +358,21 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         subagents=False,
         interrupt=True,
         streaming=True,
+    ),
+    # Snowflake CoCo (Cortex Code) native TUI. Tool approvals stay in the
+    # vendor TUI (its three-tier confirm/plan/bypass modes) — no web mirror
+    # yet. streaming=False by construction: the forwarder mirrors finished
+    # turns from CoCo's transcript at each Stop hook, so no delta path exists.
+    "coco-native": _C(
+        _IM.NATIVE_TUI,
+        _EL.NONE,
+        _RS.WARM_REATTACH,
+        _EF.NONE,
+        _MF.MULTI,
+        _AU.OWN_AUTH,
+        subagents=False,
+        interrupt=True,
+        streaming=False,
     ),
     # SDK / subprocess harnesses (run the vendor model directly). The first four
     # are bench-verified interrupt=streaming=True.
@@ -514,6 +539,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
             "antigravity-native",
             "claude-native",
             "claude-sdk",
+            "coco-native",
             "codex",
             "codex-native",
             "copilot",
@@ -541,6 +567,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "antigravity-native": "omnigent.inner.antigravity_native_harness",
         "claude-native": "omnigent.inner.claude_native_harness",
         "claude-sdk": "omnigent.inner.claude_sdk_harness",
+        "coco-native": "omnigent.inner.coco_native_harness",
         "codex": "omnigent.inner.codex_harness",
         "codex-native": "omnigent.inner.codex_native_harness",
         "copilot": "omnigent.inner.copilot_harness",
@@ -563,10 +590,15 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
     aliases={
         "agy": "antigravity",
         "claude": "claude-sdk",
+        # Snowflake CoCo ships only as a native TUI harness, so the friendly
+        # spellings (product name, binary name) all resolve to it.
+        "coco": "coco-native",
+        "cortex": "coco-native",
         "github-copilot": "copilot",
         "google-antigravity": "antigravity",
         "kimi-code": "kimi",
         "native-antigravity": "antigravity-native",
+        "native-coco": "coco-native",
         "native-goose": "goose-native",
         "native-hermes": "hermes-native",
         "native-kimi": "kimi-native",
@@ -582,6 +614,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         {
             "antigravity-native",
             "claude-native",
+            "coco-native",
             "codex-native",
             "cursor-native",
             "goose-native",
@@ -590,6 +623,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
             "kiro-native",
             "native-antigravity",
             "native-claude",
+            "native-coco",
             "native-codex",
             "native-cursor",
             "native-goose",
@@ -616,6 +650,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         QWEN_NATIVE_CODING_AGENT,
         KIMI_NATIVE_CODING_AGENT,
         HERMES_NATIVE_CODING_AGENT,
+        COCO_NATIVE_CODING_AGENT,
     ),
     model_env_keys={
         "acp": "HARNESS_ACP_MODEL",

--- a/omnigent/inner/coco_native_executor.py
+++ b/omnigent/inner/coco_native_executor.py
@@ -1,0 +1,141 @@
+"""Executor that bridges Omnigent web-chat turns into the native CoCo TUI.
+
+It does not launch ``cortex`` — the ``omnigent coco`` wrapper already launched
+the interactive Snowflake CoCo (Cortex Code) TUI in the session terminal. Each
+web-UI turn injects the latest user message into that same tmux pane
+(bracketed paste + Enter), so the message appears in the running CoCo TUI
+(and, since the web UI embeds the pane, in both surfaces). Output is
+terminal-originated; the embedded terminal renders it live and the forwarder
+mirrors the transcript.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+from omnigent.coco_native_bridge import BRIDGE_DIR_ENV_VAR, inject_user_message
+from omnigent.inner.executor import (
+    Executor,
+    ExecutorConfig,
+    ExecutorError,
+    ExecutorEvent,
+    Message,
+    ToolSpec,
+    TurnComplete,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CocoNativeExecutor(Executor):
+    """Harness-side executor for ``omnigent coco`` web-UI turns.
+
+    Injects each web-UI message into the running CoCo TUI's tmux pane. Does not
+    stream output (the embedded terminal shows it); accepts mid-turn steering
+    (CoCo queues messages typed while a turn runs).
+
+    :param bridge_dir: Optional bridge dir override; ``None`` reads
+        :data:`BRIDGE_DIR_ENV_VAR` from the harness spawn env.
+    """
+
+    def __init__(self, bridge_dir: Path | None = None) -> None:
+        self._bridge_dir = bridge_dir or _bridge_dir_from_env()
+        # Serializes writes to the shared tmux pane: run_turn (initiating
+        # message) and enqueue_session_message (steering) run concurrently
+        # against one cached executor, and injection is multi-step (clear +
+        # paste + Enter) — without the lock their keystrokes interleave.
+        self._inject_lock = asyncio.Lock()
+
+    def supports_streaming(self) -> bool:
+        """:returns: ``False`` — output is shown by the embedded terminal, not this executor."""
+        return False
+
+    def supports_live_message_queue(self) -> bool:
+        """:returns: ``True`` — messages can be injected mid-turn (steering)."""
+        return True
+
+    async def enqueue_session_message(self, session_key: str, content: Any) -> bool:
+        """Inject a live steering message into the CoCo terminal."""
+        del session_key
+        text = _content_to_text(content, self._bridge_dir)
+        if not text:
+            return False
+        try:
+            async with self._inject_lock:
+                await asyncio.to_thread(inject_user_message, self._bridge_dir, content=text)
+        except RuntimeError:
+            return False
+        return True
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],
+        system_prompt: str,
+        config: ExecutorConfig | None = None,
+    ) -> AsyncIterator[ExecutorEvent]:
+        """Inject the latest web-UI user message into the CoCo TUI pane."""
+        del tools, system_prompt, config
+        text = _latest_user_text(messages, self._bridge_dir)
+        if not text:
+            yield ExecutorError(message="coco native turn had no user text to send")
+            return
+        try:
+            async with self._inject_lock:
+                await asyncio.to_thread(inject_user_message, self._bridge_dir, content=text)
+        except RuntimeError as exc:
+            yield ExecutorError(message=str(exc))
+            return
+        yield TurnComplete(response=None)
+
+
+def _bridge_dir_from_env() -> Path:
+    """Resolve the coco-native bridge dir from the harness spawn env."""
+    raw = os.environ.get(BRIDGE_DIR_ENV_VAR, "").strip()
+    if not raw:
+        raise RuntimeError(f"{BRIDGE_DIR_ENV_VAR} is required for the coco-native harness")
+    return Path(raw)
+
+
+def _latest_user_text(messages: list[Message], bridge_dir: Path) -> str:
+    """Return the latest user message's text (attachments materialized to disk)."""
+    for message in reversed(messages):
+        if message.get("role") == "user":
+            return _content_to_text(message.get("content"), bridge_dir)
+    return ""
+
+
+def _content_to_text(content: Any, bridge_dir: Path) -> str:
+    """Normalize executor content into text the CoCo TUI receives.
+
+    Text blocks are extracted directly. Image/file blocks carrying a base64 data
+    URI are materialized to the bridge dir and referenced by absolute path
+    (``[Attached: <path>]``) so CoCo can open them with its tools — otherwise
+    web-UI attachments are silently dropped. Mirrors goose-/cursor-native.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        from omnigent.inner.native_attachments import materialize_attachment
+
+        attachment_lines: list[str] = []
+        text_parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type", "")
+            if block_type in ("input_text", "text"):
+                text = block.get("text")
+                if isinstance(text, str):
+                    text_parts.append(text)
+            elif block_type in ("input_image", "input_file"):
+                path = materialize_attachment(block, bridge_dir)
+                if path is not None:
+                    attachment_lines.append(f"[Attached: {path}]")
+        return "\n\n".join(attachment_lines + text_parts)
+    return ""

--- a/omnigent/inner/coco_native_harness.py
+++ b/omnigent/inner/coco_native_harness.py
@@ -1,0 +1,37 @@
+"""``harness: coco-native`` wrap (the native Snowflake CoCo TUI).
+
+Thin module exposing :func:`create_app` — the entry point the shared
+:mod:`omnigent.runtime.harnesses._runner` invokes after the parent process
+resolves ``"coco-native"`` to this module via
+:data:`omnigent.runtime.harnesses._HARNESS_MODULES`.
+
+Wraps a :class:`omnigent.inner.coco_native_executor.CocoNativeExecutor`, which
+injects web-UI messages into the running ``cortex`` TUI (launched by
+``omnigent coco`` in the session terminal) via tmux. The bridge dir is read
+from :data:`~omnigent.coco_native_bridge.BRIDGE_DIR_ENV_VAR` in the spawn env.
+
+Tool policies: Omnigent's PreToolUse/PostToolUse policy gates do NOT apply to
+coco-native — ``cortex`` runs its tools inside its own TUI and gates them with
+its own three-tier approval system (confirm actions / plan / bypass), which
+Omnigent does not intercept. Treat the CoCo TUI's own approval as the sole
+tool gate.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from omnigent.inner.coco_native_executor import CocoNativeExecutor
+from omnigent.inner.executor import Executor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+
+def _build_coco_native_executor() -> Executor:
+    """Construct a :class:`CocoNativeExecutor` (reads the bridge dir from env)."""
+    return CocoNativeExecutor()
+
+
+def create_app() -> FastAPI:
+    """Build the coco-native harness's FastAPI app (required entry point)."""
+    adapter = ExecutorAdapter(executor_factory=_build_coco_native_executor)
+    return adapter.build()

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -89,6 +89,11 @@ COPILOT_KEY = "copilot"
 # Omnigent-managed credentials). The ``hermes`` binary must be on PATH.
 HERMES_KEY = "hermes"
 
+# Snowflake CoCo (Cortex Code) is installed via Snowflake's curl installer and
+# authenticates against the user's own ``~/.snowflake/connections.toml`` (no
+# Omnigent-managed credentials). The binary is named ``cortex``.
+COCO_KEY = "coco"
+
 
 # Keyed by harness family (Claude=anthropic, Codex=openai) plus the pi
 # fallback. Binaries/packages mirror ucode's ``TOOL_SPECS`` so the two tools
@@ -196,6 +201,13 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         package=None,
         install_hint="curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash",
     ),
+    COCO_KEY: HarnessInstallSpec(
+        "CoCo",
+        "cortex",
+        package=None,
+        install_hint="curl -LsS https://ai.snowflake.com/static/cc-scripts/install.sh | sh",
+        auth_hint="run `cortex` once and complete the Snowflake connection setup",
+    ),
 }
 
 
@@ -260,6 +272,12 @@ _HARNESS_NAME_TO_KEY: dict[str, str] = {
     # gates on the same binary.
     "hermes-native": HERMES_KEY,
     "native-hermes": HERMES_KEY,
+    # Native Snowflake CoCo TUI (``coco-native``, via ``omni coco``) wraps the
+    # ``cortex`` CLI; all accepted spellings gate on the same binary.
+    "coco-native": COCO_KEY,
+    "native-coco": COCO_KEY,
+    COCO_KEY: COCO_KEY,
+    "cortex": COCO_KEY,
 }
 
 

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -32,6 +32,7 @@ import omnigent.onboarding.gemini_auth as _gemini_auth
 from omnigent.harness_aliases import HARNESS_ALIASES, canonicalize_harness
 from omnigent.harness_plugins import harness_install_keys, valid_harnesses
 from omnigent.onboarding.harness_install import (
+    COCO_KEY,
     COPILOT_KEY,
     CURSOR_KEY,
     GOOSE_KEY,
@@ -124,6 +125,12 @@ _KIMI_NATIVE_HARNESSES: frozenset[str] = frozenset({"kimi-native", "native-kimi"
 # native CLI harnesses. Hermes owns its own auth (``hermes setup`` /
 # ``hermes model``); the headless ``hermes`` harness gates on the same binary.
 _HERMES_NATIVE_HARNESSES: frozenset[str] = frozenset({"hermes-native", "native-hermes"})
+
+# Native Snowflake CoCo harnesses. Boot the ``cortex`` TUI (``omni coco``) and
+# can't launch without the ``cortex`` binary on ``PATH`` — gate on it, like the
+# other native CLI harnesses. CoCo owns its own auth
+# (``~/.snowflake/connections.toml``, shared with the Snowflake CLI).
+_COCO_NATIVE_HARNESSES: frozenset[str] = frozenset({"coco-native", "native-coco"})
 
 # CLI-wrapping qwen harnesses. ``qwen`` / ``qwen-code`` (the ACP harness) and
 # ``qwen-native`` / ``native-qwen`` (the native TUI via ``omni qwen``) all resolve
@@ -226,6 +233,12 @@ def harness_is_configured(harness: str) -> bool:
         # Research). Auth/provider config surfaces at run time via Hermes' own
         # ``hermes model`` flow; gate only on binary presence.
         return harness_cli_installed(HERMES_KEY)
+    if canonical in _COCO_NATIVE_HARNESSES:
+        # Snowflake CoCo (``coco-native``, via ``omni coco``) wraps the
+        # ``cortex`` CLI (installed via Snowflake's curl script). Connection
+        # auth surfaces at run time via CoCo's own setup wizard; gate only on
+        # binary presence.
+        return harness_cli_installed(COCO_KEY)
     if canonical == CURSOR_KEY:
         # Cursor runs in-process via ``cursor-sdk`` and authenticates with a
         # ``CURSOR_API_KEY`` (a ``cursor-agent login`` does not apply). So,
@@ -325,6 +338,7 @@ def configured_harness_map() -> dict[str, HarnessAvailability]:
     spellings.update(_GOOSE_NATIVE_HARNESSES)
     spellings.update(_KIMI_NATIVE_HARNESSES)
     spellings.update(_HERMES_NATIVE_HARNESSES)
+    spellings.update(_COCO_NATIVE_HARNESSES)
     spellings.update(_QWEN_HARNESSES)
     spellings.add(CURSOR_KEY)
     spellings.add(KIMI_SURFACE)

--- a/omnigent/resume_dispatch.py
+++ b/omnigent/resume_dispatch.py
@@ -306,6 +306,15 @@ def _dispatch_wrapper(
             hermes_args=(),
         )
         return True
+    if native_agent.key == "coco":
+        from omnigent.coco_native import run_coco_native
+
+        run_coco_native(
+            server=server,
+            session_id=session_id,
+            coco_args=(),
+        )
+        return True
     return False
 
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -65,6 +65,7 @@ from omnigent.runner.proxy_mcp_manager import ProxyMcpManager
 from omnigent.runner.resource_registry import (
     ANTIGRAVITY_NATIVE_TERMINAL_ROLE,
     CLAUDE_NATIVE_TERMINAL_ROLE,
+    COCO_NATIVE_TERMINAL_ROLE,
     CODEX_NATIVE_TERMINAL_ROLE,
     CURSOR_NATIVE_TERMINAL_ROLE,
     GOOSE_NATIVE_TERMINAL_ROLE,
@@ -2496,6 +2497,191 @@ async def _auto_create_goose_terminal(
     _register_auto_forwarder_task(session_id, _forwarder_task)
     _logger.info(
         "Auto-created goose terminal + forwarder/approval-mirror for session %s; task=%s",
+        session_id,
+        _forwarder_task.get_name(),
+    )
+    return terminal_view
+
+
+async def _persist_coco_external_session_id(
+    server_client: httpx.AsyncClient | None,
+    session_id: str,
+    coco_session_id: str,
+) -> None:
+    """Record the CoCo session id on the Omnigent session as ``external_session_id``.
+
+    Mirrors qwen-/hermes-native: the persisted id is what a later cold resume
+    reads back from the session snapshot to relaunch ``cortex -r <id>``.
+    Best-effort — a transient failure only degrades resume, never the live
+    turn (the forwarder re-announces the id on the next hook event).
+
+    :param server_client: Runner Omnigent server client (``None`` skips the write).
+    :param session_id: Omnigent session/conversation id.
+    :param coco_session_id: The CoCo session id the lifecycle hook announced.
+    """
+    if server_client is None:
+        return
+    try:
+        resp = await server_client.patch(
+            f"/v1/sessions/{urllib.parse.quote(session_id, safe='')}",
+            json={"external_session_id": coco_session_id},
+            timeout=10.0,
+        )
+    except httpx.HTTPError:
+        _logger.warning(
+            "Could not record coco external_session_id for %s; resume will start fresh",
+            session_id,
+            exc_info=True,
+        )
+        return
+    if resp.status_code >= 400:
+        _logger.warning(
+            "AP rejected coco external_session_id PATCH (%s); session=%s",
+            resp.status_code,
+            session_id,
+        )
+
+
+async def _auto_create_coco_terminal(
+    session_id: str,
+    resource_registry: SessionResourceRegistry,
+    publish_event: Callable[[str, dict[str, Any]], None],
+    *,
+    server_client: httpx.AsyncClient | None,
+    ensure_comment_relay: Callable[..., Awaitable[None]] | None = None,
+) -> SessionResourceView:
+    """
+    Auto-create the Snowflake CoCo TUI terminal for a coco-native session.
+
+    Launches the ``cortex`` TUI in a runner-owned tmux pane with a per-session
+    ``SNOWFLAKE_HOME`` that symlinks the user's real config/auth and adds the
+    Omnigent lifecycle hook (see :func:`omnigent.coco_native_bridge.write_coco_home`).
+    CoCo mints its own session id in TUI mode, so discovery flows the other way:
+    the hook's ``SessionStart`` event announces the id and the forwarder persists
+    it as ``external_session_id`` for cold resume (``cortex -r <id>``).
+    Mirrors :func:`_auto_create_goose_terminal`.
+
+    :param session_id: Session/conversation identifier.
+    :param resource_registry: Session resource registry for launching the terminal.
+    :param publish_event: Runner session event publisher.
+    :param server_client: Runner Omnigent server client.
+    :returns: Created terminal resource view.
+    """
+    from omnigent.coco_native import resolve_coco_executable
+    from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
+
+    # Tear down any forwarder left from a prior terminal for this session before
+    # re-creating, so old and new tasks can't both mirror (double-posting), and
+    # drop the prior terminal's stale forward cursor + hook event log.
+    await _cancel_auto_forwarder_task(session_id)
+    from omnigent.coco_native_bridge import (
+        bridge_dir_for_session_id,
+        coco_session_recording_exists,
+        write_coco_home,
+        write_tmux_target,
+    )
+    from omnigent.coco_native_forwarder import clear_coco_bridge_state
+
+    bridge_dir = bridge_dir_for_session_id(session_id)
+    clear_coco_bridge_state(bridge_dir)
+    coco_home = await asyncio.to_thread(write_coco_home, bridge_dir)
+
+    # ``_pi_native_launch_config`` is a generic session-snapshot reader
+    # (workspace + terminal_launch_args); reused here, not Pi-specific.
+    launch_config = await _pi_native_launch_config(
+        session_id=session_id,
+        server_client=server_client,
+    )
+    workspace = os.path.realpath(str(launch_config.workspace))
+    coco_command = resolve_coco_executable()
+    # Cold resume: relaunch the prior CoCo session when its recording exists
+    # (``-r`` on an unknown id errors). The conversations dir is symlinked
+    # from the user's real home, so the recording check resolves either way.
+    # A fork or a never-announced session starts fresh; CoCo announces the new
+    # id via the SessionStart hook and it is persisted below.
+    resume_args: list[str] = []
+    existing_coco_id = launch_config.external_session_id
+    if existing_coco_id and coco_session_recording_exists(existing_coco_id):
+        resume_args = ["-r", existing_coco_id]
+    coco_args = [
+        *resume_args,
+        *(launch_config.terminal_launch_args or []),
+    ]
+    coco_env: dict[str, str] = {
+        # Per-session home: user config/auth symlinked in, hooks.json replaced
+        # with the Omnigent lifecycle relay the forwarder tails.
+        "SNOWFLAKE_HOME": str(coco_home),
+    }
+    terminal_view = await resource_registry.launch_required_terminal(
+        session_id=session_id,
+        terminal_name="coco",
+        session_key="main",
+        resource_role=COCO_NATIVE_TERMINAL_ROLE,
+        spec=TerminalEnvSpec(
+            os_env=OSEnvSpec(type="caller_process", cwd=workspace),
+            command=coco_command,
+            args=coco_args,
+            env=coco_env,
+            scrollback=100_000,
+            tmux_allow_passthrough=True,
+            tmux_start_on_attach=False,
+        ),
+    )
+    # Advertise the tmux socket+target so the coco-native harness executor can
+    # inject web-UI messages into this same pane (tmux paste).
+    terminal_registry = resource_registry.terminal_registry
+    if terminal_registry is not None:
+        instance = terminal_registry.get(session_id, "coco", "main")
+        if instance is not None and instance.running:
+            write_tmux_target(
+                bridge_dir,
+                socket_path=instance.socket_path,
+                tmux_target=instance.tmux_target,
+            )
+    publish_event(
+        session_id,
+        {
+            "type": "session.resource.created",
+            "resource": session_resource_view_to_dict(terminal_view),
+        },
+    )
+
+    # Mirror the CoCo TUI's conversation back into the Omnigent session so the
+    # chat view tracks the embedded terminal. Host-spawned sessions have no CLI
+    # client to start this, so the runner owns it — reusing the runner's own
+    # server URL + refresh-capable auth.
+    from omnigent.runner._entry import _make_auth_token_factory, _RunnerDatabricksAuth
+
+    server_url = _required_runner_env("RUNNER_SERVER_URL")
+    _runner_auth = _RunnerDatabricksAuth(_make_auth_token_factory())
+
+    from omnigent.coco_native_forwarder import supervise_coco_forwarder
+
+    if server_client is not None and ensure_comment_relay is not None:
+        await ensure_comment_relay(
+            session_id,
+            explicit_bridge_dir=bridge_dir,
+            await_notify=False,
+        )
+
+    async def _on_coco_session_id(coco_session_id: str) -> None:
+        await _persist_coco_external_session_id(server_client, session_id, coco_session_id)
+
+    _forwarder_task = asyncio.create_task(
+        supervise_coco_forwarder(
+            base_url=server_url,
+            headers={},
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            agent_name="coco-native-ui",
+            on_coco_session_id=_on_coco_session_id,
+            auth=_runner_auth,
+        ),
+        name=f"coco-forwarder-{session_id}",
+    )
+    _register_auto_forwarder_task(session_id, _forwarder_task)
+    _logger.info(
+        "Auto-created coco terminal + forwarder for session %s; task=%s",
         session_id,
         _forwarder_task.get_name(),
     )
@@ -6088,8 +6274,8 @@ async def _delete_native_bridge_dirs(
     holding a bridge token / auth secret + MCP config — secret material. Closing
     the pane does not remove it, so without this they accumulate even on a clean
     session delete (issue #1350). We don't know which harness this session used,
-    so delete every candidate dir for all 11 native families
-    (antigravity/claude/codex/cursor/goose/hermes/kimi/kiro/opencode/pi/qwen);
+    so delete every candidate dir for all 12 native families
+    (antigravity/claude/coco/codex/cursor/goose/hermes/kimi/kiro/opencode/pi/qwen);
     the per-target ``FileNotFoundError`` swallow makes wrong-harness / already-gone
     cases a no-op, while other ``OSError``s are logged at debug rather than hidden.
     Antigravity/claude/codex/opencode bridge ids can be rotated via a session
@@ -6111,6 +6297,9 @@ async def _delete_native_bridge_dirs(
     )
     from omnigent.claude_native_bridge import (
         bridge_dir_for_bridge_id as claude_bridge_dir,
+    )
+    from omnigent.coco_native_bridge import (
+        bridge_dir_for_session_id as coco_bridge_dir,
     )
     from omnigent.codex_native_bridge import (
         CODEX_NATIVE_BRIDGE_ID_LABEL_KEY,
@@ -6160,6 +6349,7 @@ async def _delete_native_bridge_dirs(
         claude_bridge_dir(session_id),
         codex_bridge_dir(labels.get(CODEX_NATIVE_BRIDGE_ID_LABEL_KEY) or session_id),
         codex_bridge_dir(session_id),
+        coco_bridge_dir(session_id),
         cursor_bridge_dir(session_id),
         goose_bridge_dir(session_id),
         hermes_bridge_dir(session_id),
@@ -7976,6 +8166,7 @@ def create_runner_app(
     _qwen_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     _kimi_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     _hermes_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
+    _coco_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     # Per-session lock guarding the claude-native terminal auto-create in
     # ``create_session``. Two ``POST /v1/sessions`` calls can land
     # concurrently on a host-launched runner — ``_on_runner_connect``
@@ -8970,6 +9161,10 @@ def create_runner_app(
                 from omnigent.kimi_native_bridge import build_kimi_native_spawn_env
 
                 spawn_env = build_kimi_native_spawn_env(session_id)
+            if harness_name == "coco-native" and spawn_env is None:
+                from omnigent.coco_native_bridge import build_coco_native_spawn_env
+
+                spawn_env = build_coco_native_spawn_env(session_id)
             _session_spec_cache[session_id] = spec_entry
         else:
             harness_name = "runner-test-default"
@@ -9535,6 +9730,37 @@ def create_runner_app(
                     finally:
                         _publish_terminal_pending(_publish_event, session_id, False)
 
+        if harness_name == "coco-native":
+            _coco_ensure_lock = _coco_terminal_ensure_locks.setdefault(session_id, asyncio.Lock())
+            async with _coco_ensure_lock:
+                _tr = resource_registry.terminal_registry
+                _has_coco_terminal = (
+                    _tr is not None and _tr.get(session_id, "coco", "main") is not None
+                )
+                if not _has_coco_terminal:
+                    _publish_terminal_pending(_publish_event, session_id, True)
+                    try:
+                        await _auto_create_coco_terminal(
+                            session_id,
+                            resource_registry,
+                            _publish_event,
+                            server_client=server_client,
+                            ensure_comment_relay=_ensure_comment_relay_started,
+                        )
+                    except Exception as exc:
+                        _logger.exception(
+                            "Failed to auto-create coco terminal for %s",
+                            session_id,
+                        )
+                        _publish_native_terminal_start_error(
+                            _publish_event,
+                            session_id,
+                            "CoCo",
+                            exc,
+                        )
+                    finally:
+                        _publish_terminal_pending(_publish_event, session_id, False)
+
         if harness_name == "qwen-native":
             _qwen_ensure_lock = _qwen_terminal_ensure_locks.setdefault(session_id, asyncio.Lock())
             async with _qwen_ensure_lock:
@@ -9877,6 +10103,7 @@ def create_runner_app(
         _qwen_terminal_ensure_locks.pop(session_id, None)
         _kimi_terminal_ensure_locks.pop(session_id, None)
         _hermes_terminal_ensure_locks.pop(session_id, None)
+        _coco_terminal_ensure_locks.pop(session_id, None)
         _repl_terminal_ensure_locks.pop(session_id, None)
         _interrupted_sessions.discard(session_id)
         # Stop any TUI→web transcript forwarder (cursor-/goose-native) for this
@@ -10568,6 +10795,7 @@ def create_runner_app(
             "qwen-native",
             "kimi-native",
             "hermes-native",
+            "coco-native",
         }:
             return
         if status == "idle" and harness in {"codex-native", "antigravity-native"}:
@@ -11683,6 +11911,78 @@ def create_runner_app(
         ):
             _logger.warning(
                 "Hermes-native stop succeeded but sub-agent delivery was "
+                "not confirmed; session=%s reason=%s",
+                conv_id,
+                delivery_ack.reason,
+            )
+        return Response(status_code=204)
+
+    async def _handle_coco_native_interrupt(conv_id: str) -> Response:
+        """Cancel the in-flight CoCo turn by sending ``Escape`` to its TUI pane.
+
+        coco-native turns run inside the ``cortex`` TUI; the runner harness
+        task returns right after the tmux paste, so the in-process cancel floor
+        has nothing to cancel. CoCo binds Escape to interrupt (its footer
+        advertises "esc to interrupt"); Ctrl+C is avoided because CoCo
+        double-taps it into a full TUI exit. Mirrors the goose-native interrupt.
+
+        :param conv_id: Session/conversation identifier.
+        :returns: 204 when Escape was sent; 503 if the tmux target is unavailable.
+        """
+        from omnigent.coco_native_bridge import bridge_dir_for_session_id, inject_interrupt
+
+        try:
+            await asyncio.to_thread(
+                inject_interrupt, bridge_dir_for_session_id(conv_id), timeout_s=1.0
+            )
+        except RuntimeError as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "coco_native_interrupt_failed",
+                    "detail": _client_safe_error_detail(exc, context="coco-native interrupt"),
+                },
+            )
+        _wake_parent_after_native_interrupt(conv_id)
+        return Response(status_code=204)
+
+    async def _handle_coco_native_stop(conv_id: str) -> Response:
+        """Hard-stop a coco-native session by killing its tmux session.
+
+        Mirrors :func:`_handle_goose_native_stop`: kill the pane (ends
+        ``cortex``), tear the terminal resource down, cancel the forwarder,
+        publish ``idle``, and reclaim any sub-agent work entry.
+
+        :param conv_id: Session/conversation identifier.
+        :returns: 204 on success; 503 if the tmux target is unavailable.
+        """
+        from omnigent.coco_native_bridge import bridge_dir_for_session_id, kill_session
+
+        try:
+            await asyncio.to_thread(
+                kill_session, bridge_dir_for_session_id(conv_id), timeout_s=1.0
+            )
+        except RuntimeError as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "coco_native_stop_failed",
+                    "detail": _client_safe_error_detail(exc, context="coco-native stop"),
+                },
+            )
+        await _teardown_session_terminals(conv_id)
+        await _cancel_auto_forwarder_task(conv_id)
+        _publish_event(conv_id, {"type": "session.status", "status": "idle"})
+        delivery_ack = _mark_subagent_terminal_and_wake(
+            conv_id,
+            status="cancelled",
+            output="[System: sub-agent stopped]",
+        )
+        if not delivery_ack.delivered and (
+            delivery_ack.entry is not None or conv_id in _session_sub_agent_names
+        ):
+            _logger.warning(
+                "CoCo-native stop succeeded but sub-agent delivery was "
                 "not confirmed; session=%s reason=%s",
                 conv_id,
                 delivery_ack.reason,
@@ -14205,6 +14505,10 @@ def create_runner_app(
             from omnigent.kimi_native_bridge import build_kimi_native_spawn_env
 
             spawn_env = build_kimi_native_spawn_env(conv_id)
+        if harness_name == "coco-native" and spawn_env is None:
+            from omnigent.coco_native_bridge import build_coco_native_spawn_env
+
+            spawn_env = build_coco_native_spawn_env(conv_id)
 
         agent_version = dispatch.agent_version if dispatch else body.get("agent_version")
         if agent_version is not None and conv_id in _version_cache:
@@ -15199,6 +15503,9 @@ def create_runner_app(
             if _harness == "kimi-native":
                 # kimi turn lives in the kimi TUI; send Escape to stop it.
                 return await _handle_kimi_native_interrupt(conversation_id)
+            if _harness == "coco-native":
+                # coco turn lives in the cortex TUI; send Escape to stop it.
+                return await _handle_coco_native_interrupt(conversation_id)
             # In-process harness: mark interrupted, forward an interrupt to the
             # harness, and force-cancel the runner turn task so the turn ends
             # promptly even if the harness can't honor the interrupt in time.
@@ -15297,6 +15604,9 @@ def create_runner_app(
             if _harness == "kimi-native":
                 # Hard-kill the kimi tmux pane (the TUI is the runtime).
                 return await _handle_kimi_native_stop(conversation_id)
+            if _harness == "coco-native":
+                # Hard-kill the cortex tmux pane (the TUI is the runtime).
+                return await _handle_coco_native_stop(conversation_id)
             await _cancel_inprocess_turn(conversation_id)
             return Response(status_code=204)
 
@@ -16177,6 +16487,41 @@ def create_runner_app(
                         session_id,
                     )
                     return _native_terminal_start_error_response(exc, "Hermes")
+            return JSONResponse(
+                status_code=200,
+                content=session_resource_view_to_dict(terminal_view),
+            )
+
+        if (
+            body.get("ensure_native_terminal")
+            and terminal_name == "coco"
+            and session_key == "main"
+        ):
+            coco_terminal_id = terminal_resource_id("coco", "main")
+            ensure_lock = _coco_terminal_ensure_locks.setdefault(session_id, asyncio.Lock())
+            async with ensure_lock:
+                existing = await resource_registry.get_terminal_resource(
+                    session_id, coco_terminal_id
+                )
+                if existing is not None:
+                    return JSONResponse(
+                        status_code=200,
+                        content=session_resource_view_to_dict(existing),
+                    )
+                try:
+                    terminal_view = await _auto_create_coco_terminal(
+                        session_id,
+                        resource_registry,
+                        _publish_event,
+                        server_client=server_client,
+                        ensure_comment_relay=_ensure_comment_relay_started,
+                    )
+                except Exception as exc:
+                    _logger.exception(
+                        "CoCo terminal ensure failed for session=%s",
+                        session_id,
+                    )
+                    return _native_terminal_start_error_response(exc, "CoCo")
             return JSONResponse(
                 status_code=200,
                 content=session_resource_view_to_dict(terminal_view),
@@ -18091,6 +18436,7 @@ def create_runner_app(
         _qwen_terminal_ensure_locks.pop(session_id, None)
         _kimi_terminal_ensure_locks.pop(session_id, None)
         _hermes_terminal_ensure_locks.pop(session_id, None)
+        _coco_terminal_ensure_locks.pop(session_id, None)
         _repl_terminal_ensure_locks.pop(session_id, None)
         await resource_registry.cleanup_session(session_id)
         # This is the runner endpoint the SERVER's session-delete actually
@@ -18161,6 +18507,7 @@ def create_runner_app(
         _qwen_terminal_ensure_locks.pop(session_id, None)
         _kimi_terminal_ensure_locks.pop(session_id, None)
         _hermes_terminal_ensure_locks.pop(session_id, None)
+        _coco_terminal_ensure_locks.pop(session_id, None)
         _repl_terminal_ensure_locks.pop(session_id, None)
         # Close terminals with ``session.resource.deleted`` events BEFORE
         # cleanup_session — cleanup_conversation would silently pop them

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -62,6 +62,7 @@ ANTIGRAVITY_NATIVE_TERMINAL_ROLE = "antigravity-native"
 QWEN_NATIVE_TERMINAL_ROLE = "qwen-native"
 KIMI_NATIVE_TERMINAL_ROLE = "kimi-native"
 HERMES_NATIVE_TERMINAL_ROLE = "hermes-native"
+COCO_NATIVE_TERMINAL_ROLE = "coco-native"
 # Role marker for the embedded Omnigent REPL terminal auto-created for
 # runner-hosted SDK sessions (``omnigent attach`` in a tmux pane — the
 # SDK mirror of the native terminals above). The attach WebSocket uses
@@ -1022,6 +1023,12 @@ class SessionResourceRegistry:
             # SQLite transcript, not status), so the PTY watcher is its status
             # source too.
             HERMES_NATIVE_TERMINAL_ROLE,
+            # coco-native injects then returns. Its forwarder posts hook-driven
+            # per-turn edges, but the PTY watcher is still needed as the
+            # id-less status source: it seeds the exit-classification memo
+            # (so a /quit before the first turn reads as clean, not a crash)
+            # and the pane reaper's busy check.
+            COCO_NATIVE_TERMINAL_ROLE,
         }
         if activity_publisher is None and not emit_status and exit_publisher is None:
             return

--- a/omnigent/runtime/harnesses/__init__.py
+++ b/omnigent/runtime/harnesses/__init__.py
@@ -145,6 +145,12 @@ _HARNESS_MODULES: dict[str, str] = {
     # name stays the headless subprocess harness. See
     # omnigent/inner/hermes_native_harness.py.
     "hermes-native": "omnigent.inner.hermes_native_harness",
+    # coco-native harness wrap. Drives the resident Snowflake CoCo (Cortex
+    # Code) ``cortex`` TUI by injecting each web-UI turn into its tmux pane and
+    # mirroring the transcript back from CoCo's hook event log + conversations
+    # store — a native-CLI harness like goose-native, so it IS in
+    # ``NATIVE_HARNESSES``. See omnigent/inner/coco_native_harness.py.
+    "coco-native": "omnigent.inner.coco_native_harness",
 }
 
 # Keep the historical mutable dict surface while sourcing builtins and

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -29,6 +29,7 @@ from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_plugins import (
     ANTIGRAVITY_NATIVE_CODING_AGENT,
     CLAUDE_NATIVE_CODING_AGENT,
+    COCO_NATIVE_CODING_AGENT,
     CODEX_NATIVE_CODING_AGENT,
     CURSOR_NATIVE_CODING_AGENT,
     GOOSE_NATIVE_CODING_AGENT,
@@ -165,6 +166,7 @@ _HERMES_NATIVE_AGENT_NAME = HERMES_NATIVE_CODING_AGENT.agent_name
 _ANTIGRAVITY_NATIVE_AGENT_NAME = ANTIGRAVITY_NATIVE_CODING_AGENT.agent_name
 _QWEN_NATIVE_AGENT_NAME = QWEN_NATIVE_CODING_AGENT.agent_name
 _KIMI_NATIVE_AGENT_NAME = KIMI_NATIVE_CODING_AGENT.agent_name
+_COCO_NATIVE_AGENT_NAME = COCO_NATIVE_CODING_AGENT.agent_name
 _DEBBY_AGENT_NAME = "debby"
 _POLLY_AGENT_NAME = "polly"
 _UNMATCHED_ROUTE_TEMPLATE = "<unmatched>"
@@ -452,6 +454,7 @@ def _ensure_default_agents(
     _ensure_default_antigravity_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_qwen_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_kimi_native_agent(agent_store, artifact_store, agent_cache)
+    _ensure_default_coco_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_debby_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_polly_agent(agent_store, artifact_store, agent_cache)
     _ensure_extra_builtin_agents(agent_store, artifact_store, agent_cache)
@@ -953,6 +956,34 @@ def _ensure_default_kimi_native_agent(
         agent_cache,
         name=_KIMI_NATIVE_AGENT_NAME,
         bundle_bytes=_build_kimi_native_bundle(),
+    )
+
+
+def _build_coco_native_bundle() -> bytes:
+    """Build a gzipped tarball of the coco-native-ui agent spec."""
+    import tempfile
+
+    from omnigent.coco_native import _materialize_coco_agent_spec
+    from omnigent.spec import materialize_bundle
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        spec_path = _materialize_coco_agent_spec(Path(tmpdir))
+        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
+        return _tar_gz_dir(bundle_dir)
+
+
+def _ensure_default_coco_agent(
+    agent_store: AgentStore,
+    artifact_store: ArtifactStore,
+    agent_cache: Any,
+) -> None:
+    """Register or refresh the coco-native-ui agent."""
+    _ensure_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_cache,
+        name=_COCO_NATIVE_AGENT_NAME,
+        bundle_bytes=_build_coco_native_bundle(),
     )
 
 

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -91,6 +91,7 @@ OMNIGENT_HARNESSES = frozenset(
         "antigravity-native",
         "claude-native",
         "claude-sdk",
+        "coco-native",
         "codex",
         "codex-native",
         "copilot",
@@ -130,6 +131,9 @@ OMNIGENT_HARNESS_ALIASES = frozenset(
         "native-hermes",
         "github-copilot",
         "native-kimi",
+        "coco",
+        "cortex",
+        "native-coco",
     }
 )
 _OMNIGENT_ACCEPTED_HARNESSES = OMNIGENT_HARNESSES | OMNIGENT_HARNESS_ALIASES

--- a/omnigent/terminals/pane_reaper.py
+++ b/omnigent/terminals/pane_reaper.py
@@ -51,6 +51,7 @@ _logger = logging.getLogger(__name__)
 NATIVE_PANE_TERMINAL_NAMES: frozenset[str] = frozenset(
     {
         "claude",
+        "coco",
         "codex",
         "cursor",
         "goose",

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1638,7 +1638,7 @@ def _overview_row_names(options: list[str], selectable: list[bool]) -> list[str]
 def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeypatch) -> None:
     """The overview shows every harness on one compact row, in 0.3 priority order.
 
-    No "More" folding: all thirteen harnesses are visible at once, followed by
+    No "More" folding: all fourteen harnesses are visible at once, followed by
     Quit. A regression that hides a harness, reorders the core six, or
     reintroduces a collapse row fails here. The menu also opts into the compact
     top-level rendering.
@@ -1659,6 +1659,7 @@ def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeyp
         "Copilot",
         "Kiro",
         "Kimi Code",
+        "Snowflake CoCo",
         "Custom ACP agent",
         "Quit",
     ]
@@ -1860,7 +1861,8 @@ def test_overview_truncates_long_status_for_narrow_terminal(isolated_config, mon
         ("10", "_manage_copilot_harness"),
         ("11", "_manage_kiro_harness"),
         ("12", "_manage_kimi_harness"),
-        ("13", "_add_acp_agent"),
+        ("13", "_manage_coco_harness"),
+        ("14", "_add_acp_agent"),
     ],
 )
 def test_overview_dispatches_to_correct_manager(

--- a/tests/inner/test_coco_native_executor.py
+++ b/tests/inner/test_coco_native_executor.py
@@ -1,0 +1,92 @@
+"""Unit tests for CocoNativeExecutor — the harness-side tmux injector."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.inner import coco_native_executor as cne
+from omnigent.inner.executor import ExecutorError, TurnComplete
+
+
+def test_supports_flags(tmp_path: Path) -> None:
+    ex = cne.CocoNativeExecutor(bridge_dir=tmp_path)
+    assert ex.supports_streaming() is False
+    assert ex.supports_live_message_queue() is True
+
+
+def test_content_to_text_plain_and_parts(tmp_path: Path) -> None:
+    assert cne._content_to_text("hello", tmp_path) == "hello"
+    blocks = [{"type": "input_text", "text": "a"}, {"type": "text", "text": "b"}]
+    assert cne._content_to_text(blocks, tmp_path) == "a\n\nb"
+
+
+def test_latest_user_text_picks_last_user(tmp_path: Path) -> None:
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply"},
+        {"role": "user", "content": "second"},
+    ]
+    assert cne._latest_user_text(messages, tmp_path) == "second"
+
+
+def test_bridge_dir_from_env_requires_var(monkeypatch) -> None:
+    monkeypatch.delenv(cne.BRIDGE_DIR_ENV_VAR, raising=False)
+    with pytest.raises(RuntimeError):
+        cne._bridge_dir_from_env()
+
+
+async def test_run_turn_injects_latest_user_message(tmp_path: Path, monkeypatch) -> None:
+    injected: list[tuple[Path, str]] = []
+
+    def _fake_inject(bridge_dir: Path, *, content: str) -> None:
+        injected.append((bridge_dir, content))
+
+    monkeypatch.setattr(cne, "inject_user_message", _fake_inject)
+    ex = cne.CocoNativeExecutor(bridge_dir=tmp_path)
+    events = [e async for e in ex.run_turn([{"role": "user", "content": "do it"}], [], "")]
+    assert injected == [(tmp_path, "do it")]
+    assert len(events) == 1 and isinstance(events[0], TurnComplete)
+    assert events[0].response is None
+
+
+async def test_run_turn_errors_with_no_user_text(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(cne, "inject_user_message", lambda *a, **k: None)
+    ex = cne.CocoNativeExecutor(bridge_dir=tmp_path)
+    events = [e async for e in ex.run_turn([{"role": "assistant", "content": "x"}], [], "")]
+    assert len(events) == 1 and isinstance(events[0], ExecutorError)
+
+
+async def test_run_turn_errors_when_injection_fails(tmp_path: Path, monkeypatch) -> None:
+    def _boom(bridge_dir: Path, *, content: str) -> None:
+        raise RuntimeError("tmux pane gone")
+
+    monkeypatch.setattr(cne, "inject_user_message", _boom)
+    ex = cne.CocoNativeExecutor(bridge_dir=tmp_path)
+    events = [e async for e in ex.run_turn([{"role": "user", "content": "go"}], [], "")]
+    assert len(events) == 1 and isinstance(events[0], ExecutorError)
+    assert "tmux pane gone" in events[0].message
+
+
+async def test_enqueue_session_message_injects(tmp_path: Path, monkeypatch) -> None:
+    seen: list[str] = []
+    monkeypatch.setattr(
+        cne, "inject_user_message", lambda bridge_dir, *, content: seen.append(content)
+    )
+    ex = cne.CocoNativeExecutor(bridge_dir=tmp_path)
+    assert await ex.enqueue_session_message("main", "steer") is True
+    assert seen == ["steer"]
+    # Empty content is a no-op (no injection).
+    assert await ex.enqueue_session_message("main", "") is False
+
+
+async def test_enqueue_session_message_false_on_injection_error(
+    tmp_path: Path, monkeypatch
+) -> None:
+    def _boom(bridge_dir: Path, *, content: str) -> None:
+        raise RuntimeError("tmux pane gone")
+
+    monkeypatch.setattr(cne, "inject_user_message", _boom)
+    ex = cne.CocoNativeExecutor(bridge_dir=tmp_path)
+    assert await ex.enqueue_session_message("main", "steer") is False

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -188,6 +188,12 @@ def test_configured_harness_map_covers_all_spellings(
         "hermes",
         "hermes-native",
         "native-hermes",
+        # Snowflake CoCo — native TUI (``omni coco``); all spellings gate on
+        # the ``cortex`` CLI.
+        "coco",
+        "coco-native",
+        "native-coco",
+        "cortex",
         # Generic ACP harness — config-gated (≥1 agent in the acp: block), no CLI
         # binary of its own; the acp:<slug> picks are config-derived, not keyed here.
         "acp",

--- a/tests/test_coco_native.py
+++ b/tests/test_coco_native.py
@@ -1,0 +1,45 @@
+"""Unit tests for the omni coco CLI-side helpers (no server needed)."""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from omnigent import coco_native as cn
+
+
+def test_resolve_coco_executable_found() -> None:
+    resolved = cn.resolve_coco_executable(
+        env={}, which=lambda cmd: f"/usr/local/bin/{cmd}" if cmd == "cortex" else None
+    )
+    assert resolved == "/usr/local/bin/cortex"
+
+
+def test_resolve_coco_executable_honors_path_override() -> None:
+    resolved = cn.resolve_coco_executable(
+        env={"OMNIGENT_CORTEX_PATH": "/opt/cortex"},
+        which=lambda cmd: cmd if cmd == "/opt/cortex" else None,
+    )
+    assert resolved == "/opt/cortex"
+
+
+def test_resolve_coco_executable_missing_raises_with_hint() -> None:
+    with pytest.raises(click.ClickException) as exc:
+        cn.resolve_coco_executable(env={}, which=lambda _cmd: None)
+    assert "install.sh" in str(exc.value)
+    assert "OMNIGENT_CORTEX_PATH" in str(exc.value)
+
+
+def test_build_coco_launch_argv() -> None:
+    launch = cn.build_coco_launch(
+        ["--resume", "abc"],
+        env={},
+        which=lambda cmd: f"/bin/{cmd}",
+    )
+    assert launch.executable == "/bin/cortex"
+    assert launch.argv == ["/bin/cortex", "--resume", "abc"]
+
+
+def test_terminal_resource_id_stable() -> None:
+    assert cn.coco_terminal_resource_id() == cn.coco_terminal_resource_id()
+    assert cn.coco_terminal_resource_id().startswith("terminal_")

--- a/tests/test_coco_native_bridge.py
+++ b/tests/test_coco_native_bridge.py
@@ -1,0 +1,310 @@
+"""Unit tests for the coco-native tmux bridge (no real tmux or cortex needed)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from omnigent import coco_native_bridge as b
+
+
+def test_bridge_dir_is_per_session_and_under_root() -> None:
+    d1 = b.bridge_dir_for_session_id("conv_a")
+    d2 = b.bridge_dir_for_session_id("conv_b")
+    assert d1 != d2
+    assert d1.parent == b.bridge_root()
+    # Deterministic for the same session id.
+    assert d1 == b.bridge_dir_for_session_id("conv_a")
+
+
+def test_build_spawn_env_publishes_bridge_dir(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(b, "_BRIDGE_ROOT", tmp_path / "coco-native")
+    env = b.build_coco_native_spawn_env("conv_x")
+    assert env[b.BRIDGE_DIR_ENV_VAR] == str(b.bridge_dir_for_session_id("conv_x"))
+    # The dir is created so the executor can read the advertised target.
+    assert Path(env[b.BRIDGE_DIR_ENV_VAR]).is_dir()
+
+
+def test_write_then_read_tmux_target_roundtrip(tmp_path) -> None:
+    b.write_tmux_target(tmp_path, socket_path=Path("/tmp/sock"), tmux_target="sess:0.0", pid=42)
+    info = b.read_tmux_info(tmp_path)
+    assert info == {"socket_path": "/tmp/sock", "tmux_target": "sess:0.0"}
+
+
+def test_read_tmux_info_missing_and_malformed(tmp_path) -> None:
+    assert b.read_tmux_info(tmp_path) is None  # no tmux.json
+    (tmp_path / "tmux.json").write_text("not json", encoding="utf-8")
+    assert b.read_tmux_info(tmp_path) is None
+    (tmp_path / "tmux.json").write_text(json.dumps({"socket_path": ""}), encoding="utf-8")
+    assert b.read_tmux_info(tmp_path) is None  # incomplete
+
+
+def test_paste_payload_bytes_normalizes() -> None:
+    out = b._paste_payload_bytes("a\r\nb\tc\x1b\n")
+    # \r\n and \n → CR (0x0D); tab kept; ESC (control) dropped.
+    assert out == b"a\rb\tc\r"
+
+
+def test_paste_payload_bytes_lone_cr_and_unicode() -> None:
+    # Lone \r normalizes like \n; non-ASCII text survives as UTF-8.
+    assert b._paste_payload_bytes("x\ry\x00é") == b"x\ry\xc3\xa9"
+
+
+def test_submit_needle_prefers_last_qualifying_line() -> None:
+    assert b._submit_needle("hi\nthere is a longer tail line") == "there is a longer tail l"
+    # Truncated to 24 chars.
+    assert len(b._submit_needle("x" * 80)) == 24
+    # Too-short content yields no needle (blind-submit path).
+    assert b._submit_needle("ok") == ""
+
+
+def test_submit_needle_falls_back_to_stripped_content() -> None:
+    # No line is >= 4 chars on its own, but the stripped whole qualifies.
+    assert b._submit_needle("ab\ncd") == "ab\ncd"
+
+
+def _write_user_home(tmp_path, monkeypatch, *, hooks_json: str | None = None) -> Path:
+    """Create a fake user ``~/.snowflake`` and point SNOWFLAKE_HOME at it."""
+    user_home = tmp_path / "user_snowflake"
+    (user_home / "cortex" / "conversations").mkdir(parents=True)
+    (user_home / "connections.toml").write_text("[default]\n", encoding="utf-8")
+    (user_home / "cortex" / "config.toml").write_text("model = 'x'\n", encoding="utf-8")
+    if hooks_json is not None:
+        (user_home / "cortex" / "hooks.json").write_text(hooks_json, encoding="utf-8")
+    monkeypatch.setenv("SNOWFLAKE_HOME", str(user_home))
+    return user_home
+
+
+def test_write_coco_home_symlinks_and_hooks(tmp_path, monkeypatch) -> None:
+    user_home = _write_user_home(tmp_path, monkeypatch)
+    bridge_dir = tmp_path / "bridge"
+
+    home = b.write_coco_home(bridge_dir)
+
+    assert home == bridge_dir / "snowflake_home"
+    # Top-level entries symlinked, except the cortex dir itself.
+    link = home / "connections.toml"
+    assert link.is_symlink() and link.resolve() == (user_home / "connections.toml").resolve()
+    assert not (home / "cortex").is_symlink()
+    # cortex children symlinked, except hooks.json.
+    conv = home / "cortex" / "conversations"
+    assert conv.is_symlink()
+    assert conv.resolve() == (user_home / "cortex" / "conversations").resolve()
+    assert (home / "cortex" / "config.toml").is_symlink()
+    hooks_path = home / "cortex" / "hooks.json"
+    assert hooks_path.is_file() and not hooks_path.is_symlink()
+
+    hooks = json.loads(hooks_path.read_text(encoding="utf-8"))["hooks"]
+    assert set(hooks) == {"SessionStart", "UserPromptSubmit", "Stop"}
+    for event in ("SessionStart", "UserPromptSubmit", "Stop"):
+        groups = hooks[event]
+        assert len(groups) == 1
+        (hook,) = groups[0]["hooks"]
+        assert hook["type"] == "command"
+        assert "coco_native_hook.py" in hook["command"]
+        assert str(bridge_dir) in hook["command"]
+        assert sys.executable in hook["command"]
+
+
+def test_write_coco_home_merges_wrapped_user_hooks(tmp_path, monkeypatch) -> None:
+    user_group = {"hooks": [{"type": "command", "command": "echo user"}]}
+    _write_user_home(
+        tmp_path,
+        monkeypatch,
+        hooks_json=json.dumps({"hooks": {"Stop": [user_group], "PreToolUse": [user_group]}}),
+    )
+
+    home = b.write_coco_home(tmp_path / "bridge")
+
+    hooks = json.loads((home / "cortex" / "hooks.json").read_text(encoding="utf-8"))["hooks"]
+    # The user's Stop group is kept, with the Omnigent relay appended after it.
+    assert hooks["Stop"][0] == user_group
+    assert "coco_native_hook.py" in hooks["Stop"][1]["hooks"][0]["command"]
+    # Events the bridge does not register survive untouched.
+    assert hooks["PreToolUse"] == [user_group]
+
+
+def test_write_coco_home_merges_bare_map_user_hooks(tmp_path, monkeypatch) -> None:
+    user_group = {"hooks": [{"type": "command", "command": "echo bare"}]}
+    _write_user_home(tmp_path, monkeypatch, hooks_json=json.dumps({"SessionStart": [user_group]}))
+
+    home = b.write_coco_home(tmp_path / "bridge")
+
+    hooks = json.loads((home / "cortex" / "hooks.json").read_text(encoding="utf-8"))["hooks"]
+    assert hooks["SessionStart"][0] == user_group
+    assert "coco_native_hook.py" in hooks["SessionStart"][1]["hooks"][0]["command"]
+
+
+def test_write_coco_home_tolerates_malformed_user_hooks(tmp_path, monkeypatch) -> None:
+    _write_user_home(tmp_path, monkeypatch, hooks_json="{not json!")
+
+    home = b.write_coco_home(tmp_path / "bridge")
+
+    hooks = json.loads((home / "cortex" / "hooks.json").read_text(encoding="utf-8"))["hooks"]
+    # Malformed user config degrades to Omnigent-only hooks, not a failure.
+    assert set(hooks) == {"SessionStart", "UserPromptSubmit", "Stop"}
+
+
+def test_write_coco_home_is_idempotent(tmp_path, monkeypatch) -> None:
+    user_home = _write_user_home(tmp_path, monkeypatch)
+    bridge_dir = tmp_path / "bridge"
+    home = b.write_coco_home(bridge_dir)
+    # A file appearing in the user's home after the first run gets linked too.
+    (user_home / "config.toml").write_text("x = 1\n", encoding="utf-8")
+
+    assert b.write_coco_home(bridge_dir) == home
+
+    assert (home / "config.toml").is_symlink()
+    hooks = json.loads((home / "cortex" / "hooks.json").read_text(encoding="utf-8"))["hooks"]
+    # Re-running does not stack duplicate Omnigent hook groups.
+    for event in ("SessionStart", "UserPromptSubmit", "Stop"):
+        assert len(hooks[event]) == 1
+
+
+def test_read_coco_home(tmp_path) -> None:
+    assert b.read_coco_home(tmp_path) is None
+    (tmp_path / "snowflake_home").mkdir()
+    assert b.read_coco_home(tmp_path) == tmp_path / "snowflake_home"
+
+
+def test_coco_session_recording_exists(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("SNOWFLAKE_HOME", str(tmp_path))
+    assert b.coco_session_recording_exists("") is False
+    assert b.coco_session_recording_exists("sess-1") is False
+    conv = tmp_path / "cortex" / "conversations"
+    conv.mkdir(parents=True)
+    (conv / "sess-1.history.jsonl").write_text("{}\n", encoding="utf-8")
+    assert b.coco_session_recording_exists("sess-1") is True
+    assert b.coco_session_recording_exists("sess-2") is False
+
+
+def _patch_inject_tmux(monkeypatch, calls: list[tuple[str, ...]]) -> None:
+    """Common monkeypatches: live pane, instant settle, capture shows needle."""
+    monkeypatch.setattr(
+        b, "_wait_for_tmux_info", lambda *_a, **_k: {"socket_path": "/s", "tmux_target": "t"}
+    )
+    monkeypatch.setattr(b, "_session_alive", lambda *_a, **_k: True)
+    monkeypatch.setattr(b, "_settle_pane", lambda *_a, **_k: None)
+    # Pane already shows the needle so the commit-wait returns immediately.
+    monkeypatch.setattr(b, "_capture_pane", lambda *_a, **_k: "do something now")
+    monkeypatch.setattr(b.time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(b, "_run_tmux", lambda _sock, *args: calls.append(args))
+
+
+def test_inject_user_message_clears_pastes_and_submits(tmp_path, monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+    _patch_inject_tmux(monkeypatch, calls)
+
+    b.inject_user_message(tmp_path, content="do something now")
+
+    # Draft cleared (C-a, C-k), buffer loaded + bracketed paste, one Enter.
+    assert calls[0] == ("send-keys", "-t", "t", "C-a")
+    assert calls[1] == ("send-keys", "-t", "t", "C-k")
+    assert calls[2][0] == "load-buffer"
+    assert calls[3][0] == "paste-buffer" and "-p" in calls[3]
+    assert calls[4] == ("send-keys", "-t", "t", "Enter")
+    assert len(calls) == 5
+    # The temp paste file is cleaned up.
+    assert not list(tmp_path.glob("paste_*.bin"))
+
+
+def test_inject_user_message_requires_content(tmp_path) -> None:
+    with pytest.raises(RuntimeError, match="non-empty"):
+        b.inject_user_message(tmp_path, content="")
+
+
+def test_inject_user_message_raises_when_target_never_advertised(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(b.time, "sleep", lambda *_a, **_k: None)
+    with pytest.raises(RuntimeError, match="not advertised"):
+        b.inject_user_message(tmp_path, content="hi", timeout_s=0.05)
+
+
+def test_inject_user_message_dead_pane_raises(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        b, "_wait_for_tmux_info", lambda *_a, **_k: {"socket_path": "/s", "tmux_target": "t"}
+    )
+    monkeypatch.setattr(b, "_session_alive", lambda *_a, **_k: False)
+    with pytest.raises(RuntimeError, match="no longer running"):
+        b.inject_user_message(tmp_path, content="hi")
+
+
+def test_inject_interrupt_sends_escape_key_name(tmp_path, monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(
+        b, "_wait_for_tmux_info", lambda *_a, **_k: {"socket_path": "/s", "tmux_target": "t"}
+    )
+    monkeypatch.setattr(b, "_run_tmux", lambda _sock, *args: calls.append(args))
+    b.inject_interrupt(tmp_path)
+    # No ``-l``: Escape must be interpreted as a key name, not literal text.
+    assert calls == [("send-keys", "-t", "t", "Escape")]
+
+
+def test_kill_session_kills_target(tmp_path, monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(
+        b, "_wait_for_tmux_info", lambda *_a, **_k: {"socket_path": "/s", "tmux_target": "t"}
+    )
+    monkeypatch.setattr(b, "_run_tmux", lambda _sock, *args: calls.append(args))
+    b.kill_session(tmp_path)
+    assert calls == [("kill-session", "-t", "t")]
+
+
+def test_capture_pane_none_when_no_target_or_dead(tmp_path, monkeypatch) -> None:
+    assert b.capture_coco_pane(tmp_path) is None  # no tmux.json
+    monkeypatch.setattr(b, "read_tmux_info", lambda _d: {"socket_path": "/s", "tmux_target": "t"})
+    monkeypatch.setattr(b, "_session_alive", lambda *_a, **_k: False)
+    assert b.capture_coco_pane(tmp_path) is None
+
+
+def test_capture_pane_returns_text_when_alive(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(b, "read_tmux_info", lambda _d: {"socket_path": "/s", "tmux_target": "t"})
+    monkeypatch.setattr(b, "_session_alive", lambda *_a, **_k: True)
+    monkeypatch.setattr(b, "_capture_pane", lambda *_a, **_k: "pane text")
+    assert b.capture_coco_pane(tmp_path) == "pane text"
+
+
+def test_write_coco_home_heals_broken_symlinks(tmp_path, monkeypatch) -> None:
+    """A symlink whose target vanished since the last launch is re-created."""
+    from omnigent.coco_native_bridge import write_coco_home
+
+    user_home = tmp_path / "snowflake"
+    (user_home / "cortex").mkdir(parents=True)
+    (user_home / "connections.toml").write_text("[default]\n", encoding="utf-8")
+    monkeypatch.setenv("SNOWFLAKE_HOME", str(user_home))
+    bridge = tmp_path / "bridge"
+
+    home = write_coco_home(bridge)
+    link = home / "connections.toml"
+    assert link.is_symlink() and link.exists()
+
+    # Simulate the user's file being replaced (delete + recreate): the old
+    # link target vanishes, leaving a broken symlink in the per-session home.
+    (user_home / "connections.toml").unlink()
+    assert link.is_symlink() and not link.exists()
+    (user_home / "connections.toml").write_text("[default]\nname='new'\n", encoding="utf-8")
+
+    write_coco_home(bridge)
+    assert link.exists() and "new" in link.read_text(encoding="utf-8")
+
+
+def test_write_coco_home_creates_user_conversations_dir_on_first_run(
+    tmp_path, monkeypatch
+) -> None:
+    """First run (no ~/.snowflake yet): the user-side conversations store is
+    created and symlinked, so transcripts land in the durable user home rather
+    than a real dir inside the throwaway bridge dir."""
+    from omnigent.coco_native_bridge import write_coco_home
+
+    user_home = tmp_path / "fresh-snowflake"
+    assert not user_home.exists()
+    monkeypatch.setenv("SNOWFLAKE_HOME", str(user_home))
+    bridge = tmp_path / "bridge"
+
+    home = write_coco_home(bridge)
+    assert (user_home / "cortex" / "conversations").is_dir()
+    link = home / "cortex" / "conversations"
+    assert link.is_symlink()
+    assert link.resolve() == (user_home / "cortex" / "conversations").resolve()

--- a/tests/test_coco_native_forwarder.py
+++ b/tests/test_coco_native_forwarder.py
@@ -1,0 +1,621 @@
+"""Unit tests for the coco-native hook-event forwarder.
+
+Builds fixture ``hook_events.jsonl`` + ``<session_id>.history.jsonl`` files
+matching CoCo v1.1.1's verified shapes (Anthropic-style ``text`` / ``tool_use``
+/ ``tool_result`` content blocks) and exercises the durable cursor round trip,
+partial-line-safe event tailing, history-path derivation, block-to-item
+mapping, and 1-based history line numbering. The poll-loop tests at the bottom
+drive ``forward_coco_events_to_session`` end to end against a recording poster
+to pin session adoption (resume seeds the cursor, no re-mirror), the per-turn
+``coco:turn:<n>`` running/idle lifecycle, the stalled-turn backstop, and the
+supervisor's crash-restart backoff.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from omnigent import coco_native_forwarder as f
+from omnigent.coco_native_hook import HOOK_EVENTS_FILE
+
+# ── state persistence ─────────────────────────────────────────────────────────
+
+
+def test_state_roundtrip(tmp_path: Path) -> None:
+    state = f._ForwardState(
+        coco_session_id="coco-1",
+        history_path="/conv/coco-1.history.jsonl",
+        last_line=5,
+        events_offset=123,
+        turn_seq=2,
+    )
+    assert f._write_state(tmp_path, state) is True
+    loaded = f._read_state(tmp_path)
+    assert loaded == state
+
+
+def test_read_state_missing_or_corrupt_is_cold_default(tmp_path: Path) -> None:
+    assert f._read_state(tmp_path) == f._ForwardState()
+    (tmp_path / "coco_forwarder.json").write_text("not-json", encoding="utf-8")
+    assert f._read_state(tmp_path) == f._ForwardState()
+    # A JSON scalar (not an object) is also cold.
+    (tmp_path / "coco_forwarder.json").write_text('"hi"', encoding="utf-8")
+    assert f._read_state(tmp_path) == f._ForwardState()
+    # Wrong-typed / negative fields fall back per-field.
+    (tmp_path / "coco_forwarder.json").write_text(
+        json.dumps({"coco_session_id": 7, "last_line": -1, "turn_seq": 3}), encoding="utf-8"
+    )
+    loaded = f._read_state(tmp_path)
+    assert loaded.coco_session_id is None
+    assert loaded.last_line == 0
+    assert loaded.turn_seq == 3
+
+
+def test_clear_coco_bridge_state_removes_state_and_event_log(tmp_path: Path) -> None:
+    f._write_state(tmp_path, f._ForwardState(coco_session_id="coco-1"))
+    (tmp_path / HOOK_EVENTS_FILE).write_text('{"hook_event_name": "Stop"}\n', encoding="utf-8")
+    f.clear_coco_bridge_state(tmp_path)
+    assert not (tmp_path / "coco_forwarder.json").exists()
+    assert not (tmp_path / HOOK_EVENTS_FILE).exists()
+    assert f._read_state(tmp_path) == f._ForwardState()
+    # Clearing an already-clean dir is a no-op, not an error.
+    f.clear_coco_bridge_state(tmp_path)
+
+
+# ── _read_new_events ──────────────────────────────────────────────────────────
+
+
+def test_read_new_events_missing_file(tmp_path: Path) -> None:
+    events, offset = f._read_new_events(tmp_path / HOOK_EVENTS_FILE, 3)
+    assert events == []
+    assert offset == 3
+
+
+def test_read_new_events_leaves_trailing_partial_unconsumed(tmp_path: Path) -> None:
+    path = tmp_path / HOOK_EVENTS_FILE
+    whole = b'{"hook_event_name": "SessionStart"}\n'
+    path.write_bytes(whole + b'{"hook_event_name": "St')  # hook mid-write
+    events, offset = f._read_new_events(path, 0)
+    assert [e["hook_event_name"] for e in events] == ["SessionStart"]
+    assert offset == len(whole)  # the partial line stays for the next poll
+    # The write completes; the next poll picks it up whole from the offset.
+    with open(path, "ab") as fh:
+        fh.write(b'op"}\n')
+    events, offset = f._read_new_events(path, offset)
+    assert [e["hook_event_name"] for e in events] == ["Stop"]
+    assert offset == path.stat().st_size
+
+
+def test_read_new_events_skips_malformed_interior_lines(tmp_path: Path) -> None:
+    path = tmp_path / HOOK_EVENTS_FILE
+    path.write_bytes(b'{"a": 1}\nnot-json\n[1, 2]\n{"b": 2}\n')
+    events, offset = f._read_new_events(path, 0)
+    # Bad JSON and non-dict lines are dropped but still consumed.
+    assert events == [{"a": 1}, {"b": 2}]
+    assert offset == path.stat().st_size
+    # Fully consumed: a re-read from the new offset yields nothing.
+    assert f._read_new_events(path, offset) == ([], offset)
+
+
+# ── _history_path_for_transcript ──────────────────────────────────────────────
+
+
+def test_history_path_for_transcript_shapes() -> None:
+    assert f._history_path_for_transcript("/conv/S1.json") == "/conv/S1.history.jsonl"
+    # Already the history file -> passthrough.
+    assert f._history_path_for_transcript("/conv/S1.history.jsonl") == "/conv/S1.history.jsonl"
+    assert f._history_path_for_transcript("") is None
+    assert f._history_path_for_transcript("/conv/S1.txt") is None
+
+
+# ── _message_to_items ─────────────────────────────────────────────────────────
+
+
+def test_message_to_items_user_text_strips_attachment_marker() -> None:
+    obj = {"role": "user", "content": [{"type": "text", "text": "hi [Attached: /x.png]"}]}
+    items = f._message_to_items(3, obj, "coco", "coco:turn:1")
+    assert len(items) == 1
+    assert items[0].item_type == "message"
+    assert items[0].item_data == {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "hi"}],
+    }
+    # User bubbles keep the per-line id even while a turn is open.
+    assert items[0].response_id == "coco:3"
+
+
+def test_message_to_items_assistant_text() -> None:
+    obj = {"role": "assistant", "content": [{"type": "text", "text": "hello"}]}
+    items = f._message_to_items(4, obj, "coco-native-ui", "coco:turn:2")
+    assert len(items) == 1
+    assert items[0].item_type == "message"
+    assert items[0].item_data["agent"] == "coco-native-ui"
+    assert items[0].item_data["content"] == [{"type": "output_text", "text": "hello"}]
+    assert items[0].response_id == "coco:turn:2"
+
+
+def test_message_to_items_assistant_falls_back_to_per_line_id() -> None:
+    obj = {"role": "assistant", "content": [{"type": "text", "text": "hello"}]}
+    items = f._message_to_items(7, obj, "coco", None)
+    assert items[0].response_id == "coco:7"
+
+
+def test_message_to_items_tool_use() -> None:
+    obj = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Running ls"},
+            {
+                "type": "tool_use",
+                "tool_use": {"tool_use_id": "tu_1", "name": "bash", "input": {"command": "ls"}},
+            },
+        ],
+    }
+    items = f._message_to_items(5, obj, "coco", "coco:turn:1")
+    assert [i.item_type for i in items] == ["function_call", "message"]
+    fc = items[0]
+    assert fc.item_data["call_id"] == "tu_1"
+    assert fc.item_data["name"] == "bash"
+    assert json.loads(fc.item_data["arguments"]) == {"command": "ls"}
+    assert fc.response_id == "coco:turn:1"
+
+
+def test_message_to_items_tool_use_requires_call_id_and_assistant_role() -> None:
+    block = {"type": "tool_use", "tool_use": {"name": "bash", "input": {}}}  # no tool_use_id
+    assert f._message_to_items(1, {"role": "assistant", "content": [block]}, "coco", None) == []
+    # A user-row tool_use (never valid in CoCo history) is ignored.
+    block = {"type": "tool_use", "tool_use": {"tool_use_id": "tu_x", "name": "bash"}}
+    assert f._message_to_items(1, {"role": "user", "content": [block]}, "coco", None) == []
+
+
+def test_message_to_items_tool_result_content_shapes() -> None:
+    def result_row(content: Any) -> dict[str, Any]:
+        block = {"type": "tool_result", "tool_result": {"tool_use_id": "tu_1", "content": content}}
+        return {"role": "user", "content": [block]}
+
+    # Plain-string content.
+    items = f._message_to_items(6, result_row("file.txt"), "coco", "coco:turn:1")
+    assert len(items) == 1
+    assert items[0].item_type == "function_call_output"
+    assert items[0].item_data == {"call_id": "tu_1", "output": "file.txt"}
+    assert items[0].response_id == "coco:turn:1"
+    # List content flattens strings and text parts; non-text parts are dropped.
+    mixed = ["a", {"type": "text", "text": "b"}, {"type": "image", "source": {}}, 42]
+    items = f._message_to_items(6, result_row(mixed), "coco", None)
+    assert items[0].item_data["output"] == "ab"
+    # Unrecognized content -> empty output, item still posted for the call.
+    items = f._message_to_items(6, result_row(None), "coco", None)
+    assert items[0].item_data["output"] == ""
+
+
+def test_message_to_items_skips_image_nondict_and_unknown_roles() -> None:
+    obj = {
+        "role": "assistant",
+        "content": [{"type": "image", "source": {"data": "..."}}, "stray-string", 42],
+    }
+    assert f._message_to_items(1, obj, "coco", None) == []
+    assert (
+        f._message_to_items(1, {"role": "system", "content": [{"type": "text"}]}, "coco", None)
+        == []
+    )
+    assert f._message_to_items(1, {"role": "user", "content": "not-a-list"}, "coco", None) == []
+
+
+# ── _read_history_lines ───────────────────────────────────────────────────────
+
+
+def _user_row(text: str) -> str:
+    return json.dumps({"role": "user", "content": [{"type": "text", "text": text}]})
+
+
+def _assistant_row(text: str) -> str:
+    return json.dumps({"role": "assistant", "content": [{"type": "text", "text": text}]})
+
+
+def test_read_history_lines_numbers_past_cursor(tmp_path: Path) -> None:
+    path = tmp_path / "S1.history.jsonl"
+    path.write_text(_user_row("one") + "\n" + _assistant_row("two") + "\n", encoding="utf-8")
+    rows = f._read_history_lines(str(path), 0)
+    assert [n for n, _ in rows] == [1, 2]
+    assert rows[1][1]["role"] == "assistant"
+    # Resuming past line 1 yields only line 2.
+    rows = f._read_history_lines(str(path), 1)
+    assert [n for n, _ in rows] == [2]
+    assert f._read_history_lines(str(path), 2) == []
+    assert f._read_history_lines(str(tmp_path / "missing.jsonl"), 0) == []
+
+
+def test_read_history_lines_trailing_partial_excluded_interior_bad_advances(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "S1.history.jsonl"
+    path.write_text(
+        _user_row("one") + "\n" + "not-json\n" + _assistant_row("three") + "\n" + '{"partial',
+        encoding="utf-8",
+    )
+    rows = f._read_history_lines(str(path), 0)
+    # The interior bad line yields an empty row (so the cursor still advances
+    # past it); the unterminated tail is mid-write and excluded entirely.
+    assert rows == [
+        (1, json.loads(_user_row("one"))),
+        (2, {}),
+        (3, json.loads(_assistant_row("three"))),
+    ]
+
+
+# ── poll-loop lifecycle ───────────────────────────────────────────────────────
+
+_SID = "coco-sess-1"
+
+
+class _Recorder:
+    """Records every status edge and mirrored item the loop posts, in order."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, str | None]] = []
+
+    async def post_status(self, client, *, session_id, status, response_id=None, **_) -> None:
+        self.events.append(("status", status, response_id))
+
+    async def post_item(self, client, *, session_id, item) -> None:
+        self.events.append(("item", item.item_type, item.response_id))
+
+    def statuses(self) -> list[tuple[str, str | None]]:
+        return [(status, rid) for kind, status, rid in self.events if kind == "status"]
+
+
+class _Fixture:
+    """A bridge dir + conversations dir wired like the coco-native bridge."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.bridge_dir = tmp_path / "bridge"
+        self.bridge_dir.mkdir()
+        conversations = tmp_path / "conversations"
+        conversations.mkdir()
+        self.transcript_path = conversations / f"{_SID}.json"
+        self.history_path = conversations / f"{_SID}.history.jsonl"
+
+    def emit(self, kind: str) -> None:
+        """Append one hook event as the CoCo lifecycle hook would."""
+        with open(self.bridge_dir / HOOK_EVENTS_FILE, "a", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {
+                        "hook_event_name": kind,
+                        "session_id": _SID,
+                        "transcript_path": str(self.transcript_path),
+                    }
+                )
+                + "\n"
+            )
+
+    def append_history(self, *rows: str) -> None:
+        with open(self.history_path, "a", encoding="utf-8") as fh:
+            for row in rows:
+                fh.write(row + "\n")
+
+
+async def _run_loop(fx: _Fixture, rec: _Recorder, monkeypatch, until, *, on_sid=None) -> None:
+    """Run the real poll loop against *fx* + *rec* until *until()* holds.
+
+    Raises if the condition is never reached within ~3s — i.e. the loop wedged
+    or the expected posts never happened.
+    """
+    monkeypatch.setattr(f, "post_external_session_status", rec.post_status)
+    monkeypatch.setattr(f, "_post_conversation_item", rec.post_item)
+    task = asyncio.create_task(
+        f.forward_coco_events_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv_1",
+            bridge_dir=fx.bridge_dir,
+            agent_name="coco-native",
+            on_coco_session_id=on_sid,
+            poll_interval_s=0.001,
+        )
+    )
+    try:
+        for _ in range(1500):
+            if until():
+                break
+            await asyncio.sleep(0.002)
+        else:
+            raise AssertionError(f"loop never reached expected state; events={rec.events}")
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+async def test_forward_loop_adopts_mirrors_turns_and_resumes(tmp_path, monkeypatch) -> None:
+    """End to end: adoption seeds the cursor past pre-existing history (resume
+    must not re-mirror what Omnigent already holds), each UserPromptSubmit/Stop
+    pair runs one ``coco:turn:<n>`` running/idle lifecycle, and the session-id
+    callback fires exactly once for the one discovered session."""
+    fx = _Fixture(tmp_path)
+    # A resumed session opens with its prior turns already flushed.
+    fx.append_history(_user_row("old ask"), _assistant_row("old answer"))
+    fx.emit("SessionStart")
+
+    seen_sids: list[str] = []
+
+    async def _on_sid(sid: str) -> None:
+        seen_sids.append(sid)
+
+    rec = _Recorder()
+    monkeypatch.setattr(f, "post_external_session_status", rec.post_status)
+    monkeypatch.setattr(f, "_post_conversation_item", rec.post_item)
+    task = asyncio.create_task(
+        f.forward_coco_events_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv_1",
+            bridge_dir=fx.bridge_dir,
+            agent_name="coco-native",
+            on_coco_session_id=_on_sid,
+            poll_interval_s=0.001,
+        )
+    )
+
+    async def _wait(until) -> None:
+        for _ in range(1500):
+            if until():
+                return
+            await asyncio.sleep(0.002)
+        raise AssertionError(f"loop never reached expected state; events={rec.events}")
+
+    try:
+        # Adoption: session id persisted, cursor seeded past the 2 old lines.
+        await _wait(lambda: f._read_state(fx.bridge_dir).coco_session_id == _SID)
+        assert f._read_state(fx.bridge_dir).last_line == 2
+        assert seen_sids == [_SID]
+        assert rec.events == []  # pre-existing history was NOT re-mirrored
+
+        # Turn 1: prompt submitted -> user bubble mirrored, running edge opens.
+        fx.append_history(_user_row("hi [Attached: /x.png]"))
+        fx.emit("UserPromptSubmit")
+        await _wait(lambda: ("status", "running", "coco:turn:1") in rec.events)
+        # The user bubble is standalone (per-line id, line 3), mirrored before
+        # the turn opened.
+        assert rec.events.index(("item", "message", "coco:3")) < rec.events.index(
+            ("status", "running", "coco:turn:1")
+        )
+
+        # Turn 1 finishes: CoCo flushes the reply, then fires Stop.
+        fx.append_history(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "on it"},
+                        {
+                            "type": "tool_use",
+                            "tool_use": {"tool_use_id": "tu_1", "name": "bash", "input": {}},
+                        },
+                    ],
+                }
+            ),
+            json.dumps(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_result": {"tool_use_id": "tu_1", "content": "ok"},
+                        }
+                    ],
+                }
+            ),
+            _assistant_row("done"),
+        )
+        fx.emit("Stop")
+        await _wait(lambda: ("status", "idle", "coco:turn:1") in rec.events)
+        # The whole reply shares the turn id and precedes the closing idle.
+        for item_type in ("function_call", "function_call_output", "message"):
+            assert ("item", item_type, "coco:turn:1") in rec.events
+        assert rec.events[-1] == ("status", "idle", "coco:turn:1")
+
+        # Turn 2 mints the next id; the callback does not re-fire.
+        fx.append_history(_user_row("again"))
+        fx.emit("UserPromptSubmit")
+        await _wait(lambda: ("status", "running", "coco:turn:2") in rec.events)
+        fx.append_history(_assistant_row("done again"))
+        fx.emit("Stop")
+        await _wait(lambda: ("status", "idle", "coco:turn:2") in rec.events)
+        assert rec.statuses() == [
+            ("running", "coco:turn:1"),
+            ("idle", "coco:turn:1"),
+            ("running", "coco:turn:2"),
+            ("idle", "coco:turn:2"),
+        ]
+        assert seen_sids == [_SID]
+        assert f._read_state(fx.bridge_dir).turn_seq == 2
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+async def test_stalled_turn_backstop_closes_without_stop(tmp_path, monkeypatch) -> None:
+    """A turn whose Stop hook never fires (killed pane, CoCo crash) is closed by
+    the inactivity backstop instead of spinning forever."""
+    monkeypatch.setattr(f, "_STALLED_TURN_IDLE_S", 0.05)
+    fx = _Fixture(tmp_path)
+    fx.history_path.touch()
+    fx.emit("SessionStart")
+    fx.emit("UserPromptSubmit")
+
+    rec = _Recorder()
+    await _run_loop(fx, rec, monkeypatch, lambda: ("status", "idle", "coco:turn:1") in rec.events)
+    assert rec.statuses() == [("running", "coco:turn:1"), ("idle", "coco:turn:1")]
+
+
+# ── supervisor ────────────────────────────────────────────────────────────────
+
+
+def _supervisor_kwargs(tmp_path: Path) -> dict[str, Any]:
+    return {
+        "base_url": "http://test",
+        "headers": {},
+        "session_id": "conv_1",
+        "bridge_dir": tmp_path / "bridge",
+        "agent_name": "coco-native",
+    }
+
+
+async def test_supervisor_restarts_with_backoff_and_propagates_cancel(
+    tmp_path, monkeypatch
+) -> None:
+    crashes = {"n": 0}
+
+    async def fake_forwarder(**_: Any) -> None:
+        crashes["n"] += 1
+        if crashes["n"] <= 3:
+            raise RuntimeError(f"simulated crash {crashes['n']}")
+        raise asyncio.CancelledError()
+
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    # Pin monotonic so every run looks instantaneous and the healthy-uptime
+    # reset branch never fires.
+    monkeypatch.setattr(f, "_supervisor_monotonic", lambda: 1000.0)
+    monkeypatch.setattr(f, "forward_coco_events_to_session", fake_forwarder)
+    monkeypatch.setattr(f, "_supervisor_sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await f.supervise_coco_forwarder(**_supervisor_kwargs(tmp_path))
+
+    # 3 crashes -> 3 doubling backoff sleeps; the CancelledError on run 4
+    # propagates without a further sleep.
+    assert sleeps == [1.0, 2.0, 4.0]
+    assert crashes["n"] == 4
+
+
+async def test_supervisor_resets_backoff_after_healthy_uptime(tmp_path, monkeypatch) -> None:
+    healthy = f._SUPERVISOR_HEALTHY_UPTIME_S
+    # Two readings per iteration (run start, run end): runs 1-2 are instant
+    # crashes, run 3 exceeds the healthy uptime so backoff resets before its
+    # post-run sleep.
+    monotonic_values = iter([0.0, 1.0, 10.0, 11.0, 20.0, 20.0 + healthy + 1.0, 200.0, 201.0])
+    crashes = {"n": 0}
+
+    async def fake_forwarder(**_: Any) -> None:
+        crashes["n"] += 1
+        if crashes["n"] >= 4:
+            raise asyncio.CancelledError()
+        raise RuntimeError("simulated crash")
+
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(f, "_supervisor_monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(f, "forward_coco_events_to_session", fake_forwarder)
+    monkeypatch.setattr(f, "_supervisor_sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await f.supervise_coco_forwarder(**_supervisor_kwargs(tmp_path))
+
+    # Run 3's healthy uptime resets the backoff to the initial value; without
+    # the reset the third sleep would be 4.0.
+    assert sleeps == [1.0, 2.0, f._SUPERVISOR_INITIAL_BACKOFF_S]
+
+
+def test_message_to_items_strips_coco_system_reminder_blocks() -> None:
+    """CoCo's injected ``<system-reminder>`` context blocks never reach the web bubble."""
+    from omnigent.coco_native_forwarder import _message_to_items
+
+    row = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "<system-reminder>\n## Rules\nstuff\n</system-reminder>\n"},
+            {"type": "text", "text": "<system-reminder>more plumbing</system-reminder>\n"},
+            {"type": "text", "text": "Reply with exactly: e2e-ok."},
+        ],
+    }
+    items = _message_to_items(3, row, "coco-native-ui", None)
+    assert len(items) == 1
+    (item,) = items
+    assert item.item_data["content"] == [
+        {"type": "input_text", "text": "Reply with exactly: e2e-ok."}
+    ]
+
+
+def test_message_to_items_reminder_only_user_row_yields_nothing() -> None:
+    """A user row that is pure injected context (no real text) mirrors nothing."""
+    from omnigent.coco_native_forwarder import _message_to_items
+
+    row = {
+        "role": "user",
+        "content": [{"type": "text", "text": "<system-reminder>only plumbing</system-reminder>"}],
+    }
+    assert _message_to_items(4, row, "coco-native-ui", None) == []
+
+
+def test_state_round_trips_turn_live(tmp_path) -> None:
+    """``turn_live`` survives a state write/read cycle (restart restore)."""
+    from omnigent.coco_native_forwarder import _ForwardState, _read_state, _write_state
+
+    state = _ForwardState(coco_session_id="sid", history_path="/x.history.jsonl", turn_seq=3)
+    state.turn_live = True
+    assert _write_state(tmp_path, state)
+    restored = _read_state(tmp_path)
+    assert restored.turn_live is True and restored.turn_seq == 3
+
+
+def test_mirror_cursor_snaps_down_when_history_shrinks(tmp_path, monkeypatch) -> None:
+    """A compacted (shorter) history file resets the cursor instead of going dead."""
+    fx = _Fixture(tmp_path)
+    fx.append_history(_user_row("hi"), _assistant_row("yo"))
+    # Persisted cursor claims five lines were already mirrored (pre-compaction).
+    f._write_state(
+        fx.bridge_dir,
+        f._ForwardState(coco_session_id=_SID, history_path=str(fx.history_path), last_line=5),
+    )
+    fx.emit("Stop")
+    rec = _Recorder()
+
+    async def _drive() -> None:
+        await _run_loop(fx, rec, monkeypatch, lambda: f._read_state(fx.bridge_dir).last_line == 2)
+
+    asyncio.run(_drive())
+    # Cursor snapped 5 -> 2 (the rewritten span counts as seen); nothing was
+    # re-mirrored, and the next appended row would mirror normally.
+    assert rec.events == []
+
+
+def test_restart_with_live_turn_closes_it_on_stop(tmp_path, monkeypatch) -> None:
+    """A restart mid-turn restores the open turn; Stop closes the ORIGINAL id."""
+    fx = _Fixture(tmp_path)
+    fx.append_history(_assistant_row("late reply"))
+    # Persisted state says turn 7 opened (running posted) before the crash.
+    f._write_state(
+        fx.bridge_dir,
+        f._ForwardState(
+            coco_session_id=_SID,
+            history_path=str(fx.history_path),
+            last_line=0,
+            turn_seq=7,
+            turn_live=True,
+        ),
+    )
+    fx.emit("Stop")
+    rec = _Recorder()
+
+    async def _drive() -> None:
+        await _run_loop(
+            fx, rec, monkeypatch, lambda: ("status", "idle", "coco:turn:7") in rec.events
+        )
+
+    asyncio.run(_drive())
+    # The restored turn id stamps the mirrored rows AND the closing idle edge;
+    # no fresh turn id was minted for the recovered turn.
+    assert ("item", "message", "coco:turn:7") in rec.events
+    assert f._read_state(fx.bridge_dir).turn_live is False

--- a/tests/test_coco_native_hook.py
+++ b/tests/test_coco_native_hook.py
@@ -1,0 +1,85 @@
+"""Tests for the coco-native lifecycle-event hook."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from omnigent import coco_native_hook
+
+
+def _feed_stdin(monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(raw))
+
+
+def _events(bridge_dir: Path) -> list[object]:
+    path = bridge_dir / coco_native_hook.HOOK_EVENTS_FILE
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_main_appends_payload_as_one_line(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A valid JSON payload is appended verbatim as one JSONL record."""
+    payload = {
+        "hook_event_name": "SessionStart",
+        "session_id": "coco-1234",
+        "transcript_path": "/tmp/conversations/coco-1234.json",
+    }
+    _feed_stdin(monkeypatch, json.dumps(payload))
+
+    exit_code = coco_native_hook.main(["--bridge-dir", str(tmp_path)])
+
+    assert exit_code == 0
+    assert _events(tmp_path) == [payload]
+
+
+def test_main_appends_across_invocations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The events file is append-only: successive hooks add lines in order."""
+    _feed_stdin(monkeypatch, json.dumps({"hook_event_name": "UserPromptSubmit"}))
+    assert coco_native_hook.main(["--bridge-dir", str(tmp_path)]) == 0
+    _feed_stdin(monkeypatch, json.dumps({"hook_event_name": "Stop"}))
+    assert coco_native_hook.main(["--bridge-dir", str(tmp_path)]) == 0
+
+    assert _events(tmp_path) == [
+        {"hook_event_name": "UserPromptSubmit"},
+        {"hook_event_name": "Stop"},
+    ]
+
+
+def test_main_empty_stdin_writes_empty_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty stdin still exits 0 and records an empty payload."""
+    _feed_stdin(monkeypatch, "")
+
+    assert coco_native_hook.main(["--bridge-dir", str(tmp_path)]) == 0
+    assert _events(tmp_path) == [{}]
+
+
+def test_main_invalid_json_never_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-JSON stdin exits 0 without raising (hook must never block the TUI)."""
+    _feed_stdin(monkeypatch, "not json at all {")
+
+    assert coco_native_hook.main(["--bridge-dir", str(tmp_path)]) == 0
+
+
+def test_main_non_dict_payload_is_wrapped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A JSON payload that is not an object is wrapped as malformed_payload."""
+    _feed_stdin(monkeypatch, json.dumps(["a", "list"]))
+
+    assert coco_native_hook.main(["--bridge-dir", str(tmp_path)]) == 0
+    assert _events(tmp_path) == [{"malformed_payload": '["a", "list"]'}]
+
+
+def test_main_unwritable_bridge_dir_never_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing/unwritable bridge dir still exits 0 (failure stays silent)."""
+    _feed_stdin(monkeypatch, json.dumps({"hook_event_name": "Stop"}))
+    missing = tmp_path / "does" / "not" / "exist"
+
+    assert coco_native_hook.main(["--bridge-dir", str(missing)]) == 0
+    assert not missing.exists()

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -761,6 +761,68 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@base-ui/react": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.3.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+      "integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
@@ -961,6 +1023,36 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/utilities": {
@@ -1190,6 +1282,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@emoji-mart/data": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.2.1.tgz",
+      "integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@emoji-mart/react": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "emoji-mart": "^5.2",
+        "react": "^16.8 || ^17 || ^18"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -1264,6 +1374,16 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
       "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
     },
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
@@ -1376,6 +1496,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
       }
@@ -1385,28 +1506,64 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
       }
     },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.20",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.20.tgz",
+      "integrity": "sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
+        "@floating-ui/dom": "^1.8.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@floating-ui/react-dom/node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom/node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
     },
     "node_modules/@fontsource-variable/geist-mono": {
@@ -1416,6 +1573,19 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@giscus/react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@giscus/react/-/react-3.1.0.tgz",
+      "integrity": "sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==",
+      "peer": true,
+      "dependencies": {
+        "giscus": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18 || ^19",
+        "react-dom": "^16 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1574,6 +1744,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@lobehub/emojilib": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@lobehub/emojilib/-/emojilib-1.0.0.tgz",
@@ -1637,13 +1824,202 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@lobehub/ui": {
+      "version": "5.22.3",
+      "resolved": "https://registry.npmjs.org/@lobehub/ui/-/ui-5.22.3.tgz",
+      "integrity": "sha512-sw773r8aXCDKacJgxtshJHLk5flpIRAHHAGImKCD3Z6USO4C5lj9Q6JK4B67c18gSOE7X2JsI8QK6Korim0dzA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ant-design/cssinjs": "^2.1.2",
+        "@base-ui/react": "1.6.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@emoji-mart/data": "^1.2.1",
+        "@emoji-mart/react": "^1.1.1",
+        "@emotion/is-prop-valid": "^1.4.0",
+        "@floating-ui/react": "^0.27.19",
+        "@giscus/react": "^3.1.0",
+        "@mdx-js/mdx": "^3.1.1",
+        "@mdx-js/react": "^3.1.1",
+        "@pierre/diffs": "1.2.12",
+        "@radix-ui/react-slot": "^1.3.0",
+        "@shikijs/core": "^4.3.1",
+        "@shikijs/stream": "^4.3.1",
+        "@shikijs/transformers": "^4.3.1",
+        "@splinetool/runtime": "1.12.98",
+        "ahooks": "^3.9.7",
+        "antd-style": "^4.1.0",
+        "chroma-js": "^3.2.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "dayjs": "^1.11.21",
+        "emoji-mart": "^5.6.0",
+        "es-toolkit": "^1.49.0",
+        "fast-deep-equal": "^3.1.3",
+        "hast-util-to-jsx-runtime": "^2.3.6",
+        "html-url-attributes": "^3.0.1",
+        "immer": "^11.1.11",
+        "katex": "^0.17.0",
+        "leva": "^0.10.1",
+        "lucide-react": "^1.24.0",
+        "marked": "^18.0.6",
+        "mermaid": "^11.16.0",
+        "motion": "^12.0.0",
+        "numeral": "^2.0.6",
+        "polished": "^4.3.1",
+        "query-string": "^9.4.1",
+        "rc-collapse": "^4.0.0",
+        "rc-footer": "^0.6.8",
+        "rc-image": "^7.12.0",
+        "rc-input-number": "^9.5.0",
+        "rc-menu": "^9.16.1",
+        "re-resizable": "^6.11.2",
+        "react-avatar-editor": "^15.1.0",
+        "react-error-boundary": "^6.1.2",
+        "react-hotkeys-hook": "^5.3.3",
+        "react-markdown": "^10.1.0",
+        "react-merge-refs": "^3.0.2",
+        "react-rnd": "^10.5.3",
+        "react-zoom-pan-pinch": "^4.0.3",
+        "rehype-github-alerts": "^4.2.0",
+        "rehype-katex": "^7.0.1",
+        "rehype-raw": "^7.0.0",
+        "remark-breaks": "^4.0.0",
+        "remark-cjk-friendly": "^2.3.1",
+        "remark-gfm": "^4.0.1",
+        "remark-github": "^12.0.0",
+        "remark-math": "^6.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remend": "^1.3.0",
+        "shiki": "^4.3.1",
+        "swr": "^2.4.2",
+        "ts-md5": "^2.0.1",
+        "unified": "^11.0.5",
+        "url-join": "^5.0.0",
+        "use-merge-value": "^1.2.0",
+        "uuid": "^14.0.1",
+        "vfile": "^6.0.3",
+        "virtua": "^0.49.3"
+      },
+      "engines": {
+        "node": ">=22.22.0"
+      },
+      "peerDependencies": {
+        "@lobehub/fluent-emoji": "^4.0.0",
+        "@lobehub/icons": "^5.0.0",
+        "antd": "^6.1.1",
+        "motion": "^12.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/@lobehub/ui/node_modules/katex": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.17.0.tgz",
+      "integrity": "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/@lobehub/ui/node_modules/marked": {
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.6.tgz",
+      "integrity": "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@mdx-js/mdx/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@mdx-js/react": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdx": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -2401,6 +2777,77 @@
       ],
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@pierre/diffs": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.2.12.tgz",
+      "integrity": "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ==",
+      "license": "apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@pierre/theme": "1.1.0",
+        "@pierre/theming": "0.0.2",
+        "@shikijs/transformers": "^3.0.0 || ^4.0.0",
+        "diff": "9.0.0",
+        "hast-util-to-html": "9.0.5",
+        "lru_map": "0.4.1",
+        "shiki": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/@pierre/diffs/node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@pierre/theme": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.1.0.tgz",
+      "integrity": "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "vscode": "^1.0.0"
+      }
+    },
+    "node_modules/@pierre/theming": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@pierre/theming/-/theming-0.0.2.tgz",
+      "integrity": "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw==",
+      "license": "apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "@pierre/theme": "^1.1.0",
+        "@shikijs/themes": "^3.0.0 || ^4.0.0",
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0",
+        "shiki": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@pierre/theme": {
+          "optional": true
+        },
+        "@shikijs/themes": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "shiki": {
+          "optional": true
+        }
       }
     },
     "node_modules/@primer/octicons": {
@@ -4964,6 +5411,39 @@
         "node": ">=20"
       }
     },
+    "node_modules/@shikijs/stream": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/stream/-/stream-4.3.1.tgz",
+      "integrity": "sha512-QsZDisEVgtvnEgLftu/Ng5JkZlPn37AJoJQY330RnFoNcRtszr0JV3ldRLjIpgvl+qPRKF4t6h1P7FQhjQj6Sw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/core": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "solid-js": "^1.9.0",
+        "svelte": "^5.0.0-0",
+        "vue": "^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@shikijs/themes": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
@@ -4971,6 +5451,20 @@
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.3.1.tgz",
+      "integrity": "sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/core": "4.3.1",
+        "@shikijs/types": "4.3.1"
       },
       "engines": {
         "node": ">=20"
@@ -5019,12 +5513,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@splinetool/runtime": {
+      "version": "1.12.98",
+      "resolved": "https://registry.npmjs.org/@splinetool/runtime/-/runtime-1.12.98.tgz",
+      "integrity": "sha512-UWZH/+4XtNgMMgmDiWhZS55WOwUDGuTj4uH6fiZV6Jol3d3v3z1RRBObspx8GMio0HajOYGg7FJ8TZdyBdpW4A==",
+      "peer": true,
+      "dependencies": {
+        "on-change": "4.0.0",
+        "semver-compare": "1.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stitches/react": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@stitches/react/-/react-1.2.8.tgz",
+      "integrity": "sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
     },
     "node_modules/@streamdown/cjk": {
       "version": "1.0.3",
@@ -6374,6 +6888,13 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/katex": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
@@ -6388,6 +6909,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -6414,7 +6942,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6424,7 +6951,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6483,6 +7009,26 @@
       "optionalDependencies": {
         "d3-selection": "^3.0.0",
         "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/@vercel/oidc": {
@@ -6796,6 +7342,16 @@
         "acorn": "^8"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -6803,6 +7359,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ahooks": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/ahooks/-/ahooks-3.9.7.tgz",
+      "integrity": "sha512-S0lvzhbdlhK36RFBkGv+RbOM/dbbweym+BIHM/bwwuWVSVN5TuVErHPMWo4w0t1NDYg5KPp2iEf7Y7E5LASYiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@types/js-cookie": "^3.0.6",
+        "dayjs": "^1.9.1",
+        "intersection-observer": "^0.12.0",
+        "js-cookie": "^3.0.5",
+        "lodash": "^4.17.21",
+        "react-fast-compare": "^3.2.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.0.0",
+        "tslib": "^2.4.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/ai": {
@@ -7040,6 +7619,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -7071,6 +7660,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
     "node_modules/atomically": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
@@ -7078,6 +7677,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -7489,6 +8098,13 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/chroma-js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.2.0.tgz",
+      "integrity": "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==",
+      "license": "(BSD-3-Clause AND Apache-2.0)",
+      "peer": true
+    },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
@@ -7512,6 +8128,13 @@
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -7614,6 +8237,17 @@
       "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
       "license": "MIT"
     },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7631,6 +8265,13 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -8464,6 +9105,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/decode-uri-component": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -8687,6 +9338,13 @@
       "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
       "license": "ISC"
     },
+    "node_modules/emoji-mart": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
+      "integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -8824,14 +9482,48 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.48.1.tgz",
-      "integrity": "sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
       "license": "MIT",
       "workspaces": [
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -8879,6 +9571,37 @@
         "node": ">=4"
       }
     },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-util-is-identifier-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
@@ -8889,11 +9612,66 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -9042,6 +9820,29 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend-shallow/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9177,6 +9978,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/file-selector": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.5.0.tgz",
+      "integrity": "sha512-s8KNnmIDTBoD0p9uJ9uD0XY38SCeBOtj0UMXyQSLg1Ypfrfj8+dAvwsLjYQkQ2GjhVtp2HrnF5cJzMhBjfD8HA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -9187,6 +10001,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/finalhandler": {
@@ -9228,6 +10055,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -9247,6 +10084,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fresh": {
@@ -9411,6 +10276,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/giscus": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/giscus/-/giscus-1.6.0.tgz",
+      "integrity": "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lit": "^3.2.1"
       }
     },
     "node_modules/github-from-package": {
@@ -9676,6 +10561,35 @@
         "@types/hast": "^3.0.0",
         "@ungap/structured-clone": "^1.0.0",
         "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9955,6 +10869,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
+      "integrity": "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -10033,6 +10958,14 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/intersection-observer": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.12.2.tgz",
+      "integrity": "sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==",
+      "deprecated": "The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -10120,6 +11053,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -10246,6 +11192,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -10319,6 +11278,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -10376,6 +11345,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -10551,6 +11527,48 @@
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
       "license": "MIT"
+    },
+    "node_modules/leva": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/leva/-/leva-0.10.1.tgz",
+      "integrity": "sha512-BcjnfUX8jpmwZUz2L7AfBtF9vn4ggTH33hmeufDULbP3YgNZ/C+ss/oO3stbrqRQyaOmRwy70y7BGTGO81S3rA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@radix-ui/react-portal": "^1.1.4",
+        "@radix-ui/react-tooltip": "^1.1.8",
+        "@stitches/react": "^1.2.8",
+        "@use-gesture/react": "^10.2.5",
+        "colord": "^2.9.2",
+        "dequal": "^2.0.2",
+        "merge-value": "^1.0.0",
+        "react-colorful": "^5.5.1",
+        "react-dropzone": "^12.0.0",
+        "v8n": "^1.3.3",
+        "zustand": "^3.6.9"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/leva/node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -10844,6 +11862,40 @@
       "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "license": "MIT"
     },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -10856,6 +11908,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -10913,6 +11972,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/lru-cache": {
       "version": "11.5.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
@@ -10924,9 +11990,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
-      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.25.0.tgz",
+      "integrity": "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -10996,6 +12062,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
+      }
+    },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-table": {
@@ -11195,6 +12274,24 @@
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.1.0",
         "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -11440,6 +12537,22 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
     },
+    "node_modules/merge-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/merge-value/-/merge-value-1.0.0.tgz",
+      "integrity": "sha512-fJMmvat4NeKz63Uv9iHWcPDjCWcCkoiRoajRTEO8hlhUC6rwaHg0QCF9hBOTjZmm4JuglPckPSTtcuJL5kp0TQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-value": "^2.0.6",
+        "is-extendable": "^1.0.0",
+        "mixin-deep": "^1.2.0",
+        "set-value": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -11450,26 +12563,26 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -11770,6 +12883,113 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
@@ -11811,6 +13031,34 @@
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
       }
     },
     "node_modules/micromark-factory-space": {
@@ -12013,6 +13261,32 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
@@ -12261,6 +13535,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -12295,6 +13583,50 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
+      "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "framer-motion": "^12.42.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -12522,6 +13854,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -12564,6 +13906,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-change": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/on-change/-/on-change-4.0.0.tgz",
+      "integrity": "sha512-PTu7C9Jsz4b+sNMDpH0eZFTr7uxdOtoDWRnhaVNK50bgrrnW5nvbWI0jm5DG9qOoTnIhBzE9xoKVFPD9xgtbdg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/on-change?sponsor=1"
       }
     },
     "node_modules/on-finished": {
@@ -13212,6 +14567,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/property-information": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
@@ -13401,6 +14775,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/query-string": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.4.1.tgz",
+      "integrity": "sha512-lSyJeN3RuaG7DZGWThtYRhk96+kEyZ/+doZpERuWbjeFL+Ok3vEat/swU498rAI0NcVt5/RJp8UDuLz7FckxrA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "decode-uri-component": "^0.4.1",
+        "filter-obj": "^5.1.0",
+        "split-on-first": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -13554,6 +14946,283 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/rc-collapse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-4.0.0.tgz",
+      "integrity": "sha512-SwoOByE39/3oIokDs/BnkqI+ltwirZbP8HZdq1/3SkPSBi7xDdvWHTp7cpNI9ullozkR6mwTWQi6/E/9huQVrA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "rc-motion": "^2.3.4",
+        "rc-util": "^5.27.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-dialog": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.6.0.tgz",
+      "integrity": "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/portal": "^1.0.0-8",
+        "classnames": "^2.2.6",
+        "rc-motion": "^2.3.0",
+        "rc-util": "^5.21.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-dialog/node_modules/@rc-component/portal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+      "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-footer": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/rc-footer/-/rc-footer-0.6.8.tgz",
+      "integrity": "sha512-JBZ+xcb6kkex8XnBd4VHw1ZxjV6kmcwUumSHaIFdka2qzMCo7Klcy4sI6G0XtUpG/vtpislQCc+S9Bc+NLHYMg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/rc-image": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.12.0.tgz",
+      "integrity": "sha512-cZ3HTyyckPnNnUb9/DRqduqzLfrQRyi+CdHjdqgsyDpI3Ln5UX1kXnAhPBSJj9pVRzwRFgqkN7p9b6HBDjmu/Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "@rc-component/portal": "^1.0.2",
+        "classnames": "^2.2.6",
+        "rc-dialog": "~9.6.0",
+        "rc-motion": "^2.6.2",
+        "rc-util": "^5.34.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-image/node_modules/@rc-component/portal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+      "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-input": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.8.0.tgz",
+      "integrity": "sha512-KXvaTbX+7ha8a/k+eg6SYRVERK0NddX8QX7a7AnRvUa/rEH0CNMlpcBzBkhI0wp2C8C4HlMoYl8TImSN+fuHKA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.18.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/rc-input-number": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.5.0.tgz",
+      "integrity": "sha512-bKaEvB5tHebUURAEXw35LDcnRZLq3x1k7GxfAqBMzmpHkDGzjAtnUL8y4y5N15rIFIg5IJgwr211jInl3cipag==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/mini-decimal": "^1.0.1",
+        "classnames": "^2.2.5",
+        "rc-input": "~1.8.0",
+        "rc-util": "^5.40.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-menu": {
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.1.tgz",
+      "integrity": "sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "2.x",
+        "rc-motion": "^2.4.3",
+        "rc-overflow": "^1.3.1",
+        "rc-util": "^5.27.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-menu/node_modules/@rc-component/portal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+      "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-menu/node_modules/@rc-component/trigger": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.3.1.tgz",
+      "integrity": "sha512-ORENF39PeXTzM+gQEshuk460Z8N4+6DkjpxlpE7Q3gYy1iBpLrx0FOJz3h62ryrJZ/3zCAUIkT1Pb/8hHWpb3A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "@rc-component/portal": "^1.1.0",
+        "classnames": "^2.3.2",
+        "rc-motion": "^2.0.0",
+        "rc-resize-observer": "^1.3.1",
+        "rc-util": "^5.44.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-motion": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
+      "integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.44.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-overflow": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.5.0.tgz",
+      "integrity": "sha512-Lm/v9h0LymeUYJf0x39OveU52InkdRXqnn2aYXfWmo8WdOonIKB2kfau+GF0fWq6jPgtdO9yMqveGcK6aIhJmg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.37.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-resize-observer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz",
+      "integrity": "sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.44.1",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util": {
+      "version": "5.44.4",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
+      "integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/re-resizable": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -13564,6 +15233,28 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-avatar-editor": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/react-avatar-editor/-/react-avatar-editor-15.1.0.tgz",
+      "integrity": "sha512-Zto7u9l6Wd5LPPtjeFJ+7uwoT4bs01OSgkN2kxD18lWl8IiZ0GY3nWCbKPx4qIU7Au1vENsMJm19rfVWHHayaQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^0.14.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.8.0.tgz",
+      "integrity": "sha512-Wy9OzPfjSN9bF12OB8N7UQvlsZ0I+7wHxpN+bV5BjNQGxOj6IiwkRjevJK9yOBjJWGQvAaf1OXtn8rUeEatAng==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {
@@ -13578,6 +15269,56 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.7.0.tgz",
+      "integrity": "sha512-kTpANmKWVnFXiZ76Ag2ZowiFStuBYnJ606PI1TbUsOg29/400/JNIxI9+CuenhiAqFuXWJffz6F4UI3R51kUug==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-dropzone": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-12.1.0.tgz",
+      "integrity": "sha512-iBYHA1rbopIvtzokEX4QubO6qk5IF/x3BtKGu74rF2JkQDXnwC4uO/lHKpaw4PJIV6iIAYOlwLv2FpiGyqHNog==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.5.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.2.tgz",
+      "integrity": "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-hook-form": {
       "version": "7.80.0",
@@ -13596,9 +15337,9 @@
       }
     },
     "node_modules/react-hotkeys-hook": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-5.3.2.tgz",
-      "integrity": "sha512-DDDy9xK6mbTQ6aPlQvIl0dA/a90T/AWml4Rm21JXFDLlRHalIg4/Rv3equUQYs5xPTWq+oEl6RD7mi/nBpU3Uw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-5.3.3.tgz",
+      "integrity": "sha512-aswgyWUnE25hmhzHTfKDmKzsaSE5DJ4LKaU/o6rQSXkDd/1Bh9TfAFQbHkf6fLy11HvlYkp+cDDarGdhmCDhoQ==",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -13639,6 +15380,25 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-merge-refs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-3.0.2.tgz",
+      "integrity": "sha512-MSZAfwFfdbEvwkKWP5EI5chuLYnNUxNS7vyS0i1Jp+wtd8J4Ga2ddzhaE68aMol2Z4vCnRM/oGOo1a3V75UPlw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-pdf": {
@@ -13717,6 +15477,29 @@
         }
       }
     },
+    "node_modules/react-rnd": {
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.3.tgz",
+      "integrity": "sha512-s/sIT3pGZnQ+57egijkTp9mizjIWrJz68Pq6yd+F/wniFY3IriML18dUXnQe/HP9uMiJ+9MAp44hljG99fZu6Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "re-resizable": "^6.11.2",
+        "react-draggable": "^4.5.0",
+        "tslib": "2.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-rnd/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD",
+      "peer": true
+    },
     "node_modules/react-router": {
       "version": "6.30.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
@@ -13771,6 +15554,21 @@
         }
       }
     },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-4.0.3.tgz",
+      "integrity": "sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -13809,6 +15607,77 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/redent": {
@@ -13901,6 +15770,22 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14014,6 +15899,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-github": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/remark-github/-/remark-github-12.0.0.tgz",
+      "integrity": "sha512-ByefQKFN184LeiGRCabfl7zUJsdlMYWEhiLX1gpmQ11yFg6xSuOTW7LVCv0oc1x+YvUMJW23NU36sJX2RWGgvg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "to-vfile": "^8.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-math": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
@@ -14024,6 +15928,21 @@
         "mdast-util-math": "^3.0.0",
         "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14114,6 +16033,20 @@
       "engines": {
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -14366,6 +16299,19 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
@@ -14386,6 +16332,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -14437,6 +16390,32 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
       "integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
       "license": "MIT"
+    },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/set-value/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -14770,6 +16749,46 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/split-on-first": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -15053,6 +17072,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -15086,6 +17119,13 @@
         "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -15112,7 +17152,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
       "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -15247,6 +17286,20 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/to-vfile": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-8.0.0.tgz",
+      "integrity": "sha512-IcmH1xB5576MJc9qcfEC/m/nQCFt3fzMHz45sSlgJyTWjRbKW1HAkJpuf3DgE57YzIlZcwcBZA5ENQbBo4aLkg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -15320,6 +17373,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.10"
+      }
+    },
+    "node_modules/ts-md5": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-2.0.1.tgz",
+      "integrity": "sha512-yF35FCoEOFBzOclSkMNEUbFQZuv89KEQ+5Xz03HrMSGUGB1+r+El+JiGOFwsP4p9RFNzwlrydYoTLvPOuICl9w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-morph": {
@@ -15424,7 +17487,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15527,6 +17590,20 @@
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
       "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -15752,6 +17829,13 @@
         "uuid": "dist-node/bin/uuid"
       }
     },
+    "node_modules/v8n": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/v8n/-/v8n-1.5.1.tgz",
+      "integrity": "sha512-LdabyT4OffkyXFCe9UT+uMkxNBs5rcTVuZClvxQr08D5TUgo1OFKkoT65qYRCsiKBl/usHjpXvP4hHMzzDRj3A==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
@@ -15810,6 +17894,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/virtua": {
+      "version": "0.49.3",
+      "resolved": "https://registry.npmjs.org/virtua/-/virtua-0.49.3.tgz",
+      "integrity": "sha512-k1Yn988Vz/L40uDtEWPjfdVo15Suumh4tU4/z5Srs0elNcU9DgBskqdh3llpHyAlXrCeHWTfcclYvY1uU4MmIg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0",
+        "solid-js": ">=1.0",
+        "svelte": ">=5.0",
+        "vue": ">=3.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/web/src/components/AgentCard.tsx
+++ b/web/src/components/AgentCard.tsx
@@ -1,6 +1,7 @@
 import { BotIcon } from "lucide-react";
 import { AntigravityIcon } from "@/components/icons/AntigravityIcon";
 import { ClaudeIcon } from "@/components/icons/ClaudeIcon";
+import { CocoIcon } from "@/components/icons/CocoIcon";
 import { CodexIcon } from "@/components/icons/CodexIcon";
 import { CursorIcon } from "@/components/icons/CursorIcon";
 import { GooseIcon } from "@/components/icons/GooseIcon";
@@ -41,12 +42,15 @@ function iconForAgent(agent: AvailableAgent): ComponentType<SVGProps<SVGSVGEleme
   if (nativeAgent?.iconKind === "kimi") return KimiIcon;
   if (nativeAgent?.iconKind === "antigravity") return AntigravityIcon;
   if (nativeAgent?.iconKind === "hermes") return HermesIcon;
+  if (nativeAgent?.iconKind === "coco") return CocoIcon;
   // A null harness (spec couldn't load) flows through to the bot fallback.
   if (agent.harness?.includes("codex")) return CodexIcon;
   if (agent.harness?.includes("claude")) return ClaudeIcon;
   // Both the SDK "cursor" harness and "cursor-native" get the Cursor glyph.
   if (agent.harness?.includes("cursor")) return CursorIcon;
   if (agent.harness?.includes("hermes")) return HermesIcon;
+  // Both the "coco-native" harness and its "cortex" alias get the CoCo glyph.
+  if (agent.harness?.includes("coco") || agent.harness === "cortex") return CocoIcon;
   if (agent.harness?.includes("kiro")) return KiroIcon;
   if (agent.harness?.includes("goose")) return GooseIcon;
   // Both the SDK "kimi"/"kimi-code" harness and "kimi-native" get the Kimi glyph.

--- a/web/src/components/icons/CocoIcon.tsx
+++ b/web/src/components/icons/CocoIcon.tsx
@@ -1,0 +1,27 @@
+import type { SVGProps } from "react";
+
+// Snowflake CoCo (Cortex Code) glyph — an original six-armed snowflake with
+// chevron branches, evoking the product's Snowflake home without copying the
+// vendor's brand asset. Drawn in currentColor so it follows the app theme
+// like its sibling icons; one arm (spoke + branch pair) is authored once and
+// stamped at 60° rotations around the center for exact symmetry.
+export function CocoIcon(props: SVGProps<SVGSVGElement>) {
+  // One arm pointing up from the center: the spoke plus a chevron branch pair.
+  const arm = "M12 12 V 4.6 M12 7.4 L 9.9 5.9 M12 7.4 L 14.1 5.9";
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      {[0, 60, 120, 180, 240, 300].map((angle) => (
+        <path key={angle} d={arm} transform={`rotate(${angle} 12 12)`} />
+      ))}
+    </svg>
+  );
+}

--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -82,6 +82,7 @@ export const AGENT_TERMINAL_IDS: ReadonlySet<string> = new Set([
   "terminal_antigravity_main",
   "terminal_kimi_main",
   "terminal_hermes_main",
+  "terminal_coco_main",
 ]);
 
 /**

--- a/web/src/lib/agentGrouping.ts
+++ b/web/src/lib/agentGrouping.ts
@@ -22,6 +22,7 @@ export const BUILTIN_AGENTS = new Set([
   "goose-native-ui", // Goose
   "qwen-native-ui", // Qwen Code
   "kimi-native-ui", // Kimi
+  "coco-native-ui", // Snowflake CoCo
   "polly",
   "debby",
 ]);
@@ -40,6 +41,7 @@ export const AGENT_DISPLAY_ORDER = [
   "Antigravity",
   "Qwen Code",
   "Kimi",
+  "CoCo",
   "Polly",
   "Debby",
 ];

--- a/web/src/lib/forkHarness.ts
+++ b/web/src/lib/forkHarness.ts
@@ -18,8 +18,8 @@
 //
 // Hence two predicates: forkTargetCarriesHistory (rebuild ∪ preamble ∪ SDK)
 // and switchTargetCarriesHistory (rebuild ∪ SDK — no preamble). Native
-// harnesses with no carry path (kiro/kimi/goose) are offered by neither; an
-// unclassifiable harness (catalog harness=null) is conservatively dropped.
+// harnesses with no carry path (kiro/kimi/goose/coco) are offered by neither;
+// an unclassifiable harness (catalog harness=null) is conservatively dropped.
 
 /** Provider family a harness consumes, or null when unknown. */
 export function harnessFamily(
@@ -121,7 +121,7 @@ const PREAMBLE_FORK_HARNESSES: ReadonlySet<string> = new Set([
  * replays the transcript as context). Conservatively false for an
  * unclassifiable harness (the catalog can report harness=null when the bundle
  * failed to load) and for native harnesses with no carry path
- * (kiro/kimi/goose).
+ * (kiro/kimi/goose/coco).
  *
  * NOTE: the SDK branch is `harnessFamily(h) !== null`, which also matches the
  * one native harness that has a single family today — antigravity-native

--- a/web/src/lib/nativeCodingAgents.ts
+++ b/web/src/lib/nativeCodingAgents.ts
@@ -15,7 +15,8 @@ export type NativeCodingAgentIconKind =
   | "qwen"
   | "antigravity"
   | "kimi"
-  | "hermes";
+  | "hermes"
+  | "coco";
 export type NativeCodingAgentCapability = "permissionMode" | "approvalMode" | "cursorMode";
 
 export interface NativeCodingAgentSpec {
@@ -155,6 +156,18 @@ export const NATIVE_CODING_AGENTS = [
     iconKind: "hermes",
     sortRank: 80,
   },
+  {
+    // Snowflake CoCo (Cortex Code). Auth/approval surface in the embedded
+    // terminal (CoCo's own connection wizard + three-tier approvals), so no
+    // capability flags are declared here.
+    key: "coco",
+    agentName: "coco-native-ui",
+    harness: "coco-native",
+    wrapperLabel: "coco-native-ui",
+    displayName: "CoCo",
+    iconKind: "coco",
+    sortRank: 90,
+  },
 ] as const satisfies readonly NativeCodingAgentSpec[];
 
 const BY_AGENT_NAME: Map<string, NativeCodingAgentSpec> = new Map(
@@ -181,6 +194,11 @@ const HARNESS_ALIASES: Record<string, string> = {
   "native-kimi": "kimi-native",
   "native-hermes": "hermes-native",
   "native-opencode": "opencode-native",
+  "native-coco": "coco-native",
+  // Friendly server-side spellings (product + binary name) fold to the
+  // canonical native harness, mirroring omnigent.harness_plugins aliases.
+  coco: "coco-native",
+  cortex: "coco-native",
 };
 
 export function nativeCodingAgentForAgentName(

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -36,6 +36,7 @@ import { Link, useLocation } from "@/lib/routing";
 import { Badge } from "@/components/ui/badge";
 import { AntigravityIcon } from "@/components/icons/AntigravityIcon";
 import { ClaudeIcon } from "@/components/icons/ClaudeIcon";
+import { CocoIcon } from "@/components/icons/CocoIcon";
 import { CodexIcon } from "@/components/icons/CodexIcon";
 import { CursorIcon } from "@/components/icons/CursorIcon";
 import { GooseIcon } from "@/components/icons/GooseIcon";
@@ -456,6 +457,7 @@ function brandChildIcon(child: ChildSessionInfo): AgentRowIcon | null {
   if (nativeAgent?.iconKind === "goose") return GooseIcon;
   if (nativeAgent?.iconKind === "kimi") return KimiIcon;
   if (nativeAgent?.iconKind === "hermes") return HermesIcon;
+  if (nativeAgent?.iconKind === "coco") return CocoIcon;
   // Exact match — substring checks would false-match names like "pipeline".
   if (child.tool === PI_AGENT_NAME) return PiIcon;
   return null;
@@ -630,6 +632,7 @@ function iconForWrapperOrHarness(
   if (iconKind === "cursor" || harness?.includes("cursor")) return CursorIcon;
   if (iconKind === "kiro" || harness?.includes("kiro")) return KiroIcon;
   if (iconKind === "goose" || harness?.includes("goose")) return GooseIcon;
+  if (iconKind === "coco" || harness?.includes("coco")) return CocoIcon;
   if (iconKind === "kimi" || harness?.includes("kimi")) return KimiIcon;
   if (iconKind === "antigravity" || harness?.includes("antigravity")) return AntigravityIcon;
   // Exact match — a substring check would false-match e.g. "openapi".

--- a/web/src/shell/sidebarNav.ts
+++ b/web/src/shell/sidebarNav.ts
@@ -39,6 +39,7 @@ export type ConversationIconKind =
   | "qwen"
   | "kimi"
   | "hermes"
+  | "coco"
   | "nessie"
   | null;
 


### PR DESCRIPTION
## Related issue

N/A — no existing issue tracks Snowflake CoCo support (searched for coco/cortex/snowflake).

## Summary

- Adds **`coco-native`** — a native TUI harness for **Snowflake CoCo** (Cortex Code, the `cortex` CLI): `omnigent coco` (or picking **CoCo** in the web UI) launches the live TUI in a runner-owned tmux pane, web turns paste-inject into it, Stop sends Escape, and sessions cold-resume via `cortex -r <id>`.
- Unlike the store-tailing siblings (goose/hermes), CoCo flushes its transcript **lazily** — so the mirror is **hook-driven**: the bridge builds a per-session `SNOWFLAKE_HOME` (user config/auth/`conversations` symlinked in; only `cortex/hooks.json` replaced, merged with any user hooks) and a stdlib-only relay appends `SessionStart`/`UserPromptSubmit`/`Stop` events to the bridge dir. `Stop` guarantees the transcript is on disk (verified), so the forwarder mirrors each finished turn — text, `tool_use`, `tool_result` — as conversation items with per-turn `running`/`idle` edges.
- Discovery flows backwards from the hook: CoCo's TUI **ignores `--session-id`** (v1.1.1), so `SessionStart` announces the real id, which the runner persists as `external_session_id` for resume.

ELI5: CoCo is Snowflake's Claude-Code-like terminal agent. This PR teaches Omnigent to run it in an embedded terminal like the other native harnesses, and uses CoCo's own (Claude-Code-compatible) hook system as the "turn finished — transcript ready" doorbell that makes web-chat mirroring possible at all.

```mermaid
flowchart TD
    UI[Web chat] -->|user turn| EX[CocoNativeExecutor<br/>tmux paste + Enter]
    EX --> TUI[cortex TUI<br/>tmux pane, embedded]
    TUI -->|SessionStart / UserPromptSubmit / Stop| HOOK[coco_native_hook.py<br/>appends hook_events.jsonl]
    HOOK --> FWD[coco_native_forwarder]
    FWD -->|running/idle edges +<br/>message / function_call items| UI
    FWD -.->|reads at Stop| HIST[(conversations/&lt;sid&gt;.history.jsonl)]
    UI -.->|Stop button| ESC[runner sends Escape]
    ESC -.-> TUI
```

All vendor behavior was **verified live against CoCo v1.1.1** (macOS arm64) and is written up in `docs/COCO_NATIVE_DESIGN.md`, including: hooks load only from `$SNOWFLAKE_HOME/cortex/hooks.json`; the transcript is on disk at Stop-hook time; Escape interrupts cleanly while Ctrl+C double-taps into a full TUI exit (why the interrupt path avoids it); resume does not re-mirror prior history. Deliberate v1 scope cuts (the qwen PR-1/PR-2 precedent, listed as follow-ups in the design doc): web approval mirror via the `PermissionRequest` hook, MCP relay via `--mcp-config`, fork-with-history (`--fork-session`), cost tracking from `stats/usage.json`, and a piped `coco` harness (`cortex acp serve` exists).

## Test Plan

- **73 new unit tests** (`tests/test_coco_native{,_bridge,_forwarder,_hook}.py`, `tests/inner/test_coco_native_executor.py`) covering the bridge (home construction + hooks merge + symlink healing, tmux paste sequence, interrupt/kill), forwarder (event/line cursors, block mapping, turn lifecycle incl. restart-restore, history-shrink guard, stalled-turn backstop, supervisor backoff), executor, CLI wrapper, and hook relay.
- **Live end-to-end** against the real `cortex` binary through the actual bridge/forwarder code (a stub HTTP server capturing the forwarder's posts): fresh session (`running` → clean user bubble → assistant reply → `idle`, correct `coco:turn:<n>` grouping), **cold resume with no history re-mirror**, Escape interrupt mid-tool ("Tool execution was interrupted by user"), and kill-session.
- **Multi-agent adversarial review** of the diff (5 dimension finders, 2 independent verifiers per finding): 16 candidates, 10 double-confirmed, all fixed with regression tests — notably the quit-before-first-turn `required_terminal_exited` misclassification (CoCo's terminal role now joins the PTY `emit_status` set, goose parity), first-run transcripts being trapped in the throwaway bridge dir, and forwarder restart/compaction robustness.
- **Suites**: registry/alias/capability/wrapper-label suites, `tests/cli`, `tests/onboarding`, `tests/spec`, and CI-style shards of `tests/runtime`, `tests/inner`, `tests/server`, `tests/stores`, `tests/db`, `tests/repl`, `tests/terminals`, `tests/runner`, root `tests/test_*.py` (~12k tests, `-n 8 -m "not databricks"`): every remaining failure reproduces identically on a clean `main` checkout (missing databricks extra / macOS sandbox env). Web: `tsc --noEmit` clean, 584 vitest tests green. `pre-commit run` clean.

## Demo

Live mirror capture from the e2e run (real `cortex` v1.1.1, forwarder posts captured by a stub server):

```
=== hook events seen ===          === captured POSTs ===
  SessionStart 0422e650-7f0         status running       rid=coco:turn:1
  UserPromptSubmit 0422e650-7f0     item message         rid=coco:1      role=user  'Reply with exactly: e2e-ok…'
  Stop 0422e650-7f0                 item message         rid=coco:turn:1 role=assistant 'e2e-ok'
                                    status idle          rid=coco:turn:1
E2E RESULT: PASS   (cold-resume run: new turn mirrored, zero prior rows re-mirrored)
```

The web-UI surface change is a new agent-picker row ("CoCo", original snowflake glyph in `CocoIcon.tsx`) — happy to attach a screenshot on request.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = the live runs above (they require a Snowflake account + the `cortex` binary, so they are not CI-able; the design doc records the verified vendor contract each unit test pins). Registry-driven suites (`test_harness_aliases`, `test_harness_capabilities`, `test_harness_plugins`, onboarding readiness, builtin bundles, web `nativeCodingAgents`/`forkHarness`/`useTerminals`) pick the new harness up automatically.

## Changelog

`omnigent coco` embeds Snowflake CoCo (Cortex Code) as a native terminal harness — live TUI in the session, web-chat mirroring, interrupt, and resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
