### PR TITLE
fix(setup): detect Kimi Code login

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -12504,7 +12504,7 @@ def _run_configure_harnesses_interactive() -> None:
         # logged-in installation is not incorrectly reported as unconfigured.
         if harness_cli_installed(KIMI_KEY):
             if kimi_login_detected():
-                rows.append((_KIMI, "Kimi Code", "Ready", "ok", "Kimi login detected."))
+                rows.append((_KIMI, "Kimi Code", "Ready", "ready", "Kimi login detected."))
             else:
                 rows.append(
                     (_KIMI, "Kimi Code", "Not configured", "warn", "Sign in with `kimi login`.")

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -12157,6 +12157,7 @@ def _run_configure_harnesses_interactive() -> None:
         harness_install_spec,
     )
     from omnigent.onboarding.interactive import select
+    from omnigent.onboarding.kimi_auth import kimi_login_detected
     from omnigent.onboarding.provider_config import (
         ANTHROPIC_FAMILY,
         OPENAI_FAMILY,
@@ -12498,13 +12499,16 @@ def _run_configure_harnesses_interactive() -> None:
             )
             rows.append((_KIRO, "Kiro", "Not installed", "missing", _install_hint(kiro_hint)))
 
-        # Kimi Code — native CLI, own auth via `kimi login`; there is no local
-        # login status probe yet. Curl-installed (no npm package), so use its
-        # install_hint when absent and show "not configured" when present.
+        # Kimi Code — native CLI, own auth via `kimi login`. Detect credential
+        # directories from current and legacy releases so a
+        # logged-in installation is not incorrectly reported as unconfigured.
         if harness_cli_installed(KIMI_KEY):
-            rows.append(
-                (_KIMI, "Kimi Code", "Not configured", "warn", "Sign in with `kimi login`.")
-            )
+            if kimi_login_detected():
+                rows.append((_KIMI, "Kimi Code", "Ready", "ok", "Kimi login detected."))
+            else:
+                rows.append(
+                    (_KIMI, "Kimi Code", "Not configured", "warn", "Sign in with `kimi login`.")
+                )
         else:
             kimi_spec = harness_install_spec(KIMI_KEY)
             kimi_hint = (kimi_spec.install_hint if kimi_spec else None) or "see Kimi Code docs"

--- a/omnigent/onboarding/kimi_auth.py
+++ b/omnigent/onboarding/kimi_auth.py
@@ -16,7 +16,7 @@ def kimi_credential_dirs(home: Path | None = None) -> tuple[Path, ...]:
     default_home = Path.home()
     paths = [default_home / ".kimi" / "credentials", default_home / ".kimi-code" / "credentials"]
     if configured_home:
-        paths.insert(0, Path(configured_home) / "credentials")
+        paths.insert(0, Path(configured_home).expanduser() / "credentials")
     return tuple(dict.fromkeys(paths))
 
 

