### PR TITLE
perf(runtime): enable git fsmonitor on large repos (follow-up to #2905)

### DIFF
--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -839,9 +839,12 @@ class GitFilesystemRegistry(FilesystemRegistry):
         - **Version gate.** Below git 2.37 (:data:`_FSMONITOR_MIN_GIT_VERSION`)
           ``core.fsmonitor`` names a *hook script*, so ``true`` would make every
           ``git status`` fail. We only enable at or above that version.
+        - **Respect existing config.** If ``core.fsmonitor`` is already set we
+          leave it alone rather than clobber an operator's value.
         - **Verify-and-rollback.** After enabling we run a cheap ``git status``;
-          if it doesn't cleanly return we unset ``core.fsmonitor`` so we never
-          leave the changed-files view broken.
+          if it doesn't cleanly return — a non-zero exit *or* a timeout / spawn
+          error — we unset ``core.fsmonitor`` so we never leave the changed-files
+          view broken.
         - **Opt-out.** ``OMNIGENT_GIT_FSMONITOR=0`` disables enablement entirely.
 
         Runs at most once per git-root per process (same rationale as the
@@ -864,7 +867,19 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 self._git_root,
             )
             return
+
+        config_set = False
         try:
+            # Don't clobber an operator's existing core.fsmonitor (a custom hook
+            # path, or a deliberate ``false``): exit 0 means the key is set.
+            existing = subprocess.run(
+                ["git", "config", "--get", "core.fsmonitor"],
+                cwd=root_key,
+                capture_output=True,
+                timeout=_git_timeout_seconds(),
+            )
+            if existing.returncode == 0:
+                return
             set_result = subprocess.run(
                 ["git", "config", "core.fsmonitor", "true"],
                 cwd=root_key,
@@ -873,9 +888,10 @@ class GitFilesystemRegistry(FilesystemRegistry):
             )
             if set_result.returncode != 0:
                 return
+            config_set = True
             # Verify with a cheap status (``-uno`` skips the untracked walk, so
             # this is fast even on huge repos) and also warms the daemon. If it
-            # fails, fsmonitor is misbehaving here — roll the setting back.
+            # doesn't cleanly return, fsmonitor is misbehaving here — roll back.
             verify = subprocess.run(
                 ["git", "status", "--porcelain", "-uno"],
                 cwd=root_key,
@@ -888,16 +904,45 @@ class GitFilesystemRegistry(FilesystemRegistry):
                     "in %s; rolling back",
                     self._git_root,
                 )
-                subprocess.run(
-                    ["git", "config", "--unset", "core.fsmonitor"],
-                    cwd=root_key,
-                    capture_output=True,
-                    timeout=_git_timeout_seconds(),
-                )
+                self._rollback_fsmonitor(root_key)
         except (subprocess.TimeoutExpired, OSError):
+            # A hung or unspawnable verify is the canonical "doesn't cleanly
+            # return" case — and the most likely outcome against a cold daemon
+            # on a giant repo. If we already wrote the config, undo it so the
+            # changed-files view isn't left running under a broken fsmonitor.
             _logger.debug(
                 "GitFilesystemRegistry: could not enable core.fsmonitor in %s",
                 self._git_root,
+                exc_info=True,
+            )
+            if config_set:
+                self._rollback_fsmonitor(root_key)
+
+    def _rollback_fsmonitor(self, root_key: str) -> None:
+        """Best-effort ``git config --unset core.fsmonitor`` after a failed enable.
+
+        Never raises; a failed unset is logged at WARNING because it leaves the
+        broken ``true`` in place (the one state this guard must avoid).
+        """
+        try:
+            unset = subprocess.run(
+                ["git", "config", "--unset", "core.fsmonitor"],
+                cwd=root_key,
+                capture_output=True,
+                timeout=_git_timeout_seconds(),
+            )
+            if unset.returncode != 0:
+                _logger.warning(
+                    "GitFilesystemRegistry: failed to unset core.fsmonitor in %s "
+                    "(exit %d); it may remain enabled",
+                    root_key,
+                    unset.returncode,
+                )
+        except (subprocess.TimeoutExpired, OSError):
+            _logger.warning(
+                "GitFilesystemRegistry: could not unset core.fsmonitor in %s; "
+                "it may remain enabled",
+                root_key,
                 exc_info=True,
             )
 

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -27,6 +27,7 @@ import dataclasses
 import fnmatch
 import logging
 import os
+import re
 import subprocess
 import threading
 import time
@@ -68,6 +69,53 @@ def _git_timeout_seconds() -> float:
 # so without this guard every request would re-spawn the ``git config``.
 _untracked_cache_enabled: set[str] = set()
 _untracked_cache_lock = threading.Lock()
+
+# Git roots whose ``core.fsmonitor`` we've already tried to enable this process.
+# Same one-shot rationale as the untracked cache above.
+_fsmonitor_enabled: set[str] = set()
+_fsmonitor_lock = threading.Lock()
+
+# Minimum git version whose built-in fsmonitor daemon understands
+# ``core.fsmonitor=true``.  On older git the value is read as a *hook path*, so
+# ``true`` would make every ``git status`` try to exec a hook named "true" and
+# fail — hence we never enable it below this version.
+_FSMONITOR_MIN_GIT_VERSION = (2, 37)
+
+
+def _fsmonitor_opt_out() -> bool:
+    """Return ``True`` when fsmonitor enablement is disabled via env.
+
+    ``OMNIGENT_GIT_FSMONITOR`` set to ``0``/``false``/``no``/``off`` (any case)
+    suppresses the long-lived fsmonitor daemon for operators who don't want it.
+    Unset or any other value leaves the default-on behavior.
+    """
+    raw = os.environ.get("OMNIGENT_GIT_FSMONITOR")
+    return raw is not None and raw.strip().lower() in {"0", "false", "no", "off"}
+
+
+def _git_version(cwd: str) -> tuple[int, ...] | None:
+    """Return the installed git version as a tuple, or ``None`` if unknown.
+
+    Parses ``git version X.Y.Z`` into ``(X, Y, Z)``.  Any spawn error, timeout,
+    or unparseable output yields ``None`` so callers treat the version as
+    unknown rather than crash.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "version"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=_git_timeout_seconds(),
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", result.stdout)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups(default="0"))
 
 
 class GitStatusUnavailable(RuntimeError):
@@ -722,6 +770,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
         super().__init__(watch_path)
         self._git_root = git_root
         self._enable_untracked_cache()
+        self._enable_fsmonitor()
 
     def _enable_untracked_cache(self) -> None:
         """Best-effort ``core.untrackedCache=true`` on this repo.
@@ -771,6 +820,83 @@ class GitFilesystemRegistry(FilesystemRegistry):
         except (subprocess.TimeoutExpired, OSError):
             _logger.debug(
                 "GitFilesystemRegistry: could not enable core.untrackedCache in %s",
+                self._git_root,
+                exc_info=True,
+            )
+
+    def _enable_fsmonitor(self) -> None:
+        """Best-effort ``core.fsmonitor=true`` on this repo (git ≥ 2.37).
+
+        The built-in fsmonitor daemon watches the working tree via the OS's
+        native change-notification API, so ``git status`` only re-stats paths
+        that actually changed instead of walking the whole tree — the dominant
+        cost on huge monorepos where even ``-uall`` with an empty untracked set
+        takes tens of seconds.
+
+        Correctness guards, because unlike the untracked cache this can *break*
+        ``git status`` rather than merely fail to speed it up:
+
+        - **Version gate.** Below git 2.37 (:data:`_FSMONITOR_MIN_GIT_VERSION`)
+          ``core.fsmonitor`` names a *hook script*, so ``true`` would make every
+          ``git status`` fail. We only enable at or above that version.
+        - **Verify-and-rollback.** After enabling we run a cheap ``git status``;
+          if it doesn't cleanly return we unset ``core.fsmonitor`` so we never
+          leave the changed-files view broken.
+        - **Opt-out.** ``OMNIGENT_GIT_FSMONITOR=0`` disables enablement entirely.
+
+        Runs at most once per git-root per process (same rationale as the
+        untracked cache). Failures are swallowed; the daemon is a pure speedup.
+        """
+        if _fsmonitor_opt_out():
+            return
+        root_key = str(self._git_root)
+        with _fsmonitor_lock:
+            if root_key in _fsmonitor_enabled:
+                return
+            _fsmonitor_enabled.add(root_key)
+
+        version = _git_version(root_key)
+        if version is None or version < _FSMONITOR_MIN_GIT_VERSION:
+            _logger.debug(
+                "GitFilesystemRegistry: git %s < %s in %s; not enabling fsmonitor",
+                version,
+                _FSMONITOR_MIN_GIT_VERSION,
+                self._git_root,
+            )
+            return
+        try:
+            set_result = subprocess.run(
+                ["git", "config", "core.fsmonitor", "true"],
+                cwd=root_key,
+                capture_output=True,
+                timeout=_git_timeout_seconds(),
+            )
+            if set_result.returncode != 0:
+                return
+            # Verify with a cheap status (``-uno`` skips the untracked walk, so
+            # this is fast even on huge repos) and also warms the daemon. If it
+            # fails, fsmonitor is misbehaving here — roll the setting back.
+            verify = subprocess.run(
+                ["git", "status", "--porcelain", "-uno"],
+                cwd=root_key,
+                capture_output=True,
+                timeout=_git_timeout_seconds(),
+            )
+            if verify.returncode != 0:
+                _logger.warning(
+                    "GitFilesystemRegistry: git status failed after enabling fsmonitor "
+                    "in %s; rolling back",
+                    self._git_root,
+                )
+                subprocess.run(
+                    ["git", "config", "--unset", "core.fsmonitor"],
+                    cwd=root_key,
+                    capture_output=True,
+                    timeout=_git_timeout_seconds(),
+                )
+        except (subprocess.TimeoutExpired, OSError):
+            _logger.debug(
+                "GitFilesystemRegistry: could not enable core.fsmonitor in %s",
                 self._git_root,
                 exc_info=True,
             )

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -1048,6 +1048,65 @@ def test_fsmonitor_rolled_back_when_status_breaks(tmp_path: Path, monkeypatch) -
     )
 
 
