### PR TITLE
[e2e-ui] Stabilize nightly multi-agent journeys

### DIFF
--- a/tests/e2e_ui/agents/conftest.py
+++ b/tests/e2e_ui/agents/conftest.py
@@ -29,7 +29,7 @@ import pytest
 
 # Private helpers from the parent conftest — same import pattern the
 # sibling chat tests use for ``open_right_rail`` / ``TwoAgentChatSession``.
-from tests.e2e_ui.conftest import _ensure_runner_online, _server_state
+from tests.e2e_ui.conftest import _ensure_runner_online, _server_state, configure_mock_llm
 
 _JOKE_DIRECTOR_NAME = "joke_director"
 
@@ -44,12 +44,14 @@ class JokeSubagentsSession:
         e.g. ``"scarecrow-3a7f9c2e1b"``.
     :param code_two: Per-run nonce only ``comic_two``'s joke carries,
         e.g. ``"sleepmode-9c2e1b3a7f"``.
+    :param routing_token: Per-run token that selects the parent's mock queue.
     """
 
     base_url: str
     session_id: str
     code_one: str
     code_two: str
+    routing_token: str
 
 
 def _joke_director_yaml(code_one: str, code_two: str) -> str:
@@ -122,21 +124,77 @@ tools:
 @pytest.fixture
 def joke_subagents_session(
     live_server: str,
+    mock_llm_server_url: str,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Iterator[JokeSubagentsSession]:
     """Create a runner-bound session for the two-comedian joke director.
 
     Same runner-respawn + bind contract as ``two_agent_chat_session`` in
-    the parent conftest. Yields the per-run nonces so a test can assert
-    that the sub-agents' jokes (and only the sub-agents') reached the UI.
+    the parent conftest. Separate content-routed mock queues drive the
+    parent and each comedian so concurrent child turns cannot race for a
+    shared response. The original model ids remain in the agent spec, so
+    a future real-gateway job can reuse the same journey.
 
     :param live_server: Spawned server fixture from the parent conftest.
