### PR TITLE
feat(docs): add parallel worktree development guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,16 @@
 Guidance for AI agents (Claude Code, Copilot, Cursor, etc.) working in this
 repository. See `CONTRIBUTING.md` for the full contributor workflow.
 
+## Parallel development
+
+For one or more independently running Omnigent revisions, use one source
+checkout or worktree and one isolated `omnidev` pod per revision. Sessions and
+target project directories using the same revision may share its pod. Do not
+share databases, ports, or pod directories between checkouts. Follow [Develop
+and test one or more
+changes](CONTRIBUTING.md#develop-and-test-one-or-more-changes) and see the
+[`omnidev` reference](dev/omnidev/README.md) for pod behavior and options.
+
 ## Committing
 
 Run the `pre-commit` hook before committing (`pre-commit run --all-files`, or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,83 @@ The host URL can also be passed positionally (`omnigent host
 http://localhost:6767`). See the [README](README.md) for more on hosts,
 harnesses, and credentials.
 
+### Develop and test one or more changes
+
+Use one isolated [`omnidev`](dev/omnidev/README.md) pod for each Omnigent
+source checkout whose code must run independently. For `N = 1`, run one pod in
+your current checkout or a dedicated worktree. For `N > 1`, run one pod per
+worktree or separate clone. `omnidev` keys pod state to the checkout's canonical
+path and allocates distinct ports, so existing worktrees work without extra
+configuration.
+
+A pod belongs to an Omnigent source checkout, not to an individual chat session
+or target project directory:
+
+- sessions and project directories using the same Omnigent revision may share
+  one pod;
+- revisions that need independent server code, database migrations, config, or
+  runtime state need separate checkouts and pods.
+
+List any worktrees you already have:
+
+```bash
+git worktree list
+```
+
+If the required worktrees already exist, skip creation. Otherwise, create one
+for each missing change from the main checkout:
+
+```bash
+git fetch origin
+mkdir -p ../omnigent-worktrees
+
+add_omnigent_worktrees() {
+  for change in "$@"; do
+    git worktree add "../omnigent-worktrees/$change" \
+      -b "feature/$change" origin/main
+  done
+}
+
+add_omnigent_worktrees search-export billing-alerts
+```
+
+Pass one name for `N = 1` or as many names as needed. In a separate persistent
+terminal for each checkout, run:
+
+```bash
+cd <path-to-omnigent-checkout-or-worktree>
+cargo run --manifest-path dev/omnidev/Cargo.toml
+```
+
+When starting several new pods, wait for each one to display its header and
+ports before starting the next. `omnidev` requires a current stable Rust
+toolchain in addition to the regular development prerequisites. Each invocation
+starts that checkout's server, host, and Vite frontend with:
+
+- automatically allocated backend and frontend ports;
+- an isolated database, config, artifacts, logs, and process state;
+- inherited provider credentials and package caches;
+- backend reloads and frontend hot-module replacement.
+
+Open the UI URL shown in each `omnidev` header. For a session that modifies
+Omnigent itself, select the source worktree served by that pod. Sessions working
+on other project directories may share the pod and host.
+
+Coding harnesses should keep each pod in its own persistent PTY or tmux session
+and execute tests from the matching Omnigent checkout. Keep the default pod
+directory and automatic ports unless explicit unique overrides are required.
+
+Press `q` or `Ctrl-C` to stop a pod. After merging, remove only worktrees you
+created for finished changes:
+
+```bash
+git worktree remove ../omnigent-worktrees/<change-name>
+git branch -d feature/<change-name>
+```
+
+See [`dev/omnidev/README.md`](dev/omnidev/README.md) for port overrides,
+backend-only mode, LAN testing, logs, and keyboard controls.
+
 ### Backend-only local development validation
 
 Use this when you want to validate the Python backend and local API server from

--- a/dev/omnidev/README.md
+++ b/dev/omnidev/README.md
@@ -2,7 +2,7 @@
 
 Dev tooling for Omnigent, in one binary with two independent capabilities:
 
-1. A per-repo dev **pod supervisor** (bare `omnidev`) — the default.
+1. A per-checkout dev **pod supervisor** (bare `omnidev`) — the default.
 2. **Install management** (`omnidev install`/`update`/`check`) — install and
    keep a git-based omnigent up to date. See
    [Managing your omnigent install](#managing-your-omnigent-install). These
@@ -10,7 +10,7 @@ Dev tooling for Omnigent, in one binary with two independent capabilities:
 
 ## Pod supervisor
 
-A per-repo dev **pod** supervisor, as a single long-running terminal UI. It
+A per-checkout dev **pod** supervisor, as a single long-running terminal UI. It
 replaces the three-terminal local dev flow (`omnigent server`, `omnigent host`,
 `npm run dev`) with one process that:
 
@@ -29,7 +29,7 @@ replaces the three-terminal local dev flow (`omnigent server`, `omnigent host`,
 ## Build & run
 
 Requires the repo's usual dev prerequisites (`uv` for Python, `npm` for the
-web UI) plus a Rust toolchain.
+web UI) plus a current stable Rust toolchain.
 
 ```bash
 cd dev/omnidev
@@ -40,6 +40,23 @@ Run it from anywhere inside the checkout — it walks up to the repo root
 (the `.jj`/`.git` marker) and requires `omnigent/` and
 `web/` to be present. Build a release binary with `cargo build --release`
 (lands at `target/release/omnidev`).
+
+### Scaling across checkouts, sessions, and projects
+
+Run one `omnidev` process for each independently running Omnigent source
+checkout. `N = 1` uses one checkout and pod; `N > 1` uses one pod per worktree
+or separate clone. Existing worktrees need no special setup because the default
+pod directory is keyed to each checkout's canonical path. A per-pod lock rejects
+a second `omnidev` process in the same checkout.
+
+A pod is not tied to one chat session or target project directory. Multiple
+sessions and projects may share a pod when they use the same Omnigent server
+revision. Use another checkout and pod only when the Omnigent code, database
+migrations, config, or runtime state must differ.
+
+When starting several previously unseen checkouts, wait for each pod to display
+its header and allocated ports before starting the next. Keep the default pod
+directories and automatic ports unless explicit unique overrides are required.
 
 ## What it starts
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Current guides availalble in CONTRIBUTING.md and AGENTS.md does not talk about the best practice to setup and test multiple changes or features for Omnigent
- Document the supported `N >= 1` workflow: one isolated `omnidev` pod per independently running Omnigent checkout, whether it is the current checkout, an existing worktree, a new worktree, or a separate clone.
- Clarify that multiple sessions and target project directories may share a pod when they use the same Omnigent revision, while differing server code or runtime state requires another checkout and pod.
- Point coding harnesses, including Claude through the existing `CLAUDE.md` symlink, to the contributor workflow and expanded canonical `omnidev` reference.

ELI5: each independently running version of Omnigent gets its own development stack; chats and projects using that version can share it.

```text
Omnigent checkout A -> omnidev pod A -> sessions/projects using revision A
Omnigent checkout B -> omnidev pod B -> sessions/projects using revision B
                  ... ->          ... -> ...
```

## Test Plan

- `uv run pre-commit run --all-files`
- `git diff --check`
- Verified `CLAUDE.md` remains a symlink to `AGENTS.md` and exposes the same generalized guidance.
- Verified the relative links and renamed `CONTRIBUTING.md#develop-and-test-one-or-more-changes` anchor.
- Verified both contributor and canonical `omnidev` docs cover `N = 1`, `N > 1`, existing worktrees, separate clones, sessions, and project directories.

## Demo

N/A — documentation-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only change with no runtime behavior. Repository-wide pre-commit checks, whitespace validation, symlink verification, and relative-link and coverage assertions passed.

## Changelog

Contributors can run isolated development stacks for one or more Omnigent checkouts while sharing each stack across compatible sessions and projects.
