### PR TITLE
fix(web): show busy spinner on new-session Send while create is in flight

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -592,6 +592,118 @@ async def _drive_permission_mode(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
+def test_start_session_send_shows_busy_spinner(seeded_session: tuple[str, str]) -> None:
+    """Send shows a busy spinner while the create is in flight, then navigates.
+
+    The create awaits the backend (session bootstrap + git worktree setup)
+    before navigating, so the landing screen lingers for the whole round-trip.
+    Without feedback the Send button just goes inert and the typed message sits
+    in the composer, so the click reads as "frozen". This holds the create POST
+    open with a gate so that in-flight window is observable, and asserts the
+    Send button flips to a busy/spinning state (disabled + ``aria-busy`` +
+    "Starting session" label) before the response lands and navigation happens.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_send_busy_spinner(base_url, session_id))
+
+
+async def _drive_send_busy_spinner(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            # A gate the create handler awaits before responding, so the POST
+            # stays pending long enough to observe the button's busy state. The
+            # test opens it after asserting the spinner, letting navigation run.
+            release_create = asyncio.Event()
+
+            async def handle_hosts(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_hosts_body()
+                )
+
+            async def handle_agents(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_agents_body()
+                )
+
+            async def handle_events(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+                )
+
+            async def handle_sessions(route: Route) -> None:
+                if route.request.method == "POST":
+                    create_bodies.append(route.request.post_data_json)
+                    # Hold the create open so the composer stays in its
+                    # `creating` state — the window under test.
+                    await release_create.wait()
+                    await route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=json.dumps({"id": session_id}),
+                    )
+                else:
+                    await route.continue_()
+
+            await page.route("**/v1/hosts", handle_hosts)
+            await page.route("**/v1/agents", handle_agents)
+            await page.route("**/v1/sessions/*/events", handle_events)
+            await page.route(_SESSIONS_RE, handle_sessions)
+
+            # Keep the agent-discovery scan empty so only the stubbed Claude
+            # agent feeds the picker (see _drive_permission_mode for why).
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"data": []}),
+                )
+
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            submit = page.get_by_test_id("new-chat-landing-submit")
+            await page.get_by_test_id("new-chat-landing-input").fill("set up the project")
+            # Idle with a message typed: enabled, not busy (arrow, no spin).
+            await expect(submit).to_be_enabled()
+            await expect(submit).to_have_attribute("aria-busy", "false")
+
+            await submit.click()
+
+            # The POST reached the server (proving we're truly in flight, not
+            # blocked by a disabled button) and the button shows the busy state.
+            await _wait_until(lambda: len(create_bodies) == 1)
+            await expect(submit).to_be_disabled()
+            await expect(submit).to_have_attribute("aria-busy", "true")
+            await expect(submit).to_have_attribute("aria-label", "Starting session")
+            # Still on the landing screen — the "frozen"-looking window.
+            await expect(page.get_by_test_id("new-chat-landing-input")).to_be_visible()
+
+            # Release the create: the flow completes and navigates to the
+            # session, so the landing composer unmounts.
+            release_create.set()
+            await expect(page.get_by_test_id("new-chat-landing-input")).to_have_count(
+                0, timeout=30_000
+            )
+        finally:
+            await browser.close()
+
+
 def test_start_session_remembers_last_picked_host(seeded_session: tuple[str, str]) -> None:
     """The host chip restores the last explicitly-picked host after a reload.
 

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -234,6 +234,46 @@ describe("NewChatLandingScreen create flow", () => {
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_new"));
   });
 
+  it("shows a busy spinner on the submit button while the create is in flight", async () => {
+    // The create awaits the backend (session bootstrap + worktree setup) before
+    // navigating, so the landing screen lingers for the whole round-trip. Hold
+    // the POST open with a deferred promise to freeze that window, and assert
+    // the submit button flips to a busy/spinning state so the click reads as
+    // "working", not "frozen". Without feedback the button just goes inert and
+    // the message sits in the composer, so the user thinks nothing was sent.
+    let resolveCreate!: (res: Response) => void;
+    vi.mocked(authenticatedFetch).mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveCreate = resolve;
+      }) as ReturnType<typeof authenticatedFetch>,
+    );
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("inspect the repo");
+
+    const submit = screen.getByTestId("new-chat-landing-submit");
+    // Before submitting, the button is idle: enabled, not busy, arrow (no spin).
+    expect(submit).not.toBeDisabled();
+    expect(submit).toHaveAttribute("aria-busy", "false");
+    expect(submit.querySelector(".animate-spin")).toBeNull();
+
+    fireEvent.click(submit);
+
+    // While the POST is pending the button is disabled + aria-busy, its label
+    // reflects the in-flight state, and the spinner icon is mounted.
+    await waitFor(() => expect(submit).toBeDisabled());
+    expect(submit).toHaveAttribute("aria-busy", "true");
+    expect(submit).toHaveAttribute("aria-label", "Starting session");
+    expect(submit.querySelector(".animate-spin")).not.toBeNull();
+    // Navigation hasn't happened yet — we're still in the "frozen" window.
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    // Let the backend respond: the flow completes and navigates away.
+    resolveCreate({ ok: true, json: async () => ({ id: "conv_new" }) } as unknown as Response);
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_new"));
+  });
+
   it("keeps the seeded working directory when the already-selected host is re-picked", async () => {
     renderLanding();
     await waitForWorkspaceSeed();

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -19,6 +19,7 @@ import {
   ChevronRightIcon,
   GitBranchIcon,
   ArrowUpIcon,
+  Loader2Icon,
   FileTextIcon,
   FolderIcon,
   ImageIcon,
@@ -3338,11 +3339,16 @@ export function NewChatLandingScreen() {
                           type="submit"
                           size="icon"
                           disabled={!canSubmit}
-                          aria-label="Start session"
+                          aria-label={creating ? "Starting session" : "Start session"}
+                          aria-busy={creating}
                           data-testid="new-chat-landing-submit"
                           className="size-8 rounded-full bg-foreground text-card transition-opacity hover:opacity-80 disabled:opacity-50"
                         >
-                          <ArrowUpIcon className="size-4" />
+                          {creating ? (
+                            <Loader2Icon className="size-4 animate-spin" />
+                          ) : (
+                            <ArrowUpIcon className="size-4" />
+                          )}
                         </Button>
                       </span>
                     </TooltipTrigger>


### PR DESCRIPTION
## Related issue

N/A

## Summary

- When you type a prompt in the new-session landing screen and hit Send, the page appears to freeze on the landing screen for several seconds before it jumps to the new session — it looks like nothing was sent.
- The handler (`handleCreate`) awaits the full backend round-trip — session bootstrap and, when a branch is named, **git worktree creation** — before navigating to `/c/{id}`. During that window the Send button only went `disabled` with no other feedback, so the click read as inert and the typed message just sat in the composer.
- This is the **perceived-latency** fix: the Send button's static arrow now swaps to a spinning `Loader2Icon` while `creating` is true, with `aria-busy` and a "Starting session" label. Backend timing is unchanged; the wait is just made legible.

## Test Plan

- **Unit/component** (`web/src/shell/NewChatDialog.flow.test.tsx`): holds the create POST open with a deferred promise and asserts the submit button flips to disabled + `aria-busy="true"` + spinner mounted while in flight, then navigates once the backend responds.
- **E2E** (`tests/e2e_ui/start_session/test_start_session.py::test_start_session_send_shows_busy_spinner`): Playwright test that gates the create POST so the in-flight window is observable, asserts the busy state (disabled + `aria-busy="true"` + "Starting session" label) with the landing composer still mounted, then releases the create and asserts navigation. Passes locally.
- `cd web && npm test` → 4237 passed / 3 expected-fail / 2 skipped.
- `cd web && npm run build` → clean (`tsc -b && vite build`).
- Prettier + oxlint clean on the touched web files; `ruff format`/`ruff check` + custom lint hooks clean on the e2e test.

## Demo

Before: Send button goes inert (static arrow, disabled) during the multi-second create; looks frozen.
After: Send button shows a spinning loader immediately and stays spinning until navigation.

To reproduce locally: `cd web && npm run dev`, open the new-session screen, type a prompt, name a branch (so a worktree is created — the slow path), and hit Send. The arrow swaps to a spinner until it navigates.

_(UI change — screen recording to be attached.)_

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the dev server, confirmed the spinner appears on Send during the create window and clears on navigation. Automated coverage added at two layers — a deferred-promise component test and a gated-create Playwright e2e_ui test — both freezing the in-flight window and asserting the busy state.

## Changelog

New-session Send button shows a spinner while the session is being created, instead of looking frozen

This pull request and its description were written by Isaac.