### PR TITLE
feat(credentials): per-user GitHub connection injected into managed sandboxes

### DIFF
--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -356,6 +356,9 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     policy_store = SqlAlchemyPolicyStore(database_url)
     scheduled_task_store = SqlAlchemyScheduledTaskStore(database_url)
     project_store = SqlAlchemyProjectStore(database_url)
+    from omnigent.stores.credential_store import CredentialStore
+
+    credential_store = CredentialStore(database_url)
     # Fail startup loud on a malformed `sandbox:` section (an operator
     # typo should not surface as a runtime 502 on the first managed
     # session); the startup catch-all below logs it.
@@ -419,6 +422,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         host_store=host_store,
         scheduled_task_store=scheduled_task_store,
         project_store=project_store,
+        credential_store=credential_store,
         auth_provider=auth_provider,
         account_store=account_store,
         # Non-secret auth settings from the config file (admins are the

--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -304,6 +304,22 @@ def _build_routing(
     return _build_local_llm_routing_client(server_llm), settings
 
 
+def _resolve_execution_timeout(cfg: dict[str, Any]) -> int:
+    """Resolve the max wall-clock seconds per agent execution.
+
+    Mirrors the CLI's ``execution_timeout`` resolution (``omnigent server
+    --execution-timeout``) minus the flag layer, since a Docker deploy has no
+    CLI invocation to read one from: config file, else ``RuntimeCaps``'s own
+    default (7200s = 2 hours).
+
+    :param cfg: The parsed server config mapping.
+    :returns: The effective timeout in seconds.
+    """
+    from omnigent.runtime.caps import RuntimeCaps
+
+    return int(cfg.get("execution_timeout") or RuntimeCaps.execution_timeout)
+
+
 def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     """Resolve config if needed, wire the stores, and build the app.
 
@@ -377,6 +393,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     routing_client, routing_settings = _build_routing(cfg, server_llm)
 
     caps = RuntimeCaps(
+        execution_timeout=_resolve_execution_timeout(cfg),
         default_policies=parse_default_policies(cfg.get("policies")),
         llm=server_llm,
         routing_client=routing_client,

--- a/docs/superpowers/plans/2026-08-08-github-repo-picker.md
+++ b/docs/superpowers/plans/2026-08-08-github-repo-picker.md
@@ -354,7 +354,7 @@ export type GithubReposResult = { ok: true; repos: GithubRepoInfo[] } | Credenti
 export async function listGithubRepos(): Promise<GithubReposResult> {
   let res: Response;
   try {
-    res = await fetch("/v1/credentials/github/repos");
+    res = await authenticatedFetch("/v1/credentials/github/repos");
   } catch {
     return NETWORK_FAILURE;
   }
@@ -365,6 +365,12 @@ export async function listGithubRepos(): Promise<GithubReposResult> {
   return failureFrom(res, "Could not load your GitHub repos.");
 }
 ```
+
+Note: `credentialsApi.ts` already has `import { authenticatedFetch } from "@/lib/identity";` at
+the top (its other three functions were migrated from bare `fetch()` to
+`authenticatedFetch` in a prerequisite fix — the project's `no-restricted-globals`
+oxlint rule bans bare `fetch()` outside `src/lib/host.ts`). Use the existing
+import; do not add a second one.
 
 - [ ] **Step 4: Add state and the filtered-repos memo to `NewChatDialog.tsx`**
 

--- a/docs/superpowers/plans/2026-08-08-github-repo-picker.md
+++ b/docs/superpowers/plans/2026-08-08-github-repo-picker.md
@@ -1,0 +1,536 @@
+# GitHub Repo Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user with GitHub connected (Settings → Credentials) pick a repo from a searchable dropdown in the New Chat dialog's sandbox "Repository" field, instead of only typing/pasting a URL.
+
+**Architecture:** One new server-side route (`GET /v1/credentials/github/repos`) proxies GitHub's `/user/repos` API using the caller's stored, decrypted OAuth token — the token never reaches the browser. The frontend adds a typed client function and turns the existing plain-text repository input into a combobox (reusing the exact interaction pattern already built for this dialog's git-worktree branch-name field): focus fetches the list once, typing filters it client-side, selecting an item fills the URL field, and typing anything that matches nothing keeps working as free text exactly as today.
+
+**Tech Stack:** FastAPI + httpx (backend), React + TypeScript + Vitest/Testing Library (frontend). No new dependencies.
+
+Spec: `docs/superpowers/specs/2026-08-08-github-repo-picker-design.md`
+
+## Global Constraints
+
+- Only the GitHub provider is supported (matches the existing credentials feature — `provider="github"` throughout `credentials.py`).
+- Repo list is capped to GitHub's single-page maximum (100 repos), sorted most-recently-pushed first (`sort=pushed`). No pagination beyond that — anything not in the list is still reachable by pasting a URL.
+- The GitHub OAuth token must never be sent to the browser at any point.
+- Every failure mode (not connected, decrypt failure, GitHub API error) must leave the field working as plain text — never block or error-toast the user.
+- Repos returned must cover everything the `repo` OAuth scope already grants: owner, collaborator, and organization-member affiliations (`affiliation=owner,collaborator,organization_member`).
+
+---
+
+### Task 1: Backend — `GET /v1/credentials/github/repos`
+
+**Files:**
+- Modify: `omnigent/server/routes/credentials.py`
+- Test: `tests/server/routes/test_credentials.py`
+
+**Interfaces:**
+- Consumes: `CredentialStore.get(user_id, "github") -> UserCredential | None`, `CredentialStore.decrypt_token(cred) -> str | None` (both already exist in `omnigent/stores/credential_store.py`).
+- Produces: `_fetch_github_repos(token: str) -> list[dict[str, Any]]` (a monkeypatch seam for route-level tests, mirroring the existing `_fetch_github_user`). Route response shape on success: `{"repos": [{"full_name": str, "clone_url": str, "default_branch": str, "private": bool}, ...]}`. On failure: an `OmnigentError` — `code=ErrorCode.CONFLICT` (409) when not connected or the token can't be decrypted, `code=ErrorCode.INTERNAL_ERROR` (500) when the GitHub call itself fails.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/server/routes/test_credentials.py`, after the existing `test_callback_happy_path_then_list_and_disconnect` test (end of file):
+
+```python
+async def test_repos_requires_connected_github(client: httpx.AsyncClient) -> None:
+    resp = await client.get("/v1/credentials/github/repos")
+    assert resp.status_code == 409
+
+
+async def test_repos_returns_mapped_list(
+    client: httpx.AsyncClient, credential_store: CredentialStore, monkeypatch
+) -> None:
+    credential_store.upsert(_USER, "github", token="gho_live", login="alice-gh", scopes="repo")
+
+    async def fake_repos(token: str) -> list[dict]:
+        assert token == "gho_live"
+        return [
+            {
+                "full_name": "alice/proj",
+                "clone_url": "https://github.com/alice/proj.git",
+                "default_branch": "main",
+                "private": False,
+                "id": 1,  # extra GitHub fields the mapping must drop
+            },
+        ]
+
+    monkeypatch.setattr(credentials_routes, "_fetch_github_repos", fake_repos)
+    resp = await client.get("/v1/credentials/github/repos")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "repos": [
+            {
+                "full_name": "alice/proj",
+                "clone_url": "https://github.com/alice/proj.git",
+                "default_branch": "main",
+                "private": False,
+            }
+        ]
+    }
+
+
+async def test_repos_undecryptable_credential_treated_as_not_connected(
+    client: httpx.AsyncClient, credential_store: CredentialStore, monkeypatch
+) -> None:
+    credential_store.upsert(_USER, "github", token="gho_live", login="alice-gh", scopes="repo")
+    # Rotate the key after writing — the stored ciphertext no longer decrypts.
+    monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    resp = await client.get("/v1/credentials/github/repos")
+    assert resp.status_code == 409
+
+
+async def test_repos_github_api_failure_returns_500(
+    client: httpx.AsyncClient, credential_store: CredentialStore, monkeypatch
+) -> None:
+    credential_store.upsert(_USER, "github", token="gho_live", login="alice-gh", scopes="repo")
+
+    async def failing_repos(token: str) -> list[dict]:
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(credentials_routes, "_fetch_github_repos", failing_repos)
+    resp = await client.get("/v1/credentials/github/repos")
+    assert resp.status_code == 500
+
+
+@respx.mock
+async def test_fetch_github_repos_requests_all_affiliations_sorted_by_pushed() -> None:
+    route = respx.get("https://api.github.com/user/repos").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "full_name": "alice/proj",
+                    "clone_url": "https://github.com/alice/proj.git",
+                    "default_branch": "main",
+                    "private": False,
+                }
+            ],
+        )
+    )
+    repos = await credentials_routes._fetch_github_repos("gho_live")
+    assert repos[0]["full_name"] == "alice/proj"
+    request = route.calls.last.request
+    assert request.headers["authorization"] == "Bearer gho_live"
+    assert request.url.params["affiliation"] == "owner,collaborator,organization_member"
+    assert request.url.params["sort"] == "pushed"
+    assert request.url.params["per_page"] == "100"
+```
+
+Add `import respx` to the imports at the top of the file, alongside the existing `import httpx`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/pzharyuk/Documents/Claude/Projects/omnigent && source .venv/bin/activate && python3 -m pytest tests/server/routes/test_credentials.py -v -k repos`
+Expected: FAIL — `404 Not Found` on the new route (doesn't exist yet), and `AttributeError: module 'omnigent.server.routes.credentials' has no attribute '_fetch_github_repos'` for the respx test.
+
+- [ ] **Step 3: Implement `_fetch_github_repos`**
+
+In `omnigent/server/routes/credentials.py`, add this function immediately after `_fetch_github_user` (which ends right before `def create_credentials_router`):
+
+```python
+async def _fetch_github_repos(token: str) -> list[dict[str, Any]]:
+    """Fetch repos the token can access — owner, collaborator, and org member
+    affiliations, most-recently-pushed first, capped at GitHub's 100/page
+    maximum (raises on HTTP error)."""
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(
+            f"{_USER_URL}/repos",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+            params={
+                "affiliation": "owner,collaborator,organization_member",
+                "sort": "pushed",
+                "per_page": 100,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+- [ ] **Step 4: Implement the route**
+
+In `omnigent/server/routes/credentials.py`, add this route inside `create_credentials_router`, immediately after `list_credentials` and before `connect_github`:
+
+```python
+    @router.get("/v1/credentials/github/repos")
+    async def list_github_repos(request: Request) -> dict[str, Any]:
+        """The caller's GitHub repos — owner, collaborator, and org member."""
+        user_id = _user(request)
+        cred = credential_store.get(user_id, "github")
+        if cred is None:
+            raise OmnigentError("github_not_connected", code=ErrorCode.CONFLICT)
+        token = credential_store.decrypt_token(cred)
+        if token is None:
+            raise OmnigentError("github_not_connected", code=ErrorCode.CONFLICT)
+        try:
+            repos = await _fetch_github_repos(token)
+        except httpx.HTTPError as exc:
+            logger.warning("github repo listing failed for %s", user_id, exc_info=True)
+            raise OmnigentError(
+                "github_repos_fetch_failed", code=ErrorCode.INTERNAL_ERROR
+            ) from exc
+        return {
+            "repos": [
+                {
+                    "full_name": r["full_name"],
+                    "clone_url": r["clone_url"],
+                    "default_branch": r["default_branch"],
+                    "private": r["private"],
+                }
+                for r in repos
+            ]
+        }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/pzharyuk/Documents/Claude/Projects/omnigent && source .venv/bin/activate && python3 -m pytest tests/server/routes/test_credentials.py -v`
+Expected: PASS — all tests in the file, including the 5 new ones.
+
+- [ ] **Step 6: Lint and type-check**
+
+Run: `cd /Users/pzharyuk/Documents/Claude/Projects/omnigent && source .venv/bin/activate && ruff format omnigent/server/routes/credentials.py tests/server/routes/test_credentials.py && ruff check omnigent/server/routes/credentials.py tests/server/routes/test_credentials.py`
+Expected: no changes needed beyond formatting, no lint errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/pzharyuk/Documents/Claude/Projects/omnigent
+git add omnigent/server/routes/credentials.py tests/server/routes/test_credentials.py
+git commit -m "feat(credentials): add GET /v1/credentials/github/repos
+
+Server-side proxy that lists the caller's GitHub repos (owner,
+collaborator, and org-member affiliations) using their stored,
+decrypted OAuth token. The token never reaches the browser."
+```
+
+---
+
+### Task 2: Frontend — repo picker combobox in the New Chat dialog
+
+**Files:**
+- Modify: `web/src/lib/credentialsApi.ts`
+- Modify: `web/src/shell/NewChatDialog.tsx`
+- Test: `web/src/shell/NewChatDialog.test.tsx`
+
+**Interfaces:**
+- Consumes: `GET /v1/credentials/github/repos` from Task 1 (response shape `{"repos": [{"full_name", "clone_url", "default_branch", "private"}]}` on 200; non-2xx on failure).
+- Produces: `listGithubRepos(): Promise<GithubReposResult>` where `GithubReposResult = { ok: true; repos: GithubRepoInfo[] } | CredentialsFailure`, `GithubRepoInfo = { full_name: string; clone_url: string; default_branch: string; private: boolean }`. Both exported from `web/src/lib/credentialsApi.ts`.
+
+- [ ] **Step 1: Write the failing frontend tests**
+
+In `web/src/shell/NewChatDialog.test.tsx`, add this mock setup near the top of the file, alongside the other `vi.mock` calls (after the `vi.mock("@/hooks/useHosts", ...)` block):
+
+```typescript
+const credentialsMocks = vi.hoisted(() => ({
+  listGithubRepos: vi.fn(),
+}));
+vi.mock("@/lib/credentialsApi", () => credentialsMocks);
+```
+
+In `setupLandingMocks` (the function used as the `NewChatLandingScreen` describe block's `beforeEach`), add a reset and a safe default so every other existing test — which doesn't care about this feature — sees the field behave exactly as before:
+
+```typescript
+  credentialsMocks.listGithubRepos.mockReset();
+  credentialsMocks.listGithubRepos.mockResolvedValue({
+    ok: false,
+    error: "github_not_connected",
+    status: 409,
+  });
+```
+(Add these two lines right after the existing `authenticatedFetchMock.mockReset();` line in `setupLandingMocks`.)
+
+Then add these three tests inside the `describe("NewChatLandingScreen", ...)` block, after the existing `it("blocks submit on an invalid repository URL or a dangling branch", ...)` test:
+
+```typescript
+  it("shows connected GitHub repos in a filterable dropdown and fills the URL on selection", async () => {
+    credentialsMocks.listGithubRepos.mockResolvedValue({
+      ok: true,
+      repos: [
+        {
+          full_name: "alice/proj-one",
+          clone_url: "https://github.com/alice/proj-one.git",
+          default_branch: "main",
+          private: false,
+        },
+        {
+          full_name: "alice/proj-two",
+          clone_url: "https://github.com/alice/proj-two.git",
+          default_branch: "main",
+          private: true,
+        },
+      ],
+    });
+    renderLanding({ managed_sandboxes_enabled: true });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
+    fireEvent.focus(screen.getByTestId("new-chat-landing-repo-input"));
+    await waitFor(() => expect(credentialsMocks.listGithubRepos).toHaveBeenCalledTimes(1));
+    const options = await screen.findAllByTestId("new-chat-landing-repo-option");
+    expect(options).toHaveLength(2);
+
+    fireEvent.change(screen.getByTestId("new-chat-landing-repo-input"), {
+      target: { value: "proj-two" },
+    });
+    await waitFor(() =>
+      expect(screen.getAllByTestId("new-chat-landing-repo-option")).toHaveLength(1),
+    );
+
+    fireEvent.mouseDown(screen.getByTestId("new-chat-landing-repo-option"));
+    expect((screen.getByTestId("new-chat-landing-repo-input") as HTMLInputElement).value).toBe(
+      "https://github.com/alice/proj-two.git",
+    );
+  });
+
+  it("shows a connect-GitHub hint when GitHub isn't connected", async () => {
+    renderLanding({ managed_sandboxes_enabled: true });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
+    fireEvent.focus(screen.getByTestId("new-chat-landing-repo-input"));
+    await waitFor(() => expect(credentialsMocks.listGithubRepos).toHaveBeenCalledTimes(1));
+    expect(
+      await screen.findByText("Connect GitHub in Settings to browse your repos"),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-repo-option")).toBeNull();
+  });
+
+  it("still accepts an arbitrary pasted URL when the repo list is loaded", async () => {
+    credentialsMocks.listGithubRepos.mockResolvedValue({
+      ok: true,
+      repos: [
+        {
+          full_name: "alice/proj-one",
+          clone_url: "https://github.com/alice/proj-one.git",
+          default_branch: "main",
+          private: false,
+        },
+      ],
+    });
+    renderLanding({ managed_sandboxes_enabled: true });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
+    fireEvent.focus(screen.getByTestId("new-chat-landing-repo-input"));
+    await waitFor(() => expect(credentialsMocks.listGithubRepos).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId("new-chat-landing-repo-input"), {
+      target: { value: "https://github.com/someone-else/other-repo" },
+    });
+    expect(screen.queryByTestId("new-chat-landing-repo-option")).toBeNull();
+    expect((screen.getByTestId("new-chat-landing-repo-input") as HTMLInputElement).value).toBe(
+      "https://github.com/someone-else/other-repo",
+    );
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/pzharyuk/Documents/Claude/Projects/omnigent/web && npx vitest run src/shell/NewChatDialog.test.tsx -t "GitHub repo"`
+Expected: FAIL — `listGithubRepos` doesn't exist in `@/lib/credentialsApi`, and `new-chat-landing-repo-option`/the connect hint don't exist in the DOM yet.
+
+- [ ] **Step 3: Add `listGithubRepos` to `credentialsApi.ts`**
+
+Append to the end of `web/src/lib/credentialsApi.ts`:
+
+```typescript
+/** One repo the caller's connected GitHub credential can access. */
+export interface GithubRepoInfo {
+  full_name: string;
+  clone_url: string;
+  default_branch: string;
+  private: boolean;
+}
+
+export type GithubReposResult = { ok: true; repos: GithubRepoInfo[] } | CredentialsFailure;
+
+/** GET /v1/credentials/github/repos — the caller's accessible GitHub repos. */
+export async function listGithubRepos(): Promise<GithubReposResult> {
+  let res: Response;
+  try {
+    res = await fetch("/v1/credentials/github/repos");
+  } catch {
+    return NETWORK_FAILURE;
+  }
+  if (res.ok) {
+    const data = (await res.json()) as { repos: GithubRepoInfo[] };
+    return { ok: true, repos: data.repos };
+  }
+  return failureFrom(res, "Could not load your GitHub repos.");
+}
+```
+
+- [ ] **Step 4: Add state and the filtered-repos memo to `NewChatDialog.tsx`**
+
+Add the import, alongside the other `@/lib/*` imports (after `import { cn } from "@/lib/utils";`):
+
+```typescript
+import { listGithubRepos, type GithubRepoInfo } from "@/lib/credentialsApi";
+```
+
+Find this block (the `sandboxRepoBranch` state declaration):
+
+```typescript
+  const [sandboxRepoBranch, setSandboxRepoBranch] = useState<string>(
+    () => landingDraft?.sandboxRepoBranch ?? "",
+  );
+```
+
+Immediately after it, add:
+
+```typescript
+  // The repository field doubles as a combobox: focusing it fetches the
+  // caller's GitHub repos (once per dialog instance) if connected, and
+  // typing filters them. A value matching none is used as a plain URL,
+  // unchanged from the field's pre-picker behavior.
+  type GithubRepoPickerState =
+    | { status: "idle" }
+    | { status: "loading" }
+    | { status: "ready"; repos: GithubRepoInfo[] }
+    | { status: "not_connected" }
+    | { status: "error" };
+  const [githubRepoPicker, setGithubRepoPicker] = useState<GithubRepoPickerState>({
+    status: "idle",
+  });
+  const [repoInputFocused, setRepoInputFocused] = useState(false);
+  const fetchGithubRepos = useCallback(() => {
+    if (githubRepoPicker.status !== "idle") return;
+    setGithubRepoPicker({ status: "loading" });
+    void listGithubRepos().then((result) => {
+      if (!result.ok) {
+        setGithubRepoPicker(
+          result.status === 409 ? { status: "not_connected" } : { status: "error" },
+        );
+        return;
+      }
+      setGithubRepoPicker({ status: "ready", repos: result.repos });
+    });
+  }, [githubRepoPicker]);
+  const filteredGithubRepos = useMemo(() => {
+    if (githubRepoPicker.status !== "ready") return [];
+    const q = sandboxRepoUrl.trim().toLowerCase();
+    if (q === "") return githubRepoPicker.repos;
+    return githubRepoPicker.repos.filter((r) => r.full_name.toLowerCase().includes(q));
+  }, [githubRepoPicker, sandboxRepoUrl]);
+```
+
+- [ ] **Step 5: Wire the combobox into the repository popover JSX**
+
+Find this block (the sandbox repository chip's URL input, currently a plain `<input>` directly inside the `flex flex-col gap-2` popover content):
+
+```typescript
+                      <input
+                        id="landing-repo-url"
+                        type="text"
+                        value={sandboxRepoUrl}
+                        onChange={(e) => setSandboxRepoUrl(e.target.value)}
+                        placeholder="https://github.com/org/repo"
+                        className="rounded-md border border-input bg-background px-3 py-2 text-xs outline-none transition-colors focus-visible:border-ring"
+                        data-testid="new-chat-landing-repo-input"
+                      />
+```
+
+Replace it with:
+
+```typescript
+                      <div className="relative flex flex-col">
+                        <input
+                          id="landing-repo-url"
+                          type="text"
+                          value={sandboxRepoUrl}
+                          onChange={(e) => setSandboxRepoUrl(e.target.value)}
+                          onFocus={() => {
+                            setRepoInputFocused(true);
+                            fetchGithubRepos();
+                          }}
+                          // Delay so a click on a dropdown option registers
+                          // before the list unmounts on blur.
+                          onBlur={() => setTimeout(() => setRepoInputFocused(false), 120)}
+                          placeholder="https://github.com/org/repo"
+                          role="combobox"
+                          aria-expanded={repoInputFocused && filteredGithubRepos.length > 0}
+                          aria-autocomplete="list"
+                          className="rounded-md border border-input bg-background px-3 py-2 text-xs outline-none transition-colors focus-visible:border-ring"
+                          data-testid="new-chat-landing-repo-input"
+                        />
+                        {repoInputFocused && filteredGithubRepos.length > 0 && (
+                          <div
+                            className="absolute top-full right-0 left-0 z-20 mt-1 flex max-h-40 flex-col overflow-y-auto rounded-md border border-input bg-popover p-1 shadow-md"
+                            data-testid="new-chat-landing-repo-dropdown"
+                          >
+                            <ul className="flex flex-col gap-0.5">
+                              {filteredGithubRepos.map((r) => (
+                                <li key={r.full_name}>
+                                  <button
+                                    type="button"
+                                    // onMouseDown (not onClick): fires before
+                                    // the input's blur, so the selection lands
+                                    // even though blur is about to hide the list.
+                                    onMouseDown={(e) => {
+                                      e.preventDefault();
+                                      setSandboxRepoUrl(r.clone_url);
+                                      setRepoInputFocused(false);
+                                    }}
+                                    className="flex w-full items-center justify-between gap-2 rounded-md px-2 py-1 text-left text-xs transition-colors hover:bg-accent"
+                                    data-testid="new-chat-landing-repo-option"
+                                  >
+                                    <span className="truncate text-foreground">
+                                      {r.full_name}
+                                    </span>
+                                    {r.private && (
+                                      <span className="shrink-0 text-[10px] text-muted-foreground">
+                                        private
+                                      </span>
+                                    )}
+                                  </button>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                      </div>
+                      {githubRepoPicker.status === "not_connected" && (
+                        <p className="text-xs text-muted-foreground">
+                          Connect GitHub in Settings to browse your repos
+                        </p>
+                      )}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd /Users/pzharyuk/Documents/Claude/Projects/omnigent/web && npx vitest run src/shell/NewChatDialog.test.tsx`
+Expected: PASS — the full file, including the 3 new tests and every pre-existing test in it (the repo-picker changes must not regress `"sends the repository inputs as the managed workspace string"`, `"shows host-provided git credentials tooltip content..."`, or `"blocks submit on an invalid repository URL..."`).
+
+- [ ] **Step 7: Type-check and lint**
+
+Run: `cd /Users/pzharyuk/Documents/Claude/Projects/omnigent/web && npx tsc --noEmit && node_modules/.bin/oxlint --deny-warnings src/lib/credentialsApi.ts src/shell/NewChatDialog.tsx src/shell/NewChatDialog.test.tsx && node_modules/.bin/prettier --check src/lib/credentialsApi.ts src/shell/NewChatDialog.tsx src/shell/NewChatDialog.test.tsx`
+Expected: no type errors, no lint errors, no formatting diffs.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/pzharyuk/Documents/Claude/Projects/omnigent
+git add web/src/lib/credentialsApi.ts web/src/shell/NewChatDialog.tsx web/src/shell/NewChatDialog.test.tsx
+git commit -m "feat(web): GitHub repo picker in the sandbox Repository field
+
+Focusing the repository field in the New Chat dialog's sandbox flow
+now fetches the caller's connected GitHub repos (once per dialog
+instance) and offers them as a filterable dropdown, alongside the
+existing free-text URL entry. Falls back silently to plain text when
+GitHub isn't connected or the fetch fails."
+```
+
+---
+
+## Post-implementation checklist
+
+- [ ] Run the full backend suite touching this area: `cd /Users/pzharyuk/Documents/Claude/Projects/omnigent && source .venv/bin/activate && python3 -m pytest tests/server/routes/test_credentials.py -v`
+- [ ] Run the full frontend suite for the touched file: `cd /Users/pzharyuk/Documents/Claude/Projects/omnigent/web && npx vitest run src/shell/NewChatDialog.test.tsx`
+- [ ] `pre-commit run --files omnigent/server/routes/credentials.py tests/server/routes/test_credentials.py web/src/lib/credentialsApi.ts web/src/shell/NewChatDialog.tsx web/src/shell/NewChatDialog.test.tsx`
+- [ ] Manually verify in a running server with `OMNIGENT_GITHUB_CREDENTIAL_CLIENT_ID`/`_SECRET` configured and GitHub connected: opening the sandbox Repository popover and focusing the URL field shows your repos; typing filters them; selecting one fills the field; pasting an unrelated URL still works.

--- a/docs/superpowers/specs/2026-08-08-github-repo-picker-design.md
+++ b/docs/superpowers/specs/2026-08-08-github-repo-picker-design.md
@@ -1,0 +1,152 @@
+# GitHub repo picker for the sandbox "Repository" field
+
+## Problem
+
+The New Chat dialog's sandbox flow asks for a git repository URL as a plain
+text field (`Repository (optional)` in the sandbox repository chip,
+`web/src/shell/NewChatDialog.tsx`). A user who has connected GitHub via
+Settings → Credentials (the per-user credentials feature) already has an
+OAuth token with `repo` scope on file server-side, but has no way to browse
+their own repos from this dialog — they still have to copy/paste a URL from
+GitHub.
+
+## Goals
+
+- Let a user with GitHub connected pick a repo from a searchable list instead
+  of typing/pasting a URL.
+- Never regress the existing behavior: pasting an arbitrary URL must keep
+  working exactly as it does today, for repos not in the list (private org
+  repos outside the returned page, repos under an account other than the
+  connected one, non-GitHub git hosts) and for users who haven't connected
+  GitHub at all.
+- Never expose the stored GitHub token to the browser.
+
+## Non-goals
+
+- Providers other than GitHub (the credentials feature only supports GitHub
+  today — `provider="github"` is effectively hardcoded through
+  `credentials.py`).
+- Repo lists beyond GitHub's single-page maximum (100 repos). Anything
+  outside that is reachable via manual URL entry, same as today.
+- Persisting or syncing the repo list server-side; it's fetched live on
+  demand.
+
+## Architecture
+
+### Backend: `GET /v1/credentials/github/repos`
+
+Added to `omnigent/server/routes/credentials.py`, alongside the existing
+`GET /v1/credentials`, `POST /v1/credentials/github/connect`, and
+`DELETE /v1/credentials/github` routes, following the same conventions:
+
+- Resolves the caller via the existing `_user(request)` helper.
+- Looks up the credential via `credential_store.get(user_id, "github")`; if
+  `None`, returns a `not_connected` failure (see Error handling below).
+- Decrypts the token via `credential_store.decrypt_token(cred)` (same call
+  used by `_owner_credential_env` in
+  `omnigent/server/routes/_sessions/helpers.py`); if decryption fails
+  (rotated encryption key), treat identically to "not connected."
+- Calls `GET https://api.github.com/user/repos` with
+  `affiliation=owner,collaborator,organization_member&sort=pushed&per_page=100`
+  using the same `httpx.AsyncClient(timeout=15.0)` pattern as
+  `_fetch_github_user`. This surfaces owned, collaborator, and
+  organization-member repos — everything the `repo` scope already grants
+  access to — sorted most-recently-pushed first, capped at GitHub's 100/page
+  maximum.
+- Maps the response to a compact shape per repo: `full_name`, `clone_url`,
+  `default_branch`, `private`. The rest of GitHub's per-repo payload is
+  discarded — the client never needs it.
+- On any `httpx.HTTPError` from the GitHub call, returns a generic failure
+  (see Error handling).
+
+### Frontend: `credentialsApi.ts`
+
+New `listGithubRepos()` function, following the existing discriminated-union
+result pattern in this file:
+
+```ts
+export interface GithubRepoInfo {
+  fullName: string;
+  cloneUrl: string;
+  defaultBranch: string;
+  private: boolean;
+}
+
+export type GithubReposResult =
+  | { ok: true; repos: GithubRepoInfo[] }
+  | CredentialsFailure;
+
+export async function listGithubRepos(): Promise<GithubReposResult> { … }
+```
+
+### Frontend: `NewChatDialog.tsx`
+
+The plain `<input id="landing-repo-url">` inside the sandbox repository
+popover becomes a combobox, reusing the exact interaction pattern already
+implemented a few hundred lines down for the git-worktree branch-name field
+(`landing-branch-name`: `onFocus`-revealed dropdown, blur-with-delay close,
+type-to-filter, `filteredWorktrees`-style local filtering):
+
+- On first `onFocus` of the repository field, if not already fetched this
+  dialog instance, call `listGithubRepos()` once and store the result in
+  component state (`githubRepos`, `githubReposFetched`).
+- While the field is focused and `githubRepos` is non-empty, render a
+  dropdown of repos filtered by case-insensitive substring match against
+  `full_name`, in a scrollable container capped to a fixed max-height (same
+  `max-h-*` + `overflow-y-auto` treatment the worktree dropdown already uses)
+  so a 100-repo list doesn't blow out the popover — no separate row-count
+  cap, the scroll container handles it.
+- Clicking a repo sets `sandboxRepoUrl` to its `clone_url` and closes the
+  dropdown. The `default_branch` is available on the object but is **not**
+  auto-filled into the branch field — that field's placeholder already says
+  "defaults to the repo's default," so leaving it blank is correct and
+  auto-filling would be redundant.
+- Typing text that matches no repo leaves the typed value as-is in
+  `sandboxRepoUrl` — unchanged from today's plain-text behavior.
+- Fetched-but-not-connected or fetch-failed states render no dropdown items;
+  a small `text-muted-foreground` hint appears below the field: "Connect
+  GitHub in Settings to browse your repos" (only shown in the
+  not-connected case, not on a transient fetch error — an error is silent,
+  matching this popover's low-stakes, non-blocking tone elsewhere).
+- State resets when the dialog unmounts/remounts (no cross-session cache).
+
+## Data flow
+
+1. User opens the sandbox "Repository" popover and focuses the URL field.
+2. First focus triggers one `GET /v1/credentials/github/repos` call.
+3. Connected + success → server decrypts the token, calls GitHub, returns
+   the mapped list → frontend renders it as a filterable dropdown.
+4. Typing filters the list client-side; selecting an item fills the URL
+   field and closes the dropdown.
+5. Not connected, decrypt failure, or GitHub API failure → dropdown stays
+   empty (with the inline hint only for the not-connected case); the field
+   works exactly as a plain text input, same as before this feature existed.
+
+## Error handling
+
+| Condition | Backend response | Frontend behavior |
+|---|---|---|
+| No GitHub credential on file | `{ok:false, error:"not_connected", status:409}`-shaped failure | Inline hint, no console noise |
+| Token decrypt fails (key rotated) | Same as not connected | Same as not connected |
+| GitHub API error/timeout/rate limit | Generic failure, logged server-side (matches existing `logger.warning` pattern in this file) | Silent fallback to plain text, `console.warn` only |
+
+None of these block the user from typing/pasting a URL and proceeding — the
+repo picker is purely additive.
+
+## Testing
+
+**Backend** (`tests/server/routes/test_credentials.py`, extending the
+existing structure):
+- Connected + GitHub returns repos → 200 with the mapped list.
+- Not connected → `not_connected` failure.
+- Token decrypt failure → treated as not connected.
+- GitHub API failure (mocked `httpx` error) → generic failure, no
+  unhandled exception.
+
+**Frontend**:
+- Extend `credentialsApi` tests with `listGithubRepos()` success/failure
+  cases.
+- `NewChatDialog` test: repos populate the dropdown once connected,
+  filtering narrows the list as you type, clicking an item fills
+  `sandboxRepoUrl`, and typing an arbitrary URL (no matching repo) still
+  sets the field directly — the regression case that matters most.

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1310,6 +1310,48 @@ class SqlHost(OmnigentBase):
     )
 
 
+class SqlUserCredential(OmnigentBase):
+    """
+    SQLAlchemy model for the ``user_credentials`` table.
+
+    One row per (user, provider): an external-service credential the user
+    connected in the web UI (Settings → Credentials), e.g. a GitHub OAuth
+    token. The token is Fernet-encrypted at rest with
+    ``OMNIGENT_CREDENTIAL_ENCRYPTION_KEY`` — this table never holds a
+    usable token without that key.
+
+    :param workspace_id: Tenant partition key (0 = default), matching the
+        convention of every other tenant-scoped table.
+    :param user_id: Owning user id as the auth provider reports it, e.g.
+        ``"alice@example.com"``.
+    :param provider: External service, e.g. ``"github"``.
+    :param token_encrypted: Fernet ciphertext of the provider token.
+    :param login: Provider-side account name for display, e.g. the
+        GitHub login ``"alice"``.
+    :param scopes: Comma/space-joined granted scopes for display, e.g.
+        ``"repo"``.
+    :param created_at: Unix epoch seconds of first connect.
+    :param updated_at: Unix epoch seconds of the last (re)connect.
+    """
+
+    __tablename__ = "user_credentials"
+
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
+    )
+    user_id: Mapped[str] = mapped_column(String(256), primary_key=True)
+    provider: Mapped[str] = mapped_column(String(32), primary_key=True)
+    token_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
+    login: Mapped[str] = mapped_column(String(256), nullable=False)
+    scopes: Mapped[str] = mapped_column(String(256), nullable=False, default="")
+    created_at: Mapped[int] = mapped_column(Integer)
+    updated_at: Mapped[int] = mapped_column(Integer)
+
+
 class SqlUserDailyCost(OmnigentBase):
     """
     SQLAlchemy model for the ``user_daily_cost`` table.

--- a/omnigent/db/migrations/versions/e8a4416a05a1_add_user_credentials_table.py
+++ b/omnigent/db/migrations/versions/e8a4416a05a1_add_user_credentials_table.py
@@ -1,0 +1,49 @@
+"""Add the user_credentials table.
+
+Revision ID: e8a4416a05a1
+Revises: f7a8b9c0d1e2
+Create Date: 2026-07-20 00:00:00.000000
+
+One row per (workspace, user, provider): an external-service credential
+connected in the web UI (Settings → Credentials), e.g. a GitHub OAuth
+token. ``token_encrypted`` holds Fernet ciphertext — the encryption key
+lives only in the ``OMNIGENT_CREDENTIAL_ENCRYPTION_KEY`` env var, so the
+table alone never yields a usable token. Read at managed-sandbox launch
+to inject the owner's ``GIT_TOKEN``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e8a4416a05a1"
+down_revision: str | None = "f7a8b9c0d1e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_credentials",
+        sa.Column(
+            "workspace_id",
+            sa.BigInteger,
+            primary_key=True,
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("user_id", sa.String(256), primary_key=True, nullable=False),
+        sa.Column("provider", sa.String(32), primary_key=True, nullable=False),
+        sa.Column("token_encrypted", sa.Text, nullable=False),
+        sa.Column("login", sa.String(256), nullable=False),
+        sa.Column("scopes", sa.String(256), nullable=False, server_default=""),
+        sa.Column("created_at", sa.Integer, nullable=False),
+        sa.Column("updated_at", sa.Integer, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_credentials")

--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -816,6 +816,7 @@ class SandboxHostLauncher(SandboxLifecycle):
         repo_name: str | None = None,
         host_config: dict[str, object] | None = None,
         on_stage: Callable[[str], None] | None = None,
+        extra_env: dict[str, str] | None = None,
     ) -> str:
         """
         Start ``omnigent host`` in the sandbox and return the workspace path.
@@ -835,6 +836,8 @@ class SandboxHostLauncher(SandboxLifecycle):
             content installed into the sandbox's config BEFORE the host starts.
         :param on_stage: Progress observer invoked with ``"cloning"`` and
             ``"starting"``.
+        :param extra_env: Per-launch env pairs for the host process (e.g. the
+            session owner's ``GIT_TOKEN``), or ``None`` for none.
         :returns: The absolute in-sandbox workspace path.
         """
 
@@ -867,6 +870,7 @@ class ExecModelHostLauncher(SandboxHostLauncher, SandboxExecTransport):
         repo_name: str | None = None,
         host_config: dict[str, object] | None = None,
         on_stage: Callable[[str], None] | None = None,
+        extra_env: dict[str, str] | None = None,
     ) -> str:
         """
         Start ``omnigent host`` in the sandbox and return the workspace path.
@@ -878,6 +882,8 @@ class ExecModelHostLauncher(SandboxHostLauncher, SandboxExecTransport):
         detached (``setsid``-backgrounded, identity + token in the process
         environment) — all driven through :meth:`run` / :meth:`run_background`.
 
+        :param extra_env: Per-launch env pairs for the host process (e.g. the
+            session owner's ``GIT_TOKEN``), or ``None`` for none.
         :returns: The absolute in-sandbox workspace path.
         """
         home = self.run(sandbox_id, 'printf %s "$HOME"').stdout.strip()
