### PR TITLE
docs: add parallel worktree development guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,14 @@
 Guidance for AI agents (Claude Code, Copilot, Cursor, etc.) working in this
 repository. See `CONTRIBUTING.md` for the full contributor workflow.
 
+## Parallel development
+
+For concurrent changes, use one Git worktree and one isolated `omnidev` pod per
+change. Do not share databases, ports, or pod directories between worktrees.
+Follow [Develop multiple changes in
+parallel](CONTRIBUTING.md#develop-multiple-changes-in-parallel) and see the
+[`omnidev` reference](dev/omnidev/README.md) for pod behavior and options.
+
 ## Committing
 
 Run the `pre-commit` hook before committing (`pre-commit run --all-files`, or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,66 @@ The host URL can also be passed positionally (`omnigent host
 http://localhost:6767`). See the [README](README.md) for more on hosts,
 harnesses, and credentials.
 
+### Develop multiple changes in parallel
+
+Use one Git worktree and one isolated
+[`omnidev`](dev/omnidev/README.md) pod per change. This works for any number
+of concurrent changes, limited only by your machine's resources.
+
+Do not run multiple worktrees against the default shared Omnigent data
+directory. Branches may contain incompatible database migrations or runtime
+state.
+
+From the main checkout, create one worktree per change:
+
+```bash
+git fetch origin
+mkdir -p ../omnigent-worktrees
+
+add_omnigent_worktrees() {
+  for change in "$@"; do
+    git worktree add "../omnigent-worktrees/$change" \
+      -b "feature/$change" origin/main
+  done
+}
+
+add_omnigent_worktrees search-export billing-alerts
+```
+
+Pass as many change names as needed. In a separate terminal for each worktree,
+run:
+
+```bash
+cd ../omnigent-worktrees/<change-name>
+cargo run --manifest-path dev/omnidev/Cargo.toml
+```
+
+`omnidev` requires a Rust toolchain in addition to the regular development
+prerequisites. Each invocation starts that checkout's server, host, and Vite
+frontend with:
+
+- automatically allocated backend and frontend ports;
+- an isolated database, config, artifacts, logs, and process state;
+- inherited provider credentials and package caches;
+- backend reloads and frontend hot-module replacement.
+
+Open the UI URL shown in each `omnidev` header. When starting a session, select
+the worktree corresponding to that feature.
+
+Coding harnesses should run each pod in its own persistent PTY or tmux session
+and execute tests from the matching worktree. Never reuse another worktree's
+pod directory or manually start several servers on the default ports.
+
+Press `q` or `Ctrl-C` to stop a pod. After merging a change:
+
+```bash
+git worktree remove ../omnigent-worktrees/<change-name>
+git branch -d feature/<change-name>
+```
+
+See [`dev/omnidev/README.md`](dev/omnidev/README.md) for port overrides,
+backend-only mode, LAN testing, logs, and keyboard controls.
+
 ### Backend-only local development validation
 
 Use this when you want to validate the Python backend and local API server from


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Document the supported workflow for developing and testing any number of changes concurrently with one Git worktree and isolated `omnidev` pod per change.
- Point coding harnesses, including Claude through the existing `CLAUDE.md` symlink, to the contributor workflow and canonical `omnidev` reference.

ELI5: each change gets its own folder and development stack, so its ports, database, config, and processes cannot interfere with another change.

```text
worktree A -> omnidev pod A -> ports and state A
worktree B -> omnidev pod B -> ports and state B
       ... ->          ... ->             ...
```

## Test Plan

- `uv run pre-commit run --all-files`
- `git diff --check`
- Verified `CLAUDE.md` remains a symlink to `AGENTS.md` and therefore exposes the same parallel-development guidance.
- Verified the relative links to `CONTRIBUTING.md` and `dev/omnidev/README.md` resolve in the repository.

## Demo

N/A — documentation-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only change with no runtime behavior. Repository-wide pre-commit checks, whitespace validation, symlink verification, and relative-link checks passed.

## Changelog

Contributors can run isolated Omnigent development stacks for any number of parallel worktrees.
