### PR TITLE
feat(UI): add /revert mechanism across all interfaces

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -5620,14 +5620,8 @@ async def _cmd_revert(
             message_id,
             revert_files=revert_files,
         )
-        reverted = result.get("session")
-        new_id = reverted.get("id") if isinstance(reverted, dict) else None
-        if not isinstance(new_id, str):
-            raise RuntimeError("Revert response did not include a session id")
-        if new_id != current_id:
-            raise RuntimeError("Revert unexpectedly created a different session")
         await _attach_to_conversation(
-            new_id,
+            current_id,
             session,
             client,
             host,

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -14,6 +14,7 @@ import logging
 import os
 import pathlib
 import re
+import shlex
 import sys
 import tempfile
 from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
@@ -5523,6 +5524,129 @@ async def _cmd_fork(
             f"To return to the previous conversation, run /switch {current_id}[/{fmt.muted}]"
         )
     )
+
+
+def _revert_user_messages(items: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Return selectable, non-meta user messages newest first."""
+    return [
+        item
+        for item in reversed(items)
+        if item.get("type") == "message"
+        and item.get("role") == "user"
+        and not item.get("is_meta")
+        and not _extract_message_text(item).lstrip().startswith("[System:")
+        and isinstance(item.get("id"), str)
+    ]
+
+
+async def _pick_revert_message(
+    items: list[dict[str, object]],
+) -> tuple[str, bool] | None:
+    """Open prompt-toolkit message and option pickers for ``/revert``."""
+    from prompt_toolkit.application import run_in_terminal
+    from prompt_toolkit.shortcuts import checkboxlist_dialog, radiolist_dialog
+
+    candidates = _revert_user_messages(items)
+    if not candidates:
+        return None
+
+    def choose_message() -> str | None:
+        values = []
+        for item in candidates:
+            text = " ".join(_extract_message_text(item).split()) or "(attachments only)"
+            if len(text) > 88:
+                text = text[:87].rstrip() + "…"
+            values.append((str(item["id"]), text))
+        return radiolist_dialog(
+            title="Revert conversation",
+            text="Choose the user message to return to. The original session is preserved.",
+            values=values,
+        ).run()
+
+    selected = await run_in_terminal(choose_message, in_executor=True)
+    if selected is None:
+        return None
+
+    def choose_options() -> list[str] | None:
+        return checkboxlist_dialog(
+            title="Revert options",
+            text="Conversation history always rewinds. Select any additional actions:",
+            values=[("files", "Restore Git files to this point")],
+        ).run()
+
+    options = await run_in_terminal(choose_options, in_executor=True)
+    if options is None:
+        return None
+    return selected, "files" in options
+
+
+@_cmd("/revert", "Revert to a past user message")
+async def _cmd_revert(
+    arg: str,
+    session: Session,
+    client: OmnigentClient,
+    host: TerminalHost,
+    fmt: RichBlockFormatter,
+) -> None:
+    """Create and enter a safe branch before a selected user message."""
+    current_id = getattr(session, "session_id", None)
+    if current_id is None:
+        host.output(Text("  /revert requires the sessions API.", style="bold red"))
+        return
+    try:
+        tokens = shlex.split(arg)
+    except ValueError as exc:
+        host.output(Text(f"  Invalid /revert arguments: {exc}", style="bold red"))
+        return
+    unknown = [token for token in tokens if token.startswith("-") and token != "--files"]
+    ids = [token for token in tokens if not token.startswith("-")]
+    if unknown or len(ids) > 1:
+        host.output(Text("  Usage: /revert [user-message-id] [--files]", style="bold red"))
+        return
+    try:
+        items = await _list_all_conversation_items(client, current_id)
+        if ids:
+            selected = (ids[0], "--files" in tokens)
+        elif not _revert_user_messages(items):
+            host.output(Text(f"  [{fmt.muted}]No user messages to revert to.[/{fmt.muted}]"))
+            return
+        else:
+            selected = await _pick_revert_message(items)
+        if selected is None:
+            return
+        message_id, revert_files = selected
+        result = await client.sessions.revert(
+            current_id,
+            message_id,
+            revert_files=revert_files,
+        )
+        reverted = result.get("session")
+        new_id = reverted.get("id") if isinstance(reverted, dict) else None
+        if not isinstance(new_id, str):
+            raise RuntimeError("Revert response did not include a session id")
+        if new_id != current_id:
+            raise RuntimeError("Revert unexpectedly created a different session")
+        await _attach_to_conversation(
+            new_id,
+            session,
+            client,
+            host,
+            fmt,
+            ui_name=_humanize_agent_name(session.model),
+            redraw_screen=True,
+        )
+    except Exception as exc:  # noqa: BLE001 — command boundary renders failures inline
+        _log.exception("Revert failed")
+        host.output(Text(f"  Revert failed: {exc}", style="bold red"))
+        return
+
+    host.output(Text.from_markup(f"  [{fmt.muted}]Reverted this session.[/{fmt.muted}]"))
+    file_error = result.get("file_revert_error")
+    if isinstance(file_error, str) and file_error:
+        host.output(Text(f"  {file_error}", style="yellow"))
+    draft = result.get("draft")
+    if isinstance(draft, str) and draft:
+        host.output(Text.from_markup(f"\n  [bold]Message to retry[/]\n  {escape(draft)}"))
 
 
 @_cmd("/history", "Show current conversation history")

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1773,11 +1773,10 @@ async def _resolve_pi_resume_session(
        (cross-machine, a fresh runner, or a cleared bridge dir). Synthesize the
        file from committed Omnigent items so ``pi --session <id>`` opens with
        prior context. An existing file is reused untouched.
-    2. **Fork rebuild** — a forked clone bound to a pi-native target with NO
-       captured session of its own and a carry-history marker: mint a new Pi
-       session id, build its file from the clone's OWN copied Omnigent items,
-       and patch the server so Omnigent reflects the clone's session id and a
-       later relaunch resumes it via case 1.
+    2. **History rebuild** — a forked or rewound pi-native session with no
+       captured native id and a carry-history marker: mint a new Pi session id,
+       build its file from the session's current Omnigent items, and patch the
+       server so a later relaunch resumes it via case 1.
     3. **Fresh / nothing to carry** — return ``None`` so Pi launches a brand
        new session.
 
@@ -1847,8 +1846,8 @@ async def _resolve_pi_resume_session(
             return None
         return launch_config.external_session_id
 
-    # Case 2: forked clone bound to a pi-native target with no captured session
-    # yet. Build the clone's session from its OWN copied Omnigent items under a
+    # Case 2: a forked or rewound pi-native session with no captured session
+    # yet. Build its native session from its current Omnigent items under a
     # minted id. (A same-provider source's captured id, when present, is stamped
     # as fork_source_external_id; but Pi session files are runner-local and the
     # clone has its OWN copied items, so we rebuild from items either way —
@@ -1867,12 +1866,12 @@ async def _resolve_pi_resume_session(
         except Exception:  # noqa: BLE001 — best-effort; launch fresh on failure
             built = None
             _logger.warning(
-                "Could not build Pi session from items for forked clone %s; launching fresh",
+                "Could not rebuild Pi session from items for %s; launching fresh",
                 session_id,
                 exc_info=True,
             )
         _logger.info(
-            "Pi terminal fork-rebuild decision: session=%s minted=%s built=%s",
+            "Pi terminal history-rebuild decision: session=%s minted=%s built=%s",
             session_id,
             minted,
             str(built) if built is not None else None,
@@ -1890,7 +1889,7 @@ async def _resolve_pi_resume_session(
                 )
             except httpx.HTTPError:
                 _logger.warning(
-                    "Could not pre-set external_session_id for forked Pi clone %s; "
+                    "Could not pre-set rebuilt external_session_id for Pi session %s; "
                     "relying on extension capture",
                     session_id,
                     exc_info=True,
@@ -8728,6 +8727,32 @@ def create_runner_app(
         _session_fs_registries[session_id] = registry
         return registry
 
+    async def _capture_revert_checkpoint(
+        session_id: str,
+        body: dict[str, Any],
+    ) -> bool:
+        """Best-effort workspace snapshot immediately before a user turn."""
+        checkpoint_id = body.get("revert_checkpoint_id") or body.get("persisted_item_id")
+        if not isinstance(checkpoint_id, str) or not checkpoint_id:
+            return False
+        registry = await _resolve_session_fs_registry(session_id)
+        if registry is None:
+            return False
+        try:
+            return await asyncio.to_thread(
+                registry.create_revert_checkpoint,
+                session_id,
+                checkpoint_id,
+            )
+        except Exception:  # noqa: BLE001 — chat must still work if snapshotting fails
+            _logger.warning(
+                "Could not create revert checkpoint for session=%s item=%s",
+                session_id,
+                checkpoint_id,
+                exc_info=True,
+            )
+            return False
+
     from omnigent.entities.environment_filesystem import (
         FilesystemEntry,
         ResourceError,
@@ -9967,7 +9992,7 @@ def create_runner_app(
         _session_snapshot_cache.pop(session_id, None)
         _session_snapshot_locks.pop(session_id, None)
         _session_spec_locks.pop(session_id, None)
-        _session_fs_registries.pop(session_id, None)
+        session_fs_registry = _session_fs_registries.pop(session_id, None)
         _session_agent_ids.pop(session_id, None)
         _session_tool_schemas.pop(session_id, None)
         if _relay := _session_comment_relays.pop(session_id, None):
@@ -9986,8 +10011,9 @@ def create_runner_app(
         # spawned sub-agent child (no-op otherwise).
         unregister_child_session(session_id)
         unregister_subagent_work_for_session(session_id)
-        if filesystem_registry is not None:
-            filesystem_registry.unregister_conversation(session_id)
+        checkpoint_registry = session_fs_registry or filesystem_registry
+        if checkpoint_registry is not None:
+            checkpoint_registry.unregister_conversation(session_id)
         for _task, evt in _session_async_tasks.pop(session_id, {}).values():
             evt.set()
         for _tmr in _session_timers.pop(session_id, {}).values():
@@ -13192,6 +13218,7 @@ def create_runner_app(
                 next_body = buf.pop(0)
                 if not buf:
                     _session_message_buffers.pop(session_id, None)
+                await _capture_revert_checkpoint(session_id, next_body)
                 _session_histories.setdefault(session_id, []).append(
                     {
                         "type": "message",
@@ -13207,6 +13234,7 @@ def create_runner_app(
                 _session_message_buffers.pop(session_id, None)
 
                 for body in all_bodies:
+                    await _capture_revert_checkpoint(session_id, body)
                     _session_histories.setdefault(session_id, []).append(
                         {
                             "type": "message",
@@ -15138,6 +15166,11 @@ def create_runner_app(
                         },
                     )
 
+                # Snapshot immediately before this turn. Queued messages take
+                # this path only when they actually start (the drain above), so
+                # their checkpoint never races an earlier active turn.
+                await _capture_revert_checkpoint(conversation_id, message_body)
+
                 # Make the new user message visible to the turn. On the
                 # first touch of a conversation after a runner restart the
                 # in-memory cache is empty; seeding it with ONLY this
@@ -15230,6 +15263,80 @@ def create_runner_app(
                 async with _cond:
                     _ingest_now_serving[conversation_id] = _seq + 1
                     _cond.notify_all()
+
+        if body_type == "capture_revert_checkpoint":
+            checkpoint_id = body.get("checkpoint_id") if isinstance(body, dict) else None
+            if not isinstance(checkpoint_id, str) or not checkpoint_id:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "invalid_input", "detail": "checkpoint_id is required"},
+                )
+            captured = await _capture_revert_checkpoint(
+                conversation_id,
+                {"revert_checkpoint_id": checkpoint_id},
+            )
+            if not captured:
+                return JSONResponse(
+                    status_code=409,
+                    content={
+                        "error": "checkpoint_unavailable",
+                        "detail": "File checkpoints require a Git workspace.",
+                    },
+                )
+            return JSONResponse(status_code=200, content={"captured": True})
+
+        if body_type == "revert_files":
+            checkpoint_id = body.get("checkpoint_id") if isinstance(body, dict) else None
+            if not isinstance(checkpoint_id, str) or not checkpoint_id:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "invalid_input", "detail": "checkpoint_id is required"},
+                )
+            if conversation_id in _active_turns:
+                return JSONResponse(
+                    status_code=409,
+                    content={"error": "session_busy", "detail": "Wait for the turn to finish."},
+                )
+            registry = await _resolve_session_fs_registry(conversation_id)
+            if registry is None:
+                restored = False
+            else:
+                try:
+                    restored = await asyncio.to_thread(
+                        registry.restore_revert_checkpoint,
+                        conversation_id,
+                        checkpoint_id,
+                    )
+                except KeyError:
+                    return JSONResponse(
+                        status_code=404,
+                        content={
+                            "error": "checkpoint_not_found",
+                            "detail": "No file checkpoint exists for that message.",
+                        },
+                    )
+                except Exception:
+                    _logger.exception(
+                        "File revert failed for session=%s checkpoint=%s",
+                        conversation_id,
+                        checkpoint_id,
+                    )
+                    return JSONResponse(
+                        status_code=500,
+                        content={
+                            "error": "revert_failed",
+                            "detail": "Git could not restore the checkpoint.",
+                        },
+                    )
+            if not restored:
+                return JSONResponse(
+                    status_code=409,
+                    content={
+                        "error": "checkpoint_unavailable",
+                        "detail": "File checkpoints require a Git workspace.",
+                    },
+                )
+            return JSONResponse(status_code=200, content={"restored": True})
 
         if body_type == "interrupt":
             # Native harnesses get a key sent to their TUI pane — a forwarded

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -23,10 +23,14 @@ defines the full public interface.
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import fnmatch
+import hashlib
 import logging
+import os
 import subprocess
+import tempfile
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -39,6 +43,7 @@ _logger = logging.getLogger(__name__)
 # short so a slow/hung repo can't block the panel; each call degrades cleanly
 # on timeout rather than raising. Bump if very large repos need more headroom.
 _GIT_TIMEOUT_SECONDS = 5
+_GIT_REVERT_TIMEOUT_SECONDS = 30
 
 
 class GitStatusUnavailable(RuntimeError):
@@ -389,13 +394,29 @@ class FilesystemRegistry(ABC):
         """Drop per-session state when a session is deleted.
 
         Called on session teardown so implementations can evict in-memory
-        events and snapshots.  No-op by default (e.g.
-        :class:`GitFilesystemRegistry` holds no per-session state).
+        events and snapshots.  No-op by default.
 
         :param conversation_id: The conversation to remove,
             e.g. ``"conv_abc123"``.
         """
         return
+
+    def create_revert_checkpoint(self, session_id: str, checkpoint_id: str) -> bool:
+        """Snapshot the workspace before a user turn.
+
+        The base implementation reports unsupported; Git-backed registries
+        override it with an object-database snapshot that survives runner
+        restarts.
+        """
+        return False
+
+    def restore_revert_checkpoint(self, session_id: str, checkpoint_id: str) -> bool:
+        """Restore a checkpoint created by :meth:`create_revert_checkpoint`.
+
+        The base implementation reports unsupported. Implementations must
+        either restore the whole watched workspace or leave it unchanged.
+        """
+        return False
 
     def start(self) -> None:
         """Start any background observers.  Idempotent."""
@@ -692,6 +713,124 @@ class GitFilesystemRegistry(FilesystemRegistry):
         """
         super().__init__(watch_path)
         self._git_root = git_root
+
+    def create_revert_checkpoint(self, session_id: str, checkpoint_id: str) -> bool:
+        """Write the current workspace tree to a private Git ref.
+
+        A temporary index captures tracked, staged, unstaged, and untracked
+        (non-ignored) files without touching the user's real index or branch.
+        """
+        ref = self._revert_ref(session_id, checkpoint_id)
+        with tempfile.TemporaryDirectory(prefix="omnigent-revert-") as tmp:
+            env = {**os.environ, "GIT_INDEX_FILE": str(Path(tmp) / "index")}
+            head = self._git_optional(["rev-parse", "--verify", "HEAD"])
+            self._git(["read-tree", head if head is not None else "--empty"], env=env)
+            self._git(["add", "-A", "--", self._workspace_pathspec()], env=env)
+            tree = self._git(["write-tree"], env=env)
+            commit_args = ["commit-tree", tree]
+            if head is not None:
+                commit_args.extend(["-p", head])
+            commit = self._git(commit_args, env=env, input_=b"Omnigent revert checkpoint\n")
+            self._git(["update-ref", ref, commit])
+        return True
+
+    def restore_revert_checkpoint(self, session_id: str, checkpoint_id: str) -> bool:
+        """Restore the watched workspace to a private checkpoint tree.
+
+        The current state is checkpointed first and automatically restored if
+        applying the target tree fails, so a partial Git operation cannot lose
+        the user's work.
+        """
+        target = self._git_optional(
+            ["rev-parse", "--verify", self._revert_ref(session_id, checkpoint_id)]
+        )
+        if target is None:
+            raise KeyError(f"revert checkpoint not found: {checkpoint_id}")
+        rescue_id = f"rescue-{time.time_ns()}"
+        self.create_revert_checkpoint(session_id, rescue_id)
+        rescue = self._git(["rev-parse", "--verify", self._revert_ref(session_id, rescue_id)])
+        try:
+            self._restore_tree(target)
+        except Exception:
+            with contextlib.suppress(Exception):
+                self._restore_tree(rescue)
+            raise
+        finally:
+            self._git_optional(["update-ref", "-d", self._revert_ref(session_id, rescue_id)])
+        return True
+
+    def unregister_conversation(self, conversation_id: str) -> None:
+        """Delete private checkpoint refs for a removed session."""
+        prefix = self._revert_ref_prefix(conversation_id)
+        refs = self._git_optional(["for-each-ref", "--format=%(refname)", prefix])
+        for ref in refs.splitlines() if refs else []:
+            self._git_optional(["update-ref", "-d", ref])
+
+    def _restore_tree(self, target: str) -> None:
+        """Make the watched workspace match *target* without moving HEAD."""
+        head = self._git_optional(["rev-parse", "--verify", "HEAD"])
+        if head is None:
+            raise RuntimeError("cannot restore a revert checkpoint in a repository without HEAD")
+        pathspec = self._workspace_pathspec()
+        patch = self._git_bytes(["diff", "--binary", "--full-index", head, target, "--", pathspec])
+        self._git(["restore", "--source", head, "--staged", "--worktree", "--", pathspec])
+        # ponytail: ignored files are intentionally outside checkpoints; add an
+        # archive backend if reverting generated/ignored artifacts becomes necessary.
+        self._git(["clean", "-fd", "--", pathspec])
+        if patch:
+            self._git(["apply", "--whitespace=nowarn", "-"], input_=patch)
+
+    def _workspace_pathspec(self) -> str:
+        relative = self._cwd.relative_to(self._git_root)
+        return "." if relative == Path(".") else f":(literal){relative.as_posix()}"
+
+    @staticmethod
+    def _ref_component(value: str) -> str:
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+    def _revert_ref_prefix(self, session_id: str) -> str:
+        return f"refs/omnigent/revert/{self._ref_component(session_id)}"
+
+    def _revert_ref(self, session_id: str, checkpoint_id: str) -> str:
+        return f"{self._revert_ref_prefix(session_id)}/{self._ref_component(checkpoint_id)}"
+
+    def _git(
+        self,
+        args: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        input_: bytes | None = None,
+    ) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=self._git_root,
+            env=env,
+            input=input_,
+            capture_output=True,
+            timeout=_GIT_REVERT_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.decode("utf-8", errors="replace").strip()
+            raise RuntimeError(f"git {' '.join(args)} failed: {detail or result.returncode}")
+        return result.stdout.decode("utf-8", errors="replace").strip()
+
+    def _git_bytes(self, args: list[str]) -> bytes:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=self._git_root,
+            capture_output=True,
+            timeout=_GIT_REVERT_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.decode("utf-8", errors="replace").strip()
+            raise RuntimeError(f"git {' '.join(args)} failed: {detail or result.returncode}")
+        return result.stdout
+
+    def _git_optional(self, args: list[str]) -> str | None:
+        try:
+            return self._git(args)
+        except (OSError, RuntimeError, subprocess.TimeoutExpired):
+            return None
 
     def list_changed_files(self, conversation_id: str, *, limit: int) -> list[dict[str, Any]]:
         """Return all uncommitted changes in the working tree, newest first.

--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -1128,9 +1128,7 @@ files and return `file_revert_error`.
 ```
 200 OK
 {
-  "session": { ...SessionResponse },
   "draft": "selected prompt text",
-  "files_reverted": false,
   "file_revert_error": null
 }
 

--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -1106,6 +1106,43 @@ shape as `GET /v1/sessions/{id}` — with status `"idle"` and all
 copied items in chronological order. Clients must bind a runner
 before opening the fork's SSE stream or posting events.
 
+### Revert Session
+
+```
+POST /v1/sessions/{source_id}/revert
+Content-Type: application/json
+
+{
+  "user_message_id": "msg_abc123",
+  "revert_files": false
+}
+```
+
+Rewinds the existing session in place, deleting the selected non-meta user
+message and everything after it. The session id, title, agent, runner, and
+workspace remain unchanged. The selected prompt is returned as `draft` so
+clients can prefill it. `revert_files` restores the Git workspace checkpoint
+captured before that prompt; non-Git, offline, or older sessions keep current
+files and return `file_revert_error`.
+
+```
+200 OK
+{
+  "session": { ...SessionResponse },
+  "draft": "selected prompt text",
+  "files_reverted": false,
+  "file_revert_error": null
+}
+
+400 Bad Request — the item is missing, is not selectable, or belongs to a sub-agent
+403 Forbidden — edit access is required
+409 Conflict — the source session is running
+```
+
+Revert always requires edit access because it mutates conversation history.
+For supported native harnesses, the live terminal is reset and rebuilt from the
+retained history before the next turn.
+
 ### Stream Session
 
 ```

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -263,6 +263,8 @@ from omnigent.server.schemas import (
     SessionResourceObject,
     SessionResourcePaginatedList,
     SessionResponse,
+    SessionRevertRequest,
+    SessionRevertResponse,
     SessionSandboxStatusEvent,
     SessionSkillsEvent,
     SessionStatusEvent,
@@ -5283,6 +5285,7 @@ async def _persist_external_conversation_item(
     body: SessionEventInput,
     conversation_store: ConversationStore,
     created_by: str | None = None,
+    runner_router: RunnerRouter | None = None,
 ) -> str:
     """
     Persist and broadcast a conversation item produced outside AP.
@@ -5349,6 +5352,21 @@ async def _persist_external_conversation_item(
     persisted_items = await asyncio.to_thread(conversation_store.append, session_id, [item])
     await _seed_missing_title_from_user_message(conv, item, conversation_store)
     persisted = persisted_items[0]
+    if (
+        persisted.type == "message"
+        and isinstance(persisted.data, MessageData)
+        and persisted.data.role == "user"
+        and not persisted.data.is_meta
+    ):
+        # Native TUI input bypasses the runner's regular message-ingest path.
+        # Capture here, when the transcript first mirrors the accepted prompt,
+        # so direct terminal input gets the same file checkpoint as web input.
+        await _forward_session_change_to_runner(
+            session_id,
+            runner_router,
+            {"type": "capture_revert_checkpoint", "checkpoint_id": persisted.id},
+            timeout=35.0,
+        )
     _publish_external_conversation_item(
         session_id, persisted, cleared_pending_id=cleared_pending_id
     )
@@ -8386,6 +8404,7 @@ async def _forward_native_terminal_message(
     body: SessionEventInput,
     file_store: FileStore | None = None,
     artifact_store: ArtifactStore | None = None,
+    checkpoint_id: str | None = None,
 ) -> None:
     """
     Forward one Omnigent web-chat message to the native terminal harness.
@@ -8411,6 +8430,8 @@ async def _forward_native_terminal_message(
     """
     display_name, _, _ = _native_terminal_runtime(conv)
     event = _build_native_terminal_message_event(conv, body)
+    if checkpoint_id is not None:
+        event["revert_checkpoint_id"] = checkpoint_id
     _logger.info(
         "%s terminal message forward starting: session=%s block_types=%s",
         display_name,
@@ -8542,6 +8563,8 @@ async def _forward_session_change_to_runner(
     session_id: str,
     runner_router: Any,
     event: dict[str, Any],
+    *,
+    timeout: float = 5.0,
 ) -> _RunnerForwardResult | None:
     """
     Best-effort POST a control event to the bound runner.
@@ -8581,6 +8604,7 @@ async def _forward_session_change_to_runner(
         ``{"type": "effort_change", "effort": "high"}``,
         ``{"type": "model_change", "model": "claude-opus-4-7"}``, or
         ``{"type": "compact"}``.
+    :param timeout: Runner POST timeout in seconds.
     :returns: The runner's HTTP status/body, or ``None`` when no
         runner client could be resolved or the POST failed at the
         transport layer (in both cases the AP-side persisted value /
@@ -8597,7 +8621,7 @@ async def _forward_session_change_to_runner(
         resp = await runner_client.post(
             f"/v1/sessions/{session_id}/events",
             json=event,
-            timeout=5.0,
+            timeout=timeout,
         )
     except (httpx.HTTPError, ConnectionError):
         _logger.exception(
@@ -9809,6 +9833,7 @@ async def _dispatch_session_event_to_runner(
                 body,
                 file_store=file_store,
                 artifact_store=artifact_store,
+                checkpoint_id=pending_id,
             )
             forwarded = True
         finally:
@@ -10901,6 +10926,26 @@ async def _ensure_runner_relay_ready(
 # Per-session compaction locks so concurrent ``/compact`` POSTs
 # don't race.
 _COMPACT_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def _list_all_items_for_revert(
+    conversation_store: ConversationStore,
+    session_id: str,
+) -> list[ConversationItem]:
+    """Read a complete transcript through the store's cursor contract."""
+    items: list[ConversationItem] = []
+    after: str | None = None
+    while True:
+        page = conversation_store.list_items(
+            session_id,
+            limit=1000,
+            after=after,
+            order="asc",
+        )
+        items.extend(page.data)
+        if not page.has_more or not page.data:
+            return items
+        after = page.data[-1].id
 
 
 async def _run_compact_locked(
@@ -16577,6 +16622,154 @@ def create_sessions_router(
             agent_name=base_agent.name,
         )
 
+    # ── POST /sessions/{source_id}/revert ────────────────────────
+
+    @router.post(
+        "/sessions/{source_id}/revert",
+        response_model=None,
+        responses={200: {"model": SessionRevertResponse}},
+    )
+    async def revert_session(
+        request: Request,
+        source_id: str,
+        body: SessionRevertRequest,
+    ) -> SessionRevertResponse:
+        """Rewind one session to immediately before a selected user message."""
+        user_id = _get_user_id(request, auth_provider)
+        access = await _require_access_and_level(
+            user_id,
+            source_id,
+            LEVEL_EDIT,
+            permission_store,
+            conversation_store,
+        )
+        source = access.conversation
+        if source is None:
+            source = await asyncio.to_thread(conversation_store.get_conversation, source_id)
+        if source is None:
+            raise _session_not_found()
+        if source.kind == "sub_agent":
+            raise OmnigentError(
+                "Only top-level sessions can be reverted.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        if _session_status_from_cache(source_id) in ("running", "waiting"):
+            raise OmnigentError(
+                "Wait for the current turn to finish before reverting.",
+                code=ErrorCode.CONFLICT,
+            )
+
+        items = await asyncio.to_thread(
+            _list_all_items_for_revert,
+            conversation_store,
+            source_id,
+        )
+        target_index = next(
+            (index for index, item in enumerate(items) if item.id == body.user_message_id),
+            None,
+        )
+        if target_index is None:
+            raise OmnigentError(
+                f"User message not found: {body.user_message_id!r}",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        target = items[target_index]
+        if (
+            target.type != "message"
+            or not isinstance(target.data, MessageData)
+            or target.data.role != "user"
+            or target.data.is_meta
+            or (_message_text(target.data.content) or "").lstrip().startswith("[System:")
+        ):
+            raise OmnigentError(
+                "The revert point must be a user message.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        if source.agent_id is None:
+            raise OmnigentError("Session has no agent binding.", code=ErrorCode.INVALID_INPUT)
+        agent = await asyncio.to_thread(agent_store.get, source.agent_id)
+        if agent is None:
+            raise OmnigentError("Session agent not found.", code=ErrorCode.NOT_FOUND)
+
+        target_is_cursor = await asyncio.to_thread(_agent_carries_cursor_fork_history, agent)
+        carry_history_into_native = target_is_cursor or await asyncio.to_thread(
+            _agent_carries_native_fork_history,
+            agent,
+        )
+        is_native = await asyncio.to_thread(_agent_is_native, agent)
+        runner_client = (
+            await _get_runner_client(source_id, runner_router)
+            if is_native or body.revert_files
+            else None
+        )
+        if is_native and runner_client is not None:
+            try:
+                reset_response = await runner_client.post(
+                    f"/v1/sessions/{urllib.parse.quote(source_id, safe='')}/reset-state",
+                    timeout=15.0,
+                )
+                reset_response.raise_for_status()
+            except (httpx.HTTPError, ConnectionError) as exc:
+                raise OmnigentError(
+                    "The native session could not be reset. Please retry.",
+                    code=ErrorCode.RUNNER_UNAVAILABLE,
+                ) from exc
+
+        draft = _message_text(target.data.content) or ""
+        try:
+            rewound = await asyncio.to_thread(
+                conversation_store.rewind_conversation,
+                source_id,
+                before_item_id=target.id,
+                carry_history_into_native=carry_history_into_native,
+            )
+        except LookupError as exc:
+            raise OmnigentError(str(exc), code=ErrorCode.INVALID_INPUT) from exc
+
+        files_reverted = False
+        file_revert_error: str | None = None
+        if body.revert_files:
+            if runner_client is None:
+                file_revert_error = "The runner is offline, so file changes were kept."
+            else:
+                try:
+                    restore_response = await runner_client.post(
+                        f"/v1/sessions/{source_id}/events",
+                        json={"type": "revert_files", "checkpoint_id": target.id},
+                        timeout=35.0,
+                    )
+                    files_reverted = restore_response.status_code == 200
+                    if not files_reverted:
+                        file_revert_error = (
+                            "No Git checkpoint was available for that message, so file changes "
+                            "were kept."
+                            if restore_response.status_code in (404, 409)
+                            else "File changes could not be restored, so they were kept."
+                        )
+                except (httpx.HTTPError, ConnectionError):
+                    file_revert_error = "The runner disconnected, so file changes were kept."
+
+        rewound_items = await asyncio.to_thread(
+            conversation_store.list_items,
+            source_id,
+            limit=10000,
+        )
+        level = await _get_permission_level(user_id, source_id, permission_store)
+        session_response = _build_session_response(
+            rewound,
+            rewound_items.data,
+            "idle",
+            permission_level=level,
+            last_task_error=None,
+            agent_name=agent.name,
+        )
+        return SessionRevertResponse(
+            session=session_response,
+            draft=draft,
+            files_reverted=files_reverted,
+            file_revert_error=file_revert_error,
+        )
+
     # ── POST /sessions/{session_id}/switch-agent ─────────────────
 
     @router.post(
@@ -20417,6 +20610,7 @@ def create_sessions_router(
                 body,
                 conversation_store,
                 created_by=_attribution_user(user_id),
+                runner_router=runner_router,
             )
             return {"queued": False, "item_id": item_id}
         if body.type == _EXTERNAL_OUTPUT_TEXT_DELTA_TYPE:

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -16664,16 +16664,12 @@ def create_sessions_router(
             conversation_store,
             source_id,
         )
-        target_index = next(
-            (index for index, item in enumerate(items) if item.id == body.user_message_id),
-            None,
-        )
-        if target_index is None:
+        target = next((item for item in items if item.id == body.user_message_id), None)
+        if target is None:
             raise OmnigentError(
                 f"User message not found: {body.user_message_id!r}",
                 code=ErrorCode.INVALID_INPUT,
             )
-        target = items[target_index]
         if (
             target.type != "message"
             or not isinstance(target.data, MessageData)
@@ -16717,7 +16713,7 @@ def create_sessions_router(
 
         draft = _message_text(target.data.content) or ""
         try:
-            rewound = await asyncio.to_thread(
+            await asyncio.to_thread(
                 conversation_store.rewind_conversation,
                 source_id,
                 before_item_id=target.id,
@@ -16726,7 +16722,6 @@ def create_sessions_router(
         except LookupError as exc:
             raise OmnigentError(str(exc), code=ErrorCode.INVALID_INPUT) from exc
 
-        files_reverted = False
         file_revert_error: str | None = None
         if body.revert_files:
             if runner_client is None:
@@ -16738,8 +16733,7 @@ def create_sessions_router(
                         json={"type": "revert_files", "checkpoint_id": target.id},
                         timeout=35.0,
                     )
-                    files_reverted = restore_response.status_code == 200
-                    if not files_reverted:
+                    if restore_response.status_code != 200:
                         file_revert_error = (
                             "No Git checkpoint was available for that message, so file changes "
                             "were kept."
@@ -16749,26 +16743,7 @@ def create_sessions_router(
                 except (httpx.HTTPError, ConnectionError):
                     file_revert_error = "The runner disconnected, so file changes were kept."
 
-        rewound_items = await asyncio.to_thread(
-            conversation_store.list_items,
-            source_id,
-            limit=10000,
-        )
-        level = await _get_permission_level(user_id, source_id, permission_store)
-        session_response = _build_session_response(
-            rewound,
-            rewound_items.data,
-            "idle",
-            permission_level=level,
-            last_task_error=None,
-            agent_name=agent.name,
-        )
-        return SessionRevertResponse(
-            session=session_response,
-            draft=draft,
-            files_reverted=files_reverted,
-            file_revert_error=file_revert_error,
-        )
+        return SessionRevertResponse(draft=draft, file_revert_error=file_revert_error)
 
     # ── POST /sessions/{session_id}/switch-agent ─────────────────
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2074,12 +2074,10 @@ class SessionRevertRequest(BaseModel):
 
 
 class SessionRevertResponse(BaseModel):
-    """Rewound session plus the selected prompt and optional file result."""
+    """Selected prompt plus any non-fatal file-restore warning."""
 
-    session: SessionResponse
     draft: str
-    files_reverted: bool = False
-    file_revert_error: str | None = None
+    file_revert_error: str | None
 
 
 class ReadStatePutRequest(BaseModel):

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2064,6 +2064,24 @@ class SessionForkRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class SessionRevertRequest(BaseModel):
+    """Request to rewind a session to before a past user message."""
+
+    user_message_id: str = Field(min_length=1)
+    revert_files: bool = False
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class SessionRevertResponse(BaseModel):
+    """Rewound session plus the selected prompt and optional file result."""
+
+    session: SessionResponse
+    draft: str
+    files_reverted: bool = False
+    file_revert_error: str | None = None
+
+
 class ReadStatePutRequest(BaseModel):
     """
     Request body for ``PUT /v1/sessions/{session_id}/read-state``.

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -38,10 +38,9 @@ FORK_SOURCE_LABEL_KEY = "omnigent.fork.source_id"
 # ``external_session_id`` is still NULL. Cleared/ignored thereafter.
 FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY = "omnigent.fork.source_external_session_id"
 
-# Fork directive: set when the fork binds a NATIVE target harness
-# (claude-native / codex-native) whose history should carry over. A native
-# CLI ignores the Omnigent transcript, so the runner rebuilds the target's
-# on-disk transcript before launch. Two rebuild paths share this directive:
+# Native-history replay directive used by forks, agent switches, and in-place
+# rewinds. A native CLI ignores the Omnigent transcript, so the runner rebuilds
+# the target's on-disk transcript before launch. Two rebuild paths share it:
 # when the source was a SAME-FAMILY native session its captured
 # ``external_session_id`` is also stamped (see
 # FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY) and the runner clones that
@@ -104,15 +103,17 @@ PROJECT_LABEL_KEY = "omni_project"
 #     typed re-confirmation and no banner, violating the "impossible to
 #     enable accidentally" contract (#657). Dropping it forces each session
 #     that runs bypass to make its own explicit opt-in.
-_INSTANCE_SCOPED_LABEL_KEYS = frozenset(
+_RUNTIME_INSTANCE_LABEL_KEYS = frozenset(
     {
         "omnigent.claude_native.bridge_id",
         "omnigent.codex_native.bridge_id",
         "omnigent.last_context_tokens",
         "omnigent.last_context_window",
-        CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY,
     }
 )
+_INSTANCE_SCOPED_LABEL_KEYS = _RUNTIME_INSTANCE_LABEL_KEYS | {
+    CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY
+}
 
 # Source identity belongs only to the original imported session. Unlike runtime
 # instance labels, these survive an in-place agent switch but never a fork.
@@ -1334,6 +1335,28 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def rewind_conversation(
+        self,
+        conversation_id: str,
+        *,
+        before_item_id: str,
+        carry_history_into_native: bool = False,
+    ) -> Conversation:
+        """Delete a selected item and everything after it in the same session.
+
+        Resets the native runtime identity so a supported native harness
+        rebuilds from the retained Agent Platform items on its next launch.
+
+        :param conversation_id: Session to rewind, e.g. ``"conv_abc123"``.
+        :param before_item_id: First item to delete, e.g. ``"msg_def456"``.
+        :param carry_history_into_native: Whether to mark the retained items for
+            native transcript replay.
+        :returns: The updated conversation with the same id.
+        :raises LookupError: If the conversation or cutoff item does not exist.
+        """
+        ...
+
+    @abstractmethod
     def fork_conversation(
         self,
         source_conversation_id: str,
@@ -1426,8 +1449,8 @@ class ConversationStore(ABC):
         :returns: The newly created :class:`Conversation`.
         :raises LookupError: If no conversation with
             *source_conversation_id* exists.
-        :raises ValueError: If *up_to_response_id* is set but no item in
-            the source conversation has that ``response_id``.
+        :raises ValueError: If the requested response/item cutoff is invalid
+            or does not exist in the source conversation.
         """
         ...
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -79,6 +79,7 @@ from omnigent.session_import.models import (
 from omnigent.stores.conversation_store import (
     _FORK_ONLY_DROPPED_LABEL_KEYS,
     _INSTANCE_SCOPED_LABEL_KEYS,
+    _RUNTIME_INSTANCE_LABEL_KEYS,
     FORK_CARRY_HISTORY_LABEL_KEY,
     FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY,
     FORK_SOURCE_LABEL_KEY,
@@ -3094,6 +3095,94 @@ class SqlAlchemyConversationStore(ConversationStore):
         return _created_session_from_rows(
             conversation_row, meta_row, agent_config_row, agent_row, labels
         )
+
+    def rewind_conversation(
+        self,
+        conversation_id: str,
+        *,
+        before_item_id: str,
+        carry_history_into_native: bool = False,
+    ) -> Conversation:
+        """Delete a selected item and all later items from one conversation."""
+        now = now_epoch()
+        with self._conv_session() as session:
+            conversation = session.get(
+                SqlConversation,
+                (current_workspace_id(), conversation_id),
+            )
+            if conversation is None:
+                raise LookupError(f"conversation not found: {conversation_id!r}")
+            target_position = session.execute(
+                select(SqlConversationItem.position).where(
+                    SqlConversationItem.workspace_id == current_workspace_id(),
+                    SqlConversationItem.conversation_id == conversation_id,
+                    SqlConversationItem.id == before_item_id,
+                )
+            ).scalar_one_or_none()
+            if target_position is None:
+                raise LookupError(
+                    f"item not found in conversation {conversation_id!r}: {before_item_id!r}"
+                )
+
+            # ponytail: child sessions lack an origin item id; add that link before
+            # cascading post-rewind children instead of guessing from timestamps.
+            kept_items = (
+                session.execute(
+                    select(SqlConversationItem)
+                    .where(
+                        SqlConversationItem.workspace_id == current_workspace_id(),
+                        SqlConversationItem.conversation_id == conversation_id,
+                        SqlConversationItem.position < target_position,
+                    )
+                    .order_by(SqlConversationItem.position.asc())
+                )
+                .scalars()
+                .all()
+            )
+            delete_fts_by_conversation(session, conversation_id)
+            session.execute(
+                delete(SqlConversationItem).where(
+                    SqlConversationItem.workspace_id == current_workspace_id(),
+                    SqlConversationItem.conversation_id == conversation_id,
+                    SqlConversationItem.position >= target_position,
+                )
+            )
+            for item in kept_items:
+                insert_fts(session, item.id, conversation_id, item.search_text or "")
+
+            conversation.next_position = target_position
+            conversation.updated_at = now
+            reset_label_keys = _RUNTIME_INSTANCE_LABEL_KEYS | {
+                FORK_CARRY_HISTORY_LABEL_KEY,
+                FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY,
+            }
+            session.execute(
+                delete(SqlConversationLabel).where(
+                    SqlConversationLabel.workspace_id == current_workspace_id(),
+                    SqlConversationLabel.conversation_id == conversation_id,
+                    SqlConversationLabel.key.in_(reset_label_keys),
+                )
+            )
+            if carry_history_into_native:
+                _upsert_labels(
+                    session,
+                    conversation_id,
+                    {FORK_CARRY_HISTORY_LABEL_KEY: "1"},
+                    now,
+                )
+
+        with self._session() as session:
+            metadata = session.get(
+                SqlConversationMetadata,
+                (current_workspace_id(), conversation_id),
+            )
+            if metadata is not None:
+                metadata.external_session_id = None
+
+        updated = self.get_conversation(conversation_id)
+        if updated is None:
+            raise LookupError(f"conversation not found: {conversation_id!r}")
+        return updated
 
     def fork_conversation(
         self,

--- a/openapi.json
+++ b/openapi.json
@@ -5071,6 +5071,61 @@
         "title": "SessionResponse",
         "type": "object"
       },
+      "SessionRevertRequest": {
+        "additionalProperties": false,
+        "description": "Request to rewind a session to before a past user message.",
+        "properties": {
+          "revert_files": {
+            "default": false,
+            "title": "Revert Files",
+            "type": "boolean"
+          },
+          "user_message_id": {
+            "minLength": 1,
+            "title": "User Message Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_message_id"
+        ],
+        "title": "SessionRevertRequest",
+        "type": "object"
+      },
+      "SessionRevertResponse": {
+        "description": "Rewound session plus the selected prompt and optional file result.",
+        "properties": {
+          "draft": {
+            "title": "Draft",
+            "type": "string"
+          },
+          "file_revert_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Revert Error"
+          },
+          "files_reverted": {
+            "default": false,
+            "title": "Files Reverted",
+            "type": "boolean"
+          },
+          "session": {
+            "$ref": "#/components/schemas/SessionResponse"
+          }
+        },
+        "required": [
+          "session",
+          "draft"
+        ],
+        "title": "SessionRevertResponse",
+        "type": "object"
+      },
       "SessionSandboxStatusEvent": {
         "description": "Managed-sandbox launch progress for a `host_type=\"managed\"` session.\n\nA managed create returns before its sandbox exists; the Omnigent\nserver emits this event as the background launch pipeline advances\nso the Web UI can show live provisioning progress on the session\npage instead of a silent dead chat: sandbox provision \u2192 repository\nclone \u2192 host startup \u2192 runner connect \u2192 ready, or a terminal\nfailure with the reason.",
         "properties": {
@@ -11209,6 +11264,59 @@
           }
         },
         "summary": "Fork Session",
+        "tags": [
+          "sessions"
+        ]
+      }
+    },
+    "/v1/sessions/{source_id}/revert": {
+      "post": {
+        "description": "Rewind one session to immediately before a selected user message.",
+        "operationId": "revert_session_v1_sessions__source_id__revert_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "source_id",
+            "required": true,
+            "schema": {
+              "title": "Source Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionRevertRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionRevertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Revert Session",
         "tags": [
           "sessions"
         ]

--- a/openapi.json
+++ b/openapi.json
@@ -5093,7 +5093,7 @@
         "type": "object"
       },
       "SessionRevertResponse": {
-        "description": "Rewound session plus the selected prompt and optional file result.",
+        "description": "Selected prompt plus any non-fatal file-restore warning.",
         "properties": {
           "draft": {
             "title": "Draft",
@@ -5109,19 +5109,11 @@
               }
             ],
             "title": "File Revert Error"
-          },
-          "files_reverted": {
-            "default": false,
-            "title": "Files Reverted",
-            "type": "boolean"
-          },
-          "session": {
-            "$ref": "#/components/schemas/SessionResponse"
           }
         },
         "required": [
-          "session",
-          "draft"
+          "draft",
+          "file_revert_error"
         ],
         "title": "SessionRevertResponse",
         "type": "object"

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -936,11 +936,7 @@ class SessionsNamespace:
         *,
         revert_files: bool = False,
     ) -> dict[str, Any]:
-        """Rewind a session to immediately before a past user message.
-
-        The response contains the updated ``session``, the selected prompt as
-        ``draft``, and optional file-rollback results.
-        """
+        """Rewind a session and return the selected prompt plus any file warning."""
         body: dict[str, Any] = {
             "user_message_id": user_message_id,
             "revert_files": revert_files,

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -929,6 +929,32 @@ class SessionsNamespace:
             f"POST /v1/sessions/{source_session_id}/fork",
         )
 
+    async def revert(
+        self,
+        source_session_id: str,
+        user_message_id: str,
+        *,
+        revert_files: bool = False,
+    ) -> dict[str, Any]:
+        """Rewind a session to immediately before a past user message.
+
+        The response contains the updated ``session``, the selected prompt as
+        ``draft``, and optional file-rollback results.
+        """
+        body: dict[str, Any] = {
+            "user_message_id": user_message_id,
+            "revert_files": revert_files,
+        }
+        resp = await self._http.post(
+            f"{self._base}/v1/sessions/{source_session_id}/revert",
+            json=body,
+        )
+        raise_for_status(resp.status_code, response_body(resp))
+        return require_json_object(
+            resp,
+            f"POST /v1/sessions/{source_session_id}/revert",
+        )
+
     async def compact(self, session_id: str) -> None:
         """
         Request explicit context compaction for a session.

--- a/tests/repl/test_repl_revert_command.py
+++ b/tests/repl/test_repl_revert_command.py
@@ -11,28 +11,22 @@ pytestmark = pytest.mark.asyncio
 
 async def test_revert_command_registered_and_filters_system_messages() -> None:
     """``/revert`` is discoverable and only offers real user prompts."""
+
+    def message(item_id: str, text: str, **extra: object) -> dict[str, object]:
+        return {
+            "id": item_id,
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": text}],
+            **extra,
+        }
+
     assert "/revert" in repl_mod.COMMANDS
     candidates = repl_mod._revert_user_messages(
         [
-            {
-                "id": "msg_real",
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "retry me"}],
-            },
-            {
-                "id": "msg_system",
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "[System: timer fired]"}],
-            },
-            {
-                "id": "msg_meta",
-                "type": "message",
-                "role": "user",
-                "is_meta": True,
-                "content": [{"type": "input_text", "text": "hidden"}],
-            },
+            message("msg_real", "retry me"),
+            message("msg_system", "[System: timer fired]"),
+            message("msg_meta", "hidden", is_meta=True),
         ]
     )
     assert [item["id"] for item in candidates] == ["msg_real"]

--- a/tests/repl/test_repl_revert_command.py
+++ b/tests/repl/test_repl_revert_command.py
@@ -1,0 +1,38 @@
+"""Tests for the REPL ``/revert`` slash command."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.repl import _repl as repl_mod
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_revert_command_registered_and_filters_system_messages() -> None:
+    """``/revert`` is discoverable and only offers real user prompts."""
+    assert "/revert" in repl_mod.COMMANDS
+    candidates = repl_mod._revert_user_messages(
+        [
+            {
+                "id": "msg_real",
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "retry me"}],
+            },
+            {
+                "id": "msg_system",
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "[System: timer fired]"}],
+            },
+            {
+                "id": "msg_meta",
+                "type": "message",
+                "role": "user",
+                "is_meta": True,
+                "content": [{"type": "input_text", "text": "hidden"}],
+            },
+        ]
+    )
+    assert [item["id"] for item in candidates] == ["msg_real"]

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -35,7 +35,6 @@ import asyncio
 import json
 import logging
 import os
-import subprocess
 import tempfile
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
@@ -43,6 +42,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace, TracebackType
 from typing import Any, cast
+from unittest.mock import Mock
 
 import httpx
 import pytest
@@ -7035,47 +7035,34 @@ async def test_create_session_reinit_preserves_existing_inbox() -> None:
 
 
 @pytest.mark.asyncio
-async def test_revert_file_control_restores_runner_git_checkpoint(tmp_path: Path) -> None:
-    """Runner capture/revert controls restore the workspace without a harness turn."""
-    env = {
-        **os.environ,
-        "GIT_AUTHOR_NAME": "Test",
-        "GIT_AUTHOR_EMAIL": "test@example.com",
-        "GIT_COMMITTER_NAME": "Test",
-        "GIT_COMMITTER_EMAIL": "test@example.com",
-    }
-    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
-    tracked = tmp_path / "tracked.py"
-    tracked.write_text("base\n")
-    subprocess.run(["git", "add", "tracked.py"], cwd=tmp_path, check=True, env=env)
-    subprocess.run(
-        ["git", "commit", "-m", "init"],
-        cwd=tmp_path,
-        check=True,
-        capture_output=True,
-        env=env,
-    )
-    tracked.write_text("checkpoint\n")
+async def test_revert_file_control_routes_to_filesystem_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Runner capture/revert controls call the session filesystem registry."""
     app = create_runner_app(
         process_manager=cast(HarnessProcessManager, _FakeProcessManager()),
         server_client=NullServerClient(),  # type: ignore[arg-type]
         runner_workspace=tmp_path,
     )
+    registry = app.state.filesystem_registry
+    create_checkpoint = Mock(return_value=True)
+    restore_checkpoint = Mock(return_value=True)
+    monkeypatch.setattr(registry, "create_revert_checkpoint", create_checkpoint)
+    monkeypatch.setattr(registry, "restore_revert_checkpoint", restore_checkpoint)
 
     async with _runner_test_client(app) as http:
         captured = await http.post(
             "/v1/sessions/conv_revert/events",
             json={"type": "capture_revert_checkpoint", "checkpoint_id": "msg_1"},
         )
-        assert captured.status_code == 200, captured.text
-        tracked.write_text("later\n")
         restored = await http.post(
             "/v1/sessions/conv_revert/events",
             json={"type": "revert_files", "checkpoint_id": "msg_1"},
         )
 
-    assert restored.status_code == 200, restored.text
-    assert tracked.read_text() == "checkpoint\n"
+    assert captured.status_code == restored.status_code == 200
+    create_checkpoint.assert_called_once_with("conv_revert", "msg_1")
+    restore_checkpoint.assert_called_once_with("conv_revert", "msg_1")
 
 
 # ── approval-event flattening (elicitation-approval hang regression) ──────

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -35,6 +35,7 @@ import asyncio
 import json
 import logging
 import os
+import subprocess
 import tempfile
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
@@ -7031,6 +7032,50 @@ async def test_create_session_reinit_preserves_existing_inbox() -> None:
             )
     finally:
         runner_app._session_inboxes_ref.pop(session_id, None)
+
+
+@pytest.mark.asyncio
+async def test_revert_file_control_restores_runner_git_checkpoint(tmp_path: Path) -> None:
+    """Runner capture/revert controls restore the workspace without a harness turn."""
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    tracked = tmp_path / "tracked.py"
+    tracked.write_text("base\n")
+    subprocess.run(["git", "add", "tracked.py"], cwd=tmp_path, check=True, env=env)
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    tracked.write_text("checkpoint\n")
+    app = create_runner_app(
+        process_manager=cast(HarnessProcessManager, _FakeProcessManager()),
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        runner_workspace=tmp_path,
+    )
+
+    async with _runner_test_client(app) as http:
+        captured = await http.post(
+            "/v1/sessions/conv_revert/events",
+            json={"type": "capture_revert_checkpoint", "checkpoint_id": "msg_1"},
+        )
+        assert captured.status_code == 200, captured.text
+        tracked.write_text("later\n")
+        restored = await http.post(
+            "/v1/sessions/conv_revert/events",
+            json={"type": "revert_files", "checkpoint_id": "msg_1"},
+        )
+
+    assert restored.status_code == 200, restored.text
+    assert tracked.read_text() == "checkpoint\n"
 
 
 # ── approval-event flattening (elicitation-approval hang regression) ──────

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -1038,3 +1038,51 @@ def test_git_line_counts_numstat_failure_degrades_but_status_intact(
     assert rec["status"] == "modified"
     assert rec["lines_added"] is None, rec
     assert rec["lines_removed"] is None, rec
+
+
+def test_git_revert_checkpoint_restores_tracked_and_untracked_files(tmp_path: Path) -> None:
+    """A checkpoint restores the exact non-ignored workspace tree without moving HEAD."""
+    env = _init_git_with_commit(tmp_path, "tracked.py", "base\n")
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout.strip()
+    (tmp_path / "tracked.py").write_text("at checkpoint\n")
+    (tmp_path / "checkpoint-only.py").write_text("keep me\n")
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+
+    assert reg.create_revert_checkpoint("conv_test", "msg_1") is True
+
+    (tmp_path / "tracked.py").write_text("after checkpoint\n")
+    (tmp_path / "checkpoint-only.py").unlink()
+    (tmp_path / "later.py").write_text("remove me\n")
+
+    assert reg.restore_revert_checkpoint("conv_test", "msg_1") is True
+    assert (tmp_path / "tracked.py").read_text() == "at checkpoint\n"
+    assert (tmp_path / "checkpoint-only.py").read_text() == "keep me\n"
+    assert not (tmp_path / "later.py").exists()
+    restored_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout.strip()
+    assert restored_head == head
+    assert (
+        subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=tmp_path, env=env).returncode
+        == 0
+    )
+
+
+def test_non_git_revert_checkpoint_is_unsupported(tmp_path: Path) -> None:
+    """Non-Git workspaces keep files instead of pretending a checkpoint exists."""
+    reg = AgentEditFilesystemRegistry(watch_path=tmp_path)
+
+    assert reg.create_revert_checkpoint("conv_test", "msg_1") is False
+    assert reg.restore_revert_checkpoint("conv_test", "msg_1") is False

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -1043,41 +1043,28 @@ def test_git_line_counts_numstat_failure_degrades_but_status_intact(
 def test_git_revert_checkpoint_restores_tracked_and_untracked_files(tmp_path: Path) -> None:
     """A checkpoint restores the exact non-ignored workspace tree without moving HEAD."""
     env = _init_git_with_commit(tmp_path, "tracked.py", "base\n")
-    head = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=tmp_path,
-        check=True,
-        capture_output=True,
-        text=True,
-        env=env,
-    ).stdout.strip()
+    head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=tmp_path, text=True, env=env)
     (tmp_path / "tracked.py").write_text("at checkpoint\n")
     (tmp_path / "checkpoint-only.py").write_text("keep me\n")
     reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
 
-    assert reg.create_revert_checkpoint("conv_test", "msg_1") is True
+    reg.create_revert_checkpoint("conv_test", "msg_1")
 
     (tmp_path / "tracked.py").write_text("after checkpoint\n")
     (tmp_path / "checkpoint-only.py").unlink()
     (tmp_path / "later.py").write_text("remove me\n")
 
-    assert reg.restore_revert_checkpoint("conv_test", "msg_1") is True
+    reg.restore_revert_checkpoint("conv_test", "msg_1")
     assert (tmp_path / "tracked.py").read_text() == "at checkpoint\n"
     assert (tmp_path / "checkpoint-only.py").read_text() == "keep me\n"
     assert not (tmp_path / "later.py").exists()
-    restored_head = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=tmp_path,
-        check=True,
-        capture_output=True,
-        text=True,
-        env=env,
-    ).stdout.strip()
-    assert restored_head == head
     assert (
-        subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=tmp_path, env=env).returncode
-        == 0
+        subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=tmp_path, text=True, env=env)
+        == head
     )
+    assert not subprocess.run(
+        ["git", "diff", "--cached", "--quiet"], cwd=tmp_path, env=env
+    ).returncode
 
 
 def test_non_git_revert_checkpoint_is_unsupported(tmp_path: Path) -> None:

--- a/tests/server/integration/test_sessions_revert.py
+++ b/tests/server/integration/test_sessions_revert.py
@@ -1,0 +1,100 @@
+"""Integration tests for in-place session revert."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.server.helpers import create_test_agent
+from tests.server.integration.test_sessions_endpoints import (
+    _create_session,
+    _wait_for_idle,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _get_session_items(
+    client: httpx.AsyncClient,
+    session_id: str,
+) -> list[dict[str, Any]]:
+    response = await client.get(f"/v1/sessions/{session_id}/items")
+    assert response.status_code == 200, response.text
+    return response.json()["data"]
+
+
+async def test_revert_rewinds_the_same_session_before_selected_user_message(
+    client: httpx.AsyncClient,
+) -> None:
+    """Revert mutates the source id and returns the selected prompt as a draft."""
+    agent = await create_test_agent(client)
+    source = await _create_session(client, agent["id"], initial_message="retry this prompt")
+    await _wait_for_idle(client, source["id"])
+    source_items = await _get_session_items(client, source["id"])
+    target = next(
+        item for item in source_items if item["type"] == "message" and item["role"] == "user"
+    )
+
+    response = await client.post(
+        f"/v1/sessions/{source['id']}/revert",
+        json={"user_message_id": target["id"]},
+    )
+
+    assert response.status_code == 200, response.text
+    result = response.json()
+    assert result["session"]["id"] == source["id"]
+    assert result["draft"] == "retry this prompt"
+    assert result["files_reverted"] is False
+    assert await _get_session_items(client, source["id"]) == []
+
+
+async def test_revert_resets_a_live_native_runtime_before_rewinding(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Native terminals are closed so discarded native history cannot return."""
+    from omnigent.server.routes import sessions as sessions_module
+
+    agent = await create_test_agent(client)
+    source = await _create_session(client, agent["id"], initial_message="retry native prompt")
+    await _wait_for_idle(client, source["id"])
+    source_items = await _get_session_items(client, source["id"])
+    target = next(
+        item for item in source_items if item["type"] == "message" and item["role"] == "user"
+    )
+    reset_paths: list[str] = []
+
+    def runner_handler(request: httpx.Request) -> httpx.Response:
+        reset_paths.append(request.url.path)
+        return httpx.Response(200, json={"reset": True})
+
+    runner_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(runner_handler),
+        base_url="http://runner",
+    )
+
+    async def get_runner(*_args: object, **_kwargs: object) -> httpx.AsyncClient:
+        return runner_client
+
+    monkeypatch.setattr(sessions_module, "_agent_is_native", lambda _agent: True)
+    monkeypatch.setattr(
+        sessions_module,
+        "_agent_carries_native_fork_history",
+        lambda _agent: True,
+    )
+    monkeypatch.setattr(sessions_module, "_get_runner_client", get_runner)
+    try:
+        response = await client.post(
+            f"/v1/sessions/{source['id']}/revert",
+            json={"user_message_id": target["id"]},
+        )
+    finally:
+        await runner_client.aclose()
+
+    assert response.status_code == 200, response.text
+    assert reset_paths == [f"/v1/sessions/{source['id']}/reset-state"]
+    result = response.json()
+    assert result["session"]["id"] == source["id"]
+    assert result["session"]["labels"]["omnigent.fork.carry_history"] == "1"

--- a/tests/server/integration/test_sessions_revert.py
+++ b/tests/server/integration/test_sessions_revert.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -16,13 +17,12 @@ from tests.server.integration.test_sessions_endpoints import (
 pytestmark = pytest.mark.asyncio
 
 
-async def _get_session_items(
-    client: httpx.AsyncClient,
-    session_id: str,
-) -> list[dict[str, Any]]:
-    response = await client.get(f"/v1/sessions/{session_id}/items")
-    assert response.status_code == 200, response.text
-    return response.json()["data"]
+def _first_user_message(snapshot: dict[str, Any]) -> dict[str, Any]:
+    return next(
+        item
+        for item in snapshot["items"]
+        if item["type"] == "message" and item["data"]["role"] == "user"
+    )
 
 
 async def test_revert_rewinds_the_same_session_before_selected_user_message(
@@ -31,11 +31,7 @@ async def test_revert_rewinds_the_same_session_before_selected_user_message(
     """Revert mutates the source id and returns the selected prompt as a draft."""
     agent = await create_test_agent(client)
     source = await _create_session(client, agent["id"], initial_message="retry this prompt")
-    await _wait_for_idle(client, source["id"])
-    source_items = await _get_session_items(client, source["id"])
-    target = next(
-        item for item in source_items if item["type"] == "message" and item["role"] == "user"
-    )
+    target = _first_user_message(await _wait_for_idle(client, source["id"]))
 
     response = await client.post(
         f"/v1/sessions/{source['id']}/revert",
@@ -43,11 +39,10 @@ async def test_revert_rewinds_the_same_session_before_selected_user_message(
     )
 
     assert response.status_code == 200, response.text
-    result = response.json()
-    assert result["session"]["id"] == source["id"]
-    assert result["draft"] == "retry this prompt"
-    assert result["files_reverted"] is False
-    assert await _get_session_items(client, source["id"]) == []
+    assert response.json() == {"draft": "retry this prompt", "file_revert_error": None}
+    snapshot = (await client.get(f"/v1/sessions/{source['id']}")).json()
+    assert snapshot["id"] == source["id"]
+    assert snapshot["items"] == []
 
 
 async def test_revert_resets_a_live_native_runtime_before_rewinding(
@@ -59,24 +54,13 @@ async def test_revert_resets_a_live_native_runtime_before_rewinding(
 
     agent = await create_test_agent(client)
     source = await _create_session(client, agent["id"], initial_message="retry native prompt")
-    await _wait_for_idle(client, source["id"])
-    source_items = await _get_session_items(client, source["id"])
-    target = next(
-        item for item in source_items if item["type"] == "message" and item["role"] == "user"
+    target = _first_user_message(await _wait_for_idle(client, source["id"]))
+    runner_client = AsyncMock()
+    runner_client.post.return_value = httpx.Response(
+        200,
+        json={"reset": True},
+        request=httpx.Request("POST", "http://runner/reset-state"),
     )
-    reset_paths: list[str] = []
-
-    def runner_handler(request: httpx.Request) -> httpx.Response:
-        reset_paths.append(request.url.path)
-        return httpx.Response(200, json={"reset": True})
-
-    runner_client = httpx.AsyncClient(
-        transport=httpx.MockTransport(runner_handler),
-        base_url="http://runner",
-    )
-
-    async def get_runner(*_args: object, **_kwargs: object) -> httpx.AsyncClient:
-        return runner_client
 
     monkeypatch.setattr(sessions_module, "_agent_is_native", lambda _agent: True)
     monkeypatch.setattr(
@@ -84,17 +68,20 @@ async def test_revert_resets_a_live_native_runtime_before_rewinding(
         "_agent_carries_native_fork_history",
         lambda _agent: True,
     )
-    monkeypatch.setattr(sessions_module, "_get_runner_client", get_runner)
-    try:
-        response = await client.post(
-            f"/v1/sessions/{source['id']}/revert",
-            json={"user_message_id": target["id"]},
-        )
-    finally:
-        await runner_client.aclose()
+    monkeypatch.setattr(
+        sessions_module,
+        "_get_runner_client",
+        AsyncMock(return_value=runner_client),
+    )
+    response = await client.post(
+        f"/v1/sessions/{source['id']}/revert",
+        json={"user_message_id": target["id"]},
+    )
 
     assert response.status_code == 200, response.text
-    assert reset_paths == [f"/v1/sessions/{source['id']}/reset-state"]
-    result = response.json()
-    assert result["session"]["id"] == source["id"]
-    assert result["session"]["labels"]["omnigent.fork.carry_history"] == "1"
+    runner_client.post.assert_awaited_once_with(
+        f"/v1/sessions/{source['id']}/reset-state",
+        timeout=15.0,
+    )
+    snapshot = (await client.get(f"/v1/sessions/{source['id']}")).json()
+    assert snapshot["labels"]["omnigent.fork.carry_history"] == "1"

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3544,6 +3544,52 @@ def test_fork_conversation_up_to_response_truncates_items(
     assert len(conversation_store.list_items(source.id).data) == 6
 
 
+def test_rewind_conversation_removes_selected_prompt_and_later_history(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Rewind mutates one session, resets native state, and keeps FTS valid."""
+    from omnigent.stores.conversation_store import (
+        CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY,
+        FORK_CARRY_HISTORY_LABEL_KEY,
+    )
+
+    source = conversation_store.create_conversation(title="Keep this title")
+    conversation_store.set_external_session_id(source.id, "native-session-old")
+    conversation_store.set_labels(
+        source.id,
+        {
+            "omnigent.claude_native.bridge_id": "bridge-old",
+            CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY: "1",
+        },
+    )
+    _append_three_responses(conversation_store, source.id)
+    source_items = conversation_store.list_items(source.id).data
+
+    rewound = conversation_store.rewind_conversation(
+        source.id,
+        before_item_id=source_items[2].id,
+        carry_history_into_native=True,
+    )
+
+    rewound_items = conversation_store.list_items(source.id).data
+    texts = [
+        block["text"]
+        for item in rewound_items
+        for block in item.data.content  # type: ignore[union-attr]
+    ]
+    assert rewound.id == source.id
+    assert rewound.title == "Keep this title"
+    assert rewound.external_session_id is None
+    assert rewound.labels[FORK_CARRY_HISTORY_LABEL_KEY] == "1"
+    assert "omnigent.claude_native.bridge_id" not in rewound.labels
+    assert rewound.labels[CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY] == "1"
+    assert texts == ["Q1", "A1"]
+    assert conversation_store.search("Q2", conversation_id=source.id) == []
+    assert [item.id for item in conversation_store.search("Q1", conversation_id=source.id)] == [
+        rewound_items[0].id
+    ]
+
+
 def test_fork_conversation_truncated_drops_external_session_directive(
     conversation_store: SqlAlchemyConversationStore,
     agent_store: SqlAlchemyAgentStore,

--- a/web/src/components/SlashCommandMenu.tsx
+++ b/web/src/components/SlashCommandMenu.tsx
@@ -18,6 +18,7 @@ export const BUILTIN_SLASH_COMMANDS: Record<string, string> = {
   "/context": "Show context window usage for this session",
   "/effort": "Set reasoning effort: /effort low | medium | high | default",
   "/model": "Switch the model for this session: /model <name> | default",
+  "/revert": "Return to a past user message",
   "/help": "Show available slash commands",
 };
 

--- a/web/src/lib/sessionDrafts.ts
+++ b/web/src/lib/sessionDrafts.ts
@@ -1,0 +1,41 @@
+const SESSION_DRAFTS_KEY = "omnigent.sessionDrafts";
+export const SESSION_TEXT_DRAFT_EVENT = "omnigent:session-text-draft";
+
+function loadDraftsFromStorage(): Map<string, { text: string; files: File[] }> {
+  try {
+    const raw = window.sessionStorage.getItem(SESSION_DRAFTS_KEY);
+    if (!raw) return new Map();
+    const stored = JSON.parse(raw) as Record<string, string>;
+    return new Map(
+      Object.entries(stored)
+        .filter(([, text]) => Boolean(text))
+        .map(([id, text]) => [id, { text, files: [] }]),
+    );
+  } catch {
+    return new Map();
+  }
+}
+
+export const sessionDrafts = loadDraftsFromStorage();
+
+export function saveDraftsToStorage(drafts: Map<string, { text: string; files: File[] }>): void {
+  try {
+    const stored = Object.fromEntries(
+      [...drafts].filter(([, draft]) => Boolean(draft.text)).map(([id, draft]) => [id, draft.text]),
+    );
+    if (Object.keys(stored).length > 0) {
+      window.sessionStorage.setItem(SESSION_DRAFTS_KEY, JSON.stringify(stored));
+    } else {
+      window.sessionStorage.removeItem(SESSION_DRAFTS_KEY);
+    }
+  } catch {
+    // In-memory drafts still work when storage is unavailable.
+  }
+}
+
+export function setSessionTextDraft(sessionId: string, text: string): void {
+  if (text) sessionDrafts.set(sessionId, { text, files: [] });
+  else sessionDrafts.delete(sessionId);
+  saveDraftsToStorage(sessionDrafts);
+  window.dispatchEvent(new CustomEvent(SESSION_TEXT_DRAFT_EVENT, { detail: { sessionId, text } }));
+}

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -312,25 +312,12 @@ describe("forkSession", () => {
 });
 
 describe("revertSession", () => {
-  it("POSTs snake-case options and parses the nested session result", async () => {
+  it("POSTs snake-case options and parses the result", async () => {
     fetchMock.mockResolvedValueOnce(
-      mockJsonResponse({
-        session: {
-          id: "conv source",
-          agent_id: "agent_clone",
-          status: "idle",
-          created_at: 1704067200,
-          items: [],
-        },
-        draft: "retry this",
-        files_reverted: true,
-        file_revert_error: null,
-      }),
+      mockJsonResponse({ draft: "retry this", file_revert_error: null }),
     );
 
-    const result = await revertSession("conv source", "msg_1", {
-      revertFiles: true,
-    });
+    const result = await revertSession("conv source", "msg_1", true);
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("/v1/sessions/conv%20source/revert");
@@ -338,9 +325,7 @@ describe("revertSession", () => {
       user_message_id: "msg_1",
       revert_files: true,
     });
-    expect(result.session.id).toBe("conv source");
-    expect(result.draft).toBe("retry this");
-    expect(result.filesReverted).toBe(true);
+    expect(result).toEqual({ draft: "retry this", fileRevertError: null });
   });
 });
 

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -20,6 +20,7 @@ import {
   listRunners,
   openSessionStream,
   postEvent,
+  revertSession,
   SESSION_HISTORY_PAGE_SIZE,
   stopSession,
   updateSession,
@@ -307,6 +308,39 @@ describe("forkSession", () => {
   it("surfaces a non-ok response as a thrown error (e.g. 403 no access)", async () => {
     fetchMock.mockResolvedValueOnce(mockJsonResponse({}, { ok: false, status: 403 }));
     await expect(forkSession("conv_src")).rejects.toThrow(/403/);
+  });
+});
+
+describe("revertSession", () => {
+  it("POSTs snake-case options and parses the nested session result", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        session: {
+          id: "conv source",
+          agent_id: "agent_clone",
+          status: "idle",
+          created_at: 1704067200,
+          items: [],
+        },
+        draft: "retry this",
+        files_reverted: true,
+        file_revert_error: null,
+      }),
+    );
+
+    const result = await revertSession("conv source", "msg_1", {
+      revertFiles: true,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv%20source/revert");
+    expect(JSON.parse(init.body as string)).toEqual({
+      user_message_id: "msg_1",
+      revert_files: true,
+    });
+    expect(result.session.id).toBe("conv source");
+    expect(result.draft).toBe("retry this");
+    expect(result.filesReverted).toBe(true);
   });
 });
 

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -550,9 +550,7 @@ export async function forkSession(
  *   is running) so the caller can surface it inline.
  */
 export interface RevertSessionResult {
-  session: Session;
   draft: string;
-  filesReverted: boolean;
   fileRevertError: string | null;
 }
 
@@ -560,28 +558,21 @@ export interface RevertSessionResult {
 export async function revertSession(
   sourceId: string,
   userMessageId: string,
-  options: { revertFiles?: boolean } = {},
+  revertFiles = false,
 ): Promise<RevertSessionResult> {
   const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sourceId)}/revert`, {
     method: "POST",
     headers: { "Content-Type": "application/json", "X-Omnigent-Client": getClientSurface() },
     body: JSON.stringify({
       user_message_id: userMessageId,
-      revert_files: options.revertFiles ?? false,
+      revert_files: revertFiles,
     }),
   });
   const body = await readJsonOrThrow<{
-    session: SessionResponseWire;
     draft: string;
-    files_reverted?: boolean;
-    file_revert_error?: string | null;
+    file_revert_error: string | null;
   }>(res);
-  return {
-    session: sessionFromWire(body.session),
-    draft: body.draft,
-    filesReverted: body.files_reverted ?? false,
-    fileRevertError: body.file_revert_error ?? null,
-  };
+  return { draft: body.draft, fileRevertError: body.file_revert_error };
 }
 
 export async function switchSessionAgent(sessionId: string, agentId: string): Promise<Session> {

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -549,6 +549,41 @@ export async function forkSession(
  * @throws Error carrying the server's failure detail (e.g. 409 when a turn
  *   is running) so the caller can surface it inline.
  */
+export interface RevertSessionResult {
+  session: Session;
+  draft: string;
+  filesReverted: boolean;
+  fileRevertError: string | null;
+}
+
+/** Rewind a session to immediately before a selected user message. */
+export async function revertSession(
+  sourceId: string,
+  userMessageId: string,
+  options: { revertFiles?: boolean } = {},
+): Promise<RevertSessionResult> {
+  const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sourceId)}/revert`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-Omnigent-Client": getClientSurface() },
+    body: JSON.stringify({
+      user_message_id: userMessageId,
+      revert_files: options.revertFiles ?? false,
+    }),
+  });
+  const body = await readJsonOrThrow<{
+    session: SessionResponseWire;
+    draft: string;
+    files_reverted?: boolean;
+    file_revert_error?: string | null;
+  }>(res);
+  return {
+    session: sessionFromWire(body.session),
+    draft: body.draft,
+    filesReverted: body.files_reverted ?? false,
+    fileRevertError: body.file_revert_error ?? null,
+  };
+}
+
 export async function switchSessionAgent(sessionId: string, agentId: string): Promise<Session> {
   const res = await authenticatedFetch(
     `/v1/sessions/${encodeURIComponent(sessionId)}/switch-agent`,

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -32,6 +32,7 @@ import {
   TerminalIcon,
   WifiOffIcon,
   XIcon,
+  Undo2Icon,
 } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -176,6 +177,7 @@ import { GoalControl, GoalStatusPill, useGoalState, type Goal } from "@/componen
 import { copyText } from "@/lib/clipboard";
 import { showToast } from "@/components/ui/toast";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
+import { saveDraftsToStorage, sessionDrafts, SESSION_TEXT_DRAFT_EVENT } from "@/lib/sessionDrafts";
 
 // Matches both wordings the native executors emit: "[Attached: <path>]"
 // (claude/pi/cursor) and "[Attached file: <path>]" (codex). Capturing group
@@ -504,46 +506,8 @@ function truncateTitle(raw: string, max = 60): string {
   return slice.slice(0, cut).join("").trimEnd() + "…";
 }
 
-// Per-session draft storage — module-level so it survives the Composer
-// unmount/remount that happens during the loading gate between session
-// switches (ChatPage returns <HydratingPlaceholder /> while
-// loadingConversation is true, which unmounts the entire chat surface).
-// Text drafts are also persisted to sessionStorage so they survive page
-// refreshes; File objects can't be serialized, so only text round-trips.
-const SESSION_DRAFTS_KEY = "omnigent.sessionDrafts";
-
-function loadDraftsFromStorage(): Map<string, { text: string; files: File[] }> {
-  try {
-    const raw = window.sessionStorage.getItem(SESSION_DRAFTS_KEY);
-    if (!raw) return new Map();
-    const entries = JSON.parse(raw) as Record<string, string>;
-    const map = new Map<string, { text: string; files: File[] }>();
-    for (const [id, text] of Object.entries(entries)) {
-      if (text) map.set(id, { text, files: [] });
-    }
-    return map;
-  } catch {
-    return new Map();
-  }
-}
-
-function saveDraftsToStorage(drafts: Map<string, { text: string; files: File[] }>): void {
-  try {
-    const obj: Record<string, string> = {};
-    for (const [id, draft] of drafts) {
-      if (draft.text) obj[id] = draft.text;
-    }
-    if (Object.keys(obj).length === 0) {
-      window.sessionStorage.removeItem(SESSION_DRAFTS_KEY);
-    } else {
-      window.sessionStorage.setItem(SESSION_DRAFTS_KEY, JSON.stringify(obj));
-    }
-  } catch {
-    // Storage full or unavailable — drafts still work in-memory.
-  }
-}
-
-const sessionDrafts = loadDraftsFromStorage();
+// Draft storage is shared with RevertSessionDialog so a selected past prompt
+// can be prefilled in the newly-created session before its composer mounts.
 
 /**
  * Single component that drives the chat surface. Streaming + history
@@ -3061,6 +3025,7 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
   const sessionId = useChatStore((s) => s.conversationId);
   // Author labels only matter once the session is shared with someone else.
   const isSessionShared = useContext(SessionSharedContext);
+  const forkDialog = useForkDialog();
   // Plain-text path is the common case.
   // - input_image: render inline <img> when the file is uploaded (file_id
   //   doesn't start with "pending:"); show a chip while the upload is
@@ -3213,11 +3178,24 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
           {text && <FilePathAwareMessageResponse breaks>{text}</FilePathAwareMessageResponse>}
         </MessageContent>
       </div>
-      {text && (
+      {(text || forkDialog?.canRevert) && (
         <MessageActions className="mt-1 ml-auto opacity-40 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100">
-          <MessageAction tooltip="Copy" onClick={handleCopy}>
-            {isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
-          </MessageAction>
+          {text && (
+            <MessageAction tooltip="Copy" onClick={handleCopy}>
+              {isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
+            </MessageAction>
+          )}
+          {forkDialog?.canRevert &&
+            !bubble.itemId.startsWith("pend_") &&
+            !bubble.itemId.startsWith("pending_") && (
+              <MessageAction
+                tooltip="Revert to here"
+                data-testid="revert-from-message"
+                onClick={() => forkDialog.openRevertDialog({ userMessageId: bubble.itemId })}
+              >
+                <Undo2Icon size={14} />
+              </MessageAction>
+            )}
         </MessageActions>
       )}
     </Message>
@@ -3799,6 +3777,7 @@ export function Composer({
 }: ComposerProps) {
   const [value, setValue] = useState("");
   const [files, setFiles] = useState<File[]>([]);
+  const forkDialog = useForkDialog();
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [commandError, setCommandError] = useState<string | null>(null);
   const [planModeBusy, setPlanModeBusy] = useState(false);
@@ -3964,6 +3943,21 @@ export function Composer({
       }
       saveDraftsToStorage(sessionDrafts);
     };
+  }, [conversationId]);
+
+  useEffect(() => {
+    const applyDraft = (event: Event): void => {
+      const detail = (event as CustomEvent<{ sessionId: string; text: string }>).detail;
+      if (detail.sessionId !== conversationId) return;
+      sessionDrafts.delete(detail.sessionId);
+      saveDraftsToStorage(sessionDrafts);
+      setValue(detail.text);
+      setFiles([]);
+      dirtyRef.current = false;
+      if (!isMobileRef.current) textareaRef.current?.focus();
+    };
+    window.addEventListener(SESSION_TEXT_DRAFT_EVENT, applyDraft);
+    return () => window.removeEventListener(SESSION_TEXT_DRAFT_EVENT, applyDraft);
   }, [conversationId]);
 
   // Adding a reply quote (via the floating "Reply" button) should drop the
@@ -4215,6 +4209,17 @@ export function Composer({
           .catch((err: unknown) => {
             setCommandError(err instanceof Error ? err.message : "Failed to set model");
           });
+        return true;
+      }
+      case "/revert": {
+        if (!forkDialog?.canRevert) {
+          setCommandError("/revert is unavailable for this session");
+          return true;
+        }
+        dirtyRef.current = true;
+        setValue("");
+        setCommandError(null);
+        forkDialog.openRevertDialog({ userMessageId: arg || undefined });
         return true;
       }
       case "/context": {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -89,6 +89,7 @@ import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
 import { CommandPalette } from "./CommandPalette";
 import { Toaster } from "@/components/ui/toast";
 import { ForkSessionDialog } from "./ForkSessionDialog";
+import { RevertSessionDialog } from "./RevertSessionDialog";
 import { ForkDialogContextProvider, type ForkDialogContextValue } from "./ForkDialogContext";
 import { InlineTerminalsSection } from "./InlineTerminalsSection";
 import { WorkspacePanel } from "./WorkspacePanel";
@@ -257,6 +258,8 @@ export function AppShell() {
   );
   const [shareOpen, setShareOpen] = useState(false);
   const [forkOpen, setForkOpen] = useState(false);
+  const [revertOpen, setRevertOpen] = useState(false);
+  const [revertUserMessageId, setRevertUserMessageId] = useState<string | null>(null);
   // Truncation point for a "fork from here" opened from a message's
   // actions (ChatPage, via ForkDialogContext). `null` = full clone —
   // the mobile menu Clone entry's behavior. Cleared whenever the dialog
@@ -406,6 +409,8 @@ export function AppShell() {
   // the per-message "Fork from here" action is the only fork entry point.
   const canClone =
     !!conversationId && isKnownTopLevel && (permissionLevel === null || permissionLevel >= 1);
+  const canRevert =
+    !!conversationId && isKnownTopLevel && (permissionLevel === null || permissionLevel >= 2);
   // Agent tools/policies exist to show.
   const hasAgentInfo = !!conversationId && agentHasInfo(boundAgent, conversationId);
   // Whether the mobile three-dot menu has any entry to offer.
@@ -1218,8 +1223,13 @@ export function AppShell() {
         setForkUpToResponseId(opts?.upToResponseId ?? null);
         setForkOpen(true);
       },
+      canRevert,
+      openRevertDialog: (opts?: { userMessageId?: string }) => {
+        setRevertUserMessageId(opts?.userMessageId ?? null);
+        setRevertOpen(true);
+      },
     }),
-    [canClone],
+    [canClone, canRevert],
   );
 
   return (
@@ -1473,6 +1483,20 @@ export function AppShell() {
               sessionId={conversationId}
               open={shareOpen}
               onOpenChange={setShareOpen}
+            />
+          )}
+          {conversationId && (
+            <RevertSessionDialog
+              key={`revert-session-dialog-${conversationId}`}
+              sourceSessionId={conversationId}
+              sourceWorkspace={activeSession?.workspace}
+              canModifySource={permissionLevel === null || permissionLevel >= 2}
+              initialUserMessageId={revertUserMessageId}
+              open={revertOpen}
+              onOpenChange={(open) => {
+                setRevertOpen(open);
+                if (!open) setRevertUserMessageId(null);
+              }}
             />
           )}
           {conversationId && (

--- a/web/src/shell/ForkDialogContext.tsx
+++ b/web/src/shell/ForkDialogContext.tsx
@@ -20,6 +20,10 @@ export interface ForkDialogContextValue {
    * a full clone (the header button's behavior).
    */
   openForkDialog: (opts?: { upToResponseId?: string }) => void;
+  /** Whether the caller may edit and rewind the active top-level session. */
+  canRevert: boolean;
+  /** Open the shared revert picker, optionally preselecting a user message. */
+  openRevertDialog: (opts?: { userMessageId?: string }) => void;
 }
 
 const ForkDialogContext = createContext<ForkDialogContextValue | null>(null);

--- a/web/src/shell/RevertSessionDialog.test.tsx
+++ b/web/src/shell/RevertSessionDialog.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RevertSessionDialog } from "./RevertSessionDialog";
+import { fetchSessionItemsPage, revertSession } from "@/lib/sessionsApi";
+import { setSessionTextDraft } from "@/lib/sessionDrafts";
+
+const { reloadCurrentMock } = vi.hoisted(() => ({ reloadCurrentMock: vi.fn() }));
+vi.mock("@/lib/sessionsApi", () => ({
+  fetchSessionItemsPage: vi.fn(),
+  revertSession: vi.fn(),
+}));
+vi.mock("@/lib/sessionDrafts", () => ({ setSessionTextDraft: vi.fn() }));
+vi.mock("@/store/chatStore", () => ({
+  useChatStore: { getState: () => ({ reloadCurrent: reloadCurrentMock }) },
+}));
+vi.mock("@/components/ui/toast", () => ({ showToast: vi.fn() }));
+
+const fetchItemsMock = vi.mocked(fetchSessionItemsPage);
+const revertMock = vi.mocked(revertSession);
+const setDraftMock = vi.mocked(setSessionTextDraft);
+
+function renderDialog(initialUserMessageId: string | null = null) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <RevertSessionDialog
+          sourceSessionId="conv_source"
+          sourceWorkspace="/repo"
+          canModifySource
+          initialUserMessageId={initialUserMessageId}
+          open
+          onOpenChange={vi.fn()}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  reloadCurrentMock.mockReset();
+  reloadCurrentMock.mockResolvedValue(undefined);
+  fetchItemsMock.mockReset();
+  revertMock.mockReset();
+  setDraftMock.mockReset();
+  fetchItemsMock.mockResolvedValue({
+    items: [
+      {
+        id: "msg_1",
+        type: "message",
+        response_id: "resp_1",
+        status: "completed",
+        role: "user",
+        content: [{ type: "input_text", text: "first prompt" }],
+      },
+      {
+        id: "msg_2",
+        type: "message",
+        response_id: "resp_2",
+        status: "completed",
+        role: "user",
+        content: [{ type: "input_text", text: "second prompt" }],
+      },
+    ],
+    hasMore: false,
+  });
+  revertMock.mockResolvedValue({
+    session: { id: "conv_source" } as Awaited<ReturnType<typeof revertSession>>["session"],
+    draft: "first prompt",
+    filesReverted: true,
+    fileRevertError: null,
+  });
+});
+
+afterEach(cleanup);
+
+describe("RevertSessionDialog", () => {
+  it("reloads the same session before restoring the selected prompt draft", async () => {
+    let finishReload = (): void => {};
+    reloadCurrentMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishReload = resolve;
+      }),
+    );
+    renderDialog("msg_1");
+
+    await screen.findByText("first prompt");
+    expect(screen.getByDisplayValue("msg_1")).toBeChecked();
+    fireEvent.click(screen.getByText("Restore file changes"));
+    fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+
+    await waitFor(() =>
+      expect(revertMock).toHaveBeenCalledWith("conv_source", "msg_1", {
+        revertFiles: true,
+      }),
+    );
+    await waitFor(() => expect(reloadCurrentMock).toHaveBeenCalledOnce());
+    expect(setDraftMock).not.toHaveBeenCalled();
+
+    finishReload();
+    await waitFor(() => expect(setDraftMock).toHaveBeenCalledWith("conv_source", "first prompt"));
+  });
+});

--- a/web/src/shell/RevertSessionDialog.test.tsx
+++ b/web/src/shell/RevertSessionDialog.test.tsx
@@ -1,8 +1,8 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RevertSessionDialog } from "./RevertSessionDialog";
+import type { MessageItem } from "@/lib/conversationItems";
 import { fetchSessionItemsPage, revertSession } from "@/lib/sessionsApi";
 import { setSessionTextDraft } from "@/lib/sessionDrafts";
 
@@ -21,22 +21,33 @@ const fetchItemsMock = vi.mocked(fetchSessionItemsPage);
 const revertMock = vi.mocked(revertSession);
 const setDraftMock = vi.mocked(setSessionTextDraft);
 
+function userMessage(id: string, text: string): MessageItem {
+  return {
+    id,
+    type: "message",
+    response_id: `resp_${id}`,
+    status: "completed",
+    role: "user",
+    content: [{ type: "input_text", text }],
+  };
+}
+
 function renderDialog(initialUserMessageId: string | null = null) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
+  const dialog = (open: boolean) => (
     <QueryClientProvider client={client}>
-      <MemoryRouter>
-        <RevertSessionDialog
-          sourceSessionId="conv_source"
-          sourceWorkspace="/repo"
-          canModifySource
-          initialUserMessageId={initialUserMessageId}
-          open
-          onOpenChange={vi.fn()}
-        />
-      </MemoryRouter>
-    </QueryClientProvider>,
+      <RevertSessionDialog
+        sourceSessionId="conv_source"
+        sourceWorkspace="/repo"
+        canModifySource
+        initialUserMessageId={initialUserMessageId}
+        open={open}
+        onOpenChange={vi.fn()}
+      />
+    </QueryClientProvider>
   );
+  const view = render(dialog(true));
+  return { ...view, setOpen: (open: boolean) => view.rerender(dialog(open)) };
 }
 
 beforeEach(() => {
@@ -46,60 +57,46 @@ beforeEach(() => {
   revertMock.mockReset();
   setDraftMock.mockReset();
   fetchItemsMock.mockResolvedValue({
-    items: [
-      {
-        id: "msg_1",
-        type: "message",
-        response_id: "resp_1",
-        status: "completed",
-        role: "user",
-        content: [{ type: "input_text", text: "first prompt" }],
-      },
-      {
-        id: "msg_2",
-        type: "message",
-        response_id: "resp_2",
-        status: "completed",
-        role: "user",
-        content: [{ type: "input_text", text: "second prompt" }],
-      },
-    ],
+    items: [userMessage("msg_1", "first prompt"), userMessage("msg_2", "second prompt")],
     hasMore: false,
   });
-  revertMock.mockResolvedValue({
-    session: { id: "conv_source" } as Awaited<ReturnType<typeof revertSession>>["session"],
-    draft: "first prompt",
-    filesReverted: true,
-    fileRevertError: null,
-  });
+  revertMock.mockResolvedValue({ draft: "second prompt", fileRevertError: null });
 });
 
 afterEach(cleanup);
 
 describe("RevertSessionDialog", () => {
-  it("reloads the same session before restoring the selected prompt draft", async () => {
-    let finishReload = (): void => {};
-    reloadCurrentMock.mockReturnValueOnce(
-      new Promise<void>((resolve) => {
-        finishReload = resolve;
-      }),
+  it("restores the draft and reloads current messages when reopened", async () => {
+    let finishReload!: () => void;
+    reloadCurrentMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishReload = resolve;
+        }),
     );
-    renderDialog("msg_1");
+    const { setOpen } = renderDialog("msg_2");
 
-    await screen.findByText("first prompt");
-    expect(screen.getByDisplayValue("msg_1")).toBeChecked();
-    fireEvent.click(screen.getByText("Restore file changes"));
+    await screen.findByText("second prompt");
+    expect(screen.getByDisplayValue("msg_2")).toBeChecked();
+    fireEvent.click(screen.getByText("Revert file changes"));
     fireEvent.click(screen.getByRole("button", { name: "Revert" }));
 
-    await waitFor(() =>
-      expect(revertMock).toHaveBeenCalledWith("conv_source", "msg_1", {
-        revertFiles: true,
-      }),
-    );
+    await waitFor(() => expect(revertMock).toHaveBeenCalledWith("conv_source", "msg_2", true));
     await waitFor(() => expect(reloadCurrentMock).toHaveBeenCalledOnce());
     expect(setDraftMock).not.toHaveBeenCalled();
 
     finishReload();
-    await waitFor(() => expect(setDraftMock).toHaveBeenCalledWith("conv_source", "first prompt"));
+    await waitFor(() => expect(setDraftMock).toHaveBeenCalledWith("conv_source", "second prompt"));
+
+    setOpen(false);
+    fetchItemsMock.mockResolvedValueOnce({
+      items: [userMessage("msg_1", "first prompt")],
+      hasMore: false,
+    });
+    setOpen(true);
+
+    await screen.findByText("first prompt");
+    expect(fetchItemsMock).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText("second prompt")).not.toBeInTheDocument();
   });
 });

--- a/web/src/shell/RevertSessionDialog.tsx
+++ b/web/src/shell/RevertSessionDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { HistoryIcon, Loader2Icon } from "lucide-react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -63,68 +63,54 @@ export function RevertSessionDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const queryClient = useQueryClient();
-  const [messages, setMessages] = useState<MessageItem[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [fileChoice, setFileChoice] = useState<"keep" | "revert">("keep");
-  const [loading, setLoading] = useState(false);
+  const [revertFiles, setRevertFiles] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const {
+    data: messages = [],
+    isLoading: loading,
+    error: loadError,
+  } = useQuery({
+    queryKey: ["session", sourceSessionId, "revert-messages"],
+    queryFn: () => loadUserMessages(sourceSessionId),
+    enabled: open,
+  });
 
   useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    void loadUserMessages(sourceSessionId)
-      .then((loaded) => {
-        if (cancelled) return;
-        setMessages(loaded);
-        setSelectedId(
-          initialUserMessageId && loaded.some((message) => message.id === initialUserMessageId)
-            ? initialUserMessageId
-            : (loaded[0]?.id ?? null),
-        );
-      })
-      .catch((reason: unknown) => {
-        if (!cancelled) {
-          setError(
-            reason instanceof Error ? reason.message : "Couldn't load conversation history.",
-          );
-        }
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [initialUserMessageId, open, sourceSessionId]);
+    if (!open || loading) return;
+    setSelectedId(
+      initialUserMessageId && messages.some((message) => message.id === initialUserMessageId)
+        ? initialUserMessageId
+        : (messages[0]?.id ?? null),
+    );
+  }, [initialUserMessageId, loading, messages, open]);
 
   useEffect(() => {
     if (!open) {
-      setFileChoice("keep");
+      queryClient.removeQueries({
+        queryKey: ["session", sourceSessionId, "revert-messages"],
+      });
+      setRevertFiles(false);
       setError(null);
     }
-  }, [open]);
+  }, [open, queryClient, sourceSessionId]);
+
+  const errorMessage = error ?? loadError?.message ?? null;
 
   async function handleRevert(): Promise<void> {
     if (!selectedId || submitting) return;
     setSubmitting(true);
     setError(null);
     try {
-      const result = await revertSession(sourceSessionId, selectedId, {
-        revertFiles: fileChoice === "revert",
-      });
-      if (result.session.id !== sourceSessionId) {
-        throw new Error("Revert unexpectedly created a different session.");
-      }
+      const result = await revertSession(sourceSessionId, selectedId, revertFiles);
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
       await useChatStore.getState().reloadCurrent();
       setSessionTextDraft(sourceSessionId, result.draft);
       onOpenChange(false);
       showToast(
         result.fileRevertError ||
-          (result.filesReverted
+          (revertFiles
             ? "Conversation and files reverted."
             : "Conversation reverted; file changes kept."),
       );
@@ -189,56 +175,31 @@ export function RevertSessionDialog({
           )}
         </div>
 
-        <div className="grid gap-5 rounded-xl border p-4">
-          <fieldset className="grid gap-3">
-            <legend className="mb-2 text-sm font-semibold text-foreground">File changes</legend>
-            <label
-              className={cn(
-                "flex cursor-pointer items-start gap-3 rounded-lg border p-3",
-                fileChoice === "keep" && "border-primary/50 bg-accent",
-              )}
-            >
-              <input
-                type="radio"
-                name="revert-files"
-                checked={fileChoice === "keep"}
-                onChange={() => setFileChoice("keep")}
-                className="mt-0.5 accent-primary"
-              />
-              <span>
-                <span className="block text-sm font-medium">Keep current changes</span>
-                <span className="block text-xs text-muted-foreground">
-                  Only rewind the conversation.
-                </span>
+        <div className="rounded-xl border p-4">
+          <label
+            className={cn(
+              "flex items-start gap-3",
+              sourceWorkspace && canModifySource ? "cursor-pointer" : "opacity-50",
+            )}
+          >
+            <input
+              type="checkbox"
+              checked={revertFiles}
+              disabled={!sourceWorkspace || !canModifySource}
+              onChange={(event) => setRevertFiles(event.target.checked)}
+              className="mt-0.5 accent-primary"
+            />
+            <span>
+              <span className="block text-sm font-medium">Revert file changes</span>
+              <span className="block text-xs text-muted-foreground">
+                Return your files to how they were before this message.
               </span>
-            </label>
-            <label
-              className={cn(
-                "flex items-start gap-3 rounded-lg border p-3",
-                sourceWorkspace && canModifySource ? "cursor-pointer" : "opacity-50",
-                fileChoice === "revert" && "border-primary/50 bg-accent",
-              )}
-            >
-              <input
-                type="radio"
-                name="revert-files"
-                checked={fileChoice === "revert"}
-                disabled={!sourceWorkspace || !canModifySource}
-                onChange={() => setFileChoice("revert")}
-                className="mt-0.5 accent-primary"
-              />
-              <span>
-                <span className="block text-sm font-medium">Restore file changes</span>
-                <span className="block text-xs text-muted-foreground">
-                  Restores a Git checkpoint captured before the selected message.
-                </span>
-              </span>
-            </label>
-          </fieldset>
+            </span>
+          </label>
         </div>
 
         <div>
-          {error && <p className="mb-2 text-sm text-destructive">{error}</p>}
+          {errorMessage && <p className="mb-2 text-sm text-destructive">{errorMessage}</p>}
           <DialogFooter>
             <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
               Cancel

--- a/web/src/shell/RevertSessionDialog.tsx
+++ b/web/src/shell/RevertSessionDialog.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useState } from "react";
+import { HistoryIcon, Loader2Icon } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { showToast } from "@/components/ui/toast";
+import { isMessageItem, type MessageItem } from "@/lib/conversationItems";
+import { fetchSessionItemsPage, revertSession } from "@/lib/sessionsApi";
+import { setSessionTextDraft } from "@/lib/sessionDrafts";
+import { isSystemUserContent } from "@/lib/systemMessage";
+import { cn } from "@/lib/utils";
+import { useChatStore } from "@/store/chatStore";
+
+function messageText(item: MessageItem): string {
+  return item.content
+    .filter((block) => block.type === "input_text")
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+}
+
+async function loadUserMessages(sessionId: string): Promise<MessageItem[]> {
+  let items: MessageItem[] = [];
+  let olderThan: string | undefined;
+  while (true) {
+    const page = await fetchSessionItemsPage(sessionId, { olderThan, limit: 1000 });
+    items = [
+      ...page.items.filter(
+        (item): item is MessageItem =>
+          isMessageItem(item) &&
+          item.role === "user" &&
+          item.is_meta !== true &&
+          !isSystemUserContent(item.content),
+      ),
+      ...items,
+    ];
+    if (!page.hasMore || page.items.length === 0) break;
+    olderThan = page.items[0].id;
+  }
+  return items.reverse();
+}
+
+export function RevertSessionDialog({
+  sourceSessionId,
+  sourceWorkspace,
+  canModifySource,
+  initialUserMessageId,
+  open,
+  onOpenChange,
+}: {
+  sourceSessionId: string;
+  sourceWorkspace?: string | null;
+  canModifySource: boolean;
+  initialUserMessageId?: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  const [messages, setMessages] = useState<MessageItem[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [fileChoice, setFileChoice] = useState<"keep" | "revert">("keep");
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void loadUserMessages(sourceSessionId)
+      .then((loaded) => {
+        if (cancelled) return;
+        setMessages(loaded);
+        setSelectedId(
+          initialUserMessageId && loaded.some((message) => message.id === initialUserMessageId)
+            ? initialUserMessageId
+            : (loaded[0]?.id ?? null),
+        );
+      })
+      .catch((reason: unknown) => {
+        if (!cancelled) {
+          setError(
+            reason instanceof Error ? reason.message : "Couldn't load conversation history.",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [initialUserMessageId, open, sourceSessionId]);
+
+  useEffect(() => {
+    if (!open) {
+      setFileChoice("keep");
+      setError(null);
+    }
+  }, [open]);
+
+  async function handleRevert(): Promise<void> {
+    if (!selectedId || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await revertSession(sourceSessionId, selectedId, {
+        revertFiles: fileChoice === "revert",
+      });
+      if (result.session.id !== sourceSessionId) {
+        throw new Error("Revert unexpectedly created a different session.");
+      }
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      await useChatStore.getState().reloadCurrent();
+      setSessionTextDraft(sourceSessionId, result.draft);
+      onOpenChange(false);
+      showToast(
+        result.fileRevertError ||
+          (result.filesReverted
+            ? "Conversation and files reverted."
+            : "Conversation reverted; file changes kept."),
+      );
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "Couldn't revert the session.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="grid max-h-[85vh] grid-rows-[auto_minmax(0,1fr)_auto_auto] gap-5 sm:max-w-2xl">
+        <DialogHeader className="gap-3 pr-8">
+          <DialogTitle className="flex items-center gap-2.5 text-lg leading-tight sm:text-xl">
+            <HistoryIcon className="size-5" />
+            Revert conversation
+          </DialogTitle>
+          <DialogDescription className="leading-6">
+            Choose a user message to return to. That message and everything after it will be removed
+            from this session.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          className="min-h-0 space-y-2 overflow-y-auto rounded-xl border p-2"
+          data-testid="revert-message-list"
+        >
+          {loading ? (
+            <div className="flex items-center justify-center gap-2 py-10 text-muted-foreground">
+              <Loader2Icon className="size-4 animate-spin" /> Loading messages…
+            </div>
+          ) : messages.length === 0 ? (
+            <p className="p-4 text-center text-muted-foreground">No user messages to revert to.</p>
+          ) : (
+            messages.map((message) => {
+              const text = messageText(message) || "(attachments only)";
+              const active = selectedId === message.id;
+              return (
+                <label
+                  key={message.id}
+                  className={cn(
+                    "flex cursor-pointer gap-3 rounded-lg px-3 py-3 hover:bg-accent",
+                    active && "bg-accent ring-1 ring-primary/30",
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="revert-message"
+                    value={message.id}
+                    checked={active}
+                    onChange={() => setSelectedId(message.id)}
+                    className="mt-1 accent-primary"
+                  />
+                  <span className="min-w-0">
+                    <span className="block text-xs font-medium text-muted-foreground">You</span>
+                    <span className="line-clamp-2 block text-sm leading-5">{text}</span>
+                  </span>
+                </label>
+              );
+            })
+          )}
+        </div>
+
+        <div className="grid gap-5 rounded-xl border p-4">
+          <fieldset className="grid gap-3">
+            <legend className="mb-2 text-sm font-semibold text-foreground">File changes</legend>
+            <label
+              className={cn(
+                "flex cursor-pointer items-start gap-3 rounded-lg border p-3",
+                fileChoice === "keep" && "border-primary/50 bg-accent",
+              )}
+            >
+              <input
+                type="radio"
+                name="revert-files"
+                checked={fileChoice === "keep"}
+                onChange={() => setFileChoice("keep")}
+                className="mt-0.5 accent-primary"
+              />
+              <span>
+                <span className="block text-sm font-medium">Keep current changes</span>
+                <span className="block text-xs text-muted-foreground">
+                  Only rewind the conversation.
+                </span>
+              </span>
+            </label>
+            <label
+              className={cn(
+                "flex items-start gap-3 rounded-lg border p-3",
+                sourceWorkspace && canModifySource ? "cursor-pointer" : "opacity-50",
+                fileChoice === "revert" && "border-primary/50 bg-accent",
+              )}
+            >
+              <input
+                type="radio"
+                name="revert-files"
+                checked={fileChoice === "revert"}
+                disabled={!sourceWorkspace || !canModifySource}
+                onChange={() => setFileChoice("revert")}
+                className="mt-0.5 accent-primary"
+              />
+              <span>
+                <span className="block text-sm font-medium">Restore file changes</span>
+                <span className="block text-xs text-muted-foreground">
+                  Restores a Git checkpoint captured before the selected message.
+                </span>
+              </span>
+            </label>
+          </fieldset>
+        </div>
+
+        <div>
+          {error && <p className="mb-2 text-sm text-destructive">{error}</p>}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void handleRevert()}
+              disabled={!selectedId || loading || submitting}
+            >
+              {submitting && <Loader2Icon className="animate-spin" />}
+              Revert
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -464,14 +464,9 @@ describe("chatStore — switchTo", () => {
 
     const state = useChatStore.getState();
     expect(state.conversationId).toBe("conv_rewind");
-    expect(state.blocks).toHaveLength(2);
-    expect(
-      state.blocks.some(
-        (block) =>
-          block.type === "user_message" &&
-          block.content.some((part) => part.type === "input_text" && part.text === "discard"),
-      ),
-    ).toBe(false);
+    expect(state.blocks.map((block) => block.ctx.itemId)).toEqual(
+      original.slice(0, 2).map((item) => item.id),
+    );
   });
 
   it("hydrates pendingUserMessages from the snapshot's pending_inputs (native rebind)", async () => {

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -450,6 +450,30 @@ describe("chatStore — switchTo", () => {
     expect(state.conversationLoadError).toBeNull();
   });
 
+  it("reloads a rewound history without changing the active session id", async () => {
+    const original = [
+      userMessage("resp_1", "keep"),
+      assistantMessage("resp_1", "kept response"),
+      userMessage("resp_2", "discard"),
+    ];
+    seedSession("conv_rewind", original);
+    await useChatStore.getState().switchTo("conv_rewind");
+
+    seedSession("conv_rewind", original.slice(0, 2));
+    await useChatStore.getState().reloadCurrent();
+
+    const state = useChatStore.getState();
+    expect(state.conversationId).toBe("conv_rewind");
+    expect(state.blocks).toHaveLength(2);
+    expect(
+      state.blocks.some(
+        (block) =>
+          block.type === "user_message" &&
+          block.content.some((part) => part.type === "input_text" && part.text === "discard"),
+      ),
+    ).toBe(false);
+  });
+
   it("hydrates pendingUserMessages from the snapshot's pending_inputs (native rebind)", async () => {
     // The core fix: a native web message that hasn't round-tripped
     // through the transcript yet is replayed by the server in

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -614,6 +614,8 @@ export interface ChatState {
   ) => Promise<void>;
   stop: () => void;
   switchTo: (conversationId: string | null) => Promise<void>;
+  /** Re-fetch the active session after its history changes in place. */
+  reloadCurrent: () => Promise<void>;
   submitApproval: (
     elicitationId: string,
     action: "accept" | "decline" | "cancel",
@@ -1646,6 +1648,33 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // native messages; when one was, bindStream dedupes it against the
     // committed snapshot. Reconnect/rebind paths pass false so they never
     // overwrite the live optimistic bubbles (which would flink).
+    await bindStream(conversationId, set, get, true);
+  },
+
+  reloadCurrent: async () => {
+    const conversationId = get().conversationId;
+    if (conversationId === null) return;
+    get().abortController?.abort();
+    set((state) => {
+      const pendingByConversation = { ...state.pendingByConversation };
+      delete pendingByConversation[conversationId];
+      return {
+        blocks: [],
+        pendingUserMessages: [],
+        pendingByConversation,
+        activeResponse: null,
+        interruptedResponseIds: [],
+        status: "idle",
+        sessionStatus: "idle",
+        loadingConversation: true,
+        conversationLoadError: null,
+        hasMoreHistory: false,
+        loadingMoreHistory: false,
+        oldestItemId: null,
+        abortController: null,
+        historyGeneration: state.historyGeneration + 1,
+      };
+    });
     await bindStream(conversationId, set, get, true);
   },
 


### PR DESCRIPTION
## Related issue

https://github.com/omnigent-ai/omnigent/issues/2880

## Summary

- Add `/revert` across CLI, web, desktop, iOS, and Android to rewind the current session to before a selected user prompt and prefill that prompt for editing.
- Optionally revert tracked and untracked workspace files to their pre-turn Git checkpoint without moving `HEAD`; leaving **Revert file changes** unchecked keeps the current files.
- Preserve the session identity and metadata while resetting native harness state so discarded history cannot reappear.
- Keep the API and UI lean: return only the draft plus any file warning, use the existing query layer for the picker, and clear its cache when closed so removed prompts cannot reappear on the next `/revert`.

**ELI5:** Pick an earlier prompt, optionally put the files back too, then edit and retry it in the same conversation.

## Logic and state management

```mermaid
sequenceDiagram
    autonumber
    actor User
    participant Client as Web / CLI / mobile / native TUI
    participant API as Sessions API
    participant Store as Conversation store
    participant Runner as Bound runner
    participant Git as Private Git refs

    Note over Client,Git: Before each accepted user turn
    Client->>API: Persist user prompt
    API->>Runner: capture_revert_checkpoint(message_id)
    Runner->>Git: Snapshot non-ignored workspace tree
    Git-->>Runner: Private ref keyed by session + message

    Note over User,Git: Revert selected prompt
    User->>Client: Select prompt and file option
    Client->>API: POST /sessions/{id}/revert
    API->>Store: Load and validate selected prompt
    opt Native harness
        API->>Runner: reset-state
        Runner-->>API: Native runtime cleared
    end
    API->>Store: Delete selected and later items
    Store->>Store: Clear native runtime labels and external session ID
    opt Revert file changes
        API->>Runner: revert_files(checkpoint_id)
        Runner->>Git: Restore checkpoint workspace tree
        Git-->>Runner: Working tree restored, HEAD unchanged
        Runner-->>API: Success or best-effort warning
    end
    API-->>Client: Draft + optional file warning
    Client->>Client: Reload transcript, clear picker cache, set draft
    Client-->>User: Same session, prompt ready to edit
```

State after a successful rewind:

- **Preserved:** Omnigent session ID, URL, agent binding, non-runtime metadata, retained earlier conversation items, Git `HEAD`, and commit history.
- **Rewound or reset:** the selected prompt and later conversation items, native runtime identity/labels, and optionally the workspace tree.
- **Returned to the client:** the selected prompt as an editable draft plus a warning when the optional file restore could not be completed.

## Git restore behavior and limitations

- File restore does not move `HEAD` or alter commit history. Commits made after the selected checkpoint remain and accumulate; Omnigent does not remove them or create reversal commits.
- Restored differences are left unstaged (and restored files absent from `HEAD` may be untracked), so a later `git add -A` will include them.
- Checkpoints preserve working-tree contents, not the staged/unstaged split. Untracked files ignored by Git are not captured or restored; tracked files remain covered even if an ignore rule matches them.

### Example: restoring files after a commit

```mermaid
flowchart LR
    A["Pre-turn checkpoint<br/>HEAD C0<br/>app.py v1<br/>old.py present"] --> B["Commit C1<br/>app.py v2<br/>new.py added<br/>old.py deleted"]
    B --> C["Omnigent file restore<br/>HEAD still C1<br/>working tree matches checkpoint"]
```

Because commit `C1` remains checked out, restoring the checkpoint produces the inverse as unstaged or untracked working-tree changes:

```text
$ git status --short
 M app.py
 D new.py
?? old.py
```

| Change committed in `C1` | Workspace after restore | `git status` |
| --- | --- | --- |
| Modified `app.py` from v1 to v2 | `app.py` contains v1 | ` M app.py` |
| Added `new.py` | `new.py` is removed | ` D new.py` |
| Deleted `old.py` | `old.py` is recreated | `?? old.py` |

What a checkpoint preserves:

| Git state | Captured? | Restore behavior |
| --- | --- | --- |
| Tracked file contents | Yes | Restored to the checkpoint contents |
| Non-ignored untracked files | Yes | Recreated as untracked files when absent from `HEAD` |
| Staged versus unstaged split | No | Restored differences are left unstaged or untracked |
| Untracked ignored files such as `.env` or `dist/` | No | Left unchanged rather than restored or deleted |
| `HEAD` and commit history | Not modified | Existing commits remain in place |

For example, if `HEAD` contains version A, the index contains staged version B, and the working tree contains version C, the checkpoint stores version C only. Restoring later returns version C as an unstaged change; it does not recreate staged version B.

## Test Plan

- `PYTHONPATH="$PWD/sdks/python-client:$PWD" .venv/bin/python -m pytest tests/server/integration/test_sessions_revert.py tests/server/integration/test_sessions_fork.py tests/stores/test_conversation_store.py::test_rewind_conversation_removes_selected_prompt_and_later_history tests/stores/test_conversation_store.py::test_fork_conversation_up_to_response_truncates_items tests/runtime/test_filesystem_registry.py tests/runner/test_runner_dispatch.py::test_revert_file_control_routes_to_filesystem_registry tests/repl/test_repl_revert_command.py tests/server/test_openapi_drift.py -q`
- `cd web && npx vitest run src/store/chatStore.test.ts src/lib/sessionsApi.test.ts src/shell/RevertSessionDialog.test.tsx src/pages/ChatPage.composer.test.tsx` (397 tests)
- `cd web && npm run type-check`
- `pre-commit run --all-files`

## Demo

### Web UI & Desktop App

Revert option shows up as both `/revert`, or as a clickable icon under each user message
<img width="893" height="982" alt="Screenshot 2026-07-19 at 14 10 42" src="https://github.com/user-attachments/assets/6e7fe53b-65f5-4428-a4fd-8895bd20f76b" />

Using the web UI or desktop app would open up a revert option screen, which allows the user to select which step do they want to revert to, and whether they want to also revert the file changes (tracked through git)
<img width="798" height="602" alt="Screenshot 2026-07-19 at 14 11 26" src="https://github.com/user-attachments/assets/348912fe-2e3d-4a80-9cee-f4273702033c" />

When revert file changes is selected, file modifications that happen after the user message the session is reverting back to is removed
<img width="1783" height="1039" alt="Screenshot 2026-07-19 at 14 11 35" src="https://github.com/user-attachments/assets/b678d3d8-f896-43bd-ade0-2d5d01ffd3a7" />

The user can also decide to revert to an earlier chat message without reverting the file changes, in which case the file modifications that happen after the user message the session is reverting to is kept.
<img width="851" height="543" alt="Screenshot 2026-07-19 at 14 18 09" src="https://github.com/user-attachments/assets/46b84ea8-0d9d-4140-8e15-b6e990dcfae9" />
<img width="1796" height="1044" alt="Screenshot 2026-07-19 at 14 18 20" src="https://github.com/user-attachments/assets/a38d6aaf-15a9-4304-a2cf-93e38deee7fb" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage exercises in-place conversation truncation, native runtime reset, Git checkpoint restore, SDK/API behavior, same-session reload, draft delivery, and reopening the picker without stale removed prompts. Manual verification covered reverting the second prompt with file changes both enabled and disabled, preserving the session URL, restoring the draft, and reopening `/revert` after the rewind.

## Changelog

You can now rewind a session to an earlier prompt, optionally revert its file changes, and edit the prompt before retrying.




