### PR TITLE
feat(Codex): Render Codex native and headless plans in Web/Desktop tasks list

### DIFF
--- a/omnigent/_codex_plan.py
+++ b/omnigent/_codex_plan.py
@@ -1,0 +1,35 @@
+"""Normalize Codex plan notifications for the shared Tasks UI."""
+
+from __future__ import annotations
+
+
+def todos_from_plan_update(params: object) -> list[dict[str, object]] | None:
+    """Map ``turn/plan/updated`` params to the shared todo schema."""
+    if not isinstance(params, dict):
+        return None
+    plan = params.get("plan")
+    if not isinstance(plan, list) or not plan:
+        return None
+
+    todos: list[dict[str, object]] = []
+    for entry in plan:
+        if not isinstance(entry, dict):
+            continue
+        step = entry.get("step")
+        if not isinstance(step, str) or not step:
+            continue
+        status = entry.get("status")
+        todos.append(
+            {
+                "content": step,
+                "status": (
+                    "completed"
+                    if status == "completed"
+                    else "in_progress"
+                    if status in {"inProgress", "in_progress"}
+                    else "pending"
+                ),
+                "activeForm": step,
+            }
+        )
+    return todos or None

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import httpx
 
+from omnigent._codex_plan import todos_from_plan_update
 from omnigent._native_forwarder_health import (
     note_post_success as note_native_post_success,
 )
@@ -3084,41 +3085,14 @@ async def _handle_turn_plan_updated(
     session_id: str,
     params: dict[str, Any],
 ) -> None:
-    """
-    Mirror a Codex plan update in both the transcript and the todo panel.
-
-    Codex emits plan changes as app-server notifications rather than
-    ordinary assistant text. The forwarder posts the structured plan as an
-    ``external_session_todos`` event so the web ``TodoPanel`` renders it like
-    Claude's todo list, and also mirrors it as a compact assistant message so
-    the plan stays visible inline in the transcript.
-
-    :param client: HTTP client for Omnigent event posts.
-    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
-    :param params: Codex ``turn/plan/updated`` params.
-    :returns: None.
-    """
-    todos = _plan_todos_from_update(params)
+    """Publish a Codex plan update to the todo panel."""
+    todos = todos_from_plan_update(params)
     if todos is not None:
         await _post_external_session_todos(
             client,
             session_id=session_id,
             todos=todos,
         )
