### PR TITLE
fix(web): trust server session.status so "Working…" clears on idle

### DIFF
--- a/tests/e2e_ui/chat/test_working_indicator_idle_clears.py
+++ b/tests/e2e_ui/chat/test_working_indicator_idle_clears.py
@@ -1,0 +1,87 @@
+"""The main chat Working indicator clears when the server reports idle.
+
+Regression: the indicator reads only ``sessionStatus``, but the
+``session.status`` handler used to drop a bare ``idle`` (no ``response_id``)
+whenever an ``activeResponse`` was still ``streaming`` — deferring to
+``response_end`` to own that lifecycle. ``response_end`` only settles the
+local ``status``/``activeResponse``, never ``sessionStatus``, so a dropped
+idle stranded the one field the shimmer reads: the server, sidebar, and
+local status all reported idle while "Working…" stayed lit.
+
+This drives the exact edge shape the claude-native PTY-activity watcher
+emits on a plain turn — a turn-start ``running`` carrying a ``response_id``
+(which opens the streaming ``activeResponse``), then a trailing bare
+``idle`` with no ``response_id`` once the pane quiesces. The fix makes the
+client trust ``session.status`` 1:1, so that bare idle clears Working.
+
+Both edges go through the Sessions events route (the same path the
+claude-native forwarder posts to), so the test is deterministic — no live
+LLM turn whose timing would make it flaky.
+"""
+
+from __future__ import annotations
+
+import httpx
+from playwright.sync_api import Page, expect
+
+_WORKING = '[data-testid="working-indicator"]'
+
+
+def _publish_status(
+    base_url: str, session_id: str, status: str, response_id: str | None = None
+) -> None:
+    """Publish a session status through the native-harness events route.
+
+    :param base_url: Base URL of the local e2e server.
+    :param session_id: Session/conversation id.
+    :param status: Session status to publish, e.g. ``"running"``.
+    :param response_id: Optional in-flight turn id. Set on the turn-start
+        ``running`` edge (opening the streaming ``activeResponse``) and
+        omitted on the trailing PTY-activity ``idle`` — reproducing the
+        bare, id-less idle the old guard dropped.
+    :returns: None.
+    """
+    data: dict[str, str] = {"status": status}
+    if response_id is not None:
+        data["response_id"] = response_id
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={"type": "external_session_status", "data": data},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def test_bare_idle_clears_working_indicator(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A trailing bare ``idle`` clears Working even while a turn was streaming.
+
+    1. A turn-start ``running`` edge carrying a ``response_id`` opens the
+       streaming ``activeResponse`` and lights the indicator.
+    2. A trailing ``idle`` with no ``response_id`` (the PTY-activity
+       watcher's quiescence edge) arrives while that response is still
+       locally streaming — the exact case the dropped-idle guard covered.
+       The indicator must go out; before the fix it stayed lit forever.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server
+        fixture.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    working = page.locator(_WORKING)
+    response_id = "resp_idle_clears_1"
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_role("textbox", name="Message the agent")).to_be_visible(timeout=20_000)
+
+    # Turn starts: the id-bearing running edge opens a streaming activeResponse.
+    _publish_status(base_url, session_id, "running", response_id=response_id)
+    expect(working).to_be_visible(timeout=15_000)
+
+    # Turn ends: a bare idle (no response_id) — the trailing PTY-activity
+    # edge. The server says idle, so Working must clear.
+    _publish_status(base_url, session_id, "idle")
+    expect(working).to_have_count(0, timeout=15_000)

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2484,8 +2484,9 @@ describe("chatStore — send while streaming (queueing)", () => {
     // The denied queued message was never persisted, so its optimistic
     // bubble must disappear even though the previous response is still live.
     expect(state.pendingUserMessages).toEqual([]);
-    // Denying the queued input must not mark the already-streaming prior
-    // response idle; that response still needs its own response_end.
+    // The denied branch of `send` only settles status when NOT already
+    // streaming, so the POST-return path leaves the prior turn's
+    // running/streaming state intact here.
     expect(state.status).toBe("streaming");
     expect(state.sessionStatus).toBe("running");
     expect(state.activeResponse).toEqual({
@@ -2494,17 +2495,28 @@ describe("chatStore — send while streaming (queueing)", () => {
       error: null,
     });
 
+    // Accepted trade-off: the server's deny short-circuit still publishes a
+    // session-level running→idle pair for the denied out-of-band input, and
+    // the client now trusts `session.status` 1:1 (the guard that used to
+    // suppress this stray idle was removed to fix the fresh-session
+    // "Working…" persists bug). So this idle DOES flip `sessionStatus` to
+    // idle mid-stream. The bubble lifecycle is unaffected — `status` /
+    // `activeResponse` still defer to the streaming turn's own response_end —
+    // and the next real status edge re-asserts running, so the effect is a
+    // brief indicator blip confined to the rare deny-while-streaming case.
     handleSessionEvent({
       type: "session_status",
       conversationId: "conv_abc",
       status: "idle",
     });
     const afterIdle = useChatStore.getState();
-    // The server's deny short-circuit publishes running→idle for the
-    // queued input. That idle must not clear the prior response's
-    // running/working signal while its active response is still streaming.
+    expect(afterIdle.sessionStatus).toBe("idle");
     expect(afterIdle.status).toBe("streaming");
-    expect(afterIdle.sessionStatus).toBe("running");
+    expect(afterIdle.activeResponse).toEqual({
+      responseId: "resp_in_flight",
+      state: "streaming",
+      error: null,
+    });
   });
 });
 
@@ -3209,7 +3221,7 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       ]);
     });
 
