### PR TITLE
fix(sessions): don't show runner_disconnected error on intentional stop

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8706,7 +8706,7 @@ async def _stop_session_host_runner(
     host_id: str,
     runner_id: str,
     host_registry: Any,
-) -> None:
+) -> bool:
     """
     Terminate the host-launched runner backing a host-spawned session.
 
@@ -8743,10 +8743,14 @@ async def _stop_session_host_runner(
     :param host_registry: The :class:`HostRegistry` tracking live host
         tunnels on this replica, or ``None`` when host support is not wired
         (in-process / test setups without a host tunnel).
-    :returns: None.
+    :returns: ``True`` when the stop was delivered and acknowledged (the
+        runner is exiting, so a tunnel drop is expected); ``False`` on any
+        best-effort early-out (no host registry, host offline/replaced,
+        ack timeout, or host-reported failure) where the runner may keep
+        running and no tunnel drop will follow.
     """
     if host_registry is None:
-        return
+        return False
     conn = host_registry.get(host_id)
     if conn is None:
         _logger.warning(
@@ -8757,7 +8761,7 @@ async def _stop_session_host_runner(
             session_id,
             host_id,
         )
-        return
+        return False
     from omnigent.host.frames import HostStopRunnerFrame, encode_host_frame
 
     request_id = secrets.token_hex(8)
@@ -8776,7 +8780,7 @@ async def _stop_session_host_runner(
             session_id,
             host_id,
         )
-        return
+        return False
     try:
         result = await asyncio.wait_for(
             future,
@@ -8790,7 +8794,7 @@ async def _stop_session_host_runner(
             runner_id,
             session_id,
         )
-        return
+        return False
     if result.get("status") == "failed":
         _logger.warning(
             "Host %s failed to stop runner %s for session %s: %s",
@@ -8799,6 +8803,8 @@ async def _stop_session_host_runner(
             session_id,
             result.get("error"),
         )
+        return False
+    return True
 
 
 def _build_new_item(
@@ -10393,11 +10399,6 @@ async def _relay_runner_stream(
                     if session_id in _interrupt_fenced_sessions:
                         if evt_type == "session.status" and event.get("status") == "running":
                             _interrupt_fenced_sessions.discard(session_id)
-                            # A new turn proves the runner is live again: a stop
-                            # that never dropped the tunnel must not leave the
-                            # intentional-stop marker to swallow a later genuine
-                            # disconnect.
-                            _intentional_stop_sessions.discard(session_id)
                         elif evt_type in _TERMINAL_RESPONSE_EVENT_TYPES:
                             # Terminal proves the stopped turn is over (completed =
                             # the stop lost the race); process it normally.
@@ -10434,6 +10435,13 @@ async def _relay_runner_stream(
                                     None,
                                     conversation_store,
                                 )
+                                # A new turn proves the runner is live again, so
+                                # a prior Stop that never dropped the tunnel must
+                                # not leave the intentional-stop marker to swallow
+                                # this turn's genuine disconnect. Fence-independent
+                                # (the fence may already be cleared by a terminal
+                                # stop event), so it fires on every running edge.
+                                _intentional_stop_sessions.discard(session_id)
                             # PTY-activity status is a UI signal only. Terminal
                             # sub-agent delivery rides the Stop/StopFailure hook
                             # via external_session_status (the codex-shared path)
@@ -10796,6 +10804,12 @@ async def _relay_runner_stream(
         # mid-turn, or a rebind cancellation) can't strand it forever.
         # Normal turn-ends already clear via record_publish.
         inflight_text.discard(session_id)
+        # The intentional-stop marker is consumed by the disconnect handler
+        # above on the expected path; discard it here too so a relay that
+        # exits some other way (clean [DONE], rebind cancellation) can't
+        # leave a stale marker to swallow a later genuine disconnect on the
+        # reused per-session relay task.
+        _intentional_stop_sessions.discard(session_id)
         # Relay ended (runner dropped/rebound): re-discover runner-backed
         # snapshot overlays next time. Cancel in-flight fetches so they can't
         # land stale values from the dead runner after this pop.
@@ -20311,12 +20325,20 @@ def create_sessions_router(
                 # sessions drop the tunnel on Stop; other harnesses leave the
                 # runner connected, so there is nothing to suppress for them.
                 _intentional_stop_sessions.add(session_id)
-                await _stop_session_host_runner(
+                teardown_delivered = await _stop_session_host_runner(
                     session_id,
                     stop_conv.host_id,
                     stop_conv.runner_id,
                     getattr(request.app.state, "host_registry", None),
                 )
+                if not teardown_delivered:
+                    # Best-effort stop did not land (host offline / timeout /
+                    # failure): no tunnel drop will follow, so the relay won't
+                    # reach the disconnect handler that consumes the marker.
+                    # Discard it now so it can't outlive this turn on the
+                    # reused per-session relay task and later swallow a genuine
+                    # runner_disconnected as a quiet idle.
+                    _intentional_stop_sessions.discard(session_id)
             # Stop is non-sticky: no persistent marker is written. The
             # runner tunnel dropping above flips ``runner_online`` to false
             # honestly, and the next message auto-relaunches the session on

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -1054,6 +1054,13 @@ def _prune_session_read_state(session_id: str) -> None:
 # turn's "running" status or on any terminal response.* event.
 _interrupt_fenced_sessions: set[str] = set()
 
+# Host-spawned sessions whose runner tunnel we are about to tear down on
+# purpose as part of a user-initiated Stop. The relay's disconnect handler
+# consults this so an intentional tunnel drop resolves to a quiet idle state
+# instead of a scary ``runner_disconnected`` failure. One-shot: the disconnect
+# handler discards it, so a later genuine disconnect still surfaces normally.
+_intentional_stop_sessions: set[str] = set()
+
 # Turn-terminal response lifecycle events: the relay flushes buffered
 # assistant text on each of these and resets its turn-scoped state.
 _TERMINAL_RESPONSE_EVENT_TYPES: frozenset[str] = frozenset(
@@ -10386,6 +10393,11 @@ async def _relay_runner_stream(
                     if session_id in _interrupt_fenced_sessions:
                         if evt_type == "session.status" and event.get("status") == "running":
                             _interrupt_fenced_sessions.discard(session_id)
+                            # A new turn proves the runner is live again: a stop
+                            # that never dropped the tunnel must not leave the
+                            # intentional-stop marker to swallow a later genuine
+                            # disconnect.
+                            _intentional_stop_sessions.discard(session_id)
                         elif evt_type in _TERMINAL_RESPONSE_EVENT_TYPES:
                             # Terminal proves the stopped turn is over (completed =
                             # the stop lost the race); process it normally.
@@ -10740,26 +10752,41 @@ async def _relay_runner_stream(
             session_id,
             exc_info=True,
         )
-        # Publish a failed status so the client's SSE stream sees a
-        # clean error event instead of silent truncation (#1114).
-        disconnect_error = ErrorDetail(
-            code="runner_disconnected",
-            message="Runner disconnected unexpectedly.",
-        )
-        _publish_status(session_id, "failed", disconnect_error)
-        # Persist the disconnect cause as durable labels so the
-        # distinction survives into snapshots and child-session
-        # summaries. Without this the relay-fed cache only carries a
-        # generic ``failed`` and ``last_task_error`` is dropped, leaving
-        # the UI unable to tell a benign runner disconnect from a real
-        # task failure (Option B: render a "Disconnected" pill, not the
-        # red "Failed" pill). Cleared on the next ``running`` edge by the
-        # session.status handler, exactly like other failure labels.
-        await _persist_session_status_error_labels(
-            session_id,
-            disconnect_error,
-            conversation_store,
-        )
+        if session_id in _intentional_stop_sessions:
+            # User clicked Stop: the Stop handler brought this runner's tunnel
+            # down on purpose (see _stop_session_host_runner), so the drop is
+            # expected — not a failure. Publish a quiet idle and clear any error
+            # label so the chat and sidebar settle to a stopped state instead of
+            # rendering "Error · runner_disconnected". One-shot: discard the
+            # marker so a genuine later disconnect surfaces normally.
+            _intentional_stop_sessions.discard(session_id)
+            _publish_status(session_id, "idle")
+            await _persist_session_status_error_labels(
+                session_id,
+                None,
+                conversation_store,
+            )
+        else:
+            # Publish a failed status so the client's SSE stream sees a
+            # clean error event instead of silent truncation (#1114).
+            disconnect_error = ErrorDetail(
+                code="runner_disconnected",
+                message="Runner disconnected unexpectedly.",
+            )
+            _publish_status(session_id, "failed", disconnect_error)
+            # Persist the disconnect cause as durable labels so the
+            # distinction survives into snapshots and child-session
+            # summaries. Without this the relay-fed cache only carries a
+            # generic ``failed`` and ``last_task_error`` is dropped, leaving
+            # the UI unable to tell a benign runner disconnect from a real
+            # task failure (Option B: render a "Disconnected" pill, not the
+            # red "Failed" pill). Cleared on the next ``running`` edge by the
+            # session.status handler, exactly like other failure labels.
+            await _persist_session_status_error_labels(
+                session_id,
+                disconnect_error,
+                conversation_store,
+            )
     except asyncio.CancelledError:
         raise
     finally:
@@ -20278,6 +20305,12 @@ def create_sessions_router(
             # only ever stop the runner bound to this session.
             stop_conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
             if stop_conv is not None and stop_conv.host_id and stop_conv.runner_id:
+                # Mark the tunnel drop as intentional BEFORE tearing it down so
+                # the relay's disconnect handler renders a quiet stopped state
+                # rather than "Error · runner_disconnected". Only host-spawned
+                # sessions drop the tunnel on Stop; other harnesses leave the
+                # runner connected, so there is nothing to suppress for them.
+                _intentional_stop_sessions.add(session_id)
                 await _stop_session_host_runner(
                     session_id,
                     stop_conv.host_id,
@@ -21328,6 +21361,7 @@ def create_sessions_router(
                 reason="session-delete",
             )
         _interrupt_fenced_sessions.discard(session_id)
+        _intentional_stop_sessions.discard(session_id)
         deleted = await conversation_store.delete_conversation(session_id)
         if not deleted:
             raise _session_not_found()

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -631,3 +631,71 @@ async def test_runner_recovery_clears_persisted_disconnect_error_labels() -> Non
         sessions_module._runner_relay_tasks.clear()
         sessions_module._session_status_cache.pop(session_id, None)
         session_stream.close(session_id)
+
+
+@pytest.mark.asyncio
+async def test_relay_suppresses_disconnect_error_on_intentional_stop() -> None:
+    """
+    A user-initiated Stop drops the tunnel quietly, not as a failure.
+
+    Stopping a host-spawned session tears down its runner tunnel on
+    purpose, which makes the relay hit the same ``ConnectionError`` path a
+    genuine runner death takes. The Stop handler marks the session in
+    ``_intentional_stop_sessions`` first, so the relay must resolve to a
+    quiet ``idle`` (no ``runner_disconnected`` status, no persisted error
+    labels) rather than rendering "Error · runner_disconnected".
+    """
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+
+    sessions_module._runner_relay_tasks.clear()
+    gate = asyncio.Event()
+    fake_runner = _TunnelCloseRunnerClient(gate)
+    store = _RecordingLabelStore()
+    session_id = "b7c1e2d3f4a5968778695a4b3c2d1e0f"
+
+    collector = None
+    try:
+        # Simulate the Stop handler: mark the intentional teardown before
+        # the tunnel drops.
+        sessions_module._intentional_stop_sessions.add(session_id)
+
+        handle = await sessions_module._ensure_runner_relay_ready(
+            session_id,
+            "runner_intentional_stop",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=store,  # type: ignore[arg-type]
+        )
+        assert handle is not None
+
+        collector = await start_session_stream_collector(session_id)
+        gate.set()
+        await asyncio.wait_for(handle.task, timeout=2.0)
+
+        # The relay publishes a quiet idle, never a runner_disconnected failure.
+        event = await asyncio.wait_for(collector.queue.get(), timeout=2.0)
+        assert event.get("type") == "session.status"
+        assert event.get("status") == "idle"
+        assert event.get("error") is None
+
+        # The marker is one-shot: consumed by the disconnect handler.
+        assert session_id not in sessions_module._intentional_stop_sessions
+
+        # No durable runner_disconnected label persists, so snapshots and
+        # child summaries stay clean.
+        persisted = store.labels.get(session_id)
+        assert persisted is not None
+        assert sessions_module._last_task_error_from_labels(persisted) is None
+    finally:
+        gate.set()
+        sessions_module._intentional_stop_sessions.discard(session_id)
+        if collector is not None:
+            await collector.stop()
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None and not handle.task.done():
+            handle.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(handle.task, timeout=1.0)
+        sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
+        session_stream.close(session_id)

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -699,3 +699,137 @@ async def test_relay_suppresses_disconnect_error_on_intentional_stop() -> None:
         sessions_module._runner_relay_tasks.clear()
         sessions_module._session_status_cache.pop(session_id, None)
         session_stream.close(session_id)
+
+
+class _ScriptedThenDropStreamResponse:
+    """Async stream that emits scripted SSE frames, then raises ``ConnectionError``.
+
+    Unlike ``_ScriptedStreamResponse`` (which closes cleanly with
+    ``[DONE]``), this replays scripted frames and then drops the tunnel so
+    the relay hits its disconnect handler after processing them.
+
+    :param frames: Ready-to-send ``data: ...`` frames yielded in order
+        before the tunnel drop.
+    :param gate: Event the test sets once subscribed, gating the drop so
+        the collector observes every scripted frame first.
+    """
+
+    def __init__(self, frames: list[str], gate: asyncio.Event) -> None:
+        self._frames = frames
+        self._gate = gate
+
+    async def __aenter__(self) -> _ScriptedThenDropStreamResponse:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exc_type, exc, traceback
+
+    async def aiter_text(self) -> AsyncIterator[str]:
+        yield 'data: {"type": "session.heartbeat"}\n\n'
+        for frame in self._frames:
+            yield frame
+        await self._gate.wait()
+        raise ConnectionError("tunnel closed before request completed")
+
+
+class _ScriptedThenDropRunnerClient:
+    """Fake runner client whose stream replays scripted frames then drops."""
+
+    def __init__(self, frames: list[str], gate: asyncio.Event) -> None:
+        self._frames = frames
+        self._gate = gate
+
+    def stream(
+        self,
+        method: str,
+        path: str,
+        *,
+        timeout: Any,
+    ) -> _ScriptedThenDropStreamResponse:
+        del method, path, timeout
+        return _ScriptedThenDropStreamResponse(self._frames, self._gate)
+
+
+@pytest.mark.asyncio
+async def test_relay_running_edge_clears_stale_intentional_stop_marker() -> None:
+    """
+    A new turn after a Stop must not suppress a later genuine disconnect.
+
+    The relay task is long-lived and reused across turns, and the marker
+    set is module-level. A Stop typically emits a terminal
+    ``response.cancelled`` (which clears the interrupt fence) before any
+    tunnel drop, and a stop that never drops the tunnel leaves the marker
+    set. The next turn's ``running`` edge must clear the marker — fence
+    membership is already gone — so that a genuine runner death during that
+    later turn still surfaces ``runner_disconnected`` rather than being
+    silently downgraded to a quiet idle.
+    """
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+
+    sessions_module._runner_relay_tasks.clear()
+    gate = asyncio.Event()
+    # Terminal stop event clears the fence, then a new turn's running edge
+    # must clear the stale intentional-stop marker, then the tunnel drops.
+    frames = [
+        'data: {"type": "response.cancelled"}\n\n',
+        'data: {"type": "session.status", "status": "running"}\n\n',
+    ]
+    fake_runner = _ScriptedThenDropRunnerClient(frames, gate)
+    store = _RecordingLabelStore()
+    session_id = "c9d2f3a4b5061728394a5b6c7d8e9f01"
+
+    collector = None
+    try:
+        # A prior Stop left both markers set (terminal event will clear the
+        # fence; the marker must survive to the running edge, then clear).
+        sessions_module._interrupt_fenced_sessions.add(session_id)
+        sessions_module._intentional_stop_sessions.add(session_id)
+
+        handle = await sessions_module._ensure_runner_relay_ready(
+            session_id,
+            "runner_stale_marker",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=store,  # type: ignore[arg-type]
+        )
+        assert handle is not None
+
+        collector = await start_session_stream_collector(session_id)
+        gate.set()
+        await asyncio.wait_for(handle.task, timeout=2.0)
+
+        # The running edge cleared the marker, so the subsequent tunnel drop
+        # is treated as a GENUINE disconnect: failed + runner_disconnected.
+        statuses = []
+        while not collector.queue.empty():
+            statuses.append(await collector.queue.get())
+        failed = [e for e in statuses if e.get("status") == "failed"]
+        assert failed, f"expected a failed status, saw {statuses}"
+        assert failed[-1]["error"]["code"] == "runner_disconnected"
+
+        # And the disconnect cause persisted as durable labels.
+        persisted = store.labels.get(session_id)
+        assert persisted is not None
+        assert sessions_module._last_task_error_from_labels(persisted) == {
+            "code": "runner_disconnected",
+            "message": "Runner disconnected unexpectedly.",
+        }
+    finally:
+        gate.set()
+        sessions_module._interrupt_fenced_sessions.discard(session_id)
+        sessions_module._intentional_stop_sessions.discard(session_id)
+        if collector is not None:
+            await collector.stop()
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None and not handle.task.done():
+            handle.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(handle.task, timeout=1.0)
+        sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
+        session_stream.close(session_id)


### PR DESCRIPTION
## Related issue

N/A

## Summary

Clicking **Stop session** in the web UI on a host-spawned session showed a red **"Error · runner_disconnected / Runner disconnected unexpectedly."** card even though the user stopped it on purpose.

- Stop deliberately tears the runner's WS tunnel down (`_stop_session_host_runner`) so `runner_online` flips false — but that makes the SSE relay hit the same `except (httpx.HTTPError, ConnectionError)` path a genuine runner death takes. The block couldn't tell an intentional stop from a crash, so it published a `failed` status with `runner_disconnected` and persisted durable error labels (which also polluted snapshots / child summaries).
- Adds a one-shot `_intentional_stop_sessions` marker set alongside the existing `_interrupt_fenced_sessions`. The stop handler marks the session right before tearing the tunnel down (host-spawned branch only); the relay's disconnect handler consults it and resolves an intentional drop to a quiet `idle` with cleared error labels, while a genuine disconnect still surfaces `runner_disconnected` as before.
- Safety-net `discard` on the next `running` edge and on session delete keeps a stale marker from swallowing a later real disconnect.

## Test Plan

- `python -m pytest tests/server/routes/test_sessions_runner_relay.py` → 6 passed, including the new `test_relay_suppresses_disconnect_error_on_intentional_stop` (asserts quiet `idle`, one-shot marker consumed, no persisted `runner_disconnected` label). The existing `test_relay_publishes_failed_status_on_tunnel_close` / labels tests remain as regression guards for genuine disconnects.
- `ruff format --check` + `ruff check` clean; pre-commit hooks pass.

## Demo

N/A — backend-only change, no UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit test covers the intentional-stop suppression path; existing tests cover the genuine-disconnect path so both branches are guarded.

## Changelog

Clicking "Stop session" no longer shows a spurious "runner disconnected" error

This pull request and its description were written by Isaac.