### PR TITLE
test(e2e): de-flake custom-theme randomize color picker

### DIFF
--- a/tests/e2e_ui/sessions/test_color_theme.py
+++ b/tests/e2e_ui/sessions/test_color_theme.py
@@ -207,10 +207,22 @@ def test_custom_theme_colors_can_be_randomized(
     """Randomizing accent and tint updates the picker and persisted theme."""
     base_url, _session_id = seeded_session
     _open_appearance(page, base_url)
+    # The color popover animates in and Floating UI repositions it on mount,
+    # which can leave its controls briefly unstable / remounting on a loaded
+    # runner — a click racing that enter transition flakes with "element is not
+    # stable" / "detached from the DOM". Kill transitions/animations so the
+    # popover is clickable the instant it mounts.
+    page.add_style_tag(
+        content="*, *::before, *::after "
+        "{ animation: none !important; transition: none !important; }"
+    )
     page.evaluate("Math.random = () => 0.5")
 
     for test_id in ["custom-theme-accent", "custom-theme-tint"]:
         page.get_by_test_id(f"{test_id}-trigger").click()
+        # Wait for the popover to fully mount (its hex input is visible) before
+        # clicking randomize, so the click can't land on a not-yet-settled node.
+        expect(page.get_by_test_id(f"{test_id}-input")).to_be_visible()
         page.get_by_test_id(f"{test_id}-randomize").click()
         expect(page.get_by_test_id(f"{test_id}-input")).to_have_value("#3AD2D2")
         page.keyboard.press("Escape")


### PR DESCRIPTION
## Related issue

N/A

## Summary

`tests/e2e_ui/sessions/test_color_theme.py::test_custom_theme_colors_can_be_randomized` is flaky in CI ([example failure](https://github.com/omnigent-ai/omnigent/actions/runs/29722618311/job/88288768080?pr=2765)).

- The failure is a Playwright *timeout* ("element is not stable" → "element was detached from the DOM"), not an assertion — so the feature works; the test races the UI.
- Root cause: the randomize button lives inside a Radix `PopoverContent` (`web/src/components/theme/ThemeColorPicker.tsx`) that animates in and is repositioned by Floating UI on mount, and carries `transition-[…,transform]` classes. On a loaded runner a click can land while the popover is still animating/remounting. The first (`accent`) picker won the race; the second (`tint`) picker lost it — the classic timing-flake signature.
- Fix: inject a stylesheet disabling all CSS `animation`/`transition`, and wait for the popover to fully mount (its hex `input` visible) before clicking randomize. The randomize `onClick` is a pure `onChange(randomColor())`, so behaviour is unchanged and the existing value/persistence assertions still guard correctness.

## Test Plan

Run locally against a freshly built SPA + spawned mock server:

```bash
uv sync --extra dev
uv run playwright install --with-deps chromium
uv run pytest tests/e2e_ui/sessions/test_color_theme.py::test_custom_theme_colors_can_be_randomized -q  # builds SPA once
```

Verified the fix is stable:
- 5× reruns (fresh) → 5/5 pass
- 10× reruns → 10/10 pass
- 8× reruns while system load average was ~220 (a harsher condition than the CI runner that flaked) → 8/8 pass
- Full `test_color_theme.py` (4 tests) → all pass
- `ruff format` + `ruff check` clean; pre-commit hooks green

## Demo

N/A — test-only change, no UI behaviour change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Stabilizes an existing E2E test; verified by repeated local reruns (including under heavy CPU load) as described in the Test Plan.

This pull request and its description were written by Isaac.