### PR TITLE
feat(benchmarks): add end-to-end UI performance benchmark

### DIFF
--- a/.github/workflows/e2e-ui-benchmark.yml
+++ b/.github/workflows/e2e-ui-benchmark.yml
@@ -1,0 +1,135 @@
+name: UI Benchmark
+
+# Nightly run of the end-to-end UI performance benchmark
+# (dev/benchmarks/omnigent_ui). Boots a real server + runner against a
+# zero-latency mock LLM, builds & serves the web SPA, drives real browser
+# journeys with Playwright, and uploads the JSON report as an artifact —
+# per-journey latency plus network-request counts (by resource type and by
+# method+path). Same artifact contract as the HTTP benchmark (benchmark.yml),
+# so the workspace ETL notebook can ingest it the same way.
+#
+# Scheduled -> runs on the trusted default branch with the repo GITHUB_TOKEN;
+# it reads no PR-authored code. Also dispatchable for an ad-hoc run.
+
+on:
+  schedule:
+    - cron: "43 7 * * *" # 07:43 UTC nightly (just after the HTTP benchmark)
+  workflow_dispatch:
+    inputs:
+      checkout_sha:
+        description: "Commit SHA to benchmark (blank = branch HEAD)"
+        required: false
+        default: ""
+      iterations:
+        description: "Timed browser ops per run (clamped per journey)"
+        required: false
+        default: "8"
+      runs:
+        description: "Timed runs per journey"
+        required: false
+        default: "3"
+
+permissions:
+  contents: read
+
+env:
+  # No SPA build during `uv sync`: a dedicated step builds the bundle, and the
+  # setup.py build otherwise times out on public npm.
+  OMNIGENT_SKIP_WEB_UI: "true"
+  # Scrub harness credentials the benchmark server must not pick up
+  # (OPENAI_* are overridden to the mock inside the spawned server/runner env).
+  ANTHROPIC_API_KEY: ""
+  DATABRICKS_TOKEN: ""
+  UV_INDEX_URL: https://pypi.org/simple
+  PIP_INDEX_URL: https://pypi.org/simple
+  # Root/container Chromium refuses to start without --no-sandbox; the harness
+  # adds the flag when this is set (matches the e2e_ui suite).
+  OMNIGENT_PW_NO_SANDBOX: "1"
+  ITERATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.iterations || '8' }}
+  RUNS: ${{ github.event_name == 'workflow_dispatch' && inputs.runs || '3' }}
+
+concurrency:
+  # Never cancel a scheduled run mid-flight (each is a distinct data point).
+  # Manual dispatches get a per-run group so repeated ad-hoc runs never cancel.
+  group: ui-benchmark-${{ github.event_name }}-${{ github.ref }}-${{ github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
+
+jobs:
+  ui-benchmark:
+    name: Run UI benchmark
+    if: github.repository == 'omnigent-ai/omnigent'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Pin the benchmarked code to a specific commit when dispatched with
+          # checkout_sha; the workflow definition still comes from the trusted
+          # dispatch ref. Blank falls back to the ref's HEAD (schedule/default).
+          ref: ${{ inputs.checkout_sha || github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: Set up Node 20
+        uses: ./.github/actions/setup-node
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v3
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --locked --extra all --extra dev
+
+      - name: Install bubblewrap + tmux
+        # The runner opens terminals under os_env, whose linux_bwrap backend
+        # needs `bwrap`; the apparmor sysctl mirrors the e2e-ui workflow
+        # (Ubuntu 24.04 blocks the user namespaces bwrap's unshare needs).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap tmux
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright Chromium
+        run: uv run playwright install --with-deps chromium
+
+      - name: Build web SPA
+        # Build BEFORE the benchmark: Vite's emptyOutDir clobbers the static
+        # dir, so it must never run alongside the live server. The harness then
+        # runs with --skip-build to reuse this bundle.
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          cd web
+          npm ci --legacy-peer-deps --no-audit --no-fund
+          npm run build
+
+      - name: Run UI benchmark
+        run: |
+          uv run --no-sync dev/benchmarks/omnigent_ui/run.py \
+            --skip-build \
+            --iterations "$ITERATIONS" \
+            --runs "$RUNS" \
+            --output ui-benchmark-results.json
+
+      - name: Upload UI benchmark results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: ui-benchmark-results-${{ github.run_id }}
+          path: ui-benchmark-results.json
+          retention-days: 90
+          if-no-files-found: warn

--- a/.github/workflows/e2e-ui-benchmark.yml
+++ b/.github/workflows/e2e-ui-benchmark.yml
@@ -8,10 +8,18 @@ name: UI Benchmark
 # method+path). Same artifact contract as the HTTP benchmark (benchmark.yml),
 # so the workspace ETL notebook can ingest it the same way.
 #
-# Scheduled -> runs on the trusted default branch with the repo GITHUB_TOKEN;
-# it reads no PR-authored code. Also dispatchable for an ad-hoc run.
+# Pull requests run one functional sample per journey. Scheduled/manual runs
+# collect the full latency distribution and publish the long-lived artifact.
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/e2e-ui-benchmark.yml"
+      - "dev/benchmarks/omnigent/**"
+      - "dev/benchmarks/omnigent_ui/**"
+      - "omnigent/**"
+      - "tests/benchmarks/test_ui_benchmark_smoke.py"
+      - "web/**"
   schedule:
     - cron: "43 7 * * *" # 07:43 UTC nightly (just after the HTTP benchmark)
   workflow_dispatch:
@@ -33,32 +41,23 @@ permissions:
   contents: read
 
 env:
-  # No SPA build during `uv sync`: a dedicated step builds the bundle, and the
-  # setup.py build otherwise times out on public npm.
-  OMNIGENT_SKIP_WEB_UI: "true"
-  # Scrub harness credentials the benchmark server must not pick up
-  # (OPENAI_* are overridden to the mock inside the spawned server/runner env).
-  ANTHROPIC_API_KEY: ""
-  DATABRICKS_TOKEN: ""
   UV_INDEX_URL: https://pypi.org/simple
   PIP_INDEX_URL: https://pypi.org/simple
   # Root/container Chromium refuses to start without --no-sandbox; the harness
   # adds the flag when this is set (matches the e2e_ui suite).
   OMNIGENT_PW_NO_SANDBOX: "1"
-  ITERATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.iterations || '8' }}
-  RUNS: ${{ github.event_name == 'workflow_dispatch' && inputs.runs || '3' }}
+  ITERATIONS: ${{ github.event_name == 'pull_request' && '1' || (github.event_name == 'workflow_dispatch' && inputs.iterations || '8') }}
+  RUNS: ${{ github.event_name == 'pull_request' && '1' || (github.event_name == 'workflow_dispatch' && inputs.runs || '3') }}
 
 concurrency:
-  # Never cancel a scheduled run mid-flight (each is a distinct data point).
-  # Manual dispatches get a per-run group so repeated ad-hoc runs never cancel.
-  group: ui-benchmark-${{ github.event_name }}-${{ github.ref }}-${{ github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
+  group: ui-benchmark-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   ui-benchmark:
     name: Run UI benchmark
     if: github.repository == 'omnigent-ai/omnigent'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
       - name: Check out repo
@@ -75,8 +74,10 @@ jobs:
         with:
           python-version-file: ".python-version"
 
-      - name: Set up Node 20
+      - name: Set up Node 22
         uses: ./.github/actions/setup-node
+        with:
+          node-version: "22"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v3
@@ -84,16 +85,12 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --locked --extra all --extra dev
-
-      - name: Install bubblewrap + tmux
-        # The runner opens terminals under os_env, whose linux_bwrap backend
-        # needs `bwrap`; the apparmor sysctl mirrors the e2e-ui workflow
-        # (Ubuntu 24.04 blocks the user namespaces bwrap's unshare needs).
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y bubblewrap tmux
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        # Skip setup.py's implicit SPA build only for dependency installation.
+        # The dedicated build below uses npm ci, then the harness verifies that
+        # exact bundle via --skip-build.
+        env:
+          OMNIGENT_SKIP_WEB_UI: "true"
+        run: uv sync --locked --extra dev
 
       - name: Cache Playwright browsers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4
@@ -123,6 +120,7 @@ jobs:
             --skip-build \
             --iterations "$ITERATIONS" \
             --runs "$RUNS" \
+            --artifacts-dir ui-benchmark-artifacts \
             --output ui-benchmark-results.json
 
       - name: Upload UI benchmark results
@@ -131,5 +129,14 @@ jobs:
         with:
           name: ui-benchmark-results-${{ github.run_id }}
           path: ui-benchmark-results.json
-          retention-days: 90
+          retention-days: ${{ github.event_name == 'pull_request' && 7 || 90 }}
           if-no-files-found: warn
+
+      - name: Upload UI benchmark diagnostics
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: ui-benchmark-diagnostics-${{ github.run_id }}
+          path: ui-benchmark-artifacts/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/dev/benchmarks/omnigent/README.md
+++ b/dev/benchmarks/omnigent/README.md
@@ -173,7 +173,7 @@ document without running the harness.
 
 ```jsonc
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "generated_at": "<ISO-8601 UTC>",
   "git_sha": "<HEAD sha>",
   "git_branch": "<branch>",

--- a/dev/benchmarks/omnigent/environment.py
+++ b/dev/benchmarks/omnigent/environment.py
@@ -52,6 +52,20 @@ from tests._helpers.compat import (
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _MOCK_SERVER = _REPO_ROOT / "tests" / "server" / "integration" / "mock_llm_server.py"
 
+# Benchmark subprocesses must never discover ambient provider credentials. The
+# harness wires its own mock connection below; inherited auth can otherwise
+# select a real provider or a developer's Databricks profile.
+_AMBIENT_CREDENTIAL_VARS = (
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE",
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CODE_EXECPATH",
+    "CODEX",
+    "DATABRICKS_CONFIG_PROFILE",
+    "DATABRICKS_TOKEN",
+)
+
 _HEALTH_TIMEOUT_S = 90.0
 _MOCK_TIMEOUT_S = 15.0
 _POLL_INTERVAL_S = 0.2
@@ -126,6 +140,8 @@ class BenchEnvironment:
     :param harness: Harness for full-turn agents when ``with_runner`` (default
         ``openai-agents``, a base dependency needing no vendor CLI binary).
     :param model: Model string baked into registered agent specs.
+    :param artifacts_dir: Optional directory that receives subprocess logs on
+        teardown. Useful in CI where the temporary environment is deleted.
     """
 
     def __init__(
@@ -136,6 +152,7 @@ class BenchEnvironment:
         database_uri: str | None = None,
         harness: str = _DEFAULT_HARNESS,
         model: str = _DEFAULT_MODEL,
+        artifacts_dir: Path | None = None,
     ) -> None:
         # with_host is additive over with_runner: the boot runner still serves
         # the warm journeys, and the host daemon additionally lets the cold-start
@@ -145,6 +162,7 @@ class BenchEnvironment:
         self.database_uri = database_uri
         self.harness = harness
         self.model = model
+        self.artifacts_dir = artifacts_dir
         self.base_url = ""
         self.mock_url = ""
         self.runner_id = ""
@@ -211,6 +229,16 @@ class BenchEnvironment:
         binding_token = uuid.uuid4().hex
 
         base_env = {**os.environ}
+        for name in _AMBIENT_CREDENTIAL_VARS:
+            base_env.pop(name, None)
+        base_env.update(
+            {
+                "DATABRICKS_CONFIG_FILE": str(self._tmp / "no-databrickscfg"),
+                "OMNIGENT_CONFIG_HOME": str(self._tmp / "config"),
+                "OMNIGENT_NO_UPDATE_CHECK": "1",
+                "OMNIGENT_SKIP_ONBOARD": "1",
+            }
+        )
         if self.with_runner:
             self.runner_id = token_bound_runner_id(binding_token)
             base_env["OPENAI_API_KEY"] = "mock-key"
@@ -255,6 +283,10 @@ class BenchEnvironment:
             handle.close()
         import shutil
 
+        if self.artifacts_dir is not None:
+            self.artifacts_dir.mkdir(parents=True, exist_ok=True)
+            for log_path in self._tmp.glob("*.log"):
+                shutil.copy2(log_path, self.artifacts_dir / log_path.name)
         shutil.rmtree(self._tmp, ignore_errors=True)
 
     def _sample_resources(self, interval: float = 1.0) -> None:
@@ -656,7 +688,13 @@ class BenchEnvironment:
         created.raise_for_status()
         return str(created.json()["id"])
 
-    async def seed_items(self, session_id: str, count: int) -> None:
+    async def seed_items(
+        self,
+        session_id: str,
+        count: int,
+        *,
+        text_prefix: str = "benchmark seed item",
+    ) -> None:
         """Append *count* history items over HTTP, with no runner or LLM.
 
         Uses the ``external_conversation_item`` event, which the server
@@ -675,7 +713,7 @@ class BenchEnvironment:
                     "item_type": "message",
                     "item_data": {
                         "role": "user",
-                        "content": [{"type": "input_text", "text": f"benchmark seed item {i}"}],
+                        "content": [{"type": "input_text", "text": f"{text_prefix} {i}"}],
                     },
                 },
             }

--- a/dev/benchmarks/omnigent/sample_output.json
+++ b/dev/benchmarks/omnigent/sample_output.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "generated_at": "2026-07-08T18:30:00+00:00",
   "git_sha": "0000000000000000000000000000000000000000",
   "git_branch": "main",

--- a/dev/benchmarks/omnigent/schema.py
+++ b/dev/benchmarks/omnigent/schema.py
@@ -16,7 +16,11 @@ import subprocess
 # v4: per-journey ``summary`` gained ``runs_total`` / ``runs_ok`` (and omits the
 # metric keys when every run failed); a journey that errored out of measurement
 # entirely carries ``skipped: true`` + ``error`` with empty ``runs``/``summary``.
-SCHEMA_VERSION = 4
+# v5 added the browser UI benchmark (dev/benchmarks/omnigent_ui): its per-journey
+# blocks carry a ``network`` sub-object (and optional ``browser_timing``)
+# alongside the shared ``runs``/``summary`` latency shape, under
+# ``harness="web-ui-playwright"``. HTTP-benchmark reports are unchanged.
+SCHEMA_VERSION = 5
 
 
 def _git(*args: str) -> str:

--- a/dev/benchmarks/omnigent/schema.py
+++ b/dev/benchmarks/omnigent/schema.py
@@ -17,7 +17,7 @@ import subprocess
 # metric keys when every run failed); a journey that errored out of measurement
 # entirely carries ``skipped: true`` + ``error`` with empty ``runs``/``summary``.
 # v5 added the browser UI benchmark (dev/benchmarks/omnigent_ui): its per-journey
-# blocks carry a ``network`` sub-object (and optional ``browser_timing``)
+# blocks carry ``distribution`` / ``network`` sub-objects (and optional ``browser_timing``)
 # alongside the shared ``runs``/``summary`` latency shape, under
 # ``harness="web-ui-playwright"``. HTTP-benchmark reports are unchanged.
 SCHEMA_VERSION = 5

--- a/dev/benchmarks/omnigent_ui/README.md
+++ b/dev/benchmarks/omnigent_ui/README.md
@@ -1,0 +1,124 @@
+# Omnigent end-to-end UI benchmark
+
+Baseline, repeatable numbers for real **browser** user journeys through the web
+SPA, so we can track UI latency and network chattiness over time and catch
+regressions the HTTP benchmark (`dev/benchmarks/omnigent/`) can't see — SPA boot,
+SSE streaming to first paint, client-side navigation, and asset/API request
+counts.
+
+The harness boots a real `omnigent server` + runner against a zero-latency mock
+LLM, builds and serves the web SPA, opens a Playwright Chromium browser, drives
+the selected journeys, prints per-journey latency tables, and writes a
+versioned JSON report. Each journey block carries the same `runs`/`summary`
+latency shape as the HTTP benchmark **plus** a `network` sub-object counting the
+requests the journey issued.
+
+Because the mock LLM is zero-latency, the numbers are Omnigent + SSE + browser
+render overhead, not model latency — exactly what a UI regression benchmark
+wants.
+
+## Run it
+
+One-time setup (in a worktree the venv + node deps may be missing):
+
+```bash
+OMNIGENT_SKIP_WEB_UI=true uv sync --extra dev --extra e2e-ui   # venv (once)
+uv run playwright install --with-deps chromium                  # browser (once)
+```
+
+Then:
+
+```bash
+# All journeys (8 iterations × 3 runs each), writing a report.
+uv run --no-sync dev/benchmarks/omnigent_ui/run.py --output ui-benchmark.json
+
+# A single journey, quick.
+uv run --no-sync dev/benchmarks/omnigent_ui/run.py \
+    --journeys landing_load --runs 1 --iterations 2
+
+# Local debugging: visible browser, reuse an existing SPA build.
+uv run --no-sync dev/benchmarks/omnigent_ui/run.py --headed --skip-build
+
+# CI gating: exit 1 if a threshold is breached.
+uv run --no-sync dev/benchmarks/omnigent_ui/run.py --max-p50-ms 2000
+```
+
+`--no-sync` runs against the already-installed venv. The harness builds the SPA
+into `omnigent/server/static/web-ui/` on startup (serialized by
+`web/.build.lock`); pass `--skip-build` to reuse a build already there.
+
+On a root/container runner where Chromium refuses to start without
+`--no-sandbox`, set `OMNIGENT_PW_NO_SANDBOX=1` (same knob the e2e_ui suite
+uses).
+
+Key flags (`--help` for all): `--journeys A,B`, `--database-uri URI` (default:
+throwaway empty SQLite), `--iterations N` (per run, clamped per journey),
+`--runs N`, `--warmup N`, `--headed`, `--skip-build`, `--output FILE`,
+`--max-p50-ms` / `--max-p99-ms` (CI thresholds).
+
+## Journeys
+
+| Journey | What it times | Isolation |
+| --- | --- | --- |
+| `landing_load` | `goto /` → landing composer visible (cold first paint) | fresh context per rep |
+| `new_session_first_token` | fresh bound session → type in composer → Send → first streamed assistant token | fresh context per rep |
+| `switch_sessions` | click between two seeded sessions in the sidebar (client-side nav) → target conversation renders | one shared page (JS state must survive) |
+| `fork_session` | fork from an assistant response → forked conversation renders | fresh context per rep |
+
+`landing_load` and `new_session_first_token` use a fresh browser context each
+repetition so they measure a true cold visit. `switch_sessions` reuses one page
+because a client-side sidebar switch depends on the SPA's in-memory store —
+a full reload would reset it, so it must not `goto`.
+
+Determinism: driven turns use a reset-surviving streaming mock fallback so every
+turn streams the same reply; the server's policy-classifier and generic-turn
+fallbacks (`_policy_llm_`, `gpt-4o-mini`) are set by the base environment so no
+turn blocks or reaches a real provider. Sessions created/forked during a run are
+deleted in each journey's teardown to bound DB drift.
+
+## Report
+
+Same JSON contract as the HTTP benchmark (`schema.py` `build_report`,
+`schema_version` 5), with `harness: "web-ui-playwright"`. Each journey block:
+
+```jsonc
+{
+  "kind": "ui-latency",
+  "backend": "sqlite",
+  "runs": [ { "n_success": 8, "p50_ms": 412.0, "p95_ms": 480.0, ... } ],
+  "summary": { "avg_p50_ms": 412.0, "avg_p95_ms": 480.0, "avg_p99_ms": 495.0, ... },
+  "network": {
+    "aggregation": "median_per_rep",   // counts are the median across reps
+    "reps": 8,
+    "by_resource_type": { "document": 1, "script": 6, "fetch": 4, "websocket": 1 },
+    "by_endpoint": { "GET /v1/sessions/:id": 2, "POST /v1/sessions/:id/events": 1 },
+    "median_total_requests": 14,
+    "max_total_requests": 16,
+    "per_rep_total_requests": [14, 14, 15, 14, 16, 14, 14, 14]
+  },
+  "browser_timing": { "first_contentful_paint_ms": 210.4, "dom_content_loaded_ms": 180.2 }
+}
+```
+
+Network counts are grouped **two** ways: by Playwright resource type
+(`document`/`script`/`stylesheet`/`xhr`/`fetch`/`websocket`/`image`/`font`) and
+by `"{METHOD} {normalized_path}"`, where session/agent ids and asset hashes are
+collapsed to `:id` / `:n` / stem so counts aggregate across reps. Counts are the
+**median per rep** (iteration-count independent); `per_rep_total_requests` and
+`max_total_requests` expose any nondeterminism. `browser_timing` (Navigation
+Timing + FCP) is a **secondary** signal only — the primary latency number is the
+wall-clock span around each journey's awaited stop-assertion.
+
+Latency-regression comparison reuses the HTTP benchmark's comparator unchanged
+(it reads only `summary.avg_p50_ms`/`avg_p95_ms`):
+
+```bash
+uv run --no-sync dev/benchmarks/omnigent/compare.py \
+    --baseline nightly-ui.json --candidate pr-ui.json --threshold 0.20
+```
+
+## CI
+
+`.github/workflows/e2e-ui-benchmark.yml` runs this nightly (and on
+`workflow_dispatch`) and uploads `ui-benchmark-results.json` as an artifact. No
+PR gate for now.

--- a/dev/benchmarks/omnigent_ui/README.md
+++ b/dev/benchmarks/omnigent_ui/README.md
@@ -22,8 +22,8 @@ wants.
 One-time setup (in a worktree the venv + node deps may be missing):
 
 ```bash
-OMNIGENT_SKIP_WEB_UI=true uv sync --extra dev --extra e2e-ui   # venv (once)
-uv run playwright install --with-deps chromium                  # browser (once)
+OMNIGENT_SKIP_WEB_UI=true uv sync --extra dev        # venv (once)
+uv run playwright install --with-deps chromium       # browser (once)
 ```
 
 Then:
@@ -54,19 +54,19 @@ uses).
 Key flags (`--help` for all): `--journeys A,B`, `--database-uri URI` (default:
 throwaway empty SQLite), `--iterations N` (per run, clamped per journey),
 `--runs N`, `--warmup N`, `--headed`, `--skip-build`, `--output FILE`,
-`--max-p50-ms` / `--max-p99-ms` (CI thresholds).
+`--artifacts-dir DIR`, `--max-p50-ms` / `--max-p99-ms` (CI thresholds).
 
 ## Journeys
 
 | Journey | What it times | Isolation |
 | --- | --- | --- |
 | `landing_load` | `goto /` → landing composer visible (cold first paint) | fresh context per rep |
-| `new_session_first_token` | fresh bound session → type in composer → Send → first streamed assistant token | fresh context per rep |
+| `warm_session_first_token` | prepared prompt on a fresh session using the warm boot runner → Send → first rendered assistant token | fresh context per rep |
 | `switch_sessions` | click between two seeded sessions in the sidebar (client-side nav) → target conversation renders | one shared page (JS state must survive) |
 | `fork_session` | fork from an assistant response → forked conversation renders | fresh context per rep |
 
-`landing_load` and `new_session_first_token` use a fresh browser context each
-repetition so they measure a true cold visit. `switch_sessions` reuses one page
+`landing_load` and `warm_session_first_token` use a fresh browser context each
+repetition so browser cache and storage never leak between samples. `switch_sessions` reuses one page
 because a client-side sidebar switch depends on the SPA's in-memory store —
 a full reload would reset it, so it must not `goto`.
 
@@ -87,9 +87,10 @@ Same JSON contract as the HTTP benchmark (`schema.py` `build_report`,
   "backend": "sqlite",
   "runs": [ { "n_success": 8, "p50_ms": 412.0, "p95_ms": 480.0, ... } ],
   "summary": { "avg_p50_ms": 412.0, "avg_p95_ms": 480.0, "avg_p99_ms": 495.0, ... },
+  "distribution": { "samples": 24, "p50_ms": 412.0, "p95_ms": 480.0, ... },
   "network": {
     "aggregation": "median_per_rep",   // counts are the median across reps
-    "reps": 8,
+    "reps": 24,
     "by_resource_type": { "document": 1, "script": 6, "fetch": 4, "websocket": 1 },
     "by_endpoint": { "GET /v1/sessions/:id": 2, "POST /v1/sessions/:id/events": 1 },
     "median_total_requests": 14,
@@ -99,6 +100,10 @@ Same JSON contract as the HTTP benchmark (`schema.py` `build_report`,
   "browser_timing": { "first_contentful_paint_ms": 210.4, "dom_content_loaded_ms": 180.2 }
 }
 ```
+
+UI percentile fields in `summary` are computed over the pooled successful
+samples across all runs, rather than averaging tiny per-run percentile
+estimates. `distribution` records that pooled sample count explicitly.
 
 Network counts are grouped **two** ways: by Playwright resource type
 (`document`/`script`/`stylesheet`/`xhr`/`fetch`/`websocket`/`image`/`font`) and
@@ -119,6 +124,6 @@ uv run --no-sync dev/benchmarks/omnigent/compare.py \
 
 ## CI
 
-`.github/workflows/e2e-ui-benchmark.yml` runs this nightly (and on
-`workflow_dispatch`) and uploads `ui-benchmark-results.json` as an artifact. No
-PR gate for now.
+`.github/workflows/e2e-ui-benchmark.yml` runs one functional sample per journey
+on relevant pull requests. Nightly and `workflow_dispatch` runs collect the full
+configured sample count and upload `ui-benchmark-results.json` as an artifact.

--- a/dev/benchmarks/omnigent_ui/__init__.py
+++ b/dev/benchmarks/omnigent_ui/__init__.py
@@ -1,0 +1,11 @@
+"""Omnigent end-to-end UI performance benchmark.
+
+Stands up a real server + runner against a zero-latency mock LLM, builds and
+serves the web SPA, opens a Playwright Chromium browser, and drives real user
+journeys through the rendered UI — measuring per-journey latency and the number
+of network requests each journey issues (grouped by resource type and by
+method+path). Emits the same versioned JSON report as the HTTP benchmark
+(``dev/benchmarks/omnigent``), with an added ``network`` block per journey.
+
+See ``README.md`` for the workflow and the report contract.
+"""

--- a/dev/benchmarks/omnigent_ui/environment.py
+++ b/dev/benchmarks/omnigent_ui/environment.py
@@ -1,0 +1,118 @@
+"""UI-benchmark environment: server + runner + mock LLM + a served SPA.
+
+:class:`UIEnvironment` extends the HTTP benchmark's :class:`BenchEnvironment`
+(``dev/benchmarks/omnigent/environment.py``) — which already spawns the mock
+LLM, ``omni server``, and a runner with readiness polling — and adds the one
+thing a browser benchmark needs that the HTTP one doesn't: a **built web SPA**
+on disk so the spawned server mounts and serves it at ``base_url``. A Playwright
+browser then navigates there.
+
+The runner is always on (``with_runner=True``): every journey renders the real
+SPA and at least one drives a streamed turn. No host daemon is needed — the
+first-token journey uses the boot runner via an in-session composer turn rather
+than the host-launched cold path (see ``journeys.py``), so ``with_host`` stays
+off to keep the run fast and deterministic.
+
+The SPA build is serialized by the same cross-process file lock the e2e_ui
+suite uses (``web/.build.lock``), and can be skipped with ``skip_build=True``
+when a build is already present (CI builds once, up front).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import filelock
+
+from dev.benchmarks.omnigent.environment import BenchEnvironment
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WEB_DIR = _REPO_ROOT / "web"
+_BUILD_OUTPUT = _REPO_ROOT / "omnigent" / "server" / "static" / "web-ui"
+_BUILD_LOCK = _WEB_DIR / ".build.lock"
+# Vite's emptyOutDir nukes the dir before writing, so concurrent worktrees would
+# clobber each other; the lock serializes builds. Generous: a cold npm ci +
+# build on a fresh tree runs into minutes.
+_BUILD_LOCK_TIMEOUT_S = 600.0
+
+# Files a usable SPA build must contain (subset of the e2e_ui PWA assertion —
+# we only need "the app shell is present", not the service-worker contract).
+_REQUIRED_BUILD_FILES = ("index.html",)
+
+
+class SPABuildError(RuntimeError):
+    """The web SPA build is missing or failed."""
+
+
+def ensure_spa_built(*, skip_build: bool) -> None:
+    """Build the web SPA into ``omnigent/server/static/web-ui/`` (once).
+
+    Mirrors the e2e_ui ``built_spa`` fixture: ``npm ci --legacy-peer-deps``
+    then ``npm run build``, serialized by ``web/.build.lock``. With
+    *skip_build* set, only asserts an existing build is present.
+
+    :param skip_build: Reuse whatever is already in the build dir instead of
+        rebuilding. Raises if no build is present.
+    :raises SPABuildError: If the build is missing (skip mode) or npm fails.
+    """
+    if skip_build:
+        _assert_build_present()
+        return
+
+    with filelock.FileLock(str(_BUILD_LOCK), timeout=_BUILD_LOCK_TIMEOUT_S):
+        # --legacy-peer-deps matches the workflow + e2e_ui fixture: the lockfile
+        # already pins the tree, so this avoids a slow React 19 peer re-resolve.
+        try:
+            subprocess.run(
+                ["npm", "ci", "--legacy-peer-deps", "--no-audit", "--no-fund"],
+                cwd=_WEB_DIR,
+                check=True,
+            )
+            subprocess.run(["npm", "run", "build"], cwd=_WEB_DIR, check=True)
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise SPABuildError(f"web SPA build failed: {exc}") from exc
+    _assert_build_present()
+
+
+def _assert_build_present() -> None:
+    """Fail if the built SPA app shell is missing from the output dir."""
+    for name in _REQUIRED_BUILD_FILES:
+        if not (_BUILD_OUTPUT / name).is_file():
+            raise SPABuildError(
+                f"SPA build missing {name} at {_BUILD_OUTPUT} — run without "
+                "--skip-build, or build web/ first (npm ci && npm run build)."
+            )
+
+
+class UIEnvironment(BenchEnvironment):
+    """A :class:`BenchEnvironment` that also serves the web SPA for a browser.
+
+    Always boots with a runner (the SPA + streamed turns need it); no host
+    daemon. Building on the base class means the mock-LLM control
+    (``configure_mock`` / ``set_mock_fallback``), session primitives
+    (``ensure_agent`` / ``create_bound_session`` / ``drive_turn`` /
+    ``seed_items``), and the resource sampler all come for free.
+
+    :param database_uri: DB the server boots against; ``None`` uses a fresh
+        throwaway SQLite file (the empty-DB path).
+    :param skip_build: Reuse an existing SPA build instead of rebuilding.
+    """
+
+    def __init__(
+        self,
+        *,
+        database_uri: str | None = None,
+        skip_build: bool = False,
+    ) -> None:
+        super().__init__(with_runner=True, with_host=False, database_uri=database_uri)
+        self._skip_build = skip_build
+
+    async def __aenter__(self) -> UIEnvironment:
+        # Build the SPA before the server boots so it mounts the static bundle.
+        # Synchronous npm work off the event loop.
+        import asyncio
+
+        await asyncio.to_thread(ensure_spa_built, skip_build=self._skip_build)
+        await super().__aenter__()
+        return self

--- a/dev/benchmarks/omnigent_ui/environment.py
+++ b/dev/benchmarks/omnigent_ui/environment.py
@@ -22,10 +22,14 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import filelock
 
 from dev.benchmarks.omnigent.environment import BenchEnvironment
+
+if TYPE_CHECKING:
+    from playwright.async_api import Page
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _WEB_DIR = _REPO_ROOT / "web"
@@ -97,6 +101,7 @@ class UIEnvironment(BenchEnvironment):
     :param database_uri: DB the server boots against; ``None`` uses a fresh
         throwaway SQLite file (the empty-DB path).
     :param skip_build: Reuse an existing SPA build instead of rebuilding.
+    :param artifacts_dir: Optional directory for subprocess logs and screenshots.
     """
 
     def __init__(
@@ -104,9 +109,16 @@ class UIEnvironment(BenchEnvironment):
         *,
         database_uri: str | None = None,
         skip_build: bool = False,
+        artifacts_dir: Path | None = None,
     ) -> None:
-        super().__init__(with_runner=True, with_host=False, database_uri=database_uri)
+        super().__init__(
+            with_runner=True,
+            with_host=False,
+            database_uri=database_uri,
+            artifacts_dir=artifacts_dir,
+        )
         self._skip_build = skip_build
+        self._failure_index = 0
 
     async def __aenter__(self) -> UIEnvironment:
         # Build the SPA before the server boots so it mounts the static bundle.
@@ -116,3 +128,12 @@ class UIEnvironment(BenchEnvironment):
         await asyncio.to_thread(ensure_spa_built, skip_build=self._skip_build)
         await super().__aenter__()
         return self
+
+    async def capture_failure(self, page: Page, journey_name: str) -> None:
+        """Save the current page when CI requested diagnostic artifacts."""
+        if self.artifacts_dir is None:
+            return
+        self.artifacts_dir.mkdir(parents=True, exist_ok=True)
+        self._failure_index += 1
+        path = self.artifacts_dir / f"{journey_name}-{self._failure_index}.png"
+        await page.screenshot(path=path, full_page=True)

--- a/dev/benchmarks/omnigent_ui/journeys.py
+++ b/dev/benchmarks/omnigent_ui/journeys.py
@@ -1,0 +1,501 @@
+"""Browser user-journey definitions and the runner that times them.
+
+A :class:`UIJourney` names a user-facing browser flow, an optional ``setup``
+run once, an optional per-repetition ``prepare`` (untimed — positions the page
+at the journey's starting state), a ``measure`` coroutine (the timed unit), and
+an optional ``teardown``. :func:`run_ui_journey` boots each journey's pages,
+runs ``warmup`` throwaway reps then ``runs``×``iterations`` timed reps, times the
+awaited stop-assertion inside ``measure`` with :func:`time.perf_counter`, and
+tallies each timed rep's network requests (see :mod:`netcapture`).
+
+Isolation is per journey:
+
+- ``fresh_context`` — a new browser context + page per rep, so cold-visit
+  journeys (``landing_load``, ``new_session_first_token``) measure a true first
+  paint. Prerequisite sessions are created (untimed) in ``prepare``.
+- ``shared_page`` — one page reused across a journey's reps, so JS module state
+  survives. ``switch_sessions`` needs this: switching is client-side navigation
+  via the sidebar link, and a full reload would reset the store.
+
+The four journeys:
+
+- ``landing_load`` — navigate to ``/`` and wait for the landing composer.
+- ``new_session_first_token`` — on a fresh bound session, type into the
+  in-session composer and time to the first streamed assistant token.
+- ``switch_sessions`` — click between two seeded sessions in the sidebar
+  (client-side) and time to the target conversation rendering.
+- ``fork_session`` — fork from an assistant response and time to the forked
+  conversation rendering.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Literal, cast
+
+import httpx
+from playwright.async_api import Page, expect
+
+from dev.benchmarks.omnigent.measure import RunResult
+
+from .environment import UIEnvironment
+from .netcapture import NetCapture, RepCapture, aggregate_network
+from .ui_driver import (
+    ASSISTANT_BUBBLE,
+    COMPOSER_PLACEHOLDER,
+    FORK_FROM_RESPONSE,
+    FORK_SUBMIT,
+    LANDING_INPUT,
+    SEND_BUTTON_NAME,
+    USER_BUBBLE,
+    UIDriver,
+    read_browser_timing,
+    sidebar_session_link,
+)
+
+Isolation = Literal["fresh_context", "shared_page"]
+
+# Opaque per-journey context returned by ``setup`` and threaded to the other
+# hooks; each hook casts it to the concrete type it expects.
+JourneyContext = object
+
+# Per-assertion budgets. A UI stop-assertion waits on real render/stream work,
+# so these are generous enough to absorb a cold first paint without masking a
+# true hang (mirrors the e2e_ui suite's timeouts).
+_ASSERT_TIMEOUT_MS = 30_000
+_FIRST_TOKEN_TIMEOUT_MS = 60_000
+
+# Iteration cap: browser journeys cost ~1s+ per rep (real render + stream), so a
+# large --iterations tuned for the millisecond HTTP journeys would overrun CI.
+# Take a few samples per run and lean on --runs for repeats.
+_UI_MAX_ITERATIONS = 8
+
+# Seeded history items per switch-journey session — enough to render a
+# conversation the switch can wait on, cheap to seed over HTTP.
+_SWITCH_SEED_ITEMS = 4
+
+# Deterministic mock reply streamed word-by-word for the turn-driving journeys.
+_REPLY_TEXT = "Hello there, this is a mock benchmark reply."
+_TURN_PROMPT = "Say hello."
+
+
+@dataclass
+class UIJourney:
+    """One benchmarkable browser journey.
+
+    :param name: Stable id used on the CLI and as the report key.
+    :param isolation: ``fresh_context`` (new page per rep) or ``shared_page``
+        (one page reused, preserving JS state).
+    :param measure: Coroutine performing exactly one timed browser operation,
+        given ``(env, page, ctx)``. Its awaited stop-assertion bounds the timer.
+    :param setup: Coroutine run once before timing; its return is the ``ctx``.
+    :param prepare: Coroutine run before every rep, OUTSIDE the timer, to
+        position the page at the journey's starting state.
+    :param teardown: Coroutine run once after timing, given ``ctx``.
+    :param capture_nav_timing: Read Navigation Timing + FCP after each timed
+        rep (only meaningful for journeys whose ``measure`` is a navigation).
+    :param max_iterations: Upper bound clamping ``--iterations`` down (never up).
+    :param description: One-liner for ``--list`` / the report.
+    """
+
+    name: str
+    isolation: Isolation
+    measure: Callable[[UIEnvironment, Page, JourneyContext], Awaitable[None]]
+    setup: Callable[[UIEnvironment], Awaitable[JourneyContext]] | None = None
+    prepare: Callable[[UIEnvironment, Page, JourneyContext], Awaitable[None]] | None = None
+    teardown: Callable[[UIEnvironment, JourneyContext], Awaitable[None]] | None = None
+    capture_nav_timing: bool = False
+    max_iterations: int = _UI_MAX_ITERATIONS
+    description: str = ""
+
+    async def run_setup(self, env: UIEnvironment) -> JourneyContext:
+        return await self.setup(env) if self.setup is not None else None
+
+    async def run_prepare(self, env: UIEnvironment, page: Page, ctx: JourneyContext) -> None:
+        if self.prepare is not None:
+            await self.prepare(env, page, ctx)
+
+    async def run_teardown(self, env: UIEnvironment, ctx: JourneyContext) -> None:
+        if self.teardown is not None:
+            await self.teardown(env, ctx)
+
+
+@dataclass
+class _Sink:
+    """Where a timed rep records its latency, network tally, and browser timing."""
+
+    result: RunResult
+    net_reps: list[RepCapture]
+    timings: list[dict[str, float]]
+
+
+async def _one_rep(
+    journey: UIJourney,
+    env: UIEnvironment,
+    driver: UIDriver,
+    ctx: JourneyContext,
+    shared_page: Page | None,
+    sink: _Sink | None,
+) -> None:
+    """Run one repetition: acquire a page, prepare (untimed), then time ``measure``.
+
+    *sink* is ``None`` for warmup reps (everything discarded). For a timed rep,
+    a failure in ``prepare`` or ``measure`` is recorded as a failure reason
+    rather than aborting the run.
+    """
+    if journey.isolation == "fresh_context":
+        page_ctx = await driver.new_context()
+        page = await page_ctx.new_page()
+    else:
+        page_ctx = None
+        assert shared_page is not None
+        page = shared_page
+
+    netcap = NetCapture(page)
+    try:
+        try:
+            await journey.run_prepare(env, page, ctx)
+        except Exception as exc:  # noqa: BLE001 — a prepare failure is a data point
+            if sink is not None:
+                sink.result.record_failure(f"prepare:{exc.__class__.__name__}")
+            return
+
+        netcap.start()
+        start = time.perf_counter()
+        try:
+            await journey.measure(env, page, ctx)
+        except Exception as exc:  # noqa: BLE001 — any measure failure is recorded
+            netcap.stop()
+            if sink is not None:
+                sink.result.record_failure(exc.__class__.__name__)
+            return
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        rep = netcap.stop()
+
+        if sink is not None:
+            sink.result.latencies_ms.append(elapsed_ms)
+            sink.net_reps.append(rep)
+            if journey.capture_nav_timing:
+                timing = await read_browser_timing(page)
+                if timing is not None:
+                    sink.timings.append(timing)
+    finally:
+        if page_ctx is not None:
+            await driver.close_context(page_ctx)
+
+
+async def run_ui_journey(
+    journey: UIJourney,
+    env: UIEnvironment,
+    driver: UIDriver,
+    *,
+    runs: int,
+    iterations: int,
+    warmup: int,
+) -> tuple[list[RunResult], list[RepCapture], list[dict[str, float]]]:
+    """Run a journey's warmup + timed reps; return per-run results + network + timing.
+
+    :returns: ``(results, net_reps, browser_timings)`` — one :class:`RunResult`
+        per timed run, the flat list of every timed rep's network tally, and any
+        captured browser-timing samples.
+    """
+    ctx = await journey.run_setup(env)
+    results: list[RunResult] = []
+    net_reps: list[RepCapture] = []
+    timings: list[dict[str, float]] = []
+
+    shared_page: Page | None = None
+    shared_ctx = None
+    try:
+        if journey.isolation == "shared_page":
+            shared_ctx = await driver.new_context()
+            shared_page = await shared_ctx.new_page()
+
+        for _ in range(warmup):
+            with contextlib.suppress(Exception):  # warmup errors are non-fatal
+                await _one_rep(journey, env, driver, ctx, shared_page, sink=None)
+
+        for _ in range(runs):
+            result = RunResult()
+            sink = _Sink(result=result, net_reps=net_reps, timings=timings)
+            wall_start = time.perf_counter()
+            for _ in range(iterations):
+                await _one_rep(journey, env, driver, ctx, shared_page, sink=sink)
+            result.wall_time = time.perf_counter() - wall_start
+            results.append(result)
+    finally:
+        if shared_ctx is not None:
+            await driver.close_context(shared_ctx)
+        await journey.run_teardown(env, ctx)
+
+    return results, net_reps, timings
+
+
+# ── shared setup helpers ─────────────────────────────────────
+
+
+async def _setup_agent(env: UIEnvironment) -> str:
+    """Register the benchmark agent and return its id."""
+    name = await env.ensure_agent()
+    return await env.agent_id(name)
+
+
+async def _ensure_streaming_reply(env: UIEnvironment) -> None:
+    """Set a reset-surviving streaming fallback so driven turns emit deltas."""
+    await env.set_mock_fallback(_REPLY_TEXT, stream=True)
+
+
+async def _delete_sessions(env: UIEnvironment, ids: list[str]) -> None:
+    """Best-effort DELETE of sessions created during a run (untimed teardown)."""
+    assert env.client is not None
+    for sid in ids:
+        with contextlib.suppress(httpx.HTTPError):
+            await env.client.delete(f"/v1/sessions/{sid}")
+
+
+# ── journey 1: landing page load ─────────────────────────────
+
+
+async def _measure_landing_load(_env: UIEnvironment, page: Page, _ctx: JourneyContext) -> None:
+    """Navigate to ``/`` and wait for the landing composer to be interactive."""
+    await page.goto("/", wait_until="commit")
+    await expect(page.locator(LANDING_INPUT)).to_be_visible(timeout=_ASSERT_TIMEOUT_MS)
+
+
+# ── journey 2: new session → first streamed token ────────────
+
+
+@dataclass
+class _FirstTokenCtx:
+    """First-token context: the agent to chat with + sessions to clean up."""
+
+    agent_id: str
+    created_ids: list[str] = field(default_factory=list)
+
+
+async def _setup_first_token(env: UIEnvironment) -> _FirstTokenCtx:
+    """Register a streaming-reply agent for the first-token journey."""
+    await _ensure_streaming_reply(env)
+    agent_id = await _setup_agent(env)
+    return _FirstTokenCtx(agent_id=agent_id)
+
+
+async def _prepare_first_token(env: UIEnvironment, page: Page, ctx: JourneyContext) -> None:
+    """Create a fresh bound session and open it, ready for the first message."""
+    fc = cast(_FirstTokenCtx, ctx)
+    session_id = await env.create_bound_session(fc.agent_id)
+    fc.created_ids.append(session_id)
+    await page.goto(f"/c/{session_id}", wait_until="commit")
+    await expect(page.get_by_placeholder(COMPOSER_PLACEHOLDER)).to_be_visible(
+        timeout=_ASSERT_TIMEOUT_MS
+    )
+
+
+async def _measure_first_token(_env: UIEnvironment, page: Page, _ctx: JourneyContext) -> None:
+    """Send the first message and wait for the first streamed assistant token.
+
+    Stops on a real assistant bubble carrying non-whitespace text — NOT the
+    ``working-indicator`` shimmer (which would let the timer stop on the spinner
+    before any token streamed).
+    """
+    composer = page.get_by_placeholder(COMPOSER_PLACEHOLDER)
+    await composer.fill(_TURN_PROMPT)
+    await page.get_by_role("button", name=SEND_BUTTON_NAME, exact=True).click()
+    assistant = page.locator(ASSISTANT_BUBBLE).first
+    await expect(assistant).to_be_visible(timeout=_FIRST_TOKEN_TIMEOUT_MS)
+    await expect(assistant).to_have_text(re.compile(r"\S"), timeout=_FIRST_TOKEN_TIMEOUT_MS)
+
+
+async def _teardown_first_token(env: UIEnvironment, ctx: JourneyContext) -> None:
+    await _delete_sessions(env, cast(_FirstTokenCtx, ctx).created_ids)
+
+
+# ── journey 3: switch between sessions (client-side) ─────────
+
+
+@dataclass
+class _SwitchCtx:
+    """Switch-journey context: the two sessions clicked between in the sidebar."""
+
+    session_a: str
+    session_b: str
+
+
+async def _setup_switch(env: UIEnvironment) -> _SwitchCtx:
+    """Create two bound sessions with a little seeded history to render."""
+    agent_id = await _setup_agent(env)
+    session_a = await env.create_bound_session(agent_id)
+    session_b = await env.create_bound_session(agent_id)
+    await env.seed_items(session_a, _SWITCH_SEED_ITEMS)
+    await env.seed_items(session_b, _SWITCH_SEED_ITEMS)
+    return _SwitchCtx(session_a=session_a, session_b=session_b)
+
+
+async def _prepare_switch(_env: UIEnvironment, page: Page, ctx: JourneyContext) -> None:
+    """Position on session A, via a full load on first rep then client-side after.
+
+    Waits until session B's sidebar link is present so the timed switch has a
+    stable click target.
+    """
+    sc = cast(_SwitchCtx, ctx)
+    if "/c/" not in page.url:
+        await page.goto(f"/c/{sc.session_a}", wait_until="commit")
+    else:
+        await page.locator(sidebar_session_link(sc.session_a)).click()
+    await page.wait_for_url(
+        re.compile(rf"/c/{re.escape(sc.session_a)}"), timeout=_ASSERT_TIMEOUT_MS
+    )
+    await expect(page.locator(sidebar_session_link(sc.session_b))).to_be_visible(
+        timeout=_ASSERT_TIMEOUT_MS
+    )
+
+
+async def _measure_switch(_env: UIEnvironment, page: Page, ctx: JourneyContext) -> None:
+    """Click session B's sidebar link and wait for its conversation to render."""
+    sc = cast(_SwitchCtx, ctx)
+    await page.locator(sidebar_session_link(sc.session_b)).click()
+    await page.wait_for_url(
+        re.compile(rf"/c/{re.escape(sc.session_b)}"), timeout=_ASSERT_TIMEOUT_MS
+    )
+    await expect(page.locator(USER_BUBBLE).first).to_be_visible(timeout=_ASSERT_TIMEOUT_MS)
+
+
+async def _teardown_switch(env: UIEnvironment, ctx: JourneyContext) -> None:
+    sc = cast(_SwitchCtx, ctx)
+    await _delete_sessions(env, [sc.session_a, sc.session_b])
+
+
+# ── journey 4: fork a session ────────────────────────────────
+
+
+@dataclass
+class _ForkCtx:
+    """Fork-journey context: the source session + the forks to clean up."""
+
+    source_id: str
+    fork_ids: list[str] = field(default_factory=list)
+
+
+async def _setup_fork(env: UIEnvironment) -> _ForkCtx:
+    """Create a bound session and drive one turn so it has an assistant bubble."""
+    await _ensure_streaming_reply(env)
+    agent_id = await _setup_agent(env)
+    source_id = await env.create_bound_session(agent_id)
+    await env.drive_turn(source_id, _TURN_PROMPT)
+    return _ForkCtx(source_id=source_id)
+
+
+async def _prepare_fork(_env: UIEnvironment, page: Page, ctx: JourneyContext) -> None:
+    """Open the source conversation and wait for its assistant bubble to render."""
+    fc = cast(_ForkCtx, ctx)
+    await page.goto(f"/c/{fc.source_id}", wait_until="commit")
+    await expect(page.locator(ASSISTANT_BUBBLE).first).to_be_visible(
+        timeout=_FIRST_TOKEN_TIMEOUT_MS
+    )
+
+
+async def _measure_fork(_env: UIEnvironment, page: Page, ctx: JourneyContext) -> None:
+    """Fork from the first assistant response and wait for the clone to render."""
+    fc = cast(_ForkCtx, ctx)
+    first_assistant = page.locator(ASSISTANT_BUBBLE).first
+    await first_assistant.hover()
+    await first_assistant.locator(FORK_FROM_RESPONSE).click()
+    await page.locator(FORK_SUBMIT).click()
+    # Land on a DIFFERENT /c/<id> — a 32-hex id that is not the source.
+    await page.wait_for_url(
+        re.compile(rf"/c/(?!{re.escape(fc.source_id)})[0-9a-f]{{32}}"),
+        timeout=_ASSERT_TIMEOUT_MS,
+    )
+    await expect(page.locator(USER_BUBBLE).first).to_be_visible(timeout=_ASSERT_TIMEOUT_MS)
+    fork_id = page.url.rsplit("/c/", 1)[1].split("?", 1)[0]
+    fc.fork_ids.append(fork_id)
+
+
+async def _teardown_fork(env: UIEnvironment, ctx: JourneyContext) -> None:
+    fc = cast(_ForkCtx, ctx)
+    await _delete_sessions(env, [fc.source_id, *fc.fork_ids])
+
+
+# ── registry ─────────────────────────────────────────────────
+
+ALL_UI_JOURNEYS: dict[str, UIJourney] = {
+    j.name: j
+    for j in (
+        UIJourney(
+            name="landing_load",
+            isolation="fresh_context",
+            measure=_measure_landing_load,
+            capture_nav_timing=True,
+            description="Navigate to / and wait for the landing composer (cold first paint).",
+        ),
+        UIJourney(
+            name="new_session_first_token",
+            isolation="fresh_context",
+            setup=_setup_first_token,
+            prepare=_prepare_first_token,
+            measure=_measure_first_token,
+            teardown=_teardown_first_token,
+            description="On a fresh bound session, send a message; time to the first "
+            "streamed assistant token.",
+        ),
+        UIJourney(
+            name="switch_sessions",
+            isolation="shared_page",
+            setup=_setup_switch,
+            prepare=_prepare_switch,
+            measure=_measure_switch,
+            teardown=_teardown_switch,
+            description="Click between two seeded sessions in the sidebar (client-side "
+            "nav); time to the target conversation rendering.",
+        ),
+        UIJourney(
+            name="fork_session",
+            isolation="fresh_context",
+            setup=_setup_fork,
+            prepare=_prepare_fork,
+            measure=_measure_fork,
+            teardown=_teardown_fork,
+            description="Fork from an assistant response; time to the forked "
+            "conversation rendering.",
+        ),
+    )
+}
+
+
+def resolve_ui_journeys(names: list[str] | None) -> list[UIJourney]:
+    """Resolve requested journey *names* (or all when ``None``/empty).
+
+    :raises KeyError: If a requested name isn't registered.
+    """
+    if not names:
+        return list(ALL_UI_JOURNEYS.values())
+    resolved = []
+    for name in names:
+        if name not in ALL_UI_JOURNEYS:
+            raise KeyError(f"unknown journey {name!r}; known: {', '.join(ALL_UI_JOURNEYS)}")
+        resolved.append(ALL_UI_JOURNEYS[name])
+    return resolved
+
+
+def summarize_browser_timing(samples: list[dict[str, float]]) -> dict[str, float]:
+    """Mean of each browser-timing metric across *samples* (empty when none)."""
+    if not samples:
+        return {}
+    import statistics
+
+    keys = set().union(*samples)
+    out: dict[str, float] = {}
+    for key in keys:
+        values = [s[key] for s in samples if isinstance(s.get(key), (int, float))]
+        if values:
+            out[key] = statistics.mean(values)
+    return out
+
+
+def build_network_block(net_reps: list[RepCapture]) -> dict[str, object]:
+    """Public wrapper around :func:`aggregate_network` for the report builder."""
+    return aggregate_network(net_reps)

--- a/dev/benchmarks/omnigent_ui/journeys.py
+++ b/dev/benchmarks/omnigent_ui/journeys.py
@@ -11,8 +11,8 @@ tallies each timed rep's network requests (see :mod:`netcapture`).
 Isolation is per journey:
 
 - ``fresh_context`` — a new browser context + page per rep, so cold-visit
-  journeys (``landing_load``, ``new_session_first_token``) measure a true first
-  paint. Prerequisite sessions are created (untimed) in ``prepare``.
+  journeys (``landing_load``, ``warm_session_first_token``) isolate cache and
+  storage. Prerequisite sessions are created (untimed) in ``prepare``.
 - ``shared_page`` — one page reused across a journey's reps, so JS module state
   survives. ``switch_sessions`` needs this: switching is client-side navigation
   via the sidebar link, and a full reload would reset the store.
@@ -20,8 +20,8 @@ Isolation is per journey:
 The four journeys:
 
 - ``landing_load`` — navigate to ``/`` and wait for the landing composer.
-- ``new_session_first_token`` — on a fresh bound session, type into the
-  in-session composer and time to the first streamed assistant token.
+- ``warm_session_first_token`` — on a fresh session bound to the warm runner,
+  click Send on a prepared prompt and time to the first rendered assistant token.
 - ``switch_sessions`` — click between two seeded sessions in the sidebar
   (client-side) and time to the target conversation rendering.
 - ``fork_session`` — fork from an assistant response and time to the forked
@@ -96,6 +96,7 @@ class UIJourney:
     :param prepare: Coroutine run before every rep, OUTSIDE the timer, to
         position the page at the journey's starting state.
     :param teardown: Coroutine run once after timing, given ``ctx``.
+    :param cleanup: Coroutine run after every repetition, outside the timer.
     :param capture_nav_timing: Read Navigation Timing + FCP after each timed
         rep (only meaningful for journeys whose ``measure`` is a navigation).
     :param max_iterations: Upper bound clamping ``--iterations`` down (never up).
@@ -108,6 +109,7 @@ class UIJourney:
     setup: Callable[[UIEnvironment], Awaitable[JourneyContext]] | None = None
     prepare: Callable[[UIEnvironment, Page, JourneyContext], Awaitable[None]] | None = None
     teardown: Callable[[UIEnvironment, JourneyContext], Awaitable[None]] | None = None
+    cleanup: Callable[[UIEnvironment, Page, JourneyContext], Awaitable[None]] | None = None
     capture_nav_timing: bool = False
     max_iterations: int = _UI_MAX_ITERATIONS
     description: str = ""
@@ -122,6 +124,10 @@ class UIJourney:
     async def run_teardown(self, env: UIEnvironment, ctx: JourneyContext) -> None:
         if self.teardown is not None:
             await self.teardown(env, ctx)
+
+    async def run_cleanup(self, env: UIEnvironment, page: Page, ctx: JourneyContext) -> None:
+        if self.cleanup is not None:
+            await self.cleanup(env, page, ctx)
 
 
 @dataclass
@@ -160,6 +166,8 @@ async def _one_rep(
         try:
             await journey.run_prepare(env, page, ctx)
         except Exception as exc:  # noqa: BLE001 — a prepare failure is a data point
+            with contextlib.suppress(Exception):
+                await env.capture_failure(page, journey.name)
             if sink is not None:
                 sink.result.record_failure(f"prepare:{exc.__class__.__name__}")
             return
@@ -170,6 +178,8 @@ async def _one_rep(
             await journey.measure(env, page, ctx)
         except Exception as exc:  # noqa: BLE001 — any measure failure is recorded
             netcap.stop()
+            with contextlib.suppress(Exception):
+                await env.capture_failure(page, journey.name)
             if sink is not None:
                 sink.result.record_failure(exc.__class__.__name__)
             return
@@ -184,6 +194,14 @@ async def _one_rep(
                 if timing is not None:
                     sink.timings.append(timing)
     finally:
+        try:
+            await journey.run_cleanup(env, page, ctx)
+        except Exception as exc:  # noqa: BLE001 — cleanup drift invalidates the sample
+            with contextlib.suppress(Exception):
+                await env.capture_failure(page, journey.name)
+            if sink is not None:
+                sink.result.record_failure(f"cleanup:{exc.__class__.__name__}")
+        netcap.stop()
         if page_ctx is not None:
             await driver.close_context(page_ctx)
 
@@ -249,12 +267,19 @@ async def _ensure_streaming_reply(env: UIEnvironment) -> None:
     await env.set_mock_fallback(_REPLY_TEXT, stream=True)
 
 
-async def _delete_sessions(env: UIEnvironment, ids: list[str]) -> None:
-    """Best-effort DELETE of sessions created during a run (untimed teardown)."""
+async def _delete_sessions(
+    env: UIEnvironment, ids: list[str], *, best_effort: bool = True
+) -> None:
+    """Delete sessions created during a run, optionally suppressing failures."""
     assert env.client is not None
     for sid in ids:
-        with contextlib.suppress(httpx.HTTPError):
-            await env.client.delete(f"/v1/sessions/{sid}")
+        try:
+            response = await env.client.delete(f"/v1/sessions/{sid}")
+            if response.status_code != 404:
+                response.raise_for_status()
+        except httpx.HTTPError:
+            if not best_effort:
+                raise
 
 
 # ── journey 1: landing page load ─────────────────────────────
@@ -275,6 +300,7 @@ class _FirstTokenCtx:
 
     agent_id: str
     created_ids: list[str] = field(default_factory=list)
+    active_id: str | None = None
 
 
 async def _setup_first_token(env: UIEnvironment) -> _FirstTokenCtx:
@@ -289,10 +315,12 @@ async def _prepare_first_token(env: UIEnvironment, page: Page, ctx: JourneyConte
     fc = cast(_FirstTokenCtx, ctx)
     session_id = await env.create_bound_session(fc.agent_id)
     fc.created_ids.append(session_id)
+    fc.active_id = session_id
     await page.goto(f"/c/{session_id}", wait_until="commit")
     await expect(page.get_by_placeholder(COMPOSER_PLACEHOLDER)).to_be_visible(
         timeout=_ASSERT_TIMEOUT_MS
     )
+    await page.get_by_placeholder(COMPOSER_PLACEHOLDER).fill(_TURN_PROMPT)
 
 
 async def _measure_first_token(_env: UIEnvironment, page: Page, _ctx: JourneyContext) -> None:
@@ -302,8 +330,6 @@ async def _measure_first_token(_env: UIEnvironment, page: Page, _ctx: JourneyCon
     ``working-indicator`` shimmer (which would let the timer stop on the spinner
     before any token streamed).
     """
-    composer = page.get_by_placeholder(COMPOSER_PLACEHOLDER)
-    await composer.fill(_TURN_PROMPT)
     await page.get_by_role("button", name=SEND_BUTTON_NAME, exact=True).click()
     assistant = page.locator(ASSISTANT_BUBBLE).first
     await expect(assistant).to_be_visible(timeout=_FIRST_TOKEN_TIMEOUT_MS)
@@ -312,6 +338,17 @@ async def _measure_first_token(_env: UIEnvironment, page: Page, _ctx: JourneyCon
 
 async def _teardown_first_token(env: UIEnvironment, ctx: JourneyContext) -> None:
     await _delete_sessions(env, cast(_FirstTokenCtx, ctx).created_ids)
+
+
+async def _cleanup_first_token(env: UIEnvironment, _page: Page, ctx: JourneyContext) -> None:
+    fc = cast(_FirstTokenCtx, ctx)
+    if fc.active_id is None:
+        return
+    session_id = fc.active_id
+    await _delete_sessions(env, [session_id], best_effort=False)
+    fc.active_id = None
+    with contextlib.suppress(ValueError):
+        fc.created_ids.remove(session_id)
 
 
 # ── journey 3: switch between sessions (client-side) ─────────
@@ -323,6 +360,8 @@ class _SwitchCtx:
 
     session_a: str
     session_b: str
+    marker_a: str
+    marker_b: str
 
 
 async def _setup_switch(env: UIEnvironment) -> _SwitchCtx:
@@ -330,9 +369,16 @@ async def _setup_switch(env: UIEnvironment) -> _SwitchCtx:
     agent_id = await _setup_agent(env)
     session_a = await env.create_bound_session(agent_id)
     session_b = await env.create_bound_session(agent_id)
-    await env.seed_items(session_a, _SWITCH_SEED_ITEMS)
-    await env.seed_items(session_b, _SWITCH_SEED_ITEMS)
-    return _SwitchCtx(session_a=session_a, session_b=session_b)
+    prefix_a = "benchmark switch A item"
+    prefix_b = "benchmark switch B item"
+    await env.seed_items(session_a, _SWITCH_SEED_ITEMS, text_prefix=prefix_a)
+    await env.seed_items(session_b, _SWITCH_SEED_ITEMS, text_prefix=prefix_b)
+    return _SwitchCtx(
+        session_a=session_a,
+        session_b=session_b,
+        marker_a=f"{prefix_a} {_SWITCH_SEED_ITEMS - 1}",
+        marker_b=f"{prefix_b} {_SWITCH_SEED_ITEMS - 1}",
+    )
 
 
 async def _prepare_switch(_env: UIEnvironment, page: Page, ctx: JourneyContext) -> None:
@@ -349,6 +395,9 @@ async def _prepare_switch(_env: UIEnvironment, page: Page, ctx: JourneyContext) 
     await page.wait_for_url(
         re.compile(rf"/c/{re.escape(sc.session_a)}"), timeout=_ASSERT_TIMEOUT_MS
     )
+    await expect(page.locator(USER_BUBBLE, has_text=sc.marker_a)).to_be_visible(
+        timeout=_ASSERT_TIMEOUT_MS
+    )
     await expect(page.locator(sidebar_session_link(sc.session_b))).to_be_visible(
         timeout=_ASSERT_TIMEOUT_MS
     )
@@ -361,7 +410,9 @@ async def _measure_switch(_env: UIEnvironment, page: Page, ctx: JourneyContext) 
     await page.wait_for_url(
         re.compile(rf"/c/{re.escape(sc.session_b)}"), timeout=_ASSERT_TIMEOUT_MS
     )
-    await expect(page.locator(USER_BUBBLE).first).to_be_visible(timeout=_ASSERT_TIMEOUT_MS)
+    await expect(page.locator(USER_BUBBLE, has_text=sc.marker_b)).to_be_visible(
+        timeout=_ASSERT_TIMEOUT_MS
+    )
 
 
 async def _teardown_switch(env: UIEnvironment, ctx: JourneyContext) -> None:
@@ -377,7 +428,9 @@ class _ForkCtx:
     """Fork-journey context: the source session + the forks to clean up."""
 
     source_id: str
+    expected_fork_title: str
     fork_ids: list[str] = field(default_factory=list)
+    active_fork_id: str | None = None
 
 
 async def _setup_fork(env: UIEnvironment) -> _ForkCtx:
@@ -385,8 +438,15 @@ async def _setup_fork(env: UIEnvironment) -> _ForkCtx:
     await _ensure_streaming_reply(env)
     agent_id = await _setup_agent(env)
     source_id = await env.create_bound_session(agent_id)
+    source_title = "UI benchmark fork source"
     await env.drive_turn(source_id, _TURN_PROMPT)
-    return _ForkCtx(source_id=source_id)
+    assert env.client is not None
+    renamed = await env.client.patch(f"/v1/sessions/{source_id}", json={"title": source_title})
+    renamed.raise_for_status()
+    return _ForkCtx(
+        source_id=source_id,
+        expected_fork_title=f"Fork of {source_title}",
+    )
 
 
 async def _prepare_fork(_env: UIEnvironment, page: Page, ctx: JourneyContext) -> None:
@@ -410,9 +470,37 @@ async def _measure_fork(_env: UIEnvironment, page: Page, ctx: JourneyContext) ->
         re.compile(rf"/c/(?!{re.escape(fc.source_id)})[0-9a-f]{{32}}"),
         timeout=_ASSERT_TIMEOUT_MS,
     )
-    await expect(page.locator(USER_BUBBLE).first).to_be_visible(timeout=_ASSERT_TIMEOUT_MS)
     fork_id = page.url.rsplit("/c/", 1)[1].split("?", 1)[0]
     fc.fork_ids.append(fork_id)
+    fc.active_fork_id = fork_id
+    await expect(page).to_have_title(fc.expected_fork_title, timeout=_ASSERT_TIMEOUT_MS)
+
+
+async def _cleanup_fork(env: UIEnvironment, page: Page, ctx: JourneyContext) -> None:
+    fc = cast(_ForkCtx, ctx)
+    fork_id = fc.active_fork_id
+    if fork_id is None and "/c/" in page.url:
+        candidate = page.url.rsplit("/c/", 1)[1].split("?", 1)[0]
+        if candidate != fc.source_id:
+            fork_id = candidate
+    if fork_id is None:
+        assert env.client is not None
+        listing = await env.client.get("/v1/sessions", params={"limit": 30, "order": "desc"})
+        listing.raise_for_status()
+        fork_id = next(
+            (
+                str(row["id"])
+                for row in listing.json().get("data", [])
+                if row.get("title") == fc.expected_fork_title and row.get("id") != fc.source_id
+            ),
+            None,
+        )
+    if fork_id is None:
+        return
+    await _delete_sessions(env, [fork_id], best_effort=False)
+    fc.active_fork_id = None
+    with contextlib.suppress(ValueError):
+        fc.fork_ids.remove(fork_id)
 
 
 async def _teardown_fork(env: UIEnvironment, ctx: JourneyContext) -> None:
@@ -433,14 +521,15 @@ ALL_UI_JOURNEYS: dict[str, UIJourney] = {
             description="Navigate to / and wait for the landing composer (cold first paint).",
         ),
         UIJourney(
-            name="new_session_first_token",
+            name="warm_session_first_token",
             isolation="fresh_context",
             setup=_setup_first_token,
             prepare=_prepare_first_token,
             measure=_measure_first_token,
+            cleanup=_cleanup_first_token,
             teardown=_teardown_first_token,
-            description="On a fresh bound session, send a message; time to the first "
-            "streamed assistant token.",
+            description="On a fresh session bound to the warm runner, click Send on a "
+            "prepared prompt; time to the first rendered assistant token.",
         ),
         UIJourney(
             name="switch_sessions",
@@ -458,6 +547,7 @@ ALL_UI_JOURNEYS: dict[str, UIJourney] = {
             setup=_setup_fork,
             prepare=_prepare_fork,
             measure=_measure_fork,
+            cleanup=_cleanup_fork,
             teardown=_teardown_fork,
             description="Fork from an assistant response; time to the forked "
             "conversation rendering.",

--- a/dev/benchmarks/omnigent_ui/netcapture.py
+++ b/dev/benchmarks/omnigent_ui/netcapture.py
@@ -1,0 +1,207 @@
+"""Per-journey network-request capture and aggregation.
+
+A :class:`NetCapture` attaches to a Playwright page for exactly one timed
+journey repetition, tallies every request the browser issues, and produces two
+groupings:
+
+- **by resource type** — ``document`` / ``script`` / ``stylesheet`` / ``xhr`` /
+  ``fetch`` / ``websocket`` / ``image`` / ``font`` / … (Playwright's
+  ``request.resource_type``).
+- **by endpoint** — ``"{METHOD} {normalized_path}"`` where volatile path
+  segments (session ids, agent ids, hashes) are collapsed to placeholders so
+  ``GET /v1/sessions/:id`` aggregates across repetitions instead of fanning out
+  into one bucket per id.
+
+:func:`aggregate_network` folds the per-rep tallies of a journey into a single
+report block. Counts are reported as the **median across reps** (not the sum),
+so the numbers are independent of how many iterations were run and a stray
+one-off request doesn't inflate the headline. ``per_rep_total_requests`` and
+``max_total_requests`` are kept alongside so nondeterminism stays visible.
+"""
+
+from __future__ import annotations
+
+import re
+import statistics
+from collections import Counter
+from dataclasses import dataclass, field
+from urllib.parse import urlsplit
+
+from playwright.async_api import Page, Request, WebSocket
+
+# Path-segment normalizers, applied in order to each ``/``-split segment so
+# volatile ids collapse to stable placeholders and endpoint counts aggregate.
+_ID_NORMALIZERS: tuple[tuple[re.Pattern[str], str], ...] = (
+    # 32-hex session/conversation ids and uuids (with or without dashes).
+    (re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE), ":id"),
+    (
+        re.compile(
+            r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            re.IGNORECASE,
+        ),
+        ":id",
+    ),
+    # Prefixed ids the API mints, e.g. ``conv_ab12``, ``ag_cd34``, ``msg_...``.
+    (re.compile(r"^(?:conv|ag|msg|resp|run|ci|host|item)_[0-9a-z]+$", re.IGNORECASE), ":id"),
+    # Bare numeric segments.
+    (re.compile(r"^\d+$"), ":n"),
+)
+
+# Vite/rolldown build-hashed asset chunks: one or more ``-<fingerprint>`` groups
+# before the extension, e.g. ``index-a1b2c3d4.js`` or the double-hashed
+# ``chunk-CSCIHK7Q-Cqn_ZLae.js``. A fingerprint is 8+ base64url-ish chars
+# containing at least one uppercase letter, digit, or underscore — so a plain
+# lowercase word suffix (``jsx-runtime.js``, ``preload-helper.js``) is left
+# alone. Stripping every deploy's hashes lets asset counts aggregate across
+# builds (the hashes change each build, but the stem is stable).
+_ASSET_RE = re.compile(
+    r"^(?P<stem>.+?)(?:-(?=[A-Za-z0-9_]*[A-Z0-9_])[A-Za-z0-9_]{8,})+"
+    r"\.(?P<ext>js|css|woff2?|map)$"
+)
+
+
+def normalize_path(url: str) -> str:
+    """Reduce *url* to a ``/``-path with volatile segments placeholdered.
+
+    The query string and fragment are dropped (they carry per-request nonces
+    and cursor tokens that would otherwise explode the endpoint cardinality).
+
+    :param url: The absolute request URL.
+    :returns: The normalized path, e.g. ``/v1/sessions/:id/items``.
+    """
+    path = urlsplit(url).path or "/"
+    out: list[str] = []
+    for segment in path.split("/"):
+        if not segment:
+            continue
+        out.append(_normalize_segment(segment))
+    return "/" + "/".join(out) if out else "/"
+
+
+def _normalize_segment(segment: str) -> str:
+    """Collapse one path segment to a placeholder if it matches a volatile shape."""
+    for pattern, replacement in _ID_NORMALIZERS:
+        if pattern.match(segment):
+            return replacement
+    # Hashed-asset rule: keep the human stem, drop the build fingerprint(s).
+    asset = _ASSET_RE.match(segment)
+    if asset is not None:
+        return f"{asset.group('stem')}.{asset.group('ext')}"
+    return segment
+
+
+@dataclass
+class RepCapture:
+    """One repetition's request tally, collected live off the page.
+
+    :param by_resource_type: Count of requests per Playwright resource type.
+    :param by_endpoint: Count of requests per ``"{METHOD} {normalized_path}"``.
+    :param websocket_opened: Number of WebSocket connections opened.
+    :param total: Total requests observed in the timed window.
+    """
+
+    by_resource_type: Counter[str] = field(default_factory=Counter)
+    by_endpoint: Counter[str] = field(default_factory=Counter)
+    websocket_opened: int = 0
+    total: int = 0
+
+
+class NetCapture:
+    """Attaches request/websocket listeners to a page for one timed rep.
+
+    Use as a context-managed span around exactly the timed operation::
+
+        cap = NetCapture(page)
+        cap.start()
+        ...  # the timed journey action
+        rep = cap.stop()
+
+    ``start``/``stop`` bracket the listeners so requests fired by setup or
+    between reps are never counted. A single :class:`NetCapture` instance is
+    reusable — each ``start`` resets the tally.
+    """
+
+    def __init__(self, page: Page) -> None:
+        self._page = page
+        self._rep = RepCapture()
+        self._active = False
+
+    def _on_request(self, request: Request) -> None:
+        if not self._active:
+            return
+        self._rep.total += 1
+        self._rep.by_resource_type[request.resource_type or "other"] += 1
+        self._rep.by_endpoint[f"{request.method} {normalize_path(request.url)}"] += 1
+
+    def _on_websocket(self, ws: WebSocket) -> None:
+        if not self._active:
+            return
+        self._rep.websocket_opened += 1
+        self._rep.by_resource_type["websocket"] += 1
+        self._rep.by_endpoint[f"WS {normalize_path(ws.url)}"] += 1
+
+    def start(self) -> None:
+        """Begin counting: reset the tally and arm the listeners."""
+        self._rep = RepCapture()
+        if not self._active:
+            self._page.on("request", self._on_request)
+            self._page.on("websocket", self._on_websocket)
+            self._active = True
+
+    def stop(self) -> RepCapture:
+        """Stop counting, detach the listeners, and return this rep's tally."""
+        if self._active:
+            self._page.remove_listener("request", self._on_request)
+            self._page.remove_listener("websocket", self._on_websocket)
+            self._active = False
+        return self._rep
+
+
+def _median_counter(counters: list[Counter[str]]) -> dict[str, float]:
+    """Median count per key across *counters* (absent key counts as 0).
+
+    Every key seen in any rep is scored across ALL reps — a key present in only
+    some reps contributes 0 for the reps that lack it, so its median reflects
+    how consistently it fires, not just its value when it does.
+    """
+    if not counters:
+        return {}
+    keys = set().union(*counters)
+    out: dict[str, float] = {}
+    for key in keys:
+        out[key] = statistics.median(c.get(key, 0) for c in counters)
+    # Stable, high-count-first ordering for a readable report.
+    return dict(sorted(out.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def aggregate_network(reps: list[RepCapture]) -> dict[str, object]:
+    """Fold a journey's per-rep captures into a report ``network`` block.
+
+    :param reps: One :class:`RepCapture` per timed repetition (warmup excluded).
+    :returns: A JSON-serializable dict with ``by_resource_type`` /
+        ``by_endpoint`` median-per-rep count maps, plus totals and the raw
+        per-rep totals so nondeterminism is visible. Empty maps when *reps* is
+        empty.
+    """
+    if not reps:
+        return {
+            "aggregation": "median_per_rep",
+            "reps": 0,
+            "by_resource_type": {},
+            "by_endpoint": {},
+            "median_total_requests": 0.0,
+            "max_total_requests": 0,
+            "websocket_opened_median": 0.0,
+            "per_rep_total_requests": [],
+        }
+    totals = [r.total for r in reps]
+    return {
+        "aggregation": "median_per_rep",
+        "reps": len(reps),
+        "by_resource_type": _median_counter([r.by_resource_type for r in reps]),
+        "by_endpoint": _median_counter([r.by_endpoint for r in reps]),
+        "median_total_requests": statistics.median(totals),
+        "max_total_requests": max(totals),
+        "websocket_opened_median": statistics.median(r.websocket_opened for r in reps),
+        "per_rep_total_requests": totals,
+    }

--- a/dev/benchmarks/omnigent_ui/netcapture.py
+++ b/dev/benchmarks/omnigent_ui/netcapture.py
@@ -97,7 +97,7 @@ class RepCapture:
     :param by_resource_type: Count of requests per Playwright resource type.
     :param by_endpoint: Count of requests per ``"{METHOD} {normalized_path}"``.
     :param websocket_opened: Number of WebSocket connections opened.
-    :param total: Total requests observed in the timed window.
+    :param total: Total HTTP requests plus WebSocket connections observed.
     """
 
     by_resource_type: Counter[str] = field(default_factory=Counter)
@@ -129,6 +129,10 @@ class NetCapture:
     def _on_request(self, request: Request) -> None:
         if not self._active:
             return
+        # Playwright can surface the WebSocket handshake as a request as well as
+        # a websocket event. Count the connection once in _on_websocket.
+        if request.resource_type == "websocket":
+            return
         self._rep.total += 1
         self._rep.by_resource_type[request.resource_type or "other"] += 1
         self._rep.by_endpoint[f"{request.method} {normalize_path(request.url)}"] += 1
@@ -136,6 +140,7 @@ class NetCapture:
     def _on_websocket(self, ws: WebSocket) -> None:
         if not self._active:
             return
+        self._rep.total += 1
         self._rep.websocket_opened += 1
         self._rep.by_resource_type["websocket"] += 1
         self._rep.by_endpoint[f"WS {normalize_path(ws.url)}"] += 1

--- a/dev/benchmarks/omnigent_ui/run.py
+++ b/dev/benchmarks/omnigent_ui/run.py
@@ -1,0 +1,233 @@
+"""Omnigent end-to-end UI benchmark runner.
+
+Boots a real ``omnigent server`` + runner against a zero-latency mock LLM,
+builds and serves the web SPA, opens a Playwright Chromium browser, drives the
+selected browser journeys, prints per-journey latency tables, and writes a
+versioned JSON report. Each journey block carries the shared ``runs``/``summary``
+latency shape PLUS a ``network`` sub-object counting the requests the journey
+issued (by resource type and by method+normalized-path).
+
+Runs in the project venv — it imports ``omnigent`` and ``tests._helpers`` and
+spawns the real server. Invoke with ``--no-sync`` so ``uv`` uses the existing
+environment (a plain ``uv run`` would trigger a web-UI build inside the sync
+that fails in a worktree). Chromium must be installed
+(``uv run playwright install --with-deps chromium``)::
+
+    uv run --no-sync dev/benchmarks/omnigent_ui/run.py
+    uv run --no-sync dev/benchmarks/omnigent_ui/run.py --journeys landing_load
+    uv run --no-sync dev/benchmarks/omnigent_ui/run.py --runs 3 --iterations 8 --output ui.json
+    uv run --no-sync dev/benchmarks/omnigent_ui/run.py --headed --skip-build   # local debug
+
+The JSON is the same contract the HTTP benchmark emits (see
+``dev/benchmarks/omnigent/README.md``), with ``harness="web-ui-playwright"`` and
+an added per-journey ``network`` block.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime
+import json
+import sys
+from pathlib import Path
+
+# Allow ``uv run <path>`` (no package context) to import the sibling modules and
+# the shared HTTP-benchmark report primitives.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from dev.benchmarks.omnigent.measure import (
+    aggregate,
+    check_thresholds,
+    console,
+    print_results,
+)
+from dev.benchmarks.omnigent.schema import build_report
+from dev.benchmarks.omnigent_ui.environment import UIEnvironment
+from dev.benchmarks.omnigent_ui.journeys import (
+    ALL_UI_JOURNEYS,
+    UIJourney,
+    build_network_block,
+    resolve_ui_journeys,
+    run_ui_journey,
+    summarize_browser_timing,
+)
+from dev.benchmarks.omnigent_ui.ui_driver import LaunchOptions, UIDriver
+
+_HARNESS = "web-ui-playwright"
+
+
+def _backend_of(database_uri: str | None) -> str:
+    """Classify the DB URI into a coarse backend label for the report."""
+    if database_uri is None or database_uri.startswith("sqlite"):
+        return "sqlite"
+    if database_uri.startswith("postgres"):
+        return "postgres"
+    if database_uri.startswith("mysql"):
+        return "mysql"
+    return "other"
+
+
+def _effective_iterations(journey: UIJourney, requested: int) -> int:
+    """Clamp *requested* iterations down to the journey's ``max_iterations``."""
+    return min(requested, journey.max_iterations)
+
+
+async def run_benchmark(args: argparse.Namespace) -> tuple[dict[str, object], bool]:
+    """Run all selected UI journeys and build the report.
+
+    :returns: ``(report, passed)`` where *passed* is ``False`` if any journey
+        breached a supplied threshold.
+    """
+    journeys = resolve_ui_journeys(args.journeys)
+    journey_results: dict[str, dict[str, object]] = {}
+    passed = True
+    backend = _backend_of(args.database_uri)
+
+    async with UIEnvironment(database_uri=args.database_uri, skip_build=args.skip_build) as env:
+        launch = LaunchOptions.from_env(headed=args.headed)
+        async with UIDriver(env.base_url, launch) as driver:
+            for journey in journeys:
+                console.print(f"\n[bold]Benchmarking[/bold] {journey.name} [dim]({backend})[/dim]")
+                iterations = _effective_iterations(journey, args.iterations)
+                results, net_reps, timings = await run_ui_journey(
+                    journey,
+                    env,
+                    driver,
+                    runs=args.runs,
+                    iterations=iterations,
+                    warmup=args.warmup,
+                )
+                print_results(journey.name, results)
+
+                block = aggregate(results)
+                block["kind"] = "ui-latency"
+                block["backend"] = backend
+                block["network"] = build_network_block(net_reps)
+                browser_timing = summarize_browser_timing(timings)
+                if browser_timing:
+                    block["browser_timing"] = browser_timing
+                journey_results[journey.name] = block
+
+                if not check_thresholds(
+                    results,
+                    min_rps=None,
+                    max_p50_ms=args.max_p50_ms,
+                    max_p99_ms=args.max_p99_ms,
+                ):
+                    passed = False
+        resource_usage = env.resource_usage
+
+    config = {
+        "iterations": args.iterations,
+        "runs": args.runs,
+        "warmup": args.warmup,
+        "with_runner": True,
+        "with_host": False,
+        "backend": backend,
+        "headed": args.headed,
+        "network_grouping": ["resource_type", "method_path"],
+    }
+    generated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    report = build_report(
+        journey_results,
+        generated_at=generated_at,
+        config=config,
+        harness=_HARNESS,
+        resource_usage=resource_usage,
+    )
+    return report, passed
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="omnigent-ui-benchmark",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--journeys",
+        type=lambda s: [p.strip() for p in s.split(",") if p.strip()],
+        default=None,
+        metavar="A,B,C",
+        help=f"Comma-separated journeys to run. Default: all ({', '.join(ALL_UI_JOURNEYS)}).",
+    )
+    parser.add_argument(
+        "--database-uri",
+        default=None,
+        metavar="URI",
+        help="DB the server boots against. Default: a fresh throwaway SQLite DB. "
+        "The report's `backend` field is derived from this.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=8,
+        metavar="N",
+        help="Timed browser operations per run, clamped per journey (default: 8).",
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=3,
+        metavar="N",
+        help="Timed runs per journey; results are per-run and averaged (default: 3).",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=2,
+        metavar="N",
+        help="Warmup operations discarded before each journey's timed runs (default: 2).",
+    )
+    parser.add_argument(
+        "--headed",
+        action="store_true",
+        default=False,
+        help="Launch a visible browser (local debugging only; CI runs headless).",
+    )
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        default=False,
+        help="Reuse the existing SPA build in omnigent/server/static/web-ui/ "
+        "instead of rebuilding. Fails if no build is present.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help="Write the JSON report to FILE (for CI artifact upload).",
+    )
+    parser.add_argument(
+        "--max-p50-ms",
+        type=float,
+        default=None,
+        metavar="N",
+        help="Exit 1 if any journey's avg P50 latency exceeds N ms.",
+    )
+    parser.add_argument(
+        "--max-p99-ms",
+        type=float,
+        default=None,
+        metavar="N",
+        help="Exit 1 if any journey's avg P99 latency exceeds N ms.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    report, passed = asyncio.run(run_benchmark(args))
+    if args.output is not None:
+        args.output.write_text(json.dumps(report, indent=2))
+        console.print(f"\n  Results written to [cyan]{args.output}[/cyan]")
+    if not passed:
+        console.print("\n[red]One or more thresholds failed.[/red]")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/benchmarks/omnigent_ui/run.py
+++ b/dev/benchmarks/omnigent_ui/run.py
@@ -37,6 +37,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from dev.benchmarks.omnigent.measure import (
+    RunResult,
     aggregate,
     check_thresholds,
     console,
@@ -73,6 +74,78 @@ def _effective_iterations(journey: UIJourney, requested: int) -> int:
     return min(requested, journey.max_iterations)
 
 
+def _aggregate_ui_results(results: list[RunResult]) -> dict[str, object]:
+    """Aggregate UI samples, computing percentiles over the pooled distribution."""
+    block = aggregate(results)
+    samples = [latency for result in results for latency in result.latencies_ms]
+    if not samples:
+        return block
+    pooled = RunResult(latencies_ms=samples)
+    distribution = {
+        "samples": len(samples),
+        "mean_ms": pooled.mean_ms(),
+        "p50_ms": pooled.percentile(50),
+        "p95_ms": pooled.percentile(95),
+        "p99_ms": pooled.percentile(99),
+        "max_ms": pooled.max_ms(),
+    }
+    block["distribution"] = distribution
+    summary = block["summary"]
+    assert isinstance(summary, dict)
+    # Preserve the shared ETL keys while avoiding an average of tiny per-run
+    # percentile estimates. Throughput remains the per-run average.
+    summary.update(
+        {
+            "avg_mean_ms": distribution["mean_ms"],
+            "avg_p50_ms": distribution["p50_ms"],
+            "avg_p95_ms": distribution["p95_ms"],
+            "avg_p99_ms": distribution["p99_ms"],
+        }
+    )
+    return block
+
+
+def _has_failures(results: list[RunResult]) -> bool:
+    """Return whether any timed repetition or cleanup failed."""
+    return any(result.n_failures for result in results)
+
+
+def _pooled_result(results: list[RunResult]) -> list[RunResult]:
+    """Return one result whose latency distribution matches the report summary."""
+    samples = [latency for result in results for latency in result.latencies_ms]
+    if not samples:
+        return results
+    return [RunResult(latencies_ms=samples, wall_time=sum(r.wall_time for r in results))]
+
+
+def _skipped_block(journey: UIJourney, backend: str, exc: Exception) -> dict[str, object]:
+    """Build a report block for a journey that could not produce samples."""
+    return {
+        "kind": "ui-latency",
+        "backend": backend,
+        "runs": [],
+        "summary": {},
+        "network": build_network_block([]),
+        "skipped": True,
+        "error": f"{exc.__class__.__name__}: {exc}",
+        "description": journey.description,
+    }
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def _non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be at least 0")
+    return parsed
+
+
 async def run_benchmark(args: argparse.Namespace) -> tuple[dict[str, object], bool]:
     """Run all selected UI journeys and build the report.
 
@@ -83,34 +156,55 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[dict[str, object], bo
     journey_results: dict[str, dict[str, object]] = {}
     passed = True
     backend = _backend_of(args.database_uri)
+    effective_iterations: dict[str, int] = {}
+    browser_metadata: dict[str, object] = {}
 
-    async with UIEnvironment(database_uri=args.database_uri, skip_build=args.skip_build) as env:
+    async with UIEnvironment(
+        database_uri=args.database_uri,
+        skip_build=args.skip_build,
+        artifacts_dir=args.artifacts_dir,
+    ) as env:
         launch = LaunchOptions.from_env(headed=args.headed)
         async with UIDriver(env.base_url, launch) as driver:
+            browser_metadata = driver.metadata
             for journey in journeys:
                 console.print(f"\n[bold]Benchmarking[/bold] {journey.name} [dim]({backend})[/dim]")
                 iterations = _effective_iterations(journey, args.iterations)
-                results, net_reps, timings = await run_ui_journey(
-                    journey,
-                    env,
-                    driver,
-                    runs=args.runs,
-                    iterations=iterations,
-                    warmup=args.warmup,
-                )
+                effective_iterations[journey.name] = iterations
+                try:
+                    results, net_reps, timings = await run_ui_journey(
+                        journey,
+                        env,
+                        driver,
+                        runs=args.runs,
+                        iterations=iterations,
+                        warmup=args.warmup,
+                    )
+                except Exception as exc:  # noqa: BLE001 — preserve the rest of the suite
+                    console.print(
+                        f"  [red]FAILED:[/red] {journey.name} errored "
+                        f"({exc.__class__.__name__}: {exc}); excluded from summary."
+                    )
+                    journey_results[journey.name] = _skipped_block(journey, backend, exc)
+                    passed = False
+                    continue
                 print_results(journey.name, results)
 
-                block = aggregate(results)
+                block = _aggregate_ui_results(results)
                 block["kind"] = "ui-latency"
                 block["backend"] = backend
+                block["description"] = journey.description
                 block["network"] = build_network_block(net_reps)
                 browser_timing = summarize_browser_timing(timings)
                 if browser_timing:
                     block["browser_timing"] = browser_timing
                 journey_results[journey.name] = block
 
+                if _has_failures(results):
+                    passed = False
+
                 if not check_thresholds(
-                    results,
+                    _pooled_result(results),
                     min_rps=None,
                     max_p50_ms=args.max_p50_ms,
                     max_p99_ms=args.max_p99_ms,
@@ -120,6 +214,7 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[dict[str, object], bo
 
     config = {
         "iterations": args.iterations,
+        "effective_iterations": effective_iterations,
         "runs": args.runs,
         "warmup": args.warmup,
         "with_runner": True,
@@ -127,6 +222,7 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[dict[str, object], bo
         "backend": backend,
         "headed": args.headed,
         "network_grouping": ["resource_type", "method_path"],
+        "browser": browser_metadata,
     }
     generated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
     report = build_report(
@@ -161,21 +257,21 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--iterations",
-        type=int,
+        type=_positive_int,
         default=8,
         metavar="N",
         help="Timed browser operations per run, clamped per journey (default: 8).",
     )
     parser.add_argument(
         "--runs",
-        type=int,
+        type=_positive_int,
         default=3,
         metavar="N",
         help="Timed runs per journey; results are per-run and averaged (default: 3).",
     )
     parser.add_argument(
         "--warmup",
-        type=int,
+        type=_non_negative_int,
         default=2,
         metavar="N",
         help="Warmup operations discarded before each journey's timed runs (default: 2).",
@@ -199,6 +295,13 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default=None,
         metavar="FILE",
         help="Write the JSON report to FILE (for CI artifact upload).",
+    )
+    parser.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Save subprocess logs and failure screenshots under DIR.",
     )
     parser.add_argument(
         "--max-p50-ms",

--- a/dev/benchmarks/omnigent_ui/ui_driver.py
+++ b/dev/benchmarks/omnigent_ui/ui_driver.py
@@ -1,0 +1,148 @@
+"""Playwright browser lifecycle + shared UI selectors for the UI benchmark.
+
+:class:`UIDriver` owns the async Chromium instance for a whole benchmark run.
+Journeys ask it for a page under one of two isolation modes:
+
+- ``fresh_context`` — a brand-new :class:`BrowserContext` (own cache + storage)
+  per repetition, so cold-visit journeys (landing load, first token) measure a
+  true first paint with nothing warm.
+- ``shared_page`` — one long-lived page reused across a journey's reps, so
+  journeys that depend on surviving client-side JS state (session switching via
+  the sidebar, forking) keep the SPA's in-memory store between reps.
+
+The module also centralises the ``data-testid`` / accessibility selectors the
+journeys use and the browser-timing readout (Navigation Timing + First
+Contentful Paint), so a UI change lands in one place.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from dataclasses import dataclass
+
+from playwright.async_api import Browser, BrowserContext, Page, async_playwright
+
+# ── selectors (shared by journeys) ───────────────────────────
+# Landing "new chat" composer (web/src/shell/NewChatDialog.tsx).
+LANDING_INPUT = '[data-testid="new-chat-landing-input"]'
+LANDING_SUBMIT = '[data-testid="new-chat-landing-submit"]'
+# In-session chat composer (web/src/pages/ChatPage.tsx) — accessibility-first.
+COMPOSER_PLACEHOLDER = "Ask the agent anything…"
+SEND_BUTTON_NAME = "Send"
+# A real assistant message bubble — NOT the streaming "Working…" shimmer, which
+# renders with data-testid="working-indicator" (web/src/pages/ChatPage.tsx).
+ASSISTANT_BUBBLE = '[data-testid="message-bubble"][data-role="assistant"]'
+USER_BUBBLE = '[data-testid="message-bubble"][data-role="user"]'
+WORKING_INDICATOR = '[data-testid="working-indicator"]'
+# Per-message fork action + the fork dialog's submit (web/src/shell/*).
+FORK_FROM_RESPONSE = '[data-testid="fork-from-response"]'
+FORK_SUBMIT = '[data-testid="fork-session-submit"]'
+
+
+def sidebar_session_link(session_id: str) -> str:
+    """CSS for a session's sidebar row link (client-side nav target).
+
+    The sidebar renders each conversation as ``<Link to={`/c/${id}`}>`` (see
+    ``web/src/shell/Sidebar.tsx``), so clicking this anchor navigates
+    client-side — preserving the SPA's JS module state, unlike ``page.goto``.
+    """
+    return f'a[href="/c/{session_id}"]'
+
+
+# In-browser performance metrics read after a navigation-based journey. Kept as
+# a secondary signal only — the primary latency number is the perf_counter span
+# around the awaited stop-assertion.
+_BROWSER_TIMING_JS = """
+() => {
+  const nav = performance.getEntriesByType('navigation')[0];
+  const paints = performance.getEntriesByType('paint');
+  const fcp = paints.find((p) => p.name === 'first-contentful-paint');
+  if (!nav) return null;
+  return {
+    dom_content_loaded_ms: nav.domContentLoadedEventEnd,
+    load_event_ms: nav.loadEventEnd,
+    response_end_ms: nav.responseEnd,
+    first_contentful_paint_ms: fcp ? fcp.startTime : null,
+  };
+}
+"""
+
+
+async def read_browser_timing(page: Page) -> dict[str, float] | None:
+    """Read Navigation Timing + FCP for the page's current document.
+
+    :param page: A page that has completed a ``goto`` navigation.
+    :returns: A dict of millisecond metrics, or ``None`` when the browser
+        exposes no navigation entry (e.g. after a client-side-only transition).
+    """
+    return await page.evaluate(_BROWSER_TIMING_JS)
+
+
+@dataclass
+class LaunchOptions:
+    """Chromium launch knobs for the run.
+
+    :param headed: Launch a visible browser (local debugging only). CI always
+        runs headless.
+    :param no_sandbox: Add ``--no-sandbox`` / ``--disable-dev-shm-usage`` — set
+        by the ``OMNIGENT_PW_NO_SANDBOX`` env var for root/container runners
+        (matches the e2e_ui suite's launch args).
+    """
+
+    headed: bool = False
+    no_sandbox: bool = False
+
+    @classmethod
+    def from_env(cls, *, headed: bool) -> LaunchOptions:
+        """Build options from the CLI ``--headed`` flag + environment."""
+        return cls(headed=headed, no_sandbox=bool(os.environ.get("OMNIGENT_PW_NO_SANDBOX")))
+
+
+class UIDriver:
+    """Async context manager owning Playwright + a Chromium browser.
+
+    One instance spans the whole run; journeys borrow contexts/pages from it.
+    """
+
+    def __init__(self, base_url: str, options: LaunchOptions) -> None:
+        self.base_url = base_url
+        self._options = options
+        self._pw = None
+        self._browser: Browser | None = None
+        self._contexts: list[BrowserContext] = []
+
+    async def __aenter__(self) -> UIDriver:
+        self._pw = await async_playwright().start()
+        args: list[str] = []
+        if self._options.no_sandbox:
+            args += ["--no-sandbox", "--disable-dev-shm-usage"]
+        self._browser = await self._pw.chromium.launch(
+            headless=not self._options.headed,
+            args=args,
+        )
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        for ctx in self._contexts:
+            with contextlib.suppress(Exception):  # teardown best-effort
+                await ctx.close()
+        if self._browser is not None:
+            await self._browser.close()
+        if self._pw is not None:
+            await self._pw.stop()
+
+    async def new_context(self) -> BrowserContext:
+        """Open a fresh browser context (own cache/storage), tracked for cleanup."""
+        assert self._browser is not None
+        ctx = await self._browser.new_context(base_url=self.base_url)
+        self._contexts.append(ctx)
+        return ctx
+
+    async def close_context(self, ctx: BrowserContext) -> None:
+        """Close and untrack a context opened via :meth:`new_context`."""
+        try:
+            await ctx.close()
+        finally:
+            if ctx in self._contexts:
+                self._contexts.remove(ctx)

--- a/dev/benchmarks/omnigent_ui/ui_driver.py
+++ b/dev/benchmarks/omnigent_ui/ui_driver.py
@@ -4,8 +4,7 @@
 Journeys ask it for a page under one of two isolation modes:
 
 - ``fresh_context`` — a brand-new :class:`BrowserContext` (own cache + storage)
-  per repetition, so cold-visit journeys (landing load, first token) measure a
-  true first paint with nothing warm.
+  per repetition, so navigation/setup starts without browser cache or storage.
 - ``shared_page`` — one long-lived page reused across a journey's reps, so
   journeys that depend on surviving client-side JS state (session switching via
   the sidebar, forking) keep the SPA's in-memory store between reps.
@@ -123,6 +122,17 @@ class UIDriver:
         )
         return self
 
+    @property
+    def metadata(self) -> dict[str, object]:
+        """Browser provenance recorded alongside latency samples."""
+        assert self._browser is not None
+        return {
+            "engine": "chromium",
+            "version": self._browser.version,
+            "headless": not self._options.headed,
+            "viewport": {"width": 1280, "height": 720},
+        }
+
     async def __aexit__(self, *exc: object) -> None:
         for ctx in self._contexts:
             with contextlib.suppress(Exception):  # teardown best-effort
@@ -135,7 +145,10 @@ class UIDriver:
     async def new_context(self) -> BrowserContext:
         """Open a fresh browser context (own cache/storage), tracked for cleanup."""
         assert self._browser is not None
-        ctx = await self._browser.new_context(base_url=self.base_url)
+        ctx = await self._browser.new_context(
+            base_url=self.base_url,
+            viewport={"width": 1280, "height": 720},
+        )
         self._contexts.append(ctx)
         return ctx
 

--- a/tests/benchmarks/test_ui_benchmark_smoke.py
+++ b/tests/benchmarks/test_ui_benchmark_smoke.py
@@ -1,0 +1,246 @@
+"""Smoke tests for the end-to-end UI benchmark harness (dev/benchmarks/omnigent_ui).
+
+The pure layers — path normalization, network aggregation, iteration clamping,
+and the report-block shape — get direct unit checks that run on the normal CI
+lane (no browser, no server, no creds).
+
+The full browser end-to-end test needs a built SPA and an installed Playwright
+Chromium, which the normal lane lacks, so it auto-skips unless both are present
+(run it locally after ``uv sync --extra e2e-ui`` + ``playwright install
+chromium``). CI exercises the full path nightly via e2e-ui-benchmark.yml.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from collections import Counter
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from dev.benchmarks.omnigent.measure import RunResult, aggregate
+from dev.benchmarks.omnigent.schema import SCHEMA_VERSION, build_report
+from dev.benchmarks.omnigent_ui import run as ui_run
+from dev.benchmarks.omnigent_ui.environment import _BUILD_OUTPUT
+from dev.benchmarks.omnigent_ui.journeys import (
+    ALL_UI_JOURNEYS,
+    build_network_block,
+    resolve_ui_journeys,
+    summarize_browser_timing,
+)
+from dev.benchmarks.omnigent_ui.netcapture import (
+    RepCapture,
+    aggregate_network,
+    normalize_path,
+)
+
+_ALL = ["landing_load", "new_session_first_token", "switch_sessions", "fork_session"]
+
+
+def _d(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return cast(dict[str, object], value)
+
+
+# ── path normalization ───────────────────────────────────────
+
+
+def test_normalize_path_collapses_hex_session_ids() -> None:
+    sid = "a" * 32
+    assert normalize_path(f"http://h/v1/sessions/{sid}") == "/v1/sessions/:id"
+    assert (
+        normalize_path(f"http://h/v1/sessions/{sid}/items?order=asc") == "/v1/sessions/:id/items"
+    )
+
+
+def test_normalize_path_collapses_uuid_and_prefixed_ids() -> None:
+    uuid = "12345678-1234-1234-1234-1234567890ab"
+    assert normalize_path(f"http://h/v1/hosts/{uuid}/filesystem") == "/v1/hosts/:id/filesystem"
+    assert normalize_path("http://h/v1/agents/ag_ab12cd34") == "/v1/agents/:id"
+    assert normalize_path("http://h/v1/sessions/conv_xy99/events") == "/v1/sessions/:id/events"
+
+
+def test_normalize_path_dehashes_vite_assets_and_drops_query() -> None:
+    assert normalize_path("http://h/assets/index-a1b2c3d4.js") == "/assets/index.js"
+    assert normalize_path("http://h/assets/main-deadbeef99.css?v=2") == "/assets/main.css"
+    # Real rolldown shapes seen in the built SPA: mixed-case + underscore, and
+    # double-hashed chunks. Both collapse to the stable stem so asset counts
+    # aggregate across deploys (each build re-hashes them).
+    assert normalize_path("http://h/assets/bundle-mjs-B_AA55HL.js") == "/assets/bundle-mjs.js"
+    assert normalize_path("http://h/assets/chunk-CSCIHK7Q-Cqn_ZLae.js") == "/assets/chunk.js"
+    assert normalize_path("http://h/assets/useQuery-B4Bqc_LO.js") == "/assets/useQuery.js"
+
+
+def test_normalize_path_keeps_unhashed_asset_names() -> None:
+    # A plain lowercase word suffix is NOT a build fingerprint — leave it.
+    assert normalize_path("http://h/assets/jsx-runtime.js") == "/assets/jsx-runtime.js"
+    assert normalize_path("http://h/assets/preload-helper.js") == "/assets/preload-helper.js"
+    assert normalize_path("http://h/assets/react-dom.js") == "/assets/react-dom.js"
+
+
+def test_normalize_path_root_and_numeric() -> None:
+    assert normalize_path("http://h/") == "/"
+    assert normalize_path("http://h/v1/items/42") == "/v1/items/:n"
+
+
+# ── network aggregation ──────────────────────────────────────
+
+
+def test_aggregate_network_medians_across_reps() -> None:
+    reps = [
+        RepCapture(
+            by_resource_type=Counter({"document": 1, "script": 6}),
+            by_endpoint=Counter({"GET /v1/sessions/:id": 2}),
+            total=9,
+        ),
+        RepCapture(
+            by_resource_type=Counter({"document": 1, "script": 6}),
+            by_endpoint=Counter({"GET /v1/sessions/:id": 2}),
+            total=9,
+        ),
+        RepCapture(
+            by_resource_type=Counter({"document": 1, "script": 8}),
+            by_endpoint=Counter({"GET /v1/sessions/:id": 3}),
+            total=12,
+        ),
+    ]
+    block = aggregate_network(reps)
+    assert block["aggregation"] == "median_per_rep"
+    assert block["reps"] == 3
+    assert _d(block["by_resource_type"])["script"] == 6  # median(6,6,8)
+    assert _d(block["by_endpoint"])["GET /v1/sessions/:id"] == 2  # median(2,2,3)
+    assert block["median_total_requests"] == 9
+    assert block["max_total_requests"] == 12
+    assert block["per_rep_total_requests"] == [9, 9, 12]
+
+
+def test_aggregate_network_missing_key_counts_as_zero() -> None:
+    # A key present in only one of three reps has median 0 — it fires rarely.
+    reps = [
+        RepCapture(by_endpoint=Counter({"GET /v1/info": 1}), total=1),
+        RepCapture(total=0),
+        RepCapture(total=0),
+    ]
+    block = aggregate_network(reps)
+    assert _d(block["by_endpoint"])["GET /v1/info"] == 0
+
+
+def test_aggregate_network_empty() -> None:
+    block = aggregate_network([])
+    assert block["reps"] == 0
+    assert block["by_resource_type"] == {}
+    assert block["per_rep_total_requests"] == []
+
+
+# ── iteration clamp + registry ───────────────────────────────
+
+
+def test_effective_iterations_clamps_down_not_up() -> None:
+    journey = ALL_UI_JOURNEYS["landing_load"]
+    assert ui_run._effective_iterations(journey, 100) == journey.max_iterations
+    assert ui_run._effective_iterations(journey, 1) == 1
+
+
+def test_resolve_ui_journeys_all_and_named() -> None:
+    assert [j.name for j in resolve_ui_journeys(None)] == _ALL
+    assert [j.name for j in resolve_ui_journeys(["fork_session"])] == ["fork_session"]
+    with pytest.raises(KeyError):
+        resolve_ui_journeys(["nope"])
+
+
+def test_backend_of_classifies_uri_schemes() -> None:
+    assert ui_run._backend_of(None) == "sqlite"
+    assert ui_run._backend_of("postgresql+psycopg://u@h/db") == "postgres"
+    assert ui_run._backend_of("mysql+mysqldb://u@h/db") == "mysql"
+
+
+# ── report block shape ───────────────────────────────────────
+
+
+def test_report_block_carries_network_and_summary() -> None:
+    """A journey block folds latency summary + a network block under schema v4."""
+    block = aggregate([RunResult(latencies_ms=[400.0, 420.0], wall_time=1.0)])
+    block["kind"] = "ui-latency"
+    block["network"] = build_network_block(
+        [RepCapture(by_resource_type=Counter({"document": 1}), total=1)]
+    )
+    report = build_report(
+        {"landing_load": block},
+        generated_at="2026-07-20T00:00:00+00:00",
+        config={"iterations": 8},
+        harness="web-ui-playwright",
+    )
+    assert report["schema_version"] == SCHEMA_VERSION == 5
+    assert report["harness"] == "web-ui-playwright"
+    landing = _d(_d(report["journeys"])["landing_load"])
+    assert landing["kind"] == "ui-latency"
+    assert set(_d(landing["summary"])) >= {"avg_p50_ms", "avg_p95_ms", "avg_p99_ms"}
+    assert _d(_d(landing["network"])["by_resource_type"])["document"] == 1
+
+
+def test_summarize_browser_timing_means() -> None:
+    samples = [
+        {"first_contentful_paint_ms": 200.0, "dom_content_loaded_ms": 180.0},
+        {"first_contentful_paint_ms": 220.0, "dom_content_loaded_ms": 200.0},
+    ]
+    out = summarize_browser_timing(samples)
+    assert out["first_contentful_paint_ms"] == 210.0
+    assert out["dom_content_loaded_ms"] == 190.0
+    assert summarize_browser_timing([]) == {}
+
+
+# ── full browser end-to-end (auto-skips without a build + chromium) ──
+
+
+def _chromium_available() -> bool:
+    """Whether Playwright's Chromium is importable and installed."""
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        return False
+    try:
+        with sync_playwright() as pw:
+            return Path(pw.chromium.executable_path).exists()
+    except Exception:
+        return False
+
+
+_HAS_SPA_BUILD = (_BUILD_OUTPUT / "index.html").is_file()
+_HAS_NPM = shutil.which("npm") is not None
+
+
+@pytest.mark.timeout(300)
+@pytest.mark.skipif(
+    not (_HAS_SPA_BUILD or _HAS_NPM),
+    reason="no SPA build present and npm unavailable to build one",
+)
+@pytest.mark.skipif(not _chromium_available(), reason="Playwright Chromium not installed")
+async def test_ui_benchmark_smoke_end_to_end() -> None:
+    """Boot server+runner+SPA, run one journey once in a real browser, check the report."""
+    args = argparse.Namespace(
+        journeys=["landing_load"],
+        database_uri=None,
+        iterations=1,
+        runs=1,
+        warmup=0,
+        headed=False,
+        skip_build=_HAS_SPA_BUILD,
+        output=None,
+        max_p50_ms=None,
+        max_p99_ms=None,
+    )
+    report, passed = await ui_run.run_benchmark(args)
+
+    assert passed
+    assert report["schema_version"] == 5
+    assert report["harness"] == "web-ui-playwright"
+    landing = _d(_d(report["journeys"])["landing_load"])
+    run_rows = cast(list[dict[str, object]], landing["runs"])
+    assert run_rows, "landing_load produced no runs"
+    assert run_rows[0]["n_failures"] == 0, run_rows[0]["failures"]
+    assert cast(float, _d(landing["summary"])["avg_p50_ms"]) > 0.0
+    assert _d(landing["network"])["reps"] == 1
+    # The landing page load must fetch at least the document + some assets.
+    assert cast(int, _d(landing["network"])["max_total_requests"]) >= 1

--- a/tests/benchmarks/test_ui_benchmark_smoke.py
+++ b/tests/benchmarks/test_ui_benchmark_smoke.py
@@ -6,7 +6,7 @@ lane (no browser, no server, no creds).
 
 The full browser end-to-end test needs a built SPA and an installed Playwright
 Chromium, which the normal lane lacks, so it auto-skips unless both are present
-(run it locally after ``uv sync --extra e2e-ui`` + ``playwright install
+(run it locally after ``uv sync --extra dev`` + ``playwright install
 chromium``). CI exercises the full path nightly via e2e-ui-benchmark.yml.
 """
 
@@ -16,7 +16,8 @@ import argparse
 import shutil
 from collections import Counter
 from pathlib import Path
-from typing import cast
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -31,12 +32,13 @@ from dev.benchmarks.omnigent_ui.journeys import (
     summarize_browser_timing,
 )
 from dev.benchmarks.omnigent_ui.netcapture import (
+    NetCapture,
     RepCapture,
     aggregate_network,
     normalize_path,
 )
 
-_ALL = ["landing_load", "new_session_first_token", "switch_sessions", "fork_session"]
+_ALL = ["landing_load", "warm_session_first_token", "switch_sessions", "fork_session"]
 
 
 def _d(value: object) -> dict[str, object]:
@@ -134,6 +136,32 @@ def test_aggregate_network_empty() -> None:
     assert block["per_rep_total_requests"] == []
 
 
+def test_netcapture_counts_websocket_once() -> None:
+    class _Page:
+        def on(self, _event: str, _handler: object) -> None:
+            pass
+
+        def remove_listener(self, _event: str, _handler: object) -> None:
+            pass
+
+    capture = NetCapture(cast(Any, _Page()))
+    capture.start()
+    request = SimpleNamespace(
+        resource_type="websocket",
+        method="GET",
+        url="http://h/v1/sessions/" + "a" * 32 + "/events",
+    )
+    websocket = SimpleNamespace(url=request.url)
+    capture._on_request(cast(Any, request))
+    capture._on_websocket(cast(Any, websocket))
+    rep = capture.stop()
+
+    assert rep.total == 1
+    assert rep.websocket_opened == 1
+    assert rep.by_resource_type == Counter({"websocket": 1})
+    assert rep.by_endpoint == Counter({"WS /v1/sessions/:id/events": 1})
+
+
 # ── iteration clamp + registry ───────────────────────────────
 
 
@@ -156,11 +184,65 @@ def test_backend_of_classifies_uri_schemes() -> None:
     assert ui_run._backend_of("mysql+mysqldb://u@h/db") == "mysql"
 
 
+def test_ui_aggregate_pools_percentiles_across_runs() -> None:
+    block = ui_run._aggregate_ui_results(
+        [
+            RunResult(latencies_ms=[1.0, 100.0], wall_time=1.0),
+            RunResult(latencies_ms=[2.0, 3.0], wall_time=1.0),
+        ]
+    )
+    distribution = _d(block["distribution"])
+    assert distribution["samples"] == 4
+    assert distribution["p50_ms"] == 2.0
+    assert distribution["p95_ms"] == 100.0
+    assert _d(block["summary"])["avg_p50_ms"] == 2.0
+
+
+def test_ui_failures_fail_the_run_without_thresholds() -> None:
+    failed = RunResult()
+    failed.record_failure("TimeoutError")
+    assert ui_run._has_failures([failed])
+    assert not ui_run._has_failures([RunResult(latencies_ms=[1.0])])
+
+
+def test_ui_threshold_distribution_matches_report_summary() -> None:
+    results = [
+        RunResult(latencies_ms=[1.0, 100.0], wall_time=1.0),
+        RunResult(latencies_ms=[2.0, 3.0], wall_time=1.0),
+    ]
+    pooled = ui_run._pooled_result(results)
+    assert len(pooled) == 1
+    assert pooled[0].percentile(50) == 2.0
+    assert pooled[0].percentile(95) == 100.0
+
+
+def test_ui_skipped_block_has_no_latency_metrics() -> None:
+    journey = ALL_UI_JOURNEYS["switch_sessions"]
+    block = ui_run._skipped_block(journey, "sqlite", RuntimeError("boom"))
+    assert block["skipped"] is True
+    assert block["summary"] == {}
+    assert block["error"] == "RuntimeError: boom"
+    assert _d(block["network"])["reps"] == 0
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--iterations", "0"],
+        ["--runs", "0"],
+        ["--warmup", "-1"],
+    ],
+)
+def test_parse_args_rejects_invalid_sample_counts(argv: list[str]) -> None:
+    with pytest.raises(SystemExit):
+        ui_run._parse_args(argv)
+
+
 # ── report block shape ───────────────────────────────────────
 
 
 def test_report_block_carries_network_and_summary() -> None:
-    """A journey block folds latency summary + a network block under schema v4."""
+    """A journey block folds latency summary + a network block under schema v5."""
     block = aggregate([RunResult(latencies_ms=[400.0, 420.0], wall_time=1.0)])
     block["kind"] = "ui-latency"
     block["network"] = build_network_block(
@@ -227,6 +309,7 @@ async def test_ui_benchmark_smoke_end_to_end() -> None:
         warmup=0,
         headed=False,
         skip_build=_HAS_SPA_BUILD,
+        artifacts_dir=None,
         output=None,
         max_p50_ms=None,
         max_p99_ms=None,


### PR DESCRIPTION
## Related issue

N/A

## Summary

This adds a Playwright benchmark suite for real end-to-end UI latency: a real server, warm runner, mock LLM, built SPA, and Chromium execute four user journeys and emit schema-v5 JSON compatible with the existing benchmark tooling.

- Measures `landing_load`, `warm_session_first_token`, `switch_sessions`, and `fork_session`, with stable journey-specific completion signals and prompt setup excluded from first-token timing.
- Pools successful latency samples across runs for percentiles, records browser/network provenance, fails on any incomplete repetition, and preserves logs/screenshots for diagnosis.
- Runs a one-sample smoke suite on relevant PRs and the full distribution nightly/manually. Dependency sync skips the implicit SPA build only during `uv sync`; CI then performs one explicit `npm ci && npm run build`, which `--skip-build` verifies and reuses. Benchmark subprocesses sanitize ambient provider credentials instead of relying on workflow-specific empty variables.

ELI5: this drives the product like a user, starts and stops a stopwatch around one visible action at a time, and saves enough context to distinguish a slow UI from extra network work or a broken sample.

```mermaid
flowchart LR
  A["Server + warm runner + mock LLM"] --> B["Built web UI in Chromium"]
  B --> C["Playwright user journey"]
  C --> D["Pooled latency samples"]
  C --> E["Normalized network counts"]
  C --> F["Failure screenshots + logs"]
  D --> G["Schema-v5 report"]
  E --> G
```

## Test Plan

- `uv run --no-sync pytest tests/benchmarks/test_ui_benchmark_smoke.py -q` — 22 passed, including the real browser/server/runner smoke test.
- `uv run --no-sync pytest tests/benchmarks/test_benchmark_smoke.py -q` — 25 passed.
- `uv run --no-sync pre-commit run --all-files` — all hooks passed, including Ruff, formatting, and YAML validation.
- Ran all journeys once with `--runs 1 --iterations 1 --warmup 0`; all completed with zero failures and emitted a schema-v5 report with browser metadata, pooled distributions, normalized network counts, and reconciled totals.

## Demo

N/A — this is a headless benchmark harness and does not change the product UI.

Example one-sample run:

```text
landing_load                 377.9 ms, 0 failures
warm_session_first_token    2405.1 ms, 0 failures
switch_sessions               78.4 ms, 0 failures
fork_session                 383.6 ms, 0 failures
```

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover argument validation, pooled percentile semantics, failure gating, network accounting, report shape, and path normalization. The browser smoke test boots the complete local stack and exercises Chromium; manual verification ran every journey and inspected the generated report.

## Changelog

Developers can benchmark complete UI user journeys with pooled latency distributions and normalized network-request diagnostics.