+    :param mock_llm_server_url: Mock LLM server used by credential-free runs.
     :param tmp_path_factory: Pytest temp path factory (for a respawn log).
     :returns: A :class:`JokeSubagentsSession` handle.
     """
     code_one = f"scarecrow-{uuid.uuid4().hex[:10]}"
     code_two = f"kitkat-{uuid.uuid4().hex[:10]}"
+    suffix = uuid.uuid4().hex[:10]
+    routing_token = f"joke-parent-{suffix}"
+    comic_one_token = f"joke-comic-one-{suffix}"
+    comic_two_token = f"joke-comic-two-{suffix}"
     yaml_text = _joke_director_yaml(code_one, code_two)
+
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_comic_one",
+                        "name": "sys_session_send",
+                        "arguments": json.dumps(
+                            {
+                                "agent": "comic_one",
+                                "title": "comic_one",
+                                "args": f"Tell a joke. Routing marker: {comic_one_token}",
+                            }
+                        ),
+                    },
+                    {
+                        "call_id": "call_comic_two",
+                        "name": "sys_session_send",
+                        "arguments": json.dumps(
+                            {
+                                "agent": "comic_two",
+                                "title": "comic_two",
+                                "args": f"Tell a joke. Routing marker: {comic_two_token}",
+                            }
+                        ),
+                    },
+                ]
+            },
+            {"text": "Dispatched both comedians; waiting for their replies."},
+            {"text": f"The comedians replied with joke codes {code_one} and {code_two}."},
+        ],
+        key=routing_token,
+        match=routing_token,
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": f"Scarecrow joke. Joke code: {code_one}."}],
+        key=comic_one_token,
+        match=comic_one_token,
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": f"Computer joke. Joke code: {code_two}."}],
+        key=comic_two_token,
+        match=comic_two_token,
+    )
     respawned_runner = _ensure_runner_online(live_server, tmp_path_factory)
     runner_id = str(_server_state["runner_id"])
 
@@ -171,6 +229,7 @@ def joke_subagents_session(
             session_id=session_id,
             code_one=code_one,
             code_two=code_two,
+            routing_token=routing_token,
         )
     finally:
         httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)

--- a/tests/e2e_ui/agents/test_subagent_navigation.py
+++ b/tests/e2e_ui/agents/test_subagent_navigation.py
@@ -53,11 +53,9 @@ def _send(page: Page, text: str) -> None:
     page.get_by_role("button", name="Send", exact=True).click()
 
 
-# Nightly: several serial real-LLM turns (dispatch + two sub-agents +
-# auto-wake continuation), too heavy and 429-sensitive for the PR gate.
-# The 600s budget overrides the suite-wide 300s default for the same
-# reason test_two_agent_chat.py uses it: FMAPI backoff stacks
-# multiplicatively across the serial turns.
+# Nightly: this exercises the full dispatch + two-child + auto-wake UI
+# journey. Scripted LLM queues keep it deterministic, while the nightly
+# marker keeps the heavier multi-session browser coverage off the PR gate.
 @pytest.mark.nightly
 @pytest.mark.timeout(600)
 def test_two_joke_subagents_appear_and_navigate(
@@ -73,7 +71,7 @@ def test_two_joke_subagents_appear_and_navigate(
         page,
         "Please get one joke from comic_one and one joke from comic_two, "
         "then tell me both jokes exactly as they said them, including each "
-        "joke code.",
+        f"joke code. Routing marker: {chat.routing_token}",
     )
 
     # Both comedians' jokes (identified by their nonces) reached the

--- a/tests/e2e_ui/approvals/test_inbox_approval.py
+++ b/tests/e2e_ui/approvals/test_inbox_approval.py
@@ -308,7 +308,7 @@ def test_reparked_elicitation_reliably_resurfaces_in_inbox(
         sink = _park_in_thread(base_url, session_id, eid, workers)
         first = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]')
         expect(first).to_be_visible(timeout=_REPARK_TIMEOUT_MS)
-        first.get_by_role("button", name="Approve").click()
+        first.get_by_role("button", name="Approve", exact=True).click()
         _assert_allow(sink, "initial park")
         _settle_after_drain(page, base_url, session_id, rng)
 
@@ -327,11 +327,11 @@ def test_reparked_elicitation_reliably_resurfaces_in_inbox(
             expect(resurfaced).to_have_attribute(
                 "data-state", "pending", timeout=_REPARK_TIMEOUT_MS
             )
-            expect(resurfaced.get_by_role("button", name="Approve")).to_be_visible()
+            expect(resurfaced.get_by_role("button", name="Approve", exact=True)).to_be_visible()
 
             # Approve again (re-arming the stale verdict), then settle so the
             # next retry is a clean 0→1 diff the socket won't coalesce.
-            resurfaced.get_by_role("button", name="Approve").click()
+            resurfaced.get_by_role("button", name="Approve", exact=True).click()
             _assert_allow(sink, f"re-park {cycle}")
             _settle_after_drain(page, base_url, session_id, rng)
     finally:

--- a/tests/e2e_ui/chat/test_two_agent_chat.py
+++ b/tests/e2e_ui/chat/test_two_agent_chat.py
@@ -116,9 +116,9 @@ def _expect_relayed_reply(page: Page, nonce: str) -> None:
 def _expect_dispatch_tool_call_rendered(page: Page) -> None:
     """Assert the `sys_session_send` dispatch shows as a transcript tool call.
 
-    Completed turns fold their tool calls into a collapsed "See N steps"
-    group (ToolCard.tsx ToolGroupSummary), so every group is expanded
-    first. The trigger renders toolTitle.ts's raw-name fallback
+    A lone call can render directly; completed multi-step turns fold calls
+    into a collapsed "See N steps" group. Expand groups when present. The
+    trigger renders toolTitle.ts's raw-name fallback
     ("sys_session_send(...)"), not the friendly "Start child session:"
     verb: sessionTitle() reads `tool`/`session` args while the named
     spawn schema (omnigent/tools/builtins/spawn.py) sends `agent`/`title`,
