### PR TITLE
fix: omni login for Databricks workspace with custom URLs

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -13157,6 +13157,73 @@ def _with_default_scheme(server_url: str) -> str:
     return f"{scheme}://{server_url}"
 
 
+_AZURE_DATABRICKS_SUFFIX = ".azuredatabricks.net"
+# Azure spreads workspaces across a fixed set of regional shards; the
+# canonical host embeds the shard as workspace_id modulo this count.
+_AZURE_WORKSPACE_SHARD_COUNT = 20
+
+
+def _canonical_azure_workspace_host(host: str, org_id: str | None) -> str | None:
+    """Derive the canonical Azure Databricks host for a vanity workspace URL.
+
+    Azure serves every workspace at the shard-addressed canonical domain
+    ``adb-<workspace_id>.<shard>.azuredatabricks.net`` where
+    ``shard = workspace_id % 20`` — regardless of any custom / vanity URL
+    configured on top of it. Some vanity edges hide the omnigent mount
+    from unauthenticated requests (a 303 to a login page), so a workspace
+    that logs in fine on the canonical host cannot be detected through its
+    vanity host. The ``?o=`` selector carries the workspace id, which is
+    all the canonical host needs.
+
+    :param host: The URL host, e.g. ``"mydomain.azuredatabricks.net"``.
+    :param org_id: The ``?o=`` workspace id (see :func:`_org_id_from_url`),
+        e.g. ``"1140651659700000"``.
+    :returns: The canonical host, e.g.
+        ``"adb-1140651659700000.0.azuredatabricks.net"``, or ``None`` when
+        *host* is not an Azure ``azuredatabricks.net`` domain, is already
+        the ``adb-`` canonical form, or *org_id* is missing / non-numeric.
+    """
+    if not org_id or not org_id.isdigit():
+        return None
+    host = host.lower()
+    if not host.endswith(_AZURE_DATABRICKS_SUFFIX) or host.startswith("adb-"):
+        return None
+    shard = int(org_id) % _AZURE_WORKSPACE_SHARD_COUNT
+    return f"adb-{org_id}.{shard}{_AZURE_DATABRICKS_SUFFIX}"
+
+
+def _canonical_azure_workspace_mount(scheme: str, host: str, org_id: str | None) -> str | None:
+    """Probe the canonical Azure workspace's omnigent mount for a vanity host.
+
+    Used as a last resort when a custom / vanity Azure workspace URL never
+    yields the mount (its edge 303-redirects the anonymous probe to a
+    login page). Derives the canonical host from the ``?o=`` selector and
+    probes its ``/api/2.0/omnigent`` mount anonymously — the canonical
+    host answers the same DatabricksRealm challenge the AWS proxy does.
+
+    :param scheme: The URL scheme, e.g. ``"https"``.
+    :param host: The vanity URL host, e.g. ``"mydomain.azuredatabricks.net"``.
+    :param org_id: The ``?o=`` workspace id (see :func:`_org_id_from_url`).
+    :returns: The canonical ``/api/2.0/omnigent`` mount URL when the
+        canonical host answers as a workspace-hosted omnigent server, e.g.
+        ``"https://adb-<id>.<shard>.azuredatabricks.net/api/2.0/omnigent"``
+        — or ``None`` when no canonical host applies or its mount is dark.
+    """
+    import httpx as _httpx
+
+    from omnigent.conversation_browser import WORKSPACE_API_PATH
+
+    canonical_host = _canonical_azure_workspace_host(host, org_id)
+    if canonical_host is None:
+        return None
+    mount = f"{scheme}://{canonical_host}{WORKSPACE_API_PATH}"
+    try:
+        probe = _httpx.get(f"{mount}/v1/me", timeout=10.0)
+    except _httpx.HTTPError:
+        return None
+    return mount if _workspace_mount_probe_matches(mount, probe) else None
+
+
 def _workspace_api_server_url(server: str) -> str:
     """Expand a bare Databricks workspace URL to its omnigent API base.
 
@@ -13199,6 +13266,9 @@ def _workspace_api_server_url(server: str) -> str:
 
     server = server.rstrip("/")
     parsed = urlsplit(server)
+    # Read the ?o= selector before the query is stripped below — the
+    # canonical-Azure fallback needs the workspace id to rebuild the host.
+    org_id = _org_id_from_url(server)
     # Strip any ?o= selector / query / fragment before probing: callers append
     # a path (``f"{base}/v1/..."``), so a query-bearing base would push that
     # path into the query (``…/?o=123/v1/me``) and break the probe + expansion.
@@ -13219,6 +13289,19 @@ def _workspace_api_server_url(server: str) -> str:
         return expanded if expanded != root else server
     if parsed.path not in ("", "/") or parsed.scheme != "https":
         return server
+
+    def _canonical_fallback() -> str | None:
+        """Adopt the canonical Azure mount when a vanity host hides its own."""
+        canonical = _canonical_azure_workspace_mount(parsed.scheme, parsed.hostname or "", org_id)
+        if canonical is None:
+            return None
+        click.echo(
+            f"Note: {server} hides the omnigent mount from unauthenticated "
+            f"requests; using the canonical workspace URL "
+            f"{display_server_url(canonical)} instead."
+        )
+        return canonical
+
     try:
         probe = _httpx.get(f"{server}/v1/me", timeout=10.0)
     except _httpx.HTTPError:
@@ -13232,7 +13315,10 @@ def _workspace_api_server_url(server: str) -> str:
         return server
     server_header = probe.headers.get("server")
     if server_header is None or server_header.lower() != "databricks":
-        return server
+        # A vanity Azure edge can front the workspace without echoing the
+        # databricks server header; the ?o= selector still reaches the
+        # canonical host, so try that before leaving the URL untouched.
+        return _canonical_fallback() or server
     candidate = urlunsplit((parsed.scheme, parsed.netloc, WORKSPACE_API_PATH, "", ""))
     try:
         api_probe = _httpx.get(f"{candidate}/v1/me", timeout=10.0)
@@ -13244,10 +13330,11 @@ def _workspace_api_server_url(server: str) -> str:
         )
         return candidate
     # The anonymous probe came back inconclusive (404 on Azure even
-    # when the mount exists). Retry it with a cached workspace bearer;
-    # either way, say what was decided — this branch is only reached
-    # for genuine workspace web hosts, where a silent decline strands
-    # the user on a bare URL that can only 404.
+    # when the mount exists, or a 303 to a login page on custom/vanity
+    # domains). Retry it with a cached workspace bearer; either way, say
+    # what was decided — this branch is only reached for genuine
+    # workspace web hosts, where a silent decline strands the user on a
+    # bare URL that can only 404.
     token = _cached_workspace_bearer(server)
     if token is not None:
         try:
@@ -13263,6 +13350,14 @@ def _workspace_api_server_url(server: str) -> str:
                 f"Using {display_server_url(candidate)} (Databricks workspace-hosted omnigent)."
             )
             return candidate
+    # The given host never yielded the mount. Azure serves every
+    # workspace at the canonical adb-<id>.<shard>.azuredatabricks.net
+    # domain no matter what custom/vanity URL fronts it, so derive it
+    # from the ?o= selector and adopt its mount when it answers.
+    canonical = _canonical_fallback()
+    if canonical is not None:
+        return canonical
+    if token is not None:
         click.echo(
             f"Note: {server} answers like a Databricks workspace, but "
             f"{candidate} did not answer as an omnigent server even with "

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -31,6 +31,14 @@ _WORKSPACE = "https://example.databricks.com"
 _APPS_REDIRECT = f"{_WORKSPACE}/oidc/oauth2/v2.0/authorize?client_id=abc&response_type=code"
 _WORKSPACE_API_URL = f"{_WORKSPACE}/api/2.0/omnigent"
 
+# A custom / vanity Azure workspace URL and the canonical
+# ``adb-<workspace_id>.<shard>.azuredatabricks.net`` host it maps to
+# (``shard = workspace_id % 20`` → ``1234567890123457 % 20 == 17``).
+_AZURE_VANITY = "https://mydomain.azuredatabricks.net"
+_AZURE_ORG_ID = "1234567890123457"
+_AZURE_CANONICAL = "https://adb-1234567890123457.17.azuredatabricks.net"
+_AZURE_CANONICAL_API_URL = f"{_AZURE_CANONICAL}/api/2.0/omnigent"
+
 
 @dataclass
 class _FakeHttpx:
@@ -861,6 +869,186 @@ def test_workspace_url_skips_authed_probe_without_databricks_extra(
     assert result == _WORKSPACE
     # Only the two anonymous probes — no token, no authed retry.
     assert [r["authorization"] for r in fake.requests] == [None, None]
+
+
+# ── custom / vanity Azure workspace URLs → canonical adb-* host ──
+
+
+@pytest.mark.parametrize(
+    ("host", "org_id", "expected"),
+    [
+        # Vanity azuredatabricks.net host + numeric ?o= → canonical adb-* host.
+        ("mydomain.azuredatabricks.net", "1234567890123457", _AZURE_CANONICAL[len("https://") :]),
+        # shard = workspace_id % 20; a different id lands on a different shard.
+        ("mydomain.azuredatabricks.net", "40", "adb-40.0.azuredatabricks.net"),
+        ("mydomain.azuredatabricks.net", "43", "adb-43.3.azuredatabricks.net"),
+        # Case-insensitive host match.
+        ("MyDomain.AzureDatabricks.NET", "43", "adb-43.3.azuredatabricks.net"),
+        # Already the canonical adb-* form → no rewrite (avoid a self-probe).
+        ("adb-43.3.azuredatabricks.net", "43", None),
+        # Not an Azure domain → no canonical form to derive.
+        ("example.databricks.com", "43", None),
+        ("myapp.aws.databricksapps.com", "43", None),
+        # No workspace id, or a non-numeric one → nothing to rebuild the host from.
+        ("mydomain.azuredatabricks.net", None, None),
+        ("mydomain.azuredatabricks.net", "", None),
+        ("mydomain.azuredatabricks.net", "not-a-number", None),
+    ],
+)
+def test_canonical_azure_workspace_host(
+    host: str, org_id: str | None, expected: str | None
+) -> None:
+    """The canonical Azure host is derived from the ``?o=`` workspace id.
+
+    Azure serves every workspace at ``adb-<id>.<shard>.azuredatabricks.net``
+    (``shard = id % 20``) regardless of any vanity URL, so the ``?o=``
+    selector is enough to rebuild the working host — but only for Azure
+    domains that are not already canonical and carry a numeric id.
+    """
+
+    assert cli_mod._canonical_azure_workspace_host(host, org_id) == expected
+
+
+def test_workspace_url_falls_back_to_canonical_when_vanity_mount_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A vanity Azure host that 303-hides its mount resolves via the canonical host.
+
+    Custom workspace URLs front the same workspace but some edges redirect
+    the unauthenticated ``/api/2.0/omnigent`` probe to a login page (303),
+    hiding the mount. The canonical ``adb-<id>.<shard>`` host always
+    answers the DatabricksRealm challenge, so with the ``?o=`` selector we
+    derive it and adopt its mount instead of stranding the user.
+    """
+
+    probed = _scripted_normalizer_httpx(
+        monkeypatch,
+        {
+            # Bare vanity root: workspace web app shape → triggers expansion.
+            f"{_AZURE_VANITY}/v1/me": _response(404, headers={"server": "databricks"}),
+            # Vanity mount, anonymous: hidden behind the login redirect.
+            f"{_AZURE_VANITY}/api/2.0/omnigent/v1/me": _response(
+                303,
+                headers={
+                    "location": "/login?next_url=%2Fapi%2F2.0%2Fomnigent",
+                    "server": "databricks",
+                },
+            ),
+            # Canonical mount: answers the DatabricksRealm challenge.
+            f"{_AZURE_CANONICAL_API_URL}/v1/me": _response(
+                401, headers={"www-authenticate": 'Bearer realm="DatabricksRealm"'}
+            ),
+        },
+    )
+    # No cached grant → the authed retry never runs; only anonymous probes.
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.databricks_sdk_installed",
+        lambda: False,
+    )
+
+    result = cli_mod._workspace_api_server_url(f"{_AZURE_VANITY}/?o={_AZURE_ORG_ID}")
+
+    assert result == _AZURE_CANONICAL_API_URL
+    # The canonical mount was probed after the vanity mount came back dark.
+    assert f"{_AZURE_CANONICAL_API_URL}/v1/me" in probed
+    # The note names the canonical host it switched to (as the display /
+    # web-UI URL) so the user understands why the URL changed.
+    out = capsys.readouterr().out
+    assert _AZURE_CANONICAL in out
+
+
+def test_workspace_url_falls_back_to_canonical_when_vanity_lacks_databricks_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A vanity edge that omits the ``databricks`` header still reaches canonical.
+
+    Some vanity edges answer the bare root without echoing ``server:
+    databricks``, so the header-driven expansion never fires — but the
+    ``?o=`` selector on an ``azuredatabricks.net`` host is signal enough
+    to try the canonical host before leaving the URL untouched.
+    """
+
+    probed = _scripted_normalizer_httpx(
+        monkeypatch,
+        {
+            # Bare vanity root: 404 with no databricks header.
+            f"{_AZURE_VANITY}/v1/me": _response(404),
+            # Canonical mount: answers the DatabricksRealm challenge.
+            f"{_AZURE_CANONICAL_API_URL}/v1/me": _response(
+                401, headers={"www-authenticate": 'Bearer realm="DatabricksRealm"'}
+            ),
+        },
+    )
+
+    result = cli_mod._workspace_api_server_url(f"{_AZURE_VANITY}/?o={_AZURE_ORG_ID}")
+
+    assert result == _AZURE_CANONICAL_API_URL
+    # The vanity mount is skipped entirely (no databricks header); the
+    # canonical mount is probed straight off the bare-root response.
+    assert f"{_AZURE_VANITY}/api/2.0/omnigent/v1/me" not in probed
+    assert f"{_AZURE_CANONICAL_API_URL}/v1/me" in probed
+
+
+def test_workspace_url_keeps_vanity_when_its_own_mount_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A vanity host whose own mount answers is kept — no canonical rewrite.
+
+    Private-link / custom-DNS deployments may reach only the vanity host,
+    so the canonical adb-* host must stay a fallback: when the vanity mount
+    answers the challenge itself, it is adopted and the canonical host is
+    never probed.
+    """
+
+    probed = _scripted_normalizer_httpx(
+        monkeypatch,
+        {
+            f"{_AZURE_VANITY}/v1/me": _response(404, headers={"server": "databricks"}),
+            f"{_AZURE_VANITY}/api/2.0/omnigent/v1/me": _response(
+                401, headers={"www-authenticate": 'Bearer realm="DatabricksRealm"'}
+            ),
+        },
+    )
+
+    result = cli_mod._workspace_api_server_url(f"{_AZURE_VANITY}/?o={_AZURE_ORG_ID}")
+
+    assert result == f"{_AZURE_VANITY}/api/2.0/omnigent"
+    # The canonical host was never probed — the vanity mount worked.
+    assert all("adb-" not in url for url in probed)
+
+
+def test_resolve_server_url_falls_back_to_canonical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared normalizer wires the canonical fallback end to end.
+
+    ``_resolve_server_url`` is the single seam ``login`` / ``host`` route
+    through, so a schemeless vanity host carrying ``?o=`` must resolve to
+    the canonical ``/api/2.0/omnigent`` mount over https.
+    """
+
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.databricks_sdk_installed",
+        lambda: False,
+    )
+    _scripted_normalizer_httpx(
+        monkeypatch,
+        {
+            f"{_AZURE_VANITY}/v1/me": _response(404, headers={"server": "databricks"}),
+            f"{_AZURE_VANITY}/api/2.0/omnigent/v1/me": _response(
+                303, headers={"location": "/login", "server": "databricks"}
+            ),
+            f"{_AZURE_CANONICAL_API_URL}/v1/me": _response(
+                401, headers={"www-authenticate": 'Bearer realm="DatabricksRealm"'}
+            ),
+        },
+    )
+
+    assert (
+        cli_mod._resolve_server_url(f"mydomain.azuredatabricks.net/?o={_AZURE_ORG_ID}")
+        == _AZURE_CANONICAL_API_URL
+    )
 
 
 # ── schemeless input + web-UI URL acceptance (internal user guide) ──


### PR DESCRIPTION
## Related issue

Closes #2781

## Summary
Fixes `omni login` for Azure Databricks workspaces accessed via a custom / vanity URL (e.g. https://mydomain.azuredatabricks.net). Some vanity edges hide the omnigent mount from unauthenticated requests — the anonymous probe gets a `303` to a login page, or the edge drops the `server: databricks` header — so URL expansion never fired and the user was stranded on a bare URL that only 404s.

The fix adds a canonical-host fallback in `omnigent/cli.py`: Azure always serves a workspace at `adb-<workspace_id>.<shard>.azuredatabricks.net` (`shard = workspace_id % 20`) regardless of the vanity URL, and the `?o=` selector carries the workspace id needed to rebuild that host. When the vanity host won't yield its mount, we derive the canonical host, probe its `/api/2.0/omnigent` mount, and adopt it (printing a Note: so the user sees why the URL changed). The vanity host is still preferred when its own mount answers, keeping canonical a true fallback.

## Test Plan
- `test_canonical_azure_workspace_host`: parametrized unit tests for host derivation: shard math (`id % 20`), case-insensitive matching, and the no-rewrite cases (already-canonical, non-Azure domains, missing/non-numeric `?o=`).
- `test_workspace_url_falls_back_to_canonical_when_vanity_mount_hidden`: vanity mount 303-redirects to login → resolves via canonical host, prints the note.
- `test_workspace_url_falls_back_to_canonical_when_vanity_lacks_databricks_header`: vanity root omits the `databricks` header → still reaches canonical.
- `test_workspace_url_keeps_vanity_when_its_own_mount_answers`: vanity mount answers → kept, canonical never probed.
- `test_resolve_server_url_falls_back_to_canonical`: end-to-end through the shared `_resolve_server_url` seam that `login/host` route through.

## Demo
N/A


## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated - 5 new tests across `test_login_databricks.py`
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

 Verified via unit tests with scripted httpx responses (5 functions / 14 cases) covering canonical-host derivation and the vanity→canonical fallback branches. No live manual verification — I don't have access to an Azure Databricks workspace. Two real-world assumptions the mocks can't validate: (1) the shard formula workspace_id % 20, and (2) that the canonical adb-* host answers the DatabricksRealm challenge when a vanity edge hides its mount. A reviewer with Azure workspace access should confirm an end-to-end omni login against a real custom-URL workspace before merge

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->
