### PR TITLE
feat(cli): client-side model routing via routes:select endpoint

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -71,6 +71,7 @@ from omnigent.spec.types import AgentSpec, SkillSpec
 
 if TYPE_CHECKING:
     from omnigent._runner_startup import RunnerStartupProgress
+    from omnigent.repl._client_routing import ClientRouter
 
 console = Console()
 
@@ -851,6 +852,63 @@ def _server_auth(
     if creds is not None and creds.token:
         return _DatabricksTokenAuth(server_url=server_url)
     return None
+
+
+def _build_client_router(
+    *,
+    agent_yaml: Path | None,
+    server_url: str,
+) -> ClientRouter | None:
+    """Build the client-side model router from config, if configured.
+
+    Reads the ``client_router`` block from the effective client config.
+    When it names a ``base_url``, returns a :class:`ClientRouter` that
+    routes the first turn of a fresh session; otherwise returns ``None``.
+
+    Auth is resolved per-endpoint: when the router's host matches the
+    omni server the client already talks to, the server auth is reused
+    (so a local unauthenticated server needs no token); otherwise a
+    Databricks bearer is minted for the router's own host.
+
+    :param agent_yaml: Path to the local agent spec; the spec supplies
+        the candidate model catalog. ``None`` (e.g. URL/attach targets)
+        disables client routing.
+    :param server_url: The omni server base URL, for host comparison.
+    :returns: A configured router, or ``None`` when disabled.
+    """
+    if agent_yaml is None:
+        return None
+    from omnigent.cli import _load_effective_config
+
+    cfg = _load_effective_config()
+    router_cfg = cfg.get("client_router")
+    if not isinstance(router_cfg, dict):
+        return None
+    base_url = router_cfg.get("base_url")
+    if not isinstance(base_url, str) or not base_url.strip():
+        return None
+    router_name = router_cfg.get("router_name")
+    if not isinstance(router_name, str) or not router_name.strip():
+        logger.warning("client_router.base_url is set but router_name is missing; skipping")
+        return None
+
+    from urllib.parse import urlparse
+
+    from omnigent.repl._client_routing import ClientRouter
+
+    router_host = urlparse(base_url).netloc
+    server_host = urlparse(server_url).netloc
+    if router_host == server_host:
+        auth = _server_auth(server_url=server_url)
+    else:
+        from omnigent.inner.databricks_executor import _resolve_databricks_auth
+
+        try:
+            auth, _host = _resolve_databricks_auth(host=router_host)
+        except Exception:  # noqa: BLE001 — auth resolution is best-effort; unauthed request falls through
+            logger.debug("client_router auth resolution failed for %s", router_host, exc_info=True)
+            auth = None
+    return ClientRouter(base_url=base_url.strip(), router_name=router_name.strip(), auth=auth)
 
 
 def _chat_with_server(
@@ -3974,6 +4032,18 @@ def _run_repl(
         if attach_harness is not None:
             launch_harness = attach_harness
 
+        # Client-side model routing (opt-in via the client_router config
+        # block). The loaded spec supplies the candidate model catalog;
+        # only fresh sessions route (enforced in the REPL adapter).
+        client_router = _build_client_router(agent_yaml=agent_yaml, server_url=base_url)
+        routing_agent_spec: object | None = None
+        if client_router is not None and agent_yaml is not None:
+            try:
+                routing_agent_spec = load_spec(agent_yaml)
+            except Exception:  # noqa: BLE001 — spec unreadable → disable routing, never block startup
+                logger.debug("client routing: spec load failed; disabling", exc_info=True)
+                client_router = None
+
         async with OmnigentClient(
             base_url=base_url,
             headers=_server_headers(runner_id=runner_id),
@@ -4015,6 +4085,8 @@ def _run_repl(
                 agent_description=agent_description,
                 used_families=used_families,
                 attach_only=attach_only,
+                client_router=client_router,
+                agent_spec=routing_agent_spec,
                 on_session_start=(
                     lambda session_id: open_conversation_link_if_enabled(
                         base_url=base_url,

--- a/omnigent/repl/_client_routing.py
+++ b/omnigent/repl/_client_routing.py
@@ -1,0 +1,135 @@
+"""Client-side model routing via a ``routes:select`` endpoint.
+
+At the start of a fresh session the REPL can ask a routing service which
+model to run the turn on, then attach that choice as the event's
+``model_override``. The service speaks the ``omnigent.api.routing.v1``
+proto (``SelectRouteRequest`` -> ``SelectRouteResponse``) over HTTP as
+proto3-JSON with the original snake_case field names.
+
+The endpoint is pluggable via a base URL: a remote Databricks AI-Gateway
+router, or the omni server itself once it exposes the same API. The
+candidate models come from the agent spec's own model catalog
+(:func:`omnigent.model_catalog.catalog_for_spec`), the same source the
+server-side router uses.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from google.protobuf import json_format
+
+from omnigent.api.routing.v1 import routing_pb2 as pb
+
+_log = logging.getLogger(__name__)
+
+# Routing runs once at session start; a generous-but-bounded timeout keeps
+# a slow router from stalling the first turn indefinitely.
+_ROUTE_TIMEOUT_S = 20.0
+
+
+def route_options_from_spec(spec: Any) -> list[pb.RouteOption]:  # type: ignore[explicit-any]  # structural spec
+    """Build the ``route_options`` candidate list from an agent spec.
+
+    Enumerates the spec's own harness plus each sub-agent via
+    :func:`omnigent.model_catalog.catalog_for_spec`, flattening to one
+    ``RouteOption`` per (harness, model). The catalog always includes a
+    ``"self"`` row for the brain harness; it is mapped to its real harness
+    name (via :func:`spec_harness`) and de-duplicated against a same-named
+    sub-agent row.
+
+    :param spec: The agent spec (or structural equivalent).
+    :returns: Candidate route options; possibly empty when no models
+        resolve (caller should skip routing in that case).
+    """
+    from omnigent.model_catalog import catalog_for_spec, spec_harness
+
+    catalog = catalog_for_spec(spec)
+    self_harness = spec_harness(spec)
+    options: list[pb.RouteOption] = []
+    seen: set[tuple[str | None, str]] = set()
+    for worker, row in catalog.items():
+        harness = self_harness if worker == "self" else worker
+        for model in row.get("models", []):
+            model_id = model.get("id") if isinstance(model, dict) else None
+            if not isinstance(model_id, str):
+                continue
+            key = (harness, model_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            options.append(pb.RouteOption(model=model_id, harness=harness or ""))
+    return options
+
+
+class ClientRouter:
+    """Selects a model for a turn by calling a ``routes:select`` service.
+
+    Owns nothing session-specific: one instance is reused across a REPL
+    session and issues a short-lived HTTP request per :meth:`select`.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        router_name: str,
+        auth: httpx.Auth | None = None,
+    ) -> None:
+        """
+        :param base_url: Routing service base, e.g.
+            ``"https://host/ai-gateway/routing/v1"`` or
+            ``"http://localhost:6767/v1"``. ``/routes:select`` is appended.
+        :param router_name: Router strategy name, e.g. ``"task_v0"``.
+        :param auth: Optional httpx auth for the endpoint's host (a
+            Databricks bearer for a remote gateway; ``None`` for a local
+            unauthenticated server).
+        """
+        self._url = base_url.rstrip("/") + "/routes:select"
+        self._router_name = router_name
+        self._auth = auth
+
+    async def select(
+        self,
+        *,
+        prompt: str,
+        route_options: list[pb.RouteOption],
+    ) -> str | None:
+        """Ask the router which model to use for *prompt*.
+
+        :param prompt: The user's message text.
+        :param route_options: Candidate (model, harness) pairs.
+        :returns: The chosen model id, or ``None`` when routing is
+            unavailable, returns no selection, or fails. Failures are
+            logged at debug and swallowed so the turn proceeds.
+        """
+        if not route_options:
+            return None
+        request = pb.SelectRouteRequest(
+            route_options=route_options,
+            task=pb.Task(prompt=prompt),
+            route_selector=pb.RouteSelector(router_name=self._router_name),
+        )
+        # snake_case wire format (the gateway uses the proto field names).
+        body = json_format.MessageToDict(request, preserving_proto_field_name=True)
+        try:
+            async with httpx.AsyncClient(timeout=_ROUTE_TIMEOUT_S) as http:
+                resp = await http.post(
+                    self._url,
+                    headers={"Content-Type": "application/json"},
+                    json=body,
+                    auth=self._auth,
+                )
+                resp.raise_for_status()
+                out = json_format.ParseDict(resp.json(), pb.SelectRouteResponse())
+        except (httpx.HTTPError, ValueError, json_format.ParseError):
+            _log.debug("client routing failed; proceeding without override", exc_info=True)
+            return None
+        if not out.route_selection:
+            return None
+        model = out.route_selection[0].route_option.model
+        if model:
+            _log.debug("client routing selected model=%s rationale=%s", model, out.rationale)
+        return model or None

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -70,6 +70,7 @@ from rich.text import Text
 from omnigent.spec.types import SkillSpec
 
 if TYPE_CHECKING:
+    from omnigent.repl._client_routing import ClientRouter
     from omnigent.server.schemas import SessionStatusEvent
 
 _log = logging.getLogger(__name__)
@@ -1269,6 +1270,8 @@ class _SessionsChatReplAdapter:
         field_input_state: _FieldInputState | None = None,
         host: TerminalHost | None = None,
         fmt: RichBlockFormatter | None = None,
+        client_router: ClientRouter | None = None,
+        agent_spec: object | None = None,
     ) -> None:
         """
         Wire the adapter; do NOT issue any HTTP calls.
@@ -1315,6 +1318,12 @@ class _SessionsChatReplAdapter:
             field values interactively via the main input loop.
         :param host: Terminal output channel for rendering field prompts.
         :param fmt: Formatter for styling field prompts.
+        :param client_router: Optional client-side model router. When set
+            (and this is a fresh session), the first user message is
+            routed through it and the chosen model is attached as the
+            event's ``model_override``. ``None`` disables client routing.
+        :param agent_spec: The loaded agent spec, used to build the
+            router's candidate model list. Required for client routing.
         """
         self._client = client
         self._agent_id: str | None = None
@@ -1325,6 +1334,15 @@ class _SessionsChatReplAdapter:
         self._host = host
         self._fmt = fmt
         self._session_id: str | None = session_id
+        # Client-side routing fires only on the first message of a
+        # freshly-created session; resumed sessions keep their persisted
+        # model. Snapshot fresh-vs-resumed at construction time because
+        # _ensure_session sets self._session_id on fresh creation, so it
+        # can't distinguish the two by the time send() runs.
+        self._client_router = client_router
+        self._agent_spec = agent_spec
+        self._is_fresh_session = session_id is None
+        self._routed_once = False
         self._session_bundle = session_bundle
         self._session_bundle_filename = session_bundle_filename
         self._runner_id = runner_id
@@ -2165,7 +2183,25 @@ class _SessionsChatReplAdapter:
             "data": {"role": "user", "content": content},
         }
         if self._model_override is not None:
+            # An explicit /model override always wins over client routing.
             event_payload["model_override"] = self._model_override
+        elif (
+            self._client_router is not None
+            and self._is_fresh_session
+            and not self._routed_once
+            and isinstance(input, str)
+        ):
+            # Route the first message of a fresh session. One shot per
+            # session; failures fall through to the agent's default model.
+            self._routed_once = True
+            from omnigent.repl._client_routing import route_options_from_spec
+
+            picked = await self._client_router.select(
+                prompt=input,
+                route_options=route_options_from_spec(self._agent_spec),
+            )
+            if picked is not None:
+                event_payload["model_override"] = picked
 
         # Signal that a turn is active. The _on_event callback
         # uses this to know it should handle streaming text deltas
@@ -2961,6 +2997,8 @@ async def run_repl(
     agent_description: str | None = None,
     used_families: list[str] | None = None,
     attach_only: bool = False,
+    client_router: ClientRouter | None = None,
+    agent_spec: object | None = None,
 ) -> str | None:
     """The entire REPL — using the framework.
 
@@ -3150,6 +3188,8 @@ async def run_repl(
         field_input_state=field_input_state,
         host=host,
         fmt=fmt,
+        client_router=client_router,
+        agent_spec=agent_spec,
     )
     # Make per-invocation log paths visible to slash commands such as
     # /logs without broadening the slash-command dispatch signature.

--- a/tests/repl/test_client_routing.py
+++ b/tests/repl/test_client_routing.py
@@ -1,0 +1,150 @@
+"""Tests for client-side model routing (``omnigent.repl._client_routing``).
+
+Covers building ``route_options`` from a spec catalog (flatten, dedupe,
+``"self"`` → real-harness mapping) and the ``ClientRouter.select`` HTTP
+path (snake_case request body, response parsing, and graceful failure).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+import omnigent.model_catalog as model_catalog
+from omnigent.api.routing.v1 import routing_pb2 as pb
+from omnigent.repl._client_routing import ClientRouter, route_options_from_spec
+
+
+def _patch_client(transport: httpx.MockTransport):
+    """Patch the module's ``httpx.AsyncClient`` to use *transport*."""
+    real = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real(*args, **kwargs)
+
+    return patch("omnigent.repl._client_routing.httpx.AsyncClient", factory)
+
+
+def test_route_options_from_spec_flattens_and_maps_self() -> None:
+    """`"self"` maps to the real harness; rows flatten to (model, harness)."""
+    catalog = {
+        "codex": {"models": [{"id": "gpt-5-5"}, {"id": "gpt-5-4-mini"}]},
+        "self": {"models": [{"id": "claude-opus-4-8"}]},
+        "cursor": {"models": [{"id": "glm-5-2"}]},
+    }
+    with (
+        patch.object(model_catalog, "catalog_for_spec", return_value=catalog),
+        patch.object(model_catalog, "spec_harness", return_value="claude"),
+    ):
+        options = route_options_from_spec(object())
+
+    pairs = [(o.harness, o.model) for o in options]
+    assert ("claude", "claude-opus-4-8") in pairs  # "self" mapped to claude
+    assert all(o.harness != "self" for o in options)
+    assert ("codex", "gpt-5-5") in pairs
+    assert ("cursor", "glm-5-2") in pairs
+    assert len(options) == 4
+
+
+def test_route_options_dedupes_repeated_model() -> None:
+    """A model shared by ``"self"`` and its named harness is emitted once."""
+    catalog = {
+        "claude": {"models": [{"id": "claude-opus-4-8"}]},
+        "self": {"models": [{"id": "claude-opus-4-8"}]},
+    }
+    with (
+        patch.object(model_catalog, "catalog_for_spec", return_value=catalog),
+        patch.object(model_catalog, "spec_harness", return_value="claude"),
+    ):
+        options = route_options_from_spec(object())
+
+    assert [(o.harness, o.model) for o in options] == [("claude", "claude-opus-4-8")]
+
+
+@pytest.mark.asyncio
+async def test_select_sends_snake_case_and_parses_selection() -> None:
+    """The request body is snake_case proto3-JSON; the model is parsed back."""
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "route_selection": [
+                    {
+                        "route_option": {"model": "claude-opus-4-8", "harness": "claude"},
+                        "params": {},
+                    }
+                ],
+                "rationale": "task_v0 matched rule 'bugfix_to_opus'.",
+            },
+        )
+
+    router = ClientRouter(base_url="https://host/ai-gateway/routing/v1", router_name="task_v0")
+    with _patch_client(httpx.MockTransport(handler)):
+        model = await router.select(
+            prompt="fix this code: x = y + 2",
+            route_options=[
+                pb.RouteOption(model="claude-opus-4-8", harness="claude"),
+                pb.RouteOption(model="gpt-5-5", harness="codex"),
+            ],
+        )
+
+    assert model == "claude-opus-4-8"
+    assert captured["url"] == "https://host/ai-gateway/routing/v1/routes:select"
+    body = captured["body"]
+    assert body["route_selector"]["router_name"] == "task_v0"  # snake_case field
+    assert body["task"]["prompt"] == "fix this code: x = y + 2"
+    assert body["route_options"][0] == {"model": "claude-opus-4-8", "harness": "claude"}
+
+
+@pytest.mark.asyncio
+async def test_select_empty_options_skips_call() -> None:
+    """No candidates → no HTTP call, returns None."""
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={})
+
+    router = ClientRouter(base_url="http://localhost:6767/v1", router_name="task_v0")
+    with _patch_client(httpx.MockTransport(handler)):
+        assert await router.select(prompt="hi", route_options=[]) is None
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_select_swallows_http_error() -> None:
+    """A router outage never blocks the turn — returns None."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    router = ClientRouter(base_url="http://localhost:6767/v1", router_name="task_v0")
+    with _patch_client(httpx.MockTransport(handler)):
+        model = await router.select(
+            prompt="hi", route_options=[pb.RouteOption(model="a", harness="b")]
+        )
+    assert model is None
+
+
+@pytest.mark.asyncio
+async def test_select_empty_selection_returns_none() -> None:
+    """An empty ``route_selection`` (e.g. routing disabled) yields None."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"route_selection": [], "rationale": ""})
+
+    router = ClientRouter(base_url="http://localhost:6767/v1", router_name="task_v0")
+    with _patch_client(httpx.MockTransport(handler)):
+        model = await router.select(
+            prompt="hi", route_options=[pb.RouteOption(model="a", harness="b")]
+        )
+    assert model is None


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds opt-in **client-side model routing**: at the start of a fresh REPL session, the client asks a configured routing service which model to run the turn on, then attaches the choice as the event's `model_override`. The server already honors a client-supplied override and skips its own in-band routing for top-level sessions, so **no server change is needed**.
- The routing service is **pluggable via a base URL** (`client_router.base_url` in `~/.omnigent/config.yaml`) — a remote Databricks AI-Gateway router today, or the omni server itself once it exposes the same API (a later phase). Requests use the `omnigent.api.routing.v1` proto (`SelectRouteRequest` → `SelectRouteResponse`) as **snake_case** proto3-JSON.
- Candidate models come from the agent spec's own catalog via `catalog_for_spec` — the same source the server-side router uses. Routing fires **only on freshly-created sessions**; resumed sessions (`--continue` / `--resume`) keep their persisted model. Auth is resolved per-endpoint: the omni server's auth is reused when the router shares its host, otherwise a Databricks bearer is minted for the router's host.

**ELI5:** Before, the server quietly picked your model. Now the client can ask a routing endpoint "given this first message and these available models, which should I use?" and pin that choice for the session — without the server having to know about it.

```
omni claude ──first message──▶ ClientRouter.select()
     │                              │  POST <base_url>/routes:select
     │                              ▼
     │                     routing service (remote gateway
     │                     ──or later── the omni server)
     │                              │  {route_selection:[{route_option:{model}}]}
     ▼                              ▼
  event {model_override: <picked>} ──▶ omni server (honors override, skips its own routing)
```

Config to enable:
```yaml
client_router:
  base_url: https://<host>/ai-gateway/routing/v1   # or http://localhost:6767/v1
  router_name: task_v0
```

## Test Plan

- **Unit** (`tests/repl/test_client_routing.py`, 6 tests): `route_options_from_spec` flatten + dedupe + `"self"`→real-harness mapping; `ClientRouter.select` sends the exact snake_case body (`route_options` / `task.prompt` / `route_selector.router_name`) to `<base_url>/routes:select`, parses `route_selection[0].route_option.model`, short-circuits on empty options, and swallows HTTP errors / empty selections (returns `None` so the turn proceeds).
- Verified the request body byte-for-byte matches the gateway's documented `routes:select` contract, and a sample gateway response parses to the selected model.
- Regression: existing `tests/repl/test_repl_pending_model_override.py` still passes (adapter model-override handoff unchanged).
- `pre-commit` (ruff format + check, secret scan) passes on all changed files.

Manual (requires a reachable gateway + workspace creds, not run in this sandbox):
1. Set the `client_router` block above; `uv run omni server -c config.yaml`.
2. `uv run omni claude`, send a message → confirm `ClientRouter.select` debug log and the session runs on the gateway's pick.
3. `--continue` the session → confirm **no** routes:select call and the model is preserved.

## Demo

N/A — no UI/visual surface (CLI/config change).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the routing module (request/response contract, spec→route_options, failure handling). The `chat.py` wiring (config read, per-endpoint auth, spec load, fresh-session gate) and the `_repl.py` send-path hook are exercised manually per the Test Plan — they depend on a live REPL session + a reachable routing endpoint, which isn't available in CI here. The fresh-vs-resumed gate is a construction-time boolean (`session_id is None`) and failures are swallowed to `None`, so the change is inert unless `client_router` is configured.

## Changelog

Client can route the first turn of a session to a model chosen by a configurable `routes:select` endpoint via `client_router` in `~/.omnigent/config.yaml`
