### PR TITLE
perf(runtime): speed up changed-files git status on large repos

### DIFF
--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -62,6 +62,14 @@ def _git_timeout_seconds() -> float:
     return _DEFAULT_GIT_TIMEOUT_SECONDS
 
 
+# Git roots whose ``core.untrackedCache`` we've already enabled this process, so
+# the one-shot config write doesn't repeat.  The host fallback path builds a
+# fresh registry per fs request (unlike the runner, which caches per session),
+# so without this guard every request would re-spawn the ``git config``.
+_untracked_cache_enabled: set[str] = set()
+_untracked_cache_lock = threading.Lock()
+
+
 class GitStatusUnavailable(RuntimeError):
     """A ``git`` invocation backing the changed-files view could not complete.
 
@@ -721,14 +729,22 @@ class GitFilesystemRegistry(FilesystemRegistry):
         The untracked cache (upstream git ≥ 2.8) records untracked file/dir
         mtimes in the index so ``git status --untracked-files=all`` skips
         re-stat'ing every untracked path — the dominant cost on large repos.
-        Idempotent and safe to run once per registry; failures are ignored
-        (old git, read-only .git, or an mtime-unreliable filesystem) since the
-        setting is a pure speedup with no behavioral effect.
+        Runs at most once per git-root per process (guarded by
+        :data:`_untracked_cache_enabled`) so the host fallback path — which
+        builds a fresh registry per fs request — doesn't re-spawn the config
+        write each time.  Failures are ignored (old git, read-only .git, or an
+        mtime-unreliable filesystem) since the setting is a pure speedup with
+        no behavioral effect.
         """
+        root_key = str(self._git_root)
+        with _untracked_cache_lock:
+            if root_key in _untracked_cache_enabled:
+                return
+            _untracked_cache_enabled.add(root_key)
         try:
             subprocess.run(
                 ["git", "config", "core.untrackedCache", "true"],
-                cwd=str(self._git_root),
+                cwd=root_key,
                 capture_output=True,
                 timeout=_git_timeout_seconds(),
             )

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import dataclasses
 import fnmatch
 import logging
+import os
 import subprocess
 import threading
 import time
@@ -35,10 +36,30 @@ from typing import Any
 
 _logger = logging.getLogger(__name__)
 
-# Wall-clock cap for git subprocesses backing the changed-files view. Kept
-# short so a slow/hung repo can't block the panel; each call degrades cleanly
-# on timeout rather than raising. Bump if very large repos need more headroom.
-_GIT_TIMEOUT_SECONDS = 5
+# Wall-clock cap for git subprocesses backing the changed-files view. Large
+# repos (many untracked files, slow disk) can make `git status` slow, so this
+# is generous by default and overridable via OMNIGENT_GIT_STATUS_TIMEOUT_SECONDS
+# for repos that need more (or less) headroom. It still bounds a genuinely hung
+# git so the panel surfaces a failure rather than blocking forever.
+_DEFAULT_GIT_TIMEOUT_SECONDS = 30.0
+
+
+def _git_timeout_seconds() -> float:
+    """Return the git-subprocess timeout, honoring the env override.
+
+    Reads ``OMNIGENT_GIT_STATUS_TIMEOUT_SECONDS`` on each call so operators can
+    tune it without a restart. Falls back to the default on unset/invalid/
+    non-positive values.
+    """
+    raw = os.environ.get("OMNIGENT_GIT_STATUS_TIMEOUT_SECONDS")
+    if raw is not None:
+        try:
+            value = float(raw)
+        except ValueError:
+            value = 0.0
+        if value > 0:
+            return value
+    return _DEFAULT_GIT_TIMEOUT_SECONDS
 
 
 class GitStatusUnavailable(RuntimeError):
@@ -692,6 +713,31 @@ class GitFilesystemRegistry(FilesystemRegistry):
         """
         super().__init__(watch_path)
         self._git_root = git_root
+        self._enable_untracked_cache()
+
+    def _enable_untracked_cache(self) -> None:
+        """Best-effort ``core.untrackedCache=true`` on this repo.
+
+        The untracked cache (upstream git ≥ 2.8) records untracked file/dir
+        mtimes in the index so ``git status --untracked-files=all`` skips
+        re-stat'ing every untracked path — the dominant cost on large repos.
+        Idempotent and safe to run once per registry; failures are ignored
+        (old git, read-only .git, or an mtime-unreliable filesystem) since the
+        setting is a pure speedup with no behavioral effect.
+        """
+        try:
+            subprocess.run(
+                ["git", "config", "core.untrackedCache", "true"],
+                cwd=str(self._git_root),
+                capture_output=True,
+                timeout=_git_timeout_seconds(),
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            _logger.debug(
+                "GitFilesystemRegistry: could not enable core.untrackedCache in %s",
+                self._git_root,
+                exc_info=True,
+            )
 
     def list_changed_files(self, conversation_id: str, *, limit: int) -> list[dict[str, Any]]:
         """Return all uncommitted changes in the working tree, newest first.