@@ -907,6 +913,7 @@ class ExecModelHostLauncher(SandboxHostLauncher, SandboxExecTransport):
                 (HOST_TOKEN_ENV_VAR, token),
                 (HOST_ID_ENV_VAR, host_id),
                 (HOST_NAME_ENV_VAR, host_name),
+                *sorted((extra_env or {}).items()),
             )
         )
         self.run_background(

--- a/omnigent/onboarding/sandboxes/islo.py
+++ b/omnigent/onboarding/sandboxes/islo.py
@@ -540,6 +540,7 @@ class IsloSandboxLauncher(SandboxLauncher):
         repo_name: str | None = None,
         host_config: dict[str, object] | None = None,
         on_stage: Callable[[str], None] | None = None,
+        extra_env: dict[str, str] | None = None,
     ) -> str:
         """Stop any memory-preserved host daemon, then start with a fresh token."""
         self._stop_preserved_host_daemon(sandbox_id)
@@ -554,6 +555,7 @@ class IsloSandboxLauncher(SandboxLauncher):
             repo_name=repo_name,
             host_config=host_config,
             on_stage=on_stage,
+            extra_env=extra_env,
         )
 
     def _stop_preserved_host_daemon(self, sandbox_id: str) -> None:

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -454,7 +454,7 @@ def _render_host_command(server_url: str) -> list[str]:
 
 
 def build_token_secret_manifest(
-    *, secret_name: str, namespace: str, token: str
+    *, secret_name: str, namespace: str, token: str, extra: dict[str, str] | None = None
 ) -> dict[str, object]:
     """
     Build the per-Pod launch-token Secret manifest as a plain dict.
@@ -470,6 +470,8 @@ def build_token_secret_manifest(
     :param namespace: Namespace the Secret is created in.
     :param token: The raw launch token (the apiserver base64-encodes
         ``stringData``).
+    :param extra: Additional per-launch env pairs riding the same Secret
+        (e.g. the session owner's ``GIT_TOKEN``), or ``None`` for none.
     :returns: The Secret manifest dict.
     """
     return {
@@ -481,7 +483,7 @@ def build_token_secret_manifest(
             "labels": {_MANAGED_BY_LABEL: _MANAGED_BY_VALUE, _ROLE_LABEL: _ROLE_VALUE},
         },
         "type": "Opaque",
-        "stringData": {HOST_TOKEN_ENV_VAR: token},
+        "stringData": {HOST_TOKEN_ENV_VAR: token, **(extra or {})},
     }
 
 
