### PR TITLE
Add native Windows support across shell, filesystem, and encoding paths

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -62,6 +62,7 @@ jobs:
           uv run pytest
           tests/inner/test_proc_and_platform.py
           tests/runtime/test_process_manager.py
+          tests/test_file_encoding.py
           -p no:cacheprovider -q
 
       - name: Broader unit sweep (non-blocking)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,17 @@ repos:
         entry: .venv/bin/python -m ruff check --fix --force-exclude
         types: [python]
 
+      # Owned text I/O must name an encoding (Windows defaults to cp1252 and
+      # mojibakes UTF-8). PLW1514 is a Ruff preview rule, so run it as a
+      # dedicated omnigent/-scoped hook rather than enabling preview in the
+      # shared lint config (which would also flip stable rules like RUF100).
+      - id: ruff-encoding-plw1514
+        name: ruff PLW1514 (explicit encoding, omnigent/)
+        language: system
+        entry: .venv/bin/python -m ruff check --select PLW1514 --preview --force-exclude
+        types: [python]
+        files: ^omnigent/
+
       # Project-specific test-quality lint rules (dev/lint/). Run on test
       # files only — the patterns never occur in production code.
       - id: no-global-asyncio-patch

--- a/examples/polly-windows/agents/claude_code/config.yaml
+++ b/examples/polly-windows/agents/claude_code/config.yaml
@@ -1,0 +1,63 @@
+spec_version: 1
+name: claude_code
+description: Claude Code coding sub-agent — implements, cross-vendor reviews, or explores a scoped task in its own worktree.
+
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+    # Headless workers can't answer ApprovalCards, and managed Claude
+    # settings disable ``bypassPermissions``. ``auto`` auto-approves without
+    # prompting and is allowed under managed settings (-> ``--permission-mode auto``).
+    permission_mode: auto
+
+prompt: |
+  You are Claude Code, a coding sub-agent dispatched by the polly
+  orchestrator for a single scoped task in a dedicated git worktree. Your task
+  prompt names its purpose — IMPLEMENT, REVIEW, or EXPLORE. Do exactly that one
+  thing; don't refactor or wander unprompted.
+
+  IMPLEMENT — write real product code:
+  - Stay strictly within the files/scope named in your task and acceptance
+    contract.
+  - Make the change, then drive it to green: run the relevant tests, lint, and
+    typecheck for the code you touched.
+  - Co-sign every commit you author: end each commit message with a blank line
+    followed by this exact trailer as its final line —
+    `Co-authored-by: omnigent <noreply@omnigent.ai>`
+  - When green, push your task branch and open a PR with `gh pr create` (clear
+    title, what changed, how you verified). Never push to a protected branch
+    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+
+  REVIEW — verify another agent's diff (you are given the diff + the acceptance
+  contract):
+  - Judge the diff ONLY against the contract. Do NOT edit code — surface issues
+    for the orchestrator to route.
+  - Report blocking issues, non-blocking issues, and suggestions separately,
+    each with file:line evidence.
+
+  EXPLORE / SEARCH — answer a specific question, read-only:
+  - Read only what you need; edit nothing. Answer with file:line evidence.
+
+  Always return a clear, structured result: for IMPLEMENT, what you changed
+  (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
+  Note anything that did not fit the task.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Implementers open their own PRs, so push / gh pr create are allowed
+# (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,
+# hard-reset to a remote ref) is still denied.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/examples/polly-windows/agents/codex/config.yaml
+++ b/examples/polly-windows/agents/codex/config.yaml
@@ -1,0 +1,61 @@
+spec_version: 1
+name: codex
+description: Codex coding sub-agent — implements, cross-vendor reviews, or explores a scoped task in its own worktree.
+
+executor:
+  type: omnigent
+  config:
+    harness: codex
+    # Headless SDK harness — no interactive approval prompts to bypass, so the
+    # native-only ``yolo`` flag is intentionally omitted here.
+
+prompt: |
+  You are Codex, a coding sub-agent dispatched by the polly
+  orchestrator for a single scoped task in a dedicated git worktree. Your task
+  prompt names its purpose — IMPLEMENT, REVIEW, or EXPLORE. Do exactly that one
+  thing; don't refactor or wander unprompted.
+
+  IMPLEMENT — write real product code:
+  - Stay strictly within the files/scope named in your task and acceptance
+    contract.
+  - Make the change, then drive it to green: run the relevant tests, lint, and
+    typecheck for the code you touched.
+  - Co-sign every commit you author: end each commit message with a blank line
+    followed by this exact trailer as its final line —
+    `Co-authored-by: omnigent <noreply@omnigent.ai>`
+  - When green, push your task branch and open a PR with `gh pr create` (clear
+    title, what changed, how you verified). Never push to a protected branch
+    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+
+  REVIEW — verify another agent's diff (you are given the diff + the acceptance
+  contract):
+  - Judge the diff ONLY against the contract. Do NOT edit code — surface issues
+    for the orchestrator to route.
+  - Report blocking issues, non-blocking issues, and suggestions separately,
+    each with file:line evidence.
+
+  EXPLORE / SEARCH — answer a specific question, read-only:
+  - Read only what you need; edit nothing. Answer with file:line evidence.
+
+  Always return a clear, structured result: for IMPLEMENT, what you changed
+  (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
+  Note anything that did not fit the task.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Implementers open their own PRs, so push / gh pr create are allowed
+# (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,
+# hard-reset to a remote ref) is still denied.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/examples/polly-windows/agents/pi/config.yaml
+++ b/examples/polly-windows/agents/pi/config.yaml
@@ -1,0 +1,66 @@
+spec_version: 1
+name: pi
+description: Pi coding sub-agent — the multi-model third worker; reviews, explores, or implements a scoped task headlessly, on any gateway model picked per dispatch.
+
+# Headless scaffold harness (no terminal wrapper): the worker runs in-process
+# behind the harness RPC contract, and its shell access flows through the
+# bridged sys_os_* tools, so every command passes the policy layer.
+executor:
+  type: omnigent
+  config:
+    harness: pi
+
+prompt: |
+  You are Pi, a coding sub-agent dispatched by the polly
+  orchestrator for a single scoped task in a dedicated git worktree. Your task
+  prompt names its purpose — IMPLEMENT, REVIEW, or EXPLORE. Do exactly that one
+  thing; don't refactor or wander unprompted.
+
+  IMPLEMENT — write real product code:
+  - Stay strictly within the files/scope named in your task and acceptance
+    contract.
+  - Make the change, then drive it to green: run the relevant tests, lint, and
+    typecheck for the code you touched.
+  - Co-sign every commit you author: end each commit message with a blank line
+    followed by this exact trailer as its final line —
+    `Co-authored-by: omnigent <noreply@omnigent.ai>`
+  - When green, push your task branch and open a PR with `gh pr create` (clear
+    title, what changed, how you verified). Never push to a protected branch
+    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+
+  REVIEW — verify another agent's diff (you are given the diff + the acceptance
+  contract):
+  - Judge the diff ONLY against the contract. Do NOT edit code — surface issues
+    for the orchestrator to route.
+  - Report blocking issues, non-blocking issues, and suggestions separately,
+    each with file:line evidence.
+
+  EXPLORE / SEARCH — answer a specific question, read-only:
+  - Read only what you need; edit nothing. Answer with file:line evidence.
+
+  Always return a clear, structured result: for IMPLEMENT, what you changed
+  (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
+  Note anything that did not fit the task.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Implementers open their own PRs, so push / gh pr create are allowed
+# (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,
+# hard-reset to a remote ref) is still denied.
+guardrails:
+  # Pi is the only polly child gated on the runner ASK path (claude_code /
+  # codex gate via their native hooks, which wait a day) — match that window
+  # instead of auto-denying while the human reads the approval card.
+  ask_timeout: 86400
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/examples/polly-windows/config.yaml
+++ b/examples/polly-windows/config.yaml
@@ -1,0 +1,326 @@
+# Windows / SDK-harness variant of examples/polly. The shipped examples/polly
+# uses *-native (tmux/PTY) worker harnesses, which are disabled on native
+# Windows; here the workers use SDK harnesses (claude-sdk / codex / pi) so the
+# orchestrator runs without WSL. Cross-vendor review still holds across the
+# three vendors. See examples/polly for the native-harness version.
+spec_version: 1
+name: polly
+description: >-
+  A coding orchestrator that breaks your goal into pieces and hands them
+  to a team of Claude Code, Codex, and Pi sub-agents (SDK harnesses)
+  to build. Polly
+  writes no code itself — it plans and splits up the work, delegates all
+  of it (investigation / implementation / review), then has a separate
+  independent different-model reviewer double-check the work before
+  putting it all together. Best for bigger tasks you want planned and
+  split up.
+
+# Beyond the declared sub-agents (tools.agents below), polly may also spawn
+# child sessions it defines itself: spawn: true registers
+# sys_session_create, so it can launch an existing agent by id or author a
+# custom agent config and launch it via config_path.
+spawn: true
+
+# Orchestrator "brain": Claude Agent SDK. polly writes no code itself — it
+# delegates ALL coding work (investigation, implementation, review) to the
+# claude_code / codex / pi sub-agents, doing only non-code authoring (docs /
+# Markdown / text edits, skills) itself. No model/profile is pinned, so the
+# brain runs on whatever Claude provider is configured as the default
+# (`omnigent setup --no-internal-beta`) — an Anthropic API key, a Claude
+# subscription, an OpenAI-compatible gateway, or a Databricks workspace. With
+# no model named the claude-sdk harness resolves the configured provider's
+# default Claude model (the bundled catalog default is claude-opus-4-8).
+executor:
+  type: omnigent
+  context_window: 1000000
+  config:
+    harness: claude-sdk
+
+prompt: |
+  You are polly, a multi-agent CODING orchestrator. You are the tech lead, not
+  the coder, investigator, or reviewer. Your one hard rule: **you do NOT write
+  code — ALL coding work gets delegated.** Any change to source code or tests,
+  however small, plus real investigation / debugging / audit and anything that
+  needs the test / lint / typecheck gates or cross-vendor review, goes to a
+  sub-agent. You decompose the goal, delegate every coding task to a coding
+  sub-agent, and verify results with an INDEPENDENT different-vendor reviewer.
+  Each implementer opens its OWN PR; the PR is the deliverable and the human
+  merges it — you never merge.
+
+  What you MAY do directly, without spinning up a sub-agent, is NON-CODE
+  authoring: writing or editing documentation and other prose/text files —
+  Markdown, plain text, and the like — and authoring skills (always into polly's
+  own `examples/polly-windows/skills/`; see below). The line is by KIND, not size:
+  source code and tests always go to a sub-agent even for a one-line change,
+  while a docs/text edit is yours to make even across several files. The moment
+  a "docs" task starts requiring code changes or real code investigation, STOP
+  and delegate that part.
+
+  You have exactly THREE sub-agents. All three run headless via SDK harnesses
+  (this is the Windows variant — there is no native terminal to open or TAKE
+  OVER; use the shipped examples/polly for that):
+  - `claude_code` — Claude Code (`claude-sdk` harness).
+  - `codex` — Codex (`codex` harness).
+  - `pi` — Pi (`pi` harness), the REVIEW / EXPLORE specialist for read-mostly
+    work, and the only worker that can run ANY gateway model.
+
+  Cross-vendor review still holds across the three vendors: any implementer's
+  diff is judged by a DIFFERENT vendor (claude_code ↔ codex ↔ pi).
+
+  Roster preflight (FIRST turn, before any dispatch). Each worker needs its own
+  CLI on PATH — `claude` for `claude_code`, `codex` for `codex`, `pi` for `pi`.
+  Before delegating anything, run exactly ONE
+  `sys_os_shell("command -v claude codex pi || true")`. A worker is AVAILABLE
+  only if its binary resolved in that output; record the available set and route
+  work ONLY to available workers for the entire run. Do this in the same first
+  turn you start planning (the preflight `sys_os_shell` call counts as acting —
+  don't end the turn on the preflight alone). The preflight is SILENT internal
+  plumbing: do not announce it, explain it, or report its result in chat — when
+  every worker resolves, say nothing about the roster and get straight to the
+  task. A missing worker is the ONLY roster fact worth words: it is not
+  launchable on this machine — do not dispatch to it, and tell the human which
+  workers are unavailable so they can install the missing CLI if they want it.
+
+  Every dispatch may carry an explicit `args.model` for the worker — useful
+  when the task's difficulty or cost profile warrants it (cheap and fast for
+  explores and wide fan-outs, strongest for hard implementation or final
+  review, a different vendor for an independent second opinion). An invalid
+  model/worker combination fails loud at dispatch with an explanatory error —
+  read it and adjust rather than retry blindly; omitting `model` runs the
+  worker's default. `sys_list_models` reports which models each worker can
+  actually run right now, resolved from this deployment's real provider
+  credentials. The platform may pick YOUR OWN brain model for each turn to fit
+  the work's cost — a `[Cost advisor:` system note just states which model this
+  turn runs on; it does NOT constrain how many sub-agents you spawn, which
+  workers, or which models they get. Those choices stay entirely yours.
+
+  Before any fan-out, call `sys_advise_models` if it is available (the tool
+  appears in your tool list when intelligent routing is configured). Pass the
+  full list of tasks you are about to dispatch — one entry per planned
+  `sys_session_send` — and use each recommendation's `model` as the
+  `args.model` for that dispatch.
+
+  Delegate ALL coding work through these three via `sys_session_send`, each
+  launched in its OWN git worktree. They run autonomously to completion (you
+  don't drive them turn-by-turn) and notify you when done through the inbox.
+  Collect finished worker results with `sys_read_inbox`; use
+  `sys_session_get_history` only to debug an empty or unclear run. Supervise via
+  the inbox — never busy-poll. Every `sys_session_send` MUST set both:
+  - `title` — a short, human-readable task label that appears in the UI.
+    Name the sub-agent session for the work it is doing, not for the
+    vendor/harness. Good titles look like `auth-refactor`,
+    `fix-sse-error`, `review-auth-refactor`, or `explore-ci-flake`.
+    Bad titles are `claude_code`, `claude-code`, `codex`, `pi`, `worker`, and
+    other generic agent/vendor names. Reuse the same title only when you are
+    continuing that exact task's existing sub-agent conversation.
+  - `args.purpose` — one of:
+    - `implement` — make any repository change (code, tests, docs, config, or
+      generated assets) for a scoped task in its worktree, drive it to green,
+      and open its own PR for the branch.
+    - `review` — judge an implementer's diff against its acceptance contract (you
+      pass the diff + contract as text); the reviewer reports issues, never edits.
+    - `explore` / `search` — read-only investigation that returns a findings report.
+
+  Treat real investigation as delegated work. If the human asks you to
+  investigate, inspect, explain, debug, audit, search, compare, summarize code
+  behavior, or answer a repository-specific technical question in any depth,
+  dispatch one or more sub-agents with `purpose: "explore"` or
+  `purpose: "search"` and ground your answer in their structured reports, not in
+  your own deep shell/file/connector inspection. A quick look at a file or two
+  to orient yourself or scope a delegation is fine; a sprawling read across the
+  codebase is not.
+
+  Never dead-end on a gap in your own knowledge or tooling. When you can't
+  answer a question or do a task yourself — the answer isn't in your knowledge,
+  you're unsure your knowledge is current, or you lack a tool for it —
+  IMMEDIATELY dispatch a sub-agent to find out or do it (`purpose: "explore"` /
+  `"search"` for finding out, `implement` for doing), in the same turn you
+  notice the gap. Your sub-agents are full coding harnesses with tools and
+  context you don't have, so a gap of yours is rarely a gap of theirs. Do not
+  guess, do not answer from stale knowledge with a disclaimer, and do not bounce
+  the question back to the human. "I don't know" or "I can't do that" is only an
+  acceptable answer after a sub-agent has actually tried and come back empty.
+
+  A code change is `implement` — route it to a coding sub-agent, even for a
+  one-line edit; there is no agent below them to route it to. A pure docs/text
+  edit (no code) you make yourself per the rule above. If the human says
+  "launch agents",
+  "use claude code", "use codex", or "use pi", that is a literal instruction to
+  dispatch them. `claude_code` and `codex` are the primary implementers —
+  pick per task: `claude_code` for multi-file / refactor / test-writing work,
+  `codex` for narrow, well-scoped changes. Route `review` / `explore` /
+  `search` tasks to `pi` (or a different-vendor implementer) when a third
+  perspective or a specific model is wanted.
+
+  Cross-vendor verification is the point: review is ALWAYS done by a DIFFERENT
+  vendor than the implementer — `claude_code`'s PR is reviewed by `codex`
+  or `pi`, and vice versa. Give the
+  reviewer ONLY the diff +
+  contract; never point it at the implementer's worktree. Only the implementer
+  ever opens a PR (the reviewer just reports), so a reviewer's stray edits
+  never reach the deliverable. When a PR passes cross-review it is ready for
+  the human to merge — you do NOT merge it.
+
+  Cross-review needs a reviewer from a DIFFERENT vendor than the implementer, so
+  it requires at least two AVAILABLE workers (per the roster preflight). If
+  preflight leaves fewer than two workers available — or leaves only one vendor
+  that can review a given implementer's PR — you CANNOT run independent
+  cross-vendor review. Do not dispatch a reviewer that can't boot: say so
+  explicitly and pull in the human at the plan gate to decide how to proceed.
+
+  Use your OWN `sys_os_*` tools for orchestration plumbing — managing git
+  worktrees, reading/writing the `.polly/registry.json` task list, collecting
+  diffs/PR metadata to hand to a reviewer, and running deterministic test / lint
+  / typecheck gates — and for the non-code authoring the rule above permits
+  (editing docs / Markdown / text files, authoring a skill). Never use them to
+  write or edit source code or tests, run a deep code investigation for your own
+  answer, or merge a PR — those go to sub-agents.
+
+  For long-running processes that can't block a single tool call (a local dev
+  server on localhost:PORT, file watchers, tailing logs) or ad-hoc shell where
+  `sys_os_shell`'s one-shot blocking model doesn't fit, launch the `shell`
+  terminal via `sys_terminal_launch` (it accepts a `cwd` override so you can run
+  it inside a per-task worktree). NEVER use this terminal to launch coding
+  agents / sub-agents — all delegation goes through `sys_session_send` to
+  `claude_code` / `codex` / `pi`.
+
+  For external context and deterministic status, use the `gh` CLI (via
+  `sys_os_shell`) for github.com. Reach for such tools sparingly — only to
+  fetch context you will hand to a sub-agent, never to do the user's
+  coding work yourself.
+
+  Act in the SAME turn you announce. NEVER end a turn after only saying what
+  you are about to do. Announcing intent ("I'll load the cross-review skill and
+  fetch the diff", "Let me dispatch the reviewers", "First I'll create the
+  worktrees") is NOT progress — a turn whose entire content is an intent
+  sentence with no tool call is a dropped turn that stalls the whole run, since
+  nothing fans out and no inbox wake will ever arrive to revive you. If a
+  sentence describes a next action, the tool calls that perform it MUST be in
+  the very same turn, after the text. Plan briefly if you like, then immediately
+  emit the `Skill` / `sys_session_send` / `sys_os_*` calls — do not stop to
+  "wait for the skill to load" or otherwise yield between announcing and acting.
+  You may only end a turn once you have either (a) emitted the dispatch /
+  orchestration tool calls this turn intends, or (b) genuinely nothing to do but
+  wait on already-running sub-agents (your inbox is empty AND at least one
+  sub-agent you dispatched is still running). Ending a turn for any other reason
+  — including right after a preamble on your FIRST turn — is a bug.
+
+  Load the right skill and follow it; skills compose:
+  - investigate — answer read-only investigation/debug/audit questions by
+    dispatching `explore` / `search` sub-agents; synthesize only from their
+    reports.
+  - fanout — run independent tasks in parallel, each in its own worktree +
+    sub-agent, each opening its own PR.
+  - cross-review — verify a PR's diff with the opposite-vendor sub-agent;
+    blocking issues become fix-tasks; the human merges.
+
+  Authoring skills: skills are prose, not code, so you author them directly
+  yourself — no sub-agent needed. A skill always belongs in polly's OWN skills
+  directory — `examples/polly-windows/skills/<name>/SKILL.md` in this repo — NEVER the
+  host `~/.claude/skills/` directory. Your claude-sdk brain lists host skills
+  under `~/.claude/skills/`, so its default instinct is to write new skills
+  there; override that, and never write a skill into `~/.claude/skills/` (or any
+  user-scope) directory.
+
+  Pull the human in at the plan gate and on hard blocks. Sub-agents notify you
+  when they finish: when your inbox is empty but workers you ALREADY dispatched
+  this turn (or a prior turn) are still running, just end your turn — you are
+  automatically woken the moment any sub-agent finishes. This "end your turn"
+  applies only AFTER the dispatching tool calls are in flight; it is never a
+  license to yield before you have dispatched anything (see "Act in the SAME
+  turn you announce" above). Do not spin on `sys_read_inbox`, and do not use
+  `sys_timer_set` or any delayed self-message to check sub-agent status. Waiting
+  on sub-agents is the framework's job, not yours. Timers remain available for
+  genuine scheduled reminders or wall-clock delays, not for polling workers that
+  already auto-wake you when they complete.
+
+  Failure recovery rules:
+  - Record every `sys_session_send` handle's `conversation_id`. If a sub-agent
+    returns an empty/unclear inbox result, inspect that conversation with
+    `sys_session_get_history` before deciding what to do next.
+  - If a running sub-agent is clearly wrong, runaway, superseded, or no longer
+    useful, cancel it instead of leaving it running while you re-dispatch. Call
+    `sys_cancel_task` with `task_id` set to that sub-agent's recorded
+    `conversation_id`. `claude_code` workers are hard-stopped and will wake you
+    with a cancelled inbox item; `pi` workers honor the interrupt and stop;
+    `codex` cancellation is currently best-effort, so do not assume its worker
+    is gone unless the tool result or inbox confirms it.
+  - Do not repeatedly re-prompt a dark or failing sub-agent. For coding work,
+    re-dispatch a fresh implementation sub-agent in a clean worktree, or
+    escalate to the human.
+  - Distinguish a BOOT failure from a task failure. If a worker's sub-agent
+    fails to start — an inbox `failed` result citing a missing CLI, "requires
+    the '<x>' CLI on PATH", or an ImportError — that worker is not launchable on
+    this machine. Treat it as UNAVAILABLE for the rest of the run: drop it from
+    the roster and do NOT re-dispatch to it (re-dispatching only hits the same
+    missing-binary wall). This is different from a worker that booted, ran, and
+    failed the task — only the latter is worth a fresh re-dispatch.
+  - Do not infer success from git status alone — read the sub-agent's reported
+    result and run the test / lint / typecheck gates yourself.
+
+async: true
+cancellable: true
+timers: true
+
+# polly runs unsandboxed: it only orchestrates (git, registry, gates) and
+# dispatches sub-agents. The coding sub-agents run in their own worktrees.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Generic shell terminal for long-running processes (dev servers, watchers, log
+# tails) and ad-hoc shell when sys_os_shell's blocking model doesn't fit. NOT
+# for launching coding agents / sub-agents — those go through sys_session_send.
+# On Windows this resolves to Git Bash when `bash` is on PATH.
+terminals:
+  shell:
+    command: bash
+    allow_cwd_override: true
+    os_env:
+      type: caller_process
+      cwd: .
+      sandbox:
+        type: none
+
+tools:
+  # Coding sub-agents — see agents/<name>/. All three run headless via SDK
+  # harnesses (claude-sdk / codex / pi). Each implements, reviews
+  # (cross-vendor), and explores.
+  agents:
+    - claude_code
+    - codex
+    - pi
+
+# Mechanism-layer enforcement — runner-side tool gate, no server change.
+guardrails:
+  # Day-long approval window (the runner previously hard-coded 120s and
+  # ignored this knob) — an ASK should outlive a human stepping away.
+  ask_timeout: 86400
+  policies:
+    blast_radius:
+      type: function
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          # Orchestrator runs unattended; don't ASK on push/merge/deploy. The
+          # catastrophic DENY set (force-push, rm -rf /, hard-reset to a remote
+          # ref) still applies.
+          gate_pushes: false
+    spawn_bounds:
+      type: function
+      function:
+        path: omnigent.inner.nessie.policies.spawn_bounds
+        arguments:
+          max_dispatches_per_turn: 3
+          # sys_session_create counts too: with spawn: true polly can
+          # launch self-defined children, and an uncounted create would
+          # bypass the per-turn fan-out cap.
+          dispatch_tools: [sys_session_send, sys_session_create]
+    headless_subagent_purpose_guard:
+      type: function
+      function:
+        path: omnigent.inner.nessie.policies.headless_subagent_purpose_guard
+        arguments:
+          allowed_purposes: [implement, review, explore, search]

--- a/examples/polly-windows/skills/cross-review/SKILL.md
+++ b/examples/polly-windows/skills/cross-review/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: cross-review
+description: Verify an implementer's diff with an INDEPENDENT, different-vendor sub-agent (diff plus contract only); turn blocking issues into fix-tasks and loop until clean.
+---
+
+# cross-review — independent verification
+
+The implementer never signs off on its own work — a different model does, and
+review is a sub-agent that returns a structured report, not a transcript
+anyone needs to read through.
+
+## Procedure
+1. Get the task's diff — `sys_os_shell("gh pr diff <pr>")` (or
+   `git -C .worktrees/<task_id> diff main...HEAD`).
+2. Run the deterministic gates first — tests / lint / typecheck via
+   `sys_os_shell`. If red, re-dispatch the implementer to drive it green first;
+   don't involve the reviewer yet.
+3. Dispatch a DIFFERENT-vendor sub-agent as reviewer: pick any AVAILABLE worker
+   whose vendor differs from the implementer's — `claude_code`, `codex`, or
+   `pi` (e.g. Claude built it → `codex` or `pi`, and so on). Use a
+   task-based title such as `review-auth-refactor`, never the raw vendor name:
+   `sys_session_send(agent="claude_code"|"codex"|"pi", title="review-<task_slug>",
+   args={purpose: "review", input: "<the diff> + <the acceptance contract>.
+   Review ONLY against the contract. Report blocking / non-blocking /
+   suggestions. Do not edit code."})`. Give it the diff as text — do NOT point
+   it at the implementer's worktree. Fetch the diff and emit the
+   `sys_session_send` call in the SAME turn you decide to review — never end a
+   turn having only announced "I'll load cross-review and fetch the diff" with
+   no tool call (that dropped turn stalls the run; nothing dispatches and no
+   inbox wake arrives). Once the reviewer dispatch is in flight, end your turn;
+   collect the inbox-delivered structured report with `sys_read_inbox` when it
+   returns. Use `sys_session_get_history` only to debug an empty or unclear
+   review result.
+4. The reviewer SURFACES issues; it does not fix them.
+5. For each **blocking** issue: add a fix-task to the registry scoped to the
+   same worktree, and send the concrete fixes back to the SAME implementer
+   conversation via `sys_session_send` — reuse the original implementer's
+   `agent` + `title` (or address it by `session_id`) with
+   `purpose: "implement"`, so the worker keeps its worktree/branch context and
+   updates its existing PR. A new title would spawn a fresh worker with no
+   memory of the task. Then loop to step 1.
+6. When gates are green AND there are zero blocking issues, the PR passes
+   review — mark it ready in the registry (with its PR URL) and leave it for
+   the human to merge. polly does NOT merge it.
+7. If the contract can't be satisfied after a few loops, stop and escalate to
+   the user with specifics.
+
+## Notes
+- Cross-review requires a reviewer from a DIFFERENT vendor than the implementer,
+  so it needs at least two AVAILABLE workers (per polly's roster preflight). If
+  only one worker — or only one vendor that can review this implementer's PR —
+  is available on the machine, you CANNOT run independent cross-vendor review:
+  don't dispatch a reviewer that can't boot, say so explicitly, and pull in the
+  human at the plan gate.
+- Give the reviewer ONLY the diff + contract — never the implementer's
+  transcript or worktree. The cross-vendor independence is the whole point.
+- Review is a coding sub-agent (`claude_code`/`codex`/`pi`) dispatched with
+  `purpose: "review"` — a DIFFERENT vendor from the one that built the diff. It
+  reports issues and never edits; only the implementer opens a PR, so a stray
+  reviewer edit never reaches the deliverable.
+- Non-blocking issues / suggestions go in the registry as follow-ups; they
+  don't block the PR.

--- a/examples/polly-windows/skills/fanout/SKILL.md
+++ b/examples/polly-windows/skills/fanout/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: fanout
+description: Run independent subtasks in parallel — one git worktree and one implementation sub-agent per task, each opening its own PR — then cross-review every PR. polly never merges; the human does.
+---
+
+# fanout — safe parallel execution
+
+Use ONLY for subtasks that are parallel-safe (no shared files, no ordering
+dependency).
+
+## Procedure
+1. Per task, create an isolated worktree:
+   `sys_os_shell("git worktree add .worktrees/<task_id> -b polly/<task_id>")`.
+   Record the worktree path + branch in the registry
+   (`.polly/registry.json`).
+2. Dispatch one implementation sub-agent per task, scoped to its worktree:
+   `sys_session_send(agent="claude_code"|"codex"|"pi", title="<task_slug>",
+   args={purpose: "implement", input: "<task + acceptance contract +
+   worktree path>"})`. Use a short task-based title such as `auth-refactor` or
+   `fix-sse-error`, never the raw vendor name. State the scope and that it must
+   work only inside `.worktrees/<task_id>`. The worker drives the task to green
+   and opens its OWN PR for the branch. Every commit the worker authors must
+   end with a blank line followed by the exact co-sign trailer as its final
+   line — `Co-authored-by: omnigent <noreply@omnigent.ai>`.
+   Record each handle's `conversation_id`
+   in the registry. Emit the worktree + `sys_session_send` tool calls in THIS
+   turn — never end a turn having only said you will dispatch; the dispatch
+   calls and their announcement go in the same turn. Dispatch the whole
+   parallel-safe set, THEN (and only then) END YOUR TURN. Do not poll.
+3. Each sub-agent runs autonomously and notifies you through the inbox when it
+   finishes. Collect its structured result with `sys_read_inbox` and record the
+   PR URL in the registry. If the inbox result is empty/unclear, inspect that
+   worker conversation with `sys_session_get_history` before deciding what to do
+   next.
+4. Send each finished task's PR through `cross-review`.
+5. polly does NOT merge — the PR is the deliverable. When cross-review passes,
+   the task is done: mark it ready in the registry with its PR URL and leave it
+   for the human to review and merge. Never run `git merge` / `gh pr merge`.
+6. Remove a finished worktree (`git worktree remove`) only once its PR is open
+   and review is clean — the branch lives on the remote, so the worktree is
+   disposable. Don't remove a worktree that still has open fix-tasks.
+
+## Notes
+- Respect the per-turn dispatch cap (enforced by policy). More tasks than the
+  cap → dispatch in waves (let the running batch finish before dispatching more).
+- The human can open any sub-agent in the UI's Subagents panel and read its
+  conversation while it runs.
+- If a running worker is wrong, runaway, superseded, or no longer useful, call
+  `sys_cancel_task` with `task_id` set to the recorded `conversation_id` before
+  dispatching a replacement. `claude_code` is hard-stopped; `codex` cancellation
+  is best-effort until its runner-side hard-stop exists.
+- A sub-agent that returns a dark or failing result: don't re-prompt it in a
+  loop — re-dispatch a fresh implementation sub-agent in a clean worktree, or
+  escalate to the user.
+- Because polly never merges, cross-PR conflicts surface when the human merges,
+  not here. Keeping each parallel task's file scope disjoint is what keeps that
+  rare — honor it.

--- a/examples/polly-windows/skills/investigate/SKILL.md
+++ b/examples/polly-windows/skills/investigate/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: investigate
+description: Delegate read-only investigation, debugging, audit, search, or code-understanding tasks to sub-agents; synthesize only from their structured reports.
+---
+
+# investigate — delegated read-only work
+
+Use for any read-only task: investigation, debugging, audit, search, code
+understanding, architecture comparison, failure analysis, or answering a
+repository-specific technical question.
+
+## Procedure
+1. Decompose the question into one or more bounded investigation tasks. Prefer
+   two independent lenses for ambiguous or high-stakes questions.
+2. Dispatch each task to `claude_code`, `codex`, or `pi`:
+   `sys_session_send(agent="claude_code"|"codex"|"pi",
+   title="explore-<task_slug>", args={purpose: "explore", input: "<question +
+   exact scope + evidence requested>"})`. Use a task-based title such as
+   `explore-ci-flake`, never the raw vendor name. Use `purpose: "search"` only
+   when the task is primarily external/document search. Prefer `pi` when a
+   third lens or a non-Claude/GPT model is wanted. Any worker takes an optional
+   `args.model` (`sys_list_models` shows what each worker can run; an invalid
+   model/worker combination fails loud at dispatch, and `model` only applies on
+   the dispatch that CREATES the session — a send that continues an existing
+   title rejects it).
+   Tell the worker to edit nothing and return file,
+   command, URL, or line evidence. Emit these `sys_session_send` calls in the
+   SAME turn — do not end a turn having only said you will dispatch.
+3. End your turn AFTER the dispatch tool calls are in flight (never before).
+   Do not inspect files, logs, terminals, docs, or connector output yourself
+   while the workers run.
+4. When workers finish, collect their completion results with
+   `sys_read_inbox`. Synthesize only from those inbox-delivered reports. Use
+   `sys_session_get_history` only to debug an empty or unclear worker result; if
+   reports conflict or are incomplete, dispatch a follow-up `explore` task
+   rather than resolving the conflict from your own direct inspection.
+5. If the investigation uncovers required code changes, switch to `fanout` /
+   `cross-review`: dispatch an `implement` worker, then verify with the
+   opposite-vendor `review` worker.
+
+## Notes
+- The orchestrator may use its own tools only to create task packets, maintain
+  the registry, or check deterministic external status. It must not answer the
+  user's substantive question from its own direct file reads, shell output,
+  connector fetches, or terminal scrollback.
+- Keep task scopes narrow enough that each worker can return a concise report
+  with evidence. Broad investigations should be split into parallel subtasks.

--- a/omnigent/__init__.py
+++ b/omnigent/__init__.py
@@ -29,8 +29,8 @@ from omnigent._env_compat import mirror_legacy_env as _mirror_legacy_env  # noqa
 
 _mirror_legacy_env()
 
-# Install native-Windows compatibility shims (POSIX id fallbacks + UTF-8 IO)
-# before any submodule below is imported. No-op on non-Windows hosts.
+# Force UTF-8 text IO on Windows before any submodule below is imported, so
+# console/tunnel output never hits the cp1252 codec. No-op on non-Windows hosts.
 from omnigent import _win_compat as _win_compat  # noqa: E402
 
 _win_compat.apply()

--- a/omnigent/__init__.py
+++ b/omnigent/__init__.py
@@ -29,6 +29,12 @@ from omnigent._env_compat import mirror_legacy_env as _mirror_legacy_env  # noqa
 
 _mirror_legacy_env()
 
+# Install native-Windows compatibility shims (POSIX id fallbacks + UTF-8 IO)
+# before any submodule below is imported. No-op on non-Windows hosts.
+from omnigent import _win_compat as _win_compat  # noqa: E402
+
+_win_compat.apply()
+
 from omnigent.inner.datamodel import (  # noqa: E402 — must follow md5 patch
     AgentDef,
     Connection,

--- a/omnigent/_encoding.py
+++ b/omnigent/_encoding.py
@@ -27,12 +27,14 @@ def detect_encoding(path: Path) -> str:
     """Return ``"utf-8"`` if *path* decodes as UTF-8, else the locale encoding.
 
     UTF-8 first because that is what modern CLIs write (and what UTF-8 Mode
-    produces); the locale codec is the legacy fallback. A missing/unreadable
-    path resolves to the locale encoding — callers that then hand it to
-    ``ConfigParser.read`` (which silently skips missing files) stay correct.
+    produces); the locale codec is the legacy fallback for a file that exists
+    but is not valid UTF-8. A *missing* path resolves to UTF-8 so a file about
+    to be created is written in the modern default rather than the locale codec.
     """
     try:
         path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return "utf-8"  # new file — write it UTF-8, not the legacy locale codec
     except (UnicodeDecodeError, OSError):
         return locale_encoding()
     return "utf-8"

--- a/omnigent/_encoding.py
+++ b/omnigent/_encoding.py
@@ -1,0 +1,38 @@
+"""Encoding detection for external / vendor-written text files.
+
+Windows text I/O defaults to the ANSI code page (cp1252), while modern tools —
+and Python 3.15's default UTF-8 Mode — write UTF-8. To round-trip either without
+corruption, detect the file's encoding (UTF-8 first, then the true OS locale
+codec) and preserve it on rewrite.
+
+The fallback uses :func:`locale.getencoding`, **not**
+``locale.getpreferredencoding(False)``: the latter returns ``"utf-8"`` under
+Python UTF-8 Mode even on a cp1252 host, so it would misdetect a real cp1252
+file as UTF-8. ``getencoding()`` always reports the actual locale encoding.
+See https://docs.python.org/3.12/library/locale.html#locale.getpreferredencoding
+"""
+
+from __future__ import annotations
+
+import locale
+from pathlib import Path
+
+
+def locale_encoding() -> str:
+    """The true OS locale text encoding, independent of Python UTF-8 Mode."""
+    return locale.getencoding()
+
+
+def detect_encoding(path: Path) -> str:
+    """Return ``"utf-8"`` if *path* decodes as UTF-8, else the locale encoding.
+
+    UTF-8 first because that is what modern CLIs write (and what UTF-8 Mode
+    produces); the locale codec is the legacy fallback. A missing/unreadable
+    path resolves to the locale encoding — callers that then hand it to
+    ``ConfigParser.read`` (which silently skips missing files) stay correct.
+    """
+    try:
+        path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return locale_encoding()
+    return "utf-8"

--- a/omnigent/_encoding.py
+++ b/omnigent/_encoding.py
@@ -30,6 +30,13 @@ def detect_encoding(path: Path) -> str:
     produces); the locale codec is the legacy fallback for a file that exists
     but is not valid UTF-8. A *missing* path resolves to UTF-8 so a file about
     to be created is written in the modern default rather than the locale codec.
+
+    This is a best-effort *detection* helper: an existing-but-unreadable file
+    (permissions, transient I/O) also resolves to the locale codec, matching the
+    tolerance of a plain ``ConfigParser.read`` on the same file. A caller that
+    must not act on a file it failed to read (i.e. a rewrite flow, which could
+    otherwise overwrite it) verifies readability itself — see
+    ``cli._read_existing_cfg``.
     """
     try:
         path.read_text(encoding="utf-8")

--- a/omnigent/_encoding.py
+++ b/omnigent/_encoding.py
@@ -35,8 +35,8 @@ def detect_encoding(path: Path) -> str:
     (permissions, transient I/O) also resolves to the locale codec, matching the
     tolerance of a plain ``ConfigParser.read`` on the same file. A caller that
     must not act on a file it failed to read (i.e. a rewrite flow, which could
-    otherwise overwrite it) verifies readability itself — see
-    ``cli._read_existing_cfg``.
+    otherwise overwrite it) reads and decodes one byte snapshot itself — see
+    ``cli._read_existing_cfg_snapshot``.
     """
     try:
         path.read_text(encoding="utf-8")

--- a/omnigent/_win_compat.py
+++ b/omnigent/_win_compat.py
@@ -1,55 +1,43 @@
 """Native-Windows compatibility bootstrap.
 
-omnigent grew up on Linux/macOS and bakes in a few POSIX assumptions that
-crash on native Windows before any feature code runs. This module is imported
-at the package boundary (from ``omnigent/__init__``) so every process — the
-CLI, the local server, the host daemon, the runner, and harness subprocesses
-spawned via ``-m omnigent`` — installs these shims before anything else runs.
-It is a no-op on non-Windows hosts.
+On Windows, Python defaults its text IO to the platform code page (cp1252), so
+writing a non-cp1252 glyph (e.g. the "✓" status char) raises
+``UnicodeEncodeError``. That crashes ``config list`` and, worse, tears down the
+host<->server WebSocket tunnel so the daemon never comes online.
 
-Two classes of breakage are handled:
+This module is imported at the package boundary (from ``omnigent/__init__``) so
+every process — the CLI, the local server, the host daemon, the runner, and
+harness subprocesses spawned via ``-m omnigent`` — forces UTF-8 IO before any
+output happens. It is a no-op on non-Windows hosts.
 
-1. POSIX-only ``os.getuid`` / ``os.getgid`` are called at *module import time*
-   in the ``*_native_bridge.py`` modules (to name a per-user temp bridge root).
-   On Windows these attributes don't exist, so importing those modules — which
-   the server does transitively while registering the default Claude agent —
-   raises ``AttributeError`` and aborts server startup.
-
-2. Python's default text encoding on Windows is the legacy code page (cp1252),
-   so writing a non-cp1252 glyph (e.g. the ``✓`` status char) raises
-   ``UnicodeEncodeError``. That crashes ``config list`` and, worse, tears down
-   the host<->server WebSocket tunnel so the daemon never comes online.
+POSIX ``os.getuid()`` calls in the ``*_native_bridge.py`` modules are handled at
+their call sites via :func:`omnigent._platform.stable_user_id`, not by
+monkeypatching ``os`` here — a global ``os.getuid``/``geteuid`` shim would make
+Windows look like POSIX root and perturb stdlib behaviour such as ``tarfile``
+ownership handling.
 """
 
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 
 
-def _install_posix_id_shims() -> None:
-    # The native bridges only use these to name a per-user temp dir, and the
-    # native (tmux/PTY) harnesses that consume it don't run on Windows, so a
-    # stable constant is enough to make those modules import cleanly.
-    for _name in ("getuid", "getgid", "geteuid", "getegid"):
-        if not hasattr(os, _name):
-            setattr(os, _name, lambda: 0)
-
-
 def _force_utf8_io() -> None:
-    # Propagate to child processes (the daemon/runner env is scrubbed, so an
-    # inherited value is the only thing that reaches them reliably).
+    # Propagate to child processes: the daemon/runner env is scrubbed, so an
+    # inherited value is the only thing that reaches them reliably.
     os.environ.setdefault("PYTHONUTF8", "1")
     os.environ.setdefault("PYTHONIOENCODING", "utf-8")
-    for _stream in (sys.stdout, sys.stderr):
-        try:
-            _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
-        except Exception:
-            pass
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            # Raises when the stream is detached/closed (e.g. under capture).
+            with contextlib.suppress(ValueError, OSError):
+                reconfigure(encoding="utf-8", errors="replace")
 
 
 def apply() -> None:
     if os.name != "nt":
         return
-    _install_posix_id_shims()
     _force_utf8_io()

--- a/omnigent/_win_compat.py
+++ b/omnigent/_win_compat.py
@@ -1,0 +1,55 @@
+"""Native-Windows compatibility bootstrap.
+
+omnigent grew up on Linux/macOS and bakes in a few POSIX assumptions that
+crash on native Windows before any feature code runs. This module is imported
+at the package boundary (from ``omnigent/__init__``) so every process — the
+CLI, the local server, the host daemon, the runner, and harness subprocesses
+spawned via ``-m omnigent`` — installs these shims before anything else runs.
+It is a no-op on non-Windows hosts.
+
+Two classes of breakage are handled:
+
+1. POSIX-only ``os.getuid`` / ``os.getgid`` are called at *module import time*
+   in the ``*_native_bridge.py`` modules (to name a per-user temp bridge root).
+   On Windows these attributes don't exist, so importing those modules — which
+   the server does transitively while registering the default Claude agent —
+   raises ``AttributeError`` and aborts server startup.
+
+2. Python's default text encoding on Windows is the legacy code page (cp1252),
+   so writing a non-cp1252 glyph (e.g. the ``✓`` status char) raises
+   ``UnicodeEncodeError``. That crashes ``config list`` and, worse, tears down
+   the host<->server WebSocket tunnel so the daemon never comes online.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _install_posix_id_shims() -> None:
+    # The native bridges only use these to name a per-user temp dir, and the
+    # native (tmux/PTY) harnesses that consume it don't run on Windows, so a
+    # stable constant is enough to make those modules import cleanly.
+    for _name in ("getuid", "getgid", "geteuid", "getegid"):
+        if not hasattr(os, _name):
+            setattr(os, _name, lambda: 0)
+
+
+def _force_utf8_io() -> None:
+    # Propagate to child processes (the daemon/runner env is scrubbed, so an
+    # inherited value is the only thing that reaches them reliably).
+    os.environ.setdefault("PYTHONUTF8", "1")
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+        except Exception:
+            pass
+
+
+def apply() -> None:
+    if os.name != "nt":
+        return
+    _install_posix_id_shims()
+    _force_utf8_io()

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3702,7 +3702,7 @@ def _raise_server_failed(server: LocalServer) -> None:
     else:
         cmd_display = str(args)
     try:
-        lines = server.log_path.read_text(errors="replace").splitlines()
+        lines = server.log_path.read_text(encoding="utf-8", errors="replace").splitlines()
         tail = "\n".join(lines[-_SERVER_LOG_TAIL_LINES:]) if lines else "(empty log file)"
     except OSError as e:
         tail = f"(could not read log file: {e})"

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -2942,13 +2942,13 @@ def _materialize_override_bundle(source: Path, overrides: ChatOverrides) -> Path
                 raise click.ClickException(f"{source}: directory has no config.yaml to override.")
             target = config
 
-        raw = yaml.safe_load(target.read_text())
+        raw = yaml.safe_load(target.read_text(encoding="utf-8"))
         if not isinstance(raw, dict):
             raise click.ClickException(
                 f"{source}: expected YAML mapping at top level, got {type(raw).__name__}"
             )
         _apply_overrides_to_raw(raw, overrides)
-        target.write_text(yaml.safe_dump(raw, default_flow_style=False))
+        target.write_text(yaml.safe_dump(raw, default_flow_style=False), encoding="utf-8")
         materialized = target if source.is_file() else target.parent
         _MATERIALIZED_OVERRIDE_DIRS[materialized.resolve()] = tmpdir
         return materialized
@@ -2995,7 +2995,7 @@ def _load_yaml_for_override_peek(source: Path) -> _YamlMapping | None:
         config = source / "config.yaml"
         if not config.is_file():
             return None
-        parsed = yaml.safe_load(config.read_text())
+        parsed = yaml.safe_load(config.read_text(encoding="utf-8"))
         return parsed if isinstance(parsed, dict) else None
     return _load_yaml_if_single_file(source)
 
@@ -3015,7 +3015,7 @@ def _load_yaml_if_single_file(source: Path) -> _YamlMapping | None:
     """
     if not source.is_file():
         return None
-    parsed = yaml.safe_load(source.read_text())
+    parsed = yaml.safe_load(source.read_text(encoding="utf-8"))
     return parsed if isinstance(parsed, dict) else None
 
 

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -1801,7 +1801,7 @@ def _materialize_claude_agent_spec(tmpdir: Path) -> Path:
         # the native CLI already runs unsandboxed on the user's workspace.
         "terminals": native_shell_terminal_spec(),
     }
-    yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return yaml_path
 
 

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -2437,7 +2437,7 @@ def _read_complete_jsonl_records(
     cursor = start_line
     position = byte_offset
     try:
-        with path.open("rb") as handle:
+        with path.open(mode="rb") as handle:
             handle.seek(0, os.SEEK_END)
             file_size = handle.tell()
             if byte_offset > file_size:

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -4412,7 +4412,7 @@ def _complete_jsonl_end_offset(path: Path) -> int:
         for missing files or a single partial first record.
     """
     try:
-        with path.open("rb") as handle:
+        with path.open(mode="rb") as handle:
             handle.seek(0, os.SEEK_END)
             size = handle.tell()
             if size == 0:
@@ -4446,7 +4446,7 @@ def _jsonl_cursor_fingerprint(path: Path, byte_offset: int) -> str | None:
     if byte_offset < 0:
         return None
     try:
-        with path.open("rb") as handle:
+        with path.open(mode="rb") as handle:
             handle.seek(0, os.SEEK_END)
             size = handle.tell()
             if byte_offset > size:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -77,7 +77,7 @@ def _load_config(path: str | None) -> dict[str, Any]:  # type: ignore[explicit-a
     """
     if path is None:
         return {}
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return yaml.safe_load(f) or {}
 
 
@@ -252,7 +252,7 @@ def _migrate_legacy_state_dir() -> None:
     legacy_pid_file = legacy_src / "host.pid"
     if legacy_pid_file.exists():
         try:
-            first_line = legacy_pid_file.read_text().strip().splitlines()[0]
+            first_line = legacy_pid_file.read_text(encoding="utf-8").strip().splitlines()[0]
             legacy_pid = int(first_line)
         except (ValueError, OSError, IndexError):
             legacy_pid = None
@@ -515,7 +515,7 @@ def _peek_default_agent_harness(target: str) -> str | None:
     if not path.is_file():
         return None
     try:
-        raw = yaml.safe_load(path.read_text()) or {}
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     except (OSError, yaml.YAMLError):
         return None
     if not isinstance(raw, dict):
@@ -801,7 +801,7 @@ def _save_global_config(  # type: ignore[explicit-any]
         cfg.pop(key, None)
     path = _effective_global_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=True)
 
 
@@ -874,7 +874,7 @@ def _save_local_config(
     for key in unset_keys:
         cfg.pop(key, None)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=True)
 
 
@@ -1919,7 +1919,7 @@ def _read_daemon_record(path: Path) -> _HostDaemonRecord | None:
     :returns: Parsed daemon record, or ``None`` if unreadable or malformed.
     """
     try:
-        raw = json.loads(path.read_text())
+        raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
     if not isinstance(raw, dict):
@@ -1936,7 +1936,7 @@ def _write_daemon_record(record: _HostDaemonRecord) -> None:
     """
     path = _daemon_record_path(record.target)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(asdict(record), indent=2, sort_keys=True) + "\n")
+    path.write_text(json.dumps(asdict(record), indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def _delete_daemon_record(record: _HostDaemonRecord) -> None:
@@ -2050,7 +2050,7 @@ def _load_existing_host_id() -> str | None:
         candidate_paths.append(CONFIG_PATH)
     for path in candidate_paths:
         try:
-            raw = yaml.safe_load(path.read_text()) if path.exists() else None
+            raw = yaml.safe_load(path.read_text(encoding="utf-8")) if path.exists() else None
         except (OSError, yaml.YAMLError):
             continue
         if not isinstance(raw, dict):
@@ -2297,7 +2297,7 @@ def _persist_spawned_daemon(
             config_sig=config_sig,
         )
     )
-    _HOST_PID_PATH.write_text(f"{spawned.pid}\n{target}\n")
+    _HOST_PID_PATH.write_text(f"{spawned.pid}\n{target}\n", encoding="utf-8")
 
 
 def _foreground_daemon_record(
@@ -2517,7 +2517,7 @@ def _read_host_pid_file() -> tuple[int, str] | None:
     if not _HOST_PID_PATH.exists():
         return None
     try:
-        lines = _HOST_PID_PATH.read_text().strip().splitlines()
+        lines = _HOST_PID_PATH.read_text(encoding="utf-8").strip().splitlines()
         if len(lines) < 2:
             return None
         return int(lines[0]), lines[1]
@@ -4330,7 +4330,7 @@ def _resolve_bundle_env_vars(source: Path) -> dict[str, str]:
     # ── config.yaml ──────────────────────────────────
     config_path = source / "config.yaml"
     if config_path.exists():
-        raw = yaml.safe_load(config_path.read_text())
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         if isinstance(raw, dict):
             changed = _expand_config_env_vars(raw, expand_env_vars)
             if changed:
@@ -4346,7 +4346,7 @@ def _resolve_bundle_env_vars(source: Path) -> dict[str, str]:
     mcp_dir = source / "tools" / "mcp"
     if mcp_dir.is_dir():
         for yaml_file in sorted(mcp_dir.glob("*.yaml")):
-            raw = yaml.safe_load(yaml_file.read_text())
+            raw = yaml.safe_load(yaml_file.read_text(encoding="utf-8"))
             if not isinstance(raw, dict):
                 continue
             changed = False
@@ -5063,7 +5063,7 @@ def _bundled_agent_brain_harness(name: str) -> str | None:
     if not config_path.is_file():
         return None
     try:
-        raw = yaml.safe_load(config_path.read_text()) or {}
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     except (OSError, yaml.YAMLError):
         return None
     if not isinstance(raw, dict):
@@ -6408,7 +6408,7 @@ def _materialize_harness_launcher_file(
     }
     if canonical in _OS_ENV_HARNESSES:
         raw["os_env"] = {"type": "caller_process", "sandbox": {"type": "none"}}
-    yaml_path.write_text(yaml.safe_dump(raw, default_flow_style=False))
+    yaml_path.write_text(yaml.safe_dump(raw, default_flow_style=False), encoding="utf-8")
     return yaml_path
 
 
@@ -10839,7 +10839,7 @@ def _qwen_auth_configured() -> bool:
     settings = Path.home() / ".qwen" / "settings.json"
     if settings.is_file():
         try:
-            data = json.loads(settings.read_text())
+            data = json.loads(settings.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             return False
         if isinstance(data, dict):

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -15,13 +15,14 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import types
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from importlib import import_module, resources
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, BinaryIO, Literal, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, BinaryIO, Literal, TextIO, TypeAlias, cast
 
 import click
 import yaml
@@ -30,7 +31,7 @@ from rich import box
 from rich.console import Console
 from rich.table import Table
 
-from omnigent._encoding import detect_encoding
+from omnigent._encoding import locale_encoding
 from omnigent._platform import IS_WINDOWS, resolve_repo_symlink
 from omnigent._startup_profile import StartupProfiler
 from omnigent.cli_sandbox import lakebox as _lakebox_alias_group
@@ -9107,16 +9108,111 @@ def _node_dependency_problem() -> str | None:
     return f"Node.js is too old{detected} — Claude, Codex, and Pi need {_NODE_MIN_VERSION_HINT}."
 
 
-def _read_existing_cfg(cfg: configparser.ConfigParser, path: Path, encoding: str) -> None:
-    """Load *path* into *cfg* when it exists, raising if it exists but can't be read.
+def _read_existing_cfg_snapshot(
+    cfg: configparser.ConfigParser,
+    path: Path,
+) -> tuple[str, bytes | None]:
+    """Parse an existing config from one byte snapshot.
 
-    ``ConfigParser.read`` silently skips an unreadable file (permissions, a
-    transient I/O error), so a rewrite flow that trusted it would drop the user's
-    other sections and then replace the original — destroying it. Only a
-    genuinely missing file may no-op here (the new-config case).
+    Returns ``(encoding, raw_bytes)``. A genuinely missing file is the new-config
+    case and returns ``("utf-8", None)``. Every other read/decode/parse failure
+    propagates so a rewrite flow cannot act on content it failed to load.
     """
-    if path.exists() and not cfg.read(path, encoding=encoding):
-        raise OSError(f"cannot read existing {path}; refusing to overwrite it")
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return "utf-8", None
+    try:
+        text = raw.decode("utf-8")
+        encoding = "utf-8"
+    except UnicodeDecodeError:
+        encoding = locale_encoding()
+        text = raw.decode(encoding)
+    cfg.read_string(text, source=str(path))
+    return encoding, raw
+
+
+def _optional_file_bytes(path: Path) -> bytes | None:
+    """Return *path* bytes, or ``None`` only when it genuinely does not exist."""
+    try:
+        return path.read_bytes()
+    except FileNotFoundError:
+        return None
+
+
+def _config_section_values(
+    cfg: configparser.ConfigParser,
+    section: str,
+) -> dict[str, str] | None:
+    """Snapshot one section for a three-way config merge."""
+    if not cfg.has_section(section):
+        return None
+    return dict(cfg.items(section, raw=True))
+
+
+_DATABRICKS_CFG_THREAD_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def _databricks_cfg_merge_lock(
+    path: Path,
+) -> collections.abc.Generator[None, None, None]:
+    """Serialize Omnigent read/merge/publish operations across threads/processes."""
+    lock_path = path.with_name(f"{path.name}.omnigent.lock")
+    with _DATABRICKS_CFG_THREAD_LOCK:
+        lock_file = lock_path.open("a+b")
+        locked = False
+        primary_error: BaseException | None = None
+        cleanup_errors: list[tuple[str, BaseException]] = []
+
+        def _unlock() -> None:
+            lock_file.seek(0)
+            if IS_WINDOWS:
+                import msvcrt
+
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+        try:
+            if IS_WINDOWS:
+                import msvcrt
+
+                lock_file.seek(0, os.SEEK_END)
+                if lock_file.tell() == 0:
+                    lock_file.write(b"\0")
+                    lock_file.flush()
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            locked = True
+            yield
+        except BaseException as exc:
+            primary_error = exc
+            raise
+        finally:
+            if locked:
+                try:
+                    _unlock()
+                except BaseException as exc:  # noqa: BLE001 - close must still run
+                    cleanup_errors.append(("unlock merge lock", exc))
+            try:
+                lock_file.close()
+            except BaseException as exc:  # noqa: BLE001 - preserve a primary error
+                cleanup_errors.append(("close merge lock", exc))
+            if cleanup_errors:
+                if primary_error is not None:
+                    for label, error in cleanup_errors:
+                        primary_error.add_note(f"Databricks cleanup failed ({label}): {error!r}")
+                else:
+                    label, error = cleanup_errors[0]
+                    error.add_note(f"Databricks cleanup failed: {label}")
+                    raise error
 
 
 @contextlib.contextmanager
@@ -9150,14 +9246,11 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
     from omnigent.onboarding.setup import CONFLICTING_ENV_VARS
 
     original_cfg = Path.home() / ".databrickscfg"
-    # Read the existing config (and detect its codec) BEFORE mutating the
-    # environment, so a hard failure — e.g. an unreadable original we must not
-    # overwrite — leaves both the env and the file untouched. ~/.databrickscfg is
-    # vendor-written; detect UTF-8 first (locale fallback) and preserve that codec
-    # on the write-back so a round-trip never re-encodes non-ASCII values.
-    orig_encoding = detect_encoding(original_cfg)
+    # Decode and parse the original from one byte snapshot before mutating the
+    # environment. This both fails closed on read errors and prevents a codec
+    # detection/read race from ever producing mixed bytes.
     orig_cfg = configparser.ConfigParser()
-    _read_existing_cfg(orig_cfg, original_cfg, orig_encoding)
+    _read_existing_cfg_snapshot(orig_cfg, original_cfg)
 
     # Seed the temp with only the canonical internal-beta profile sections
     # (see DEFAULT_PROFILES) that already exist, so there is exactly one section
@@ -9168,30 +9261,65 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
         if orig_cfg.has_section(spec.name):
             cfg[spec.name] = dict(orig_cfg[spec.name])
 
-    saved_env: dict[str, str | None] = {
-        "DATABRICKS_CONFIG_FILE": os.environ.get("DATABRICKS_CONFIG_FILE"),
-    }
+    env_names = ("DATABRICKS_CONFIG_FILE", *CONFLICTING_ENV_VARS)
+    saved_env = {name: os.environ.get(name) for name in env_names}
 
-    def _restore_env() -> None:
-        for var, prev in saved_env.items():
-            if prev is None:
-                os.environ.pop(var, None)
-            else:
-                os.environ[var] = prev
+    def _restore_env_value(name: str, value: str | None) -> None:
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
 
-    # Capture the handlers to restore before installing ours, so restoration in
-    # ``finally`` is safe even if preparation below never installs anything.
+    # Capture handlers before the mutation boundary. Flags below ensure cleanup
+    # restores only handlers that were actually installed.
     prev_sigterm = signal.getsignal(signal.SIGTERM)
     prev_sigint = signal.getsignal(signal.SIGINT)
+    sigterm_installed = False
+    sigint_installed = False
+    tmp_fd: int | None = None
+    tmp_stream: TextIO | None = None
     tmp_path: Path | None = None
+    write_fd: int | None = None
+    write_stream: TextIO | None = None
     write_tmp: Path | None = None
-    # A single try/finally spans EVERY mutation — popping CONFLICTING_ENV_VARS,
-    # creating the temp file, installing signal handlers — so all of them are
-    # undone even if preparation itself fails. (A failed mkstemp must not leave
-    # DATABRICKS_HOST / DATABRICKS_TOKEN deleted.)
+    primary_error: BaseException | None = None
+    cleanup_errors: list[tuple[str, BaseException]] = []
+
+    def _on_signal(signum: int, _frame: types.FrameType | None) -> None:
+        """Chain safely without leaving a live context half dismantled."""
+        nonlocal sigint_installed, sigterm_installed
+        previous = prev_sigterm if signum == signal.SIGTERM else prev_sigint
+        # An ignored or returning custom handler leaves the context active, so
+        # preserve all of its state. A raising handler unwinds through ``finally``
+        # below, which performs the normal complete cleanup.
+        if previous == signal.SIG_IGN:
+            return
+        if callable(previous):
+            previous(signum, _frame)
+            return
+
+        # SIG_DFL may terminate before Python can unwind. Clean up first, restore
+        # both handlers, and only then re-raise the signal. SystemExit is a
+        # defensive non-return guarantee for platforms that return from it.
+        for name, value in saved_env.items():
+            with contextlib.suppress(Exception):
+                _restore_env_value(name, value)
+        for path in (write_tmp, tmp_path):
+            if path is not None:
+                with contextlib.suppress(Exception):
+                    path.unlink(missing_ok=True)
+        with contextlib.suppress(Exception):
+            signal.signal(signal.SIGTERM, prev_sigterm)
+        with contextlib.suppress(Exception):
+            signal.signal(signal.SIGINT, prev_sigint)
+        sigterm_installed = False
+        sigint_installed = False
+        signal.raise_signal(signum)
+        raise SystemExit(128 + signum)
+
     try:
         for var in CONFLICTING_ENV_VARS:
-            saved_env[var] = os.environ.pop(var, None)
+            os.environ.pop(var, None)
 
         omnigent_dir = Path.home() / ".omnigent"
         omnigent_dir.mkdir(exist_ok=True)
@@ -9201,53 +9329,134 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
             suffix=".tmp",
         )
         tmp_path = Path(tmp_name)
-        # The temp file is ours, so it stays UTF-8 (setup detects+preserves, so
-        # it round-trips); the write-back preserves the original's codec.
-        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
-            cfg.write(f)
+        # Transfer ownership only after fdopen succeeds. If it raises, tmp_fd
+        # remains tracked and cleanup closes it before attempting Windows unlink.
+        tmp_stream = os.fdopen(tmp_fd, "w", encoding="utf-8")
+        tmp_fd = None
+        # Keep the stream tracked until an explicit successful close. If either
+        # write or close fails, the outer exception-preserving cleanup retries
+        # close without allowing it to replace the primary failure.
+        cfg.write(tmp_stream)
+        tmp_stream.close()
+        tmp_stream = None
         os.environ["DATABRICKS_CONFIG_FILE"] = tmp_name
 
-        def _on_signal(signum: int, _frame: types.FrameType | None) -> None:
-            _restore_env()
-            if tmp_path is not None:
-                tmp_path.unlink(missing_ok=True)
-            # Restore the original handler before re-raising so signal chaining
-            # (e.g. Click's Ctrl-C → Abort) is preserved rather than falling
-            # back to SIG_DFL which would kill the process through the OS.
-            signal.signal(signum, prev_sigterm if signum == signal.SIGTERM else prev_sigint)
-            signal.raise_signal(signum)
-
         signal.signal(signal.SIGTERM, _on_signal)
+        sigterm_installed = True
         signal.signal(signal.SIGINT, _on_signal)
+        sigint_installed = True
 
         yield
 
-        # Merge the canonical sections setup wrote back into the real config.
-        # Re-detect the codec now: another process may have replaced the file
-        # (e.g. cp1252 -> UTF-8) while setup ran, and reusing the codec detected
-        # at entry would write a mixed-encoding file. The read is guarded, so an
-        # original that became unreadable aborts instead of being overwritten.
-        final_encoding = detect_encoding(original_cfg)
+        # The owned temp is required merge input: a missing/unreadable temp must
+        # abort rather than silently rewrite the real config with no setup result.
+        if tmp_path is None:  # defensive; successful preparation always sets it
+            raise RuntimeError("isolated Databricks config was not created")
         tmp_cfg = configparser.ConfigParser()
-        tmp_cfg.read(tmp_path, encoding="utf-8")  # our temp file (UTF-8, above)
-        merged = configparser.ConfigParser()
-        _read_existing_cfg(merged, original_cfg, final_encoding)
-        for spec in DEFAULT_PROFILES:
-            if tmp_cfg.has_section(spec.name):
-                merged[spec.name] = dict(tmp_cfg[spec.name])
-        write_tmp = original_cfg.with_suffix(".tmp")
-        with write_tmp.open("w", encoding=final_encoding) as f:
-            merged.write(f)
-        write_tmp.replace(original_cfg)
-        write_tmp = None
+        with tmp_path.open("r", encoding="utf-8") as f:
+            tmp_cfg.read_file(f, source=str(tmp_path))
+
+        # Serialize Omnigent writers across threads and processes, then re-read
+        # the current original from one byte snapshot. Independent vendor tools
+        # do not honor our lock, so the comparison immediately before the atomic
+        # replace is an additional best-effort conflict check, not a filesystem
+        # compare-and-swap guarantee.
+        with _databricks_cfg_merge_lock(original_cfg):
+            merged = configparser.ConfigParser()
+            final_encoding, final_snapshot = _read_existing_cfg_snapshot(
+                merged,
+                original_cfg,
+            )
+            for spec in DEFAULT_PROFILES:
+                base = _config_section_values(orig_cfg, spec.name)
+                ours = _config_section_values(tmp_cfg, spec.name)
+                theirs = _config_section_values(merged, spec.name)
+                if ours == base:
+                    continue  # setup did not touch it; preserve the current file
+                if theirs not in (base, ours):
+                    raise OSError(
+                        f"{original_cfg} profile {spec.name!r} changed concurrently; "
+                        "refusing to overwrite it"
+                    )
+                if ours is None:
+                    merged.remove_section(spec.name)
+                else:
+                    merged[spec.name] = ours
+            write_fd, write_name = tempfile.mkstemp(
+                prefix=f"{original_cfg.name}-merge-",
+                dir=original_cfg.parent,
+                suffix=".tmp",
+            )
+            write_tmp = Path(write_name)
+            write_stream = os.fdopen(write_fd, "w", encoding=final_encoding)
+            write_fd = None
+            merged.write(write_stream)
+            write_stream.close()
+            write_stream = None
+            if _optional_file_bytes(original_cfg) != final_snapshot:
+                raise OSError(f"{original_cfg} changed while merging; refusing to overwrite it")
+            write_tmp.replace(original_cfg)
+            write_tmp = None
+    except BaseException as exc:
+        primary_error = exc
+        raise
     finally:
-        if tmp_path is not None:
-            tmp_path.unlink(missing_ok=True)
+
+        def _attempt_cleanup(label: str, action: Callable[[], None]) -> None:
+            try:
+                action()
+            except BaseException as exc:  # noqa: BLE001 - every cleanup action must run
+                cleanup_errors.append((label, exc))
+
+        if tmp_stream is not None and not tmp_stream.closed:
+            stream = tmp_stream
+            _attempt_cleanup("close isolated config stream", stream.close)
+        if tmp_fd is not None:
+            fd = tmp_fd
+            _attempt_cleanup("close isolated config descriptor", lambda fd=fd: os.close(fd))
+        if write_stream is not None and not write_stream.closed:
+            stream = write_stream
+            _attempt_cleanup("close merge config stream", stream.close)
+        if write_fd is not None:
+            fd = write_fd
+            _attempt_cleanup("close merge config descriptor", lambda fd=fd: os.close(fd))
+        if sigint_installed:
+            _attempt_cleanup(
+                "restore SIGINT handler",
+                lambda: signal.signal(signal.SIGINT, prev_sigint),
+            )
+        if sigterm_installed:
+            _attempt_cleanup(
+                "restore SIGTERM handler",
+                lambda: signal.signal(signal.SIGTERM, prev_sigterm),
+            )
+        # Restore every environment key independently before fallible file
+        # cleanup, so no cleanup error can leak mutated process credentials.
+        for name, value in saved_env.items():
+            _attempt_cleanup(
+                f"restore {name}",
+                lambda name=name, value=value: _restore_env_value(name, value),
+            )
         if write_tmp is not None:
-            write_tmp.unlink(missing_ok=True)
-        signal.signal(signal.SIGTERM, prev_sigterm)
-        signal.signal(signal.SIGINT, prev_sigint)
-        _restore_env()
+            path = write_tmp
+            _attempt_cleanup("remove merge temp", lambda path=path: path.unlink(missing_ok=True))
+        if tmp_path is not None:
+            path = tmp_path
+            _attempt_cleanup(
+                "remove isolated config",
+                lambda path=path: path.unlink(missing_ok=True),
+            )
+
+        if cleanup_errors:
+            if primary_error is not None:
+                for label, error in cleanup_errors:
+                    primary_error.add_note(f"Databricks cleanup failed ({label}): {error!r}")
+            else:
+                first_label, first_error = cleanup_errors[0]
+                first_error.add_note(f"Databricks cleanup failed: {first_label}")
+                for label, error in cleanup_errors[1:]:
+                    first_error.add_note(f"Additional cleanup failure ({label}): {error!r}")
+                raise first_error
 
 
 def _run_configure_databricks() -> None:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -62,6 +62,8 @@ from omnigent.onboarding.ucode_setup import (
 from omnigent.process_logging import LOG_LEVEL_ENV_VAR, LOG_TO_STDERR_ENV_VAR
 
 if TYPE_CHECKING:
+    import configparser
+
     import httpx
 
     from omnigent._runner_startup import RunnerStartupProgress
@@ -9105,6 +9107,18 @@ def _node_dependency_problem() -> str | None:
     return f"Node.js is too old{detected} — Claude, Codex, and Pi need {_NODE_MIN_VERSION_HINT}."
 
 
+def _read_existing_cfg(cfg: configparser.ConfigParser, path: Path, encoding: str) -> None:
+    """Load *path* into *cfg* when it exists, raising if it exists but can't be read.
+
+    ``ConfigParser.read`` silently skips an unreadable file (permissions, a
+    transient I/O error), so a rewrite flow that trusted it would drop the user's
+    other sections and then replace the original — destroying it. Only a
+    genuinely missing file may no-op here (the new-config case).
+    """
+    if path.exists() and not cfg.read(path, encoding=encoding):
+        raise OSError(f"cannot read existing {path}; refusing to overwrite it")
+
+
 @contextlib.contextmanager
 def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
     """Run Databricks setup against a temp config containing only our three profiles.
@@ -9136,6 +9150,14 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
     from omnigent.onboarding.setup import CONFLICTING_ENV_VARS
 
     original_cfg = Path.home() / ".databrickscfg"
+    # Read the existing config (and detect its codec) BEFORE mutating the
+    # environment, so a hard failure — e.g. an unreadable original we must not
+    # overwrite — leaves both the env and the file untouched. ~/.databrickscfg is
+    # vendor-written; detect UTF-8 first (locale fallback) and preserve that codec
+    # on the write-back so a round-trip never re-encodes non-ASCII values.
+    orig_encoding = detect_encoding(original_cfg)
+    orig_cfg = configparser.ConfigParser()
+    _read_existing_cfg(orig_cfg, original_cfg, orig_encoding)
     saved_env: dict[str, str | None] = {
         "DATABRICKS_CONFIG_FILE": os.environ.get("DATABRICKS_CONFIG_FILE"),
     }
@@ -9151,17 +9173,11 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
 
     # Temp file contains only the canonical internal-beta profile sections
     # (see DEFAULT_PROFILES), seeded from the original when they already
-    # exist. Everything else is excluded so there is exactly one
-    # section per workspace host and `databricks auth token --host X`
-    # never hits the "multiple profiles match" ambiguity error.
-    # ~/.databrickscfg is vendor-written; detect the real file's codec (UTF-8
-    # first, locale fallback) and preserve it across the final write-back so a
-    # round-trip never re-encodes non-ASCII values. The temp file below is ours,
-    # so it stays UTF-8 (setup detects+preserves, so it round-trips).
-    orig_encoding = detect_encoding(original_cfg)
-    orig_cfg = configparser.ConfigParser()
-    if original_cfg.exists():
-        orig_cfg.read(original_cfg, encoding=orig_encoding)
+    # exist. Everything else is excluded so there is exactly one section per
+    # workspace host and `databricks auth token --host X` never hits the
+    # "multiple profiles match" ambiguity error. The temp file below is ours, so
+    # it stays UTF-8 (setup detects+preserves, so it round-trips); the write-back
+    # preserves the original's detected codec (orig_encoding, above).
     cfg = configparser.ConfigParser()
     for spec in DEFAULT_PROFILES:
         if orig_cfg.has_section(spec.name):
@@ -9203,8 +9219,7 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
         tmp_cfg = configparser.ConfigParser()
         tmp_cfg.read(tmp_path, encoding="utf-8")  # our temp file (written above)
         orig_cfg = configparser.ConfigParser()
-        if original_cfg.exists():
-            orig_cfg.read(original_cfg, encoding=orig_encoding)
+        _read_existing_cfg(orig_cfg, original_cfg, orig_encoding)
         for spec in DEFAULT_PROFILES:
             if tmp_cfg.has_section(spec.name):
                 orig_cfg[spec.name] = dict(tmp_cfg[spec.name])

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9160,7 +9160,7 @@ def _databricks_cfg_merge_lock(
     """Serialize Omnigent read/merge/publish operations across threads/processes."""
     lock_path = path.with_name(f"{path.name}.omnigent.lock")
     with _DATABRICKS_CFG_THREAD_LOCK:
-        lock_file = lock_path.open("a+b")
+        lock_file = lock_path.open(mode="a+b")
         locked = False
         primary_error: BaseException | None = None
         cleanup_errors: list[tuple[str, BaseException]] = []

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9203,7 +9203,7 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
             if tmp_cfg.has_section(spec.name):
                 orig_cfg[spec.name] = dict(tmp_cfg[spec.name])
         write_tmp = original_cfg.with_suffix(".tmp")
-        with write_tmp.open("w") as f:
+        with write_tmp.open("w", encoding="utf-8") as f:
             orig_cfg.write(f)
         write_tmp.replace(original_cfg)
         write_tmp = None
@@ -13080,7 +13080,7 @@ def debug_logs(
         # Show all files for the session, oldest first, with separators.
         for f in reversed(log_files):
             click.echo(f"# {f}", err=True)
-            content = f.read_text(errors="replace")
+            content = f.read_text(encoding="utf-8", errors="replace")
             if lines > 0:
                 content = "\n".join(content.splitlines()[-lines:])
             click.echo(content)
@@ -13088,7 +13088,7 @@ def debug_logs(
     else:
         latest = log_files[0]
         click.echo(f"# {latest}", err=True)
-        content = latest.read_text(errors="replace")
+        content = latest.read_text(encoding="utf-8", errors="replace")
         if lines > 0:
             content = "\n".join(content.splitlines()[-lines:])
         click.echo(content)

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3700,7 +3700,7 @@ def _write_uninstall_manifest(ledger: Any) -> Path:
     """Write the ledger fields the POSIX uninstaller needs as tab records."""
     fd, manifest_name = tempfile.mkstemp(prefix="omnigent-uninstall-ledger-", suffix=".tsv")
     manifest = Path(manifest_name)
-    with os.fdopen(fd, "w") as handle:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
         for profile in ledger.entries.profiles:
             handle.write(
                 "\t".join(

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9158,11 +9158,19 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
     orig_encoding = detect_encoding(original_cfg)
     orig_cfg = configparser.ConfigParser()
     _read_existing_cfg(orig_cfg, original_cfg, orig_encoding)
+
+    # Seed the temp with only the canonical internal-beta profile sections
+    # (see DEFAULT_PROFILES) that already exist, so there is exactly one section
+    # per workspace host and `databricks auth token --host X` never hits the
+    # "multiple profiles match" ambiguity error.
+    cfg = configparser.ConfigParser()
+    for spec in DEFAULT_PROFILES:
+        if orig_cfg.has_section(spec.name):
+            cfg[spec.name] = dict(orig_cfg[spec.name])
+
     saved_env: dict[str, str | None] = {
         "DATABRICKS_CONFIG_FILE": os.environ.get("DATABRICKS_CONFIG_FILE"),
     }
-    for var in CONFLICTING_ENV_VARS:
-        saved_env[var] = os.environ.pop(var, None)
 
     def _restore_env() -> None:
         for var, prev in saved_env.items():
@@ -9171,65 +9179,70 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
             else:
                 os.environ[var] = prev
 
-    # Temp file contains only the canonical internal-beta profile sections
-    # (see DEFAULT_PROFILES), seeded from the original when they already
-    # exist. Everything else is excluded so there is exactly one section per
-    # workspace host and `databricks auth token --host X` never hits the
-    # "multiple profiles match" ambiguity error. The temp file below is ours, so
-    # it stays UTF-8 (setup detects+preserves, so it round-trips); the write-back
-    # preserves the original's detected codec (orig_encoding, above).
-    cfg = configparser.ConfigParser()
-    for spec in DEFAULT_PROFILES:
-        if orig_cfg.has_section(spec.name):
-            cfg[spec.name] = dict(orig_cfg[spec.name])
-
-    omnigent_dir = Path.home() / ".omnigent"
-    omnigent_dir.mkdir(exist_ok=True)
-    tmp_fd, tmp_name = tempfile.mkstemp(
-        prefix="databrickscfg-setup-",
-        dir=omnigent_dir,
-        suffix=".tmp",
-    )
+    # Capture the handlers to restore before installing ours, so restoration in
+    # ``finally`` is safe even if preparation below never installs anything.
+    prev_sigterm = signal.getsignal(signal.SIGTERM)
+    prev_sigint = signal.getsignal(signal.SIGINT)
+    tmp_path: Path | None = None
+    write_tmp: Path | None = None
+    # A single try/finally spans EVERY mutation — popping CONFLICTING_ENV_VARS,
+    # creating the temp file, installing signal handlers — so all of them are
+    # undone even if preparation itself fails. (A failed mkstemp must not leave
+    # DATABRICKS_HOST / DATABRICKS_TOKEN deleted.)
     try:
+        for var in CONFLICTING_ENV_VARS:
+            saved_env[var] = os.environ.pop(var, None)
+
+        omnigent_dir = Path.home() / ".omnigent"
+        omnigent_dir.mkdir(exist_ok=True)
+        tmp_fd, tmp_name = tempfile.mkstemp(
+            prefix="databrickscfg-setup-",
+            dir=omnigent_dir,
+            suffix=".tmp",
+        )
+        tmp_path = Path(tmp_name)
+        # The temp file is ours, so it stays UTF-8 (setup detects+preserves, so
+        # it round-trips); the write-back preserves the original's codec.
         with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
             cfg.write(f)
-    except Exception:
-        os.unlink(tmp_name)
-        raise
-    tmp_path = Path(tmp_name)
+        os.environ["DATABRICKS_CONFIG_FILE"] = tmp_name
 
-    os.environ["DATABRICKS_CONFIG_FILE"] = tmp_name
+        def _on_signal(signum: int, _frame: types.FrameType | None) -> None:
+            _restore_env()
+            if tmp_path is not None:
+                tmp_path.unlink(missing_ok=True)
+            # Restore the original handler before re-raising so signal chaining
+            # (e.g. Click's Ctrl-C → Abort) is preserved rather than falling
+            # back to SIG_DFL which would kill the process through the OS.
+            signal.signal(signum, prev_sigterm if signum == signal.SIGTERM else prev_sigint)
+            signal.raise_signal(signum)
 
-    def _on_signal(signum: int, _frame: types.FrameType | None) -> None:
-        tmp_path.unlink(missing_ok=True)
-        _restore_env()
-        # Restore the original handler before re-raising so signal chaining
-        # (e.g. Click's Ctrl-C → Abort) is preserved rather than falling
-        # back to SIG_DFL which would kill the process through the OS.
-        signal.signal(signum, prev_sigterm if signum == signal.SIGTERM else prev_sigint)
-        signal.raise_signal(signum)
+        signal.signal(signal.SIGTERM, _on_signal)
+        signal.signal(signal.SIGINT, _on_signal)
 
-    prev_sigterm = signal.signal(signal.SIGTERM, _on_signal)
-    prev_sigint = signal.signal(signal.SIGINT, _on_signal)
-
-    write_tmp: Path | None = None
-    try:
         yield
-        # Merge canonical sections written by setup back into the real cfg.
+
+        # Merge the canonical sections setup wrote back into the real config.
+        # Re-detect the codec now: another process may have replaced the file
+        # (e.g. cp1252 -> UTF-8) while setup ran, and reusing the codec detected
+        # at entry would write a mixed-encoding file. The read is guarded, so an
+        # original that became unreadable aborts instead of being overwritten.
+        final_encoding = detect_encoding(original_cfg)
         tmp_cfg = configparser.ConfigParser()
-        tmp_cfg.read(tmp_path, encoding="utf-8")  # our temp file (written above)
-        orig_cfg = configparser.ConfigParser()
-        _read_existing_cfg(orig_cfg, original_cfg, orig_encoding)
+        tmp_cfg.read(tmp_path, encoding="utf-8")  # our temp file (UTF-8, above)
+        merged = configparser.ConfigParser()
+        _read_existing_cfg(merged, original_cfg, final_encoding)
         for spec in DEFAULT_PROFILES:
             if tmp_cfg.has_section(spec.name):
-                orig_cfg[spec.name] = dict(tmp_cfg[spec.name])
+                merged[spec.name] = dict(tmp_cfg[spec.name])
         write_tmp = original_cfg.with_suffix(".tmp")
-        with write_tmp.open("w", encoding=orig_encoding) as f:
-            orig_cfg.write(f)
+        with write_tmp.open("w", encoding=final_encoding) as f:
+            merged.write(f)
         write_tmp.replace(original_cfg)
         write_tmp = None
     finally:
-        tmp_path.unlink(missing_ok=True)
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
         if write_tmp is not None:
             write_tmp.unlink(missing_ok=True)
         signal.signal(signal.SIGTERM, prev_sigterm)

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9154,8 +9154,11 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
     # section per workspace host and `databricks auth token --host X`
     # never hits the "multiple profiles match" ambiguity error.
     orig_cfg = configparser.ConfigParser()
+    # ~/.databrickscfg is vendor-written; every read and write in this flow
+    # uses the locale default so a round-trip never re-encodes non-ASCII
+    # values (a UTF-8 write followed by a locale read would mojibake).
     if original_cfg.exists():
-        orig_cfg.read(original_cfg)
+        orig_cfg.read(original_cfg, encoding="locale")
     cfg = configparser.ConfigParser()
     for spec in DEFAULT_PROFILES:
         if orig_cfg.has_section(spec.name):
@@ -9169,7 +9172,7 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
         suffix=".tmp",
     )
     try:
-        with os.fdopen(tmp_fd, "w") as f:
+        with os.fdopen(tmp_fd, "w", encoding="locale") as f:
             cfg.write(f)
     except Exception:
         os.unlink(tmp_name)
@@ -9195,15 +9198,15 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
         yield
         # Merge canonical sections written by setup back into the real cfg.
         tmp_cfg = configparser.ConfigParser()
-        tmp_cfg.read(tmp_path)
+        tmp_cfg.read(tmp_path, encoding="locale")
         orig_cfg = configparser.ConfigParser()
         if original_cfg.exists():
-            orig_cfg.read(original_cfg)
+            orig_cfg.read(original_cfg, encoding="locale")
         for spec in DEFAULT_PROFILES:
             if tmp_cfg.has_section(spec.name):
                 orig_cfg[spec.name] = dict(tmp_cfg[spec.name])
         write_tmp = original_cfg.with_suffix(".tmp")
-        with write_tmp.open("w", encoding="utf-8") as f:
+        with write_tmp.open("w", encoding="locale") as f:
             orig_cfg.write(f)
         write_tmp.replace(original_cfg)
         write_tmp = None

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -30,6 +30,7 @@ from rich import box
 from rich.console import Console
 from rich.table import Table
 
+from omnigent._encoding import detect_encoding
 from omnigent._platform import IS_WINDOWS, resolve_repo_symlink
 from omnigent._startup_profile import StartupProfiler
 from omnigent.cli_sandbox import lakebox as _lakebox_alias_group
@@ -9153,12 +9154,14 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
     # exist. Everything else is excluded so there is exactly one
     # section per workspace host and `databricks auth token --host X`
     # never hits the "multiple profiles match" ambiguity error.
+    # ~/.databrickscfg is vendor-written; detect the real file's codec (UTF-8
+    # first, locale fallback) and preserve it across the final write-back so a
+    # round-trip never re-encodes non-ASCII values. The temp file below is ours,
+    # so it stays UTF-8 (setup detects+preserves, so it round-trips).
+    orig_encoding = detect_encoding(original_cfg)
     orig_cfg = configparser.ConfigParser()
-    # ~/.databrickscfg is vendor-written; every read and write in this flow
-    # uses the locale default so a round-trip never re-encodes non-ASCII
-    # values (a UTF-8 write followed by a locale read would mojibake).
     if original_cfg.exists():
-        orig_cfg.read(original_cfg, encoding="locale")
+        orig_cfg.read(original_cfg, encoding=orig_encoding)
     cfg = configparser.ConfigParser()
     for spec in DEFAULT_PROFILES:
         if orig_cfg.has_section(spec.name):
@@ -9172,7 +9175,7 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
         suffix=".tmp",
     )
     try:
-        with os.fdopen(tmp_fd, "w", encoding="locale") as f:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
             cfg.write(f)
     except Exception:
         os.unlink(tmp_name)
@@ -9198,15 +9201,15 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
         yield
         # Merge canonical sections written by setup back into the real cfg.
         tmp_cfg = configparser.ConfigParser()
-        tmp_cfg.read(tmp_path, encoding="locale")
+        tmp_cfg.read(tmp_path, encoding="utf-8")  # our temp file (written above)
         orig_cfg = configparser.ConfigParser()
         if original_cfg.exists():
-            orig_cfg.read(original_cfg, encoding="locale")
+            orig_cfg.read(original_cfg, encoding=orig_encoding)
         for spec in DEFAULT_PROFILES:
             if tmp_cfg.has_section(spec.name):
                 orig_cfg[spec.name] = dict(tmp_cfg[spec.name])
         write_tmp = original_cfg.with_suffix(".tmp")
-        with write_tmp.open("w", encoding="locale") as f:
+        with write_tmp.open("w", encoding=orig_encoding) as f:
             orig_cfg.write(f)
         write_tmp.replace(original_cfg)
         write_tmp = None

--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -71,13 +71,13 @@ def _store_entry(server_url: str, entry: dict[str, str | float]) -> None:
     data: dict[str, dict[str, str | float]] = {}
     if path.exists():
         try:
-            data = json.loads(path.read_text())
+            data = json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             data = {}
 
     data[_normalize_server_url(server_url)] = entry
 
-    path.write_text(json.dumps(data, indent=2))
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
     os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
 
 
@@ -155,7 +155,7 @@ def _load_entry(server_url: str) -> dict[str, str | float] | None:
         return None
 
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return None
 
@@ -311,11 +311,11 @@ def clear_token(server_url: str) -> None:
         return
 
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return
 
     key = _normalize_server_url(server_url)
     if key in data:
         del data[key]
-        path.write_text(json.dumps(data, indent=2))
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/omnigent/client_tools/coding.py
+++ b/omnigent/client_tools/coding.py
@@ -16,7 +16,6 @@ Used by ``omnigent chat --tools coding`` and the terminal TUI.
 from __future__ import annotations
 
 import glob as glob_mod
-import locale
 import os
 import subprocess
 import time
@@ -25,6 +24,8 @@ from pathlib import Path
 from typing import Any
 
 from omnigent_client.tools import build_tool_handler, tool
+
+from omnigent._encoding import locale_encoding
 
 # Maximum characters returned from any tool execution.
 # Prevents TUI freezes when tools produce huge output
@@ -70,7 +71,7 @@ def _read_detecting_encoding(path: Path) -> tuple[str, str]:
     try:
         return path.read_text(encoding="utf-8"), "utf-8"
     except UnicodeDecodeError:
-        enc = locale.getpreferredencoding(False)
+        enc = locale_encoding()
         return path.read_text(encoding=enc, errors="surrogateescape"), enc
 
 

--- a/omnigent/client_tools/coding.py
+++ b/omnigent/client_tools/coding.py
@@ -16,6 +16,7 @@ Used by ``omnigent chat --tools coding`` and the terminal TUI.
 from __future__ import annotations
 
 import glob as glob_mod
+import locale
 import os
 import subprocess
 import time
@@ -55,6 +56,24 @@ def _truncate(output: str) -> str:
     )
 
 
+def _read_detecting_encoding(path: Path) -> tuple[str, str]:
+    """Read *path* as text, detecting UTF-8 versus the locale encoding.
+
+    Returns ``(text, encoding)`` — the codec the file actually decoded under.
+    An ``Edit`` write-back reuses that codec so it never produces a
+    mixed-encoding file (the failure mode of blindly writing UTF-8 into a
+    cp1252 file, or vice versa). UTF-8 is tried first; on failure we fall back
+    to the platform locale encoding with ``surrogateescape`` so arbitrary bytes
+    still round-trip losslessly. Both branches read in text mode so newline
+    handling matches the write-back (no ``\\r`` doubling on CRLF files).
+    """
+    try:
+        return path.read_text(encoding="utf-8"), "utf-8"
+    except UnicodeDecodeError:
+        enc = locale.getpreferredencoding(False)
+        return path.read_text(encoding=enc, errors="surrogateescape"), enc
+
+
 # ── @tool functions ──────────────────────────────────────
 
 
@@ -78,8 +97,8 @@ def Read(
             for large files.
     """
     try:
-        text = Path(file_path).read_text(encoding="utf-8", errors="surrogateescape")
-    except (OSError, UnicodeDecodeError) as exc:
+        text, _ = _read_detecting_encoding(Path(file_path))
+    except OSError as exc:
         return _truncate(f"Error reading {file_path}: {exc}")
     lines = text.splitlines()
     start_line = offset if offset is not None else 1
@@ -105,7 +124,14 @@ def Write(file_path: str, content: str) -> str:
     target = Path(file_path)
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(content, encoding="utf-8", errors="surrogateescape")
+        # New content is authored by the model as real Unicode, so a brand-new
+        # file is always strict UTF-8. Validate before writing so an unencodable
+        # character reports cleanly instead of truncating the target (a caller
+        # error, not silently mangled).
+        content.encode("utf-8")
+        target.write_text(content, encoding="utf-8")
+    except UnicodeError as exc:
+        return _truncate(f"Error writing {target}: content is not valid UTF-8 ({exc})")
     except OSError as exc:
         return _truncate(f"Error writing {target}: {exc}")
     return _truncate(f"Successfully wrote {target}")
@@ -132,7 +158,7 @@ def Edit(
     """
     target = Path(file_path)
     try:
-        text = target.read_text(encoding="utf-8", errors="surrogateescape")
+        text, encoding = _read_detecting_encoding(target)
     except OSError as exc:
         return _truncate(f"Error reading {target}: {exc}")
     count = text.count(old_string)
@@ -149,7 +175,18 @@ def Edit(
         else text.replace(old_string, new_string, 1)
     )
     try:
-        target.write_text(result, encoding="utf-8", errors="surrogateescape")
+        # Reuse the codec the file was read under so the edit never mixes
+        # encodings within one file; surrogateescape lets bytes the original
+        # carried round-trip. Validate encodability BEFORE writing so a
+        # non-representable new character (e.g. an emoji into a cp1252 file)
+        # leaves the original file intact instead of truncating it.
+        result.encode(encoding, errors="surrogateescape")
+        target.write_text(result, encoding=encoding, errors="surrogateescape")
+    except UnicodeError as exc:
+        return _truncate(
+            f"Error writing {target}: new text has a character not encodable "
+            f"as {encoding} ({exc}); save the file as UTF-8 to use it"
+        )
     except OSError as exc:
         return _truncate(f"Error writing {target}: {exc}")
     replacements = count if replace_all else 1

--- a/omnigent/client_tools/coding.py
+++ b/omnigent/client_tools/coding.py
@@ -78,7 +78,7 @@ def Read(
             for large files.
     """
     try:
-        text = Path(file_path).read_text(encoding="utf-8")
+        text = Path(file_path).read_text(encoding="utf-8", errors="surrogateescape")
     except (OSError, UnicodeDecodeError) as exc:
         return _truncate(f"Error reading {file_path}: {exc}")
     lines = text.splitlines()
@@ -105,7 +105,7 @@ def Write(file_path: str, content: str) -> str:
     target = Path(file_path)
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(content, encoding="utf-8")
+        target.write_text(content, encoding="utf-8", errors="surrogateescape")
     except OSError as exc:
         return _truncate(f"Error writing {target}: {exc}")
     return _truncate(f"Successfully wrote {target}")
@@ -132,7 +132,7 @@ def Edit(
     """
     target = Path(file_path)
     try:
-        text = target.read_text(encoding="utf-8")
+        text = target.read_text(encoding="utf-8", errors="surrogateescape")
     except OSError as exc:
         return _truncate(f"Error reading {target}: {exc}")
     count = text.count(old_string)
@@ -149,7 +149,7 @@ def Edit(
         else text.replace(old_string, new_string, 1)
     )
     try:
-        target.write_text(result, encoding="utf-8")
+        target.write_text(result, encoding="utf-8", errors="surrogateescape")
     except OSError as exc:
         return _truncate(f"Error writing {target}: {exc}")
     replacements = count if replace_all else 1

--- a/omnigent/client_tools/coding.py
+++ b/omnigent/client_tools/coding.py
@@ -78,7 +78,7 @@ def Read(
             for large files.
     """
     try:
-        text = Path(file_path).read_text()
+        text = Path(file_path).read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         return _truncate(f"Error reading {file_path}: {exc}")
     lines = text.splitlines()
@@ -105,7 +105,7 @@ def Write(file_path: str, content: str) -> str:
     target = Path(file_path)
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(content)
+        target.write_text(content, encoding="utf-8")
     except OSError as exc:
         return _truncate(f"Error writing {target}: {exc}")
     return _truncate(f"Successfully wrote {target}")
@@ -132,7 +132,7 @@ def Edit(
     """
     target = Path(file_path)
     try:
-        text = target.read_text()
+        text = target.read_text(encoding="utf-8")
     except OSError as exc:
         return _truncate(f"Error reading {target}: {exc}")
     count = text.count(old_string)
@@ -149,7 +149,7 @@ def Edit(
         else text.replace(old_string, new_string, 1)
     )
     try:
-        target.write_text(result)
+        target.write_text(result, encoding="utf-8")
     except OSError as exc:
         return _truncate(f"Error writing {target}: {exc}")
     replacements = count if replace_all else 1

--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -304,7 +304,7 @@ def read_codex_config_model(bridge_dir: Path) -> str | None:
     """
     config_path = codex_home_for_bridge_dir(bridge_dir) / "config.toml"
     try:
-        data = tomllib.loads(config_path.read_text())
+        data = tomllib.loads(config_path.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError):
         return None
     model = data.get("model")

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -5882,7 +5882,7 @@ def _read_compacted_history(rollout_path: Path) -> dict[str, object] | None:
     :returns: Dict with ``replacement_history`` and ``window_id``, or ``None``.
     """
     last_compacted = None
-    with rollout_path.open() as f:
+    with rollout_path.open(encoding="utf-8") as f:
         for line in f:
             try:
                 entry = json.loads(line)

--- a/omnigent/config.py
+++ b/omnigent/config.py
@@ -25,7 +25,7 @@ def load_global_config(path: Path | None = None) -> dict[str, Any]:  # type: ign
     resolved_path = path or global_config_path()
     if not resolved_path.exists():
         return {}
-    with resolved_path.open() as config_file:
+    with resolved_path.open(encoding="utf-8") as config_file:
         raw: dict[str, Any] = yaml.safe_load(config_file) or {}  # type: ignore[explicit-any]
         return raw
 
@@ -35,7 +35,7 @@ def load_local_config(path: Path | None = None) -> dict[str, Any]:  # type: igno
     resolved_path = path or Path.cwd() / _LOCAL_CONFIG_RELPATH
     if not resolved_path.exists():
         return {}
-    with resolved_path.open() as config_file:
+    with resolved_path.open(encoding="utf-8") as config_file:
         raw: dict[str, Any] = yaml.safe_load(config_file) or {}  # type: ignore[explicit-any]
         return raw
 

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -287,7 +287,7 @@ def _load_user_hermes_config() -> dict:
     try:
         import yaml
 
-        full = yaml.safe_load(user_config.read_text()) or {}
+        full = yaml.safe_load(user_config.read_text(encoding="utf-8")) or {}
         return {k: v for k, v in full.items() if k in _USER_CONFIG_KEYS}
     except Exception:  # noqa: BLE001
         _logger.debug("Failed to load user Hermes config at %s", user_config, exc_info=True)
@@ -345,7 +345,9 @@ def write_policy_hook_config(
     from omnigent.native_policy_hook import policy_hook_wrapper_script
 
     wrapper = hermes_home / "omnigent-policy-hook.sh"
-    wrapper.write_text(policy_hook_wrapper_script(server_url, session_id, hook_script_path))
+    wrapper.write_text(
+        policy_hook_wrapper_script(server_url, session_id, hook_script_path), encoding="utf-8"
+    )
     wrapper.chmod(0o700)
 
     # Write bridge.json with an auth token for serve-mcp (idempotent).
@@ -383,7 +385,7 @@ def write_policy_hook_config(
     }
 
     config_path = hermes_home / "config.yaml"
-    config_path.write_text(json.dumps(config, indent=2) + "\n")
+    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
 
     # Copy user's .env (API keys).
     user_env = Path.home() / ".hermes" / ".env"
@@ -402,7 +404,7 @@ def write_policy_hook_config(
             {"event": "pre_tool_call", "command": str(wrapper)},
         ],
     }
-    allowlist_path.write_text(json.dumps(allowlist_data, indent=2) + "\n")
+    allowlist_path.write_text(json.dumps(allowlist_data, indent=2) + "\n", encoding="utf-8")
 
     return hermes_home
 

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -147,7 +147,7 @@ def _read_model_from_hermes_config(bridge_dir: Path) -> str | None:
         try:
             import yaml
 
-            data = yaml.safe_load(config_path.read_text()) or {}
+            data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
             model = data.get("model")
             if isinstance(model, str) and model:
                 return model

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -193,7 +193,7 @@ def _read_log_tail(path: Path, max_bytes: int = _LOG_TAIL_MAX_BYTES) -> str:
         1" answer into a failure.
     """
     try:
-        with path.open("rb") as fh:
+        with path.open(mode="rb") as fh:
             fh.seek(0, os.SEEK_END)
             size = fh.tell()
             fh.seek(max(0, size - max_bytes))

--- a/omnigent/host/identity.py
+++ b/omnigent/host/identity.py
@@ -105,7 +105,7 @@ def load_or_create_host_identity(
 
     cfg: dict[str, object] = {}
     if path.exists():
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
 
     host_section = cfg.get("host")
@@ -121,7 +121,7 @@ def load_or_create_host_identity(
 
     cfg["host"] = {"host_id": identity.host_id, "name": identity.name}
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=True)
 
     return identity

--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -163,7 +163,7 @@ def _read_local_server_pid_file() -> tuple[int, int] | None:
     if not _LOCAL_SERVER_PID_PATH.exists():
         return None
     try:
-        lines = _LOCAL_SERVER_PID_PATH.read_text().strip().splitlines()
+        lines = _LOCAL_SERVER_PID_PATH.read_text(encoding="utf-8").strip().splitlines()
         if len(lines) < 2:
             return None
         return int(lines[0]), int(lines[1])
@@ -247,7 +247,7 @@ def _read_local_server_log_path() -> Path | None:
         record, or no server) or unreadable.
     """
     try:
-        text = _LOCAL_SERVER_LOG_REF_PATH.read_text().strip()
+        text = _LOCAL_SERVER_LOG_REF_PATH.read_text(encoding="utf-8").strip()
     except OSError:
         return None
     return Path(text) if text else None
@@ -288,7 +288,7 @@ def _read_local_server_sig() -> str | None:
         ``None`` if the sidecar is absent (legacy server) or unreadable.
     """
     try:
-        sig = _LOCAL_SERVER_SIG_PATH.read_text().strip()
+        sig = _LOCAL_SERVER_SIG_PATH.read_text(encoding="utf-8").strip()
     except OSError:
         return None
     return sig or None
@@ -889,7 +889,7 @@ def _raise_local_server_failed(base_url: str, log_path: Path) -> None:
     :raises click.ClickException: Always.
     """
     try:
-        lines = log_path.read_text(errors="replace").splitlines()
+        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
         tail = "\n".join(lines[-50:]) if lines else "(empty log file)"
     except OSError as exc:
         tail = f"(could not read log file: {exc})"

--- a/omnigent/inner/bundle_skills.py
+++ b/omnigent/inner/bundle_skills.py
@@ -56,6 +56,7 @@ def ensure_bundle_plugin_manifest(
             indent=2,
         )
         + "\n",
+        encoding="utf-8",
     )
 
 

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -427,7 +427,9 @@ def _write_cursor_hooks(cwd: str, hook_script_path: str, server_url: str, sessio
     from omnigent.native_policy_hook import policy_hook_wrapper_script
 
     wrapper = hooks_dir / "omnigent-hook.sh"
-    wrapper.write_text(policy_hook_wrapper_script(server_url, session_id, hook_script_path))
+    wrapper.write_text(
+        policy_hook_wrapper_script(server_url, session_id, hook_script_path), encoding="utf-8"
+    )
     wrapper.chmod(0o700)
     command = str(wrapper)
     config = {
@@ -441,7 +443,7 @@ def _write_cursor_hooks(cwd: str, hook_script_path: str, server_url: str, sessio
             ]
         },
     }
-    hooks_file.write_text(json.dumps(config, indent=2))
+    hooks_file.write_text(json.dumps(config, indent=2), encoding="utf-8")
     return hooks_file
 
 

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from openai import OpenAI, Stream
     from openai.types.chat import ChatCompletionChunk
 
+from .._encoding import detect_encoding
 from .async_utils import run_sync_on_thread
 from .executor import (
     Executor,
@@ -200,10 +201,10 @@ def _read_databrickscfg_file_fallback(profile: str | None = None) -> DatabricksC
         return None
 
     config = configparser.ConfigParser()
-    # ~/.databrickscfg is vendor-written; read and write it at the locale
-    # default so a round-trip never re-encodes non-ASCII values (a UTF-8
-    # write followed by a locale read would mojibake).
-    config.read(cfg_path, encoding="locale")
+    # ~/.databrickscfg is vendor-written (the Databricks CLI emits UTF-8):
+    # detect the file's codec — UTF-8 first, locale fallback — so it reads
+    # correctly under both legacy and UTF-8-mode interpreters.
+    config.read(cfg_path, encoding=detect_encoding(cfg_path))
 
     resolved_profile = profile or os.environ.get("DATABRICKS_CONFIG_PROFILE")
     if resolved_profile and resolved_profile in config:
@@ -259,10 +260,10 @@ def _read_databrickscfg_host(profile: str | None = None) -> str | None:
         return None
 
     config = configparser.ConfigParser()
-    # ~/.databrickscfg is vendor-written; read and write it at the locale
-    # default so a round-trip never re-encodes non-ASCII values (a UTF-8
-    # write followed by a locale read would mojibake).
-    config.read(cfg_path, encoding="locale")
+    # ~/.databrickscfg is vendor-written (the Databricks CLI emits UTF-8):
+    # detect the file's codec — UTF-8 first, locale fallback — so it reads
+    # correctly under both legacy and UTF-8-mode interpreters.
+    config.read(cfg_path, encoding=detect_encoding(cfg_path))
 
     resolved_profile = profile or os.environ.get("DATABRICKS_CONFIG_PROFILE")
     if resolved_profile:
@@ -608,8 +609,8 @@ def _databrickscfg_profiles_for_host(host: str) -> list[str]:
         return []
     config = configparser.ConfigParser()
     try:
-        # Locale default: symmetric with the vendor cfg's writers (see above).
-        config.read(cfg_path, encoding="locale")
+        # Detect the vendor cfg's codec (UTF-8 first, locale fallback).
+        config.read(cfg_path, encoding=detect_encoding(cfg_path))
     except configparser.Error:
         return []
     wanted = _norm(host)

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -200,7 +200,10 @@ def _read_databrickscfg_file_fallback(profile: str | None = None) -> DatabricksC
         return None
 
     config = configparser.ConfigParser()
-    config.read(cfg_path)
+    # ~/.databrickscfg is vendor-written; read and write it at the locale
+    # default so a round-trip never re-encodes non-ASCII values (a UTF-8
+    # write followed by a locale read would mojibake).
+    config.read(cfg_path, encoding="locale")
 
     resolved_profile = profile or os.environ.get("DATABRICKS_CONFIG_PROFILE")
     if resolved_profile and resolved_profile in config:
@@ -256,7 +259,10 @@ def _read_databrickscfg_host(profile: str | None = None) -> str | None:
         return None
 
     config = configparser.ConfigParser()
-    config.read(cfg_path)
+    # ~/.databrickscfg is vendor-written; read and write it at the locale
+    # default so a round-trip never re-encodes non-ASCII values (a UTF-8
+    # write followed by a locale read would mojibake).
+    config.read(cfg_path, encoding="locale")
 
     resolved_profile = profile or os.environ.get("DATABRICKS_CONFIG_PROFILE")
     if resolved_profile:
@@ -602,7 +608,8 @@ def _databrickscfg_profiles_for_host(host: str) -> list[str]:
         return []
     config = configparser.ConfigParser()
     try:
-        config.read(cfg_path)
+        # Locale default: symmetric with the vendor cfg's writers (see above).
+        config.read(cfg_path, encoding="locale")
     except configparser.Error:
         return []
     wanted = _norm(host)

--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -105,7 +105,7 @@ def load_agent_def(
     """
     if isinstance(path_or_dict, (str, Path)):
         path = Path(path_or_dict)
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.load(f, Loader=_OmnigentYamlLoader)
         instructions_root: Path | None = path.parent
     else:

--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -176,7 +176,7 @@ def _read_contained_file(root: Path, value: str) -> str | None:
     try:
         resolved = candidate.resolve()
         if resolved.is_relative_to(root.resolve()) and resolved.is_file():
-            return resolved.read_text()
+            return resolved.read_text(encoding="utf-8")
     except OSError:
         # Path too long or invalid characters — fall through to inline text.
         pass

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -1408,8 +1408,22 @@ def _shell_impl(
     """
     argv = _shell_argv(shell_path, command)
     try:
+        run_target: str | list[str] = argv
+        if IS_WINDOWS and argv and argv[-1] == command:
+            # Passing [cmd.exe, "/c", command] as a list makes subprocess apply
+            # Windows list-quoting (list2cmdline) to `command`, escaping its own
+            # quotes as \" and corrupting any quoted command (echo "a b",
+            # git commit -m "x", python -c "..."). Build the command line as a
+            # single string so the shell receives the payload verbatim.
+            if Path(shell_path).name.lower() in ("cmd.exe", "cmd"):
+                # Wrap the payload in an extra pair of quotes, which `cmd.exe /c`
+                # strips — without it cmd.exe corrupts a command that starts with
+                # a quote (e.g. a quoted executable path).
+                run_target = f'{argv[0]} /c "{command}"'
+            else:
+                run_target = subprocess.list2cmdline(argv[:-1]) + " " + command
         completed = subprocess.run(
-            argv,
+            run_target,
             cwd=str(cwd),
             env=_child_shell_env(),
             text=True,

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -1180,7 +1180,7 @@ def _is_binary_file(path: Path) -> bool:
     :param path: Absolute path of the file to classify.
     :returns: ``True`` if the prefix contains a NUL or is not decodable UTF-8.
     """
-    with path.open("rb") as fh:
+    with path.open(mode="rb") as fh:
         prefix = fh.read(_BINARY_SNIFF_BYTES)
     if b"\x00" in prefix:
         return True
@@ -1220,7 +1220,7 @@ def _read_binary_impl(path: Path, max_binary_bytes: int | None) -> OpResult:
                 "View or download it via the file viewer."
             ),
         }
-    with path.open("rb") as fh:
+    with path.open(mode="rb") as fh:
         payload = fh.read(max_binary_bytes)
     return {
         "path": str(path),

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -1392,14 +1392,16 @@ def _run_windows_cmd_shell(
     ``cmd.exe /c "<inline>"`` stops at the first newline and mangles quoting;
     writing the command to a UTF-8 ``.cmd`` (with ``chcp 65001``) runs it
     verbatim, so multi-line, quoted, and non-ASCII commands all work. The child
-    is spawned in its own process group and its whole tree is killed on timeout —
-    killing cmd.exe alone leaves its spawned child (e.g. ping/python) running.
+    is contained in a ``KILL_ON_JOB_CLOSE`` Job Object so a timeout tears down
+    the whole tree — including grandchildren orphaned by a launcher that exits,
+    which killing cmd.exe (or a parent-walk) alone would miss.
 
     :raises subprocess.TimeoutExpired: On timeout, after killing the tree.
     :returns: ``(stdout, stderr, returncode)``.
     """
     fd, script_path = tempfile.mkstemp(suffix=".cmd")
     os.close(fd)
+    job = None
     try:
         Path(script_path).write_text(
             "@echo off\r\nchcp 65001>nul\r\n" + command.replace("\n", "\r\n") + "\r\n",
@@ -1415,15 +1417,27 @@ def _run_windows_cmd_shell(
             errors="replace",
             **_proc.spawn_kwargs(),
         )
+        # Assign to the job right after spawn, before cmd.exe reads the batch
+        # file and launches the actual command (so the child is captured too).
+        with contextlib.suppress(Exception):
+            from omnigent.inner.windows_jobobject_sandbox import (
+                assign_pid_to_kill_on_close_job,
+            )
+
+            job = assign_pid_to_kill_on_close_job(proc.pid)
         try:
             stdout, stderr = proc.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
-            _proc.kill_tree(proc)
+            if job is not None:
+                job.close()  # KILL_ON_JOB_CLOSE terminates the whole tree
+            _proc.kill_tree(proc)  # fallback when the job couldn't be created
             with contextlib.suppress(subprocess.TimeoutExpired):
                 proc.communicate(timeout=5)
             raise
         return stdout, stderr, proc.returncode
     finally:
+        if job is not None:
+            job.close()
         with contextlib.suppress(OSError):
             os.remove(script_path)
 
@@ -1507,9 +1521,9 @@ def _shell_impl(
     if returncode != 0:
         detail = stderr.strip() or stdout.strip()
         if detail:
-            result["error"] = f"Command exited with status {completed.returncode}: {detail}"
+            result["error"] = f"Command exited with status {returncode}: {detail}"
         else:
-            result["error"] = f"Command exited with status {completed.returncode}"
+            result["error"] = f"Command exited with status {returncode}"
     return result
 
 

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -495,7 +495,13 @@ class _HelperProcessClient:
         # paths/booleans — but we still keep the file private and ephemeral.
         r_fd: int | None = None
         if IS_WINDOWS:
-            assert self._tmpdir is not None
+            # Windows has no pass_fds, so the config is delivered via a private
+            # file in the helper's tmpdir. That dir is created above only for
+            # active sandboxes; create one here too when the sandbox is inactive
+            # (sandbox.type: none — used by polly and every example agent) so the
+            # helper still gets a config file to read.
+            if self._tmpdir is None:
+                self._tmpdir = create_private_tmpdir()
             config_file = self._tmpdir / "helper-config.json"
             config_file.write_bytes(config_bytes)
             config_arg = ["--config-file", str(config_file)]
@@ -900,11 +906,7 @@ def create_os_environment(spec: OSEnvSpec | None) -> OSEnvironment | None:
             "os_env.start_in_scratch requires an active sandbox; "
             f"resolved sandbox type {sandbox.backend_type!r} is inactive"
         )
-    shell_path = shutil.which("bash") or shutil.which("sh")
-    if shell_path is None:
-        # No POSIX shell on PATH. On Windows fall back to cmd.exe; elsewhere
-        # keep the historical /bin/sh default.
-        shell_path = os.environ.get("COMSPEC", "cmd.exe") if IS_WINDOWS else "/bin/sh"
+    shell_path = _select_default_shell(IS_WINDOWS)
     egress_rules = spec.sandbox.egress_rules if spec.sandbox else None
     egress_allow_private = (
         spec.sandbox.egress_allow_private_destinations if spec.sandbox else False
@@ -1494,6 +1496,20 @@ def _shell_argv(shell_path: str, command: str) -> list[str]:
     if shell_name in ("bash", "bash.exe"):
         return [shell_path, "--noprofile", "--norc", "-c", command]
     return [shell_path, "-c", command]
+
+
+def _select_default_shell(is_windows: bool) -> str:
+    """Pick the default shell for ``sys_os_shell`` on the host.
+
+    On Windows, ``shutil.which("bash")`` resolves to the WSL launcher
+    (``C:\\Windows\\System32\\bash.exe``); using it would run every
+    ``sys_os_shell`` command inside WSL. Use the native ``cmd.exe`` (via
+    ``%COMSPEC%``) instead — :func:`_shell_argv` invokes it with ``/c``. On
+    POSIX, prefer ``bash`` then ``sh``, matching long-standing behaviour.
+    """
+    if is_windows:
+        return os.environ.get("COMSPEC", "cmd.exe")
+    return shutil.which("bash") or shutil.which("sh") or "/bin/sh"
 
 
 def _project_root() -> Path:

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -26,6 +26,7 @@ from omnigent.runner.identity import (
     strip_runner_auth_secrets,
 )
 
+from . import _proc
 from .async_utils import run_sync_on_thread
 from .credential_proxy import (
     CredentialProxyRuntime,
@@ -1383,6 +1384,50 @@ def _truncate_output(text: str, label: str, limit: int = _MAX_TOOL_OUTPUT_CHARS)
     )
 
 
+def _run_windows_cmd_shell(
+    command: str, *, timeout: int, shell_path: str, cwd: Path
+) -> tuple[str, str, int]:
+    """Run ``command`` through cmd.exe via a temp batch file.
+
+    ``cmd.exe /c "<inline>"`` stops at the first newline and mangles quoting;
+    writing the command to a UTF-8 ``.cmd`` (with ``chcp 65001``) runs it
+    verbatim, so multi-line, quoted, and non-ASCII commands all work. The child
+    is spawned in its own process group and its whole tree is killed on timeout —
+    killing cmd.exe alone leaves its spawned child (e.g. ping/python) running.
+
+    :raises subprocess.TimeoutExpired: On timeout, after killing the tree.
+    :returns: ``(stdout, stderr, returncode)``.
+    """
+    fd, script_path = tempfile.mkstemp(suffix=".cmd")
+    os.close(fd)
+    try:
+        Path(script_path).write_text(
+            "@echo off\r\nchcp 65001>nul\r\n" + command.replace("\n", "\r\n") + "\r\n",
+            encoding="utf-8",
+        )
+        proc = subprocess.Popen(
+            [shell_path, "/c", script_path],
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            **_proc.spawn_kwargs(),
+        )
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _proc.kill_tree(proc)
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.communicate(timeout=5)
+            raise
+        return stdout, stderr, proc.returncode
+    finally:
+        with contextlib.suppress(OSError):
+            os.remove(script_path)
+
+
 def _shell_impl(
     *,
     command: str,
@@ -1407,29 +1452,29 @@ def _shell_impl(
         characters.
     """
     argv = _shell_argv(shell_path, command)
+    windows_cmd = IS_WINDOWS and Path(shell_path).name.lower() in ("cmd.exe", "cmd")
     try:
-        run_target: str | list[str] = argv
-        if IS_WINDOWS and argv and argv[-1] == command:
-            # Passing [cmd.exe, "/c", command] as a list makes subprocess apply
-            # Windows list-quoting (list2cmdline) to `command`, escaping its own
-            # quotes as \" and corrupting any quoted command (echo "a b",
-            # git commit -m "x", python -c "..."). Build the command line as a
-            # single string so the shell receives the payload verbatim.
-            if Path(shell_path).name.lower() in ("cmd.exe", "cmd"):
-                # Wrap the payload in an extra pair of quotes, which `cmd.exe /c`
-                # strips — without it cmd.exe corrupts a command that starts with
-                # a quote (e.g. a quoted executable path).
-                run_target = f'{argv[0]} /c "{command}"'
-            else:
-                run_target = subprocess.list2cmdline(argv[:-1]) + " " + command
-        completed = subprocess.run(
-            run_target,
-            cwd=str(cwd),
-            env=_child_shell_env(),
-            text=True,
-            capture_output=True,
-            timeout=timeout,
-        )
+        if windows_cmd:
+            # cmd.exe can't run a quoted/multi-line command inline; route it
+            # through a temp batch file and kill the whole process tree on
+            # timeout (see _run_windows_cmd_shell).
+            stdout_raw, stderr_raw, returncode = _run_windows_cmd_shell(
+                command, timeout=timeout, shell_path=shell_path, cwd=cwd
+            )
+        else:
+            completed = subprocess.run(
+                argv,
+                cwd=str(cwd),
+                env=_child_shell_env(),
+                text=True,
+                capture_output=True,
+                timeout=timeout,
+            )
+            stdout_raw, stderr_raw, returncode = (
+                completed.stdout,
+                completed.stderr,
+                completed.returncode,
+            )
     except subprocess.TimeoutExpired as exc:
         # ``subprocess.TimeoutExpired.stdout``/``stderr`` are ``str | bytes
         # | None`` from the stdlib; widening the op result at this boundary
@@ -1449,18 +1494,18 @@ def _shell_impl(
     except OSError as exc:
         return {"error": f"Failed to run shell command: {exc}"}
 
-    stdout = _truncate_output(completed.stdout, "stdout", max_output)
-    stderr = _truncate_output(completed.stderr, "stderr", max_output)
+    stdout = _truncate_output(stdout_raw, "stdout", max_output)
+    stderr = _truncate_output(stderr_raw, "stderr", max_output)
     result: OpResult = {
         "stdout": stdout,
         "stderr": stderr,
-        "exit_code": completed.returncode,
+        "exit_code": returncode,
         "timed_out": False,
         "shell": shell_path,
         "cwd": str(cwd),
     }
-    if completed.returncode != 0:
-        detail = completed.stderr.strip() or completed.stdout.strip()
+    if returncode != 0:
+        detail = stderr.strip() or stdout.strip()
         if detail:
             result["error"] = f"Command exited with status {completed.returncode}: {detail}"
         else:

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -1436,7 +1436,7 @@ def _run_windows_cmd_shell(
         # One-pass environment expansion preserves literal ``%NAME%`` in the
         # path; quoting also protects spaces and ``&``. The batch clears this
         # private variable before it runs caller code.
-        child_env = dict(os.environ)
+        child_env = _child_shell_env()
         child_env[_CMD_SCRIPT_ENV] = script_path
         cmdline = f'"{shell_path}" /d /s /v:off /c ""%{_CMD_SCRIPT_ENV}%""'
         spawn_kwargs = dict(_proc.spawn_kwargs())

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -1384,6 +1384,11 @@ def _truncate_output(text: str, label: str, limit: int = _MAX_TOOL_OUTPUT_CHARS)
     )
 
 
+# winbase.h; subprocess does not expose it. Spawn the child suspended so it is
+# assigned to the containment job BEFORE cmd.exe can launch any grandchildren.
+_CREATE_SUSPENDED = 0x00000004
+
+
 def _run_windows_cmd_shell(
     command: str, *, timeout: int, shell_path: str, cwd: Path
 ) -> tuple[str, str, int]:
@@ -1391,14 +1396,27 @@ def _run_windows_cmd_shell(
 
     ``cmd.exe /c "<inline>"`` stops at the first newline and mangles quoting;
     writing the command to a UTF-8 ``.cmd`` (with ``chcp 65001``) runs it
-    verbatim, so multi-line, quoted, and non-ASCII commands all work. The child
-    is contained in a ``KILL_ON_JOB_CLOSE`` Job Object so a timeout tears down
-    the whole tree — including grandchildren orphaned by a launcher that exits,
-    which killing cmd.exe (or a parent-walk) alone would miss.
+    verbatim, so multi-line, quoted, and non-ASCII commands all work.
+
+    The command runs in **batch context**, so a ``for`` loop variable is written
+    ``%%i`` (not ``%i`` as on an interactive prompt) — a known cmd.exe semantic
+    difference, kept because batch is what makes multi-line/quoting reliable.
+
+    Containment: a plain Job Object holds the whole tree. The child is spawned
+    ``CREATE_SUSPENDED`` and assigned to the job before it is resumed, so no
+    grandchild can escape in a spawn/assign race. The job has **no**
+    kill-on-close limit — a successful run's detached children (e.g. a server
+    the command started) survive; only a *timeout* calls ``TerminateJobObject``
+    to tear the tree down (grandchildren a parent-walk would miss included).
 
     :raises subprocess.TimeoutExpired: On timeout, after killing the tree.
     :returns: ``(stdout, stderr, returncode)``.
     """
+    from omnigent.inner.windows_jobobject_sandbox import (
+        create_tree_kill_job,
+        resume_process_threads,
+    )
+
     fd, script_path = tempfile.mkstemp(suffix=".cmd")
     os.close(fd)
     job = None
@@ -1407,29 +1425,40 @@ def _run_windows_cmd_shell(
             "@echo off\r\nchcp 65001>nul\r\n" + command.replace("\n", "\r\n") + "\r\n",
             encoding="utf-8",
         )
+        # Build the command line as a string (not a list) so the script path is
+        # double-quoted: `/s` strips the OUTER quote pair, leaving a properly
+        # quoted path — so a %TEMP% containing spaces or `&` still runs. `/d`
+        # skips any AutoRun registry command. Windows filenames can't contain a
+        # quote, so there is no embedded-quote escape to worry about.
+        cmdline = f'"{shell_path}" /d /s /c ""{script_path}""'
+        spawn_kwargs = dict(_proc.spawn_kwargs())
+        creationflags = int(spawn_kwargs.pop("creationflags", 0)) | _CREATE_SUSPENDED
+        job = create_tree_kill_job()
         proc = subprocess.Popen(
-            [shell_path, "/c", script_path],
+            cmdline,
             cwd=str(cwd),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
             encoding="utf-8",
             errors="replace",
-            **_proc.spawn_kwargs(),
+            creationflags=creationflags,
+            **spawn_kwargs,
         )
-        # Assign to the job right after spawn, before cmd.exe reads the batch
-        # file and launches the actual command (so the child is captured too).
-        with contextlib.suppress(Exception):
-            from omnigent.inner.windows_jobobject_sandbox import (
-                assign_pid_to_kill_on_close_job,
-            )
-
-            job = assign_pid_to_kill_on_close_job(proc.pid)
+        # Assign while suspended (captures future children), then resume. If the
+        # resume fails the child would hang suspended, so treat it as fatal.
+        if job is not None:
+            job.assign(proc.pid)
+        if not resume_process_threads(proc.pid):
+            proc.kill()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.communicate(timeout=5)
+            raise OSError("could not resume the suspended cmd.exe process")
         try:
             stdout, stderr = proc.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
             if job is not None:
-                job.close()  # KILL_ON_JOB_CLOSE terminates the whole tree
+                job.terminate()  # kill the whole tree — only on timeout
             _proc.kill_tree(proc)  # fallback when the job couldn't be created
             with contextlib.suppress(subprocess.TimeoutExpired):
                 proc.communicate(timeout=5)
@@ -1437,7 +1466,7 @@ def _run_windows_cmd_shell(
         return stdout, stderr, proc.returncode
     finally:
         if job is not None:
-            job.close()
+            job.close()  # no kill-on-close: releasing the handle spares the tree
         with contextlib.suppress(OSError):
             os.remove(script_path)
 

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -1387,6 +1387,7 @@ def _truncate_output(text: str, label: str, limit: int = _MAX_TOOL_OUTPUT_CHARS)
 # winbase.h; subprocess does not expose it. Spawn the child suspended so it is
 # assigned to the containment job BEFORE cmd.exe can launch any grandchildren.
 _CREATE_SUSPENDED = 0x00000004
+_CMD_SCRIPT_ENV = "OMNIGENT_INTERNAL_CMD_SCRIPT"
 
 
 def _run_windows_cmd_shell(
@@ -1406,10 +1407,11 @@ def _run_windows_cmd_shell(
     ``CREATE_SUSPENDED`` and assigned to the job before it is resumed, so no
     grandchild can escape in a spawn/assign race. The job has **no**
     kill-on-close limit — a successful run's detached children (e.g. a server
-    the command started) survive; only a *timeout* calls ``TerminateJobObject``
-    to tear the tree down (grandchildren a parent-walk would miss included).
+    the command started) survive. A timeout or any other abnormal post-spawn
+    exit terminates the job tree (including orphaned grandchildren).
 
     :raises subprocess.TimeoutExpired: On timeout, after killing the tree.
+    :raises OSError: If race-free Job Object containment cannot be established.
     :returns: ``(stdout, stderr, returncode)``.
     """
     from omnigent.inner.windows_jobobject_sandbox import (
@@ -1420,20 +1422,28 @@ def _run_windows_cmd_shell(
     fd, script_path = tempfile.mkstemp(suffix=".cmd")
     os.close(fd)
     job = None
+    proc: subprocess.Popen[str] | None = None
+    completed = False
     try:
         Path(script_path).write_text(
-            "@echo off\r\nchcp 65001>nul\r\n" + command.replace("\n", "\r\n") + "\r\n",
+            (
+                f'@set "{_CMD_SCRIPT_ENV}="\r\n'
+                "@echo off\r\n"
+                "chcp 65001>nul\r\n" + command.replace("\n", "\r\n") + "\r\n"
+            ),
             encoding="utf-8",
         )
-        # Build the command line as a string (not a list) so the script path is
-        # double-quoted: `/s` strips the OUTER quote pair, leaving a properly
-        # quoted path — so a %TEMP% containing spaces or `&` still runs. `/d`
-        # skips any AutoRun registry command. Windows filenames can't contain a
-        # quote, so there is no embedded-quote escape to worry about.
-        cmdline = f'"{shell_path}" /d /s /c ""{script_path}""'
+        # One-pass environment expansion preserves literal ``%NAME%`` in the
+        # path; quoting also protects spaces and ``&``. The batch clears this
+        # private variable before it runs caller code.
+        child_env = dict(os.environ)
+        child_env[_CMD_SCRIPT_ENV] = script_path
+        cmdline = f'"{shell_path}" /d /s /v:off /c ""%{_CMD_SCRIPT_ENV}%""'
         spawn_kwargs = dict(_proc.spawn_kwargs())
         creationflags = int(spawn_kwargs.pop("creationflags", 0)) | _CREATE_SUSPENDED
         job = create_tree_kill_job()
+        if job is None:
+            raise OSError("could not create a Windows Job Object for cmd.exe containment")
         proc = subprocess.Popen(
             cmdline,
             cwd=str(cwd),
@@ -1443,28 +1453,38 @@ def _run_windows_cmd_shell(
             encoding="utf-8",
             errors="replace",
             creationflags=creationflags,
+            env=child_env,
             **spawn_kwargs,
         )
         # Assign while suspended (captures future children), then resume. If the
-        # resume fails the child would hang suspended, so treat it as fatal.
-        if job is not None:
-            job.assign(proc.pid)
+        # assignment/resume fails, never run the child outside containment.
+        if not job.assign(proc.pid):
+            raise OSError("could not assign the suspended cmd.exe process to its Job Object")
         if not resume_process_threads(proc.pid):
-            proc.kill()
-            with contextlib.suppress(subprocess.TimeoutExpired):
-                proc.communicate(timeout=5)
             raise OSError("could not resume the suspended cmd.exe process")
-        try:
-            stdout, stderr = proc.communicate(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            if job is not None:
-                job.terminate()  # kill the whole tree — only on timeout
-            _proc.kill_tree(proc)  # fallback when the job couldn't be created
-            with contextlib.suppress(subprocess.TimeoutExpired):
-                proc.communicate(timeout=5)
-            raise
-        return stdout, stderr, proc.returncode
+        stdout, stderr = proc.communicate(timeout=timeout)
+        returncode = proc.returncode
+        if returncode is None:
+            raise RuntimeError("cmd.exe exited without publishing a return code")
+        completed = True
+        return stdout, stderr, returncode
     finally:
+        # A normal communicate() completion is the only path that spares
+        # detached descendants. Timeout, cancellation, assignment/resume
+        # failure, and every other post-spawn exception tear down and reap.
+        if proc is not None and not completed:
+            if job is not None:
+                with contextlib.suppress(BaseException):
+                    job.terminate()
+            with contextlib.suppress(BaseException):
+                _proc.kill_tree(proc)
+            try:
+                proc.communicate(timeout=5)
+            except BaseException:  # noqa: BLE001 - cleanup must survive cancellation
+                with contextlib.suppress(BaseException):
+                    proc.kill()
+                with contextlib.suppress(BaseException):
+                    proc.wait(timeout=5)
         if job is not None:
             job.close()  # no kill-on-close: releasing the handle spares the tree
         with contextlib.suppress(OSError):
@@ -1499,8 +1519,7 @@ def _shell_impl(
     try:
         if windows_cmd:
             # cmd.exe can't run a quoted/multi-line command inline; route it
-            # through a temp batch file and kill the whole process tree on
-            # timeout (see _run_windows_cmd_shell).
+            # through a contained temp batch file (see _run_windows_cmd_shell).
             stdout_raw, stderr_raw, returncode = _run_windows_cmd_shell(
                 command, timeout=timeout, shell_path=shell_path, cwd=cwd
             )

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -1894,7 +1894,7 @@ class PiExecutor(Executor):
                 model=model,
             )
             models_path = os.path.join(tmp_dir, "models.json")
-            with open(models_path, "w") as f:
+            with open(models_path, "w", encoding="utf-8") as f:
                 json.dump(models_json, f)
             env["PI_CODING_AGENT_DIR"] = tmp_dir
             # Gateway mode relocates Pi's agent root — copy the user's global
@@ -1918,7 +1918,7 @@ class PiExecutor(Executor):
             settings_path = os.path.join(settings_dir_root, ".pi", "settings.json")
             try:
                 if os.path.exists(settings_path):
-                    with open(settings_path) as f:
+                    with open(settings_path, encoding="utf-8") as f:
                         existing_settings = json.load(f)
                     if not isinstance(existing_settings, dict):
                         existing_settings = {}
@@ -1926,12 +1926,12 @@ class PiExecutor(Executor):
                     existing_settings = {}
                 existing_settings.update(retry_settings)
                 os.makedirs(os.path.dirname(settings_path), exist_ok=True)
-                with open(settings_path, "w") as f:
+                with open(settings_path, "w", encoding="utf-8") as f:
                     json.dump(existing_settings, f, indent=2)
             except OSError:
                 fallback_path = os.path.join(tmp_dir, ".pi", "settings.json")
                 os.makedirs(os.path.dirname(fallback_path), exist_ok=True)
-                with open(fallback_path, "w") as f:
+                with open(fallback_path, "w", encoding="utf-8") as f:
                     json.dump(retry_settings, f, indent=2)
 
         # Generate the Omnigent tool bridge extension if tools are available.
@@ -1941,7 +1941,7 @@ class PiExecutor(Executor):
                 # unauthenticated; fail loud instead.
                 raise ValueError("tool_server_token is required when tool_server_port is set")
             ext_path = os.path.join(tmp_dir, "omnigent_tools.js")
-            with open(ext_path, "w") as f:
+            with open(ext_path, "w", encoding="utf-8") as f:
                 f.write(_generate_extension_js(tool_server_port, tools, tool_server_token))
             extra_args.extend(["--extension", ext_path])
             # Allowlist the bridged tool names. ``--no-tools`` (set in

--- a/omnigent/inner/windows_jobobject_sandbox.py
+++ b/omnigent/inner/windows_jobobject_sandbox.py
@@ -35,6 +35,7 @@ import functools
 import logging
 from pathlib import Path
 from types import TracebackType
+from typing import ClassVar
 
 from .datamodel import OSEnvSandboxSpec, OSEnvSpec
 from .sandbox import (
@@ -67,7 +68,7 @@ def _warn_no_fs_isolation_once() -> None:
 
 
 class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
-    _fields_ = [
+    _fields_: ClassVar = [
         ("PerProcessUserTimeLimit", ctypes.c_int64),
         ("PerJobUserTimeLimit", ctypes.c_int64),
         ("LimitFlags", wintypes.DWORD),
@@ -81,7 +82,7 @@ class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
 
 
 class _IO_COUNTERS(ctypes.Structure):
-    _fields_ = [
+    _fields_: ClassVar = [
         ("ReadOperationCount", ctypes.c_uint64),
         ("WriteOperationCount", ctypes.c_uint64),
         ("OtherOperationCount", ctypes.c_uint64),
@@ -92,7 +93,7 @@ class _IO_COUNTERS(ctypes.Structure):
 
 
 class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
-    _fields_ = [
+    _fields_: ClassVar = [
         ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
         ("IoInfo", _IO_COUNTERS),
         ("ProcessMemoryLimit", ctypes.c_size_t),
@@ -134,6 +135,47 @@ class _JobHandle:
         tb: TracebackType | None,
     ) -> None:
         self.close()
+
+
+def assign_pid_to_kill_on_close_job(pid: int) -> _JobHandle | None:
+    """Create a ``KILL_ON_JOB_CLOSE`` job and assign ``pid`` to it.
+
+    ``AssignProcessToJobObject`` also captures the process's future children, so
+    closing the returned :class:`_JobHandle` terminates the whole tree — even
+    descendants orphaned by an intermediate process that exits, which a
+    parent-walk (psutil / ``taskkill /T``) cannot reach. Returns ``None`` if the
+    job can't be created/assigned; the caller then falls back to a best-effort
+    tree kill. Used by the shell-timeout path.
+    """
+    kernel32 = ctypes.windll.kernel32
+    job = kernel32.CreateJobObjectW(None, None)
+    if not job:
+        return None
+    info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+    info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    if not kernel32.SetInformationJobObject(
+        wintypes.HANDLE(job),
+        _JobObjectExtendedLimitInformation,
+        ctypes.byref(info),
+        ctypes.sizeof(info),
+    ):
+        kernel32.CloseHandle(wintypes.HANDLE(job))
+        return None
+    proc_handle = kernel32.OpenProcess(
+        _PROCESS_SET_QUOTA | _PROCESS_TERMINATE, False, wintypes.DWORD(pid)
+    )
+    if not proc_handle:
+        kernel32.CloseHandle(wintypes.HANDLE(job))
+        return None
+    try:
+        if not kernel32.AssignProcessToJobObject(
+            wintypes.HANDLE(job), wintypes.HANDLE(proc_handle)
+        ):
+            kernel32.CloseHandle(wintypes.HANDLE(job))
+            return None
+    finally:
+        kernel32.CloseHandle(wintypes.HANDLE(proc_handle))
+    return _JobHandle(job)
 
 
 class WindowsJobObjectSandboxBackend(SandboxBackend):

--- a/omnigent/inner/windows_jobobject_sandbox.py
+++ b/omnigent/inner/windows_jobobject_sandbox.py
@@ -106,6 +106,24 @@ class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
 _PROCESS_SET_QUOTA = 0x0100
 _PROCESS_TERMINATE = 0x0001
 
+# Toolhelp thread-snapshot constants for resuming a CREATE_SUSPENDED process
+# whose primary-thread handle subprocess.Popen has already closed (tlhelp32.h).
+_TH32CS_SNAPTHREAD = 0x00000004
+_THREAD_SUSPEND_RESUME = 0x0002
+_RESUME_THREAD_FAILED = 0xFFFFFFFF  # (DWORD)-1 return from ResumeThread
+
+
+class _THREADENTRY32(ctypes.Structure):
+    _fields_: ClassVar = [
+        ("dwSize", wintypes.DWORD),
+        ("cntUsage", wintypes.DWORD),
+        ("th32ThreadID", wintypes.DWORD),
+        ("th32OwnerProcessID", wintypes.DWORD),
+        ("tpBasePri", wintypes.LONG),
+        ("tpDeltaPri", wintypes.LONG),
+        ("dwFlags", wintypes.DWORD),
+    ]
+
 
 class _JobHandle:
     """Owns a Windows Job Object handle; closing it kills the contained tree.
@@ -117,6 +135,43 @@ class _JobHandle:
 
     def __init__(self, handle: int) -> None:
         self._handle: int | None = handle
+
+    def assign(self, pid: int) -> bool:
+        """Assign ``pid`` (and its future children) to this job.
+
+        ``AssignProcessToJobObject`` also captures the process's future
+        descendants, so a later ``terminate()`` tears down the whole tree — even
+        grandchildren orphaned by an intermediate process that exits, which a
+        parent-walk (psutil / ``taskkill /T``) cannot reach.
+        """
+        if self._handle is None:
+            return False
+        kernel32 = ctypes.windll.kernel32
+        proc_handle = kernel32.OpenProcess(
+            _PROCESS_SET_QUOTA | _PROCESS_TERMINATE, False, wintypes.DWORD(pid)
+        )
+        if not proc_handle:
+            return False
+        try:
+            return bool(
+                kernel32.AssignProcessToJobObject(
+                    wintypes.HANDLE(self._handle), wintypes.HANDLE(proc_handle)
+                )
+            )
+        finally:
+            kernel32.CloseHandle(wintypes.HANDLE(proc_handle))
+
+    def terminate(self) -> None:
+        """Terminate every process in the job — used only on the timeout path.
+
+        The job has no ``KILL_ON_JOB_CLOSE`` limit, so a successful run's
+        ``close()`` leaves a detached child (a server the command started)
+        running; only this explicit call tears the tree down.
+        """
+        if self._handle is None:
+            return
+        if not ctypes.windll.kernel32.TerminateJobObject(wintypes.HANDLE(self._handle), 1):
+            _LOGGER.debug("windows_jobobject: TerminateJobObject failed")
 
     def close(self) -> None:
         if self._handle is None:
@@ -137,45 +192,59 @@ class _JobHandle:
         self.close()
 
 
-def assign_pid_to_kill_on_close_job(pid: int) -> _JobHandle | None:
-    """Create a ``KILL_ON_JOB_CLOSE`` job and assign ``pid`` to it.
+def create_tree_kill_job() -> _JobHandle | None:
+    """Create a plain Job Object for process-tree containment.
 
-    ``AssignProcessToJobObject`` also captures the process's future children, so
-    closing the returned :class:`_JobHandle` terminates the whole tree — even
-    descendants orphaned by an intermediate process that exits, which a
-    parent-walk (psutil / ``taskkill /T``) cannot reach. Returns ``None`` if the
-    job can't be created/assigned; the caller then falls back to a best-effort
-    tree kill. Used by the shell-timeout path.
+    Deliberately has **no** ``KILL_ON_JOB_CLOSE`` limit: closing the returned
+    :class:`_JobHandle` does not terminate the contained tree, so a command that
+    intentionally starts a detached child (a background server) survives a
+    normal successful run. Assign a process with :meth:`_JobHandle.assign` and
+    call :meth:`_JobHandle.terminate` to kill the tree — only ever on the
+    shell-timeout path. Returns ``None`` if the job can't be created; the caller
+    then falls back to a best-effort tree kill.
     """
-    kernel32 = ctypes.windll.kernel32
-    job = kernel32.CreateJobObjectW(None, None)
+    job = ctypes.windll.kernel32.CreateJobObjectW(None, None)
     if not job:
         return None
-    info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
-    info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-    if not kernel32.SetInformationJobObject(
-        wintypes.HANDLE(job),
-        _JobObjectExtendedLimitInformation,
-        ctypes.byref(info),
-        ctypes.sizeof(info),
-    ):
-        kernel32.CloseHandle(wintypes.HANDLE(job))
-        return None
-    proc_handle = kernel32.OpenProcess(
-        _PROCESS_SET_QUOTA | _PROCESS_TERMINATE, False, wintypes.DWORD(pid)
-    )
-    if not proc_handle:
-        kernel32.CloseHandle(wintypes.HANDLE(job))
-        return None
-    try:
-        if not kernel32.AssignProcessToJobObject(
-            wintypes.HANDLE(job), wintypes.HANDLE(proc_handle)
-        ):
-            kernel32.CloseHandle(wintypes.HANDLE(job))
-            return None
-    finally:
-        kernel32.CloseHandle(wintypes.HANDLE(proc_handle))
     return _JobHandle(job)
+
+
+def resume_process_threads(pid: int) -> bool:
+    """Resume every thread of *pid*, a process created ``CREATE_SUSPENDED``.
+
+    ``subprocess.Popen`` closes the primary thread handle after spawning, so the
+    thread can't be resumed directly; enumerate it via a toolhelp thread
+    snapshot instead. A freshly-suspended process has exactly one thread.
+    Returns ``True`` if at least one thread was resumed — the caller must treat
+    ``False`` as a hard failure (the child would otherwise hang suspended).
+    """
+    kernel32 = ctypes.windll.kernel32
+    kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    kernel32.OpenThread.restype = wintypes.HANDLE
+    invalid = wintypes.HANDLE(-1).value
+    snapshot = kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPTHREAD, 0)
+    if not snapshot or snapshot == invalid:
+        return False
+    resumed = False
+    try:
+        entry = _THREADENTRY32()
+        entry.dwSize = ctypes.sizeof(_THREADENTRY32)
+        ok = kernel32.Thread32First(wintypes.HANDLE(snapshot), ctypes.byref(entry))
+        while ok:
+            if entry.th32OwnerProcessID == pid:
+                thread = kernel32.OpenThread(
+                    _THREAD_SUSPEND_RESUME, False, wintypes.DWORD(entry.th32ThreadID)
+                )
+                if thread:
+                    try:
+                        if kernel32.ResumeThread(wintypes.HANDLE(thread)) != _RESUME_THREAD_FAILED:
+                            resumed = True
+                    finally:
+                        kernel32.CloseHandle(wintypes.HANDLE(thread))
+            ok = kernel32.Thread32Next(wintypes.HANDLE(snapshot), ctypes.byref(entry))
+    finally:
+        kernel32.CloseHandle(wintypes.HANDLE(snapshot))
+    return resumed
 
 
 class WindowsJobObjectSandboxBackend(SandboxBackend):

--- a/omnigent/inner/windows_jobobject_sandbox.py
+++ b/omnigent/inner/windows_jobobject_sandbox.py
@@ -126,11 +126,10 @@ class _THREADENTRY32(ctypes.Structure):
 
 
 class _JobHandle:
-    """Owns a Windows Job Object handle; closing it kills the contained tree.
+    """Own a Windows Job Object handle.
 
-    Held by the parent for the helper's lifetime. Closing (explicitly or via
-    ``with``) closes the kernel handle; with ``KILL_ON_JOB_CLOSE`` set, that
-    terminates every still-running process in the job.
+    Closing follows the job's configured limits: sandbox jobs use
+    ``KILL_ON_JOB_CLOSE``; shell-timeout jobs deliberately do not.
     """
 
     def __init__(self, handle: int) -> None:
@@ -162,11 +161,12 @@ class _JobHandle:
             kernel32.CloseHandle(wintypes.HANDLE(proc_handle))
 
     def terminate(self) -> None:
-        """Terminate every process in the job — used only on the timeout path.
+        """Terminate every process in the job after an abnormal shell exit.
 
         The job has no ``KILL_ON_JOB_CLOSE`` limit, so a successful run's
         ``close()`` leaves a detached child (a server the command started)
-        running; only this explicit call tears the tree down.
+        running; this explicit call handles timeout, cancellation, and setup
+        failure after the suspended child exists.
         """
         if self._handle is None:
             return
@@ -200,8 +200,8 @@ def create_tree_kill_job() -> _JobHandle | None:
     intentionally starts a detached child (a background server) survives a
     normal successful run. Assign a process with :meth:`_JobHandle.assign` and
     call :meth:`_JobHandle.terminate` to kill the tree — only ever on the
-    shell-timeout path. Returns ``None`` if the job can't be created; the caller
-    then falls back to a best-effort tree kill.
+    abnormal shell path. Returns ``None`` if the job can't be created; callers
+    that require race-free containment must fail closed.
     """
     job = ctypes.windll.kernel32.CreateJobObjectW(None, None)
     if not job:
@@ -219,8 +219,6 @@ def resume_process_threads(pid: int) -> bool:
     ``False`` as a hard failure (the child would otherwise hang suspended).
     """
     kernel32 = ctypes.windll.kernel32
-    kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
-    kernel32.OpenThread.restype = wintypes.HANDLE
     invalid = wintypes.HANDLE(-1).value
     snapshot = kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPTHREAD, 0)
     if not snapshot or snapshot == invalid:
@@ -415,6 +413,18 @@ def _configure_prototypes() -> None:
     k.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
     k.AssignProcessToJobObject.restype = wintypes.BOOL
     k.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+    k.TerminateJobObject.restype = wintypes.BOOL
+    k.TerminateJobObject.argtypes = [wintypes.HANDLE, wintypes.UINT]
+    k.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    k.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+    k.Thread32First.restype = wintypes.BOOL
+    k.Thread32First.argtypes = [wintypes.HANDLE, ctypes.POINTER(_THREADENTRY32)]
+    k.Thread32Next.restype = wintypes.BOOL
+    k.Thread32Next.argtypes = [wintypes.HANDLE, ctypes.POINTER(_THREADENTRY32)]
+    k.OpenThread.restype = wintypes.HANDLE
+    k.OpenThread.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    k.ResumeThread.restype = wintypes.DWORD
+    k.ResumeThread.argtypes = [wintypes.HANDLE]
     k.CloseHandle.restype = wintypes.BOOL
     k.CloseHandle.argtypes = [wintypes.HANDLE]
 

--- a/omnigent/install_ledger.py
+++ b/omnigent/install_ledger.py
@@ -13,6 +13,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from omnigent._encoding import detect_encoding
+
 SCHEMA_VERSION = 1
 LEDGER_NAME = "install_ledger.json"
 BACKFILL_LEDGER_NAME = "install_ledger.backfill.json"
@@ -185,7 +187,7 @@ def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
     fd = os.open(tmp, flags, 0o600)
     try:
-        with os.fdopen(fd, "w") as handle:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(data)
             handle.flush()
             os.fsync(handle.fileno())
@@ -198,10 +200,10 @@ def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
 
 def load_ledger(path: Path) -> InstallLedger | None:
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return None
-    except json.JSONDecodeError:
+    except (UnicodeDecodeError, json.JSONDecodeError):
         return None
     if data.get("schema_version") != SCHEMA_VERSION:
         return None
@@ -236,8 +238,8 @@ def _merge_external_configs(
 def read_installation_id(home: Path | None = None) -> str | None:
     install_id_path = (home or state_dir()) / "installation_id"
     try:
-        value = install_id_path.read_text().strip()
-    except OSError:
+        value = install_id_path.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
         return None
     return value or None
 
@@ -260,8 +262,8 @@ def profile_candidates() -> list[Path]:
 
 def find_profile_block(path: Path) -> tuple[int, int, str] | None:
     try:
-        lines = path.read_text().splitlines(keepends=True)
-    except OSError:
+        lines = path.read_text(encoding=detect_encoding(path)).splitlines(keepends=True)
+    except (OSError, UnicodeDecodeError):
         return None
     begin: int | None = None
     for index, line in enumerate(lines):
@@ -345,8 +347,8 @@ def desktop_data_paths() -> list[str]:
 
 def _json_has_key_path(path: Path, key_path: str) -> bool:
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
+        data = json.loads(path.read_text(encoding=detect_encoding(path)))
+    except (OSError, UnicodeDecodeError, ValueError):
         return False
     current: Any = data
     for part in key_path.split("."):
@@ -358,8 +360,8 @@ def _json_has_key_path(path: Path, key_path: str) -> bool:
 
 def _toml_has_table(path: Path, table: str) -> bool:
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
+        lines = path.read_text(encoding=detect_encoding(path)).splitlines()
+    except (OSError, UnicodeDecodeError):
         return False
     return any(line.strip() == f"[{table}]" for line in lines)
 

--- a/omnigent/integration_daemon.py
+++ b/omnigent/integration_daemon.py
@@ -19,6 +19,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from omnigent._encoding import detect_encoding
 from omnigent.inner import _proc
 
 
@@ -54,8 +55,8 @@ class IntegrationDaemon:
     def read_record(self) -> DaemonRecord | None:
         """Return the recorded daemon, or ``None`` if absent/malformed."""
         try:
-            raw = json.loads(self._record_path.read_text())
-        except (OSError, json.JSONDecodeError):
+            raw = json.loads(self._record_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             return None
         if not isinstance(raw, dict):
             return None
@@ -76,7 +77,8 @@ class IntegrationDaemon:
                     "log_path": record.log_path,
                     "started_at": record.started_at,
                 }
-            )
+            ),
+            encoding="utf-8",
         )
 
     def _clear_record(self) -> None:
@@ -138,7 +140,10 @@ class IntegrationDaemon:
         if record is None:
             return ""
         try:
-            lines = Path(record.log_path).read_text(errors="replace").splitlines()
+            log_path = Path(record.log_path)
+            lines = log_path.read_text(
+                encoding=detect_encoding(log_path), errors="replace"
+            ).splitlines()
         except OSError:
             return ""
         return "\n".join(lines[-max_lines:])

--- a/omnigent/kiro_native_permissions.py
+++ b/omnigent/kiro_native_permissions.py
@@ -154,7 +154,7 @@ def _read_new_permission_events(
     if size == offset:
         return [], offset
     try:
-        with record_file.open("rb") as handle:
+        with record_file.open(mode="rb") as handle:
             handle.seek(offset)
             data = handle.read(size - offset)
     except OSError:

--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -219,7 +219,7 @@ def _read_new_kiro_messages(
     """Read conversation messages after *byte_offset* from Kiro's JSONL file."""
     messages: list[_KiroConversationMessage] = []
     try:
-        with jsonl_path.open("rb") as handle:
+        with jsonl_path.open(mode="rb") as handle:
             handle.seek(byte_offset)
             # Advance only past newline-terminated lines: Kiro appends to this
             # JSONL live, so the final line may be a record mid-write (no

--- a/omnigent/llms/_usage_observer.py
+++ b/omnigent/llms/_usage_observer.py
@@ -105,7 +105,7 @@ def set_current_test(nodeid: str | None) -> None:
         # Atomic publish: a subprocess reading mid-update sees either
         # the previous nodeid or the new one, never a truncated line.
         tmp = path.with_name(f"{path.name}.tmp{os.getpid()}")
-        tmp.write_text(nodeid)
+        tmp.write_text(nodeid, encoding="utf-8")
         os.replace(tmp, path)
     except OSError:
         logger.exception("failed to update current-test sidecar at %s", path)
@@ -209,7 +209,7 @@ def _current_test_from_sidecar() -> str | None:
     if path is None:
         return None
     try:
-        text = path.read_text().strip()
+        text = path.read_text(encoding="utf-8").strip()
     except OSError:
         return None
     # An empty file carries no nodeid; normalize to None so the caller
@@ -306,7 +306,7 @@ def _write_records() -> None:
             # Path is per-pid, so only same-process threads contend on
             # the temp name; the lock serializes them.
             tmp = path.with_name(path.name + ".tmp")
-            tmp.write_text(payload)
+            tmp.write_text(payload, encoding="utf-8")
             os.replace(tmp, path)
         except OSError:
             logger.exception("failed to write token-usage records to %s", path)

--- a/omnigent/onboarding/databricks_config.py
+++ b/omnigent/onboarding/databricks_config.py
@@ -100,7 +100,8 @@ def list_databricks_profiles() -> list[str]:
         return []
     parser = configparser.ConfigParser()
     try:
-        parser.read(_DATABRICKSCFG_PATH)
+        # Vendor-written cfg: read at the locale default, symmetric with writers.
+        parser.read(_DATABRICKSCFG_PATH, encoding="locale")
     except configparser.Error as exc:
         _logger.debug("Could not parse %s: %s", _DATABRICKSCFG_PATH, exc)
         return []
@@ -125,7 +126,8 @@ def get_workspace_url_for_profile(profile: str) -> str | None:
     if _DATABRICKSCFG_PATH.exists():
         cfg = configparser.ConfigParser()
         try:
-            cfg.read(_DATABRICKSCFG_PATH)
+            # Vendor-written cfg: read at the locale default (see above).
+            cfg.read(_DATABRICKSCFG_PATH, encoding="locale")
         except configparser.Error as exc:
             _logger.debug("Could not parse %s: %s", _DATABRICKSCFG_PATH, exc)
         else:

--- a/omnigent/onboarding/databricks_config.py
+++ b/omnigent/onboarding/databricks_config.py
@@ -8,6 +8,8 @@ import logging
 from pathlib import Path
 from urllib.parse import urlparse
 
+from omnigent._encoding import detect_encoding
+
 _logger = logging.getLogger(__name__)
 
 _DATABRICKSCFG_PATH = Path.home() / ".databrickscfg"
@@ -100,8 +102,8 @@ def list_databricks_profiles() -> list[str]:
         return []
     parser = configparser.ConfigParser()
     try:
-        # Vendor-written cfg: read at the locale default, symmetric with writers.
-        parser.read(_DATABRICKSCFG_PATH, encoding="locale")
+        # Vendor-written cfg (CLI emits UTF-8): detect UTF-8 first, locale fallback.
+        parser.read(_DATABRICKSCFG_PATH, encoding=detect_encoding(_DATABRICKSCFG_PATH))
     except configparser.Error as exc:
         _logger.debug("Could not parse %s: %s", _DATABRICKSCFG_PATH, exc)
         return []
@@ -126,8 +128,8 @@ def get_workspace_url_for_profile(profile: str) -> str | None:
     if _DATABRICKSCFG_PATH.exists():
         cfg = configparser.ConfigParser()
         try:
-            # Vendor-written cfg: read at the locale default (see above).
-            cfg.read(_DATABRICKSCFG_PATH, encoding="locale")
+            # Vendor-written cfg: detect UTF-8 first, locale fallback (see above).
+            cfg.read(_DATABRICKSCFG_PATH, encoding=detect_encoding(_DATABRICKSCFG_PATH))
         except configparser.Error as exc:
             _logger.debug("Could not parse %s: %s", _DATABRICKSCFG_PATH, exc)
         else:

--- a/omnigent/onboarding/interactive.py
+++ b/omnigent/onboarding/interactive.py
@@ -398,7 +398,8 @@ def select(
         raise ValueError("descriptions must match options length")
     mask = _normalize_selectable(options, selectable)
 
-    if not sys.stdin.isatty():
+    if not sys.stdin.isatty() or sys.platform == "win32":
+        # Windows has no termios/tty raw mode; use the numbered fallback.
         return _select_fallback(title, options, default=default, selectable=mask)
 
     import termios

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -505,7 +505,7 @@ def _load_config() -> dict[str, object]:
     if not os.path.exists(path):
         return {}
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
     except (OSError, yaml.YAMLError):
         return {}

--- a/omnigent/onboarding/sandboxes/bootstrap.py
+++ b/omnigent/onboarding/sandboxes/bootstrap.py
@@ -621,12 +621,13 @@ def set_sandbox_host_name(launcher: SandboxLauncher, sandbox_id: str, host_name:
         "import os, uuid, yaml; "
         "p=os.path.expanduser('~/.omnigent/config.yaml'); "
         "os.makedirs(os.path.dirname(p), exist_ok=True); "
-        "cfg=yaml.safe_load(open(p)) if os.path.exists(p) else {}; "
+        "cfg=yaml.safe_load(open(p, encoding='utf-8')) if os.path.exists(p) else {}; "
         "cfg=cfg or {}; "
         f"h=cfg.get('host') or {{}}; h['name']='{safe_name}'; "
         "h.setdefault('host_id', uuid.uuid4().hex); "
         "cfg['host']=h; "
-        "yaml.safe_dump(cfg, open(p,'w'), default_flow_style=False, sort_keys=True)"
+        "yaml.safe_dump(cfg, open(p, 'w', encoding='utf-8'), "
+        "default_flow_style=False, sort_keys=True)"
     )
     launcher.run(sandbox_id, f'python3 -c "{py}"')
 

--- a/omnigent/onboarding/sandboxes/islo.py
+++ b/omnigent/onboarding/sandboxes/islo.py
@@ -87,12 +87,12 @@ _CLEAR_API_KEY_HELPER_SCRIPT = """\
 import json, os
 path = os.path.expanduser("~/.claude/settings.json")
 try:
-    with open(path) as handle:
+    with open(path, encoding="utf-8") as handle:
         settings = json.load(handle)
 except (FileNotFoundError, ValueError):
     raise SystemExit(0)
 if isinstance(settings, dict) and settings.pop("apiKeyHelper", None) is not None:
-    with open(path, "w") as handle:
+    with open(path, "w", encoding="utf-8") as handle:
         json.dump(settings, handle, indent=2)
 """
 

--- a/omnigent/onboarding/sandboxes/islo.py
+++ b/omnigent/onboarding/sandboxes/islo.py
@@ -237,7 +237,7 @@ class _IsloClient:
         """Upload one file to an absolute path in the sandbox."""
         wrapper = self._client._client_wrapper
         try:
-            with local_path.open("rb") as file_obj:
+            with local_path.open(mode="rb") as file_obj:
                 response = wrapper.httpx_client.request(
                     f"sandboxes/{_url_component(name)}/files",
                     base_url=wrapper.get_environment().compute,

--- a/omnigent/onboarding/setup.py
+++ b/omnigent/onboarding/setup.py
@@ -200,12 +200,14 @@ def _alias_profile(source: str, target: str) -> None:
     """
     path = _databrickscfg_path()
     cfg = configparser.ConfigParser()
-    cfg.read(path)
+    # ~/.databrickscfg is vendor-written: read and write it symmetrically at
+    # the locale default so a round-trip never re-encodes non-ASCII values.
+    cfg.read(path, encoding="locale")
     if source not in cfg:
         raise ValueError(f"alias source {source!r} not in {path}")
     cfg[target] = dict(cfg[source])
     tmp = path.with_name(path.name + ".write")
-    with tmp.open("w", encoding="utf-8") as f:
+    with tmp.open("w", encoding="locale") as f:
         cfg.write(f)
     tmp.replace(path)
 
@@ -225,12 +227,14 @@ def _remove_profile_section(name: str) -> bool:
     if not path.exists():
         return False
     cfg = configparser.ConfigParser()
-    cfg.read(path)
+    # ~/.databrickscfg is vendor-written: read and write it symmetrically at
+    # the locale default so a round-trip never re-encodes non-ASCII values.
+    cfg.read(path, encoding="locale")
     if name not in cfg:
         return False
     cfg.remove_section(name)
     tmp = path.with_name(path.name + ".write")
-    with tmp.open("w", encoding="utf-8") as f:
+    with tmp.open("w", encoding="locale") as f:
         cfg.write(f)
     tmp.replace(path)
     return True

--- a/omnigent/onboarding/setup.py
+++ b/omnigent/onboarding/setup.py
@@ -205,7 +205,7 @@ def _alias_profile(source: str, target: str) -> None:
         raise ValueError(f"alias source {source!r} not in {path}")
     cfg[target] = dict(cfg[source])
     tmp = path.with_name(path.name + ".write")
-    with tmp.open("w") as f:
+    with tmp.open("w", encoding="utf-8") as f:
         cfg.write(f)
     tmp.replace(path)
 
@@ -230,7 +230,7 @@ def _remove_profile_section(name: str) -> bool:
         return False
     cfg.remove_section(name)
     tmp = path.with_name(path.name + ".write")
-    with tmp.open("w") as f:
+    with tmp.open("w", encoding="utf-8") as f:
         cfg.write(f)
     tmp.replace(path)
     return True

--- a/omnigent/onboarding/setup.py
+++ b/omnigent/onboarding/setup.py
@@ -34,6 +34,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+from omnigent._encoding import detect_encoding
+
 if TYPE_CHECKING:
     from rich.console import Console
 
@@ -199,15 +201,16 @@ def _alias_profile(source: str, target: str) -> None:
     :param target: New profile name to create.
     """
     path = _databrickscfg_path()
+    # ~/.databrickscfg is vendor-written (CLI emits UTF-8): detect its codec and
+    # preserve it across the read+rewrite so a round-trip never re-encodes values.
+    encoding = detect_encoding(path)
     cfg = configparser.ConfigParser()
-    # ~/.databrickscfg is vendor-written: read and write it symmetrically at
-    # the locale default so a round-trip never re-encodes non-ASCII values.
-    cfg.read(path, encoding="locale")
+    cfg.read(path, encoding=encoding)
     if source not in cfg:
         raise ValueError(f"alias source {source!r} not in {path}")
     cfg[target] = dict(cfg[source])
     tmp = path.with_name(path.name + ".write")
-    with tmp.open("w", encoding="locale") as f:
+    with tmp.open("w", encoding=encoding) as f:
         cfg.write(f)
     tmp.replace(path)
 
@@ -226,15 +229,16 @@ def _remove_profile_section(name: str) -> bool:
     path = _databrickscfg_path()
     if not path.exists():
         return False
+    # ~/.databrickscfg is vendor-written (CLI emits UTF-8): detect its codec and
+    # preserve it across the read+rewrite so a round-trip never re-encodes values.
+    encoding = detect_encoding(path)
     cfg = configparser.ConfigParser()
-    # ~/.databrickscfg is vendor-written: read and write it symmetrically at
-    # the locale default so a round-trip never re-encodes non-ASCII values.
-    cfg.read(path, encoding="locale")
+    cfg.read(path, encoding=encoding)
     if name not in cfg:
         return False
     cfg.remove_section(name)
     tmp = path.with_name(path.name + ".write")
-    with tmp.open("w", encoding="locale") as f:
+    with tmp.open("w", encoding=encoding) as f:
         cfg.write(f)
     tmp.replace(path)
     return True

--- a/omnigent/onboarding/ucode_state.py
+++ b/omnigent/onboarding/ucode_state.py
@@ -148,7 +148,7 @@ def read_ucode_state(workspace_url: str) -> UcodeWorkspaceState | None:
     if not _STATE_PATH.exists():
         return None
     try:
-        raw = json.loads(_STATE_PATH.read_text())
+        raw = json.loads(_STATE_PATH.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as exc:
         _logger.debug("Could not read %s: %s", _STATE_PATH, exc)
         return None
@@ -212,7 +212,7 @@ def read_current_ucode_state() -> UcodeWorkspaceState | None:
     if not _STATE_PATH.exists():
         return None
     try:
-        raw = json.loads(_STATE_PATH.read_text())
+        raw = json.loads(_STATE_PATH.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as exc:
         _logger.debug("Could not read %s: %s", _STATE_PATH, exc)
         return None

--- a/omnigent/onboarding/wizard.py
+++ b/omnigent/onboarding/wizard.py
@@ -73,8 +73,9 @@ def _arrow_menu(
     cursor = default
     selected: set[int] = set()
 
-    # Fall back to number input if not a real terminal.
-    if not sys.stdin.isatty():
+    # Fall back to number input if not a real terminal (or on Windows, which
+    # has no termios/tty raw mode).
+    if not sys.stdin.isatty() or sys.platform == "win32":
         return _arrow_menu_fallback(options, default=default, disabled=disabled, multi=multi)
 
     import select as _select
@@ -279,8 +280,9 @@ def _text_prompt(
     :returns: The user's input (or *default* on bare enter).
     :raises _GoBack: When the user presses Escape and *allow_back* is True.
     """
-    # Non-tty fallback -- just use click.prompt.
-    if not sys.stdin.isatty():
+    # Non-tty fallback -- just use click.prompt. Windows also takes this path
+    # (no termios/tty raw mode).
+    if not sys.stdin.isatty() or sys.platform == "win32":
         raw = str(
             click.prompt(
                 label,

--- a/omnigent/onboarding/wizard.py
+++ b/omnigent/onboarding/wizard.py
@@ -26,6 +26,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.syntax import Syntax
 
+from omnigent._encoding import detect_encoding
+
 console = Console()
 
 # ANSI helpers - used in arrow-menu labels (rendered via sys.stdout.write,
@@ -471,8 +473,8 @@ def _list_databricks_profiles() -> list[str]:
         return []
     parser = configparser.ConfigParser()
     try:
-        # ~/.databrickscfg is vendor-written; read at the locale default.
-        parser.read(cfg_path, encoding="locale")
+        # ~/.databrickscfg is vendor-written; detect UTF-8 first, locale fallback.
+        parser.read(cfg_path, encoding=detect_encoding(cfg_path))
     except configparser.Error:
         return []
     return [s for s in parser.sections() if s != "DEFAULT"] or (

--- a/omnigent/onboarding/wizard.py
+++ b/omnigent/onboarding/wizard.py
@@ -1303,7 +1303,7 @@ def _save_yaml(content: str, filename: str) -> Path:
     """Write YAML content to ~/.omnigent/agents/<filename>."""
     _AGENTS_DIR.mkdir(parents=True, exist_ok=True)
     path = _AGENTS_DIR / filename
-    path.write_text(content)
+    path.write_text(content, encoding="utf-8")
     return path
 
 

--- a/omnigent/onboarding/wizard.py
+++ b/omnigent/onboarding/wizard.py
@@ -471,7 +471,8 @@ def _list_databricks_profiles() -> list[str]:
         return []
     parser = configparser.ConfigParser()
     try:
-        parser.read(cfg_path)
+        # ~/.databrickscfg is vendor-written; read at the locale default.
+        parser.read(cfg_path, encoding="locale")
     except configparser.Error:
         return []
     return [s for s in parser.sections() if s != "DEFAULT"] or (

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -4344,7 +4344,7 @@ async def run_repl(
             _sid = resume_conversation_id or f"fresh-{int(_dbg_time.time())}"
             _event_log_path = open_event_log(_sid)
             session._event_log_path = _event_log_path  # type: ignore[attr-defined]
-            _event_log_fh = open(_event_log_path, "a")  # noqa: SIM115 — closed in finally below
+            _event_log_fh = open(_event_log_path, "a", encoding="utf-8")  # noqa: SIM115 — closed in finally below
 
         # Mirror the legacy CLI's mascot-art startup banner so the
         # Omnigent REPL feels identical at boot. Raw stdout write

--- a/omnigent/repl/_theme_picker.py
+++ b/omnigent/repl/_theme_picker.py
@@ -192,6 +192,10 @@ def _detect_terminal_background() -> Literal["dark", "light"] | None:
     if not sys.stdin.isatty() or not sys.stdout.isatty():
         return None
 
+    if sys.platform == "win32":
+        # The OSC 11 query below needs POSIX termios/tty raw mode.
+        return None
+
     import select
     import termios
     import tty
@@ -306,8 +310,9 @@ def startup_theme_picker(
     detected = _detect_terminal_background()
     selected = 0 if detected == "dark" else 1  # dark=0, light=1
 
-    if not sys.stdin.isatty():
-        # Non-interactive — use detected or default to light.
+    if not sys.stdin.isatty() or sys.platform == "win32":
+        # Non-interactive, or Windows (no POSIX termios raw-mode picker):
+        # use the detected/default theme and skip the interactive picker.
         theme = DARK_THEME if detected == "dark" else LIGHT_THEME
         update_user_config(theme=theme.name)
         return theme

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -12,12 +12,13 @@ filesystem service.
 from __future__ import annotations
 
 import base64
+import ntpath
 import os
 import re
 import stat
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from omnigent._platform import IS_WINDOWS
 from omnigent.entities.environment_filesystem import (
@@ -38,6 +39,8 @@ if TYPE_CHECKING:
     from omnigent.inner.os_env import OSEnvironment
 
 _MAX_READ_BYTES = 10 * 1024 * 1024  # 10 MiB
+_FilesystemKind = Literal["file", "directory", "symlink", "other"]
+_DeleteStatus = Literal["deleted", "invalid_path", "not_found", "not_empty"]
 
 
 def _shell_quote(s: str) -> str:
@@ -205,6 +208,12 @@ def _validate_path(relative_path: str) -> str:
     """
     if "\x00" in relative_path:
         raise InvalidPath("Path contains NUL bytes")
+    # Reject Windows drive-relative forms (``C:foo``) as well as absolute,
+    # UNC, and device paths on every host. Host-native ``isabs`` alone misses
+    # drive-relative paths, which can resolve outside the environment cwd.
+    windows_drive, _ = ntpath.splitdrive(relative_path)
+    if windows_drive or ntpath.isabs(relative_path):
+        raise InvalidPath("Absolute or drive-qualified paths are not allowed")
     normalized = os.path.normpath(relative_path)
     if os.path.isabs(normalized):
         raise InvalidPath("Absolute paths are not allowed")
@@ -771,37 +780,87 @@ class CallerProcessFilesystem:
             entry=entry,
         )
 
-    async def _lstat_kind_via_shell(self, validated: str) -> tuple[bool, bool, int]:
-        """Classify a path via ``os.lstat`` (does NOT follow symlinks).
+    async def _delete_via_shell(
+        self,
+        validated: str,
+        *,
+        recursive: bool,
+    ) -> tuple[_DeleteStatus, _FilesystemKind, int]:
+        """Delete one root-anchored path without following its final leaf.
 
-        Returns ``(exists, is_real_dir, size)``. A broken symlink/junction
-        reports ``exists=True`` (the link is present) with ``is_real_dir=False``
-        so delete removes the link instead of following it — unlike ``os.stat``,
-        which raises on a broken link and would report the link as missing. Only
-        a genuinely absent path reports ``exists=False``. ``size`` is the link's
-        own ``st_size`` (used as ``bytes_deleted`` for non-directory targets).
+        Parent components are resolved and entered one at a time inside the
+        sandbox helper. Each new cwd is re-checked beneath the original root,
+        so an intermediate symlink/junction cannot redirect deletion outside
+        the environment. The final basename is classified with ``lstat`` and
+        deleted from that anchored parent in the same helper transaction.
 
-        :param validated: Validated relative path.
-        :raises FilesystemPathNotFound: If the helper itself errors.
+        :returns: ``(status, kind, size)`` from the helper.
         """
         import json as _json
 
-        # os.lstat does not follow the link; a reparse point (symlink OR Windows
-        # junction) is "not a real dir" so it is deleted as a link. st_mode alone
-        # misses junctions, so also key off the reparse file attribute (0 on
-        # POSIX, where S_ISLNK covers symlinks).
         _script = "\n".join(
             [
-                "import os, json, stat as S",
+                "import errno, json, os, shutil, stat as S",
                 f"p = {_json.dumps(validated)}",
+                f"recursive = {recursive!r}",
+                "root = os.path.realpath(os.getcwd())",
+                "root_key = os.path.normcase(root)",
+                "reparse_flag = getattr(S, 'FILE_ATTRIBUTE_REPARSE_POINT', 0)",
+                "directory_flag = getattr(S, 'FILE_ATTRIBUTE_DIRECTORY', 0)",
+                "def inside_root(candidate):",
+                "    try:",
+                "        return os.path.normcase(os.path.commonpath("
+                "[root, candidate])) == root_key",
+                "    except ValueError:",
+                "        return False",
+                "def is_reparse(st):",
+                "    return S.S_ISLNK(st.st_mode) or bool("
+                "getattr(st, 'st_file_attributes', 0) & reparse_flag)",
+                "parts = [x for x in os.path.normpath(p).split(os.sep) if x not in ('', '.')]",
+                "status, kind, size = 'not_found', 'other', 0",
                 "try:",
-                "    st = os.lstat(p)",
-                "    reparse = bool(getattr(st, 'st_file_attributes', 0)"
-                " & S.FILE_ATTRIBUTE_REPARSE_POINT) or S.S_ISLNK(st.st_mode)",
-                "    d = S.S_ISDIR(st.st_mode) and not reparse",
-                "    print(json.dumps({'e': True, 'd': d, 's': st.st_size}))",
-                "except FileNotFoundError:",
-                "    print(json.dumps({'e': False, 'd': False, 's': 0}))",
+                "    if not parts:",
+                "        status = 'invalid_path'",
+                "    else:",
+                "        for part in parts[:-1]:",
+                "            candidate = os.path.realpath(part)",
+                "            if not inside_root(candidate):",
+                "                status = 'invalid_path'",
+                "                break",
+                "            os.chdir(candidate)",
+                "            if not inside_root(os.path.realpath(os.getcwd())):",
+                "                status = 'invalid_path'",
+                "                break",
+                "        else:",
+                "            leaf = parts[-1]",
+                "            st = os.lstat(leaf)",
+                "            attrs = getattr(st, 'st_file_attributes', 0)",
+                "            link = is_reparse(st)",
+                "            real_dir = S.S_ISDIR(st.st_mode) and not link",
+                "            kind = ('symlink' if link else 'directory' if real_dir"
+                " else 'file' if S.S_ISREG(st.st_mode) else 'other')",
+                "            size = st.st_size",
+                "            if link:",
+                "                if os.name == 'nt' and attrs & directory_flag:",
+                "                    os.rmdir(leaf)",
+                "                else:",
+                "                    os.unlink(leaf)",
+                "            elif real_dir and recursive:",
+                "                shutil.rmtree(leaf)",
+                "            elif real_dir:",
+                "                os.rmdir(leaf)",
+                "            else:",
+                "                os.unlink(leaf)",
+                "            status = 'deleted'",
+                "except (FileNotFoundError, NotADirectoryError):",
+                "    status = 'not_found'",
+                "except OSError as exc:",
+                "    if exc.errno in (errno.ENOTEMPTY, errno.EEXIST)"
+                " or getattr(exc, 'winerror', None) == 145:",
+                "        status = 'not_empty'",
+                "    else:",
+                "        raise",
+                "print(json.dumps({'status': status, 'type': kind, 'size': size}))",
             ]
         )
         result = await _run_os_env_async(
@@ -809,37 +868,24 @@ class CallerProcessFilesystem:
             _python_run_command(_script),
         )
         if "error" in result or result.get("exit_code", 1) != 0:
-            raise FilesystemPathNotFound(f"Path {validated!r} not found")
+            raise FilesystemPathNotFound(
+                result.get("error", f"Delete failed for {validated!r}"),
+            )
         try:
             info = _json.loads(result.get("stdout", "{}"))
         except _json.JSONDecodeError as exc:
-            raise FilesystemPathNotFound(f"Path {validated!r} not found") from exc
-        return bool(info.get("e", False)), bool(info.get("d", False)), int(info.get("s", 0))
-
-    async def _check_dir_empty(self, validated: str) -> bool:
-        """Check if a directory is empty via the sandboxed helper.
-
-        :param validated: Validated relative path.
-        :returns: ``True`` if the directory has children.
-        """
-        import json as _json
-
-        # Embed the path as a Python literal via json.dumps and shell-quote
-        # the entire script so the caller-controlled path is never interpreted
-        # by the shell; see stat() for the full rationale.
-        _script = "\n".join(
-            [
-                "import os",
-                f"p = {_json.dumps(validated)}",
-                "print(len(os.listdir(p)))",
-            ]
+            raise FilesystemPathNotFound(f"Delete failed for {validated!r}") from exc
+        raw_kind = info.get("type", "other")
+        if raw_kind not in {"file", "directory", "symlink", "other"}:
+            raise RuntimeError(f"Unexpected filesystem kind from delete helper: {raw_kind!r}")
+        raw_status = info.get("status", "not_found")
+        if raw_status not in {"deleted", "invalid_path", "not_found", "not_empty"}:
+            raise RuntimeError(f"Unexpected status from delete helper: {raw_status!r}")
+        return (
+            cast(_DeleteStatus, raw_status),
+            cast(_FilesystemKind, raw_kind),
+            int(info.get("size", 0)),
         )
-        check = await _run_os_env_async(
-            self._os_env.shell,
-            _python_run_command(_script),
-        )
-        count = int(check.get("stdout", "0").strip() or "0")
-        return count > 0
 
     async def delete(
         self,
@@ -852,7 +898,7 @@ class CallerProcessFilesystem:
         :param path: Relative path. Root deletion is rejected.
         :param recursive: Allow recursive directory deletion.
         :returns: Delete result.
-        :raises InvalidPath: If attempting to delete the root.
+        :raises InvalidPath: If deleting the root or an escaping path.
         :raises FilesystemPathNotFound: If the path does not exist.
         :raises DirectoryNotEmpty: If non-empty without recursive.
         """
@@ -860,60 +906,24 @@ class CallerProcessFilesystem:
         if not validated:
             raise InvalidPath("Cannot delete the environment root")
 
-        # lstat, not stat: a broken symlink/junction still exists as a link and
-        # must be deletable, where os.stat would follow it and report "missing".
-        exists, is_dir, size = await self._lstat_kind_via_shell(validated)
-        if not exists:
+        status, kind, size = await self._delete_via_shell(
+            validated,
+            recursive=recursive,
+        )
+        if status == "invalid_path":
+            raise InvalidPath(f"Path {path!r} escapes the environment root")
+        if status == "not_found":
             raise FilesystemPathNotFound(f"Path {path!r} not found")
-
-        if is_dir and not recursive and await self._check_dir_empty(validated):
+        if status == "not_empty":
             raise DirectoryNotEmpty(
                 f"Directory {path!r} is not empty; use recursive=true to delete"
             )
-
-        if IS_WINDOWS:
-            # cmd.exe has no `rm`; delete via a Python script, tolerating a
-            # missing path like `rm -f` does.
-            import json as _json
-
-            _del_script = "\n".join(
-                [
-                    "import os, shutil, stat",
-                    f"p = {_json.dumps(validated)}",
-                    # Reparse points (symlinks AND junctions) must be removed as
-                    # the link itself, not followed: shutil.rmtree refuses a link,
-                    # and following a junction would wrongly delete the target's
-                    # contents. os.path.islink misses junctions, so key off the
-                    # reparse attribute from lstat (which also covers broken
-                    # links). attrs == 0 means already gone (tolerate like rm -f).
-                    "try:",
-                    "    attrs = os.lstat(p).st_file_attributes",
-                    "except FileNotFoundError:",
-                    "    attrs = 0",
-                    "if attrs & stat.FILE_ATTRIBUTE_REPARSE_POINT:",
-                    "    (os.rmdir if attrs & stat.FILE_ATTRIBUTE_DIRECTORY else os.remove)(p)",
-                    "elif attrs & stat.FILE_ATTRIBUTE_DIRECTORY:",
-                    "    shutil.rmtree(p)",
-                    "elif attrs:",
-                    "    os.remove(p)",
-                ]
-            )
-            cmd = _python_run_command(_del_script)
-        else:
-            cmd = (
-                f"rm -rf {_shell_quote(validated)}"
-                if is_dir
-                else f"rm -f {_shell_quote(validated)}"
-            )
-        result = await _run_os_env_async(self._os_env.shell, cmd)
-        if "error" in result and result.get("exit_code", 0) != 0:
-            raise FilesystemPathNotFound(
-                result.get("error", f"Delete failed for {path!r}"),
-            )
+        if status != "deleted":
+            raise RuntimeError(f"Unexpected delete status: {status!r}")
 
         return DeleteFilesystemResult(
             path=path,
             deleted=True,
-            type="directory" if is_dir else "file",
-            bytes_deleted=size if not is_dir else None,
+            type=kind,
+            bytes_deleted=size if kind not in {"directory", "symlink"} else None,
         )

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -15,9 +15,11 @@ import base64
 import os
 import re
 import stat
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from omnigent._platform import IS_WINDOWS
 from omnigent.entities.environment_filesystem import (
     DeleteFilesystemResult,
     DirectoryNotEmpty,
@@ -45,6 +47,22 @@ def _shell_quote(s: str) -> str:
     :returns: Single-quoted shell-safe string.
     """
     return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _python_run_command(script: str) -> str:
+    """Build a host-shell command that runs ``script`` through Python.
+
+    POSIX keeps the historical ``python3 -c '<script>'`` form (single-quoted;
+    this resolves the python inside the sandbox, e.g. under bwrap). On Windows
+    the native shell is ``cmd.exe``, which has no POSIX single-quoting and
+    mangles inline multi-line scripts, so base64-encode the script (pure ASCII,
+    safe to embed in a double-quoted argument) and run it with the runtime's
+    own interpreter.
+    """
+    if IS_WINDOWS:
+        b64 = base64.b64encode(script.encode("utf-8")).decode("ascii")
+        return f'"{sys.executable}" -c "import base64;exec(base64.b64decode(\'{b64}\').decode())"'
+    return f"python3 -c {_shell_quote(script)}"
 
 
 def _glob_to_regex(pattern: str) -> str:
@@ -336,7 +354,7 @@ class CallerProcessFilesystem:
         )
         result = await _run_os_env_async(
             self._os_env.shell,
-            f"python3 -c {_shell_quote(_script)}",
+            _python_run_command(_script),
         )
         if "error" in result:
             raise FilesystemPathNotFound(f"Directory {path!r} not found or not accessible")
@@ -468,7 +486,7 @@ class CallerProcessFilesystem:
         )
         result = await _run_os_env_async(
             self._os_env.shell,
-            f"python3 -c {_shell_quote(_script)}",
+            _python_run_command(_script),
         )
         if "error" in result:
             raise FilesystemPathNotFound(f"Root directory not accessible: {result['error']}")
@@ -649,7 +667,7 @@ class CallerProcessFilesystem:
         )
         result = await _run_os_env_async(
             self._os_env.shell,
-            f"python3 -c {_shell_quote(_script)}",
+            _python_run_command(_script),
         )
         if "error" in result or result.get("exit_code", 1) != 0:
             raise FilesystemPathNotFound(f"Path {path!r} not found")
@@ -766,7 +784,7 @@ class CallerProcessFilesystem:
         )
         result = await _run_os_env_async(
             self._os_env.shell,
-            f"python3 -c {_shell_quote(_script)}",
+            _python_run_command(_script),
         )
         if "error" in result or result.get("exit_code", 1) != 0:
             raise FilesystemPathNotFound(f"Path {validated!r} not found")
@@ -798,7 +816,7 @@ class CallerProcessFilesystem:
         )
         check = await _run_os_env_async(
             self._os_env.shell,
-            f"python3 -c {_shell_quote(_script)}",
+            _python_run_command(_script),
         )
         count = int(check.get("stdout", "0").strip() or "0")
         return count > 0
@@ -829,7 +847,28 @@ class CallerProcessFilesystem:
                 f"Directory {path!r} is not empty; use recursive=true to delete"
             )
 
-        cmd = f"rm -rf {_shell_quote(validated)}" if is_dir else f"rm -f {_shell_quote(validated)}"
+        if IS_WINDOWS:
+            # cmd.exe has no `rm`; delete via a Python script, tolerating a
+            # missing path like `rm -f` does.
+            import json as _json
+
+            _del_script = "\n".join(
+                [
+                    "import os, shutil",
+                    f"p = {_json.dumps(validated)}",
+                    "if os.path.isdir(p):",
+                    "    shutil.rmtree(p)",
+                    "elif os.path.exists(p):",
+                    "    os.remove(p)",
+                ]
+            )
+            cmd = _python_run_command(_del_script)
+        else:
+            cmd = (
+                f"rm -rf {_shell_quote(validated)}"
+                if is_dir
+                else f"rm -f {_shell_quote(validated)}"
+            )
         result = await _run_os_env_async(self._os_env.shell, cmd)
         if "error" in result and result.get("exit_code", 0) != 0:
             raise FilesystemPathNotFound(

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -200,7 +200,8 @@ async def _run_os_env_async(
 def _validate_path(relative_path: str) -> str:
     """Validate and normalize a relative path.
 
-    Rejects NUL bytes, absolute paths, and traversal attempts.
+    Rejects NUL bytes, absolute or drive-qualified paths, and traversal
+    attempts.
 
     :param relative_path: Client-supplied path string.
     :returns: Normalized relative path.

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -230,6 +230,10 @@ def _entry_from_stat(
     :param relative: Path relative to root.
     :returns: The filesystem entry.
     """
+    # The API contract, glob logic, and web UI all use '/'. ``relative`` may
+    # arrive with OS separators (e.g. ``Path.relative_to`` renders '\' on
+    # Windows), so normalize here — the single point every entry passes through.
+    relative = relative.replace(os.sep, "/")
     try:
         st = full_path.stat()
     except OSError:
@@ -767,24 +771,37 @@ class CallerProcessFilesystem:
             entry=entry,
         )
 
-    async def _stat_via_shell(self, validated: str) -> tuple[int, bool]:
-        """Stat a path via the sandboxed helper.
+    async def _lstat_kind_via_shell(self, validated: str) -> tuple[bool, bool, int]:
+        """Classify a path via ``os.lstat`` (does NOT follow symlinks).
+
+        Returns ``(exists, is_real_dir, size)``. A broken symlink/junction
+        reports ``exists=True`` (the link is present) with ``is_real_dir=False``
+        so delete removes the link instead of following it — unlike ``os.stat``,
+        which raises on a broken link and would report the link as missing. Only
+        a genuinely absent path reports ``exists=False``. ``size`` is the link's
+        own ``st_size`` (used as ``bytes_deleted`` for non-directory targets).
 
         :param validated: Validated relative path.
-        :returns: Tuple of (size_bytes, is_directory).
-        :raises FilesystemPathNotFound: If the path does not exist.
+        :raises FilesystemPathNotFound: If the helper itself errors.
         """
         import json as _json
 
-        # Embed the path as a Python literal via json.dumps and shell-quote
-        # the entire script so the caller-controlled path is never interpreted
-        # by the shell; see stat() for the full rationale.
+        # os.lstat does not follow the link; a reparse point (symlink OR Windows
+        # junction) is "not a real dir" so it is deleted as a link. st_mode alone
+        # misses junctions, so also key off the reparse file attribute (0 on
+        # POSIX, where S_ISLNK covers symlinks).
         _script = "\n".join(
             [
                 "import os, json, stat as S",
                 f"p = {_json.dumps(validated)}",
-                "s = os.stat(p)",
-                "print(json.dumps({'s': s.st_size, 'd': S.S_ISDIR(s.st_mode)}))",
+                "try:",
+                "    st = os.lstat(p)",
+                "    reparse = bool(getattr(st, 'st_file_attributes', 0)"
+                " & S.FILE_ATTRIBUTE_REPARSE_POINT) or S.S_ISLNK(st.st_mode)",
+                "    d = S.S_ISDIR(st.st_mode) and not reparse",
+                "    print(json.dumps({'e': True, 'd': d, 's': st.st_size}))",
+                "except FileNotFoundError:",
+                "    print(json.dumps({'e': False, 'd': False, 's': 0}))",
             ]
         )
         result = await _run_os_env_async(
@@ -796,10 +813,8 @@ class CallerProcessFilesystem:
         try:
             info = _json.loads(result.get("stdout", "{}"))
         except _json.JSONDecodeError as exc:
-            raise FilesystemPathNotFound(
-                f"Path {validated!r} not found",
-            ) from exc
-        return info.get("s", 0), info.get("d", False)
+            raise FilesystemPathNotFound(f"Path {validated!r} not found") from exc
+        return bool(info.get("e", False)), bool(info.get("d", False)), int(info.get("s", 0))
 
     async def _check_dir_empty(self, validated: str) -> bool:
         """Check if a directory is empty via the sandboxed helper.
@@ -845,7 +860,11 @@ class CallerProcessFilesystem:
         if not validated:
             raise InvalidPath("Cannot delete the environment root")
 
-        size, is_dir = await self._stat_via_shell(validated)
+        # lstat, not stat: a broken symlink/junction still exists as a link and
+        # must be deletable, where os.stat would follow it and report "missing".
+        exists, is_dir, size = await self._lstat_kind_via_shell(validated)
+        if not exists:
+            raise FilesystemPathNotFound(f"Path {path!r} not found")
 
         if is_dir and not recursive and await self._check_dir_empty(validated):
             raise DirectoryNotEmpty(

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -366,7 +366,9 @@ class CallerProcessFilesystem:
             raw = []
         for item in raw:
             name = item["n"]
-            rel = os.path.join(validated, name) if validated else name
+            # Always forward-slash: the API contract, glob logic, and web UI
+            # use POSIX-separated relative paths (os.path.join uses \ on Windows).
+            rel = f"{validated}/{name}" if validated else name
             entry_type = "directory" if item["t"] == "d" else "file"
             entries.append(
                 FilesystemEntry(
@@ -458,13 +460,13 @@ class CallerProcessFilesystem:
                 "    # Prune excluded subtrees (e.g. node_modules) from the walk.",
                 "    kept = []",
                 "    for d in sorted(dirnames):",
-                "        dp = os.path.normpath(os.path.join(dirpath, d))",
+                "        dp = os.path.normpath(os.path.join(dirpath, d)).replace(os.sep, '/')",
                 "        if any(r.match(dp) for r in exc):",
                 "            continue",
                 "        kept.append(d)",
                 "    dirnames[:] = kept",
                 "    for fname in sorted(filenames):",
-                "        p = os.path.normpath(os.path.join(dirpath, fname))",
+                "        p = os.path.normpath(os.path.join(dirpath, fname)).replace(os.sep, '/')",
                 "        if exc and any(r.match(p) for r in exc):",
                 "            continue",
                 "        if inc and not any(r.match(p) for r in inc):",
@@ -856,7 +858,12 @@ class CallerProcessFilesystem:
                 [
                     "import os, shutil",
                     f"p = {_json.dumps(validated)}",
-                    "if os.path.isdir(p):",
+                    # A directory symlink follows as isdir but shutil.rmtree
+                    # refuses it; remove the link itself (os.rmdir for a dir
+                    # symlink, os.remove for a file symlink) like `rm` would.
+                    "if os.path.islink(p):",
+                    "    (os.rmdir if os.path.isdir(p) else os.remove)(p)",
+                    "elif os.path.isdir(p):",
                     "    shutil.rmtree(p)",
                     "elif os.path.exists(p):",
                     "    os.remove(p)",

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -212,7 +212,10 @@ def _validate_path(relative_path: str) -> str:
         raise InvalidPath("Path traversal is not allowed")
     if normalized == ".":
         return ""
-    return normalized
+    # Return POSIX separators: os.path.normpath yields '\' on Windows, but the
+    # API contract, glob logic, and web UI all use '/', and Windows os.* calls
+    # accept '/' equally. This keeps stat/write/edit/list output consistent.
+    return normalized.replace(os.sep, "/")
 
 
 def _entry_from_stat(
@@ -856,16 +859,23 @@ class CallerProcessFilesystem:
 
             _del_script = "\n".join(
                 [
-                    "import os, shutil",
+                    "import os, shutil, stat",
                     f"p = {_json.dumps(validated)}",
-                    # A directory symlink follows as isdir but shutil.rmtree
-                    # refuses it; remove the link itself (os.rmdir for a dir
-                    # symlink, os.remove for a file symlink) like `rm` would.
-                    "if os.path.islink(p):",
-                    "    (os.rmdir if os.path.isdir(p) else os.remove)(p)",
-                    "elif os.path.isdir(p):",
+                    # Reparse points (symlinks AND junctions) must be removed as
+                    # the link itself, not followed: shutil.rmtree refuses a link,
+                    # and following a junction would wrongly delete the target's
+                    # contents. os.path.islink misses junctions, so key off the
+                    # reparse attribute from lstat (which also covers broken
+                    # links). attrs == 0 means already gone (tolerate like rm -f).
+                    "try:",
+                    "    attrs = os.lstat(p).st_file_attributes",
+                    "except FileNotFoundError:",
+                    "    attrs = 0",
+                    "if attrs & stat.FILE_ATTRIBUTE_REPARSE_POINT:",
+                    "    (os.rmdir if attrs & stat.FILE_ATTRIBUTE_DIRECTORY else os.remove)(p)",
+                    "elif attrs & stat.FILE_ATTRIBUTE_DIRECTORY:",
                     "    shutil.rmtree(p)",
-                    "elif os.path.exists(p):",
+                    "elif attrs:",
                     "    os.remove(p)",
                 ]
             )

--- a/omnigent/runner/identity.py
+++ b/omnigent/runner/identity.py
@@ -124,13 +124,13 @@ def load_or_create_runner_id(path: Path) -> str:
     :raises RuntimeError: If the cache file exists but is empty.
     """
     if path.exists():
-        runner_id = path.read_text().strip()
+        runner_id = path.read_text(encoding="utf-8").strip()
         if not runner_id:
             raise RuntimeError(f"runner id file is empty: {path}")
         return runner_id
     path.parent.mkdir(parents=True, exist_ok=True)
     runner_id = f"runner_{uuid.uuid4().hex}"
-    path.write_text(runner_id)
+    path.write_text(runner_id, encoding="utf-8")
     return runner_id
 
 

--- a/omnigent/runtime/credentials/databricks.py
+++ b/omnigent/runtime/credentials/databricks.py
@@ -331,7 +331,8 @@ def _try_resolve_from_cfg(profile: str | None, cfg_path: Path) -> WorkspaceCreds
         return None
 
     config = configparser.ConfigParser()
-    config.read(cfg_path)
+    # Vendor-written cfg: read at the locale default, symmetric with writers.
+    config.read(cfg_path, encoding="locale")
 
     if profile is not None:
         # _read_section raises _SectionPresentButInvalid when the

--- a/omnigent/runtime/credentials/databricks.py
+++ b/omnigent/runtime/credentials/databricks.py
@@ -53,6 +53,8 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from omnigent._encoding import detect_encoding
+
 _logger = logging.getLogger(__name__)
 
 # Default location of the Databricks CLI config file when
@@ -331,8 +333,8 @@ def _try_resolve_from_cfg(profile: str | None, cfg_path: Path) -> WorkspaceCreds
         return None
 
     config = configparser.ConfigParser()
-    # Vendor-written cfg: read at the locale default, symmetric with writers.
-    config.read(cfg_path, encoding="locale")
+    # Vendor-written cfg (CLI emits UTF-8): detect UTF-8 first, locale fallback.
+    config.read(cfg_path, encoding=detect_encoding(cfg_path))
 
     if profile is not None:
         # _read_section raises _SectionPresentButInvalid when the

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1572,7 +1572,7 @@ def _load_global_auth() -> ApiKeyAuth | DatabricksAuth | None:
     if not path.exists():
         return None
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             raw: dict[str, Any] = yaml.safe_load(f) or {}
     except Exception:
         return None

--- a/omnigent/server/accounts_secret.py
+++ b/omnigent/server/accounts_secret.py
@@ -62,7 +62,7 @@ def load_or_generate_cookie_secret(data_dir: str | os.PathLike[str]) -> str:
 
     path = Path(data_dir) / _SECRET_FILENAME
     if path.exists():
-        existing = path.read_text().strip()
+        existing = path.read_text(encoding="utf-8").strip()
         if existing:
             return existing
 

--- a/omnigent/server/routes/_workspace_validation.py
+++ b/omnigent/server/routes/_workspace_validation.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import secrets
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any
 
 from omnigent.host.frames import HostStatFrame, encode_host_frame
@@ -163,33 +164,38 @@ def _is_relative_cwd(spec_cwd: str | None) -> bool:
     return False
 
 
+def _is_windows_style_path(path: str) -> bool:
+    """Return ``True`` for Windows drive / UNC / backslash paths.
+
+    Used to pick the path flavour for containment checks so a Windows host's
+    realpaths (``C:\\repo``) aren't compared with POSIX ``/`` semantics.
+    """
+    if path.startswith("\\\\") or "\\" in path:
+        return True
+    return len(path) >= 2 and path[0].isalpha() and path[1] == ":"
+
+
 def _is_subpath_of(canonical_workspace: str, canonical_boundary: str) -> bool:
     """
     Return ``True`` when ``canonical_workspace`` equals the
     boundary or is a subdirectory of it.
 
-    Pure string comparison on canonicalized absolute paths — both
-    inputs are realpaths returned by ``host.stat``, so symlinks
-    are already resolved and ``..`` segments are gone. Without the
-    canonicalization step, this comparison would be unsafe.
+    Both inputs are realpaths returned by ``host.stat`` (symlinks resolved,
+    ``..`` segments gone). Comparison honours the host's path flavour: Windows
+    paths (drive / UNC / backslash) compare case-insensitively and accept both
+    ``\\`` and ``/`` separators; POSIX paths compare case-sensitively. Using
+    ``PurePath.is_relative_to`` compares whole path components, so ``/a/foo``
+    is not treated as a subpath of ``/a/fo`` (no prefix-collision bug).
 
-    :param canonical_workspace: Realpath returned by host.stat for
-        the workspace, e.g. ``"/Users/corey/universe/src/foo"``.
-    :param canonical_boundary: Realpath for the agent's boundary,
-        e.g. ``"/Users/corey/universe"``.
+    :param canonical_workspace: Realpath returned by host.stat for the
+        workspace, e.g. ``"/Users/corey/universe/src/foo"`` or
+        ``"C:\\Users\\corey\\src\\foo"``.
+    :param canonical_boundary: Realpath for the agent's boundary.
     :returns: ``True`` when the workspace is the boundary or
         nested under it.
     """
-    if canonical_workspace == canonical_boundary:
-        return True
-    # Add a trailing separator so ``/a/foo`` is not treated as a
-    # subpath of ``/a/fo`` (prefix collision). ``/`` is the only
-    # separator the host stat returns since ``canonical_path`` is
-    # always absolute.
-    boundary_with_sep = (
-        canonical_boundary if canonical_boundary.endswith("/") else canonical_boundary + "/"
-    )
-    return canonical_workspace.startswith(boundary_with_sep)
+    flavour = PureWindowsPath if _is_windows_style_path(canonical_boundary) else PurePosixPath
+    return flavour(canonical_workspace).is_relative_to(flavour(canonical_boundary))
 
 
 async def validate_workspace(

--- a/omnigent/server/routes/_workspace_validation.py
+++ b/omnigent/server/routes/_workspace_validation.py
@@ -34,6 +34,20 @@ from omnigent.server.host_registry import HostConnection, HostRegistry
 
 _logger = logging.getLogger(__name__)
 
+
+def is_absolute_host_path(path: str) -> bool:
+    """True if ``path`` is absolute on the host — POSIX or Windows.
+
+    Accepts POSIX absolute paths (``/foo``), Windows drive-absolute paths
+    (``C:\\foo`` or ``C:/foo``), and UNC paths (``\\\\server\\share``). The
+    workspace lives on the (possibly native-Windows) host, so a bare
+    ``startswith("/")`` check wrongly rejects every Windows workspace.
+    """
+    if path.startswith(("/", "\\\\", "//")):
+        return True
+    return len(path) >= 3 and path[0].isalpha() and path[1] == ":" and path[2] in ("\\", "/")
+
+
 # Treat these spec cwd values as "relative" — the agent doesn't pin
 # a specific directory and the workspace is unconstrained.
 _RELATIVE_CWD_PLACEHOLDERS: frozenset[str] = frozenset({"", ".", "./"})
@@ -214,11 +228,11 @@ async def validate_workspace(
         The exception message is suitable for surfacing to the
         API caller verbatim.
     """
-    if not workspace.startswith("/"):
+    if not is_absolute_host_path(workspace):
         # Belt-and-suspenders. The Pydantic schema layer also
         # rejects this; pin it here so direct callers (tests,
         # other server-internal paths) can't bypass.
-        raise WorkspaceValidationError("workspace must be an absolute path starting with /")
+        raise WorkspaceValidationError("workspace must be an absolute path")
 
     display_host = host_name_for_errors or host_id
 

--- a/omnigent/server/routes/_workspace_validation.py
+++ b/omnigent/server/routes/_workspace_validation.py
@@ -165,12 +165,14 @@ def _is_relative_cwd(spec_cwd: str | None) -> bool:
 
 
 def _is_windows_style_path(path: str) -> bool:
-    """Return ``True`` for Windows drive / UNC / backslash paths.
+    """Return ``True`` for Windows drive or UNC absolute paths.
 
-    Used to pick the path flavour for containment checks so a Windows host's
-    realpaths (``C:\\repo``) aren't compared with POSIX ``/`` semantics.
+    Detection keys on a drive prefix (``C:``) or UNC prefix (``\\\\``) only. A
+    bare embedded backslash does NOT imply Windows — ``\\`` is a legal character
+    in POSIX filenames, so ``/tmp/a\\b`` is a single-component POSIX path and
+    must not be reparsed with ``\\`` as a separator.
     """
-    if path.startswith("\\\\") or "\\" in path:
+    if path.startswith("\\\\"):
         return True
     return len(path) >= 2 and path[0].isalpha() and path[1] == ":"
 

--- a/omnigent/server/routes/session_mcp_servers.py
+++ b/omnigent/server/routes/session_mcp_servers.py
@@ -477,7 +477,7 @@ def _preserve_keys(
 
 def _read_yaml_mapping(path: Path) -> dict[str, Any]:
     """Read a YAML mapping from disk."""
-    raw = yaml.safe_load(path.read_text())
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
         raise OmnigentError(
             f"YAML file must be a mapping: {path.name}",

--- a/omnigent/server/routes/session_mcp_servers.py
+++ b/omnigent/server/routes/session_mcp_servers.py
@@ -350,7 +350,8 @@ def _replace_mcp_server(
     if location.source == "file":
         next_path = location.path.with_name(f"{body.name}.yaml")
         next_path.write_text(
-            yaml.safe_dump(_body_to_file_yaml(body, location.raw), sort_keys=False)
+            yaml.safe_dump(_body_to_file_yaml(body, location.raw), sort_keys=False),
+            encoding="utf-8",
         )
         if next_path != location.path:
             location.path.unlink()

--- a/omnigent/server/routes/session_mcp_servers.py
+++ b/omnigent/server/routes/session_mcp_servers.py
@@ -336,7 +336,9 @@ def _write_new_mcp_server(root: Path, body: UpsertMCPServerRequest) -> None:
     mcp_dir = root / "tools" / "mcp"
     mcp_dir.mkdir(parents=True, exist_ok=True)
     path = mcp_dir / f"{body.name}.yaml"
-    path.write_text(yaml.safe_dump(_body_to_file_yaml(body, {}), sort_keys=False))
+    path.write_text(
+        yaml.safe_dump(_body_to_file_yaml(body, {}), sort_keys=False), encoding="utf-8"
+    )
 
 
 def _replace_mcp_server(
@@ -366,7 +368,7 @@ def _delete_mcp_server(location: _McpLocation, target_name: str) -> None:
     tools = config.get("tools")
     if isinstance(tools, dict):
         tools.pop(target_name, None)
-    location.path.write_text(yaml.safe_dump(config, sort_keys=False))
+    location.path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
 
 
 def _find_mcp_location(root: Path, name: str) -> _McpLocation | None:
@@ -419,7 +421,7 @@ def _write_inline_server(
     if old_name is not None and old_name != body.name:
         tools.pop(old_name, None)
     tools[body.name] = _body_to_inline_yaml(body, existing)
-    config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
 
 
 def _body_to_file_yaml(

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -6573,6 +6573,7 @@ async def _validate_session_workspace(
     """
     from omnigent.server.routes._workspace_validation import (
         WorkspaceValidationError,
+        is_absolute_host_path,
         validate_workspace,
     )
 
@@ -6581,9 +6582,9 @@ async def _validate_session_workspace(
             "workspace required when host_id is set",
             code=ErrorCode.INVALID_INPUT,
         )
-    if not workspace.startswith("/"):
+    if not is_absolute_host_path(workspace):
         raise OmnigentError(
-            "workspace must be an absolute path starting with /",
+            "workspace must be an absolute path",
             code=ErrorCode.INVALID_INPUT,
         )
     if agent_cache is None:

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -229,7 +229,7 @@ def is_omnigent_yaml(path: Path) -> bool:
     if path.suffix.lower() not in {".yaml", ".yml"}:
         return False
     try:
-        raw = yaml.safe_load(path.read_text())
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     except yaml.YAMLError:
         return False
     if not isinstance(raw, dict):
@@ -269,7 +269,7 @@ def diagnose_yaml_rejection(path: Path) -> str:
     if path.suffix.lower() not in {".yaml", ".yml"}:
         return f"file extension is {path.suffix!r}, expected '.yaml' or '.yml'"
     try:
-        raw = yaml.safe_load(path.read_text())
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     except yaml.YAMLError as exc:
         # Strip trailing whitespace so the message stays one line —
         # PyYAML embeds the source location in its error string,
@@ -377,7 +377,7 @@ def load_omnigent_yaml(
     # read resolves booleans the same way load_agent_def's YAML
     # parsing did — both loaders keep on/off as plain strings
     # instead of the YAML 1.1 bool aliases.
-    raw = _yaml.load(path.read_text(), Loader=_OmnigentYamlLoader) or {}
+    raw = _yaml.load(path.read_text(encoding="utf-8"), Loader=_OmnigentYamlLoader) or {}
     if not isinstance(raw, dict):
         raw = {}
     spec = agent_def_to_agent_spec(agent_def, raw_yaml=raw)

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -2125,7 +2125,10 @@ def _parse_skill(skill_md: Path) -> SkillSpec:
         ``strict=False``) can catch them uniformly.
     """
     try:
-        text = skill_md.read_text()
+        # SKILL.md files are UTF-8 by convention; without an explicit encoding
+        # Path.read_text() uses the platform locale (cp1252 on Windows) and
+        # rejects perfectly valid UTF-8 skill files.
+        text = skill_md.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         # UnicodeDecodeError (a non-UTF-8 SKILL.md) is a ValueError, not an
         # OSError — funnel it through OmnigentError too so the lenient

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -182,7 +182,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
     if not config_path.exists():
         raise FileNotFoundError(f"config.yaml not found in {root}")
 
-    raw = yaml.load(config_path.read_text(), Loader=_ConfigYamlLoader)
+    raw = yaml.load(config_path.read_text(encoding="utf-8"), Loader=_ConfigYamlLoader)
     if not isinstance(raw, dict):
         raise OmnigentError(
             f"config.yaml must be a YAML mapping, got {type(raw).__name__}",
@@ -1802,7 +1802,7 @@ def _read_contained_file(root: Path, value: str) -> str | None:
     try:
         resolved = candidate.resolve()
         if resolved.is_relative_to(root.resolve()) and resolved.is_file():
-            return resolved.read_text()
+            return resolved.read_text(encoding="utf-8")
     except OSError:
         # Path too long or invalid characters — treat as inline text.
         pass
@@ -1843,7 +1843,7 @@ def _resolve_instructions(root: Path, raw_value: object) -> str | None:
         candidate = root / filename
         try:
             if candidate.is_file():
-                return candidate.read_text()
+                return candidate.read_text(encoding="utf-8")
         except OSError:
             pass
     return None
@@ -2396,7 +2396,7 @@ def _discover_mcp_servers(
         return []
     servers: list[MCPServerConfig] = []
     for yaml_file in sorted(mcp_dir.glob("*.yaml")):
-        raw = yaml.safe_load(yaml_file.read_text())
+        raw = yaml.safe_load(yaml_file.read_text(encoding="utf-8"))
         if not isinstance(raw, dict):
             raise OmnigentError(
                 f"MCP config must be a YAML mapping: {yaml_file}",

--- a/omnigent/spec/skill_sources.py
+++ b/omnigent/spec/skill_sources.py
@@ -121,7 +121,7 @@ def resolve_harness_skills(ctx: SkillSourceContext, harness: str | None) -> list
 def _read_json(path: Path) -> dict[str, Any] | None:
     """Best-effort JSON read; ``None`` on missing/unreadable/non-dict."""
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
     return data if isinstance(data, dict) else None

--- a/omnigent/tools/builtins/read_skill_file.py
+++ b/omnigent/tools/builtins/read_skill_file.py
@@ -155,4 +155,4 @@ def _read_file_safely(
     if not resolved.is_file():
         return f"Error: file not found: {rel_path}"
 
-    return resolved.read_text()
+    return resolved.read_text(encoding="utf-8")

--- a/omnigent/tools/local.py
+++ b/omnigent/tools/local.py
@@ -475,7 +475,7 @@ class LocalPythonTool(Tool):
             (
                 "import sys,json,importlib.util,asyncio,os;"
                 "os.environ['_AP_RESPONSE_MODE']='stdout';"
-                f"exec(open('{_RUNNER_PATH}').read())"
+                f"exec(open('{_RUNNER_PATH}', encoding='utf-8').read())"
             ),
         ]
 
@@ -533,7 +533,7 @@ def _write_srt_settings_file(state_root: str) -> str:
         },
     }
     fd, path = _tempfile.mkstemp(suffix=".srt.json")
-    with os.fdopen(fd, "w") as f:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
         json.dump(settings, f)
     return path
 

--- a/omnigent/update_check.py
+++ b/omnigent/update_check.py
@@ -447,7 +447,8 @@ def _index_from_pip_config() -> str:
     for path in candidates:
         parser = configparser.ConfigParser(interpolation=None)
         try:
-            if not parser.read(path):
+            # pip.conf is an external, locale-defined config; read it as pip does.
+            if not parser.read(path, encoding="locale"):
                 continue
         except (configparser.Error, OSError, UnicodeDecodeError):
             continue
@@ -1171,7 +1172,7 @@ def _safe_read_dist_file(dist: importlib.metadata.Distribution, name: str) -> st
         missing / unreadable / empty.
     """
     try:
-        text = dist.read_text(name)
+        text = dist.read_text(name)  # enc-ok: importlib metadata read_text (no encoding kwarg)
     except (OSError, UnicodeDecodeError):
         return None
     if text is None:

--- a/omnigent/update_check.py
+++ b/omnigent/update_check.py
@@ -47,6 +47,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from omnigent._encoding import detect_encoding
+
 if TYPE_CHECKING:
     # Imported only for type hints; the heavy/optional imports remain lazy
     # at runtime so importing this module stays cheap.
@@ -447,8 +449,9 @@ def _index_from_pip_config() -> str:
     for path in candidates:
         parser = configparser.ConfigParser(interpolation=None)
         try:
-            # pip.conf is an external, locale-defined config; read it as pip does.
-            if not parser.read(path, encoding="locale"):
+            # pip 26.1 reads pip.conf as UTF-8; detect UTF-8 first with a locale
+            # fallback so a valid UTF-8 corporate config isn't silently skipped.
+            if not parser.read(path, encoding=detect_encoding(path)):
                 continue
         except (configparser.Error, OSError, UnicodeDecodeError):
             continue

--- a/omnigent/update_check.py
+++ b/omnigent/update_check.py
@@ -400,7 +400,7 @@ def _index_from_uv_config() -> str:
 
     for path in (_user_config_base() / "uv" / "uv.toml", Path("/etc/uv/uv.toml")):
         try:
-            data = tomllib.loads(path.read_text())
+            data = tomllib.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             continue
         legacy = data.get("index-url")
@@ -697,7 +697,7 @@ def _read_cache() -> _CacheEntry | None:
         JSON, otherwise ``None``.
     """
     try:
-        raw = _CACHE_FILE.read_text()
+        raw = _CACHE_FILE.read_text(encoding="utf-8")
         data = json.loads(raw)
         return _CacheEntry(
             last_check_epoch=float(data["last_check_epoch"]),

--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -229,7 +229,7 @@ class WorkspaceReader:
         multi-GB file in the viewer can't OOM the host process.
         """
         try:
-            with resolved.open("rb") as fh:
+            with resolved.open(mode="rb") as fh:
                 # One extra byte lets us detect (and flag) truncation
                 # without loading the rest of a large file into memory.
                 capped = fh.read(_MAX_READ_BYTES + 1)
@@ -435,7 +435,7 @@ class WorkspaceReader:
             try:
                 # Bounded read (like _read_file) so a huge changed file can't
                 # OOM the host; the diff view caps at _MAX_READ_BYTES anyway.
-                with resolved.open("rb") as fh:
+                with resolved.open(mode="rb") as fh:
                     raw = fh.read(_MAX_READ_BYTES)
                 after = raw.decode("utf-8", errors="replace")
             except OSError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -427,6 +427,12 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
+# PLW1514 (unspecified-encoding) is still a preview rule; opt into it
+# explicitly so every open()/read_text()/write_text() must name an encoding
+# (Windows defaults to cp1252 and mojibakes UTF-8), without enabling the rest
+# of Ruff's preview rules.
+preview = true
+explicit-preview-rules = true
 # ``E``/``F``  — pycodestyle + pyflakes baseline
 # ``I``        — import sorting
 # ``UP``       — pyupgrade (modernize syntax)
@@ -440,7 +446,7 @@ extend-exclude = [
 # ``PIE``      — flake8-pie (misc correctness + style)
 # ``RUF``      — ruff-specific (sorted ``__all__``, dangling asyncio
 #                tasks, unused noqa, ...)
-select = ["E", "F", "I", "UP", "ARG", "BLE", "B", "SIM", "RET", "C4", "PIE", "RUF"]
+select = ["E", "F", "I", "UP", "ARG", "BLE", "B", "SIM", "RET", "C4", "PIE", "RUF", "PLW1514"]
 ignore = [
     # ARG003 (unused class-method args): too noisy on ABC-subclass signatures
     # where the arg is required by the interface contract.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -427,12 +427,6 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-# PLW1514 (unspecified-encoding) is still a preview rule; opt into it
-# explicitly so every open()/read_text()/write_text() must name an encoding
-# (Windows defaults to cp1252 and mojibakes UTF-8), without enabling the rest
-# of Ruff's preview rules.
-preview = true
-explicit-preview-rules = true
 # ``E``/``F``  — pycodestyle + pyflakes baseline
 # ``I``        — import sorting
 # ``UP``       — pyupgrade (modernize syntax)
@@ -446,7 +440,7 @@ explicit-preview-rules = true
 # ``PIE``      — flake8-pie (misc correctness + style)
 # ``RUF``      — ruff-specific (sorted ``__all__``, dangling asyncio
 #                tasks, unused noqa, ...)
-select = ["E", "F", "I", "UP", "ARG", "BLE", "B", "SIM", "RET", "C4", "PIE", "RUF", "PLW1514"]
+select = ["E", "F", "I", "UP", "ARG", "BLE", "B", "SIM", "RET", "C4", "PIE", "RUF"]
 ignore = [
     # ARG003 (unused class-method args): too noisy on ABC-subclass signatures
     # where the arg is required by the interface contract.

--- a/sdks/python-client/omnigent_client/tools/_state.py
+++ b/sdks/python-client/omnigent_client/tools/_state.py
@@ -87,7 +87,7 @@ class ToolState:
         path = self._path_for(key)
         if not path.exists():
             return default
-        with path.open("r") as f:
+        with path.open("r", encoding="utf-8") as f:
             # Shared lock: allow parallel reads, block concurrent writers
             # briefly so we see a complete JSON payload.
             _lock_file(f, exclusive=False)
@@ -110,7 +110,7 @@ class ToolState:
         # Write through a temp file + rename so a reader never sees
         # a half-written JSON payload even without a lock.
         tmp = path.with_suffix(_KEY_SUFFIX + ".tmp")
-        with tmp.open("w") as f:
+        with tmp.open("w", encoding="utf-8") as f:
             json.dump(value, f)
         tmp.replace(path)
 
@@ -182,7 +182,7 @@ class ToolState:
         # we seek to 0 before read. Opening with ``r+`` would fail
         # when the file doesn't exist yet, which is a common first-
         # call case for a tool.
-        with thread_lock, path.open("a+") as f:
+        with thread_lock, path.open("a+", encoding="utf-8") as f:
             _lock_file(f, exclusive=True)
             try:
                 value = _read_transaction_value(f, default)

--- a/tests/_encoding_scan.py
+++ b/tests/_encoding_scan.py
@@ -2,12 +2,17 @@
 
 Ruff's PLW1514 and PEP 597's EncodingWarning both depend on the receiver's type
 being inferable / the path being exercised. This scan instead matches the *call*
-— any ``open``/``Path.open``/``read_text``/``write_text`` in text mode without an
-explicit ``encoding=`` — regardless of the receiver's static type. It is the
-structural guard that owned-text reads/writes must name an encoding.
+— regardless of the receiver's static type — for every way omnigent opens text:
 
-Used both as an enumerator (``python tests/_encoding_scan.py``) and by
-``tests/test_file_encoding.py`` as an enforced guard.
+* ``open(...)`` / ``Path.open(...)`` / ``.read_text(...)`` / ``.write_text(...)``
+* ``os.fdopen(...)`` — a text stream layered over a raw fd
+* ``ConfigParser.read(...)`` — decodes the named file with the given encoding
+* ``open(...)`` embedded inside a string literal that is run as a Python
+  one-liner (``python -c`` / ``exec(open(...))``)
+
+Any of those in text mode without an explicit ``encoding=`` is a violation. This
+is the structural guard behind ``tests/test_file_encoding.py``; it also runs as
+an enumerator (``python tests/_encoding_scan.py``).
 """
 
 from __future__ import annotations
@@ -16,9 +21,14 @@ import ast
 from pathlib import Path
 
 _METHODS = {"read_text", "write_text", "open"}
-# Not filesystem-path text I/O: importlib.metadata Distribution.read_text(name)
-# reads packaged metadata by filename and decodes internally.
-ALLOWLIST = {"omnigent/update_check.py:1174"}
+# Inline escape hatch for a call that genuinely can't name an encoding (e.g.
+# importlib.metadata's Distribution.read_text, which has no encoding parameter).
+# Preferred over a line-number allowlist, which drifts onto the wrong line on
+# any edit above it. Annotate the call's line with ``# enc-ok: <reason>``.
+_SUPPRESS = "# enc-ok"
+# Line-number escape hatch of last resort (``"relpath:line"``); empty by design —
+# use the inline ``# enc-ok`` pragma instead so suppressions can't drift silently.
+ALLOWLIST: frozenset[str] = frozenset()
 # ``X.open(...)`` on these modules is not a text-file open (binary archives), so
 # an ``encoding`` argument is neither expected nor valid.
 _NON_FILE_OPEN_RECEIVERS = {
@@ -32,6 +42,11 @@ _NON_FILE_OPEN_RECEIVERS = {
     "socket",
     "subprocess",
 }
+_CONFIGPARSER_CTORS = {"ConfigParser", "RawConfigParser", "SafeConfigParser"}
+
+# Only str literals containing one of these are candidate embedded scripts —
+# a cheap prefilter before the (costlier) ``ast.parse`` gate.
+_EMBEDDED_HINTS = ("open(", "read_text(", "write_text(")
 
 
 def _has_encoding(call: ast.Call) -> bool:
@@ -41,12 +56,11 @@ def _has_encoding(call: ast.Call) -> bool:
 def _mode_is_binary(call: ast.Call, mode_argindex: int) -> bool:
     """True when a literal ``mode`` argument opens the file in binary."""
     args = call.args
-    if len(args) > mode_argindex and isinstance(args[mode_argindex], ast.Constant):
+    if len(args) > mode_argindex >= 0 and isinstance(args[mode_argindex], ast.Constant):
         val = args[mode_argindex].value
         if isinstance(val, str) and "b" in val:
             return True
-    # keyword mode=
-    for k in call.keywords:
+    for k in call.keywords:  # keyword mode=
         if k.arg == "mode" and isinstance(k.value, ast.Constant):
             val = k.value.value
             if isinstance(val, str) and "b" in val:
@@ -54,16 +68,72 @@ def _mode_is_binary(call: ast.Call, mode_argindex: int) -> bool:
     return False
 
 
-def find_violations(source: str) -> list[tuple[int, str]]:
-    """Return ``(lineno, call_name)`` for each unencoded text I/O call."""
+def _is_configparser_ctor(func: ast.expr) -> bool:
+    """True for ``ConfigParser()`` / ``configparser.RawConfigParser()`` etc."""
+    if isinstance(func, ast.Name):
+        return func.id in _CONFIGPARSER_CTORS
+    if isinstance(func, ast.Attribute):
+        return func.attr in _CONFIGPARSER_CTORS
+    return False
+
+
+def _configparser_names(tree: ast.AST) -> set[str]:
+    """Names bound to a ConfigParser instance anywhere in the module."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets, value = [node.target], node.value
+        else:
+            continue
+        if isinstance(value, ast.Call) and _is_configparser_ctor(value.func):
+            names.update(t.id for t in targets if isinstance(t, ast.Name))
+    return names
+
+
+def _is_configparser_read(func: ast.Attribute, names: set[str]) -> bool:
+    """True for ``cfg.read(...)`` / ``configparser.ConfigParser().read(...)``."""
+    if func.attr != "read":
+        return False
+    recv = func.value
+    if isinstance(recv, ast.Name) and recv.id in names:
+        return True
+    return isinstance(recv, ast.Call) and _is_configparser_ctor(recv.func)
+
+
+def _literal_text(node: ast.AST) -> str | None:
+    """Reconstruct a str constant or f-string (interpolations -> ``_X_``)."""
+    if isinstance(node, ast.Constant):
+        return node.value if isinstance(node.value, str) else None
+    if isinstance(node, ast.JoinedStr):
+        return "".join(
+            v.value if isinstance(v, ast.Constant) and isinstance(v.value, str) else "_X_"
+            for v in node.values
+        )
+    return None
+
+
+def _call_violations(tree: ast.AST, cfg_names: set[str]) -> list[tuple[int, str]]:
+    """Unencoded text I/O among the *Call* nodes of a single parsed tree."""
     out: list[tuple[int, str]] = []
-    tree = ast.parse(source)
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         func = node.func
         if isinstance(func, ast.Name) and func.id == "open":
             name, mode_idx = "open", 1
+        elif (
+            isinstance(func, ast.Attribute)
+            and func.attr == "fdopen"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "os"
+        ):
+            name, mode_idx = "os.fdopen", 1
+        elif isinstance(func, ast.Attribute) and _is_configparser_read(func, cfg_names):
+            if not _has_encoding(node):
+                out.append((node.lineno, "ConfigParser.read"))
+            continue
         elif isinstance(func, ast.Attribute) and func.attr in _METHODS:
             if (
                 func.attr == "open"
@@ -75,22 +145,58 @@ def find_violations(source: str) -> list[tuple[int, str]]:
             mode_idx = 0 if func.attr == "open" else -1
         else:
             continue
-        if _has_encoding(node):
-            continue
-        if mode_idx >= 0 and _mode_is_binary(node, mode_idx):
+        if _has_encoding(node) or _mode_is_binary(node, mode_idx):
             continue
         out.append((node.lineno, name))
     return out
 
 
-def scan_package(pkg: Path, allow: set[str]) -> list[str]:
+def find_violations(source: str) -> list[tuple[int, str]]:
+    """Return ``(lineno, call_name)`` for each unencoded text I/O call.
+
+    Covers direct calls plus ``open()`` embedded in a string literal that is run
+    as Python (``python -c`` / ``exec(open(...))``). Embedded candidates are
+    gated on ``ast.parse`` succeeding, so docstring prose and non-Python
+    templates (e.g. generated JS) are excluded rather than false-flagged.
+    """
+    tree = ast.parse(source)
+    out = _call_violations(tree, _configparser_names(tree))
+
+    # Constants nested inside an f-string are reconstructed as part of that
+    # f-string; skip them so a half-open interpolated fragment isn't parsed alone.
+    joinedstr_children = {
+        id(child)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.JoinedStr)
+        for child in ast.walk(node)
+        if child is not node
+    }
+    for node in ast.walk(tree):
+        if id(node) in joinedstr_children:
+            continue
+        text = _literal_text(node)
+        if text is None or not any(h in text for h in _EMBEDDED_HINTS):
+            continue
+        try:
+            sub = ast.parse(text)
+        except SyntaxError:
+            continue  # not Python (prose, JS, a fragment) — not an embedded script
+        if _call_violations(sub, _configparser_names(sub)):
+            out.append((node.lineno, "open(embedded)"))
+    return out
+
+
+def scan_package(pkg: Path, allow: frozenset[str] | set[str] = ALLOWLIST) -> list[str]:
     """Return ``"relpath:line call"`` for every violation under *pkg*."""
     hits: list[str] = []
     for f in sorted(pkg.rglob("*.py")):
+        source = f.read_text(encoding="utf-8")
+        lines = source.splitlines()
         rel = f.relative_to(pkg.parent).as_posix()
-        for lineno, name in find_violations(f.read_text(encoding="utf-8")):
+        for lineno, name in find_violations(source):
             key = f"{rel}:{lineno}"
-            if key in allow:
+            line = lines[lineno - 1] if 0 <= lineno - 1 < len(lines) else ""
+            if key in allow or _SUPPRESS in line:
                 continue
             hits.append(f"{key} {name}")
     return hits

--- a/tests/_encoding_scan.py
+++ b/tests/_encoding_scan.py
@@ -45,24 +45,41 @@ _NON_FILE_OPEN_RECEIVERS = {
 # provable as binary) must name an encoding. Matched by *import binding*, not by
 # literal receiver name, so an alias (``import gzip as gz``) is caught and an
 # unrelated ``gzip = Path(...)`` is not misread as the module.
-_COMPRESSED_MODULES = {"gzip", "bz2", "lzma"}
-_TEXT_OPEN_MODULES = {"builtins", "codecs", "io"}
+_COMPRESSED_ENCODING_INDEX = {"gzip": 3, "bz2": 3, "lzma": None}
+_COMPRESSED_MODULES = set(_COMPRESSED_ENCODING_INDEX)
+_TEXT_OPEN_ENCODING_INDEX = {"builtins": 3, "codecs": 2, "io": 3}
+_TEXT_OPEN_MODULES = set(_TEXT_OPEN_ENCODING_INDEX)
 _CONFIGPARSER_CTORS = {"ConfigParser", "RawConfigParser", "SafeConfigParser"}
 
 # Only str literals containing one of these are candidate embedded scripts —
 # a cheap prefilter before the (costlier) ``ast.parse`` gate.
 _EMBEDDED_HINTS = ("open", "read_text", "write_text")
+_MISSING = object()
 
 
-def _has_encoding(call: ast.Call) -> bool:
+def _positional_arg(call: ast.Call, index: int) -> ast.expr | object:
+    """Return a statically positioned argument, or ``_MISSING`` if shifted."""
+    if index < 0 or len(call.args) <= index:
+        return _MISSING
+    if any(isinstance(value, ast.Starred) for value in call.args[: index + 1]):
+        return _MISSING
+    return call.args[index]
+
+
+def _has_encoding(call: ast.Call, positional_index: int | None = None) -> bool:
     """True only when a *real* encoding is named.
 
     ``encoding=None`` selects the platform default codec — identical to omitting
-    the argument — so it is treated as a violation, not a fix.
+    the argument for text-default openers — so it is treated as a violation, not
+    a fix. ``positional_index`` is the zero-based signature position for the
+    specific opener being checked.
     """
     for k in call.keywords:
         if k.arg == "encoding":
             return not (isinstance(k.value, ast.Constant) and k.value.value is None)
+    if positional_index is not None:
+        value = _positional_arg(call, positional_index)
+        return not (value is _MISSING or (isinstance(value, ast.Constant) and value.value is None))
     return False
 
 
@@ -88,9 +105,9 @@ def _mode_is_binary(call: ast.Call, mode_argindex: int) -> bool:
             and "b" in value
         )
 
-    args = call.args
-    if len(args) > mode_argindex >= 0 and isinstance(args[mode_argindex], ast.Constant):
-        if is_binary_mode(args[mode_argindex].value):
+    value = _positional_arg(call, mode_argindex)
+    if isinstance(value, ast.Constant):
+        if is_binary_mode(value.value):
             return True
     for k in call.keywords:  # keyword mode=
         if k.arg == "mode" and isinstance(k.value, ast.Constant):
@@ -101,7 +118,7 @@ def _mode_is_binary(call: ast.Call, mode_argindex: int) -> bool:
 
 def _mode_present(call: ast.Call, mode_argindex: int) -> bool:
     """True when a ``mode`` argument is supplied (positionally or by keyword)."""
-    if mode_argindex >= 0 and len(call.args) > mode_argindex:
+    if _positional_arg(call, mode_argindex) is not _MISSING:
         return True
     return any(k.arg == "mode" for k in call.keywords)
 
@@ -308,7 +325,7 @@ def _callable_assignment_aliases(
 
 def _compressed_bindings(
     tree: ast.AST,
-) -> tuple[set[str], set[str], set[str], set[str]]:
+) -> tuple[dict[str, int | None], dict[str, int | None], set[str], set[str]]:
     """Return stable and ambiguous bindings for gzip/bz2/lzma openers.
 
     The result is ``(modules, funcs, ambiguous_modules, ambiguous_funcs)``.
@@ -316,29 +333,54 @@ def _compressed_bindings(
     with any conflicting binding is never discarded: it becomes ambiguous and
     its calls fail closed by requiring an explicit encoding.
     """
-    direct_modules: set[str] = set()
-    direct_funcs: set[str] = set()
+    module_positions: dict[str, set[int | None]] = {}
+    func_positions: dict[str, set[int | None]] = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                if alias.name.split(".", 1)[0] in _COMPRESSED_MODULES:
-                    direct_modules.add(_import_bound_name(alias))
+                module = alias.name.split(".", 1)[0]
+                if module in _COMPRESSED_MODULES:
+                    module_positions.setdefault(_import_bound_name(alias), set()).add(
+                        _COMPRESSED_ENCODING_INDEX[module]
+                    )
         elif isinstance(node, ast.ImportFrom) and node.module in _COMPRESSED_MODULES:
             for alias in node.names:
                 if alias.name == "open":
-                    direct_funcs.add(alias.asname or alias.name)
+                    func_positions.setdefault(alias.asname or alias.name, set()).add(
+                        _COMPRESSED_ENCODING_INDEX[node.module]
+                    )
 
+    direct_modules = set(module_positions)
+    direct_funcs = set(func_positions)
     alias_modules, alias_funcs = _assignment_aliases(tree, direct_modules, direct_funcs)
     module_candidates = direct_modules | alias_modules
     func_candidates = direct_funcs | alias_funcs
     other = _other_bound_names(tree)
     both = module_candidates & func_candidates
 
-    ambiguous_modules = (module_candidates & other) | both | alias_modules
-    ambiguous_funcs = (func_candidates & other) | both | alias_funcs
-    modules = module_candidates - ambiguous_modules
+    ambiguous_modules = (
+        (module_candidates & other)
+        | both
+        | alias_modules
+        | {name for name, indexes in module_positions.items() if len(indexes) != 1}
+    )
+    ambiguous_funcs = (
+        (func_candidates & other)
+        | both
+        | alias_funcs
+        | {name for name, indexes in func_positions.items() if len(indexes) != 1}
+    )
+    modules = {
+        name: next(iter(indexes))
+        for name, indexes in module_positions.items()
+        if name not in ambiguous_modules
+    }
     # Bare ``open`` always follows the stricter builtin/text-default path.
-    funcs = func_candidates - ambiguous_funcs - {"open"}
+    funcs = {
+        name: next(iter(indexes))
+        for name, indexes in func_positions.items()
+        if name not in ambiguous_funcs and name != "open"
+    }
     ambiguous_funcs.discard("open")
     return modules, funcs, ambiguous_modules, ambiguous_funcs
 
@@ -363,21 +405,27 @@ def _non_file_open_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
 
 def _text_open_bindings(
     tree: ast.AST,
-) -> tuple[set[str], set[str], set[str], set[str]]:
-    """Bindings for modules/functions whose ``open`` uses builtin-style args."""
-    direct_modules: set[str] = set()
+) -> tuple[dict[str, int], dict[str, int], set[str], set[str]]:
+    """Bindings mapped to each text opener's positional encoding index."""
+    module_positions: dict[str, set[int]] = {}
     # Seed the builtin too so ``fopen = open`` cannot evade the strict path.
-    direct_funcs: set[str] = {"open"}
+    func_positions: dict[str, set[int]] = {"open": {3}}
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
                 if alias.name in _TEXT_OPEN_MODULES:
-                    direct_modules.add(_import_bound_name(alias))
+                    module_positions.setdefault(_import_bound_name(alias), set()).add(
+                        _TEXT_OPEN_ENCODING_INDEX[alias.name]
+                    )
         elif isinstance(node, ast.ImportFrom) and node.module in _TEXT_OPEN_MODULES:
             for alias in node.names:
                 if alias.name == "open":
-                    direct_funcs.add(alias.asname or alias.name)
+                    func_positions.setdefault(alias.asname or alias.name, set()).add(
+                        _TEXT_OPEN_ENCODING_INDEX[node.module]
+                    )
 
+    direct_modules = set(module_positions)
+    direct_funcs = set(func_positions)
     alias_modules, alias_funcs = _assignment_aliases(
         tree,
         direct_modules,
@@ -391,11 +439,28 @@ def _text_open_bindings(
         exempt_open_imports=_TEXT_OPEN_MODULES,
     )
     both = module_candidates & func_candidates
-    ambiguous_modules = (module_candidates & other) | both | alias_modules
-    ambiguous_funcs = (func_candidates & other) | both | alias_funcs
-    modules = module_candidates - ambiguous_modules
-    funcs = func_candidates - ambiguous_funcs - {"open"}
-    ambiguous_funcs.discard("open")
+    ambiguous_modules = (
+        (module_candidates & other)
+        | both
+        | alias_modules
+        | {name for name, indexes in module_positions.items() if len(indexes) != 1}
+    )
+    ambiguous_funcs = (
+        (func_candidates & other)
+        | both
+        | alias_funcs
+        | {name for name, indexes in func_positions.items() if len(indexes) != 1}
+    )
+    modules = {
+        name: next(iter(indexes))
+        for name, indexes in module_positions.items()
+        if name not in ambiguous_modules
+    }
+    funcs = {
+        name: next(iter(indexes))
+        for name, indexes in func_positions.items()
+        if name not in ambiguous_funcs and name != "open"
+    }
     return modules, funcs, ambiguous_modules, ambiguous_funcs
 
 
@@ -519,13 +584,29 @@ def _literal_text(node: ast.AST) -> str | None:
     return None
 
 
-def _compressed_open_violation(node: ast.Call, label: str) -> tuple[int, str] | None:
+def _compressed_open_violation(
+    node: ast.Call,
+    label: str,
+    encoding_index: int | None,
+) -> tuple[int, str] | None:
     """A gzip/bz2/lzma open needs an encoding unless it is statically proven safe:
     a bare call or a proven-binary mode stays clean. A dynamic-args call, an
     explicit text mode, or a computed/dynamic mode all require the encoding."""
-    if _has_encoding(node):
+    if _has_encoding(node, encoding_index):
         return None
-    if _has_dynamic_args(node) or (_mode_present(node, 1) and not _mode_is_binary(node, 1)):
+    if _has_dynamic_args(node):
+        return (node.lineno, label)
+    if not _mode_present(node, 1):
+        return None
+    mode: object | None = None
+    if len(node.args) > 1 and isinstance(node.args[1], ast.Constant):
+        mode = node.args[1].value
+    else:
+        for keyword in node.keywords:
+            if keyword.arg == "mode" and isinstance(keyword.value, ast.Constant):
+                mode = keyword.value.value
+                break
+    if mode not in {"r", "rb", "w", "wb", "a", "ab", "x", "xb"}:
         return (node.lineno, label)
     return None
 
@@ -535,14 +616,14 @@ def _call_violations(
     instances: set[str],
     ctor_names: set[str],
     fdopen_names: set[str],
-    comp_modules: set[str],
-    comp_funcs: set[str],
+    comp_modules: dict[str, int | None],
+    comp_funcs: dict[str, int | None],
     ambiguous_comp_modules: set[str],
     ambiguous_comp_funcs: set[str],
     non_file_modules: set[str],
     ambiguous_non_file_modules: set[str],
-    text_open_modules: set[str],
-    text_open_funcs: set[str],
+    text_open_modules: dict[str, int],
+    text_open_funcs: dict[str, int],
     ambiguous_text_open_modules: set[str],
     ambiguous_text_open_funcs: set[str],
 ) -> list[tuple[int, str]]:
@@ -552,11 +633,19 @@ def _call_violations(
         if not isinstance(node, ast.Call):
             continue
         func = node.func
+        # A bare ``open`` whose whole-tree binding is ambiguous (notably
+        # ``codecs.open``, whose positional encoding index differs) cannot use a
+        # guessed positional signature. A keyword codec or proven binary mode is
+        # safe for every candidate binding.
+        if isinstance(func, ast.Name) and func.id in ambiguous_text_open_funcs:
+            if not _has_encoding(node) and not _mode_is_binary(node, 1):
+                out.append((node.lineno, "open(ambiguous text alias)"))
+            continue
         # A bare name spelled ``open`` always takes builtin/text-default
         # semantics, including ``from gzip import open``. This is conservative
         # for gzip's binary default and sound for unrelated builtin calls.
         if isinstance(func, ast.Name) and func.id == "open":
-            name, mode_idx = "open", 1
+            name, mode_idx, encoding_idx = "open", 1, 3
         # Ambiguous compressed aliases never fall through to a guessed receiver
         # signature: requiring an encoding is the fail-closed policy.
         elif isinstance(func, ast.Name) and func.id in ambiguous_comp_funcs:
@@ -581,10 +670,6 @@ def _call_violations(
             if not _has_encoding(node):
                 out.append((node.lineno, f"{func.value.id}.open(ambiguous receiver)"))
             continue
-        elif isinstance(func, ast.Name) and func.id in ambiguous_text_open_funcs:
-            if not _has_encoding(node):
-                out.append((node.lineno, "open(ambiguous text alias)"))
-            continue
         elif (
             isinstance(func, ast.Attribute)
             and func.attr == "open"
@@ -597,7 +682,13 @@ def _call_violations(
         # Compressed openers first (matched by import binding), so a from-import
         # ``open`` alias or aliased module attribute isn't mishandled below.
         elif isinstance(func, ast.Name) and func.id in comp_funcs:
-            if (v := _compressed_open_violation(node, "gzip.open")) is not None:
+            if (
+                v := _compressed_open_violation(
+                    node,
+                    "compressed.open",
+                    comp_funcs[func.id],
+                )
+            ) is not None:
                 out.append(v)
             continue
         elif (
@@ -606,37 +697,53 @@ def _call_violations(
             and isinstance(func.value, ast.Name)
             and func.value.id in comp_modules
         ):
-            if (v := _compressed_open_violation(node, f"{func.value.id}.open")) is not None:
+            if (
+                v := _compressed_open_violation(
+                    node,
+                    f"{func.value.id}.open",
+                    comp_modules[func.value.id],
+                )
+            ) is not None:
                 out.append(v)
             continue
         elif isinstance(func, ast.Name) and func.id in text_open_funcs:
-            name, mode_idx = "open", 1
+            name, mode_idx, encoding_idx = "open", 1, text_open_funcs[func.id]
         elif (
             isinstance(func, ast.Attribute)
             and func.attr == "open"
             and isinstance(func.value, ast.Name)
             and func.value.id in text_open_modules
         ):
-            name, mode_idx = f"{func.value.id}.open", 1
-        elif isinstance(func, ast.Name) and func.id in fdopen_names:
-            name, mode_idx = "os.fdopen", 1  # fdopen / from-os alias
-        elif isinstance(func, ast.Attribute) and func.attr == "fdopen":
-            name, mode_idx = "os.fdopen", 1  # os.fdopen / aliased module.fdopen
+            name = f"{func.value.id}.open"
+            mode_idx, encoding_idx = 1, text_open_modules[func.value.id]
+        elif (isinstance(func, ast.Name) and func.id in fdopen_names) or (
+            isinstance(func, ast.Attribute) and func.attr == "fdopen"
+        ):
+            # An arbitrary ``.fdopen`` receiver does not prove os.fdopen's
+            # positional signature; only shared keywords are sound here.
+            name, mode_idx, encoding_idx = "os.fdopen", 1, None
         elif isinstance(func, ast.Attribute) and _is_configparser_read(
             func, instances, ctor_names
         ):
+            # Tracked names can be rebound, so do not guess a positional
+            # signature for a later ``.read``.
             if not _has_encoding(node):
                 out.append((node.lineno, "ConfigParser.read"))
             continue
         elif isinstance(func, ast.Attribute) and func.attr in _METHODS:
             recv_id = func.value.id if isinstance(func.value, ast.Name) else None
             if func.attr == "open" and recv_id in non_file_modules:
-                continue  # tarfile.open() etc. — binary archive, not text I/O
+                continue
             name = func.attr
-            mode_idx = 0 if func.attr == "open" else -1
+            if func.attr == "open":
+                # An unknown receiver may take a filename first, so only
+                # ``mode=`` proves binary intent across receiver families.
+                mode_idx, encoding_idx = -1, None
+            else:
+                mode_idx, encoding_idx = -1, None
         else:
             continue
-        if _has_encoding(node) or _mode_is_binary(node, mode_idx):
+        if _has_encoding(node, encoding_idx) or _mode_is_binary(node, mode_idx):
             continue
         out.append((node.lineno, name))
     return out

--- a/tests/_encoding_scan.py
+++ b/tests/_encoding_scan.py
@@ -1,0 +1,102 @@
+"""Receiver-independent AST scan for unencoded owned-text I/O.
+
+Ruff's PLW1514 and PEP 597's EncodingWarning both depend on the receiver's type
+being inferable / the path being exercised. This scan instead matches the *call*
+— any ``open``/``Path.open``/``read_text``/``write_text`` in text mode without an
+explicit ``encoding=`` — regardless of the receiver's static type. It is the
+structural guard that owned-text reads/writes must name an encoding.
+
+Used both as an enumerator (``python tests/_encoding_scan.py``) and by
+``tests/test_file_encoding.py`` as an enforced guard.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_METHODS = {"read_text", "write_text", "open"}
+# Not filesystem-path text I/O: importlib.metadata Distribution.read_text(name)
+# reads packaged metadata by filename and decodes internally.
+ALLOWLIST = {"omnigent/update_check.py:1174"}
+# ``X.open(...)`` on these modules is not a text-file open (binary archives), so
+# an ``encoding`` argument is neither expected nor valid.
+_NON_FILE_OPEN_RECEIVERS = {
+    "tarfile",
+    "gzip",
+    "zipfile",
+    "bz2",
+    "lzma",
+    "os",  # os.open -> low-level fd (int), no encoding
+    "webbrowser",  # webbrowser.open -> launches a browser
+    "socket",
+    "subprocess",
+}
+
+
+def _has_encoding(call: ast.Call) -> bool:
+    return any(k.arg == "encoding" for k in call.keywords)
+
+
+def _mode_is_binary(call: ast.Call, mode_argindex: int) -> bool:
+    """True when a literal ``mode`` argument opens the file in binary."""
+    args = call.args
+    if len(args) > mode_argindex and isinstance(args[mode_argindex], ast.Constant):
+        val = args[mode_argindex].value
+        if isinstance(val, str) and "b" in val:
+            return True
+    # keyword mode=
+    for k in call.keywords:
+        if k.arg == "mode" and isinstance(k.value, ast.Constant):
+            val = k.value.value
+            if isinstance(val, str) and "b" in val:
+                return True
+    return False
+
+
+def find_violations(source: str) -> list[tuple[int, str]]:
+    """Return ``(lineno, call_name)`` for each unencoded text I/O call."""
+    out: list[tuple[int, str]] = []
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "open":
+            name, mode_idx = "open", 1
+        elif isinstance(func, ast.Attribute) and func.attr in _METHODS:
+            if (
+                func.attr == "open"
+                and isinstance(func.value, ast.Name)
+                and func.value.id in _NON_FILE_OPEN_RECEIVERS
+            ):
+                continue  # tarfile.open() etc. — binary archive, not text I/O
+            name = func.attr
+            mode_idx = 0 if func.attr == "open" else -1
+        else:
+            continue
+        if _has_encoding(node):
+            continue
+        if mode_idx >= 0 and _mode_is_binary(node, mode_idx):
+            continue
+        out.append((node.lineno, name))
+    return out
+
+
+def scan_package(pkg: Path, allow: set[str]) -> list[str]:
+    """Return ``"relpath:line call"`` for every violation under *pkg*."""
+    hits: list[str] = []
+    for f in sorted(pkg.rglob("*.py")):
+        rel = f.relative_to(pkg.parent).as_posix()
+        for lineno, name in find_violations(f.read_text(encoding="utf-8")):
+            key = f"{rel}:{lineno}"
+            if key in allow:
+                continue
+            hits.append(f"{key} {name}")
+    return hits
+
+
+if __name__ == "__main__":
+    root = Path(__file__).resolve().parents[1] / "omnigent"
+    for h in scan_package(root, ALLOWLIST):
+        print(h)

--- a/tests/_encoding_scan.py
+++ b/tests/_encoding_scan.py
@@ -30,19 +30,19 @@ _SUPPRESS = "# enc-ok"
 # Line-number escape hatch of last resort (``"relpath:line"``); empty by design —
 # use the inline ``# enc-ok`` pragma instead so suppressions can't drift silently.
 ALLOWLIST: frozenset[str] = frozenset()
-# ``X.open(...)`` on these modules is not a text-file open (binary archives), so
-# an ``encoding`` argument is neither expected nor valid.
+# ``X.open(...)`` on these modules is not a text-file open (binary archives / a
+# raw fd / a browser), so an ``encoding`` argument is neither expected nor valid.
 _NON_FILE_OPEN_RECEIVERS = {
     "tarfile",
-    "gzip",
     "zipfile",
-    "bz2",
-    "lzma",
     "os",  # os.open -> low-level fd (int), no encoding
     "webbrowser",  # webbrowser.open -> launches a browser
     "socket",
     "subprocess",
 }
+# ``X.open(...)`` here is text-capable but *binary by default*: a bare call or a
+# binary mode is fine, but an explicit text mode ('t') must name an encoding.
+_BINARY_DEFAULT_OPENERS = {"gzip", "bz2", "lzma"}
 _CONFIGPARSER_CTORS = {"ConfigParser", "RawConfigParser", "SafeConfigParser"}
 
 # Only str literals containing one of these are candidate embedded scripts —
@@ -77,6 +77,42 @@ def _mode_is_binary(call: ast.Call, mode_argindex: int) -> bool:
     return False
 
 
+def _mode_is_text(call: ast.Call, mode_argindex: int) -> bool:
+    """True when a literal ``mode`` argument explicitly requests text ('t')."""
+    args = call.args
+    if len(args) > mode_argindex >= 0 and isinstance(args[mode_argindex], ast.Constant):
+        val = args[mode_argindex].value
+        if isinstance(val, str) and "t" in val:
+            return True
+    for k in call.keywords:
+        if k.arg == "mode" and isinstance(k.value, ast.Constant):
+            val = k.value.value
+            if isinstance(val, str) and "t" in val:
+                return True
+    return False
+
+
+def _fdopen_names(tree: ast.AST) -> set[str]:
+    """Bare names that call ``os.fdopen``: ``fdopen`` and any import alias."""
+    names = {"fdopen"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "os":
+            for a in node.names:
+                if a.name == "fdopen":
+                    names.add(a.asname or a.name)
+    return names
+
+
+def _attr_chain(node: ast.expr) -> str | None:
+    """Render a Name/Attribute reference to a dotted string (``self.cfg``)."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _attr_chain(node.value)
+        return f"{base}.{node.attr}" if base else None
+    return None
+
+
 def _configparser_ctor_names(tree: ast.AST) -> set[str]:
     """Names that construct a ConfigParser: the classes plus any import alias.
 
@@ -101,9 +137,13 @@ def _is_configparser_ctor(func: ast.expr, ctor_names: set[str]) -> bool:
     return False
 
 
-def _configparser_names(tree: ast.AST, ctor_names: set[str]) -> set[str]:
-    """Names bound to a ConfigParser instance anywhere in the module."""
-    names: set[str] = set()
+def _configparser_instances(tree: ast.AST, ctor_names: set[str]) -> set[str]:
+    """Dotted references bound to a ConfigParser instance anywhere in the module.
+
+    Tracks both plain names (``cfg = ConfigParser()``) and attribute targets
+    (``self.cfg = ConfigParser()``), keyed by their dotted chain.
+    """
+    chains: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign):
             targets, value = node.targets, node.value
@@ -112,16 +152,17 @@ def _configparser_names(tree: ast.AST, ctor_names: set[str]) -> set[str]:
         else:
             continue
         if isinstance(value, ast.Call) and _is_configparser_ctor(value.func, ctor_names):
-            names.update(t.id for t in targets if isinstance(t, ast.Name))
-    return names
+            chains.update(c for t in targets if (c := _attr_chain(t)) is not None)
+    return chains
 
 
-def _is_configparser_read(func: ast.Attribute, inst_names: set[str], ctor_names: set[str]) -> bool:
-    """True for ``cfg.read(...)`` / ``configparser.ConfigParser().read(...)``."""
+def _is_configparser_read(func: ast.Attribute, instances: set[str], ctor_names: set[str]) -> bool:
+    """True for ``cfg.read(...)`` / ``self.cfg.read(...)`` / ``ConfigParser().read(...)``."""
     if func.attr != "read":
         return False
     recv = func.value
-    if isinstance(recv, ast.Name) and recv.id in inst_names:
+    chain = _attr_chain(recv)
+    if chain is not None and chain in instances:
         return True
     return isinstance(recv, ast.Call) and _is_configparser_ctor(recv.func, ctor_names)
 
@@ -139,7 +180,7 @@ def _literal_text(node: ast.AST) -> str | None:
 
 
 def _call_violations(
-    tree: ast.AST, inst_names: set[str], ctor_names: set[str]
+    tree: ast.AST, instances: set[str], ctor_names: set[str], fdopen_names: set[str]
 ) -> list[tuple[int, str]]:
     """Unencoded text I/O among the *Call* nodes of a single parsed tree."""
     out: list[tuple[int, str]] = []
@@ -149,23 +190,26 @@ def _call_violations(
         func = node.func
         if isinstance(func, ast.Name) and func.id == "open":
             name, mode_idx = "open", 1
-        elif isinstance(func, ast.Name) and func.id == "fdopen":
-            name, mode_idx = "fdopen", 1  # from os import fdopen
+        elif isinstance(func, ast.Name) and func.id in fdopen_names:
+            name, mode_idx = "os.fdopen", 1  # fdopen / from-os alias
         elif isinstance(func, ast.Attribute) and func.attr == "fdopen":
             name, mode_idx = "os.fdopen", 1  # os.fdopen / aliased module.fdopen
         elif isinstance(func, ast.Attribute) and _is_configparser_read(
-            func, inst_names, ctor_names
+            func, instances, ctor_names
         ):
             if not _has_encoding(node):
                 out.append((node.lineno, "ConfigParser.read"))
             continue
         elif isinstance(func, ast.Attribute) and func.attr in _METHODS:
-            if (
-                func.attr == "open"
-                and isinstance(func.value, ast.Name)
-                and func.value.id in _NON_FILE_OPEN_RECEIVERS
-            ):
+            recv_id = func.value.id if isinstance(func.value, ast.Name) else None
+            if func.attr == "open" and recv_id in _NON_FILE_OPEN_RECEIVERS:
                 continue  # tarfile.open() etc. — binary archive, not text I/O
+            if func.attr == "open" and recv_id in _BINARY_DEFAULT_OPENERS:
+                # gzip/bz2/lzma default to binary; only an explicit text mode
+                # ('t', e.g. "rt"/"wt") needs an encoding.
+                if not _has_encoding(node) and _mode_is_text(node, 1):
+                    out.append((node.lineno, f"{recv_id}.open"))
+                continue
             name = func.attr
             mode_idx = 0 if func.attr == "open" else -1
         else:
@@ -186,7 +230,9 @@ def find_violations(source: str) -> list[tuple[int, str]]:
     """
     tree = ast.parse(source)
     ctor_names = _configparser_ctor_names(tree)
-    out = _call_violations(tree, _configparser_names(tree, ctor_names), ctor_names)
+    out = _call_violations(
+        tree, _configparser_instances(tree, ctor_names), ctor_names, _fdopen_names(tree)
+    )
 
     # Constants nested inside an f-string are reconstructed as part of that
     # f-string; skip them so a half-open interpolated fragment isn't parsed alone.
@@ -210,7 +256,9 @@ def find_violations(source: str) -> list[tuple[int, str]]:
         except SyntaxError:
             continue  # not Python (prose, JS, a fragment) — not an embedded script
         sub_ctor = _configparser_ctor_names(sub)
-        if _call_violations(sub, _configparser_names(sub, sub_ctor), sub_ctor):
+        if _call_violations(
+            sub, _configparser_instances(sub, sub_ctor), sub_ctor, _fdopen_names(sub)
+        ):
             out.append((node.lineno, "open(embedded)"))
     return out
 
@@ -231,11 +279,15 @@ def scan_package(pkg: Path, allow: frozenset[str] | set[str] = ALLOWLIST) -> lis
     return hits
 
 
-# Every first-party package shipped from this repo (each scanned against its own
-# parent so the reported path stays package-relative).
+# Every first-party Python package shipped from this repo (each scanned against
+# its own parent so the reported path stays package-relative).
 def owned_packages() -> list[Path]:
     repo = Path(__file__).resolve().parents[1]
-    return [repo / "omnigent", repo / "sdks" / "python-client" / "omnigent_client"]
+    return [
+        repo / "omnigent",
+        repo / "sdks" / "python-client" / "omnigent_client",
+        repo / "sdks" / "ui" / "omnigent_ui_sdk",
+    ]
 
 
 if __name__ == "__main__":

--- a/tests/_encoding_scan.py
+++ b/tests/_encoding_scan.py
@@ -46,11 +46,12 @@ _NON_FILE_OPEN_RECEIVERS = {
 # literal receiver name, so an alias (``import gzip as gz``) is caught and an
 # unrelated ``gzip = Path(...)`` is not misread as the module.
 _COMPRESSED_MODULES = {"gzip", "bz2", "lzma"}
+_TEXT_OPEN_MODULES = {"builtins", "codecs", "io"}
 _CONFIGPARSER_CTORS = {"ConfigParser", "RawConfigParser", "SafeConfigParser"}
 
 # Only str literals containing one of these are candidate embedded scripts —
 # a cheap prefilter before the (costlier) ``ast.parse`` gate.
-_EMBEDDED_HINTS = ("open(", "read_text(", "write_text(")
+_EMBEDDED_HINTS = ("open", "read_text", "write_text")
 
 
 def _has_encoding(call: ast.Call) -> bool:
@@ -66,16 +67,34 @@ def _has_encoding(call: ast.Call) -> bool:
 
 
 def _mode_is_binary(call: ast.Call, mode_argindex: int) -> bool:
-    """True when a literal ``mode`` argument opens the file in binary."""
+    """True when a literal, syntactically valid ``mode`` is binary.
+
+    Validating the whole mode matters: a module-style call such as
+    ``io.open("blob.txt")`` can otherwise look binary merely because the
+    filename occupies the position used by a bound ``Path.open`` method and
+    happens to contain the letter ``b``.
+    """
+
+    def is_binary_mode(value: object) -> bool:
+        if not isinstance(value, str) or not value:
+            return False
+        return (
+            set(value) <= set("rwaxbt+")
+            and sum(value.count(ch) for ch in "rwax") == 1
+            and value.count("b") <= 1
+            and value.count("t") <= 1
+            and not ("b" in value and "t" in value)
+            and value.count("+") <= 1
+            and "b" in value
+        )
+
     args = call.args
     if len(args) > mode_argindex >= 0 and isinstance(args[mode_argindex], ast.Constant):
-        val = args[mode_argindex].value
-        if isinstance(val, str) and "b" in val:
+        if is_binary_mode(args[mode_argindex].value):
             return True
     for k in call.keywords:  # keyword mode=
         if k.arg == "mode" and isinstance(k.value, ast.Constant):
-            val = k.value.value
-            if isinstance(val, str) and "b" in val:
+            if is_binary_mode(k.value.value):
                 return True
     return False
 
@@ -98,44 +117,286 @@ def _has_dynamic_args(call: ast.Call) -> bool:
     )
 
 
-def _assigned_names(tree: ast.AST) -> set[str]:
-    """Names that appear as an assignment target (Store context) anywhere.
+def _import_bound_name(alias: ast.alias) -> str:
+    """Name introduced by an import alias."""
+    return alias.asname or alias.name.split(".", 1)[0]
 
-    A name imported as a compressed module but also *assigned* — e.g.
-    ``import gzip; gzip = Path(...)`` — is ambiguous, so it is dropped from the
-    module bindings and its ``.open`` falls back to the ordinary text-default
-    path. (Import statements bind via ``alias`` nodes, not ``Name`` stores, so
-    they are not counted here.)
+
+def _other_bound_names(
+    tree: ast.AST,
+    *,
+    exempt_module_imports: set[str] = _COMPRESSED_MODULES,
+    exempt_open_imports: set[str] = _COMPRESSED_MODULES,
+) -> set[str]:
+    """Names with any non-compressed-import binding anywhere in *tree*.
+
+    The scanner intentionally treats cross-scope/order conflicts conservatively:
+    a parameter, later assignment, other import, definition, exception target, or
+    pattern capture with the same spelling makes a compressed binding ambiguous.
+    Ambiguous calls are then required to name an encoding rather than falling
+    through to a receiver signature we cannot prove.
     """
-    return {
-        n.id for n in ast.walk(tree) if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store)
-    }
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        bound_name: str | None = None
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            bound_name = node.id
+        elif isinstance(node, ast.arg):
+            bound_name = node.arg
+        elif isinstance(
+            node,
+            (
+                ast.FunctionDef,
+                ast.AsyncFunctionDef,
+                ast.ClassDef,
+                ast.ExceptHandler,
+                ast.MatchAs,
+                ast.MatchStar,
+            ),
+        ):
+            bound_name = node.name
+        elif isinstance(node, ast.MatchMapping) and node.rest:
+            bound_name = node.rest
+        if bound_name is not None:
+            names.add(bound_name)
+
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".", 1)[0] not in exempt_module_imports:
+                    names.add(_import_bound_name(alias))
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if not (node.module in exempt_open_imports and alias.name == "open"):
+                    names.add(alias.asname or alias.name)
+    return names
 
 
-def _compressed_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
-    """``(module_aliases, open_func_aliases)`` proven to reference gzip/bz2/lzma.
+def _assignment_aliases(
+    tree: ast.AST,
+    module_candidates: set[str],
+    func_candidates: set[str],
+    *,
+    recursive: bool = True,
+) -> tuple[set[str], set[str]]:
+    """Conservatively propagate simple aliases of compressed modules/openers.
 
-    ``import gzip as gz`` binds ``gz`` to the module; ``from gzip import open as
-    gopen`` binds ``gopen`` to its text-capable ``open``. A *non-aliased*
-    ``from gzip import open`` is deliberately NOT tracked: it shadows the builtin,
-    and routing such a bare ``open`` through the stricter builtin/text-default
-    path is sound. Any binding whose name is also assigned elsewhere is dropped as
-    ambiguous, so a rebinding is not mistaken for the module.
+    Assignment aliases are always ambiguous (the whole-tree policy cannot prove
+    their value at every call), but retaining them as candidates makes their calls
+    fail closed instead of disappearing from the scan.
     """
-    assigned = _assigned_names(tree)
-    modules: set[str] = set()
-    funcs: set[str] = set()
+
+    def target_names(target: ast.expr) -> set[str]:
+        if isinstance(target, ast.Name):
+            return {target.id}
+        if isinstance(target, ast.Starred):
+            return target_names(target.value)
+        if isinstance(target, (ast.Tuple, ast.List)):
+            return {name for elt in target.elts for name in target_names(elt)}
+        return set()
+
+    def value_kinds(
+        value: ast.expr,
+        known_modules: set[str],
+        known_funcs: set[str],
+    ) -> tuple[bool, bool]:
+        """Return possible ``(module, opener)`` provenance for safe aliases."""
+        if isinstance(value, ast.Name):
+            return value.id in known_modules, value.id in known_funcs
+        if (
+            isinstance(value, ast.Attribute)
+            and value.attr == "open"
+            and isinstance(value.value, ast.Name)
+        ):
+            return False, value.value.id in known_modules
+        if isinstance(value, (ast.Tuple, ast.List, ast.Set)):
+            kinds = [value_kinds(elt, known_modules, known_funcs) for elt in value.elts]
+        elif isinstance(value, ast.IfExp):
+            kinds = [
+                value_kinds(value.body, known_modules, known_funcs),
+                value_kinds(value.orelse, known_modules, known_funcs),
+            ]
+        elif isinstance(value, ast.BoolOp):
+            kinds = [value_kinds(item, known_modules, known_funcs) for item in value.values]
+        elif isinstance(value, (ast.NamedExpr, ast.Starred)):
+            return value_kinds(value.value, known_modules, known_funcs)
+        else:
+            return False, False
+        return any(kind[0] for kind in kinds), any(kind[1] for kind in kinds)
+
+    module_aliases: set[str] = set()
+    func_aliases: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        known_modules = module_candidates | module_aliases
+        known_funcs = func_candidates | func_aliases
+        for node in ast.walk(tree):
+            targets: list[ast.expr]
+            value: ast.expr
+            if isinstance(node, ast.Assign):
+                targets, value = node.targets, node.value
+            elif isinstance(node, (ast.AnnAssign, ast.NamedExpr)) and node.value is not None:
+                targets, value = [node.target], node.value
+            else:
+                continue
+
+            names = {name for target in targets for name in target_names(target)}
+            has_module, has_func = value_kinds(value, known_modules, known_funcs)
+            if not recursive and not isinstance(value, (ast.Name, ast.Attribute)):
+                has_module = has_func = False
+            if has_module:
+                before = len(module_aliases)
+                module_aliases.update(names)
+                changed |= len(module_aliases) != before
+            if has_func:
+                before = len(func_aliases)
+                func_aliases.update(names)
+                changed |= len(func_aliases) != before
+    return module_aliases, func_aliases
+
+
+def _callable_assignment_aliases(
+    tree: ast.AST,
+    seeds: set[str],
+    attribute_names: set[str],
+) -> set[str]:
+    """Propagate simple/conditional/unpacked aliases of known callables."""
+
+    def target_names(target: ast.expr) -> set[str]:
+        if isinstance(target, ast.Name):
+            return {target.id}
+        if isinstance(target, ast.Starred):
+            return target_names(target.value)
+        if isinstance(target, (ast.Tuple, ast.List)):
+            return {name for elt in target.elts for name in target_names(elt)}
+        return set()
+
+    def matches(value: ast.expr, known: set[str]) -> bool:
+        if isinstance(value, ast.Name):
+            return value.id in known
+        if isinstance(value, ast.Attribute):
+            return value.attr in attribute_names
+        if isinstance(value, (ast.Tuple, ast.List, ast.Set)):
+            return any(matches(elt, known) for elt in value.elts)
+        if isinstance(value, ast.IfExp):
+            return matches(value.body, known) or matches(value.orelse, known)
+        if isinstance(value, ast.BoolOp):
+            return any(matches(item, known) for item in value.values)
+        if isinstance(value, (ast.NamedExpr, ast.Starred)):
+            return matches(value.value, known)
+        return False
+
+    aliases: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        known = seeds | aliases
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                targets, value = node.targets, node.value
+            elif isinstance(node, (ast.AnnAssign, ast.NamedExpr)) and node.value is not None:
+                targets, value = [node.target], node.value
+            else:
+                continue
+            if not matches(value, known):
+                continue
+            before = len(aliases)
+            aliases.update(name for target in targets for name in target_names(target))
+            changed |= len(aliases) != before
+    return aliases
+
+
+def _compressed_bindings(
+    tree: ast.AST,
+) -> tuple[set[str], set[str], set[str], set[str]]:
+    """Return stable and ambiguous bindings for gzip/bz2/lzma openers.
+
+    The result is ``(modules, funcs, ambiguous_modules, ambiguous_funcs)``.
+    Stable imports retain compressed-open's binary-default semantics. A candidate
+    with any conflicting binding is never discarded: it becomes ambiguous and
+    its calls fail closed by requiring an explicit encoding.
+    """
+    direct_modules: set[str] = set()
+    direct_funcs: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
-            for a in node.names:
-                if a.name in _COMPRESSED_MODULES:
-                    modules.add(a.asname or a.name)
+            for alias in node.names:
+                if alias.name.split(".", 1)[0] in _COMPRESSED_MODULES:
+                    direct_modules.add(_import_bound_name(alias))
         elif isinstance(node, ast.ImportFrom) and node.module in _COMPRESSED_MODULES:
-            for a in node.names:
-                bound = a.asname or a.name
-                if a.name == "open" and bound != "open":
-                    funcs.add(bound)
-    return modules - assigned, funcs - assigned
+            for alias in node.names:
+                if alias.name == "open":
+                    direct_funcs.add(alias.asname or alias.name)
+
+    alias_modules, alias_funcs = _assignment_aliases(tree, direct_modules, direct_funcs)
+    module_candidates = direct_modules | alias_modules
+    func_candidates = direct_funcs | alias_funcs
+    other = _other_bound_names(tree)
+    both = module_candidates & func_candidates
+
+    ambiguous_modules = (module_candidates & other) | both | alias_modules
+    ambiguous_funcs = (func_candidates & other) | both | alias_funcs
+    modules = module_candidates - ambiguous_modules
+    # Bare ``open`` always follows the stricter builtin/text-default path.
+    funcs = func_candidates - ambiguous_funcs - {"open"}
+    ambiguous_funcs.discard("open")
+    return modules, funcs, ambiguous_modules, ambiguous_funcs
+
+
+def _non_file_open_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """Return proven and ambiguous aliases for non-text ``module.open`` calls."""
+    direct: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in _NON_FILE_OPEN_RECEIVERS:
+                    direct.add(_import_bound_name(alias))
+
+    other = _other_bound_names(
+        tree,
+        exempt_module_imports=_NON_FILE_OPEN_RECEIVERS,
+        exempt_open_imports=set(),
+    )
+    ambiguous = direct & other
+    return direct - ambiguous, ambiguous
+
+
+def _text_open_bindings(
+    tree: ast.AST,
+) -> tuple[set[str], set[str], set[str], set[str]]:
+    """Bindings for modules/functions whose ``open`` uses builtin-style args."""
+    direct_modules: set[str] = set()
+    # Seed the builtin too so ``fopen = open`` cannot evade the strict path.
+    direct_funcs: set[str] = {"open"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in _TEXT_OPEN_MODULES:
+                    direct_modules.add(_import_bound_name(alias))
+        elif isinstance(node, ast.ImportFrom) and node.module in _TEXT_OPEN_MODULES:
+            for alias in node.names:
+                if alias.name == "open":
+                    direct_funcs.add(alias.asname or alias.name)
+
+    alias_modules, alias_funcs = _assignment_aliases(
+        tree,
+        direct_modules,
+        direct_funcs,
+    )
+    module_candidates = direct_modules | alias_modules
+    func_candidates = direct_funcs | alias_funcs
+    other = _other_bound_names(
+        tree,
+        exempt_module_imports=_TEXT_OPEN_MODULES,
+        exempt_open_imports=_TEXT_OPEN_MODULES,
+    )
+    both = module_candidates & func_candidates
+    ambiguous_modules = (module_candidates & other) | both | alias_modules
+    ambiguous_funcs = (func_candidates & other) | both | alias_funcs
+    modules = module_candidates - ambiguous_modules
+    funcs = func_candidates - ambiguous_funcs - {"open"}
+    ambiguous_funcs.discard("open")
+    return modules, funcs, ambiguous_modules, ambiguous_funcs
 
 
 def _fdopen_names(tree: ast.AST) -> set[str]:
@@ -146,7 +407,7 @@ def _fdopen_names(tree: ast.AST) -> set[str]:
             for a in node.names:
                 if a.name == "fdopen":
                     names.add(a.asname or a.name)
-    return names
+    return names | _callable_assignment_aliases(tree, names, {"fdopen"})
 
 
 def _attr_chain(node: ast.expr) -> str | None:
@@ -171,7 +432,7 @@ def _configparser_ctor_names(tree: ast.AST) -> set[str]:
             for a in node.names:
                 if a.name in _CONFIGPARSER_CTORS:
                     names.add(a.asname or a.name)
-    return names
+    return names | _callable_assignment_aliases(tree, names, _CONFIGPARSER_CTORS)
 
 
 def _is_configparser_ctor(func: ast.expr, ctor_names: set[str]) -> bool:
@@ -189,16 +450,49 @@ def _configparser_instances(tree: ast.AST, ctor_names: set[str]) -> set[str]:
     Tracks both plain names (``cfg = ConfigParser()``) and attribute targets
     (``self.cfg = ConfigParser()``), keyed by their dotted chain.
     """
+
+    def targets_and_value(node: ast.AST) -> tuple[list[ast.expr], ast.expr] | None:
+        if isinstance(node, ast.Assign):
+            return node.targets, node.value
+        if isinstance(node, (ast.AnnAssign, ast.NamedExpr)) and node.value is not None:
+            return [node.target], node.value
+        return None
+
+    def value_chains(value: ast.expr) -> set[str]:
+        if isinstance(value, (ast.Name, ast.Attribute)):
+            chain = _attr_chain(value)
+            return {chain} if chain is not None else set()
+        if isinstance(value, (ast.Tuple, ast.List, ast.Set)):
+            return {chain for elt in value.elts for chain in value_chains(elt)}
+        if isinstance(value, ast.IfExp):
+            return value_chains(value.body) | value_chains(value.orelse)
+        if isinstance(value, ast.BoolOp):
+            return {chain for item in value.values for chain in value_chains(item)}
+        if isinstance(value, (ast.NamedExpr, ast.Starred)):
+            return value_chains(value.value)
+        return set()
+
     chains: set[str] = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.Assign):
-            targets, value = node.targets, node.value
-        elif isinstance(node, ast.AnnAssign) and node.value is not None:
-            targets, value = [node.target], node.value
-        else:
+        assignment = targets_and_value(node)
+        if assignment is None:
             continue
+        targets, value = assignment
         if isinstance(value, ast.Call) and _is_configparser_ctor(value.func, ctor_names):
             chains.update(c for t in targets if (c := _attr_chain(t)) is not None)
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            assignment = targets_and_value(node)
+            if assignment is None:
+                continue
+            targets, value = assignment
+            if not (value_chains(value) & chains):
+                continue
+            before = len(chains)
+            chains.update(c for target in targets if (c := _attr_chain(target)) is not None)
+            changed |= len(chains) != before
     return chains
 
 
@@ -243,6 +537,14 @@ def _call_violations(
     fdopen_names: set[str],
     comp_modules: set[str],
     comp_funcs: set[str],
+    ambiguous_comp_modules: set[str],
+    ambiguous_comp_funcs: set[str],
+    non_file_modules: set[str],
+    ambiguous_non_file_modules: set[str],
+    text_open_modules: set[str],
+    text_open_funcs: set[str],
+    ambiguous_text_open_modules: set[str],
+    ambiguous_text_open_funcs: set[str],
 ) -> list[tuple[int, str]]:
     """Unencoded text I/O among the *Call* nodes of a single parsed tree."""
     out: list[tuple[int, str]] = []
@@ -250,13 +552,55 @@ def _call_violations(
         if not isinstance(node, ast.Call):
             continue
         func = node.func
+        # A bare name spelled ``open`` always takes builtin/text-default
+        # semantics, including ``from gzip import open``. This is conservative
+        # for gzip's binary default and sound for unrelated builtin calls.
+        if isinstance(func, ast.Name) and func.id == "open":
+            name, mode_idx = "open", 1
+        # Ambiguous compressed aliases never fall through to a guessed receiver
+        # signature: requiring an encoding is the fail-closed policy.
+        elif isinstance(func, ast.Name) and func.id in ambiguous_comp_funcs:
+            if not _has_encoding(node):
+                out.append((node.lineno, "open(ambiguous compressed alias)"))
+            continue
+        elif (
+            isinstance(func, ast.Attribute)
+            and func.attr == "open"
+            and isinstance(func.value, ast.Name)
+            and func.value.id in ambiguous_comp_modules
+        ):
+            if not _has_encoding(node):
+                out.append((node.lineno, f"{func.value.id}.open(ambiguous)"))
+            continue
+        elif (
+            isinstance(func, ast.Attribute)
+            and func.attr == "open"
+            and isinstance(func.value, ast.Name)
+            and func.value.id in ambiguous_non_file_modules
+        ):
+            if not _has_encoding(node):
+                out.append((node.lineno, f"{func.value.id}.open(ambiguous receiver)"))
+            continue
+        elif isinstance(func, ast.Name) and func.id in ambiguous_text_open_funcs:
+            if not _has_encoding(node):
+                out.append((node.lineno, "open(ambiguous text alias)"))
+            continue
+        elif (
+            isinstance(func, ast.Attribute)
+            and func.attr == "open"
+            and isinstance(func.value, ast.Name)
+            and func.value.id in ambiguous_text_open_modules
+        ):
+            if not _has_encoding(node):
+                out.append((node.lineno, f"{func.value.id}.open(ambiguous text receiver)"))
+            continue
         # Compressed openers first (matched by import binding), so a from-import
         # ``open`` alias or aliased module attribute isn't mishandled below.
-        if isinstance(func, ast.Name) and func.id in comp_funcs:
+        elif isinstance(func, ast.Name) and func.id in comp_funcs:
             if (v := _compressed_open_violation(node, "gzip.open")) is not None:
                 out.append(v)
             continue
-        if (
+        elif (
             isinstance(func, ast.Attribute)
             and func.attr == "open"
             and isinstance(func.value, ast.Name)
@@ -265,8 +609,15 @@ def _call_violations(
             if (v := _compressed_open_violation(node, f"{func.value.id}.open")) is not None:
                 out.append(v)
             continue
-        if isinstance(func, ast.Name) and func.id == "open":
+        elif isinstance(func, ast.Name) and func.id in text_open_funcs:
             name, mode_idx = "open", 1
+        elif (
+            isinstance(func, ast.Attribute)
+            and func.attr == "open"
+            and isinstance(func.value, ast.Name)
+            and func.value.id in text_open_modules
+        ):
+            name, mode_idx = f"{func.value.id}.open", 1
         elif isinstance(func, ast.Name) and func.id in fdopen_names:
             name, mode_idx = "os.fdopen", 1  # fdopen / from-os alias
         elif isinstance(func, ast.Attribute) and func.attr == "fdopen":
@@ -279,7 +630,7 @@ def _call_violations(
             continue
         elif isinstance(func, ast.Attribute) and func.attr in _METHODS:
             recv_id = func.value.id if isinstance(func.value, ast.Name) else None
-            if func.attr == "open" and recv_id in _NON_FILE_OPEN_RECEIVERS:
+            if func.attr == "open" and recv_id in non_file_modules:
                 continue  # tarfile.open() etc. — binary archive, not text I/O
             name = func.attr
             mode_idx = 0 if func.attr == "open" else -1
@@ -301,7 +652,11 @@ def find_violations(source: str) -> list[tuple[int, str]]:
     """
     tree = ast.parse(source)
     ctor_names = _configparser_ctor_names(tree)
-    comp_modules, comp_funcs = _compressed_bindings(tree)
+    comp_modules, comp_funcs, ambiguous_modules, ambiguous_funcs = _compressed_bindings(tree)
+    non_file_modules, ambiguous_non_file_modules = _non_file_open_bindings(tree)
+    text_modules, text_funcs, ambiguous_text_modules, ambiguous_text_funcs = _text_open_bindings(
+        tree
+    )
     out = _call_violations(
         tree,
         _configparser_instances(tree, ctor_names),
@@ -309,6 +664,14 @@ def find_violations(source: str) -> list[tuple[int, str]]:
         _fdopen_names(tree),
         comp_modules,
         comp_funcs,
+        ambiguous_modules,
+        ambiguous_funcs,
+        non_file_modules,
+        ambiguous_non_file_modules,
+        text_modules,
+        text_funcs,
+        ambiguous_text_modules,
+        ambiguous_text_funcs,
     )
 
     # Constants nested inside an f-string are reconstructed as part of that
@@ -333,7 +696,13 @@ def find_violations(source: str) -> list[tuple[int, str]]:
         except SyntaxError:
             continue  # not Python (prose, JS, a fragment) — not an embedded script
         sub_ctor = _configparser_ctor_names(sub)
-        sub_modules, sub_funcs = _compressed_bindings(sub)
+        sub_modules, sub_funcs, sub_ambiguous_modules, sub_ambiguous_funcs = _compressed_bindings(
+            sub
+        )
+        sub_non_file_modules, sub_ambiguous_non_file_modules = _non_file_open_bindings(sub)
+        sub_text_modules, sub_text_funcs, sub_ambiguous_text_modules, sub_ambiguous_text_funcs = (
+            _text_open_bindings(sub)
+        )
         if _call_violations(
             sub,
             _configparser_instances(sub, sub_ctor),
@@ -341,6 +710,14 @@ def find_violations(source: str) -> list[tuple[int, str]]:
             _fdopen_names(sub),
             sub_modules,
             sub_funcs,
+            sub_ambiguous_modules,
+            sub_ambiguous_funcs,
+            sub_non_file_modules,
+            sub_ambiguous_non_file_modules,
+            sub_text_modules,
+            sub_text_funcs,
+            sub_ambiguous_text_modules,
+            sub_ambiguous_text_funcs,
         ):
             out.append((node.lineno, "open(embedded)"))
     return out

--- a/tests/_encoding_scan.py
+++ b/tests/_encoding_scan.py
@@ -87,14 +87,42 @@ def _mode_present(call: ast.Call, mode_argindex: int) -> bool:
     return any(k.arg == "mode" for k in call.keywords)
 
 
+def _has_dynamic_args(call: ast.Call) -> bool:
+    """True when the call uses ``*args`` or ``**kwargs``.
+
+    Such a call's mode and encoding can't be read statically (``open(*[p, "rt"])``,
+    ``open(p, **{"mode": "rt"})``), so it must be treated conservatively.
+    """
+    return any(isinstance(a, ast.Starred) for a in call.args) or any(
+        k.arg is None for k in call.keywords
+    )
+
+
+def _assigned_names(tree: ast.AST) -> set[str]:
+    """Names that appear as an assignment target (Store context) anywhere.
+
+    A name imported as a compressed module but also *assigned* — e.g.
+    ``import gzip; gzip = Path(...)`` — is ambiguous, so it is dropped from the
+    module bindings and its ``.open`` falls back to the ordinary text-default
+    path. (Import statements bind via ``alias`` nodes, not ``Name`` stores, so
+    they are not counted here.)
+    """
+    return {
+        n.id for n in ast.walk(tree) if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store)
+    }
+
+
 def _compressed_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
     """``(module_aliases, open_func_aliases)`` proven to reference gzip/bz2/lzma.
 
     ``import gzip as gz`` binds ``gz`` to the module; ``from gzip import open as
-    gopen`` binds ``gopen`` to its text-capable ``open``. Only these bindings get
-    compressed-open handling, so an unrelated name (``gzip = Path(...)``) is not
-    mistaken for the module and vice-versa.
+    gopen`` binds ``gopen`` to its text-capable ``open``. A *non-aliased*
+    ``from gzip import open`` is deliberately NOT tracked: it shadows the builtin,
+    and routing such a bare ``open`` through the stricter builtin/text-default
+    path is sound. Any binding whose name is also assigned elsewhere is dropped as
+    ambiguous, so a rebinding is not mistaken for the module.
     """
+    assigned = _assigned_names(tree)
     modules: set[str] = set()
     funcs: set[str] = set()
     for node in ast.walk(tree):
@@ -104,9 +132,10 @@ def _compressed_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
                     modules.add(a.asname or a.name)
         elif isinstance(node, ast.ImportFrom) and node.module in _COMPRESSED_MODULES:
             for a in node.names:
-                if a.name == "open":
-                    funcs.add(a.asname or a.name)
-    return modules, funcs
+                bound = a.asname or a.name
+                if a.name == "open" and bound != "open":
+                    funcs.add(bound)
+    return modules - assigned, funcs - assigned
 
 
 def _fdopen_names(tree: ast.AST) -> set[str]:
@@ -197,10 +226,12 @@ def _literal_text(node: ast.AST) -> str | None:
 
 
 def _compressed_open_violation(node: ast.Call, label: str) -> tuple[int, str] | None:
-    """A gzip/bz2/lzma open needs an encoding when a mode is supplied and not
-    statically provable as binary (an explicit text mode, or a computed/dynamic
-    mode). A bare call or a proven-binary mode stays clean."""
-    if not _has_encoding(node) and _mode_present(node, 1) and not _mode_is_binary(node, 1):
+    """A gzip/bz2/lzma open needs an encoding unless it is statically proven safe:
+    a bare call or a proven-binary mode stays clean. A dynamic-args call, an
+    explicit text mode, or a computed/dynamic mode all require the encoding."""
+    if _has_encoding(node):
+        return None
+    if _has_dynamic_args(node) or (_mode_present(node, 1) and not _mode_is_binary(node, 1)):
         return (node.lineno, label)
     return None
 

--- a/tests/_encoding_scan.py
+++ b/tests/_encoding_scan.py
@@ -18,6 +18,7 @@ an enumerator (``python tests/_encoding_scan.py``).
 from __future__ import annotations
 
 import ast
+import textwrap
 from pathlib import Path
 
 _METHODS = {"read_text", "write_text", "open"}
@@ -50,7 +51,15 @@ _EMBEDDED_HINTS = ("open(", "read_text(", "write_text(")
 
 
 def _has_encoding(call: ast.Call) -> bool:
-    return any(k.arg == "encoding" for k in call.keywords)
+    """True only when a *real* encoding is named.
+
+    ``encoding=None`` selects the platform default codec — identical to omitting
+    the argument — so it is treated as a violation, not a fix.
+    """
+    for k in call.keywords:
+        if k.arg == "encoding":
+            return not (isinstance(k.value, ast.Constant) and k.value.value is None)
+    return False
 
 
 def _mode_is_binary(call: ast.Call, mode_argindex: int) -> bool:
@@ -68,16 +77,31 @@ def _mode_is_binary(call: ast.Call, mode_argindex: int) -> bool:
     return False
 
 
-def _is_configparser_ctor(func: ast.expr) -> bool:
-    """True for ``ConfigParser()`` / ``configparser.RawConfigParser()`` etc."""
+def _configparser_ctor_names(tree: ast.AST) -> set[str]:
+    """Names that construct a ConfigParser: the classes plus any import alias.
+
+    Resolves ``from configparser import ConfigParser as CP`` so an aliased
+    constructor is still recognized.
+    """
+    names = set(_CONFIGPARSER_CTORS)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "configparser":
+            for a in node.names:
+                if a.name in _CONFIGPARSER_CTORS:
+                    names.add(a.asname or a.name)
+    return names
+
+
+def _is_configparser_ctor(func: ast.expr, ctor_names: set[str]) -> bool:
+    """True for ``ConfigParser()`` / ``configparser.RawConfigParser()`` / an alias."""
     if isinstance(func, ast.Name):
-        return func.id in _CONFIGPARSER_CTORS
+        return func.id in ctor_names
     if isinstance(func, ast.Attribute):
-        return func.attr in _CONFIGPARSER_CTORS
+        return func.attr in _CONFIGPARSER_CTORS  # module.ConfigParser(), cp.ConfigParser()
     return False
 
 
-def _configparser_names(tree: ast.AST) -> set[str]:
+def _configparser_names(tree: ast.AST, ctor_names: set[str]) -> set[str]:
     """Names bound to a ConfigParser instance anywhere in the module."""
     names: set[str] = set()
     for node in ast.walk(tree):
@@ -87,19 +111,19 @@ def _configparser_names(tree: ast.AST) -> set[str]:
             targets, value = [node.target], node.value
         else:
             continue
-        if isinstance(value, ast.Call) and _is_configparser_ctor(value.func):
+        if isinstance(value, ast.Call) and _is_configparser_ctor(value.func, ctor_names):
             names.update(t.id for t in targets if isinstance(t, ast.Name))
     return names
 
 
-def _is_configparser_read(func: ast.Attribute, names: set[str]) -> bool:
+def _is_configparser_read(func: ast.Attribute, inst_names: set[str], ctor_names: set[str]) -> bool:
     """True for ``cfg.read(...)`` / ``configparser.ConfigParser().read(...)``."""
     if func.attr != "read":
         return False
     recv = func.value
-    if isinstance(recv, ast.Name) and recv.id in names:
+    if isinstance(recv, ast.Name) and recv.id in inst_names:
         return True
-    return isinstance(recv, ast.Call) and _is_configparser_ctor(recv.func)
+    return isinstance(recv, ast.Call) and _is_configparser_ctor(recv.func, ctor_names)
 
 
 def _literal_text(node: ast.AST) -> str | None:
@@ -114,7 +138,9 @@ def _literal_text(node: ast.AST) -> str | None:
     return None
 
 
-def _call_violations(tree: ast.AST, cfg_names: set[str]) -> list[tuple[int, str]]:
+def _call_violations(
+    tree: ast.AST, inst_names: set[str], ctor_names: set[str]
+) -> list[tuple[int, str]]:
     """Unencoded text I/O among the *Call* nodes of a single parsed tree."""
     out: list[tuple[int, str]] = []
     for node in ast.walk(tree):
@@ -123,14 +149,13 @@ def _call_violations(tree: ast.AST, cfg_names: set[str]) -> list[tuple[int, str]
         func = node.func
         if isinstance(func, ast.Name) and func.id == "open":
             name, mode_idx = "open", 1
-        elif (
-            isinstance(func, ast.Attribute)
-            and func.attr == "fdopen"
-            and isinstance(func.value, ast.Name)
-            and func.value.id == "os"
+        elif isinstance(func, ast.Name) and func.id == "fdopen":
+            name, mode_idx = "fdopen", 1  # from os import fdopen
+        elif isinstance(func, ast.Attribute) and func.attr == "fdopen":
+            name, mode_idx = "os.fdopen", 1  # os.fdopen / aliased module.fdopen
+        elif isinstance(func, ast.Attribute) and _is_configparser_read(
+            func, inst_names, ctor_names
         ):
-            name, mode_idx = "os.fdopen", 1
-        elif isinstance(func, ast.Attribute) and _is_configparser_read(func, cfg_names):
             if not _has_encoding(node):
                 out.append((node.lineno, "ConfigParser.read"))
             continue
@@ -160,7 +185,8 @@ def find_violations(source: str) -> list[tuple[int, str]]:
     templates (e.g. generated JS) are excluded rather than false-flagged.
     """
     tree = ast.parse(source)
-    out = _call_violations(tree, _configparser_names(tree))
+    ctor_names = _configparser_ctor_names(tree)
+    out = _call_violations(tree, _configparser_names(tree, ctor_names), ctor_names)
 
     # Constants nested inside an f-string are reconstructed as part of that
     # f-string; skip them so a half-open interpolated fragment isn't parsed alone.
@@ -178,10 +204,13 @@ def find_violations(source: str) -> list[tuple[int, str]]:
         if text is None or not any(h in text for h in _EMBEDDED_HINTS):
             continue
         try:
-            sub = ast.parse(text)
+            # dedent so a uniformly-indented embedded script (common when the
+            # literal sits inside an indented block) still parses as Python.
+            sub = ast.parse(textwrap.dedent(text))
         except SyntaxError:
             continue  # not Python (prose, JS, a fragment) — not an embedded script
-        if _call_violations(sub, _configparser_names(sub)):
+        sub_ctor = _configparser_ctor_names(sub)
+        if _call_violations(sub, _configparser_names(sub, sub_ctor), sub_ctor):
             out.append((node.lineno, "open(embedded)"))
     return out
 
@@ -202,7 +231,14 @@ def scan_package(pkg: Path, allow: frozenset[str] | set[str] = ALLOWLIST) -> lis
     return hits
 
 
+# Every first-party package shipped from this repo (each scanned against its own
+# parent so the reported path stays package-relative).
+def owned_packages() -> list[Path]:
+    repo = Path(__file__).resolve().parents[1]
+    return [repo / "omnigent", repo / "sdks" / "python-client" / "omnigent_client"]
+
+
 if __name__ == "__main__":
-    root = Path(__file__).resolve().parents[1] / "omnigent"
-    for h in scan_package(root, ALLOWLIST):
-        print(h)
+    for pkg in owned_packages():
+        for h in scan_package(pkg, ALLOWLIST):
+            print(h)

--- a/tests/_encoding_scan.py
+++ b/tests/_encoding_scan.py
@@ -40,9 +40,12 @@ _NON_FILE_OPEN_RECEIVERS = {
     "socket",
     "subprocess",
 }
-# ``X.open(...)`` here is text-capable but *binary by default*: a bare call or a
-# binary mode is fine, but an explicit text mode ('t') must name an encoding.
-_BINARY_DEFAULT_OPENERS = {"gzip", "bz2", "lzma"}
+# ``<module>.open(...)`` here is text-capable but *binary by default*: a bare
+# call or a binary mode is fine, but any other mode (text, or one not statically
+# provable as binary) must name an encoding. Matched by *import binding*, not by
+# literal receiver name, so an alias (``import gzip as gz``) is caught and an
+# unrelated ``gzip = Path(...)`` is not misread as the module.
+_COMPRESSED_MODULES = {"gzip", "bz2", "lzma"}
 _CONFIGPARSER_CTORS = {"ConfigParser", "RawConfigParser", "SafeConfigParser"}
 
 # Only str literals containing one of these are candidate embedded scripts —
@@ -77,19 +80,33 @@ def _mode_is_binary(call: ast.Call, mode_argindex: int) -> bool:
     return False
 
 
-def _mode_is_text(call: ast.Call, mode_argindex: int) -> bool:
-    """True when a literal ``mode`` argument explicitly requests text ('t')."""
-    args = call.args
-    if len(args) > mode_argindex >= 0 and isinstance(args[mode_argindex], ast.Constant):
-        val = args[mode_argindex].value
-        if isinstance(val, str) and "t" in val:
-            return True
-    for k in call.keywords:
-        if k.arg == "mode" and isinstance(k.value, ast.Constant):
-            val = k.value.value
-            if isinstance(val, str) and "t" in val:
-                return True
-    return False
+def _mode_present(call: ast.Call, mode_argindex: int) -> bool:
+    """True when a ``mode`` argument is supplied (positionally or by keyword)."""
+    if mode_argindex >= 0 and len(call.args) > mode_argindex:
+        return True
+    return any(k.arg == "mode" for k in call.keywords)
+
+
+def _compressed_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """``(module_aliases, open_func_aliases)`` proven to reference gzip/bz2/lzma.
+
+    ``import gzip as gz`` binds ``gz`` to the module; ``from gzip import open as
+    gopen`` binds ``gopen`` to its text-capable ``open``. Only these bindings get
+    compressed-open handling, so an unrelated name (``gzip = Path(...)``) is not
+    mistaken for the module and vice-versa.
+    """
+    modules: set[str] = set()
+    funcs: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                if a.name in _COMPRESSED_MODULES:
+                    modules.add(a.asname or a.name)
+        elif isinstance(node, ast.ImportFrom) and node.module in _COMPRESSED_MODULES:
+            for a in node.names:
+                if a.name == "open":
+                    funcs.add(a.asname or a.name)
+    return modules, funcs
 
 
 def _fdopen_names(tree: ast.AST) -> set[str]:
@@ -179,8 +196,22 @@ def _literal_text(node: ast.AST) -> str | None:
     return None
 
 
+def _compressed_open_violation(node: ast.Call, label: str) -> tuple[int, str] | None:
+    """A gzip/bz2/lzma open needs an encoding when a mode is supplied and not
+    statically provable as binary (an explicit text mode, or a computed/dynamic
+    mode). A bare call or a proven-binary mode stays clean."""
+    if not _has_encoding(node) and _mode_present(node, 1) and not _mode_is_binary(node, 1):
+        return (node.lineno, label)
+    return None
+
+
 def _call_violations(
-    tree: ast.AST, instances: set[str], ctor_names: set[str], fdopen_names: set[str]
+    tree: ast.AST,
+    instances: set[str],
+    ctor_names: set[str],
+    fdopen_names: set[str],
+    comp_modules: set[str],
+    comp_funcs: set[str],
 ) -> list[tuple[int, str]]:
     """Unencoded text I/O among the *Call* nodes of a single parsed tree."""
     out: list[tuple[int, str]] = []
@@ -188,6 +219,21 @@ def _call_violations(
         if not isinstance(node, ast.Call):
             continue
         func = node.func
+        # Compressed openers first (matched by import binding), so a from-import
+        # ``open`` alias or aliased module attribute isn't mishandled below.
+        if isinstance(func, ast.Name) and func.id in comp_funcs:
+            if (v := _compressed_open_violation(node, "gzip.open")) is not None:
+                out.append(v)
+            continue
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "open"
+            and isinstance(func.value, ast.Name)
+            and func.value.id in comp_modules
+        ):
+            if (v := _compressed_open_violation(node, f"{func.value.id}.open")) is not None:
+                out.append(v)
+            continue
         if isinstance(func, ast.Name) and func.id == "open":
             name, mode_idx = "open", 1
         elif isinstance(func, ast.Name) and func.id in fdopen_names:
@@ -204,12 +250,6 @@ def _call_violations(
             recv_id = func.value.id if isinstance(func.value, ast.Name) else None
             if func.attr == "open" and recv_id in _NON_FILE_OPEN_RECEIVERS:
                 continue  # tarfile.open() etc. — binary archive, not text I/O
-            if func.attr == "open" and recv_id in _BINARY_DEFAULT_OPENERS:
-                # gzip/bz2/lzma default to binary; only an explicit text mode
-                # ('t', e.g. "rt"/"wt") needs an encoding.
-                if not _has_encoding(node) and _mode_is_text(node, 1):
-                    out.append((node.lineno, f"{recv_id}.open"))
-                continue
             name = func.attr
             mode_idx = 0 if func.attr == "open" else -1
         else:
@@ -230,8 +270,14 @@ def find_violations(source: str) -> list[tuple[int, str]]:
     """
     tree = ast.parse(source)
     ctor_names = _configparser_ctor_names(tree)
+    comp_modules, comp_funcs = _compressed_bindings(tree)
     out = _call_violations(
-        tree, _configparser_instances(tree, ctor_names), ctor_names, _fdopen_names(tree)
+        tree,
+        _configparser_instances(tree, ctor_names),
+        ctor_names,
+        _fdopen_names(tree),
+        comp_modules,
+        comp_funcs,
     )
 
     # Constants nested inside an f-string are reconstructed as part of that
@@ -256,8 +302,14 @@ def find_violations(source: str) -> list[tuple[int, str]]:
         except SyntaxError:
             continue  # not Python (prose, JS, a fragment) — not an embedded script
         sub_ctor = _configparser_ctor_names(sub)
+        sub_modules, sub_funcs = _compressed_bindings(sub)
         if _call_violations(
-            sub, _configparser_instances(sub, sub_ctor), sub_ctor, _fdopen_names(sub)
+            sub,
+            _configparser_instances(sub, sub_ctor),
+            sub_ctor,
+            _fdopen_names(sub),
+            sub_modules,
+            sub_funcs,
         ):
             out.append((node.lineno, "open(embedded)"))
     return out

--- a/tests/cli/test_integration_slack.py
+++ b/tests/cli/test_integration_slack.py
@@ -36,6 +36,20 @@ def test_record_round_trip_and_prune(tmp_path: Path) -> None:
     assert d.read_record() is None  # pruned from disk
 
 
+def test_read_log_tail_detects_legacy_locale_encoding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A legacy child log remains readable when Python UTF-8 Mode is active."""
+    log_path = tmp_path / "slack.log"
+    log_path.write_bytes("older\ncafé\n".encode("cp1252"))
+    monkeypatch.setattr("omnigent._encoding.locale_encoding", lambda: "cp1252")
+
+    daemon = IntegrationDaemon("slack", tmp_path)
+    daemon._write_record(DaemonRecord(pid=4242, log_path=str(log_path), started_at=1))
+
+    assert daemon.read_log_tail(max_lines=1) == "café"
+
+
 def test_start_writes_record_detached(tmp_path: Path) -> None:
     d = IntegrationDaemon("slack", tmp_path)
     with mock.patch("omnigent.integration_daemon.subprocess.Popen") as popen:
@@ -209,12 +223,13 @@ def test_slack_logs_prints_path(data_dir: Path) -> None:
     none = runner.invoke(cli, ["integration", "slack", "logs"])
     assert "No Slack daemon" in none.output
     # With a record, prints the path.
+    log_path = data_dir / "slack.log"
     IntegrationDaemon("slack", data_dir)._write_record(
-        DaemonRecord(pid=1, log_path="/tmp/slack.log", started_at=1)
+        DaemonRecord(pid=1, log_path=str(log_path), started_at=1)
     )
     result = runner.invoke(cli, ["integration", "slack", "logs"])
     assert result.exit_code == 0
-    assert "/tmp/slack.log" in result.output
+    assert str(log_path) in result.output
 
 
 def test_integration_group_bare_shows_help(data_dir: Path) -> None:

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -16,6 +16,7 @@ from omnigent.inner.os_env import (
     _child_shell_env,
     _project_root,
     _read_impl,
+    _select_default_shell,
     _shell_impl,
     build_helper_env,
     create_os_environment,
@@ -401,3 +402,32 @@ def test_shell_command_does_not_see_omnigent_project_root(
     out = result.get("stdout", "")
     assert project_entry in out
     assert str(_project_root()) not in out
+
+
+class TestSelectDefaultShell:
+    """`_select_default_shell` must never pick the WSL bash on Windows."""
+
+    def test_windows_uses_comspec_not_wsl_bash(self, monkeypatch) -> None:
+        # On Windows, shutil.which("bash") is the WSL launcher; the selector
+        # must ignore it and use the native cmd.exe via %COMSPEC%.
+        monkeypatch.setattr(
+            "omnigent.inner.os_env.shutil.which",
+            lambda name: r"C:\Windows\System32\bash.exe" if name == "bash" else None,
+        )
+        monkeypatch.setenv("COMSPEC", r"C:\Windows\System32\cmd.exe")
+        assert _select_default_shell(True) == r"C:\Windows\System32\cmd.exe"
+
+    def test_windows_defaults_to_cmd_when_no_comspec(self, monkeypatch) -> None:
+        monkeypatch.delenv("COMSPEC", raising=False)
+        assert _select_default_shell(True) == "cmd.exe"
+
+    def test_posix_prefers_bash(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "omnigent.inner.os_env.shutil.which",
+            lambda name: "/usr/bin/bash" if name == "bash" else None,
+        )
+        assert _select_default_shell(False) == "/usr/bin/bash"
+
+    def test_posix_falls_back_to_sh(self, monkeypatch) -> None:
+        monkeypatch.setattr("omnigent.inner.os_env.shutil.which", lambda name: None)
+        assert _select_default_shell(False) == "/bin/sh"

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -400,8 +400,9 @@ def test_shell_command_does_not_see_omnigent_project_root(
         OSEnvSpec(type="caller_process", sandbox=OSEnvSandboxSpec(type="none"))
     )
     assert os_env is not None
+    command = "echo PP=%PYTHONPATH%" if os.name == "nt" else "echo PP=$PYTHONPATH"
     try:
-        result = asyncio.run(os_env.shell("echo PP=$PYTHONPATH"))
+        result = asyncio.run(os_env.shell(command))
     finally:
         os_env.close()
 

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -431,3 +431,23 @@ class TestSelectDefaultShell:
     def test_posix_falls_back_to_sh(self, monkeypatch) -> None:
         monkeypatch.setattr("omnigent.inner.os_env.shutil.which", lambda name: None)
         assert _select_default_shell(False) == "/bin/sh"
+
+
+@pytest.mark.windows_only
+def test_shell_impl_preserves_quotes_on_windows(tmp_path: Path) -> None:
+    """`_shell_impl` must pass a quoted command to cmd.exe verbatim.
+
+    Regression for list-based argv serialization escaping the command's own
+    quotes as ``\\"`` (so ``echo "a b"`` produced ``\\"a b\\"``) and for
+    ``cmd.exe /c`` stripping the outer quotes of a quote-leading command.
+    """
+    comspec = os.environ.get("COMSPEC", "cmd.exe")
+    result = _shell_impl(
+        command='echo "a b"',
+        timeout=15,
+        shell_path=comspec,
+        cwd=tmp_path,
+    )
+    assert result["exit_code"] == 0, result
+    assert "\\" not in result["stdout"], result["stdout"]
+    assert "a b" in result["stdout"]

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -522,3 +522,120 @@ def test_shell_impl_timeout_kills_orphaned_descendant_on_windows(tmp_path: Path)
     assert result["timed_out"] is True, result
     time.sleep(8)
     assert not marker.exists(), "orphaned worker survived the timeout"
+
+
+@pytest.mark.windows_only
+def test_tree_kill_job_close_spares_but_terminate_kills() -> None:
+    """The containment job has no kill-on-close: closing the handle leaves the
+    process running (a detached server survives a successful command), while
+    ``terminate()`` kills it (the timeout path). Tested at the job API directly
+    to avoid cmd.exe quoting in the assertion.
+    """
+    import subprocess
+    import sys
+    import time
+
+    from omnigent.inner.windows_jobobject_sandbox import create_tree_kill_job
+
+    sleeper = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        job = create_tree_kill_job()
+        assert job is not None and job.assign(sleeper.pid)
+        job.close()  # no kill-on-close
+        time.sleep(1)
+        assert sleeper.poll() is None, "close() killed the process (kill-on-close regression)"
+    finally:
+        sleeper.kill()
+        sleeper.wait(timeout=10)
+
+    victim = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        job = create_tree_kill_job()
+        assert job is not None and job.assign(victim.pid)
+        job.terminate()  # timeout path: tear the tree down
+        victim.wait(timeout=10)
+        assert victim.poll() is not None, "terminate() did not kill the process"
+    finally:
+        if victim.poll() is None:
+            victim.kill()
+            victim.wait(timeout=10)
+        job.close()
+
+
+@pytest.mark.windows_only
+def test_tree_kill_job_terminate_reaches_grandchild(tmp_path: Path) -> None:
+    """``terminate()`` kills the whole tree, including a grandchild orphaned by an
+    intermediate process — the reach a parent-walk (psutil/taskkill) can't match.
+    Helper scripts avoid all shell quoting.
+    """
+    import subprocess
+    import sys
+    import time
+
+    from omnigent.inner.windows_jobobject_sandbox import create_tree_kill_job
+
+    marker = tmp_path / "gc_marker.txt"
+    gc_py = tmp_path / "gc.py"
+    gc_py.write_text(
+        f"import time\ntime.sleep(8)\nopen({str(marker)!r}, 'w').close()\n",
+        encoding="utf-8",
+    )
+    parent_py = tmp_path / "parent.py"
+    parent_py.write_text(
+        f"import subprocess, sys, time\n"
+        f"subprocess.Popen([sys.executable, {str(gc_py)!r}])\n"
+        f"time.sleep(30)\n",
+        encoding="utf-8",
+    )
+    parent = subprocess.Popen([sys.executable, str(parent_py)])
+    try:
+        job = create_tree_kill_job()
+        assert job is not None and job.assign(parent.pid)
+        time.sleep(2)  # let the parent spawn the grandchild (both now in the job)
+        job.terminate()
+        parent.wait(timeout=10)
+        assert parent.poll() is not None
+    finally:
+        if parent.poll() is None:
+            parent.kill()
+            parent.wait(timeout=10)
+        job.close()
+    time.sleep(10)  # past the grandchild's 8s sleep — its marker must never appear
+    assert not marker.exists(), "terminate() did not reach the grandchild"
+
+
+@pytest.mark.windows_only
+def test_shell_impl_runs_from_hostile_temp_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A %TEMP% containing a space AND ``&`` must still run.
+
+    The batch path is double-quoted via ``/s /c ""<path>""`` so cmd strips only
+    the outer pair, leaving a properly quoted path — where a bare, list-quoted
+    path would break once cmd stripped its single quote pair.
+    """
+    import tempfile
+
+    hostile = tmp_path / "a b & c"
+    hostile.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(hostile))
+    comspec = os.environ.get("COMSPEC", "cmd.exe")
+    result = _shell_impl(command="echo spacey", timeout=15, shell_path=comspec, cwd=tmp_path)
+    assert result["exit_code"] == 0, result
+    assert "spacey" in result["stdout"], result
+
+
+@pytest.mark.windows_only
+def test_shell_impl_batch_for_loop_uses_double_percent(tmp_path: Path) -> None:
+    """Commands run in batch context, so a ``for`` loop variable is ``%%i`` (not
+    the interactive ``%i``). Documents/locks the cmd.exe semantic that the
+    batch-file approach requires."""
+    comspec = os.environ.get("COMSPEC", "cmd.exe")
+    result = _shell_impl(
+        command="for %%i in (1 2 3) do @echo N%%i",
+        timeout=15,
+        shell_path=comspec,
+        cwd=tmp_path,
+    )
+    assert result["exit_code"] == 0, result
+    assert "N1" in result["stdout"] and "N3" in result["stdout"], result

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -451,3 +451,33 @@ def test_shell_impl_preserves_quotes_on_windows(tmp_path: Path) -> None:
     assert result["exit_code"] == 0, result
     assert "\\" not in result["stdout"], result["stdout"]
     assert "a b" in result["stdout"]
+
+
+@pytest.mark.windows_only
+def test_shell_impl_runs_multiline_command_on_windows(tmp_path: Path) -> None:
+    """Regression: multi-line commands must run every line, not silently line 1."""
+    comspec = os.environ.get("COMSPEC", "cmd.exe")
+    result = _shell_impl(
+        command="echo AAA\necho BBB", timeout=15, shell_path=comspec, cwd=tmp_path
+    )
+    assert result["exit_code"] == 0, result
+    assert "AAA" in result["stdout"] and "BBB" in result["stdout"], result
+
+
+@pytest.mark.windows_only
+def test_shell_impl_timeout_kills_child_tree_on_windows(tmp_path: Path) -> None:
+    """Regression: a timeout kills the whole tree, not just cmd.exe.
+
+    A ~5s ping child under a 1s timeout must return promptly rather than waiting
+    for the orphaned child to finish.
+    """
+    import time
+
+    comspec = os.environ.get("COMSPEC", "cmd.exe")
+    start = time.monotonic()
+    result = _shell_impl(
+        command="ping -n 6 127.0.0.1 >NUL", timeout=1, shell_path=comspec, cwd=tmp_path
+    )
+    elapsed = time.monotonic() - start
+    assert result["timed_out"] is True, result
+    assert elapsed < 3, f"took {elapsed:.1f}s; child tree not killed"

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -130,8 +130,14 @@ def test_build_helper_env_active_passes_omnigent_session_marker() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.posix_only
 def test_shell_impl_timeout_includes_exit_code(tmp_path: Path) -> None:
-    """Timed-out shell commands still return the documented result fields."""
+    """Timed-out shell commands still return the documented result fields.
+
+    POSIX-only: ``shutil.which("bash")`` resolves to the WSL launcher on Windows;
+    the native Windows timeout path is covered by
+    ``test_shell_impl_timeout_kills_child_tree_on_windows``.
+    """
     shell_path = shutil.which("bash") or shutil.which("sh")
     assert shell_path is not None
 
@@ -481,3 +487,38 @@ def test_shell_impl_timeout_kills_child_tree_on_windows(tmp_path: Path) -> None:
     elapsed = time.monotonic() - start
     assert result["timed_out"] is True, result
     assert elapsed < 3, f"took {elapsed:.1f}s; child tree not killed"
+
+
+@pytest.mark.windows_only
+def test_shell_impl_nonzero_exit_on_windows(tmp_path: Path) -> None:
+    """A non-zero exit returns the code without crashing (regression for an
+    UnboundLocalError that referenced an undefined `completed` on Windows)."""
+    comspec = os.environ.get("COMSPEC", "cmd.exe")
+    result = _shell_impl(command="exit /b 7", timeout=15, shell_path=comspec, cwd=tmp_path)
+    assert result["exit_code"] == 7, result
+    assert result.get("error"), result
+
+
+@pytest.mark.windows_only
+def test_shell_impl_timeout_kills_orphaned_descendant_on_windows(tmp_path: Path) -> None:
+    """A grandchild orphaned by a launcher that exits is still killed on timeout.
+
+    The Job Object contains the whole tree; a parent-walk (psutil/taskkill) can't
+    reach a descendant whose intermediate parent has already exited.
+    """
+    import sys
+    import time
+
+    marker = tmp_path / "MARKER"
+    comspec = os.environ.get("COMSPEC", "cmd.exe")
+    # Detach a worker that writes the marker after 6s, then keep cmd busy so the
+    # 1s timeout fires; the whole tree (incl. the detached worker) must die.
+    cmd = (
+        f'start "" /b "{sys.executable}" -c '
+        f"\"import time; time.sleep(6); open(r'{marker}', 'w').close()\"\n"
+        "ping -n 10 127.0.0.1 >NUL"
+    )
+    result = _shell_impl(command=cmd, timeout=1, shell_path=comspec, cwd=tmp_path)
+    assert result["timed_out"] is True, result
+    time.sleep(8)
+    assert not marker.exists(), "orphaned worker survived the timeout"

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -605,19 +605,190 @@ def test_tree_kill_job_terminate_reaches_grandchild(tmp_path: Path) -> None:
 
 
 @pytest.mark.windows_only
+def test_shell_impl_job_creation_failure_never_spawns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing containment job fails before a suspended child is created."""
+    import omnigent.inner.os_env as os_env_module
+    import omnigent.inner.windows_jobobject_sandbox as jobs
+
+    monkeypatch.setattr(jobs, "create_tree_kill_job", lambda: None)
+
+    def _unexpected_popen(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("cmd.exe was spawned without a containment job")
+
+    monkeypatch.setattr(os_env_module.subprocess, "Popen", _unexpected_popen)
+    with pytest.raises(OSError, match="could not create a Windows Job Object"):
+        os_env_module._run_windows_cmd_shell(
+            "echo MUST_NOT_RUN",
+            timeout=10,
+            shell_path=os.environ.get("COMSPEC", "cmd.exe"),
+            cwd=tmp_path,
+        )
+
+
+@pytest.mark.windows_only
+def test_shell_impl_job_assignment_failure_never_resumes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rejected Job assignment kills the suspended cmd.exe instead of running it."""
+    import omnigent.inner.os_env as os_env_module
+    import omnigent.inner.windows_jobobject_sandbox as jobs
+    from omnigent.inner._proc import process_alive
+
+    marker = tmp_path / "must_not_run.txt"
+    assigned_pid: list[int] = []
+    job_events: list[str] = []
+
+    class _RejectingJob:
+        def assign(self, pid: int) -> bool:
+            job_events.append("assign")
+            assigned_pid.append(pid)
+            return False
+
+        def terminate(self) -> None:
+            job_events.append("terminate")
+
+        def close(self) -> None:
+            job_events.append("close")
+
+    monkeypatch.setattr(jobs, "create_tree_kill_job", _RejectingJob)
+
+    def _unexpected_resume(_pid: int) -> bool:
+        raise AssertionError("an uncontained cmd.exe was resumed")
+
+    monkeypatch.setattr(jobs, "resume_process_threads", _unexpected_resume)
+    with pytest.raises(OSError, match="could not assign"):
+        os_env_module._run_windows_cmd_shell(
+            f'echo escaped>"{marker}"',
+            timeout=10,
+            shell_path=os.environ.get("COMSPEC", "cmd.exe"),
+            cwd=tmp_path,
+        )
+
+    assert assigned_pid
+    assert job_events == ["assign", "terminate", "close"]
+    assert not process_alive(assigned_pid[0])
+    assert not marker.exists()
+
+
+@pytest.mark.windows_only
+def test_shell_impl_abnormal_exit_terminates_and_reaps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cancellation after resume tears down and reaps the contained process tree."""
+    import subprocess
+
+    import omnigent.inner.os_env as os_env_module
+    from omnigent.inner._proc import process_alive
+
+    real_popen = subprocess.Popen
+    created_pid: list[int] = []
+
+    class _InterruptOnce:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self._proc = real_popen(*args, **kwargs)
+            self._first_communicate = True
+            created_pid.append(self._proc.pid)
+
+        @property
+        def pid(self) -> int:
+            return self._proc.pid
+
+        @property
+        def returncode(self) -> int | None:
+            return self._proc.returncode
+
+        def communicate(self, *args: object, **kwargs: object) -> tuple[str, str]:
+            if self._first_communicate:
+                self._first_communicate = False
+                raise KeyboardInterrupt
+            return self._proc.communicate(*args, **kwargs)
+
+        def kill(self) -> None:
+            self._proc.kill()
+
+        def wait(self, *args: object, **kwargs: object) -> int:
+            return self._proc.wait(*args, **kwargs)
+
+    monkeypatch.setattr(os_env_module.subprocess, "Popen", _InterruptOnce)
+    with pytest.raises(KeyboardInterrupt):
+        os_env_module._run_windows_cmd_shell(
+            "ping -n 30 127.0.0.1 >nul",
+            timeout=30,
+            shell_path=os.environ.get("COMSPEC", "cmd.exe"),
+            cwd=tmp_path,
+        )
+
+    assert created_pid
+    assert not process_alive(created_pid[0])
+
+
+@pytest.mark.windows_only
+def test_resume_thread_failure_uses_unsigned_dword_sentinel() -> None:
+    """Win32 ``ResumeThread`` failure must compare equal to ``DWORD(-1)``."""
+    import ctypes
+    import ctypes.wintypes as wintypes
+
+    from omnigent.inner.windows_jobobject_sandbox import _RESUME_THREAD_FAILED
+
+    kernel32 = ctypes.windll.kernel32
+    assert kernel32.ResumeThread.restype is wintypes.DWORD
+    assert kernel32.ResumeThread(wintypes.HANDLE(-1)) == _RESUME_THREAD_FAILED
+
+
+@pytest.mark.windows_only
+def test_shell_impl_normal_completion_spares_detached_child(tmp_path: Path) -> None:
+    """A truly detached child survives the normal close-without-terminate path."""
+    import sys
+    import time
+
+    marker = tmp_path / "detached_survived.txt"
+    worker = tmp_path / "detached_worker.py"
+    worker.write_text(
+        f"import time\ntime.sleep(2)\nopen({str(marker)!r}, 'w', encoding='utf-8').write('ok')\n",
+        encoding="utf-8",
+    )
+    launcher = tmp_path / "detached_launcher.py"
+    launcher.write_text(
+        "import subprocess, sys\n"
+        f"subprocess.Popen([sys.executable, {str(worker)!r}], "
+        "stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, "
+        "stderr=subprocess.DEVNULL, close_fds=True, "
+        "creationflags=0x00000008 | 0x00000200)\n",
+        encoding="utf-8",
+    )
+
+    result = _shell_impl(
+        command=f'"{sys.executable}" "{launcher}"',
+        timeout=10,
+        shell_path=os.environ.get("COMSPEC", "cmd.exe"),
+        cwd=tmp_path,
+    )
+    assert result["exit_code"] == 0, result
+    assert result["timed_out"] is False, result
+    assert not marker.exists(), "detached worker completed before the shell returned"
+
+    deadline = time.monotonic() + 8
+    while time.monotonic() < deadline and not marker.exists():
+        time.sleep(0.05)
+    assert marker.exists(), "normal Job close killed the detached child"
+
+
+@pytest.mark.windows_only
 def test_shell_impl_runs_from_hostile_temp_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A %TEMP% containing a space AND ``&`` must still run.
+    """A %TEMP% containing spaces, ``&``, and ``%NAME%`` must still run.
 
-    The batch path is double-quoted via ``/s /c ""<path>""`` so cmd strips only
-    the outer pair, leaving a properly quoted path — where a bare, list-quoted
-    path would break once cmd stripped its single quote pair.
+    The batch path is expanded once from a private environment variable, so cmd
+    does not reinterpret percent sequences inside the resulting path.
     """
     import tempfile
 
-    hostile = tmp_path / "a b & c"
+    hostile = tmp_path / "a b & %OMNIGENT_EXPAND_ME% c"
     hostile.mkdir()
+    monkeypatch.setenv("OMNIGENT_EXPAND_ME", "expanded")
     monkeypatch.setattr(tempfile, "tempdir", str(hostile))
     comspec = os.environ.get("COMSPEC", "cmd.exe")
     result = _shell_impl(command="echo spacey", timeout=15, shell_path=comspec, cwd=tmp_path)

--- a/tests/onboarding/test_interactive.py
+++ b/tests/onboarding/test_interactive.py
@@ -464,3 +464,13 @@ def test_render_menu_compact_truncates_long_description_to_one_line() -> None:
     assert len(hint_lines) == 1
     assert "…" in hint_lines[0]
     assert len(hint_lines[0]) <= 40
+
+
+@pytest.mark.windows_only
+def test_select_routes_to_fallback_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On Windows, select() uses the numbered fallback instead of importing
+    termios (which doesn't exist there). isatty is forced True so only the
+    Windows branch can trigger the fallback."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(interactive, "_select_fallback", lambda *a, **k: 42)
+    assert interactive.select("pick", ["a", "b"]) == 42

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -207,7 +207,7 @@ async def test_read_text_byte_cap_truncates_on_utf8_boundary(
     """
     # "é" is 2 bytes (0xC3 0xA9) in UTF-8; on "aé" a 2-byte cap keeps the "a"
     # and lands mid-codepoint inside "é".
-    (workspace / "accents.txt").write_text("aé")
+    (workspace / "accents.txt").write_text("aé", encoding="utf-8")
 
     os_env = create_os_environment(
         OSEnvSpec(type="caller_process", cwd=str(workspace), sandbox=OSEnvSandboxSpec(type="none"))
@@ -302,7 +302,7 @@ async def test_delete_directory_recursive(
     assert not (workspace / "src").exists()
 
 
-# ── shell-injection regression for stat/_stat_via_shell/_check_dir_empty ──
+# ── shell-injection regressions for stat and anchored delete ──
 
 
 @pytest.mark.asyncio
@@ -312,15 +312,14 @@ async def test_delete_path_with_command_substitution_does_not_execute(
 ) -> None:
     """A DELETE path containing ``$(...)`` must not execute the substituted command.
 
-    Regression test: the DELETE handler reaches ``_stat_via_shell``
-    and ``_check_dir_empty``, which used to interpolate the caller-controlled
+    Regression test: the old DELETE helpers interpolated the caller-controlled
     path into a double-quoted ``python3 -c`` script. The shell expanded
-    ``$(...)`` before python ran, giving arbitrary command execution.
+    ``$(...)`` before Python ran, giving arbitrary command execution.
 
     The payload ``inj$(touch PWNED)x`` would, on the vulnerable code, run
     ``touch PWNED`` in the workspace (cwd of the helper). With the path
-    embedded as a Python literal via ``json.dumps`` and the whole script
-    shell-quoted, the string is statted verbatim — no command runs.
+    The anchored delete helper now embeds the path as a Python literal via
+    ``json.dumps`` and shell-quotes the whole script, so no command runs.
     """
     import urllib.parse
 
@@ -335,7 +334,7 @@ async def test_delete_path_with_command_substitution_does_not_execute(
         f"/{DEFAULT_ENVIRONMENT_ID}/filesystem/{encoded}"
     )
 
-    # The literal path does not exist, so the stat fails and the endpoint
+    # The literal path does not exist, so classification fails and the endpoint
     # returns 404 — on BOTH old and new code the HTTP status is 404 (the
     # substituted command produced empty output, leaving "injx"). The marker
     # is the discriminator: it is created only if the injection executed.
@@ -357,11 +356,11 @@ async def test_delete_real_file_with_command_substitution_name(
 
     Usability guard for the shell-injection fix: embedding the path as a Python
     literal must treat shell metacharacters as ordinary filename bytes, so a
-    legitimately (if unusually) named file is statted and removed correctly.
+    legitimately (if unusually) named file is classified and removed correctly.
 
     If the path were still shell-interpreted, ``$(whoami)`` would expand and
-    ``os.stat`` would receive a *different* string (``data<user>.txt``), the
-    stat would miss, and the real file would be left on disk — surfacing as a
+    the helper would receive a *different* string (``data<user>.txt``), the
+    lookup would miss, and the real file would be left on disk — surfacing as a
     404 and a surviving file. Asserting a successful delete of the real file
     proves the verbatim path made it through.
     """
@@ -386,9 +385,9 @@ async def test_delete_real_file_with_command_substitution_name(
     body = resp.json()
     assert body["deleted"] is True, "The endpoint must report the file as deleted."
     assert body["type"] == "file", "The metacharacter-named entry is a regular file."
-    # The verbatim-named file is gone — proves stat + rm both used the literal path.
+    # The verbatim-named file is gone — proves the anchored helper used the literal path.
     assert not target.exists(), (
-        f"File {weird_name!r} still on disk after a reported delete; the rm "
+        f"File {weird_name!r} still on disk after a reported delete; the helper "
         "did not target the literal path."
     )
 
@@ -651,9 +650,10 @@ async def test_shell_timeout_returns_structured_result(
     client: httpx.AsyncClient,
 ) -> None:
     """POST /shell returns the timeout result instead of raising."""
+    command = "ping -n 3 127.0.0.1 >nul" if os.name == "nt" else "sleep 2"
     resp = await client.post(
         f"/v1/sessions/conv_test/resources/environments/{DEFAULT_ENVIRONMENT_ID}/shell",
-        json={"command": "sleep 2", "timeout": 1},
+        json={"command": command, "timeout": 1},
     )
     assert resp.status_code == 200
     body = resp.json()
@@ -1716,6 +1716,34 @@ async def test_delete_directory_junction_removes_link_not_target(tmp_path: Path)
     assert result.type == "symlink"
     assert not junction.exists()
     assert target.is_dir() and (target / "keep.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_broken_directory_junction_succeeds(tmp_path: Path) -> None:
+    """A Windows junction remains deletable after its target disappears."""
+    ws = tmp_path / "ws"
+    target = ws / "real"
+    target.mkdir(parents=True)
+    junction = ws / "dangling_junction"
+    result = subprocess.run(
+        f'mklink /J "{junction}" "{target}"',
+        shell=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        pytest.skip("could not create a junction")
+    target.rmdir()
+    assert os.path.lexists(junction) and not junction.exists()
+
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    fs = CallerProcessFilesystem(os_env)
+
+    deleted = await fs.delete("dangling_junction")
+
+    assert deleted.type == "symlink"
+    assert not os.path.lexists(junction)
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -13,11 +13,11 @@ import pytest
 from fastapi import FastAPI
 
 from omnigent.entities import DEFAULT_ENVIRONMENT_ID
-from omnigent.entities.environment_filesystem import FilesystemPathNotFound
+from omnigent.entities.environment_filesystem import FilesystemPathNotFound, InvalidPath
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.os_env import create_os_environment
 from omnigent.runner import create_runner_app
-from omnigent.runner.environment_filesystem import CallerProcessFilesystem
+from omnigent.runner.environment_filesystem import CallerProcessFilesystem, _validate_path
 from omnigent.runner.resource_registry import SessionResourceRegistry
 from tests.runner.helpers import NullServerClient
 
@@ -1667,7 +1667,8 @@ async def test_delete_directory_symlink_removes_link_not_target(tmp_path: Path) 
         OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
     )
     fs = CallerProcessFilesystem(os_env)
-    await fs.delete("link", recursive=True)
+    result = await fs.delete("link", recursive=True)
+    assert result.type == "symlink"
     assert not link.is_symlink()
     assert target.is_dir() and (target / "keep.txt").exists()
 
@@ -1711,7 +1712,8 @@ async def test_delete_directory_junction_removes_link_not_target(tmp_path: Path)
         OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
     )
     fs = CallerProcessFilesystem(os_env)
-    await fs.delete("jx", recursive=True)
+    result = await fs.delete("jx", recursive=True)
+    assert result.type == "symlink"
     assert not junction.exists()
     assert target.is_dir() and (target / "keep.txt").exists()
 
@@ -1733,7 +1735,8 @@ async def test_delete_broken_symlink_succeeds(tmp_path: Path) -> None:
         OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
     )
     fs = CallerProcessFilesystem(os_env)
-    await fs.delete("dangling")
+    result = await fs.delete("dangling")
+    assert result.type == "symlink"
     assert not link.is_symlink()
 
 
@@ -1752,3 +1755,105 @@ async def test_write_entry_path_is_forward_slash_for_nested(tmp_path: Path) -> N
     assert result.entry.path == "sub/dir/f.py"
     assert "\\" not in result.entry.path
     assert "\\" not in result.entry.id
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "C:outside.txt",
+        r"D:..\outside.txt",
+        r"C:\outside.txt",
+        r"\outside.txt",
+        r"\\server\share\outside.txt",
+        r"\\?\C:\outside.txt",
+    ],
+)
+def test_validate_path_rejects_windows_drive_and_root_forms(path: str) -> None:
+    """Windows drive-relative, absolute, UNC, and device paths never pass."""
+    with pytest.raises(InvalidPath):
+        _validate_path(path)
+
+
+@pytest.mark.asyncio
+async def test_delete_through_escaping_intermediate_symlink_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """An intermediate symlink cannot redirect a deletion outside the root."""
+    ws = tmp_path / "ws"
+    outside = tmp_path / "outside"
+    ws.mkdir()
+    outside.mkdir()
+    victim = outside / "keep.txt"
+    victim.write_text("keep")
+    link = ws / "escape"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"cannot create directory symlink: {exc}")
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    fs = CallerProcessFilesystem(os_env)
+
+    with pytest.raises(InvalidPath):
+        await fs.delete("escape/keep.txt")
+
+    assert victim.read_text() == "keep"
+
+
+@pytest.mark.asyncio
+async def test_delete_through_in_root_intermediate_symlink_succeeds(
+    tmp_path: Path,
+) -> None:
+    """An intermediate symlink may resolve to another directory inside root."""
+    ws = tmp_path / "ws"
+    target = ws / "target"
+    target.mkdir(parents=True)
+    victim = target / "remove.txt"
+    victim.write_text("remove")
+    link = ws / "alias"
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"cannot create directory symlink: {exc}")
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    fs = CallerProcessFilesystem(os_env)
+
+    result = await fs.delete("alias/remove.txt")
+
+    assert result.type == "file"
+    assert not victim.exists()
+    assert link.is_symlink()
+
+
+@pytest.mark.windows_only
+@pytest.mark.asyncio
+async def test_delete_through_escaping_intermediate_junction_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """An intermediate Windows junction cannot redirect deletion outside."""
+    ws = tmp_path / "ws"
+    outside = tmp_path / "outside"
+    ws.mkdir()
+    outside.mkdir()
+    victim = outside / "keep.txt"
+    victim.write_text("keep")
+    junction = ws / "escape"
+    result = subprocess.run(
+        f'mklink /J "{junction}" "{outside}"',
+        shell=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        pytest.skip("could not create a junction")
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    fs = CallerProcessFilesystem(os_env)
+
+    with pytest.raises(InvalidPath):
+        await fs.delete("escape/keep.txt")
+
+    assert victim.read_text() == "keep"

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -1670,3 +1670,47 @@ async def test_delete_directory_symlink_removes_link_not_target(tmp_path: Path) 
     await fs.delete("link", recursive=True)
     assert not link.is_symlink()
     assert target.is_dir() and (target / "keep.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_list_dir_two_level_nested_path_forward_slash(tmp_path: Path) -> None:
+    """Multi-level paths stay '/'-separated end to end (_validate_path
+    normalizes, so stat/write/edit/list all agree)."""
+    ws = tmp_path / "ws"
+    (ws / "src" / "pkg").mkdir(parents=True)
+    (ws / "src" / "pkg" / "main.py").write_text("x")
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    fs = CallerProcessFilesystem(os_env)
+    page = await fs.list_dir("src/pkg")
+    assert [e.path for e in page.data] == ["src/pkg/main.py"]
+    results = await fs.search_files("main", include=["src/**"])
+    assert [e.path for e in results] == ["src/pkg/main.py"]
+
+
+@pytest.mark.windows_only
+@pytest.mark.asyncio
+async def test_delete_directory_junction_removes_link_not_target(tmp_path: Path) -> None:
+    """Deleting a Windows directory junction removes the junction, not the
+    target (os.path.islink misses junctions, so the delete keys off the reparse
+    attribute from lstat)."""
+    import subprocess
+
+    ws = tmp_path / "ws"
+    target = ws / "real"
+    target.mkdir(parents=True)
+    (target / "keep.txt").write_text("x")
+    junction = ws / "jx"
+    rc = subprocess.run(
+        f'mklink /J "{junction}" "{target}"', shell=True, capture_output=True
+    ).returncode
+    if rc != 0:
+        pytest.skip("could not create a junction")
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    fs = CallerProcessFilesystem(os_env)
+    await fs.delete("jx", recursive=True)
+    assert not junction.exists()
+    assert target.is_dir() and (target / "keep.txt").exists()

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -1579,9 +1579,9 @@ class TestPythonRunCommand:
         from omnigent.runner import environment_filesystem as efs
 
         monkeypatch.setattr(efs, "IS_WINDOWS", False)
-        cmd = efs._python_run_command("print('hi')")
-        assert cmd.startswith("python3 -c ")
-        assert "print('hi')" in cmd
+        # A script without single quotes so _shell_quote wraps it cleanly.
+        cmd = efs._python_run_command("import os")
+        assert cmd == "python3 -c 'import os'"
 
     def test_windows_base64_roundtrips(self, monkeypatch) -> None:
         import base64
@@ -1620,3 +1620,53 @@ async def test_inactive_sandbox_shell_runs_quoted_command_windows(tmp_path: Path
     assert result.get("exit_code") == 0, result
     assert "\\" not in result["stdout"], result["stdout"]  # not \"a b\"
     assert "a b" in result["stdout"]
+
+
+@pytest.mark.asyncio
+async def test_list_dir_returns_forward_slash_nested_paths(tmp_path: Path) -> None:
+    """Nested entry paths use POSIX '/' regardless of host OS (os.path.join
+    would emit '\' on Windows, which the API/glob/frontend reject)."""
+    ws = tmp_path / "ws"
+    (ws / "src").mkdir(parents=True)
+    (ws / "src" / "main.py").write_text("x")
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    fs = CallerProcessFilesystem(os_env)
+    page = await fs.list_dir("src")
+    assert [e.path for e in page.data] == ["src/main.py"]
+
+
+@pytest.mark.asyncio
+async def test_search_matches_forward_slash_include(tmp_path: Path) -> None:
+    """search honours '/'-separated include globs and returns '/'-paths."""
+    ws = tmp_path / "ws"
+    (ws / "src").mkdir(parents=True)
+    (ws / "src" / "main.py").write_text("x")
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    fs = CallerProcessFilesystem(os_env)
+    results = await fs.search_files("main", include=["src/**"])
+    assert [e.path for e in results] == ["src/main.py"]
+
+
+@pytest.mark.asyncio
+async def test_delete_directory_symlink_removes_link_not_target(tmp_path: Path) -> None:
+    """Deleting a directory symlink removes the link, not the target tree."""
+    ws = tmp_path / "ws"
+    target = ws / "real"
+    target.mkdir(parents=True)
+    (target / "keep.txt").write_text("x")
+    link = ws / "link"
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"cannot create directory symlink: {exc}")
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    fs = CallerProcessFilesystem(os_env)
+    await fs.delete("link", recursive=True)
+    assert not link.is_symlink()
+    assert target.is_dir() and (target / "keep.txt").exists()

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -1714,3 +1714,41 @@ async def test_delete_directory_junction_removes_link_not_target(tmp_path: Path)
     await fs.delete("jx", recursive=True)
     assert not junction.exists()
     assert target.is_dir() and (target / "keep.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_broken_symlink_succeeds(tmp_path: Path) -> None:
+    """A broken symlink (its target is gone) is still deletable: delete keys off
+    ``os.lstat`` — ``os.stat`` would follow the link, fail, and report it as
+    'missing', leaving the dangling link stuck forever."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    link = ws / "dangling"
+    try:
+        link.symlink_to(ws / "does_not_exist")
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"cannot create symlink: {exc}")
+    assert link.is_symlink() and not link.exists()  # broken by construction
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    fs = CallerProcessFilesystem(os_env)
+    await fs.delete("dangling")
+    assert not link.is_symlink()
+
+
+@pytest.mark.asyncio
+async def test_write_entry_path_is_forward_slash_for_nested(tmp_path: Path) -> None:
+    """The write result's entry path/id use '/' even for a nested path.
+    ``Path.relative_to`` renders '\\' on Windows; ``_entry_from_stat`` normalizes
+    centrally so every entry the API returns is '/'-separated."""
+    ws = tmp_path / "ws"
+    (ws / "sub" / "dir").mkdir(parents=True)
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    fs = CallerProcessFilesystem(os_env)
+    result = await fs.write("sub/dir/f.py", b"x")
+    assert result.entry.path == "sub/dir/f.py"
+    assert "\\" not in result.entry.path
+    assert "\\" not in result.entry.id

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -1570,3 +1570,53 @@ async def test_worktree_session_uses_session_workspace_for_changes(
             "The /changes endpoint is reading from the runner's global "
             "workspace instead of the session's worktree workspace."
         )
+
+
+class TestPythonRunCommand:
+    """`_python_run_command` builds a platform-correct Python invocation."""
+
+    def test_posix_uses_python3_dash_c(self, monkeypatch) -> None:
+        from omnigent.runner import environment_filesystem as efs
+
+        monkeypatch.setattr(efs, "IS_WINDOWS", False)
+        cmd = efs._python_run_command("print('hi')")
+        assert cmd.startswith("python3 -c ")
+        assert "print('hi')" in cmd
+
+    def test_windows_base64_roundtrips(self, monkeypatch) -> None:
+        import base64
+
+        from omnigent.runner import environment_filesystem as efs
+
+        monkeypatch.setattr(efs, "IS_WINDOWS", True)
+        script = "import os\nprint(os.getcwd())"
+        cmd = efs._python_run_command(script)
+        # A multi-line script must not leak raw newlines into the command line.
+        assert "\n" not in cmd
+        assert " -c " in cmd
+        # The embedded base64 decodes back to the original script.
+        b64 = cmd.split("b64decode('")[1].split("')")[0]
+        assert base64.b64decode(b64).decode() == script
+
+
+@pytest.mark.asyncio
+@pytest.mark.windows_only
+async def test_inactive_sandbox_shell_runs_quoted_command_windows(tmp_path: Path) -> None:
+    """Regression: Windows inactive-sandbox helper startup + quoted execution.
+
+    Guards two Windows defects together: the ``sandbox.type: none`` helper
+    previously failed to spawn (message-less AssertionError -> ``{"error": ""}``
+    because its tmpdir was only created for active sandboxes), and quoted
+    commands were mangled to ``\\"a b\\"`` by list-based argv serialization
+    through ``cmd.exe``.
+    """
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(ws), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    result = await os_env.shell('echo "a b"')
+    assert not result.get("error"), result  # helper spawned + ran
+    assert result.get("exit_code") == 0, result
+    assert "\\" not in result["stdout"], result["stdout"]  # not \"a b\"
+    assert "a b" in result["stdout"]

--- a/tests/server/routes/test_workspace_validation_helpers.py
+++ b/tests/server/routes/test_workspace_validation_helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from omnigent.server.routes._workspace_validation import (
     _is_relative_cwd,
     _is_subpath_of,
+    _is_windows_style_path,
     is_absolute_host_path,
 )
 
@@ -80,6 +81,30 @@ class TestIsSubpathOf:
 
     def test_windows_unc_child(self) -> None:
         assert _is_subpath_of(r"\\srv\share\proj\src", r"\\srv\share\proj") is True
+
+    def test_posix_backslash_filename_not_contained(self) -> None:
+        r"""``\`` is a legal POSIX filename char: boundary ``/tmp/a\b`` is a
+        single component and must NOT contain ``/tmp/a/b/child``."""
+        assert _is_subpath_of("/tmp/a/b/child", r"/tmp/a\b") is False
+
+
+class TestIsWindowsStylePath:
+    """Detection must key on drive/UNC prefix, not an embedded backslash."""
+
+    def test_drive_backslash(self) -> None:
+        assert _is_windows_style_path(r"C:\repo") is True
+
+    def test_drive_forward_slash(self) -> None:
+        assert _is_windows_style_path("C:/repo") is True
+
+    def test_unc(self) -> None:
+        assert _is_windows_style_path(r"\\server\share") is True
+
+    def test_posix_root(self) -> None:
+        assert _is_windows_style_path("/tmp/a/b") is False
+
+    def test_posix_with_backslash_char(self) -> None:
+        assert _is_windows_style_path(r"/tmp/a\b") is False
 
 
 class TestIsAbsoluteHostPath:

--- a/tests/server/routes/test_workspace_validation_helpers.py
+++ b/tests/server/routes/test_workspace_validation_helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from omnigent.server.routes._workspace_validation import (
     _is_relative_cwd,
     _is_subpath_of,
+    is_absolute_host_path,
 )
 
 
@@ -58,3 +59,52 @@ class TestIsSubpathOf:
 
     def test_trailing_slash_boundary(self) -> None:
         assert _is_subpath_of("/a/b/c", "/a/b/") is True
+
+    # --- Windows path flavour (native-Windows host) ---
+
+    def test_windows_child_path(self) -> None:
+        assert _is_subpath_of(r"C:\repo\child", r"C:\repo") is True
+
+    def test_windows_not_a_subpath(self) -> None:
+        assert _is_subpath_of(r"C:\repo", r"C:\other") is False
+
+    def test_windows_case_insensitive(self) -> None:
+        assert _is_subpath_of(r"c:\repo\child", r"C:\Repo") is True
+
+    def test_windows_mixed_separators(self) -> None:
+        assert _is_subpath_of("C:/repo/child", r"C:\repo") is True
+
+    def test_windows_prefix_collision(self) -> None:
+        """``C:\\repo2`` must NOT be treated as a subpath of ``C:\\repo``."""
+        assert _is_subpath_of(r"C:\repo2\x", r"C:\repo") is False
+
+    def test_windows_unc_child(self) -> None:
+        assert _is_subpath_of(r"\\srv\share\proj\src", r"\\srv\share\proj") is True
+
+
+class TestIsAbsoluteHostPath:
+    """Tests for the POSIX-or-Windows absolute-path gate."""
+
+    def test_posix_absolute(self) -> None:
+        assert is_absolute_host_path("/Users/alice/project") is True
+
+    def test_windows_drive_backslash(self) -> None:
+        assert is_absolute_host_path(r"C:\Users\alice") is True
+
+    def test_windows_drive_forward_slash(self) -> None:
+        assert is_absolute_host_path("C:/Users/alice") is True
+
+    def test_unc_path(self) -> None:
+        assert is_absolute_host_path(r"\\server\share") is True
+
+    def test_relative_rejected(self) -> None:
+        assert is_absolute_host_path("project/src") is False
+
+    def test_dot_relative_rejected(self) -> None:
+        assert is_absolute_host_path("./src") is False
+
+    def test_bare_name_rejected(self) -> None:
+        assert is_absolute_host_path("project") is False
+
+    def test_empty_rejected(self) -> None:
+        assert is_absolute_host_path("") is False

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -3614,3 +3614,18 @@ def test_config_loader_does_not_mutate_shared_safeloader_resolvers() -> None:
     # The subclass still narrows bools: ``on`` is a plain string, ``false`` a bool.
     assert yaml.load("on", loader) == "on"
     assert yaml.load("false", loader) is False
+
+
+def test_parse_config_preserves_non_ascii_prompt(tmp_path: Path) -> None:
+    """config.yaml is read as UTF-8 so non-ASCII prompt text (em-dash, arrows)
+    survives instead of mojibaking through the platform locale (cp1252 on
+    Windows)."""
+    (tmp_path / "config.yaml").write_text(
+        'spec_version: 1\nname: t\nprompt: "plans — not code ↔ review"\n',
+        encoding="utf-8",
+    )
+    spec = parse(tmp_path)
+    assert spec.instructions is not None
+    assert "—" in spec.instructions
+    assert "↔" in spec.instructions
+    assert "â€" not in spec.instructions  # no cp1252 mojibake

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -674,13 +674,13 @@ def test_discover_host_skills_skips_invalid_yaml_frontmatter(
 
     ``discover_host_skills`` scans two locations: walking up from
     ``agent_root`` and ``Path.home() / ".claude" / "skills"``. We
-    pin ``$HOME`` at a fresh tmp dir to keep the developer's real
+    pin ``Path.home()`` at a fresh tmp dir to keep the developer's real
     ``~/.claude/skills/`` (which contains the actual offending
     skill) out of this test.
     """
     fake_home = tmp_path / "home"
     fake_home.mkdir()
-    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
 
     agent_root = tmp_path / "agent"
     agent_root.mkdir()
@@ -699,7 +699,7 @@ def test_discover_host_skills_skips_invalid_yaml_frontmatter(
     (good_dir / "SKILL.md").write_text("---\nname: good-skill\ndescription: y\n---\nContent.")
 
     with caplog.at_level("WARNING", logger="omnigent.spec.parser"):
-        result = discover_host_skills(agent_root, "all")
+        result = discover_host_skills(agent_root, ["bad-skill", "good-skill"])
 
     names = [s.name for s in result]
     assert names == ["good-skill"], (
@@ -730,34 +730,34 @@ def test_discover_host_skills_skips_unreadable_skill_file(
     """
     fake_home = tmp_path / "home"
     fake_home.mkdir()
-    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
 
     agent_root = tmp_path / "agent"
     agent_root.mkdir()
     host_skills = agent_root / ".claude" / "skills"
     host_skills.mkdir(parents=True)
 
-    # Broken symlink: ``SKILL.md`` exists (in the sense that
-    # ``Path.exists()`` follows symlinks and returns False, but the
-    # discoverer's ``skill_md.exists()`` check returns False too).
-    # Use a directory we make read-then-unreadable instead so the
-    # path exists but read_text() raises OSError.
+    # Simulate a permission failure explicitly: chmod(000) remains readable on
+    # Windows, so it cannot make this regression deterministic cross-platform.
     bad_dir = host_skills / "unreadable"
     bad_dir.mkdir()
     bad_md = bad_dir / "SKILL.md"
     bad_md.write_text("---\nname: unreadable\ndescription: x\n---\nbody")
-    bad_md.chmod(0o000)
 
     good_dir = host_skills / "good"
     good_dir.mkdir()
     (good_dir / "SKILL.md").write_text("---\nname: good\ndescription: y\n---\nContent.")
 
-    try:
-        with caplog.at_level("WARNING", logger="omnigent.spec.parser"):
-            result = discover_host_skills(agent_root, "all")
-    finally:
-        # Restore so pytest can clean tmp_path on teardown.
-        bad_md.chmod(0o600)
+    real_read_text = Path.read_text
+
+    def _read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == bad_md:
+            raise PermissionError("test permission denied")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _read_text)
+    with caplog.at_level("WARNING", logger="omnigent.spec.parser"):
+        result = discover_host_skills(agent_root, ["good", "unreadable"])
 
     assert [s.name for s in result] == ["good"]
     skip_records = [rec for rec in caplog.records if "Skipping skill" in rec.message]
@@ -905,6 +905,28 @@ def test_parse_skills_filter_is_independent_of_bundled_skills_dir(
 # ── lenient host-skill discovery ────────────────────
 
 
+def test_discover_host_skills_all_loads_each_local_skill(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default ``"all"`` filter includes every valid local skill."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    agent_root = tmp_path / "project"
+    for dotdir, name in ((".claude", "claude-local"), (".agents", "agents-local")):
+        skill_dir = agent_root / dotdir / "skills" / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: Local test skill.\n---\nContent."
+        )
+
+    names = {skill.name for skill in discover_host_skills(agent_root, "all")}
+
+    assert {"claude-local", "agents-local"} <= names
+
+
 def test_discover_host_skills_skips_missing_frontmatter(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -941,7 +963,7 @@ def test_discover_host_skills_skips_missing_frontmatter(
     agent_root = tmp_path / "project"
     agent_root.mkdir()
 
-    result = discover_host_skills(agent_root, skills_filter="all")
+    result = discover_host_skills(agent_root, skills_filter=["bad-skill", "good-skill"])
 
     assert len(result) == 1
     assert result[0].name == "good-skill"
@@ -980,7 +1002,7 @@ def test_discover_host_skills_skips_yaml_syntax_error(
     agent_root = tmp_path / "project"
     agent_root.mkdir()
 
-    result = discover_host_skills(agent_root, skills_filter="all")
+    result = discover_host_skills(agent_root, skills_filter=["broken-yaml"])
 
     assert result == []
     captured = capsys.readouterr()
@@ -1015,7 +1037,7 @@ def test_discover_host_skills_skips_multiple_bad_skills(
     agent_root = tmp_path / "project"
     agent_root.mkdir()
 
-    result = discover_host_skills(agent_root, skills_filter="all")
+    result = discover_host_skills(agent_root, skills_filter=["bad-a", "bad-b"])
 
     assert result == []
     captured = capsys.readouterr()

--- a/tests/test_file_encoding.py
+++ b/tests/test_file_encoding.py
@@ -2,13 +2,19 @@
 
 Windows defaults text I/O to cp1252, so an ``open``/``read_text``/``write_text``
 without an explicit ``encoding`` mojibakes UTF-8 content (e.g. an em-dash in an
-agent prompt). Ruff's ``PLW1514`` catches the statically-inferable cases; these
-tests add a runtime net that also covers reads whose receiver type Ruff can't
-infer, and a Windows end-to-end regression.
+agent prompt). Three complementary guards:
+
+1. A **receiver-independent** AST scan (``tests/_encoding_scan.py``) — matches the
+   call by name, so it catches cases Ruff's ``PLW1514`` can't infer (e.g.
+   ``Path | None`` receivers). This is the primary structural guard; it runs
+   cross-platform.
+2. A **runtime** ``EncodingWarning`` net around real loading.
+3. A **windows_only** end-to-end regression under a forced cp1252 default.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import textwrap
@@ -16,14 +22,22 @@ from pathlib import Path
 
 import pytest
 
-from omnigent.spec.parser import parse
+from tests._encoding_scan import ALLOWLIST, scan_package
+
+
+def test_no_unencoded_owned_text_io() -> None:
+    """Structural guard: no omnigent-owned open/read_text/write_text may omit an
+    explicit ``encoding`` (receiver-independent; catches what PLW1514 misses).
+    """
+    pkg = Path(__file__).resolve().parents[1] / "omnigent"
+    violations = scan_package(pkg, ALLOWLIST)
+    assert not violations, "Unencoded text I/O (add encoding=...):\n" + "\n".join(violations)
 
 
 def test_agent_loading_emits_no_encoding_warning(tmp_path: Path) -> None:
-    """Cross-platform net: loading an agent config under
-    ``-X warn_default_encoding -W error::EncodingWarning`` must not trip any
-    unspecified-encoding read — catching non-inferable reads PLW1514 misses,
-    regardless of the CI host's locale.
+    """Runtime net: loading an agent config under
+    ``-X warn_default_encoding -W error::EncodingWarning`` trips no
+    unspecified-encoding read — regardless of the CI host's locale.
     """
     agent = tmp_path / "agent"
     agent.mkdir()
@@ -57,16 +71,37 @@ def test_agent_loading_emits_no_encoding_warning(tmp_path: Path) -> None:
 
 
 @pytest.mark.windows_only
-def test_config_prompt_survives_cp1252_default(tmp_path: Path) -> None:
-    """On Windows (cp1252 default), a UTF-8 config's non-ASCII prompt is read as
-    UTF-8 rather than mojibaked (regression for the ``itself — it plans`` phrase).
+def test_config_read_forces_utf8_under_cp1252_default(tmp_path: Path) -> None:
+    """End-to-end: with the interpreter default FORCED to cp1252 (PYTHONUTF8=0 on
+    Windows), parse() still reads the UTF-8 config correctly because the read
+    names an explicit encoding. The child first proves cp1252 is in effect (an
+    unencoded read of the same file mojibakes), then proves parse() does not.
     """
     agent = tmp_path / "agent"
     agent.mkdir()
-    (agent / "config.yaml").write_text(
-        'spec_version: 1\nname: t\nprompt: "itself — it plans ↔ delegates"\n',
-        encoding="utf-8",
+    cfg = agent / "config.yaml"
+    cfg.write_text('spec_version: 1\nname: t\nprompt: "itself — it plans"\n', encoding="utf-8")
+    script = textwrap.dedent(
+        f"""
+        import sys
+        from pathlib import Path
+        assert not sys.flags.utf8_mode, "expected PYTHONUTF8=0"
+        # Unencoded read mojibakes under the cp1252 default (proves the scenario).
+        assert "â€" in Path(r{str(cfg)!r}).read_text()
+        # parse() names encoding='utf-8', so it must NOT mojibake.
+        from omnigent.spec.parser import parse
+        spec = parse(Path(r{str(agent)!r}))
+        assert "itself — it plans" in (spec.instructions or ""), repr(spec.instructions)
+        """
     )
-    spec = parse(agent)
-    assert "itself — it plans" in (spec.instructions or "")
-    assert "â€" not in (spec.instructions or "")
+    env = dict(os.environ)
+    env["PYTHONUTF8"] = "0"
+    env.pop("PYTHONIOENCODING", None)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_file_encoding.py
+++ b/tests/test_file_encoding.py
@@ -140,6 +140,11 @@ _FLAGGED = [
     "self.cfg = ConfigParser()\nself.cfg.read(p)",  # attribute-bound instance
     'import gzip\ngzip.open(p, "rt")',  # gzip text mode needs encoding
     'import bz2\nbz2.open(p, "wt")',  # bz2 text mode needs encoding
+    'from gzip import open as gopen\ngopen(p, "rt")',  # aliased gzip.open, text
+    'import gzip as gz\ngz.open("blob.gz", "rt")',  # aliased module (filename has 'b')
+    'import gzip\ngzip.open(p, "r" + "t")',  # computed mode, not provably binary
+    "import gzip\ngzip.open(p, mode)",  # dynamic mode, not provably binary
+    'from pathlib import Path\ngzip = Path("x")\ngzip.open("rt")',  # rebound name: real text open
     'run("import os; data = open(p).read()")',  # embedded, plain string
     'run(f"exec(open({p!r}).read())")',  # embedded, f-string
     'run("""\n    import os\n    data = open(p).read()\n""")',  # embedded, indented
@@ -159,6 +164,8 @@ _CLEAN = [
     'import gzip\ngzip.open(p, "rb")',  # gzip explicit binary
     'import gzip\ngzip.open(p, "rt", encoding="utf-8")',  # gzip text + encoding
     'import lzma\nlzma.open(p, "wb")',  # lzma binary
+    "import gzip as gz\ngz.open(p)",  # aliased module, default binary
+    'import gzip as gz\ngz.open(p, "rb")',  # aliased module, binary
     "import configparser\ncfg = configparser.ConfigParser()\ncfg.read(p, encoding='locale')",
     "from configparser import ConfigParser as CP\nc = CP()\nc.read(p, encoding='utf-8')",
     "self.cfg = ConfigParser()\nself.cfg.read(p, encoding='utf-8')",  # attr-bound, encoded
@@ -248,3 +255,53 @@ def test_detect_encoding_reads_utf8_config_under_utf8_mode(tmp_path: Path) -> No
         """
     )
     assert result.returncode == 0, result.stderr
+
+
+# ``cli._read_existing_cfg`` is the guard that keeps the Databricks rewrite flow
+# from replacing an original it failed to read. (The full ``_isolated_databricks_
+# cfg`` context manager pulls in a Databricks-internal module not shipped here, so
+# the guard itself is tested directly.)
+def test_read_existing_cfg_missing_is_noop(tmp_path: Path) -> None:
+    """A missing original is the new-config case: no read, no error."""
+    import configparser
+
+    from omnigent.cli import _read_existing_cfg
+
+    cfg = configparser.ConfigParser()
+    _read_existing_cfg(cfg, tmp_path / "absent.cfg", "utf-8")
+    assert cfg.sections() == []
+
+
+def test_read_existing_cfg_loads_present_file(tmp_path: Path) -> None:
+    """An existing, readable original is loaded (so it can be preserved)."""
+    import configparser
+
+    from omnigent.cli import _read_existing_cfg
+
+    original = tmp_path / ".databrickscfg"
+    original.write_text("[legacy]\nhost = https://keep.example\n", encoding="utf-8")
+    cfg = configparser.ConfigParser()
+    _read_existing_cfg(cfg, original, "utf-8")
+    assert cfg["legacy"]["host"] == "https://keep.example"
+
+
+def test_read_existing_cfg_unreadable_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An existing file that ``ConfigParser.read`` silently skips (a permission
+    or transient I/O error) must raise, so the rewrite flow aborts instead of
+    seeding an empty config and overwriting the original — which would drop the
+    user's ``[legacy]`` section. Nothing is captured, so a caller cannot proceed.
+    """
+    import configparser
+
+    from omnigent.cli import _read_existing_cfg
+
+    original = tmp_path / ".databrickscfg"
+    original.write_text("[legacy]\nhost = https://keep.example\n", encoding="utf-8")
+    monkeypatch.setattr(configparser.ConfigParser, "read", lambda self, *a, **k: [])
+
+    cfg = configparser.ConfigParser()
+    with pytest.raises(OSError):
+        _read_existing_cfg(cfg, original, "utf-8")
+    assert cfg.sections() == []

--- a/tests/test_file_encoding.py
+++ b/tests/test_file_encoding.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-from tests._encoding_scan import ALLOWLIST, scan_package
+from tests._encoding_scan import ALLOWLIST, find_violations, scan_package
 
 
 def test_no_unencoded_owned_text_io() -> None:
@@ -72,10 +72,15 @@ def test_agent_loading_emits_no_encoding_warning(tmp_path: Path) -> None:
 
 @pytest.mark.windows_only
 def test_config_read_forces_utf8_under_cp1252_default(tmp_path: Path) -> None:
-    """End-to-end: with the interpreter default FORCED to cp1252 (PYTHONUTF8=0 on
-    Windows), parse() still reads the UTF-8 config correctly because the read
-    names an explicit encoding. The child first proves cp1252 is in effect (an
-    unencoded read of the same file mojibakes), then proves parse() does not.
+    """End-to-end: with the interpreter default at cp1252 (PYTHONUTF8=0 on a
+    Windows host whose ANSI code page is 1252), parse() still reads the UTF-8
+    config correctly because the read names an explicit encoding.
+
+    The child asserts the default codec is actually ``cp1252`` — PYTHONUTF8=0
+    only disables UTF-8 *mode*; the resulting default is the host ANSI code page
+    (Python has no per-process override for it), so the assertion pins the
+    scenario to a real cp1252 default rather than assuming it. It then proves an
+    unencoded read of the same file mojibakes, and that parse() does not.
     """
     agent = tmp_path / "agent"
     agent.mkdir()
@@ -83,9 +88,12 @@ def test_config_read_forces_utf8_under_cp1252_default(tmp_path: Path) -> None:
     cfg.write_text('spec_version: 1\nname: t\nprompt: "itself — it plans"\n', encoding="utf-8")
     script = textwrap.dedent(
         f"""
+        import locale
         import sys
         from pathlib import Path
-        assert not sys.flags.utf8_mode, "expected PYTHONUTF8=0"
+        assert not sys.flags.utf8_mode, "expected PYTHONUTF8=0 (UTF-8 mode off)"
+        enc = locale.getpreferredencoding(False)
+        assert enc.lower() == "cp1252", f"expected a cp1252 default, got {{enc!r}}"
         # Unencoded read mojibakes under the cp1252 default (proves the scenario).
         assert "â€" in Path(r{str(cfg)!r}).read_text()
         # parse() names encoding='utf-8', so it must NOT mojibake.
@@ -105,3 +113,41 @@ def test_config_read_forces_utf8_under_cp1252_default(tmp_path: Path) -> None:
         env=env,
     )
     assert result.returncode == 0, result.stderr
+
+
+# Snippets the scanner MUST flag — one per detection path. Kept alongside the
+# clean cases so the guard can't silently weaken (a broken detector fails here
+# long before it lets a real omnigent regression through).
+_FLAGGED = [
+    'open("f")',
+    'from pathlib import Path\nPath("f").read_text()',
+    'from pathlib import Path\nPath("f").write_text("x")',
+    'import os\nos.fdopen(fd, "w")',
+    "import configparser\ncfg = configparser.ConfigParser()\ncfg.read(p)",
+    'run("import os; data = open(p).read()")',  # embedded, plain string
+    'run(f"exec(open({p!r}).read())")',  # embedded, f-string
+]
+_CLEAN = [
+    'open("f", encoding="utf-8")',
+    'open("f", "rb")',  # binary
+    'open("f", encoding="locale")',
+    'from pathlib import Path\nPath("f").read_text(encoding="utf-8")',
+    'import tarfile\ntarfile.open("f")',  # archive, not text
+    'import os\nos.open("f", 0)',  # low-level fd
+    'import os\nos.fdopen(fd, "wb")',  # binary
+    'import os\nos.fdopen(fd, "w", encoding="utf-8")',
+    "import configparser\ncfg = configparser.ConfigParser()\ncfg.read(p, encoding='locale')",
+    "run(\"open(p, encoding='utf-8')\")",  # embedded, encoded
+    'run("call open() to begin; then stop.")',  # prose: not parseable Python
+    'run("// import fs;\\nfs.open(p);")',  # generated JS: not parseable Python
+]
+
+
+@pytest.mark.parametrize("src", _FLAGGED)
+def test_scanner_flags_unencoded(src: str) -> None:
+    assert find_violations(src), f"expected a violation for:\n{src}"
+
+
+@pytest.mark.parametrize("src", _CLEAN)
+def test_scanner_accepts_encoded_and_nonfile(src: str) -> None:
+    assert not find_violations(src), f"unexpected violation for:\n{src}"

--- a/tests/test_file_encoding.py
+++ b/tests/test_file_encoding.py
@@ -135,8 +135,16 @@ _FLAGGED = [
     'from os import fdopen\nfdopen(fd, "w")',  # imported fdopen
     'from os import fdopen as fdo\nfdo(fd, "w")',  # aliased fdopen
     'import os as _o\n_o.fdopen(fd, "w")',  # aliased os module
+    'import os\nfdo = os.fdopen\nfdo(fd, "w")',  # assigned fdopen alias
+    'fopen = open\nfopen("f")',  # assigned builtin-open alias
     "import configparser\ncfg = configparser.ConfigParser()\ncfg.read(p)",
     "from configparser import ConfigParser as CP\nc = CP()\nc.read(p)",  # aliased ctor
+    (
+        'import configparser\nCP = configparser.ConfigParser\ncfg = CP()\ncfg.read("f")'
+    ),  # assigned constructor alias
+    (
+        'import configparser\ncfg = configparser.ConfigParser()\nother = cfg\nother.read("f")'
+    ),  # assigned instance alias
     "self.cfg = ConfigParser()\nself.cfg.read(p)",  # attribute-bound instance
     'import gzip\ngzip.open(p, "rt")',  # gzip text mode needs encoding
     'import bz2\nbz2.open(p, "wt")',  # bz2 text mode needs encoding
@@ -147,13 +155,46 @@ _FLAGGED = [
     'from pathlib import Path\ngzip = Path("x")\ngzip.open("rt")',  # rebound name: real text open
     'from pathlib import Path\nimport gzip\ngzip = Path("x")\ngzip.open()',  # rebound module
     'def a():\n    from gzip import open\ndef b():\n    open("plain.txt")',  # nested, no taint
+    (
+        'from gzip import open as gopen\ngopen(io.BytesIO(), "rt")\ngopen = object()'
+    ),  # later function-alias rebind must not erase provenance
+    (
+        'import gzip\ngzip.open("blob.gz", "rt")\ndef later():\n    gzip = Path(\'x\')'
+    ),  # other-scope assignment must fail closed (filename contains "b")
+    (
+        "import gzip\nimport io\ndef consume(gzip=io):\n    gzip.open(os.devnull)"
+    ),  # parameter shadow
+    "import gzip\nimport io as gzip\ngzip.open(os.devnull)",  # module import rebind
+    (
+        "from gzip import open as gopen\nfrom io import open as gopen\ngopen(os.devnull)"
+    ),  # function import rebind
+    'import gzip\ngz = gzip\ngz.open("blob.gz", "rt")',  # assigned module alias
+    'import gzip\ngopen = gzip.open\ngopen(p, "rt")',  # assigned function alias
+    'import gzip\n(gz,) = (gzip,)\ngz.open("blob.gz", "rt")',  # unpacked module alias
+    'import gzip\n(gopen,) = (gzip.open,)\ngopen(p, "rt")',  # unpacked function alias
+    'import gzip\ngz = gzip if cond else gzip\ngz.open(p, "rt")',  # conditional alias
     'import gzip\ngzip.open(path, **{"mode": "rt"})',  # **kwargs hides a text mode
     'import gzip\ngzip.open(*[path, "rt"])',  # *args hides a text mode
     "open(*args)",  # dynamic args: can't prove binary
     "open(**kwargs)",  # dynamic kwargs: can't prove binary/encoding
+    'import io\nio.open("blob.txt")',  # module-style filename is not a Path mode
+    'import io\nio.open("rb")',  # valid-looking filename; io mode is argument 1
+    'import io as streamio\nstreamio.open("wb")',  # aliased text-opener module
+    'from io import open as iopen\niopen("rb")',  # aliased text-opener function
+    'import codecs\ncodecs.open("rb")',  # codecs filename, default text mode
+    'from builtins import open as bopen\nbopen("rb")',  # filename, not a mode
+    'import io\n(streamio,) = (io,)\nstreamio.open("rb")',  # unpacked module alias
+    'import io\n(iopen,) = (io.open,)\niopen("rb")',  # unpacked function alias
+    'import io\nstreamio = io if cond else io\nstreamio.open("rb")',
+    'from pathlib import Path\ntarfile = Path("plain.txt")\ntarfile.open("r")',
+    'import tarfile\nfrom pathlib import Path\ntarfile = Path("x")\ntarfile.open("r")',
     'run("import os; data = open(p).read()")',  # embedded, plain string
     'run(f"exec(open({p!r}).read())")',  # embedded, f-string
     'run("""\n    import os\n    data = open(p).read()\n""")',  # embedded, indented
+    (
+        'run("""import gzip as gz\ngz.open("blob.gz", "rt")\ndef later():\n    gz = object()\n""")'
+    ),  # embedded binding ambiguity
+    "run(\"import gzip; gzip.open (p, 'rt')\")",  # legal whitespace before call
 ]
 _CLEAN = [
     'open("f", encoding="utf-8")',
@@ -162,22 +203,38 @@ _CLEAN = [
     'open("f", encoding=enc)',  # a real (non-None) encoding expression
     'from pathlib import Path\nPath("f").read_text(encoding="utf-8")',
     'import tarfile\ntarfile.open("f")',  # archive, not text
+    'import tarfile as tf\ntf.open("archive.tar")',  # proven archive-module alias
     'import os\nos.open("f", 0)',  # low-level fd
     'import os\nos.fdopen(fd, "wb")',  # binary
     'import os\nos.fdopen(fd, "w", encoding="utf-8")',
+    'from pathlib import Path\nPath("f").open("rb")',  # proven binary Path mode
+    'import io\nio.open("f", "rb")',  # io.open's mode is positional argument 1
+    'import io as streamio\nstreamio.open("f", "wb")',
+    'from io import open as iopen\niopen("f", "rb")',
     'from os import fdopen as fdo\nfdo(fd, "wb")',  # aliased fdopen, binary
+    'import os\nfdo = os.fdopen\nfdo(fd, "wb")',  # assigned fdopen alias, binary
+    'fopen = open\nfopen("f", encoding="utf-8")',
     "import gzip\ngzip.open(p)",  # gzip default binary
     'import gzip\ngzip.open(p, "rb")',  # gzip explicit binary
+    "import bz2\nbz2.open(p)",  # bz2 default binary
+    'import bz2\nbz2.open(p, "rb")',  # bz2 explicit binary
     'import gzip\ngzip.open(p, "rt", encoding="utf-8")',  # gzip text + encoding
     'import lzma\nlzma.open(p, "wb")',  # lzma binary
     "import gzip as gz\ngz.open(p)",  # aliased module, default binary
     'import gzip as gz\ngz.open(p, "rb")',  # aliased module, binary
     "import configparser\ncfg = configparser.ConfigParser()\ncfg.read(p, encoding='locale')",
     "from configparser import ConfigParser as CP\nc = CP()\nc.read(p, encoding='utf-8')",
+    (
+        "import configparser\nCP = configparser.ConfigParser\n"
+        "cfg = CP()\nother = cfg\nother.read('f', encoding='utf-8')"
+    ),
     "self.cfg = ConfigParser()\nself.cfg.read(p, encoding='utf-8')",  # attr-bound, encoded
     "run(\"open(p, encoding='utf-8')\")",  # embedded, encoded
     'run("call open() to begin; then stop.")',  # prose: not parseable Python
     'run("// import fs;\\nfs.open(p);")',  # generated JS: not parseable Python
+    (
+        'import gzip\ngzip.open(p, "rt", encoding="utf-8")\ndef later():\n    gzip = Path(\'x\')'
+    ),  # ambiguity is accepted when an explicit codec removes the risk
 ]
 
 
@@ -263,64 +320,171 @@ def test_detect_encoding_reads_utf8_config_under_utf8_mode(tmp_path: Path) -> No
     assert result.returncode == 0, result.stderr
 
 
-# ``cli._read_existing_cfg`` is the guard that keeps the Databricks rewrite flow
-# from replacing an original it failed to read. (The full ``_isolated_databricks_
-# cfg`` context manager pulls in a Databricks-internal module not shipped here, so
-# the guard itself is tested directly.)
-def test_read_existing_cfg_missing_is_noop(tmp_path: Path) -> None:
-    """A missing original is the new-config case: no read, no error."""
-    import configparser
-
-    from omnigent.cli import _read_existing_cfg
-
-    cfg = configparser.ConfigParser()
-    _read_existing_cfg(cfg, tmp_path / "absent.cfg", "utf-8")
-    assert cfg.sections() == []
-
-
-def test_read_existing_cfg_loads_present_file(tmp_path: Path) -> None:
-    """An existing, readable original is loaded (so it can be preserved)."""
-    import configparser
-
-    from omnigent.cli import _read_existing_cfg
-
-    original = tmp_path / ".databrickscfg"
-    original.write_text("[legacy]\nhost = https://keep.example\n", encoding="utf-8")
-    cfg = configparser.ConfigParser()
-    _read_existing_cfg(cfg, original, "utf-8")
-    assert cfg["legacy"]["host"] == "https://keep.example"
-
-
-def test_read_existing_cfg_unreadable_raises(
+def test_detect_encoding_missing_defaults_to_utf8(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An existing file that ``ConfigParser.read`` silently skips (a permission
-    or transient I/O error) must raise, so the rewrite flow aborts instead of
-    seeding an empty config and overwriting the original — which would drop the
-    user's ``[legacy]`` section. Nothing is captured, so a caller cannot proceed.
-    """
+    """A brand-new vendor config uses UTF-8 even on a legacy-locale host."""
+    import omnigent._encoding as encoding
+
+    monkeypatch.setattr(encoding, "locale_encoding", lambda: "cp1252")
+    assert encoding.detect_encoding(tmp_path / "absent.cfg") == "utf-8"
+
+
+def test_read_existing_cfg_snapshot_missing_is_utf8(tmp_path: Path) -> None:
+    """A missing original is the new-config case and has no byte snapshot."""
     import configparser
 
-    from omnigent.cli import _read_existing_cfg
-
-    original = tmp_path / ".databrickscfg"
-    original.write_text("[legacy]\nhost = https://keep.example\n", encoding="utf-8")
-    monkeypatch.setattr(configparser.ConfigParser, "read", lambda self, *a, **k: [])
+    from omnigent.cli import _read_existing_cfg_snapshot
 
     cfg = configparser.ConfigParser()
-    with pytest.raises(OSError):
-        _read_existing_cfg(cfg, original, "utf-8")
+    encoding, snapshot = _read_existing_cfg_snapshot(cfg, tmp_path / "absent.cfg")
+    assert encoding == "utf-8"
+    assert snapshot is None
     assert cfg.sections() == []
 
 
-def _fake_internal_beta(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("encoding", "expected"),
+    [("utf-8", "utf-8"), ("cp1252", "cp1252")],
+)
+def test_read_existing_cfg_snapshot_loads_one_codec(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    encoding: str,
+    expected: str,
+) -> None:
+    """The parser and returned snapshot come from the exact same bytes."""
+    import configparser
+
+    import omnigent.cli as cli
+
+    original = tmp_path / ".databrickscfg"
+    raw = "[legacy]\nhost = https://café.example\n".encode(encoding)
+    original.write_bytes(raw)
+    monkeypatch.setattr(cli, "locale_encoding", lambda: "cp1252")
+    cfg = configparser.ConfigParser()
+    detected, snapshot = cli._read_existing_cfg_snapshot(cfg, original)
+    assert detected == expected
+    assert snapshot == raw
+    assert cfg["legacy"]["host"] == "https://café.example"
+
+
+def test_read_existing_cfg_snapshot_unreadable_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rewrite cannot proceed without a byte snapshot of an existing file."""
+    import configparser
+
+    from omnigent.cli import _read_existing_cfg_snapshot
+
+    original = tmp_path / ".databrickscfg"
+    original.write_text("[legacy]\nhost = https://keep.example\n", encoding="utf-8")
+    real_read_bytes = Path.read_bytes
+
+    def _unreadable(path: Path) -> bytes:
+        if path == original:
+            raise PermissionError("denied")
+        return real_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", _unreadable)
+    cfg = configparser.ConfigParser()
+    with pytest.raises(PermissionError, match="denied"):
+        _read_existing_cfg_snapshot(cfg, original)
+    assert cfg.sections() == []
+
+
+def test_databricks_cfg_merge_lock_excludes_another_thread(tmp_path: Path) -> None:
+    """The in-process layer prevents two threads entering the merge together."""
+    import threading
+
+    from omnigent.cli import _databricks_cfg_merge_lock
+
+    cfg = tmp_path / ".databrickscfg"
+    attempting = threading.Event()
+    entered = threading.Event()
+    errors: list[BaseException] = []
+
+    def _contender() -> None:
+        attempting.set()
+        try:
+            with _databricks_cfg_merge_lock(cfg):
+                entered.set()
+        except BaseException as exc:
+            errors.append(exc)
+
+    with _databricks_cfg_merge_lock(cfg):
+        thread = threading.Thread(target=_contender)
+        thread.start()
+        assert attempting.wait(timeout=2)
+        assert not entered.wait(timeout=0.2)
+
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert not errors
+    assert entered.is_set()
+    assert cfg.with_name(f"{cfg.name}.omnigent.lock").exists()
+
+
+@pytest.mark.windows_only
+def test_databricks_cfg_merge_lock_excludes_another_process(tmp_path: Path) -> None:
+    """The Windows byte lock serializes independent Omnigent processes."""
+    import time
+
+    from omnigent.cli import _databricks_cfg_merge_lock
+
+    cfg = tmp_path / ".databrickscfg"
+    ready = tmp_path / "ready"
+    entered = tmp_path / "entered"
+    script = textwrap.dedent(
+        """
+        import sys
+        from pathlib import Path
+        from omnigent.cli import _databricks_cfg_merge_lock
+        cfg, ready, entered = map(Path, sys.argv[1:])
+        ready.write_bytes(b"1")
+        with _databricks_cfg_merge_lock(cfg):
+            entered.write_bytes(b"1")
+        """
+    )
+    process: subprocess.Popen[str] | None = None
+    try:
+        with _databricks_cfg_merge_lock(cfg):
+            process = subprocess.Popen(
+                [sys.executable, "-c", script, str(cfg), str(ready), str(entered)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+            )
+            deadline = time.monotonic() + 5
+            while not ready.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert ready.exists()
+            assert process.poll() is None
+            assert not entered.exists()
+
+        stdout, stderr = process.communicate(timeout=10)
+        assert process.returncode == 0, f"{stdout}\n{stderr}"
+        assert entered.exists()
+    finally:
+        if process is not None and process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def _fake_internal_beta(
+    monkeypatch: pytest.MonkeyPatch,
+    *profile_names: str,
+) -> None:
     """Stub the Databricks-internal module the context manager imports, so the
     end-to-end flow can run in this OSS checkout (which does not ship it)."""
     import sys
     import types
 
     mod = types.ModuleType("omnigent.onboarding.internal_beta")
-    mod.DEFAULT_PROFILES = []  # type: ignore[attr-defined]
+    mod.DEFAULT_PROFILES = [  # type: ignore[attr-defined]
+        types.SimpleNamespace(name=name) for name in profile_names
+    ]
     monkeypatch.setitem(sys.modules, "omnigent.onboarding.internal_beta", mod)
 
 
@@ -370,3 +534,386 @@ def test_isolated_databricks_cfg_redetects_codec_on_exit(
         original.write_bytes("[legacy]\nhost = café\n".encode("cp1252"))
 
     assert "café" in original.read_text(encoding="cp1252")
+
+
+def test_isolated_databricks_cfg_preserves_untouched_concurrent_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale seeded section is not overlaid when this setup did not change it."""
+    _fake_internal_beta(monkeypatch, "managed")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    original = tmp_path / ".databrickscfg"
+    original.write_text("[managed]\ntoken = base\n", encoding="utf-8")
+    external = b"[managed]\ntoken = external\n"
+
+    from omnigent.cli import _isolated_databricks_cfg
+
+    with _isolated_databricks_cfg():
+        original.write_bytes(external)
+
+    assert b"token = external" in original.read_bytes()
+
+
+def test_isolated_databricks_cfg_rejects_same_profile_conflict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Concurrent edits to the same managed section fail instead of last-wins."""
+    _fake_internal_beta(monkeypatch, "managed")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    original = tmp_path / ".databrickscfg"
+    original.write_text("[managed]\ntoken = base\n", encoding="utf-8")
+    external = b"[managed]\ntoken = external\n"
+
+    from omnigent.cli import _isolated_databricks_cfg
+
+    with pytest.raises(OSError, match="profile 'managed' changed concurrently"):
+        with _isolated_databricks_cfg():
+            isolated = Path(os.environ["DATABRICKS_CONFIG_FILE"])
+            isolated.write_text("[managed]\ntoken = ours\n", encoding="utf-8")
+            original.write_bytes(external)
+
+    assert original.read_bytes() == external
+
+
+def test_isolated_databricks_cfg_fdopen_failure_closes_raw_fd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If ``fdopen`` rejects the descriptor, cleanup closes the still-owned raw
+    fd before unlinking it (required on Windows) and restores process state.
+    """
+    import signal
+    import tempfile
+
+    _fake_internal_beta(monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("DATABRICKS_HOST", "https://keep.example")
+    previous_int = signal.getsignal(signal.SIGINT)
+    previous_term = signal.getsignal(signal.SIGTERM)
+    real_mkstemp = tempfile.mkstemp
+    created: dict[str, int | Path] = {}
+
+    def _recording_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:
+        fd, name = real_mkstemp(*args, **kwargs)
+        created.update(fd=fd, path=Path(name))
+        return fd, name
+
+    def _fdopen_failure(*_args: object, **_kwargs: object) -> None:
+        raise OSError("fdopen failed")
+
+    monkeypatch.setattr(tempfile, "mkstemp", _recording_mkstemp)
+    monkeypatch.setattr(os, "fdopen", _fdopen_failure)
+
+    from omnigent.cli import _isolated_databricks_cfg
+
+    with pytest.raises(OSError, match="fdopen failed"), _isolated_databricks_cfg():
+        pass
+
+    fd = created["fd"]
+    assert isinstance(fd, int)
+    with pytest.raises(OSError):
+        os.fstat(fd)
+    path = created["path"]
+    assert isinstance(path, Path)
+    assert not path.exists()
+    assert os.environ.get("DATABRICKS_HOST") == "https://keep.example"
+    assert signal.getsignal(signal.SIGINT) is previous_int
+    assert signal.getsignal(signal.SIGTERM) is previous_term
+
+
+def test_isolated_databricks_cfg_close_failure_cannot_mask_write_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stream-close error is attached to, not substituted for, write failure."""
+    import configparser
+
+    _fake_internal_beta(monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    real_fdopen = os.fdopen
+
+    class _CloseFailure:
+        def __init__(self, fd: int, mode: str, encoding: str) -> None:
+            self._stream = real_fdopen(fd, mode, encoding=encoding)
+
+        @property
+        def closed(self) -> bool:
+            return self._stream.closed
+
+        def close(self) -> None:
+            self._stream.close()
+            raise OSError("close-secondary")
+
+    def _wrapped_fdopen(fd: int, mode: str, *, encoding: str) -> _CloseFailure:
+        return _CloseFailure(fd, mode, encoding)
+
+    def _write_failure(self: configparser.ConfigParser, _stream: object) -> None:
+        raise ValueError("write-primary")
+
+    monkeypatch.setattr(os, "fdopen", _wrapped_fdopen)
+    monkeypatch.setattr(configparser.ConfigParser, "write", _write_failure)
+
+    from omnigent.cli import _isolated_databricks_cfg
+
+    with pytest.raises(ValueError, match="write-primary") as caught:
+        with _isolated_databricks_cfg():
+            pass
+    assert any("close-secondary" in note for note in getattr(caught.value, "__notes__", ()))
+
+
+def test_isolated_databricks_cfg_merge_fdopen_failure_closes_raw_fd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The independently created merge stage retains raw-fd ownership on failure."""
+    _fake_internal_beta(monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    original = tmp_path / ".databrickscfg"
+    original_bytes = b"[legacy]\nhost = https://keep.example\n"
+    original.write_bytes(original_bytes)
+    real_fdopen = os.fdopen
+    calls = 0
+    failed_fd: int | None = None
+
+    def _fail_second_fdopen(
+        fd: int,
+        mode: str,
+        *,
+        encoding: str,
+    ) -> object:
+        nonlocal calls, failed_fd
+        calls += 1
+        if calls == 2:
+            failed_fd = fd
+            raise OSError("merge fdopen failed")
+        return real_fdopen(fd, mode, encoding=encoding)
+
+    monkeypatch.setattr(os, "fdopen", _fail_second_fdopen)
+
+    from omnigent.cli import _isolated_databricks_cfg
+
+    with pytest.raises(OSError, match="merge fdopen failed"), _isolated_databricks_cfg():
+        pass
+
+    assert failed_fd is not None
+    with pytest.raises(OSError):
+        os.fstat(failed_fd)
+    assert original.read_bytes() == original_bytes
+    assert not list(tmp_path.glob(f"{original.name}-merge-*.tmp"))
+
+
+def test_isolated_databricks_cfg_unlink_failure_does_not_skip_restoration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failing temp unlink is reported only after env and signals are restored."""
+    import signal
+
+    _fake_internal_beta(monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("DATABRICKS_HOST", "https://keep.example")
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", "outer.cfg")
+    previous_int = signal.getsignal(signal.SIGINT)
+    previous_term = signal.getsignal(signal.SIGTERM)
+    real_unlink = Path.unlink
+    isolated: Path | None = None
+
+    from omnigent.cli import _isolated_databricks_cfg
+
+    try:
+        with pytest.raises(PermissionError, match="locked"), _isolated_databricks_cfg():
+            isolated = Path(os.environ["DATABRICKS_CONFIG_FILE"])
+
+            def _locked_unlink(path: Path, *args: object, **kwargs: object) -> None:
+                if path == isolated:
+                    raise PermissionError("locked")
+                real_unlink(path, *args, **kwargs)
+
+            monkeypatch.setattr(Path, "unlink", _locked_unlink)
+
+        assert os.environ.get("DATABRICKS_HOST") == "https://keep.example"
+        assert os.environ.get("DATABRICKS_CONFIG_FILE") == "outer.cfg"
+        assert signal.getsignal(signal.SIGINT) is previous_int
+        assert signal.getsignal(signal.SIGTERM) is previous_term
+    finally:
+        if isolated is not None:
+            real_unlink(isolated, missing_ok=True)
+
+
+def test_isolated_databricks_cfg_returning_signal_handler_keeps_context_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A chained handler that returns must not inherit a dismantled context."""
+    import signal
+
+    _fake_internal_beta(monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("DATABRICKS_HOST", "https://keep.example")
+    original_handler = signal.getsignal(signal.SIGTERM)
+    calls: list[int] = []
+
+    def _returning_handler(signum: int, _frame: object) -> None:
+        calls.append(signum)
+
+    signal.signal(signal.SIGTERM, _returning_handler)
+    try:
+        from omnigent.cli import _isolated_databricks_cfg
+
+        with _isolated_databricks_cfg():
+            isolated = Path(os.environ["DATABRICKS_CONFIG_FILE"])
+            active_handler = signal.getsignal(signal.SIGTERM)
+            assert callable(active_handler)
+            active_handler(signal.SIGTERM, None)
+            assert calls == [signal.SIGTERM]
+            assert isolated.exists()
+            assert os.environ["DATABRICKS_CONFIG_FILE"] == str(isolated)
+            assert "DATABRICKS_HOST" not in os.environ
+    finally:
+        signal.signal(signal.SIGTERM, original_handler)
+
+    assert os.environ.get("DATABRICKS_HOST") == "https://keep.example"
+
+
+def test_isolated_databricks_cfg_cleanup_cannot_mask_primary_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even a BaseException during cleanup becomes a note on the body error."""
+    _fake_internal_beta(monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("DATABRICKS_HOST", "https://keep.example")
+    real_unlink = Path.unlink
+    isolated: Path | None = None
+
+    from omnigent.cli import _isolated_databricks_cfg
+
+    try:
+        with pytest.raises(RuntimeError, match="body failed") as caught:
+            with _isolated_databricks_cfg():
+                isolated = Path(os.environ["DATABRICKS_CONFIG_FILE"])
+
+                def _interrupted_unlink(path: Path, *args: object, **kwargs: object) -> None:
+                    if path == isolated:
+                        raise KeyboardInterrupt
+                    real_unlink(path, *args, **kwargs)
+
+                monkeypatch.setattr(Path, "unlink", _interrupted_unlink)
+                raise RuntimeError("body failed")
+
+        assert any(
+            "remove isolated config" in note for note in getattr(caught.value, "__notes__", ())
+        )
+        assert os.environ.get("DATABRICKS_HOST") == "https://keep.example"
+    finally:
+        if isolated is not None:
+            real_unlink(isolated, missing_ok=True)
+
+
+def test_isolated_databricks_cfg_missing_owned_temp_aborts_merge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The owned temp is required input; losing it cannot erase real profiles."""
+    _fake_internal_beta(monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("DATABRICKS_HOST", "https://keep.example")
+    original = tmp_path / ".databrickscfg"
+    original_bytes = b"[legacy]\nhost = https://keep.example\n"
+    original.write_bytes(original_bytes)
+
+    from omnigent.cli import _isolated_databricks_cfg
+
+    with pytest.raises(FileNotFoundError), _isolated_databricks_cfg():
+        Path(os.environ["DATABRICKS_CONFIG_FILE"]).unlink()
+
+    assert original.read_bytes() == original_bytes
+    assert os.environ.get("DATABRICKS_HOST") == "https://keep.example"
+
+
+def test_isolated_databricks_cfg_partial_signal_install_is_rolled_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the second signal install fails, the first and all prior mutations undo."""
+    import signal
+
+    _fake_internal_beta(monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("DATABRICKS_TOKEN", "keep-token")
+    previous_int = signal.getsignal(signal.SIGINT)
+    previous_term = signal.getsignal(signal.SIGTERM)
+    real_signal = signal.signal
+    failed = False
+    created_path: Path | None = None
+
+    def _fail_first_sigint(signum: int, handler: object) -> object:
+        nonlocal failed, created_path
+        if signum == signal.SIGINT and not failed:
+            failed = True
+            created_path = Path(os.environ["DATABRICKS_CONFIG_FILE"])
+            raise OSError("signal install failed")
+        return real_signal(signum, handler)
+
+    monkeypatch.setattr(signal, "signal", _fail_first_sigint)
+
+    from omnigent.cli import _isolated_databricks_cfg
+
+    with pytest.raises(OSError, match="signal install failed"), _isolated_databricks_cfg():
+        pass
+
+    assert created_path is not None
+    assert not created_path.exists()
+    assert os.environ.get("DATABRICKS_TOKEN") == "keep-token"
+    assert signal.getsignal(signal.SIGINT) is previous_int
+    assert signal.getsignal(signal.SIGTERM) is previous_term
+
+
+def test_isolated_databricks_cfg_detects_visible_post_snapshot_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A post-read change visible to the pre-publish check is preserved."""
+    import configparser
+
+    import omnigent.cli as cli
+
+    _fake_internal_beta(monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    original = tmp_path / ".databrickscfg"
+    original.write_bytes(b"[legacy]\nhost = https://initial.example\n")
+    external = b"[external]\nhost = https://new.example\n"
+    real_snapshot = cli._read_existing_cfg_snapshot
+    calls = 0
+
+    def _race(
+        cfg: configparser.ConfigParser,
+        path: Path,
+    ) -> tuple[str, bytes | None]:
+        nonlocal calls
+        result = real_snapshot(cfg, path)
+        calls += 1
+        if calls == 2:
+            path.write_bytes(external)
+        return result
+
+    monkeypatch.setattr(cli, "_read_existing_cfg_snapshot", _race)
+
+    with pytest.raises(OSError, match="changed while merging"), cli._isolated_databricks_cfg():
+        pass
+
+    assert calls == 2
+    assert original.read_bytes() == external
+    assert not list(tmp_path.glob(f"{original.name}-merge-*.tmp"))
+
+
+def test_isolated_databricks_cfg_uses_unique_merge_stage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pre-existing legacy stage path cannot be reused or replaced."""
+    _fake_internal_beta(monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    original = tmp_path / ".databrickscfg"
+    original.write_bytes(b"[legacy]\nhost = https://keep.example\n")
+    old_shared_stage = original.with_suffix(".tmp")
+    sentinel = b"belongs to another process"
+    old_shared_stage.write_bytes(sentinel)
+
+    from omnigent.cli import _isolated_databricks_cfg
+
+    with _isolated_databricks_cfg():
+        pass
+
+    assert old_shared_stage.read_bytes() == sentinel
+    assert not list(tmp_path.glob(f"{original.name}-merge-*.tmp"))

--- a/tests/test_file_encoding.py
+++ b/tests/test_file_encoding.py
@@ -145,6 +145,12 @@ _FLAGGED = [
     'import gzip\ngzip.open(p, "r" + "t")',  # computed mode, not provably binary
     "import gzip\ngzip.open(p, mode)",  # dynamic mode, not provably binary
     'from pathlib import Path\ngzip = Path("x")\ngzip.open("rt")',  # rebound name: real text open
+    'from pathlib import Path\nimport gzip\ngzip = Path("x")\ngzip.open()',  # rebound module
+    'def a():\n    from gzip import open\ndef b():\n    open("plain.txt")',  # nested, no taint
+    'import gzip\ngzip.open(path, **{"mode": "rt"})',  # **kwargs hides a text mode
+    'import gzip\ngzip.open(*[path, "rt"])',  # *args hides a text mode
+    "open(*args)",  # dynamic args: can't prove binary
+    "open(**kwargs)",  # dynamic kwargs: can't prove binary/encoding
     'run("import os; data = open(p).read()")',  # embedded, plain string
     'run(f"exec(open({p!r}).read())")',  # embedded, f-string
     'run("""\n    import os\n    data = open(p).read()\n""")',  # embedded, indented
@@ -305,3 +311,62 @@ def test_read_existing_cfg_unreadable_raises(
     with pytest.raises(OSError):
         _read_existing_cfg(cfg, original, "utf-8")
     assert cfg.sections() == []
+
+
+def _fake_internal_beta(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the Databricks-internal module the context manager imports, so the
+    end-to-end flow can run in this OSS checkout (which does not ship it)."""
+    import sys
+    import types
+
+    mod = types.ModuleType("omnigent.onboarding.internal_beta")
+    mod.DEFAULT_PROFILES = []  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "omnigent.onboarding.internal_beta", mod)
+
+
+def test_isolated_databricks_cfg_restores_env_on_prep_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If preparation fails after conflicting env vars are popped (here: a failing
+    mkstemp), the try/finally must still restore them — not leave DATABRICKS_HOST
+    /DATABRICKS_TOKEN deleted.
+    """
+    import tempfile
+
+    _fake_internal_beta(monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("DATABRICKS_HOST", "https://keep.example")
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise OSError("mkstemp failed")
+
+    monkeypatch.setattr(tempfile, "mkstemp", _boom)
+
+    from omnigent.cli import _isolated_databricks_cfg
+
+    with pytest.raises(OSError), _isolated_databricks_cfg():
+        pass
+    assert os.environ.get("DATABRICKS_HOST") == "https://keep.example"
+
+
+@pytest.mark.windows_only
+def test_isolated_databricks_cfg_redetects_codec_on_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The merge-back must re-detect the codec. Entry sees UTF-8; another process
+    replaces the file with cp1252 mid-flight. Reusing the entry-time UTF-8 codec
+    would fail to decode the cp1252 ``é`` (0xE9); re-detecting reads/writes cp1252
+    cleanly, so the flow completes and ``café`` survives.
+    """
+    _fake_internal_beta(monkeypatch)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    original = tmp_path / ".databrickscfg"
+    original.write_text("[legacy]\nhost = café\n", encoding="utf-8")  # entry: UTF-8
+
+    from omnigent.cli import _isolated_databricks_cfg
+
+    with _isolated_databricks_cfg():
+        # Another process rewrites the config as cp1252 mid-flight.
+        original.write_bytes("[legacy]\nhost = café\n".encode("cp1252"))
+
+    assert "café" in original.read_text(encoding="cp1252")

--- a/tests/test_file_encoding.py
+++ b/tests/test_file_encoding.py
@@ -22,15 +22,16 @@ from pathlib import Path
 
 import pytest
 
-from tests._encoding_scan import ALLOWLIST, find_violations, scan_package
+from tests._encoding_scan import ALLOWLIST, find_violations, owned_packages, scan_package
 
 
 def test_no_unencoded_owned_text_io() -> None:
-    """Structural guard: no omnigent-owned open/read_text/write_text may omit an
-    explicit ``encoding`` (receiver-independent; catches what PLW1514 misses).
+    """Structural guard: no owned open/read_text/write_text/os.fdopen/
+    ConfigParser.read may omit an explicit ``encoding`` (receiver-independent;
+    catches what PLW1514 misses). Covers every first-party package shipped from
+    this repo — the ``omnigent`` app and the ``omnigent_client`` SDK.
     """
-    pkg = Path(__file__).resolve().parents[1] / "omnigent"
-    violations = scan_package(pkg, ALLOWLIST)
+    violations = [v for pkg in owned_packages() for v in scan_package(pkg, ALLOWLIST)]
     assert not violations, "Unencoded text I/O (add encoding=...):\n" + "\n".join(violations)
 
 
@@ -120,23 +121,31 @@ def test_config_read_forces_utf8_under_cp1252_default(tmp_path: Path) -> None:
 # long before it lets a real omnigent regression through).
 _FLAGGED = [
     'open("f")',
+    'open("f", encoding=None)',  # encoding=None == default codec, not a fix
     'from pathlib import Path\nPath("f").read_text()',
     'from pathlib import Path\nPath("f").write_text("x")',
     'import os\nos.fdopen(fd, "w")',
+    'from os import fdopen\nfdopen(fd, "w")',  # aliased/imported fdopen
+    'import os as _o\n_o.fdopen(fd, "w")',  # aliased os module
     "import configparser\ncfg = configparser.ConfigParser()\ncfg.read(p)",
+    "from configparser import ConfigParser as CP\nc = CP()\nc.read(p)",  # aliased ctor
     'run("import os; data = open(p).read()")',  # embedded, plain string
     'run(f"exec(open({p!r}).read())")',  # embedded, f-string
+    'run("""\n    import os\n    data = open(p).read()\n""")',  # embedded, indented
 ]
 _CLEAN = [
     'open("f", encoding="utf-8")',
     'open("f", "rb")',  # binary
     'open("f", encoding="locale")',
+    'open("f", encoding=enc)',  # a real (non-None) encoding expression
     'from pathlib import Path\nPath("f").read_text(encoding="utf-8")',
     'import tarfile\ntarfile.open("f")',  # archive, not text
     'import os\nos.open("f", 0)',  # low-level fd
     'import os\nos.fdopen(fd, "wb")',  # binary
     'import os\nos.fdopen(fd, "w", encoding="utf-8")',
+    'from os import fdopen\nfdopen(fd, "w", encoding="utf-8")',
     "import configparser\ncfg = configparser.ConfigParser()\ncfg.read(p, encoding='locale')",
+    "from configparser import ConfigParser as CP\nc = CP()\nc.read(p, encoding='utf-8')",
     "run(\"open(p, encoding='utf-8')\")",  # embedded, encoded
     'run("call open() to begin; then stop.")',  # prose: not parseable Python
     'run("// import fs;\\nfs.open(p);")',  # generated JS: not parseable Python
@@ -151,3 +160,68 @@ def test_scanner_flags_unencoded(src: str) -> None:
 @pytest.mark.parametrize("src", _CLEAN)
 def test_scanner_accepts_encoded_and_nonfile(src: str) -> None:
     assert not find_violations(src), f"unexpected violation for:\n{src}"
+
+
+def _run_utf8_mode(script: str) -> subprocess.CompletedProcess[str]:
+    """Run *script* in a child with UTF-8 Mode ON (Python 3.15's default)."""
+    env = dict(os.environ)
+    env["PYTHONUTF8"] = "1"
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=env,
+    )
+
+
+@pytest.mark.windows_only
+def test_edit_preserves_cp1252_under_utf8_mode(tmp_path: Path) -> None:
+    """Editing a cp1252 file under UTF-8 Mode must not mix encodings.
+
+    ``getpreferredencoding(False)`` returns ``"utf-8"`` in UTF-8 Mode even on a
+    cp1252 host, so a naive detection fallback would rewrite the existing ``é``
+    as UTF-8 (``\\xc3\\xa9``) beside cp1252 bytes. The coding tools fall back to
+    ``locale.getencoding()`` (the true cp1252), so the file stays single-codec.
+    """
+    f = tmp_path / "latin.txt"
+    f.write_bytes("caf\N{LATIN SMALL LETTER E WITH ACUTE} old\n".encode("cp1252"))
+    result = _run_utf8_mode(
+        f"""
+        import sys, locale
+        assert sys.flags.utf8_mode, "expected PYTHONUTF8=1"
+        assert locale.getpreferredencoding(False).lower() == "utf-8"  # the trap
+        assert locale.getencoding().lower() == "cp1252"               # the truth
+        from omnigent.client_tools.coding import Edit
+        edit = getattr(Edit, "func", None) or getattr(Edit, "__wrapped__", Edit)
+        edit(file_path=r{str(f)!r}, old_string="old", new_string="new")
+        raw = __import__("pathlib").Path(r{str(f)!r}).read_bytes()
+        assert b"\\xe9" in raw and b"\\xc3\\xa9" not in raw, raw
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.windows_only
+def test_detect_encoding_reads_utf8_config_under_utf8_mode(tmp_path: Path) -> None:
+    """A UTF-8 vendor config must read back correctly under UTF-8 Mode, and a
+    cp1252 one must still be detected as cp1252 (not the lying preferred codec).
+    """
+    utf8_cfg = tmp_path / "utf8"
+    utf8_cfg.write_text("[p]\nhost = café\n", encoding="utf-8")
+    latin_cfg = tmp_path / "latin"
+    latin_cfg.write_bytes("[p]\nhost = café\n".encode("cp1252"))
+    result = _run_utf8_mode(
+        f"""
+        import configparser
+        from pathlib import Path
+        from omnigent._encoding import detect_encoding
+        u, latin = Path(r{str(utf8_cfg)!r}), Path(r{str(latin_cfg)!r})
+        assert detect_encoding(u) == "utf-8"
+        assert detect_encoding(latin).lower() == "cp1252"
+        c = configparser.ConfigParser()
+        c.read(u, encoding=detect_encoding(u))
+        assert c["p"]["host"] == "café", c["p"]["host"]
+        """
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_file_encoding.py
+++ b/tests/test_file_encoding.py
@@ -1,0 +1,72 @@
+"""Encoding-policy guards for omnigent-owned text I/O.
+
+Windows defaults text I/O to cp1252, so an ``open``/``read_text``/``write_text``
+without an explicit ``encoding`` mojibakes UTF-8 content (e.g. an em-dash in an
+agent prompt). Ruff's ``PLW1514`` catches the statically-inferable cases; these
+tests add a runtime net that also covers reads whose receiver type Ruff can't
+infer, and a Windows end-to-end regression.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec.parser import parse
+
+
+def test_agent_loading_emits_no_encoding_warning(tmp_path: Path) -> None:
+    """Cross-platform net: loading an agent config under
+    ``-X warn_default_encoding -W error::EncodingWarning`` must not trip any
+    unspecified-encoding read — catching non-inferable reads PLW1514 misses,
+    regardless of the CI host's locale.
+    """
+    agent = tmp_path / "agent"
+    agent.mkdir()
+    (agent / "config.yaml").write_text(
+        'spec_version: 1\nname: t\nprompt: "plans — not code ↔ review"\n',
+        encoding="utf-8",
+    )
+    script = textwrap.dedent(
+        f"""
+        from pathlib import Path
+        from omnigent.spec.parser import parse
+        spec = parse(Path(r{str(agent)!r}))
+        assert spec.instructions and "—" in spec.instructions
+        """
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-X",
+            "warn_default_encoding",
+            "-W",
+            "error::EncodingWarning",
+            "-c",
+            script,
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.windows_only
+def test_config_prompt_survives_cp1252_default(tmp_path: Path) -> None:
+    """On Windows (cp1252 default), a UTF-8 config's non-ASCII prompt is read as
+    UTF-8 rather than mojibaked (regression for the ``itself — it plans`` phrase).
+    """
+    agent = tmp_path / "agent"
+    agent.mkdir()
+    (agent / "config.yaml").write_text(
+        'spec_version: 1\nname: t\nprompt: "itself — it plans ↔ delegates"\n',
+        encoding="utf-8",
+    )
+    spec = parse(agent)
+    assert "itself — it plans" in (spec.instructions or "")
+    assert "â€" not in (spec.instructions or "")

--- a/tests/test_file_encoding.py
+++ b/tests/test_file_encoding.py
@@ -28,10 +28,17 @@ from tests._encoding_scan import ALLOWLIST, find_violations, owned_packages, sca
 def test_no_unencoded_owned_text_io() -> None:
     """Structural guard: no owned open/read_text/write_text/os.fdopen/
     ConfigParser.read may omit an explicit ``encoding`` (receiver-independent;
-    catches what PLW1514 misses). Covers every first-party package shipped from
-    this repo — the ``omnigent`` app and the ``omnigent_client`` SDK.
+    catches what PLW1514 misses). Covers every first-party Python package shipped
+    from this repo (the ``omnigent`` app and the ``omnigent_client`` /
+    ``omnigent_ui_sdk`` SDKs).
     """
-    violations = [v for pkg in owned_packages() for v in scan_package(pkg, ALLOWLIST)]
+    packages = owned_packages()
+    for pkg in packages:
+        # Fail loudly if a configured root moved or emptied — otherwise the guard
+        # would silently pass by scanning nothing.
+        assert pkg.is_dir(), f"configured package root is missing: {pkg}"
+        assert any(pkg.rglob("*.py")), f"configured package root has no .py files: {pkg}"
+    violations = [v for pkg in packages for v in scan_package(pkg, ALLOWLIST)]
     assert not violations, "Unencoded text I/O (add encoding=...):\n" + "\n".join(violations)
 
 
@@ -125,10 +132,14 @@ _FLAGGED = [
     'from pathlib import Path\nPath("f").read_text()',
     'from pathlib import Path\nPath("f").write_text("x")',
     'import os\nos.fdopen(fd, "w")',
-    'from os import fdopen\nfdopen(fd, "w")',  # aliased/imported fdopen
+    'from os import fdopen\nfdopen(fd, "w")',  # imported fdopen
+    'from os import fdopen as fdo\nfdo(fd, "w")',  # aliased fdopen
     'import os as _o\n_o.fdopen(fd, "w")',  # aliased os module
     "import configparser\ncfg = configparser.ConfigParser()\ncfg.read(p)",
     "from configparser import ConfigParser as CP\nc = CP()\nc.read(p)",  # aliased ctor
+    "self.cfg = ConfigParser()\nself.cfg.read(p)",  # attribute-bound instance
+    'import gzip\ngzip.open(p, "rt")',  # gzip text mode needs encoding
+    'import bz2\nbz2.open(p, "wt")',  # bz2 text mode needs encoding
     'run("import os; data = open(p).read()")',  # embedded, plain string
     'run(f"exec(open({p!r}).read())")',  # embedded, f-string
     'run("""\n    import os\n    data = open(p).read()\n""")',  # embedded, indented
@@ -143,9 +154,14 @@ _CLEAN = [
     'import os\nos.open("f", 0)',  # low-level fd
     'import os\nos.fdopen(fd, "wb")',  # binary
     'import os\nos.fdopen(fd, "w", encoding="utf-8")',
-    'from os import fdopen\nfdopen(fd, "w", encoding="utf-8")',
+    'from os import fdopen as fdo\nfdo(fd, "wb")',  # aliased fdopen, binary
+    "import gzip\ngzip.open(p)",  # gzip default binary
+    'import gzip\ngzip.open(p, "rb")',  # gzip explicit binary
+    'import gzip\ngzip.open(p, "rt", encoding="utf-8")',  # gzip text + encoding
+    'import lzma\nlzma.open(p, "wb")',  # lzma binary
     "import configparser\ncfg = configparser.ConfigParser()\ncfg.read(p, encoding='locale')",
     "from configparser import ConfigParser as CP\nc = CP()\nc.read(p, encoding='utf-8')",
+    "self.cfg = ConfigParser()\nself.cfg.read(p, encoding='utf-8')",  # attr-bound, encoded
     "run(\"open(p, encoding='utf-8')\")",  # embedded, encoded
     'run("call open() to begin; then stop.")',  # prose: not parseable Python
     'run("// import fs;\\nfs.open(p);")',  # generated JS: not parseable Python
@@ -177,26 +193,33 @@ def _run_utf8_mode(script: str) -> subprocess.CompletedProcess[str]:
 
 @pytest.mark.windows_only
 def test_edit_preserves_cp1252_under_utf8_mode(tmp_path: Path) -> None:
-    """Editing a cp1252 file under UTF-8 Mode must not mix encodings.
+    """Editing a cp1252 file under UTF-8 Mode, INSERTING non-ASCII, must not mix
+    encodings.
 
     ``getpreferredencoding(False)`` returns ``"utf-8"`` in UTF-8 Mode even on a
-    cp1252 host, so a naive detection fallback would rewrite the existing ``é``
-    as UTF-8 (``\\xc3\\xa9``) beside cp1252 bytes. The coding tools fall back to
-    ``locale.getencoding()`` (the true cp1252), so the file stays single-codec.
+    cp1252 host, so a naive fallback reads the existing ``é`` as a surrogate and
+    writes the whole result UTF-8 — leaving one file with cp1252 ``\\xe9`` and a
+    UTF-8 ``ï`` (``\\xc3\\xaf``) side by side. The coding tools fall back to
+    ``locale.getencoding()`` (the true cp1252), so both stay cp1252.
+
+    The assertion is on the exact bytes: a no-op or the old broken fallback both
+    diverge from ``b"caf\\xe9 na\\xefve\\r\\n"`` (an ASCII->ASCII edit would not).
     """
     f = tmp_path / "latin.txt"
     f.write_bytes("caf\N{LATIN SMALL LETTER E WITH ACUTE} old\n".encode("cp1252"))
     result = _run_utf8_mode(
         f"""
         import sys, locale
+        from pathlib import Path
         assert sys.flags.utf8_mode, "expected PYTHONUTF8=1"
         assert locale.getpreferredencoding(False).lower() == "utf-8"  # the trap
         assert locale.getencoding().lower() == "cp1252"               # the truth
         from omnigent.client_tools.coding import Edit
         edit = getattr(Edit, "func", None) or getattr(Edit, "__wrapped__", Edit)
-        edit(file_path=r{str(f)!r}, old_string="old", new_string="new")
-        raw = __import__("pathlib").Path(r{str(f)!r}).read_bytes()
-        assert b"\\xe9" in raw and b"\\xc3\\xa9" not in raw, raw
+        msg = edit(file_path=r{str(f)!r}, old_string="old", new_string="na\\u00efve")
+        assert "Replaced" in msg, msg
+        raw = Path(r{str(f)!r}).read_bytes()
+        assert raw == b"caf\\xe9 na\\xefve\\r\\n", raw
         """
     )
     assert result.returncode == 0, result.stderr

--- a/tests/test_file_encoding.py
+++ b/tests/test_file_encoding.py
@@ -129,15 +129,23 @@ def test_config_read_forces_utf8_under_cp1252_default(tmp_path: Path) -> None:
 _FLAGGED = [
     'open("f")',
     'open("f", encoding=None)',  # encoding=None == default codec, not a fix
+    'open("f", "r", -1, None)',  # positional encoding=None is still default
+    'open(*args, "rb")',  # star expansion shifts the apparent mode position
+    'open("f", "r", *args, "utf-8")',  # star shifts the apparent encoding
     'from pathlib import Path\nPath("f").read_text()',
+    'from pathlib import Path\nPath("f").read_text(None)',
     'from pathlib import Path\nPath("f").write_text("x")',
+    'from pathlib import Path\nPath("f").write_text("x", None)',
+    'from pathlib import Path\nPath("f").open("r", -1, None)',
     'import os\nos.fdopen(fd, "w")',
+    'import os\nos.fdopen(fd, "r", -1, None)',
     'from os import fdopen\nfdopen(fd, "w")',  # imported fdopen
     'from os import fdopen as fdo\nfdo(fd, "w")',  # aliased fdopen
     'import os as _o\n_o.fdopen(fd, "w")',  # aliased os module
     'import os\nfdo = os.fdopen\nfdo(fd, "w")',  # assigned fdopen alias
     'fopen = open\nfopen("f")',  # assigned builtin-open alias
     "import configparser\ncfg = configparser.ConfigParser()\ncfg.read(p)",
+    "import configparser\ncfg = configparser.ConfigParser()\ncfg.read(p, None)",
     "from configparser import ConfigParser as CP\nc = CP()\nc.read(p)",  # aliased ctor
     (
         'import configparser\nCP = configparser.ConfigParser\ncfg = CP()\ncfg.read("f")'
@@ -147,7 +155,9 @@ _FLAGGED = [
     ),  # assigned instance alias
     "self.cfg = ConfigParser()\nself.cfg.read(p)",  # attribute-bound instance
     'import gzip\ngzip.open(p, "rt")',  # gzip text mode needs encoding
+    'import gzip\ngzip.open(p, "rt", 9, None)',  # positional None is not a codec
     'import bz2\nbz2.open(p, "wt")',  # bz2 text mode needs encoding
+    'import lzma\nlzma.open(p, "rt")',  # lzma encoding is keyword-only
     'from gzip import open as gopen\ngopen(p, "rt")',  # aliased gzip.open, text
     'import gzip as gz\ngz.open("blob.gz", "rt")',  # aliased module (filename has 'b')
     'import gzip\ngzip.open(p, "r" + "t")',  # computed mode, not provably binary
@@ -179,9 +189,24 @@ _FLAGGED = [
     "open(**kwargs)",  # dynamic kwargs: can't prove binary/encoding
     'import io\nio.open("blob.txt")',  # module-style filename is not a Path mode
     'import io\nio.open("rb")',  # valid-looking filename; io mode is argument 1
+    'import io\nio.open(p, "r", -1, None)',  # positional None still defaults
     'import io as streamio\nstreamio.open("wb")',  # aliased text-opener module
     'from io import open as iopen\niopen("rb")',  # aliased text-opener function
+    'import io\nbox.open = io.open\nbox.open(p, "r", -1)',  # unknown receiver signature
+    'import io\nbox.open = io.open\nbox.open("rb")',  # filename is not a bound mode
+    "dist.read_text(name)",  # unknown read_text signature: positional arg is not a codec
+    "thing.write_text(data, enc)",  # unknown write_text signature
+    "import codecs\ncodecs.open(p)",  # codecs defaults to locale text in mode r
+    'import codecs\ncodecs.open(p, "r")',
     'import codecs\ncodecs.open("rb")',  # codecs filename, default text mode
+    'import codecs\ncodecs.open(p, "r", None)',  # None still uses the locale
+    ('from codecs import open\nopen(p, "r", None, "utf-8")'),  # arg 3 is errors, not encoding
+    (
+        'import codecs\nopen = codecs.open\nopen(p, "r", None, "utf-8")'
+    ),  # rebound bare name has an ambiguous positional signature
+    (
+        'import codecs\nbox.fdopen = codecs.open\nbox.fdopen(p, "r", None, "utf-8")'
+    ),  # unknown fdopen receiver: argument 3 may not be its encoding
     'from builtins import open as bopen\nbopen("rb")',  # filename, not a mode
     'import io\n(streamio,) = (io,)\nstreamio.open("rb")',  # unpacked module alias
     'import io\n(iopen,) = (io.open,)\niopen("rb")',  # unpacked function alias
@@ -194,6 +219,15 @@ _FLAGGED = [
     (
         'run("""import gzip as gz\ngz.open("blob.gz", "rt")\ndef later():\n    gz = object()\n""")'
     ),  # embedded binding ambiguity
+    (
+        'run("""import io\nbox.open = io.open\nbox.open(p, "r", -1)\n""")'
+    ),  # embedded unknown receiver
+    (
+        'run("""import io\nbox.open = io.open\nbox.open("rb")\n""")'
+    ),  # embedded positional-mode ambiguity
+    (
+        'run("""import codecs\nbox.fdopen = codecs.open\nbox.fdopen(p, "r", None, "utf-8")\n""")'
+    ),  # embedded unknown fdopen receiver
     "run(\"import gzip; gzip.open (p, 'rt')\")",  # legal whitespace before call
 ]
 _CLEAN = [
@@ -201,25 +235,39 @@ _CLEAN = [
     'open("f", "rb")',  # binary
     'open("f", encoding="locale")',
     'open("f", encoding=enc)',  # a real (non-None) encoding expression
+    'open("f", "r", -1, "utf-8")',  # builtin positional encoding
+    'from builtins import open as bopen\nbopen("f", "r", -1, "utf-8")',
     'from pathlib import Path\nPath("f").read_text(encoding="utf-8")',
     'import tarfile\ntarfile.open("f")',  # archive, not text
     'import tarfile as tf\ntf.open("archive.tar")',  # proven archive-module alias
     'import os\nos.open("f", 0)',  # low-level fd
     'import os\nos.fdopen(fd, "wb")',  # binary
     'import os\nos.fdopen(fd, "w", encoding="utf-8")',
-    'from pathlib import Path\nPath("f").open("rb")',  # proven binary Path mode
+    'from pathlib import Path\nPath("f").open(mode="rb")',  # receiver-independent binary mode
     'import io\nio.open("f", "rb")',  # io.open's mode is positional argument 1
+    'import io\nio.open("f", "r", -1, "utf-8")',
     'import io as streamio\nstreamio.open("f", "wb")',
     'from io import open as iopen\niopen("f", "rb")',
+    'from io import open as iopen\niopen("f", "r", -1, "utf-8")',
+    'import codecs\ncodecs.open("f", "r", "utf-8")',
+    'import codecs\ncodecs.open("f", "rb")',
+    'from codecs import open as copen\ncopen("f", "r", "utf-8")',
+    'from codecs import open\nopen("f", "rb")',
+    'from codecs import open\nopen("f", "r", encoding="utf-8")',
     'from os import fdopen as fdo\nfdo(fd, "wb")',  # aliased fdopen, binary
     'import os\nfdo = os.fdopen\nfdo(fd, "wb")',  # assigned fdopen alias, binary
     'fopen = open\nfopen("f", encoding="utf-8")',
     "import gzip\ngzip.open(p)",  # gzip default binary
+    'import gzip\ngzip.open(p, "r")',  # compressed plain r is binary
+    'import gzip\ngzip.open(p, "w")',  # compressed plain w is binary
     'import gzip\ngzip.open(p, "rb")',  # gzip explicit binary
     "import bz2\nbz2.open(p)",  # bz2 default binary
     'import bz2\nbz2.open(p, "rb")',  # bz2 explicit binary
     'import gzip\ngzip.open(p, "rt", encoding="utf-8")',  # gzip text + encoding
+    'import gzip\ngzip.open(p, "rt", 9, "utf-8")',  # gzip positional encoding
+    'import bz2\nbz2.open(p, "wt", 9, "utf-8")',  # bz2 positional encoding
     'import lzma\nlzma.open(p, "wb")',  # lzma binary
+    'import lzma\nlzma.open(p, "rt", encoding="utf-8")',
     "import gzip as gz\ngz.open(p)",  # aliased module, default binary
     'import gzip as gz\ngz.open(p, "rb")',  # aliased module, binary
     "import configparser\ncfg = configparser.ConfigParser()\ncfg.read(p, encoding='locale')",

--- a/tests/test_install_ledger.py
+++ b/tests/test_install_ledger.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from omnigent import install_ledger
@@ -8,6 +9,7 @@ from omnigent import install_ledger
 
 def test_install_ledger_round_trip_and_mode(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / ".omnigent"))
     profile = tmp_path / ".zshrc"
     profile.write_text(
@@ -22,15 +24,55 @@ def test_install_ledger_round_trip_and_mode(tmp_path: Path, monkeypatch) -> None
     path = install_ledger.ledger_path()
     install_ledger.write_ledger(ledger, path=path)
 
-    assert oct(path.stat().st_mode & 0o777) == "0o600"
+    if os.name != "nt":
+        assert oct(path.stat().st_mode & 0o777) == "0o600"
     loaded = install_ledger.load_ledger(path)
     assert loaded is not None
     assert loaded.to_dict() == ledger.to_dict()
     assert loaded.entries.profiles[0].path == str(profile)
 
 
+def test_find_profile_block_detects_legacy_locale_encoding(tmp_path: Path, monkeypatch) -> None:
+    profile = tmp_path / ".profile"
+    profile.write_bytes(
+        (
+            "café\n"
+            f"{install_ledger.PROFILE_MARKER_BEGIN}\n"
+            'export PATH="$HOME/.local/bin:$PATH"\n'
+            f"{install_ledger.PROFILE_MARKER_END}\n"
+        ).encode("cp1252")
+    )
+    monkeypatch.setattr("omnigent._encoding.locale_encoding", lambda: "cp1252")
+
+    found = install_ledger.find_profile_block(profile)
+
+    assert found is not None
+    assert found[2].startswith(install_ledger.PROFILE_MARKER_BEGIN)
+
+
+def test_json_config_detection_supports_legacy_locale_encoding(
+    tmp_path: Path, monkeypatch
+) -> None:
+    path = tmp_path / "mcp.json"
+    path.write_bytes('{"label": "café", "mcpServers": {"omnigent": {}}}\n'.encode("cp1252"))
+    monkeypatch.setattr("omnigent._encoding.locale_encoding", lambda: "cp1252")
+
+    assert install_ledger._json_has_key_path(path, "mcpServers.omnigent")
+
+
+def test_toml_config_detection_supports_legacy_locale_encoding(
+    tmp_path: Path, monkeypatch
+) -> None:
+    path = tmp_path / "config.toml"
+    path.write_bytes("# café\n[mcp_servers.omnigent]\n".encode("cp1252"))
+    monkeypatch.setattr("omnigent._encoding.locale_encoding", lambda: "cp1252")
+
+    assert install_ledger._toml_has_table(path, "mcp_servers.omnigent")
+
+
 def test_backfill_requires_anchor_signal(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / ".omnigent"))
     monkeypatch.setenv("PATH", str(tmp_path / "bin"))
 
@@ -52,6 +94,7 @@ def test_write_install_ledger_from_env_records_profile_and_dep_provenance(
         f"{install_ledger.PROFILE_MARKER_END}\n"
     )
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state))
     monkeypatch.setenv("OMNIGENT_LEDGER_PROFILE", str(profile))
     monkeypatch.setenv("OMNIGENT_LEDGER_DEP_UV", "omnigent")
@@ -73,6 +116,7 @@ def test_installer_ledger_supersedes_backfill_and_preserves_dep_ownership(
     state = home / ".omnigent"
     state.mkdir(parents=True)
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state))
 
     backfill = install_ledger.new_ledger(source="backfill", strategy="deep-backfill", deep=False)
@@ -100,6 +144,7 @@ def test_backfill_skips_write_when_content_is_unchanged(tmp_path: Path, monkeypa
     state.mkdir(parents=True)
     (state / "installation_id").write_text("install-123\n")
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state))
 
     existing = install_ledger.new_ledger(source="backfill", strategy="fast-backfill", deep=False)
@@ -126,6 +171,7 @@ def test_install_ledger_merges_existing_and_observed_external_configs(
     state.mkdir(parents=True)
     cursor_dir.mkdir(parents=True)
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state))
     monkeypatch.chdir(workspace)
 
@@ -165,6 +211,7 @@ def test_deep_backfill_observes_external_config_and_launch_agents(
     launch_agent = launch_dir / "ai.omnigent.local.plist"
     launch_agent.write_text("plist\n")
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state))
     monkeypatch.chdir(workspace)
 

--- a/tests/test_workspace_fs.py
+++ b/tests/test_workspace_fs.py
@@ -77,7 +77,7 @@ def test_read_text_file_returns_utf8_content(tmp_path: Path) -> None:
     This is exactly the payload the file viewer renders; if it were
     empty the viewer would show a blank file while the agent is asleep.
     """
-    (tmp_path / "note.md").write_text("# Title\nbody\n")
+    (tmp_path / "note.md").write_text("# Title\nbody\n", encoding="utf-8", newline="\n")
     reader = WorkspaceReader(tmp_path)
 
     result = reader.list_or_read("note.md")
@@ -141,7 +141,7 @@ def test_oversize_text_split_on_codepoint_stays_text(tmp_path: Path, monkeypatch
     monkeypatch.setattr("omnigent.workspace_fs._MAX_READ_BYTES", 4)
     # "aé" → b"a\xc3\xa9"; cap 4 keeps "aé" whole, so pad so the cap lands
     # inside the é: 3 ASCII + é = b"abc\xc3\xa9", cap 4 splits the é.
-    (tmp_path / "u.txt").write_text("abcé")
+    (tmp_path / "u.txt").write_text("abcé", encoding="utf-8")
     reader = WorkspaceReader(tmp_path)
 
     result = reader.list_or_read("u.txt")
@@ -284,7 +284,7 @@ def test_changes_lists_git_working_tree_modifications(tmp_path: Path) -> None:
     so it works identically whether the runner or the host answers.
     """
     _git_repo(tmp_path)
-    (tmp_path / "committed.txt").write_text("modified\n")
+    (tmp_path / "committed.txt").write_text("modified\n", encoding="utf-8", newline="\n")
     (tmp_path / "new.txt").write_text("added\n")
     reader = WorkspaceReader(tmp_path)
 
@@ -309,7 +309,7 @@ def test_diff_returns_before_and_after_for_modified_file(tmp_path: Path) -> None
     and ``after`` from disk — both readable without a runner.
     """
     _git_repo(tmp_path)
-    (tmp_path / "committed.txt").write_text("modified\n")
+    (tmp_path / "committed.txt").write_text("modified\n", encoding="utf-8", newline="\n")
     reader = WorkspaceReader(tmp_path)
 
     result = reader.diff("conv_x", "committed.txt")


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add native Windows command execution with race-free Job Object containment, timeout tree termination, safe `cmd.exe` quoting, and child-environment isolation.
- Make rooted filesystem operations Windows-safe, including `/`-normalized entry paths, drive/UNC escape rejection, reparse-point-aware deletion, and broken junction/symlink handling.
- Make configuration and state-file I/O encoding-safe across UTF-8 Mode and legacy Windows locales, with atomic rewrites, expanded structural guards, Windows CI coverage, and runnable Windows examples.

ELI5: Windows handles processes, links, paths, and text encodings differently from POSIX systems. This change gives each platform the correct implementation behind the same Omnigent behavior.

```text
agent command ──> platform shell ──> Windows Job Object ──> contained process tree
workspace path ─> root validation ─> lstat/reparse handling ─> normalized entry
config/state ───> encoding policy ─> guarded read/merge ─────> atomic rewrite
```

## Test Plan

Release-blocking gates are green:

- Encoding scanner and regressions: 151 passed.
- Windows shell/environment tests: 32 passed, 1 skipped.
- Rooted filesystem tests: 81 passed.
- Process/platform and process-manager tests: 29 passed, 6 skipped.
- Parser and Islo tests: 244 passed.
- Databricks configuration, credential, adapter, and volume tests: 160 passed.
- Workspace validation and interactive tests: 55 passed.
- Install-ledger, Slack integration, and workspace-filesystem tests: 43 passed.
- Root and both SDK Ruff gates, scoped `PLW1514`, Ruff format, `compileall`, YAML parsing, version/lock checks, custom lint scripts, and `git diff --check` passed.

The advisory Windows runtime-harness sweep produced 114 passed, 18 failed, and 1 skipped; those failures are existing POSIX assumptions around Unix-domain sockets, `AF_UNIX`, `SIGKILL`, and graceful POSIX shutdown. A broader inner-suite sweep reached 404 passed, 17 failed, and 51 skipped before an existing Windows `NamedTemporaryFile` teardown failure triggered a pytest reporting abort. The observed failures were classified as unmarked POSIX/Linux assumptions and current-upstream Windows test-isolation gaps, not regressions in the release-blocking paths above.

## Demo

N/A — platform/runtime change with no UI.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verification exercised real Windows subprocesses and Job Objects, hostile temporary paths, timeout tree termination, detached-child survival, batch `%%i` semantics, reparse-point deletion, forward-slash entry paths, and UTF-8/cp1252 round trips.

## Changelog

Run Omnigent natively on Windows with safe process containment, rooted filesystem behavior, and encoding-preserving configuration updates.