-    it("idle preserves a still-streaming active response until response_end arrives", () => {
+    it("idle settles sessionStatus but preserves a still-streaming bubble until response_end", () => {
       useChatStore.setState({
         status: "streaming",
         sessionStatus: "running",
@@ -3223,16 +3235,20 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       });
 
       const state = useChatStore.getState();
-      // A real response bubble is closed by response_end, not by the
-      // coarser session.status signal. Clearing status here would make
-      // the bubble lifecycle disagree with the streaming reducer.
+      // sessionStatus tracks the server's session-level status 1:1 — a server
+      // idle means idle, and the "Working…" indicator (which reads only
+      // sessionStatus) must turn off. The bubble lifecycle is separate: a real
+      // response bubble is still closed by response_end, not by the coarser
+      // session.status signal, so the local `status`/`activeResponse` stay
+      // streaming until response_end lands (dropping the guard that used to
+      // strand sessionStatus at "running" — the "Working…" persists bug).
+      expect(state.sessionStatus).toBe("idle");
       expect(state.status).toBe("streaming");
       expect(state.activeResponse).toEqual({
         responseId: "resp_live",
         state: "streaming",
         error: null,
       });
-      expect(state.sessionStatus).toBe("running");
     });
 
     it("idle refetches the parent's child list when the conversation is a child", () => {

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -4179,16 +4179,13 @@ export function handleSessionEvent(event: StreamEvent): void {
       // running/waiting status carrying an unseen id marks a new turn.
       const prevResponseId = useChatStore.getState().activeResponse?.responseId;
       useChatStore.setState((s) => {
-        if (
-          event.status === "idle" &&
-          event.responseId === undefined &&
-          s.activeResponse?.state === "streaming"
-        ) {
-          // A denied queued input publishes running→idle while the prior
-          // response is still streaming. That idle must not clear the
-          // prior turn's working signal; response_end owns that lifecycle.
-          return {};
-        }
+        // `sessionStatus` tracks the server's session-level status 1:1 — a
+        // server `idle` means the session is idle, full stop, and the
+        // "Working…" indicator (which reads only `sessionStatus`) turns off.
+        // There is exactly one idle heuristic and it lives server-side (the
+        // runner's PTY-activity watcher); the client must not second-guess it.
+        // The bubble lifecycle below (`status`/`activeResponse`) still defers
+        // to response_end, but that is separate from the session-level status.
         const patch: Partial<ChatState> = { sessionStatus: event.status };
         // The background-shell tally is STICKY. Only the Stop-hook-derived
         // status carries an authoritative count (the forwarder relabels its


### PR DESCRIPTION
## Related issue

N/A

## Summary

The main chat's "Working…" indicator persisted even after the server reported the session idle — reproducible on a fresh session by just sending "hello", with no background tasks involved.

- The indicator reads **only** `sessionStatus`. The `session.status` SSE handler dropped a bare `idle` (no `responseId`) whenever an `activeResponse` was still `streaming`, deferring to `response_end` to "own that lifecycle."
- But `response_end` only sets the local `status`/`activeResponse` — it **never** touches `sessionStatus`. So when that guard fired, nothing ever cleared the one field the indicator reads.
- On a fresh session, the first-turn wrapper-response id mismatch leaves `activeResponse` stuck `streaming`, so the turn's *genuine* terminal `idle` got eaten and the shimmer stayed lit — even though the server, sidebar, and local status all said idle.

The fix removes the guard so `sessionStatus` tracks the server's session-level status 1:1. The idle heuristic now lives in exactly **one** place — the runner's PTY-activity watcher — rather than being split between server and client. The bubble lifecycle (`status`/`activeResponse`) still defers to `response_end`, independently of the session-level status.

**ELI5:** the server was saying "I'm done", but the UI had a rule that ignored that message while it thought a reply was still being typed. On the first message of a session, the UI can wrongly believe a reply is still in flight forever, so it ignored "I'm done" forever and kept spinning. We deleted that rule and now the UI just believes the server.

**Trade-off (accepted):** if you queue a 2nd message mid-stream and policy *denies* it, the server's deny short-circuit still publishes a stray session-level `idle`, which now briefly flips the indicator off mid-turn until the next status edge re-asserts `running`. This is rare (requires a mid-turn policy deny on a queued input) and self-corrects. The alternative — a server-side fix to stop the deny path from moving session status — has broader blast radius and was intentionally left out of this PR.

## Test Plan

- `vitest run src/store/chatStore.test.ts src/pages/ChatPage.test.ts` — 416 passing, including:
  - updated `handleSessionEvent` test: a bare `idle` while streaming now settles `sessionStatus` to `idle` (indicator off) while the bubble's `status`/`activeResponse` still defer to `response_end`.
  - updated deny-while-streaming test to document the accepted mid-turn blip.
- `tsc -b --noEmit` — clean.
- `pre-commit run --files …` (prettier etc.) — clean.

## Demo

N/A — behavioral fix to an existing indicator; the change is "the shimmer stops when the server says idle." No new UI surface to screenshot. (Repro before fix: send "hello" to a fresh claude-native session → "Working…" never clears after the reply completes.)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit-level: the store handler + indicator predicate are covered deterministically (`chatStore.test.ts`, `ChatPage.test.ts`). The exact fresh-session trigger (wrapper-response id mismatch stranding `activeResponse` as `streaming`) was reproduced against the real store handler during investigation. A full live claude-native drive (real server + host daemon + `claude` CLI in tmux) was not run — tmux launches are currently broken in this sandbox (socket path length) — so the end-to-end path is verified by reasoning + unit repro rather than a live session.

## Changelog

The main chat "Working…" indicator now clears reliably when the session goes idle, instead of occasionally staying lit after a reply completes.
