### PR TITLE
perf(db): drop the redundant conversations created_at/updated_at indexes

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -770,10 +770,9 @@ class SqlConversation(ConversationBase):
     )
 
     __table_args__ = (
-        Index("ix_conversations_created_at", "workspace_id", "created_at", "id"),
-        Index("ix_conversations_updated_at", "workspace_id", "updated_at", "id"),
-        # Default sidebar filters archived=false and sorts by updated_at DESC;
-        # archived leads as an equality so the page walk stays index-only.
+        # No bare created_at/updated_at indexes: the sessions list is ACL-scoped
+        # (id IN (...)) and resolves via the PK; the default sidebar (archived=
+        # false, updated_at DESC) is served by the archived_updated index below.
         Index("ix_conversations_archived_updated", "workspace_id", "archived", "updated_at", "id"),
         Index(
             "ix_conversations_root_conversation_id",

--- a/omnigent/db/migrations/versions/f4a1c8b2d3e6_drop_conversations_timestamp_indexes.py
+++ b/omnigent/db/migrations/versions/f4a1c8b2d3e6_drop_conversations_timestamp_indexes.py
@@ -1,0 +1,54 @@
+"""Drop the redundant conversations created_at / updated_at indexes.
+
+Revision ID: f4a1c8b2d3e6
+Revises: d1e2f3a4b5c6
+Create Date: 2026-07-20 00:00:00.000000
+
+The two bare sort indexes on ``conversations`` no longer earn their write cost:
+
+- ``ix_conversations_created_at`` (``workspace_id, created_at, id``)
+- ``ix_conversations_updated_at`` (``workspace_id, updated_at, id``)
+
+Every path that sorts these columns already narrows the rows by something with
+a better index. The sessions list is ACL-scoped, so it filters ``id IN (...)``
+and resolves through the primary key ``(workspace_id, id)``; the default sidebar
+(``archived = false`` sorted by ``updated_at DESC``) is served by
+``ix_conversations_archived_updated``; and the sub-agent / root listings filter
+on ``parent_conversation_id`` / ``root_conversation_id`` and use their own
+indexes. So neither bare index is the chosen access path, while ``updated_at``
+is rewritten on every item append — pure write amplification.
+
+Index-only: no columns change, so no table rebuild is needed. ``DROP INDEX`` is
+native on every dialect. Downgrade recreates both composite indexes exactly.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "f4a1c8b2d3e6"
+down_revision: str | None = "d1e2f3a4b5c6"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    """Drop the two redundant timestamp sort indexes."""
+    op.drop_index("ix_conversations_created_at", table_name="conversations")
+    op.drop_index("ix_conversations_updated_at", table_name="conversations")
+
+
+def downgrade() -> None:
+    """Recreate the composite ``(workspace_id, <ts>, id)`` sort indexes."""
+    op.create_index(
+        "ix_conversations_created_at",
+        "conversations",
+        ["workspace_id", "created_at", "id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_conversations_updated_at",
+        "conversations",
+        ["workspace_id", "updated_at", "id"],
+        unique=False,
+    )

--- a/omnigent/server/DBSPEC.md
+++ b/omnigent/server/DBSPEC.md
@@ -46,7 +46,7 @@ in `omnigent/db/db_models.py`.
 | created_at | Integer NOT NULL | |
 | title | Text | nullable, user-settable conversation title |
 
-**Indexes:** `ix_conversations_created_at`
+**Indexes:** `ix_conversations_archived_updated` (backs the default sidebar list)
 
 ---
 

--- a/tests/db/test_migration_drop_conversations_timestamp_indexes.py
+++ b/tests/db/test_migration_drop_conversations_timestamp_indexes.py
@@ -1,0 +1,106 @@
+"""Tests for dropping the redundant conversations timestamp sort indexes.
+
+``ix_conversations_created_at`` and ``ix_conversations_updated_at`` were bare
+``(workspace_id, <ts>, id)`` sort indexes. Every query that sorts those columns
+already narrows rows by a more selective key — the ACL id-set (resolved via the
+PK), the default sidebar (served by ``ix_conversations_archived_updated``), or
+parent/root listings (their own indexes) — so neither bare index is the chosen
+access path, while ``updated_at`` is rewritten on every item append. Migration
+``f4a1c8b2d3e6`` drops both; these tests assert the drop and that the downgrade
+restores them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+
+_DROP_REVISION = "f4a1c8b2d3e6"
+_PRE_DROP_REVISION = "d1e2f3a4b5c6"
+
+_DROPPED = ("ix_conversations_created_at", "ix_conversations_updated_at")
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Iterator[Engine]:
+    """
+    Fresh SQLite DB with the full alembic chain applied; cleaned up after.
+
+    :param tmp_path: Pytest-managed temp directory for the SQLite file.
+    :returns: Engine pointed at the migrated database (at head).
+    """
+    uri = f"sqlite:///{tmp_path / 'test.db'}"
+    engine = get_or_create_engine(uri)
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+def _conv_indexes(engine: Engine) -> set[str]:
+    """Return the set of index names on ``conversations`` by reflection."""
+    return {i["name"] for i in sa.inspect(engine).get_indexes("conversations")}
+
+
+def test_timestamp_indexes_absent_at_head(db_engine: Engine) -> None:
+    """
+    At head the two bare sort indexes are gone, but the sidebar index survives.
+
+    A failure means the drop migration didn't apply (the indexes would keep
+    absorbing writes) or that it over-reached and removed the archived+updated
+    index that actually backs the default ``GET /v1/sessions`` listing.
+    """
+    idx = _conv_indexes(db_engine)
+    for name in _DROPPED:
+        assert name not in idx, f"{name} should be dropped at head; found it in {sorted(idx)}."
+    assert "ix_conversations_archived_updated" in idx, (
+        "ix_conversations_archived_updated must survive — it backs the default sidebar list."
+    )
+
+
+def test_downgrade_restores_indexes(tmp_path: Path) -> None:
+    """
+    Downgrade recreates both composite indexes; a re-upgrade drops them again.
+
+    The downgrade leg matters because the ``get_or_create_engine`` fixtures only
+    ever run ``upgrade head`` — this is the one place the ``downgrade`` body is
+    exercised, proving the chain stays reversible.
+    """
+    uri = f"sqlite:///{tmp_path / 'roundtrip.db'}"
+    cfg = _build_alembic_config(uri)
+    engine = sa.create_engine(uri)
+    try:
+        with engine.begin() as conn:
+            cfg.attributes["connection"] = conn
+            command.upgrade(cfg, _DROP_REVISION)
+        assert not (set(_DROPPED) & _conv_indexes(engine)), (
+            "the two timestamp indexes should be absent at the drop revision."
+        )
+
+        with engine.begin() as conn:
+            cfg.attributes["connection"] = conn
+            command.downgrade(cfg, _PRE_DROP_REVISION)
+        restored = _conv_indexes(engine)
+        for name in _DROPPED:
+            assert name in restored, f"downgrade must recreate {name}; have {sorted(restored)}."
+
+        with engine.begin() as conn:
+            cfg.attributes["connection"] = conn
+            command.upgrade(cfg, _DROP_REVISION)
+        assert not (set(_DROPPED) & _conv_indexes(engine)), (
+            "re-upgrade after downgrade should drop the indexes again."
+        )
+    finally:
+        engine.dispose()
+        clear_engine_cache()


### PR DESCRIPTION
## Related issue

N/A

## Summary

The `conversations` table carried two bare sort indexes —
`ix_conversations_created_at` and `ix_conversations_updated_at`
(`(workspace_id, <ts>, id)`) — that no longer earn their write cost:

- Every path that sorts these columns already narrows rows by a more selective
  key, so neither index is the chosen access path:
  - the sessions list (`GET /v1/sessions`) is ACL-scoped, so it filters
    `id IN (...)` and resolves through the PK `(workspace_id, id)`;
  - the default sidebar (`archived=false`, `updated_at DESC`) is served by
    `ix_conversations_archived_updated`;
  - sub-agent / root listings filter on `parent_conversation_id` /
    `root_conversation_id` and use their own indexes.
- Meanwhile `updated_at` is rewritten on **every** conversation-item append, so
  `ix_conversations_updated_at` is pure write amplification on a hot path.

**ELI5:** these two indexes were shortcuts for "sort a whole workspace's
conversations by time." Nothing asks for that anymore — every real query first
narrows to a specific set of rows (your sessions, one parent's children) that a
better index or the primary key already covers. So we're paying to keep them
updated on every write and getting nothing back. This drops them.

Migration `f4a1c8b2d3e6` drops both; the downgrade recreates the composites
exactly. Pure index DDL — no columns or data change.

## Test Plan

```
.venv/bin/python -m pytest \
  tests/db/test_migration_drop_conversations_timestamp_indexes.py \
  tests/db/test_migrations_sqlite_safe.py -q
# → new per-migration test (2 cases) + full-chain up→down→up roundtrip pass

.venv/bin/python -m pytest tests/db/ -q
# → 331 passed (no regression from removing the two Index() entries)

pre-commit run --files <the 4 changed files>   # ruff format/check + hooks pass
```

The new test asserts both indexes are absent at head (while
`ix_conversations_archived_updated` survives) and that the downgrade restores
them; `test_migrations_sqlite_safe.py` exercises the `upgrade` and `downgrade`
across the whole chain on SQLite.

Before merge: confirm the indexes are unused in prod
(`sys.schema_unused_indexes` on MySQL / `pg_stat_user_indexes.idx_scan`).

## Demo

N/A — non-visual database migration.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New per-migration test covers the drop and the downgrade restore; the existing
`test_migrations_sqlite_safe.py` chain roundtrip covers `upgrade`/`downgrade`
end-to-end.

This pull request and its description were written by Isaac.
