### PR TITLE
Add cron-time-popup utility

### DIFF
--- a/scripts/cron-time-popup/README.md
+++ b/scripts/cron-time-popup/README.md
@@ -1,0 +1,52 @@
+# cron-time-popup
+
+A tiny, self-contained utility that shows a desktop popup with the current
+time, fired via a cron job roughly 10 seconds after being scheduled.
+
+## What it does
+
+- `show-time-popup.sh` — sleeps 10 seconds, then shows the current date/time
+  in a native macOS dialog (`osascript`). On non-macOS systems it falls back
+  to a `notify-send` desktop notification if available, or just echoes the
+  time to stdout if neither is available.
+- `install-cron.sh` — adds a one-shot crontab entry that runs
+  `show-time-popup.sh` at the top of the next minute, then removes itself
+  from the crontab so it only fires once.
+
+## Caveat: cron's minute granularity vs. the 10-second sleep
+
+Standard cron can only schedule at minute granularity — it has no way to
+express "run in 10 seconds". `install-cron.sh` works around this by
+scheduling the job for the *next* minute boundary (up to ~60 seconds away),
+and `show-time-popup.sh` itself sleeps 10 seconds before showing the popup.
+So the popup shows the time ~10 seconds after the script starts running, but
+the script itself may start up to ~60 seconds after you run `install-cron.sh`
+(whenever the next minute boundary hits), not exactly 10 seconds after
+install.
+
+## Install
+
+```bash
+./install-cron.sh
+```
+
+This adds a temporary entry to your user crontab for the next minute. Once
+it fires, the popup appears (~10s later) and the entry is automatically
+removed from the crontab.
+
+## Remove manually (before it fires)
+
+```bash
+crontab -l | grep -v 'cron-time-popup' | crontab -
+```
+
+Or run `crontab -e` and delete the line tagged `# cron-time-popup`.
+
+## Run directly (no cron)
+
+```bash
+./show-time-popup.sh
+```
+
+This skips scheduling entirely and just runs the sleep-then-popup sequence
+immediately.

--- a/scripts/cron-time-popup/install-cron.sh
+++ b/scripts/cron-time-popup/install-cron.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Installs a one-shot cron entry that fires ~10 seconds from now.
+#
+# Cron can only be scheduled at minute granularity, so this schedules
+# show-time-popup.sh for the *next* minute; the script's own `sleep 10`
+# then brings the popup close to the requested "10 seconds from install
+# time". The cron entry removes itself from the crontab right after it
+# runs, so it only fires once.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POPUP_SCRIPT="${SCRIPT_DIR}/show-time-popup.sh"
+MARKER="cron-time-popup"
+
+chmod +x "${POPUP_SCRIPT}"
+
+next_minute="$(date -v+1M +%M 2>/dev/null || date -d '+1 minute' +%M)"
+hour="$(date -v+1M +%H 2>/dev/null || date -d '+1 minute' +%H)"
+
+# Self-cleaning: run the popup, then strip this line (tagged by $MARKER)
+# out of the crontab so the entry only ever fires once.
+cron_command="${POPUP_SCRIPT} >> /tmp/cron-time-popup.log 2>&1; crontab -l | grep -v '${MARKER}' | crontab -"
+cron_line="${next_minute} ${hour} * * * ${cron_command} # ${MARKER}"
+
+existing_crontab="$(crontab -l 2>/dev/null || true)"
+printf '%s\n%s\n' "${existing_crontab}" "${cron_line}" | grep -v '^$' | crontab -
+
+echo "Installed one-shot cron entry for ${hour}:${next_minute} (fires within the next ~60s, then sleeps 10s before showing the popup)."
+echo "To remove it manually before it fires: crontab -l | grep -v '${MARKER}' | crontab -"

--- a/scripts/cron-time-popup/show-time-popup.sh
+++ b/scripts/cron-time-popup/show-time-popup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Shows a desktop popup with the current time, ~10 seconds after being invoked.
+#
+# Cron itself only has minute-level granularity, so it cannot fire "10
+# seconds from now" on its own. This script closes that gap: it sleeps 10
+# seconds first, then displays the time *at that point*, so when it's
+# scheduled for the top of the next minute the popup lands ~10s in.
+set -euo pipefail
+
+sleep 10
+
+current_time="$(date)"
+message="Current time: ${current_time}"
+
+if command -v osascript >/dev/null 2>&1; then
+    osascript -e "display dialog \"${message}\" with title \"Time Popup\" buttons {\"OK\"} default button \"OK\""
+elif command -v notify-send >/dev/null 2>&1; then
+    notify-send "Time Popup" "${message}"
+    echo "${message}"
+else
+    echo "${message}"
+fi


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- Adds a small, self-contained `scripts/cron-time-popup/` utility that shows a
  desktop popup with the current time, fired via a cron job roughly 10
  seconds after being scheduled.
- `show-time-popup.sh` sleeps 10s, then displays the time via
  `osascript display dialog` on macOS, falling back to `notify-send` or plain
  `echo` on other platforms.
- `install-cron.sh` adds a one-shot crontab entry for the next minute
  boundary (cron only has minute granularity) that runs the popup script and
  then removes itself from the crontab so it only fires once.
- `README.md` documents install/removal and the cron-minute-granularity vs.
  10-second-sleep caveat.

## Test Plan

- `bash -n` syntax-checked both shell scripts.
- Ran `scripts/cron-time-popup/show-time-popup.sh` directly on macOS: it
  slept 10s, then `osascript` displayed the dialog and returned
  `button returned:OK`, confirming the popup rendered with the current time
  and the process exited cleanly (no hang, no error).
- Ran `pre-commit run --files scripts/cron-time-popup/*` (via `pipx run
  pre-commit`, since no project `.venv` was set up locally) — all applicable
  hooks (trailing-whitespace, end-of-file-fixer, merge-conflict check, large
  file check, case-conflict check, line-ending check) passed; Python/web/
  mobile hooks skipped since no matching files.
- Did not run `install-cron.sh` against a real crontab as part of this PR
  (it mutates the local user's crontab); documented as a manual step in the
  README for reviewers/users to verify end-to-end.

## Demo

N/A — CLI utility with no UI beyond a native OS dialog/notification.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually ran `show-time-popup.sh` on macOS and confirmed the `osascript`
dialog displayed and returned successfully with the current time. This is a
standalone shell-script utility outside the Python/web app, so no automated
test suite covers it; `install-cron.sh`'s crontab mutation was reviewed by
inspection rather than executed against a live crontab in this environment.

## Changelog

Add `scripts/cron-time-popup/` utility to show a desktop popup with the current time via a one-shot cron job