@@ -128,6 +128,11 @@ def _expect_dispatch_tool_call_rendered(page: Page) -> None:
 
     :param page: The Playwright page, on the parent session.
     """
+    direct_call = page.get_by_role("button", name=re.compile(r"^sys_session_send\("))
+    if direct_call.count():
+        expect(direct_call.first).to_be_visible()
+        return
+
     step_groups = page.get_by_text(re.compile(r"^See \d+ steps?$"))
     expect(step_groups.first).to_be_visible()
     for group in step_groups.all():
@@ -186,11 +191,9 @@ def _expect_child_transcript(page: Page, child_session_id: str, nonces: list[str
         expect(page.locator(_ASSISTANT, has_text=nonce).first).to_be_visible(timeout=30_000)
 
 
-# Nightly: six serial real-LLM turns (two rounds of dispatch + sub-agent +
-# auto-wake continuation), so it is too heavy and 429-sensitive for the PR
-# gate. The 600s budget overrides the suite-wide 300s default for the same
-# reason tests/e2e/test_named_sub_agent_persistence.py uses it: FMAPI
-# backoff stacks multiplicatively across the serial turns.
+# Nightly: two full dispatch + child + auto-wake rounds exercise a heavier
+# multi-session browser journey than the PR gate needs. Scripted LLM queues
+# preserve the orchestration coverage without gateway cost or 429 flakes.
 @pytest.mark.nightly
 @pytest.mark.timeout(600)
 def test_two_agents_discuss_hitchhikers_guide(
@@ -207,7 +210,7 @@ def test_two_agents_discuss_hitchhikers_guide(
         "Let's talk about The Hitchhiker's Guide to the Galaxy. Ask Deep "
         "Thought for the Answer to the Ultimate Question of Life, the "
         "Universe, and Everything, then tell me exactly what it said, "
-        "including its verification code.",
+        f"including its verification code. Routing marker: {chat.routing_token}",
     )
     _expect_relayed_reply(page, chat.verification_code)
     # Deep Thought's Answer itself rendered too — the relay was verbatim.
@@ -224,7 +227,8 @@ def test_two_agents_discuss_hitchhikers_guide(
     _send(
         page,
         "Now ask Deep Thought what the Ultimate Question actually IS, and "
-        "report back exactly what it says, including any code.",
+        "report back exactly what it says, including any code. "
+        f"Routing marker: {chat.routing_token}",
     )
     _expect_relayed_reply(page, chat.question_code)
 

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -1495,12 +1495,14 @@ class TwoAgentChatSession:
         carries, e.g. ``"vogon-3a7f9c2e1b"``.
     :param question_code: Per-run nonce only Deep Thought's QUESTION reply
         carries (round 2), e.g. ``"babelfish-9c2e1b3a7f"``.
+    :param routing_token: Per-run token that selects Arthur's mock queue.
     """
 
     base_url: str
     session_id: str
     verification_code: str
     question_code: str
+    routing_token: str
 
 
 def _two_agent_chat_yaml(verification_code: str, question_code: str) -> str:
@@ -1583,15 +1585,18 @@ tools:
 @pytest.fixture
 def two_agent_chat_session(
     live_server: str,
+    mock_llm_server_url: str,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Iterator[TwoAgentChatSession]:
     """Create a runner-bound session for the two-agent Hitchhiker's chat.
 
     Same runner-respawn and bind contract as :func:`terminal_session`.
-    Yields the per-run nonces so the test can assert that the sub-agent's
-    replies (and only the sub-agent's) reached the UI.
+    Separate content-routed mock queues drive Arthur and Deep Thought,
+    including both dispatch, child, and auto-wake turns. The original
+    model ids remain in the spec for a future real-gateway job.
 
     :param live_server: Spawned server fixture.
+    :param mock_llm_server_url: Mock LLM server used by credential-free runs.
     :param tmp_path_factory: Pytest temp path factory (for a respawn log).
     :returns: A :class:`TwoAgentChatSession` handle.
     """
@@ -1600,7 +1605,66 @@ def two_agent_chat_session(
 
     verification_code = f"vogon-{uuid.uuid4().hex[:10]}"
     question_code = f"babelfish-{uuid.uuid4().hex[:10]}"
+    suffix = uuid.uuid4().hex[:10]
+    routing_token = f"hitchhiker-parent-{suffix}"
+    child_token = f"hitchhiker-child-{suffix}"
     yaml_text = _two_agent_chat_yaml(verification_code, question_code)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_deep_thought_answer",
+                        "name": "sys_session_send",
+                        "arguments": json.dumps(
+                            {
+                                "agent": "deep_thought",
+                                "title": "deep_thought",
+                                "args": (
+                                    "What is the Answer to the Ultimate Question? "
+                                    f"Routing marker: {child_token}"
+                                ),
+                            }
+                        ),
+                    }
+                ]
+            },
+            {"text": "Dispatched Deep Thought; waiting for the answer."},
+            {"text": f"Deep Thought replied: 42. Verification code: {verification_code}."},
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_deep_thought_question",
+                        "name": "sys_session_send",
+                        "arguments": json.dumps(
+                            {
+                                "agent": "deep_thought",
+                                "title": "deep_thought",
+                                "args": (
+                                    "What is the Ultimate Question itself? "
+                                    f"Routing marker: {child_token}"
+                                ),
+                            }
+                        ),
+                    }
+                ]
+            },
+            {"text": "Dispatched the follow-up; waiting for the question."},
+            {"text": f"Deep Thought replied with question code {question_code}."},
+        ],
+        key=routing_token,
+        match=routing_token,
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {"text": f"The Answer is 42. Verification code: {verification_code}."},
+            {"text": f"The Ultimate Question is unknown. Question code: {question_code}."},
+        ],
+        key=child_token,
+        match=child_token,
+    )
     respawned_runner = _ensure_runner_online(live_server, tmp_path_factory)
     runner_id = str(_server_state["runner_id"])
 
