### PR TITLE
fix(ci): point feature-blog footer to releases page

### DIFF
--- a/.github/workflows/feature-blog.yml
+++ b/.github/workflows/feature-blog.yml
@@ -483,7 +483,7 @@ jobs:
             fi
 
             if [ -n "$post" ]; then
-              printf '\n---\n\n**Enjoying Omnigent?** If this is useful to you, [give us a star on GitHub ⭐](https://github.com/omnigent-ai/omnigent). Come say hi on [Discord](https://discord.gg/omnigent), or [download the latest release](https://omnigent.ai/download).\n' \
+              printf '\n---\n\n**Enjoying Omnigent?** If this is useful to you, [give us a star on GitHub ⭐](https://github.com/omnigent-ai/omnigent). Come say hi on [Discord](https://discord.gg/omnigent), or [check the latest release](https://omnigent.ai/releases).\n' \
                 >> "${SITE}/${post}"
             fi
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The feature-blog post footer linked "download the latest release" to `https://omnigent.ai/download`, which is not a valid page.
- Convert the link text to "check the latest release" and point it at `https://omnigent.ai/releases`.

## Test Plan

- Change is a one-line copy/URL fix in a workflow's `printf` string; no runtime behaviour changes.
- `pre-commit` hooks (yaml syntax, whitespace, EOF) pass on commit.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Non-functional copy/link fix inside a GitHub Actions workflow string; no automated coverage applicable.

This pull request and its description were written by Isaac.