--- a/omnigent/onboarding/kimi_auth.py
+++ b/omnigent/onboarding/kimi_auth.py
@@ -1,0 +1,31 @@
+"""Detect an existing Kimi Code login from its local credential directories."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+KIMI_CODE_HOME_ENV_VAR = "KIMI_CODE_HOME"
+
+
+def kimi_credential_dirs(home: Path | None = None) -> tuple[Path, ...]:
+    """Return the credential directories used by current and legacy Kimi Code."""
+    if home is not None:
+        return (home / ".kimi" / "credentials", home / ".kimi-code" / "credentials")
+    configured_home = os.environ.get(KIMI_CODE_HOME_ENV_VAR)
+    default_home = Path.home()
+    paths = [default_home / ".kimi" / "credentials", default_home / ".kimi-code" / "credentials"]
+    if configured_home:
+        paths.insert(0, Path(configured_home) / "credentials")
+    return tuple(dict.fromkeys(paths))
+
+
+def kimi_login_detected(home: Path | None = None) -> bool:
+    """Return whether any known Kimi credential directory contains a file."""
+    for directory in kimi_credential_dirs(home):
+        try:
+            if directory.is_dir() and any(path.is_file() for path in directory.iterdir()):
+                return True
+        except OSError:
+            continue
+    return False

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1985,9 +1985,7 @@ def test_installed_native_cli_auth_unknown_rows_are_not_configured(
     assert descriptions[row_index]
 
 
-def test_overview_kimi_row_is_ready_when_login_is_detected(
-    isolated_config, monkeypatch
-) -> None:
+def test_overview_kimi_row_is_ready_when_login_is_detected(isolated_config, monkeypatch) -> None:
     """An installed, logged-in Kimi CLI is shown as ready in setup."""
     from rich.text import Text
 

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1975,6 +1975,7 @@ def test_installed_native_cli_auth_unknown_rows_are_not_configured(
     monkeypatch.setattr(
         "omnigent.onboarding.harness_install.harness_cli_installed", lambda family: True
     )
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_login_detected", lambda: False)
     options, selectable, descriptions, _compact, _max_visible = _capture_setup_overview(
         monkeypatch
     )
@@ -1982,6 +1983,25 @@ def test_installed_native_cli_auth_unknown_rows_are_not_configured(
     assert "[yellow]✗ Not configured[/]" in options[row_index]
     assert "[green]✓ Installed[/]" not in options[row_index]
     assert descriptions[row_index]
+
+
+def test_overview_kimi_row_is_ready_when_login_is_detected(
+    isolated_config, monkeypatch
+) -> None:
+    """An installed, logged-in Kimi CLI is shown as ready in setup."""
+    from rich.text import Text
+
+    monkeypatch.setattr(
+        "omnigent.onboarding.harness_install.harness_cli_installed", lambda family: True
+    )
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_login_detected", lambda: True)
+    options, selectable, descriptions, _compact, _max_visible = _capture_setup_overview(
+        monkeypatch
+    )
+    row_index = _overview_row_names(options, selectable).index("Kimi Code")
+    assert "Ready" in Text.from_markup(options[row_index]).plain
+    assert "Not configured" not in Text.from_markup(options[row_index]).plain
+    assert descriptions[row_index] == "Kimi login detected."
 
 
 def test_overview_descriptions_map_to_their_rows(isolated_config, monkeypatch) -> None:

--- a/tests/onboarding/test_kimi_auth.py
+++ b/tests/onboarding/test_kimi_auth.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from omnigent.onboarding.kimi_auth import kimi_login_detected
+from omnigent.onboarding.kimi_auth import kimi_credential_dirs, kimi_login_detected
 
 
 def test_detects_current_kimi_code_credentials(tmp_path: Path) -> None:
@@ -20,3 +20,11 @@ def test_detects_legacy_kimi_credentials(tmp_path: Path) -> None:
 def test_empty_or_missing_kimi_credentials_are_not_a_login(tmp_path: Path) -> None:
     (tmp_path / ".kimi-code" / "credentials").mkdir(parents=True)
     assert kimi_login_detected(tmp_path) is False
+
+
+def test_expands_user_in_configured_kimi_home(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("KIMI_CODE_HOME", "~/.kimi-code")
+
+    assert kimi_credential_dirs()[0] == tmp_path / ".kimi-code" / "credentials"

--- a/tests/onboarding/test_kimi_auth.py
+++ b/tests/onboarding/test_kimi_auth.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from omnigent.onboarding.kimi_auth import kimi_login_detected
+
+
+def test_detects_current_kimi_code_credentials(tmp_path: Path) -> None:
+    credentials = tmp_path / ".kimi-code" / "credentials"
+    credentials.mkdir(parents=True)
+    (credentials / "auth.json").write_text("{}", encoding="utf-8")
+    assert kimi_login_detected(tmp_path) is True
+
+
+def test_detects_legacy_kimi_credentials(tmp_path: Path) -> None:
+    credentials = tmp_path / ".kimi" / "credentials"
+    credentials.mkdir(parents=True)
+    (credentials / "token").write_text("token", encoding="utf-8")
+    assert kimi_login_detected(tmp_path) is True
+
+
+def test_empty_or_missing_kimi_credentials_are_not_a_login(tmp_path: Path) -> None:
+    (tmp_path / ".kimi-code" / "credentials").mkdir(parents=True)
+    assert kimi_login_detected(tmp_path) is False


### PR DESCRIPTION
## Summary
- detect Kimi Code credentials in current and legacy home directories
- respect KIMI_CODE_HOME when checking login state
- show the setup overview as Ready for installed, logged-in Kimi Code

## Validation
- uv run pytest tests/onboarding/test_kimi_auth.py tests/cli/test_configure_models.py -k 'kimi or installed_native_cli_auth_unknown' -q
- uv run ruff check omnigent/onboarding/kimi_auth.py omnigent/cli.py tests/onboarding/test_kimi_auth.py tests/cli/test_configure_models.py
- uv run ruff format --check omnigent/onboarding/kimi_auth.py omnigent/cli.py tests/onboarding/test_kimi_auth.py tests/cli/test_configure_models.py
- git diff --check

Fixes #2914