### PR TITLE
fix(server): resolve nested sub-agent harness via full-tree search

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -3021,6 +3021,7 @@ def _resolve_harness(conv: Conversation | None) -> str | None:
         from omnigent.harness_aliases import canonicalize_harness
         from omnigent.runtime import get_agent_cache
         from omnigent.runtime._globals import _agent_store
+        from omnigent.runtime.workflow import _find_spec_by_name
 
         if _agent_store is None:
             return None
@@ -3033,13 +3034,13 @@ def _resolve_harness(conv: Conversation | None) -> str | None:
         executor = loaded.spec.executor
         # For a bundled-agent head sub-agent, report the HEAD's own harness,
         # not the bundle brain's — `harness` is this session's provider family
-        # (a gpt head runs codex, not the claude-sdk brain). Falls back to the
-        # brain harness when the head declares none or can't be matched.
+        # (a gpt head runs codex, not the claude-sdk brain). Resolve the child
+        # through the full sub-agent tree (the same resolver the runner uses),
+        # so a nested grandchild head resolves rather than falling back to the
+        # brain harness. Falls back to the brain when the head declares none or
+        # can't be matched.
         if conv.sub_agent_name:
-            sub = next(
-                (s for s in loaded.spec.sub_agents if s.name == conv.sub_agent_name),
-                None,
-            )
+            sub = _find_spec_by_name(loaded.spec, conv.sub_agent_name)
             if sub is not None:
                 executor = sub.executor
         harness = (

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -16,8 +16,10 @@ from omnigent.server.routes.sessions import (
     _get_session_snapshot,
     _persist_session_status_error_labels,
     _publish_subtree_cost_to_ancestors,
+    _resolve_harness,
     _truncate_label,
 )
+from omnigent.spec.types import AgentSpec, ExecutorSpec
 
 
 async def _drain_runner_skills(session_id: str) -> None:
@@ -1765,3 +1767,101 @@ async def test_persist_error_labels_short_message_stored_verbatim() -> None:
         captured["d6e1678fb446a1cf5a892e0df60aaba3"]["omnigent.last_task_error_code"]
         == "runner_error"
     )
+
+
+def _harness_spec_tree() -> AgentSpec:
+    """Build a 3-level bundle: advisor → mid → executor (grandchild).
+
+    The advisor brain runs ``claude-sdk``; only the grandchild ``executor``
+    declares ``codex``. A ``sub_agent_name="executor"`` session must resolve
+    the grandchild's harness, not the brain's.
+    """
+    executor = AgentSpec(
+        spec_version=1,
+        name="executor",
+        executor=ExecutorSpec(config={"harness": "codex"}),
+    )
+    mid = AgentSpec(
+        spec_version=1,
+        name="mid",
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}),
+        sub_agents=[executor],
+    )
+    return AgentSpec(
+        spec_version=1,
+        name="advisor",
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}),
+        sub_agents=[mid],
+    )
+
+
+def _patch_harness_stores(monkeypatch: pytest.MonkeyPatch, spec: AgentSpec) -> None:
+    """Wire ``_resolve_harness``'s agent store + cache to serve ``spec``."""
+
+    class _StoredAgent:
+        id = "ag_advisor"
+        bundle_location = "bundle"
+        session_id = None
+
+    class _AgentStore:
+        @staticmethod
+        def get(agent_id: str) -> Any:
+            assert agent_id == "ag_advisor"
+            return _StoredAgent()
+
+    class _Loaded:
+        def __init__(self, spec: AgentSpec) -> None:
+            self.spec = spec
+
+    class _AgentCache:
+        @staticmethod
+        def load(agent_id: str, bundle_location: str, *, expand_env: bool) -> Any:
+            assert (agent_id, bundle_location) == ("ag_advisor", "bundle")
+            return _Loaded(spec)
+
+    monkeypatch.setattr("omnigent.runtime._globals._agent_store", _AgentStore())
+    monkeypatch.setattr("omnigent.runtime.get_agent_cache", lambda: _AgentCache())
+
+
+def _conv_for_subagent(sub_agent_name: str | None) -> Conversation:
+    return Conversation(
+        id="conv_child",
+        created_at=1,
+        updated_at=1,
+        root_conversation_id="conv_parent",
+        parent_conversation_id="conv_parent",
+        agent_id="ag_advisor",
+        kind="sub_agent" if sub_agent_name else "default",
+        sub_agent_name=sub_agent_name,
+    )
+
+
+def test_resolve_harness_resolves_nested_grandchild_subagent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A grandchild head resolves its own harness via the full-tree search.
+
+    The pre-existing direct-children-only lookup missed a nested sub-agent
+    and fell back to the brain harness; the full-tree resolver finds it.
+    """
+    _patch_harness_stores(monkeypatch, _harness_spec_tree())
+
+    assert _resolve_harness(_conv_for_subagent("executor")) == "codex"
+
+
+def test_resolve_harness_falls_back_to_brain_for_unknown_subagent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unresolvable sub-agent name keeps the brain harness (safe fallback)."""
+    _patch_harness_stores(monkeypatch, _harness_spec_tree())
+
+    assert _resolve_harness(_conv_for_subagent("does-not-exist")) == "claude-sdk"
+
+
+def test_resolve_harness_top_level_session_uses_brain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A top-level session (no sub_agent_name) reports the brain harness."""
+    _patch_harness_stores(monkeypatch, _harness_spec_tree())
+
+    assert _resolve_harness(_conv_for_subagent(None)) == "claude-sdk"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `_resolve_harness` (the session snapshot's provider-family resolver) looked up `conv.sub_agent_name` only among the parent spec's **direct** children (`loaded.spec.sub_agents`). For a **nested** (grandchild) sub-agent head, that lookup missed and fell back to the bundle brain's harness — so the UI showed the wrong provider family / credential (e.g. `claude-sdk` for a session the runner actually spawns on `codex`).
- Route the lookup through `_find_spec_by_name` — the **same full-tree resolver the runner uses** at its boot/turn sites — so a sub-agent at any depth resolves and the snapshot reports the head's own harness. Unresolvable names still fall back to the brain, unchanged.
- Follow-up to #2408, which fixed the parallel `llm_model` / `context_window` derivation for child sessions but left this harness field resolving only direct children. This aligns all sub-agent metadata on one resolver so they can't disagree by nesting depth.

## Test Plan

```bash
OMNIGENT_SKIP_WEB_UI=true uv run --extra dev python -m pytest \
  tests/server/routes/test_sessions_snapshot.py \
  tests/test_sessions_native_messages.py \
  tests/server/integration/test_sessions_harness_override.py -q
```

- 56 passed. The new `test_resolve_harness_resolves_nested_grandchild_subagent` was confirmed to **fail** against the old direct-children-only lookup (`assert 'claude-sdk' == 'codex'`) and pass with the fix — a genuine regression test.
- `ruff check` / `ruff format --check` clean on both files.
- `mypy` error count unchanged (81 → 81 on the two files; the pre-existing errors are not in the changed region).

## Demo

N/A — server-side metadata resolution, no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests drive `_resolve_harness` directly across a 3-level bundle (advisor `claude-sdk` → mid → executor `codex`): the grandchild resolves to `codex`, while an unknown sub-agent name and a top-level session both report the brain harness (fallback preserved).