+def test_fsmonitor_rolled_back_when_verify_times_out(tmp_path: Path, monkeypatch) -> None:
+    """If the verify ``git status`` raises, ``core.fsmonitor`` is still unset.
+
+    A cold fsmonitor daemon on a huge repo is most likely to make the first
+    ``git status`` hang (``TimeoutExpired``) rather than exit non-zero — the
+    exception path must roll back too, or the config stays broken and the
+    one-shot guard prevents any retry.
+    """
+    from omnigent.runtime import filesystem_registry as fsr
+
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    monkeypatch.setattr(fsr, "_fsmonitor_enabled", set())
+    monkeypatch.delenv("OMNIGENT_GIT_FSMONITOR", raising=False)
+    monkeypatch.setattr(fsr, "_git_version", lambda _cwd: (2, 40, 0))
+
+    real_run = subprocess.run
+
+    def _timeout_status(args, *a, **kw):
+        # The verify status hangs; the config set and the rollback --unset are
+        # real so we can assert the persisted state.
+        if args[:2] == ["git", "status"]:
+            raise subprocess.TimeoutExpired(cmd="git status", timeout=30)
+        return real_run(args, *a, **kw)
+
+    monkeypatch.setattr(fsr.subprocess, "run", _timeout_status)
+
+    GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+
+    assert _fsmonitor_value(tmp_path, env) == "", (
+        "fsmonitor must be rolled back when the verify status times out."
+    )
+
+
+def test_fsmonitor_respects_existing_config(tmp_path: Path, monkeypatch) -> None:
+    """A pre-existing ``core.fsmonitor`` value is left untouched, not clobbered."""
+    from omnigent.runtime import filesystem_registry as fsr
+
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    # Operator already configured a custom fsmonitor hook path.
+    subprocess.run(
+        ["git", "config", "core.fsmonitor", "/custom/hook"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    monkeypatch.setattr(fsr, "_fsmonitor_enabled", set())
+    monkeypatch.delenv("OMNIGENT_GIT_FSMONITOR", raising=False)
+    monkeypatch.setattr(fsr, "_git_version", lambda _cwd: (2, 40, 0))
+
+    GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+
+    assert _fsmonitor_value(tmp_path, env) == "/custom/hook", (
+        "An operator's existing core.fsmonitor must not be overwritten."
+    )
+
+
 def test_fsmonitor_config_attempted_once_per_root(tmp_path: Path, monkeypatch) -> None:
     """The enablement runs at most once per git-root per process."""
     from omnigent.runtime import filesystem_registry as fsr

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -49,6 +49,18 @@ def _inject(
     registry.record_change(path, operation, conv_id)
 
 
+@pytest.fixture(autouse=True)
+def _disable_fsmonitor_by_default(monkeypatch) -> None:
+    """Opt every test out of fsmonitor unless it explicitly re-enables it.
+
+    Constructing a :class:`GitFilesystemRegistry` on a real repo would otherwise
+    start a long-lived ``git fsmonitor--daemon`` in each test's temp repo — an
+    unwanted side effect across the suite. Tests that exercise fsmonitor undo
+    this with ``monkeypatch.delenv``.
+    """
+    monkeypatch.setenv("OMNIGENT_GIT_FSMONITOR", "0")
+
+
 @pytest.fixture
 def registry(tmp_path: Path) -> AgentEditFilesystemRegistry:
     """An :class:`AgentEditFilesystemRegistry` rooted at a fresh temp directory.
@@ -894,6 +906,171 @@ def test_untracked_cache_not_enabled_when_probe_fails(tmp_path: Path, monkeypatc
     )
     assert result.stdout.strip() == "", (
         f"core.untrackedCache should be unset when the probe fails, got {result.stdout.strip()!r}."
+    )
+
+
+# ── fsmonitor enablement ──────────────────────────────────────────────────────
+
+
+def _fsmonitor_value(cwd: Path, env: dict[str, str]) -> str:
+    """Return the repo's ``core.fsmonitor`` config value (``""`` when unset)."""
+    return subprocess.run(
+        ["git", "config", "--get", "core.fsmonitor"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout.strip()
+
+
+def test_git_version_parses_output(tmp_path: Path, monkeypatch) -> None:
+    """``_git_version`` parses ``git version X.Y.Z`` into a tuple; None on failure."""
+    from omnigent.runtime import filesystem_registry as fsr
+
+    def _fake_run(args, *a, **kw):
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout="git version 2.50.1 (Apple Git-155)\n", stderr=""
+        )
+
+    monkeypatch.setattr(fsr.subprocess, "run", _fake_run)
+    assert fsr._git_version(str(tmp_path)) == (2, 50, 1)
+
+    def _fail_run(args, *a, **kw):
+        raise OSError("git not found")
+
+    monkeypatch.setattr(fsr.subprocess, "run", _fail_run)
+    assert fsr._git_version(str(tmp_path)) is None
+
+
+def test_fsmonitor_not_enabled_when_opted_out(tmp_path: Path, monkeypatch) -> None:
+    """``OMNIGENT_GIT_FSMONITOR=0`` suppresses fsmonitor enablement entirely."""
+    from omnigent.runtime import filesystem_registry as fsr
+
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    monkeypatch.setattr(fsr, "_fsmonitor_enabled", set())
+    monkeypatch.setenv("OMNIGENT_GIT_FSMONITOR", "0")
+
+    GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+
+    assert _fsmonitor_value(tmp_path, env) == "", "fsmonitor should stay unset when opted out."
+
+
+def test_fsmonitor_not_enabled_on_old_git(tmp_path: Path, monkeypatch) -> None:
+    """On git < 2.37 the config must not be written (would break git status)."""
+    from omnigent.runtime import filesystem_registry as fsr
+
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    monkeypatch.setattr(fsr, "_fsmonitor_enabled", set())
+    monkeypatch.delenv("OMNIGENT_GIT_FSMONITOR", raising=False)
+    monkeypatch.setattr(fsr, "_git_version", lambda _cwd: (2, 30, 0))
+
+    config_calls: list[tuple] = []
+    real_run = subprocess.run
+
+    def _watch_run(args, *a, **kw):
+        if args[:3] == ["git", "config", "core.fsmonitor"]:
+            config_calls.append(tuple(args))
+        return real_run(args, *a, **kw)
+
+    monkeypatch.setattr(fsr.subprocess, "run", _watch_run)
+
+    GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+
+    assert config_calls == [], (
+        f"Expected no fsmonitor config write on old git, got {config_calls}."
+    )
+    assert _fsmonitor_value(tmp_path, env) == ""
+
+
+def test_fsmonitor_enabled_on_supported_git(tmp_path: Path, monkeypatch) -> None:
+    """On git ≥ 2.37 with a healthy status, ``core.fsmonitor=true`` is written.
+
+    The verify ``git status`` is stubbed to succeed so this test doesn't spawn a
+    real ``fsmonitor--daemon`` (which pytest's tmp-dir teardown would orphan);
+    the real ``git config`` write still runs, so the assertion is meaningful.
+    """
+    from omnigent.runtime import filesystem_registry as fsr
+
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    monkeypatch.setattr(fsr, "_fsmonitor_enabled", set())
+    monkeypatch.delenv("OMNIGENT_GIT_FSMONITOR", raising=False)
+    monkeypatch.setattr(fsr, "_git_version", lambda _cwd: (2, 37, 0))
+
+    real_run = subprocess.run
+
+    def _stub_status(args, *a, **kw):
+        # Report a healthy status without starting the daemon.
+        if args[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=b"", stderr=b"")
+        return real_run(args, *a, **kw)
+
+    monkeypatch.setattr(fsr.subprocess, "run", _stub_status)
+
+    GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+
+    assert _fsmonitor_value(tmp_path, env) == "true", (
+        "fsmonitor should be enabled on supported git with a healthy status."
+    )
+
+
+def test_fsmonitor_rolled_back_when_status_breaks(tmp_path: Path, monkeypatch) -> None:
+    """If ``git status`` fails after enabling, ``core.fsmonitor`` is unset again.
+
+    Guards the correctness invariant: we must never leave the changed-files
+    view broken. Simulated by making the post-enable verify status exit non-zero.
+    """
+    from omnigent.runtime import filesystem_registry as fsr
+
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    monkeypatch.setattr(fsr, "_fsmonitor_enabled", set())
+    monkeypatch.delenv("OMNIGENT_GIT_FSMONITOR", raising=False)
+    monkeypatch.setattr(fsr, "_git_version", lambda _cwd: (2, 40, 0))
+
+    real_run = subprocess.run
+
+    def _break_status(args, *a, **kw):
+        if args[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=128, stdout=b"", stderr=b"fsmonitor hook broke"
+            )
+        return real_run(args, *a, **kw)
+
+    monkeypatch.setattr(fsr.subprocess, "run", _break_status)
+
+    GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+
+    assert _fsmonitor_value(tmp_path, env) == "", (
+        "fsmonitor must be rolled back when git status fails after enabling."
+    )
+
+
+def test_fsmonitor_config_attempted_once_per_root(tmp_path: Path, monkeypatch) -> None:
+    """The enablement runs at most once per git-root per process."""
+    from omnigent.runtime import filesystem_registry as fsr
+
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    monkeypatch.setattr(fsr, "_fsmonitor_enabled", set())
+    monkeypatch.delenv("OMNIGENT_GIT_FSMONITOR", raising=False)
+
+    version_calls = 0
+
+    def _count_version(_cwd):
+        nonlocal version_calls
+        version_calls += 1
+        return (2, 30, 0)  # old git so nothing is actually written
+
+    monkeypatch.setattr(fsr, "_git_version", _count_version)
+
+    for _ in range(3):
+        GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+
+    assert version_calls == 1, (
+        f"Expected fsmonitor enablement attempted once per root, got {version_calls}."
     )
 
 


### PR DESCRIPTION
## Related issue

N/A — follow-up to #2905.

## Summary

The durable large-repo `git status` fix flagged as follow-up in #2905. On
monorepo-scale checkouts the bottleneck is the working-tree walk itself: on the
`universe` monorepo (~883k tracked files) `git status --untracked-files=all`
takes **~46s even with zero untracked files**, so the timeout / `untrackedCache`
/ pathspec-exclude changes in #2905 couldn't help — none of them touch the
tracked-tree walk.

**fsmonitor** does: git's built-in `fsmonitor--daemon` (git ≥ 2.37) watches the
working tree via the OS's native change-notification API, so `git status` only
re-stats paths that actually changed instead of walking the whole tree.

`GitFilesystemRegistry` now best-effort enables `core.fsmonitor=true` on init,
mirroring the existing `core.untrackedCache` pattern (one-shot per git-root per
process, covering both the runner workspace and the host fallback path). Unlike
`untrackedCache`, a bad `core.fsmonitor` value can *break* `git status` rather
than merely fail to speed it up, so it carries extra correctness guards:

- **Version gate** — only enabled on git ≥ 2.37. On older git `core.fsmonitor`
  names a *hook script*, so `true` would make every `git status` try to exec a
  hook named "true" and fail.
- **Verify-and-rollback** — after enabling, run a cheap `git status` probe; if
  it doesn't cleanly return, unset `core.fsmonitor` so the changed-files view is
  never left broken.
- **Opt-out** — `OMNIGENT_GIT_FSMONITOR=0` disables enablement entirely.

### Note on effectiveness

fsmonitor is a **steady-state** optimization: the daemon must be running and has
to see a few `git status` calls before most index entries are marked valid. The
first status after enabling is still full-cost (the daemon has no history yet).
Enabling at registry construction — which happens once per long-lived
runner/host process per git-root — lets it warm over the session, which is the
whole point of doing it here rather than as a one-shot subprocess.

## Test Plan

```bash
python -m pytest tests/runtime/test_filesystem_registry.py -q
```

- **75 passed** (6 new fsmonitor tests + the existing 69).
- `ruff format` + `ruff check`: clean.
- Verified no `git fsmonitor--daemon` processes are left running after the suite
  (an autouse fixture opts every non-fsmonitor test out via
  `OMNIGENT_GIT_FSMONITOR=0`, and the enablement test stubs the verify-status so
  it doesn't spawn a real daemon in a temp dir pytest then deletes).

New tests cover: env opt-out; version gate (git < 2.37 → not written); happy-path
enablement on supported git; verify-and-rollback when status breaks; one-shot
per git-root; and the `git version` parser.

To confirm the real-world win on a large checkout:

```bash
git config core.fsmonitor true
git status; git status; git status          # warm the daemon (3+ runs)
git fsmonitor--daemon status                 # confirm the daemon is alive
```

To disable in an environment where it's unwanted:

```bash
export OMNIGENT_GIT_FSMONITOR=0
```

## Demo

N/A — non-visual (backend git-status behavior).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover each new behavior and guard. No perf benchmark added — the win
is machine/repo-dependent (and, per #2905, only material on monorepo-scale
checkouts), so a timing assertion would be a flaky CI gate; the effectiveness
was verified manually by warming the daemon on the `universe` monorepo.

This pull request and its description were written by Isaac.
