### PR TITLE
feat(desktop): add approved localhost browser access

### DIFF
--- a/web/electron/src/browserIpc.js
+++ b/web/electron/src/browserIpc.js
@@ -271,6 +271,11 @@ function registerBrowserIpc({ ipcMain, isPinnedOriginSender, getRegistryForEvent
     return { registry };
   };
 
+  const agentControlError = (registry, conversationId) => {
+    const verdict = registry.agentControlVerdict(conversationId);
+    return verdict.ok ? null : verdict.error;
+  };
+
   /** A window-scoped sender for the event's own webContents. Used to push
    *  url/nav-state pings back to exactly the renderer that drives the view. */
   const senderFor = (event) => (channel, payload) => {
@@ -334,6 +339,8 @@ function registerBrowserIpc({ ipcMain, isPinnedOriginSender, getRegistryForEvent
     const g = gateRegistry(event);
     if (g.error) return { ok: false, error: g.error };
     const { conversationId } = args ?? {};
+    const accessError = agentControlError(g.registry, conversationId);
+    if (accessError) return { ok: false, error: accessError };
     const entry = g.registry.get(conversationId);
     if (!entry) return { ok: false, error: "No browser view" };
     try {
@@ -353,6 +360,8 @@ function registerBrowserIpc({ ipcMain, isPinnedOriginSender, getRegistryForEvent
     if (g.error) return { ok: false, error: g.error };
     const { conversationId, js } = args ?? {};
     if (typeof js !== "string") return { ok: false, error: "js must be a string" };
+    const accessError = agentControlError(g.registry, conversationId);
+    if (accessError) return { ok: false, error: accessError };
     const entry = g.registry.get(conversationId);
     if (!entry) return { ok: false, error: "No browser view" };
     try {
@@ -372,6 +381,21 @@ function registerBrowserIpc({ ipcMain, isPinnedOriginSender, getRegistryForEvent
     if (g.error) return { exists: false };
     const { conversationId } = args ?? {};
     return { exists: typeof conversationId === "string" && g.registry.has(conversationId) };
+  });
+
+  ipcMain.handle("omnigent:browser-get-agent-access", (event, args) => {
+    const g = gateRegistry(event);
+    if (g.error) return { ok: false, allowed: false, error: g.error };
+    return g.registry.agentAccessStatus(args?.conversationId);
+  });
+
+  ipcMain.handle("omnigent:browser-set-agent-access", (event, args) => {
+    const g = gateRegistry(event);
+    if (g.error) return { ok: false, allowed: false, error: g.error };
+    if (typeof args?.allowed !== "boolean") {
+      return { ok: false, allowed: false, error: "allowed must be a boolean" };
+    }
+    return g.registry.setAgentAccess(args?.conversationId, args.allowed);
   });
 
   // Destroy the conversation's view (explicit close — unmount only detaches).
@@ -448,6 +472,8 @@ function registerBrowserIpc({ ipcMain, isPinnedOriginSender, getRegistryForEvent
     const g = gateRegistry(event);
     if (g.error) return { ok: false, error: g.error };
     const { conversationId } = args ?? {};
+    const accessError = agentControlError(g.registry, conversationId);
+    if (accessError) return { ok: false, error: accessError };
     const entry = g.registry.get(conversationId);
     if (!entry) return { ok: false, error: "No browser view" };
     try {

--- a/web/electron/src/browserUrlPolicy.js
+++ b/web/electron/src/browserUrlPolicy.js
@@ -67,6 +67,27 @@ function isBlockedHostname(hostname) {
   return false;
 }
 
+/** True only for HTTP(S) loopback URLs a user may grant to an agent. */
+function isLoopbackNavigationUrl(url) {
+  try {
+    const parsed = new URL(url);
+    if (!ALLOWED_SCHEMES.has(parsed.protocol)) return false;
+    const host = parsed.hostname.toLowerCase();
+    if (
+      host === "localhost" ||
+      host.endsWith(".localhost") ||
+      host === "[::1]" ||
+      host === "[::]"
+    ) {
+      return true;
+    }
+    const ipv4 = parseIpv4(host);
+    return !!ipv4 && (ipv4[0] === 127 || ipv4.every((octet) => octet === 0));
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Decide whether an AGENT-issued navigation to `url` is allowed: `{ ok: true }`
  * for an http(s) URL to a non-internal host, else `{ ok: false, error }`. Never
@@ -110,6 +131,7 @@ function isAgentNavigationAllowed(url) {
 
 module.exports = {
   isAgentNavigationAllowed,
+  isLoopbackNavigationUrl,
   // Exported for focused unit tests.
   parseIpv4,
   isBlockedIpv4,

--- a/web/electron/src/browserViewRegistry.js
+++ b/web/electron/src/browserViewRegistry.js
@@ -17,7 +17,7 @@
  *    detached on hide and destroyed only on explicit close.
  */
 
-const { isAgentNavigationAllowed } = require("./browserUrlPolicy");
+const { isAgentNavigationAllowed, isLoopbackNavigationUrl } = require("./browserUrlPolicy");
 
 const DEFAULT_CAP = 10;
 
@@ -55,6 +55,9 @@ function createBrowserViewRegistry({
       // Last URL we EXPLICITLY requested (not getURL(), which drifts as the page
       // navigates) — lets openOrNavigate skip reissuing loadURL on a re-mount.
       lastRequestedUrl: "",
+      // Exact loopback origins the user explicitly allowed this conversation's
+      // agent to inspect and control. Destroyed with the browser entry.
+      userGrantedOrigins: new Set(),
       // Whether the CURRENT navigation was agent-initiated. Set on every
       // openOrNavigate from opts.agent; read by the will-navigate/will-redirect
       // guard so the allowlist is enforced on the agent's whole nav chain
@@ -108,6 +111,85 @@ function createBrowserViewRegistry({
     wc.setWindowOpenHandler(() => ({ action: "deny" }));
   }
 
+  function httpOrigin(url) {
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === "http:" || parsed.protocol === "https:" ? parsed.origin : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function currentEntryUrl(entry) {
+    try {
+      const live = entry.view.webContents.getURL?.();
+      if (live && live !== "chrome-error://chromewebdata/") return live;
+    } catch {
+      /* destroyed */
+    }
+    return entry.lastRequestedUrl || "";
+  }
+
+  function agentNavigationVerdict(entry, url) {
+    const verdict = isAgentNavigationAllowed(url);
+    const origin = httpOrigin(url);
+    return !verdict.ok &&
+      origin &&
+      isLoopbackNavigationUrl(url) &&
+      entry &&
+      entry.userGrantedOrigins.has(origin)
+      ? { ok: true }
+      : verdict;
+  }
+
+  function agentAccessStatus(conversationId) {
+    const entry = entries.get(conversationId);
+    if (!entry) return { ok: false, allowed: false, error: "No browser view" };
+    const url = currentEntryUrl(entry);
+    const origin = httpOrigin(url);
+    if (isAgentNavigationAllowed(url).ok) {
+      return { ok: true, url, origin, kind: "public", allowed: true };
+    }
+    if (origin && isLoopbackNavigationUrl(url)) {
+      return {
+        ok: true,
+        url,
+        origin,
+        kind: "local",
+        allowed: entry.userGrantedOrigins.has(origin),
+      };
+    }
+    return { ok: true, url, origin, kind: "blocked", allowed: false };
+  }
+
+  function setAgentAccess(conversationId, allowed) {
+    const entry = entries.get(conversationId);
+    const status = agentAccessStatus(conversationId);
+    if (!entry || !status.ok) return status;
+    if (status.kind !== "local" || !status.origin) {
+      return { ...status, ok: false, error: "Only loopback HTTP(S) origins can be granted" };
+    }
+    if (allowed) entry.userGrantedOrigins.add(status.origin);
+    else entry.userGrantedOrigins.delete(status.origin);
+    return agentAccessStatus(conversationId);
+  }
+
+  function agentControlVerdict(conversationId) {
+    const status = agentAccessStatus(conversationId);
+    if (!status.ok) return { ok: false, error: status.error };
+    if (status.allowed) return { ok: true };
+    if (status.kind === "local") {
+      return {
+        ok: false,
+        error: `Agent access to ${status.origin} has not been approved. Ask the user to allow it in the Browser toolbar.`,
+      };
+    }
+    return {
+      ok: false,
+      error: `Agent access to ${status.url || "this page"} is blocked.`,
+    };
+  }
+
   // SECURITY (SSRF): enforce the agent-navigation allowlist on the child view's
   // OWN navigation events, not just the first loadURL. A server 302 / meta-
   // refresh / location.href during an agent-initiated navigation would otherwise
@@ -123,7 +205,7 @@ function createBrowserViewRegistry({
     if (!wc || typeof wc.on !== "function") return;
     const guard = (event, targetUrl) => {
       if (!entry.agentNavLocked) return; // user-driven nav: permissive
-      const verdict = isAgentNavigationAllowed(targetUrl);
+      const verdict = agentNavigationVerdict(entry, targetUrl);
       if (!verdict.ok) {
         try {
           event.preventDefault();
@@ -149,13 +231,11 @@ function createBrowserViewRegistry({
 
   function openOrNavigate(conversationId, url, bounds, opts) {
     const force = !!(opts && opts.force);
-    // Agent-driven nav (opts.agent) is gated by an allowlist (see
-    // browserUrlPolicy) so the model can't point the view at file:// /
-    // metadata / loopback / private hosts and exfiltrate via screenshot. URL-bar
-    // (user-typed) nav stays permissive. Checked before getOrCreate so a
-    // rejected nav creates no blank view.
+    // Agent-driven nav is public-web-only unless this conversation's user
+    // explicitly granted the exact HTTP(S) origin from a chat preview click.
+    // Checked before getOrCreate so a rejected nav creates no blank view.
     if (opts && opts.agent && url) {
-      const verdict = isAgentNavigationAllowed(url);
+      const verdict = agentNavigationVerdict(entries.get(conversationId), url);
       if (!verdict.ok) {
         return { ok: false, error: verdict.error };
       }
@@ -312,6 +392,9 @@ function createBrowserViewRegistry({
     setActive,
     close,
     closeAll,
+    agentAccessStatus,
+    setAgentAccess,
+    agentControlVerdict,
     // Introspection
     activeConversationId: () => activeConversationId,
     size: () => entries.size,

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -231,6 +231,12 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
    */
   browserHasView: (conversationId) =>
     ipcRenderer.invoke("omnigent:browser-has-view", { conversationId }),
+  /** Read whether the agent may inspect/control the current page. */
+  browserGetAgentAccess: (conversationId) =>
+    ipcRenderer.invoke("omnigent:browser-get-agent-access", { conversationId }),
+  /** Allow or revoke agent control for the current loopback origin. */
+  browserSetAgentAccess: (conversationId, allowed) =>
+    ipcRenderer.invoke("omnigent:browser-set-agent-access", { conversationId, allowed }),
   /**
    * Subscribe to browser-view close events (`{conversationId, reason}`) so the
    * SPA can drop the pane when the view is destroyed. Returns an unsubscribe.

--- a/web/electron/test/browserIpc.test.js
+++ b/web/electron/test/browserIpc.test.js
@@ -65,6 +65,8 @@ function makeWebContents({ canBack = false, canForward = false } = {}) {
       goForward: () => calls.push("goForward"),
     },
     reload: () => calls.push("reload"),
+    getURL: () => "http://localhost:3000/",
+    capturePage: () => Promise.resolve({ toPNG: () => Buffer.from("png") }),
     isDevToolsOpened: () => devtoolsOpen,
     isDestroyed: () => false,
     getZoomFactor: () => 1,
@@ -106,9 +108,17 @@ function nonceFromScripts(scripts) {
 }
 
 /** Build a registry stub around one entry keyed by conversationId. */
-function makeRegistry(conversationId, webContents) {
+function makeRegistry(conversationId, webContents, agentAllowed = true) {
   const entries = new Map();
   if (conversationId) entries.set(conversationId, { view: { webContents } });
+  let allowed = agentAllowed;
+  const accessStatus = () => ({
+    ok: true,
+    url: "http://localhost:3000/",
+    origin: "http://localhost:3000",
+    kind: "local",
+    allowed,
+  });
   return {
     get: (id) => entries.get(id) ?? null,
     has: (id) => entries.has(id),
@@ -120,15 +130,27 @@ function makeRegistry(conversationId, webContents) {
     },
     setActive: () => ({ ok: true }),
     close: () => ({ ok: true, removed: true }),
+    agentAccessStatus: accessStatus,
+    setAgentAccess: (_id, next) => {
+      allowed = next;
+      return accessStatus();
+    },
+    agentControlVerdict: () =>
+      allowed ? { ok: true } : { ok: false, error: "Agent access has not been approved" },
   };
 }
 
 /** Register the IPC surface with injectable gate + registry, and capture the
  *  events sent to a fake sender. */
-function setup({ pinned = true, conversationId = "conv_1", webContents } = {}) {
+function setup({
+  pinned = true,
+  conversationId = "conv_1",
+  webContents,
+  agentAllowed = true,
+} = {}) {
   const ipcMain = makeIpcMain();
   const wc = webContents ?? makeWebContents();
-  const registry = makeRegistry(conversationId, wc);
+  const registry = makeRegistry(conversationId, wc, agentAllowed);
   const sent = [];
   const event = { sender: { send: (channel, payload) => sent.push({ channel, payload }) } };
   registerBrowserIpc({
@@ -150,6 +172,8 @@ describe("browserIpc — trust gate", () => {
       "omnigent:browser-screenshot",
       "omnigent:browser-execute",
       "omnigent:browser-has-view",
+      "omnigent:browser-get-agent-access",
+      "omnigent:browser-set-agent-access",
       "omnigent:browser-close",
       "omnigent:browser-go-back",
       "omnigent:browser-go-forward",
@@ -178,6 +202,51 @@ describe("browserIpc — trust gate", () => {
       assert.equal(r.ok, false, `${channels[i]} should be gated`);
       assert.match(r.error, /connected server's page/);
     });
+  });
+});
+
+describe("browserIpc — local agent access", () => {
+  it("blocks screenshot, execute, and design mode before approval", async () => {
+    const wc = makeWebContents();
+    const { ipcMain, event } = setup({ webContents: wc, agentAllowed: false });
+    const [screenshot, execute, design] = await Promise.all([
+      ipcMain.invoke("omnigent:browser-screenshot", event, { conversationId: "conv_1" }),
+      ipcMain.invoke("omnigent:browser-execute", event, {
+        conversationId: "conv_1",
+        js: "document.title",
+      }),
+      ipcMain.invoke("omnigent:browser-enable-design-mode", event, {
+        conversationId: "conv_1",
+      }),
+    ]);
+    for (const result of [screenshot, execute, design]) {
+      assert.equal(result.ok, false);
+      assert.match(result.error, /not been approved/);
+    }
+    assert.equal(
+      wc.calls.some((call) => call.startsWith("executeJavaScript:")),
+      false,
+    );
+  });
+
+  it("reports, grants, and revokes access through trusted IPC", async () => {
+    const { ipcMain, event } = setup({ agentAllowed: false });
+    const before = await ipcMain.invoke("omnigent:browser-get-agent-access", event, {
+      conversationId: "conv_1",
+    });
+    assert.equal(before.allowed, false);
+
+    const granted = await ipcMain.invoke("omnigent:browser-set-agent-access", event, {
+      conversationId: "conv_1",
+      allowed: true,
+    });
+    assert.equal(granted.allowed, true);
+
+    const revoked = await ipcMain.invoke("omnigent:browser-set-agent-access", event, {
+      conversationId: "conv_1",
+      allowed: false,
+    });
+    assert.equal(revoked.allowed, false);
   });
 });
 

--- a/web/electron/test/browserUrlPolicy.test.js
+++ b/web/electron/test/browserUrlPolicy.test.js
@@ -9,7 +9,31 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 
-const { isAgentNavigationAllowed } = require("../src/browserUrlPolicy");
+const { isAgentNavigationAllowed, isLoopbackNavigationUrl } = require("../src/browserUrlPolicy");
+
+describe("browserUrlPolicy — user-grantable loopback origins", () => {
+  it("allows only HTTP(S) loopback URLs", () => {
+    for (const url of [
+      "http://localhost:3000/",
+      "https://app.localhost/path",
+      "http://127.5.6.7:8080/",
+      "http://0.0.0.0:5173/",
+      "http://[::1]/",
+      "http://[::]/",
+    ]) {
+      assert.equal(isLoopbackNavigationUrl(url), true, `expected loopback: ${url}`);
+    }
+    for (const url of [
+      "https://example.com/",
+      "http://10.0.0.1/",
+      "http://192.168.1.2/",
+      "http://169.254.169.254/",
+      "file:///tmp/app.html",
+    ]) {
+      assert.equal(isLoopbackNavigationUrl(url), false, `expected non-grantable: ${url}`);
+    }
+  });
+});
 
 describe("browserUrlPolicy — agent navigation allowlist", () => {
   it("allows ordinary public http(s) URLs", () => {

--- a/web/electron/test/browserViewRegistry.test.js
+++ b/web/electron/test/browserViewRegistry.test.js
@@ -197,6 +197,72 @@ describe("browserViewRegistry — agent-navigation allowlist", () => {
     assert.equal(loaded.length, 0);
   });
 
+  it("opens localhost user-only until the exact origin is explicitly granted", () => {
+    const { registry, loaded } = makeLoadTrackingRegistry();
+    const opened = registry.openOrNavigate("conv_1", "http://localhost:3000/app", undefined, {
+      force: true,
+    });
+    assert.equal(opened.ok, true);
+    assert.deepEqual(registry.agentAccessStatus("conv_1"), {
+      ok: true,
+      url: "http://localhost:3000/app",
+      origin: "http://localhost:3000",
+      kind: "local",
+      allowed: false,
+    });
+    assert.match(registry.agentControlVerdict("conv_1").error, /has not been approved/);
+
+    const granted = registry.setAgentAccess("conv_1", true);
+    assert.equal(granted.ok, true);
+    assert.equal(granted.allowed, true);
+
+    const sameOrigin = registry.openOrNavigate(
+      "conv_1",
+      "http://localhost:3000/settings",
+      undefined,
+      { agent: true },
+    );
+    assert.equal(sameOrigin.ok, true);
+
+    const otherPort = registry.openOrNavigate("conv_1", "http://localhost:3001/admin", undefined, {
+      agent: true,
+    });
+    assert.equal(otherPort.ok, false);
+
+    const otherConversation = registry.openOrNavigate(
+      "conv_2",
+      "http://localhost:3000/admin",
+      undefined,
+      { agent: true },
+    );
+    assert.equal(otherConversation.ok, false);
+    assert.deepEqual(loaded, ["http://localhost:3000/app", "http://localhost:3000/settings"]);
+  });
+
+  it("revokes the current origin and clears grants when the view closes", () => {
+    const { registry } = makeLoadTrackingRegistry();
+    registry.openOrNavigate("conv_1", "http://localhost:3000/");
+    assert.equal(registry.setAgentAccess("conv_1", true).allowed, true);
+    assert.equal(registry.setAgentAccess("conv_1", false).allowed, false);
+    assert.equal(registry.agentControlVerdict("conv_1").ok, false);
+
+    registry.setAgentAccess("conv_1", true);
+    registry.close("conv_1", "user");
+    registry.openOrNavigate("conv_1", "http://localhost:3000/");
+    assert.equal(registry.agentAccessStatus("conv_1").allowed, false);
+  });
+
+  it("never grants file or private-network origins", () => {
+    const { registry } = makeLoadTrackingRegistry();
+    for (const url of ["file:///tmp/app.html", "http://10.0.0.2/admin"]) {
+      registry.openOrNavigate("conv_1", url, undefined, { force: true });
+      const grant = registry.setAgentAccess("conv_1", true);
+      assert.equal(grant.ok, false);
+      assert.equal(grant.allowed, false);
+      assert.equal(registry.agentControlVerdict("conv_1").ok, false);
+    }
+  });
+
   it("allows agent navigation to a normal public https URL (loadURL runs)", () => {
     const { registry, loaded } = makeLoadTrackingRegistry();
     const r = registry.openOrNavigate("conv_1", "https://example.com/", undefined, {
@@ -292,6 +358,16 @@ describe("browserViewRegistry — redirect/nav guard (SSRF: allowlist on every h
     registry.openOrNavigate("conv_1", "https://example.com/", undefined, { agent: true });
     const ev = fire("will-navigate", "http://10.1.2.3/admin");
     assert.equal(ev.prevented, true);
+  });
+
+  it("allows only the granted local origin through the redirect guard", () => {
+    const { registry, fire } = makeEventCapturingRegistry();
+    registry.openOrNavigate("conv_1", "http://localhost:3000/");
+    registry.setAgentAccess("conv_1", true);
+    registry.openOrNavigate("conv_1", "http://localhost:3000/app", undefined, { agent: true });
+
+    assert.equal(fire("will-navigate", "http://localhost:3000/settings").prevented, false);
+    assert.equal(fire("will-navigate", "http://localhost:3001/admin").prevented, true);
   });
 
   it("allows an agent-locked redirect between normal public https hosts", () => {

--- a/web/src/components/BrowserPane/BrowserPane.test.tsx
+++ b/web/src/components/BrowserPane/BrowserPane.test.tsx
@@ -28,6 +28,23 @@ function installBridge(overrides: Record<string, unknown> = {}) {
     browserSetActive: vi.fn().mockResolvedValue({ ok: true }),
     browserResize: vi.fn().mockResolvedValue({ ok: true }),
     browserOpenOrNavigate: vi.fn().mockResolvedValue({ ok: true, created: true }),
+    browserGetAgentAccess: vi.fn().mockResolvedValue({
+      ok: true,
+      url: "https://example.com/",
+      origin: "https://example.com",
+      kind: "public",
+      allowed: true,
+    }),
+    browserSetAgentAccess: vi.fn().mockImplementation((_conversationId: string, allowed: boolean) =>
+      Promise.resolve({
+        ok: true,
+        url: "http://localhost:3000/",
+        origin: "http://localhost:3000",
+        kind: "local",
+        allowed,
+      }),
+    ),
+    browserClose: vi.fn().mockResolvedValue({ ok: true, removed: true }),
     browserGoBack: vi.fn().mockResolvedValue({ ok: true }),
     browserGoForward: vi.fn().mockResolvedValue({ ok: true }),
     browserReload: vi.fn().mockResolvedValue({ ok: true }),
@@ -167,6 +184,91 @@ describe("BrowserPane design-mode toggle", () => {
       "aria-pressed",
       "false",
     );
+  });
+});
+
+describe("BrowserPane local agent access", () => {
+  async function renderWithAccess(kind: "local" | "blocked", allowed: boolean) {
+    let fireCreated: ((p: { conversationId: string }) => void) | undefined;
+    const status = {
+      ok: true,
+      url: kind === "local" ? "http://localhost:3000/" : "file:///tmp/app.html",
+      origin: kind === "local" ? "http://localhost:3000" : null,
+      kind,
+      allowed,
+    };
+    const bridge = installBridge({
+      onBrowserViewCreated: vi.fn((cb: (p: { conversationId: string }) => void) => {
+        fireCreated = cb;
+        return () => {};
+      }),
+      browserGetAgentAccess: vi.fn().mockResolvedValue(status),
+      browserSetAgentAccess: vi
+        .fn()
+        .mockImplementation((_conversationId: string, next: boolean) =>
+          Promise.resolve({ ...status, allowed: next }),
+        ),
+    });
+    render(<BrowserPane conversationId="conv_access" />);
+    await screen.findByRole("textbox", { name: /address bar/i });
+    act(() => fireCreated?.({ conversationId: "conv_access" }));
+    await waitFor(() => expect(bridge.browserGetAgentAccess).toHaveBeenCalled());
+    return bridge;
+  }
+
+  it("opens localhost user-only and asks before enabling every agent control", async () => {
+    const bridge = await renderWithAccess("local", false);
+
+    expect(
+      await screen.findByText(/allow the agent to inspect and control http:\/\/localhost:3000/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /enter design mode/i })).toBeDisabled();
+
+    screen.getByRole("button", { name: "Not now" }).click();
+    await waitFor(() => {
+      expect(screen.queryByText(/this includes page content/i)).toBeNull();
+    });
+    screen.getByRole("button", { name: /allow agent access to http:\/\/localhost:3000/i }).click();
+    expect(await screen.findByText(/this includes page content/i)).toBeInTheDocument();
+
+    screen.getByRole("button", { name: "Allow for this conversation" }).click();
+    await waitFor(() => {
+      expect(bridge.browserSetAgentAccess).toHaveBeenCalledWith("conv_access", true);
+      expect(
+        screen.getByRole("button", {
+          name: "Revoke agent access to http://localhost:3000",
+        }),
+      ).toHaveTextContent("Agent on");
+    });
+    expect(screen.getByRole("button", { name: /enter design mode/i })).not.toBeDisabled();
+  });
+
+  it("revokes the current local origin from the persistent indicator", async () => {
+    const bridge = await renderWithAccess("local", true);
+    const revoke = await screen.findByRole("button", {
+      name: "Revoke agent access to http://localhost:3000",
+    });
+    revoke.click();
+    await waitFor(() => {
+      expect(bridge.browserSetAgentAccess).toHaveBeenCalledWith("conv_access", false);
+      expect(screen.getByText(/allow the agent to inspect and control/i)).toBeInTheDocument();
+    });
+  });
+
+  it("closes the browser view and clears its visible state", async () => {
+    const bridge = await renderWithAccess("local", true);
+    screen.getByRole("button", { name: /close browser and revoke agent access/i }).click();
+    await waitFor(() => {
+      expect(bridge.browserClose).toHaveBeenCalledWith("conv_access", "user");
+      expect(screen.getByText(/enter a url above to get started/i)).toBeInTheDocument();
+    });
+  });
+
+  it("never offers an allow action for file or private pages", async () => {
+    await renderWithAccess("blocked", false);
+    expect(await screen.findByText("Agent blocked")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /allow agent access/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /enter design mode/i })).toBeDisabled();
   });
 });
 

--- a/web/src/components/BrowserPane/BrowserPane.tsx
+++ b/web/src/components/BrowserPane/BrowserPane.tsx
@@ -21,6 +21,7 @@ import {
   RotateCwIcon,
   SquareDashedMousePointerIcon,
   WrenchIcon,
+  XIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { supportsBrowser } from "@/lib/nativeBridge";
@@ -45,6 +46,15 @@ interface NavResult {
   error?: string;
 }
 
+interface AgentAccessStatus {
+  ok: boolean;
+  allowed: boolean;
+  url?: string;
+  origin?: string | null;
+  kind?: "public" | "local" | "blocked";
+  error?: string;
+}
+
 /** Subset of `window.omnigentDesktop` the pane calls. Typed locally so the
  *  component doesn't depend on the full nativeBridge type; every method is
  *  optional (an older shell may predate the browser feature). */
@@ -66,6 +76,12 @@ interface BrowserPaneBridge {
   openBrowserDevTools?: (conversationId: string) => Promise<{ ok: boolean; error?: string }>;
   browserEnableDesignMode?: (conversationId: string) => Promise<{ ok: boolean; error?: string }>;
   browserDisableDesignMode?: (conversationId: string) => Promise<{ ok: boolean; error?: string }>;
+  browserGetAgentAccess?: (conversationId: string) => Promise<AgentAccessStatus>;
+  browserSetAgentAccess?: (conversationId: string, allowed: boolean) => Promise<AgentAccessStatus>;
+  browserClose?: (
+    conversationId: string,
+    reason?: string,
+  ) => Promise<{ ok: boolean; removed?: boolean; error?: string }>;
   onBrowserHostActiveChanged?: (
     callback: (payload: { conversationId: string | null }) => void,
   ) => () => void;
@@ -123,6 +139,18 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
   // Design-mode toggle: on, the main process injects the in-page picker; submit
   // routing lives in AppShell. This flag only drives the button + enable/disable IPC.
   const [designMode, setDesignMode] = useState(false);
+  const [agentAccess, setAgentAccess] = useState<AgentAccessStatus | null>(null);
+  const [accessPromptDismissed, setAccessPromptDismissed] = useState(false);
+
+  const refreshAgentAccess = useCallback(async () => {
+    const result = await getBridge()?.browserGetAgentAccess?.(conversationId);
+    if (!result?.ok) {
+      setAgentAccess(null);
+      return;
+    }
+    setAgentAccess(result);
+    if (!urlEditingRef.current && result.url) setCurrentUrl(result.url);
+  }, [conversationId]);
 
   // Feed `viewActive` from three signals so the placeholder mounts exactly when
   // a view exists: (1) browser-view-created — first navigate (often detached,
@@ -137,21 +165,37 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
 
     // (2) Re-show an already-created view when the pane remounts.
     void bridge.browserHasView?.(conversationId).then((r) => {
-      if (!cancelled && r?.exists) setViewActive(true);
+      if (!cancelled && r?.exists) {
+        setViewActive(true);
+        void refreshAgentAccess();
+      }
     });
 
     // (1) A view was just created for this conversation (first navigate).
     const unsubCreated = bridge.onBrowserViewCreated?.((payload) => {
-      if (payload.conversationId === conversationId) setViewActive(true);
+      if (payload.conversationId === conversationId) {
+        setViewActive(true);
+        void refreshAgentAccess();
+      }
     });
     // (3) Attach/detach transitions. An attach for another conversation, or a
     // detach (null), means this pane's view is no longer the visible one.
     const unsubActive = bridge.onBrowserHostActiveChanged?.((payload) => {
-      if (payload.conversationId === conversationId) setViewActive(true);
-      else if (payload.conversationId === null) setViewActive(false);
+      if (payload.conversationId === conversationId) {
+        setViewActive(true);
+        void refreshAgentAccess();
+      } else if (payload.conversationId === null) {
+        setViewActive(false);
+      }
     });
     const unsubClosed = bridge.onBrowserViewClosed?.((payload) => {
-      if (payload.conversationId === conversationId) setViewActive(false);
+      if (payload.conversationId !== conversationId) return;
+      setViewActive(false);
+      setCurrentUrl("");
+      setCanGoBack(false);
+      setCanGoForward(false);
+      setAgentAccess(null);
+      setAccessPromptDismissed(false);
     });
     return () => {
       cancelled = true;
@@ -159,7 +203,7 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
       unsubActive?.();
       unsubClosed?.();
     };
-  }, [conversationId, browserSupported]);
+  }, [conversationId, browserSupported, refreshAgentAccess]);
 
   // Live-track the real URL + back/forward via did-navigate listeners (redirects,
   // link clicks, agent nav all keep the bar honest), but never stomp the input
@@ -170,6 +214,7 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
     if (!bridge) return;
     const unsubUrl = bridge.onBrowserUrlChanged?.((payload) => {
       if (payload.conversationId !== conversationId) return;
+      void refreshAgentAccess();
       if (urlEditingRef.current) return;
       setCurrentUrl(payload.url);
     });
@@ -182,7 +227,11 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
       unsubUrl?.();
       unsubNav?.();
     };
-  }, [conversationId, browserSupported]);
+  }, [conversationId, browserSupported, refreshAgentAccess]);
+
+  useEffect(() => {
+    setAccessPromptDismissed(false);
+  }, [agentAccess?.origin]);
 
   // ── Toolbar handlers ─────────────────────────────────────────────────────
 
@@ -196,8 +245,12 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
     if (!raw) return;
     const navUrl = normalizeTypedUrl(raw);
     setCurrentUrl(navUrl);
-    void bridge.browserOpenOrNavigate(conversationId, navUrl, undefined, { force: true });
-  }, [conversationId, currentUrl]);
+    void bridge
+      .browserOpenOrNavigate(conversationId, navUrl, undefined, { force: true })
+      .then((result) => {
+        if (result.ok) void refreshAgentAccess();
+      });
+  }, [conversationId, currentUrl, refreshAgentAccess]);
 
   const handleBack = useCallback(() => {
     const bridge = getBridge();
@@ -236,10 +289,42 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
       void bridge.browserDisableDesignMode?.(conversationId);
       setDesignMode(false);
     } else {
-      void bridge.browserEnableDesignMode?.(conversationId);
-      setDesignMode(true);
+      void bridge.browserEnableDesignMode?.(conversationId).then((result) => {
+        if (result?.ok) setDesignMode(true);
+      });
     }
   }, [conversationId, designMode]);
+
+  const handleAgentAccess = useCallback(
+    async (allowed: boolean) => {
+      const bridge = getBridge();
+      if (!bridge?.browserSetAgentAccess) return;
+      if (!allowed && designMode) {
+        await bridge.browserDisableDesignMode?.(conversationId);
+        setDesignMode(false);
+      }
+      const result = await bridge.browserSetAgentAccess(conversationId, allowed);
+      if (result.ok) {
+        setAgentAccess(result);
+        setAccessPromptDismissed(false);
+      }
+    },
+    [conversationId, designMode],
+  );
+
+  const handleClose = useCallback(async () => {
+    const bridge = getBridge();
+    if (!bridge?.browserClose) return;
+    const result = await bridge.browserClose(conversationId, "user");
+    if (!result.ok) return;
+    setViewActive(false);
+    setCurrentUrl("");
+    setCanGoBack(false);
+    setCanGoForward(false);
+    setDesignMode(false);
+    setAgentAccess(null);
+    setAccessPromptDismissed(false);
+  }, [conversationId]);
 
   // If the view goes away (closed) while design mode is on, drop the pressed
   // state so the button doesn't lie — the injected picker died with the view.
@@ -440,6 +525,37 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
           }}
           className="h-6 min-w-0 flex-1 rounded-md border border-input bg-transparent px-2 text-foreground text-xs outline-none placeholder:text-muted-foreground focus-visible:border-ring dark:bg-input/30"
         />
+        {viewActive && agentAccess?.kind === "local" && (
+          <button
+            type="button"
+            onClick={() => {
+              if (agentAccess.allowed) void handleAgentAccess(false);
+              else setAccessPromptDismissed(false);
+            }}
+            aria-label={
+              agentAccess.allowed
+                ? `Revoke agent access to ${agentAccess.origin}`
+                : `Allow agent access to ${agentAccess.origin}`
+            }
+            title={agentAccess.allowed ? "Revoke agent access" : "Agent access is off"}
+            className={cn(
+              "h-6 shrink-0 rounded border px-2 font-medium text-[11px]",
+              agentAccess.allowed
+                ? "border-green-500/40 bg-green-500/10 text-green-700 dark:text-green-300"
+                : "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+            )}
+          >
+            Agent {agentAccess.allowed ? "on" : "off"}
+          </button>
+        )}
+        {viewActive && agentAccess?.kind === "blocked" && (
+          <span
+            className="h-6 shrink-0 rounded border border-destructive/30 bg-destructive/10 px-2 font-medium text-[11px] leading-6 text-destructive"
+            title="Agent access is blocked for this page"
+          >
+            Agent blocked
+          </span>
+        )}
         <button
           type="button"
           onClick={handleDevTools}
@@ -453,7 +569,7 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
         <button
           type="button"
           onClick={handleToggleDesignMode}
-          disabled={!viewActive}
+          disabled={!viewActive || agentAccess?.allowed !== true}
           aria-pressed={designMode}
           aria-label={designMode ? "Exit design mode" : "Enter design mode"}
           title={
@@ -468,7 +584,50 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
         >
           <SquareDashedMousePointerIcon className="size-4" />
         </button>
+        <button
+          type="button"
+          onClick={handleClose}
+          disabled={!viewActive}
+          aria-label="Close browser and revoke agent access"
+          title="Close browser and revoke agent access"
+          className="flex size-6 items-center justify-center rounded text-foreground hover:bg-muted disabled:pointer-events-none disabled:opacity-40"
+        >
+          <XIcon className="size-4" />
+        </button>
       </div>
+      {viewActive &&
+        agentAccess?.kind === "local" &&
+        !agentAccess.allowed &&
+        !accessPromptDismissed && (
+          <div
+            className="flex shrink-0 items-center gap-3 border-amber-500/30 border-b bg-amber-500/10 px-3 py-2 text-xs"
+            role="status"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="font-medium text-foreground">
+                Allow the agent to inspect and control {agentAccess.origin}?
+              </div>
+              <div className="text-muted-foreground">
+                This includes page content, screenshots, clicks, typing, and navigation within this
+                origin.
+              </div>
+            </div>
+            <button
+              type="button"
+              className="shrink-0 rounded px-2 py-1 text-muted-foreground hover:bg-muted"
+              onClick={() => setAccessPromptDismissed(true)}
+            >
+              Not now
+            </button>
+            <button
+              type="button"
+              className="shrink-0 rounded bg-primary px-2 py-1 font-medium text-primary-foreground hover:bg-primary/90"
+              onClick={() => void handleAgentAccess(true)}
+            >
+              Allow for this conversation
+            </button>
+          </div>
+        )}
       {viewActive ? (
         /* Measuring region — the native WebContentsView paints over this.
            flex-1 min-h-0 so it fills everything BELOW the toolbar; its rect

--- a/web/src/components/ai-elements/message.test.tsx
+++ b/web/src/components/ai-elements/message.test.tsx
@@ -28,6 +28,21 @@ describe("MessageResponse", () => {
     expect(document.querySelector('img[src^="https://attacker.example"]')).toBeNull();
     expect(await screen.findByText("[Image blocked: leak]")).toBeTruthy();
   });
+
+  it("marks only loopback links for the embedded preview", async () => {
+    render(
+      <MessageResponse>
+        {"[local](http://localhost:3000/app) [public](https://example.com/)"}
+      </MessageResponse>,
+    );
+
+    expect(await screen.findByRole("link", { name: "local" })).toHaveAttribute(
+      "data-omnigent-local-preview",
+    );
+    expect(screen.getByRole("link", { name: "public" })).not.toHaveAttribute(
+      "data-omnigent-local-preview",
+    );
+  });
 });
 
 describe("MessageResponse code-block copy", () => {

--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { ButtonGroup, ButtonGroupText } from "@/components/ui/button-group";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { copyText } from "@/lib/clipboard";
+import { isLocalBrowserPreviewUrl } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
 import type { UIMessage } from "ai";
 import { CheckIcon, ChevronLeftIcon, ChevronRightIcon, CopyIcon, WrapTextIcon } from "lucide-react";
@@ -423,10 +424,22 @@ function ChatCodeBlockPre({ children }: ComponentProps<"pre">) {
   );
 }
 
+function ChatLink({ href, ...props }: ComponentProps<"a">) {
+  return (
+    <a
+      {...props}
+      href={href}
+      data-omnigent-local-preview={
+        typeof href === "string" && isLocalBrowserPreviewUrl(href) ? "" : undefined
+      }
+    />
+  );
+}
+
 export const MessageResponse = memo(
   ({ className, components, controls, ...props }: MessageResponseProps) => {
     const messageComponents = useMemo(
-      () => ({ ...components, pre: ChatCodeBlockPre }),
+      () => ({ ...components, a: ChatLink, pre: ChatCodeBlockPre }),
       [components],
     );
 

--- a/web/src/lib/nativeBridge.test.ts
+++ b/web/src/lib/nativeBridge.test.ts
@@ -4,10 +4,12 @@ import {
   isAndroidShell,
   isElectronShell,
   isIOSShell,
+  isLocalBrowserPreviewUrl,
   isNativeShell,
   nativeNotify,
   onNativeNotificationActivated,
   onNativeSidebarDrag,
+  openLocalBrowserPreview,
   setBadgeCount as bridgeSetBadge,
   setNativeServerSwitcherHidden,
   supportsBrowser,
@@ -18,6 +20,7 @@ const electronSetBadge = vi.fn();
 const electronNotify = vi.fn().mockResolvedValue(true);
 const electronUnsubscribe = vi.fn();
 const electronOnNotificationActivated = vi.fn().mockReturnValue(electronUnsubscribe);
+const electronBrowserOpen = vi.fn().mockResolvedValue({ ok: true });
 
 // The iOS WKWebView bridge mock, installed on window.omnigentNative.
 const iosSetBadge = vi.fn();
@@ -57,7 +60,7 @@ function setElectron(on: boolean, withClickRouting = true, withBrowser = false):
               electronOnNotificationActivated(...args),
           }
         : {}),
-      ...(withBrowser ? { browserOpenOrNavigate: () => Promise.resolve({ ok: true }) } : {}),
+      ...(withBrowser ? { browserOpenOrNavigate: electronBrowserOpen } : {}),
     };
   } else {
     delete (window as unknown as Record<string, unknown>).omnigentDesktop;
@@ -107,6 +110,7 @@ function setAndroid(on: boolean, withClickRouting = true): void {
 beforeEach(() => {
   vi.clearAllMocks();
   electronNotify.mockResolvedValue(true);
+  electronBrowserOpen.mockResolvedValue({ ok: true });
   iosNotify.mockResolvedValue(true);
   androidNotify.mockResolvedValue(true);
 });
@@ -194,6 +198,47 @@ describe("supportsBrowser", () => {
   it("is false under a non-Electron native shell (iOS)", () => {
     setIOS(true);
     expect(supportsBrowser()).toBe(false);
+  });
+});
+
+describe("local browser previews", () => {
+  it.each([
+    "http://localhost:3000/",
+    "https://app.localhost/path",
+    "http://127.0.0.1:5173/",
+    "http://0.0.0.0:8000/",
+    "http://[::1]:4321/",
+  ])("recognizes loopback preview URL %s", (url) => {
+    expect(isLocalBrowserPreviewUrl(url)).toBe(true);
+  });
+
+  it.each(["https://example.com/", "http://192.168.1.2/", "file:///tmp/app.html", "/relative"])(
+    "rejects non-loopback preview URL %s",
+    (url) => {
+      expect(isLocalBrowserPreviewUrl(url)).toBe(false);
+    },
+  );
+
+  it("opens a preview in user-only mode", async () => {
+    setElectron(true, true, true);
+    await expect(openLocalBrowserPreview("conv_1", "http://localhost:3000/app")).resolves.toEqual({
+      ok: true,
+    });
+    expect(electronBrowserOpen).toHaveBeenCalledWith(
+      "conv_1",
+      "http://localhost:3000/app",
+      undefined,
+      { force: true },
+    );
+  });
+
+  it("does not send non-local URLs to the privileged bridge", async () => {
+    setElectron(true, true, true);
+    await expect(openLocalBrowserPreview("conv_1", "http://10.0.0.2/admin")).resolves.toEqual({
+      ok: false,
+      error: "not a local preview URL",
+    });
+    expect(electronBrowserOpen).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -295,6 +295,36 @@ export function supportsBrowser(): boolean {
   return typeof electronApi()?.browserOpenOrNavigate === "function";
 }
 
+/** True for HTTP(S) loopback URLs commonly emitted by local dev servers. */
+export function isLocalBrowserPreviewUrl(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    const host = url.hostname.toLowerCase();
+    return (
+      host === "localhost" ||
+      host.endsWith(".localhost") ||
+      /^127(?:\.\d{1,3}){3}$/.test(host) ||
+      host === "0.0.0.0" ||
+      host === "[::1]" ||
+      host === "[::]"
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Open a user-clicked local preview in user-only mode. */
+export async function openLocalBrowserPreview(
+  conversationId: string,
+  url: string,
+): Promise<{ ok: boolean; created?: boolean; error?: string }> {
+  if (!isLocalBrowserPreviewUrl(url)) return { ok: false, error: "not a local preview URL" };
+  const open = electronApi()?.browserOpenOrNavigate;
+  if (!open) return { ok: false, error: "embedded browser is unavailable" };
+  return open(conversationId, url, undefined, { force: true });
+}
+
 /**
  * True when running inside the Electron desktop shell on macOS — the one
  * platform where the shell hides the native title bar (titleBarStyle

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -324,7 +324,7 @@ function serverInfo(overrides: Partial<ServerInfo> = {}): ServerInfo {
   };
 }
 
-function renderShell(path: string, info?: ServerInfo) {
+function renderShell(path: string, info?: ServerInfo, previewHref?: string) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -350,6 +350,11 @@ function renderShell(path: string, info?: ServerInfo) {
                     <TerminalFirstViewProbe />
                     <ForkDialogProbe />
                     <LocationDisplay />
+                    {previewHref && (
+                      <a href={previewHref} data-omnigent-local-preview="">
+                        local preview
+                      </a>
+                    )}
                   </>
                 }
               />
@@ -459,7 +464,10 @@ beforeEach(() => {
   useChatStore.setState({ todos: [], terminalPending: false, sessionStatus: "idle" });
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  delete (window as unknown as Record<string, unknown>).omnigentDesktop;
+});
 
 describe("AppShell header", () => {
   it("renders the sidebar toggle on all pages", () => {
@@ -1608,6 +1616,26 @@ describe("FilesPanel visibility", () => {
 });
 
 describe("Right workspace card visibility", () => {
+  it("opens a clicked localhost chat link user-only in the Browser tab", () => {
+    const browserOpenOrNavigate = vi.fn().mockResolvedValue({ ok: true, created: true });
+    (window as unknown as Record<string, unknown>).omnigentDesktop = {
+      kind: "electron",
+      browserOpenOrNavigate,
+    };
+    mockConversations([{ id: "conv_preview", permission_level: null }]);
+
+    renderShell("/c/conv_preview", undefined, "http://localhost:3000/app");
+    fireEvent.click(screen.getByRole("link", { name: "local preview" }));
+
+    expect(browserOpenOrNavigate).toHaveBeenCalledWith(
+      "conv_preview",
+      "http://localhost:3000/app",
+      undefined,
+      { force: true },
+    );
+    expect(screen.getByRole("tab", { name: /Browser/i })).toHaveAttribute("aria-selected", "true");
+  });
+
   it("keeps the card mounted with Agents as the only tab for a minimal agent", () => {
     // A no-os_env agent (available: false) with no shells and no todos
     // still has the unconditional Agents tab (the panel lists at least

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Outlet, useParams, useSearchParams } from "@/lib/routing";
 import { useConversations } from "@/hooks/useConversations";
@@ -17,8 +17,10 @@ import {
   isAndroidShell,
   isElectronShell,
   isIOSShell,
+  isLocalBrowserPreviewUrl,
   isMacElectronShell,
   onNativeSidebarDrag,
+  openLocalBrowserPreview,
   supportsBrowser,
 } from "@/lib/nativeBridge";
 import { onBrowserActionRequest } from "@/lib/browserActionBus";
@@ -567,6 +569,34 @@ export function AppShell() {
       setRightPanelOpen(true);
     });
   }, []);
+
+  const handleLocalPreviewClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey ||
+        !conversationId ||
+        !supportsBrowser() ||
+        !(event.target instanceof Element)
+      ) {
+        return;
+      }
+      const link = event.target.closest<HTMLAnchorElement>("a[data-omnigent-local-preview]");
+      if (!link || !isLocalBrowserPreviewUrl(link.href)) return;
+
+      event.preventDefault();
+      setRightRailTab("browser");
+      setRightPanelOpen(true);
+      void openLocalBrowserPreview(conversationId, link.href).then((result) => {
+        if (!result.ok) console.warn("Could not open local browser preview:", result.error);
+      });
+    },
+    [conversationId],
+  );
 
   // Design-mode submit routing. Lives here (with the hoisted relay) because the
   // in-page popup posts back via preload IPC delivered to the always-mounted
@@ -1237,6 +1267,7 @@ export function AppShell() {
           <div
             className="app-shell relative flex h-dvh bg-sidebar text-foreground"
             data-electron-mac={isMacElectronShell() ? "true" : undefined}
+            onClick={handleLocalPreviewClick}
             data-ios-native={isIOSShell() ? "true" : undefined}
             data-android-native={isAndroidShell() ? "true" : undefined}
           >


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Open user-clicked loopback links from desktop chat in the embedded Browser without silently granting agent control; the plain Web UI keeps its existing `target="_blank"` behavior.
- Add explicit, conversation-scoped approval for the exact HTTP(S) loopback origin, and enforce it across navigation, redirects, snapshots, screenshots, clicks, typing, and design mode.
- Show persistent **Agent on/off** state with revoke and **Close Browser** controls; revoking or closing removes access.

The embedded Browser intentionally blocks agent-issued localhost access to protect local services from SSRF. This PR preserves that default while adding explicit, per-conversation approval for an exact loopback HTTP(S) origin. Once the user approves it, this unlocks an iterative website-development loop: the agent can inspect the local site, make improvements, and use clicks, typing, and screenshots to verify and refine its work without exposing the preview publicly. `localhost` on a remote runner or in a container is not Desktop `localhost`; it still needs port forwarding or another Desktop-reachable URL.

**ELI5:** Opening a local page lets the user see it, but the agent does not get the key until the user clicks **Allow for this conversation**. **Agent on** revokes that key, and closing the Browser destroys it.

```text
User clicks localhost link
          |
          v
Electron BrowserView (user-only) -- Allow exact origin --> browser_* tools
          ^                                      |
          +----------- revoke / close -----------+
```

## Test Plan

Automated:

```bash
cd web/electron
npm test -- test/browserUrlPolicy.test.js test/browserViewRegistry.test.js test/browserIpc.test.js
# 61 passed

cd ../
npm test -- src/components/BrowserPane/BrowserPane.test.tsx src/hooks/useBrowserAgentRelay.test.tsx src/lib/nativeBridge.test.ts src/shell/AppShell.test.tsx src/components/ai-elements/message.test.tsx
# 174 passed
npm run type-check

cd ..
pre-commit run --all-files
```

Manual desktop flow:

1. Clicked a chat link to `http://localhost:3000/` and confirmed the embedded Browser opened user-only with **Agent off** and the consent prompt.
2. Confirmed `browser_snapshot` was denied before approval.
3. Clicked **Allow for this conversation**, then confirmed snapshot and typing succeeded against the local page.
4. Revoked access from **Agent on** and confirmed snapshot was denied again.
5. Closed the Browser and confirmed the BrowserView was destroyed and subsequent access returned `No browser view`.

## Demo

Clicking on a localhost URL within the chat window of desktop app opens up the browser window with an explicit permission grant mechanism to allow the agent to interact with the localhost page.
<img width="1800" height="1127" alt="Screenshot 2026-07-20 at 00 37 04" src="https://github.com/user-attachments/assets/6c987ebf-6ecd-4b28-925b-98ebd91ee00c" />
<img width="859" height="580" alt="Screenshot 2026-07-20 at 00 56 27" src="https://github.com/user-attachments/assets/395da527-7f90-4754-b8fb-7451da9a4680" />

The agent cannot use the `browser_*` tools on the page until the user have explicitly grant it permission to do
<img width="1800" height="1128" alt="Screenshot 2026-07-20 at 01 05 30" src="https://github.com/user-attachments/assets/244969f1-b85a-488e-b2e9-619b2611983f" />

After the agent have gained the approval, the agent can use the `browser_*` tools on the webpage
<img width="1791" height="1131" alt="Screenshot 2026-07-20 at 01 11 25" src="https://github.com/user-attachments/assets/bc3459d7-221f-4616-9ef7-48b1026b6edb" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the complete Electron permission lifecycle against a live localhost page: user-only open, deny before approval, allow, snapshot/type, revoke, deny again, and close. Plain Web behavior is covered by renderer tests and remains capability-gated.

## Changelog

Open localhost links in the desktop Browser and approve exact-origin agent access from its toolbar.