-    text = _plan_text_from_update(params)
-    if not text:
-        return
-    await _post_external_item(
-        client,
-        session_id,
-        item_type="message",
-        item_data={
-            "role": "assistant",
-            "agent": _AGENT_NAME,
-            "content": [{"type": "output_text", "text": text}],
-        },
-        response_id=_response_id(params),
-    )
 
 
 def _handle_turn_diff_updated(
@@ -5684,7 +5658,7 @@ async def _post_external_session_todos(
     client: httpx.AsyncClient,
     *,
     session_id: str,
-    todos: list[dict[str, Any]],
+    todos: list[dict[str, object]],
 ) -> None:
     """
     Post one ``external_session_todos`` event to the Sessions API.
@@ -6849,97 +6823,6 @@ def _json_string(value: dict[str, Any]) -> str | None:
         return json.dumps(value, ensure_ascii=False)
     except (TypeError, ValueError):
         return None
-
-
-def _plan_text_from_update(params: dict[str, Any]) -> str | None:
-    """
-    Render a Codex ``turn/plan/updated`` payload as Markdown text.
-
-    :param params: Codex plan update params.
-    :returns: Markdown plan text, or ``None`` when no valid plan steps
-        are present.
-    """
-    plan = params.get("plan")
-    if not isinstance(plan, list) or not plan:
-        return None
-    lines: list[str] = []
-    explanation = params.get("explanation")
-    if isinstance(explanation, str) and explanation:
-        lines.append(explanation)
-        lines.append("")
-    lines.append("Plan:")
-    for entry in plan:
-        if not isinstance(entry, dict):
-            continue
-        step = entry.get("step")
-        if not isinstance(step, str) or not step:
-            continue
-        status = entry.get("status")
-        marker = _plan_status_marker(status)
-        lines.append(f"{marker} {step}")
-    if len(lines) == 1 or (len(lines) == 3 and lines[-1] == "Plan:"):
-        return None
-    return "\n".join(lines)
-
-
-def _plan_todos_from_update(params: dict[str, Any]) -> list[dict[str, Any]] | None:
-    """
-    Map a Codex ``turn/plan/updated`` payload to the todo-list schema.
-
-    Produces items shaped like Claude's ``TodoWrite`` output so the web
-    ``TodoPanel`` can render Codex plans through the same pipeline. Codex
-    steps have no gerund ``activeForm``, so the step text is reused there.
-
-    :param params: Codex plan update params.
-    :returns: List of ``{"content", "status", "activeForm"}`` items, or
-        ``None`` when no valid plan steps are present.
-    """
-    plan = params.get("plan")
-    if not isinstance(plan, list) or not plan:
-        return None
-    todos: list[dict[str, Any]] = []
-    for entry in plan:
-        if not isinstance(entry, dict):
-            continue
-        step = entry.get("step")
-        if not isinstance(step, str) or not step:
-            continue
-        todos.append(
-            {
-                "content": step,
-                "status": _plan_todo_status(entry.get("status")),
-                "activeForm": step,
-            }
-        )
-    return todos or None
-
-
-def _plan_todo_status(status: Any) -> str:
-    """
-    Normalize a Codex plan step status to the todo-list vocabulary.
-
-    :param status: Codex step status value.
-    :returns: One of ``"pending"``, ``"in_progress"``, ``"completed"``.
-    """
-    if status == "completed":
-        return "completed"
-    if status in {"inProgress", "in_progress"}:
-        return "in_progress"
-    return "pending"
-
-
-def _plan_status_marker(status: Any) -> str:
-    """
-    Return a readable Markdown marker for a Codex plan step status.
-
-    :param status: Codex step status value.
-    :returns: Markdown list marker.
-    """
-    return {
-        "completed": "- [x]",
-        "in_progress": "- [~]",
-        "pending": "- [ ]",
-    }[_plan_todo_status(status)]
 
 
 def _response_id(params: dict[str, Any]) -> str:

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, TypeAlias
 
+from omnigent._codex_plan import todos_from_plan_update
 from omnigent._platform import resolve_cli_binary
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.reasoning_effort import CODEX_EFFORTS, validate_effort
@@ -42,6 +43,7 @@ from .executor import (
     Message,
     ReasoningChunk,
     TextChunk,
+    TodoListUpdate,
     ToolArgs,
     ToolCallComplete,
     ToolCallRequest,
@@ -1615,6 +1617,14 @@ class _CodexAppServerSession:
                 raw_method = message.get("method")
                 method: str | None = raw_method if isinstance(raw_method, str) else None
                 params = message.get("params", {})
+
+                if method == "turn/plan/updated":
+                    if not _event_turn_matches(params):
+                        continue
+                    todos = todos_from_plan_update(params)
+                    if todos is not None:
+                        yield TodoListUpdate(todos=todos)
+                    continue
 
                 if method == "item/tool/call":
                     if not _event_turn_matches(params):

--- a/omnigent/inner/executor.py
+++ b/omnigent/inner/executor.py
@@ -131,6 +131,17 @@ class ReasoningChunk(ExecutorEvent):
 
 
 @dataclass
+class TodoListUpdate(ExecutorEvent):
+    """Replace the session's current todo list.
+
+    :param todos: Full todo-list snapshot using the shared ``content``,
+        ``status``, and ``activeForm`` item schema.
+    """
+
+    todos: list[dict[str, object]]
+
+
+@dataclass
 class ToolCallRequest(ExecutorEvent):
     """The LLM wants to call a tool.
 

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -54,6 +54,7 @@ from omnigent.inner.executor import (
     Message,
     ReasoningChunk,
     TextChunk,
+    TodoListUpdate,
     ToolCallComplete,
     ToolCallRequest,
     TurnCancelled,
@@ -72,6 +73,7 @@ from omnigent.server.schemas import (
     ReasoningStartedEvent,
     ReasoningSummaryTextDeltaEvent,
     ReasoningTextDeltaEvent,
+    SessionTodosEvent,
 )
 
 _logger = logging.getLogger(__name__)
@@ -256,6 +258,7 @@ class ExecutorAdapter(HarnessApp):
             scaffold.
         """
         executor = self._ensure_executor()
+        conversation_id = request.conversation.id if request.conversation is not None else None
         messages = _translate_input_to_messages(request.input)
         # Stamp every message with the adapter's session_key so
         # the inner :class:`ClaudeSDKExecutor` keys its cached
@@ -435,7 +438,7 @@ class ExecutorAdapter(HarnessApp):
                                 # aggregate visibility.
                                 record_llm_usage(agent_span, event.usage)
                     # --- End tracing ---
-                    self._translate_event(event, ctx)
+                    self._translate_event(event, ctx, conversation_id=conversation_id)
                     if isinstance(event, TurnComplete):
                         if tctx is not None and agent_span is not None:
                             tctx.end_agent_span(agent_span, response=response_text)
@@ -827,7 +830,13 @@ class ExecutorAdapter(HarnessApp):
             self._executor = self._executor_factory()
         return self._executor
 
-    def _translate_event(self, event: ExecutorEvent, ctx: TurnContext) -> None:
+    def _translate_event(
+        self,
+        event: ExecutorEvent,
+        ctx: TurnContext,
+        *,
+        conversation_id: str | None = None,
+    ) -> None:
         """
         Translate one inner :class:`ExecutorEvent` into Omnigent SSE
         events emitted via ``ctx.emit``.
@@ -842,6 +851,7 @@ class ExecutorAdapter(HarnessApp):
         :param event: The inner executor event to translate.
         :param ctx: The per-turn context; events are pushed onto
             its queue.
+        :param conversation_id: Session id used by session-scoped events.
         """
         if isinstance(event, TextChunk):
             ctx.emit(
@@ -873,6 +883,19 @@ class ExecutorAdapter(HarnessApp):
                         delta=event.delta,
                     ),
                 )
+        elif isinstance(event, TodoListUpdate):
+            if conversation_id is None:
+                _logger.warning("Dropping todo update without a conversation id")
+                return
+            ctx.emit(
+                SessionTodosEvent.model_validate(
+                    {
+                        "type": "session.todos",
+                        "conversation_id": conversation_id,
+                        "todos": event.todos,
+                    }
+                )
+            )
         elif isinstance(event, ToolCallRequest):
             # Observed function_call item, emitted INLINE as the
             # inner SDK parses each tool_use block — that's what

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -56,6 +56,7 @@ from omnigent.policies.types import FAIL_CLOSED_PHASES
 from omnigent.runtime.tool_output import cap_tool_output
 from omnigent.server.schemas import (
     CompletedEvent,
+    ConversationRef,
     CreatedEvent,
     CreateResponseRequest,
     ElicitationRequestEvent,
@@ -1107,7 +1108,10 @@ class HarnessApp:
             return denied
         self._check_conversation_id(request, conversation_id)
         if isinstance(body, MessageEvent):
-            return await self._start_or_inject_turn(body.to_create_request())
+            turn_request = body.to_create_request().model_copy(
+                update={"conversation": ConversationRef(id=conversation_id)}
+            )
+            return await self._start_or_inject_turn(turn_request)
         if isinstance(body, InterruptEvent):
             return await self._handle_interrupt_event()
         if isinstance(body, ToolResultEvent):

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -582,9 +582,8 @@ _LAST_TASK_ERROR_MESSAGE_LABEL_KEY: str = "omnigent.last_task_error_message"
 # from the schema so the truncation and the column can never drift apart.
 _LABEL_VALUE_MAX_LEN: int = LABEL_VALUE_MAX_LEN
 
-# Todo-list update from the claude-native forwarder. Carries the raw
-# todo items captured from PostToolUse/TodoWrite hook events. Payload
-# shape: ``{"todos": [{"content": "...", "status": "...", "activeForm": ...}]}``.
+# Todo-list update from native harness forwarders. Payload shape:
+# ``{"todos": [{"content": "...", "status": "...", "activeForm": ...}]}``.
 _EXTERNAL_SESSION_TODOS_TYPE: str = "external_session_todos"
 
 # Session labels stamped by ``omnigent claude``. A matching session
@@ -1141,9 +1140,9 @@ def announce_hosts_changed(user_id: str | None) -> None:
     user_session_stream.publish(_discovery_key(user_id), {"type": "hosts_changed"})
 
 
-# Per-session todo cache updated by external_session_todos events from the
-# claude-native forwarder. Used by _build_session_response to populate the
-# ``todos`` snapshot field so the panel survives page refresh.
+# Per-session todo cache updated by native ``external_session_todos`` events
+# and runner ``session.todos`` events. Used by _build_session_response so the
+# panel survives page refresh.
 _session_todos_cache: dict[str, list[dict[str, Any]]] = {}
 
 # Per-session terminal-spin-up flag updated by the runner SSE relay from
@@ -4043,47 +4042,16 @@ async def _persist_model_change_note(
     _publish_external_conversation_item(session_id, persisted_items[0])
 
 
-def _handle_external_session_todos(
-    session_id: str,
-    body: SessionEventInput,
-) -> None:
-    """
-    Cache and broadcast a todo-list update from a native forwarder.
-
-    Sent by the claude-native forwarder (from ``TodoWrite``) and the
-    codex-native forwarder (from Codex plan updates); the panel is
-    harness-agnostic.
-
-    Updates the in-memory ``_session_todos_cache`` so subsequent
-    ``GET /v1/sessions/{id}`` snapshot calls can populate the ``todos``
-    field without a file read. Then publishes a ``session.todos`` SSE event
-    so connected web clients update their todo panel immediately.
-
-    :param session_id: Session/conversation identifier,
-        e.g. ``"conv_abc123"``.
-    :param body: The ``external_session_todos`` event body. Must have
-        ``data.todos`` as a list of todo dicts, e.g.
-        ``[{"content": "Fix bug", "status": "in_progress", "activeForm": "Fixing the bug"}]``.
-    :raises OmnigentError: When ``data.todos`` is missing or not a list.
-    """
-    todos = body.data.get("todos")
-    if not isinstance(todos, list):
-        raise OmnigentError(
-            "external_session_todos requires data.todos to be a list",
-            code=ErrorCode.INVALID_INPUT,
-        )
-    # Filter to well-formed items before caching so that malformed entries
-    # from a buggy forwarder version don't persist in the snapshot.  The
-    # same filter is applied by sse.ts on the live-event path; keeping the
-    # two in sync means the snapshot and live panel always show the same set.
+def _publish_session_todos(session_id: str, todos: list[Any]) -> None:
+    """Validate, cache, and broadcast a complete todo-list snapshot."""
     valid_statuses = {"pending", "in_progress", "completed"}
     validated: list[dict[str, Any]] = [
-        t
-        for t in todos
-        if isinstance(t, dict)
-        and isinstance(t.get("content"), str)
-        and t.get("status") in valid_statuses
-        and isinstance(t.get("activeForm"), str)
+        item
+        for item in todos
+        if isinstance(item, dict)
+        and isinstance(item.get("content"), str)
+        and item.get("status") in valid_statuses
+        and isinstance(item.get("activeForm"), str)
     ]
     _session_todos_cache[session_id] = validated
     event = SessionTodosEvent(
@@ -4092,6 +4060,20 @@ def _handle_external_session_todos(
         todos=validated,
     )
     session_stream.publish(session_id, event.model_dump())
+
+
+def _handle_external_session_todos(
+    session_id: str,
+    body: SessionEventInput,
+) -> None:
+    """Cache and broadcast a todo-list update from a native forwarder."""
+    todos = body.data.get("todos")
+    if not isinstance(todos, list):
+        raise OmnigentError(
+            "external_session_todos requires data.todos to be a list",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    _publish_session_todos(session_id, todos)
 
 
 def _publish_external_conversation_item(
@@ -10444,6 +10426,17 @@ async def _relay_runner_stream(
                             session_id,
                             event.get("pending") is True,
                         )
+                        continue
+
+                    if evt_type == "session.todos":
+                        todos = event.get("todos")
+                        if isinstance(todos, list):
+                            _publish_session_todos(session_id, todos)
+                        else:
+                            _logger.warning(
+                                "Relay: ignored malformed todo update for session=%s",
+                                session_id,
+                            )
                         continue
 
                     # Track the turn's response_id from lifecycle

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -28,6 +28,7 @@ from omnigent.inner.executor import (
     ExecutorError,
     ReasoningChunk,
     TextChunk,
+    TodoListUpdate,
     ToolCallComplete,
     ToolCallRequest,
     ToolCallStatus,
@@ -1453,6 +1454,71 @@ class TestCodexExecutor(unittest.TestCase):
             self.assertEqual(len(events), 1)
             self.assertIsInstance(events[0], TurnComplete)
             self.assertEqual(events[0].response, "done")
+
+        _run(_t())
+
+    def test_app_server_run_turn_plan_updates_yield_todo_list(self):
+        """``turn/plan/updated`` becomes a shared todo-list update."""
+
+        async def _t():
+            session = _CodexAppServerSession(
+                codex_path="/bin/echo",
+                cwd="/tmp/workspace",
+                env={},
+                tool_executor=None,
+            )
+            session.start = AsyncMock()
+            session._proc = _FakeProcess()
+            session.thread_id = "thread-1"
+            session._request = AsyncMock(return_value={"result": {"turn": {"id": "turn-1"}}})
+
+            async def _inject() -> None:
+                await asyncio.sleep(0.01)
+                session._events.put_nowait(
+                    {
+                        "method": "turn/plan/updated",
+                        "params": {
+                            "turnId": "turn-1",
+                            "plan": [
+                                {"step": "Inspect", "status": "completed"},
+                                {"step": "Implement", "status": "inProgress"},
+                                {"step": "Verify", "status": "pending"},
+                            ],
+                        },
+                    }
+                )
+                session._events.put_nowait(
+                    {"method": "turn/completed", "params": {"turn": {"id": "turn-1"}}}
+                )
+
+            inject_task = asyncio.create_task(_inject())
+            events = [
+                event
+                async for event in session.run_turn(
+                    messages=[{"role": "user", "content": "fix it"}],
+                    tools=[],
+                    system_prompt="",
+                    model="gpt-5.4-mini",
+                    cwd=".",
+                    sandbox="workspace-write",
+                )
+            ]
+            await inject_task
+
+            todo_update = next(event for event in events if isinstance(event, TodoListUpdate))
+            self.assertFalse(any(isinstance(event, TextChunk) for event in events))
+            self.assertEqual(
+                todo_update.todos,
+                [
+                    {"content": "Inspect", "status": "completed", "activeForm": "Inspect"},
+                    {
+                        "content": "Implement",
+                        "status": "in_progress",
+                        "activeForm": "Implement",
+                    },
+                    {"content": "Verify", "status": "pending", "activeForm": "Verify"},
+                ],
+            )
 
         _run(_t())
 

--- a/tests/runtime/harnesses/_test_executor_adapter_harness.py
+++ b/tests/runtime/harnesses/_test_executor_adapter_harness.py
@@ -10,6 +10,7 @@ Four scripts:
 - ``"text_only"``: a single TurnComplete with response text.
 - ``"tool_call"``: a ToolCallRequest, then a ToolCallComplete
   with a result, then a TurnComplete (no further text).
+- ``"todo_list"``: a TodoListUpdate followed by TurnComplete.
 - ``"error"``: an ExecutorError event.
 - ``"cancelled"``: a TurnCancelled event.
 - ``"capture_messages"``: writes the received messages list as
@@ -36,6 +37,7 @@ from omnigent.inner.executor import (
     ExecutorEvent,
     Message,
     MockExecutor,
+    TodoListUpdate,
     ToolCallComplete,
     ToolCallRequest,
     ToolCallStatus,
@@ -135,6 +137,27 @@ def _build_tool_call() -> Executor:
     return executor
 
 
+def _build_todo_list() -> Executor:
+    """MockExecutor scripted with one complete todo-list snapshot."""
+    executor = MockExecutor()
+    executor._turns.append(
+        [
+            TodoListUpdate(
+                todos=[
+                    {"content": "Inspect", "status": "completed", "activeForm": "Inspect"},
+                    {
+                        "content": "Implement",
+                        "status": "in_progress",
+                        "activeForm": "Implement",
+                    },
+                ]
+            ),
+            TurnComplete(response=None),
+        ]
+    )
+    return executor
+
+
 def _build_error() -> Executor:
     """
     MockExecutor scripted with an :class:`ExecutorError`.
@@ -179,6 +202,7 @@ def _build_capture_messages() -> Executor:
 _SCRIPTS: dict[str, Callable[[], Executor]] = {
     "text_only": _build_text_only,
     "tool_call": _build_tool_call,
+    "todo_list": _build_todo_list,
     "error": _build_error,
     "cancelled": _build_cancelled,
     "capture_messages": _build_capture_messages,

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -149,6 +149,12 @@ def use_tool_call(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
+def use_todo_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MockExecutor that yields a complete todo-list snapshot."""
+    monkeypatch.setenv("MOCK_EXECUTOR_SCRIPT", "todo_list")
+
+
+@pytest.fixture
 def use_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """MockExecutor that yields an ExecutorError."""
     monkeypatch.setenv("MOCK_EXECUTOR_SCRIPT", "error")
@@ -214,6 +220,28 @@ async def test_text_chunk_translates_to_output_text_delta(
     # If a future change makes TurnComplete.response emit a
     # delta, this test should be updated.
     assert "response.completed" in event_names
+
+
+async def test_todo_list_uses_bound_conversation_id(
+    use_todo_list: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """TodoListUpdate becomes a session.todos event for the URL session."""
+    conv_id = "conv_todos"
+    client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    events: list[_ParsedSSEEvent] = []
+    async with client.stream(
+        "POST", f"/v1/sessions/{conv_id}/events", json=_start_turn_body()
+    ) as response:
+        async for event in _stream_iter(response):
+            events.append(event)
+
+    todo_event = next(event for event in events if event.event == "session.todos")
+    assert todo_event.data["conversation_id"] == conv_id
+    assert todo_event.data["todos"] == [
+        {"content": "Inspect", "status": "completed", "activeForm": "Inspect"},
+        {"content": "Implement", "status": "in_progress", "activeForm": "Implement"},
+    ]
 
 
 async def test_tool_call_translates_to_paired_function_call_items(

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -2998,6 +2998,46 @@ class _ScriptedStreamingRunnerClient:
 
 
 @pytest.mark.asyncio
+async def test_relay_caches_and_publishes_runner_todos(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runner todo events populate both the live stream and snapshot cache."""
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes.sessions import (
+        _relay_runner_stream,
+        _session_todos_cache,
+    )
+
+    session_id = "79b22ebd2309e48fdeb450c65611d51b"
+    todos = [
+        {"content": "Inspect", "status": "completed", "activeForm": "Inspect"},
+        {"content": "Implement", "status": "in_progress", "activeForm": "Implement"},
+    ]
+    published: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        session_stream,
+        "publish",
+        lambda conversation_id, event: published.append((conversation_id, event)),
+    )
+    client = _FakeStreamingRunnerClient(
+        [_sse_frame({"type": "session.todos", "todos": todos}), "data: [DONE]\n\n"]
+    )
+
+    _session_todos_cache.pop(session_id, None)
+    try:
+        await _relay_runner_stream(session_id, client, _ConversationStore())  # type: ignore[arg-type]
+        assert _session_todos_cache[session_id] == todos
+    finally:
+        _session_todos_cache.pop(session_id, None)
+
+    todo_events = [event for sid, event in published if sid == session_id]
+    assert len(todo_events) == 1
+    assert todo_events[0]["type"] == "session.todos"
+    assert todo_events[0]["conversation_id"] == session_id
+    assert todo_events[0]["todos"] == todos
+
+
+@pytest.mark.asyncio
 async def test_relay_persists_terminal_resource_created_from_runner() -> None:
     """The relay persists a ``resource_event`` for a runner-emitted create.
 

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -17,6 +17,7 @@ import pytest
 import yaml
 
 from omnigent import codex_native, codex_native_app_server, codex_native_forwarder
+from omnigent._codex_plan import todos_from_plan_update
 from omnigent._runner_startup import RunnerStartupProgress
 from omnigent.codex_native_bridge import (
     CodexNativeBridgeState,
@@ -5207,15 +5208,8 @@ def test_forwarder_skips_user_recovery_when_user_seen_live(tmp_path: Path) -> No
     assert fake_client.requests == []
 
 
-def test_forwarder_posts_codex_turn_plan_update(tmp_path: Path) -> None:
-    """
-    Codex ``turn/plan/updated`` notifications are visible in Omnigent web.
-
-    Plan mode emits plan state through a dedicated app-server
-    notification rather than assistant text. If the forwarder ignores
-    it, the terminal shows the plan while the web transcript appears to
-    skip straight to the final prompt.
-    """
+def test_forwarder_posts_codex_turn_plan_update_to_tasks_only(tmp_path: Path) -> None:
+    """Codex plan updates populate Tasks without duplicating chat history."""
     posted: list[dict[str, Any]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -5261,9 +5255,9 @@ def test_forwarder_posts_codex_turn_plan_update(tmp_path: Path) -> None:
 
     asyncio.run(run())
 
-    # The plan is mirrored to the todo panel and inline in the transcript.
-    assert len(posted) == 2
-    todos_post = next(p for p in posted if p["type"] == "external_session_todos")
+    assert len(posted) == 1
+    todos_post = posted[0]
+    assert todos_post["type"] == "external_session_todos"
     assert todos_post["data"]["todos"] == [
         {
             "content": "Inspect Codex plan events",
@@ -5282,36 +5276,16 @@ def test_forwarder_posts_codex_turn_plan_update(tmp_path: Path) -> None:
         },
     ]
 
-    message_post = next(p for p in posted if p["type"] == "external_conversation_item")
-    data = message_post["data"]
-    assert data["item_type"] == "message"
-    assert data["response_id"] == "codex_turn_123"
-    assert data["item_data"] == {
-        "role": "assistant",
-        "agent": "codex-native-ui",
-        "content": [
-            {
-                "type": "output_text",
-                "text": (
-                    "Plan:\n"
-                    "- [x] Inspect Codex plan events\n"
-                    "- [~] Mirror plans to web\n"
-                    "- [ ] Run checks"
-                ),
-            }
-        ],
-    }
-
 
 def test_plan_todos_from_update_maps_steps_and_statuses() -> None:
     """
-    ``_plan_todos_from_update`` maps Codex plan steps to the todo schema.
+    ``todos_from_plan_update`` maps Codex plan steps to the todo schema.
 
     Each step becomes ``{"content", "status", "activeForm"}`` with the
     status vocabulary normalized (``inProgress`` -> ``in_progress``) and the
     step text reused for ``activeForm`` since Codex has no gerund form.
     """
-    todos = codex_native_forwarder._plan_todos_from_update(
+    todos = todos_from_plan_update(
         {
             "plan": [
                 {"step": "Inspect", "status": "completed"},
@@ -5334,24 +5308,19 @@ def test_plan_todos_from_update_maps_steps_and_statuses() -> None:
 
 def test_plan_todos_from_update_skips_malformed_and_empty() -> None:
     """
-    ``_plan_todos_from_update`` drops malformed steps and empty plans.
+    ``todos_from_plan_update`` drops malformed steps and empty plans.
 
     Non-dict entries and steps without a usable ``step`` string are
     skipped; a plan that is missing, not a list, or yields no valid
     items returns ``None`` so the caller posts nothing.
     """
-    assert codex_native_forwarder._plan_todos_from_update({}) is None
-    assert codex_native_forwarder._plan_todos_from_update({"plan": []}) is None
-    assert codex_native_forwarder._plan_todos_from_update({"plan": "nope"}) is None
-    assert (
-        codex_native_forwarder._plan_todos_from_update(
-            {"plan": ["bad", {"step": ""}, {"status": "pending"}]}
-        )
-        is None
-    )
-    assert codex_native_forwarder._plan_todos_from_update(
-        {"plan": ["bad", {"step": "Keep me", "status": "pending"}]}
-    ) == [{"content": "Keep me", "status": "pending", "activeForm": "Keep me"}]
+    assert todos_from_plan_update({}) is None
+    assert todos_from_plan_update({"plan": []}) is None
+    assert todos_from_plan_update({"plan": "nope"}) is None
+    assert todos_from_plan_update({"plan": ["bad", {"step": ""}, {"status": "pending"}]}) is None
+    assert todos_from_plan_update({"plan": ["bad", {"step": "Keep me", "status": "pending"}]}) == [
+        {"content": "Keep me", "status": "pending", "activeForm": "Keep me"}
+    ]
 
 
 def test_forwarder_posts_completed_codex_plan_item() -> None:

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -2679,6 +2679,44 @@ describe("Mobile session menu", () => {
     expect(screen.getByTestId("todo-panel")).toBeInTheDocument();
   });
 
+  it("opens the Tasks drawer for a headless codex session with todos", () => {
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_codex_headless", permission_level: null }]);
+    useSessionMock.mockReturnValue({
+      session: {
+        id: "conv_codex_headless",
+        agentId: "ag_codex",
+        agentName: "codex-agent",
+        runnerId: null,
+        status: "idle",
+        createdAt: 0,
+        title: null,
+        labels: {},
+        items: [],
+        pendingElicitations: [],
+        permissionLevel: 4,
+        parentSessionId: null,
+        subAgentName: null,
+        harness: "codex",
+      },
+      isLoading: false,
+      error: null,
+    });
+    useChatStore.setState({
+      todos: [{ content: "Implement", status: "in_progress", activeForm: "Implement" }],
+    });
+
+    renderShell("/c/conv_codex_headless");
+    openSessionMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Tasks/i }));
+
+    expect(screen.getByTestId("todos-panel-drawer")).toHaveAttribute("data-state", "open");
+    expect(screen.getByTestId("todo-panel")).toBeInTheDocument();
+  });
+
   it("keeps the FAB with only the Agents entry for a minimal agent", () => {
     // available:false → no files; no shells, no todos, no debug. The
     // Agents entry is unconditional (badge = 1, the main agent), so the

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -347,9 +347,9 @@ export function AppShell() {
   const terminalFirst = sessionLabels["omnigent.ui"] === "terminal";
   const isClaudeNative = sessionLabels["omnigent.wrapper"] === "claude-code-native-ui";
   // Harnesses that publish a todo list to the TodoPanel: Claude via
-  // TodoWrite, and Codex which maps its plan updates to the same schema.
+  // TodoWrite, and both Codex integrations via plan updates.
   const isCodexNative = isCodexNativeSession({ labels: sessionLabels });
-  const todosSupported = isClaudeNative || isCodexNative;
+  const todosSupported = isClaudeNative || isCodexNative || activeSession?.harness === "codex";
   // Native-CLI wrapper of either family. Keys harness behavior gates
   // (composer slash commands, `/model`); terminal-first SDK sessions
   // (embedded Omnigent REPL terminal) have NO wrapper label and must


### PR DESCRIPTION
## Related issue

N/A — no linked issue.

## Summary

- Route headless Codex `turn/plan/updated` notifications through the existing session todo cache and `session.todos` UI pipeline.
  - `session.todos` is also used by harness = Claude Code 
- Share Codex plan normalization across headless and native integrations, while keeping their architecture-specific transports.
- Show headless Codex plans in Tasks and stop codex-native from duplicating structured task plans in chat within the session

**ELI5:** Codex already knows its checklist; this change carries that checklist to Omnigent's Tasks panel instead of rendering a second copy in chat.

```mermaid
%%{init: {"themeVariables": {"fontSize": "11px"}, "flowchart": {"nodeSpacing": 10, "rankSpacing": 14, "curve": "linear"}}}%%
flowchart LR
    A[Codex creates or updates a plan<br/>with update_plan] --> B[App-server emits<br/>turn/plan/updated]
    B --> C[Shared normalizer<br/>todos_from_plan_update]
    C --> D[Complete todo snapshot<br/>content, status, activeForm]

    subgraph Native["codex-native"]
        direction LR
        N1[Native forwarder] --> N2[POST<br/>external_session_todos] --> N3[Native-event handler]
    end

    subgraph Headless["headless Codex"]
        direction LR
        H1[CodexExecutor<br/>TodoListUpdate] --> H2[ExecutorAdapter<br/>SessionTodosEvent]
        H2 --> H3[Runner stream<br/>session.todos] --> H4[Runner relay]
    end

    D --> N1
    D --> H1
    N3 --> P[Shared<br/>_publish_session_todos]
    H4 --> P
    P --> V[Validate and replace<br/>session todo cache]
    P --> S[Broadcast<br/>session.todos SSE]
    V -->|snapshot on reload| U[Tasks / TodoPanel]
    S -->|live update| U
```

Each creation or update carries the complete plan snapshot, so the Tasks panel replaces its current list instead of appending duplicate items.

## Test Plan

- `uv run pytest -q tests/inner/test_codex_executor.py tests/runtime/harnesses/test_executor_adapter.py tests/runtime/harnesses/test_scaffold.py` — 160 passed.
- Targeted codex-native plan mapping, Tasks-only publication, and completed Plan-mode item tests — 3 passed.
- Targeted native/headless todo relay, cache, snapshot, and validation tests — 6 passed.
- `cd web && npm run type-check` — passed.
- `cd web && npm test -- src/shell/AppShell.test.tsx src/shell/TodoPanel.test.tsx` — 90 passed.
- `uv run mypy omnigent/_codex_plan.py` and staged-file `pre-commit` hooks — passed.
- Manually exercised a headless `harness: codex` session through the source web UI: initial plan rendered in Tasks, chat contained only the final reply, and the snapshot survived reload.

## Demo

Headless Codex publishes completed, in-progress, and pending steps to Tasks without a duplicate assistant plan in chat:

![Headless Codex task plan rendered in the Tasks panel](https://raw.githubusercontent.com/anthonyivn2/omnigent/pr-assets/pr-assets/codex-harness-todos.png)

It also works for Native Codex:
<img width="1508" height="862" alt="Screenshot 2026-07-19 at 20 23 52" src="https://github.com/user-attachments/assets/d741ec04-0658-4b47-a71b-e8b01a3fd921" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used the Vite source UI with a live local server and runner. A headless Codex `update_plan` produced exactly three Tasks with completed, in-progress, and pending states; chat showed only `plan published`, and the Tasks snapshot remained after browser reload. Native and headless adapter behavior is additionally covered by focused regression tests.

## Changelog

Codex task plans now appear in Tasks without duplicating the plan in chat.