@@ -709,14 +755,21 @@ class GitFilesystemRegistry(FilesystemRegistry):
         # inside a brand-new directory tree collapses to a single ``?? dir/``
         # line, so the UI would show the directory (stat'd as ~96 B) instead
         # of the added file.
+        #
+        # The ``:(exclude)`` pathspecs stop git from walking large untracked
+        # build/cache trees (node_modules/, .venv/ …) that we would discard
+        # below anyway.  With ``-uall`` git otherwise stat's every file in them,
+        # which dominates the runtime on big repos.  These mirror the
+        # ``_SKIP_DIRS`` root-level prune (kept below as a safety net).
         argv = ["git", "status", "--porcelain", "--untracked-files=all"]
+        argv.extend(self._skip_dir_pathspecs())
         started = time.monotonic()
         try:
             result = subprocess.run(
                 argv,
                 cwd=str(self._git_root),
                 capture_output=True,
-                timeout=_GIT_TIMEOUT_SECONDS,
+                timeout=_git_timeout_seconds(),
             )
         except subprocess.TimeoutExpired as exc:
             elapsed = time.monotonic() - started
@@ -811,7 +864,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 argv,
                 cwd=str(self._git_root),
                 capture_output=True,
-                timeout=_GIT_TIMEOUT_SECONDS,
+                timeout=_git_timeout_seconds(),
             )
         except subprocess.TimeoutExpired as exc:
             elapsed = time.monotonic() - started
@@ -879,7 +932,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 ["git", "show", f"HEAD:{git_path}"],
                 cwd=str(self._git_root),
                 capture_output=True,
-                timeout=_GIT_TIMEOUT_SECONDS,
+                timeout=_git_timeout_seconds(),
             )
             if result.returncode == 0:
                 return result.stdout.decode("utf-8", errors="replace")
@@ -892,6 +945,25 @@ class GitFilesystemRegistry(FilesystemRegistry):
         return None
 
     # ── Internals ─────────────────────────────────────────────────
+
+    def _skip_dir_pathspecs(self) -> list[str]:
+        """Return ``:(exclude)`` pathspecs pruning :data:`_SKIP_DIRS` from status.
+
+        The post-filter in :meth:`list_changed_files` only prunes skip dirs at
+        the *workspace root* (first path component), so the pathspecs are
+        anchored to the workspace's location within the git root to match —
+        e.g. a workspace at ``repo/sub`` yields ``:(exclude)sub/node_modules``,
+        which leaves a ``node_modules/`` elsewhere in the repo untouched.
+        Returns an empty list when the workspace escapes the git root (in which
+        case the post-filter alone still applies).
+        """
+        try:
+            prefix = self._cwd.relative_to(self._git_root)
+        except ValueError:
+            return []
+        prefix_posix = prefix.as_posix()
+        base = "" if prefix_posix == "." else f"{prefix_posix}/"
+        return [f":(exclude){base}{name}" for name in sorted(_SKIP_DIRS)]
 
     def _git_to_rel(self, git_path: str) -> str | None:
         """Convert a git-root-relative path to a cwd-relative path.
@@ -964,7 +1036,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 argv,
                 cwd=str(self._git_root),
                 capture_output=True,
-                timeout=_GIT_TIMEOUT_SECONDS,
+                timeout=_git_timeout_seconds(),
             )
         except (subprocess.TimeoutExpired, OSError):
             _logger.warning(

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -732,9 +732,15 @@ class GitFilesystemRegistry(FilesystemRegistry):
         Runs at most once per git-root per process (guarded by
         :data:`_untracked_cache_enabled`) so the host fallback path — which
         builds a fresh registry per fs request — doesn't re-spawn the config
-        write each time.  Failures are ignored (old git, read-only .git, or an
-        mtime-unreliable filesystem) since the setting is a pure speedup with
-        no behavioral effect.
+        write each time.
+
+        Gated on ``git update-index --test-untracked-cache`` (git's own
+        recommended probe): on filesystems with unreliable directory mtimes the
+        cache can return stale results — a newly-untracked file could then be
+        missing from the changed-files panel.  We only enable when the probe
+        passes.  Failures anywhere (old git, read-only .git, unsupported
+        filesystem) are ignored since the setting is a pure speedup with no
+        behavioral effect.
         """
         root_key = str(self._git_root)
         with _untracked_cache_lock:
