### PR TITLE
fix(pi-native): surface task plans in shared Tasks panel

### DIFF
--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -1198,6 +1198,157 @@ module.exports = function (pi) {
     }
   }
 
+  let taskList = [];
+
+  function normalizeTaskList(value) {
+    if (!Array.isArray(value)) return null;
+    const statuses = new Set(["not-started", "in-progress", "completed"]);
+    const normalized = [];
+    for (const task of value) {
+      if (
+        !task ||
+        typeof task !== "object" ||
+        !Number.isInteger(task.id) ||
+        typeof task.title !== "string" ||
+        typeof task.description !== "string" ||
+        !statuses.has(task.status)
+      ) {
+        return null;
+      }
+      normalized.push({
+        id: task.id,
+        title: task.title,
+        description: task.description,
+        status: task.status,
+      });
+    }
+    return normalized;
+  }
+
+  async function publishTaskList() {
+    const status = {
+      "not-started": "pending",
+      "in-progress": "in_progress",
+      completed: "completed",
+    };
+    await postEvent(config, {
+      type: "external_session_todos",
+      data: {
+        todos: taskList.map((task) => ({
+          content: task.title,
+          status: status[task.status],
+          activeForm: task.description || task.title,
+        })),
+      },
+    });
+  }
+
+  function restoreTaskList(ctx) {
+    taskList = [];
+    const entries =
+      ctx &&
+      ctx.sessionManager &&
+      typeof ctx.sessionManager.getBranch === "function"
+        ? ctx.sessionManager.getBranch()
+        : [];
+    for (const entry of entries) {
+      const message = entry && entry.type === "message" ? entry.message : null;
+      if (
+        !message ||
+        message.role !== "toolResult" ||
+        message.toolName !== "manage_todo_list"
+      ) {
+        continue;
+      }
+      const restored = normalizeTaskList(
+        message.details && message.details.todos,
+      );
+      if (restored) taskList = restored;
+    }
+  }
+
+  function registerTaskToolIfMissing() {
+    if (typeof pi.registerTool !== "function") return;
+    const existing =
+      typeof pi.getAllTools === "function"
+        ? pi.getAllTools().some((tool) => tool.name === "manage_todo_list")
+        : false;
+    if (existing) return;
+    pi.registerTool({
+      name: "manage_todo_list",
+      label: "Task Plan",
+      description:
+        "Read or replace the task plan shown in the Omnigent Tasks panel.",
+      promptSnippet: "Read or replace the current task plan",
+      promptGuidelines: [
+        "Use manage_todo_list for multi-step tasks and keep each task's status current.",
+      ],
+      parameters: {
+        type: "object",
+        properties: {
+          operation: { type: "string", enum: ["read", "write"] },
+          todoList: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "integer" },
+                title: { type: "string" },
+                description: { type: "string" },
+                status: {
+                  type: "string",
+                  enum: ["not-started", "in-progress", "completed"],
+                },
+              },
+              required: ["id", "title", "description", "status"],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ["operation"],
+        additionalProperties: false,
+      },
+      async execute(_toolCallId, params) {
+        if (params && params.operation === "read") {
+          return {
+            content: [
+              { type: "text", text: JSON.stringify(taskList, null, 2) },
+            ],
+            details: { operation: "read", todos: taskList },
+          };
+        }
+        if (!params || params.operation !== "write") {
+          throw new Error("operation must be read or write");
+        }
+        const next = normalizeTaskList(params.todoList);
+        if (!next) throw new Error("todoList must contain valid task items");
+        taskList = next;
+        await publishTaskList();
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Task plan updated (${taskList.length} task${taskList.length === 1 ? "" : "s"}).`,
+            },
+          ],
+          details: { operation: "write", todos: taskList },
+        };
+      },
+    });
+  }
+
+  async function syncTaskListFromResult(event) {
+    if (!event || event.toolName !== "manage_todo_list" || event.isError)
+      return;
+    const result =
+      event.result && typeof event.result === "object" ? event.result : event;
+    const next = normalizeTaskList(result.details && result.details.todos);
+    if (!next) return;
+    const changed = JSON.stringify(next) !== JSON.stringify(taskList);
+    taskList = next;
+    if (changed) await publishTaskList();
+  }
+
   // Cumulative session token usage. Pi reports PER-MESSAGE counts (one
   // assistant message per LLM call); session billing is their SUM — each call
   // is billed for the full context it re-sent, so summing per-message inputs is
@@ -1492,6 +1643,9 @@ module.exports = function (pi) {
 
   pi.on("session_start", async (_event, ctx) => {
     rememberContext(ctx);
+    registerTaskToolIfMissing();
+    restoreTaskList(ctx);
+    if (taskList.length) await publishTaskList();
     setOmnigentStatus(config, ctx, "linked");
     startInboxPoller(
       pi,
@@ -1526,6 +1680,11 @@ module.exports = function (pi) {
       type: "external_session_status",
       data: { status: "idle", response_id: `pi-${Date.now()}-${++sequence}` },
     });
+  });
+
+  pi.on("session_tree", async (_event, ctx) => {
+    restoreTaskList(ctx);
+    await publishTaskList();
   });
 
   pi.on("model_select", async (event, ctx) => {
@@ -1689,6 +1848,7 @@ module.exports = function (pi) {
   pi.on("tool_result", async (event, ctx) => {
     rememberContext(ctx);
     replayPendingInterrupt(ctx);
+    await syncTaskListFromResult(event);
     await postToolResult(event, currentResponseId());
   });
 

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.test.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.test.js
@@ -32,7 +32,7 @@ const harnesses = [];
 // Build a fresh extension instance with its own temp inbox directory. Each call
 // produces independent closure state (activeResponseId, pendingInterruptUntil,
 // latestContext, ...).
-function makeHarness({ captureEvents = false } = {}) {
+function makeHarness({ captureEvents = false, existingTools = [] } = {}) {
   const inboxDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-inbox-"));
   const configPath = path.join(inboxDir, "config.json");
   // A serverUrl + sessionId make postEvent attempt a real fetch; with a mock
@@ -58,11 +58,16 @@ function makeHarness({ captureEvents = false } = {}) {
   }
 
   const handlers = {};
+  const registeredTools = {};
   const pi = {
     on: (name, fn) => {
       handlers[name] = fn;
     },
     registerCommand: () => {},
+    registerTool: (tool) => {
+      registeredTools[tool.name] = tool;
+    },
+    getAllTools: () => existingTools,
     sendUserMessage: () => {},
   };
 
@@ -71,7 +76,7 @@ function makeHarness({ captureEvents = false } = {}) {
   const mod = require(EXT_PATH);
   mod(pi);
 
-  const h = { pi, handlers, inboxDir, postedEvents };
+  const h = { pi, handlers, inboxDir, postedEvents, registeredTools };
   harnesses.push(h);
   return h;
 }
@@ -297,6 +302,122 @@ async function testAgentStartClearsStaleWindow() {
   );
 }
 
+async function testTaskPlanPublishesTodos() {
+  const h = makeHarness({ captureEvents: true });
+  await h.handlers.session_start({}, {});
+  const tool = h.registeredTools.manage_todo_list;
+  assert("registers manage_todo_list", !!tool);
+
+  const result = await tool.execute("todo-1", {
+    operation: "write",
+    todoList: [
+      {
+        id: 1,
+        title: "Trace rendering",
+        description: "Tracing the shared event path",
+        status: "in-progress",
+      },
+      {
+        id: 2,
+        title: "Run checks",
+        description: "Run focused checks",
+        status: "not-started",
+      },
+    ],
+  });
+  const event = h.postedEvents.find(
+    (item) => item.type === "external_session_todos",
+  );
+  assert(
+    "manage_todo_list publishes the shared todo event",
+    JSON.stringify(event && event.data.todos) ===
+      JSON.stringify([
+        {
+          content: "Trace rendering",
+          status: "in_progress",
+          activeForm: "Tracing the shared event path",
+        },
+        {
+          content: "Run checks",
+          status: "pending",
+          activeForm: "Run focused checks",
+        },
+      ]),
+    JSON.stringify(event),
+  );
+  assert(
+    "manage_todo_list persists its current list in tool details",
+    result.details.todos.length === 2 &&
+      result.details.todos[0].status === "in-progress",
+    JSON.stringify(result),
+  );
+
+  const restored = makeHarness({ captureEvents: true });
+  await restored.handlers.session_start(
+    {},
+    {
+      sessionManager: {
+        getBranch: () => [
+          {
+            type: "message",
+            message: {
+              role: "toolResult",
+              toolName: "manage_todo_list",
+              details: { todos: result.details.todos },
+            },
+          },
+        ],
+      },
+    },
+  );
+  const restoredEvent = restored.postedEvents.find(
+    (item) => item.type === "external_session_todos",
+  );
+  assert(
+    "session_start restores and republishes the latest task plan",
+    restoredEvent && restoredEvent.data.todos.length === 2,
+    JSON.stringify(restoredEvent),
+  );
+}
+
+async function testExistingTaskToolIsMirroredWithoutConflict() {
+  const h = makeHarness({
+    captureEvents: true,
+    existingTools: [{ name: "manage_todo_list" }],
+  });
+  await h.handlers.session_start({}, {});
+  assert(
+    "reuses an existing manage_todo_list tool",
+    !h.registeredTools.manage_todo_list,
+  );
+
+  await h.handlers.tool_result(
+    {
+      toolCallId: "external-todo-1",
+      toolName: "manage_todo_list",
+      details: {
+        todos: [
+          {
+            id: 1,
+            title: "Use the shared tool",
+            description: "Using the shared task tool",
+            status: "in-progress",
+          },
+        ],
+      },
+    },
+    {},
+  );
+  const event = h.postedEvents.find(
+    (item) => item.type === "external_session_todos",
+  );
+  assert(
+    "mirrors an existing task tool into the shared todo event",
+    event && event.data.todos[0].content === "Use the shared tool",
+    JSON.stringify(event),
+  );
+}
+
 // The web store only clears its local "streaming" flag when a turn's `idle`
 // status edge carries the same response_id as the `running` edge that opened
 // it. A fresh id per edge left the composer stuck queueing until a tab switch
@@ -347,6 +468,8 @@ async function testRunningIdleShareResponseId() {
 (async () => {
   try {
     await testRunningIdleShareResponseId();
+    await testTaskPlanPublishesTodos();
+    await testExistingTaskToolIsMirroredWithoutConflict();
     await testIdleInterruptDoesNotPoisonNextTurn();
     await testIdleInterruptFallbackNoIsIdle();
     await testMidTurnInterruptStillAborts();

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -2645,36 +2645,31 @@ describe("Mobile session menu", () => {
     expect(screen.getByTestId("todo-panel")).toBeInTheDocument();
   });
 
-  it("opens the Tasks drawer for a codex-native session with todos", () => {
-    // Codex-native maps its plan updates to the same todo schema, so the
-    // Tasks entry must gate on codex-native too — not just claude-native.
+  it.each([
+    ["codex-native", "conv_codex", "codex-native-ui"],
+    ["pi-native", "conv_pi", "pi-native-ui"],
+  ])("opens the Tasks drawer for a %s session with todos", (_harness, id, wrapper) => {
     useEnvironmentMock.mockReturnValue({
       data: { available: true, root: null },
       isLoading: false,
     } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
     mockConversations([
       {
-        id: "conv_codex",
+        id,
         permission_level: null,
-        labels: { "omnigent.wrapper": "codex-native-ui" },
+        labels: { "omnigent.wrapper": wrapper },
       },
     ]);
     useChatStore.setState({
-      todos: [
-        { content: "Locate CLI parser", status: "in_progress", activeForm: "Locate CLI parser" },
-      ],
+      todos: [{ content: "Locate CLI parser", status: "in_progress", activeForm: "Locating" }],
     });
 
-    renderShell("/c/conv_codex");
-
+    renderShell(`/c/${id}`);
     expect(screen.getByTestId("todos-panel-drawer")).toHaveAttribute("data-state", "closed");
-    expect(screen.queryByTestId("todo-panel")).toBeNull();
 
     openSessionMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: /Tasks/i }));
 
-    // A codex-native session with a non-empty plan opens the Tasks drawer,
-    // the same as a claude-native session with todos.
     expect(screen.getByTestId("todos-panel-drawer")).toHaveAttribute("data-state", "open");
     expect(screen.getByTestId("todo-panel")).toBeInTheDocument();
   });

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -59,7 +59,6 @@ import {
 } from "@/hooks/useWorkspaceChangedFiles";
 import { cn } from "@/lib/utils";
 import { isNativeWrapper as isNativeWrapperLabel } from "@/lib/nativeCodingAgents";
-import { isCodexNativeSession } from "@/lib/codexPlanMode";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { isSingleUserMode } from "@/lib/capabilities";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
@@ -346,16 +345,14 @@ export function AppShell() {
   const sessionLabels = { ...activeConv?.labels, ...activeSession?.labels };
   const terminalFirst = sessionLabels["omnigent.ui"] === "terminal";
   const isClaudeNative = sessionLabels["omnigent.wrapper"] === "claude-code-native-ui";
-  // Harnesses that publish a todo list to the TodoPanel: Claude via
-  // TodoWrite, and Codex which maps its plan updates to the same schema.
-  const isCodexNative = isCodexNativeSession({ labels: sessionLabels });
-  const todosSupported = isClaudeNative || isCodexNative;
+  const todos = useChatStore((s) => s.todos);
+  // The session.todos contract is harness-agnostic; show Tasks when it has data.
+  const todosSupported = todos.length > 0;
   // Native-CLI wrapper of either family. Keys harness behavior gates
   // (composer slash commands, `/model`); terminal-first SDK sessions
   // (embedded Omnigent REPL terminal) have NO wrapper label and must
   // keep regular chat behavior. See TerminalFirstContext.tsx.
   const isNativeWrapper = isNativeWrapperLabel(sessionLabels["omnigent.wrapper"]);
-  const todos = useChatStore((s) => s.todos);
   const todosCompleted = todos.filter((t) => t.status === "completed").length;
   // Used for the header "Back to parent" link, which is hidden on
   // top-level sessions. The Subagents tab itself is always visible —

--- a/web/src/shell/TodoPanel.tsx
+++ b/web/src/shell/TodoPanel.tsx
@@ -23,16 +23,10 @@ function TodoIcon({ status }: { status: TodoItem["status"] }) {
 }
 
 /**
- * Displays Claude Code's active todo list for `omnigent claude` sessions.
+ * Displays the active task list published by any harness.
  *
- * Reads from `useChatStore.todos` which is populated by:
- * - the session snapshot on bind (from `_session_todos_cache` on the server)
- * - `session.todos` SSE events emitted whenever the forwarder detects a
- *   change in Claude's `~/.claude/todos/{session_id}-agent-{session_id}.json`
- *
- * Renders nothing when the todo list is empty, so the panel occupies no
- * space for sessions that have never had todos (non-claude-native, or
- * claude-native before the first turn creates any todos).
+ * Reads from `useChatStore.todos`, populated by the session snapshot and
+ * `session.todos` SSE updates. Renders nothing while the list is empty.
  */
 export function TodoPanel({ frameless = false }: TodoPanelProps) {
   const todos = useChatStore((s) => s.todos);


### PR DESCRIPTION
## Related issue

N/A — found while testing task-plan parity across native harnesses.

## Summary

- Pi task plans were not reaching the shared Tasks panel that already renders Claude Code and Codex plans. The pi-native extension now reuses an existing `manage_todo_list` tool when one is installed, otherwise registers a fallback, and maps successful task results onto the existing `external_session_todos` contract.
- Task state is restored from Pi session history and republished on session/tree restore. Deferring fallback registration also avoids crashing Pi when an extension such as `pi-archimedes` already owns the tool name.
- The web shell now shows Tasks whenever the harness-agnostic `session.todos` data exists, so browser and desktop continue to share the existing `TodoPanel`.

**ELI5:** when Pi makes a checklist, Omnigent now sends it through the same checklist pipeline used by the other coding harnesses.

```text
Pi task tool -> external_session_todos -> session.todos -> chatStore.todos -> TodoPanel
```

## Test Plan

- `node omnigent/resources/pi_native/omnigent_pi_native_extension.test.js` — 24 checks passed, including fallback registration, existing-tool reuse, result mirroring, and session restore.
- `python -m pytest tests/test_pi_native_extension.py -q` — 38 passed.
- `cd web && npm test -- src/shell/AppShell.test.tsx` — 84 passed.
- `cd web && npm run type-check` — passed.
- `pre-commit run --all-files` — passed.
- Reproduced Pi 0.80.10 startup with the globally installed `pi-archimedes` extension in an isolated tmux pane: the pre-fix duplicate tool registration exited with status 1; the fixed extension kept the Pi TUI running.

## Demo

Todo's from Pi now shows up in the `Tasks` sidebar tab:

<img width="1791" height="1020" alt="Screenshot 2026-07-19 at 15 40 52" src="https://github.com/user-attachments/assets/bfa8dffd-a3d0-479a-94df-84634612c8f8" />
<img width="1713" height="1001" alt="Screenshot 2026-07-19 at 15 43 46" src="https://github.com/user-attachments/assets/a71ed13b-dcd4-4058-9da6-ba472c9bdaa5" />
<img width="1800" height="1005" alt="Screenshot 2026-07-19 at 15 59 35" src="https://github.com/user-attachments/assets/00afe2f7-e28c-4785-bf68-2be8a848fd99" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification focused on the native Pi startup boundary and the real global-extension conflict: duplicate `manage_todo_list` registration was reproduced, then the fixed extension was confirmed to coexist with `pi-archimedes` and remain running. A browser/desktop task-panel recording remains as a draft-PR follow-up before review.

## Changelog

Pi task plans now appear in the same Tasks panel as Claude Code and Codex plans.
