### PR TITLE
Slack integration refactoring, user experience improvements and documentation

### DIFF
--- a/integrations/slack/DESIGN.md
+++ b/integrations/slack/DESIGN.md
@@ -1,0 +1,244 @@
+# Slack integration — design & architecture
+
+How the Omnigent Slack bot is built and the key technical decisions behind it.
+For operator setup (scopes, `.env`, running the daemon) see `README.md`; this
+doc is for people working on the code.
+
+## What it is
+
+A Slack **Socket Mode** bot that bridges Slack to a single, operator-configured
+Omnigent server. It maps **one Slack thread ↔ one Omnigent session**, streams
+the agent's answer into the thread live, and renders tool-approval /
+`AskUserQuestion` prompts as interactive Block Kit cards.
+
+The **guiding principle**: the Omnigent **web UI is the reference client** for
+the server API. Where possible the bot mirrors how the web UI consumes the
+server (server-authoritative state, push-driven streaming, no invented polling);
+deviations exist only where Slack's transport genuinely differs from a browser
+tab, and are called out below.
+
+## Module layout
+
+Responsibilities are split so no single file owns streaming + orchestration +
+I/O at once (the web UI splits a pure reducer from its orchestration store; this
+is the Python analogue).
+
+| Module | Responsibility |
+| --- | --- |
+| `events.py` | Pure SSE parsing + event DTOs + extractors (`extract_delta`, `session_status`, `extract_elicitation_request`, …). No I/O, no state. |
+| `omnigent.py` | HTTP/SSE client (`OmnigentClient`), connection pool, the `run_turn` stream loop and turn-end detection, error subclasses. |
+| `streaming.py` | The streamed-answer state machine: `_LiveReply` (Slack `chat.*Stream` buffering/seal/reopen) and `_AnswerReply` (ack lifecycle, seal-⇒-forget, tail reconciliation). Home of the `SlackClientProtocol`/`SlackStreamProtocol` structural types. |
+| `elicitation.py` | `ElicitationController` — in-turn approval/question orchestration (post card, spawn resolver, finalize on `elicitation_resolved`). |
+| `approvals.py` | Elicitation vocabulary: `ElicitationCoordinator` (click↔resolver bridge), Block Kit card builders, `ElicitationOutcome`, click routing/parsing. |
+| `notifications.py` | `SlackNotifier` — all outbound Slack messages (acks, replies, ephemerals, todo plan, deflection notices) + the text formatters. |
+| `service.py` | `SlackOmnigentService` — event acceptance, turn routing, turn lifecycle. Delegates streaming to `streaming.py`, elicitation to `elicitation.py`, messages to `notifications.py`. |
+| `setup.py` / `oauth.py` / `auth_manager.py` / `tokens.py` | Per-user setup modal, device/OIDC login flows, token storage (encrypted at rest). |
+| `store.py` | SQLite: thread→session mapping and per-user config. |
+| `app.py` | slack_bolt wiring: event handlers + the Block Kit action handlers. |
+
+## The turn: streaming lifecycle
+
+A turn is: user message → `POST /v1/sessions/{id}/events` → read the session
+SSE stream → render events into the thread → detect turn end → stop reading.
+
+### One stream per turn (a deliberate divergence from the web UI)
+
+The web UI holds **one long-lived SSE stream per session** open for the whole
+time the conversation is on screen; a turn boundary is just a reducer event. The
+Slack bot instead opens **one stream per turn** (`OmnigentClient.run_turn`).
+
+Why: Slack has no persistent per-thread viewer — events arrive as discrete
+webhook callbacks, and a thread can sit idle for days. Holding an SSE stream
+open per thread indefinitely isn't the web UI's situation. The cost of this
+choice is that **turn-end detection becomes load-bearing** (the loop must decide
+when to stop reading and free the thread) — see below.
+
+### Turn-end detection is server-authoritative and harness-agnostic
+
+This is the single most fought-over piece of the design; it went through several
+wrong versions before landing here. The rule mirrors the web UI's reducer, keyed
+on **"is a response currently open?"** — never on the harness name.
+
+The server exposes `session.status` events, but `response_id` on them is
+**harness-dependent by design** (documented in the server's `SessionStatusEvent`
+schema): terminal-backed harnesses (claude-native, codex) stamp the turn's
+`response_id` on their terminal `idle`/`failed` (the Stop-hook edge), while the
+in-process runtime (claude-sdk / the `debby` orchestrator) emits **all**
+`session.status` events id-less. There are also mid-answer *flaps*: claude-native's
+PTY-activity watcher emits bare `idle` (no `response_id`) during sub-second
+generation lulls — those are **not** turn ends.
+
+The loop (`_run_turn_once`) therefore:
+
+1. Marks a response **open** when it sees an id-bearing `running`/`waiting`.
+2. **Ends** the turn on `idle`/`failed` when **(a)** it is id-bearing and matches
+   the open response (or no id-bearing open was ever seen), **or** **(b)** it is
+   id-less *and* no id-bearing response is open — the in-process harness, whose
+   real end is an id-less `idle`.
+3. **Ignores** an id-less `idle` while an id-bearing response is open (the
+   claude-native mid-answer flap — ending here truncates the reply).
+4. Never ends on `waiting` (both harnesses use it for "parked on sub-agents /
+   async work").
+
+Verified against both harnesses live. Explicit `response.failed`/`.cancelled`
+and `turn.failed`/`.cancelled` are hard-terminals too.
+
+### Dead-socket backstop
+
+The stream never sends `[DONE]` and never closes on its own; the server sends
+`session.heartbeat` roughly every 15s. So the **only** condition not signalled by
+an event is a dead (half-open) socket. The loop treats "no event of any kind for
+`idle_grace_seconds`" (default 600s — comfortably above the 15s heartbeat) as a
+dead connection and ends. This is the one justified client-side heuristic: a dead
+connection by definition can't send a signal.
+
+Timing note: the read is bounded with `asyncio.wait` (not `wait_for`) — cancelling
+the generator's `__anext__` would kill it — and the in-flight read is awaited in
+`finally` before the stream context closes, or httpx raises "aclose(): async
+generator already running".
+
+### `_AnswerReply` / `_LiveReply` invariants (`streaming.py`)
+
+- **Ack visibility, no gap.** A "_Working on it…_" placeholder is posted once the
+  session is established (after a new thread's config-summary message, so the
+  thread reads metadata → ack → answer) and removed **only once real content is
+  on screen** — the first delta that actually flushes to Slack, or the finalizing
+  `stop()` for a short buffered answer. Slack's SDK buffers appends
+  (`buffer_size=256`) and flushes on threshold or stop; clearing the ack any
+  earlier shows an empty thread. Because the ack follows session start, a failed
+  start posts no placeholder to clear — just the error.
+- **Ordering via seal.** A streamed reply is one Slack message anchored to its
+  open-time timestamp, so text appended after a mid-turn out-of-band post (card,
+  policy/file notice, first todo) would sort *above* it. Before every such post
+  the reply is **sealed** (finalize the current segment; the next append opens a
+  fresh message that sorts after the post) → true chronological order.
+- **Flush-before-card.** Because the SDK buffers, short pre-interruption text
+  would otherwise become visible only at the seal (coincident with the card).
+  `flush()` forces the buffered text onto the screen *before* the card, matching
+  the web UI's live reveal.
+- **Tail reconciliation + no-delta fallback.** The final answer is whatever
+  streamed; if the model committed a final item beyond the deltas, only the
+  remainder is appended. If a turn streamed *nothing* (answer arrived committed-
+  only), the newest server message is recovered as a last resort — guarded so it
+  can't resurrect a prior turn's message (baseline compare) or re-post an answer
+  an earlier sealed segment already showed (`already_delivered`).
+
+## Elicitations (tool approvals & questions): pure-push
+
+When a turn hits an approval-gated tool call or an `AskUserQuestion`, the server
+emits `response.elicitation_request` and parks. The bot handles this **pure-push**,
+mirroring the web UI: it **keeps reading the stream** and observes resolution as
+a normal `response.elicitation_resolved` event — it does **not** block the read
+loop or poll `pending_elicitations`.
+
+Flow (`ElicitationController`):
+
+1. On `elicitation_request`: seal the current reply, post the card, and spawn a
+   background **resolver** task — then return so the loop keeps reading. (Verified
+   from server source + live: an unresolved park does *not* emit an id-bearing
+   terminal, so keeping the loop alive is safe — the turn-end detector won't fire
+   during a park.)
+2. The resolver awaits the Slack click via `ElicitationCoordinator` and POSTs the
+   verdict; on timeout it declines so the server-side park releases.
+3. On the pushed `elicitation_resolved` (our own verdict, or an answer in the web
+   UI / another client): finalize the card in place, exactly once (`finalized`
+   guard). If the answer came from elsewhere, the coordinator wakes the resolver
+   with a `RESOLVED_EXTERNALLY` sentinel so it posts nothing.
+
+Classification is by **decision shape, not the server's delivery mode**:
+
+- **Binary approval** → Approve/Deny card, with a preview of the pending action.
+- **`AskUserQuestion`** → radio buttons / checkboxes + Submit; selected labels go
+  back as `content`. Option values carry the option **index** (labels can exceed
+  Slack's 75-char value cap); the index is mapped back to the full label at
+  resolve time.
+- **Free-form typed input** (non-empty `requestedSchema`, no `ask_user_question`)
+  → the bot can't collect it with buttons, so it posts a web-UI link and doesn't
+  block. The turn stays alive and resumes once answered there.
+
+The server defaults to `url`-mode elicitations, but the bot renders a url-mode
+approval/question natively and resolves via the endpoint — only genuinely
+uncollectable typed input falls back to the link.
+
+## Concurrency: run-when-idle, two guards, no queue
+
+There is **no client-side queue**. Whether a new owner message to an existing
+thread runs is decided by two independent guards; both must pass:
+
+1. **Local stream guard** (`_active_threads`, reserved synchronously before any
+   await). One turn streams per thread at a time — a second concurrent stream
+   would render the same events into Slack twice. A message arriving while the
+   thread is streaming is deflected (not queued).
+2. **Server-activity check** (`get_session_activity`, mirroring the web UI's
+   send-gate `computeIsWorking` + pending-elicitation). Catches activity on the
+   *session* the local guard can't see — e.g. a turn driven from the web UI. If
+   the server reports `running`/`waiting` or a pending elicitation, the message
+   is deflected with a notice (wait/interrupt, or answer the pending request),
+   linking to the web UI.
+
+If both pass (server idle, no local stream) the turn **runs** — Slack is a full
+conversational surface, not kickoff-only. A message that races the check is safe
+regardless: the server buffers a mid-turn submit and runs it as a continuation
+(verified in server source; the web UI likewise queues client-side rather than
+rejecting).
+
+The local guard is safe from the stale-wedge that an earlier version hit, because
+every turn is now bounded (turn-end detection + dead-socket backstop guarantee it
+ends and releases).
+
+## Authorization
+
+Slack channels are multi-user, so the bot enforces a **per-thread owner** model
+(the web UI, single-identity, needs none of this):
+
+- A thread belongs to whoever started it. A follow-up from a different user isn't
+  added to the session; they get a private "not your session" notice. The gate is
+  **fail-closed**: an event with no user, or a record with no stored owner, is
+  refused rather than run.
+- Elicitation button/form clicks carry `"<owner> <session_id> <elicitation_id>"`
+  in their control value. A click from anyone but the owner is rejected **before**
+  any verdict is delivered — the card is visible channel-wide but only the owner
+  can act.
+
+## Turn-progress signals
+
+Beyond the streamed answer, best-effort notices (never interrupt the stream):
+`response.policy_denied` → "blocked by policy" notice; `response.output_file.done`
+→ produced-file notice; `session.todos` → a plan message posted once then edited
+in place.
+
+## Errors
+
+`_turn_error_text` is the single source of truth mapping known errors to
+user-facing messages, shared by the session-startup and mid-turn paths:
+
+- **401** → "log in again" (`/omnigent`).
+- **Unreachable** → "reconfigure" (`/omnigent`).
+- **No online host** → the `omni host --server …` command.
+- **412 `harness_not_configured`** → the server's *curated* `error.message` (run
+  `omnigent setup` on the host). Server error bodies are otherwise **not** echoed
+  to the channel (they can leak internal paths/stack traces) — only this specific,
+  actionable code's message is surfaced; everything else is logged server-side and
+  shown as a generic failure.
+
+## Authentication (per-user, delegated)
+
+Each Slack user authenticates as their own Omnigent identity — no Omnigent
+credential passes through Slack. The bot auto-detects the server's auth mode
+(unauthenticated `GET /v1/me`) and drives `accounts`-mode device grant (RFC 8628)
+or `oidc` cli-login inside the `/omnigent` modal; `header`/proxy mode is
+unsupported. Tokens are encrypted at rest when
+`OMNIGENT_SLACK_TOKEN_ENCRYPTION_KEY` is set, else in-memory only. The 401-retry
+path refreshes a delegated token once mid-request. See `README.md#authentication`
+for the operator/user view and `designs/DEVICE_AUTH.md` in the main repo for the
+threat model.
+
+## Testing notes
+
+Unit tests use fakes (`FakeOmnigentClient`, `FakeSlackClient`) that mirror the
+real SSE event shapes — including the id-bearing vs id-less `session.status`
+distinction and the SDK's buffer/flush behavior — so the turn-end and streaming
+invariants above are exercised without a live server. The trickiest behaviors
+(turn-end per harness, silent-stream hang, pure-push elicitation, flush-before-
+card) each have a regression test that fails without its fix. Live E2E against a
+dev server is used for the timing-dependent flows fakes can't fully model.

--- a/integrations/slack/README.md
+++ b/integrations/slack/README.md
@@ -6,6 +6,9 @@ bot talks to **one** Omnigent server, set by the operator via
 issues requests to that fixed host. Each user still authenticates as their own
 Omnigent identity against it.
 
+> This README is the operator/user guide (setup, scopes, running, auth). For the
+> architecture and key technical decisions, see **[DESIGN.md](DESIGN.md)**.
+
 ## Setup
 
 1. Create a Slack app with Socket Mode **and** Interactivity enabled (Socket
@@ -205,110 +208,22 @@ Mention the bot with a message to start a session:
 @your-bot help me inspect this failure
 ```
 
-Replies stream in live (via Slack's `chat.startStream` API) and render Markdown
-server-side. If a turn runs long enough that Slack finalizes the streaming
-message, the bot opens a fresh streaming reply in the same thread and keeps
-going, so a long answer arrives live across as many messages as it needs.
-Replies in that Slack thread continue the same Omnigent session. A channel
-thread belongs to whoever started it; a follow-up `@mention` from a different
-user is not added to that session — that user instead gets a private
-("Only visible to you") note explaining why, and pointing them to start their
-own thread.
+Replies stream in live and render Markdown. Replies in that Slack thread continue
+the same Omnigent session. A channel thread belongs to whoever started it; a
+follow-up from a different user gets a private ("Only visible to you") note
+pointing them to start their own thread.
 
-### Multi-agent turns
+When the agent needs you — a tool-call approval or a multiple-choice question —
+it appears in the thread as an **Approve / Deny** card or a radio/checkbox
+**Submit** form; answer it there (or in the web UI). A request it can't render
+with buttons (free-form typed input) links out to the web UI instead.
 
-`session.status: idle` is an ambiguous turn boundary, so at each idle the bot
-waits before deciding the turn is over — on two timescales:
+Send another message while the bot is still replying and it privately tells you
+to wait or continue in the web UI; a message to an idle thread just continues the
+conversation.
 
-- **Settle (short, ~2s).** A single agent oscillates `running`/`idle` *while
-  still streaming* its answer, with sub-second gaps between bursts. Every idle
-  first waits a brief settle window for the next burst, so a reply is never
-  truncated mid-answer. A genuinely final idle adds only this small tail.
-- **Snapshot + poll (coarse).** If still quiet after the settle, the bot checks
-  the session's rolled-up status, which reads `running` while any sub-agent
-  child is still working (a fan-out orchestrator like `debby` parked between
-  wake cycles). While running it polls (every 5s, up to a 10-minute cap) so a
-  slow sub-agent keeps the turn alive; otherwise the turn ends.
-
-While the agent works before the first tokens arrive, the thread shows a
-"Working on it…" placeholder. It's removed only once the reply is actually on
-screen — on the first streamed chunk, or after the finalizing flush for a
-buffered answer — so there's never an empty gap between the placeholder
-disappearing and the reply appearing.
-
-### Approvals & questions
-
-When the agent needs the user — a tool-call approval, or a multiple-choice
-question — the turn pauses and the bot surfaces it in the thread. It renders
-the server's `response.elicitation_request` in one of three ways:
-
-- **Approval** (a gated tool call): an **Approve / Deny** card with a preview of
-  the pending action. Click to resume; deny (or let it sit past the wait
-  window) to refuse.
-- **Question** (Claude's `AskUserQuestion` and equivalents): the choices render
-  as radio buttons (or checkboxes for multi-select) with a **Submit** — the
-  selected labels are sent back to the agent as its answer, exactly like the
-  web UI.
-- **Free-form input** (a request for typed values the bot can't collect with
-  buttons): the bot posts a link to resolve the request in the Omnigent web UI,
-  rather than mishandling it. The turn stays alive (via the idle grace window)
-  so it resumes once you answer there.
-
-The classification is by the *decision shape*, not the server's delivery mode.
-The server defaults to `url`-mode elicitations (carrying a suggested standalone
-approve page), but the bot still renders a `url`-mode approval or question
-natively and posts the verdict to the resolve endpoint — only genuinely
-uncollectable typed input falls back to the link.
-
-The card is updated in place with the outcome once answered, and the "Working
-on it…" placeholder is cleared while parked so it doesn't sit stale. Multiple
-requests in one turn are handled in order.
-
-This mirrors the web UI and CLI — the bot consumes `response.elicitation_request`
-and posts the verdict (with any selections as `content`) back to the session's
-resolve endpoint.
-
-While a request is outstanding the turn stays open, so a message sent to that
-thread meanwhile is deflected like any other mid-turn message (see below). If the
-user answers the request in the web UI instead of clicking the Slack card, the
-bot notices (it polls for external resolution) and continues without waiting. An
-unanswered card gives up after a few minutes so it can't hold the thread open
-indefinitely — the user can just re-send.
-
-**One turn at a time per thread.** Each turn opens its own event stream, so the
-bot runs one turn per thread at a time — a second concurrent stream would render
-into Slack twice. There is no queue. A message that arrives *while a thread is
-still streaming* is not run: the bot privately ("Only visible to you") tells the
-user it's still working and to re-send once it has replied, or to continue right
-now in the web UI (which accepts concurrent input and shows any pending actions).
-A message to a thread that is idle again runs normally — Slack stays a full
-conversational surface, not just a way to kick a session off. Messages that race
-the check are safe regardless: the server buffers a message that lands mid-turn
-and runs it as a continuation.
-
-**Ordering.** A streamed reply is a single Slack message anchored to the moment
-it opened, so text kept flowing into it would sort *before* any card or notice
-posted mid-turn — inverting cause and effect. The bot avoids this by *sealing*
-the current reply at each interruption (approval card, policy/file notice): the
-answer so far ends there, the out-of-band message sorts after it, and anything
-the agent says next opens a fresh reply below. So the thread reads in true
-order — reply, card, continued reply — even across several approvals in one turn.
-
-### Turn progress
-
-Beyond the streamed answer, the bot surfaces a few other signals when the
-harness emits them:
-
-- **Thinking** — while the agent reasons before producing output, the
-  placeholder switches to a "Thinking…" indicator so a long think isn't silent.
-- **Plan / todos** — a task list (from harnesses that report one, e.g. Claude
-  Code's `TodoWrite`) is posted once and edited in place as items progress.
-- **Blocked by policy** — when a tool call is hard-blocked by policy (a DENY,
-  with no approval offered), the bot posts why, so an absent action is
-  explained rather than silent.
-- **Produced files** — a note naming any file artifact the agent generated.
-
-All are best-effort and never interrupt the answer stream.
+For how any of this works under the hood — streaming, turn-end detection,
+elicitation handling, concurrency, ordering — see **[DESIGN.md](DESIGN.md)**.
 
 ## Development
 

--- a/integrations/slack/src/omnigent_slack/approvals.py
+++ b/integrations/slack/src/omnigent_slack/approvals.py
@@ -3,12 +3,33 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Protocol
 
 from omnigent_slack.omnigent import ElicitationRequest
 from omnigent_slack.text import truncate_for_slack
 
 _logger = logging.getLogger(__name__)
+
+
+class ElicitationOutcome(str, Enum):
+    """Past-tense label shown on a resolved elicitation card.
+
+    Single source of truth shared by the resolver (which picks the outcome from
+    the verdict) and ``resolved_card_blocks`` (which renders its icon/text) — so
+    the two can't drift on a bare string. Binary approvals use APPROVED/DENIED;
+    forms use ANSWERED/CANCELLED; TIMED_OUT is a no-response decline;
+    ANSWERED_ELSEWHERE covers a web-UI/other-client resolution (accept or reject,
+    unknown which).
+    """
+
+    APPROVED = "Approved"
+    DENIED = "Denied"
+    ANSWERED = "Answered"
+    CANCELLED = "Cancelled"
+    TIMED_OUT = "Timed out"
+    ANSWERED_ELSEWHERE = "Answered elsewhere"
+
 
 # Block Kit action ids. Binary approve/deny each carry the resolve target in
 # their ``value``; the form Submit does too, while the per-question radio/
@@ -34,6 +55,11 @@ _QUESTION_BLOCK_PREFIX = "omnigent_q::"
 # walked away, failing fast frees the thread (they can re-send). Note this is only
 # the cap — an answer via the web UI unblocks immediately (external-resolution poll).
 DEFAULT_ELICITATION_TIMEOUT_SECONDS = 3 * 60
+
+# Returned by ``ElicitationCoordinator.await_verdict`` when the server pushed a
+# ``response.elicitation_resolved`` (answered in the web UI or another client)
+# rather than a Slack click — the caller clears the card but posts no verdict.
+RESOLVED_EXTERNALLY = object()
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,7 +90,8 @@ class ElicitationCoordinator:
         # All access is on the single slack_bolt event loop (register/await from
         # the turn worker, resolve from the block-action handler), so plain dict
         # ops are safe without a lock.
-        self._pending: dict[str, asyncio.Future[Verdict]] = {}
+        # Future result is a Verdict (Slack click) or RESOLVED_EXTERNALLY.
+        self._pending: dict[str, asyncio.Future[Verdict | object]] = {}
         self._timeout = timeout_seconds
 
     def register(self, elicitation_id: str) -> None:
@@ -76,13 +103,15 @@ class ElicitationCoordinator:
         """
         self._pending[elicitation_id] = asyncio.get_running_loop().create_future()
 
-    async def await_verdict(self, elicitation_id: str) -> Verdict | None:
+    async def await_verdict(self, elicitation_id: str) -> Verdict | object | None:
         """Block on the pre-:meth:`register`ed future until answered or timeout.
 
-        Returns the :class:`Verdict`, or ``None`` when no one answered within
-        the timeout (the caller then declines so the server doesn't hang).
-        Registers on demand if the caller skipped :meth:`register` (keeps the
-        method usable standalone, e.g. in tests).
+        Returns the :class:`Verdict` (a Slack click), :data:`RESOLVED_EXTERNALLY`
+        (the server pushed ``elicitation_resolved`` — answered in the web UI or
+        another client, so the caller must NOT post its own verdict), or ``None``
+        when no one answered within the timeout (the caller then declines so the
+        server doesn't hang). Registers on demand if the caller skipped
+        :meth:`register` (keeps the method usable standalone, e.g. in tests).
         """
         future = self._pending.get(elicitation_id)
         if future is None:
@@ -96,16 +125,30 @@ class ElicitationCoordinator:
             self._pending.pop(elicitation_id, None)
 
     def resolve(self, elicitation_id: str, verdict: Verdict) -> bool:
-        """Deliver a verdict for a waiting elicitation.
+        """Deliver a Slack-click verdict to a waiting elicitation.
 
         Returns whether a live waiter was found — ``False`` means the answer
-        arrived after the worker gave up (timeout) or a duplicate click, so the
-        caller can note the request already closed.
+        arrived after the worker gave up (timeout), a duplicate click, or the
+        request was already resolved externally, so the caller can note it closed.
         """
+        return self._settle(elicitation_id, verdict)
+
+    def resolve_external(self, elicitation_id: str) -> bool:
+        """Signal that the elicitation was resolved on the server (web UI/other).
+
+        The turn loop keeps reading the stream and calls this when it observes a
+        pushed ``response.elicitation_resolved``. The waiter wakes with
+        :data:`RESOLVED_EXTERNALLY` so it clears the card WITHOUT posting a
+        verdict (the server already has one). No-op if already settled — e.g. our
+        own click won the race and the server is just echoing it back.
+        """
+        return self._settle(elicitation_id, RESOLVED_EXTERNALLY)
+
+    def _settle(self, elicitation_id: str, result: Verdict | object) -> bool:
         future = self._pending.get(elicitation_id)
         if future is None or future.done():
             return False
-        future.set_result(verdict)
+        future.set_result(result)
         return True
 
 
@@ -222,25 +265,23 @@ def _form_card_blocks(request: ElicitationRequest, owner_user_id: str) -> list[d
     return blocks
 
 
-def resolved_card_blocks(request: ElicitationRequest, *, outcome: str) -> list[dict[str, Any]]:
-    """Blocks that replace the card once answered (no controls).
-
-    ``outcome`` is a short past-tense label (``"Approved"``, ``"Denied"``,
-    ``"Answered"``, ``"Timed out"``, ``"Cancelled"``).
-    """
+def resolved_card_blocks(
+    request: ElicitationRequest, *, outcome: ElicitationOutcome
+) -> list[dict[str, Any]]:
+    """Blocks that replace the card once answered (no controls)."""
     icon = {
-        "Approved": ":white_check_mark:",
-        "Answered": ":white_check_mark:",
+        ElicitationOutcome.APPROVED: ":white_check_mark:",
+        ElicitationOutcome.ANSWERED: ":white_check_mark:",
         # "Answered elsewhere" covers accept OR reject in the web UI — neutral
         # icon since we don't know which way it went.
-        "Answered elsewhere": ":information_source:",
-        "Denied": ":no_entry:",
-        "Cancelled": ":no_entry:",
+        ElicitationOutcome.ANSWERED_ELSEWHERE: ":information_source:",
+        ElicitationOutcome.DENIED: ":no_entry:",
+        ElicitationOutcome.CANCELLED: ":no_entry:",
     }.get(outcome, ":hourglass:")
-    text = f"{icon} *{outcome}*\n{truncate_for_slack(request.message, limit=2000)}"
-    if outcome == "Timed out":
-        # A timeout declines server-side so the thread's queue is freed; tell the
-        # user the request was dropped and that re-sending starts a fresh attempt.
+    text = f"{icon} *{outcome.value}*\n{truncate_for_slack(request.message, limit=2000)}"
+    if outcome is ElicitationOutcome.TIMED_OUT:
+        # A timeout declines server-side so the thread frees; tell the user the
+        # request was dropped and that re-sending starts a fresh attempt.
         text += "\n_No response in time — I declined it. Send your message again to retry._"
     return [{"type": "section", "text": {"type": "mrkdwn", "text": text}}]
 

--- a/integrations/slack/src/omnigent_slack/elicitation.py
+++ b/integrations/slack/src/omnigent_slack/elicitation.py
@@ -1,0 +1,315 @@
+"""In-turn elicitation (tool-approval) orchestration for the Slack bot.
+
+Owns everything about a pending approval/AskUserQuestion card *during a turn*:
+posting the card, spawning the background resolver that awaits the Slack click
+(or times out) and posts the verdict, and finalizing the card in place when the
+server pushes ``response.elicitation_resolved``. Pure-push, mirroring the web
+UI: the turn loop keeps reading the stream, so the continuation and the resolved
+event arrive as normal events — no polling.
+
+Extracted from ``SlackOmnigentService`` so that class is left with event
+routing + turn lifecycle. The card-building blocks, the coordinator, and the
+outcome enum live in ``approvals``; this module is the orchestration on top.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from omnigent_slack.approvals import (
+    RESOLVED_EXTERNALLY,
+    ClickTarget,
+    ElicitationCoordinator,
+    ElicitationOutcome,
+    Verdict,
+    elicitation_card_blocks,
+    resolve_form_answers,
+    resolved_card_blocks,
+)
+from omnigent_slack.models import SlackTurn, ThreadKey
+from omnigent_slack.omnigent import ElicitationRequest, OmnigentClient
+
+if TYPE_CHECKING:
+    from omnigent_slack.streaming import SlackClientProtocol
+
+# Posts a plain thread reply (used for the unsupported-elicitation web link).
+PostReply = Callable[["SlackClientProtocol", ThreadKey, str], Awaitable[None]]
+
+
+@dataclass
+class PendingElicitation:
+    """An elicitation card in flight during a turn (pure-push model).
+
+    The turn loop keeps reading the stream while the card is shown; a background
+    ``resolver`` task awaits the Slack click (or times out) and posts the verdict.
+    The pushed ``response.elicitation_resolved`` — or the resolver itself —
+    finalizes the card exactly once (``finalized`` guards the race).
+    """
+
+    request: ElicitationRequest
+    card_ts: str | None
+    resolver: asyncio.Task[None] | None = None
+    finalized: bool = False
+    # The verdict the resolver posted (a Slack click), or None if it hasn't
+    # posted (external answer) — decides the card's outcome label.
+    verdict: Verdict | None = None
+    # Set when the resolver declined because nobody answered in time.
+    timed_out: bool = False
+
+
+@dataclass
+class ElicitationTurnState:
+    """Per-turn registry of in-flight elicitations, keyed by elicitation_id.
+
+    Owned by the turn loop and passed to each controller call, so the controller
+    holds no per-turn state itself (one controller serves all threads).
+    """
+
+    pending: dict[str, PendingElicitation] = field(default_factory=dict)
+
+
+class ElicitationController:
+    """Orchestrates elicitation cards for a turn, pure-push style.
+
+    Stateless across turns: all per-turn state lives in the
+    :class:`ElicitationTurnState` the caller threads through. Collaborators are
+    the shared :class:`ElicitationCoordinator` (bridges the Slack button handler
+    to the resolver), a ``post_reply`` for the web-link fallback, and the server
+    URL for building that link.
+    """
+
+    def __init__(
+        self,
+        coordinator: ElicitationCoordinator,
+        *,
+        server_url: str,
+        post_reply: PostReply,
+        logger: logging.Logger,
+    ) -> None:
+        self._coordinator = coordinator
+        self._server_url = server_url
+        self._post_reply = post_reply
+        self._logger = logger
+
+    async def handle_action(self, *, elicitation_id: str, verdict: Verdict) -> bool:
+        """Deliver a button/form verdict to the waiting resolver.
+
+        Returns whether a live waiter received it — ``False`` means the request
+        already expired or was answered, so the caller can tell the user.
+        """
+        return self._coordinator.resolve(elicitation_id, verdict)
+
+    async def reject_non_owner_click(
+        self, client: SlackClientProtocol, body: dict[str, Any], target: ClickTarget
+    ) -> None:
+        """Privately tell a non-owner their click on someone else's card was ignored.
+
+        The verdict is NOT delivered (the owner check already blocked it); this is
+        just feedback so the clicker isn't left wondering. Channel/thread come from
+        the interaction body (a Block Kit action payload).
+        """
+        channel = (body.get("channel") or {}).get("id")
+        clicker = (body.get("user") or {}).get("id")
+        message = body.get("message") or {}
+        thread_ts = message.get("thread_ts") or message.get("ts")
+        if not isinstance(channel, str) or not isinstance(clicker, str):
+            return
+        try:
+            await client.chat_postEphemeral(
+                channel=channel,
+                user=clicker,
+                thread_ts=thread_ts if isinstance(thread_ts, str) else None,
+                text=(
+                    "This request belongs to whoever started the thread — only they "
+                    "can answer it. Start your own thread by mentioning me (or DM me)."
+                ),
+            )
+        except Exception:
+            self._logger.warning("Non-owner click ephemeral failed; continuing")
+
+    async def start(
+        self,
+        omnigent: OmnigentClient,
+        turn: SlackTurn,
+        request: ElicitationRequest,
+        state: ElicitationTurnState,
+    ) -> None:
+        """Post the elicitation card and spawn its resolver WITHOUT blocking.
+
+        Renders a form (``AskUserQuestion``) or binary Approve/Deny and returns
+        immediately so the turn loop keeps reading the stream. A background
+        ``resolver`` task awaits the Slack click (or times out) and posts the
+        verdict; the pushed ``response.elicitation_resolved`` finalizes the card.
+
+        For an elicitation the bot can't render (a ``url``-mode page or free-form
+        typed input), it posts a web-UI link and returns — no card, no resolver;
+        the user completes it there and the stream resumes.
+        """
+        client = turn.slack_client
+        key = turn.key
+        if not request.is_supported:
+            await self._post_reply(
+                client,
+                key,
+                (
+                    ":link: Omnigent needs input I can't collect here "
+                    f"({request.message}). Open the session to respond:\n"
+                    f"{self._approve_link(request.session_id, request.elicitation_id)}"
+                ),
+            )
+            self._logger.info(
+                "Unsupported elicitation surfaced as web link thread=%s elicitation_id=%s mode=%s",
+                key.display(),
+                request.elicitation_id,
+                request.mode,
+            )
+            return
+
+        self._logger.info(
+            "Elicitation requested thread=%s elicitation_id=%s policy=%s form=%s",
+            key.display(),
+            request.elicitation_id,
+            request.policy_name,
+            request.is_form,
+        )
+        # Register the waiter BEFORE posting the card so a fast click can't reach
+        # the action handler before the future exists (lost wakeup).
+        self._coordinator.register(request.elicitation_id)
+        posted = await client.chat_postMessage(
+            channel=key.channel_id,
+            thread_ts=key.thread_ts,
+            text="Omnigent needs your input to continue.",
+            blocks=elicitation_card_blocks(request, turn.owner_user_id),
+        )
+        card_ts = posted.get("ts")
+        pending = PendingElicitation(
+            request=request, card_ts=card_ts if isinstance(card_ts, str) else None
+        )
+        state.pending[request.elicitation_id] = pending
+        pending.resolver = asyncio.create_task(self._resolve_verdict(omnigent, request, pending))
+
+    async def _resolve_verdict(
+        self,
+        omnigent: OmnigentClient,
+        request: ElicitationRequest,
+        pending: PendingElicitation,
+    ) -> None:
+        """Resolver task: await the Slack verdict, then POST it to the server.
+
+        Runs concurrently with the turn's read loop. If the user answered
+        elsewhere, the loop sees ``elicitation_resolved`` first and wakes this
+        task with ``RESOLVED_EXTERNALLY`` (via :meth:`on_resolved`), so it never
+        posts. On a Slack click it POSTs the verdict and records it on ``pending``
+        (for the card's outcome label); the server then pushes
+        ``elicitation_resolved`` back, which finalizes the card. On timeout it
+        declines so the server-side park releases.
+        """
+        verdict = await self._coordinator.await_verdict(request.elicitation_id)
+        if verdict is RESOLVED_EXTERNALLY:
+            # Already resolved server-side; post nothing (the loop finalizes).
+            return
+        content: dict[str, Any] | None = None
+        if verdict is None:
+            # Nobody answered in time — decline so the server park releases, and
+            # flag it so the card shows "Timed out" + retry, not "Denied".
+            verdict = Verdict(accepted=False)
+            pending.timed_out = True
+        elif isinstance(verdict, Verdict) and request.is_form:
+            # Form Submit = accept with selections; Cancel = decline. Selections
+            # arrive as option indices — map back to the full labels the agent
+            # expects (labels can exceed Slack's value cap).
+            content = resolve_form_answers(request, verdict.content)
+        assert isinstance(verdict, Verdict)
+        pending.verdict = verdict
+        await omnigent.resolve_elicitation(
+            request.session_id,
+            request.elicitation_id,
+            accepted=verdict.accepted,
+            content=content,
+        )
+
+    async def on_resolved(
+        self, turn: SlackTurn, elicitation_id: str, state: ElicitationTurnState
+    ) -> None:
+        """Finalize a resolved elicitation's card (idempotent).
+
+        Fired when the server pushes ``response.elicitation_resolved`` — for our
+        own posted verdict or an external answer. Wakes/awaits the resolver and
+        replaces the card with its outcome, exactly once.
+        """
+        pending = state.pending.get(elicitation_id)
+        if pending is None or pending.finalized:
+            return
+        pending.finalized = True
+        # Wake the resolver if it's still waiting on a click (external answer):
+        # RESOLVED_EXTERNALLY makes it return without posting. If it already
+        # posted (our own click), this is a no-op and the resolver just finishes.
+        self._coordinator.resolve_external(elicitation_id)
+        if pending.resolver is not None:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await pending.resolver
+        outcome = self._outcome(pending)
+        self._logger.info(
+            "Elicitation resolved thread=%s elicitation_id=%s outcome=%s",
+            turn.key.display(),
+            elicitation_id,
+            outcome.value,
+        )
+        await self._finalize_card(turn, pending, outcome)
+
+    async def finish_pending(self, turn: SlackTurn, state: ElicitationTurnState) -> None:
+        """At turn end, settle any elicitation still in flight.
+
+        Normally every elicitation is finalized by its pushed
+        ``elicitation_resolved`` before the turn ends. This is the backstop for a
+        turn that ends (or is torn down) with a card still open: wake/await the
+        resolver and finalize the card so no resolver task leaks.
+        """
+        for eid, pending in list(state.pending.items()):
+            if not pending.finalized:
+                await self.on_resolved(turn, eid, state)
+
+    @staticmethod
+    def _outcome(pending: PendingElicitation) -> ElicitationOutcome:
+        if pending.timed_out:
+            return ElicitationOutcome.TIMED_OUT
+        verdict = pending.verdict
+        if verdict is None:
+            # No Slack verdict was posted — answered elsewhere (web UI/other
+            # client). We don't know which way it went — neutral label.
+            return ElicitationOutcome.ANSWERED_ELSEWHERE
+        if pending.request.is_form:
+            return (
+                ElicitationOutcome.ANSWERED if verdict.accepted else ElicitationOutcome.CANCELLED
+            )
+        return ElicitationOutcome.APPROVED if verdict.accepted else ElicitationOutcome.DENIED
+
+    async def _finalize_card(
+        self, turn: SlackTurn, pending: PendingElicitation, outcome: ElicitationOutcome
+    ) -> None:
+        if pending.card_ts is None:
+            return
+        # Best-effort: replace the card with its outcome (no controls). A failed
+        # update must not abort the turn.
+        try:
+            await turn.slack_client.chat_update(
+                channel=turn.key.channel_id,
+                ts=pending.card_ts,
+                text=f"Request {outcome.value.lower()}.",
+                blocks=resolved_card_blocks(pending.request, outcome=outcome),
+            )
+        except Exception:
+            self._logger.warning(
+                "Elicitation card update failed thread=%s; continuing", turn.key.display()
+            )
+
+    def _approve_link(self, session_id: str, elicitation_id: str) -> str:
+        # Deep link to the elicitation's approve page in the Omnigent web UI, so
+        # a user can resolve a request the bot can't render in Slack.
+        base = self._server_url.rstrip("/")
+        return f"{base}/approve/{session_id}/{elicitation_id}"

--- a/integrations/slack/src/omnigent_slack/events.py
+++ b/integrations/slack/src/omnigent_slack/events.py
@@ -117,51 +117,52 @@ async def iter_sse_events(lines: AsyncIterator[str]) -> AsyncIterator[dict[str, 
         yield event
 
 
-def is_terminal_event(event: dict[str, Any]) -> bool:
-    # A turn ends at the SESSION level, not the response level. Orchestrator
-    # agents emit a `response.completed`/`turn.completed` every time they end a
-    # turn to wait on a background sub-agent, then resume with more responses in
-    # the same turn — so treating those as terminal cuts the stream off at the
-    # first sub-agent dispatch. `session.status` is the authoritative signal:
-    # `running` -> `waiting` (parked on async work) -> `running` -> `idle`, and
-    # only `idle`/`failed` mean the turn is truly over.
-    event_type = str(event.get("type"))
-    if event_type == "session.status":
-        return str(event.get("status")) in {"idle", "failed"}
-    # Explicit turn/response failure and cancellation still end the turn; keep
-    # them as a fallback in case the session settles without an `idle` edge.
-    return event_type in {
+def session_status(event: dict[str, Any]) -> tuple[str, str | None] | None:
+    """Parse a ``session.status`` event into ``(status, response_id)``.
+
+    Returns ``None`` for any other event. ``response_id`` is ``None`` when the
+    field is absent — critically, this distinguishes the AUTHORITATIVE turn edge
+    (the Stop hook stamps the turn's ``response_id`` on the terminal
+    ``idle``/``waiting``/``failed``) from the PTY-activity watcher's mid-answer
+    flaps (bare ``idle`` with NO ``response_id``, emitted on sub-second pane
+    lulls while the agent is still generating). The turn-end rule that consumes
+    this lives in ``OmnigentClient._run_turn_once``.
+    """
+    if event.get("type") != "session.status":
+        return None
+    status = event.get("status")
+    if not isinstance(status, str):
+        return None
+    response_id = event.get("response_id")
+    return status, response_id if isinstance(response_id, str) and response_id else None
+
+
+def extract_elicitation_resolved(event: dict[str, Any]) -> str | None:
+    """Return the ``elicitation_id`` of a ``response.elicitation_resolved`` event.
+
+    The server pushes this when an elicitation is resolved — by our own Slack
+    verdict, or externally (web UI / another client). The turn loop keeps reading
+    the stream while a card is shown, so it observes resolution as a normal push
+    event (the web UI's model) rather than polling ``pending_elicitations``.
+    """
+    if event.get("type") != "response.elicitation_resolved":
+        return None
+    eid = event.get("elicitation_id")
+    return eid if isinstance(eid, str) and eid else None
+
+
+def is_hard_terminal_event(event: dict[str, Any]) -> bool:
+    """True for an explicit turn/response failure or cancellation.
+
+    These end the turn regardless of ``response_id`` tracking — a fallback for a
+    session that fails without a clean id-matched ``session.status`` edge.
+    """
+    return event.get("type") in {
         "response.failed",
         "response.cancelled",
         "turn.failed",
         "turn.cancelled",
     }
-
-
-def is_elicitation_request(event: dict[str, Any]) -> bool:
-    """True for a ``response.elicitation_request`` event.
-
-    Like a soft idle, this is an AMBIGUOUS boundary for the read loop: the
-    consumer parks (posts a card, blocks for the verdict) while it's handled, so
-    the SSE connection goes unread for as long as the user takes to answer. When
-    the loop resumes it must NOT go straight into an unbounded read — the stale
-    connection may never deliver the post-resolve events. The caller routes the
-    next read through the grace disambiguation (poll status) instead.
-    """
-    return event.get("type") == "response.elicitation_request"
-
-
-def is_soft_idle_event(event: dict[str, Any]) -> bool:
-    """True for a ``session.status: idle`` edge — an AMBIGUOUS turn boundary.
-
-    A fan-out orchestrator (e.g. ``debby``) ends its turn to wait on sub-agents
-    and settles to ``idle`` between wake cycles, then a sub-agent completion
-    re-injects a message that wakes it and it resumes. So ``idle`` means either
-    "parked, will be re-woken" or "genuinely done" — the caller disambiguates
-    with a grace window (does anything else arrive shortly?). ``failed`` and the
-    explicit cancel/fail events are NOT soft: they end the turn immediately.
-    """
-    return event.get("type") == "session.status" and event.get("status") == "idle"
 
 
 def extract_delta(event: dict[str, Any]) -> str | None:
@@ -298,6 +299,19 @@ class SessionActivity:
     @property
     def needs_user_action(self) -> bool:
         return self.pending_elicitation
+
+
+@dataclass(frozen=True, slots=True)
+class SessionInfo:
+    """Server-authoritative session config, for the first-message summary.
+
+    ``harness`` is the runtime the session runs on (e.g. ``claude-native``);
+    ``agent_name`` is the configured agent (e.g. ``debby``). Either may be
+    ``None`` if the snapshot is unreadable or omits the field.
+    """
+
+    harness: str | None
+    agent_name: str | None
 
 
 def extract_output_file(event: dict[str, Any]) -> OutputFile | None:

--- a/integrations/slack/src/omnigent_slack/notifications.py
+++ b/integrations/slack/src/omnigent_slack/notifications.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-from typing import Any
+import logging
+from typing import TYPE_CHECKING, Any
 
+from omnigent_slack.models import ThreadKey
 from omnigent_slack.omnigent import OutputFile
 from omnigent_slack.text import truncate_for_slack
+
+if TYPE_CHECKING:
+    from omnigent_slack.streaming import SlackClientProtocol
 
 # Status → checkbox glyph for the rendered todo list.
 _TODO_MARK = {
@@ -45,3 +50,173 @@ def format_output_file(file: OutputFile) -> str:
 def format_policy_denied(reason: str) -> str:
     """Render a policy-DENY notice (the block-without-asking counterpart)."""
     return f":no_entry: Blocked by policy: {truncate_for_slack(reason, limit=2000)}"
+
+
+class SlackNotifier:
+    """All the bot's outbound Slack messages in one place.
+
+    Thin wrappers over the Slack client: the ack placeholder, plain/failure
+    thread replies, ephemeral ("only visible to you") notices, the in-place todo
+    plan message, and the two owner-facing deflection notices. The Slack
+    ``client`` is passed per-call (it's per-turn/per-event, not fixed); the
+    notifier only holds the logger and server URL. Best-effort throughout — a
+    failed side-channel post must never abort turn handling.
+    """
+
+    def __init__(self, *, server_url: str, logger: logging.Logger) -> None:
+        self._server_url = server_url
+        self._logger = logger
+
+    async def post_ack(self, client: SlackClientProtocol, key: ThreadKey, text: str) -> str | None:
+        # Best-effort: a failed ack must not abort the turn.
+        try:
+            response = await client.chat_postMessage(
+                channel=key.channel_id, thread_ts=key.thread_ts, text=text
+            )
+        except Exception:
+            self._logger.warning("Ack post failed thread=%s; continuing", key.display())
+            return None
+        ts = response.get("ts")
+        return str(ts) if ts else None
+
+    async def post_reply(self, client: SlackClientProtocol, key: ThreadKey, text: str) -> None:
+        await client.chat_postMessage(
+            channel=key.channel_id,
+            thread_ts=key.thread_ts,
+            text=truncate_for_slack(text),
+        )
+
+    async def post_failure_reply(
+        self, client: SlackClientProtocol, key: ThreadKey, error_text: str
+    ) -> None:
+        # Post the failure as its own thread reply so the streamed answer stays
+        # intact.
+        await client.chat_postMessage(
+            channel=key.channel_id,
+            thread_ts=key.thread_ts,
+            text=f":warning: Omnigent request failed: {error_text}",
+        )
+
+    async def post_session_info(
+        self,
+        client: SlackClientProtocol,
+        key: ThreadKey,
+        *,
+        harness: str | None,
+        agent_name: str | None,
+        workspace: str | None,
+        session_id: str,
+    ) -> None:
+        # Posted once when a session is created — the first durable message in the
+        # thread, orienting the user to what they're talking to and linking to the
+        # web UI. Best-effort: a failed post must not abort the turn.
+        agent = agent_name or "agent"
+        harness_note = f" ({harness})" if harness else ""
+        lines = [f":robot_face: *{agent}*{harness_note}"]
+        if workspace:
+            lines.append(f":file_folder: `{workspace}`")
+        lines.append(
+            f":globe_with_meridians: <{self._session_web_link(session_id)}|Open in Omnigent>"
+        )
+        try:
+            await client.chat_postMessage(
+                channel=key.channel_id,
+                thread_ts=key.thread_ts,
+                text="\n".join(lines),
+            )
+        except Exception:
+            self._logger.warning("Session-info post failed thread=%s; continuing", key.display())
+
+    async def post_ephemeral(
+        self, client: SlackClientProtocol, key: ThreadKey, user_id: str, text: str
+    ) -> None:
+        # Best-effort "Only visible to you" note, anchored in-thread. Used to
+        # explain privately why a message wasn't acted on, without cluttering the
+        # thread. A failed post must never abort handling.
+        try:
+            await client.chat_postEphemeral(
+                channel=key.channel_id,
+                user=user_id,
+                thread_ts=key.thread_ts,
+                text=text,
+            )
+        except Exception:
+            self._logger.warning("Ephemeral notice failed thread=%s; continuing", key.display())
+
+    async def post_or_update_todos(
+        self,
+        client: SlackClientProtocol,
+        key: ThreadKey,
+        todos: list[dict[str, Any]],
+        todos_ts: str | None,
+    ) -> str | None:
+        # Render the plan once and edit it in place on later updates so the
+        # thread carries a single, current plan message rather than a pile of
+        # snapshots. Best-effort throughout.
+        text = format_todos(todos)
+        if text is None:
+            return todos_ts
+        try:
+            if todos_ts is None:
+                response = await client.chat_postMessage(
+                    channel=key.channel_id, thread_ts=key.thread_ts, text=text
+                )
+                ts = response.get("ts")
+                return str(ts) if ts else None
+            await client.chat_update(channel=key.channel_id, ts=todos_ts, text=text)
+            return todos_ts
+        except Exception:
+            self._logger.warning("Todo update failed thread=%s; continuing", key.display())
+            return todos_ts
+
+    async def notify_non_owner(
+        self, client: SlackClientProtocol, key: ThreadKey, user_id: str
+    ) -> None:
+        await self.post_ephemeral(
+            client,
+            key,
+            user_id,
+            "This Omnigent thread belongs to whoever started it, so I can't "
+            "add your message to it. Start a new thread by mentioning me "
+            "(or DM me) to get your own session.",
+        )
+
+    async def notify_thread_busy(
+        self,
+        client: SlackClientProtocol,
+        key: ThreadKey,
+        user_id: str,
+        *,
+        needs_action: bool,
+        session_id: str | None,
+    ) -> None:
+        """Tell the owner their message can't run because the server is busy.
+
+        Mirrors the web UI's two "can't send now" states: (a) ``needs_action`` —
+        the session is parked awaiting a decision, so the user must answer the
+        pending request (in Slack above, or the web UI); (b) otherwise the server
+        is running/waiting, so wait for the reply or interrupt in the web UI. The
+        message was NOT run and is NOT queued — a message to an idle thread runs
+        normally, so re-sending once the session frees works.
+        """
+        link = self._session_web_link(session_id) if session_id else None
+        if needs_action:
+            text = (
+                ":hourglass: I'm waiting on your response to the request above before I can "
+                "continue. Answer it here"
+            )
+            text += f", or in the <{link}|web UI>." if link else "."
+        else:
+            text = (
+                ":hourglass: I'm still working on your previous message in this thread — "
+                "I handle one at a time here, so send this again once I've replied"
+            )
+            text += f", or wait / interrupt in the <{link}|web UI>." if link else "."
+        await self.post_ephemeral(client, key, user_id, text)
+
+    def _session_web_link(self, session_id: str) -> str:
+        # Link to the session's conversation page in the Omnigent web UI, where a
+        # user can continue a thread that's mid-turn in Slack (the web UI accepts
+        # concurrent input and shows any pending actions).
+        base = self._server_url.rstrip("/")
+        return f"{base}/c/{session_id}"

--- a/integrations/slack/src/omnigent_slack/omnigent.py
+++ b/integrations/slack/src/omnigent_slack/omnigent.py
@@ -22,6 +22,7 @@ from omnigent_slack.events import (
     OmnigentError,
     OutputFile,
     SessionActivity,
+    SessionInfo,
     _extract_list,
     _extract_runner_id,
     _extract_session_id,
@@ -30,14 +31,14 @@ from omnigent_slack.events import (
     extract_assistant_text,
     extract_delta,
     extract_elicitation_request,
+    extract_elicitation_resolved,
     extract_error_text,
     extract_output_file,
     extract_policy_denied,
     extract_todos,
-    is_elicitation_request,
-    is_soft_idle_event,
-    is_terminal_event,
+    is_hard_terminal_event,
     iter_sse_events,
+    session_status,
 )
 
 __all__ = [
@@ -47,6 +48,7 @@ __all__ = [
     "ElicitationOption",
     "ElicitationQuestion",
     "ElicitationRequest",
+    "HarnessNotConfiguredError",
     "HostUnavailableError",
     "OmnigentClient",
     "OmnigentClientPool",
@@ -55,27 +57,22 @@ __all__ = [
     "RunnerUnavailableError",
     "ServerUnreachableError",
     "SessionActivity",
+    "SessionInfo",
     "ValidatedServer",
     "extract_assistant_text",
     "extract_delta",
     "extract_elicitation_request",
+    "extract_elicitation_resolved",
     "extract_error_text",
     "extract_output_file",
     "extract_policy_denied",
     "extract_todos",
-    "is_elicitation_request",
-    "is_soft_idle_event",
-    "is_terminal_event",
+    "is_hard_terminal_event",
     "iter_sse_events",
+    "session_status",
 ]
 
 _logger = logging.getLogger(__name__)
-
-# Sentinels for the idle-grace disambiguation. ``_NO_RESUMPTION``: the grace
-# window elapsed and the snapshot confirms the turn is over. ``_RESUMED``: the
-# stream produced another event (or ended), so the turn continues.
-_NO_RESUMPTION = object()
-_RESUMED = object()
 
 
 class RunnerUnavailableError(OmnigentError):
@@ -100,6 +97,15 @@ class HostUnavailableError(OmnigentError):
     Raised when the server reports no online hosts, the user's preferred host is
     offline/missing, or a launched runner never comes online — cases the user
     resolves by starting a host with ``omni host --server <url>``.
+    """
+
+
+class HarnessNotConfiguredError(OmnigentError):
+    """The selected harness isn't configured on the host (HTTP 412).
+
+    A precondition failure the user resolves by running ``omnigent setup`` on the
+    host machine — a retry can't succeed without that. Carries the server's
+    curated ``error.message`` (safe to show for this specific code).
     """
 
 
@@ -472,16 +478,13 @@ class OmnigentClient:
         workspace: str | None = None,
         host_id: str | None = None,
         idle_grace_seconds: float = 600.0,
-        idle_poll_seconds: float = 5.0,
-        idle_settle_seconds: float = 2.0,
     ) -> AsyncIterator[dict[str, Any]]:
         try:
-            async for event in self._run_turn_once(
-                session_id, text, idle_grace_seconds, idle_poll_seconds, idle_settle_seconds
-            ):
+            async for event in self._run_turn_once(session_id, text, idle_grace_seconds):
                 yield event
             return
         except RunnerUnavailableError:
+            # No runner bound to the session — launch one and retry the turn once.
             if not workspace:
                 raise
             self._logger.info(
@@ -491,9 +494,7 @@ class OmnigentClient:
             )
             await self.launch_runner(session_id, workspace=workspace, host_id=host_id)
 
-        async for event in self._run_turn_once(
-            session_id, text, idle_grace_seconds, idle_poll_seconds, idle_settle_seconds
-        ):
+        async for event in self._run_turn_once(session_id, text, idle_grace_seconds):
             yield event
 
     async def _run_turn_once(
@@ -501,55 +502,55 @@ class OmnigentClient:
         session_id: str,
         text: str,
         idle_grace_seconds: float,
-        idle_poll_seconds: float,
-        idle_settle_seconds: float,
     ) -> AsyncIterator[dict[str, Any]]:
+        # Turn-end detection is SERVER-AUTHORITATIVE and HARNESS-AGNOSTIC,
+        # mirroring the web UI's reducer. The discriminator is "is a response
+        # currently OPEN?", NOT the harness name — because `session.status`
+        # carries a `response_id` only for terminal-backed harnesses
+        # (claude-native/codex) and is id-LESS for the in-process runtime
+        # (debby/claude-sdk); the schema documents this as intentional.
+        #
+        # A response is OPEN once we see an id-bearing `running`/`waiting`
+        # (claude-native's Stop-hook edge). The turn ENDS on `idle`/`failed` when:
+        #   (a) it is id-bearing and matches the open response, OR
+        #   (b) it is id-LESS and NO id-bearing response is open — this covers the
+        #       in-process harness, whose running/waiting are all id-less so
+        #       nothing is ever "open", and whose id-less `idle` is the real end.
+        # An id-less `idle` while an id-bearing response IS open is a claude-native
+        # PTY-activity flap (mid-answer generation lull) — IGNORED, else the reply
+        # truncates at the first pause. `waiting` NEVER ends the turn (both
+        # harnesses use it for "parked on sub-agents / async work").
+        #
+        # The stream never sends `[DONE]` and never closes; heartbeats fire every
+        # ~15s. So the ONLY non-event case is a dead SOCKET (half-open) — treat a
+        # read that produces nothing for `idle_grace_seconds` as dead and end.
         async with self.stream_session_events(session_id) as events:
             await self.submit_message(session_id, text)
             iterator = events.__aiter__()
-            # A single in-flight "next event" task, reused across idle grace
-            # windows. Timing it out must NOT cancel the underlying __anext__
-            # (that would terminate the async generator), so we keep the task
-            # alive with asyncio.wait and only await it again next window.
+            # A single in-flight "next event" task. A liveness timeout must NOT
+            # cancel it (that would terminate the async generator); we keep it
+            # alive with asyncio.wait and await it again next window.
             pending: asyncio.Task[dict[str, Any]] | None = None
-            # The FIRST read is unbounded — the turn hasn't started producing yet,
-            # so a bare wait is correct (the server may be `idle` for a beat right
-            # after submit before it goes `running`). Every read AFTER the first
-            # event is disambiguated via the grace window: this makes the turn
-            # ALWAYS bounded — it can only stay alive while the server reports
-            # `running`. A stream that goes silent without a terminal/idle event
-            # (half-open connection, or an `idle` edge missed because the consumer
-            # was parked on an elicitation) would otherwise block this read
-            # forever and wedge the thread. Active streaming pays NO latency: the
-            # settle-wait returns immediately when events are flowing, so the
-            # status poll only fires after a genuine quiet gap.
-            disambiguate = False
+            open_response_id: str | None = None
+            saw_open_running = False
             try:
                 while True:
                     if pending is None:
                         pending = asyncio.ensure_future(iterator.__anext__())
 
-                    if disambiguate:
-                        # Time out the wait WITHOUT cancelling the in-flight read
-                        # (cancelling __anext__ would kill the generator); on a
-                        # quiet window consult the rolled-up snapshot — while a
-                        # sub-agent child is still running the parent reads
-                        # `running`, so keep waiting (a slow child can outlast the
-                        # grace window). Ends only when the snapshot is not running.
-                        resumed = await self._await_within_grace(
-                            pending,
-                            session_id,
+                    done, _ = await asyncio.wait({pending}, timeout=idle_grace_seconds)
+                    if not done:
+                        # No event for the whole liveness window — with 15s
+                        # heartbeats on a live connection, this means the socket
+                        # is dead (half-open). End rather than hang forever.
+                        pending.cancel()
+                        self._logger.info(
+                            "Omnigent stream silent for %ss (no heartbeat) — ending turn "
+                            "session_id=%s",
                             idle_grace_seconds,
-                            idle_poll_seconds,
-                            idle_settle_seconds,
+                            session_id,
                         )
-                        if resumed is _NO_RESUMPTION:
-                            pending.cancel()
-                            self._logger.info(
-                                "Omnigent turn settled idle with no resumption session_id=%s",
-                                session_id,
-                            )
-                            break
+                        break
 
                     try:
                         event = await pending
@@ -564,21 +565,45 @@ class OmnigentClient:
                     )
                     yield event
 
-                    # Every subsequent read is bounded by the grace disambiguation.
-                    disambiguate = True
-
-                    # A HARD terminal (failed/cancelled) ends the turn now. A soft
-                    # `idle` is NOT terminal here: a fan-out orchestrator settles
-                    # idle between wake cycles, so we DON'T break — the next
-                    # (bounded) read either resumes when more arrives or ends via
-                    # the status poll when the server is genuinely done.
-                    if is_terminal_event(event) and not is_soft_idle_event(event):
+                    if is_hard_terminal_event(event):
                         self._logger.info(
-                            "Omnigent turn reached terminal event session_id=%s type=%s",
+                            "Omnigent turn reached hard-terminal event session_id=%s type=%s",
                             session_id,
                             event.get("type"),
                         )
                         break
+
+                    parsed = session_status(event)
+                    if parsed is None:
+                        continue
+                    status, response_id = parsed
+                    if status in ("running", "waiting") and response_id is not None:
+                        # An id-bearing open edge (claude-native Stop hook). Mark a
+                        # response OPEN so a later matching terminal ends the turn
+                        # and a bare id-less idle is treated as a mid-answer flap.
+                        open_response_id = response_id
+                        saw_open_running = True
+                    elif status in ("idle", "failed"):
+                        # Terminal edge. End when:
+                        #  (a) id-bearing and matches the open response (or we saw
+                        #      no id-bearing open — some paths only stamp the end);
+                        #  (b) id-less AND no id-bearing response is open — the
+                        #      in-process (debby/claude-sdk) real end. `waiting`
+                        #      would have kept us going; only `idle`/`failed` here.
+                        # An id-less idle WHILE an id-bearing response is open is a
+                        # claude-native PTY flap → ignored (falls through).
+                        id_bearing_match = response_id is not None and (
+                            not saw_open_running or response_id == open_response_id
+                        )
+                        id_less_end = response_id is None and not saw_open_running
+                        if id_bearing_match or id_less_end:
+                            self._logger.info(
+                                "Omnigent turn ended session_id=%s status=%s response_id=%s",
+                                session_id,
+                                status,
+                                response_id,
+                            )
+                            break
             finally:
                 # Cancel and AWAIT the in-flight read so the underlying httpx
                 # stream isn't still running when the context manager closes it
@@ -588,78 +613,6 @@ class OmnigentClient:
                     pending.cancel()
                     with contextlib.suppress(asyncio.CancelledError, Exception):
                         await pending
-
-    async def _await_within_grace(
-        self,
-        pending: asyncio.Task[dict[str, Any]],
-        session_id: str,
-        grace_seconds: float,
-        poll_seconds: float,
-        settle_seconds: float,
-    ) -> object:
-        """After a soft ``idle``, wait for the stream to resume or confirm it ended.
-
-        Waits on the in-flight read WITHOUT cancelling it (``asyncio.wait``
-        leaves the task pending, so the async generator survives to be awaited
-        again). Returns ``_RESUMED`` when the stream produced another event (or
-        ended — the caller's ``await`` then surfaces ``StopAsyncIteration``), or
-        ``_NO_RESUMPTION`` once the turn is genuinely over.
-
-        Two timescales, because ``idle`` is doubly ambiguous:
-
-        1. **Settle wait** (``settle_seconds``, short): a claude-native turn
-           oscillates ``running``/``idle`` *while still streaming* its answer,
-           with sub-second gaps between bursts. So EVERY idle first waits a short
-           settle window for the next burst — ending here would truncate the
-           reply mid-answer. Bounded and small so a genuinely-final idle adds
-           only a brief tail.
-        2. **Snapshot + poll** (``poll_seconds``, coarse): if still quiet after
-           the settle, consult the rolled-up status. A fan-out orchestrator
-           parked between wake cycles reads ``running`` (a sub-agent is working),
-           so keep polling — a slow child can take many seconds. Only when the
-           snapshot is no longer ``running`` is the turn over.
-
-        ``grace_seconds`` caps the total wait so a stuck session can't park the
-        turn forever.
-        """
-        deadline = asyncio.get_running_loop().time() + grace_seconds
-        while True:
-            # Settle: wait briefly for the next streaming burst. Handles the
-            # mid-answer running/idle oscillation without truncating.
-            done, _ = await asyncio.wait({pending}, timeout=settle_seconds)
-            if done:
-                return _RESUMED
-            # Still quiet — is the session genuinely done, or a fan-out parent
-            # waiting on a sub-agent (rolled-up status still `running`)?
-            status = await self.get_session_status(session_id)
-            # The status fetch is a network round-trip; the next event may have
-            # arrived during it. Re-check before ending, or we'd cancel a
-            # completed read and truncate the reply.
-            if pending.done():
-                return _RESUMED
-            # Only a DEFINITIVE not-running status ends the turn. A ``None`` here
-            # is a best-effort snapshot failure (transient network/server blip) —
-            # treating it as "done" would truncate a still-live fan-out on a
-            # momentary hiccup, so keep waiting until the grace cap instead.
-            if status is not None and status != "running":
-                return _NO_RESUMPTION
-            if asyncio.get_running_loop().time() >= deadline:
-                self._logger.info(
-                    "Idle grace cap (%ss) elapsed while still running session_id=%s; "
-                    "ending turn to avoid parking forever",
-                    grace_seconds,
-                    session_id,
-                )
-                return _NO_RESUMPTION
-            # Fan-out parent still working — wait a coarser poll for resumption.
-            done, _ = await asyncio.wait({pending}, timeout=poll_seconds)
-            if done:
-                return _RESUMED
-            self._logger.debug(
-                "Idle poll quiet but session still running (sub-agent "
-                "outstanding) session_id=%s; continuing to wait",
-                session_id,
-            )
 
     async def _get_json(self, url: str, **kwargs: Any) -> dict[str, Any] | None:
         """Best-effort GET returning the JSON body as a dict, else ``None``.
@@ -677,20 +630,6 @@ class OmnigentClient:
             # ValueError covers json.JSONDecodeError (non-JSON 200 body).
             return None
         return payload if isinstance(payload, dict) else None
-
-    async def get_session_status(self, session_id: str) -> str | None:
-        """Fetch the session's rolled-up status from the snapshot.
-
-        The snapshot's ``status`` rolls direct sub-agent child activity into the
-        parent: a fan-out orchestrator parked between wake cycles reads
-        ``running`` here (a child is still working) even though its own runner
-        emitted ``idle`` on the stream. That makes this the authoritative "is the
-        turn really over?" check when a stream ``idle`` is ambiguous. Best-effort
-        — returns ``None`` on any failure so the caller falls back to the timer.
-        """
-        snapshot = await self._get_json(f"/v1/sessions/{session_id}")
-        status = snapshot.get("status") if snapshot else None
-        return status if isinstance(status, str) else None
 
     async def get_session_activity(self, session_id: str) -> SessionActivity:
         """Snapshot of whether the SERVER considers this session busy.
@@ -713,25 +652,26 @@ class OmnigentClient:
             pending_elicitation=bool(self._parse_pending(snapshot)),
         )
 
+    async def get_session_info(self, session_id: str) -> SessionInfo:
+        """Read the session's harness + agent name from the snapshot.
+
+        For the first-message config summary. Best-effort: fields default to
+        ``None`` if the snapshot is unreadable or omits them.
+        """
+        snapshot = await self._get_json(f"/v1/sessions/{session_id}")
+        if snapshot is None:
+            return SessionInfo(harness=None, agent_name=None)
+        harness = snapshot.get("harness")
+        agent_name = snapshot.get("agent_name")
+        return SessionInfo(
+            harness=harness if isinstance(harness, str) and harness else None,
+            agent_name=agent_name if isinstance(agent_name, str) and agent_name else None,
+        )
+
     @staticmethod
     def _parse_pending(snapshot: dict[str, Any] | None) -> list[dict[str, Any]]:
         pending = snapshot.get("pending_elicitations") if snapshot else None
         return [e for e in pending if isinstance(e, dict)] if isinstance(pending, list) else []
-
-    async def is_elicitation_pending(self, session_id: str, elicitation_id: str) -> bool:
-        """Whether ``elicitation_id`` is still outstanding on the server.
-
-        Lets a Slack-side waiter detect that the elicitation was resolved
-        *elsewhere* (the web UI, another client) and stop waiting. Best-effort:
-        on a read failure returns ``True`` (assume still pending) so a transient
-        hiccup doesn't spuriously abandon the wait.
-        """
-        snapshot = await self._get_json(f"/v1/sessions/{session_id}")
-        if snapshot is None:
-            return True  # read failed — assume still pending, don't abandon.
-        return any(
-            e.get("elicitation_id") == elicitation_id for e in self._parse_pending(snapshot)
-        )
 
     async def latest_assistant_message(self, session_id: str) -> tuple[str | None, str] | None:
         """Return ``(item_id, text)`` of the newest assistant message, or None.
@@ -846,15 +786,27 @@ async def _raise_for_status(response: httpx.Response) -> None:
     try:
         response.raise_for_status()
     except httpx.HTTPStatusError as exc:
-        error_code = _extract_error_code(response)
+        # A streaming response (the SSE tail) hasn't had its body read, so the
+        # ``.text``/``.json()`` inspection below would raise ``ResponseNotRead``
+        # and mask the real status. Pull the (small) error body in first; the
+        # classification then works the same as for an ordinary request — so a
+        # 401 on the stream still becomes AuthRequiredError, not a raw httpx error.
+        if not response.is_closed:
+            with contextlib.suppress(Exception):
+                await response.aread()
+        error_code, error_message = _extract_error(response)
         # The raw server body can carry internal paths/stack traces; log it for
         # operators but keep it out of the exception message, which surfaces to
-        # the Slack channel (visible to everyone in the thread).
+        # the Slack channel (visible to everyone in the thread). Guard the body
+        # access: if the stream couldn't be read, classify on status alone.
+        body = "<unread>"
+        with contextlib.suppress(Exception):
+            body = response.text
         _logger.warning(
             "Omnigent request failed status=%s url=%s body=%r",
             response.status_code,
             response.request.url,
-            response.text,
+            body,
         )
         if response.status_code == 503 and error_code == "runner_unavailable":
             raise RunnerUnavailableError("Omnigent runner is unavailable.") from exc
@@ -862,20 +814,40 @@ async def _raise_for_status(response: httpx.Response) -> None:
             raise AuthRequiredError(
                 f"Omnigent server requires authentication for {response.request.url}"
             ) from exc
+        if response.status_code == 412 and error_code == "harness_not_configured":
+            # A precondition failure the user CAN act on (the harness isn't set up
+            # on the host — run `omnigent setup` there). The server's structured
+            # error.message is curated actionable guidance for this code, so it's
+            # safe to surface (unlike a raw body); fall back to a generic hint.
+            raise HarnessNotConfiguredError(
+                error_message or "The selected harness isn't configured on the host."
+            ) from exc
         raise OmnigentError(
             f"Omnigent request failed with status {response.status_code}."
         ) from exc
 
 
-def _extract_error_code(response: httpx.Response) -> str | None:
+def _extract_error(response: httpx.Response) -> tuple[str | None, str | None]:
+    """Return ``(code, message)`` from a server error body, or ``(None, None)``.
+
+    The server wraps failures as ``{"error": {"code": ..., "message": ...}}``.
+    The message is only surfaced to users for specific, curated codes (see
+    ``_raise_for_status``) — never blindly, since a raw body can leak internals.
+    """
     try:
         payload = response.json()
-    except json.JSONDecodeError:
-        return None
+    except (json.JSONDecodeError, httpx.StreamError):
+        # StreamError (e.g. ResponseNotRead) when a streaming body couldn't be
+        # read — classify on status alone rather than masking it.
+        return None, None
     if not isinstance(payload, dict):
-        return None
+        return None, None
     error = payload.get("error")
     if not isinstance(error, dict):
-        return None
+        return None, None
     code = error.get("code")
-    return code if isinstance(code, str) else None
+    message = error.get("message")
+    return (
+        code if isinstance(code, str) else None,
+        message if isinstance(message, str) and message else None,
+    )

--- a/integrations/slack/src/omnigent_slack/service.py
+++ b/integrations/slack/src/omnigent_slack/service.py
@@ -1,31 +1,26 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
-from dataclasses import dataclass
-from typing import Any, Protocol
-
-from slack_sdk.errors import SlackApiError
+from dataclasses import dataclass, field
+from typing import Any
 
 from omnigent_slack.approvals import (
     ClickTarget,
     ElicitationCoordinator,
     Verdict,
-    elicitation_card_blocks,
-    resolve_form_answers,
-    resolved_card_blocks,
 )
 from omnigent_slack.auth_manager import pack_user_key
+from omnigent_slack.elicitation import ElicitationController, ElicitationTurnState
 from omnigent_slack.models import SlackTurn, ThreadKey
 from omnigent_slack.notifications import (
+    SlackNotifier,
     format_output_file,
     format_policy_denied,
-    format_todos,
 )
 from omnigent_slack.omnigent import (
     AuthRequiredError,
-    ElicitationRequest,
+    HarnessNotConfiguredError,
     HostUnavailableError,
     OmnigentClient,
     OmnigentClientPool,
@@ -33,6 +28,7 @@ from omnigent_slack.omnigent import (
     extract_assistant_text,
     extract_delta,
     extract_elicitation_request,
+    extract_elicitation_resolved,
     extract_error_text,
     extract_output_file,
     extract_policy_denied,
@@ -40,26 +36,11 @@ from omnigent_slack.omnigent import (
 )
 from omnigent_slack.setup import SetupFlow, host_unavailable_text
 from omnigent_slack.store import SQLiteStore
-from omnigent_slack.text import strip_bot_mention, truncate_for_slack
-
-
-class SlackStreamProtocol(Protocol):
-    async def append(self, *, markdown_text: str | None = ..., chunks: Any = ...) -> Any: ...
-
-    async def stop(self, *, markdown_text: str | None = ...) -> Any: ...
-
-
-class SlackClientProtocol(Protocol):
-    async def chat_postMessage(self, **kwargs: Any) -> dict[str, Any]: ...
-
-    async def chat_postEphemeral(self, **kwargs: Any) -> dict[str, Any]: ...
-
-    async def chat_delete(self, **kwargs: Any) -> dict[str, Any]: ...
-
-    async def chat_update(self, **kwargs: Any) -> dict[str, Any]: ...
-
-    async def chat_stream(self, **kwargs: Any) -> SlackStreamProtocol: ...
-
+from omnigent_slack.streaming import (
+    SlackClientProtocol,
+    _AnswerReply,
+)
+from omnigent_slack.text import strip_bot_mention
 
 # Immediate acknowledgement shown while the session spins up and while the agent
 # works before the first streamed tokens arrive. Deleted only once real content
@@ -80,22 +61,6 @@ _AUTH_REQUIRED_TEXT = (
     ":lock: Your Omnigent login has expired or isn't set up. Run /omnigent to log in again."
 )
 
-# Slack streaming messages have a limited lifetime: after a stretch with no
-# activity Slack finalizes the message itself, and any further append/stop then
-# fails with this error. A long-running turn (waiting on a sub-agent, a slow
-# tool) can outlast that window, so the bot opens a fresh streaming reply and
-# continues into it rather than treating this as a turn failure.
-_STREAM_CLOSED_ERROR = "message_not_in_streaming_state"
-
-# How often, while awaiting a Slack Approve/Deny click, to check whether the
-# elicitation was resolved elsewhere (web UI, another client) so the turn can
-# stop waiting and continue instead of blocking to the coordinator timeout.
-_EXTERNAL_RESOLVE_POLL_SECONDS = 3.0
-
-# Sentinel: the elicitation was resolved outside Slack, so the bot must NOT post
-# its own verdict — just continue the turn.
-_RESOLVED_EXTERNALLY = object()
-
 
 class _TurnAborted(Exception):
     """A turn can't proceed; ``text`` is the user-facing reason to deliver."""
@@ -115,6 +80,8 @@ class _StreamState:
     error_text: str | None = None
     # Set when a known error was delivered mid-stream and the turn should stop.
     aborted: bool = False
+    # In-flight elicitation cards this turn (owned by the ElicitationController).
+    elicitations: ElicitationTurnState = field(default_factory=ElicitationTurnState)
 
 
 def _turn_error_text(exc: BaseException, server_url: str) -> str | None:
@@ -129,289 +96,11 @@ def _turn_error_text(exc: BaseException, server_url: str) -> str | None:
         return _SERVER_UNREACHABLE_TEXT
     if isinstance(exc, HostUnavailableError):
         return host_unavailable_text(server_url)
+    if isinstance(exc, HarnessNotConfiguredError):
+        # The server's message is curated, actionable guidance for this code —
+        # surface it so the user knows to run `omnigent setup` on the host.
+        return f":warning: {exc}"
     return None
-
-
-def _is_stream_closed_error(exc: BaseException) -> bool:
-    return (
-        isinstance(exc, SlackApiError)
-        and getattr(exc.response, "get", lambda _k: None)("error") == _STREAM_CLOSED_ERROR
-    )
-
-
-class _LiveReply:
-    """A streaming Slack reply that reopens itself when Slack finalizes it.
-
-    Slack finalizes a streaming message after an idle stretch, and a long turn
-    (parked on a sub-agent, a slow tool) can outlast that window. When an
-    append or stop hits ``message_not_in_streaming_state``, this opens a fresh
-    streaming message in the same thread and continues, so the answer keeps
-    streaming live across as many messages as the turn needs. The already-
-    delivered messages stay intact — Slack has finalized them.
-    """
-
-    def __init__(
-        self,
-        client: SlackClientProtocol,
-        key: ThreadKey,
-        *,
-        recipient_user_id: str,
-    ) -> None:
-        self._client = client
-        self._key = key
-        self._recipient_user_id = recipient_user_id
-        self._stream: SlackStreamProtocol | None = None
-        # Number of streaming messages opened; >1 means the reply was split
-        # because Slack closed an earlier segment mid-turn.
-        self.segments = 0
-        # Whether text has been appended but not yet flushed to Slack (the SDK
-        # buffers until buffer_size). Lets ``flush`` skip an empty API call.
-        self._pending_unflushed = False
-
-    async def _open(self) -> SlackStreamProtocol:
-        self._stream = await self._client.chat_stream(
-            channel=self._key.channel_id,
-            thread_ts=self._key.thread_ts,
-            recipient_user_id=self._recipient_user_id,
-            recipient_team_id=self._key.team_id,
-        )
-        self.segments += 1
-        return self._stream
-
-    async def append(self, markdown_text: str) -> bool:
-        # The SDK buffers in memory and only calls Slack once the buffer fills,
-        # returning a response on that flush and None while still buffering.
-        # Return whether this append actually put text on screen so the caller
-        # can hold the placeholder until the streamed message is visible.
-        stream = self._stream or await self._open()
-        try:
-            flushed = await stream.append(markdown_text=markdown_text)
-        except SlackApiError as exc:
-            if not _is_stream_closed_error(exc):
-                raise
-            # Slack finalized the message out from under us; continue the answer
-            # in a fresh streaming reply so nothing stalls or is lost.
-            flushed = await (await self._open()).append(markdown_text=markdown_text)
-        # Track buffered-but-unflushed text so ``flush`` can force it visible.
-        self._pending_unflushed = flushed is None
-        return flushed is not None
-
-    async def flush(self) -> None:
-        # Force any buffered-but-unflushed text onto the screen NOW, without
-        # finalizing the segment. The SDK flushes its buffer when ``append`` is
-        # called with ``chunks`` set (even an empty list), so a short answer
-        # doesn't stay invisible until the segment is stopped. Used before an
-        # out-of-band post so streamed text appears BEFORE the card/notice, not
-        # coincident with it (matches the web UI's live reveal). No-op when
-        # nothing is buffered or no stream is open.
-        if self._stream is None or not self._pending_unflushed:
-            return
-        try:
-            await self._stream.append(chunks=[])
-        except SlackApiError as exc:
-            if not _is_stream_closed_error(exc):
-                raise
-            # Segment was finalized under us; the buffered text already landed.
-        self._pending_unflushed = False
-
-    async def stop(self, markdown_text: str | None = None) -> None:
-        # chat.stopStream rejects empty text, so only pass markdown_text when
-        # there is some. Nothing ever streamed and no tail to deliver → no-op.
-        if self._stream is None:
-            if not markdown_text:
-                return
-            await self._open()
-        try:
-            await self._stop_current(markdown_text)
-        except SlackApiError as exc:
-            if not _is_stream_closed_error(exc):
-                raise
-            if markdown_text:
-                await self._open()
-                await self._stop_current(markdown_text)
-
-    async def seal(self) -> None:
-        """Finalize the current streaming segment so a later message sorts after it.
-
-        Slack orders messages by the timestamp fixed when a streaming message
-        opens, so text appended to a long-lived stream stays anchored there.
-        Before posting any out-of-band message mid-turn (an approval card, a
-        policy/file notice), seal the current answer segment: it ends here, the
-        out-of-band message sorts after it, and the next append opens a fresh
-        segment that sorts after *that* — keeping chronological order across an
-        interruption. No-op when nothing is streaming.
-        """
-        if self._stream is None:
-            return
-        stream = self._stream
-        # Drop the reference first so the next append opens a fresh segment even
-        # if the stop below races a Slack-side finalize.
-        self._stream = None
-        self._pending_unflushed = False
-        try:
-            await stream.stop()
-        except SlackApiError as exc:
-            if not _is_stream_closed_error(exc):
-                raise
-
-    async def _stop_current(self, markdown_text: str | None) -> None:
-        assert self._stream is not None
-        if markdown_text:
-            await self._stream.stop(markdown_text=markdown_text)
-        else:
-            await self._stream.stop()
-
-
-class _AnswerReply:
-    """Owns one turn's streamed answer: the live reply, the accumulated text,
-    the "Working on it…" placeholder, and the interruption/finalization rules.
-
-    Centralizes three invariants that were previously enforced by convention
-    inside the turn loop:
-
-    - **Placeholder visibility.** The ``ack`` is removed only once real content
-      is on screen — the first append that actually flushes to Slack, or the
-      finalizing ``stop()`` for a buffered answer — so the thread never shows a
-      gap between the placeholder vanishing and the reply appearing.
-    - **Seal ⇒ forget.** Sealing a segment before an out-of-band message
-      (approval card, notice) also resets the accumulated text, so the tail
-      reconciliation only ever considers the current segment.
-    - **Tail reconciliation.** The final answer is whatever streamed; if the
-      model reported a final item beyond the deltas, only the remainder is
-      appended, and a no-delta answer falls back to the committed item.
-    """
-
-    def __init__(
-        self,
-        client: SlackClientProtocol,
-        key: ThreadKey,
-        *,
-        recipient_user_id: str,
-        ack_ts: str | None,
-        logger: logging.Logger,
-    ) -> None:
-        self._reply = _LiveReply(client, key, recipient_user_id=recipient_user_id)
-        self._client = client
-        self._key = key
-        self._ack_ts = ack_ts
-        self._logger = logger
-        self._streamed = ""
-        self._final: str | None = None
-        # Text put on screen in each sealed segment this turn. Unlike
-        # ``_streamed``/``_final`` (which reset at each seal), this survives
-        # interruptions, so the no-delta fallback can tell whether the server's
-        # newest assistant message is one we ALREADY showed (a trailing notice
-        # sealed off an answer we streamed → don't re-post) from a genuinely new
-        # message that never streamed (e.g. the post-elicitation answer arrived
-        # only committed → DO recover it).
-        self._delivered_texts: list[str] = []
-
-    @property
-    def segments(self) -> int:
-        return self._reply.segments
-
-    @property
-    def streamed_len(self) -> int:
-        return len(self._streamed)
-
-    async def add_delta(self, delta: str) -> None:
-        # Append the delta; the SDK buffers and only flushes to Slack once the
-        # buffer fills. Clear the placeholder only on the flush that actually
-        # puts content on screen — never while still buffering — so there's no
-        # empty gap.
-        self._streamed += delta
-        if await self._reply.append(delta):
-            await self._clear_ack()
-
-    def set_final(self, text: str) -> None:
-        self._final = text
-
-    async def seal_for_interruption(self) -> None:
-        # Before an out-of-band message: reveal any buffered streamed text FIRST
-        # (so it appears above the interruption as it did on screen in the web UI,
-        # not coincident with the card), drop the placeholder (it would sit stale
-        # above the interruption for the whole wait), finalize the current segment
-        # so the interruption sorts after it, and forget the accumulated text so
-        # the next segment reconciles independently. Record what this segment
-        # delivered BEFORE resetting, so the fallback can recognize an
-        # already-shown message and not re-post it.
-        await self._reply.flush()
-        shown = self._streamed + self._tail()
-        if shown:
-            self._delivered_texts.append(shown)
-        await self._clear_ack()
-        await self._reply.seal()
-        self._streamed, self._final = "", None
-
-    async def finalize(self, *, error_text: str | None) -> bool:
-        # Deliver the answer tail, then clear the placeholder only after that
-        # final flush (a short buffered answer becomes visible only at stop()).
-        # Returns whether a real answer was delivered — when an error also
-        # occurred, the caller posts the failure as a separate reply so the
-        # answer stays intact; when nothing was produced, the error IS the reply.
-        tail = self._tail()
-        delivered_answer = bool(self._streamed or tail)
-        if delivered_answer:
-            await self._reply.stop(tail or None)
-        else:
-            await self._reply.stop(
-                f"Omnigent request failed: {error_text}"
-                if error_text
-                else "Omnigent completed without returning response text."
-            )
-        await self._clear_ack()
-        return delivered_answer
-
-    def _tail(self) -> str:
-        if self._final and self._final.startswith(self._streamed):
-            return self._final[len(self._streamed) :]
-        if self._final and not self._streamed:
-            return self._final
-        return ""
-
-    def needs_fallback_text(self) -> bool:
-        # True when the current (final) segment has no answer to deliver — the
-        # caller may then recover the server's newest committed message. This is
-        # a per-segment check; ``already_delivered`` guards against re-posting a
-        # message an earlier sealed segment already showed.
-        return not self._streamed and not self._tail()
-
-    def already_delivered(self, text: str) -> bool:
-        # Whether ``text`` matches something already put on screen this turn (a
-        # sealed segment, or the current one). Lets the fallback distinguish a
-        # message that already streamed but was sealed off by a trailing notice
-        # (don't re-post) from one that never streamed (recover it).
-        candidate = text.strip()
-        if not candidate:
-            return True
-        shown = [*self._delivered_texts, self._streamed + self._tail()]
-        return any(candidate == s.strip() for s in shown if s)
-
-    def set_fallback_text(self, text: str) -> None:
-        self._final = text
-
-    async def stop_with(self, text: str) -> None:
-        # Terminal notice (auth/unreachable/host errors, or a no-op abort): clear
-        # the placeholder, then deliver ``text`` as a plain thread reply. Empty
-        # text is a silent stop (nothing to say). A notice is not a streamed
-        # answer, so it goes via a normal message, not the streaming reply.
-        await self._clear_ack()
-        if text:
-            await self._client.chat_postMessage(
-                channel=self._key.channel_id,
-                thread_ts=self._key.thread_ts,
-                text=truncate_for_slack(text),
-            )
-
-    async def _clear_ack(self) -> None:
-        # Best-effort, idempotent: a failed delete must not abort the turn.
-        if not self._ack_ts:
-            return
-        ack_ts, self._ack_ts = self._ack_ts, None
-        try:
-            await self._client.chat_delete(channel=self._key.channel_id, ts=ack_ts)
-        except Exception:
-            self._logger.warning("Ack delete failed thread=%s; continuing", self._key.display())
 
 
 class SlackOmnigentService:
@@ -433,12 +122,22 @@ class SlackOmnigentService:
         # ignored, so a config change points every thread at the new server.
         self._server_url = server_url
         self._bot_user_id = bot_user_id
-        # Bridges a parked turn (blocked awaiting the user) to the button/form
-        # interaction that answers it. Shared with the block-action handler.
+        self._logger = logging.getLogger(__name__)
+        # All outbound Slack messages (acks, replies, ephemerals, todo plan,
+        # deflection notices) — keeps message formatting out of this class.
+        self._notifier = SlackNotifier(server_url=server_url, logger=self._logger)
+        # Bridges an in-flight elicitation card to the button/form interaction
+        # that answers it (and to the pushed elicitation_resolved). Shared with
+        # the block-action handler.
         self._elicitations = elicitations or ElicitationCoordinator()
-        # How often, while awaiting a Slack click, to poll for external
-        # resolution (overridable in tests to avoid real-time waits).
-        self._external_resolve_poll_seconds = _EXTERNAL_RESOLVE_POLL_SECONDS
+        # Owns all elicitation-card orchestration during a turn (post, resolver
+        # task, finalize) — keeps this class to routing + turn lifecycle.
+        self._elicitation = ElicitationController(
+            self._elicitations,
+            server_url=server_url,
+            post_reply=self._notifier.post_reply,
+            logger=self._logger,
+        )
         # Threads with a turn actively streaming IN THIS PROCESS. Each turn opens
         # its own SSE stream; two at once would render the same events into Slack
         # twice. This is a LOCAL concurrency guard (reserved synchronously, before
@@ -452,7 +151,6 @@ class SlackOmnigentService:
         self._active_threads: set[ThreadKey] = set()
         # In-flight turn tasks, tracked so shutdown can cancel them.
         self._turn_tasks: set[asyncio.Task[None]] = set()
-        self._logger = logging.getLogger(__name__)
 
     @property
     def elicitations(self) -> ElicitationCoordinator:
@@ -601,9 +299,15 @@ class SlackOmnigentService:
             )
             record = await self._store.get_session(key)
             if record is not None and record.owner_user_id != requester:
-                await self._notify_non_owner(client, key, requester)
+                await self._notifier.notify_non_owner(client, key, requester)
             else:
-                await self._notify_thread_busy(client, key, requester, needs_action=False)
+                await self._notifier.notify_thread_busy(
+                    client,
+                    key,
+                    requester,
+                    needs_action=False,
+                    session_id=record.session_id if record is not None else None,
+                )
             return
         self._active_threads.add(key)
         spawned = False
@@ -623,7 +327,7 @@ class SlackOmnigentService:
                         record.owner_user_id,
                         requester,
                     )
-                    await self._notify_non_owner(client, key, requester)
+                    await self._notifier.notify_non_owner(client, key, requester)
                     return
                 # Cross-surface check: the SERVER decides busy/awaiting-action
                 # (web UI or another client may be driving the session), mirroring
@@ -640,8 +344,12 @@ class SlackOmnigentService:
                         activity.status,
                         activity.pending_elicitation,
                     )
-                    await self._notify_thread_busy(
-                        client, key, requester, needs_action=activity.needs_user_action
+                    await self._notifier.notify_thread_busy(
+                        client,
+                        key,
+                        requester,
+                        needs_action=activity.needs_user_action,
+                        session_id=record.session_id,
                     )
                     return
                 self._spawn_turn(
@@ -650,7 +358,9 @@ class SlackOmnigentService:
                         text=text,
                         user_id=requester,
                         create_if_missing=False,
-                        title=_session_title(event, text),
+                        # Title is only used when creating a session; an existing
+                        # thread already has one, so skip the permalink lookup.
+                        title="",
                         slack_client=client,
                         agent_id="",
                         owner_user_id=record.owner_user_id or requester,
@@ -683,7 +393,7 @@ class SlackOmnigentService:
                     text=text,
                     user_id=requester,
                     create_if_missing=True,
-                    title=_session_title(event, text),
+                    title=await _session_title(client, key, event),
                     slack_client=client,
                     agent_id=config.agent_id,
                     owner_user_id=requester,
@@ -725,28 +435,29 @@ class SlackOmnigentService:
             self._server_url, pack_user_key(turn.key.team_id, turn.user_id)
         )
 
-        # Acknowledge immediately: a new session's create + runner launch can take
-        # several seconds, and the streamed reply message only appears once the
-        # first tokens flush, so post a lightweight placeholder now.
-        ack_ts = await self._post_ack(turn.slack_client, turn.key)
         reply = _AnswerReply(
             turn.slack_client,
             turn.key,
             recipient_user_id=turn.owner_user_id,
-            ack_ts=ack_ts,
+            ack_ts=None,
             logger=self._logger,
         )
 
         try:
-            session_id = await self._ensure_session(turn, omnigent, reply)
+            session_id = await self._ensure_session(turn, omnigent)
         except _TurnAborted as aborted:
             await reply.stop_with(aborted.text)
             return
         if session_id is None:
             # No session and creation disabled (a follow-up on a dead thread):
-            # nothing to run. Drop the placeholder so it doesn't linger.
-            await reply.stop_with("")
+            # nothing to run.
             return
+
+        # Acknowledge now — AFTER any session-config summary — so a new thread
+        # reads metadata → "Working on it…" → answer. The create + runner launch
+        # is already done; the placeholder covers the wait until the first tokens
+        # flush, and is cleared once the reply is actually on screen.
+        reply.set_ack(await self._notifier.post_ack(turn.slack_client, turn.key, _ACK_TEXT))
 
         # Baseline the newest assistant message BEFORE the turn runs, so the
         # no-delta fallback below can tell this turn's answer from a prior one.
@@ -760,15 +471,17 @@ class SlackOmnigentService:
             return
 
         if reply.needs_fallback_text():
-            # The current segment delivered nothing (e.g. a post-elicitation
-            # answer that arrived only as a committed item, never streamed).
-            # Recover the server's newest assistant message, but only when it's
-            # genuinely new: it must differ from the pre-turn baseline (else a
-            # no-answer turn like a denied approval would resurrect the PREVIOUS
-            # turn's message) AND not be something an earlier sealed segment this
-            # turn already showed (else a trailing notice would re-post the answer
-            # we just streamed). Compare the whole (id, text) tuple so an id-less
-            # message is judged by its text, not a blank id.
+            # Last-resort safety net: the turn delivered no answer text on the
+            # stream at all. Recover the server's newest assistant message, but
+            # only when it's genuinely new: it must differ from the pre-turn
+            # baseline (else a no-answer turn like a denied approval would
+            # resurrect the PREVIOUS turn's message) AND not be something an
+            # earlier sealed segment this turn already showed (else a trailing
+            # notice would re-post the answer we just streamed). Compare the whole
+            # (id, text) tuple so an id-less message is judged by its text.
+            # (The pure-push elicitation model keeps the stream reading across a
+            # park, so a post-approval answer now streams normally rather than
+            # relying on this fetch.)
             latest = await omnigent.latest_assistant_message(session_id)
             if (
                 latest is not None
@@ -778,7 +491,7 @@ class SlackOmnigentService:
                 reply.set_fallback_text(latest[1])
         delivered_answer = await reply.finalize(error_text=error_text)
         if error_text and delivered_answer:
-            await self._post_failure_reply(turn.slack_client, turn.key, error_text)
+            await self._notifier.post_failure_reply(turn.slack_client, turn.key, error_text)
 
         self._logger.info(
             "Completed Slack turn thread=%s session=%s streamed_chars=%s segments=%s errored=%s",
@@ -789,9 +502,7 @@ class SlackOmnigentService:
             bool(error_text),
         )
 
-    async def _ensure_session(
-        self, turn: SlackTurn, omnigent: OmnigentClient, reply: _AnswerReply
-    ) -> str | None:
+    async def _ensure_session(self, turn: SlackTurn, omnigent: OmnigentClient) -> str | None:
         """Return the session id for this turn, creating one if needed.
 
         Returns ``None`` when there's no session and creation is disabled (a
@@ -818,7 +529,12 @@ class SlackOmnigentService:
             runner_id = await omnigent.launch_runner(
                 session_id, workspace=turn.workspace or "", host_id=turn.host_id
             )
-        except (AuthRequiredError, ServerUnreachableError, HostUnavailableError) as exc:
+        except (
+            AuthRequiredError,
+            ServerUnreachableError,
+            HostUnavailableError,
+            HarnessNotConfiguredError,
+        ) as exc:
             self._logger.info("Session startup failed thread=%s: %s", turn.key.display(), exc)
             raise _TurnAborted(_turn_error_text(exc, self._server_url) or str(exc)) from exc
         except Exception as exc:
@@ -843,6 +559,24 @@ class SlackOmnigentService:
             session_id,
             runner_id,
         )
+        # Orient the user on a NEW session: post a one-line config summary (agent
+        # / harness / workspace + web-UI link) as the first durable message,
+        # before the answer streams. Server-authoritative harness/agent from the
+        # snapshot; best-effort so a snapshot/post failure never aborts the turn.
+        try:
+            info = await omnigent.get_session_info(session_id)
+            await self._notifier.post_session_info(
+                turn.slack_client,
+                turn.key,
+                harness=info.harness,
+                agent_name=info.agent_name,
+                workspace=turn.workspace,
+                session_id=session_id,
+            )
+        except Exception:
+            self._logger.warning(
+                "Session-info summary failed thread=%s; continuing", turn.key.display()
+            )
         return session_id
 
     async def _stream_turn(
@@ -867,13 +601,22 @@ class SlackOmnigentService:
                 session_id, turn.text, workspace=turn.workspace, host_id=turn.host_id
             ):
                 await self._dispatch_stream_event(event, turn, omnigent, session_id, reply, state)
-        except (AuthRequiredError, ServerUnreachableError, HostUnavailableError) as exc:
+        except (
+            AuthRequiredError,
+            ServerUnreachableError,
+            HostUnavailableError,
+            HarnessNotConfiguredError,
+        ) as exc:
             self._logger.info("Turn error mid-stream thread=%s: %s", turn.key.display(), exc)
             await reply.stop_with(_turn_error_text(exc, self._server_url) or str(exc))
             state.aborted = True
         except Exception as exc:
             self._logger.exception("Omnigent turn failed for %s", turn.key.display())
             state.error_text = str(exc)
+        finally:
+            # Settle any card still open (turn ended before its resolution push,
+            # or was torn down) so no resolver task leaks.
+            await self._elicitation.finish_pending(turn, state.elicitations)
         if state.aborted:
             raise _TurnAborted("")  # already delivered; signal the caller to stop
         return state.error_text
@@ -903,26 +646,33 @@ class SlackOmnigentService:
 
         elicitation = extract_elicitation_request(event, session_id)
         if elicitation is not None:
-            # Parked awaiting the user: seal the answer so far (it sorts before
-            # the card), then post the card and block for the verdict. The stream
-            # stays open (session sits in `waiting`), and resumed text opens a
-            # fresh segment after the card.
+            # Seal the answer so far (it sorts before the card), then post the
+            # card and spawn a background resolver — WITHOUT blocking this loop.
+            # Keeping the read loop live is the whole point: the continuation
+            # deltas and the ``elicitation_resolved`` push arrive as normal
+            # events (the web UI's model), so no polling is needed.
             await reply.seal_for_interruption()
-            await self._handle_elicitation(
-                omnigent, client, turn.key, turn.owner_user_id, elicitation
-            )
+            await self._elicitation.start(omnigent, turn, elicitation, state.elicitations)
+            return
+
+        resolved_eid = extract_elicitation_resolved(event)
+        if resolved_eid is not None:
+            # The server resolved the elicitation (our own posted verdict, or an
+            # answer elsewhere). Wake the resolver so it stops waiting, and
+            # finalize the card in place. Idempotent via the `finalized` guard.
+            await self._elicitation.on_resolved(turn, resolved_eid, state.elicitations)
             return
 
         denied_reason = extract_policy_denied(event)
         if denied_reason is not None:
             await reply.seal_for_interruption()
-            await self._post_reply(client, turn.key, format_policy_denied(denied_reason))
+            await self._notifier.post_reply(client, turn.key, format_policy_denied(denied_reason))
             return
 
         output_file = extract_output_file(event)
         if output_file is not None:
             await reply.seal_for_interruption()
-            await self._post_reply(client, turn.key, format_output_file(output_file))
+            await self._notifier.post_reply(client, turn.key, format_output_file(output_file))
             return
 
         todos = extract_todos(event)
@@ -931,7 +681,7 @@ class SlackOmnigentService:
             # later updates edit it in place (no boundary, no fragmentation).
             if state.todos_ts is None:
                 await reply.seal_for_interruption()
-            state.todos_ts = await self._post_or_update_todos(
+            state.todos_ts = await self._notifier.post_or_update_todos(
                 client, turn.key, todos, state.todos_ts
             )
             return
@@ -944,331 +694,17 @@ class SlackOmnigentService:
         if event_error:
             state.error_text = event_error
 
-    async def _post_ack(self, client: SlackClientProtocol, key: ThreadKey) -> str | None:
-        # Best-effort: a failed ack must not abort the turn.
-        try:
-            response = await client.chat_postMessage(
-                channel=key.channel_id,
-                thread_ts=key.thread_ts,
-                text=_ACK_TEXT,
-            )
-        except Exception:
-            self._logger.warning("Ack post failed thread=%s; continuing", key.display())
-            return None
-        ts = response.get("ts")
-        return str(ts) if ts else None
-
-    async def _post_or_update_todos(
-        self,
-        client: SlackClientProtocol,
-        key: ThreadKey,
-        todos: list[dict[str, Any]],
-        todos_ts: str | None,
-    ) -> str | None:
-        # Render the plan once and edit it in place on later updates so the
-        # thread carries a single, current plan message rather than a pile of
-        # snapshots. Best-effort throughout.
-        text = format_todos(todos)
-        if text is None:
-            return todos_ts
-        try:
-            if todos_ts is None:
-                response = await client.chat_postMessage(
-                    channel=key.channel_id, thread_ts=key.thread_ts, text=text
-                )
-                ts = response.get("ts")
-                return str(ts) if ts else None
-            await client.chat_update(channel=key.channel_id, ts=todos_ts, text=text)
-            return todos_ts
-        except Exception:
-            self._logger.warning("Todo update failed thread=%s; continuing", key.display())
-            return todos_ts
-
-    async def _post_reply(
-        self,
-        client: SlackClientProtocol,
-        key: ThreadKey,
-        text: str,
-    ) -> None:
-        await client.chat_postMessage(
-            channel=key.channel_id,
-            thread_ts=key.thread_ts,
-            text=truncate_for_slack(text),
-        )
-
-    async def _post_failure_reply(
-        self,
-        client: SlackClientProtocol,
-        key: ThreadKey,
-        error_text: str,
-    ) -> None:
-        # Post the failure as its own thread reply so the streamed answer stays
-        # intact.
-        await client.chat_postMessage(
-            channel=key.channel_id,
-            thread_ts=key.thread_ts,
-            text=f":warning: Omnigent request failed: {error_text}",
-        )
-
-    async def _post_ephemeral(
-        self,
-        client: SlackClientProtocol,
-        key: ThreadKey,
-        user_id: str,
-        text: str,
-    ) -> None:
-        # Best-effort "Only visible to you" note, anchored in-thread. Used to
-        # explain privately why a message wasn't acted on, without cluttering the
-        # thread. A failed post must never abort handling.
-        try:
-            await client.chat_postEphemeral(
-                channel=key.channel_id,
-                user=user_id,
-                thread_ts=key.thread_ts,
-                text=text,
-            )
-        except Exception:
-            self._logger.warning("Ephemeral notice failed thread=%s; continuing", key.display())
-
-    async def _notify_non_owner(
-        self, client: SlackClientProtocol, key: ThreadKey, user_id: str
-    ) -> None:
-        await self._post_ephemeral(
-            client,
-            key,
-            user_id,
-            "This Omnigent thread belongs to whoever started it, so I can't "
-            "add your message to it. Start a new thread by mentioning me "
-            "(or DM me) to get your own session.",
-        )
-
-    async def _notify_thread_busy(
-        self,
-        client: SlackClientProtocol,
-        key: ThreadKey,
-        user_id: str,
-        *,
-        needs_action: bool,
-    ) -> None:
-        """Tell the owner their message can't run because the server is busy.
-
-        Mirrors the web UI's two "can't send now" states: (a) ``needs_action`` —
-        the session is parked awaiting a decision, so the user must answer the
-        pending request (in Slack above, or the web UI); (b) otherwise the server
-        is running/waiting, so wait for the reply or interrupt in the web UI. The
-        message was NOT run and is NOT queued — a message to an idle thread runs
-        normally, so re-sending once the session frees works.
-        """
-        record = await self._store.get_session(key)
-        link = self._session_web_link(record.session_id) if record is not None else None
-        if needs_action:
-            text = (
-                ":hourglass: I'm waiting on your response to the request above before I can "
-                "continue. Answer it here"
-            )
-            text += f", or in the <{link}|web UI>." if link else "."
-        else:
-            text = (
-                ":hourglass: I'm still working on your previous message in this thread — "
-                "I handle one at a time here, so send this again once I've replied"
-            )
-            text += f", or wait / interrupt in the <{link}|web UI>." if link else "."
-        await self._post_ephemeral(client, key, user_id, text)
-
     async def handle_elicitation_action(self, *, elicitation_id: str, verdict: Verdict) -> bool:
-        """Deliver a button/form verdict to the waiting turn worker.
-
-        Returns whether a live waiter received it — ``False`` means the request
-        already expired or was answered, so the caller can tell the user.
-        """
-        return self._elicitations.resolve(elicitation_id, verdict)
+        """Deliver a button/form verdict (block-action handler entry point)."""
+        return await self._elicitation.handle_action(
+            elicitation_id=elicitation_id, verdict=verdict
+        )
 
     async def reject_non_owner_click(
         self, client: SlackClientProtocol, body: dict[str, Any], target: ClickTarget
     ) -> None:
-        """Privately tell a non-owner their click on someone else's card was ignored.
-
-        The verdict is NOT delivered (the owner check already blocked it); this
-        is just feedback so the clicker isn't left wondering. Channel/thread come
-        from the interaction body (a Block Kit action payload).
-        """
-        channel = (body.get("channel") or {}).get("id")
-        clicker = (body.get("user") or {}).get("id")
-        message = body.get("message") or {}
-        thread_ts = message.get("thread_ts") or message.get("ts")
-        if not isinstance(channel, str) or not isinstance(clicker, str):
-            return
-        try:
-            await client.chat_postEphemeral(
-                channel=channel,
-                user=clicker,
-                thread_ts=thread_ts if isinstance(thread_ts, str) else None,
-                text=(
-                    "This request belongs to whoever started the thread — only they "
-                    "can answer it. Start your own thread by mentioning me (or DM me)."
-                ),
-            )
-        except Exception:
-            self._logger.warning("Non-owner click ephemeral failed; continuing")
-
-    def _session_link(self, session_id: str, elicitation_id: str) -> str:
-        # Deep link to the elicitation's approve page in the Omnigent web UI, so
-        # a user can resolve a request the bot can't render in Slack.
-        base = self._server_url.rstrip("/")
-        return f"{base}/approve/{session_id}/{elicitation_id}"
-
-    def _session_web_link(self, session_id: str) -> str:
-        # Link to the session's conversation page in the Omnigent web UI, where a
-        # user can continue a thread that's mid-turn in Slack (the web UI accepts
-        # concurrent input and shows any pending actions).
-        base = self._server_url.rstrip("/")
-        return f"{base}/c/{session_id}"
-
-    async def _handle_elicitation(
-        self,
-        omnigent: OmnigentClient,
-        client: SlackClientProtocol,
-        key: ThreadKey,
-        owner_user_id: str,
-        request: ElicitationRequest,
-    ) -> None:
-        """Post the elicitation card, wait for the answer, and resolve it.
-
-        Renders a multiple-choice form (``AskUserQuestion``) or a binary
-        Approve/Deny, blocks the turn worker until the user answers or the wait
-        times out (a timeout declines so the server-side park doesn't hang
-        either), then updates the card in place with the outcome and forwards
-        the verdict — including any form selections as ``content``.
-
-        For an elicitation the bot can't render (a ``url``-mode page or a
-        request for typed input), it posts a link to resolve in the Omnigent web
-        UI and returns without blocking — the user completes it there and the
-        stream resumes (the turn stays alive via the idle grace window).
-        """
-        if not request.is_supported:
-            await self._post_reply(
-                client,
-                key,
-                (
-                    ":link: Omnigent needs input I can't collect here "
-                    f"({request.message}). Open the session to respond:\n"
-                    f"{self._session_link(request.session_id, request.elicitation_id)}"
-                ),
-            )
-            self._logger.info(
-                "Unsupported elicitation surfaced as web link thread=%s elicitation_id=%s mode=%s",
-                key.display(),
-                request.elicitation_id,
-                request.mode,
-            )
-            return
-
-        self._logger.info(
-            "Elicitation requested thread=%s elicitation_id=%s policy=%s form=%s",
-            key.display(),
-            request.elicitation_id,
-            request.policy_name,
-            request.is_form,
-        )
-        # Register the waiter BEFORE posting the card: a fast click could
-        # otherwise reach the action handler before the awaiter exists and be
-        # dropped (silent timeout-deny). Registering first closes that window.
-        self._elicitations.register(request.elicitation_id)
-        posted = await client.chat_postMessage(
-            channel=key.channel_id,
-            thread_ts=key.thread_ts,
-            text="Omnigent needs your input to continue.",
-            blocks=elicitation_card_blocks(request, owner_user_id),
-        )
-        card_ts = posted.get("ts")
-
-        verdict = await self._await_verdict_or_external(omnigent, request)
-        if verdict is _RESOLVED_EXTERNALLY:
-            # The user answered elsewhere (web UI, another client). The server
-            # already has the verdict; don't post our own. Just clear the card
-            # and let the turn continue.
-            outcome = "Answered elsewhere"
-        else:
-            assert verdict is None or isinstance(verdict, Verdict)
-            content: dict[str, Any] | None = None
-            if verdict is None:
-                # Nobody answered in time — decline so the server park releases.
-                verdict = Verdict(accepted=False)
-                outcome = "Timed out"
-            elif request.is_form:
-                # A form Submit is an accept with selections; Cancel is a decline.
-                # Selections arrive as option indices — map them back to the full
-                # labels the agent expects (labels can exceed Slack's value cap).
-                content = resolve_form_answers(request, verdict.content)
-                outcome = "Answered" if verdict.accepted else "Cancelled"
-            else:
-                outcome = "Approved" if verdict.accepted else "Denied"
-            await omnigent.resolve_elicitation(
-                request.session_id,
-                request.elicitation_id,
-                accepted=verdict.accepted,
-                content=content,
-            )
-        self._logger.info(
-            "Elicitation resolved thread=%s elicitation_id=%s outcome=%s",
-            key.display(),
-            request.elicitation_id,
-            outcome,
-        )
-
-        if isinstance(card_ts, str):
-            # Best-effort: replace the card with its outcome (no controls). A
-            # failed update must not abort the turn.
-            try:
-                await client.chat_update(
-                    channel=key.channel_id,
-                    ts=card_ts,
-                    text=f"Request {outcome.lower()}.",
-                    blocks=resolved_card_blocks(request, outcome=outcome),
-                )
-            except Exception:
-                self._logger.warning(
-                    "Elicitation card update failed thread=%s; continuing", key.display()
-                )
-
-    async def _await_verdict_or_external(
-        self, omnigent: OmnigentClient, request: ElicitationRequest
-    ) -> Verdict | None | object:
-        """Wait for a Slack button verdict OR external resolution.
-
-        The turn worker blocks here on the Slack card, but the user may instead
-        answer in the web UI (or another client). Since this worker isn't
-        reading the stream while blocked, it can't see ``elicitation_resolved`` —
-        so it also polls the server, and if the elicitation is no longer pending
-        it returns ``_RESOLVED_EXTERNALLY`` to stop waiting (the verdict is
-        already recorded server-side; posting our own would be wrong). Otherwise
-        returns the :class:`Verdict` from the click, or ``None`` on timeout.
-
-        Without this, a web-UI answer would leave the worker blocked until the
-        coordinator timeout — holding the thread's turn open (and deflecting its
-        follow-ups) the whole time.
-        """
-        verdict_task = asyncio.ensure_future(
-            self._elicitations.await_verdict(request.elicitation_id)
-        )
-        try:
-            while True:
-                done, _ = await asyncio.wait(
-                    {verdict_task}, timeout=self._external_resolve_poll_seconds
-                )
-                if verdict_task in done:
-                    return verdict_task.result()
-                if not await omnigent.is_elicitation_pending(
-                    request.session_id, request.elicitation_id
-                ):
-                    return _RESOLVED_EXTERNALLY
-        finally:
-            # Stop the coordinator waiter if we returned on the external path, so
-            # a later stray click doesn't resolve a dead future.
-            if not verdict_task.done():
-                verdict_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError, Exception):
-                    await verdict_task
+        """Privately tell a non-owner their click on someone else's card was ignored."""
+        await self._elicitation.reject_non_owner_click(client, body, target)
 
     async def _accept_event(
         self,
@@ -1339,8 +775,22 @@ def _team_id(body: dict[str, Any], event: dict[str, Any]) -> str:
     return str(team_id)
 
 
-def _session_title(event: dict[str, Any], text: str) -> str:
-    channel = str(event.get("channel") or "channel")
-    thread_ts = str(event.get("thread_ts") or event.get("ts") or "thread")
-    summary = truncate_for_slack(text, limit=80).replace("\n", " ")
-    return f"Slack {channel}/{thread_ts}: {summary}"
+async def _session_title(
+    client: SlackClientProtocol, key: ThreadKey, event: dict[str, Any]
+) -> str:
+    """Build the Omnigent session title: ``Slack: <thread permalink>``.
+
+    A real Slack thread permalink (via ``chat.getPermalink``) is a clickable URL
+    that the web UI linkifies, so the session list points back at the originating
+    thread. Falls back to a plain channel/ts descriptor if the lookup fails (e.g.
+    a missing scope) — the title is cosmetic and must never block session start.
+    """
+    ts = event.get("thread_ts") or event.get("ts")
+    try:
+        response = await client.chat_getPermalink(channel=key.channel_id, message_ts=ts)
+        permalink = response.get("permalink")
+        if isinstance(permalink, str) and permalink:
+            return f"Slack: {permalink}"
+    except Exception:
+        pass
+    return f"Slack thread {key.channel_id}/{ts}"

--- a/integrations/slack/src/omnigent_slack/streaming.py
+++ b/integrations/slack/src/omnigent_slack/streaming.py
@@ -1,0 +1,339 @@
+"""Streamed-answer machinery for a Slack turn.
+
+``_LiveReply`` wraps Slack's ``chat.*Stream`` API (buffering, seal-for-ordering,
+reopen-on-finalize). ``_AnswerReply`` layers the turn's answer semantics on top:
+the "Working on it…" ack lifecycle, seal-⇒-forget across interruptions, and the
+tail reconciliation that recovers a committed final item the deltas didn't carry.
+Also home to the ``SlackClientProtocol``/``SlackStreamProtocol`` structural types
+(the Slack-client surface the whole package depends on).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+from slack_sdk.errors import SlackApiError
+
+from omnigent_slack.models import ThreadKey
+from omnigent_slack.text import truncate_for_slack
+
+
+class SlackStreamProtocol(Protocol):
+    async def append(self, *, markdown_text: str | None = ..., chunks: Any = ...) -> Any: ...
+
+    async def stop(self, *, markdown_text: str | None = ...) -> Any: ...
+
+
+class SlackClientProtocol(Protocol):
+    async def chat_postMessage(self, **kwargs: Any) -> dict[str, Any]: ...
+
+    async def chat_postEphemeral(self, **kwargs: Any) -> dict[str, Any]: ...
+
+    async def chat_delete(self, **kwargs: Any) -> dict[str, Any]: ...
+
+    async def chat_update(self, **kwargs: Any) -> dict[str, Any]: ...
+
+    async def chat_getPermalink(self, **kwargs: Any) -> dict[str, Any]: ...
+
+    async def chat_stream(self, **kwargs: Any) -> SlackStreamProtocol: ...
+
+
+# Slack streaming messages have a limited lifetime: after a stretch with no
+# activity Slack finalizes the message itself, and any further append/stop then
+# fails with this error. A long-running turn (waiting on a sub-agent, a slow
+# tool) can outlast that window, so the bot opens a fresh streaming reply and
+# continues into it rather than treating this as a turn failure.
+_STREAM_CLOSED_ERROR = "message_not_in_streaming_state"
+
+
+def _is_stream_closed_error(exc: BaseException) -> bool:
+    return (
+        isinstance(exc, SlackApiError)
+        and getattr(exc.response, "get", lambda _k: None)("error") == _STREAM_CLOSED_ERROR
+    )
+
+
+class _LiveReply:
+    """A streaming Slack reply that reopens itself when Slack finalizes it.
+
+    Slack finalizes a streaming message after an idle stretch, and a long turn
+    (parked on a sub-agent, a slow tool) can outlast that window. When an
+    append or stop hits ``message_not_in_streaming_state``, this opens a fresh
+    streaming message in the same thread and continues, so the answer keeps
+    streaming live across as many messages as the turn needs. The already-
+    delivered messages stay intact — Slack has finalized them.
+    """
+
+    def __init__(
+        self,
+        client: SlackClientProtocol,
+        key: ThreadKey,
+        *,
+        recipient_user_id: str,
+    ) -> None:
+        self._client = client
+        self._key = key
+        self._recipient_user_id = recipient_user_id
+        self._stream: SlackStreamProtocol | None = None
+        # Number of streaming messages opened; >1 means the reply was split
+        # because Slack closed an earlier segment mid-turn.
+        self.segments = 0
+        # Whether text has been appended but not yet flushed to Slack (the SDK
+        # buffers until buffer_size). Lets ``flush`` skip an empty API call.
+        self._pending_unflushed = False
+
+    async def _open(self) -> SlackStreamProtocol:
+        self._stream = await self._client.chat_stream(
+            channel=self._key.channel_id,
+            thread_ts=self._key.thread_ts,
+            recipient_user_id=self._recipient_user_id,
+            recipient_team_id=self._key.team_id,
+        )
+        self.segments += 1
+        return self._stream
+
+    async def append(self, markdown_text: str) -> bool:
+        # The SDK buffers in memory and only calls Slack once the buffer fills,
+        # returning a response on that flush and None while still buffering.
+        # Return whether this append actually put text on screen so the caller
+        # can hold the placeholder until the streamed message is visible.
+        stream = self._stream or await self._open()
+        try:
+            flushed = await stream.append(markdown_text=markdown_text)
+        except SlackApiError as exc:
+            if not _is_stream_closed_error(exc):
+                raise
+            # Slack finalized the message out from under us; continue the answer
+            # in a fresh streaming reply so nothing stalls or is lost.
+            flushed = await (await self._open()).append(markdown_text=markdown_text)
+        # Track buffered-but-unflushed text so ``flush`` can force it visible.
+        self._pending_unflushed = flushed is None
+        return flushed is not None
+
+    async def flush(self) -> None:
+        # Force any buffered-but-unflushed text onto the screen NOW, without
+        # finalizing the segment. The SDK flushes its buffer when ``append`` is
+        # called with ``chunks`` set (even an empty list), so a short answer
+        # doesn't stay invisible until the segment is stopped. Used before an
+        # out-of-band post so streamed text appears BEFORE the card/notice, not
+        # coincident with it (matches the web UI's live reveal). No-op when
+        # nothing is buffered or no stream is open.
+        if self._stream is None or not self._pending_unflushed:
+            return
+        try:
+            await self._stream.append(chunks=[])
+        except SlackApiError as exc:
+            if not _is_stream_closed_error(exc):
+                raise
+            # Segment was finalized under us; the buffered text already landed.
+        self._pending_unflushed = False
+
+    async def stop(self, markdown_text: str | None = None) -> None:
+        # chat.stopStream rejects empty text, so only pass markdown_text when
+        # there is some. Nothing ever streamed and no tail to deliver → no-op.
+        if self._stream is None:
+            if not markdown_text:
+                return
+            await self._open()
+        try:
+            await self._stop_current(markdown_text)
+        except SlackApiError as exc:
+            if not _is_stream_closed_error(exc):
+                raise
+            if markdown_text:
+                await self._open()
+                await self._stop_current(markdown_text)
+
+    async def seal(self) -> None:
+        """Finalize the current streaming segment so a later message sorts after it.
+
+        Slack orders messages by the timestamp fixed when a streaming message
+        opens, so text appended to a long-lived stream stays anchored there.
+        Before posting any out-of-band message mid-turn (an approval card, a
+        policy/file notice), seal the current answer segment: it ends here, the
+        out-of-band message sorts after it, and the next append opens a fresh
+        segment that sorts after *that* — keeping chronological order across an
+        interruption. No-op when nothing is streaming.
+        """
+        if self._stream is None:
+            return
+        stream = self._stream
+        # Drop the reference first so the next append opens a fresh segment even
+        # if the stop below races a Slack-side finalize.
+        self._stream = None
+        self._pending_unflushed = False
+        try:
+            await stream.stop()
+        except SlackApiError as exc:
+            if not _is_stream_closed_error(exc):
+                raise
+
+    async def _stop_current(self, markdown_text: str | None) -> None:
+        assert self._stream is not None
+        if markdown_text:
+            await self._stream.stop(markdown_text=markdown_text)
+        else:
+            await self._stream.stop()
+
+
+class _AnswerReply:
+    """Owns one turn's streamed answer: the live reply, the accumulated text,
+    the "Working on it…" placeholder, and the interruption/finalization rules.
+
+    Centralizes three invariants that were previously enforced by convention
+    inside the turn loop:
+
+    - **Placeholder visibility.** The ``ack`` is removed only once real content
+      is on screen — the first append that actually flushes to Slack, or the
+      finalizing ``stop()`` for a buffered answer — so the thread never shows a
+      gap between the placeholder vanishing and the reply appearing.
+    - **Seal ⇒ forget.** Sealing a segment before an out-of-band message
+      (approval card, notice) also resets the accumulated text, so the tail
+      reconciliation only ever considers the current segment.
+    - **Tail reconciliation.** The final answer is whatever streamed; if the
+      model reported a final item beyond the deltas, only the remainder is
+      appended, and a no-delta answer falls back to the committed item.
+    """
+
+    def __init__(
+        self,
+        client: SlackClientProtocol,
+        key: ThreadKey,
+        *,
+        recipient_user_id: str,
+        ack_ts: str | None,
+        logger: logging.Logger,
+    ) -> None:
+        self._reply = _LiveReply(client, key, recipient_user_id=recipient_user_id)
+        self._client = client
+        self._key = key
+        self._ack_ts = ack_ts
+        self._logger = logger
+        self._streamed = ""
+        self._final: str | None = None
+        # Text put on screen in each sealed segment this turn. Unlike
+        # ``_streamed``/``_final`` (which reset at each seal), this survives
+        # interruptions, so the no-delta fallback can tell whether the server's
+        # newest assistant message is one we ALREADY showed (a trailing notice
+        # sealed off an answer we streamed → don't re-post) from a genuinely new
+        # message that never streamed (e.g. the post-elicitation answer arrived
+        # only committed → DO recover it).
+        self._delivered_texts: list[str] = []
+
+    def set_ack(self, ack_ts: str | None) -> None:
+        """Attach the placeholder ack posted after the reply was constructed.
+
+        The ack is posted only after any session-config summary, so the thread
+        reads metadata → "Working on it…" → answer. Once set, the ack is cleared
+        by the same rules as if it had been passed at construction.
+        """
+        self._ack_ts = ack_ts
+
+    @property
+    def segments(self) -> int:
+        return self._reply.segments
+
+    @property
+    def streamed_len(self) -> int:
+        return len(self._streamed)
+
+    async def add_delta(self, delta: str) -> None:
+        # Append the delta; the SDK buffers and only flushes to Slack once the
+        # buffer fills. Clear the placeholder only on the flush that actually
+        # puts content on screen — never while still buffering — so there's no
+        # empty gap.
+        self._streamed += delta
+        if await self._reply.append(delta):
+            await self._clear_ack()
+
+    def set_final(self, text: str) -> None:
+        self._final = text
+
+    async def seal_for_interruption(self) -> None:
+        # Before an out-of-band message: reveal any buffered streamed text FIRST
+        # (so it appears above the interruption as it did on screen in the web UI,
+        # not coincident with the card), drop the placeholder (it would sit stale
+        # above the interruption for the whole wait), finalize the current segment
+        # so the interruption sorts after it, and forget the accumulated text so
+        # the next segment reconciles independently. Record what this segment
+        # delivered BEFORE resetting, so the fallback can recognize an
+        # already-shown message and not re-post it.
+        await self._reply.flush()
+        shown = self._streamed + self._tail()
+        if shown:
+            self._delivered_texts.append(shown)
+        await self._clear_ack()
+        await self._reply.seal()
+        self._streamed, self._final = "", None
+
+    async def finalize(self, *, error_text: str | None) -> bool:
+        # Deliver the answer tail, then clear the placeholder only after that
+        # final flush (a short buffered answer becomes visible only at stop()).
+        # Returns whether a real answer was delivered — when an error also
+        # occurred, the caller posts the failure as a separate reply so the
+        # answer stays intact; when nothing was produced, the error IS the reply.
+        tail = self._tail()
+        delivered_answer = bool(self._streamed or tail)
+        if delivered_answer:
+            await self._reply.stop(tail or None)
+        else:
+            await self._reply.stop(
+                f"Omnigent request failed: {error_text}"
+                if error_text
+                else "Omnigent completed without returning response text."
+            )
+        await self._clear_ack()
+        return delivered_answer
+
+    def _tail(self) -> str:
+        # The remainder of the committed final item beyond what already streamed.
+        # ``startswith`` also covers the no-delta case (an empty ``_streamed`` is a
+        # prefix of everything), so a committed-only answer returns in full.
+        if self._final and self._final.startswith(self._streamed):
+            return self._final[len(self._streamed) :]
+        return ""
+
+    def needs_fallback_text(self) -> bool:
+        # True when the current (final) segment has no answer to deliver — the
+        # caller may then recover the server's newest committed message. This is
+        # a per-segment check; ``already_delivered`` guards against re-posting a
+        # message an earlier sealed segment already showed.
+        return not self._streamed and not self._tail()
+
+    def already_delivered(self, text: str) -> bool:
+        # Whether ``text`` matches something already put on screen this turn (a
+        # sealed segment, or the current one). Lets the fallback distinguish a
+        # message that already streamed but was sealed off by a trailing notice
+        # (don't re-post) from one that never streamed (recover it).
+        candidate = text.strip()
+        if not candidate:
+            return True
+        shown = [*self._delivered_texts, self._streamed + self._tail()]
+        return any(candidate == s.strip() for s in shown if s)
+
+    def set_fallback_text(self, text: str) -> None:
+        self._final = text
+
+    async def stop_with(self, text: str) -> None:
+        # Terminal notice (auth/unreachable/host errors, or a no-op abort): clear
+        # the placeholder, then deliver ``text`` as a plain thread reply. Empty
+        # text is a silent stop (nothing to say). A notice is not a streamed
+        # answer, so it goes via a normal message, not the streaming reply.
+        await self._clear_ack()
+        if text:
+            await self._client.chat_postMessage(
+                channel=self._key.channel_id,
+                thread_ts=self._key.thread_ts,
+                text=truncate_for_slack(text),
+            )
+
+    async def _clear_ack(self) -> None:
+        # Best-effort, idempotent: a failed delete must not abort the turn.
+        if not self._ack_ts:
+            return
+        ack_ts, self._ack_ts = self._ack_ts, None
+        try:
+            await self._client.chat_delete(channel=self._key.channel_id, ts=ack_ts)
+        except Exception:
+            self._logger.warning("Ack delete failed thread=%s; continuing", self._key.display())

--- a/integrations/slack/tests/test_approvals.py
+++ b/integrations/slack/tests/test_approvals.py
@@ -8,6 +8,7 @@ from omnigent_slack.approvals import (
     ACTION_FORM_SUBMIT,
     ClickTarget,
     ElicitationCoordinator,
+    ElicitationOutcome,
     Verdict,
     elicitation_card_blocks,
     parse_action_value,
@@ -218,7 +219,7 @@ def test_resolve_form_answers_drops_unknown_indices() -> None:
 
 
 def test_resolved_card_drops_controls() -> None:
-    blocks = resolved_card_blocks(_binary(), outcome="Approved")
+    blocks = resolved_card_blocks(_binary(), outcome=ElicitationOutcome.APPROVED)
     assert not any(b.get("type") == "actions" for b in blocks)
     assert "Approved" in blocks[0]["text"]["text"]
 

--- a/integrations/slack/tests/test_omnigent.py
+++ b/integrations/slack/tests/test_omnigent.py
@@ -5,6 +5,7 @@ import httpx
 import respx
 from omnigent_slack.omnigent import (
     AuthRequiredError,
+    HarnessNotConfiguredError,
     HostUnavailableError,
     OmnigentClient,
     OmnigentClientPool,
@@ -16,27 +17,42 @@ from omnigent_slack.omnigent import (
     extract_output_file,
     extract_policy_denied,
     extract_todos,
-    is_terminal_event,
+    is_hard_terminal_event,
     iter_sse_events,
+    session_status,
 )
 
 
-def test_is_terminal_event_only_ends_on_session_idle_or_failed() -> None:
-    # Per-response completions are NOT terminal: an orchestrator emits one each
-    # time it ends a turn to wait on a sub-agent, then resumes the same turn.
-    assert not is_terminal_event({"type": "response.completed"})
-    assert not is_terminal_event({"type": "turn.completed"})
-    assert not is_terminal_event({"type": "response.output_text.delta", "delta": "x"})
-    assert not is_terminal_event({"type": "session.status", "status": "running"})
-    assert not is_terminal_event({"type": "session.status", "status": "waiting"})
+def test_session_status_parses_status_and_response_id() -> None:
+    # The turn-end signal is a session.status carrying a response_id (Stop hook);
+    # a bare idle (no response_id) is a PTY-watcher flap and must be
+    # distinguishable — response_id parses to None there.
+    assert session_status(
+        {"type": "session.status", "status": "running", "response_id": "resp_1"}
+    ) == ("running", "resp_1")
+    assert session_status({"type": "session.status", "status": "idle"}) == ("idle", None)
+    assert session_status(
+        {"type": "session.status", "status": "idle", "response_id": "resp_1"}
+    ) == ("idle", "resp_1")
+    # Empty/blank response_id normalizes to None.
+    assert session_status({"type": "session.status", "status": "idle", "response_id": ""}) == (
+        "idle",
+        None,
+    )
+    # Non-status events → None.
+    assert session_status({"type": "response.output_text.delta", "delta": "x"}) is None
+    assert session_status({"type": "response.completed"}) is None
 
-    # The session settling is the authoritative turn boundary.
-    assert is_terminal_event({"type": "session.status", "status": "idle"})
-    assert is_terminal_event({"type": "session.status", "status": "failed"})
 
-    # Explicit failure/cancel still ends the turn as a fallback.
-    assert is_terminal_event({"type": "response.failed"})
-    assert is_terminal_event({"type": "turn.cancelled"})
+def test_is_hard_terminal_event() -> None:
+    # Explicit failure/cancel end the turn regardless of response_id tracking.
+    assert is_hard_terminal_event({"type": "response.failed"})
+    assert is_hard_terminal_event({"type": "response.cancelled"})
+    assert is_hard_terminal_event({"type": "turn.failed"})
+    assert is_hard_terminal_event({"type": "turn.cancelled"})
+    # A normal completion / delta / status is NOT hard-terminal.
+    assert not is_hard_terminal_event({"type": "response.completed"})
+    assert not is_hard_terminal_event({"type": "session.status", "status": "idle"})
 
 
 async def _lines(values: list[str]) -> AsyncIterator[str]:
@@ -372,18 +388,17 @@ async def test_request_wraps_transport_failure_as_server_unreachable() -> None:
 
 
 @respx.mock
-async def test_run_turn_streams_across_multiple_responses_until_session_idle() -> None:
+async def test_run_turn_streams_across_multiple_responses_until_id_terminal() -> None:
     # An orchestrator ends its first response to wait on a sub-agent, then
-    # resumes with the real answer in a second response. The turn is only over
-    # once the session settles to idle — `response.completed` alone must not
-    # cut the stream off after the "dispatched, waiting" message.
+    # resumes with the real answer in a second response. `response.completed`
+    # alone must NOT end the turn; only the id-bearing terminal session.status
+    # (the Stop-hook edge) does.
     sse_body = (
         'data: {"type":"response.output_text.delta","delta":"Explorer dispatched."}\n\n'
         'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
         'data: {"type":"response.output_text.delta","delta":"Here is the report."}\n\n'
         'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
-        'data: {"type":"session.status","conversation_id":"conv_1","status":"idle"}\n\n'
-        "data: [DONE]\n\n"
+        'data: {"type":"session.status","status":"idle","response_id":"resp_1"}\n\n'
     )
     respx.get("http://omnigent.test/v1/sessions/conv_1/stream").mock(
         return_value=httpx.Response(200, text=sse_body)
@@ -407,19 +422,19 @@ async def test_run_turn_streams_across_multiple_responses_until_session_idle() -
 
 
 @respx.mock
-async def test_run_turn_resumes_after_idle_when_stream_continues() -> None:
-    # A fan-out orchestrator ends its turn to wait on sub-agents, settling to
-    # `idle` between wake cycles, then resumes with more output when a sub-agent
-    # completes. The bot must NOT stop at the first idle: within the grace
-    # window the stream delivers more, so the turn keeps going to the real end.
+async def test_run_turn_ignores_bare_idle_flaps_until_id_terminal() -> None:
+    # claude-native's PTY watcher emits `session.status: idle` WITH NO
+    # response_id mid-answer, between output bursts, while still generating. Those
+    # flaps must be IGNORED — ending on one truncates the reply. The turn ends
+    # only on the id-bearing idle (the Stop hook), after all bursts.
     sse_body = (
-        'data: {"type":"response.output_text.delta","delta":"Fanning out."}\n\n'
-        'data: {"type":"session.status","conversation_id":"conv_1","status":"idle"}\n\n'
-        'data: {"type":"response.output_text.delta","delta":"Collecting results."}\n\n'
-        'data: {"type":"session.status","conversation_id":"conv_1","status":"idle"}\n\n'
-        'data: {"type":"response.output_text.delta","delta":"All done."}\n\n'
-        'data: {"type":"session.status","conversation_id":"conv_1","status":"idle"}\n\n'
-        "data: [DONE]\n\n"
+        'data: {"type":"session.status","status":"running","response_id":"resp_1"}\n\n'
+        'data: {"type":"response.output_text.delta","delta":"Part one. "}\n\n'
+        'data: {"type":"session.status","status":"idle"}\n\n'  # bare flap — ignore
+        'data: {"type":"response.output_text.delta","delta":"Part two. "}\n\n'
+        'data: {"type":"session.status","status":"idle"}\n\n'  # bare flap — ignore
+        'data: {"type":"response.output_text.delta","delta":"Part three."}\n\n'
+        'data: {"type":"session.status","status":"idle","response_id":"resp_1"}\n\n'  # real end
     )
     respx.get("http://omnigent.test/v1/sessions/conv_1/stream").mock(
         return_value=httpx.Response(200, text=sse_body)
@@ -432,65 +447,63 @@ async def test_run_turn_resumes_after_idle_when_stream_continues() -> None:
     try:
         deltas = [
             event.get("delta")
-            async for event in client.run_turn("conv_1", "go", idle_grace_seconds=5.0)
+            async for event in client.run_turn("conv_1", "go")
             if event.get("type") == "response.output_text.delta"
         ]
     finally:
         await client.aclose()
 
-    # All three segments streamed across the intermediate idle edges — the turn
-    # only ends at the final idle when the stream itself closes.
-    assert deltas == ["Fanning out.", "Collecting results.", "All done."]
+    # All three bursts delivered — the bare-idle flaps did not truncate.
+    assert deltas == ["Part one. ", "Part two. ", "Part three."]
 
 
 @respx.mock
-async def test_run_turn_transient_idle_midstream_does_not_truncate() -> None:
-    # claude-native oscillates running/idle WHILE still streaming its answer,
-    # with a sub-second gap before the next burst — and the snapshot reads `idle`
-    # during that gap. The settle wait must catch the resumption rather than
-    # ending the turn on the transient idle (which truncated the reply).
-    async def _bursty_stream() -> AsyncIterator[bytes]:
-        yield b'data: {"type":"response.output_text.delta","delta":"Part one. "}\n\n'
-        yield b'data: {"type":"session.status","status":"idle"}\n\n'
-        # Real gap before the next burst — shorter than the settle window.
-        await asyncio.sleep(0.2)
-        yield b'data: {"type":"response.output_text.delta","delta":"Part two. "}\n\n'
-        yield b'data: {"type":"session.status","status":"idle"}\n\n'
-        await asyncio.sleep(0.2)
-        yield b'data: {"type":"response.output_text.delta","delta":"Part three."}\n\n'
-        yield b'data: {"type":"session.status","status":"idle"}\n\n'
-        yield b"data: [DONE]\n\n"
+async def test_run_turn_ends_on_idless_idle_for_in_process_harness() -> None:
+    # Incident dc05b28 (debby / claude-sdk in-process harness): ALL session.status
+    # events are id-LESS for this harness (verified live + in schema). The turn
+    # brackets are: id-less running -> deltas -> id-less WAITING (mid-fan-out,
+    # sub-agents dispatched) -> id-less running -> final summary -> id-less IDLE.
+    # The turn must: NOT end on the mid-fan-out `waiting`, stream the summary that
+    # follows it, and END on the final id-less `idle`. (No response_id is ever
+    # stamped, so the claude-native id-match strategy can't apply here.)
+    async def _in_process_stream() -> AsyncIterator[bytes]:
+        yield b'data: {"type":"session.status","status":"running"}\n\n'
+        yield b'data: {"type":"response.output_text.delta","delta":"Dispatching partners."}\n\n'
+        yield b'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+        yield b'data: {"type":"session.status","status":"waiting"}\n\n'  # mid-fan-out
+        yield b'data: {"type":"session.status","status":"running"}\n\n'
+        yield b'data: {"type":"response.output_text.delta","delta":"Both partners are back."}\n\n'
+        yield b'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+        yield b'data: {"type":"session.status","status":"idle"}\n\n'  # id-less REAL end
+        # The real server does NOT close after idle — it stays open with 15s
+        # heartbeats. So ending REQUIRES recognizing the id-less idle; otherwise
+        # the loop hangs to the liveness timeout. Model that with a long silence.
+        await asyncio.sleep(30)
 
     respx.get("http://omnigent.test/v1/sessions/conv_1/stream").mock(
-        return_value=httpx.Response(200, stream=_bursty_stream())
+        return_value=httpx.Response(200, stream=_in_process_stream())
     )
     respx.post("http://omnigent.test/v1/sessions/conv_1/events").mock(
         return_value=httpx.Response(200, json={})
     )
-    # Snapshot reads `idle` during the gaps — the WRONG signal to end on. The
-    # settle wait must win over it while text is still coming.
-    respx.get("http://omnigent.test/v1/sessions/conv_1").mock(
-        return_value=httpx.Response(200, json={"status": "idle"})
-    )
     client = OmnigentClient("http://omnigent.test")
 
-    try:
-        deltas = [
+    async def _drain() -> list[str | None]:
+        return [
             event.get("delta")
-            async for event in client.run_turn(
-                "conv_1",
-                "go",
-                idle_grace_seconds=5.0,
-                idle_poll_seconds=5.0,
-                idle_settle_seconds=1.0,
-            )
+            async for event in client.run_turn("conv_1", "fan out", idle_grace_seconds=5.0)
             if event.get("type") == "response.output_text.delta"
         ]
+
+    try:
+        # Must end on the id-less idle, well within the 30s silence.
+        deltas = await asyncio.wait_for(_drain(), timeout=5.0)
     finally:
         await client.aclose()
 
-    # All three bursts delivered — no mid-answer truncation despite the idles.
-    assert deltas == ["Part one. ", "Part two. ", "Part three."]
+    # The post-`waiting` summary streamed (waiting didn't end the turn), and the
+    # id-less idle ended it cleanly — no truncation, no hang.
+    assert deltas == ["Dispatching partners.", "Both partners are back."]
 
 
 @respx.mock
@@ -503,7 +516,7 @@ async def test_run_turn_ends_when_stream_goes_silent_without_idle_event() -> Non
     # snapshot shows the server is idle.
     async def _silent_after_output() -> AsyncIterator[bytes]:
         yield b'data: {"type":"response.output_text.delta","delta":"Some answer."}\n\n'
-        await asyncio.sleep(30)  # then nothing: no idle, no [DONE] — a bare read hangs
+        await asyncio.sleep(30)  # then nothing: no terminal, no heartbeat, no [DONE]
 
     respx.get("http://omnigent.test/v1/sessions/conv_1/stream").mock(
         return_value=httpx.Response(200, stream=_silent_after_output())
@@ -511,91 +524,70 @@ async def test_run_turn_ends_when_stream_goes_silent_without_idle_event() -> Non
     respx.post("http://omnigent.test/v1/sessions/conv_1/events").mock(
         return_value=httpx.Response(200, json={})
     )
-    # The server is actually done (idle) — the stream just never told us.
-    respx.get("http://omnigent.test/v1/sessions/conv_1").mock(
-        return_value=httpx.Response(200, json={"status": "idle"})
-    )
     client = OmnigentClient("http://omnigent.test")
 
     async def _drain() -> list[str | None]:
+        # A live connection heartbeats every ~15s; no event for idle_grace_seconds
+        # means the socket is dead → end (the liveness backstop).
         return [
             event.get("delta")
-            async for event in client.run_turn(
-                "conv_1",
-                "go",
-                idle_grace_seconds=5.0,
-                idle_poll_seconds=0.05,
-                idle_settle_seconds=0.05,
-            )
+            async for event in client.run_turn("conv_1", "go", idle_grace_seconds=0.3)
             if event.get("type") == "response.output_text.delta"
         ]
 
     try:
-        # Must finish well within the 30s silent stall — bounded by the poll.
         deltas = await asyncio.wait_for(_drain(), timeout=5.0)
     finally:
         await client.aclose()
 
-    assert deltas == ["Some answer."]  # delivered, then the turn ended cleanly
+    assert deltas == ["Some answer."]  # delivered, then the dead socket ended it
 
 
 @respx.mock
-async def test_run_turn_ends_when_idle_grace_elapses_and_snapshot_idle() -> None:
-    # A truly-final idle: the stream stays open briefly (no `[DONE]`) but nothing
-    # more arrives within the grace window, and the snapshot confirms the session
-    # is idle — so the turn ends rather than hanging on the late delta.
-    async def _slow_stream() -> AsyncIterator[bytes]:
+async def test_run_turn_ends_on_id_terminal_ignoring_later_deltas() -> None:
+    # The id-bearing terminal is authoritative: once it arrives, the turn is over.
+    # A stray later delta on the same (now-stale) stream is not delivered.
+    async def _stream() -> AsyncIterator[bytes]:
+        yield b'data: {"type":"session.status","status":"running","response_id":"resp_1"}\n\n'
         yield b'data: {"type":"response.output_text.delta","delta":"Answer."}\n\n'
-        yield b'data: {"type":"session.status","status":"idle"}\n\n'
+        yield b'data: {"type":"session.status","status":"idle","response_id":"resp_1"}\n\n'
         await asyncio.sleep(0.4)
         yield b'data: {"type":"response.output_text.delta","delta":"too late"}\n\n'
 
     respx.get("http://omnigent.test/v1/sessions/conv_1/stream").mock(
-        return_value=httpx.Response(200, stream=_slow_stream())
+        return_value=httpx.Response(200, stream=_stream())
     )
     respx.post("http://omnigent.test/v1/sessions/conv_1/events").mock(
         return_value=httpx.Response(200, json={})
-    )
-    # Snapshot says idle → nothing outstanding → end the turn.
-    respx.get("http://omnigent.test/v1/sessions/conv_1").mock(
-        return_value=httpx.Response(200, json={"status": "idle"})
     )
     client = OmnigentClient("http://omnigent.test")
 
     try:
         deltas = [
             event.get("delta")
-            async for event in client.run_turn(
-                "conv_1",
-                "go",
-                idle_grace_seconds=5.0,
-                idle_poll_seconds=0.05,
-                idle_settle_seconds=0.05,
-            )
+            async for event in client.run_turn("conv_1", "go")
             if event.get("type") == "response.output_text.delta"
         ]
     finally:
         await client.aclose()
 
-    # The settle window (0.05s) was quiet and the snapshot is idle, so the turn
-    # ended at the idle before the late delta (0.4s); it was never delivered.
+    # Ended at the id-terminal; the late delta after it was never delivered.
     assert deltas == ["Answer."]
 
 
 @respx.mock
 async def test_run_turn_does_not_hang_after_elicitation_when_stream_silent() -> None:
     # Incident 10f1d893: after an elicitation, the consumer parks to handle it,
-    # leaving the SSE connection unread. When it resumes, the (now stale) stream
-    # delivers nothing more and never closes — a bare read would hang forever,
-    # wedging the thread. The loop must treat the elicitation like a soft idle:
-    # settle-wait, then poll the snapshot, and END when the session is idle.
+    # leaving the SSE connection unread. If the stream then delivers nothing and
+    # never closes, a bare read would hang forever, wedging the thread. The
+    # liveness backstop (no event for idle_grace_seconds) ends the turn.
     async def _stalls_after_elicitation() -> AsyncIterator[bytes]:
         yield b'data: {"type":"response.output_text.delta","delta":"Before deleting."}\n\n'
         yield (
             b'data: {"type":"response.elicitation_request",'
             b'"elicitation_id":"e1","params":{"message":"Approve?"}}\n\n'
         )
-        # Then nothing: no more events, no [DONE]. A bare read here hangs.
+        # Then nothing: no more events, no [DONE], no heartbeat.
         await asyncio.sleep(30)
 
     respx.get("http://omnigent.test/v1/sessions/conv_1/stream").mock(
@@ -604,147 +596,22 @@ async def test_run_turn_does_not_hang_after_elicitation_when_stream_silent() -> 
     respx.post("http://omnigent.test/v1/sessions/conv_1/events").mock(
         return_value=httpx.Response(200, json={})
     )
-    # The server has gone idle (the turn actually finished server-side).
-    respx.get("http://omnigent.test/v1/sessions/conv_1").mock(
-        return_value=httpx.Response(200, json={"status": "idle"})
-    )
     client = OmnigentClient("http://omnigent.test")
 
     async def _drain() -> list[str]:
         return [
             event.get("type")
-            async for event in client.run_turn(
-                "conv_1",
-                "go",
-                idle_grace_seconds=5.0,
-                idle_poll_seconds=0.05,
-                idle_settle_seconds=0.05,
-            )
+            async for event in client.run_turn("conv_1", "go", idle_grace_seconds=0.3)
         ]
 
     try:
-        # Must complete well within the stream's 30s stall — bounded by the poll,
-        # not hanging on the read.
+        # Must complete well within the 30s stall — bounded by the liveness window.
         types = await asyncio.wait_for(_drain(), timeout=5.0)
     finally:
         await client.aclose()
 
     # The elicitation event was surfaced, then the turn ended cleanly (no hang).
     assert "response.elicitation_request" in types
-
-
-async def test_await_within_grace_waits_while_snapshot_running() -> None:
-    # The idle-disambiguation helper: each quiet poll consults the snapshot.
-    # While the rolled-up status is `running` (a sub-agent child is still
-    # working), it keeps waiting past the poll interval rather than ending;
-    # once the in-flight read completes it reports resumption.
-    from omnigent_slack.omnigent import _NO_RESUMPTION
-
-    async def _slow_read() -> dict[str, object]:
-        # Longer than the poll interval, so several polls fire first.
-        await asyncio.sleep(0.15)
-        return {"type": "response.output_text.delta", "delta": "Collected."}
-
-    client = OmnigentClient("http://omnigent.test")
-
-    async def _running_status(session_id: str) -> str | None:
-        return "running"  # child still working across every quiet poll
-
-    client.get_session_status = _running_status  # type: ignore[method-assign]
-    pending = asyncio.ensure_future(_slow_read())
-    try:
-        # Poll every 0.05s, generous 5s cap — resumes well before the cap.
-        result = await client._await_within_grace(pending, "conv_1", 5.0, 0.05, 0.05)
-    finally:
-        await client.aclose()
-
-    # Snapshot said running across the quiet polls, so it waited for the read
-    # to complete (resumption) instead of returning the end sentinel.
-    assert result is not _NO_RESUMPTION
-    assert pending.done() and pending.result()["delta"] == "Collected."
-
-
-async def test_await_within_grace_ends_when_snapshot_not_running() -> None:
-    from omnigent_slack.omnigent import _NO_RESUMPTION
-
-    async def _silent_read() -> dict[str, object]:
-        await asyncio.sleep(5.0)  # never completes within the poll interval
-        return {"type": "response.output_text.delta", "delta": "too late"}
-
-    client = OmnigentClient("http://omnigent.test")
-
-    async def _idle_status(session_id: str) -> str | None:
-        return "idle"
-
-    client.get_session_status = _idle_status  # type: ignore[method-assign]
-    pending = asyncio.ensure_future(_silent_read())
-    try:
-        result = await client._await_within_grace(pending, "conv_1", 5.0, 0.02, 0.02)
-    finally:
-        pending.cancel()
-        await client.aclose()
-
-    # First quiet poll + snapshot idle → the turn is genuinely over.
-    assert result is _NO_RESUMPTION
-
-
-async def test_await_within_grace_keeps_waiting_on_transient_status_none() -> None:
-    # A None status is a best-effort snapshot failure (transient blip), NOT a
-    # confirmed end. Treating it as "done" would truncate a still-live fan-out on
-    # a momentary hiccup. The loop must keep waiting until the grace cap instead.
-    from omnigent_slack.omnigent import _NO_RESUMPTION
-
-    async def _never_read() -> dict[str, object]:
-        await asyncio.sleep(60.0)
-        return {"type": "response.output_text.delta", "delta": "never"}
-
-    client = OmnigentClient("http://omnigent.test")
-    calls = 0
-
-    async def _flaky_status(session_id: str) -> str | None:
-        nonlocal calls
-        calls += 1
-        return None  # snapshot fetch keeps failing
-
-    client.get_session_status = _flaky_status  # type: ignore[method-assign]
-    pending = asyncio.ensure_future(_never_read())
-    try:
-        # Cap 0.08s, poll 0.02s → several polls; each returns None but must not
-        # end early — only the cap ends it.
-        result = await client._await_within_grace(pending, "conv_1", 0.08, 0.02, 0.02)
-    finally:
-        pending.cancel()
-        await client.aclose()
-
-    assert result is _NO_RESUMPTION  # ended by the cap, not the first None
-    assert calls >= 2  # kept polling through the transient failures
-
-
-async def test_await_within_grace_cap_ends_even_while_running() -> None:
-    # The cap is a backstop: if the snapshot stays `running` forever (stuck
-    # session), the turn still ends once the total grace cap elapses rather than
-    # parking indefinitely.
-    from omnigent_slack.omnigent import _NO_RESUMPTION
-
-    async def _never_read() -> dict[str, object]:
-        await asyncio.sleep(60.0)
-        return {"type": "response.output_text.delta", "delta": "never"}
-
-    client = OmnigentClient("http://omnigent.test")
-
-    async def _stuck_running(session_id: str) -> str | None:
-        return "running"  # never settles
-
-    client.get_session_status = _stuck_running  # type: ignore[method-assign]
-    pending = asyncio.ensure_future(_never_read())
-    try:
-        # Poll 0.02s, cap 0.05s → a couple of polls then the cap ends it.
-        result = await client._await_within_grace(pending, "conv_1", 0.05, 0.02, 0.02)
-    finally:
-        pending.cancel()
-        await client.aclose()
-
-    assert result is _NO_RESUMPTION
 
 
 @respx.mock
@@ -768,6 +635,64 @@ async def test_client_raises_runner_unavailable() -> None:
         await client.aclose()
 
     assert raised is True
+
+
+@respx.mock
+async def test_launch_runner_412_propagates_harness_not_configured_message() -> None:
+    # A 412 harness_not_configured is an actionable precondition failure — the
+    # server's curated error.message must reach the user, not collapse to the
+    # generic "failed with status 412".
+    respx.post("http://omnigent.test/v1/hosts/host_1/runners").mock(
+        return_value=httpx.Response(
+            412,
+            json={
+                "error": {
+                    "code": "harness_not_configured",
+                    "message": "launch failed: claude CLI missing; run omnigent setup",
+                }
+            },
+        )
+    )
+    client = OmnigentClient("http://omnigent.test")
+    try:
+        raised: HarnessNotConfiguredError | None = None
+        try:
+            await client.launch_runner("conv_1", workspace="/home/u", host_id="host_1")
+        except HarnessNotConfiguredError as exc:
+            raised = exc
+    finally:
+        await client.aclose()
+
+    assert raised is not None
+    # The server's message is preserved verbatim (it's the actionable guidance).
+    assert "omnigent setup" in str(raised)
+    assert "status 412" not in str(raised)  # not the generic fallback
+
+
+@respx.mock
+async def test_stream_401_raises_auth_required_not_response_not_read() -> None:
+    # A 401 on the SSE stream must classify as AuthRequiredError so the bot can
+    # prompt "/omnigent to log in again". The stream response body is unread, so
+    # the error classifier must read it before inspecting — otherwise httpx
+    # raises ResponseNotRead and the real 401 is masked as a generic failure.
+    respx.get("http://omnigent.test/v1/sessions/conv_1/stream").mock(
+        return_value=httpx.Response(
+            401, json={"error": {"code": "unauthorized", "message": "Authentication required"}}
+        )
+    )
+    client = OmnigentClient("http://omnigent.test")
+    try:
+        raised: Exception | None = None
+        try:
+            async with client.stream_session_events("conv_1") as events:
+                async for _event in events:
+                    pass
+        except Exception as exc:
+            raised = exc
+    finally:
+        await client.aclose()
+
+    assert isinstance(raised, AuthRequiredError)
 
 
 def test_extract_elicitation_request_parses_fields() -> None:

--- a/integrations/slack/tests/test_service.py
+++ b/integrations/slack/tests/test_service.py
@@ -7,6 +7,7 @@ from omnigent_slack.approvals import Verdict, parse_action_value
 from omnigent_slack.models import ThreadKey, UserConfig
 from omnigent_slack.omnigent import (
     AuthRequiredError,
+    HarnessNotConfiguredError,
     HostUnavailableError,
     OmnigentError,
     ServerUnreachableError,
@@ -177,6 +178,11 @@ class FakeSlackClient:
                 post.update(kwargs)
         return {"ok": True, "ts": ts}
 
+    async def chat_getPermalink(self, **kwargs: Any) -> dict[str, Any]:
+        channel = kwargs.get("channel")
+        ts = kwargs.get("message_ts")
+        return {"ok": True, "permalink": f"https://slack.test/archives/{channel}/p{ts}"}
+
     async def chat_stream(self, **kwargs: Any) -> FakeStream:
         # Only the first stream auto-closes (Slack finalizes the idle message);
         # the continuation the bot opens streams fresh, mirroring reality.
@@ -206,19 +212,16 @@ class FakeOmnigentClient:
         self.resolved_content: list[dict[str, Any] | None] = []
         self.next_session_id = "conv_1"
         self.final_text = final_text
-        # Rolled-up status the grace window polls at a soft idle; default idle so
-        # a turn ends promptly unless a test sets it to "running".
-        self.status = "idle"
         # Newest assistant message the server would return, for the no-delta
         # fallback. ``latest_message_id`` pins the id (else each call gets a
         # fresh id, so the fallback treats it as new relative to the baseline).
         self.latest_message: str | None = None
         self.latest_message_id: str | None = None
         self._latest_calls = 0
-        # Whether an outstanding elicitation is still pending server-side. Default
-        # True so the Slack-click path is exercised; a test sets it False to
-        # simulate the user answering elsewhere (web UI).
-        self.elicitation_pending = True
+        # Fires when the bot POSTs a verdict via resolve_elicitation — lets a
+        # fixture generator wait for the answer before emitting the server's
+        # elicitation_resolved + continuation (the pure-push model).
+        self.resolve_signal = asyncio.Event()
         # Server activity reported at ROUTE time (before a turn) — the gate that
         # decides whether a new message runs or is deflected. Defaults to free
         # (idle, no pending) so a follow-up runs; a test sets these to simulate a
@@ -226,9 +229,9 @@ class FakeOmnigentClient:
         # in-turn grace window polls) so the two don't collide.
         self.route_status: str | None = "idle"
         self.route_pending_elicitation = False
-
-    async def get_session_status(self, session_id: str) -> str | None:
-        return self.status
+        # Server-authoritative harness/agent for the first-message config summary.
+        self.info_harness: str | None = "claude-native"
+        self.info_agent_name: str | None = "debby"
 
     async def get_session_activity(self, session_id: str) -> Any:
         from omnigent_slack.omnigent import SessionActivity
@@ -237,8 +240,10 @@ class FakeOmnigentClient:
             status=self.route_status, pending_elicitation=self.route_pending_elicitation
         )
 
-    async def is_elicitation_pending(self, session_id: str, elicitation_id: str) -> bool:
-        return self.elicitation_pending
+    async def get_session_info(self, session_id: str) -> Any:
+        from omnigent_slack.omnigent import SessionInfo
+
+        return SessionInfo(harness=self.info_harness, agent_name=self.info_agent_name)
 
     async def create_session(self, agent_id: str, title: str) -> str:
         self.created.append((agent_id, title))
@@ -293,6 +298,7 @@ class FakeOmnigentClient:
     ) -> None:
         self.resolved.append((session_id, elicitation_id, accepted))
         self.resolved_content.append(content)
+        self.resolve_signal.set()
 
 
 class FakePool:
@@ -405,6 +411,9 @@ async def test_app_mention_creates_session_and_posts_response(tmp_path: Path) ->
     record = await store.get_session(key)
     assert record is not None and record.session_id == "conv_1"
     assert omnigent.created[0][0] == "ag_1"
+    # Session title is "Slack: <thread permalink>" (a clickable URL the web UI
+    # linkifies), not the old opaque "Slack C…/ts" descriptor.
+    assert omnigent.created[0][1] == "Slack: https://slack.test/archives/C1/p100.1"
     assert omnigent.bound == ["conv_1"]
     assert omnigent.turns == [("conv_1", "hello")]
     # The stream replies in-thread and delivers the streamed answer.
@@ -416,7 +425,16 @@ async def test_app_mention_creates_session_and_posts_response(tmp_path: Path) ->
     # started streaming — leaving no leftover placeholder.
     assert len(slack.acks) == 1
     assert slack.acks[0]["ts"] in slack.deleted_ts
-    assert slack.posts == []
+    # A new session posts one durable config-summary message (agent / harness /
+    # workspace + web-UI link) as the first thread message.
+    assert len(slack.posts) == 1
+    info_text = slack.posts[0]["text"]
+    assert "debby" in info_text  # agent name
+    assert "claude-native" in info_text  # harness
+    assert "/c/conv_1|Open in Omnigent>" in info_text  # web-UI link
+    # The config summary comes FIRST, then the "Working on it…" ack: the thread
+    # reads metadata → ack → answer.
+    assert slack.posts[0]["order"] < slack.acks[0]["order"]
     # The placeholder stayed up until the streamed message was actually on
     # screen. This short answer buffers in the SDK and only becomes visible at
     # stop(); the ack was still live then and is deleted only afterwards, so the
@@ -424,9 +442,63 @@ async def test_app_mention_creates_session_and_posts_response(tmp_path: Path) ->
     assert stream.ack_live_when_visible is True
 
 
-async def test_ack_is_posted_and_cleared_on_host_unavailable(tmp_path: Path) -> None:
-    # Even when the session can't start, the immediate ack is posted and then
-    # deleted before the guidance reply, so no placeholder lingers.
+async def test_session_title_falls_back_when_permalink_unavailable(tmp_path: Path) -> None:
+    # The title lookup is cosmetic and must never block session start: if
+    # chat.getPermalink fails (e.g. a missing scope), fall back to a plain
+    # channel/ts descriptor and still create the session.
+    store = await _store(tmp_path)
+
+    class NoPermalinkSlack(FakeSlackClient):
+        async def chat_getPermalink(self, **kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("missing scope")
+
+    slack = NoPermalinkSlack()
+    omnigent = FakeOmnigentClient()
+    service, _pool, _setup = _service(store, omnigent)
+    await _configure_user(store, "T1", "U1")
+
+    await service.handle_app_mention(
+        body={"team_id": "T1", "event_id": "Ev1"},
+        event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> hello"},
+        client=slack,
+        context={"bot_user_id": "B1"},
+    )
+    await _wait_for_stream_stop(slack)
+    await service.shutdown()
+
+    assert len(omnigent.created) == 1
+    assert omnigent.created[0][1] == "Slack thread C1/100.1"
+
+
+async def test_session_info_omits_missing_fields(tmp_path: Path) -> None:
+    # The config summary degrades gracefully when the snapshot omits harness /
+    # agent (unreadable or older session) — no "None", no crash.
+    store = await _store(tmp_path)
+    slack = FakeSlackClient()
+    omnigent = FakeOmnigentClient()
+    omnigent.info_harness = None
+    omnigent.info_agent_name = None
+    service, _pool, _setup = _service(store, omnigent)
+    await _configure_user(store, "T1", "U1")
+
+    await service.handle_app_mention(
+        body={"team_id": "T1", "event_id": "Ev1"},
+        event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> hello"},
+        client=slack,
+        context={"bot_user_id": "B1"},
+    )
+    await _wait_for_stream_stop(slack)
+    await service.shutdown()
+
+    info_text = slack.posts[0]["text"]
+    assert "None" not in info_text
+    assert "/c/conv_1|Open in Omnigent>" in info_text  # link still present
+
+
+async def test_no_ack_when_session_cannot_start_host_unavailable(tmp_path: Path) -> None:
+    # The "Working on it…" placeholder is posted only after the session is
+    # established, so a failed start shows just the guidance — no placeholder
+    # flicker to clear.
     store = await _store(tmp_path)
     slack = FakeSlackClient()
     omnigent = HostUnavailableClient()
@@ -442,9 +514,8 @@ async def test_ack_is_posted_and_cleared_on_host_unavailable(tmp_path: Path) -> 
     await _wait_for_posts(slack, 1)
     await service.shutdown()
 
-    assert len(slack.acks) == 1
-    assert slack.acks[0]["ts"] in slack.deleted_ts
-    # The only durable post is the guidance, not the ack.
+    assert slack.acks == []
+    # The only durable post is the guidance.
     assert len(slack.posts) == 1
     assert "omni host --server http://omnigent.test" in slack.posts[-1]["text"]
 
@@ -507,8 +578,8 @@ class StreamingClient(FakeOmnigentClient):
 class NoDeltaIdleClient(FakeOmnigentClient):
     """Mirrors a real claude-native short answer: NO text deltas — the answer
     arrives only as a committed ``output_item.done`` — and the turn ends on
-    ``session.status: idle`` (not ``response.completed``), exercising the grace
-    window. The ack must stay live until the buffered answer is on screen.
+    ``session.status: idle`` (not ``response.completed``). The ack must stay live
+    until the buffered answer is on screen.
     """
 
     async def run_turn(
@@ -541,8 +612,6 @@ async def test_no_delta_idle_answer_keeps_ack_until_visible(tmp_path: Path) -> N
     slack = FakeSlackClient()
     omnigent = NoDeltaIdleClient(final_text="Here is the answer.")
     service, _pool, _setup = _service(store, omnigent)
-    # Snapshot idle so the grace window ends promptly.
-    omnigent.status = "idle"  # type: ignore[attr-defined]
     await _configure_user(store, "T1", "U1")
 
     await service.handle_app_mention(
@@ -582,9 +651,10 @@ async def test_long_answer_streams_in_full(tmp_path: Path) -> None:
     await service.shutdown()
 
     # The full answer is delivered (deltas + stop tail) with one stream, no
-    # overflow chat.postMessage replies.
+    # overflow chat.postMessage replies — the only durable post is the session
+    # config summary, which never carries answer text.
     assert stream.text == long_answer
-    assert slack.posts == []
+    assert all(long_answer not in str(p.get("text", "")) for p in slack.posts)
 
 
 async def test_turn_error_posts_separate_reply_and_keeps_answer(tmp_path: Path) -> None:
@@ -679,8 +749,9 @@ async def test_turn_error_without_answer_finalizes_with_error(tmp_path: Path) ->
     await service.shutdown()
 
     assert "boom" in (stream.stop_text or "")
-    # No extra failure reply when there was no answer to preserve.
-    assert slack.posts == []
+    # No extra failure reply when there was no answer to preserve (the error is
+    # in the stream's stop text). The only durable post is the config summary.
+    assert all("failed" not in str(p.get("text", "")).lower() for p in slack.posts)
 
 
 async def test_stream_closed_mid_turn_continues_in_new_stream(tmp_path: Path) -> None:
@@ -708,9 +779,10 @@ async def test_stream_closed_mid_turn_continues_in_new_stream(tmp_path: Path) ->
     # first, and together they reconstruct the full answer with no lost text.
     assert len(slack.streams) >= 2
     assert slack.streamed_text == "chunk-a" + "y" * 600
-    # The continuation streamed in the same thread; no static catch-up reply.
+    # The continuation streamed in the same thread; no static catch-up reply
+    # (the answer text never appears in a durable post — only the config summary).
     assert slack.streams[-1].start_kwargs["thread_ts"] == "100.1"
-    assert slack.posts == []
+    assert all("chunk-a" not in str(p.get("text", "")) for p in slack.posts)
 
 
 async def test_stream_closed_then_error_continues_and_posts_failure(tmp_path: Path) -> None:
@@ -1285,10 +1357,10 @@ async def test_unreachable_server_prompts_config_command(tmp_path: Path) -> None
     assert "couldn't reach" in text.lower()
 
 
-async def test_auth_required_clears_ack_and_prompts_relogin(tmp_path: Path) -> None:
+async def test_auth_required_prompts_relogin(tmp_path: Path) -> None:
     # A user with saved config but no valid token (e.g. bot restarted, in-memory
-    # tokens lost) must NOT be left with a lingering "Working on it…" — the ack
-    # is cleared and a re-login prompt is posted instead.
+    # tokens lost) is told to log in again. The ack is posted only after the
+    # session starts, so a failed start leaves no "Working on it…" behind.
     store = await _store(tmp_path)
     slack = FakeSlackClient()
     omnigent = AuthRequiredClient()
@@ -1304,9 +1376,8 @@ async def test_auth_required_clears_ack_and_prompts_relogin(tmp_path: Path) -> N
     await _wait_for_posts(slack, 1)
     await service.shutdown()
 
-    # The placeholder was posted and then deleted — nothing lingers.
-    assert len(slack.acks) == 1
-    assert slack.acks[0]["ts"] in slack.deleted_ts
+    # No placeholder was posted (session never started).
+    assert slack.acks == []
     # No session persisted; the user is told to log in again.
     assert await store.get_session(ThreadKey("T1", "C1", "100.1")) is None
     text = slack.posts[-1]["text"]
@@ -1314,10 +1385,11 @@ async def test_auth_required_clears_ack_and_prompts_relogin(tmp_path: Path) -> N
     assert "log in" in text.lower() or "login" in text.lower()
 
 
-async def test_server_error_creating_session_clears_ack_and_reports(tmp_path: Path) -> None:
+async def test_server_error_creating_session_reports(tmp_path: Path) -> None:
     # A 500 from create_session raises a bare OmnigentError (not one of the
-    # specifically-handled subclasses). It must still clear the "Working on
-    # it…" placeholder and post a failure — never strand the thread.
+    # specifically-handled subclasses). It must still post a failure and never
+    # strand the thread. The ack posts only after the session starts, so a
+    # failed start leaves no placeholder to clear.
     store = await _store(tmp_path)
     slack = FakeSlackClient()
     omnigent = ServerErrorClient()
@@ -1333,9 +1405,8 @@ async def test_server_error_creating_session_clears_ack_and_reports(tmp_path: Pa
     await _wait_for_posts(slack, 1)
     await service.shutdown()
 
-    # Placeholder posted then deleted — nothing lingers on "Working on it…".
-    assert len(slack.acks) == 1
-    assert slack.acks[0]["ts"] in slack.deleted_ts
+    # No placeholder was posted (session never started).
+    assert slack.acks == []
     # A failure reply was posted, and no session was persisted.
     assert await store.get_session(ThreadKey("T1", "C1", "100.1")) is None
     text = slack.posts[-1]["text"]
@@ -1362,6 +1433,41 @@ async def test_no_online_host_prompts_omni_host_command(tmp_path: Path) -> None:
     text = slack.posts[-1]["text"]
     assert "omni host --server http://omnigent.test" in text
     assert "/omnigent" in text
+
+
+class HarnessNotConfiguredClient(FakeOmnigentClient):
+    async def launch_runner(
+        self, session_id: str, *, workspace: str, host_id: str | None = None
+    ) -> str:
+        raise HarnessNotConfiguredError(
+            "host failed to launch runner: claude CLI not found; run omnigent setup"
+        )
+
+
+async def test_harness_not_configured_412_surfaces_server_message(tmp_path: Path) -> None:
+    # A 412 on runner launch (harness not set up on the host) is actionable — the
+    # server's message must reach the user so they know to run `omnigent setup`,
+    # not a generic "request failed".
+    store = await _store(tmp_path)
+    slack = FakeSlackClient()
+    omnigent = HarnessNotConfiguredClient()
+    service, _pool, _setup = _service(store, omnigent)
+    await _configure_user(store, "T1", "U1")
+
+    await service.handle_app_mention(
+        body={"team_id": "T1", "event_id": "Ev1"},
+        event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> hi"},
+        client=slack,
+        context={"bot_user_id": "B1"},
+    )
+    await _wait_for_posts(slack, 1)
+    await service.shutdown()
+
+    # Session was not persisted (startup failed) and the actionable message shows.
+    assert await store.get_session(ThreadKey("T1", "C1", "100.1")) is None
+    text = slack.posts[-1]["text"]
+    assert "omnigent setup" in text
+    assert "status 412" not in text  # not the generic fallback
 
 
 # ── Tool-approval (elicitation) flow ─────────────────────────────────
@@ -1407,12 +1513,26 @@ def _form_elicitation_event(elicitation_id: str = "elicit_form") -> dict[str, An
     }
 
 
+async def _wait_any(*events: asyncio.Event) -> None:
+    """Wait until any of ``events`` is set (with a safety timeout)."""
+    waiters = [asyncio.ensure_future(e.wait()) for e in events]
+    try:
+        await asyncio.wait(waiters, timeout=5.0, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        for w in waiters:
+            if not w.done():
+                w.cancel()
+
+
 class ApprovalClient(FakeOmnigentClient):
     """A turn that streams, parks on an elicitation, then streams a tail.
 
-    The generator yields the elicitation event and then blocks until the worker
-    resolves it (the worker awaits the verdict before pulling the next event).
-    This mirrors the server keeping the stream open across the park.
+    Pure-push model: the generator yields the elicitation event, then WAITS for
+    the verdict to be resolved — either the bot POSTs it (``resolve_signal``, a
+    Slack click) or the test resolves it externally (``resolve_externally``).
+    It then emits the server's ``response.elicitation_resolved`` push, streams
+    the continuation, and ends on an id-bearing idle. This mirrors the real
+    server holding the continuation until the elicitation is answered.
     """
 
     def __init__(
@@ -1421,6 +1541,9 @@ class ApprovalClient(FakeOmnigentClient):
         super().__init__(final_text="done")
         self._elicitation_id = elicitation_id
         self._event = event or _elicitation_event(elicitation_id)
+        # When set, the fixture emits elicitation_resolved WITHOUT waiting for the
+        # bot to POST a verdict — models an answer in the web UI / another client.
+        self.resolve_externally = asyncio.Event()
 
     async def run_turn(
         self,
@@ -1433,10 +1556,15 @@ class ApprovalClient(FakeOmnigentClient):
         self.turns.append((session_id, text))
         yield {"type": "response.output_text.delta", "delta": "work"}
         yield self._event
-        # The worker resolves the elicitation before requesting more events;
-        # by the time control returns here the verdict has been delivered.
+        # Keep the stream "open": wait until the elicitation is answered — either
+        # the bot POSTs a verdict (Slack click) or the test resolves it elsewhere.
+        await _wait_any(self.resolve_signal, self.resolve_externally)
+        yield {
+            "type": "response.elicitation_resolved",
+            "elicitation_id": self._elicitation_id,
+        }
         yield {"type": "response.output_text.delta", "delta": "ing"}
-        yield {"type": "session.status", "status": "idle"}
+        yield {"type": "session.status", "status": "idle", "response_id": "resp_1"}
 
 
 class PreambleThenCommittedAnswerClient(FakeOmnigentClient):
@@ -1470,6 +1598,9 @@ class PreambleThenCommittedAnswerClient(FakeOmnigentClient):
             },
         }
         yield self._event
+        # Wait for the answer, then the server pushes elicitation_resolved.
+        await _wait_any(self.resolve_signal)
+        yield {"type": "response.elicitation_resolved", "elicitation_id": "elicit_form"}
         # Post-answer message arrives ONLY as a committed item (no deltas) — the
         # tail must be recovered and delivered, not dropped.
         yield {
@@ -1480,7 +1611,7 @@ class PreambleThenCommittedAnswerClient(FakeOmnigentClient):
                 "content": [{"type": "output_text", "text": "You picked A. Full summary here."}],
             },
         }
-        yield {"type": "session.status", "status": "idle"}
+        yield {"type": "session.status", "status": "idle", "response_id": "resp_1"}
 
 
 async def _wait_for_card(client: FakeSlackClient) -> dict[str, Any]:
@@ -1610,6 +1741,36 @@ async def test_tool_approval_deny_forwards_decline(tmp_path: Path) -> None:
     assert "Denied" in slack.updates[-1]["blocks"][0]["text"]["text"]
 
 
+async def test_elicitation_resolved_externally_finalizes_without_posting(tmp_path: Path) -> None:
+    # Pure-push: the user answers in the web UI (not the Slack card). The loop
+    # keeps reading and sees response.elicitation_resolved; it must finalize the
+    # card ("Answered elsewhere") WITHOUT posting its own verdict, and the
+    # continuation must still stream.
+    store = await _store(tmp_path)
+    slack = FakeSlackClient()
+    omnigent = ApprovalClient()
+    service, _pool, _setup = _service(store, omnigent)
+    await _configure_user(store, "T1", "U1")
+
+    await service.handle_app_mention(
+        body={"team_id": "T1", "event_id": "Ev1"},
+        event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> edit"},
+        client=slack,
+        context={"bot_user_id": "B1"},
+    )
+    await _wait_for_card(slack)
+    # No Slack click — resolve elsewhere; the fixture then emits the push.
+    omnigent.resolve_externally.set()
+    await _wait_for_turn_end(slack)
+    await service.shutdown()
+
+    # We posted NO verdict (answered elsewhere), the card shows the neutral
+    # outcome, and the continuation ("ing") streamed after the card.
+    assert omnigent.resolved == []
+    assert "Answered elsewhere" in slack.updates[-1]["blocks"][0]["text"]["text"]
+    assert any("ing" in s.text for s in slack.streams)
+
+
 async def test_elicitation_resolved_externally_unblocks_without_verdict(tmp_path: Path) -> None:
     # The user answers the request in the web UI instead of clicking the Slack
     # card. The worker must stop waiting (once the server shows it no longer
@@ -1663,9 +1824,12 @@ async def test_denied_approval_does_not_resurrect_prior_answer(tmp_path: Path) -
             host_id: str | None = None,
         ) -> AsyncIterator[dict[str, Any]]:
             self.turns.append((session_id, text))
-            # Only a gated tool call, no answer text; ends on idle.
+            # Only a gated tool call, no answer text. Park until the deny is
+            # posted, then the server resolves and ends the turn — no answer.
             yield _elicitation_event("elicit_rm")
-            yield {"type": "session.status", "status": "idle"}
+            await _wait_any(self.resolve_signal)
+            yield {"type": "response.elicitation_resolved", "elicitation_id": "elicit_rm"}
+            yield {"type": "session.status", "status": "idle", "response_id": "resp_1"}
 
     omnigent = DeniedNoAnswerClient()
     # A stale prior-turn answer exists on the server, pinned to a fixed id so it
@@ -1887,11 +2051,10 @@ async def test_post_answer_message_only_committed_is_not_dropped(tmp_path: Path)
 
 
 class PreambleThenSilentAfterElicitationClient(FakeOmnigentClient):
-    """Models the stale-connection incident: a preamble streams, the elicitation
-    is handled, then the SSE connection goes SILENT — the post-answer message
-    never arrives on the stream (only the terminal idle does). The final answer
-    lives solely in the server's latest_assistant_message, recovered by the
-    no-delta fallback. Regression for a turn that hung + dropped the answer.
+    """The turn produces NO answer text on the stream at all — a preamble seals
+    at the elicitation, and after resolution the answer never streams (it lives
+    only in the server's committed message). Exercises the no-delta fallback
+    safety net: the final answer is recovered from latest_assistant_message.
     """
 
     def __init__(self, event: dict[str, Any]) -> None:
@@ -1909,10 +2072,12 @@ class PreambleThenSilentAfterElicitationClient(FakeOmnigentClient):
         self.turns.append((session_id, text))
         yield {"type": "response.output_text.delta", "delta": "Before deleting, let me look."}
         yield self._event
-        # After the verdict resolves, the connection is stale — no post-answer
-        # event arrives, only the eventual terminal idle. The answer is recovered
-        # from the server snapshot (latest_message), not the stream.
-        yield {"type": "session.status", "status": "idle"}
+        # Park until the verdict is posted; the answer then never streams (no
+        # delta, no committed item) — only the id-bearing terminal. The final
+        # answer is recovered from the server snapshot (latest_message).
+        await _wait_any(self.resolve_signal)
+        yield {"type": "response.elicitation_resolved", "elicitation_id": "elicit_form"}
+        yield {"type": "session.status", "status": "idle", "response_id": "resp_1"}
 
 
 async def test_post_elicitation_answer_recovered_when_stream_silent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Refactors the Slack integration for clarity and correctness, adds a couple of
user-experience improvements, and documents the architecture. Behaviour is
preserved except where explicitly called out.

- **Refactor — split the monolithic service.** `SlackOmnigentService` shrank
  from ~840 lines of streaming + orchestration + I/O into a thin
  event-routing + turn-lifecycle class. Responsibilities moved into focused
  modules:
  - `streaming.py` (new) — the streamed-answer state machine (`_LiveReply`
    Slack `chat.*Stream` buffering/seal/reopen, `_AnswerReply` ack lifecycle +
    tail reconciliation) and the shared `SlackClientProtocol` structural types.
  - `elicitation.py` (new) — `ElicitationController`, the pure-push tool-approval
    / `AskUserQuestion` card orchestration (post card, spawn resolver, finalize
    on `elicitation_resolved`).
  - `notifications.py` — `SlackNotifier`, all outbound messages (acks, replies,
    ephemerals, todo plan, deflection notices) in one place.
  - `events.py` — pure SSE parsing, event DTOs, and extractors, with no I/O.
  - Removed dead code (grace-window turn-end apparatus, unused
    `is_elicitation_request`, an unreachable `_tail()` branch) and a shared
    `ElicitationOutcome` enum so the resolver and card renderer can't drift.

- **UX — first-reply session summary.** A new thread now posts a one-line
  config summary first (agent / harness, workspace, "Open in Omnigent" link),
  then the "Working on it…" ack, then the streamed answer — so the thread reads
  metadata → ack → answer.

- **UX — readable session titles.** Sessions are titled
  `Slack: <thread permalink>` (a clickable URL the web UI linkifies) instead of
  the opaque `Slack <channel>/<ts>` descriptor, with a plain fallback if the
  permalink lookup fails.

- **Fix — actionable error messages.**
  - A `412 harness_not_configured` on session start now surfaces the server's
    curated message (run `omnigent setup` on the host) instead of a generic
    failure.
  - A `401` on the SSE stream now classifies as "log in again" (`/omnigent`)
    instead of leaking a raw `httpx.ResponseNotRead` error — the streaming error
    body is read before classification.

- **Docs.** Added `DESIGN.md` (architecture, turn-end detection, pure-push
  elicitation, concurrency guards, auth) and trimmed the duplicated internals
  out of `README.md`, leaving it an operator/user guide.

## Test Plan

- `uv run --extra dev --extra slack pytest integrations/slack/tests -q` — 188
  tests pass (added a regression test for the streaming-401 case that fails
  without the fix).
- `uv run --extra dev --extra slack ruff check integrations/slack` — clean.
- `uv run --extra dev --extra slack mypy integrations/slack/src` — clean.
- Live against a dev server: mentioned the bot in a fresh thread and confirmed
  the thread order (config summary → "Working on it…" → streamed answer), the
  `Slack: <permalink>` session title, and that an expired token surfaces the
  "/omnigent to log in again" message rather than a raw streaming error.

## Demo

### User experience improvements
Session metadata as the first reply
<img width="587" height="303" alt="image" src="https://github.com/user-attachments/assets/d6227a87-4c90-4f57-917e-6408aa6a6847" />

Improved streaming reliability
Ex. tested with long running sessions
<img width="592" height="878" alt="image" src="https://github.com/user-attachments/assets/50d2338e-82f9-4914-9b1b-f91f54f00416" />


### Error messages

Auth failures
<img width="576" height="131" alt="image" src="https://github.com/user-attachments/assets/2117c621-9eea-4927-8c9b-516c750ee547" />

Host unavailable
<img width="564" height="102" alt="image" src="https://github.com/user-attachments/assets/4b16b416-0dcf-42e4-8d56-936db86537a1" />

Harness unavailable
<img width="589" height="144" alt="image" src="https://github.com/user-attachments/assets/2f247c11-dfca-4872-b3bf-82bd77270a0d" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The refactor is covered by the existing 188-test suite (turn-end per harness,
silent-stream backstop, pure-push elicitation, flush-before-card, ack ordering).
New behaviour has dedicated tests: the session-config summary and permalink
title (+ graceful fallback) in `test_service.py`, and the streaming-401
classification in `test_omnigent.py` (verified to fail without the fix).
Manual verification covered the live thread ordering, session title, and the
expired-token error path against a dev server.