@@ -742,6 +748,20 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 return
             _untracked_cache_enabled.add(root_key)
         try:
+            # Read-only probe: exit 0 iff the filesystem's mtime is reliable
+            # enough for the untracked cache to be correct here.
+            probe = subprocess.run(
+                ["git", "update-index", "--test-untracked-cache"],
+                cwd=root_key,
+                capture_output=True,
+                timeout=_git_timeout_seconds(),
+            )
+            if probe.returncode != 0:
+                _logger.debug(
+                    "GitFilesystemRegistry: untracked cache unsupported in %s; not enabling",
+                    self._git_root,
+                )
+                return
             subprocess.run(
                 ["git", "config", "core.untrackedCache", "true"],
                 cwd=root_key,

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -21,6 +21,7 @@ from omnigent.runtime.filesystem_registry import (
     AgentEditFilesystemRegistry,
     GitFilesystemRegistry,
     GitStatusUnavailable,
+    _git_timeout_seconds,
     _normalize_path,
     _parse_git_porcelain_line,
     _unquote_git_path,
@@ -667,6 +668,154 @@ def test_git_list_changed_files_expands_untracked_nested_dir(tmp_path: Path) -> 
     assert record["status"] == "created", (
         f"Expected status 'created' for the new file, got {record['status']!r}."
     )
+
+
+# ── git-status performance tuning (timeout / pathspec / untracked cache) ──────
+
+
+def test_git_timeout_seconds_default_and_env_override(monkeypatch) -> None:
+    """The git timeout defaults to 30s and honors the env override.
+
+    Guards the large-repo headroom bump and the operator-tunable knob: unset
+    → default, a valid positive value → that value, and invalid/non-positive
+    values fall back to the default rather than raising or disabling the cap.
+    """
+    monkeypatch.delenv("OMNIGENT_GIT_STATUS_TIMEOUT_SECONDS", raising=False)
+    assert _git_timeout_seconds() == pytest.approx(30.0)
+
+    monkeypatch.setenv("OMNIGENT_GIT_STATUS_TIMEOUT_SECONDS", "90")
+    assert _git_timeout_seconds() == pytest.approx(90.0)
+
+    for bad in ("not-a-number", "0", "-5", ""):
+        monkeypatch.setenv("OMNIGENT_GIT_STATUS_TIMEOUT_SECONDS", bad)
+        assert _git_timeout_seconds() == pytest.approx(30.0), (
+            f"Expected fallback to default for invalid value {bad!r}."
+        )
+
+
+def test_git_list_changed_files_honors_env_timeout(tmp_path: Path, monkeypatch) -> None:
+    """``list_changed_files`` passes the env-overridden timeout to the subprocess.
+
+    A slow-but-not-hung ``git status`` on a large repo must survive when the
+    operator raises the timeout, instead of failing at the old 5s cap.
+    """
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    monkeypatch.setenv("OMNIGENT_GIT_STATUS_TIMEOUT_SECONDS", "42")
+
+    seen: dict[str, float | None] = {}
+
+    def _capture(*_args, **kwargs):
+        seen["timeout"] = kwargs.get("timeout")
+        return subprocess.CompletedProcess(args="git", returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr("omnigent.runtime.filesystem_registry.subprocess.run", _capture)
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    reg.list_changed_files("any-conv", limit=100)
+
+    assert seen["timeout"] == pytest.approx(42.0), (
+        f"Expected the env-overridden 42s timeout, got {seen['timeout']!r}."
+    )
+
+
+def test_git_list_changed_files_excludes_skip_dirs_via_pathspec(tmp_path: Path) -> None:
+    """Untracked files inside ``_SKIP_DIRS`` are excluded and never returned.
+
+    The ``:(exclude)`` pathspecs stop git from walking large build/cache trees
+    (node_modules/ …). A real repo confirms both that git honors the pathspec
+    (the skip-dir file is absent) and that a genuine change still surfaces.
+    """
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+    # Root-level skip dir: must be pruned.
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "big.js").write_text("x" * 10)
+    # A skip-dir name nested under a real source dir is NOT a root-level match,
+    # so it stays visible — mirrors the first-component post-filter semantics.
+    (tmp_path / "src" / "node_modules").mkdir(parents=True)
+    (tmp_path / "src" / "node_modules" / "keep.js").write_text("y")
+    (tmp_path / "real_change.py").write_text("agent wrote this")
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    paths = [r["path"] for r in reg.list_changed_files("any-conv", limit=100)]
+
+    assert "real_change.py" in paths, f"Expected 'real_change.py' in results but got {paths}."
+    assert not any(p.startswith("node_modules/") for p in paths), (
+        f"Root-level node_modules/ should be pruned but got {paths}."
+    )
+    assert "src/node_modules/keep.js" in paths, (
+        f"Nested (non-root) node_modules should stay visible but got {paths}."
+    )
+
+
+def test_skip_dir_pathspecs_anchored_to_workspace_subdir(tmp_path: Path) -> None:
+    """Pathspecs are anchored to the workspace's prefix within the git root.
+
+    When the workspace is a subdirectory of the git root, the excludes must be
+    prefixed with that subdir so a skip dir elsewhere in the repo is untouched.
+    """
+    git_root = tmp_path
+    workspace = tmp_path / "sub" / "ws"
+    workspace.mkdir(parents=True)
+
+    reg = GitFilesystemRegistry(watch_path=workspace, git_root=git_root)
+    specs = reg._skip_dir_pathspecs()
+
+    assert ":(exclude)sub/ws/node_modules" in specs, (
+        f"Expected workspace-prefixed exclude pathspec, got {specs}."
+    )
+    # No bare (unprefixed) skip-dir exclude should be present.
+    assert ":(exclude)node_modules" not in specs
+
+
+def test_untracked_cache_enabled_on_init(tmp_path: Path) -> None:
+    """The registry enables ``core.untrackedCache`` on the repo at construction.
+
+    This is the large-repo ``git status`` speedup (upstream git ≥ 2.8); the
+    registry sets it best-effort on init. Verifies the config lands.
+    """
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+
+    GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+
+    result = subprocess.run(
+        ["git", "config", "--get", "core.untrackedCache"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.stdout.strip() == "true", (
+        f"Expected core.untrackedCache=true after init, got {result.stdout.strip()!r}."
+    )
+
+
+def test_untracked_cache_failure_does_not_break_init(tmp_path: Path, monkeypatch) -> None:
+    """A failure enabling the untracked cache must not break registry construction.
+
+    The setting is a pure speedup; old git / read-only .git / mtime-unreliable
+    filesystems should degrade silently rather than raising.
+    """
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+
+    def _raise_oserror(*_args, **_kwargs):
+        raise OSError("git not found")
+
+    monkeypatch.setattr("omnigent.runtime.filesystem_registry.subprocess.run", _raise_oserror)
+
+    # Construction must not raise even though the config subprocess fails.
+    GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
 
 
 # ── _normalize_path ──────────────────────────────────────────────────────────

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -818,6 +818,40 @@ def test_untracked_cache_failure_does_not_break_init(tmp_path: Path, monkeypatch
     GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
 
 
+def test_untracked_cache_config_written_once_per_root(tmp_path: Path, monkeypatch) -> None:
+    """The ``git config`` write runs at most once per git-root per process.
+
+    The host fallback path builds a fresh registry per fs request, so without
+    the one-shot guard every request would re-spawn ``git config``. Building
+    several registries on the same root must issue the config write only once.
+    """
+    from omnigent.runtime import filesystem_registry as fsr
+
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+
+    # Reset the process-global guard so this test is order-independent.
+    monkeypatch.setattr(fsr, "_untracked_cache_enabled", set())
+
+    config_calls: list[tuple] = []
+    real_run = subprocess.run
+
+    def _counting_run(args, *a, **kw):
+        if args[:3] == ["git", "config", "core.untrackedCache"]:
+            config_calls.append(tuple(args))
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=b"", stderr=b"")
+        return real_run(args, *a, **kw)
+
+    monkeypatch.setattr(fsr.subprocess, "run", _counting_run)
+
+    for _ in range(3):
+        GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+
+    assert len(config_calls) == 1, (
+        f"Expected core.untrackedCache config write exactly once, got {len(config_calls)}."
+    )
+
+
 # ── _normalize_path ──────────────────────────────────────────────────────────
 
 

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -852,6 +852,51 @@ def test_untracked_cache_config_written_once_per_root(tmp_path: Path, monkeypatc
     )
 
 
+def test_untracked_cache_not_enabled_when_probe_fails(tmp_path: Path, monkeypatch) -> None:
+    """When ``--test-untracked-cache`` fails, the cache config is not written.
+
+    On mtime-unreliable filesystems git's probe exits non-zero; enabling the
+    cache there risks a newly-untracked file missing from the panel, so the
+    registry must leave ``core.untrackedCache`` unset.
+    """
+    from omnigent.runtime import filesystem_registry as fsr
+
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+
+    monkeypatch.setattr(fsr, "_untracked_cache_enabled", set())
+
+    config_calls: list[tuple] = []
+    real_run = subprocess.run
+
+    def _probe_fails_run(args, *a, **kw):
+        if args[:2] == ["git", "update-index"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=1, stdout=b"", stderr=b"mtime unreliable"
+            )
+        if args[:3] == ["git", "config", "core.untrackedCache"]:
+            config_calls.append(tuple(args))
+        return real_run(args, *a, **kw)
+
+    monkeypatch.setattr(fsr.subprocess, "run", _probe_fails_run)
+
+    GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+
+    assert config_calls == [], (
+        f"Expected no config write when the probe fails, got {config_calls}."
+    )
+    result = subprocess.run(
+        ["git", "config", "--get", "core.untrackedCache"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.stdout.strip() == "", (
+        f"core.untrackedCache should be unset when the probe fails, got {result.stdout.strip()!r}."
+    )
+
+
 # ── _normalize_path ──────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

The changed-files panel (Files view, `/changes`, `/diff`) runs
`git status --porcelain --untracked-files=all` with a hardcoded **5s** cap. On
large repos that walk is slow, and when it exceeds the cap the panel fails hard
(HTTP 500 / `git_status_failed`) — the same path the host fallback uses when the
runner is offline. This speeds up and hardens that path:

- **Configurable timeout, default 5s → 30s.** New
  `OMNIGENT_GIT_STATUS_TIMEOUT_SECONDS` env override so operators can tune it
  (e.g. 60–120s for monorepos) without a code change. Invalid/non-positive
  values fall back to the default.
- **`core.untrackedCache=true` best-effort on init** (upstream git ≥ 2.8) so
  `git status` stops re-stat'ing every untracked path. Guarded by a
  process-global set keyed by git-root so the write runs **at most once per
  root per process** — important because the host fallback builds a fresh
  registry per fs request (the runner caches per session).
- **`:(exclude)` pathspecs for `_SKIP_DIRS`** so git never walks large
  untracked build/cache trees (`node_modules/`, `.venv/`, …) that we discard
  anyway. Anchored to the workspace's location within the git root to preserve
  the existing root-level-only prune semantics; the post-filter stays as a
  safety net.

Applies to both the runner path and the host-direct fallback path (both go
through `WorkspaceReader` → `GitFilesystemRegistry`).

### Measured context (universe monorepo, 883k tracked files)

`git status -uall` is ~46s there even with **0 untracked files** — the cost is
the untracked *directory walk* over the tracked tree, not untracked-file
re-stat. So on that class of repo, `untrackedCache`/pathspec excludes give
little gain and the **env timeout override** is the load-bearing fix; the
durable win (fsmonitor) is a **planned follow-up** at workspace provisioning.
On typical app repos with large untracked `node_modules/` trees, the pathspec
excludes and untracked cache are the wins.

## Test Plan

```bash
python -m pytest tests/runtime/test_filesystem_registry.py \
                 tests/runner/test_environment_filesystem.py -q
```

- `tests/runtime/test_filesystem_registry.py`: **68 passed** (8 new)
- `tests/runner/test_environment_filesystem.py` (`/changes` + `/diff`
  endpoints): **61 passed**
- `ruff format` + `ruff check`: clean

New tests cover: timeout default + env override + invalid-value fallback; the
timeout is passed to the subprocess; root-level skip dirs pruned via pathspec
while nested ones stay visible; pathspecs anchored correctly for a workspace
subdir; `core.untrackedCache=true` lands on init; init survives a config
failure; and the config write is one-shot per git-root.

To tune on a running runner:

```bash
export OMNIGENT_GIT_STATUS_TIMEOUT_SECONDS=60
git -C <workspace> config --get core.untrackedCache   # → true
```

## Demo

N/A — non-visual (backend git-status behavior).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Timeout/error contract already covered by existing tests; new functional tests
added for each new behavior (timeout knob, pathspec excludes, untracked-cache
init + one-shot guard). No perf benchmark added — absolute timings are
machine-dependent and would be flaky as a gate; verified the real-world win by
timing `git status` variants on the universe monorepo manually.

## Changelog

DELETE THIS WHOLE SECTION — internal perf/refactor, no user-facing change.

This pull request and its description were written by Isaac.