### PR TITLE
fix(sub-agents): Clarify parallel subagent title requirements

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1599,12 +1599,16 @@ async def _execute_subagent_tool(
         ):
             return (
                 f"Error: sub-agent {sub_agent_name!r} title {session_name!r} "
-                "already has a launching or running turn; wait for completion before sending again"
+                "already has a launching or running turn. Use a distinct task-based title "
+                "for independent parallel work; reuse this title only to continue the same "
+                "conversation after completion."
             )
         if existing.get("busy") is True:
             return (
                 f"Error: sub-agent {sub_agent_name!r} title {session_name!r} "
-                "is already running; wait for completion before sending again"
+                "is already running. Use a distinct task-based title for independent "
+                "parallel work; reuse this title only to continue the same conversation "
+                "after completion."
             )
     else:
         child_harness = _subagent_harness(str(sub_agent_name), agent_spec)

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -127,8 +127,10 @@ class SysSessionSendTool(Tool):
             "of (agent + title) or session_id, always with args. "
             "Returns the child's output when its turn completes. To run "
             "multiple sessions in parallel, emit multiple "
-            "sys_session_send tool_calls in the same response — they "
-            "dispatch concurrently. "
+            "sys_session_send tool_calls in the same response with a "
+            "distinct task-based title for each independent session — "
+            "they dispatch concurrently. Reusing a title continues the "
+            "same session and cannot run another turn concurrently. "
             "To attach previously-uploaded files, "
             "pass their file ids via the object args form's 'file_ids' "
             "list on the first named (agent, title) send only; file_ids "
@@ -227,13 +229,14 @@ def _build_sys_session_send_schema(
                 "type": "string",
                 "description": (
                     "Named mode: a unique-within-this-parent "
-                    "label for the sub-agent session, e.g. "
-                    "'auth' or 'payments'. Lets later turns "
-                    "reuse the same conversation via another "
-                    "sys_session_send call with the same "
-                    "title. Titles must be distinct under one "
-                    "parent for the same agent. Pair with "
-                    "'agent'; omit when using 'session_id'."
+                    "task-based identity for the sub-agent session, "
+                    "e.g. 'auth' or 'payments'. Reusing it in a later "
+                    "sys_session_send call continues the same "
+                    "conversation. Every independent parallel call "
+                    "for the same agent must use a distinct title; "
+                    "reusing a title cannot start another concurrent "
+                    "turn. Pair with 'agent'; omit when using "
+                    "'session_id'."
                 ),
             },
         }

--- a/tests/tools/builtins/test_spawn.py
+++ b/tests/tools/builtins/test_spawn.py
@@ -76,6 +76,16 @@ def test_file_ids_description_mentions_fresh_named_spawn_only() -> None:
     assert "continuing an existing named session" in file_ids_description
 
 
+def test_parallel_description_requires_distinct_titles() -> None:
+    schema = _schema_with_subagent()
+    description = schema["function"]["description"]
+    title_description = schema["function"]["parameters"]["properties"]["title"]["description"]
+
+    assert "distinct task-based title" in description
+    assert "Every independent parallel call" in title_description
+    assert "cannot start another concurrent turn" in title_description
+
+
 # ── Happy paths ───────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A

 ## Problem

`sys_session_send` uses the combination of agent and title to identify a child session. The existing description
 made title sound like a display label, so orchestrators could reuse the same title for multiple independent
 tasks.

 For example, several calls using the title health were treated as requests to the same child session. Once the
 first call started, the remaining calls were rejected because that session was already busy. This made
 parallel sub-agent execution appear broken, even though it already works when each task has a distinct title.

 ## Why this change is needed

 Agents rely on the tool description and error messages to decide how to call `sys_session_send`. The previous
 guidance did not clearly explain that:

 - distinct tasks need distinct titles to run in parallel;
 - reusing a title continues an existing conversation.

 This change makes that behavior explicit and gives agents actionable guidance when they reuse a busy title. It
 prevents unnecessary retries, enables the existing parallel behavior, and gives each task a meaningful label
 in the Subagents panel.

## Summary

- Clarify that independent `sys_session_send` calls must use distinct task-based titles; reusing an `(agent, title)` pair continues the same child session and cannot create concurrent work.
- Make busy-session errors tell orchestrators how to recover instead of only telling them to wait.
- Add regression coverage for the parallel-title guidance exposed in the tool schema.

## Test Plan

- `uv run --extra dev pytest -q tests/tools/builtins/test_spawn.py tests/e2e/test_sub_agent_phase3_e2e.py -k 'parallel or spawn'` (`13 passed, 2 deselected`)
- `uv run --extra dev pre-commit run --files omnigent/runner/tool_dispatch.py omnigent/tools/builtins/spawn.py tests/tools/builtins/test_spawn.py`

## Demo

<img width="1422" height="861" alt="image" src="https://github.com/user-attachments/assets/995874d3-04fa-4963-a68e-ac0fdb75c105" />
<img width="1390" height="868" alt="image" src="https://github.com/user-attachments/assets/83540f7a-7d97-4edd-b402-36eb9da9266e" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test locks the user-facing schema guidance, while the existing parallel sub-agent E2E verifies that multiple `sys_session_send` calls still dispatch successfully together.

## Changelog

Parallel sub-agent dispatch now explains when to use distinct task titles instead of accidentally reusing and serializing one child session.
