### PR TITLE
fix(web): enable legacy-peer-deps in .npmrc for plain npm ci

### DIFF
--- a/web/.npmrc
+++ b/web/.npmrc
@@ -12,3 +12,8 @@
 # new-enough npm before regenerating; that workflow, not this file, is the
 # real enforcement point.
 min-release-age=7
+
+# React 19 peer conflict: several UI deps still declare React 18 peers while the
+# app pins React 19. CI and local installs must use legacy peer resolution so
+# plain `npm ci` matches `npm ci --legacy-peer-deps` used in workflows.
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
- Set `legacy-peer-deps=true` in `web/.npmrc`.
- Plain `npm ci` was failing with EUSAGE / missing peer packages (`@lobehub/ui`, `@floating-ui/*`, …) because several UI deps still declare React 18 peers while the app pins React 19.
- CI already uses `npm ci --legacy-peer-deps`; this makes the local default match that path without requiring the flag every time.
- No lockfile rewrite needed — `npm install --package-lock-only --legacy-peer-deps` stays a no-op on current `package-lock.json`.

## Test Plan
- [x] `cd web && npm ci --dry-run` succeeds after the `.npmrc` change
- [x] `cd web && npm ci --legacy-peer-deps --dry-run` still succeeds
- [x] `cd web && npm install --package-lock-only --legacy-peer-deps --no-audit --no-fund` leaves the lockfile unchanged
- [ ] N/A for Demo (no UI/runtime change)

## Demo
N/A — install/config only.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] UI / frontend change
- [ ] Other

## Test coverage
- [x] Manual verification completed
- [ ] Automated tests added/updated
- [ ] Not applicable

## Coverage notes
Verified with `npm ci --dry-run` (plain and `--legacy-peer-deps`) and lockfile regen no-op.

Fixes #2887
