### PR TITLE
fix(host): ride out a transient 404 on an already-connected host (#2039)

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -991,11 +991,15 @@ class HostProcess:
             ``403``.
         :returns: A :class:`HostConnectError` for a permanent 4xx, or
             ``None`` for a transient status (retryable 4xx in
-            :data:`_RETRYABLE_UPGRADE_STATUSES`, or any non-4xx such as a
-            5xx server bounce) that the reconnect loop should retry.
+            :data:`_RETRYABLE_UPGRADE_STATUSES`, a 404 on a host that has
+            already connected per :meth:`_classify_transient_404`, or any
+            non-4xx such as a 5xx server bounce) that the reconnect loop
+            should retry.
         """
         if status in _RETRYABLE_UPGRADE_STATUSES or not (400 <= status < 500):
             return None
+        if status == 404:
+            return self._classify_transient_404()
         if status == 401:
             return HostConnectError(
                 "Authentication failed (HTTP 401): the server rejected the "
@@ -1028,6 +1032,33 @@ class HostProcess:
             f"Connection refused (HTTP {status}): the server rejected the host "
             "tunnel request. This is a permanent error; retrying will not help. "
             "Check the server URL and your access."
+        )
+
+    def _classify_transient_404(self) -> HostConnectError | None:
+        """Treat a 404 on the tunnel upgrade as a transient restart blip.
+
+        A reverse proxy in front of the server answers 404 for the tunnel
+        route while the backend container restarts (upgrade, config change,
+        agent re-seed bounce). A host that has already completed an upgrade
+        in this process rides that window out indefinitely, so a routine
+        server bounce never tears down its live runner sessions (issue
+        #2039).
+
+        A host that has NEVER connected keeps the pre-existing behaviour: a
+        404 is a permanent client error and fails loud on the first attempt,
+        so a genuinely wrong server URL -- or a server too old to expose the
+        tunnel route -- surfaces immediately instead of hanging.
+
+        :returns: ``None`` while an already-connected host should retry the
+            404, or a :class:`HostConnectError` for a never-connected host.
+        """
+        if self._ever_connected:
+            return None
+        return HostConnectError(
+            "Connection refused (HTTP 404): the server did not expose the "
+            "host tunnel route. The server URL may be wrong, or the server "
+            "may predate the host API (the /v1/hosts tunnel route). Check the "
+            "URL and that the server is up to date, then retry."
         )
 
     async def _handle_launch(

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -2300,12 +2300,70 @@ async def test_connected_host_retries_login_redirects_indefinitely(
     assert spy.call_count == 6
 
 
+async def test_connected_host_rides_out_404_restart_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host that already connected retries 404s indefinitely (#2039).
+
+    A reverse proxy in front of the server answers 404 for the tunnel
+    route while the backend container restarts (deploy, config change,
+    nightly backup window). A host that has already completed an upgrade
+    is watching a routine restart — killing it would drop its live
+    runners — so it must ride the 404 window out and reconnect when the
+    backend returns, rather than exiting 1 and tearing down its sessions.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    not_found = _invalid_status(404)
+    # Accepted upgrade first (None), then a burst of 404s (the restart
+    # window), then another accepted upgrade, then a cancel to end.
+    spy = _ConnectSpy([None, not_found, not_found, not_found, None, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    # Returns normally: if the post-connect 404s were misclassified as
+    # fatal this would raise HostConnectError after the first 404 instead
+    # of reconnecting.
+    await host.run()
+
+    # 6 = accepted connect + 3 ridden-out 404s + reconnect + ending
+    # cancel. Fewer means the host died mid-restart (the #2039 bug).
+    assert spy.call_count == 6
+
+
+async def test_never_connected_host_fails_loud_on_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host that has NEVER connected fails loud on 404, first attempt.
+
+    The narrow #2039 fix rescues only already-connected hosts. A host
+    that never authenticated treats a 404 as a permanent client error — a
+    wrong server URL, or a server too old to expose the tunnel route — and
+    must fail loud immediately (no grace window, no silent looping) so the
+    operator gets instant feedback, exactly as before the fix.
+    """
+    spy = _ConnectSpy([_invalid_status(404)])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    with pytest.raises(HostConnectError) as excinfo:
+        await host.run()
+
+    message = str(excinfo.value)
+    assert "HTTP 404" in message
+    assert "host tunnel route" in message
+    # A 404 is not an auth failure, so no `omnigent login` remedy.
+    assert "omnigent login" not in message
+    # Exactly one attempt — fails loud immediately, unlike the
+    # already-connected ride-out path above.
+    assert spy.call_count == 1
+
+
 @pytest.mark.parametrize(
     "status,expected",
     [
         (401, "HTTP 401"),
         (403, "HTTP 403"),
-        (404, "permanent"),
+        (404, "HTTP 404"),
     ],
 )
 async def test_run_fails_loud_on_permanent_4xx(
@@ -2315,7 +2373,11 @@ async def test_run_fails_loud_on_permanent_4xx(
 
     401/403/other-4xx mean unauthenticated / unauthorized / wrong-or-old
     server — reconnecting can never succeed, so run() must raise
-    HostConnectError immediately rather than backing off.
+    HostConnectError immediately rather than backing off. A 404 on a host
+    that has never connected is permanent too (wrong URL / route missing);
+    its message names the tunnel route rather than the word "permanent",
+    so this asserts on "HTTP 404". An *already-connected* host instead
+    rides a 404 out — the #2039 fix, covered separately below.
     """
     spy = _ConnectSpy([_invalid_status(status)])
     _patch_connect(monkeypatch, spy)


### PR DESCRIPTION
Narrower follow-up to #2083 (closed), per @fanzeyi's review. Keeps only the
already-connected path and drops the never-connected grace window entirely.

A reverse proxy in front of the server answers 404 for the tunnel-upgrade
route while the backend container restarts (upgrade, config change, agent
re-seed bounce). `HostProcess` classified any non-special-cased 4xx as a
permanent client error, so a 404 during that window raised `HostConnectError`,
the reconnect loop re-raised, `run_host_process` exited 1 — tearing down every
live runner session on the host as collateral (#2039).

- A host that has **already** connected in this process (`_ever_connected`)
  rides out 404s indefinitely, so a routine server bounce never kills its live
  runners.
- A host that has **never** connected is unchanged from today: a 404 is a
  permanent client error and fails loud on the **first** attempt (message names
  the tunnel route, omits the login hint), so a wrong server URL — or a server
  too old to expose the tunnel route — surfaces immediately. **No grace window.**
- 401/403/409 and every other 4xx stay fatal on the first attempt, as before.

Tests: an already-connected host rides out a 404 burst and reconnects; a
never-connected host fails loud on the first 404; the permanent-4xx
parametrization keeps 404 as a fail-loud case. `tests/host/test_connect.py`
green (74/74).
