### PR TITLE
fix(claude-native): relax delivery ack when a turn is in flight

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -178,6 +178,14 @@ _TURN_START_TIMEOUT_S = 20.0
 _TURN_START_HOOK_EVENTS: frozenset[str] = frozenset(
     {"PreToolUse", "PostToolUse", "Notification", "Stop", "StopFailure"}
 )
+# Parent hooks that mean a turn is actively running — the prompt was
+# accepted and no ``Stop`` / ``StopFailure`` has ended it yet. Used to
+# detect a turn in flight so the post-inject ack can be relaxed: a
+# message injected mid-turn is queued by Claude Code and does not fire
+# its own ``UserPromptSubmit`` until the running turn stops.
+_TURN_ACTIVE_HOOK_EVENTS: frozenset[str] = frozenset(
+    {"UserPromptSubmit", "PreToolUse", "PostToolUse", "Notification"}
+)
 # Claude Code collapses large pastes into this placeholder in the
 # input box instead of rendering the text itself.
 _PASTED_PLACEHOLDER_PREFIX = "[Pasted text"
@@ -2349,6 +2357,48 @@ def _turn_activity_hook_seen_since(bridge_dir: Path, start_event_count: int) -> 
     return False
 
 
+def _turn_in_flight(bridge_dir: Path) -> bool:
+    """
+    Return whether a parent turn is running right now.
+
+    A turn is in flight when the most recent parent (non-subagent) hook
+    is a turn-active event (:data:`_TURN_ACTIVE_HOOK_EVENTS` — the prompt
+    was accepted and tools may be running) rather than a terminal
+    ``Stop`` / ``StopFailure``. Subagent hooks are skipped so a running
+    subagent under an idle parent does not read as the parent being busy.
+
+    This is the signal for relaxing the delivery ack: a message injected
+    while a turn is in flight is queued by Claude Code and does not fire
+    its own ``UserPromptSubmit`` until the running turn stops, so the
+    strict Phase-1 ack would time out on an otherwise-healthy delivery.
+
+    :param bridge_dir: Bridge directory path.
+    :returns: ``True`` when the latest parent hook is a turn-active event.
+    """
+    path = bridge_dir / _HOOKS_FILE
+    last_event: str | None = None
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    envelope = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                payload = envelope.get("payload") if isinstance(envelope, dict) else None
+                event_name = payload.get("hook_event_name") if isinstance(payload, dict) else None
+                if event_name is None:
+                    continue
+                transcript_path = (
+                    payload.get("transcript_path") if isinstance(payload, dict) else None
+                )
+                if isinstance(transcript_path, str) and "/subagents/" in transcript_path:
+                    continue
+                last_event = event_name
+    except FileNotFoundError:
+        return False
+    return last_event in _TURN_ACTIVE_HOOK_EVENTS
+
+
 def _assistant_turn_started_since(
     bridge_dir: Path,
     *,
@@ -2823,6 +2873,12 @@ def inject_user_message(
     hook_cursor, _ = read_hook_events_since(bridge_dir, 0)
     ack_transcript_path = read_transcript_path(bridge_dir)
     transcript_cursor = _count_transcript_lines(ack_transcript_path)
+    # A turn already running at inject time means Claude Code queues this
+    # message and won't fire its UserPromptSubmit until that turn stops —
+    # so the strict Phase-1 hook ack cannot succeed within its window even
+    # on a healthy delivery. Captured pre-inject so our own submit can't
+    # race it; used to relax the ack to the pane-level submit below.
+    turn_in_flight = _turn_in_flight(bridge_dir)
     # Clear any leftover text in Claude's input field before typing.
     # After Escape-cancel, Claude Code re-populates the prompt area
     # with the previous input for re-editing. Without this clear,
@@ -2909,6 +2965,13 @@ def inject_user_message(
     if not verify_delivery:
         # Legacy behavior for mid-turn steering: the pane-level submit above
         # is as far as we verify (a queued steering prompt may not ack).
+        return
+    if turn_in_flight:
+        # A turn was already running when we injected, so Claude Code has
+        # queued this message and won't record its UserPromptSubmit until
+        # that turn stops — the hook ack would time out on a delivery that
+        # in fact succeeded (the draft left the box above). Treat the
+        # pane-level submit as the ack here, matching the steering path.
         return
     # End-to-end ack: confirm UserPromptSubmit registered and a turn started.
     _await_delivery_ack(

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -25,6 +25,7 @@ from omnigent.claude_native_bridge import (
     _claude_prompt_rendered,
     _hook_record_from_jsonl_record,
     _JsonlRecord,
+    _turn_in_flight,
     augment_claude_args,
     count_hook_events,
     display_cost_approval_popup,
@@ -2891,6 +2892,53 @@ def test_user_prompt_submit_seen_since_detects_parent_prompt(
     assert user_prompt_submit_seen_since(bridge_dir, 1)
 
 
+# ── _turn_in_flight ──────────────────────────────────────────────────
+
+
+def test_turn_in_flight_true_after_prompt_before_stop(tmp_path: Path) -> None:
+    """A prompt accepted with no ``Stop`` since reads as a turn in flight."""
+    bridge_dir = tmp_path / "bridge"
+    record_hook_event(bridge_dir, {"hook_event_name": "SessionStart", "session_id": "p"})
+    record_hook_event(bridge_dir, {"hook_event_name": "UserPromptSubmit", "session_id": "p"})
+    assert _turn_in_flight(bridge_dir)
+    record_hook_event(bridge_dir, {"hook_event_name": "PreToolUse", "session_id": "p"})
+    assert _turn_in_flight(bridge_dir)
+
+
+def test_turn_in_flight_false_after_stop(tmp_path: Path) -> None:
+    """A ``Stop`` as the latest parent hook means the turn is idle."""
+    bridge_dir = tmp_path / "bridge"
+    record_hook_event(bridge_dir, {"hook_event_name": "UserPromptSubmit", "session_id": "p"})
+    record_hook_event(bridge_dir, {"hook_event_name": "Stop", "session_id": "p"})
+    assert not _turn_in_flight(bridge_dir)
+
+
+def test_turn_in_flight_ignores_subagent_activity(tmp_path: Path) -> None:
+    """
+    A running subagent under an idle parent is not the parent in flight.
+
+    Subagent hooks share ``hooks.jsonl``; a subagent ``UserPromptSubmit``
+    after the parent's ``Stop`` must not read as the parent being busy.
+    """
+    bridge_dir = tmp_path / "bridge"
+    record_hook_event(bridge_dir, {"hook_event_name": "UserPromptSubmit", "session_id": "p"})
+    record_hook_event(bridge_dir, {"hook_event_name": "Stop", "session_id": "p"})
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "s",
+            "transcript_path": "/x/subagents/s.jsonl",
+        },
+    )
+    assert not _turn_in_flight(bridge_dir)
+
+
+def test_turn_in_flight_false_without_hooks_file(tmp_path: Path) -> None:
+    """A missing ``hooks.jsonl`` reports no turn in flight rather than raising."""
+    assert not _turn_in_flight(tmp_path / "bridge")
+
+
 def test_user_prompt_submit_seen_since_ignores_subagent_prompt(
     tmp_path: Path,
 ) -> None:
@@ -3023,6 +3071,54 @@ def test_inject_user_message_raises_when_prompt_never_registers(
     monkeypatch.setattr("subprocess.run", _fake_run)
     with pytest.raises(RuntimeError, match="UserPromptSubmit"):
         inject_user_message(bridge_dir, content="never delivered")
+
+
+def test_inject_user_message_relaxes_ack_when_turn_in_flight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A message injected mid-turn is delivered even without a fresh ack.
+
+    When a turn is already running, Claude Code queues the injected
+    message and does not record its ``UserPromptSubmit`` until that turn
+    stops — so the strict Phase-1 ack cannot land in its window. This is
+    the same "box clears, no new UserPromptSubmit" shape as
+    ``raises_when_prompt_never_registers``, but here a turn is in flight
+    (``UserPromptSubmit`` with no ``Stop`` since), so the pane-level
+    submit is the ack and the helper must not raise.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    _shrink_ack_timers(monkeypatch)
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(
+        bridge_dir, socket_path=Path("/tmp/example/tmux.sock"), tmux_target="claude:0.0"
+    )
+    # A turn is running: prompt accepted (UserPromptSubmit) with no Stop
+    # since. This is the pre-inject state _turn_in_flight keys on.
+    record_hook_event(bridge_dir, {"hook_event_name": "SessionStart", "session_id": "p"})
+    record_hook_event(bridge_dir, {"hook_event_name": "UserPromptSubmit", "session_id": "p"})
+
+    enters: list[list[str]] = []
+    tui = {"pane": "❯ "}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        if "capture-pane" in cmd:
+            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = "❯ steer mid turn"
+        if cmd[-1] == "Enter":
+            enters.append(cmd)
+            # Box clears (queued behind the running turn) but no new
+            # UserPromptSubmit fires until that turn stops.
+            tui["pane"] = "❯ "
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    inject_user_message(bridge_dir, content="steer mid turn")  # must not raise
+
+    assert enters, "The message should still be submitted at the pane level."
 
 
 def test_inject_user_message_raises_on_draft_restore_stall(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- A message injected into the Claude terminal **while a turn is still streaming** was raising `inner executor error: Claude Code never recorded UserPromptSubmit for the injected message within 8.0s; the message was not delivered` — even though the message *was* delivered and answered.
- Root cause: Claude Code queues a prompt typed mid-turn and doesn't fire its `UserPromptSubmit` until the running turn's `Stop`. The Phase-1 delivery ack (`_await_delivery_ack`) waits only `_SUBMIT_ACK_TIMEOUT_S` (8s) for that hook, so a turn longer than ~8s makes the ack time out on a healthy delivery.
- Fix: detect an in-flight turn **before** injecting (latest parent, non-subagent hook is a turn-active event with no `Stop`/`StopFailure` since) and, when set, treat the pane-level submit as the ack — mirroring the existing `verify_delivery=False` steering path. The idle path keeps the strict end-to-end ack unchanged.

Diagnosed from live bridge logs: session `8217df…` recorded `SessionStart → UserPromptSubmit(msg1) → [msg2 injected mid-turn] → Stop` where turn 1 ran 53s, so msg2's `UserPromptSubmit` could not land inside the 8s window.

## Test Plan

- `uv run pytest tests/test_claude_native_bridge.py` — 174 passed.
- New `test_inject_user_message_relaxes_ack_when_turn_in_flight` reproduces the failure (turn pre-recorded in-flight, box clears but no new `UserPromptSubmit`) and asserts `inject_user_message` no longer raises.
- New `_turn_in_flight` unit tests: in-flight after prompt/tool, idle after `Stop`, ignores subagent-only activity, missing hooks file → false.
- The existing `test_inject_user_message_raises_when_prompt_never_registers` still passes, confirming the idle path keeps the strict ack (narrow relaxation).
- `pre-commit run --files` on both changed files — pass. mypy: only the 68 pre-existing `explicit-any` errors (identical with the change stashed; zero new).

## Demo

N/A — non-visual (native harness delivery-ack logic).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the root-cause analysis of the live failure: correlated the runner log (`runner-8217df…`) and bridge `hooks.jsonl` timeline to confirm the queued-prompt-behind-a-running-turn mechanism, and confirmed on the same box that the per-hook subprocess (~0.3s) is not the bottleneck — the turn duration is. The new unit test encodes that scenario.

## Changelog

Stop native Claude sessions from reporting a false "message was not delivered" error when you send a message while a turn is still running