@@ -1635,6 +1699,7 @@ def two_agent_chat_session(
             session_id=session_id,
             verification_code=verification_code,
             question_code=question_code,
+            routing_token=routing_token,
         )
     finally:
         httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
@@ -2259,7 +2324,7 @@ def _temp_omnigent_mock_config(
     file (or removes it) on exit.
 
     :param mock_llm_server_url: Base URL of the mock LLM server, e.g.
-        ``"http://127.0.0.1:51235"``. No /v1 suffix — each SDK appends it.
+        ``"http://127.0.0.1:51235"``.
     :param harness: ``"claude"`` or ``"codex"``.
     """
     config_dir = Path.home() / ".omnigent"
@@ -2286,7 +2351,7 @@ def _temp_omnigent_mock_config(
                 kind: key
                 default: [openai]
                 openai:
-                  base_url: "{mock_llm_server_url}"
+                  base_url: "{mock_llm_server_url}/v1"
                   api_key: "mock-key"
                   wire_api: responses
                   models:


### PR DESCRIPTION
## Related issue

Closes #1783

## Summary

Nightly E2E UI runs are intentionally credential-free, but two multi-agent journeys were never migrated after CI stopped injecting `LLM_API_KEY`. They therefore received the generic mock fallback instead of dispatching child agents. This scripts the complete orchestration while leaving the original agent model ids intact for a future real-gateway job.

- Give each parent and child a content-routed mock queue that scripts `sys_session_send`, the post-tool acknowledgement, child replies, and inbox auto-wake continuation. Per-run routing tokens prevent concurrent children or neighboring tests from stealing responses.
- Route native Codex mock requests through `/v1/responses` instead of the nonexistent root `/responses` endpoint.
- Match the plain approval button exactly so Playwright does not also select “Approve & don't ask again.”
- Accept both valid tool-call render shapes: a direct `sys_session_send(...)` card or a collapsed multi-step group.

**ELI5:** The nightly test now gives every pretend agent its own stack of cue cards. The parent’s cards tell it when to call a child, each child has the expected answer, and the parent’s final card relays that answer back through the real UI/session pipeline.

```text
browser → parent queue → sys_session_send → child queue
                                      child reply ↓
                         parent auto-wake queue → browser
```

The `nightly` marker remains because these are heavier multi-session browser journeys, not because they require real credentials.

## Test Plan

- `pre-commit run --all-files`
- `OMNIGENT_CONFIG_HOME=$(mktemp -d) uv run pytest tests/e2e_ui/agents/test_subagent_navigation.py tests/e2e_ui/chat/test_two_agent_chat.py -m nightly -v --tb=short --ui-skip-build` — 2 passed
- Verified generated provider configs keep Claude at the root mock URL and add `/v1` only for Codex.

## Demo

N/A — test infrastructure only.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Ran both nightly-only multi-agent browser journeys together against an isolated local config and the live Omnigent server/runner stack. Both completed in 26 seconds, including child navigation, transcript assertions, and two-round named-child continuation.
