### PR TITLE
feat(routing): SMART ROUTE — server picks the harness at session start

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3332,18 +3332,25 @@ def server(
     # Hidden by default — managed deployments override
     # RuntimeCaps.routing_client with their own implementation.
     routing_client = None
+    smart_route_harnesses: list[str] = []
     if os.environ.get("OMNIGENT_SMART_ROUTING") == "1":
         routing_cfg = cfg.get("routing")
         if isinstance(routing_cfg, dict) and routing_cfg.get("provider") == "external":
             routing_client = _build_external_routing_client(routing_cfg)
         else:
             routing_client = _build_local_llm_routing_client(server_llm)
+        # SMART ROUTE candidate harnesses (create-time harness selection).
+        if isinstance(routing_cfg, dict):
+            raw_harnesses = routing_cfg.get("harnesses")
+            if isinstance(raw_harnesses, list):
+                smart_route_harnesses = [h for h in raw_harnesses if isinstance(h, str) and h]
 
     caps = RuntimeCaps(
         execution_timeout=int(effective_timeout),
         default_policies=parse_default_policies(cfg.get("policies")),
         llm=server_llm,
         routing_client=routing_client,
+        smart_route_harnesses=smart_route_harnesses,
     )
     init_runtime(
         conversation_store=conversation_store,

--- a/omnigent/runtime/caps.py
+++ b/omnigent/runtime/caps.py
@@ -75,3 +75,9 @@ class RuntimeCaps:
     # Managed deployments can supply a different implementation (e.g.
     # a rules engine or remote service).  ``None`` disables routing.
     routing_client: RoutingClient | None = None
+    # Harnesses the SMART ROUTE create-time router may choose among, from
+    # ``routing.harnesses`` in the server --config YAML. Each harness's
+    # models are resolved live at session create (model_catalog); the set is
+    # intersected with the host's launchable harnesses. Empty disables the
+    # create-time harness pick (first-message model routing still applies).
+    smart_route_harnesses: list[str] = field(default_factory=list)

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -3052,6 +3052,119 @@ def _resolve_harness(conv: Conversation | None) -> str | None:
         return None
 
 
+# Sentinel ``harness_override`` value meaning "let the server pick the harness
+# at session start" (SMART ROUTE). Detected before harness validation and
+# replaced with the routed harness; never persisted verbatim.
+SMART_ROUTE_HARNESS = "__smart_route__"
+
+
+def _load_agent_spec_from_agent(agent: Agent) -> Any | None:  # type: ignore[explicit-any]  # AgentSpec
+    """Load the parsed :class:`AgentSpec` for an agent row, or ``None``.
+
+    Mirrors :func:`_validated_harness_override`'s bundle load; used at
+    session create where no conversation row exists yet.
+    """
+    from omnigent.runtime import get_agent_cache
+
+    try:
+        loaded = get_agent_cache().load(
+            agent.id, agent.bundle_location, expand_env=agent.session_id is None
+        )
+    except (KeyError, AttributeError, ValueError, ImportError, OSError):
+        _logger.debug("smart_route: could not load spec for agent=%s", agent.id, exc_info=True)
+        return None
+    return loaded.spec
+
+
+def _first_user_text(items: list[SessionEventInput]) -> str:
+    """Return the first user message's text from create-time ``initial_items``.
+
+    Reuses :func:`_extract_user_text_for_routing`; ``""`` when no message
+    item carries text.
+    """
+    for item in items:
+        if item.type == "message":
+            text = _extract_user_text_for_routing(item)
+            if text:
+                return text
+    return ""
+
+
+def _smart_route_eligible_harnesses(host: Host | None) -> list[str]:
+    """Config-declared SMART ROUTE harnesses, filtered to launchable ones.
+
+    Intersects ``RuntimeCaps.smart_route_harnesses`` with the host's
+    ``configured_harnesses`` so the router is never offered a harness the
+    host cannot spawn. When the host has never reported its harnesses
+    (``None`` — older build), trust the config list unfiltered.
+
+    :param host: The host the session will launch on, or ``None``.
+    :returns: Eligible harness ids, possibly empty.
+    """
+    from omnigent.runtime import get_caps
+
+    declared = get_caps().smart_route_harnesses or []
+    configured = host.configured_harnesses if host is not None else None
+    if configured is None:
+        return list(declared)
+    return [h for h in declared if configured.get(h)]
+
+
+async def _smart_route_harness(
+    *,
+    spec: Any,  # type: ignore[explicit-any]  # AgentSpec
+    first_message: str,
+    host: Host | None,
+) -> tuple[str | None, str | None]:
+    """Pick a harness + model for a fresh session via the routing client.
+
+    Offers the routing client a cross-harness candidate set — each eligible
+    harness (:func:`_smart_route_eligible_harnesses`) with its live model
+    catalog (``list_models_for_worker``) — and returns the router's choice.
+
+    :param spec: The creating agent's spec (provider resolution source).
+    :param first_message: The session's first user message text.
+    :param host: The launch host (for harness eligibility).
+    :returns: ``(harness, model)`` to persist, or ``(None, None)`` to fall
+        back to the agent's default harness (routing off, empty catalog, or
+        the router declined / returned no harness).
+    """
+    from omnigent.model_catalog import list_models_for_worker
+    from omnigent.runtime import get_caps
+
+    routing_client = get_caps().routing_client
+    if routing_client is None or not first_message.strip():
+        return None, None
+
+    available: dict[str, list[str]] = {}
+    for harness in _smart_route_eligible_harnesses(host):
+        try:
+            listing = await asyncio.to_thread(list_models_for_worker, spec, harness)
+        except Exception:  # noqa: BLE001 — one bad provider must not block routing
+            _logger.debug(
+                "smart_route: model listing failed for harness=%s", harness, exc_info=True
+            )
+            continue
+        ids = [m.id for m in listing.models]
+        if ids:
+            available[harness] = ids
+    if not available:
+        _logger.info("smart_route: no eligible harness models; using agent default")
+        return None, None
+
+    result = await routing_client.route(first_message, available)
+    if result is None or result.harness is None:
+        _logger.info("smart_route: router returned no harness; using agent default")
+        return None, None
+    _logger.info(
+        "smart_route: selected harness=%s model=%s rationale=%s",
+        result.harness,
+        result.model,
+        result.rationale,
+    )
+    return result.harness, result.model
+
+
 def _validated_harness_override(value: str | None, agent: Agent) -> str | None:
     """
     Validate + canonicalize a session-create ``harness_override``.
@@ -12989,12 +13102,34 @@ async def _create_session_from_existing_agent(
         body.cost_control_mode_override
     )
 
-    # Validated against the loaded spec (known harness + omnigent
-    # executor type) before any row exists, mirroring the CLI's
-    # --harness fail-loud rules.
-    harness_override = await asyncio.to_thread(
-        _validated_harness_override, body.harness_override, agent
-    )
+    # SMART ROUTE: the sentinel asks the server to pick the harness at
+    # session start. Route now (before validation/persist) and substitute the
+    # chosen harness + model; on any failure fall through to the agent default.
+    if body.harness_override == SMART_ROUTE_HARNESS:
+        _sr_spec = await asyncio.to_thread(_load_agent_spec_from_agent, agent)
+        _sr_message = _first_user_text(body.initial_items)
+        _sr_host = None
+        if body.host_id is not None:
+            _host_store = getattr(request.app.state, "host_store", None)
+            if _host_store is not None:
+                _sr_host = await asyncio.to_thread(_host_store.get_host, body.host_id)
+        _routed_harness = None
+        if _sr_spec is not None:
+            _routed_harness, _routed_model = await _smart_route_harness(
+                spec=_sr_spec, first_message=_sr_message, host=_sr_host
+            )
+            if _routed_harness is not None and _routed_model is not None:
+                model_override = _routed_model
+        # Sentinel consumed either way: persist the routed harness or None
+        # (agent default) — never the literal sentinel.
+        harness_override = _routed_harness
+    else:
+        # Validated against the loaded spec (known harness + omnigent
+        # executor type) before any row exists, mirroring the CLI's
+        # --harness fail-loud rules.
+        harness_override = await asyncio.to_thread(
+            _validated_harness_override, body.harness_override, agent
+        )
 
     # Inherit runner affinity from the parent session so the child
     # is assigned to the same runner (sub-agent co-location).

--- a/tests/server/test_smart_route_harness.py
+++ b/tests/server/test_smart_route_harness.py
@@ -1,0 +1,160 @@
+"""Tests for create-time SMART ROUTE harness selection.
+
+Covers the sentinel helpers in ``omnigent.server.routes.sessions``:
+harness eligibility (config ∩ host.configured_harnesses), the first-message
+extractor, and ``_smart_route_harness`` (cross-harness catalog assembly +
+routing-client dispatch, with graceful fallback).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omnigent.server.routes.sessions import (
+    SMART_ROUTE_HARNESS,
+    _first_user_text,
+    _smart_route_eligible_harnesses,
+    _smart_route_harness,
+)
+from omnigent.server.schemas import SessionEventInput
+from omnigent.server.smart_routing import RoutingResult
+from omnigent.stores.host_store import Host
+
+
+def _host(configured: dict[str, Any] | None) -> Host:
+    return Host(
+        host_id="h",
+        name="n",
+        owner="o",
+        status="online",
+        created_at=0,
+        updated_at=0,
+        configured_harnesses=configured,
+    )
+
+
+def _caps(harnesses: list[str], routing_client: Any = None) -> Any:
+    return MagicMock(smart_route_harnesses=harnesses, routing_client=routing_client)
+
+
+class _Listing:
+    def __init__(self, ids: list[str]) -> None:
+        self.models = [MagicMock(id=i) for i in ids]
+
+
+def test_sentinel_value() -> None:
+    assert SMART_ROUTE_HARNESS == "__smart_route__"
+
+
+def test_eligible_intersects_configured_harnesses() -> None:
+    host = _host({"claude-native": True, "codex": False})
+    with patch(
+        "omnigent.runtime.get_caps", return_value=_caps(["claude-native", "codex", "cursor"])
+    ):
+        # codex is configured-off, cursor is absent -> only claude-native survives.
+        assert _smart_route_eligible_harnesses(host) == ["claude-native"]
+
+
+def test_eligible_trusts_config_when_host_unreported() -> None:
+    with patch("omnigent.runtime.get_caps", return_value=_caps(["claude-native", "codex"])):
+        assert _smart_route_eligible_harnesses(_host(None)) == ["claude-native", "codex"]
+        assert _smart_route_eligible_harnesses(None) == ["claude-native", "codex"]
+
+
+def test_first_user_text() -> None:
+    items = [
+        SessionEventInput(type="message", data={"content": [{"type": "input_text", "text": "hi"}]})
+    ]
+    assert _first_user_text(items) == "hi"
+    assert _first_user_text([]) == ""
+
+
+@pytest.mark.asyncio
+async def test_smart_route_harness_picks_across_harnesses() -> None:
+    host = _host({"claude-native": True, "codex": True})
+    seen: dict[str, Any] = {}
+
+    async def fake_route(message: str, available: dict[str, list[str]]) -> RoutingResult:
+        seen["available"] = available
+        return RoutingResult(model="databricks-gpt-5-5", rationale="codey", harness="codex")
+
+    caps = _caps(["claude-native", "codex"], routing_client=MagicMock(route=fake_route))
+
+    def fake_listing(spec: Any, harness: str) -> _Listing:
+        return _Listing(
+            {
+                "claude-native": ["databricks-claude-opus-4-8"],
+                "codex": ["databricks-gpt-5-5", "databricks-gpt-5-4-mini"],
+            }[harness]
+        )
+
+    with (
+        patch("omnigent.runtime.get_caps", return_value=caps),
+        patch("omnigent.model_catalog.list_models_for_worker", side_effect=fake_listing),
+    ):
+        harness, model = await _smart_route_harness(
+            spec=object(), first_message="write a codex thing", host=host
+        )
+
+    # The router saw BOTH harnesses' models (cross-harness candidate set).
+    assert set(seen["available"]) == {"claude-native", "codex"}
+    assert harness == "codex"
+    assert model == "databricks-gpt-5-5"
+
+
+@pytest.mark.asyncio
+async def test_smart_route_harness_no_routing_client() -> None:
+    caps = _caps(["claude-native"], routing_client=None)
+    with patch("omnigent.runtime.get_caps", return_value=caps):
+        assert await _smart_route_harness(
+            spec=object(), first_message="x", host=_host({"claude-native": True})
+        ) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_smart_route_harness_empty_message() -> None:
+    caps = _caps(["claude-native"], routing_client=MagicMock())
+    with patch("omnigent.runtime.get_caps", return_value=caps):
+        assert await _smart_route_harness(
+            spec=object(), first_message="   ", host=_host({"claude-native": True})
+        ) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_smart_route_harness_no_eligible_models() -> None:
+    """No eligible harness yields models -> fall back, router not called."""
+    route = MagicMock()
+    caps = _caps(["claude-native"], routing_client=MagicMock(route=route))
+    with (
+        patch("omnigent.runtime.get_caps", return_value=caps),
+        patch("omnigent.model_catalog.list_models_for_worker", return_value=_Listing([])),
+    ):
+        result = await _smart_route_harness(
+            spec=object(), first_message="x", host=_host({"claude-native": True})
+        )
+    assert result == (None, None)
+    route.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_smart_route_harness_router_declines() -> None:
+    """Router returns None (or no harness) -> fall back to agent default."""
+
+    async def fake_route(message: str, available: dict[str, list[str]]) -> None:
+        return None
+
+    caps = _caps(["claude-native"], routing_client=MagicMock(route=fake_route))
+    with (
+        patch("omnigent.runtime.get_caps", return_value=caps),
+        patch(
+            "omnigent.model_catalog.list_models_for_worker",
+            return_value=_Listing(["databricks-claude-opus-4-8"]),
+        ),
+    ):
+        result = await _smart_route_harness(
+            spec=object(), first_message="x", host=_host({"claude-native": True})
+        )
+    assert result == (None, None)

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -134,6 +134,10 @@ import { createBundledSession, launchRunner } from "@/lib/sessionsApi";
 // `kimi` / `kimi-code` are the headless SDK harness (kept for sub-agent / `run
 // --harness kimi` use) — the picker offers only the native TUI (`kimi-native-ui`).
 const NEW_SESSION_HIDDEN_AGENTS = new Set(["nessie", "kimi", "kimi-code"]);
+// Sentinel harness_override value: the synthetic "Smart route" picker entry
+// sends this on create, and the server picks the harness + model itself.
+// Must match SMART_ROUTE_HARNESS in omnigent/server/routes/sessions.py.
+const SMART_ROUTE_HARNESS = "__smart_route__";
 
 // Short picker-row blurbs — the spec descriptions are long paragraphs that
 // truncate badly in the dropdown; other dialogs keep the server values.
@@ -1543,7 +1547,13 @@ function AgentHarnessPicker({
   };
 
   const renderEntry = (agent: AvailableAgent): ReactNode => {
-    const active = agent.id === effectiveAgentId;
+    // When Smart route is picked, effectiveAgentId resolves to a real
+    // fallback agent, so highlight the Smart route row (not that agent) by
+    // its harness sentinel instead of the agent-id match.
+    const smartRouteActive = pickedHarness === SMART_ROUTE_HARNESS;
+    const active = smartRouteActive
+      ? agent.id === SMART_ROUTE_HARNESS
+      : agent.id === effectiveAgentId;
     if (!hasKnobs(agent)) {
       return (
         <DropdownMenuItem
@@ -1803,10 +1813,28 @@ export function NewChatLandingScreen() {
   // user-registered agents). This is the isNativeCodingAgent split, NOT the
   // builtins/customs split: Polly & Debby are built-ins but belong under
   // "Agents", not "Harnesses".
-  const harnessEntries = useMemo(
-    () => agentList.filter((a) => isNativeCodingAgent(a)),
-    [agentList],
-  );
+  // Read once here (before harnessEntries) so the SMART ROUTE entry can be
+  // gated on it. ``info`` is also consumed further down for sandbox chrome.
+  const info = useServerInfo();
+  const smartRoutingEnabled = info !== "loading" && info.smart_routing_enabled;
+  const harnessEntries = useMemo(() => {
+    const entries = agentList.filter((a) => isNativeCodingAgent(a));
+    // SMART ROUTE: a synthetic harness row. When picked it sends
+    // harness_override="__smart_route__" (SMART_ROUTE_HARNESS) on create; the
+    // server chooses the harness + model and binds the session to its pick.
+    // Only offered when the server advertises a routing client.
+    if (smartRoutingEnabled) {
+      entries.push({
+        id: SMART_ROUTE_HARNESS,
+        name: "smart_route",
+        display_name: "Smart route",
+        description: "Let the server pick the best harness and model for your first message.",
+        harness: null,
+        skills: [],
+      });
+    }
+    return entries;
+  }, [agentList, smartRoutingEnabled]);
   const agentEntries = useMemo(() => agentList.filter((a) => !isNativeCodingAgent(a)), [agentList]);
 
   // "Create custom agent" dialog state and pending bundle. When the user
@@ -1876,9 +1904,7 @@ export function NewChatLandingScreen() {
   // Gates the sandbox host option: only servers whose sandbox
   // config can actually serve a managed launch advertise it. "loading"
   // fails closed (option hidden) until the boot probe resolves.
-  const info = useServerInfo();
   const managedSandboxesEnabled = info !== "loading" && info.managed_sandboxes_enabled;
-  const smartRoutingEnabled = info !== "loading" && info.smart_routing_enabled;
   // Provider-named label for the sandbox option (e.g. "Modal Sandbox"),
   // falling back to the generic "New Sandbox" when the server names no
   // provider.
@@ -2717,7 +2743,12 @@ export function NewChatLandingScreen() {
   // The trigger label is just the agent name; the run-config knobs live in
   // the picker's per-entry submenu, so duplicating their values here would be
   // redundant.
-  const agentLabel = selectedAgent ? selectedAgent.display_name : "Select agent";
+  const agentLabel =
+    pickedHarness === SMART_ROUTE_HARNESS
+      ? "Smart route"
+      : selectedAgent
+        ? selectedAgent.display_name
+        : "Select agent";
 
   // Wrap the harness setter so every explicit pick is persisted to
   // localStorage. The caller can pass an explicit `agentId` for the
@@ -2737,6 +2768,14 @@ export function NewChatLandingScreen() {
   // returning user lands on the harness they used last); explicit picks
   // persist via localStorage.
   const handleSelectAgent = (agent: AvailableAgent) => {
+    // Smart route: bind to the default agent (effectiveAgentId resolves the
+    // sentinel to agentList[0]) and send the SMART_ROUTE_HARNESS override so
+    // the server picks the harness + model. Not persisted as a "last agent".
+    if (agent.id === SMART_ROUTE_HARNESS) {
+      setPickedAgentId(SMART_ROUTE_HARNESS);
+      setPickedHarness(SMART_ROUTE_HARNESS);
+      return;
+    }
     if (agent.id !== effectiveAgentId) setPickedHarness(readLastHarness(agent.id));
     setPickedAgentId(agent.id);
     writeLastAgentId(agent.id);


### PR DESCRIPTION
## Related issue

N/A — stacked on #2867 (base branch `lilly/llm-router-proto-parity`), which is stacked on #2864.

## Summary

Adds **SMART ROUTE**: the server picks the *harness* (and its model) for a fresh session, instead of routing a model within an already-bound harness. This is what lets a cross-harness router (claude-native vs codex) actually choose across harnesses — the earlier PRs could only route models *within* the session's fixed harness.

- A **`"__smart_route__"` `harness_override` sentinel** on session create asks the server to choose. It's intercepted before harness validation and never persisted verbatim.
- At create time (before the harness/model persist), the server offers the routing client a **cross-harness candidate set**: each harness in `routing.harnesses` (config), intersected with the **host's launchable harnesses** (`configured_harnesses`), each with its **live models** from `list_models_for_worker` (the same provider-agnostic catalog behind the web picker — no static table). It then binds the returned `{harness, model}`.
- **Selection, not switching.** Nothing is spawned when routing runs, so the harness is *chosen*, not changed mid-session (which isn't supported).
- Any failure — routing disabled, empty catalog, router declines / returns no harness — **falls back to the agent's default harness**. The sentinel is consumed either way.
- **Web:** a synthetic "Smart route" entry in the new-chat harness picker (`NewChatDialog.tsx`), gated on `smart_routing_enabled`, sends the sentinel on create. It binds to the default agent and highlights/labels via the sentinel rather than an agent-id match.

```
POST /v1/sessions { harness_override: "__smart_route__", initial_items:[...] }
        │  (create time, before runner spawn)
        ▼
  eligible = routing.harnesses ∩ host.configured_harnesses
  available = { h: list_models_for_worker(spec, h).ids  for h in eligible }
        ▼
  RoutingClient.route(first_message, available)  ──▶ {harness, model}
        ▼
  persist harness_override + model_override  ──▶ runner spawns on that harness
```

Config (extends the `routing:` block from #2864):
```yaml
routing:
  provider: external
  base_url: ...
  router_name: task_v0
  harnesses: [claude-native, codex]   # SMART ROUTE candidate harnesses
```

## Test Plan

- **Unit** — `tests/server/test_smart_route_harness.py` (9): eligibility intersection (config ∩ `configured_harnesses`; trusts config when the host hasn't reported), first-message extraction, and `_smart_route_harness` — cross-harness catalog assembly + router dispatch, plus every fallback path (no routing client, empty message, no eligible models → router not called, router declines).
- **Regression** — existing `tests/server/integration/test_sessions_harness_override.py` (7) pass unchanged, confirming the normal `harness_override` path (the non-sentinel branch) is intact. `test_smart_routing.py` + `test_build_routing_client.py` pass.
- `pre-commit` (ruff, secret scan) clean.

Manual, end-to-end (requires a reachable router + creds; not run in CI):
1. `routing:` with `provider: external` + `harnesses: [claude-native, codex]`; `OMNIGENT_SMART_ROUTING=1 uv run omni server -c config.yaml`.
2. `POST /v1/sessions` with `harness_override: "__smart_route__"` and a first message.
3. Confirm in logs: candidate set spans claude-native + codex with real ids from `list_models_for_worker`, the router is called, and the session's persisted `harness_override` + `model_override` match the router's pick; the runner spawns on that harness.

## Demo

UI change: adds a **"Smart route"** entry to the new-chat harness picker (shown only when the server advertises `smart_routing_enabled`). Selecting it sends `harness_override="__smart_route__"` on create. _Screenshot/recording to attach when testing._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the create-time helpers (eligibility, first-message, `_smart_route_harness` happy path + all fallbacks) with a stub routing client and mocked `list_models_for_worker`. The full create → route → spawn-on-chosen-harness path needs a reachable router + a runnable host and is covered by the manual plan rather than CI. The change is inert unless `OMNIGENT_SMART_ROUTING=1`, a `routing:` block, and the `"__smart_route__"` sentinel are all present.

**Open item to verify against the gateway:** `task_v0` previously required a full multi-harness model set (it 400'd on missing models). With `harnesses: [claude-native, codex]` the candidate set omits e.g. cursor's `glm-5-2`, so confirm the chosen router accepts a subset (or declare all harnesses it requires). Independent of this PR's logic — it's a router-contract question.

## Changelog

New "Smart route" option in the new-chat picker lets the server pick the session's harness + model at creation, from the `routing.harnesses` candidate set.