@@ -507,6 +509,7 @@ def build_pod_manifest(
     pvc_mounts: Sequence[Mapping[str, object]] | None = None,
     secret_mounts: Sequence[Mapping[str, object]] | None = None,
     agent_name: str | None = None,
+    extra_env_keys: Sequence[str] = (),
 ) -> dict[str, object]:
     """
     Build the sandbox Pod manifest as a plain dict.
@@ -585,6 +588,11 @@ def build_pod_manifest(
         ``None``/empty → omit fail-safe): the value selects which credential an
         admission policy injects, so it must equal the agent name exactly rather
         than be coerced into a collision with a different name.
+    :param extra_env_keys: Names of per-launch env entries riding the token
+        Secret (see :func:`build_token_secret_manifest` ``extra``), projected
+        via ``secretKeyRef`` into both containers — the init container so a
+        per-user ``GIT_TOKEN`` covers the clone, the host container for the
+        session. Values never enter the Pod spec.
     :returns: The Pod manifest dict.
     """
     pod_resources = _resolve_pod_resources(resources)
@@ -680,6 +688,19 @@ def build_pod_manifest(
     if harness_secret:
         # The clone may need GIT_TOKEN (private repos) from the harness Secret.
         init_container["envFrom"] = [{"secretRef": {"name": harness_secret}}]
+    extra_env: list[dict[str, object]] = [
+        {
+            "name": key,
+            "valueFrom": {"secretKeyRef": {"name": token_secret_name, "key": key}},
+        }
+        for key in extra_env_keys
+    ]
+    if extra_env:
+        # Per-user creds beat the shared harness Secret: explicit env wins
+        # over envFrom, and the clone needs them too.
+        init_env = init_container["env"]
+        assert isinstance(init_env, list)
+        init_env.extend(extra_env)
 
     host_env: list[dict[str, object]] = [
         {"name": "HOME", "value": _HOME_DIR},
@@ -692,6 +713,7 @@ def build_pod_manifest(
         },
     ]
     host_env.extend({"name": name, "value": value} for name, value in env_literals.items())
+    host_env.extend(extra_env)
 
     host_container: dict[str, object] = {
         "name": _CONTAINER_NAME,
@@ -1203,6 +1225,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         host_config: dict[str, object] | None = None,
         agent_name: str | None = None,
         on_stage: Callable[[str], None] | None = None,
+        extra_env: dict[str, str] | None = None,
     ) -> str:
         """
         Create the token Secret + runner Pod and wait for the host to start.
@@ -1234,6 +1257,8 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
             leave the runner unclassified. Threaded only because this provider
             declares ``classifies_runner_by_agent``.
         :param on_stage: Progress observer; invoked with ``"starting"``.
+        :param extra_env: Per-launch env pairs (e.g. the session owner's
+            ``GIT_TOKEN``) riding the per-Pod Secret, or ``None`` for none.
         :returns: The absolute in-sandbox workspace path (the cloned repository
             directory when *repo_url* is set).
         :raises click.ClickException: When creation fails or the host does not
@@ -1281,6 +1306,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
                     pvc_mounts=self._pvc_mounts,
                     secret_mounts=self._secret_mounts,
                     agent_name=agent_name,
+                    extra_env_keys=sorted(extra_env) if extra_env else (),
                 )
                 # Secret before Pod so the Pod's secretKeyRef resolves
                 # immediately — a Pod referencing a missing Secret would sit in
@@ -1289,7 +1315,10 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
                 core.create_namespaced_secret(
                     namespace,
                     build_token_secret_manifest(
-                        secret_name=secret_name, namespace=namespace, token=token
+                        secret_name=secret_name,
+                        namespace=namespace,
+                        token=token,
+                        extra=extra_env,
                     ),
                     _request_timeout=_POD_READY_REQUEST_TIMEOUT_S,
                 )

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -190,6 +190,41 @@ _POD_DELETE_BACKOFF_S: float = 1.0
 # clone error from the init container).
 _LOG_TAIL_LINES: int = 20
 
+# Substrings git emits when an HTTPS clone can't authenticate — a missing,
+# revoked, or under-scoped credential. Matched against the workspace-prep log
+# tail to turn the cryptic default ("could not read Username") into an
+# actionable hint (see :func:`_git_auth_hint`).
+_GIT_AUTH_FAILURE_MARKERS: tuple[str, ...] = (
+    "could not read username",
+    "could not read password",
+    "authentication failed",
+    "terminal prompts disabled",
+    "invalid username or password",
+)
+
+
+def _git_auth_hint(log_tail: str) -> str | None:
+    """
+    Return an actionable hint when a clone failed to authenticate, else ``None``.
+
+    The default git error for a private repo with no usable credential
+    (``could not read Username``) is opaque. When the workspace-prep log tail
+    carries one of :data:`_GIT_AUTH_FAILURE_MARKERS`, surface a message that
+    names the fix — connect a credential — instead.
+
+    :param log_tail: The failed init container's log tail.
+    :returns: The hint, or ``None`` when the tail shows no auth failure.
+    """
+    lowered = log_tail.lower()
+    if any(marker in lowered for marker in _GIT_AUTH_FAILURE_MARKERS):
+        return (
+            "The repository looks private and the clone could not authenticate. "
+            "Connect an account under Settings -> Credentials (and confirm it has "
+            "access to this repository), then start a new session."
+        )
+    return None
+
+
 # Container ``waiting.reason`` values that are genuinely terminal — the kubelet
 # will NOT self-heal them, so the start wait fast-fails rather than burning the
 # budget. Deliberately EXCLUDES ImagePull* (kubelet retries cold pulls / flaps)
@@ -1486,6 +1521,10 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
             tail = self._pod_log_tail(namespace, pod_name, log_container).strip()
             if tail:
                 message += f" Container '{log_container}' log tail: {tail[-1500:]}"
+                if log_container == _INIT_CONTAINER_NAME:
+                    hint = _git_auth_hint(tail)
+                    if hint is not None:
+                        message += f" {hint}"
         message += f" Inspect with `kubectl describe pod {pod_name} -n {namespace}`."
         return message
 

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1165,6 +1165,7 @@ def create_app(
     app.state.host_registry = host_registry
     app.state.host_store = host_store
     app.state.agent_store = agent_store
+    app.state.credential_store = credential_store
     app.state.sandbox_config = sandbox_config
     # Admin roster: the config ``admins:`` list (canonical) union'd with the
     # runtime-editable ``<data_dir>/admins`` file. Built once here so BOTH the

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -91,6 +91,7 @@ from omnigent.stores import (
 )
 from omnigent.stores.comment_store import CommentStore
 from omnigent.stores.conversation_store import SessionConnectivity, runner_seen_is_fresh
+from omnigent.stores.credential_store import CredentialStore
 from omnigent.stores.host_store import HostStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.policy_store import PolicyStore
@@ -746,6 +747,7 @@ def create_app(
     project_store: ProjectStore | None = None,
     auth_provider: AuthProvider | None = None,
     host_store: HostStore | None = None,
+    credential_store: CredentialStore | None = None,
     account_store: Any | None = None,  # SqlAlchemyAccountStore — accounts mode only
     extra_routers: list[tuple[Any, str, list[str]]] | None = None,
     policy_modules: list[str] | None = None,
@@ -801,6 +803,9 @@ def create_app(
     :param host_store: Store for host registrations. ``None``
         disables host connectivity features (list hosts, launch
         runners on remote hosts).
+    :param credential_store: Store for per-user external-service
+        credentials (Settings → Credentials). ``None`` disables the
+        credentials routes.
     :param policy_modules: Additional dotted module paths to
         scan for ``POLICY_REGISTRY`` lists at startup, e.g.
         ``["myorg.policies.safety"]``. Sourced from the server
@@ -2063,6 +2068,16 @@ def create_app(
             ),
             prefix="/v1",
             tags=["projects"],
+        )
+
+    # Per-user external-service credentials (Settings → Credentials). Mounted
+    # at the root: the OAuth callback lives under /auth, the API under /v1.
+    if credential_store is not None:
+        from omnigent.server.routes.credentials import create_credentials_router
+
+        app.include_router(
+            create_credentials_router(credential_store, auth_provider),
+            tags=["credentials"],
         )
 
     # ── Tunnel lifecycle callbacks (Step 8.5 crash recovery) ───

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -2202,6 +2202,7 @@ async def launch_managed_host(
     repo: RepoWorkspace | None = None,
     agent_name: str | None = None,
     on_stage: Callable[[str], None] | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> ManagedHostLaunch:
     """
     Provision a sandbox, start a host in it, and wait until it registers.
@@ -2270,6 +2271,7 @@ async def launch_managed_host(
         repo=repo,
         agent_name=agent_name,
         on_stage=on_stage,
+        extra_env=extra_env,
     )
     return ManagedHostLaunch(host_id=host_id, workspace=workspace)
 
@@ -2282,6 +2284,7 @@ async def relaunch_managed_host(
     repo: RepoWorkspace | None = None,
     agent_name: str | None = None,
     on_stage: Callable[[str], None] | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> ManagedHostLaunch:
     """
     Provision a NEW sandbox generation for an existing managed host.
@@ -2352,6 +2355,7 @@ async def relaunch_managed_host(
         agent_name=agent_name,
         on_stage=on_stage,
         keep_host_on_failure=True,
+        extra_env=extra_env,
     )
     return ManagedHostLaunch(host_id=host.host_id, workspace=workspace)
 
@@ -2370,6 +2374,7 @@ async def _start_sandbox_host(
     host_config: dict[str, object] | None,
     agent_name: str | None = None,
     on_stage: Callable[[str], None] | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> str:
     """Start a host without sending absent optional arguments to legacy launchers."""
     # Gated on the capability, not on the value: start_host is side-effecting and
@@ -2378,8 +2383,8 @@ async def _start_sandbox_host(
     # so the abstract signature does not carry it and the call is cast: the
     # capability is the runtime guarantee the static type cannot express. A
     # launcher declaring it is in-tree and current, so it also takes
-    # `host_config`/`on_stage`, keeping the legacy-omission fan-out below
-    # one-dimensional.
+    # `host_config`/`on_stage`/`extra_env`, keeping the legacy-omission fan-out
+    # below one-dimensional.
     if agent_name is not None and launcher.capabilities.classifies_runner_by_agent:
         start_classified = cast(Callable[..., str], launcher.start_host)
         return await asyncio.to_thread(
@@ -2395,58 +2400,26 @@ async def _start_sandbox_host(
             host_config=host_config,
             on_stage=on_stage,
             agent_name=agent_name,
+            extra_env=extra_env,
         )
-    if host_config is None and on_stage is None:
-        return await asyncio.to_thread(
-            launcher.start_host,
-            sandbox_id,
-            token=token,
-            host_id=host_id,
-            host_name=host_name,
-            server_url=server_url,
-            repo_url=repo_url,
-            repo_branch=repo_branch,
-            repo_name=repo_name,
-        )
-    if host_config is None:
-        return await asyncio.to_thread(
-            launcher.start_host,
-            sandbox_id,
-            token=token,
-            host_id=host_id,
-            host_name=host_name,
-            server_url=server_url,
-            repo_url=repo_url,
-            repo_branch=repo_branch,
-            repo_name=repo_name,
-            on_stage=on_stage,
-        )
-    if on_stage is None:
-        return await asyncio.to_thread(
-            launcher.start_host,
-            sandbox_id,
-            token=token,
-            host_id=host_id,
-            host_name=host_name,
-            server_url=server_url,
-            repo_url=repo_url,
-            repo_branch=repo_branch,
-            repo_name=repo_name,
-            host_config=host_config,
-        )
-    return await asyncio.to_thread(
-        launcher.start_host,
-        sandbox_id,
-        token=token,
-        host_id=host_id,
-        host_name=host_name,
-        server_url=server_url,
-        repo_url=repo_url,
-        repo_branch=repo_branch,
-        repo_name=repo_name,
-        host_config=host_config,
-        on_stage=on_stage,
-    )
+    kwargs: dict[str, object] = {
+        "token": token,
+        "host_id": host_id,
+        "host_name": host_name,
+        "server_url": server_url,
+        "repo_url": repo_url,
+        "repo_branch": repo_branch,
+        "repo_name": repo_name,
+    }
+    # Omitted entirely when unset: a deployment-injected launcher predating
+    # one of these parameters must keep launching.
+    if host_config is not None:
+        kwargs["host_config"] = host_config
+    if on_stage is not None:
+        kwargs["on_stage"] = on_stage
+    if extra_env is not None:
+        kwargs["extra_env"] = extra_env
+    return await asyncio.to_thread(launcher.start_host, sandbox_id, **kwargs)
 
 
 async def _arm_and_start_host(
@@ -2462,6 +2435,7 @@ async def _arm_and_start_host(
     agent_name: str | None = None,
     on_stage: Callable[[str], None] | None = None,
     keep_host_on_failure: bool = False,
+    extra_env: dict[str, str] | None = None,
 ) -> str:
     """
     Arm the credential, start the in-sandbox host, and await its
@@ -2531,6 +2505,7 @@ async def _arm_and_start_host(
             host_config=config.host_config,
             agent_name=agent_name,
             on_stage=on_stage,
+            extra_env=extra_env,
         )
         await _wait_for_host_online(host_store, host_id)
     except Exception as exc:

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -266,6 +266,7 @@ from omnigent.stores.conversation_store import (
     ConversationNotFoundError,
     NameAlreadyExistsError,
 )
+from omnigent.stores.credential_store import CredentialStore
 from omnigent.stores.host_store import Host, HostStore
 from omnigent.stores.permission_store import PermissionStore
 
@@ -4430,6 +4431,31 @@ async def cancel_managed_launch_tasks() -> None:
     await asyncio.gather(*tasks, return_exceptions=True)
 
 
+async def _owner_credential_env(
+    credential_store: CredentialStore | None, owner: str
+) -> dict[str, str] | None:
+    """
+    Build the per-launch env from the owner's connected credentials.
+
+    :param credential_store: The app's credential store, or ``None`` when
+        the deployment has none configured.
+    :param owner: The launching user, e.g. ``"alice@example.com"``.
+    :returns: ``{"GIT_TOKEN": <token>}`` when the owner has a usable
+        GitHub credential, else ``None`` (today's exact behavior). An
+        undecryptable token (key rotated) logs and launches without.
+    """
+    if credential_store is None:
+        return None
+    cred = await asyncio.to_thread(credential_store.get, owner, "github")
+    if cred is None:
+        return None
+    token = credential_store.decrypt_token(cred)
+    if not token:
+        _logger.warning("github credential for %s is undecryptable — launching without it", owner)
+        return None
+    return {"GIT_TOKEN": token}
+
+
 async def _provision_managed_sandbox(
     *,
     session_id: str,
@@ -4440,6 +4466,7 @@ async def _provision_managed_sandbox(
     host_store: HostStore,
     relaunch_host: Host | None,
     agent_name: str | None = None,
+    credential_store: CredentialStore | None = None,
 ) -> ManagedHostLaunch | None:
     """
     Run the provision phase of a background managed launch.
@@ -4460,6 +4487,8 @@ async def _provision_managed_sandbox(
     :param agent_name: Server-resolved built-in agent name the session
         runs, stamped as the runner Pod's ``omnigent.ai/agent`` classifier
         (Kubernetes only), or ``None`` to leave it unstamped.
+    :param credential_store: The app's credential store, used to inject the
+        owner's ``GIT_TOKEN`` into the launch when connected, or ``None``.
     :returns: The launch result, or ``None`` when the launch failed
         (the tracker entry is already settled with the reason).
     """
@@ -4477,6 +4506,7 @@ async def _provision_managed_sandbox(
         """
         _publish_sandbox_status(session_id, stage)
 
+    extra_env = await _owner_credential_env(credential_store, owner)
     try:
         if relaunch_host is not None:
             return await relaunch_managed_host(
@@ -4486,6 +4516,7 @@ async def _provision_managed_sandbox(
                 repo=repo,
                 agent_name=agent_name,
                 on_stage=_on_stage,
+                extra_env=extra_env,
             )
         return await launch_managed_host(
             config=sandbox_config,
@@ -4494,6 +4525,7 @@ async def _provision_managed_sandbox(
             repo=repo,
             agent_name=agent_name,
             on_stage=_on_stage,
+            extra_env=extra_env,
         )
     except HTTPException as exc:
         _logger.warning(
@@ -9299,6 +9331,7 @@ __all__ = [
     "_native_terminal_failure_from_runner_response",
     "_native_terminal_name_for_harness",
     "_notify_runner_of_bundled_child",
+    "_owner_credential_env",
     "_owner_from_grants",
     "_parse_external_assistant_message",
     "_parse_external_conversation_item",

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -333,6 +333,7 @@ from omnigent.stores.conversation_store import (
     ConversationNotFoundError,
     pinned_label_key,
 )
+from omnigent.stores.credential_store import CredentialStore
 from omnigent.stores.file_store import FileStore
 from omnigent.stores.host_store import Host, HostStore
 from omnigent.stores.permission_store import PermissionStore
@@ -2578,6 +2579,7 @@ async def _run_managed_launch(
     relaunch_host: Host | None = None,
     agent_store: AgentStore | None = None,
     agent_id: str | None = None,
+    credential_store: CredentialStore | None = None,
 ) -> None:
     """
     Provision a managed sandbox for a session in the background.
@@ -2626,6 +2628,7 @@ async def _run_managed_launch(
     :param relaunch_host: Existing managed host row to relaunch a new
         sandbox generation for, or ``None`` for a first launch (a
         fresh host identity is minted).
+
     The runner's agent classifier is resolved here rather than by the
     caller, so the read runs on the task that already owns the
     single-flight claim: the request path keeps no ``await`` between
@@ -2640,6 +2643,8 @@ async def _run_managed_launch(
     :param agent_id: Agent the session is bound to, resolved through the
         built-in gate into the runner Pod's ``omnigent.ai/agent``
         classifier, or ``None`` to leave it unstamped.
+    :param credential_store: The app's credential store, used to inject the
+        owner's ``GIT_TOKEN`` into the launch when connected, or ``None``.
     """
     from omnigent.server.managed_hosts import resolve_managed_agent_label
 
@@ -2660,6 +2665,7 @@ async def _run_managed_launch(
         host_store=host_store,
         relaunch_host=relaunch_host,
         agent_name=agent_name,
+        credential_store=credential_store,
     )
     if managed is None:
         return
@@ -3186,6 +3192,7 @@ def _kick_managed_relaunch(
             tracker=tracker,
             conversation_store=conversation_store,
             host_store=host_store,
+            credential_store=getattr(app_state, "credential_store", None),
             host_registry=getattr(app_state, "host_registry", None),
             tunnel_registry=getattr(app_state, "tunnel_registry", None),
             relaunch_host=host,

--- a/omnigent/server/routes/credentials.py
+++ b/omnigent/server/routes/credentials.py
@@ -1,0 +1,206 @@
+"""
+Per-user external-service credential routes (Settings → Credentials).
+
+``GET /v1/credentials`` lists the caller's connected credentials (masked —
+never the token). ``POST /v1/credentials/github/connect`` starts the GitHub
+OAuth authorize flow; ``GET /auth/github/credential-callback`` finishes it
+(code → token exchange, identity fetch, encrypted upsert);
+``DELETE /v1/credentials/github`` disconnects.
+
+The GitHub OAuth App is configured via
+``OMNIGENT_GITHUB_CREDENTIAL_CLIENT_ID`` /
+``OMNIGENT_GITHUB_CREDENTIAL_CLIENT_SECRET``. The feature also requires the
+credential store's encryption key; with either missing, the connect route
+returns 409 ``credentials_disabled`` and the rest of the app is unaffected.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import os
+import time
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import APIRouter, Request
+from fastapi.responses import RedirectResponse
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.auth import AuthProvider
+from omnigent.server.routes._auth_helpers import require_user
+from omnigent.stores.credential_store import (
+    CredentialStore,
+    credential_encryption_enabled,
+)
+
+logger = logging.getLogger(__name__)
+
+_CLIENT_ID_ENV = "OMNIGENT_GITHUB_CREDENTIAL_CLIENT_ID"
+_CLIENT_SECRET_ENV = "OMNIGENT_GITHUB_CREDENTIAL_CLIENT_SECRET"
+_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+_TOKEN_URL = "https://github.com/login/oauth/access_token"
+_USER_URL = "https://api.github.com/user"
+_SCOPES = "repo"
+_STATE_TTL_S = 600
+# Single-user deployments (no auth provider) store under this sentinel.
+_LOCAL_USER = "local"
+_SETTINGS_PATH = "/settings/credentials"
+
+
+def _client_id() -> str:
+    return os.environ.get(_CLIENT_ID_ENV, "").strip()
+
+
+def _client_secret() -> str:
+    return os.environ.get(_CLIENT_SECRET_ENV, "").strip()
+
+
+def _feature_enabled() -> bool:
+    return bool(_client_id()) and bool(_client_secret()) and credential_encryption_enabled()
+
+
+def _state_key() -> bytes:
+    # Reuse the credential encryption key as the state-HMAC key; the feature
+    # gate guarantees it exists whenever a flow can start.
+    return os.environ.get("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", "").strip().encode()
+
+
+def _mint_state(user_id: str) -> str:
+    ts = str(int(time.time()))
+    mac = hmac.new(_state_key(), f"{user_id}:{ts}".encode(), hashlib.sha256).hexdigest()
+    raw = f"{user_id}:{ts}:{mac}"
+    return base64.urlsafe_b64encode(raw.encode()).decode()
+
+
+def _check_state(state: str) -> str | None:
+    """Validate a callback state; returns the user id, or ``None``."""
+    try:
+        user_id, ts, mac = base64.urlsafe_b64decode(state.encode()).decode().rsplit(":", 2)
+    except (ValueError, UnicodeDecodeError):
+        return None
+    expected = hmac.new(_state_key(), f"{user_id}:{ts}".encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(mac, expected):
+        return None
+    if time.time() - int(ts) > _STATE_TTL_S:
+        return None
+    return user_id
+
+
+async def _exchange_code(code: str) -> dict[str, Any]:
+    """Exchange the authorize code for a token payload (raises on HTTP error)."""
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.post(
+            _TOKEN_URL,
+            headers={"Accept": "application/json"},
+            data={
+                "client_id": _client_id(),
+                "client_secret": _client_secret(),
+                "code": code,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def _fetch_github_user(token: str) -> dict[str, Any]:
+    """Fetch the token owner's GitHub profile (raises on HTTP error)."""
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(
+            _USER_URL,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+def create_credentials_router(
+    credential_store: CredentialStore,
+    auth_provider: AuthProvider | None = None,
+) -> APIRouter:
+    """Build the credentials router (mounted at the app root)."""
+    router = APIRouter()
+
+    def _user(request: Request) -> str:
+        user_id = require_user(request, auth_provider)
+        return user_id if user_id is not None else _LOCAL_USER
+
+    @router.get("/v1/credentials")
+    async def list_credentials(request: Request) -> dict[str, Any]:
+        """The caller's connected credentials — masked, never the token."""
+        user_id = _user(request)
+        creds = []
+        cred = credential_store.get(user_id, "github")
+        if cred is not None:
+            creds.append(
+                {
+                    "provider": "github",
+                    "login": cred.login,
+                    "scopes": cred.scopes,
+                    "connected_at": cred.updated_at,
+                }
+            )
+        return {"credentials": creds, "enabled": _feature_enabled()}
+
+    @router.post("/v1/credentials/github/connect")
+    async def connect_github(request: Request) -> dict[str, str]:
+        """Start the OAuth flow; the client navigates to ``authorize_url``."""
+        user_id = _user(request)
+        if not _feature_enabled():
+            raise OmnigentError(
+                "credentials_disabled",
+                code=ErrorCode.CONFLICT,
+            )
+        query = urlencode(
+            {
+                "client_id": _client_id(),
+                "scope": _SCOPES,
+                "state": _mint_state(user_id),
+            }
+        )
+        return {"authorize_url": f"{_AUTHORIZE_URL}?{query}"}
+
+    @router.get("/auth/github/credential-callback")
+    async def credential_callback(
+        code: str = "", state: str = "", error: str = ""
+    ) -> RedirectResponse:
+        """Finish the OAuth flow and land back on Settings → Credentials."""
+        if error:
+            return RedirectResponse(f"{_SETTINGS_PATH}?error=github_denied", status_code=302)
+        if not _feature_enabled():
+            return RedirectResponse(f"{_SETTINGS_PATH}?error=disabled", status_code=302)
+        user_id = _check_state(state) if state else None
+        if user_id is None or not code:
+            return RedirectResponse(f"{_SETTINGS_PATH}?error=state_mismatch", status_code=302)
+        try:
+            payload = await _exchange_code(code)
+            token = str(payload.get("access_token") or "")
+            if not token:
+                raise ValueError("no access_token in exchange response")
+            profile = await _fetch_github_user(token)
+        except (httpx.HTTPError, ValueError, KeyError):
+            logger.warning("github credential exchange failed for %s", user_id, exc_info=True)
+            return RedirectResponse(f"{_SETTINGS_PATH}?error=exchange_failed", status_code=302)
+        credential_store.upsert(
+            user_id,
+            "github",
+            token=token,
+            login=str(profile.get("login") or "unknown"),
+            scopes=str(payload.get("scope") or _SCOPES),
+        )
+        return RedirectResponse(f"{_SETTINGS_PATH}?connected=github", status_code=302)
+
+    @router.delete("/v1/credentials/github")
+    async def disconnect_github(request: Request) -> dict[str, bool]:
+        """Remove the caller's GitHub credential."""
+        user_id = _user(request)
+        credential_store.delete(user_id, "github")
+        return {"ok": True}
+
+    return router

--- a/omnigent/server/routes/credentials.py
+++ b/omnigent/server/routes/credentials.py
@@ -3,9 +3,10 @@ Per-user external-service credential routes (Settings → Credentials).
 
 ``GET /v1/credentials`` lists the caller's connected credentials (masked —
 never the token). ``GET /v1/credentials/github/repos`` lists the caller's
-GitHub repos (requires a stored, decrypted token). ``POST /v1/credentials/github/connect``
-starts the GitHub OAuth authorize flow; ``GET /auth/github/credential-callback`` finishes it
-(code → token exchange, identity fetch, encrypted upsert);
+GitHub repos (requires a stored, decrypted token).
+``POST /v1/credentials/github/connect`` starts the GitHub OAuth authorize
+flow; ``GET /auth/github/credential-callback`` finishes it (code → token
+exchange, identity fetch, encrypted upsert);
 ``DELETE /v1/credentials/github`` disconnects.
 
 The GitHub OAuth App is configured via
@@ -173,6 +174,8 @@ def create_credentials_router(
     @router.get("/v1/credentials/github/repos")
     async def list_github_repos(request: Request) -> dict[str, Any]:
         """The caller's GitHub repos — owner, collaborator, and org member."""
+        if not _feature_enabled():
+            raise OmnigentError("credentials_disabled", code=ErrorCode.CONFLICT)
         user_id = _user(request)
         cred = credential_store.get(user_id, "github")
         if cred is None:

--- a/omnigent/server/routes/credentials.py
+++ b/omnigent/server/routes/credentials.py
@@ -2,8 +2,9 @@
 Per-user external-service credential routes (Settings → Credentials).
 
 ``GET /v1/credentials`` lists the caller's connected credentials (masked —
-never the token). ``POST /v1/credentials/github/connect`` starts the GitHub
-OAuth authorize flow; ``GET /auth/github/credential-callback`` finishes it
+never the token). ``GET /v1/credentials/github/repos`` lists the caller's
+GitHub repos (requires a stored, decrypted token). ``POST /v1/credentials/github/connect``
+starts the GitHub OAuth authorize flow; ``GET /auth/github/credential-callback`` finishes it
 (code → token exchange, identity fetch, encrypted upsert);
 ``DELETE /v1/credentials/github`` disconnects.
 
@@ -120,6 +121,27 @@ async def _fetch_github_user(token: str) -> dict[str, Any]:
         return resp.json()
 
 
+async def _fetch_github_repos(token: str) -> list[dict[str, Any]]:
+    """Fetch repos the token can access — owner, collaborator, and org member
+    affiliations, most-recently-pushed first, capped at GitHub's 100/page
+    maximum (raises on HTTP error)."""
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(
+            f"{_USER_URL}/repos",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+            params={
+                "affiliation": "owner,collaborator,organization_member",
+                "sort": "pushed",
+                "per_page": 100,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
 def create_credentials_router(
     credential_store: CredentialStore,
     auth_provider: AuthProvider | None = None,
@@ -147,6 +169,35 @@ def create_credentials_router(
                 }
             )
         return {"credentials": creds, "enabled": _feature_enabled()}
+
+    @router.get("/v1/credentials/github/repos")
+    async def list_github_repos(request: Request) -> dict[str, Any]:
+        """The caller's GitHub repos — owner, collaborator, and org member."""
+        user_id = _user(request)
+        cred = credential_store.get(user_id, "github")
+        if cred is None:
+            raise OmnigentError("github_not_connected", code=ErrorCode.CONFLICT)
+        token = credential_store.decrypt_token(cred)
+        if token is None:
+            raise OmnigentError("github_not_connected", code=ErrorCode.CONFLICT)
+        try:
+            repos = await _fetch_github_repos(token)
+        except httpx.HTTPError as exc:
+            logger.warning("github repo listing failed for %s", user_id, exc_info=True)
+            raise OmnigentError(
+                "github_repos_fetch_failed", code=ErrorCode.INTERNAL_ERROR
+            ) from exc
+        return {
+            "repos": [
+                {
+                    "full_name": r["full_name"],
+                    "clone_url": r["clone_url"],
+                    "default_branch": r["default_branch"],
+                    "private": r["private"],
+                }
+                for r in repos
+            ]
+        }
 
     @router.post("/v1/credentials/github/connect")
     async def connect_github(request: Request) -> dict[str, str]:

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -417,6 +417,7 @@ def register_core_routes(
                     tracker=managed_launches,
                     conversation_store=conversation_store,
                     host_store=host_store_for_managed,
+                    credential_store=getattr(request.app.state, "credential_store", None),
                     host_registry=getattr(request.app.state, "host_registry", None),
                     tunnel_registry=getattr(request.app.state, "tunnel_registry", None),
                     agent_store=agent_store,

--- a/omnigent/stores/credential_store.py
+++ b/omnigent/stores/credential_store.py
@@ -1,0 +1,173 @@
+"""
+Persistent store for per-user external-service credentials.
+
+Rows are written by the web UI's Settings → Credentials flow (e.g.
+"Connect GitHub"), and read by the managed-sandbox launch path, which
+injects the decrypted token into the session's sandbox (``GIT_TOKEN``).
+
+Tokens are Fernet-encrypted at rest with
+``OMNIGENT_CREDENTIAL_ENCRYPTION_KEY`` (urlsafe-base64, 32 bytes — a
+``cryptography.fernet.Fernet.generate_key()`` value). Without a valid
+key the credentials feature is disabled: writes raise, reads decrypt to
+``None``, and callers fall back to launching without a credential.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+from cryptography.fernet import Fernet, InvalidToken
+from sqlalchemy import Engine, select
+from sqlalchemy import delete as sql_delete
+
+from omnigent.db.db_models import SqlUserCredential, current_workspace_id
+from omnigent.db.utils import get_or_create_engine, make_managed_session_maker, now_epoch
+
+logger = logging.getLogger(__name__)
+
+_KEY_ENV = "OMNIGENT_CREDENTIAL_ENCRYPTION_KEY"
+
+
+def _fernet() -> Fernet | None:
+    """Build the Fernet codec from the env key, or ``None`` when absent/invalid."""
+    key = os.environ.get(_KEY_ENV, "").strip()
+    if not key:
+        return None
+    try:
+        return Fernet(key.encode())
+    except (ValueError, TypeError):
+        return None
+
+
+def credential_encryption_enabled() -> bool:
+    """Whether the encryption key is configured and valid (feature gate)."""
+    return _fernet() is not None
+
+
+@dataclass
+class UserCredential:
+    """
+    A user's connected external-service credential.
+
+    :param user_id: Owning user id, e.g. ``"alice@example.com"``.
+    :param provider: External service, e.g. ``"github"``.
+    :param token_encrypted: Fernet ciphertext — decrypt via
+        :meth:`CredentialStore.decrypt_token`, never stored or logged raw.
+    :param login: Provider-side account name for display, e.g. ``"alice"``.
+    :param scopes: Granted scopes for display, e.g. ``"repo"``.
+    :param created_at: Unix epoch seconds of first connect.
+    :param updated_at: Unix epoch seconds of last (re)connect.
+    """
+
+    user_id: str
+    provider: str
+    token_encrypted: str
+    login: str
+    scopes: str
+    created_at: int
+    updated_at: int
+
+
+class CredentialStore:
+    """
+    Persistent store for user credentials backed by SQLAlchemy.
+
+    :param storage_location: SQLAlchemy database URI, e.g.
+        ``"sqlite:///creds.db"``.
+    """
+
+    def __init__(self, storage_location: str) -> None:
+        self._engine: Engine = get_or_create_engine(storage_location)
+        self._session = make_managed_session_maker(self._engine)
+
+    def get(self, user_id: str, provider: str) -> UserCredential | None:
+        """Return the user's credential for *provider*, or ``None``."""
+        with self._session() as session:
+            row = session.execute(
+                select(SqlUserCredential).where(
+                    SqlUserCredential.workspace_id == current_workspace_id(),
+                    SqlUserCredential.user_id == user_id,
+                    SqlUserCredential.provider == provider,
+                )
+            ).scalar_one_or_none()
+            if row is None:
+                return None
+            return UserCredential(
+                user_id=row.user_id,
+                provider=row.provider,
+                token_encrypted=row.token_encrypted,
+                login=row.login,
+                scopes=row.scopes,
+                created_at=row.created_at,
+                updated_at=row.updated_at,
+            )
+
+    def upsert(self, user_id: str, provider: str, *, token: str, login: str, scopes: str) -> None:
+        """
+        Store (or replace) the user's credential for *provider*.
+
+        :raises RuntimeError: When the encryption key is not configured —
+            storing a plaintext token is never acceptable.
+        """
+        codec = _fernet()
+        if codec is None:
+            raise RuntimeError(f"{_KEY_ENV} is not configured; refusing to store a credential")
+        token_encrypted = codec.encrypt(token.encode()).decode()
+        now = now_epoch()
+        with self._session() as session:
+            row = session.execute(
+                select(SqlUserCredential).where(
+                    SqlUserCredential.workspace_id == current_workspace_id(),
+                    SqlUserCredential.user_id == user_id,
+                    SqlUserCredential.provider == provider,
+                )
+            ).scalar_one_or_none()
+            if row is None:
+                session.add(
+                    SqlUserCredential(
+                        user_id=user_id,
+                        provider=provider,
+                        token_encrypted=token_encrypted,
+                        login=login,
+                        scopes=scopes,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                )
+            else:
+                row.token_encrypted = token_encrypted
+                row.login = login
+                row.scopes = scopes
+                row.updated_at = now
+            session.commit()
+
+    def delete(self, user_id: str, provider: str) -> bool:
+        """Remove the credential; ``True`` when a row was deleted."""
+        with self._session() as session:
+            result = session.execute(
+                sql_delete(SqlUserCredential).where(
+                    SqlUserCredential.workspace_id == current_workspace_id(),
+                    SqlUserCredential.user_id == user_id,
+                    SqlUserCredential.provider == provider,
+                )
+            )
+            session.commit()
+            return bool(result.rowcount)
+
+    def decrypt_token(self, cred: UserCredential) -> str | None:
+        """
+        Decrypt a credential's token.
+
+        :returns: The raw token, or ``None`` when the key is missing,
+            invalid, or was rotated after this row was written (callers
+            log + launch without the credential; the UI shows Reconnect).
+        """
+        codec = _fernet()
+        if codec is None:
+            return None
+        try:
+            return codec.decrypt(cred.token_encrypted.encode()).decode()
+        except InvalidToken:
+            return None

--- a/tests/deploy/test_docker_entrypoint_import.py
+++ b/tests/deploy/test_docker_entrypoint_import.py
@@ -185,3 +185,23 @@ def test_build_routing_defaults_without_a_routing_block() -> None:
     client, settings = _build_routing({}, None)
     assert client is None
     assert settings == RoutingSettings()
+
+
+# ── execution timeout ───────────────────────────────────────────────────────
+# The CLI's `omnigent server --execution-timeout` has no equivalent flag for a
+# Docker deploy, so `execution_timeout:` in the server config YAML is the only
+# way to raise it there — this must actually reach RuntimeCaps, not silently
+# stay pinned to the 7200s (2h) dataclass default.
+
+
+def test_resolve_execution_timeout_reads_the_config_value() -> None:
+    from deploy.docker.entrypoint import _resolve_execution_timeout
+
+    assert _resolve_execution_timeout({"execution_timeout": 86400}) == 86400
+
+
+def test_resolve_execution_timeout_defaults_without_config() -> None:
+    from deploy.docker.entrypoint import _resolve_execution_timeout
+    from omnigent.runtime.caps import RuntimeCaps
+
+    assert _resolve_execution_timeout({}) == RuntimeCaps.execution_timeout

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -911,3 +911,33 @@ def test_pod_manifest_never_inlines_extra_env_values() -> None:
     """The value only ever lives in the Secret — never in the Pod spec."""
     manifest = build_pod_manifest(**_MANIFEST_KW, extra_env_keys=["GIT_TOKEN"])
     assert "gho_" not in json.dumps(manifest)
+
+
+# ── git-auth hint on a private-repo clone failure ───────────────────
+
+
+@pytest.mark.parametrize(
+    "tail",
+    [
+        "fatal: could not read Username for 'https://github.com': No such device or address",
+        "remote: Support for password authentication was removed.\nAuthentication failed",
+        "fatal: could not read Password for 'https://github.com'",
+        "fatal: Authentication failed for 'https://github.com/acme/private.git/'",
+    ],
+)
+def test_git_auth_hint_matches_auth_failures(tail: str) -> None:
+    hint = k8s._git_auth_hint(tail)
+    assert hint is not None
+    assert "Credentials" in hint  # points the user at Settings -> Credentials
+
+
+@pytest.mark.parametrize(
+    "tail",
+    [
+        "Cloning into '/home/omnigent/workspace/repo'... done.",
+        "fatal: repository 'https://github.com/acme/missing.git/' not found",
+        "",
+    ],
+)
+def test_git_auth_hint_ignores_non_auth_output(tail: str) -> None:
+    assert k8s._git_auth_hint(tail) is None

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -909,7 +909,5 @@ def test_pod_manifest_references_extra_env_keys_in_both_containers() -> None:
 
 def test_pod_manifest_never_inlines_extra_env_values() -> None:
     """The value only ever lives in the Secret — never in the Pod spec."""
-    import json
-
     manifest = build_pod_manifest(**_MANIFEST_KW, extra_env_keys=["GIT_TOKEN"])
     assert "gho_" not in json.dumps(manifest)

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -873,3 +873,43 @@ def test_provision_reserves_pod_name_and_no_exec_transport() -> None:
     # It classifies runners by agent, so the managed launch path threads
     # ``agent_name`` into its ``start_host`` (exec-model providers do not).
     assert launcher.capabilities.classifies_runner_by_agent is True
+
+
+# ── extra_env (per-user credentials, e.g. GIT_TOKEN) ────────────────
+
+
+def test_token_secret_carries_extra_env() -> None:
+    """Extra env pairs ride the per-Pod launch-token Secret's stringData."""
+    manifest = build_token_secret_manifest(
+        secret_name="s",
+        namespace="ns",
+        token=_TOKEN,
+        extra={"GIT_TOKEN": "gho_x"},
+    )
+    assert manifest["stringData"]["GIT_TOKEN"] == "gho_x"
+    assert manifest["stringData"][HOST_TOKEN_ENV_VAR] == _TOKEN
+
+
+def test_pod_manifest_references_extra_env_keys_in_both_containers() -> None:
+    """Extra keys land as secretKeyRef env in the host AND init containers."""
+    manifest = build_pod_manifest(**_MANIFEST_KW, extra_env_keys=["GIT_TOKEN"])
+    spec = manifest["spec"]
+    expected = {
+        "name": "GIT_TOKEN",
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": _MANIFEST_KW["token_secret_name"],
+                "key": "GIT_TOKEN",
+            }
+        },
+    }
+    assert expected in spec["containers"][0]["env"]
+    assert expected in spec["initContainers"][0]["env"]
+
+
+def test_pod_manifest_never_inlines_extra_env_values() -> None:
+    """The value only ever lives in the Secret — never in the Pod spec."""
+    import json
+
+    manifest = build_pod_manifest(**_MANIFEST_KW, extra_env_keys=["GIT_TOKEN"])
+    assert "gho_" not in json.dumps(manifest)

--- a/tests/server/routes/test_credentials.py
+++ b/tests/server/routes/test_credentials.py
@@ -1,0 +1,168 @@
+"""Tests for the per-user credentials routes (``/v1/credentials``)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from starlette.requests import HTTPConnection
+
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.app import create_app
+from omnigent.server.auth import AuthProvider
+from omnigent.server.routes import credentials as credentials_routes
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.credential_store import CredentialStore
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+
+_USER = "alice@example.com"
+
+
+class _StubAuth(AuthProvider):
+    """Auth provider pinning every request to one user (or none)."""
+
+    def __init__(self, user_id: str | None) -> None:
+        self._user_id = user_id
+
+    def get_user_id(self, request: HTTPConnection) -> str | None:
+        return self._user_id
+
+
+@pytest.fixture()
+def cred_env(monkeypatch):
+    monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("OMNIGENT_GITHUB_CREDENTIAL_CLIENT_ID", "cid123")
+    monkeypatch.setenv("OMNIGENT_GITHUB_CREDENTIAL_CLIENT_SECRET", "csecret")
+
+
+@pytest.fixture()
+def credential_store(cred_env, db_uri: str) -> CredentialStore:
+    return CredentialStore(db_uri)
+
+
+def _build_app(
+    db_uri: str, tmp_path: Path, credential_store: CredentialStore, user: str | None
+) -> FastAPI:
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+        comment_store=SqlAlchemyCommentStore(db_uri),
+        credential_store=credential_store,
+        auth_provider=_StubAuth(user),
+    )
+
+
+@pytest_asyncio.fixture()
+async def client(
+    runtime_init: None, db_uri: str, tmp_path: Path, credential_store: CredentialStore
+) -> AsyncIterator[httpx.AsyncClient]:
+    app = _build_app(db_uri, tmp_path, credential_store, _USER)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture()
+async def anon_client(
+    runtime_init: None, db_uri: str, tmp_path: Path, credential_store: CredentialStore
+) -> AsyncIterator[httpx.AsyncClient]:
+    app = _build_app(db_uri, tmp_path, credential_store, None)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def test_list_requires_user(anon_client: httpx.AsyncClient) -> None:
+    resp = await anon_client.get("/v1/credentials")
+    assert resp.status_code == 401
+
+
+async def test_list_empty(client: httpx.AsyncClient) -> None:
+    resp = await client.get("/v1/credentials")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["credentials"] == []
+    assert body["enabled"] is True
+
+
+async def test_connect_returns_authorize_url_with_state(client: httpx.AsyncClient) -> None:
+    resp = await client.post("/v1/credentials/github/connect")
+    assert resp.status_code == 200
+    url = resp.json()["authorize_url"]
+    assert url.startswith("https://github.com/login/oauth/authorize?")
+    assert "client_id=cid123" in url
+    assert "state=" in url
+
+
+async def test_connect_disabled_without_client_id(client: httpx.AsyncClient, monkeypatch) -> None:
+    monkeypatch.delenv("OMNIGENT_GITHUB_CREDENTIAL_CLIENT_ID", raising=False)
+    resp = await client.post("/v1/credentials/github/connect")
+    assert resp.status_code == 409
+
+
+async def test_callback_bad_state_stores_nothing(
+    client: httpx.AsyncClient, credential_store: CredentialStore
+) -> None:
+    resp = await client.get(
+        "/auth/github/credential-callback?code=abc&state=garbage",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "error=state_mismatch" in resp.headers["location"]
+    assert credential_store.get(_USER, "github") is None
+
+
+async def test_callback_happy_path_then_list_and_disconnect(
+    client: httpx.AsyncClient, credential_store: CredentialStore, monkeypatch
+) -> None:
+    async def fake_exchange(code: str) -> dict:
+        assert code == "goodcode"
+        return {"access_token": "gho_live", "scope": "repo"}
+
+    async def fake_user(token: str) -> dict:
+        assert token == "gho_live"
+        return {"login": "alice-gh"}
+
+    monkeypatch.setattr(credentials_routes, "_exchange_code", fake_exchange)
+    monkeypatch.setattr(credentials_routes, "_fetch_github_user", fake_user)
+
+    state = credentials_routes._mint_state(_USER)
+    resp = await client.get(
+        f"/auth/github/credential-callback?code=goodcode&state={state}",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "connected=github" in resp.headers["location"]
+
+    listed = (await client.get("/v1/credentials")).json()
+    assert listed["credentials"] == [
+        {
+            "provider": "github",
+            "login": "alice-gh",
+            "scopes": "repo",
+            "connected_at": listed["credentials"][0]["connected_at"],
+        }
+    ]
+    # Token never appears in the API surface.
+    assert "gho_live" not in (await client.get("/v1/credentials")).text
+
+    resp = await client.delete("/v1/credentials/github")
+    assert resp.json() == {"ok": True}
+    assert credential_store.get(_USER, "github") is None

--- a/tests/server/routes/test_credentials.py
+++ b/tests/server/routes/test_credentials.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import httpx
 import pytest
 import pytest_asyncio
 from cryptography.fernet import Fernet
-from fastapi import FastAPI
 from starlette.requests import HTTPConnection
 
 from omnigent.runtime.agent_cache import AgentCache
@@ -50,32 +50,32 @@ def credential_store(cred_env, db_uri: str) -> CredentialStore:
     return CredentialStore(db_uri)
 
 
-def _build_app(
+@asynccontextmanager
+async def _client(
     db_uri: str, tmp_path: Path, credential_store: CredentialStore, user: str | None
-) -> FastAPI:
+) -> AsyncIterator[httpx.AsyncClient]:
     artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
-    return create_app(
+    app = create_app(
         agent_store=SqlAlchemyAgentStore(db_uri),
         file_store=SqlAlchemyFileStore(db_uri),
         conversation_store=SqlAlchemyConversationStore(db_uri),
         artifact_store=artifact_store,
-        agent_cache=AgentCache(
-            artifact_store=artifact_store,
-            cache_dir=tmp_path / "cache",
-        ),
+        agent_cache=AgentCache(artifact_store=artifact_store, cache_dir=tmp_path / "cache"),
         comment_store=SqlAlchemyCommentStore(db_uri),
         credential_store=credential_store,
         auth_provider=_StubAuth(user),
     )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
 
 
 @pytest_asyncio.fixture()
 async def client(
     runtime_init: None, db_uri: str, tmp_path: Path, credential_store: CredentialStore
 ) -> AsyncIterator[httpx.AsyncClient]:
-    app = _build_app(db_uri, tmp_path, credential_store, _USER)
-    transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+    async with _client(db_uri, tmp_path, credential_store, _USER) as c:
         yield c
 
 
@@ -83,9 +83,7 @@ async def client(
 async def anon_client(
     runtime_init: None, db_uri: str, tmp_path: Path, credential_store: CredentialStore
 ) -> AsyncIterator[httpx.AsyncClient]:
-    app = _build_app(db_uri, tmp_path, credential_store, None)
-    transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+    async with _client(db_uri, tmp_path, credential_store, None) as c:
         yield c
 
 
@@ -151,17 +149,15 @@ async def test_callback_happy_path_then_list_and_disconnect(
     assert resp.status_code == 302
     assert "connected=github" in resp.headers["location"]
 
-    listed = (await client.get("/v1/credentials")).json()
-    assert listed["credentials"] == [
-        {
-            "provider": "github",
-            "login": "alice-gh",
-            "scopes": "repo",
-            "connected_at": listed["credentials"][0]["connected_at"],
-        }
-    ]
-    # Token never appears in the API surface.
-    assert "gho_live" not in (await client.get("/v1/credentials")).text
+    listing = await client.get("/v1/credentials")
+    [cred] = listing.json()["credentials"]
+    assert cred == {
+        "provider": "github",
+        "login": "alice-gh",
+        "scopes": "repo",
+        "connected_at": cred["connected_at"],
+    }
+    assert "gho_live" not in listing.text  # token never on the API surface
 
     resp = await client.delete("/v1/credentials/github")
     assert resp.json() == {"ok": True}

--- a/tests/server/routes/test_credentials.py
+++ b/tests/server/routes/test_credentials.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import httpx
 import pytest
 import pytest_asyncio
+import respx
 from cryptography.fernet import Fernet
 from starlette.requests import HTTPConnection
 
@@ -162,3 +163,87 @@ async def test_callback_happy_path_then_list_and_disconnect(
     resp = await client.delete("/v1/credentials/github")
     assert resp.json() == {"ok": True}
     assert credential_store.get(_USER, "github") is None
+
+
+async def test_repos_requires_connected_github(client: httpx.AsyncClient) -> None:
+    resp = await client.get("/v1/credentials/github/repos")
+    assert resp.status_code == 409
+
+
+async def test_repos_returns_mapped_list(
+    client: httpx.AsyncClient, credential_store: CredentialStore, monkeypatch
+) -> None:
+    credential_store.upsert(_USER, "github", token="gho_live", login="alice-gh", scopes="repo")
+
+    async def fake_repos(token: str) -> list[dict]:
+        assert token == "gho_live"
+        return [
+            {
+                "full_name": "alice/proj",
+                "clone_url": "https://github.com/alice/proj.git",
+                "default_branch": "main",
+                "private": False,
+                "id": 1,  # extra GitHub fields the mapping must drop
+            },
+        ]
+
+    monkeypatch.setattr(credentials_routes, "_fetch_github_repos", fake_repos)
+    resp = await client.get("/v1/credentials/github/repos")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "repos": [
+            {
+                "full_name": "alice/proj",
+                "clone_url": "https://github.com/alice/proj.git",
+                "default_branch": "main",
+                "private": False,
+            }
+        ]
+    }
+
+
+async def test_repos_undecryptable_credential_treated_as_not_connected(
+    client: httpx.AsyncClient, credential_store: CredentialStore, monkeypatch
+) -> None:
+    credential_store.upsert(_USER, "github", token="gho_live", login="alice-gh", scopes="repo")
+    # Rotate the key after writing — the stored ciphertext no longer decrypts.
+    monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    resp = await client.get("/v1/credentials/github/repos")
+    assert resp.status_code == 409
+
+
+async def test_repos_github_api_failure_returns_500(
+    client: httpx.AsyncClient, credential_store: CredentialStore, monkeypatch
+) -> None:
+    credential_store.upsert(_USER, "github", token="gho_live", login="alice-gh", scopes="repo")
+
+    async def failing_repos(token: str) -> list[dict]:
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(credentials_routes, "_fetch_github_repos", failing_repos)
+    resp = await client.get("/v1/credentials/github/repos")
+    assert resp.status_code == 500
+
+
+@respx.mock
+async def test_fetch_github_repos_requests_all_affiliations_sorted_by_pushed() -> None:
+    route = respx.get("https://api.github.com/user/repos").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "full_name": "alice/proj",
+                    "clone_url": "https://github.com/alice/proj.git",
+                    "default_branch": "main",
+                    "private": False,
+                }
+            ],
+        )
+    )
+    repos = await credentials_routes._fetch_github_repos("gho_live")
+    assert repos[0]["full_name"] == "alice/proj"
+    request = route.calls.last.request
+    assert request.headers["authorization"] == "Bearer gho_live"
+    assert request.url.params["affiliation"] == "owner,collaborator,organization_member"
+    assert request.url.params["sort"] == "pushed"
+    assert request.url.params["per_page"] == "100"

--- a/tests/server/routes/test_credentials.py
+++ b/tests/server/routes/test_credentials.py
@@ -168,6 +168,30 @@ async def test_callback_happy_path_then_list_and_disconnect(
 async def test_repos_requires_connected_github(client: httpx.AsyncClient) -> None:
     resp = await client.get("/v1/credentials/github/repos")
     assert resp.status_code == 409
+    # OmnigentError.code is the generic HTTP-status category ("conflict")
+    # for both this and the disabled-deployment case below; the specific,
+    # machine-readable reason is carried in .message.
+    assert resp.json()["error"]["message"] == "github_not_connected"
+
+
+async def test_repos_disabled_without_client_id(client: httpx.AsyncClient, monkeypatch) -> None:
+    monkeypatch.delenv("OMNIGENT_GITHUB_CREDENTIAL_CLIENT_ID", raising=False)
+    resp = await client.get("/v1/credentials/github/repos")
+    assert resp.status_code == 409
+    assert resp.json()["error"]["message"] == "credentials_disabled"
+
+
+async def test_repos_disabled_takes_priority_over_connected_credential(
+    client: httpx.AsyncClient, credential_store: CredentialStore, monkeypatch
+) -> None:
+    # The feature gate is checked before the credential lookup, so a
+    # not-configured deployment reports `credentials_disabled` even for a
+    # user who has a stored (now-orphaned) credential.
+    credential_store.upsert(_USER, "github", token="gho_live", login="alice-gh", scopes="repo")
+    monkeypatch.delenv("OMNIGENT_GITHUB_CREDENTIAL_CLIENT_ID", raising=False)
+    resp = await client.get("/v1/credentials/github/repos")
+    assert resp.status_code == 409
+    assert resp.json()["error"]["message"] == "credentials_disabled"
 
 
 async def test_repos_returns_mapped_list(

--- a/tests/server/routes/test_credentials_injection.py
+++ b/tests/server/routes/test_credentials_injection.py
@@ -44,26 +44,22 @@ async def _provision(monkeypatch, credential_store: CredentialStore | None) -> d
     return captured
 
 
-@pytest.mark.asyncio
 async def test_connected_credential_injected(monkeypatch, credential_store) -> None:
     credential_store.upsert(_OWNER, "github", token="gho_x", login="alice", scopes="repo")
     captured = await _provision(monkeypatch, credential_store)
     assert captured["extra_env"] == {"GIT_TOKEN": "gho_x"}
 
 
-@pytest.mark.asyncio
 async def test_no_credential_launches_without(monkeypatch, credential_store) -> None:
     captured = await _provision(monkeypatch, credential_store)
     assert captured["extra_env"] is None
 
 
-@pytest.mark.asyncio
 async def test_no_store_launches_without(monkeypatch) -> None:
     captured = await _provision(monkeypatch, None)
     assert captured["extra_env"] is None
 
 
-@pytest.mark.asyncio
 async def test_undecryptable_credential_launches_without(monkeypatch, credential_store) -> None:
     credential_store.upsert(_OWNER, "github", token="gho_x", login="alice", scopes="repo")
     monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())

--- a/tests/server/routes/test_credentials_injection.py
+++ b/tests/server/routes/test_credentials_injection.py
@@ -1,0 +1,71 @@
+"""Owner-credential injection into managed sandbox launches."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from cryptography.fernet import Fernet
+
+from omnigent.server.routes import sessions as sessions_routes
+from omnigent.stores.credential_store import CredentialStore
+
+_OWNER = "alice@example.com"
+
+
+@pytest.fixture()
+def credential_store(tmp_path, monkeypatch) -> CredentialStore:
+    monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    return CredentialStore(f"sqlite:///{tmp_path}/creds.db")
+
+
+async def _provision(monkeypatch, credential_store: CredentialStore | None) -> dict:
+    """Drive _provision_managed_sandbox with launch_managed_host captured."""
+    captured: dict = {}
+
+    async def fake_launch(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(
+        "omnigent.server.managed_hosts.launch_managed_host",
+        fake_launch,
+    )
+    await sessions_routes._provision_managed_sandbox(
+        session_id="conv_test",
+        owner=_OWNER,
+        sandbox_config=MagicMock(),
+        repo=None,
+        tracker=MagicMock(),
+        host_store=MagicMock(),
+        relaunch_host=None,
+        credential_store=credential_store,
+    )
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_connected_credential_injected(monkeypatch, credential_store) -> None:
+    credential_store.upsert(_OWNER, "github", token="gho_x", login="alice", scopes="repo")
+    captured = await _provision(monkeypatch, credential_store)
+    assert captured["extra_env"] == {"GIT_TOKEN": "gho_x"}
+
+
+@pytest.mark.asyncio
+async def test_no_credential_launches_without(monkeypatch, credential_store) -> None:
+    captured = await _provision(monkeypatch, credential_store)
+    assert captured["extra_env"] is None
+
+
+@pytest.mark.asyncio
+async def test_no_store_launches_without(monkeypatch) -> None:
+    captured = await _provision(monkeypatch, None)
+    assert captured["extra_env"] is None
+
+
+@pytest.mark.asyncio
+async def test_undecryptable_credential_launches_without(monkeypatch, credential_store) -> None:
+    credential_store.upsert(_OWNER, "github", token="gho_x", login="alice", scopes="repo")
+    monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    captured = await _provision(monkeypatch, credential_store)
+    assert captured["extra_env"] is None

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -2135,6 +2135,7 @@ class _EntrypointFakeLauncher(FakeSandboxLauncher):
         repo_name: str | None = None,
         host_config: dict[str, object] | None = None,
         on_stage=None,
+        extra_env: dict[str, str] | None = None,
     ) -> str:
         """Record the call, prove the token already resolves, and connect."""
         self.start_calls.append(

--- a/tests/stores/test_credential_store.py
+++ b/tests/stores/test_credential_store.py
@@ -1,0 +1,64 @@
+"""Tests for the per-user credential store (encrypted at rest)."""
+
+import pytest
+from cryptography.fernet import Fernet
+
+from omnigent.stores.credential_store import (
+    CredentialStore,
+    credential_encryption_enabled,
+)
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    return CredentialStore(f"sqlite:///{tmp_path}/creds.db")
+
+
+def test_roundtrip(store):
+    store.upsert("alice@example.com", "github", token="gho_secret", login="alice", scopes="repo")
+    cred = store.get("alice@example.com", "github")
+    assert cred is not None
+    assert cred.login == "alice"
+    assert cred.scopes == "repo"
+    # Encrypted at rest — raw token never stored verbatim.
+    assert "gho_secret" not in cred.token_encrypted
+    assert store.decrypt_token(cred) == "gho_secret"
+
+
+def test_upsert_replaces_existing(store):
+    store.upsert("alice@example.com", "github", token="old", login="alice", scopes="")
+    store.upsert("alice@example.com", "github", token="new", login="alice2", scopes="repo")
+    cred = store.get("alice@example.com", "github")
+    assert cred.login == "alice2"
+    assert store.decrypt_token(cred) == "new"
+
+
+def test_get_missing_returns_none(store):
+    assert store.get("nobody@example.com", "github") is None
+
+
+def test_delete(store):
+    store.upsert("alice@example.com", "github", token="t", login="alice", scopes="")
+    assert store.delete("alice@example.com", "github") is True
+    assert store.get("alice@example.com", "github") is None
+    assert store.delete("alice@example.com", "github") is False
+
+
+def test_encryption_disabled_without_key(monkeypatch):
+    monkeypatch.delenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", raising=False)
+    assert credential_encryption_enabled() is False
+
+
+def test_encryption_disabled_with_garbage_key(monkeypatch):
+    monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", "not-a-key")
+    assert credential_encryption_enabled() is False
+
+
+def test_decrypt_returns_none_after_key_rotation(tmp_path, monkeypatch):
+    monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    store = CredentialStore(f"sqlite:///{tmp_path}/creds.db")
+    store.upsert("alice@example.com", "github", token="t", login="alice", scopes="")
+    cred = store.get("alice@example.com", "github")
+    monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    assert store.decrypt_token(cred) is None

--- a/tests/stores/test_credential_store.py
+++ b/tests/stores/test_credential_store.py
@@ -8,6 +8,8 @@ from omnigent.stores.credential_store import (
     credential_encryption_enabled,
 )
 
+_USER = "alice@example.com"
+
 
 @pytest.fixture()
 def store(tmp_path, monkeypatch):
@@ -16,20 +18,18 @@ def store(tmp_path, monkeypatch):
 
 
 def test_roundtrip(store):
-    store.upsert("alice@example.com", "github", token="gho_secret", login="alice", scopes="repo")
-    cred = store.get("alice@example.com", "github")
+    store.upsert(_USER, "github", token="gho_secret", login="alice", scopes="repo")
+    cred = store.get(_USER, "github")
     assert cred is not None
-    assert cred.login == "alice"
-    assert cred.scopes == "repo"
-    # Encrypted at rest — raw token never stored verbatim.
-    assert "gho_secret" not in cred.token_encrypted
+    assert (cred.login, cred.scopes) == ("alice", "repo")
+    assert "gho_secret" not in cred.token_encrypted  # encrypted at rest
     assert store.decrypt_token(cred) == "gho_secret"
 
 
 def test_upsert_replaces_existing(store):
-    store.upsert("alice@example.com", "github", token="old", login="alice", scopes="")
-    store.upsert("alice@example.com", "github", token="new", login="alice2", scopes="repo")
-    cred = store.get("alice@example.com", "github")
+    store.upsert(_USER, "github", token="old", login="alice", scopes="")
+    store.upsert(_USER, "github", token="new", login="alice2", scopes="repo")
+    cred = store.get(_USER, "github")
     assert cred.login == "alice2"
     assert store.decrypt_token(cred) == "new"
 
@@ -39,26 +39,23 @@ def test_get_missing_returns_none(store):
 
 
 def test_delete(store):
-    store.upsert("alice@example.com", "github", token="t", login="alice", scopes="")
-    assert store.delete("alice@example.com", "github") is True
-    assert store.get("alice@example.com", "github") is None
-    assert store.delete("alice@example.com", "github") is False
+    store.upsert(_USER, "github", token="t", login="alice", scopes="")
+    assert store.delete(_USER, "github") is True
+    assert store.get(_USER, "github") is None
+    assert store.delete(_USER, "github") is False
 
 
-def test_encryption_disabled_without_key(monkeypatch):
-    monkeypatch.delenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", raising=False)
+@pytest.mark.parametrize("key", [None, "not-a-key"])
+def test_encryption_disabled_for_missing_or_invalid_key(monkeypatch, key):
+    if key is None:
+        monkeypatch.delenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", raising=False)
+    else:
+        monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", key)
     assert credential_encryption_enabled() is False
 
 
-def test_encryption_disabled_with_garbage_key(monkeypatch):
-    monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", "not-a-key")
-    assert credential_encryption_enabled() is False
-
-
-def test_decrypt_returns_none_after_key_rotation(tmp_path, monkeypatch):
-    monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
-    store = CredentialStore(f"sqlite:///{tmp_path}/creds.db")
-    store.upsert("alice@example.com", "github", token="t", login="alice", scopes="")
-    cred = store.get("alice@example.com", "github")
+def test_decrypt_returns_none_after_key_rotation(store, monkeypatch):
+    store.upsert(_USER, "github", token="t", login="alice", scopes="")
+    cred = store.get(_USER, "github")
     monkeypatch.setenv("OMNIGENT_CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
     assert store.decrypt_token(cred) is None

--- a/web/src/lib/credentialsApi.test.ts
+++ b/web/src/lib/credentialsApi.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  connectGithub,
+  disconnectGithub,
+  listCredentials,
+  listGithubRepos,
+} from "./credentialsApi";
+import { authenticatedFetch } from "./identity";
+
+vi.mock("./identity", () => ({
+  authenticatedFetch: vi.fn(),
+}));
+
+const mockAuthenticatedFetch = vi.mocked(authenticatedFetch);
+
+function mockJsonResponse(
+  body: unknown,
+  init: { ok?: boolean; status?: number; statusText?: string } = {},
+): Response {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? "OK",
+    json: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  mockAuthenticatedFetch.mockReset();
+});
+
+describe("listCredentials", () => {
+  it("GETs /v1/credentials and returns the credentials array", async () => {
+    mockAuthenticatedFetch.mockResolvedValueOnce(
+      mockJsonResponse({
+        credentials: [
+          { provider: "github", login: "alice-gh", scopes: "repo", connected_at: 1_700_000_000 },
+        ],
+        enabled: true,
+      }),
+    );
+    const result = await listCredentials();
+    expect(mockAuthenticatedFetch).toHaveBeenCalledWith("/v1/credentials");
+    expect(result).toEqual({
+      ok: true,
+      credentials: [
+        { provider: "github", login: "alice-gh", scopes: "repo", connected_at: 1_700_000_000 },
+      ],
+      enabled: true,
+    });
+  });
+
+  it("returns a typed failure on a non-OK response", async () => {
+    mockAuthenticatedFetch.mockResolvedValueOnce(
+      mockJsonResponse(
+        { error: { code: "unauthorized", message: "Authentication required" } },
+        { ok: false, status: 401 },
+      ),
+    );
+    const result = await listCredentials();
+    expect(result).toEqual({
+      ok: false,
+      error: "Authentication required",
+      status: 401,
+      code: "Authentication required",
+    });
+  });
+});
+
+describe("connectGithub", () => {
+  it("POSTs /v1/credentials/github/connect and returns the authorize_url", async () => {
+    mockAuthenticatedFetch.mockResolvedValueOnce(
+      mockJsonResponse({ authorize_url: "https://github.com/login/oauth/authorize?client_id=x" }),
+    );
+    const result = await connectGithub();
+    expect(mockAuthenticatedFetch).toHaveBeenCalledWith("/v1/credentials/github/connect", {
+      method: "POST",
+    });
+    expect(result).toEqual({
+      ok: true,
+      authorize_url: "https://github.com/login/oauth/authorize?client_id=x",
+    });
+  });
+
+  it("surfaces the credentials_disabled 409 with a matching code", async () => {
+    mockAuthenticatedFetch.mockResolvedValueOnce(
+      mockJsonResponse(
+        { error: { code: "conflict", message: "credentials_disabled" } },
+        { ok: false, status: 409 },
+      ),
+    );
+    const result = await connectGithub();
+    expect(result).toEqual({
+      ok: false,
+      error: "credentials_disabled",
+      status: 409,
+      code: "credentials_disabled",
+    });
+  });
+});
+
+describe("disconnectGithub", () => {
+  it("DELETEs /v1/credentials/github and returns ok", async () => {
+    mockAuthenticatedFetch.mockResolvedValueOnce(mockJsonResponse({ ok: true }));
+    const result = await disconnectGithub();
+    expect(mockAuthenticatedFetch).toHaveBeenCalledWith("/v1/credentials/github", {
+      method: "DELETE",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+describe("listGithubRepos", () => {
+  it("GETs /v1/credentials/github/repos and returns the repos array", async () => {
+    mockAuthenticatedFetch.mockResolvedValueOnce(
+      mockJsonResponse({
+        repos: [
+          {
+            full_name: "alice/proj",
+            clone_url: "https://github.com/alice/proj.git",
+            default_branch: "main",
+            private: false,
+          },
+        ],
+      }),
+    );
+    const result = await listGithubRepos();
+    expect(mockAuthenticatedFetch).toHaveBeenCalledWith("/v1/credentials/github/repos");
+    expect(result).toEqual({
+      ok: true,
+      repos: [
+        {
+          full_name: "alice/proj",
+          clone_url: "https://github.com/alice/proj.git",
+          default_branch: "main",
+          private: false,
+        },
+      ],
+    });
+  });
+
+  it("distinguishes github_not_connected from credentials_disabled via result.code", async () => {
+    mockAuthenticatedFetch.mockResolvedValueOnce(
+      mockJsonResponse(
+        { error: { code: "conflict", message: "github_not_connected" } },
+        { ok: false, status: 409 },
+      ),
+    );
+    const notConnected = await listGithubRepos();
+    expect(notConnected).toEqual({
+      ok: false,
+      error: "github_not_connected",
+      status: 409,
+      code: "github_not_connected",
+    });
+
+    mockAuthenticatedFetch.mockResolvedValueOnce(
+      mockJsonResponse(
+        { error: { code: "conflict", message: "credentials_disabled" } },
+        { ok: false, status: 409 },
+      ),
+    );
+    const disabled = await listGithubRepos();
+    expect(disabled).toEqual({
+      ok: false,
+      error: "credentials_disabled",
+      status: 409,
+      code: "credentials_disabled",
+    });
+  });
+
+  it("returns NETWORK_FAILURE when the fetch itself rejects", async () => {
+    mockAuthenticatedFetch.mockRejectedValueOnce(new Error("offline"));
+    const result = await listGithubRepos();
+    expect(result).toEqual({
+      ok: false,
+      error: "Could not reach the server. Check your connection.",
+      status: 0,
+    });
+  });
+});

--- a/web/src/lib/credentialsApi.ts
+++ b/web/src/lib/credentialsApi.ts
@@ -1,0 +1,99 @@
+/**
+ * Client for the per-user credentials API (Settings → Credentials).
+ *
+ * Wraps ``GET /v1/credentials``, ``POST /v1/credentials/github/connect``,
+ * and ``DELETE /v1/credentials/github`` in a small typed surface shared by
+ * the Settings Credentials section.
+ *
+ * Errors: every helper resolves with a discriminated union instead of
+ * throwing, mirroring ``accountsApi.ts``, so the UI renders specific
+ * messages without try/catch at every call site.
+ */
+
+/** One connected credential, masked — the token never reaches the client. */
+export interface CredentialInfo {
+  provider: string;
+  login: string;
+  scopes: string;
+  connected_at: number;
+}
+
+export interface CredentialsList {
+  ok: true;
+  credentials: CredentialInfo[];
+  /** Whether the deployment has the GitHub OAuth App + encryption key configured. */
+  enabled: boolean;
+}
+
+export interface CredentialsFailure {
+  ok: false;
+  error: string;
+  status: number;
+}
+
+export type CredentialsListResult = CredentialsList | CredentialsFailure;
+export type ConnectResult = { ok: true; authorize_url: string } | CredentialsFailure;
+export type DisconnectResult = { ok: true } | CredentialsFailure;
+
+const NETWORK_FAILURE: CredentialsFailure = {
+  ok: false,
+  error: "Could not reach the server. Check your connection.",
+  status: 0,
+};
+
+async function failureFrom(res: Response, fallback: string): Promise<CredentialsFailure> {
+  let message = fallback;
+  if (res.status >= 500) {
+    message = "Server error. Try again in a moment.";
+  } else {
+    try {
+      const data = (await res.json()) as { error?: string };
+      if (data.error) message = data.error;
+    } catch {
+      // keep fallback
+    }
+  }
+  return { ok: false, error: message, status: res.status };
+}
+
+/** GET /v1/credentials — the caller's connected credentials. */
+export async function listCredentials(): Promise<CredentialsListResult> {
+  let res: Response;
+  try {
+    res = await fetch("/v1/credentials");
+  } catch {
+    return NETWORK_FAILURE;
+  }
+  if (res.ok) {
+    const data = (await res.json()) as Omit<CredentialsList, "ok">;
+    return { ok: true, ...data };
+  }
+  return failureFrom(res, "Could not load credentials.");
+}
+
+/** POST /v1/credentials/github/connect — start the GitHub OAuth flow. */
+export async function connectGithub(): Promise<ConnectResult> {
+  let res: Response;
+  try {
+    res = await fetch("/v1/credentials/github/connect", { method: "POST" });
+  } catch {
+    return NETWORK_FAILURE;
+  }
+  if (res.ok) {
+    const data = (await res.json()) as { authorize_url: string };
+    return { ok: true, authorize_url: data.authorize_url };
+  }
+  return failureFrom(res, "Could not start the GitHub connection.");
+}
+
+/** DELETE /v1/credentials/github — disconnect GitHub. */
+export async function disconnectGithub(): Promise<DisconnectResult> {
+  let res: Response;
+  try {
+    res = await fetch("/v1/credentials/github", { method: "DELETE" });
+  } catch {
+    return NETWORK_FAILURE;
+  }
+  if (res.ok) return { ok: true };
+  return failureFrom(res, "Could not disconnect GitHub.");
+}

--- a/web/src/lib/credentialsApi.ts
+++ b/web/src/lib/credentialsApi.ts
@@ -99,3 +99,28 @@ export async function disconnectGithub(): Promise<DisconnectResult> {
   if (res.ok) return { ok: true };
   return failureFrom(res, "Could not disconnect GitHub.");
 }
+
+/** One repo the caller's connected GitHub credential can access. */
+export interface GithubRepoInfo {
+  full_name: string;
+  clone_url: string;
+  default_branch: string;
+  private: boolean;
+}
+
+export type GithubReposResult = { ok: true; repos: GithubRepoInfo[] } | CredentialsFailure;
+
+/** GET /v1/credentials/github/repos — the caller's accessible GitHub repos. */
+export async function listGithubRepos(): Promise<GithubReposResult> {
+  let res: Response;
+  try {
+    res = await authenticatedFetch("/v1/credentials/github/repos");
+  } catch {
+    return NETWORK_FAILURE;
+  }
+  if (res.ok) {
+    const data = (await res.json()) as { repos: GithubRepoInfo[] };
+    return { ok: true, repos: data.repos };
+  }
+  return failureFrom(res, "Could not load your GitHub repos.");
+}

--- a/web/src/lib/credentialsApi.ts
+++ b/web/src/lib/credentialsApi.ts
@@ -10,6 +10,8 @@
  * messages without try/catch at every call site.
  */
 
+import { authenticatedFetch } from "@/lib/identity";
+
 /** One connected credential, masked — the token never reaches the client. */
 export interface CredentialInfo {
   provider: string;
@@ -60,7 +62,7 @@ async function failureFrom(res: Response, fallback: string): Promise<Credentials
 export async function listCredentials(): Promise<CredentialsListResult> {
   let res: Response;
   try {
-    res = await fetch("/v1/credentials");
+    res = await authenticatedFetch("/v1/credentials");
   } catch {
     return NETWORK_FAILURE;
   }
@@ -75,7 +77,7 @@ export async function listCredentials(): Promise<CredentialsListResult> {
 export async function connectGithub(): Promise<ConnectResult> {
   let res: Response;
   try {
-    res = await fetch("/v1/credentials/github/connect", { method: "POST" });
+    res = await authenticatedFetch("/v1/credentials/github/connect", { method: "POST" });
   } catch {
     return NETWORK_FAILURE;
   }
@@ -90,7 +92,7 @@ export async function connectGithub(): Promise<ConnectResult> {
 export async function disconnectGithub(): Promise<DisconnectResult> {
   let res: Response;
   try {
-    res = await fetch("/v1/credentials/github", { method: "DELETE" });
+    res = await authenticatedFetch("/v1/credentials/github", { method: "DELETE" });
   } catch {
     return NETWORK_FAILURE;
   }

--- a/web/src/lib/credentialsApi.ts
+++ b/web/src/lib/credentialsApi.ts
@@ -31,6 +31,15 @@ export interface CredentialsFailure {
   ok: false;
   error: string;
   status: number;
+  /**
+   * The specific, machine-readable reason (e.g. `"github_not_connected"`,
+   * `"credentials_disabled"`). The server's `OmnigentError.code` is only
+   * the generic HTTP-status category (e.g. `"conflict"`) shared by
+   * multiple reasons, so this reads the same slug that's shown in
+   * `error` — callers that need to branch on the specific reason (rather
+   * than just display it) should check `code` instead of `error`.
+   */
+  code?: string;
 }
 
 export type CredentialsListResult = CredentialsList | CredentialsFailure;
@@ -45,17 +54,24 @@ const NETWORK_FAILURE: CredentialsFailure = {
 
 async function failureFrom(res: Response, fallback: string): Promise<CredentialsFailure> {
   let message = fallback;
+  let code: string | undefined;
   if (res.status >= 500) {
     message = "Server error. Try again in a moment.";
   } else {
     try {
-      const data = (await res.json()) as { error?: string };
-      if (data.error) message = data.error;
+      const data = (await res.json()) as { error?: { code?: string; message?: string } };
+      // credentials.py's OmnigentError.message carries the specific reason
+      // (e.g. "github_not_connected"); error.code is only the generic
+      // HTTP-status category ("conflict") and can't distinguish reasons.
+      if (data.error?.message) {
+        message = data.error.message;
+        code = data.error.message;
+      }
     } catch {
       // keep fallback
     }
   }
-  return { ok: false, error: message, status: res.status };
+  return { ok: false, error: message, status: res.status, code };
 }
 
 /** GET /v1/credentials — the caller's connected credentials. */

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -52,6 +52,12 @@ vi.mock("@/lib/accountsApi", () => ({
   logout: vi.fn(),
   changePassword: vi.fn(),
 }));
+const credentialsMocks = vi.hoisted(() => ({
+  listCredentials: vi.fn(),
+  connectGithub: vi.fn(),
+  disconnectGithub: vi.fn(),
+}));
+vi.mock("@/lib/credentialsApi", () => credentialsMocks);
 vi.mock("@/lib/identity", () => ({
   resolveIdentity: () => Promise.resolve(mocks.me?.id ?? null),
   getCurrentIsAdmin: () => mocks.me?.is_admin ?? false,
@@ -987,5 +993,67 @@ describe("SettingsPage", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("CredentialsSection", () => {
+  beforeEach(() => {
+    credentialsMocks.listCredentials.mockReset();
+    credentialsMocks.connectGithub.mockReset();
+    credentialsMocks.disconnectGithub.mockReset();
+  });
+
+  it("renders Connect GitHub when nothing is connected and navigates on click", async () => {
+    credentialsMocks.listCredentials.mockResolvedValue({
+      ok: true,
+      credentials: [],
+      enabled: true,
+    });
+    credentialsMocks.connectGithub.mockResolvedValue({
+      ok: true,
+      authorize_url: "https://github.com/login/oauth/authorize?x=1",
+    });
+    const assign = vi.fn();
+    const original = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...original, assign, search: "" },
+    });
+    try {
+      renderPage("/settings/credentials");
+      const connect = await screen.findByTestId("settings-credentials-github-connect");
+      fireEvent.click(connect);
+      await waitFor(() =>
+        expect(assign).toHaveBeenCalledWith("https://github.com/login/oauth/authorize?x=1"),
+      );
+    } finally {
+      Object.defineProperty(window, "location", { configurable: true, value: original });
+    }
+  });
+
+  it("renders the connected account and disconnects", async () => {
+    credentialsMocks.listCredentials.mockResolvedValue({
+      ok: true,
+      credentials: [
+        { provider: "github", login: "alice-gh", scopes: "repo", connected_at: 1 },
+      ],
+      enabled: true,
+    });
+    credentialsMocks.disconnectGithub.mockResolvedValue({ ok: true });
+    renderPage("/settings/credentials");
+    expect(await screen.findByText(/Connected as alice-gh/)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("settings-credentials-github-disconnect"));
+    await waitFor(() => expect(credentialsMocks.disconnectGithub).toHaveBeenCalled());
+  });
+
+  it("disables Connect and explains when the deployment lacks configuration", async () => {
+    credentialsMocks.listCredentials.mockResolvedValue({
+      ok: true,
+      credentials: [],
+      enabled: false,
+    });
+    renderPage("/settings/credentials");
+    const connect = await screen.findByTestId("settings-credentials-github-connect");
+    expect(connect).toBeDisabled();
   });
 });

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1034,9 +1034,7 @@ describe("CredentialsSection", () => {
   it("renders the connected account and disconnects", async () => {
     credentialsMocks.listCredentials.mockResolvedValue({
       ok: true,
-      credentials: [
-        { provider: "github", login: "alice-gh", scopes: "repo", connected_at: 1 },
-      ],
+      credentials: [{ provider: "github", login: "alice-gh", scopes: "repo", connected_at: 1 }],
       enabled: true,
     });
     credentialsMocks.disconnectGithub.mockResolvedValue({ ok: true });

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1029,9 +1029,7 @@ function CredentialsSection() {
     }
     setBusy(false);
     setError(
-      result.status === 409
-        ? "Credentials are not configured on this deployment."
-        : result.error,
+      result.status === 409 ? "Credentials are not configured on this deployment." : result.error,
     );
   }, []);
 

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -80,6 +80,12 @@ import {
 } from "@/components/ui/dialog";
 import { KeyboardShortcutsList } from "@/components/KeyboardShortcutsDialog";
 import { changePassword, logout } from "@/lib/accountsApi";
+import {
+  connectGithub,
+  disconnectGithub,
+  listCredentials,
+  type CredentialInfo,
+} from "@/lib/credentialsApi";
 import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { useOmnigentPageView } from "@/lib/analytics";
@@ -230,6 +236,7 @@ export function SettingsPage() {
     <PageScroll contentClassName="px-8" extraBottom="2.5rem">
       {section === "appearance" && <AppearanceSection />}
       {section === "git" && <GitSection />}
+      {section === "credentials" && <CredentialsSection />}
       {section === "shortcuts" && <ShortcutsSection />}
       {section === "account" && hasAuthSession && <AccountSection />}
       {section === "archived" && <ArchivedSection />}
@@ -969,6 +976,114 @@ function GitSection() {
     <Section title="Git" description="Configure how Omnigent works with Git.">
       <div className="flex flex-col gap-8">
         <DefaultBaseBranchControl />
+      </div>
+    </Section>
+  );
+}
+
+/**
+ * Per-user external-service credentials. Connect GitHub via the deployment's
+ * OAuth App; the token is injected as GIT_TOKEN into this user's managed
+ * sandbox sessions. The callback redirects back here with ?connected= or
+ * ?error= query params, surfaced as a banner.
+ */
+function CredentialsSection() {
+  const [creds, setCreds] = useState<CredentialInfo[] | null>(null);
+  const [enabled, setEnabled] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(() => {
+    const params = new URLSearchParams(window.location.search);
+    const err = params.get("error");
+    if (!err) return null;
+    if (err === "github_denied") return "GitHub authorization was denied.";
+    if (err === "state_mismatch") return "The sign-in attempt expired. Try again.";
+    if (err === "exchange_failed") return "GitHub rejected the connection. Try again.";
+    if (err === "disabled") return "Credentials are not configured on this deployment.";
+    return "Connecting GitHub failed.";
+  });
+
+  const refresh = useCallback(async () => {
+    const result = await listCredentials();
+    if (result.ok) {
+      setCreds(result.credentials);
+      setEnabled(result.enabled);
+    } else {
+      setCreds([]);
+      setError(result.error);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const github = creds?.find((c) => c.provider === "github") ?? null;
+
+  const onConnect = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    const result = await connectGithub();
+    if (result.ok) {
+      window.location.assign(result.authorize_url);
+      return;
+    }
+    setBusy(false);
+    setError(
+      result.status === 409
+        ? "Credentials are not configured on this deployment."
+        : result.error,
+    );
+  }, []);
+
+  const onDisconnect = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    const result = await disconnectGithub();
+    setBusy(false);
+    if (result.ok) {
+      await refresh();
+    } else {
+      setError(result.error);
+    }
+  }, [refresh]);
+
+  return (
+    <Section
+      title="Credentials"
+      description="Connect external accounts. Connected credentials are injected into your managed sandbox sessions."
+    >
+      {error && (
+        <p role="alert" className="mb-4 text-sm text-destructive">
+          {error}
+        </p>
+      )}
+      <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="text-sm font-medium">GitHub</span>
+          <span className="text-sm text-muted-foreground">
+            {github
+              ? `Connected as ${github.login}${github.scopes ? ` (${github.scopes})` : ""}. Private repositories clone and push with your account.`
+              : "Authorize with GitHub so your sandbox sessions can clone and push your private repositories."}
+          </span>
+        </div>
+        {creds === null ? null : github ? (
+          <Button
+            variant="outline"
+            disabled={busy}
+            data-testid="settings-credentials-github-disconnect"
+            onClick={() => void onDisconnect()}
+          >
+            Disconnect
+          </Button>
+        ) : (
+          <Button
+            disabled={busy || !enabled}
+            data-testid="settings-credentials-github-connect"
+            onClick={() => void onConnect()}
+          >
+            Connect GitHub
+          </Button>
+        )}
       </div>
     </Section>
   );

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -686,6 +686,7 @@ function setupLandingMocks() {
     ok: false,
     error: "github_not_connected",
     status: 409,
+    code: "github_not_connected",
   });
   useHostsMock.mockReset();
   useHostModelOptionsMock.mockReset();
@@ -2496,6 +2497,28 @@ describe("NewChatLandingScreen", () => {
     fireEvent.focus(screen.getByTestId("new-chat-landing-repo-input"));
     await waitFor(() => expect(credentialsMocks.listGithubRepos).toHaveBeenCalledTimes(1));
     expect(await screen.findByText("Connect GitHub in Settings to browse your repos")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-repo-option")).toBeNull();
+  });
+
+  it("does not show the connect-GitHub hint when credentials are disabled on the deployment", async () => {
+    // A deployment with no GitHub OAuth App / encryption key configured
+    // gets the same 409 as "not connected yet", but a different code —
+    // Settings' Connect button is disabled there too, so the hint would
+    // be a dead end.
+    credentialsMocks.listGithubRepos.mockResolvedValue({
+      ok: false,
+      error: "credentials_disabled",
+      status: 409,
+      code: "credentials_disabled",
+    });
+    renderLanding({ managed_sandboxes_enabled: true });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
+    await waitFor(() => expect(screen.queryByTestId("new-chat-landing-sandbox-option")).toBeNull());
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
+    fireEvent.focus(screen.getByTestId("new-chat-landing-repo-input"));
+    await waitFor(() => expect(credentialsMocks.listGithubRepos).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText("Connect GitHub in Settings to browse your repos")).toBeNull();
     expect(screen.queryByTestId("new-chat-landing-repo-option")).toBeNull();
   });
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -63,6 +63,10 @@ vi.mock("@/hooks/useHosts", () => ({
   useStoreCredential: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useDetectedCredentials: vi.fn(() => ({ data: [] })),
 }));
+const credentialsMocks = vi.hoisted(() => ({
+  listGithubRepos: vi.fn(),
+}));
+vi.mock("@/lib/credentialsApi", () => credentialsMocks);
 // The setup dialog's copyable command rows call copyText; stub it so a click
 // can be asserted without touching the real clipboard.
 const { copyTextMock } = vi.hoisted(() => ({ copyTextMock: vi.fn(() => Promise.resolve()) }));
@@ -677,6 +681,12 @@ function mockAgents(agents: AvailableAgent[]) {
 // recent workspace so the working-directory field seeds to a known path.
 function setupLandingMocks() {
   authenticatedFetchMock.mockReset();
+  credentialsMocks.listGithubRepos.mockReset();
+  credentialsMocks.listGithubRepos.mockResolvedValue({
+    ok: false,
+    error: "github_not_connected",
+    status: 409,
+  });
   useHostsMock.mockReset();
   useHostModelOptionsMock.mockReset();
   useAvailableAgentsMock.mockReset();
@@ -2428,6 +2438,97 @@ describe("NewChatLandingScreen", () => {
       target: { value: "https://github.com/org/repo" },
     });
     expect(submit.disabled).toBe(false);
+  });
+
+  it("shows connected GitHub repos in a filterable dropdown and fills the URL on selection", async () => {
+    credentialsMocks.listGithubRepos.mockResolvedValue({
+      ok: true,
+      repos: [
+        {
+          full_name: "alice/proj-one",
+          clone_url: "https://github.com/alice/proj-one.git",
+          default_branch: "main",
+          private: false,
+        },
+        {
+          full_name: "alice/proj-two",
+          clone_url: "https://github.com/alice/proj-two.git",
+          default_branch: "main",
+          private: true,
+        },
+      ],
+    });
+    renderLanding({ managed_sandboxes_enabled: true });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
+    // Let the host-choice dropdown's close-and-restore-focus settle before
+    // opening the repo popover — otherwise its deferred focus restoration
+    // can steal focus back from the repo input mid-test.
+    await waitFor(() => expect(screen.queryByTestId("new-chat-landing-sandbox-option")).toBeNull());
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
+    fireEvent.focus(screen.getByTestId("new-chat-landing-repo-input"));
+    await waitFor(() => expect(credentialsMocks.listGithubRepos).toHaveBeenCalledTimes(1));
+    const options = await screen.findAllByTestId("new-chat-landing-repo-option");
+    expect(options).toHaveLength(2);
+
+    fireEvent.change(screen.getByTestId("new-chat-landing-repo-input"), {
+      target: { value: "proj-two" },
+    });
+    await waitFor(() =>
+      expect(screen.getAllByTestId("new-chat-landing-repo-option")).toHaveLength(1),
+    );
+
+    fireEvent.mouseDown(screen.getByTestId("new-chat-landing-repo-option"));
+    expect((screen.getByTestId("new-chat-landing-repo-input") as HTMLInputElement).value).toBe(
+      "https://github.com/alice/proj-two.git",
+    );
+  });
+
+  it("shows a connect-GitHub hint when GitHub isn't connected", async () => {
+    renderLanding({ managed_sandboxes_enabled: true });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
+    // Let the host-choice dropdown's close-and-restore-focus settle before
+    // opening the repo popover — otherwise its deferred focus restoration
+    // can steal focus back out of the popover mid-test.
+    await waitFor(() => expect(screen.queryByTestId("new-chat-landing-sandbox-option")).toBeNull());
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
+    fireEvent.focus(screen.getByTestId("new-chat-landing-repo-input"));
+    await waitFor(() => expect(credentialsMocks.listGithubRepos).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText("Connect GitHub in Settings to browse your repos")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-repo-option")).toBeNull();
+  });
+
+  it("still accepts an arbitrary pasted URL when the repo list is loaded", async () => {
+    credentialsMocks.listGithubRepos.mockResolvedValue({
+      ok: true,
+      repos: [
+        {
+          full_name: "alice/proj-one",
+          clone_url: "https://github.com/alice/proj-one.git",
+          default_branch: "main",
+          private: false,
+        },
+      ],
+    });
+    renderLanding({ managed_sandboxes_enabled: true });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
+    // Let the host-choice dropdown's close-and-restore-focus settle before
+    // opening the repo popover — otherwise its deferred focus restoration
+    // can steal focus back out of the popover mid-test.
+    await waitFor(() => expect(screen.queryByTestId("new-chat-landing-sandbox-option")).toBeNull());
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
+    fireEvent.focus(screen.getByTestId("new-chat-landing-repo-input"));
+    await waitFor(() => expect(credentialsMocks.listGithubRepos).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId("new-chat-landing-repo-input"), {
+      target: { value: "https://github.com/someone-else/other-repo" },
+    });
+    expect(screen.queryByTestId("new-chat-landing-repo-option")).toBeNull();
+    expect((screen.getByTestId("new-chat-landing-repo-input") as HTMLInputElement).value).toBe(
+      "https://github.com/someone-else/other-repo",
+    );
   });
 });
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2053,8 +2053,14 @@ export function NewChatLandingScreen() {
     setGithubRepoPicker({ status: "loading" });
     void listGithubRepos().then((result) => {
       if (!result.ok) {
+        // Only the "you haven't connected yet" case gets the "Connect
+        // GitHub in Settings" hint — a deployment with credentials
+        // disabled entirely (or any other failure) has no actionable
+        // next step there, so it falls into the silent error state.
         setGithubRepoPicker(
-          result.status === 409 ? { status: "not_connected" } : { status: "error" },
+          result.status === 409 && result.code === "github_not_connected"
+            ? { status: "not_connected" }
+            : { status: "error" },
         );
         return;
       }
@@ -4506,6 +4512,15 @@ export function NewChatLandingScreen() {
                           role="combobox"
                           aria-expanded={repoInputFocused && filteredGithubRepos.length > 0}
                           aria-autocomplete="list"
+                          // Suppress the browser's native autofill dropdown so it
+                          // doesn't overlay our repo combobox. `off` alone is
+                          // ignored by some browsers, so also disable spellcheck /
+                          // autocorrect and give it an unrecognized name.
+                          autoComplete="off"
+                          autoCorrect="off"
+                          autoCapitalize="off"
+                          spellCheck={false}
+                          name="omnigent-sandbox-repo-url"
                           className="rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors focus-visible:border-ring"
                           data-testid="new-chat-landing-repo-input"
                         />

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -132,6 +132,7 @@ import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
 import { partitionAgentsByKind, sortAgentsForDisplay } from "@/lib/agentGrouping";
 import { cn } from "@/lib/utils";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
+import { listGithubRepos, type GithubRepoInfo } from "@/lib/credentialsApi";
 import {
   isFullySupportedNativeCodingAgent,
   isNativeCodingAgent,
@@ -2033,6 +2034,39 @@ export function NewChatLandingScreen() {
   const [sandboxRepoBranch, setSandboxRepoBranch] = useState<string>(
     () => landingDraft?.sandboxRepoBranch ?? "",
   );
+  // The repository field doubles as a combobox: focusing it fetches the
+  // caller's GitHub repos (once per dialog instance) if connected, and
+  // typing filters them. A value matching none is used as a plain URL,
+  // unchanged from the field's pre-picker behavior.
+  type GithubRepoPickerState =
+    | { status: "idle" }
+    | { status: "loading" }
+    | { status: "ready"; repos: GithubRepoInfo[] }
+    | { status: "not_connected" }
+    | { status: "error" };
+  const [githubRepoPicker, setGithubRepoPicker] = useState<GithubRepoPickerState>({
+    status: "idle",
+  });
+  const [repoInputFocused, setRepoInputFocused] = useState(false);
+  const fetchGithubRepos = useCallback(() => {
+    if (githubRepoPicker.status !== "idle") return;
+    setGithubRepoPicker({ status: "loading" });
+    void listGithubRepos().then((result) => {
+      if (!result.ok) {
+        setGithubRepoPicker(
+          result.status === 409 ? { status: "not_connected" } : { status: "error" },
+        );
+        return;
+      }
+      setGithubRepoPicker({ status: "ready", repos: result.repos });
+    });
+  }, [githubRepoPicker]);
+  const filteredGithubRepos = useMemo(() => {
+    if (githubRepoPicker.status !== "ready") return [];
+    const q = sandboxRepoUrl.trim().toLowerCase();
+    if (q === "") return githubRepoPicker.repos;
+    return githubRepoPicker.repos.filter((r) => r.full_name.toLowerCase().includes(q));
+  }, [githubRepoPicker, sandboxRepoUrl]);
   const [workspace, setWorkspace] = useState<string>(() => landingDraft?.workspace ?? "");
   const [branchName, setBranchName] = useState<string>(() => landingDraft?.branchName ?? "");
   // The base branch auto-fills from the configured default (Settings › Git)
@@ -4455,15 +4489,65 @@ export function NewChatLandingScreen() {
                           </Tooltip>
                         )}
                       </div>
-                      <input
-                        id="landing-repo-url"
-                        type="text"
-                        value={sandboxRepoUrl}
-                        onChange={(e) => setSandboxRepoUrl(e.target.value)}
-                        placeholder="https://github.com/org/repo"
-                        className="rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors focus-visible:border-ring"
-                        data-testid="new-chat-landing-repo-input"
-                      />
+                      <div className="relative flex flex-col">
+                        <input
+                          id="landing-repo-url"
+                          type="text"
+                          value={sandboxRepoUrl}
+                          onChange={(e) => setSandboxRepoUrl(e.target.value)}
+                          onFocus={() => {
+                            setRepoInputFocused(true);
+                            fetchGithubRepos();
+                          }}
+                          // Delay so a click on a dropdown option registers
+                          // before the list unmounts on blur.
+                          onBlur={() => setTimeout(() => setRepoInputFocused(false), 120)}
+                          placeholder="https://github.com/org/repo"
+                          role="combobox"
+                          aria-expanded={repoInputFocused && filteredGithubRepos.length > 0}
+                          aria-autocomplete="list"
+                          className="rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors focus-visible:border-ring"
+                          data-testid="new-chat-landing-repo-input"
+                        />
+                        {repoInputFocused && filteredGithubRepos.length > 0 && (
+                          <div
+                            className="absolute top-full right-0 left-0 z-20 mt-1 flex max-h-40 flex-col overflow-y-auto rounded-[12px] border border-border bg-popover p-2 shadow-menu"
+                            data-testid="new-chat-landing-repo-dropdown"
+                          >
+                            <ul className="flex flex-col gap-0.5">
+                              {filteredGithubRepos.map((r) => (
+                                <li key={r.full_name}>
+                                  <button
+                                    type="button"
+                                    // onMouseDown (not onClick): fires before
+                                    // the input's blur, so the selection lands
+                                    // even though blur is about to hide the list.
+                                    onMouseDown={(e) => {
+                                      e.preventDefault();
+                                      setSandboxRepoUrl(r.clone_url);
+                                      setRepoInputFocused(false);
+                                    }}
+                                    className="flex w-full items-center justify-between gap-2 rounded-md px-1.5 py-1 text-left text-sm transition-colors hover:bg-muted dark:hover:bg-muted/50"
+                                    data-testid="new-chat-landing-repo-option"
+                                  >
+                                    <span className="truncate text-foreground">{r.full_name}</span>
+                                    {r.private && (
+                                      <span className="shrink-0 text-[10px] text-muted-foreground">
+                                        private
+                                      </span>
+                                    )}
+                                  </button>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                      </div>
+                      {githubRepoPicker.status === "not_connected" && (
+                        <p className="text-sm text-muted-foreground">
+                          Connect GitHub in Settings to browse your repos
+                        </p>
+                      )}
                       <input
                         type="text"
                         value={sandboxRepoBranch}

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -13,6 +13,7 @@ import {
   DownloadIcon,
   GitBranchIcon,
   KeyboardIcon,
+  KeyRoundIcon,
   PaletteIcon,
   Share2Icon,
   ShieldCheckIcon,
@@ -32,6 +33,7 @@ import { SIDEBAR_ROW } from "./sidebarStyles";
 export type SettingsSectionId =
   | "appearance"
   | "git"
+  | "credentials"
   | "shortcuts"
   | "account"
   | "members"
@@ -44,6 +46,7 @@ export type SettingsSectionId =
 const SECTION_IDS: readonly SettingsSectionId[] = [
   "appearance",
   "git",
+  "credentials",
   "shortcuts",
   "account",
   "members",
@@ -85,6 +88,7 @@ export function settingsNavGroups(
   const general: SettingsNavItem[] = [
     { id: "appearance", label: "Appearance", icon: PaletteIcon },
     { id: "git", label: "Git", icon: GitBranchIcon },
+    { id: "credentials", label: "Credentials", icon: KeyRoundIcon },
     { id: "shortcuts", label: "Keyboard shortcuts", icon: KeyboardIcon, hideOnMobile: true },
   ];
   if (hasAuthSession) {


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds a **Credentials** section to Settings where each user connects their GitHub
account via OAuth, and injects that user's token into their managed sandbox
sessions as `GIT_TOKEN` — so agents can clone and push the user's private
repositories without the operator pre-provisioning a shared `GIT_TOKEN` in the
harness Secret.

- **Store** — new `user_credentials` table (one row per user+provider) with the
  token **Fernet-encrypted at rest** under `OMNIGENT_CREDENTIAL_ENCRYPTION_KEY`.
  Missing/invalid key ⇒ feature disabled, everything else unaffected.
- **Routes** — `GET/DELETE /v1/credentials`, `POST /v1/credentials/github/connect`
  (HMAC-bound `state`), `GET /auth/github/credential-callback` (code exchange +
  identity fetch + encrypted upsert). Tokens never appear in any API response.
  Configured via `OMNIGENT_GITHUB_CREDENTIAL_CLIENT_ID/SECRET`; unset ⇒ `connect`
  returns `409 credentials_disabled`.
- **UI** — a Credentials card on `SettingsPage`: Connect GitHub (full-page OAuth
  redirect) / connected login + scopes + Disconnect, with `?connected=`/`?error=`
  banner handling.
- **Injection** — a provider-agnostic `extra_env` seam threaded
  `sessions.py → launch_managed_host → SandboxLauncher.start_host`. The Kubernetes
  launcher merges it into the **existing per-Pod launch-token Secret** (values
  never enter the Pod spec or logs) and projects it via `secretKeyRef` into both
  the clone init-container and the host. No credential connected ⇒ `extra_env`
  omitted, i.e. today's exact behavior; a launcher predating the kwarg keeps
  working.

The host image's git credential helper already answers HTTPS auth from
`GIT_TOKEN`, so no host/runner changes are needed.

### ELI5

Instead of the server operator hard-coding one GitHub token that every sandbox
shares, each person clicks "Connect GitHub" once in Settings. From then on, when
their agent runs in a cloud sandbox, it borrows *their* GitHub access to reach
*their* private repos — and the token rides the same per-session secret the
sandbox already uses, never landing in a pod spec or a log.

```
Settings ──Connect GitHub──▶ /connect ──▶ GitHub OAuth ──▶ /credential-callback
                                                                │ encrypt + store
                                                                ▼
new managed session ──▶ launch_managed_host(extra_env={GIT_TOKEN})
                                    │
                                    ▼
                        per-Pod launch Secret  ──secretKeyRef──▶ runner Pod (clone + agent)
```

### Update: GitHub repo picker for the sandbox Repository field

Once GitHub is connected, the New Chat dialog's sandbox "Repository" field is
now a searchable combobox instead of a plain URL text box:

- New `GET /v1/credentials/github/repos` route: server-side proxy that lists the
  caller's GitHub repos (owner, collaborator, and org-member affiliations, most
  recently pushed first, capped at GitHub's 100/page max) using the same stored,
  decrypted token — the token never reaches the browser, same trust boundary as
  the rest of this feature.
- Frontend: focusing the Repository field fetches the list once per dialog
  instance; typing filters it client-side; selecting a repo fills the URL field;
  typing a value that matches nothing still works as free text exactly as
  before — this field's pre-existing behavior for anyone not using the picker,
  or for repos outside the fetched page, is fully preserved.
- Every failure mode (not connected, deployment doesn't have the feature
  configured, GitHub API error) degrades to the plain-text field with no
  blocking error — the picker is purely additive.
- Also fixes two small pre-existing bugs surfaced while building this:
  `credentialsApi.ts`'s fetch calls now go through `authenticatedFetch` (matching
  every other `*Api.ts` client in the codebase — the bare `fetch()` calls were
  resolving the wrong user identity in header-auth/embedded deployments), and a
  `failureFrom` bug where the client read the server's structured
  `{error: {code, message}}` body as if `error` were a plain string.

Design spec and implementation plan for this addition are included in the diff
(`docs/superpowers/specs/2026-08-08-github-repo-picker-design.md`,
`docs/superpowers/plans/2026-08-08-github-repo-picker.md`) if useful context for
review.

## Test Plan

- `pytest tests/stores/test_credential_store.py` — encrypt/decrypt round-trip,
  key-absent + key-rotation paths.
- `pytest tests/server/routes/test_credentials.py` — auth gate, `state`
  validation, callback happy-path/bad-state, token never in the response body,
  connect-disabled-without-client-id, plus (repo picker) connected/not-connected/
  disabled/decrypt-failure/GitHub-API-failure for the new repos route, and a
  `respx`-backed test asserting the real outbound request's affiliation/sort/
  per_page params.
- `pytest tests/server/routes/test_credentials_injection.py` — owner credential →
  `extra_env`, no-credential/no-store ⇒ omitted, undecryptable ⇒ omitted + warn.
- `pytest tests/onboarding/sandboxes/test_kubernetes.py` — extra pairs ride the
  token Secret; keys projected via `secretKeyRef` into both containers; values
  never inlined in the Pod spec.
- `pytest tests/server/test_managed_hosts.py` — including the legacy-launcher
  signature guard (kwarg omitted when unset).
- Web: full `vitest` suite green + 3 new `CredentialsSection` tests + (repo
  picker) 3 new `NewChatDialog` tests (dropdown populates + filters + selects,
  connect-hint shown only for the genuine not-connected case and suppressed when
  the deployment itself doesn't have the feature configured, arbitrary pasted
  URL still works) + 8 new `credentialsApi.test.ts` tests covering all four
  exported client functions.
- Manual: deployed to a live Kubernetes-sandbox cluster; connected GitHub in
  Settings, launched a managed session, and confirmed `git ls-remote` against a
  private repo succeeds inside the sandbox; Disconnect ⇒ a new session's clone
  fails auth. (Repo picker) confirmed on the same live deployment: focusing the
  Repository field with GitHub connected populates the dropdown with real repos,
  typing filters them, selecting one fills the field correctly, and the
  resulting session workspace clones as expected.
- Built via a task-scoped plan with an independent review after each task and a
  separate final whole-branch review before merge; the final review caught and
  reverted one false-positive fix from earlier in development (an unrelated
  `radix-ui` import "fix" whose premise didn't reproduce once verified against a
  clean install) before it could land.

## Demo

End-to-end on a live Kubernetes-sandbox deployment.

**1. Settings → Credentials (disconnected)** — the new card with a "Connect GitHub" button.

<img width="2000" height="799" alt="image-1784568638995" src="https://github.com/user-attachments/assets/8451afdf-ed1b-4030-96be-ed570f3282a3" />

**2. GitHub OAuth consent** — "Sign in to GitHub to continue to Omnigent".

<img width="674" height="695" alt="image-1784568661634" src="https://github.com/user-attachments/assets/7bfc4e1a-1921-48e3-8ee1-f38b569bd625" />

**3. Settings → Credentials (connected)** — "Connected as <login> (repo)", with Disconnect.

<img width="2000" height="771" alt="image-1784568654126" src="https://github.com/user-attachments/assets/16a59775-ef95-4b51-815f-4de64d908af4" />

<img width="1274" height="826" alt="Screenshot 2026-07-20 at 11 19 58 AM" src="https://github.com/user-attachments/assets/98224431-9dd7-4f08-b05b-1062f1164633" />

Once connected, a managed sandbox session clones/pushes the user's private repos
with their `GIT_TOKEN`; Disconnect reverts a new session to no access.

**4. Repo picker (new)** — with GitHub connected, opening the sandbox
Repository chip and focusing the URL field now shows a searchable dropdown of
the connected account's repos (owner/collaborator/org-member, most-recently-
pushed first). Typing filters the list; clicking a repo fills the field with
its clone URL; typing something that matches nothing still sets the field as
plain text, identical to the pre-existing behavior. Verified manually against
this same live deployment — screenshots not attached to this update; happy to
add one on request.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the store (encryption + rotation), the OAuth routes (auth gate,
state validation, callback branches, token masking), the injection resolution,
the Kubernetes manifest wiring, and (repo picker) the new listing route plus its
frontend combobox and client wrapper. Manual verification exercised the full
end-to-end path on a live Kubernetes-sandbox deployment for both the original
credential-connect flow and the new repo picker (connect → managed session →
private-repo clone → disconnect; connect → repo picker → filter/select → session
creation). Providers other than Kubernetes accept-and-ignore `extra_env` for
now. No new database migrations in the repo-picker addition.

## Changelog

Connect your GitHub account in Settings → Credentials to give your managed
sandbox sessions access to your private repositories, and pick a repo from a
searchable dropdown in the sandbox session's Repository field instead of
pasting a URL
