### PR TITLE
fix(session-rename): background the first-turn auto-title call

### DIFF
--- a/omnigent/tools/builtins/session_rename.py
+++ b/omnigent/tools/builtins/session_rename.py
@@ -10,8 +10,10 @@ CLAUDE_NATIVE_SESSION_RENAME_TOOL = "mcp__omnigent__sys_session_rename"
 
 SESSION_RENAME_INSTRUCTION = """
 Omnigent creates each session with its title set to the user's full prompt verbatim. On the
-FIRST turn, before doing any other work or replying, call sys_session_rename with a short
-summary-style title (3-6 words, ≤60 characters, action-first). Strip filler; keep the noun + verb.
+FIRST turn, rename the session in the background: call sys_session_rename alongside your first
+real work — emit it in the same parallel tool-call batch, not as a blocking step ahead of the
+task — so titling never delays your response to the user. Use a short summary-style title
+(3-6 words, ≤60 characters, action-first). Strip filler; keep the noun + verb.
 Summarize the user's actual intent; do not copy a conversational prompt verbatim or use generic
 titles such as "Help with task", "Create new design", or "Answer question".
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

The first-turn auto-title instruction told the model to call `sys_session_rename` **"before doing any other work or replying"**, which serialized a metadata tool call ahead of the user's actual task — adding a round-trip and tokens to the top of every fresh session.

This rewrites the directive (`omnigent/tools/builtins/session_rename.py`) so the model emits `sys_session_rename` **in the same parallel tool-call batch as its first real work**, never as a blocking step, so titling no longer delays the response.

- A model can't literally detach a synchronous tool call, so the instruction is grounded in the mechanism that actually achieves "background" — a parallel tool batch — rather than an impossible directive.
- The `/auto-title` endpoint is already an idempotent compare-and-swap (it only overwrites the title while it still equals the deterministic seed), so a rename landing slightly later — or not at all — is harmless.
- All three wiring paths (SDK runner, native Claude, codex-native) share this one constant, so the change applies to every harness with no per-adapter edits.

## Test Plan

- `tests/runner/test_auto_title_instruction.py` — 4 passed. The pinned substrings (`3-6 words`, `Strip filler; keep the noun + verb`, the example titles, `ToolSearch`, `Every fresh session must call sys_session_rename`) are all preserved; only the ordering clause changed.
- `tests/inner/test_codex_native_executor.py` — 17 passed. Other test files compare the instruction by identity, so they are unaffected by the text change.
- `ruff format --check` and `ruff check` clean on the changed file.

To verify manually: start a fresh Omnigent session on any harness and watch the first turn — the title still updates to a summary (not the verbatim prompt), but the model begins its actual work in the same batch rather than pausing on the rename first.

## Demo

N/A — instruction-string change, no UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

Existing `test_auto_title_instruction.py` pins the invariant substrings of the instruction and continues to pass; the edit only touches the ordering clause, which was not asserted on. Behavior is a prompt-wording change (model no longer serializes the rename ahead of user work), verified by re-running the affected suites above.

## Changelog

Session auto-titling no longer blocks the first turn — the rename runs alongside your first real work instead of ahead of it.

This pull request and its description were written by Isaac.