### PR TITLE
fix(repl): treat /model show|list|status|current as display, not a switch

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -4771,6 +4771,7 @@ async def _cmd_effort(
 
 
 _MODEL_CLEAR_ALIASES = {"default", "off", "reset"}
+_MODEL_SHOW_ALIASES = {"show", "list", "status", "current"}
 
 
 def _model_readout_harness(active_model: str | None) -> str:
@@ -5059,8 +5060,7 @@ async def _cmd_model(
     """
     from rich.text import Text
 
-    value = arg.strip()
-    if not value:
+    def _emit_model_readout() -> None:
         from omnigent.onboarding.detected import effective_config_with_detected
         from omnigent.onboarding.provider_config import load_config
 
@@ -5071,6 +5071,12 @@ async def _cmd_model(
         config = effective_config_with_detected(load_config())
         for line in _build_model_readout_lines(config, harness, current):
             host.output(Text.from_markup(f"  [{fmt.muted}]{line}[/{fmt.muted}]"))
+
+    value = arg.strip()
+    # Bare `/model` and the display keywords both just show the readout — never
+    # persist `show`/`list`/`status`/`current` as a literal model override.
+    if not value or value.lower() in _MODEL_SHOW_ALIASES:
+        _emit_model_readout()
         return
 
     if value.lower() in _MODEL_CLEAR_ALIASES:

--- a/tests/repl/test_model_command.py
+++ b/tests/repl/test_model_command.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import pytest
+from omnigent_ui_sdk import RichBlockFormatter
+
+from omnigent.repl._repl import COMMANDS, handle_slash_command
+from tests.repl.helpers import CapturingHost
+
+_Host = CapturingHost
+
+_SENTINEL = object()
+
+
+class _Session:
+    """Fake session that records every ``set_model_override`` call.
+
+    ``override_calls`` stays empty unless the command actually persists a
+    model id, which lets the display-keyword tests prove ``/model show`` &
+    friends never route through a switch.
+    """
+
+    def __init__(self) -> None:
+        self.model_override: str | None = None
+        self.is_streaming = False
+        self.override_calls: list[str | None] = []
+
+    def set_model_override(self, target: str | None) -> None:
+        self.override_calls.append(target)
+        self.model_override = target
+
+
+@pytest.mark.asyncio
+async def test_model_command_registered() -> None:
+    assert "/model" in COMMANDS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("keyword", ["show", "list", "status", "current"])
+async def test_model_show_keywords_display_not_switch(keyword: str) -> None:
+    host = _Host()
+    session = _Session()
+    await handle_slash_command(
+        f"/model {keyword}",
+        session,
+        None,
+        host,
+        RichBlockFormatter(),  # type: ignore[arg-type]
+    )
+    # Display keyword must NOT be persisted as a model id.
+    assert session.override_calls == []
+    assert session.model_override is None
+    # It must emit the same active-credential readout as bare `/model`.
+    assert "Active:" in host.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("keyword", ["SHOW", "List", "Status", "CURRENT"])
+async def test_model_show_keywords_case_insensitive(keyword: str) -> None:
+    host = _Host()
+    session = _Session()
+    await handle_slash_command(
+        f"/model {keyword}",
+        session,
+        None,
+        host,
+        RichBlockFormatter(),  # type: ignore[arg-type]
+    )
+    assert session.override_calls == []
+    assert "Active:" in host.text
+
+
+@pytest.mark.asyncio
+async def test_model_no_arg_shows_readout() -> None:
+    host = _Host()
+    session = _Session()
+    await handle_slash_command("/model", session, None, host, RichBlockFormatter())  # type: ignore[arg-type]
+    assert session.override_calls == []
+    assert "Active:" in host.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("alias", ["default", "off", "reset"])
+async def test_model_default_aliases_clear(alias: str) -> None:
+    host = _Host()
+    session = _Session()
+    session.model_override = "claude-sonnet-4-6"
+    await handle_slash_command(
+        f"/model {alias}",
+        session,
+        None,
+        host,
+        RichBlockFormatter(),  # type: ignore[arg-type]
+    )
+    assert session.override_calls == [None]
+    assert session.model_override is None
+    assert "reset to agent default" in host.text
+
+
+@pytest.mark.asyncio
+async def test_model_sets_valid_id() -> None:
+    host = _Host()
+    session = _Session()
+    await handle_slash_command(
+        "/model claude-sonnet-4-6",
+        session,
+        None,
+        host,
+        RichBlockFormatter(),  # type: ignore[arg-type]
+    )
+    assert session.override_calls == ["claude-sonnet-4-6"]
+    assert session.model_override == "claude-sonnet-4-6"
+    assert "for future responses" in host.text

--- a/tests/repl/test_model_command.py
+++ b/tests/repl/test_model_command.py
@@ -6,10 +6,6 @@ from omnigent_ui_sdk import RichBlockFormatter
 from omnigent.repl._repl import COMMANDS, handle_slash_command
 from tests.repl.helpers import CapturingHost
 
-_Host = CapturingHost
-
-_SENTINEL = object()
-
 
 class _Session:
     """Fake session that records every ``set_model_override`` call.
@@ -35,9 +31,12 @@ async def test_model_command_registered() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("keyword", ["show", "list", "status", "current"])
+@pytest.mark.parametrize(
+    "keyword",
+    ["show", "list", "status", "current", "SHOW", "List", "Status", "CURRENT"],
+)
 async def test_model_show_keywords_display_not_switch(keyword: str) -> None:
-    host = _Host()
+    host = CapturingHost()
     session = _Session()
     await handle_slash_command(
         f"/model {keyword}",
@@ -54,24 +53,8 @@ async def test_model_show_keywords_display_not_switch(keyword: str) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("keyword", ["SHOW", "List", "Status", "CURRENT"])
-async def test_model_show_keywords_case_insensitive(keyword: str) -> None:
-    host = _Host()
-    session = _Session()
-    await handle_slash_command(
-        f"/model {keyword}",
-        session,
-        None,
-        host,
-        RichBlockFormatter(),  # type: ignore[arg-type]
-    )
-    assert session.override_calls == []
-    assert "Active:" in host.text
-
-
-@pytest.mark.asyncio
 async def test_model_no_arg_shows_readout() -> None:
-    host = _Host()
+    host = CapturingHost()
     session = _Session()
     await handle_slash_command("/model", session, None, host, RichBlockFormatter())  # type: ignore[arg-type]
     assert session.override_calls == []
@@ -81,7 +64,7 @@ async def test_model_no_arg_shows_readout() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("alias", ["default", "off", "reset"])
 async def test_model_default_aliases_clear(alias: str) -> None:
-    host = _Host()
+    host = CapturingHost()
     session = _Session()
     session.model_override = "claude-sonnet-4-6"
     await handle_slash_command(
@@ -98,7 +81,7 @@ async def test_model_default_aliases_clear(alias: str) -> None:
 
 @pytest.mark.asyncio
 async def test_model_sets_valid_id() -> None:
-    host = _Host()
+    host = CapturingHost()
     session = _Session()
     await handle_slash_command(
         "/model claude-sonnet-4-6",


### PR DESCRIPTION
## Related issue

Closes #2779

## Summary

Typing `/model show` (intending to *display* the current model) was parsed as a
switch to a literal model id `"show"`. That value was persisted as
`model_override`, so the harness respawned against an unroutable model and
**every subsequent turn failed** — with no in-REPL way to recover.

- Add a `_MODEL_SHOW_ALIASES = {"show", "list", "status", "current"}` set and an
  early branch in `_cmd_model` that routes these keywords (case-insensitive) to
  the **existing** model readout (`_build_model_readout_lines`, the same output
  as bare `/model`) via a small `_emit_model_readout()` closure — instead of
  persisting them as an override.
- Recovery already exists and is unchanged: `/model default|off|reset` clears an
  override. The two alias sets are disjoint, so the display keywords never
  swallow the clear keywords.

Minimal change (`+8 / −2` in `omnigent/repl/_repl.py`); no behavior change to the
real switch path (`/model <name>`) or the reset path.

## Test Plan

- New `tests/repl/test_model_command.py` (test-first): **8 failed before the fix
  / 14 passed after**, covering each display keyword, case-insensitivity, that
  no override is persisted, that the session stays usable, and that
  `default|off|reset` still clears.
- `python -m pytest tests/repl/test_model_command.py tests/repl/test_effort_command.py tests/repl/test_repl_pending_model_override.py`
  → **29 passed**, no regressions.
- `pre-commit run --all-files` → clean.
- Manual: ran the REPL from source (`uv run omnigent run --harness claude-sdk`);
  `/model show` now prints the model readout and the session remains fully
  usable (previously the next turn errored on the bogus `"show"` model).

## Demo

N/A — REPL/CLI behavior change, covered by the test plan above (before/after
test counts and manual repro).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `tests/repl/test_model_command.py` mirroring the existing
`test_effort_command.py` conventions. It asserts the display keywords produce
the readout without persisting a `model_override`, is case-insensitive, keeps the
session usable, and leaves the `default|off|reset` clear path intact. Manually
verified the repro in a source-run REPL.

## Changelog

Fixed `/model show` (and `list`/`status`/`current`) bricking the session: these
are now treated as "display the current model" instead of switching to a
non-existent model.
