### PR TITLE
feat(policies): let ASK policies describe approval targets

### DIFF
--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -486,6 +486,65 @@ def block_domains(blocked_domains: list[str]) -> callable:
 
 `state_updates` supports four actions: `"set"`, `"increment"`, `"delete"`, `"append"`.
 
+### Describing an approval target
+
+An `ASK` response may include policy-controlled presentation metadata derived
+from values the policy has evaluated. Core validates and transports the
+presentation; the approval renderer remains application-agnostic. The
+presentation changes visual hierarchy only. All raw arguments and the complete
+raw call remain available to the approver.
+
+Python policies can return the frozen dataclass on `PolicyResult`:
+
+```python
+from omnigent.policies import ApprovalPresentation, PolicyResult
+from omnigent.spec.types import PolicyAction
+
+return PolicyResult(
+    action=PolicyAction.ASK,
+    reason="Merge this pull request?",
+    approval=ApprovalPresentation(
+        title=f"{owner}/{repository} #{number}",
+        href=f"https://github.com/{owner}/{repository}/pull/{number}",
+        secondary_arguments=("grant_id", "idempotency_key"),
+    ),
+)
+```
+
+Dict-returning Python policies use the same nested shape. CEL policies return
+the presentation as a nested map:
+
+```cel
+{
+  "result": "ASK",
+  "reason": "Merge this pull request?",
+  "approval": {
+    "title": event.data.arguments.repository_owner + "/" +
+             event.data.arguments.repository_name + " #" +
+             string(event.data.arguments.pr_number),
+    "href": "https://github.com/" +
+            event.data.arguments.repository_owner + "/" +
+            event.data.arguments.repository_name + "/pull/" +
+            string(event.data.arguments.pr_number),
+    "secondary_arguments": ["grant_id", "idempotency_key"]
+  }
+}
+```
+
+`title` is required, trimmed, and capped at 256 characters. It must contain no
+C0/C1/DEL controls, Unicode line or paragraph separators (categories `Zl` and
+`Zp`), or Unicode bidi-formatting controls, including ALM, LRM, and RLM.
+`href` is optional; when present it must be an HTTPS URL with a hostname and no
+user information. Unknown names in `secondary_arguments` are ignored.
+Malformed presentations drop to the plain card and log at debug; validate your
+policy's presentation in policy configuration tests. The policy verdict never
+changes when presentation validation fails.
+
+When several policies return `ASK`, the first ASKing policy's presentation
+wins, matching the existing first-policy timeout and deciding-policy
+precedence. Reasons from later ASKing policies are still appended to the
+combined approval message.
+
 ### Making policies discoverable
 
 To make custom policies appear in the UI, export a `POLICY_REGISTRY` list from your module:

--- a/omnigent/policies/__init__.py
+++ b/omnigent/policies/__init__.py
@@ -37,6 +37,7 @@ from omnigent.policies.schema import (
     StateUpdateEntry,
 )
 from omnigent.policies.types import (
+    ApprovalPresentation,
     ElicitationRequest,
     EvaluationContext,
     PolicyLLMClient,
@@ -44,6 +45,7 @@ from omnigent.policies.types import (
 )
 
 __all__ = [
+    "ApprovalPresentation",
     "ElicitationRequest",
     "EvaluationContext",
     "FunctionPolicy",

--- a/omnigent/policies/builtins/cel.py
+++ b/omnigent/policies/builtins/cel.py
@@ -7,8 +7,9 @@ loops, no file I/O.
 
 The expression receives the full ``PolicyEvent`` dict as an
 ``event`` variable and must return a map with a ``result`` key
-(``"DENY"``, ``"ASK"``, or ``"ALLOW"``) and an optional
-``"reason"`` key. Non-map returns abstain.
+(``"DENY"``, ``"ASK"``, or ``"ALLOW"``), an optional
+``"reason"`` key, and an optional ``"approval"`` map. Non-map
+returns abstain.
 
 Register statically in an agent's YAML, or dynamically on a running
 session via the policy API.
@@ -74,8 +75,27 @@ from omnigent.policies.schema import (
     PolicyResponse,
     request_user_text,
 )
+from omnigent.policies.types import coerce_approval_presentation
 
 _log = logging.getLogger(__name__)
+
+
+def _cel_to_plain(value: object) -> object:
+    """Convert a CEL result value into plain Python containers.
+
+    CEL maps raise :class:`KeyError` from ``get`` on an absent key, so the
+    tolerant approval coercer must never receive one directly.
+
+    :param value: A CEL value from an evaluated expression.
+    :returns: The equivalent plain ``dict`` / ``list`` / ``str`` / scalar.
+    """
+    if isinstance(value, dict):
+        return {str(key): _cel_to_plain(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_cel_to_plain(item) for item in value]
+    if isinstance(value, str):
+        return str(value)
+    return value
 
 
 def cel_policy(
@@ -122,6 +142,7 @@ def cel_policy(
     prog = env.program(ast)
     _result_key = celpy.celtypes.StringType("result")
     _reason_key = celpy.celtypes.StringType("reason")
+    _approval_key = celpy.celtypes.StringType("approval")
 
     def evaluate(event: PolicyEvent) -> PolicyResponse | None:
         # llm_client is a live object used by Python policy callables;
@@ -160,6 +181,12 @@ def cel_policy(
             out["reason"] = str(result[_reason_key])
         elif verdict != "ALLOW":
             out["reason"] = reason
+        if _approval_key in result:
+            approval = coerce_approval_presentation(_cel_to_plain(result[_approval_key]))
+            if approval is not None:
+                out["approval"] = approval
+            else:
+                _log.debug("CEL policy returned malformed approval presentation; dropping it")
         return out
 
     return evaluate
@@ -179,7 +206,7 @@ POLICY_REGISTRY: list[dict[str, object]] = (
                 "Evaluate a CEL (Common Expression Language) expression against "
                 "every policy event. The expression receives the full event as "
                 '`event` and must return a map with `result` ("DENY", "ASK", or '
-                '"ALLOW") and optional `reason` keys. '
+                '"ALLOW") and optional `reason` and `approval` keys. '
                 "CEL is non-Turing-complete and side-effect-free."
             ),
             "params_schema": {

--- a/omnigent/policies/function.py
+++ b/omnigent/policies/function.py
@@ -41,12 +41,17 @@ from __future__ import annotations
 import asyncio
 import importlib
 import inspect
+import logging
 from collections.abc import Awaitable, Callable
 from typing import Protocol, cast
 
 from omnigent.policies.base import Policy
 from omnigent.policies.schema import PolicyEvent
-from omnigent.policies.types import EvaluationContext, PolicyResult
+from omnigent.policies.types import (
+    EvaluationContext,
+    PolicyResult,
+    coerce_approval_presentation,
+)
 from omnigent.spec.types import (
     FunctionPolicySpec,
     Phase,
@@ -58,6 +63,9 @@ from omnigent.spec.types import (
 
 class _DynamicCallable(Protocol):
     def __call__(self, *args: object, **kwargs: object) -> object: ...
+
+
+_log = logging.getLogger(__name__)
 
 
 def _phase_to_event_type(phase: Phase) -> str:
@@ -523,11 +531,19 @@ def _coerce_to_policy_result(raw: object, *, spec_name: str) -> PolicyResult:
             ) from exc
         raw_set_labels = getattr(raw, "set_labels", None)
         raw_state_updates = getattr(raw, "state_updates", None)
+        raw_approval = getattr(raw, "approval", None)
+        approval = coerce_approval_presentation(raw_approval)
+        if raw_approval is not None and approval is None:
+            _log.debug(
+                "FunctionPolicy %r returned malformed approval presentation; dropping it",
+                spec_name,
+            )
         return PolicyResult(
             action=action,
             reason=getattr(raw, "reason", None),
             set_labels=(dict(raw_set_labels) if isinstance(raw_set_labels, dict) else None),
             state_updates=_coerce_state_updates(raw_state_updates, spec_name=spec_name),
+            approval=approval,
         )
     raise TypeError(
         f"FunctionPolicy {spec_name!r} returned unsupported type "
@@ -577,12 +593,20 @@ def _policy_result_from_dict(
     raw_state_updates = raw.get("state_updates")
     raw_set_labels = raw.get("set_labels")
     reason = raw.get("reason")
+    raw_approval = raw.get("approval")
+    approval = coerce_approval_presentation(raw_approval)
+    if raw_approval is not None and approval is None:
+        _log.debug(
+            "FunctionPolicy %r returned malformed approval presentation; dropping it",
+            spec_name,
+        )
     return PolicyResult(
         action=action,
         reason=cast("str | None", reason),
         data=raw.get("data"),
         state_updates=_coerce_state_updates(raw_state_updates, spec_name=spec_name),
         set_labels=dict(raw_set_labels) if isinstance(raw_set_labels, dict) else None,
+        approval=approval,
     )
 
 

--- a/omnigent/policies/schema.py
+++ b/omnigent/policies/schema.py
@@ -38,6 +38,8 @@ from __future__ import annotations
 from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias, TypedDict, cast
 
+from omnigent.policies.types import ApprovalPresentation
+
 if TYPE_CHECKING:
     from omnigent.policies.types import PolicyLLMClient
 
@@ -278,6 +280,11 @@ class PolicyResponse(TypedDict, total=False):
                 {"key": "call_count", "action": "increment", "value": 1}
             ],
             "set_labels": {"integrity": "0"},
+            "approval": ApprovalPresentation(
+                title="example/repository #42",
+                href="https://example.com/example/repository/pull/42",
+                secondary_arguments=("grant_id",),
+            ),
         }
 
     Returning ``None`` is treated as abstain (equivalent to
@@ -299,6 +306,9 @@ class PolicyResponse(TypedDict, total=False):
         ``DENY``; withheld on ``ASK`` pending approval.
     :param set_labels: Label key-value writes. Filtered through
         the policy's ``set_labels`` whitelist (if declared).
+    :param approval: Optional target presentation for an ``ASK``.
+        It changes display hierarchy only; raw arguments remain
+        available and the renderer decides their appearance.
     """
 
     result: Literal["ALLOW", "DENY", "ASK"]
@@ -306,6 +316,7 @@ class PolicyResponse(TypedDict, total=False):
     data: object
     state_updates: list[StateUpdateEntry]
     set_labels: dict[str, str]
+    approval: ApprovalPresentation
 
 
 # ── Callable protocol ────────────────────────────────────────────────────────

--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -90,6 +90,7 @@ def coerce_approval_presentation(value: object) -> ApprovalPresentation | None:
     :param value: Candidate dataclass or mapping.
     :returns: A normalized presentation, or ``None`` when malformed.
     """
+    title: object
     if isinstance(value, ApprovalPresentation):
         title = value.title
         href = value.href

--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -15,6 +15,8 @@ Three types live in this module:
   resolved tool_name).
 - :class:`PolicyResult` — what a single policy returns and what
   the engine composes across policies.
+- :class:`ApprovalPresentation` — optional human-facing target
+  metadata supplied by an ASKing policy.
 - :class:`ElicitationRequest` — the internal contract for an
   ASK that's about to be surfaced upstream as an MCP-style
   elicitation. Carries the human-readable message plus the
@@ -54,6 +56,63 @@ class _CreateResponse(Protocol):
 
 
 _log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ApprovalPresentation:
+    """Policy-controlled presentation metadata for a policy ASK.
+
+    The ASKing policy derives the metadata from values the policy has
+    evaluated. ``secondary_arguments`` names raw tool-call arguments the
+    renderer may demote visually; it never authorizes hiding them, and the
+    complete raw call remains available.
+
+    :param title: Human-readable approval target.
+    :param href: Optional external target link. The elicitation boundary
+        validates it before transport.
+    :param secondary_arguments: Top-level argument names to render as
+        secondary detail.
+    """
+
+    title: str
+    href: str | None = None
+    secondary_arguments: tuple[str, ...] = ()
+
+
+def coerce_approval_presentation(value: object) -> ApprovalPresentation | None:
+    """Normalize a policy-supplied presentation without raising.
+
+    Python policies may return :class:`ApprovalPresentation` directly;
+    dict-returning policies and CEL use its mapping shape. A malformed
+    mapping drops only the presentation so policy evaluation can still
+    produce its ALLOW, ASK, or DENY decision.
+
+    :param value: Candidate dataclass or mapping.
+    :returns: A normalized presentation, or ``None`` when malformed.
+    """
+    if isinstance(value, ApprovalPresentation):
+        title = value.title
+        href = value.href
+        secondary = value.secondary_arguments
+    elif isinstance(value, dict):
+        title = value.get("title")
+        href = value.get("href")
+        secondary = value.get("secondary_arguments", ())
+    else:
+        return None
+    if not isinstance(title, str):
+        return None
+    if href is not None and not isinstance(href, str):
+        return None
+    if not isinstance(secondary, (list, tuple)) or not all(
+        isinstance(name, str) for name in secondary
+    ):
+        return None
+    return ApprovalPresentation(
+        title=title,
+        href=href,
+        secondary_arguments=tuple(secondary),
+    )
 
 
 # Proto-style phase wire strings (the ``type`` field on events that
@@ -272,6 +331,11 @@ class PolicyResult:
         denied ASK must leave no trace). ``None`` means "no
         state changes." e.g.
         ``[StateUpdate(key="call_count", action=StateUpdateAction.INCREMENT, value=1)]``.
+    :param approval: Optional policy-controlled presentation metadata
+        derived from values the ASKing policy has evaluated. The engine
+        keeps the first ASKing policy's value when composing several ASK
+        results. The elicitation boundary validates it before transport;
+        renderers only change hierarchy and keep raw arguments.
     """
 
     action: PolicyAction
@@ -280,6 +344,7 @@ class PolicyResult:
     deciding_policies: list[str] | None = None
     data: object | None = None
     state_updates: list[StateUpdate] | None = None
+    approval: ApprovalPresentation | None = None
 
     @property
     def deciding_policy(self) -> str | None:
@@ -328,6 +393,10 @@ class ElicitationRequest:
         gated. Lets a human reviewer see what they're approving
         without overwhelming the UI on a 50 KB payload. Surfaces in
         the elicitation event's extras.
+    :param approval: Validated policy-controlled presentation metadata
+        derived from values the policy has evaluated. Renderers may
+        headline it and demote named arguments, but the raw call remains
+        available.
     """
 
     message: str
@@ -335,6 +404,7 @@ class ElicitationRequest:
     policy_names: list[str]
     content_preview: str
     requested_schema: dict[str, object] = field(default_factory=dict)
+    approval: ApprovalPresentation | None = None
 
     @property
     def policy_name(self) -> str:
@@ -495,8 +565,10 @@ class PolicyLLMClient:
 
 
 __all__ = [
+    "ApprovalPresentation",
     "ElicitationRequest",
     "EvaluationContext",
     "PolicyLLMClient",
     "PolicyResult",
+    "coerce_approval_presentation",
 ]

--- a/omnigent/runtime/policies/approval.py
+++ b/omnigent/runtime/policies/approval.py
@@ -178,22 +178,22 @@ def approval_presentation_to_dict(
 def arguments_from_preview(content_preview: str) -> dict[str, Any]:
     """Recover the tool arguments mapping from an elicitation preview.
 
-    Two preview shapes reach this helper, so both are accepted:
+    Both preview shapes a caller may hold are accepted:
 
-    * A *wrapper* object ``{"name": ..., "arguments": {...}}`` — the whole
-      tool-call event serialized as the preview. The ``arguments`` mapping
-      is returned.
-    * A *bare* arguments mapping ``{...}`` — the preview is already just the
-      arguments. The whole dict is returned.
+    * A *wrapper* object ``{"name": ..., "arguments": {...}}`` — a serialized
+      tool-call event, the shape the :func:`_await_elicitation` seam forwards
+      as its ``content_preview``. Its ``arguments`` mapping is returned.
+    * A *bare* arguments mapping — the shape ``_register_policy_elicitation``
+      is handed, its callers passing the arguments string straight through.
+      The whole dict is returned.
 
-    The whole-dict fallback is therefore deliberate, not a safety net: bare
-    previews carry no ``arguments`` key, so restricting the lookup to that
-    key would derive ``{}`` and silently filter out every declared secondary
-    argument on those paths. The cost is that a wrapper-shaped preview whose
-    ``arguments`` value is absent or not a mapping lets its own top-level
-    keys (e.g. ``name``) count as argument names; that only ever widens the
-    set of names a policy may point the approval card at, never the values
-    rendered, so it is accepted over breaking the bare shape.
+    The whole-dict fallback is deliberate, not a safety net: a bare preview
+    carries no ``arguments`` key, so restricting the lookup to that key would
+    derive ``{}`` and silently filter out every declared secondary argument on
+    those paths. The residual cost is that a wrapper preview whose
+    ``arguments`` is absent or not a mapping lets its own top-level keys (e.g.
+    ``name``) pass as argument names, so an extra name's value may reach the
+    card; the fallback never alters or invents an argument value.
 
     :param content_preview: JSON preview string from the elicitation.
     :returns: The arguments mapping, or ``{}`` when the preview is not a

--- a/omnigent/runtime/policies/approval.py
+++ b/omnigent/runtime/policies/approval.py
@@ -37,6 +37,7 @@ full task_store + SSE stack. See POLICIES.md §7, §13.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import secrets
 import unicodedata
@@ -129,7 +130,7 @@ def validate_approval_presentation(
     # Newlines manipulate line structure, C0/C1/DEL carry control behavior, and bidi
     # marks can falsify the primary line and visible hostname. Reject to keep declared
     # and rendered text identical; the policy that evaluated the values owns hygiene.
-    if _has_disallowed_title_character(approval.title):
+    if _has_disallowed_title_character(title):
         _log_invalid_approval("unsafe title characters")
         return None
 
@@ -174,8 +175,30 @@ def approval_presentation_to_dict(
     }
 
 
-def _arguments_from_preview(content_preview: str) -> dict[str, Any]:
-    """Recover top-level tool arguments from an elicitation preview."""
+def arguments_from_preview(content_preview: str) -> dict[str, Any]:
+    """Recover the tool arguments mapping from an elicitation preview.
+
+    Two preview shapes reach this helper, so both are accepted:
+
+    * A *wrapper* object ``{"name": ..., "arguments": {...}}`` — the whole
+      tool-call event serialized as the preview. The ``arguments`` mapping
+      is returned.
+    * A *bare* arguments mapping ``{...}`` — the preview is already just the
+      arguments. The whole dict is returned.
+
+    The whole-dict fallback is therefore deliberate, not a safety net: bare
+    previews carry no ``arguments`` key, so restricting the lookup to that
+    key would derive ``{}`` and silently filter out every declared secondary
+    argument on those paths. The cost is that a wrapper-shaped preview whose
+    ``arguments`` value is absent or not a mapping lets its own top-level
+    keys (e.g. ``name``) count as argument names; that only ever widens the
+    set of names a policy may point the approval card at, never the values
+    rendered, so it is accepted over breaking the bare shape.
+
+    :param content_preview: JSON preview string from the elicitation.
+    :returns: The arguments mapping, or ``{}`` when the preview is not a
+        JSON object.
+    """
     try:
         content = json.loads(content_preview)
     except (TypeError, ValueError):
@@ -188,8 +211,6 @@ def _arguments_from_preview(content_preview: str) -> dict[str, Any]:
 
 def _log_invalid_approval(reason: str) -> None:
     """Log a presentation fallback without changing the policy verdict."""
-    import logging
-
     logging.getLogger(__name__).debug(
         "Dropping invalid approval presentation at elicitation boundary: %s",
         reason,
@@ -249,7 +270,7 @@ async def _await_elicitation(
     elicitation_id = f"elicit_{secrets.token_hex(16)}"
     approval = validate_approval_presentation(
         result.approval,
-        _arguments_from_preview(content_preview),
+        arguments_from_preview(content_preview),
     )
     elicitation = ElicitationRequest(
         message=result.reason or "",
@@ -493,6 +514,7 @@ def _truncate(text: str, *, limit: int) -> str:
 __all__ = [
     "ELICITATION_PENDING_TOOL_NAME",
     "_await_elicitation",
+    "arguments_from_preview",
     "build_elicitation_params_json",
     "build_elicitation_request_event",
     "resolve_ask_timeout",

--- a/omnigent/runtime/policies/approval.py
+++ b/omnigent/runtime/policies/approval.py
@@ -39,11 +39,13 @@ from __future__ import annotations
 import json
 import os
 import secrets
+import unicodedata
 from collections.abc import Awaitable, Callable
 from typing import Any
+from urllib.parse import urlsplit
 
 from omnigent.errors import ElicitationDeclinedError
-from omnigent.policies.types import ElicitationRequest, PolicyResult
+from omnigent.policies.types import ApprovalPresentation, ElicitationRequest, PolicyResult
 from omnigent.runtime.policies.engine import PolicyEngine
 from omnigent.spec.types import Phase
 
@@ -76,6 +78,122 @@ _EmitCallback = Callable[[dict[str, Any]], None]
 # elicitation params (stored in the row's ``arguments`` column for
 # inspection / replay).
 _RegisterCallback = Callable[[str, str, str], None]
+
+APPROVAL_TITLE_MAX_LENGTH = 256
+
+
+def _has_disallowed_title_character(title: str) -> bool:
+    """Return whether a title can manipulate its security-sensitive display line."""
+    return any(
+        character in "\r\n"
+        or ord(character) <= 0x1F
+        or 0x7F <= ord(character) <= 0x9F
+        or unicodedata.category(character) in {"Zl", "Zp"}
+        or 0x202A <= ord(character) <= 0x202E
+        or 0x2066 <= ord(character) <= 0x2069
+        or ord(character) in (0x061C, 0x200E, 0x200F)
+        for character in title
+    )
+
+
+def validate_approval_presentation(
+    approval: ApprovalPresentation | None,
+    arguments: dict[str, Any] | None,
+) -> ApprovalPresentation | None:
+    """Validate policy-supplied display metadata at the elicitation boundary.
+
+    Titles are trimmed and capped at 256 characters. Links must use HTTPS,
+    include a hostname, contain no user information, and contain no whitespace.
+    Unknown secondary argument names are ignored. Any invalid title or link
+    drops the presentation so the ordinary approval card remains usable.
+
+    :param approval: Candidate presentation from the composed policy result.
+    :param arguments: Top-level tool arguments available to the approval card.
+    :returns: A safe presentation, or ``None`` for the plain-card fallback.
+    """
+    if approval is None:
+        return None
+    if (
+        not isinstance(approval.title, str)
+        or (approval.href is not None and not isinstance(approval.href, str))
+        or not isinstance(approval.secondary_arguments, tuple)
+        or not all(isinstance(name, str) for name in approval.secondary_arguments)
+    ):
+        _log_invalid_approval("malformed fields")
+        return None
+    title = approval.title.strip()
+    if not title:
+        _log_invalid_approval("empty title")
+        return None
+    title = title[:APPROVAL_TITLE_MAX_LENGTH]
+    # Newlines manipulate line structure, C0/C1/DEL carry control behavior, and bidi
+    # marks can falsify the primary line and visible hostname. Reject to keep declared
+    # and rendered text identical; the policy that evaluated the values owns hygiene.
+    if _has_disallowed_title_character(approval.title):
+        _log_invalid_approval("unsafe title characters")
+        return None
+
+    href = approval.href
+    if href is not None:
+        try:
+            parsed = urlsplit(href)
+            valid_href = (
+                parsed.scheme == "https"
+                and parsed.hostname is not None
+                and parsed.username is None
+                and parsed.password is None
+                and not any(character.isspace() for character in href)
+            )
+        except ValueError:
+            valid_href = False
+        if not valid_href:
+            _log_invalid_approval("unsafe href")
+            return None
+
+    known_names = set(arguments or {})
+    secondary_arguments = tuple(
+        dict.fromkeys(name for name in approval.secondary_arguments if name in known_names)
+    )
+    return ApprovalPresentation(
+        title=title,
+        href=href,
+        secondary_arguments=secondary_arguments,
+    )
+
+
+def approval_presentation_to_dict(
+    approval: ApprovalPresentation | None,
+) -> dict[str, Any] | None:
+    """Return the stable wire shape for a validated presentation."""
+    if approval is None:
+        return None
+    return {
+        "title": approval.title,
+        "href": approval.href,
+        "secondary_arguments": list(approval.secondary_arguments),
+    }
+
+
+def _arguments_from_preview(content_preview: str) -> dict[str, Any]:
+    """Recover top-level tool arguments from an elicitation preview."""
+    try:
+        content = json.loads(content_preview)
+    except (TypeError, ValueError):
+        return {}
+    if not isinstance(content, dict):
+        return {}
+    arguments = content.get("arguments")
+    return arguments if isinstance(arguments, dict) else content
+
+
+def _log_invalid_approval(reason: str) -> None:
+    """Log a presentation fallback without changing the policy verdict."""
+    import logging
+
+    logging.getLogger(__name__).debug(
+        "Dropping invalid approval presentation at elicitation boundary: %s",
+        reason,
+    )
 
 
 async def _await_elicitation(
@@ -129,11 +247,16 @@ async def _await_elicitation(
         (explicit user refusal — distinct from cancel/timeout).
     """
     elicitation_id = f"elicit_{secrets.token_hex(16)}"
+    approval = validate_approval_presentation(
+        result.approval,
+        _arguments_from_preview(content_preview),
+    )
     elicitation = ElicitationRequest(
         message=result.reason or "",
         phase=phase.value,
         policy_names=result.deciding_policies or [""],
         content_preview=_truncate(content_preview, limit=1024),
+        approval=approval,
     )
     params_json = build_elicitation_params_json(elicitation)
     register(elicitation_id, task_id, params_json)
@@ -234,6 +357,9 @@ def build_elicitation_request_event(
     }
     if len(elicitation.policy_names) > 1:
         params["policy_names"] = elicitation.policy_names
+    approval = approval_presentation_to_dict(elicitation.approval)
+    if approval is not None:
+        params["approval"] = approval
     if url is not None:
         params["url"] = url
 
@@ -259,16 +385,18 @@ def build_elicitation_params_json(elicitation: ElicitationRequest) -> str:
     :returns: JSON string suitable for the
         ``pending_tool_calls.arguments`` column.
     """
-    return json.dumps(
-        {
-            "mode": "form",
-            "message": elicitation.message,
-            "requestedSchema": elicitation.requested_schema,
-            "phase": elicitation.phase,
-            "policy_name": elicitation.policy_name,
-            "content_preview": elicitation.content_preview,
-        }
-    )
+    params: dict[str, Any] = {
+        "mode": "form",
+        "message": elicitation.message,
+        "requestedSchema": elicitation.requested_schema,
+        "phase": elicitation.phase,
+        "policy_name": elicitation.policy_name,
+        "content_preview": elicitation.content_preview,
+    }
+    approval = approval_presentation_to_dict(elicitation.approval)
+    if approval is not None:
+        params["approval"] = approval
+    return json.dumps(params)
 
 
 def resolve_ask_timeout(

--- a/omnigent/runtime/policies/engine.py
+++ b/omnigent/runtime/policies/engine.py
@@ -333,6 +333,8 @@ class PolicyEngine:
         accumulated_state: list[StateUpdate] = []
         ask_reasons: list[str] = []
         deciding_ask_policies: list[str] = []
+        first_ask_approval = None
+        saw_ask = False
         # Sequentially accumulated data: each policy that returns data
         # has its output fed back into ctx.content so the next policy
         # in the chain transforms the already-transformed payload rather
@@ -374,6 +376,9 @@ class PolicyEngine:
                 # in the chain sees this policy's output, not the original.
                 ctx = replace(ctx, content=composed_data)
             if result.action == PolicyAction.ASK:
+                if not saw_ask:
+                    first_ask_approval = result.approval
+                    saw_ask = True
                 ask_reasons.append(
                     f"{policy.spec.name}: {result.reason or 'approval required'}",
                 )
@@ -392,6 +397,7 @@ class PolicyEngine:
                 state_updates=list(accumulated_state) if accumulated_state else None,
                 deciding_policies=deciding_ask_policies,
                 data=composed_data,
+                approval=first_ask_approval,
             )
         if not read_only:
             self.apply_label_writes(accumulated)

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -80,6 +80,7 @@ from omnigent.runtime import (
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.policies.approval import (
     approval_presentation_to_dict,
+    arguments_from_preview,
     build_elicitation_request_event,
     resolve_ask_timeout,
     validate_approval_presentation,
@@ -6364,12 +6365,9 @@ async def _register_policy_elicitation(
         e.g. ``"elicit_a1b2c3..."``.
     """
     elicitation_id = f"elicit_{secrets.token_hex(16)}"
-    try:
-        preview_value = json.loads(arguments_preview)
-    except (TypeError, ValueError):
-        preview_value = {}
-    arguments = preview_value if isinstance(preview_value, dict) else {}
-    approval = validate_approval_presentation(result.approval, arguments)
+    approval = validate_approval_presentation(
+        result.approval, arguments_from_preview(arguments_preview)
+    )
     elicitation = ElicitationRequest(
         message=result.reason or "Approval required",
         requested_schema={},

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -79,8 +79,10 @@ from omnigent.runtime import (
 )
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.policies.approval import (
+    approval_presentation_to_dict,
     build_elicitation_request_event,
     resolve_ask_timeout,
+    validate_approval_presentation,
 )
 from omnigent.runtime.policies.builder import (
     _sum_subtree_usage,
@@ -1905,6 +1907,10 @@ async def _hold_native_ask_gate_impl(
     """
     tool_name = data.get("name")
     tool_input = data.get("arguments")
+    approval = validate_approval_presentation(
+        result.approval,
+        tool_input if isinstance(tool_input, dict) else {},
+    )
     params = ElicitationRequestParams(
         mode="form",
         message=result.reason or "Approval required",
@@ -1912,6 +1918,7 @@ async def _hold_native_ask_gate_impl(
         phase=phase.value,
         policy_name=result.deciding_policy or "unknown",
         content_preview=json.dumps(data)[:1024],
+        approval=approval_presentation_to_dict(approval),
     )
     # Per-policy ``ask_timeout`` override wins over the spec-level default.
     timeout_s = float(resolve_ask_timeout(engine, result))
@@ -6357,12 +6364,19 @@ async def _register_policy_elicitation(
         e.g. ``"elicit_a1b2c3..."``.
     """
     elicitation_id = f"elicit_{secrets.token_hex(16)}"
+    try:
+        preview_value = json.loads(arguments_preview)
+    except (TypeError, ValueError):
+        preview_value = {}
+    arguments = preview_value if isinstance(preview_value, dict) else {}
+    approval = validate_approval_presentation(result.approval, arguments)
     elicitation = ElicitationRequest(
         message=result.reason or "Approval required",
         requested_schema={},
         phase=Phase.TOOL_CALL.value,
         policy_names=result.deciding_policies or ["unknown"],
         content_preview=arguments_preview[:1024],
+        approval=approval,
     )
     # Approval state lives on the runner (in-memory
     # _pending_approvals dict of elicitation_id → Future).

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -3572,6 +3572,9 @@ class ElicitationRequestParams(BaseModel):
         this elicitation, e.g. ``"conv_child123"``. Present when a
         child/sub-agent prompt is mirrored into an ancestor stream;
         ``None`` means resolve against the current session.
+    :param approval: Optional policy-supplied target presentation.
+        It changes display hierarchy only; the complete raw call remains
+        available to the renderer.
     """
 
     mode: Literal["form", "url"] = "form"
@@ -3585,6 +3588,7 @@ class ElicitationRequestParams(BaseModel):
     policy_name: str | None = None
     content_preview: str | None = None
     target_session_id: str | None = None
+    approval: dict[str, Any] | None = None
 
     # MCP's ElicitRequestParams uses ``extra="allow"``; mirror
     # that here so MCP-shaped passthrough (an MCP server's

--- a/openapi.json
+++ b/openapi.json
@@ -1451,6 +1451,20 @@
         "additionalProperties": true,
         "description": "Inner `params` block of a `ElicitationRequestEvent`.\n\nThe standard fields (`mode`, `message`, `requestedSchema`,\n`url`) mirror MCP's `ElicitRequestFormParams` /\n`ElicitRequestUrlParams` byte-for-byte (Principle 8 \u2014 adopt\nMCP's wire shape verbatim where it overlaps). The\nAP-specific extensions (`phase`, `policy_name`,\n`content_preview`, `target_session_id`) carry policy-engine\ncontext and mirrored-child routing for the consumer's renderer;\nMCP's `extra=\"allow\"` config permits them under the same params\nblock. Wire shape matches\n`omnigent/runtime/policies/approval.py:175`.",
         "properties": {
+          "approval": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional policy-supplied target presentation. It changes display hierarchy only; the complete raw call remains available to the renderer.",
+            "title": "Approval"
+          },
           "content_preview": {
             "anyOf": [
               {

--- a/tests/e2e_ui/approvals/test_approval_card.py
+++ b/tests/e2e_ui/approvals/test_approval_card.py
@@ -66,6 +66,9 @@ def test_approval_card_renders_and_approves(
     card = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first
     expect(card).to_be_visible(timeout=_AGENT_TURN_TIMEOUT_MS)
     expect(card.get_by_text("Approval required")).to_be_visible()
+    expect(card.get_by_role("link", name="acme/widgets: main -> origin")).to_be_visible()
+    expect(card.get_by_text("example.com", exact=True)).to_be_visible()
+    expect(card.locator('[data-testid="approval-secondary-args"]')).to_contain_text("command")
     # The server is genuinely parked on this prompt, not just an optimistic UI.
     assert _pending_elicitations(base_url, session_id), "server has no parked elicitation"
 

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -1858,10 +1858,9 @@ def two_agent_chat_session(
 # policy gate escalates an ASK to the server and the web UI renders an
 # ``ApprovalCard`` (and the same prompt surfaces on the /inbox page).
 #
-# The mechanism is the nessie ``blast_radius`` policy with ``gate_pushes:
-# true``: a plain ``git push`` is "recoverable but outward", so the policy
-# returns ASK at the TOOL_CALL phase — before the command runs — which the
-# runner forwards to ``POST /v1/sessions/{id}/policies/evaluate``. The server
+# A CEL policy returns ASK plus an ApprovalPresentation for the deterministic
+# shell command. The runner forwards the result to
+# ``POST /v1/sessions/{id}/policies/evaluate``. The server
 # parks the gate and publishes a ``response.elicitation_request`` the snapshot
 # replays in ``pendingElicitations``. The verdict travels back through
 # ``POST /v1/sessions/{id}/elicitations/{eid}/resolve`` (what the card's
@@ -1903,14 +1902,18 @@ guardrails:
   # Generous window: the parked ASK must outlive the UI assertions.
   ask_timeout: 300
   policies:
-    blast_radius:
+    repository_write_gate:
       type: function
       function:
-        path: omnigent.inner.nessie.policies.blast_radius
+        path: omnigent.policies.builtins.cel.cel_policy
         arguments:
-          # A plain `git push` is recoverable-but-outward → ASK (vs the
-          # always-DENY catastrophic set). This is the prompt the UI renders.
-          gate_pushes: true
+          expression: >-
+            event.type == "tool_call" && event.data.name == "sys_os_shell"
+            ? {{"result": "ASK", "reason": "Push this repository?",
+               "approval": {{"title": "acme/widgets: main -> origin",
+                            "href": "https://example.com/acme/widgets",
+                            "secondary_arguments": ["command"]}}}}
+            : {{"result": "ALLOW"}}
 """
 
 

--- a/tests/policies/builtins/test_cel.py
+++ b/tests/policies/builtins/test_cel.py
@@ -7,6 +7,9 @@ import pytest
 pytest.importorskip("celpy", reason="cel-python not installed")
 
 from omnigent.policies.builtins.cel import cel_policy
+from omnigent.policies.function import _coerce_to_policy_result
+from omnigent.policies.types import ApprovalPresentation
+from omnigent.runtime.policies.approval import validate_approval_presentation
 
 # ── Map return: DENY ────────────────────────────────────────────
 
@@ -91,6 +94,176 @@ def test_ask_with_fallback_reason() -> None:
     )
     result = evaluate({"type": "request"})
     assert result == {"result": "ASK", "reason": "Please approve."}
+
+
+def test_broker_merge_ask_extracts_approval_presentation() -> None:
+    """The real broker field shape produces a typed approval target."""
+    evaluate = cel_policy(
+        expression="""
+        {
+          "result": "ASK",
+          "reason": "Merge this pull request?",
+          "approval": {
+            "title": event.data.arguments.repository_owner + "/" +
+                     event.data.arguments.repository_name + " #" +
+                     string(event.data.arguments.pr_number),
+            "href": "https://github.com/" +
+                    event.data.arguments.repository_owner + "/" +
+                    event.data.arguments.repository_name + "/pull/" +
+                    string(event.data.arguments.pr_number),
+            "secondary_arguments": ["grant_id", "idempotency_key"]
+          }
+        }
+        """,
+    )
+    result = evaluate(
+        {
+            "type": "tool_call",
+            "data": {
+                "name": "github_merge_pr",
+                "arguments": {
+                    "repository_owner": "acme",
+                    "repository_name": "widgets",
+                    "pr_number": 123,
+                    "grant_id": "grant_demo",
+                    "idempotency_key": "idem_demo",
+                },
+            },
+        }
+    )
+    assert result == {
+        "result": "ASK",
+        "reason": "Merge this pull request?",
+        "approval": ApprovalPresentation(
+            title="acme/widgets #123",
+            href="https://github.com/acme/widgets/pull/123",
+            secondary_arguments=("grant_id", "idempotency_key"),
+        ),
+    }
+    policy_result = _coerce_to_policy_result(result, spec_name="github_approval_gate")
+    validated = validate_approval_presentation(
+        policy_result.approval,
+        {
+            "repository_owner": "acme",
+            "repository_name": "widgets",
+            "pr_number": 123,
+            "grant_id": "grant_demo",
+            "idempotency_key": "idem_demo",
+        },
+    )
+    assert validated == result["approval"]
+
+
+def test_broker_open_pr_ask_uses_branch_target_and_repository_link() -> None:
+    """Open-PR approval describes the target before a PR number exists."""
+    evaluate = cel_policy(
+        expression="""
+        {
+          "result": "ASK",
+          "reason": "Open this pull request?",
+          "approval": {
+            "title": event.data.arguments.repository_owner + "/" +
+                     event.data.arguments.repository_name + ": " +
+                     event.data.arguments.head + " -> " +
+                     event.data.arguments.base,
+            "href": "https://github.com/" +
+                    event.data.arguments.repository_owner + "/" +
+                    event.data.arguments.repository_name,
+            "secondary_arguments": ["grant_id", "idempotency_key"]
+          }
+        }
+        """,
+    )
+    result = evaluate(
+        {
+            "type": "tool_call",
+            "data": {
+                "name": "github_open_pr",
+                "arguments": {
+                    "repository_owner": "acme",
+                    "repository_name": "widgets",
+                    "head": "feat/rate-limiter",
+                    "base": "main",
+                    "grant_id": "grant_demo",
+                    "idempotency_key": "idem_demo",
+                },
+            },
+        }
+    )
+    assert result is not None
+    assert result["approval"] == ApprovalPresentation(
+        title="acme/widgets: feat/rate-limiter -> main",
+        href="https://github.com/acme/widgets",
+        secondary_arguments=("grant_id", "idempotency_key"),
+    )
+
+
+@pytest.mark.parametrize(
+    "approval",
+    [
+        '{"href": "https://example.com"}',
+        '{"title": 42}',
+        '{"title": "target", "href": 42}',
+        '{"title": "target", "secondary_arguments": [42]}',
+    ],
+)
+def test_malformed_cel_approval_is_dropped(approval: str) -> None:
+    """Malformed display metadata never changes the ASK verdict."""
+    evaluate = cel_policy(
+        expression=f'{{"result": "ASK", "reason": "Review", "approval": {approval}}}',
+    )
+    assert evaluate({"type": "request"}) == {"result": "ASK", "reason": "Review"}
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "line\nbreak",
+        "escape\x1btitle",
+        "delete\x7ftitle",
+        "line separator\u2028title",
+        "paragraph separator\u2029title",
+        "arabic mark\u061ctitle",
+        "override\u202etitle",
+        "isolate\u2066title",
+        "mark\u200ftitle",
+        "\x1b\u202e",
+    ],
+)
+def test_cel_presentation_drops_unsafe_title_characters(title: str) -> None:
+    """CEL policy titles use the same boundary validation as Python policies."""
+    evaluate = cel_policy(
+        expression=(
+            '{"result": "ASK", "reason": "Review", '
+            '"approval": {"title": event.data.arguments.title}}'
+        ),
+    )
+    result = evaluate({"type": "tool_call", "data": {"arguments": {"title": title}}})
+    assert result is not None
+    assert validate_approval_presentation(result["approval"], {}) is None
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "example/project #451",
+        "בקשת אישור 451",
+        "طلب موافقة 451",
+    ],
+)
+def test_cel_presentation_preserves_clean_titles(title: str) -> None:
+    """Clean LTR and RTL CEL titles pass without rewriting."""
+    evaluate = cel_policy(
+        expression=(
+            '{"result": "ASK", "reason": "Review", '
+            '"approval": {"title": event.data.arguments.title}}'
+        ),
+    )
+    result = evaluate({"type": "tool_call", "data": {"arguments": {"title": title}}})
+    assert result is not None
+    assert validate_approval_presentation(result["approval"], {}) == ApprovalPresentation(
+        title=title
+    )
 
 
 # ── Map return: ALLOW ───────────────────────────────────────────

--- a/tests/runtime/policies/conftest.py
+++ b/tests/runtime/policies/conftest.py
@@ -14,7 +14,7 @@ from typing import Any
 import pytest
 
 from omnigent.policies.function import FunctionPolicy
-from omnigent.policies.types import PolicyResult
+from omnigent.policies.types import ApprovalPresentation, PolicyResult
 from omnigent.spec.types import FunctionPolicySpec, FunctionRef, PhaseSelector, PolicyAction
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
@@ -42,6 +42,7 @@ def make_fixed_policy(
     condition: dict[str, str] | None = None,
     config: dict[str, Any] | None = None,
     ask_timeout: int | None = None,
+    approval: ApprovalPresentation | None = None,
 ) -> FunctionPolicy:
     """
     Build a :class:`FunctionPolicy` that always returns a fixed result.
@@ -64,12 +65,14 @@ def make_fixed_policy(
         the fixed callable but stored on the spec.
     :param ask_timeout: Per-policy ASK timeout override in
         seconds. ``None`` inherits the spec-wide default.
+    :param approval: Optional target presentation returned with ASK.
     :returns: A :class:`FunctionPolicy` that always returns the
         specified result.
     """
     frozen_labels = dict(set_labels) if set_labels else None
     frozen_action = action
     frozen_reason = reason
+    frozen_approval = approval
 
     def _fixed(event: dict[str, Any]) -> PolicyResult:
         """Return the fixed result regardless of event content."""
@@ -77,6 +80,7 @@ def make_fixed_policy(
             action=frozen_action,
             reason=frozen_reason,
             set_labels=frozen_labels,
+            approval=frozen_approval,
         )
 
     spec = FunctionPolicySpec(

--- a/tests/runtime/policies/test_approval.py
+++ b/tests/runtime/policies/test_approval.py
@@ -42,13 +42,14 @@ import pytest
 
 from omnigent.errors import ElicitationDeclinedError
 from omnigent.policies.function import FunctionPolicy
-from omnigent.policies.types import ElicitationRequest, PolicyResult
+from omnigent.policies.types import ApprovalPresentation, ElicitationRequest, PolicyResult
 from omnigent.runtime.policies.approval import (
     ELICITATION_PENDING_TOOL_NAME,
     _await_elicitation,
     _is_explicit_decline,
     _parse_verdict,
     _truncate,
+    validate_approval_presentation,
 )
 from omnigent.runtime.policies.approval import (
     build_elicitation_params_json as _params_json,
@@ -109,6 +110,7 @@ def _composed_ask(
     deciding_policy: str,
     reason: str = "please approve",
     set_labels: dict[str, str] | None = None,
+    approval: ApprovalPresentation | None = None,
 ) -> PolicyResult:
     """Fabricate an engine-composed ASK result."""
     return PolicyResult(
@@ -116,6 +118,7 @@ def _composed_ask(
         reason=reason,
         set_labels=set_labels,
         deciding_policies=[deciding_policy],
+        approval=approval,
     )
 
 
@@ -317,6 +320,96 @@ def test_elicitation_request_event_shape() -> None:
     assert params["phase"] == "tool_call"
     assert params["policy_name"] == "confirm_shell"
     assert params["content_preview"] == "ls -la"
+
+
+def test_presentation_serializes_identically_for_event_and_replay_params() -> None:
+    """Fresh emission and persisted replay carry the same target shape."""
+    approval = ApprovalPresentation(
+        title="acme/widgets #123",
+        href="https://github.com/acme/widgets/pull/123",
+        secondary_arguments=("grant_id", "idempotency_key"),
+    )
+    req = ElicitationRequest(
+        message="Merge this pull request?",
+        phase="tool_call",
+        policy_names=["github_approval_gate"],
+        content_preview='{"grant_id":"grant_demo","idempotency_key":"idem_demo"}',
+        approval=approval,
+    )
+    expected = {
+        "title": approval.title,
+        "href": approval.href,
+        "secondary_arguments": ["grant_id", "idempotency_key"],
+    }
+    assert _elicitation_request_event("elicit_demo", req)["params"]["approval"] == expected
+    assert json.loads(_params_json(req))["approval"] == expected
+
+
+@pytest.mark.parametrize(
+    "href",
+    [
+        "http://github.com/org/repo",
+        "javascript:alert(1)",
+        "https://user@github.com/org/repo",
+        "github.com/org/repo",
+    ],
+)
+def test_boundary_drops_unsafe_links(href: str) -> None:
+    """Hostile policy links fall back to the plain card."""
+    candidate = ApprovalPresentation(title="target", href=href)
+    assert validate_approval_presentation(candidate, {}) is None
+
+
+def test_boundary_caps_title_and_ignores_unknown_secondary_arguments() -> None:
+    """Hierarchy is bounded and secondary fields must exist in the call."""
+    candidate = ApprovalPresentation(
+        title="x" * 300,
+        secondary_arguments=("grant_id", "missing", "grant_id"),
+    )
+    result = validate_approval_presentation(candidate, {"grant_id": "g"})
+    assert result is not None
+    assert result.title == "x" * 256
+    assert result.secondary_arguments == ("grant_id",)
+
+
+def test_boundary_drops_empty_title() -> None:
+    """A presentation without a visible target cannot replace the plain card."""
+    assert validate_approval_presentation(ApprovalPresentation(title="  "), {}) is None
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "line\nbreak",
+        "escape\x1btitle",
+        "delete\x7ftitle",
+        "line separator\u2028title",
+        "paragraph separator\u2029title",
+        "arabic mark\u061ctitle",
+        "override\u202etitle",
+        "isolate\u2066title",
+        "mark\u200ftitle",
+        "\x1b\u202e",
+    ],
+)
+def test_python_presentation_drops_unsafe_title_characters(title: str) -> None:
+    """Python policy titles cannot manipulate the primary approval line."""
+    candidate = ApprovalPresentation(title=title)
+    assert validate_approval_presentation(candidate, {}) is None
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "example/project #451",
+        "בקשת אישור 451",
+        "طلب موافقة 451",
+    ],
+)
+def test_python_presentation_preserves_clean_titles(title: str) -> None:
+    """Clean LTR and RTL titles pass without rewriting."""
+    candidate = ApprovalPresentation(title=title)
+    assert validate_approval_presentation(candidate, {}) == candidate
 
 
 def test_elicitation_request_event_url_mode(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/runtime/policies/test_approval.py
+++ b/tests/runtime/policies/test_approval.py
@@ -49,6 +49,7 @@ from omnigent.runtime.policies.approval import (
     _is_explicit_decline,
     _parse_verdict,
     _truncate,
+    arguments_from_preview,
     validate_approval_presentation,
 )
 from omnigent.runtime.policies.approval import (
@@ -410,6 +411,62 @@ def test_python_presentation_preserves_clean_titles(title: str) -> None:
     """Clean LTR and RTL titles pass without rewriting."""
     candidate = ApprovalPresentation(title=title)
     assert validate_approval_presentation(candidate, {}) == candidate
+
+
+def test_boundary_validates_the_stored_title_not_the_raw_one() -> None:
+    """A disallowed character the cap removes cannot drop the card.
+
+    The check must run on the capped/stripped value that is actually
+    returned, so the string validated and the string rendered agree.
+    """
+    candidate = ApprovalPresentation(title="x" * 256 + "‮" + "y" * 20)
+    result = validate_approval_presentation(candidate, {})
+    assert result is not None
+    assert result.title == "x" * 256
+    assert "‮" not in result.title
+
+
+def test_boundary_validates_the_stripped_title() -> None:
+    """Whitespace the strip removes cannot drop the card either."""
+    result = validate_approval_presentation(ApprovalPresentation(title="target\n"), {})
+    assert result is not None
+    assert result.title == "target"
+
+
+def test_boundary_still_drops_disallowed_characters_inside_the_cap() -> None:
+    """Truncating the title must not become an escape hatch."""
+    candidate = ApprovalPresentation(title="a‮b" + "x" * 300)
+    assert validate_approval_presentation(candidate, {}) is None
+
+
+# ── arguments_from_preview — both preview shapes ──────
+
+
+def test_arguments_from_preview_unwraps_the_wrapper_shape() -> None:
+    """A whole tool-call preview yields its ``arguments`` mapping."""
+    preview = json.dumps({"name": "merge_pr", "arguments": {"grant_id": "g", "pr": 451}})
+    assert arguments_from_preview(preview) == {"grant_id": "g", "pr": 451}
+
+
+def test_arguments_from_preview_accepts_the_bare_shape() -> None:
+    """A preview that is already the arguments mapping is used as-is.
+
+    The relay paths pass the arguments string straight through, so the
+    whole-dict fallback is what lets their secondary arguments resolve.
+    """
+    preview = json.dumps({"grant_id": "g", "pr": 451})
+    assert arguments_from_preview(preview) == {"grant_id": "g", "pr": 451}
+
+
+def test_arguments_from_preview_keeps_bare_name_arguments() -> None:
+    """``name`` is a legal argument name on the bare shape."""
+    assert arguments_from_preview(json.dumps({"name": "release-1.2"})) == {"name": "release-1.2"}
+
+
+@pytest.mark.parametrize("preview", ["not json", "[1, 2]", '"text"', "null", ""])
+def test_arguments_from_preview_rejects_non_objects(preview: str) -> None:
+    """Anything that is not a JSON object resolves no argument names."""
+    assert arguments_from_preview(preview) == {}
 
 
 def test_elicitation_request_event_url_mode(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/runtime/policies/test_ask_cycle_e2e.py
+++ b/tests/runtime/policies/test_ask_cycle_e2e.py
@@ -26,7 +26,7 @@ import pytest
 
 from omnigent.errors import ElicitationDeclinedError
 from omnigent.policies.function import FunctionPolicy
-from omnigent.policies.types import EvaluationContext, PolicyResult
+from omnigent.policies.types import ApprovalPresentation, EvaluationContext, PolicyResult
 from omnigent.runtime.policies import _await_elicitation
 from omnigent.runtime.policies.engine import PolicyEngine
 from omnigent.spec.types import (
@@ -332,6 +332,39 @@ async def test_ask_cycle_multiple_askers_combined_approval(
     # All three policies' set_labels landed — single
     # approval authorized every write.
     assert engine.labels == {"a": "1", "b": "2", "c": "3"}
+
+
+@pytest.mark.asyncio
+async def test_first_asking_policy_presentation_wins(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Composition keeps the first ASK target while combining reasons."""
+    first = ApprovalPresentation(title="first target")
+    second = ApprovalPresentation(title="second target")
+    p1 = make_fixed_policy(
+        "first",
+        action=PolicyAction.ASK,
+        reason="first reason",
+        on=[PhaseSelector(phase=Phase.TOOL_CALL)],
+        approval=first,
+    )
+    p2 = make_fixed_policy(
+        "second",
+        action=PolicyAction.ASK,
+        reason="second reason",
+        on=[PhaseSelector(phase=Phase.TOOL_CALL)],
+        approval=second,
+    )
+    engine = _build_engine(conversation_store, [p1, p2])
+    result = await engine.evaluate(
+        EvaluationContext(
+            phase=Phase.TOOL_CALL,
+            content={"name": "github_merge_pr", "arguments": {}},
+            tool_name="github_merge_pr",
+        )
+    )
+    assert result.approval == first
+    assert result.reason == "first: first reason; second: second reason"
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/policies/test_function_policy.py
+++ b/tests/runtime/policies/test_function_policy.py
@@ -37,7 +37,7 @@ from omnigent.policies.function import (
     FunctionPolicy,
     resolve_function_policy,
 )
-from omnigent.policies.types import EvaluationContext, PolicyResult
+from omnigent.policies.types import ApprovalPresentation, EvaluationContext, PolicyResult
 from omnigent.runtime.policies.engine import PolicyEngine
 from omnigent.spec.types import (
     FunctionPolicySpec,
@@ -138,6 +138,47 @@ async def test_sync_callable_allow() -> None:
         {"labels": {}, "conversation_id": "c"},
     )
     assert result.action == PolicyAction.ALLOW
+
+
+@pytest.mark.asyncio
+async def test_python_policy_dict_carries_approval_presentation() -> None:
+    """Dict-returning Python policies share the typed ASK contract."""
+
+    def fn(_event: dict) -> dict[str, Any]:
+        return {
+            "result": "ASK",
+            "reason": "Review",
+            "approval": {
+                "title": "acme/widgets #123",
+                "href": "https://github.com/acme/widgets/pull/123",
+                "secondary_arguments": ["grant_id"],
+            },
+        }
+
+    result = await FunctionPolicy(_spec(), fn).evaluate(
+        EvaluationContext(phase=Phase.REQUEST, content="hi"),
+        {},
+    )
+    assert result.approval == ApprovalPresentation(
+        title="acme/widgets #123",
+        href="https://github.com/acme/widgets/pull/123",
+        secondary_arguments=("grant_id",),
+    )
+
+
+@pytest.mark.asyncio
+async def test_python_policy_malformed_approval_is_dropped() -> None:
+    """Malformed Python metadata leaves the policy decision intact."""
+
+    def fn(_event: dict) -> dict[str, Any]:
+        return {"result": "ASK", "reason": "Review", "approval": {"title": 42}}
+
+    result = await FunctionPolicy(_spec(), fn).evaluate(
+        EvaluationContext(phase=Phase.REQUEST, content="hi"),
+        {},
+    )
+    assert result.action == PolicyAction.ASK
+    assert result.approval is None
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_pending_elicitations.py
+++ b/tests/runtime/test_pending_elicitations.py
@@ -81,6 +81,24 @@ def test_record_publish_increments_count_for_elicitation_event() -> None:
     assert pending_elicitations.count_for("conv_a") == 1
 
 
+def test_snapshot_replays_approval_presentation_without_aliasing() -> None:
+    """Cold-load replay preserves nested target metadata as a deep copy."""
+    event = _elicit_event("elicit_1")
+    event["params"] = {
+        "approval": {
+            "title": "acme/widgets #123",
+            "href": "https://github.com/acme/widgets/pull/123",
+            "secondary_arguments": ["grant_id"],
+        }
+    }
+    pending_elicitations.record_publish("session_a", event)
+    first = pending_elicitations.snapshot_for("session_a")
+    assert first[0]["params"]["approval"] == event["params"]["approval"]
+    first[0]["params"]["approval"]["title"] = "mutated"
+    second = pending_elicitations.snapshot_for("session_a")
+    assert second[0]["params"]["approval"]["title"] == "acme/widgets #123"
+
+
 def test_record_publish_is_idempotent_on_repeat_publish() -> None:
     """
     Re-publishing the same elicitation_id does not double-count.

--- a/web/src/components/blocks/ApprovalCard.test.tsx
+++ b/web/src/components/blocks/ApprovalCard.test.tsx
@@ -52,6 +52,10 @@ describe("ApprovalCard - policy-supplied presentation", () => {
     expect(link.getAttribute("rel")).toBe("noopener noreferrer");
     expect(screen.getByTestId("approval-target-hostname").textContent).toBe("github.com");
 
+    const mainPreview = screen.getByText(/"repository_owner": "acme"/);
+    expect(mainPreview.textContent).not.toContain("grant_id");
+    expect(mainPreview.textContent).not.toContain("idempotency_key");
+    expect(mainPreview.textContent).not.toContain("retry_count");
     const secondary = screen.getByTestId("approval-secondary-args");
     expect(secondary.textContent).toContain("grant_id");
     expect(secondary.textContent).toContain('"scope": "merge"');
@@ -60,6 +64,56 @@ describe("ApprovalCard - policy-supplied presentation", () => {
     expect(secondary.textContent).toContain("optional_note:null");
     expect(secondary.textContent).not.toContain("unknown_name");
     expect(secondary.textContent).not.toContain("[object Object]");
+  });
+
+  it("fails open when a preview containing a secondary name is truncated", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_truncated"
+        message="Merge this pull request?"
+        phase="tool_call"
+        policyName="repository_write_gate"
+        contentPreview={'repo_merge_pr({"repository_owner":"acme","grant_id":"visible secret'}
+        requestedSchema={{}}
+        approval={{
+          title: "acme/widgets #123",
+          href: "https://github.com/acme/widgets/pull/123",
+          secondaryArguments: ["grant_id"],
+        }}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    expect(screen.getByText(/"grant_id":"visible secret/).textContent).toContain(
+      '"grant_id":"visible secret',
+    );
+    expect(screen.queryByTestId("approval-secondary-args")).toBeNull();
+  });
+
+  it("preserves a tool wrapper when its closing parenthesis was capped", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_capped_wrapper"
+        message="Merge this pull request?"
+        phase="tool_call"
+        policyName="repository_write_gate"
+        contentPreview={'repo_merge_pr({"repository_owner":"acme","grant_id":"grant-1"}'}
+        requestedSchema={{}}
+        approval={{
+          title: "acme/widgets #123",
+          href: "https://github.com/acme/widgets/pull/123",
+          secondaryArguments: ["grant_id"],
+        }}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    const mainPreview = screen.getByText(/repo_merge_pr/);
+    expect(mainPreview.textContent).toBe('repo_merge_pr({\n  "repository_owner": "acme"\n}');
+    expect(mainPreview.textContent).not.toContain("grant_id");
+    expect(screen.getByTestId("approval-secondary-args").textContent).toContain("grant_id:grant-1");
   });
 
   it("renders a repository target when no pull request number exists", () => {
@@ -108,7 +162,9 @@ describe("ApprovalCard - policy-supplied presentation", () => {
 
     expect(screen.queryByTestId("approval-target")).toBeNull();
     expect(screen.queryByTestId("approval-secondary-args")).toBeNull();
-    expect(screen.getByText(/PROJ-1234/)).toBeDefined();
+    expect(screen.getByText(/PROJ-1234/).textContent).toBe(
+      '{\n  "issueIdOrKey": "PROJ-1234",\n  "transition": {\n    "id": "31"\n  }\n}',
+    );
     expect(screen.getByRole("button", { name: /^approve$/i })).toBeDefined();
     expect(screen.getByRole("button", { name: /reject/i })).toBeDefined();
   });

--- a/web/src/components/blocks/ApprovalCard.test.tsx
+++ b/web/src/components/blocks/ApprovalCard.test.tsx
@@ -7,6 +7,137 @@ afterEach(() => {
   cleanup();
 });
 
+describe("ApprovalCard - policy-supplied presentation", () => {
+  it("renders the target first with a visible hostname and typed secondary values", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_merge"
+        message="Merge this pull request?"
+        phase="tool_call"
+        policyName="repository_write_gate"
+        contentPreview={JSON.stringify({
+          name: "repo_merge_pr",
+          arguments: {
+            repository_owner: "acme",
+            repository_name: "widgets",
+            pr_number: 123,
+            grant_id: { scope: "merge" },
+            idempotency_key: ["attempt", 2],
+            retry_count: 2,
+            optional_note: null,
+          },
+        })}
+        requestedSchema={{}}
+        approval={{
+          title: "acme/widgets #123",
+          href: "https://github.com/acme/widgets/pull/123",
+          secondaryArguments: [
+            "grant_id",
+            "idempotency_key",
+            "retry_count",
+            "optional_note",
+            "unknown_name",
+          ],
+        }}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    const target = screen.getByTestId("approval-target");
+    expect(target.parentElement?.firstElementChild).toBe(target);
+    const link = screen.getByRole("link", { name: "acme/widgets #123" });
+    expect(link.getAttribute("href")).toBe("https://github.com/acme/widgets/pull/123");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(screen.getByTestId("approval-target-hostname").textContent).toBe("github.com");
+
+    const secondary = screen.getByTestId("approval-secondary-args");
+    expect(secondary.textContent).toContain("grant_id");
+    expect(secondary.textContent).toContain('"scope": "merge"');
+    expect(secondary.textContent).toContain('"attempt"');
+    expect(secondary.textContent).toContain("retry_count:2");
+    expect(secondary.textContent).toContain("optional_note:null");
+    expect(secondary.textContent).not.toContain("unknown_name");
+    expect(secondary.textContent).not.toContain("[object Object]");
+  });
+
+  it("renders a repository target when no pull request number exists", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_open"
+        message="Open this pull request?"
+        phase="tool_call"
+        policyName="repository_write_gate"
+        contentPreview={JSON.stringify({
+          repository_owner: "acme",
+          repository_name: "widgets",
+          head: "feat/rate-limiter",
+          base: "main",
+        })}
+        requestedSchema={{}}
+        approval={{
+          title: "acme/widgets: feat/rate-limiter -> main",
+          href: "https://github.com/acme/widgets",
+          secondaryArguments: [],
+        }}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "acme/widgets: feat/rate-limiter -> main" }),
+    ).toBeDefined();
+    expect(screen.queryByText(/#undefined/)).toBeNull();
+  });
+
+  it("leaves a presentation-less card on the existing raw-preview path", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_plain"
+        message="Transition this issue?"
+        phase="tool_call"
+        policyName="issue_transition_gate"
+        contentPreview={JSON.stringify({ issueIdOrKey: "PROJ-1234", transition: { id: "31" } })}
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    expect(screen.queryByTestId("approval-target")).toBeNull();
+    expect(screen.queryByTestId("approval-secondary-args")).toBeNull();
+    expect(screen.getByText(/PROJ-1234/)).toBeDefined();
+    expect(screen.getByRole("button", { name: /^approve$/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /reject/i })).toBeDefined();
+  });
+
+  it("renders a non-HTTPS target as plain text without a hostname", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_http"
+        message="Review this target?"
+        phase="tool_call"
+        policyName="target_gate"
+        contentPreview="{}"
+        requestedSchema={{}}
+        approval={{
+          title: "Example target",
+          href: "http://example.com/target",
+          secondaryArguments: [],
+        }}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    expect(screen.getByText("Example target").tagName).toBe("SPAN");
+    expect(screen.queryByRole("link", { name: "Example target" })).toBeNull();
+    expect(screen.queryByTestId("approval-target-hostname")).toBeNull();
+  });
+});
+
 describe("ApprovalCard — binary approve/reject", () => {
   it("renders Approve and Reject buttons when requestedSchema has no enum", () => {
     // Policy-ASK and PermissionRequest cards arrive with an empty

--- a/web/src/components/blocks/ApprovalCard.tsx
+++ b/web/src/components/blocks/ApprovalCard.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/lib/askUserQuestion";
 import { isNativePolicyName, nativeCodingAgentForPolicyName } from "@/lib/nativeCodingAgents";
 import { formatPreview } from "@/lib/previewFormat";
+import type { ApprovalPresentation } from "@/lib/events";
 import type { RenderItem } from "@/lib/renderItems";
 import type { RememberScope } from "@/lib/types";
 import { useChatStore } from "@/store/chatStore";
@@ -76,6 +77,107 @@ function extractOptionLabels(schema: Record<string, unknown>): string[] {
   return enumValues.filter((v): v is string => typeof v === "string" && v.length > 0);
 }
 
+/** Extract argument values only when a presentation names secondary fields. */
+function parseApprovalArguments(raw: string): Record<string, unknown> | null {
+  let jsonText = raw;
+  const hookMatch = raw.trim().match(/^[A-Za-z0-9_.:-]+\((\{[\s\S]*\})\)$/);
+  if (hookMatch) jsonText = hookMatch[1];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+
+  const record = parsed as Record<string, unknown>;
+  if (
+    typeof record.name === "string" &&
+    record.arguments &&
+    typeof record.arguments === "object" &&
+    !Array.isArray(record.arguments) &&
+    Object.keys(record).every((key) => key === "name" || key === "arguments")
+  ) {
+    return record.arguments as Record<string, unknown>;
+  }
+  return record;
+}
+
+function ApprovalArgumentValue({ value }: { value: unknown }) {
+  if (typeof value === "string") {
+    return value.length > 100 || value.includes("\n") ? (
+      <pre className="max-h-40 overflow-y-auto rounded bg-muted px-2 py-1 font-mono text-[11px] whitespace-pre-wrap break-words">
+        {value}
+      </pre>
+    ) : (
+      <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">{value}</code>
+    );
+  }
+  if (value === null || typeof value === "number" || typeof value === "boolean") {
+    return (
+      <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">{String(value)}</code>
+    );
+  }
+  return (
+    <pre className="max-h-40 overflow-y-auto rounded bg-muted px-2 py-1 font-mono text-[11px] whitespace-pre-wrap break-words">
+      {JSON.stringify(value, null, 2)}
+    </pre>
+  );
+}
+
+function ApprovalTarget({ approval }: { approval: ApprovalPresentation }) {
+  let hostname: string | null = null;
+  if (approval.href) {
+    try {
+      const target = new URL(approval.href);
+      // Re-check HTTPS for replayed params and version-skewed servers.
+      hostname = target.protocol === "https:" ? target.hostname : null;
+    } catch {
+      hostname = null;
+    }
+  }
+  return (
+    <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1" data-testid="approval-target">
+      {approval.href && hostname ? (
+        <a
+          href={approval.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-foreground underline underline-offset-2"
+        >
+          {approval.title}
+        </a>
+      ) : (
+        <span className="font-medium text-foreground">{approval.title}</span>
+      )}
+      {hostname && (
+        <span className="text-muted-foreground text-xs" data-testid="approval-target-hostname">
+          {hostname}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function SecondaryArgEntries({ args }: { args: Record<string, unknown> }) {
+  const entries = Object.entries(args);
+  if (entries.length === 0) return null;
+  return (
+    <div
+      className="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted-foreground"
+      data-testid="approval-secondary-args"
+    >
+      {entries.map(([key, value]) => (
+        <div key={key} className="flex min-w-0 items-start gap-1">
+          <span className="shrink-0">{key}:</span>
+          <ApprovalArgumentValue value={value} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 /**
  * Verdict submitter — same signature as `chatStore.submitApproval`.
  * Injectable so surfaces outside the active chat (the Inbox page)
@@ -94,6 +196,7 @@ interface ApprovalCardProps {
   policyName: string;
   contentPreview: string;
   requestedSchema: Record<string, unknown>;
+  approval?: ApprovalPresentation | null;
   /**
    * Standalone approval page URL when the elicitation uses URL mode.
    * When present, the pending card renders a link to the approval page
@@ -167,6 +270,7 @@ export function ApprovalCard({
   policyName,
   contentPreview,
   requestedSchema,
+  approval,
   url,
   status,
   response,
@@ -274,6 +378,16 @@ export function ApprovalCard({
     isAskUserQuestion || isExitPlanMode || isMultiChoice || isCodexCommandApproval
       ? ""
       : formatPreview(contentPreview);
+  const secondaryArgs = (() => {
+    if (!approval || approval.secondaryArguments.length === 0) return {};
+    const args = parseApprovalArguments(contentPreview);
+    if (!args) return {};
+    return Object.fromEntries(
+      approval.secondaryArguments
+        .filter((name) => Object.prototype.hasOwnProperty.call(args, name))
+        .map((name) => [name, args[name]]),
+    );
+  })();
   const execPolicyAmendment =
     codexCommand?.execPolicyAmendment && codexCommand.execPolicyAmendment.length > 0
       ? codexCommand.execPolicyAmendment
@@ -420,6 +534,7 @@ export function ApprovalCard({
     // for the same reason: purposeful content instead of the raw ask.
     const showGatingMessage = !isCodexCommandApproval && !isAskUserQuestion && !isExitPlanMode;
     const hasBody =
+      (approval !== null && approval !== undefined) ||
       showGatingMessage ||
       isCodexCommandApproval ||
       submittedAnswers !== null ||
@@ -438,6 +553,7 @@ export function ApprovalCard({
         </AlertTitle>
         {hasBody && (
           <AlertDescription className="flex flex-col gap-1 text-sm">
+            {approval && <ApprovalTarget approval={approval} />}
             {isCodexCommandApproval ? (
               <>
                 {codexCommand.reason && <span>{codexCommand.reason}</span>}
@@ -544,12 +660,14 @@ export function ApprovalCard({
           </>
         ) : (
           <>
+            {approval && <ApprovalTarget approval={approval} />}
             <span>{message}</span>
             {formattedPreview && (
               <pre className="max-h-64 overflow-y-auto rounded bg-muted px-2 py-1 font-mono text-sm whitespace-pre-wrap break-words">
                 {formattedPreview}
               </pre>
             )}
+            <SecondaryArgEntries args={secondaryArgs} />
             {isExternalUrl ? (
               <div className="flex flex-wrap gap-2 pt-1">
                 <Button size="sm" asChild>
@@ -604,6 +722,7 @@ export function ElicitationCard({
       policyName={item.policyName}
       contentPreview={item.contentPreview}
       requestedSchema={item.requestedSchema}
+      approval={item.approval}
       url={item.url}
       status={item.status}
       response={item.response}

--- a/web/src/components/blocks/ApprovalCard.tsx
+++ b/web/src/components/blocks/ApprovalCard.tsx
@@ -77,31 +77,53 @@ function extractOptionLabels(schema: Record<string, unknown>): string[] {
   return enumValues.filter((v): v is string => typeof v === "string" && v.length > 0);
 }
 
-/** Extract argument values only when a presentation names secondary fields. */
-function parseApprovalArguments(raw: string): Record<string, unknown> | null {
-  let jsonText = raw;
-  const hookMatch = raw.trim().match(/^[A-Za-z0-9_.:-]+\((\{[\s\S]*\})\)$/);
-  if (hookMatch) jsonText = hookMatch[1];
+interface ParsedApprovalPreview {
+  parsed: Record<string, unknown>;
+  args: Record<string, unknown>;
+  wrapper: string | null;
+  closed: boolean;
+}
 
-  let parsed: unknown;
+/** Parse object arguments while retaining the producer's wrapper form. */
+function parseApprovalPreview(raw: string): ParsedApprovalPreview | null {
+  const trimmed = raw.trim();
+  const hookMatch = /^([A-Za-z0-9_.:-]+)\((.*)$/s.exec(trimmed);
+  const wrapper = hookMatch?.[1] ?? null;
+  let jsonText = hookMatch?.[2] ?? trimmed;
+  const closed = wrapper !== null && jsonText.endsWith(")");
+  if (closed) jsonText = jsonText.slice(0, -1);
+
+  let parsedValue: unknown;
   try {
-    parsed = JSON.parse(jsonText);
+    parsedValue = JSON.parse(jsonText);
   } catch {
     return null;
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  if (!parsedValue || typeof parsedValue !== "object" || Array.isArray(parsedValue)) return null;
 
-  const record = parsed as Record<string, unknown>;
+  const parsed = parsedValue as Record<string, unknown>;
+  let args = parsed;
   if (
-    typeof record.name === "string" &&
-    record.arguments &&
-    typeof record.arguments === "object" &&
-    !Array.isArray(record.arguments) &&
-    Object.keys(record).every((key) => key === "name" || key === "arguments")
+    typeof parsed.name === "string" &&
+    parsed.arguments &&
+    typeof parsed.arguments === "object" &&
+    !Array.isArray(parsed.arguments) &&
+    Object.keys(parsed).every((key) => key === "name" || key === "arguments")
   ) {
-    return record.arguments as Record<string, unknown>;
+    args = parsed.arguments as Record<string, unknown>;
   }
-  return record;
+  return { parsed, args, wrapper, closed };
+}
+
+function formatApprovalPreview(preview: ParsedApprovalPreview, secondaryNames: string[]): string {
+  const filteredArgs = Object.fromEntries(
+    Object.entries(preview.args).filter(([name]) => !secondaryNames.includes(name)),
+  );
+  const filtered =
+    preview.args === preview.parsed ? filteredArgs : { ...preview.parsed, arguments: filteredArgs };
+  const json = JSON.stringify(filtered);
+  const raw = preview.wrapper ? `${preview.wrapper}(${json}${preview.closed ? ")" : ""}` : json;
+  return formatPreview(raw);
 }
 
 function ApprovalArgumentValue({ value }: { value: unknown }) {
@@ -374,20 +396,22 @@ export function ApprovalCard({
   // button mode (the buttons render the choices). Codex command
   // approvals get a dedicated command render below, so showing the
   // transport JSON would expose unrelated ids and duplicate details.
+  const secondaryNames = approval?.secondaryArguments ?? [];
+  const parsedApprovalPreview =
+    secondaryNames.length > 0 ? parseApprovalPreview(contentPreview) : null;
+  const secondaryArgs = parsedApprovalPreview
+    ? Object.fromEntries(
+        secondaryNames
+          .filter((name) => Object.hasOwn(parsedApprovalPreview.args, name))
+          .map((name) => [name, parsedApprovalPreview.args[name]]),
+      )
+    : {};
   const formattedPreview =
     isAskUserQuestion || isExitPlanMode || isMultiChoice || isCodexCommandApproval
       ? ""
-      : formatPreview(contentPreview);
-  const secondaryArgs = (() => {
-    if (!approval || approval.secondaryArguments.length === 0) return {};
-    const args = parseApprovalArguments(contentPreview);
-    if (!args) return {};
-    return Object.fromEntries(
-      approval.secondaryArguments
-        .filter((name) => Object.hasOwn(args, name))
-        .map((name) => [name, args[name]]),
-    );
-  })();
+      : parsedApprovalPreview
+        ? formatApprovalPreview(parsedApprovalPreview, Object.keys(secondaryArgs))
+        : formatPreview(contentPreview);
   const execPolicyAmendment =
     codexCommand?.execPolicyAmendment && codexCommand.execPolicyAmendment.length > 0
       ? codexCommand.execPolicyAmendment

--- a/web/src/components/blocks/ApprovalCard.tsx
+++ b/web/src/components/blocks/ApprovalCard.tsx
@@ -87,7 +87,7 @@ interface ParsedApprovalPreview {
 /** Parse object arguments while retaining the producer's wrapper form. */
 function parseApprovalPreview(raw: string): ParsedApprovalPreview | null {
   const trimmed = raw.trim();
-  const hookMatch = /^([A-Za-z0-9_.:-]+)\((.*)$/s.exec(trimmed);
+  const hookMatch = trimmed.match(/^([A-Za-z0-9_.:-]+)\((.*)$/s);
   const wrapper = hookMatch?.[1] ?? null;
   let jsonText = hookMatch?.[2] ?? trimmed;
   const closed = wrapper !== null && jsonText.endsWith(")");

--- a/web/src/components/blocks/ApprovalCard.tsx
+++ b/web/src/components/blocks/ApprovalCard.tsx
@@ -384,7 +384,7 @@ export function ApprovalCard({
     if (!args) return {};
     return Object.fromEntries(
       approval.secondaryArguments
-        .filter((name) => Object.prototype.hasOwnProperty.call(args, name))
+        .filter((name) => Object.hasOwn(args, name))
         .map((name) => [name, args[name]]),
     );
   })();

--- a/web/src/lib/blockStream.test.ts
+++ b/web/src/lib/blockStream.test.ts
@@ -1460,6 +1460,11 @@ describe("BlockStream — elicitation", () => {
         phase: "tool_call",
         policyName: "approve_terminal_launch",
         contentPreview: '{"tool":"sys_terminal_launch","tool_args":{"terminal":"zsh"}}',
+        approval: {
+          title: "example/repository #42",
+          href: "https://github.com/example/repository/pull/42",
+          secondaryArguments: ["grant_id"],
+        },
       },
     ]);
 
@@ -1470,6 +1475,7 @@ describe("BlockStream — elicitation", () => {
     expect(elic!.phase).toBe("tool_call");
     expect(elic!.policyName).toBe("approve_terminal_launch");
     expect(elic!.contentPreview).toContain("sys_terminal_launch");
+    expect(elic!.approval?.title).toBe("example/repository #42");
     expect(elic!.status).toBe("pending");
     expect(elic!.response).toBeNull();
     expect(elic!.ctx.responseId).toBe("resp_1");

--- a/web/src/lib/blockStream.ts
+++ b/web/src/lib/blockStream.ts
@@ -862,6 +862,7 @@ function* processEvent(state: ReducerState, event: StreamEvent): Generator<AnyBl
         phase: event.phase,
         policyName: event.policyName,
         contentPreview: event.contentPreview,
+        approval: event.approval,
         requestedSchema: event.requestedSchema,
         url: event.url,
         status: "pending",

--- a/web/src/lib/blocks.ts
+++ b/web/src/lib/blocks.ts
@@ -430,6 +430,8 @@ export interface ElicitationBlock {
   policyName: string;
   /** Truncated snapshot of the gated content. */
   contentPreview: string;
+  /** Policy-supplied target hierarchy for this approval. */
+  approval?: import("./events").ApprovalPresentation | null;
   /** A restricted-JSON-Schema form. `{}` for a binary accept/decline. */
   requestedSchema: Record<string, unknown>;
   /** Standalone approval page URL when ``mode === "url"``. */

--- a/web/src/lib/blocks.ts
+++ b/web/src/lib/blocks.ts
@@ -8,6 +8,7 @@
 // uses camelCase fields + a `type` discriminator string equal to the
 // Python class name lowercased (e.g. ResponseStartBlock → "response_start").
 
+import type { ApprovalPresentation } from "./events";
 import type { RoutingDecisionExtras } from "./routingDecision";
 import type { RememberScope, Response } from "./types";
 
@@ -431,7 +432,7 @@ export interface ElicitationBlock {
   /** Truncated snapshot of the gated content. */
   contentPreview: string;
   /** Policy-supplied target hierarchy for this approval. */
-  approval?: import("./events").ApprovalPresentation | null;
+  approval?: ApprovalPresentation | null;
   /** A restricted-JSON-Schema form. `{}` for a binary accept/decline. */
   requestedSchema: Record<string, unknown>;
   /** Standalone approval page URL when ``mode === "url"``. */

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -190,6 +190,8 @@ export interface ElicitationRequest {
   policyName: string;
   /** Producer-supplied extra (policy ASK only): truncated snapshot of the gated content. */
   contentPreview: string;
+  /** Policy-supplied target hierarchy for an approval card. */
+  approval?: ApprovalPresentation | null;
   /**
    * Producer-supplied extra (claude-native only): structured
    * AskUserQuestion payload — present when the gated tool is
@@ -261,6 +263,12 @@ export interface ElicitationRequest {
    * where the allow rule is meaningful.
    */
   rememberScope?: RememberScope | null;
+}
+
+export interface ApprovalPresentation {
+  title: string;
+  href: string | null;
+  secondaryArguments: string[];
 }
 
 /**

--- a/web/src/lib/renderItems.ts
+++ b/web/src/lib/renderItems.ts
@@ -120,6 +120,7 @@ export type RenderItem =
       phase: string;
       policyName: string;
       contentPreview: string;
+      approval?: import("./events").ApprovalPresentation | null;
       requestedSchema: Record<string, unknown>;
       url?: string | null;
       status: "pending" | "responded";
@@ -1491,6 +1492,7 @@ function buildAssistantItems(
         phase: b.phase,
         policyName: b.policyName,
         contentPreview: b.contentPreview,
+        approval: b.approval,
         requestedSchema: b.requestedSchema,
         url: b.url,
         status: b.status,

--- a/web/src/lib/renderItems.ts
+++ b/web/src/lib/renderItems.ts
@@ -33,6 +33,7 @@ import {
   routingExtras,
 } from "./routingDecision";
 import { isSystemUserContent } from "./systemMessage";
+import type { ApprovalPresentation } from "./events";
 import type { RememberScope } from "./types";
 import type { ActiveResponse } from "@/store/types";
 
@@ -120,7 +121,7 @@ export type RenderItem =
       phase: string;
       policyName: string;
       contentPreview: string;
-      approval?: import("./events").ApprovalPresentation | null;
+      approval?: ApprovalPresentation | null;
       requestedSchema: Record<string, unknown>;
       url?: string | null;
       status: "pending" | "responded";

--- a/web/src/lib/sessionEvents.test.ts
+++ b/web/src/lib/sessionEvents.test.ts
@@ -646,6 +646,51 @@ describe("response.output_item.done (routing_decision)", () => {
 });
 
 describe("response.elicitation_request (FLAT envelope)", () => {
+  it("lifts a validated policy approval presentation", () => {
+    const out = parse("response.elicitation_request", {
+      type: "response.elicitation_request",
+      elicitation_id: "elicit_merge",
+      params: {
+        mode: "form",
+        message: "Merge this pull request?",
+        phase: "tool_call",
+        policy_name: "github_approval_gate",
+        content_preview: "{}",
+        requestedSchema: {},
+        approval: {
+          title: "acme/widgets #123",
+          href: "https://github.com/acme/widgets/pull/123",
+          secondary_arguments: ["grant_id", "idempotency_key"],
+        },
+      },
+    });
+
+    const event = out[0] as ElicitationRequest;
+    expect(event.approval).toEqual({
+      title: "acme/widgets #123",
+      href: "https://github.com/acme/widgets/pull/123",
+      secondaryArguments: ["grant_id", "idempotency_key"],
+    });
+  });
+
+  it.each([
+    "http://github.com/example/repository",
+    "javascript:alert(1)",
+    "https://user@github.com/example/repository",
+    "github.com/example/repository",
+  ])("drops an unsafe approval href before rendering: %s", (href) => {
+    const out = parse("response.elicitation_request", {
+      type: "response.elicitation_request",
+      elicitation_id: "elicit_unsafe",
+      params: {
+        message: "Review",
+        requestedSchema: {},
+        approval: { title: "target", href, secondary_arguments: [] },
+      },
+    });
+    expect((out[0] as ElicitationRequest).approval).toBeNull();
+  });
+
   it("lifts structured Codex requestUserInput payloads", () => {
     // Codex's final plan-mode prompt rides as the same
     // ``ask_user_question`` extra as Claude's AskUserQuestion flow.

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -927,6 +927,39 @@ export function parseEvent(rawType: string, data: Record<string, unknown>): Stre
     const targetSessionId = p.target_session_id;
     const phase = String(p.phase ?? "");
     const policyName = String(p.policy_name ?? "");
+    const approvalRaw = p.approval;
+    const approvalRecord =
+      approvalRaw && typeof approvalRaw === "object" && !Array.isArray(approvalRaw)
+        ? (approvalRaw as Record<string, unknown>)
+        : null;
+    const secondaryArguments = approvalRecord?.secondary_arguments;
+    const approvalHref = approvalRecord?.href;
+    let approvalHrefIsSafe = approvalHref === null || approvalHref === undefined;
+    if (typeof approvalHref === "string" && !/\s/.test(approvalHref)) {
+      try {
+        const parsedHref = new URL(approvalHref);
+        approvalHrefIsSafe =
+          parsedHref.protocol === "https:" &&
+          parsedHref.hostname.length > 0 &&
+          parsedHref.username === "" &&
+          parsedHref.password === "";
+      } catch {
+        approvalHrefIsSafe = false;
+      }
+    }
+    const approval =
+      approvalRecord &&
+      typeof approvalRecord.title === "string" &&
+      approvalRecord.title.trim().length > 0 &&
+      approvalHrefIsSafe &&
+      Array.isArray(secondaryArguments) &&
+      secondaryArguments.every((name) => typeof name === "string")
+        ? {
+            title: approvalRecord.title.trim().slice(0, 256),
+            href: typeof approvalHref === "string" ? approvalHref : null,
+            secondaryArguments: secondaryArguments as string[],
+          }
+        : null;
     // The PermissionRequest endpoint stamps an `ask_user_question`
     // extra onto params when Claude is gating the built-in
     // AskUserQuestion tool. Surface it on the event so the UI's
@@ -980,6 +1013,7 @@ export function parseEvent(rawType: string, data: Record<string, unknown>): Stre
       phase,
       policyName,
       contentPreview: String(p.content_preview ?? ""),
+      approval,
       askUserQuestion:
         askUserQuestionRaw &&
         typeof askUserQuestionRaw === "object" &&

--- a/web/src/pages/InboxPage.tsx
+++ b/web/src/pages/InboxPage.tsx
@@ -314,6 +314,7 @@ export function InboxPage() {
                   phase={item.elicitation.phase}
                   policyName={item.elicitation.policyName}
                   contentPreview={item.elicitation.contentPreview}
+                  approval={item.elicitation.approval}
                   requestedSchema={item.elicitation.requestedSchema}
                   url={item.elicitation.url}
                   status={verdict ? "responded" : "pending"}


### PR DESCRIPTION
## Related issue

Closes #2851

## Summary

A policy that returns ASK may attach an optional `ApprovalPresentation` containing a title,
an optional HTTPS link with a visible hostname, and secondary argument names. The deciding policy supplies the description; core validates structure and URL scheme constraints at the elicitation boundary and transports the
result; `ApprovalCard` renders a linked target with the hostname visible and demotes the named
arguments to fine print. Policies that do not supply a presentation render unchanged.

- `PolicyResponse.approval` / `PolicyResult.approval` / `ElicitationRequest.approval`, all optional
- CEL extraction (nested `approval` map) and Python dict/dataclass coercion, same validation for both
- Composition keeps the first ASKing policy's presentation, matching `deciding_policies[0]`;
  later ASK reasons still append
- Boundary validation: https-only href with hostname, no userinfo, and no whitespace; title trimmed, capped, and
  rejected on control characters, Unicode line/paragraph separators, and the `Bidi_Control` set
  (plain RTL text passes); unknown secondary names ignored; any invalid presentation drops to the
  plain card and never affects the verdict
- Transport on fresh emission and pending-approval replay; `/inbox` and the conversation render
  through the same component
- Renderer re-checks the scheme and links only when a hostname parses, shown beside the title

Trust framing: policy-controlled presentation metadata supplied by the policy that evaluated the operation;
core enforces URL structure and scheme constraints, the visible hostname tells the approver where the link goes.

Upstream base: `901aa8d1`. Change: 29 files, +1267/-29 (policy types and schema, CEL extraction,
coercion, composition, elicitation boundary and both server dispatch paths, wire and replay,
`ApprovalCard` rendering, tests, POLICIES.md section, regenerated `openapi.json`). The rebase
preserves the current approval-card behavior for native harness labels, answered question cards,
and message timestamps while adding the policy-supplied target presentation.

## Review focus

The related issue calls out two design decisions:

1. Whether the ASKing policy is the right owner of the three-field presentation contract.
2. Where the typed contract and tolerant decoding should live on the elicitation wire.

This PR implements the design against current upstream `main` so those decisions
can be reviewed against concrete code. Malformed optional presentation drops to the plain card in
every path and never invalidates the elicitation or changes the ASK verdict. This PR does not expand
or depend on #2149; it carries only the minimal rendering support the contract needs.

## Test Plan

- Focused pytest: 191 passed across the changed policy and elicitation modules. The broader pre-existing policy/runtime scope passed 1177 tests.
- Focused Vitest: 231 passed across `ApprovalCard`, block-stream, and session-event coverage.
- Full Vitest on local Node 25.9.0: 4873 passed, 912 failed, 3 expected failures, 1 skipped. Pristine `901aa8d1` produced the same 912 `localStorage` failures, with 4862 passed, 3 expected failures, and 1 skipped.
- Browser approval flow: 4 passed against the rebased head.
- Ruff check and format, Oxlint, TypeScript, Pyrefly, the production build, and the full pre-commit suite passed.
- Revert check: restoring production files to pristine `901aa8d1` made 10 of the 231 focused web tests fail; Python collection stopped because `ApprovalPresentation` no longer existed.

## Demo

Synthetic before/after renders attached to the issue (before: upstream `f8b333b6`; after: this
change, with the combined ideal also including open #2149's labeled arguments). Fixtures used for
the screenshots are the component test fixtures in this PR.

A screen recording of the shipped card: the plain call, the presented card for the GitHub and Jira examples, and the approve flow end to end.


https://github.com/user-attachments/assets/7b2ce212-431b-45ec-bf40-4e3f9e9ec92e



## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Existing tests cover this change

## Coverage notes

Both authoring paths (Python and CEL) share the boundary validator and are covered by parity tests;
renderer tests assert the no-presentation fallback stays unchanged against the selected base revision.

## Changelog

Approval cards can show a policy-supplied target: title, validated HTTPS link with visible hostname, and
demoted secondary arguments, without hiding the raw call.
