### PR TITLE
fix(web): host shells inline in the desktop workspace rail

### DIFF
--- a/tests/e2e_ui/files/test_right_panel.py
+++ b/tests/e2e_ui/files/test_right_panel.py
@@ -112,34 +112,29 @@ def test_right_panel_terminals_and_file_viewer(
         terminal_row = rail.get_by_role("button").filter(has_text="zsh").filter(has_text="main")
         expect(terminal_row.first).to_be_visible(timeout=60_000)
 
-        # Clicking a shell row replaces the main session view with that
-        # shell — terminal-first sessions (every runner-hosted SDK
-        # session) render it inline in the main pane via
-        # MainTerminalView; the rail never mounts an xterm of its own.
-        # The view must focus the CLICKED shell: a ``tui`` active key
-        # here means the explicit key was dropped and the view fell
-        # back to the agent's embedded REPL terminal.
+        # Clicking a shell row hosts it INLINE in the rail for a chat-first,
+        # non-wrapper session (the runner-hosted SDK REPL keeps the center),
+        # mirroring the Files tab's inline viewer — chat stays visible on the
+        # left. The full-screen center takeover (MainTerminalView) is the
+        # native-wrapper / mobile path only.
         terminal_row.first.click()
-        main_terminal = page.get_by_test_id("main-terminal-view")
-        expect(main_terminal).to_be_visible()
-        expect(main_terminal).to_have_attribute(
-            "data-active-terminal", "terminal:terminal_zsh_main"
-        )
-        expect(main_terminal).to_contain_text("zsh")
-        # The shell's xterm mounts in the main pane and connects.
-        terminal_view = page.get_by_test_id("terminal-view")
-        expect(terminal_view.last).to_be_visible(timeout=20_000)
-        expect(terminal_view.last).to_have_attribute("data-state", "connected", timeout=20_000)
-        # Chrome-free shell view: the Chat/Terminal pill is hidden (a
-        # "Chat" option under a shell misreads as the shell being the
-        # agent) and no agent tab renders next to the shell. A visible
-        # pill or "tui" text means the isShellView gate regressed.
-        expect(page.get_by_role("button", name="Chat", exact=True)).to_have_count(0)
-        expect(main_terminal).not_to_contain_text("tui")
-        # The header's close X is the way back to the conversation
-        # surface for the Files steps below.
-        page.get_by_role("button", name="Close shell").click()
-        expect(main_terminal).to_have_count(0)
+        # The shell's xterm mounts inline in the rail and connects. The rail
+        # names the CLICKED shell (zsh); a fall-back to the agent's embedded
+        # ``tui`` REPL would mean the explicit key was dropped.
+        terminal_view = rail.get_by_test_id("terminal-view")
+        expect(terminal_view).to_be_visible(timeout=20_000)
+        expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+        expect(rail).to_contain_text("zsh")
+        expect(rail).not_to_contain_text("tui")
+        # No center takeover: chat stays visible (the Chat/Terminal pill
+        # remains — inline hosting is precisely the not-chat-replacing path)
+        # and no ``main-terminal-view`` mounts.
+        expect(page.get_by_role("button", name="Chat", exact=True)).to_be_visible()
+        expect(page.get_by_test_id("main-terminal-view")).to_have_count(0)
+        # "Back to shells" collapses the inline terminal back to the list
+        # without closing the PTY, before the Files steps below.
+        rail.get_by_role("button", name="Back to shells").click()
+        expect(rail.get_by_role("button", name="New shell")).to_be_visible()
 
         # Switch to the Files tab and open the seeded file. The
         # changed-file row renders two buttons carrying the filename: the

--- a/tests/e2e_ui/sessions/test_terminal_theme.py
+++ b/tests/e2e_ui/sessions/test_terminal_theme.py
@@ -71,12 +71,19 @@ def _open_new_shell(page: Page) -> None:
     rail.get_by_role("button", name="New shell").click()
 
 
-def _connected_main_terminal(page: Page):
-    """Wait for a freshly opened shell's xterm to mount + connect in the main view."""
-    main_terminal = page.get_by_test_id("main-terminal-view")
-    expect(main_terminal).to_be_visible(timeout=60_000)
-    terminal_view = main_terminal.get_by_test_id("terminal-view").last
-    expect(terminal_view).to_be_visible(timeout=20_000)
+def _connected_rail_terminal(page: Page):
+    """Wait for a freshly opened shell's xterm to mount + connect inline in the rail.
+
+    A chat-first, non-wrapper ``terminal_session`` hosts its user shells INLINE
+    in the workspace rail, not in the center ``main-terminal-view`` (see
+    ``shells/test_new_shell.py``). The terminal-theme signal rides the same
+    ``TerminalView`` wherever it mounts (``data-terminal-theme`` is set
+    unconditionally), so the rail-hosted terminal carries it just as the center
+    one did.
+    """
+    rail = page.get_by_role("complementary", name="Workspace")
+    terminal_view = rail.get_by_test_id("terminal-view")
+    expect(terminal_view).to_be_visible(timeout=60_000)
     expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
     return terminal_view
 
@@ -99,7 +106,7 @@ def test_light_terminal_under_dark_app(page: Page, terminal_session: tuple[str, 
 
     page.goto(f"{base_url}/c/{session_id}")
     _open_new_shell(page)
-    terminal_view = _connected_main_terminal(page)
+    terminal_view = _connected_rail_terminal(page)
 
     # The terminal is light despite the dark app chrome — the two themes are
     # independent, which is the whole point of the feature.
@@ -124,7 +131,7 @@ def test_dark_terminal_under_light_app(page: Page, terminal_session: tuple[str, 
 
     page.goto(f"{base_url}/c/{session_id}")
     _open_new_shell(page)
-    terminal_view = _connected_main_terminal(page)
+    terminal_view = _connected_rail_terminal(page)
 
     expect(terminal_view).to_have_attribute("data-terminal-theme", "dark")
     assert not _html_has_dark(page), "app theme must stay light while the terminal is dark"

--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -6,21 +6,28 @@ virtual "+ New shell" row (``NewTerminalButton`` in
 ``web/src/shell/NewTerminalButton.tsx``). With a single declared
 terminal name the row creates the shell directly on click (no dropdown),
 POSTing ``/resources/terminals`` and handing the new terminal's tab key
-to ``onExpand``, which opens it in the main column via
-``MainTerminalView``. None of this needs an LLM turn — the user, not the
-agent, launches the shell — so these tests never send a chat message.
+to ``onOpenShell``. For a chat-first, non-wrapper terminal session (an
+``openai-agents`` harness with a ``terminals:`` block and no
+``omnigent.wrapper``), that hosts the shell INLINE in the workspace rail
+— the Shells tab swaps its list for the shell's terminal, mirroring the
+Files tab's inline viewer — instead of taking over the center. The
+chat-replacing full-screen center view (``MainTerminalView``) is the
+native-wrapper / mobile path only. None of this needs an LLM turn — the
+user, not the agent, launches the shell — so these tests never send a
+chat message.
 
 Three behaviors are covered:
 
-1. **"+ New shell" launches and opens a shell.** Clicking the row creates
-   a ``zsh`` shell and replaces the main session view with it: the
-   chrome-light shell view (``MainTerminalView``'s ``isShellView``) shows
-   a header naming the shell and a "Close shell" X, its xterm connects,
-   and the X returns to the conversation surface.
+1. **"+ New shell" launches and hosts the shell inline in the rail.**
+   Clicking the row creates a ``zsh`` shell and opens it inside the rail's
+   Shells tab: an inline terminal whose xterm connects, with the rail
+   naming the shell. The center is untouched — no ``main-terminal-view``
+   mounts — and "Back to shells" collapses the inline terminal back to the
+   list without closing the PTY.
 
 2. **The user can type a command into the shell.** We type ``pwd`` into
-   the connected shell and assert it keeps running — the keystrokes are
-   accepted and the bridge does not error or close. We deliberately do
+   the connected inline shell and assert it keeps running — the keystrokes
+   are accepted and the bridge does not error or close. We deliberately do
    NOT assert on the command's output: xterm renders to a WebGL canvas,
    so stdout is not in the DOM (the same reason
    ``files/test_right_panel.py`` only checks ``data-state``), and reading
@@ -44,11 +51,6 @@ from playwright.sync_api import Page, expect
 
 from tests.e2e_ui.conftest import open_right_rail
 
-# Tab key prefix for a user-created ``zsh`` shell: ``createTerminal``
-# mints a ``u-<rand>`` session key, yielding the resource id
-# ``terminal_zsh_u-<rand>`` and the tab key ``terminal:terminal_zsh_u-…``.
-_USER_ZSH_KEY_RE = re.compile(r"^terminal:terminal_zsh_u-")
-
 
 def _open_new_shell(page: Page) -> None:
     """Open the Shells tab and click the "+ New shell" row.
@@ -70,45 +72,46 @@ def _open_new_shell(page: Page) -> None:
 
 
 def test_new_shell_launches_and_opens(page: Page, terminal_session: tuple[str, str]) -> None:
-    """Clicking "+ New shell" launches a shell and opens it in the main view.
+    """Clicking "+ New shell" launches a shell hosted inline in the rail.
 
     The create is user-driven (no chat message), so the only wait is for
-    the runner to spin the PTY up and the xterm to connect. The opened
-    view must focus the freshly-created shell — a ``terminal_tui_main``
-    active key here would mean the new key was dropped and the view fell
-    back to the agent's REPL — and render as the chrome-light shell view
-    (header + close X, no Chat/Terminal pill). The X returns to chat.
+    the runner to spin the PTY up and the xterm to connect. For a chat-first
+    non-wrapper session the created shell hosts INLINE in the rail's Shells
+    tab — not the center: its xterm mounts inside the "Workspace" rail and
+    connects, the rail names the freshly-created ``zsh`` shell (a fall-back
+    to the agent's ``tui`` REPL would mean the new key was dropped), and no
+    center ``main-terminal-view`` takes over. "Back to shells" collapses the
+    inline terminal back to the list without closing the PTY.
     """
     base_url, session_id = terminal_session
 
     page.goto(f"{base_url}/c/{session_id}")
     _open_new_shell(page)
 
-    # The new shell takes over the main column (terminal-first session).
-    main_terminal = page.get_by_test_id("main-terminal-view")
-    expect(main_terminal).to_be_visible(timeout=60_000)
-    # The view focuses the CLICKED shell, not the agent's REPL terminal.
-    expect(main_terminal).to_have_attribute("data-active-terminal", _USER_ZSH_KEY_RE)
-    # Chrome-light shell view: the shell header names it and a "Close
-    # shell" X is present; the Chat/Terminal pill is hidden (a "Chat"
-    # option under a shell misreads as the shell being the agent).
-    expect(main_terminal).to_contain_text("zsh")
-    expect(page.get_by_role("button", name="Chat", exact=True)).to_have_count(0)
+    rail = page.get_by_role("complementary", name="Workspace")
+    # The new shell hosts INLINE in the rail: its xterm mounts inside the
+    # Shells tab and connects.
+    terminal_view = rail.get_by_test_id("terminal-view")
+    expect(terminal_view).to_be_visible(timeout=60_000)
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+    # The rail names the CLICKED shell (zsh), not the agent's REPL (tui).
+    expect(rail).to_contain_text("zsh")
 
-    # The shell's xterm mounts in the main pane and connects.
-    terminal_view = page.get_by_test_id("terminal-view")
-    expect(terminal_view.last).to_be_visible(timeout=20_000)
-    expect(terminal_view.last).to_have_attribute("data-state", "connected", timeout=20_000)
+    # No center takeover: the chat-replacing full-screen shell view is the
+    # native-wrapper / mobile path only, so a chat-first session never mounts
+    # ``main-terminal-view`` here.
+    expect(page.get_by_test_id("main-terminal-view")).to_have_count(0)
 
-    # The header's close X is the way back to the conversation surface.
-    page.get_by_role("button", name="Close shell").click()
-    expect(main_terminal).to_have_count(0)
+    # "Back to shells" collapses the inline terminal back to the shell list
+    # (the "+ New shell" row is visible again) without closing the PTY.
+    rail.get_by_role("button", name="Back to shells").click()
+    expect(rail.get_by_role("button", name="New shell")).to_be_visible()
 
 
 def test_new_shell_accepts_typed_command(page: Page, terminal_session: tuple[str, str]) -> None:
-    """The user can type a command into a freshly created shell.
+    """The user can type a command into a freshly created inline shell.
 
-    Types ``pwd`` into the connected shell and asserts the bridge keeps
+    Types ``pwd`` into the connected inline shell and asserts the bridge keeps
     running: the keystrokes are accepted and the PTY neither errors nor
     closes. We do NOT assert on the command's output — xterm renders to a
     WebGL canvas, so stdout never reaches the DOM, and capturing it via a
@@ -121,9 +124,10 @@ def test_new_shell_accepts_typed_command(page: Page, terminal_session: tuple[str
     page.goto(f"{base_url}/c/{session_id}")
     _open_new_shell(page)
 
-    # Wait for the shell's xterm to connect before sending keystrokes —
-    # input typed before the WS attach opens is dropped.
-    terminal_view = page.get_by_test_id("terminal-view").last
+    # Wait for the rail's inline shell xterm to connect before sending
+    # keystrokes — input typed before the WS attach opens is dropped.
+    rail = page.get_by_role("complementary", name="Workspace")
+    terminal_view = rail.get_by_test_id("terminal-view")
     expect(terminal_view).to_be_visible(timeout=60_000)
     expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
 

--- a/web/src/hooks/useIsMobileViewport.ts
+++ b/web/src/hooks/useIsMobileViewport.ts
@@ -8,9 +8,16 @@
 
 import { useSyncExternalStore } from "react";
 
-// Mirror Tailwind's `max-md` variant exactly so this hook stays in lockstep
-// with the `max-md:` / `md:` classes already used across the shell.
-const MOBILE_QUERY = "(max-width: 767.98px)";
+// The EXACT logical complement of Tailwind's `md` (desktop) boundary
+// `(min-width: 768px)` — one source of truth for both sides of the line, so
+// CSS visibility (`md:` classes flip at >= 768px) and this JS gate flip at the
+// identical point. The prior `(max-width: 767.98px)` left a gap in the open
+// interval (767.98, 768): fractional widths reachable under browser zoom /
+// display scaling where the rail was CSS-hidden (< 768) but the hook still read
+// desktop (> 767.98), so a hidden rail could keep a live PTY while the mobile
+// surface opened another. `not all and (min-width: 768px)` is true precisely
+// when `(min-width: 768px)` is false, closing the gap with no rounding slack.
+const MOBILE_QUERY = "not all and (min-width: 768px)";
 
 function subscribe(callback: () => void): () => void {
   if (typeof window === "undefined" || !window.matchMedia) return () => {};

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -154,7 +154,7 @@ describe("UserBubble copy button", () => {
     vi.stubGlobal("navigator", { clipboard: { writeText } });
     const real = window.matchMedia;
     window.matchMedia = ((query: string) => ({
-      matches: /max-width/.test(query),
+      matches: /max-width/.test(query) || /^\s*not all and/.test(query),
       media: query,
       onchange: null,
       addListener: () => {},

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -250,6 +250,15 @@ vi.mock("./TerminalsPanel", () => ({
     />
   ),
 }));
+// Stub the PTY renderer so the mobile-surface test can mount the real
+// MainTerminalView (for its shell chrome) without dragging in xterm. Existing
+// tests never mount TerminalView — TerminalsPanel and the rail section are
+// stubbed above — so this global mock is inert for them.
+vi.mock("@/components/blocks/TerminalView", () => ({
+  TerminalView: ({ terminalId }: { terminalId: string }) => (
+    <div data-testid="terminal-view" data-terminal-id={terminalId} />
+  ),
+}));
 
 import { useConversations } from "@/hooks/useConversations";
 import { useTerminals } from "@/hooks/useTerminals";
@@ -274,6 +283,7 @@ import type { Agent } from "@/hooks/useAgents";
 const useSessionAgentMock = vi.mocked(useSessionAgent);
 
 import { AppShell } from "./AppShell";
+import { MainTerminalView } from "./MainTerminalView";
 import { useTerminalFirst } from "./TerminalFirstContext";
 import { useForkDialog } from "./ForkDialogContext";
 import { useChatStore } from "@/store/chatStore";
@@ -320,6 +330,28 @@ function TerminalFirstViewProbe() {
         terminal
       </button>
     </div>
+  );
+}
+
+/**
+ * Route element that pairs the view probe with the REAL MainTerminalView,
+ * mounted (as ChatPage does) only while the view is on the terminal. Lets a
+ * test assert that a center-hosted shell's chrome — the identity header and
+ * "Close shell" X — actually reaches the DOM through AppShell's routing, not
+ * just that the context flags it.
+ */
+function MainTerminalSurfaceProbe({ conversationId }: { conversationId: string }) {
+  const ctx = useTerminalFirst();
+  return (
+    <>
+      <TerminalFirstViewProbe />
+      {ctx?.view === "terminal" && (
+        <MainTerminalView
+          conversationId={conversationId}
+          initialTerminalKey={ctx.terminalViewKey}
+        />
+      )}
+    </>
   );
 }
 
@@ -1202,6 +1234,88 @@ describe("User-shell routing gates on isNativeWrapper (not isTerminalFirst)", ()
     expect(probe()).toHaveAttribute("data-view", "terminal");
     expect(probe()).toHaveAttribute("data-is-shell-view", "true");
     expect(probe()).toHaveAttribute("data-terminal-view-key", "terminal:terminal_main");
+  });
+
+  it("center-hosts a chat-first user shell WITH its header + close X on mobile (no rail)", () => {
+    // Below md there is no rail, so a polly-shape (terminal-first, NON-wrapper)
+    // user shell hands off full-screen to the center via openTerminalsPanel —
+    // the same path a native wrapper uses. The center-hosted shell must render
+    // its own chrome (identity header + close X) and flag isShellView so the
+    // Chat/Terminal pill hides; the earlier isNativeWrapper gate left it bare
+    // and the pill mislabeled "Terminal".
+    const originalMatchMedia = window.matchMedia;
+    // useIsMobileViewport reads the `md`-complement query; report it as matching
+    // so the shell surface behaves as mobile.
+    window.matchMedia = ((query: string) => ({
+      matches: query.startsWith("not all and (min-width: 768px)"),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+
+    try {
+      useEnvironmentMock.mockReturnValue({
+        data: { available: true, root: null },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+      mockConversations([
+        { id: "conv_polly", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+      ]);
+      useTerminalsMock.mockReturnValue({
+        terminals: [
+          { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+          // The rail mock's onExpand targets "terminal:terminal_main"; give that
+          // key a real user shell so MainTerminalView can render its header.
+          { id: "terminal_main", name: "bash", session: "s1", running: true },
+        ],
+        isLoading: false,
+        error: null,
+      });
+
+      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      render(
+        <QueryClientProvider client={qc}>
+          <TooltipProvider>
+            <MemoryRouter initialEntries={["/c/conv_polly"]}>
+              <Routes>
+                <Route element={<AppShell />}>
+                  <Route
+                    path="c/:conversationId"
+                    element={<MainTerminalSurfaceProbe conversationId="conv_polly" />}
+                  />
+                </Route>
+              </Routes>
+            </MemoryRouter>
+          </TooltipProvider>
+        </QueryClientProvider>,
+      );
+
+      const probe = () => screen.getByTestId("view-probe");
+      expect(probe()).toHaveAttribute("data-is-terminal-first", "true");
+      expect(probe()).toHaveAttribute("data-is-native-wrapper", "false");
+
+      // Open a shell through the full-screen path (onExpand → openTerminalsPanel),
+      // the same handler the mobile shells drawer routes through.
+      fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rail: open terminal/i }));
+
+      // The center now hosts the shell: the view flips to terminal and
+      // isShellView is set, so the Chat/Terminal pill hides.
+      expect(probe()).toHaveAttribute("data-view", "terminal");
+      expect(probe()).toHaveAttribute("data-is-shell-view", "true");
+
+      // MainTerminalView renders the shell chrome — an identity header naming
+      // the shell and a working "Close shell" X back to chat, not a bare pane.
+      expect(screen.getByText("bash")).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Close shell" }));
+      expect(probe()).toHaveAttribute("data-view", "chat");
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
   });
 
   it("does not replay a stored user-shell key into the center for a polly session", () => {

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import {
   MemoryRouter,
   Route,
@@ -1147,6 +1147,85 @@ describe("User-shell routing gates on isNativeWrapper (not isTerminalFirst)", ()
     expect(probe()).toHaveAttribute("data-view", "chat");
     expect(probe()).toHaveAttribute("data-is-shell-view", "false");
     // The stale key is scrubbed so a later persist can't resurrect it.
+    expect(sessionStorage.getItem("omnigent.web.panel-key:conv_polly")).toBeNull();
+  });
+
+  it("does not replay a stored user-shell key on a COLD reload where labels load late", async () => {
+    // Cold hard reload: the sidebar list and the session snapshot both start
+    // empty/loading (no localStorage persistence), so terminalFirst reads
+    // false when the restore effect runs. A stored user-shell key must NOT be
+    // eagerly replayed into the center during that window — it's parked, the
+    // center stays on chat — and once the polly labels resolve it's scrubbed.
+    // Regression: eager replay opened MainTerminalView in a polly session
+    // (view flipped to terminal the moment isTerminalFirst turned true).
+    sessionStorage.setItem("omnigent.web.panel-key:conv_polly", "terminal:terminal_bash_s1");
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+
+    // Phase 1 — cold: no conversation row yet, snapshot still loading.
+    useConvMock.mockReturnValue({ data: undefined } as ReturnType<typeof useConversations>);
+    useSessionMock.mockReturnValue({ session: null, isLoading: true, error: null });
+    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const makeTree = () => (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_polly"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(makeTree());
+
+    const probe = () => screen.getByTestId("view-probe");
+    // While labels are unknown the shape isn't decided, but the key is parked
+    // (not replayed): the center stays on chat.
+    expect(probe()).toHaveAttribute("data-view", "chat");
+
+    // Phase 2 — labels resolve to a polly session (terminal-first, no wrapper).
+    mockConversations([
+      { id: "conv_polly", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    useSessionMock.mockReturnValue({
+      session: { id: "conv_polly", labels: { "omnigent.ui": "terminal" } },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useSession>);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    rerender(makeTree());
+
+    // The session is now known to be chat-first non-wrapper; the parked key
+    // resolves to a scrub, so the center never takes over and the stale key
+    // is gone.
+    await waitFor(() => {
+      expect(probe()).toHaveAttribute("data-is-terminal-first", "true");
+    });
+    expect(probe()).toHaveAttribute("data-is-native-wrapper", "false");
+    expect(probe()).toHaveAttribute("data-view", "chat");
+    expect(probe()).toHaveAttribute("data-is-shell-view", "false");
     expect(sessionStorage.getItem("omnigent.web.panel-key:conv_polly")).toBeNull();
   });
 });

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import {
   MemoryRouter,
   Route,
@@ -139,15 +139,17 @@ vi.mock("./InlineTerminalsSection", () => ({
   // mobile / native-wrapper hand off full-screen via onExpand. Tests drive
   // whichever path applies and assert the resulting state.
   InlineTerminalsSection: ({
+    conversationId,
     onExpand,
     inline,
     activeKey,
     onOpenShell,
   }: {
+    conversationId: string;
     onExpand: (key: string) => void;
     inline?: boolean;
     activeKey?: string | null;
-    onOpenShell?: (key: string) => void;
+    onOpenShell?: (key: string, source: string) => void;
   }) => (
     <div
       data-testid="inline-terminals-section"
@@ -164,9 +166,21 @@ vi.mock("./InlineTerminalsSection", () => ({
       <button
         type="button"
         aria-label="rail: host shell"
-        onClick={() => onOpenShell?.("terminal:terminal_bash_s1")}
+        // Mirror the real section: the mutation carries its SOURCE
+        // conversation so AppShell can reject a late callback after nav.
+        onClick={() => onOpenShell?.("terminal:terminal_bash_s1", conversationId)}
       >
         host-shell
+      </button>
+      <button
+        type="button"
+        aria-label="rail: stale-source shell"
+        // Simulate a create that STARTED in conv_a and resolves after the
+        // user navigated away — its callback still carries "conv_a" as the
+        // source. AppShell must reject it against the current conversation.
+        onClick={() => onOpenShell?.("terminal:terminal_bash_s1", "conv_a")}
+      >
+        host-shell-stale
       </button>
     </div>
   ),
@@ -1422,6 +1436,215 @@ describe("User-shell routing gates on isNativeWrapper (not isTerminalFirst)", ()
     // Re-open the Shells tab in B; the rail must NOT carry A's active key.
     fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
     expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute("data-active-key", "");
+  });
+
+  it("M5: rejects a pending shell-create whose source is not the current conversation", () => {
+    // A shell-create started in conv_a whose POST resolves after the user
+    // navigated to conv_b calls onOpenShell late with source "conv_a". The
+    // fix rejects the WHOLE mutation (no active shell set, rail not forced to
+    // Shells) unless the source still matches the current conversation, so a
+    // pending create in A can't rewrite B's workspace.
+    //
+    // NOTE: the harness stubs InlineTerminalsSection and TerminalView, so we
+    // assert the observable owner-gate outcome (no active-key adoption /
+    // openShellTab mutation for B), not a real PTY attach.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      { id: "conv_a", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+      { id: "conv_b", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_b"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+
+    // On conv_b, fire a callback tagged with the STALE source conv_a — as a
+    // create that began in A would after navigation.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    fireEvent.click(screen.getByRole("button", { name: /rail: stale-source shell/i }));
+
+    // The mutation is rejected: no shell adopted as active for B.
+    expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute("data-active-key", "");
+
+    // A same-conversation callback (source conv_b) is still honored — the
+    // guard rejects only the stale source, not all creates.
+    fireEvent.click(screen.getByRole("button", { name: /rail: host shell$/i }));
+    expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute(
+      "data-active-key",
+      "terminal:terminal_bash_s1",
+    );
+  });
+
+  it("M6: mounts only ONE inline shell terminal across a desktop→mobile breakpoint change", () => {
+    // Desktop hosts the shell inline (inline=true). Below the md breakpoint
+    // the desktop rail is CSS-hidden but STAYS MOUNTED, so its TerminalView +
+    // PTY would remain live under the mobile overlay path — two attachments.
+    // The fix drops ``inline`` to false on the hidden rail via a real
+    // matchMedia signal, so the desktop rail no longer hosts a live terminal
+    // there. We assert the single-mounted-terminal outcome by reading the
+    // rail section's ``data-inline`` flag across a simulated breakpoint flip
+    // (the harness stubs TerminalView, so mount count is the observable).
+    let mobileMatches = false;
+    // Only the mobile-breakpoint query's listeners drive this test; other
+    // matchMedia consumers (e.g. useResizablePanel) still get a stub but we
+    // don't notify them. useIsMobileViewport uses "(max-width: 767.98px)".
+    const mobileListeners = new Set<(e: { matches: boolean }) => void>();
+    window.matchMedia = ((query: string) => {
+      const isMobileQuery = query.includes("max-width: 767.98px");
+      return {
+        get matches() {
+          return isMobileQuery ? mobileMatches : false;
+        },
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: (_: string, cb: (e: { matches: boolean }) => void) => {
+          if (isMobileQuery) mobileListeners.add(cb);
+        },
+        removeEventListener: (_: string, cb: (e: { matches: boolean }) => void) => {
+          mobileListeners.delete(cb);
+        },
+        dispatchEvent: () => false,
+      };
+    }) as unknown as typeof window.matchMedia;
+
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      { id: "conv_polly", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_polly");
+
+    // Desktop: host the shell inline in the rail — the section is inline.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    fireEvent.click(screen.getByRole("button", { name: /rail: host shell$/i }));
+    const section = () => screen.getByTestId("inline-terminals-section");
+    expect(section()).toHaveAttribute("data-active-key", "terminal:terminal_bash_s1");
+    expect(section()).toHaveAttribute("data-inline", "true");
+
+    // Cross below md: the still-mounted desktop rail must stop hosting the
+    // live terminal (inline=false), so the mobile overlay can own the sole
+    // PTY without a second live attachment in the hidden rail.
+    mobileMatches = true;
+    act(() => {
+      mobileListeners.forEach((cb) => cb({ matches: true }));
+    });
+    expect(section()).toHaveAttribute("data-inline", "false");
+
+    // Restore the shared matchMedia stub for later tests.
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+  });
+
+  it("LOW: clears a dangling active shell key when it closes while another rail surface shows", async () => {
+    // Open shell S inline, then switch the rail to Agents. S closes
+    // externally (drops from the inventory). The inline section is now
+    // unmounted and can't call returnToShellList, so AppShell's off-surface
+    // cleanup must clear the dangling active key — otherwise the tab silently
+    // lingers and a same-id relaunch resurrects a stale tab.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      { id: "conv_polly", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    // Agent declares shell access so the Shells tab STAYS available after the
+    // last shell closes (default-visible via the "+ New shell" empty state) —
+    // otherwise the tab would hide entirely and mask the dangling-key bug.
+    useSessionAgentMock.mockReturnValue({
+      data: { id: "ag_1", object: "agent", name: "polly", terminals: ["shell"] } as Agent,
+    } as ReturnType<typeof useSessionAgent>);
+    const withShell = {
+      terminals: [
+        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    };
+    useTerminalsMock.mockReturnValue(withShell);
+
+    renderShell("/c/conv_polly");
+
+    // Host shell S inline.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    fireEvent.click(screen.getByRole("button", { name: /rail: host shell$/i }));
+    expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute(
+      "data-active-key",
+      "terminal:terminal_bash_s1",
+    );
+
+    // Switch to Agents — the inline shell section unmounts.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Agents/i }));
+    expect(screen.queryByTestId("inline-terminals-section")).toBeNull();
+
+    // S closes out from under the rail: it disappears from the inventory.
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_tui_main", name: "tui", session: "main", running: true }],
+      isLoading: false,
+      error: null,
+    });
+    // Nudge a re-render via a harmless tab round-trip so the cleanup effect
+    // re-runs against the now-dead inventory.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Files/i }));
+
+    // Returning to Shells must show the list (no dangling active key), not a
+    // resurrected S tab.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    await waitFor(() =>
+      expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute("data-active-key", ""),
+    );
   });
 
   it("does not carry a stale center panelInitialKey to a different conversation on warm navigation", () => {

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -280,6 +280,25 @@ function TerminalFirstViewProbe() {
 }
 
 /**
+ * Records the center-view terminal key (``terminalViewKey`` =
+ * AppShell's gated ``panelInitialKey``) on EVERY render into a shared
+ * array, so a test can assert on the render SEQUENCE — not just the
+ * settled end state. The B2 center-path race is a transient-render bug:
+ * on a warm A→B nav B's first render inherits A's stale key before the
+ * restore effect reconciles it, so the settled state converges either
+ * way and only the transient reveals a missing owner-gate.
+ */
+const centerKeyRenders: Array<{ path: string; key: string }> = [];
+function CenterKeyRecorder() {
+  const ctx = useTerminalFirst();
+  const { pathname } = useLocation();
+  // Pushing during render is impure but deliberate here — we need every
+  // render pass, including transient ones an effect immediately corrects.
+  centerKeyRenders.push({ path: pathname, key: ctx?.terminalViewKey ?? "" });
+  return null;
+}
+
+/**
  * Probe for ForkDialogContext — the per-message "Fork from here" entry
  * point lives in ChatPage (not mounted here), so these tests consume the
  * context the same way the real action does: read `canFork` for gating
@@ -488,6 +507,9 @@ beforeEach(() => {
   // Reset terminal-first startup signals so one test's terminalPending /
   // failed status can't leak into another's terminalStartingUp.
   useChatStore.setState({ todos: [], terminalPending: false, sessionStatus: "idle" });
+  // Clear the center-view render recorder so one test's render sequence
+  // can't leak into another's.
+  centerKeyRenders.length = 0;
 });
 
 afterEach(cleanup);
@@ -1400,6 +1422,96 @@ describe("User-shell routing gates on isNativeWrapper (not isTerminalFirst)", ()
     // Re-open the Shells tab in B; the rail must NOT carry A's active key.
     fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
     expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute("data-active-key", "");
+  });
+
+  it("does not carry a stale center panelInitialKey to a different conversation on warm navigation", () => {
+    // B2 (center path): the CENTER-view key (``panelInitialKey``) is
+    // conversation-scoped the same way the rail's lifted shell state is.
+    // Terminal ids are deterministic and not conversation-scoped, so on a warm
+    // A→B nav B's FIRST render inherits A's stale key; with B's terminal query
+    // warm-cached it would resolve to B's same-id terminal and MainTerminalView
+    // would mount TerminalView — a real read-write WebSocket attach to the
+    // WRONG session. AppShell's owner-gate makes ``panelInitialKey`` null the
+    // instant conversationId flips (owner still A ≠ B), so no stale key ever
+    // reaches the center path during the transition.
+    //
+    // This asserts the owner-GATE outcome: while on B's route the center-view
+    // key is never A's stale key on ANY render pass (transient included, via
+    // the render recorder) — NOT literal WebSocket non-attachment, since this
+    // suite stubs TerminalView. A true transport assertion would need the real
+    // component (out of scope for this harness).
+    //
+    // Native-wrapper shape: only there does a user shell occupy the CENTER
+    // (chat-first sessions host inline in the rail), so it's the shape whose
+    // center panelInitialKey can carry a stale user-shell key across a nav.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      {
+        id: "conv_a",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal", "omnigent.wrapper": "claude-code-native-ui" },
+      },
+      {
+        id: "conv_b",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal", "omnigent.wrapper": "claude-code-native-ui" },
+      },
+    ]);
+    // Both sessions warm-cached with the SAME deterministic terminal ids.
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_claude_main", name: "claude", session: "main", running: true },
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_a"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <CenterKeyRecorder />
+                      <SessionNavButton to="/c/conv_b" />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+
+    // Take over the center in A with a user shell (native-wrapper onExpand).
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    fireEvent.click(screen.getByRole("button", { name: /rail: open terminal/i }));
+    const staleKey = "terminal:terminal_main";
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-view-key", staleKey);
+
+    // Warm-navigate to B (AppShell stays mounted, only the route param changes).
+    fireEvent.click(screen.getByTestId("nav-session"));
+
+    // On EVERY render pass while on B's route the center key must not be A's
+    // stale key — the owner-gate nulls it out before it can reach the center,
+    // so B never briefly mounts A's terminal.
+    const bRenders = centerKeyRenders.filter((r) => r.path === "/c/conv_b");
+    expect(bRenders.length).toBeGreaterThan(0);
+    expect(bRenders.every((r) => r.key !== staleKey)).toBe(true);
+    // Settled: B is on chat with no stale center key.
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-view-key", "");
   });
 });
 

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -132,6 +132,16 @@ vi.mock("./FileViewer", () => ({
     </div>
   ),
 }));
+// Captured by the InlineTerminalsSection mock on each render: the latest
+// onOpenShell callback and the conversation whose render produced it. Lets a
+// test invoke A's render-bound callback after navigating to B (deferred-create
+// survival). ``mock``-prefixed so vitest's hoisted vi.mock factory may close
+// over them.
+let mockCapturedOnOpenShell:
+  | ((key: string, source: string, pendingInventory: boolean) => void)
+  | null = null;
+let mockCapturedOnOpenShellConv: string | null = null;
+
 vi.mock("./InlineTerminalsSection", () => ({
   // Stand-in exposing onExpand + the desktop `inline` flag, plus the
   // controlled-hosting props (activeKey/onOpenShell). Desktop hosts the shell
@@ -149,41 +159,61 @@ vi.mock("./InlineTerminalsSection", () => ({
     onExpand: (key: string) => void;
     inline?: boolean;
     activeKey?: string | null;
-    onOpenShell?: (key: string, source: string) => void;
-  }) => (
-    <div
-      data-testid="inline-terminals-section"
-      data-inline={String(inline ?? false)}
-      data-active-key={activeKey ?? ""}
-    >
-      <button
-        type="button"
-        aria-label="rail: open terminal"
-        onClick={() => onExpand("terminal:terminal_main")}
+    onOpenShell?: (key: string, source: string, pendingInventory: boolean) => void;
+  }) => {
+    // Capture the LATEST onOpenShell + its owning conversation on every render,
+    // so a test can grab the callback bound to conversation A's render, then
+    // invoke it AFTER navigating to B — simulating a deferred create whose
+    // A-render callback survives the unmount.
+    mockCapturedOnOpenShell = onOpenShell ?? null;
+    mockCapturedOnOpenShellConv = conversationId;
+    return (
+      <div
+        data-testid="inline-terminals-section"
+        data-inline={String(inline ?? false)}
+        data-active-key={activeKey ?? ""}
       >
-        rail-terminal
-      </button>
-      <button
-        type="button"
-        aria-label="rail: host shell"
-        // Mirror the real section: the mutation carries its SOURCE
-        // conversation so AppShell can reject a late callback after nav.
-        onClick={() => onOpenShell?.("terminal:terminal_bash_s1", conversationId)}
-      >
-        host-shell
-      </button>
-      <button
-        type="button"
-        aria-label="rail: stale-source shell"
-        // Simulate a create that STARTED in conv_a and resolves after the
-        // user navigated away — its callback still carries "conv_a" as the
-        // source. AppShell must reject it against the current conversation.
-        onClick={() => onOpenShell?.("terminal:terminal_bash_s1", "conv_a")}
-      >
-        host-shell-stale
-      </button>
-    </div>
-  ),
+        <button
+          type="button"
+          aria-label="rail: open terminal"
+          onClick={() => onExpand("terminal:terminal_main")}
+        >
+          rail-terminal
+        </button>
+        <button
+          type="button"
+          aria-label="rail: host shell"
+          // Mirror the real section selecting an EXISTING shell: the mutation
+          // carries its SOURCE conversation (so AppShell can reject a late
+          // callback after nav) and pendingInventory=false (already in
+          // inventory).
+          onClick={() => onOpenShell?.("terminal:terminal_bash_s1", conversationId, false)}
+        >
+          host-shell
+        </button>
+        <button
+          type="button"
+          aria-label="rail: create shell"
+          // Mirror the real section's CREATE path: the freshly-created shell
+          // isn't in the inventory yet (pendingInventory=true), so AppShell
+          // bridges the create→inventory gap for its off-surface cleanup.
+          onClick={() => onOpenShell?.("terminal:terminal_bash_s1", conversationId, true)}
+        >
+          create-shell
+        </button>
+        <button
+          type="button"
+          aria-label="rail: stale-source shell"
+          // Simulate a create that STARTED in conv_a and resolves after the
+          // user navigated away — its callback still carries "conv_a" as the
+          // source. AppShell must reject it against the current conversation.
+          onClick={() => onOpenShell?.("terminal:terminal_bash_s1", "conv_a", true)}
+        >
+          host-shell-stale
+        </button>
+      </div>
+    );
+  },
 }));
 vi.mock("./SubagentsPanel", () => ({
   SubagentsPanel: ({ conversationId }: { conversationId: string }) => (
@@ -524,6 +554,10 @@ beforeEach(() => {
   // Clear the center-view render recorder so one test's render sequence
   // can't leak into another's.
   centerKeyRenders.length = 0;
+  // Reset the captured rail callback so one test's deferred-callback grab
+  // can't leak into another.
+  mockCapturedOnOpenShell = null;
+  mockCapturedOnOpenShellConv = null;
 });
 
 afterEach(cleanup);
@@ -1505,6 +1539,86 @@ describe("User-shell routing gates on isNativeWrapper (not isTerminalFirst)", ()
     );
   });
 
+  it("M5-residual: rejects a deferred create from A whose SURVIVING callback resolves after A→B nav", () => {
+    // The source guard compares ``source`` against AppShell's LATEST
+    // conversation id (a ref), not the id captured in the render that produced
+    // the callback. Distinct from the M5 test above (a fresh B handler firing a
+    // literal "conv_a" source): here we grab the REAL callback bound to
+    // conversation A's render — its closure carries conversationId A AND tags
+    // source A — then invoke it AFTER navigating to B. A captured-value guard
+    // (source A === captured conversationId A) would PASS and mutate B; the
+    // ref-based guard (source A !== latest B) rejects it.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      { id: "conv_a", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+      { id: "conv_b", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_a"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <SessionNavButton to="/c/conv_b" />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+
+    // Open the Shells tab in A so the section mounts and the mock captures the
+    // onOpenShell callback bound to conversation A's render.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    const deferredCreate = mockCapturedOnOpenShell;
+    expect(deferredCreate).not.toBeNull();
+    expect(mockCapturedOnOpenShellConv).toBe("conv_a");
+
+    // Warm-navigate to B (AppShell stays mounted, only the route param changes)
+    // and park B on the Files tab — a surface OTHER than Shells, so a leaked
+    // mutation's ungated tab switch is observable.
+    fireEvent.click(screen.getByTestId("nav-session"));
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /^Files$/i }));
+    expect(screen.getByRole("tab", { name: /^Files$/i })).toHaveAttribute("aria-selected", "true");
+
+    // The deferred create from A now resolves — its A-render closure fires late,
+    // still tagging source "conv_a". The B3 owner-gate hides the active shell
+    // KEY regardless, but the guarded mutation ALSO force-switches the rail to
+    // Shells and reopens the panel (both ungated). Those must NOT happen for B:
+    // the ref-based guard rejects the stale source, so B stays on Files.
+    act(() => {
+      deferredCreate?.("terminal:terminal_bash_s1", "conv_a", true);
+    });
+
+    // B is untouched: still on Files, no shell section forced open. (A captured-
+    // value guard would have passed — source A === captured conversationId A —
+    // and yanked B onto the Shells tab.)
+    expect(screen.getByRole("tab", { name: /^Files$/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.queryByTestId("inline-terminals-section")).toBeNull();
+  });
+
   it("M6: mounts only ONE inline shell terminal across a desktop→mobile breakpoint change", () => {
     // Desktop hosts the shell inline (inline=true). Below the md breakpoint
     // the desktop rail is CSS-hidden but STAYS MOUNTED, so its TerminalView +
@@ -1517,10 +1631,11 @@ describe("User-shell routing gates on isNativeWrapper (not isTerminalFirst)", ()
     let mobileMatches = false;
     // Only the mobile-breakpoint query's listeners drive this test; other
     // matchMedia consumers (e.g. useResizablePanel) still get a stub but we
-    // don't notify them. useIsMobileViewport uses "(max-width: 767.98px)".
+    // don't notify them. useIsMobileViewport uses the `md`-complement query
+    // "not all and (min-width: 768px)".
     const mobileListeners = new Set<(e: { matches: boolean }) => void>();
     window.matchMedia = ((query: string) => {
-      const isMobileQuery = query.includes("max-width: 767.98px");
+      const isMobileQuery = query.startsWith("not all and (min-width: 768px)");
       return {
         get matches() {
           return isMobileQuery ? mobileMatches : false;
@@ -1572,6 +1687,83 @@ describe("User-shell routing gates on isNativeWrapper (not isTerminalFirst)", ()
       mobileListeners.forEach((cb) => cb({ matches: true }));
     });
     expect(section()).toHaveAttribute("data-inline", "false");
+
+    // Restore the shared matchMedia stub for later tests.
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+  });
+
+  it("M6-residual: keeps the hidden rail non-inline in the 767.98–768px fractional gap", () => {
+    // The rail's CSS visibility flips on Tailwind's `md` (>= 768px), but the
+    // OLD useIsMobileViewport matched `(max-width: 767.98px)`. In the OPEN
+    // interval (767.98, 768) — reachable under browser zoom / display scaling —
+    // BOTH the old mobile query (max-width: 767.98px) AND the desktop query
+    // (min-width: 768px) are false: the rail is CSS-hidden (< 768) yet the old
+    // hook read desktop, so ``inline`` stayed true and the hidden rail kept a
+    // live PTY while the mobile surface could open another. The fix expresses
+    // mobile as the exact logical complement of `(min-width: 768px)`, closing
+    // the gap.
+    //
+    // We simulate a real viewport at 767.99px by evaluating each media query
+    // against that width. Pre-fix (reads `max-width: 767.98px` → false → not
+    // mobile) leaves inline=true; post-fix (reads `not all and (min-width:
+    // 768px)` → true → mobile) drops inline to false — the single-mounted-
+    // terminal outcome. A plain matches:false stub can't tell the two apart, so
+    // the query-aware evaluator is what makes this fail pre-fix and pass after.
+    const GAP_WIDTH = 767.99;
+    const evalQuery = (query: string): boolean => {
+      const minMatch = query.match(/min-width:\s*([\d.]+)px/);
+      const maxMatch = query.match(/max-width:\s*([\d.]+)px/);
+      let result = true;
+      if (minMatch) result = result && GAP_WIDTH >= parseFloat(minMatch[1]);
+      if (maxMatch) result = result && GAP_WIDTH <= parseFloat(maxMatch[1]);
+      // `not all and (...)` negates the enclosed feature test.
+      return query.trim().startsWith("not all and") ? !result : result;
+    };
+    window.matchMedia = ((query: string) => ({
+      matches: evalQuery(query),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      { id: "conv_polly", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_polly");
+
+    // Host the shell inline, then read the rail's inline flag. In the fractional
+    // gap the (CSS-hidden) rail must NOT host a live inline terminal.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    fireEvent.click(screen.getByRole("button", { name: /rail: host shell$/i }));
+    const section = screen.getByTestId("inline-terminals-section");
+    expect(section).toHaveAttribute("data-active-key", "terminal:terminal_bash_s1");
+    expect(section).toHaveAttribute("data-inline", "false");
 
     // Restore the shared matchMedia stub for later tests.
     window.matchMedia = ((query: string) => ({
@@ -1644,6 +1836,85 @@ describe("User-shell routing gates on isNativeWrapper (not isTerminalFirst)", ()
     fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
     await waitFor(() =>
       expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute("data-active-key", ""),
+    );
+  });
+
+  it("LOW-residual: preserves a just-CREATED active key that leaves the shell surface before inventory arrives", async () => {
+    // The off-surface cleanup treats "active key absent from railTerminals" as
+    // proof the shell died. But right after a create SUCCEEDS the active key
+    // legitimately PRECEDES inventory while the pending-created bridge covers
+    // the gap. The existing LOW test above only covers an ESTABLISHED shell
+    // (already in inventory) that later closes; here the shell is freshly
+    // created (pendingInventory=true, NOT yet in inventory) and the user leaves
+    // the shell surface DURING the gap. Pre-fix the cleanup mistakes the pending
+    // key for a dead shell and erases it; the fix skips cleanup while the active
+    // key equals the pending-created key, so the key survives until inventory
+    // lands.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      { id: "conv_polly", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    // Agent declares shell access so the Shells tab is default-visible before
+    // any shell exists (the "+ New shell" empty state) — the create path needs
+    // it available while inventory is still empty of the new shell.
+    useSessionAgentMock.mockReturnValue({
+      data: { id: "ag_1", object: "agent", name: "polly", terminals: ["shell"] } as Agent,
+    } as ReturnType<typeof useSessionAgent>);
+    // Inventory does NOT yet contain the freshly-created shell — only the
+    // agent's own TUI pane (excluded from the shell inventory).
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_tui_main", name: "tui", session: "main", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_polly");
+
+    // Create a shell: pendingInventory=true. AppShell sets it active and records
+    // the create→inventory bridge; the shell isn't in the inventory yet.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    fireEvent.click(screen.getByRole("button", { name: /rail: create shell$/i }));
+    expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute(
+      "data-active-key",
+      "terminal:terminal_bash_s1",
+    );
+
+    // Leave the shell surface DURING the gap — switch to Agents. The inline
+    // section unmounts (its internal bridge is gone) and the off-surface
+    // cleanup runs against an inventory that still lacks the new shell.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Agents/i }));
+    expect(screen.queryByTestId("inline-terminals-section")).toBeNull();
+    // Nudge extra cleanup passes via a harmless tab round-trip.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Files/i }));
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Agents/i }));
+
+    // The legitimate pending key must NOT have been erased: returning to Shells
+    // still shows it active. Pre-fix the cleanup dropped it while off-surface.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute(
+      "data-active-key",
+      "terminal:terminal_bash_s1",
+    );
+
+    // Inventory now catches up — the shell is real and stays intact.
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Files/i }));
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    await waitFor(() =>
+      expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute(
+        "data-active-key",
+        "terminal:terminal_bash_s1",
+      ),
     );
   });
 

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -133,24 +133,40 @@ vi.mock("./FileViewer", () => ({
   ),
 }));
 vi.mock("./InlineTerminalsSection", () => ({
-  // Stand-in exposing onExpand + the desktop `inline` flag. Desktop hosts
-  // the shell inside the rail (inline=true → the row click stays local,
-  // no AppShell overlay); mobile hands off via onExpand. Tests assert the
-  // flag and can still drive the overlay path through onExpand.
+  // Stand-in exposing onExpand + the desktop `inline` flag, plus the
+  // controlled-hosting props (activeKey/onOpenShell). Desktop hosts the shell
+  // inside the rail via the parent's onOpenShell (activeKey echoed back);
+  // mobile / native-wrapper hand off full-screen via onExpand. Tests drive
+  // whichever path applies and assert the resulting state.
   InlineTerminalsSection: ({
     onExpand,
     inline,
+    activeKey,
+    onOpenShell,
   }: {
     onExpand: (key: string) => void;
     inline?: boolean;
+    activeKey?: string | null;
+    onOpenShell?: (key: string, pendingInventory: boolean) => void;
   }) => (
-    <div data-testid="inline-terminals-section" data-inline={String(inline ?? false)}>
+    <div
+      data-testid="inline-terminals-section"
+      data-inline={String(inline ?? false)}
+      data-active-key={activeKey ?? ""}
+    >
       <button
         type="button"
         aria-label="rail: open terminal"
         onClick={() => onExpand("terminal:terminal_main")}
       >
         rail-terminal
+      </button>
+      <button
+        type="button"
+        aria-label="rail: host shell"
+        onClick={() => onOpenShell?.("terminal:terminal_bash_s1", false)}
+      >
+        host-shell
       </button>
     </div>
   ),
@@ -236,6 +252,9 @@ function TerminalFirstViewProbe() {
       data-testid="view-probe"
       data-is-terminal-first={ctx.isTerminalFirst ? "true" : "false"}
       data-is-claude-native={ctx.isClaudeNative ? "true" : "false"}
+      data-is-native-wrapper={ctx.isNativeWrapper ? "true" : "false"}
+      data-is-shell-view={ctx.isShellView ? "true" : "false"}
+      data-terminal-view-key={ctx.terminalViewKey ?? ""}
       data-view={ctx.view}
       data-terminals-available={ctx.terminalsAvailable ? "true" : "false"}
       data-terminal-starting-up={ctx.terminalStartingUp ? "true" : "false"}
@@ -719,14 +738,16 @@ describe("TerminalFirstContext", () => {
       { id: "conv_other", permission_level: null, labels: {} },
     ]);
     useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "claude", session: "main", running: true }],
+      terminals: [{ id: "terminal_tui_main", name: "tui", session: "main", running: true }],
       isLoading: false,
       error: null,
     });
 
     const { unmount } = renderShell("/c/conv_native");
 
-    // Opt into terminal view.
+    // Opt into terminal view. The pill targets the AGENT terminal (the
+    // embedded REPL), so the restore exemption applies — only stored USER
+    // shells are dropped for chat-first sessions.
     fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal");
 
@@ -1024,6 +1045,109 @@ describe("Chat-mode terminal panel layout", () => {
     expect(screen.getByTestId("terminals-panel")).toHaveAttribute("data-state", "open");
     expect(screen.getByTestId("terminals-panel")).toHaveAttribute("data-fluid", "true");
     expect(chatGroup().className.split(" ")).toContain("md:hidden");
+  });
+});
+
+describe("User-shell routing gates on isNativeWrapper (not isTerminalFirst)", () => {
+  // A chat-first, NON-wrapper SDK session (polly/debby shape): omnigent.ui
+  // is "terminal" (embedded REPL) but there is NO omnigent.wrapper. Its
+  // user shells must host INLINE in the rail, never take over the center.
+  function mockPollyShape() {
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      { id: "conv_polly", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      // The embedded REPL (agent terminal) plus a user shell.
+      terminals: [
+        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+  }
+
+  it("hosts a polly-shape user shell inline in the rail (no center takeover)", () => {
+    mockPollyShape();
+    renderShell("/c/conv_polly");
+
+    // The session is chat-first but not a native wrapper.
+    const probe = () => screen.getByTestId("view-probe");
+    expect(probe()).toHaveAttribute("data-is-terminal-first", "true");
+    expect(probe()).toHaveAttribute("data-is-native-wrapper", "false");
+
+    // Open the Shells tab and host a user shell via the rail's controlled
+    // onOpenShell (the inline path).
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    fireEvent.click(screen.getByRole("button", { name: /rail: host shell/i }));
+
+    // The rail now hosts the shell inline (activeKey fed back to the
+    // section), and the center stays on chat — no shell-view takeover.
+    expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute(
+      "data-active-key",
+      "terminal:terminal_bash_s1",
+    );
+    expect(probe()).toHaveAttribute("data-view", "chat");
+    expect(probe()).toHaveAttribute("data-is-shell-view", "false");
+  });
+
+  it("still routes a native-wrapper user shell to the center MainTerminalView", () => {
+    // Genuine native-CLI wrapper: user shells KEEP their chat-replacing,
+    // center full-screen UX — the sole shape that routes via onExpand.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      {
+        id: "conv_native",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal", "omnigent.wrapper": "claude-code-native-ui" },
+      },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_claude_main", name: "claude", session: "main", running: true },
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_native");
+
+    const probe = () => screen.getByTestId("view-probe");
+    expect(probe()).toHaveAttribute("data-is-native-wrapper", "true");
+
+    // Fire the rail's onExpand (native wrappers route full-screen).
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    fireEvent.click(screen.getByRole("button", { name: /rail: open terminal/i }));
+
+    // Center takeover: the terminal key is set and it reads as a shell view
+    // (chrome-free MainTerminalView), which chat-first sessions never do.
+    expect(probe()).toHaveAttribute("data-view", "terminal");
+    expect(probe()).toHaveAttribute("data-is-shell-view", "true");
+    expect(probe()).toHaveAttribute("data-terminal-view-key", "terminal:terminal_main");
+  });
+
+  it("does not replay a stored user-shell key into the center for a polly session", () => {
+    // A stale sessionStorage panel-key pointing at a USER shell must NOT
+    // reopen the center shell on reload of a chat-first, non-wrapper
+    // session — it starts on chat instead. (The agent terminal is exempt.)
+    mockPollyShape();
+    sessionStorage.setItem("omnigent.web.panel-key:conv_polly", "terminal:terminal_bash_s1");
+
+    renderShell("/c/conv_polly");
+
+    const probe = () => screen.getByTestId("view-probe");
+    expect(probe()).toHaveAttribute("data-view", "chat");
+    expect(probe()).toHaveAttribute("data-is-shell-view", "false");
+    // The stale key is scrubbed so a later persist can't resurrect it.
+    expect(sessionStorage.getItem("omnigent.web.panel-key:conv_polly")).toBeNull();
   });
 });
 

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -133,9 +133,18 @@ vi.mock("./FileViewer", () => ({
   ),
 }));
 vi.mock("./InlineTerminalsSection", () => ({
-  // Minimal stand-in exposing onExpand so tests can trigger the inline terminal expand path.
-  InlineTerminalsSection: ({ onExpand }: { onExpand: (key: string) => void }) => (
-    <div data-testid="inline-terminals-section">
+  // Stand-in exposing onExpand + the desktop `inline` flag. Desktop hosts
+  // the shell inside the rail (inline=true → the row click stays local,
+  // no AppShell overlay); mobile hands off via onExpand. Tests assert the
+  // flag and can still drive the overlay path through onExpand.
+  InlineTerminalsSection: ({
+    onExpand,
+    inline,
+  }: {
+    onExpand: (key: string) => void;
+    inline?: boolean;
+  }) => (
+    <div data-testid="inline-terminals-section" data-inline={String(inline ?? false)}>
       <button
         type="button"
         aria-label="rail: open terminal"
@@ -826,7 +835,40 @@ describe("Right-rail terminals card", () => {
 
     // Radix Tabs activates on mousedown, not click.
     fireEvent.mouseDown(terminalsTab);
-    expect(screen.getByTestId("inline-terminals-section")).toBeInTheDocument();
+    const section = screen.getByTestId("inline-terminals-section");
+    expect(section).toBeInTheDocument();
+    // Desktop rail hosts the shell inline (mirroring the Files tab's
+    // FileViewer) — inline=true routes the row click into the rail, not
+    // the full-screen overlay.
+    expect(section).toHaveAttribute("data-inline", "true");
+  });
+
+  it("hosting a shell inline in the desktop rail never opens the full-screen overlay", () => {
+    // The desktop rail's Shells tab renders inline (inline=true), so
+    // selecting a shell stays inside the rail: chat is NOT hidden
+    // (no md:hidden on the chat+workspace group) and the TerminalsPanel
+    // drawer stays closed. This is the core desktop fix.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_abc", permission_level: null }]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_main", name: "main", session: "main", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_abc");
+
+    const chatGroup = () => screen.getByRole("main").parentElement as HTMLElement;
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+
+    // The inline section is mounted with inline=true, and the overlay
+    // signals stay quiescent: chat visible, drawer closed.
+    expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute("data-inline", "true");
+    expect(chatGroup().className.split(" ")).not.toContain("md:hidden");
+    expect(screen.getByTestId("terminals-panel")).toHaveAttribute("data-state", "closed");
   });
 
   it("hides the Terminals tab in a regular session with no terminal attached", () => {
@@ -946,8 +988,12 @@ describe("Right-rail terminals card", () => {
 });
 
 describe("Chat-mode terminal panel layout", () => {
-  it("hides chat and makes the panel fluid when a terminal is opened from the rail", () => {
-    // Rail click → chat hidden, panel fluid (no split, no resize).
+  it("hides chat and makes the panel fluid via the overlay fallback (onExpand)", () => {
+    // The full-screen overlay is the mobile fallback: `onExpand`
+    // (openTerminalsPanel) → chat hidden, panel fluid (no split, no
+    // resize). Desktop uses the inline path instead (covered above); this
+    // exercises the shared overlay mechanism the mobile drawer routes
+    // through.
     useEnvironmentMock.mockReturnValue({
       data: { available: true, root: null },
       isLoading: false,
@@ -968,12 +1014,13 @@ describe("Chat-mode terminal panel layout", () => {
     expect(screen.getByTestId("terminals-panel")).toHaveAttribute("data-fluid", "false");
     expect(chatGroup().className.split(" ")).not.toContain("md:hidden");
 
-    // Switch the rail to the Terminals tab so the inline section mounts.
+    // Switch the rail to the Terminals tab so the inline section mounts,
+    // then fire its onExpand (the overlay fallback the mobile drawer uses).
     // Radix Tabs activates on mousedown, not click.
     fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
     fireEvent.click(screen.getByRole("button", { name: /rail: open terminal/i }));
 
-    // After click: open, fluid, chat hidden.
+    // After onExpand: open, fluid, chat hidden.
     expect(screen.getByTestId("terminals-panel")).toHaveAttribute("data-state", "open");
     expect(screen.getByTestId("terminals-panel")).toHaveAttribute("data-fluid", "true");
     expect(chatGroup().className.split(" ")).toContain("md:hidden");

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -147,7 +147,7 @@ vi.mock("./InlineTerminalsSection", () => ({
     onExpand: (key: string) => void;
     inline?: boolean;
     activeKey?: string | null;
-    onOpenShell?: (key: string, pendingInventory: boolean) => void;
+    onOpenShell?: (key: string) => void;
   }) => (
     <div
       data-testid="inline-terminals-section"
@@ -164,7 +164,7 @@ vi.mock("./InlineTerminalsSection", () => ({
       <button
         type="button"
         aria-label="rail: host shell"
-        onClick={() => onOpenShell?.("terminal:terminal_bash_s1", false)}
+        onClick={() => onOpenShell?.("terminal:terminal_bash_s1")}
       >
         host-shell
       </button>
@@ -1227,6 +1227,179 @@ describe("User-shell routing gates on isNativeWrapper (not isTerminalFirst)", ()
     expect(probe()).toHaveAttribute("data-view", "chat");
     expect(probe()).toHaveAttribute("data-is-shell-view", "false");
     expect(sessionStorage.getItem("omnigent.web.panel-key:conv_polly")).toBeNull();
+  });
+
+  it("does not replay a stored user-shell key when the snapshot ERRORS before the list loads", async () => {
+    // B2: a snapshot ERROR must NOT be treated as "labels ready". In the window
+    // where useSession has errored but the conversations list is still loading,
+    // the shape is unknown — the stored user-shell key stays parked (chat), not
+    // replayed into the center. When the list later succeeds with polly labels
+    // the key is scrubbed. Regression: treating !isLoading as ready on the error
+    // path replayed the key and reopened MainTerminalView on a polly session.
+    sessionStorage.setItem("omnigent.web.panel-key:conv_polly", "terminal:terminal_bash_s1");
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+
+    // Phase 1 — snapshot errored, conversations list STILL loading (no row).
+    useConvMock.mockReturnValue({ data: undefined } as ReturnType<typeof useConversations>);
+    useSessionMock.mockReturnValue({
+      session: null,
+      isLoading: false,
+      error: new Error("snapshot failed"),
+    });
+    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const makeTree = () => (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_polly"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(makeTree());
+
+    const probe = () => screen.getByTestId("view-probe");
+    // Shape unknown despite the error → parked, center stays on chat, and the
+    // key is NOT scrubbed yet (treating the error as "ready" would scrub it
+    // here — the regression — losing a native wrapper's center key too).
+    expect(probe()).toHaveAttribute("data-view", "chat");
+    expect(sessionStorage.getItem("omnigent.web.panel-key:conv_polly")).toBe(
+      "terminal:terminal_bash_s1",
+    );
+
+    // Phase 2 — conversations list resolves with polly labels.
+    mockConversations([
+      { id: "conv_polly", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    rerender(makeTree());
+
+    await waitFor(() => {
+      expect(probe()).toHaveAttribute("data-is-terminal-first", "true");
+    });
+    expect(probe()).toHaveAttribute("data-view", "chat");
+    expect(probe()).toHaveAttribute("data-is-shell-view", "false");
+    expect(sessionStorage.getItem("omnigent.web.panel-key:conv_polly")).toBeNull();
+  });
+
+  it("returns the center to chat when a user shell is hosted inline (no dual PTY)", () => {
+    // M2: a terminal-first SDK session showing its AGENT terminal in the center
+    // must drop that center view when the user opens a rail shell — otherwise
+    // chat is hidden and two PTYs are live. Opening a shell clears the center
+    // key (view → chat) and hosts the shell inline (activeKey fed to the rail).
+    mockPollyShape();
+    renderShell("/c/conv_polly");
+
+    const probe = () => screen.getByTestId("view-probe");
+    // Put the center on the agent terminal via the pill.
+    fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
+    expect(probe()).toHaveAttribute("data-view", "terminal");
+
+    // Open a user shell inline from the rail.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    fireEvent.click(screen.getByRole("button", { name: /rail: host shell/i }));
+
+    // Center returned to chat; the rail hosts the shell.
+    expect(probe()).toHaveAttribute("data-view", "chat");
+    expect(probe()).toHaveAttribute("data-is-shell-view", "false");
+    expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute(
+      "data-active-key",
+      "terminal:terminal_bash_s1",
+    );
+  });
+
+  it("does not carry a stale active-shell key to a different conversation on warm navigation", () => {
+    // B3: terminal ids are deterministic and not conversation-scoped, so a
+    // warm-cached destination that contains the same id (terminal_bash_s1)
+    // could resolve a STALE active-shell key and attach to the wrong session.
+    // AppShell gates the lifted shell state on its OWNING conversation, so the
+    // stale key must not reach the rail for conversation B.
+    //
+    // NOTE: this asserts the AppShell owner-gate (the fix) — that no stale
+    // active-key is handed to the rail after the switch. It does NOT prove a
+    // real WebSocket never attaches, because this suite stubs both
+    // InlineTerminalsSection and TerminalView; a true attachment assertion
+    // would need the real components (out of scope for this harness).
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    // Two polly-shape sessions; both warm-cached with the SAME terminal id.
+    mockConversations([
+      { id: "conv_a", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+      { id: "conv_b", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
+        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_a"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <SessionNavButton to="/c/conv_b" />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+
+    // Host a shell inline in A.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    fireEvent.click(screen.getByRole("button", { name: /rail: host shell/i }));
+    expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute(
+      "data-active-key",
+      "terminal:terminal_bash_s1",
+    );
+
+    // Warm-navigate to B (AppShell stays mounted, only the route param changes).
+    fireEvent.click(screen.getByTestId("nav-session"));
+
+    // Re-open the Shells tab in B; the rail must NOT carry A's active key.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    expect(screen.getByTestId("inline-terminals-section")).toHaveAttribute("data-active-key", "");
   });
 });
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -233,6 +233,15 @@ export function AppShell() {
   // Skips the first persist run so mount can't write default state over the
   // values the restore effect is about to apply.
   const workspacePersistHydrated = useRef(false);
+  // A stored center-view key (``omnigent.web.panel-key:<conv>``) whose restore
+  // had to WAIT for the session labels. A user-shell key is ambiguous until we
+  // know the session shape — on a chat-first non-wrapper session it must be
+  // scrubbed (host inline, start on chat), on a native wrapper it replays into
+  // the center. On a cold hard reload the labels aren't loaded when the restore
+  // effect runs, so we park the key here (leaving the center on chat) and a
+  // follow-up effect resolves it once ``sessionLabelsReady`` flips true. Holds
+  // the conversation id it belongs to so a fast switch can't misapply it.
+  const pendingPanelKeyRef = useRef<{ conv: string; key: string } | null>(null);
   const [filesPanelShowHidden, setFilesPanelShowHidden] = useState(false);
   // Lifted so the Changes list order and the FileViewer prev/next order
   // share one source of truth (otherwise the "X/N" index won't match the
@@ -361,6 +370,15 @@ export function AppShell() {
   // (embedded Omnigent REPL terminal) have NO wrapper label and must
   // keep regular chat behavior. See TerminalFirstContext.tsx.
   const isNativeWrapper = isNativeWrapperLabel(sessionLabels["omnigent.wrapper"]);
+  // Whether the labels that decide the session shape (terminalFirst /
+  // isNativeWrapper) have actually loaded. On a hard reload the sidebar list
+  // and the session snapshot both start COLD (no localStorage persistence), so
+  // ``terminalFirst``/``isNativeWrapper`` read false until a query resolves —
+  // the workspace-restore effect must not treat that transient false as a real
+  // "regular session" verdict. True once either source has produced a row/
+  // snapshot, or the snapshot query has settled (a genuinely label-less
+  // regular session).
+  const sessionLabelsReady = activeConv !== null || activeSession !== null || !sessionLoading;
   const todos = useChatStore((s) => s.todos);
   const todosCompleted = todos.filter((t) => t.status === "completed").length;
   // Used for the header "Back to parent" link, which is hidden on
@@ -753,15 +771,31 @@ export function AppShell() {
     // so a reload starts in chat, not a chrome-free center shell. The agent's
     // own terminal (the pill's Terminal view) is exempt — that center takeover
     // is still its home. Native wrappers keep replaying any stored key.
+    //
+    // A stored USER-shell key is ambiguous until the labels load, so it can't
+    // be replayed eagerly: on a cold hard reload the labels are absent when
+    // this effect runs, and eagerly restoring it would open MainTerminalView
+    // in the center of a polly session for a frame (or until the user flips the
+    // pill). So restore only the unambiguous keys eagerly (null, or the agent
+    // terminal — safe in every shape) and PARK a user-shell key for the
+    // labels-resolved effect below. When labels are already loaded (a
+    // client-side conversation switch) we resolve it right here, no flash.
+    pendingPanelKeyRef.current = null;
     const stored = sessionStorage.getItem(`omnigent.web.panel-key:${conversationId}`);
-    const dropStoredUserShell =
-      terminalFirst && !isNativeWrapper && stored !== null && !isAgentTerminalKey(stored);
-    if (dropStoredUserShell) {
-      // Clear the stale center key so the next persist can't re-write it, and
-      // start the view on chat.
+    const storedIsUserShell = stored !== null && !isAgentTerminalKey(stored);
+    if (!storedIsUserShell) {
+      // null or the agent terminal — replay as-is.
+      setPanelInitialKeyState(stored);
+    } else if (!sessionLabelsReady) {
+      // Labels unknown → hold the key, start on chat, resolve once they arrive.
+      pendingPanelKeyRef.current = { conv: conversationId, key: stored };
+      setPanelInitialKeyState(null);
+    } else if (terminalFirst && !isNativeWrapper) {
+      // Chat-first non-wrapper: scrub the stale center key and start on chat.
       sessionStorage.removeItem(`omnigent.web.panel-key:${conversationId}`);
       setPanelInitialKeyState(null);
     } else {
+      // Native wrapper (or non-terminal-first): the center is this key's home.
       setPanelInitialKeyState(stored);
     }
 
@@ -823,6 +857,24 @@ export function AppShell() {
 
     stateConvRef.current = conversationId;
   }, [conversationId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Resolve a stored user-shell center key that the restore effect had to park
+  // because the labels weren't loaded yet (cold hard reload). Once the labels
+  // for the SAME conversation resolve, apply the shape verdict: a chat-first
+  // non-wrapper session scrubs it (stays on chat — the shell hosts inline),
+  // any other shape replays it into the center. Guarded on the parked conv id
+  // so a fast switch can't misapply it to the wrong session.
+  useEffect(() => {
+    const pending = pendingPanelKeyRef.current;
+    if (!pending || !sessionLabelsReady || pending.conv !== conversationId) return;
+    pendingPanelKeyRef.current = null;
+    if (terminalFirst && !isNativeWrapper) {
+      sessionStorage.removeItem(`omnigent.web.panel-key:${conversationId}`);
+      // Already null (parked → chat); leave the center on chat.
+    } else {
+      setPanelInitialKeyState(pending.key);
+    }
+  }, [conversationId, sessionLabelsReady, terminalFirst, isNativeWrapper]);
 
   // Persist the per-session rail tab + open file tabs whenever they change.
   // Keyed on the state (not conversationId) and targeted at the conversation
@@ -1127,27 +1179,22 @@ export function AppShell() {
   // Mirrors ``closeFile``. Closing the tab does not kill the PTY — it just
   // stops hosting it inline.
   function closeShellTab(key: string) {
-    setOpenShellKeys((prev) => {
-      const idx = prev.indexOf(key);
-      if (idx === -1) return prev;
-      const next = prev.filter((k) => k !== key);
-      setActiveShellKey((active) => {
-        if (active !== key) return active;
-        return next[idx - 1] ?? next[idx] ?? next[0] ?? null;
-      });
-      return next;
-    });
+    const idx = openShellKeys.indexOf(key);
+    if (idx === -1) return;
+    const next = openShellKeys.filter((k) => k !== key);
+    setOpenShellKeys(next);
+    if (activeShellKey === key) {
+      setActiveShellKey(next[idx - 1] ?? next[idx] ?? next[0] ?? null);
+    }
   }
 
   // Deselect the active shell back to the list. On an unexpected close (the
   // PTY vanished from under the rail) also drop its now-dangling tab.
   function returnToShellList(unexpected: boolean) {
-    setActiveShellKey((active) => {
-      if (unexpected && active !== null) {
-        setOpenShellKeys((prev) => prev.filter((k) => k !== active));
-      }
-      return null;
-    });
+    if (unexpected && activeShellKey !== null) {
+      setOpenShellKeys((prev) => prev.filter((k) => k !== activeShellKey));
+    }
+    setActiveShellKey(null);
   }
 
   function openExecutionLogsPanel(key: string) {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -200,6 +200,14 @@ export function AppShell() {
   const [openFiles, setOpenFiles] = useState<string[]>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).openFiles ?? []) : [],
   );
+  // Open shell tabs (terminalTabKey values) surfaced in the top strip beside
+  // the file tabs, the Shells-tab peer of ``openFiles``. ``activeShellKey`` is
+  // the active tab (null = the shell list is shown). Session-scoped and
+  // transient — NOT persisted, so a reload of a chat-first session lands back
+  // on chat + the shell list, never a hosted shell. Reset on conversation
+  // switch alongside the other rail state.
+  const [openShellKeys, setOpenShellKeys] = useState<string[]>([]);
+  const [activeShellKey, setActiveShellKey] = useState<string | null>(null);
   // false = full folder tree ("All"), true = changed-files-only flat list.
   // Surfaced as the Changed | All toggle inside the Files panel. Seeded from
   // the persisted, app-global preference (defaults to "All") so the choice
@@ -427,6 +435,27 @@ export function AppShell() {
     () => inventoryTerminals(terminals, terminalFirst),
     [terminals, terminalFirst],
   );
+  // Resolve the open shell tabs (keys) to their live inventory entries, in tab
+  // order, dropping any whose PTY has closed. Feeds the top-strip ShellTabsStrip.
+  const openShells = useMemo(
+    () =>
+      openShellKeys
+        .map((key) => railTerminals.find((t) => terminalTabKey(t) === key))
+        .filter((t): t is (typeof railTerminals)[number] => t !== undefined),
+    [openShellKeys, railTerminals],
+  );
+  // Prune BACKGROUND shell tabs whose PTY disappeared (a shell closed while a
+  // sibling tab was showing). The ACTIVE tab is left to InlineTerminalsSection,
+  // which owns the create-gap bridge and the "closed unexpectedly" announce and
+  // calls back through ``returnToShellList(true)`` — pruning it here would race
+  // that (and could drop a freshly-created tab before inventory catches up).
+  useEffect(() => {
+    const live = new Set(railTerminals.map((t) => terminalTabKey(t)));
+    setOpenShellKeys((prev) => {
+      const next = prev.filter((k) => live.has(k) || k === activeShellKey);
+      return next.length === prev.length ? prev : next;
+    });
+  }, [railTerminals, activeShellKey]);
   // The agent's spec declares shell access (a ``terminals:`` block) —
   // the rail's Shells tab then shows BY DEFAULT, before any shell
   // exists: its empty state carries the "+ New shell" affordance, so
@@ -701,6 +730,10 @@ export function AppShell() {
     setShellsPanelOpen(false);
     setTodosPanelOpen(false);
     setFilesPanelShowHidden(false);
+    // Shell tabs are transient (never persisted) — always start fresh on a
+    // conversation switch so a new session opens on chat + the shell list.
+    setOpenShellKeys([]);
+    setActiveShellKey(null);
     if (!conversationId) {
       // No session → no rail; false (not the open default) so rail-gated
       // effects like the ?view= URL sync stay quiet on non-session routes.
@@ -714,8 +747,23 @@ export function AppShell() {
     }
     const persisted = readSessionWorkspaceState(conversationId);
 
+    // Restore the terminal-first center view from sessionStorage — but for a
+    // chat-first, non-wrapper session (polly/debby), a stored USER-shell key
+    // must NOT replay into the center: user shells now host inline in the rail,
+    // so a reload starts in chat, not a chrome-free center shell. The agent's
+    // own terminal (the pill's Terminal view) is exempt — that center takeover
+    // is still its home. Native wrappers keep replaying any stored key.
     const stored = sessionStorage.getItem(`omnigent.web.panel-key:${conversationId}`);
-    setPanelInitialKeyState(stored);
+    const dropStoredUserShell =
+      terminalFirst && !isNativeWrapper && stored !== null && !isAgentTerminalKey(stored);
+    if (dropStoredUserShell) {
+      // Clear the stale center key so the next persist can't re-write it, and
+      // start the view on chat.
+      sessionStorage.removeItem(`omnigent.web.panel-key:${conversationId}`);
+      setPanelInitialKeyState(null);
+    } else {
+      setPanelInitialKeyState(stored);
+    }
 
     // Restore the Files view scope. A deep-link ?view= param wins and forces
     // the rail onto the Files tab: ?view=changed → "Changed" (flat list),
@@ -1036,6 +1084,12 @@ export function AppShell() {
     }
   }
 
+  // Full-screen / overlay shell takeover — the MOBILE drawer path and the
+  // NATIVE-WRAPPER desktop path (both route here via InlineTerminalsSection's
+  // ``onExpand`` when it is NOT hosting inline). Sets the center terminal key
+  // so MainTerminalView / the mobile TerminalsPanel takes over. Chat-first,
+  // non-wrapper desktop sessions never reach this for a user shell: their rail
+  // hosts the shell inline via ``openShellTab`` below.
   function openTerminalsPanel(key: string) {
     setSelectedFilePath(null); // close file viewer
     clearFileViewerUrl();
@@ -1045,6 +1099,55 @@ export function AppShell() {
     setShellsPanelOpen(false); // close mobile shells drawer
     setTodosPanelOpen(false); // close mobile tasks drawer
     setPanelInitialKey(key);
+  }
+
+  // Desktop rail: host a user shell INLINE in the Shells tab (never the
+  // center), mirroring how ``openFileViewer`` reveals a file in the Files tab.
+  // Reveals the rail + selects the Shells tab, records the open tab, and marks
+  // it active — WITHOUT touching ``panelInitialKey``, so the center stays on
+  // chat. The freshly-created (``pendingInventory``) case is recorded the same
+  // way; the shell surfaces once the inventory catches up.
+  function openShellTab(key: string, _pendingInventory: boolean) {
+    setSelectedFilePath(null); // close file viewer
+    clearFileViewerUrl();
+    setExecutionLogsKey(null);
+    setFilesPanelOpen(false);
+    setSubagentsPanelOpen(false);
+    setShellsPanelOpen(false);
+    setTodosPanelOpen(false);
+    setRightRailTab("terminals");
+    setOpenShellKeys((prev) => (prev.includes(key) ? prev : [...prev, key]));
+    setActiveShellKey(key);
+    setRightPanelOpen(true);
+    if (conversationId) writeSessionWorkspaceState(conversationId, { open: true });
+  }
+
+  // Close a single shell tab. If it was active, activate a neighbor (prefer the
+  // previous, else the next); with none left, drop back to the shell list.
+  // Mirrors ``closeFile``. Closing the tab does not kill the PTY — it just
+  // stops hosting it inline.
+  function closeShellTab(key: string) {
+    setOpenShellKeys((prev) => {
+      const idx = prev.indexOf(key);
+      if (idx === -1) return prev;
+      const next = prev.filter((k) => k !== key);
+      setActiveShellKey((active) => {
+        if (active !== key) return active;
+        return next[idx - 1] ?? next[idx] ?? next[0] ?? null;
+      });
+      return next;
+    });
+  }
+
+  // Deselect the active shell back to the list. On an unexpected close (the
+  // PTY vanished from under the rail) also drop its now-dangling tab.
+  function returnToShellList(unexpected: boolean) {
+    setActiveShellKey((active) => {
+      if (unexpected && active !== null) {
+        setOpenShellKeys((prev) => prev.filter((k) => k !== active));
+      }
+      return null;
+    });
   }
 
   function openExecutionLogsPanel(key: string) {
@@ -1174,13 +1277,16 @@ export function AppShell() {
     !terminalsAvailable &&
     sessionStatus !== "failed" &&
     (liveness.kind === "starting" || terminalPending);
-  // A rail-opened shell (any open terminal key other than the agent's
-  // own terminal) takes over the main view chrome-free:
-  // ConnectionIndicator hides the Chat/Terminal pill while this is
-  // true, and MainTerminalView renders the shell with its own close
-  // affordance. The PANEL_NO_TERMINAL_KEY sentinel ("") is falsy, so
-  // "open with no target" stays a pill view.
-  const isShellView = terminalFirst && !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
+  // A center-hosted user shell (a terminal key other than the agent's own)
+  // takes over the main view chrome-free: ConnectionIndicator hides the
+  // Chat/Terminal pill and MainTerminalView renders the shell with its own
+  // close affordance. This is the NATIVE-WRAPPER UX only — chat-first,
+  // non-wrapper sessions host user shells inline in the rail, never the
+  // center, so gating on ``isNativeWrapper`` (not ``terminalFirst``) means a
+  // stray user-shell key can't render a chrome-free center for them. The
+  // PANEL_NO_TERMINAL_KEY sentinel ("") is falsy, so "open with no target"
+  // stays a pill view.
+  const isShellView = isNativeWrapper && !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
   const terminalFirstContextValue = useMemo<TerminalFirstContextValue>(
     () => ({
       isClaudeNative,
@@ -1373,6 +1479,11 @@ export function AppShell() {
                     onShowScopeView={showScopeView}
                     onCommentsOpenChange={setFileViewerCommentsOpen}
                     openTerminalsPanel={openTerminalsPanel}
+                    openShells={openShells}
+                    activeShellKey={activeShellKey}
+                    onOpenShell={openShellTab}
+                    onCloseShell={closeShellTab}
+                    onReturnToShellList={returnToShellList}
                     permissionLevel={permissionLevel}
                     filesPanelSort={filesPanelSort}
                     onSortChange={handleFilesSortChange}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -250,7 +250,25 @@ export function AppShell() {
   const [filesPanelSort, setFilesPanelSort] = useState<ChangedSort>(
     () => readFilesPanelPreferences().sort,
   );
-  const [panelInitialKey, setPanelInitialKeyState] = useState<string | null>(null);
+  // The center-view terminal key (agent terminal or, for native wrappers, a
+  // user shell). Raw state paired with its owning conversation — the SAME
+  // ownership guarantee the lifted shell state (``shellStateConv``) carries,
+  // for the SAME reason: terminal resource ids (e.g. ``terminal_bash_s1``) are
+  // deterministic and NOT conversation-scoped, so on a warm A→B navigation B's
+  // first render still holds A's stale key. If B's terminal query is warm-
+  // cached the stale key resolves to B's same-id terminal and MainTerminalView
+  // would mount TerminalView, firing a real read-write WebSocket attach to the
+  // wrong session. The gated ``panelInitialKey`` below is null whenever the
+  // owner doesn't match the current ``conversationId``, so a stale key can
+  // never reach the center path during the transition — the label-aware
+  // restore effect then re-owns it for the destination a render later.
+  const [panelInitialKeyRaw, setPanelInitialKeyState] = useState<string | null>(null);
+  const [panelKeyConv, setPanelKeyConv] = useState<string | null>(null);
+  // The center-view key applies only while its owning conversation is on
+  // screen. On a warm A→B nav the new conversationId renders before the
+  // restore effect re-owns (or scrubs) the key, so gate here — mirroring
+  // ``shellStateActive`` for the rail's lifted shell state.
+  const panelInitialKey = panelKeyConv === conversationId ? panelInitialKeyRaw : null;
   const [executionLogsKey, setExecutionLogsKey] = useState<string | null>(null);
   const [filesPanelOpen, setFilesPanelOpen] = useState(false);
   // Mobile-only full-screen drawers for the rail tabs that have no desktop
@@ -752,6 +770,10 @@ export function AppShell() {
   const setPanelInitialKey = useCallback(
     (key: string | null) => {
       setPanelInitialKeyState(key);
+      // Tag the key with the current conversation so the gated
+      // ``panelInitialKey`` only surfaces it here (a null owner would gate it
+      // out). A null key clears ownership too — no owner needed for "no key".
+      setPanelKeyConv(key === null ? null : (conversationId ?? null));
       if (!conversationId) return;
       const storageKey = `omnigent.web.panel-key:${conversationId}`;
       if (key === null) {
@@ -790,6 +812,7 @@ export function AppShell() {
       setSelectedFilePath(null);
       setOpenFiles([]);
       setPanelInitialKeyState(null);
+      setPanelKeyConv(null);
       stateConvRef.current = null;
       return;
     }
@@ -880,24 +903,32 @@ export function AppShell() {
   // client-side switch resolves immediately with no flash.
   useEffect(() => {
     if (!conversationId) return;
+    // Re-own the key for THIS conversation whenever a value is restored. The
+    // gated ``panelInitialKey`` ignores any key whose owner isn't the current
+    // conversationId, so this re-ownership (and the null-owner reset for a
+    // parked/scrubbed key) is what lets a restored key reach the center path.
+    const restore = (key: string | null) => {
+      setPanelInitialKeyState(key);
+      setPanelKeyConv(key === null ? null : conversationId);
+    };
     const storageKey = `omnigent.web.panel-key:${conversationId}`;
     const stored = sessionStorage.getItem(storageKey);
     const isUserShell =
       stored !== null && stored !== PANEL_NO_TERMINAL_KEY && !isAgentTerminalKey(stored);
     if (!isUserShell) {
-      setPanelInitialKeyState(stored);
+      restore(stored);
       return;
     }
     if (!sessionLabelsReady) {
       // Shape unknown → park: chat now, revisit when a label source resolves.
-      setPanelInitialKeyState(null);
+      restore(null);
       return;
     }
     if (hostsShellsInline) {
       sessionStorage.removeItem(storageKey);
-      setPanelInitialKeyState(null);
+      restore(null);
     } else {
-      setPanelInitialKeyState(stored);
+      restore(stored);
     }
   }, [conversationId, sessionLabelsReady, hostsShellsInline]);
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -11,6 +11,7 @@ import { AgentInfoContent, agentHasInfo } from "@/components/AgentInfo";
 import { useIdleNotifications } from "@/hooks/useIdleNotifications";
 import { useSeedReadState } from "@/hooks/useUnseenConversations";
 import { useIOSViewportLock } from "@/hooks/useIOSViewportLock";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { readFilesPanelPreferences, writeFilesPanelPreferences } from "@/lib/filesPanelPreferences";
 import { derivePermissionLevel, isOwnerLevel } from "@/lib/permissionsApi";
 import {
@@ -125,14 +126,22 @@ import type { RightRailTab } from "./railTabs";
  * within it a "Changed only" toggle filters the full folder tree down to
  * just the changed files (flat list). Opening a file (chat link or rail
  * click) forces the rail to the Files tab so the viewer is visible.
- * Terminal-first sessions render the terminal inline in main and therefore
- * hide the rail's Terminals tab. The Agents tab only appears once there's
- * more than one agent (the root has at least one child).
+ * The Shells tab is hidden only for claude-native sub-agents (the parent
+ * owns the tmux pane) and for agents with neither an existing shell nor
+ * declared shell access; every other session — native wrapper or SDK —
+ * gets it. The Agents tab is always present (its "main" row links back to
+ * the root, so a lone agent is a one-entry list, not a dead end).
  */
 export function AppShell() {
   // Cmd/Ctrl+Enter accepts the pending harness approval prompt. Bound once
   // here so it works on every chat route, regardless of where focus sits.
   useApproveHotkey();
+
+  // Reactive md-breakpoint signal. Drives the off-surface dead-shell cleanup
+  // below (the desktop inline shell host is CSS-hidden but mounted below md,
+  // so it can't be the cleanup handler there). Named distinctly from the
+  // ``isMobileViewport()`` helper imported from Sidebar.
+  const mobileViewport = useIsMobileViewport();
 
   // Lock the iOS shell to the visual viewport so the soft keyboard can't pan
   // the whole document (which would hide the header and break the layout).
@@ -627,8 +636,8 @@ export function AppShell() {
   // render an empty white card with no way to dismiss it.
   const hasRailContent = Object.values(railTabsAvailable).some(Boolean);
   // Keep the selected tab valid. When the current tab disappears — files
-  // panel turns off, or the Shells tab hides (native wrapper / no shell
-  // and no shell access) — fall back to the first still-visible tab in
+  // panel turns off, or the Shells tab hides (claude-native sub-agent, or no
+  // shell and no shell access) — fall back to the first still-visible tab in
   // display order (Files · Agents · Shells · Tasks · Browser). Picking the first
   // available (rather than ping-ponging between two effects) keeps this
   // convergent even when several tabs vanish at once.
@@ -639,6 +648,45 @@ export function AppShell() {
     );
     if (next) setRightRailTab(next);
   }, [railTabsAvailable, rightRailTab]);
+
+  // Off-surface dead-active-shell cleanup. The ACTIVE shell tab is normally
+  // pruned by the mounted InlineTerminalsSection (it calls
+  // ``returnToShellList(true)`` on an unexpected close, owning the create-gap
+  // bridge + announce). But when the inline shell surface is NOT the displayed
+  // one — the user switched to Files/Agents, collapsed the rail, or is on
+  // mobile — that section is unmounted and can't fire, so an active shell that
+  // closes externally leaves a dangling active key. That silently drops the
+  // tab (the pruning effect above retains the active key) and lets a same-id
+  // relaunch resurrect a stale tab. Handle it here where the state lives.
+  const inlineShellSurfaceDisplayed =
+    hostsShellsInline &&
+    hasRailContent &&
+    rightPanelOpen &&
+    (terminalFirst || !panelOpen) &&
+    !executionLogsOpen &&
+    !filesPanelOpen &&
+    selectedFilePath === null &&
+    rightRailTab === "terminals" &&
+    railTabsAvailable.terminals &&
+    !mobileViewport;
+  useEffect(() => {
+    const activeKey = activeShellKeyState;
+    // Only act on the CURRENT conversation's active key (the reset effect
+    // clears a stale one on switch); skip while the inline section is mounted
+    // to handle its own active tab, and while the PTY is still live.
+    if (activeKey === null || shellStateConv !== conversationId) return;
+    if (inlineShellSurfaceDisplayed) return;
+    const live = new Set(railTerminals.map((t) => terminalTabKey(t)));
+    if (live.has(activeKey)) return;
+    setActiveShellKey(null);
+    setOpenShellKeys((prev) => prev.filter((k) => k !== activeKey));
+  }, [
+    activeShellKeyState,
+    shellStateConv,
+    conversationId,
+    inlineShellSurfaceDisplayed,
+    railTerminals,
+  ]);
 
   // Mount the relay at the always-present shell level (not BrowserPane, which
   // only mounts while its tab is selected) so it's listening before the first
@@ -767,13 +815,23 @@ export function AppShell() {
   // a deliberately narrow scope so a stale "terminal view" preference
   // can't survive across browser sessions, where the user's mental model
   // may have moved on.
+  // Set the center-view key + its owning conversation together so the two
+  // React states can never drift. ``conv`` is the owner to tag; a null key
+  // clears ownership too (no owner needed for "no key"). This does NOT touch
+  // sessionStorage — the storage writer is ``setPanelInitialKey`` below, and
+  // the restore effect's park path must set the React key to null WITHOUT
+  // removing storage. Keeping this pure to the two React states preserves both.
+  const applyPanelKey = useCallback((key: string | null, conv: string | null) => {
+    setPanelInitialKeyState(key);
+    setPanelKeyConv(key === null ? null : conv);
+  }, []);
+
   const setPanelInitialKey = useCallback(
     (key: string | null) => {
-      setPanelInitialKeyState(key);
       // Tag the key with the current conversation so the gated
       // ``panelInitialKey`` only surfaces it here (a null owner would gate it
-      // out). A null key clears ownership too — no owner needed for "no key".
-      setPanelKeyConv(key === null ? null : (conversationId ?? null));
+      // out).
+      applyPanelKey(key, conversationId ?? null);
       if (!conversationId) return;
       const storageKey = `omnigent.web.panel-key:${conversationId}`;
       if (key === null) {
@@ -782,7 +840,7 @@ export function AppShell() {
         sessionStorage.setItem(storageKey, key);
       }
     },
-    [conversationId],
+    [conversationId, applyPanelKey],
   );
 
   // Restore the per-session workspace state when switching conversations:
@@ -811,8 +869,7 @@ export function AppShell() {
       setRightRailTab("files");
       setSelectedFilePath(null);
       setOpenFiles([]);
-      setPanelInitialKeyState(null);
-      setPanelKeyConv(null);
+      applyPanelKey(null, null);
       stateConvRef.current = null;
       return;
     }
@@ -907,10 +964,10 @@ export function AppShell() {
     // gated ``panelInitialKey`` ignores any key whose owner isn't the current
     // conversationId, so this re-ownership (and the null-owner reset for a
     // parked/scrubbed key) is what lets a restored key reach the center path.
-    const restore = (key: string | null) => {
-      setPanelInitialKeyState(key);
-      setPanelKeyConv(key === null ? null : conversationId);
-    };
+    // ``applyPanelKey`` sets only the two React states — it never touches
+    // sessionStorage, so the park path below (restore(null)) leaves the stored
+    // key in place to revisit, while the scrub path removes storage explicitly.
+    const restore = (key: string | null) => applyPanelKey(key, conversationId);
     const storageKey = `omnigent.web.panel-key:${conversationId}`;
     const stored = sessionStorage.getItem(storageKey);
     const isUserShell =
@@ -930,7 +987,7 @@ export function AppShell() {
     } else {
       restore(stored);
     }
-  }, [conversationId, sessionLabelsReady, hostsShellsInline]);
+  }, [conversationId, sessionLabelsReady, hostsShellsInline, applyPanelKey]);
 
   // Persist the per-session rail tab + open file tabs whenever they change.
   // Keyed on the state (not conversationId) and targeted at the conversation
@@ -1218,8 +1275,14 @@ export function AppShell() {
   // user shell in the rail while that stays mounted would hide chat AND leave
   // two live PTY connections. Clearing the center key puts chat beside the
   // rail-hosted shell with a single PTY, matching the Files-tab pattern.
-  function openShellTab(key: string) {
-    if (!conversationId) return;
+  //
+  // ``source`` is the conversation the selection originated in. A shell-create
+  // started in A whose POST resolves after the user navigated to B calls back
+  // here late; reject the WHOLE mutation (file/panel clear, tab select, rail
+  // open, active-shell set, persistence) unless the source still matches the
+  // current conversation, so a pending create in A can't rewrite B's workspace.
+  function openShellTab(key: string, source: string) {
+    if (!conversationId || source !== conversationId) return;
     setSelectedFilePath(null); // close file viewer
     clearFileViewerUrl();
     setExecutionLogsKey(null);
@@ -1594,6 +1657,8 @@ export function AppShell() {
                     onOpenShell={openShellTab}
                     onCloseShell={closeShellTab}
                     onReturnToShellList={returnToShellList}
+                    hostsShellsInline={hostsShellsInline}
+                    sessionLabelsReady={sessionLabelsReady}
                     permissionLevel={permissionLevel}
                     filesPanelSort={filesPanelSort}
                     onSortChange={handleFilesSortChange}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -207,7 +207,17 @@ export function AppShell() {
   // on chat + the shell list, never a hosted shell. Reset on conversation
   // switch alongside the other rail state.
   const [openShellKeys, setOpenShellKeys] = useState<string[]>([]);
-  const [activeShellKey, setActiveShellKey] = useState<string | null>(null);
+  const [activeShellKeyState, setActiveShellKey] = useState<string | null>(null);
+  // The conversation the lifted shell state (open/active shell keys) belongs
+  // to. Terminal resource ids (e.g. ``terminal_bash_s1``) are deterministic
+  // and NOT conversation-scoped, so on a warm navigation the destination's
+  // terminal query may already be cached and a STALE active-shell key from the
+  // previous conversation would resolve to the destination's shell and attach a
+  // real (read-write) WebSocket to the WRONG session before the passive reset
+  // effect runs. Rendering the inline shell is gated on this matching the
+  // current ``conversationId`` (see ``shellStateActive``), so stale state can
+  // never reach TerminalView during the transition. Set by ``openShellTab``.
+  const [shellStateConv, setShellStateConv] = useState<string | null>(null);
   // false = full folder tree ("All"), true = changed-files-only flat list.
   // Surfaced as the Changed | All toggle inside the Files panel. Seeded from
   // the persisted, app-global preference (defaults to "All") so the choice
@@ -233,15 +243,6 @@ export function AppShell() {
   // Skips the first persist run so mount can't write default state over the
   // values the restore effect is about to apply.
   const workspacePersistHydrated = useRef(false);
-  // A stored center-view key (``omnigent.web.panel-key:<conv>``) whose restore
-  // had to WAIT for the session labels. A user-shell key is ambiguous until we
-  // know the session shape — on a chat-first non-wrapper session it must be
-  // scrubbed (host inline, start on chat), on a native wrapper it replays into
-  // the center. On a cold hard reload the labels aren't loaded when the restore
-  // effect runs, so we park the key here (leaving the center on chat) and a
-  // follow-up effect resolves it once ``sessionLabelsReady`` flips true. Holds
-  // the conversation id it belongs to so a fast switch can't misapply it.
-  const pendingPanelKeyRef = useRef<{ conv: string; key: string } | null>(null);
   const [filesPanelShowHidden, setFilesPanelShowHidden] = useState(false);
   // Lifted so the Changes list order and the FileViewer prev/next order
   // share one source of truth (otherwise the "X/N" index won't match the
@@ -325,7 +326,11 @@ export function AppShell() {
   // For sub-agent (child) sessions the sidebar list omits the row, so this
   // is the only path through which the UI learns the user's permission
   // level. ``derivePermissionLevel`` prefers this over ``activeConv``.
-  const { session: activeSession, isLoading: sessionLoading } = useSession(conversationId);
+  const {
+    session: activeSession,
+    isLoading: sessionLoading,
+    error: sessionError,
+  } = useSession(conversationId);
   // Same liveness the chat surface switches on (see ChatPage / useSessionLiveness).
   // AppShell reads it only to drive the Terminal pill's "loading" state: a session
   // in `starting` (a relaunch the moment a message is sent — `turnActive`) is
@@ -370,15 +375,27 @@ export function AppShell() {
   // (embedded Omnigent REPL terminal) have NO wrapper label and must
   // keep regular chat behavior. See TerminalFirstContext.tsx.
   const isNativeWrapper = isNativeWrapperLabel(sessionLabels["omnigent.wrapper"]);
-  // Whether the labels that decide the session shape (terminalFirst /
-  // isNativeWrapper) have actually loaded. On a hard reload the sidebar list
-  // and the session snapshot both start COLD (no localStorage persistence), so
-  // ``terminalFirst``/``isNativeWrapper`` read false until a query resolves —
-  // the workspace-restore effect must not treat that transient false as a real
-  // "regular session" verdict. True once either source has produced a row/
-  // snapshot, or the snapshot query has settled (a genuinely label-less
-  // regular session).
-  const sessionLabelsReady = activeConv !== null || activeSession !== null || !sessionLoading;
+  // User shells host INLINE in the rail (beside chat) for every session EXCEPT
+  // native-CLI wrappers, whose established UX is a chat-replacing full-screen
+  // center terminal. This is the single "hosts shells inline, not center"
+  // verdict — the ONE gate every shell-routing site keys on, so the gate can't
+  // drift (that drift caused the original bug). It is purely ``!isNativeWrapper``
+  // (NOT ``terminalFirst``): a regular non-wrapper session with a stray stored
+  // shell key must also flow through the inline path, never the center. Center
+  // takeover is reserved for ``isNativeWrapper`` alone.
+  const hostsShellsInline = !isNativeWrapper;
+  // Whether a SUCCESSFUL label source has identified this conversation's shape
+  // (terminalFirst / isNativeWrapper). On a hard reload the sidebar list and
+  // the session snapshot both start COLD (no localStorage persistence), so the
+  // shape flags read false until a query resolves — the panel-key restore must
+  // not treat that transient false as a real verdict. Crucially, a snapshot
+  // ERROR is NOT readiness: if useSession failed and no conversations row has
+  // arrived yet, the shape is still unknown, so an ambiguous stored shell key
+  // stays parked (chat shown) rather than replaying into the center. Ready when
+  // a row/snapshot exists, OR the snapshot settled successfully with no row
+  // (a genuinely label-less regular session).
+  const sessionLabelsReady =
+    activeConv !== null || activeSession !== null || (!sessionLoading && sessionError === null);
   const todos = useChatStore((s) => s.todos);
   const todosCompleted = todos.filter((t) => t.status === "completed").length;
   // Used for the header "Back to parent" link, which is hidden on
@@ -453,14 +470,23 @@ export function AppShell() {
     () => inventoryTerminals(terminals, terminalFirst),
     [terminals, terminalFirst],
   );
+  // The lifted shell state applies only while its owning conversation is the
+  // one on screen. During a warm navigation the new conversationId renders
+  // before the reset effect clears the old keys, so gate here to keep stale
+  // keys from resolving against the destination's (possibly cache-warm)
+  // terminals and attaching a WebSocket to the wrong session.
+  const shellStateActive = shellStateConv !== null && shellStateConv === conversationId;
+  const activeShellKey = shellStateActive ? activeShellKeyState : null;
   // Resolve the open shell tabs (keys) to their live inventory entries, in tab
   // order, dropping any whose PTY has closed. Feeds the top-strip ShellTabsStrip.
   const openShells = useMemo(
     () =>
-      openShellKeys
-        .map((key) => railTerminals.find((t) => terminalTabKey(t) === key))
-        .filter((t): t is (typeof railTerminals)[number] => t !== undefined),
-    [openShellKeys, railTerminals],
+      shellStateActive
+        ? openShellKeys
+            .map((key) => railTerminals.find((t) => terminalTabKey(t) === key))
+            .filter((t): t is (typeof railTerminals)[number] => t !== undefined)
+        : [],
+    [shellStateActive, openShellKeys, railTerminals],
   );
   // Prune BACKGROUND shell tabs whose PTY disappeared (a shell closed while a
   // sibling tab was showing). The ACTIVE tab is left to InlineTerminalsSection,
@@ -470,10 +496,10 @@ export function AppShell() {
   useEffect(() => {
     const live = new Set(railTerminals.map((t) => terminalTabKey(t)));
     setOpenShellKeys((prev) => {
-      const next = prev.filter((k) => live.has(k) || k === activeShellKey);
+      const next = prev.filter((k) => live.has(k) || k === activeShellKeyState);
       return next.length === prev.length ? prev : next;
     });
-  }, [railTerminals, activeShellKey]);
+  }, [railTerminals, activeShellKeyState]);
   // The agent's spec declares shell access (a ``terminals:`` block) —
   // the rail's Shells tab then shows BY DEFAULT, before any shell
   // exists: its empty state carries the "+ New shell" affordance, so
@@ -750,8 +776,12 @@ export function AppShell() {
     setFilesPanelShowHidden(false);
     // Shell tabs are transient (never persisted) — always start fresh on a
     // conversation switch so a new session opens on chat + the shell list.
+    // (Rendering is ALSO gated on the owning conversation — see
+    // ``shellStateActive`` — so stale shell keys can't attach to the new
+    // session during the transition, before this reset commits.)
     setOpenShellKeys([]);
     setActiveShellKey(null);
+    setShellStateConv(null);
     if (!conversationId) {
       // No session → no rail; false (not the open default) so rail-gated
       // effects like the ?view= URL sync stay quiet on non-session routes.
@@ -765,39 +795,11 @@ export function AppShell() {
     }
     const persisted = readSessionWorkspaceState(conversationId);
 
-    // Restore the terminal-first center view from sessionStorage — but for a
-    // chat-first, non-wrapper session (polly/debby), a stored USER-shell key
-    // must NOT replay into the center: user shells now host inline in the rail,
-    // so a reload starts in chat, not a chrome-free center shell. The agent's
-    // own terminal (the pill's Terminal view) is exempt — that center takeover
-    // is still its home. Native wrappers keep replaying any stored key.
-    //
-    // A stored USER-shell key is ambiguous until the labels load, so it can't
-    // be replayed eagerly: on a cold hard reload the labels are absent when
-    // this effect runs, and eagerly restoring it would open MainTerminalView
-    // in the center of a polly session for a frame (or until the user flips the
-    // pill). So restore only the unambiguous keys eagerly (null, or the agent
-    // terminal — safe in every shape) and PARK a user-shell key for the
-    // labels-resolved effect below. When labels are already loaded (a
-    // client-side conversation switch) we resolve it right here, no flash.
-    pendingPanelKeyRef.current = null;
-    const stored = sessionStorage.getItem(`omnigent.web.panel-key:${conversationId}`);
-    const storedIsUserShell = stored !== null && !isAgentTerminalKey(stored);
-    if (!storedIsUserShell) {
-      // null or the agent terminal — replay as-is.
-      setPanelInitialKeyState(stored);
-    } else if (!sessionLabelsReady) {
-      // Labels unknown → hold the key, start on chat, resolve once they arrive.
-      pendingPanelKeyRef.current = { conv: conversationId, key: stored };
-      setPanelInitialKeyState(null);
-    } else if (terminalFirst && !isNativeWrapper) {
-      // Chat-first non-wrapper: scrub the stale center key and start on chat.
-      sessionStorage.removeItem(`omnigent.web.panel-key:${conversationId}`);
-      setPanelInitialKeyState(null);
-    } else {
-      // Native wrapper (or non-terminal-first): the center is this key's home.
-      setPanelInitialKeyState(stored);
-    }
+    // The center-view key (``omnigent.web.panel-key:<conv>``) is restored by a
+    // dedicated, label-aware effect below (not here), so it can re-evaluate
+    // once the async session labels resolve. Leaving it out of this
+    // [conversationId] effect keeps the shape verdict from being computed
+    // against transiently-empty labels on a cold reload.
 
     // Restore the Files view scope. A deep-link ?view= param wins and forces
     // the rail onto the Files tab: ?view=changed → "Changed" (flat list),
@@ -858,23 +860,46 @@ export function AppShell() {
     stateConvRef.current = conversationId;
   }, [conversationId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Resolve a stored user-shell center key that the restore effect had to park
-  // because the labels weren't loaded yet (cold hard reload). Once the labels
-  // for the SAME conversation resolve, apply the shape verdict: a chat-first
-  // non-wrapper session scrubs it (stays on chat — the shell hosts inline),
-  // any other shape replays it into the center. Guarded on the parked conv id
-  // so a fast switch can't misapply it to the wrong session.
+  // Restore (or scrub) the stored center-view key, label-aware. A SINGLE
+  // effect keyed on the shape flags so it re-evaluates as the async session
+  // labels resolve — re-reading sessionStorage each run (the key survives
+  // there until we decide). It classifies the stored key:
+  //
+  //   - null or the agent terminal (incl. the PANEL_NO_TERMINAL_KEY "" sentinel,
+  //     which ``isAgentTerminalKey`` does NOT match but which must NOT be
+  //     treated as a user shell): safe in every shape → restore as-is.
+  //   - a user-shell key while labels are NOT ready: PARK it — render null
+  //     (chat), leave the key in storage — until a successful label source
+  //     resolves. On a cold reload (or a snapshot error before the list lands)
+  //     this keeps polly/debby on chat instead of flashing a center shell.
+  //   - a user-shell key on an inline-hosting session (``hostsShellsInline``):
+  //     scrub it (the shell hosts in the rail; the center stays on chat).
+  //   - a user-shell key on a native wrapper: restore it (the center is home).
+  //
+  // Runs on conversation switch too (deps include conversationId), so a warm
+  // client-side switch resolves immediately with no flash.
   useEffect(() => {
-    const pending = pendingPanelKeyRef.current;
-    if (!pending || !sessionLabelsReady || pending.conv !== conversationId) return;
-    pendingPanelKeyRef.current = null;
-    if (terminalFirst && !isNativeWrapper) {
-      sessionStorage.removeItem(`omnigent.web.panel-key:${conversationId}`);
-      // Already null (parked → chat); leave the center on chat.
-    } else {
-      setPanelInitialKeyState(pending.key);
+    if (!conversationId) return;
+    const storageKey = `omnigent.web.panel-key:${conversationId}`;
+    const stored = sessionStorage.getItem(storageKey);
+    const isUserShell =
+      stored !== null && stored !== PANEL_NO_TERMINAL_KEY && !isAgentTerminalKey(stored);
+    if (!isUserShell) {
+      setPanelInitialKeyState(stored);
+      return;
     }
-  }, [conversationId, sessionLabelsReady, terminalFirst, isNativeWrapper]);
+    if (!sessionLabelsReady) {
+      // Shape unknown → park: chat now, revisit when a label source resolves.
+      setPanelInitialKeyState(null);
+      return;
+    }
+    if (hostsShellsInline) {
+      sessionStorage.removeItem(storageKey);
+      setPanelInitialKeyState(null);
+    } else {
+      setPanelInitialKeyState(stored);
+    }
+  }, [conversationId, sessionLabelsReady, hostsShellsInline]);
 
   // Persist the per-session rail tab + open file tabs whenever they change.
   // Keyed on the state (not conversationId) and targeted at the conversation
@@ -1155,11 +1180,15 @@ export function AppShell() {
 
   // Desktop rail: host a user shell INLINE in the Shells tab (never the
   // center), mirroring how ``openFileViewer`` reveals a file in the Files tab.
-  // Reveals the rail + selects the Shells tab, records the open tab, and marks
-  // it active — WITHOUT touching ``panelInitialKey``, so the center stays on
-  // chat. The freshly-created (``pendingInventory``) case is recorded the same
-  // way; the shell surfaces once the inventory catches up.
-  function openShellTab(key: string, _pendingInventory: boolean) {
+  // Reveals the rail + selects the Shells tab, records the open tab (tagged
+  // with the owning conversation), and marks it active. Crucially it also
+  // returns the CENTER to chat (``setPanelInitialKey(null)``): a terminal-first
+  // SDK session may be showing its AGENT terminal in the center, and hosting a
+  // user shell in the rail while that stays mounted would hide chat AND leave
+  // two live PTY connections. Clearing the center key puts chat beside the
+  // rail-hosted shell with a single PTY, matching the Files-tab pattern.
+  function openShellTab(key: string) {
+    if (!conversationId) return;
     setSelectedFilePath(null); // close file viewer
     clearFileViewerUrl();
     setExecutionLogsKey(null);
@@ -1167,11 +1196,13 @@ export function AppShell() {
     setSubagentsPanelOpen(false);
     setShellsPanelOpen(false);
     setTodosPanelOpen(false);
+    setPanelInitialKey(null); // return the center to chat (no agent-terminal takeover)
     setRightRailTab("terminals");
     setOpenShellKeys((prev) => (prev.includes(key) ? prev : [...prev, key]));
     setActiveShellKey(key);
+    setShellStateConv(conversationId);
     setRightPanelOpen(true);
-    if (conversationId) writeSessionWorkspaceState(conversationId, { open: true });
+    writeSessionWorkspaceState(conversationId, { open: true });
   }
 
   // Close a single shell tab. If it was active, activate a neighbor (prefer the
@@ -1183,7 +1214,7 @@ export function AppShell() {
     if (idx === -1) return;
     const next = openShellKeys.filter((k) => k !== key);
     setOpenShellKeys(next);
-    if (activeShellKey === key) {
+    if (activeShellKeyState === key) {
       setActiveShellKey(next[idx - 1] ?? next[idx] ?? next[0] ?? null);
     }
   }
@@ -1191,8 +1222,8 @@ export function AppShell() {
   // Deselect the active shell back to the list. On an unexpected close (the
   // PTY vanished from under the rail) also drop its now-dangling tab.
   function returnToShellList(unexpected: boolean) {
-    if (unexpected && activeShellKey !== null) {
-      setOpenShellKeys((prev) => prev.filter((k) => k !== activeShellKey));
+    if (unexpected && activeShellKeyState !== null) {
+      setOpenShellKeys((prev) => prev.filter((k) => k !== activeShellKeyState));
     }
     setActiveShellKey(null);
   }
@@ -1327,13 +1358,14 @@ export function AppShell() {
   // A center-hosted user shell (a terminal key other than the agent's own)
   // takes over the main view chrome-free: ConnectionIndicator hides the
   // Chat/Terminal pill and MainTerminalView renders the shell with its own
-  // close affordance. This is the NATIVE-WRAPPER UX only — chat-first,
-  // non-wrapper sessions host user shells inline in the rail, never the
-  // center, so gating on ``isNativeWrapper`` (not ``terminalFirst``) means a
-  // stray user-shell key can't render a chrome-free center for them. The
-  // PANEL_NO_TERMINAL_KEY sentinel ("") is falsy, so "open with no target"
+  // close affordance. This is the NATIVE-WRAPPER UX only — inline-hosting
+  // sessions (``hostsShellsInline``) put user shells in the rail, never the
+  // center, so gating on ``!hostsShellsInline`` (i.e. ``isNativeWrapper``)
+  // means a stray user-shell key can't render a chrome-free center for them.
+  // The PANEL_NO_TERMINAL_KEY sentinel ("") is falsy, so "open with no target"
   // stays a pill view.
-  const isShellView = isNativeWrapper && !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
+  const isShellView =
+    !hostsShellsInline && !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
   const terminalFirstContextValue = useMemo<TerminalFirstContextValue>(
     () => ({
       isClaudeNative,

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -151,6 +151,16 @@ export function AppShell() {
   // Read early: the conversationId scopes the per-session workspace state
   // (rail open/width/tab/open files) used throughout this component.
   const { conversationId } = useParams<{ conversationId: string }>();
+  // Latest conversation id in a ref, updated every render. A shell-create
+  // callback captured in conversation A's render can survive an A→B navigation
+  // (the A-render ``openShellTab`` closure fires late, tagging its mutation with
+  // source A). Comparing source against a render-captured ``conversationId`` is
+  // not enough: a surviving A-render closure holds conversationId A too, so
+  // source A === conversationId A passes the guard and mutates B's current
+  // shared state. The guard reads THIS ref instead, so a deferred A create
+  // resolving after nav to B is rejected (source A !== latest B).
+  const conversationIdRef = useRef<string | null>(conversationId ?? null);
+  conversationIdRef.current = conversationId ?? null;
   const [fileViewerCommentsOpen, setFileViewerCommentsOpen] = useState(false);
   const [rightRailTab, setRightRailTab] = useState<RightRailTab>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).rightRailTab ?? "files") : "files",
@@ -217,6 +227,16 @@ export function AppShell() {
   // switch alongside the other rail state.
   const [openShellKeys, setOpenShellKeys] = useState<string[]>([]);
   const [activeShellKeyState, setActiveShellKey] = useState<string | null>(null);
+  // The active shell key that was just CREATED and is still bridging the
+  // create→inventory gap (the POST resolved and set it active before
+  // ``railTerminals`` exposes it). InlineTerminalsSection owns the same bridge
+  // internally while it's mounted, but when the user navigates off the shell
+  // surface during that gap the section unmounts and its bridge is gone — the
+  // off-surface cleanup below would then mistake the not-yet-in-inventory key
+  // for a dead shell and erase it. This lifts the bridge so cleanup skips a
+  // legitimately-pending key. Cleared once the key surfaces in inventory (the
+  // pruning effect) or on conversation switch.
+  const pendingCreatedShellKeyRef = useRef<string | null>(null);
   // The conversation the lifted shell state (open/active shell keys) belongs
   // to. Terminal resource ids (e.g. ``terminal_bash_s1``) are deterministic
   // and NOT conversation-scoped, so on a warm navigation the destination's
@@ -522,6 +542,12 @@ export function AppShell() {
   // that (and could drop a freshly-created tab before inventory catches up).
   useEffect(() => {
     const live = new Set(railTerminals.map((t) => terminalTabKey(t)));
+    // The pending-created key's bridge ends once it surfaces in inventory —
+    // clear it so the off-surface cleanup can treat it as an established shell
+    // again (and prune it if it later dies).
+    if (pendingCreatedShellKeyRef.current !== null && live.has(pendingCreatedShellKeyRef.current)) {
+      pendingCreatedShellKeyRef.current = null;
+    }
     setOpenShellKeys((prev) => {
       const next = prev.filter((k) => live.has(k) || k === activeShellKeyState);
       return next.length === prev.length ? prev : next;
@@ -676,6 +702,11 @@ export function AppShell() {
     // to handle its own active tab, and while the PTY is still live.
     if (activeKey === null || shellStateConv !== conversationId) return;
     if (inlineShellSurfaceDisplayed) return;
+    // A just-created key legitimately PRECEDES inventory while its bridge is
+    // live (the section owned that bridge but unmounted when the user left the
+    // shell surface). Absent-from-inventory is not proof of death here — skip
+    // until inventory catches up (the pruning effect clears the marker then).
+    if (activeKey === pendingCreatedShellKeyRef.current) return;
     const live = new Set(railTerminals.map((t) => terminalTabKey(t)));
     if (live.has(activeKey)) return;
     setActiveShellKey(null);
@@ -862,6 +893,7 @@ export function AppShell() {
     setOpenShellKeys([]);
     setActiveShellKey(null);
     setShellStateConv(null);
+    pendingCreatedShellKeyRef.current = null;
     if (!conversationId) {
       // No session → no rail; false (not the open default) so rail-gated
       // effects like the ?view= URL sync stay quiet on non-session routes.
@@ -1281,8 +1313,19 @@ export function AppShell() {
   // here late; reject the WHOLE mutation (file/panel clear, tab select, rail
   // open, active-shell set, persistence) unless the source still matches the
   // current conversation, so a pending create in A can't rewrite B's workspace.
-  function openShellTab(key: string, source: string) {
-    if (!conversationId || source !== conversationId) return;
+  function openShellTab(key: string, source: string, pendingInventory: boolean) {
+    // Compare against the LATEST conversation id (ref, updated every render),
+    // not this closure's captured ``conversationId``. A deferred create from A
+    // whose A-render callback survives an A→B nav still tags ``source`` with A;
+    // that surviving closure also holds conversationId A, so a captured-value
+    // comparison (A === A) would wrongly pass and mutate B. The ref holds B, so
+    // source A !== latest B rejects it.
+    const current = conversationIdRef.current;
+    if (!current || source !== current) return;
+    // Record the create→inventory bridge so the off-surface cleanup doesn't
+    // erase this key while it's legitimately ahead of inventory. Selecting an
+    // existing shell (not a create) clears any prior marker.
+    pendingCreatedShellKeyRef.current = pendingInventory ? key : null;
     setSelectedFilePath(null); // close file viewer
     clearFileViewerUrl();
     setExecutionLogsKey(null);
@@ -1294,9 +1337,9 @@ export function AppShell() {
     setRightRailTab("terminals");
     setOpenShellKeys((prev) => (prev.includes(key) ? prev : [...prev, key]));
     setActiveShellKey(key);
-    setShellStateConv(conversationId);
+    setShellStateConv(current);
     setRightPanelOpen(true);
-    writeSessionWorkspaceState(conversationId, { open: true });
+    writeSessionWorkspaceState(current, { open: true });
   }
 
   // Close a single shell tab. If it was active, activate a neighbor (prefer the
@@ -1319,6 +1362,9 @@ export function AppShell() {
     if (unexpected && activeShellKeyState !== null) {
       setOpenShellKeys((prev) => prev.filter((k) => k !== activeShellKeyState));
     }
+    // The active shell is being dropped; its create→inventory bridge (if any)
+    // no longer applies.
+    pendingCreatedShellKeyRef.current = null;
     setActiveShellKey(null);
   }
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1498,14 +1498,13 @@ export function AppShell() {
   // A center-hosted user shell (a terminal key other than the agent's own)
   // takes over the main view chrome-free: ConnectionIndicator hides the
   // Chat/Terminal pill and MainTerminalView renders the shell with its own
-  // close affordance. This is the NATIVE-WRAPPER UX only — inline-hosting
-  // sessions (``hostsShellsInline``) put user shells in the rail, never the
-  // center, so gating on ``!hostsShellsInline`` (i.e. ``isNativeWrapper``)
-  // means a stray user-shell key can't render a chrome-free center for them.
-  // The PANEL_NO_TERMINAL_KEY sentinel ("") is falsy, so "open with no target"
-  // stays a pill view.
-  const isShellView =
-    !hostsShellsInline && !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
+  // close affordance. ``panelInitialKey`` is a user-shell key only when the
+  // center genuinely hosts one — ``openTerminalsPanel`` sets it (native wrapper,
+  // and the mobile drawer where there's no rail), while the desktop rail's
+  // ``openShellTab`` clears it and the restore effect scrubs stray inline-host
+  // keys — so gate on ``terminalFirst``. The PANEL_NO_TERMINAL_KEY sentinel ("")
+  // is falsy, so "open with no target" stays a pill view.
+  const isShellView = terminalFirst && !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
   const terminalFirstContextValue = useMemo<TerminalFirstContextValue>(
     () => ({
       isClaudeNative,

--- a/web/src/shell/InlineTerminalsSection.integration.test.tsx
+++ b/web/src/shell/InlineTerminalsSection.integration.test.tsx
@@ -302,6 +302,8 @@ describe("InlineTerminalsSection new-shell integration", () => {
 
     // The selection callback tags conversation A as the source — AppShell's
     // openShellTab rejects it whenever the current conversation is no longer A.
-    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_shell_new", "conv_a");
+    // pendingInventory=true: a freshly-created shell not yet in the inventory,
+    // so AppShell bridges the create→inventory gap for its off-surface cleanup.
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_shell_new", "conv_a", true);
   });
 });

--- a/web/src/shell/InlineTerminalsSection.integration.test.tsx
+++ b/web/src/shell/InlineTerminalsSection.integration.test.tsx
@@ -1,0 +1,122 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type TerminalInfo, useTerminals } from "@/hooks/useTerminals";
+import { InlineTerminalsSection } from "./InlineTerminalsSection";
+import type { TerminalFirstContextValue } from "./TerminalFirstContext";
+import { TerminalFirstContextProvider } from "./TerminalFirstContext";
+
+vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/useTerminals")>()),
+  useTerminals: vi.fn(),
+}));
+
+vi.mock("@/components/blocks/TerminalView", () => ({
+  TerminalView: ({ terminalId }: { terminalId: string }) => (
+    <div data-testid="terminal-view" data-terminal-id={terminalId} />
+  ),
+}));
+
+const useTerminalsMock = vi.mocked(useTerminals);
+const fetchMock = vi.fn();
+
+const REGULAR_CTX = {
+  isClaudeNative: false,
+  isNativeWrapper: false,
+  isTerminalFirst: false,
+  isShellView: false,
+  view: "chat",
+  terminalViewKey: null,
+  setView: () => {},
+  terminalsAvailable: true,
+  terminalStartingUp: false,
+} as TerminalFirstContextValue;
+
+function mockResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function makeTerminal(id: string, name: string, session: string): TerminalInfo {
+  return { id, name, session, running: true };
+}
+
+beforeEach(() => {
+  useTerminalsMock.mockReset();
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("InlineTerminalsSection new-shell integration", () => {
+  it("shows the shell selected by NewTerminalButton.onCreated after inventory catches up", async () => {
+    let terminals: TerminalInfo[] = [];
+    useTerminalsMock.mockImplementation(() => ({ terminals, isLoading: false, error: null }));
+
+    let finishCreate: (response: Response) => void = () => {};
+    const createResponse = new Promise<Response>((resolve) => {
+      finishCreate = resolve;
+    });
+    fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "POST") return createResponse;
+      return mockResponse({
+        id: "ag_1",
+        object: "agent",
+        name: "test-agent",
+        terminals: ["shell"],
+      });
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const onExpand = vi.fn();
+    const section = () => (
+      <QueryClientProvider client={queryClient}>
+        <TerminalFirstContextProvider value={REGULAR_CTX}>
+          <InlineTerminalsSection conversationId="conv_terminal" onExpand={onExpand} inline />
+        </TerminalFirstContextProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(section());
+
+    const newShellButton = await screen.findByRole("button", { name: /new shell/i });
+    fireEvent.click(newShellButton);
+    await waitFor(() => expect(newShellButton).toBeDisabled());
+
+    finishCreate(
+      mockResponse({
+        id: "terminal_shell_new",
+        object: "session.resource",
+        type: "terminal",
+        session_id: "conv_terminal",
+        name: "shell:new",
+        metadata: { terminal_name: "shell", session_key: "new", running: true },
+      }),
+    );
+    await waitFor(() => expect(newShellButton).toBeEnabled());
+
+    // onCreated can run before the inventory hook's next render. That gap
+    // must not be mistaken for an unexpected close and clear the selection.
+    expect(screen.queryByTestId("terminal-view")).toBeNull();
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
+
+    terminals = [makeTerminal("terminal_shell_new", "shell", "new")];
+    rerender(section());
+
+    expect(screen.getByTestId("terminal-view")).toHaveAttribute(
+      "data-terminal-id",
+      "terminal_shell_new",
+    );
+    expect(onExpand).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/shell/InlineTerminalsSection.integration.test.tsx
+++ b/web/src/shell/InlineTerminalsSection.integration.test.tsx
@@ -119,4 +119,189 @@ describe("InlineTerminalsSection new-shell integration", () => {
     );
     expect(onExpand).not.toHaveBeenCalled();
   });
+
+  it("M4: re-checks the latest routing verdict when a create finishes after native labels arrive", async () => {
+    // Cold-load a native-wrapper session while labels are pending: the
+    // routing verdict defaults inline (hostsShellsInline=true), so "New
+    // shell" captures an inline target. If the POST completes AFTER the
+    // native verdict lands (hostsShellsInline=false), the fix re-reads the
+    // LATEST verdict in the create callback and routes full-screen via
+    // onExpand instead of hosting an inline-owned tab that renders no
+    // terminal. NOTE: this suite stubs TerminalView, so we assert the
+    // observable routing outcome (onExpand vs in-rail mount), not a real
+    // PTY attach.
+    let terminals: TerminalInfo[] = [];
+    useTerminalsMock.mockImplementation(() => ({ terminals, isLoading: false, error: null }));
+
+    let finishCreate: (response: Response) => void = () => {};
+    const createResponse = new Promise<Response>((resolve) => {
+      finishCreate = resolve;
+    });
+    fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "POST") return createResponse;
+      return mockResponse({
+        id: "ag_1",
+        object: "agent",
+        name: "test-agent",
+        terminals: ["shell"],
+      });
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const onExpand = vi.fn();
+    // ``hostsShellsInline`` is AppShell's single verdict; start true (labels
+    // pending → inline default), flip false once native labels resolve.
+    const section = (hostsShellsInline: boolean) => (
+      <QueryClientProvider client={queryClient}>
+        <TerminalFirstContextProvider value={REGULAR_CTX}>
+          <InlineTerminalsSection
+            conversationId="conv_native"
+            onExpand={onExpand}
+            inline
+            hostsShellsInline={hostsShellsInline}
+          />
+        </TerminalFirstContextProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(section(true));
+
+    const newShellButton = await screen.findByRole("button", { name: /new shell/i });
+    fireEvent.click(newShellButton);
+    await waitFor(() => expect(newShellButton).toBeDisabled());
+
+    // Native labels resolve mid-flight: the verdict flips to full-screen.
+    rerender(section(false));
+
+    finishCreate(
+      mockResponse({
+        id: "terminal_shell_new",
+        object: "session.resource",
+        type: "terminal",
+        session_id: "conv_native",
+        name: "shell:new",
+        metadata: { terminal_name: "shell", session_key: "new", running: true },
+      }),
+    );
+    await waitFor(() => expect(newShellButton).toBeEnabled());
+
+    // The create callback re-read the CURRENT verdict (native) and routed
+    // full-screen — no inline xterm was hosted.
+    expect(onExpand).toHaveBeenCalledWith("terminal:terminal_shell_new");
+    terminals = [makeTerminal("terminal_shell_new", "shell", "new")];
+    rerender(section(false));
+    expect(screen.queryByTestId("terminal-view")).toBeNull();
+  });
+
+  it("M4: parks shell-create until the routing verdict is authoritative (labels not ready)", async () => {
+    // While sessionLabelsReady is false the routing target is ambiguous, so
+    // the "New shell" affordance is disabled — a shell can't be created
+    // against a mislabeled default and stranded.
+    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
+    fetchMock.mockImplementation(async () =>
+      mockResponse({ id: "ag_1", object: "agent", name: "test-agent", terminals: ["shell"] }),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <TerminalFirstContextProvider value={REGULAR_CTX}>
+          <InlineTerminalsSection
+            conversationId="conv_native"
+            onExpand={vi.fn()}
+            inline
+            hostsShellsInline
+            sessionLabelsReady={false}
+          />
+        </TerminalFirstContextProvider>
+      </QueryClientProvider>,
+    );
+
+    const newShellButton = await screen.findByRole("button", { name: /new shell/i });
+    expect(newShellButton).toBeDisabled();
+
+    // Once the labels settle the affordance re-enables.
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <TerminalFirstContextProvider value={REGULAR_CTX}>
+          <InlineTerminalsSection
+            conversationId="conv_native"
+            onExpand={vi.fn()}
+            inline
+            hostsShellsInline
+            sessionLabelsReady
+          />
+        </TerminalFirstContextProvider>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByRole("button", { name: /new shell/i })).toBeEnabled();
+  });
+
+  it("M5: a create started in A carries A as its source, not the navigated-to B", async () => {
+    // Start "New shell" in conversation A, then navigate to B (the keyed
+    // remount unmounts A's section). If A's POST resolved against a
+    // still-mounted A instance, the onOpenShell callback must carry A as the
+    // source so AppShell can reject the mutation for B. Here we assert the
+    // SOURCE tag is A's id — the observable half of the owner gate (the
+    // suite stubs the transport, so we don't assert a real B attach).
+    let terminals: TerminalInfo[] = [];
+    useTerminalsMock.mockImplementation(() => ({ terminals, isLoading: false, error: null }));
+
+    let finishCreate: (response: Response) => void = () => {};
+    const createResponse = new Promise<Response>((resolve) => {
+      finishCreate = resolve;
+    });
+    fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "POST") return createResponse;
+      return mockResponse({
+        id: "ag_1",
+        object: "agent",
+        name: "test-agent",
+        terminals: ["shell"],
+      });
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const onOpenShell = vi.fn();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TerminalFirstContextProvider value={REGULAR_CTX}>
+          <InlineTerminalsSection
+            conversationId="conv_a"
+            onExpand={vi.fn()}
+            inline
+            hostsShellsInline
+            activeKey={null}
+            onOpenShell={onOpenShell}
+            onReturnToList={vi.fn()}
+          />
+        </TerminalFirstContextProvider>
+      </QueryClientProvider>,
+    );
+
+    const newShellButton = await screen.findByRole("button", { name: /new shell/i });
+    fireEvent.click(newShellButton);
+    await waitFor(() => expect(newShellButton).toBeDisabled());
+
+    finishCreate(
+      mockResponse({
+        id: "terminal_shell_new",
+        object: "session.resource",
+        type: "terminal",
+        session_id: "conv_a",
+        name: "shell:new",
+        metadata: { terminal_name: "shell", session_key: "new", running: true },
+      }),
+    );
+    await waitFor(() => expect(newShellButton).toBeEnabled());
+
+    // The selection callback tags conversation A as the source — AppShell's
+    // openShellTab rejects it whenever the current conversation is no longer A.
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_shell_new", "conv_a");
+  });
 });

--- a/web/src/shell/InlineTerminalsSection.test.tsx
+++ b/web/src/shell/InlineTerminalsSection.test.tsx
@@ -282,6 +282,62 @@ describe("InlineTerminalsSection inline mode hosts the shell in the rail", () =>
     expect(onExpand).not.toHaveBeenCalled();
   });
 
+  it("routes shell selection to the parent in controlled mode (rail-lifted active shell)", () => {
+    // When the parent owns the active shell (onOpenShell supplied — the
+    // desktop rail's top-strip-tab wiring), a row click must call back
+    // instead of self-hosting, so the shell surfaces as a header tab.
+    const onOpenShell = vi.fn();
+    useTerminalsMock.mockReturnValue({
+      terminals: [makeTerminal("terminal_bash_s1", "bash", "s1")],
+      isLoading: false,
+      error: null,
+    });
+    render(
+      <TerminalFirstContextProvider value={TERMINAL_FIRST_SDK_CTX}>
+        <InlineTerminalsSection
+          conversationId="conv_terminal"
+          onExpand={vi.fn()}
+          inline
+          activeKey={null}
+          onOpenShell={onOpenShell}
+          onReturnToList={vi.fn()}
+        />
+      </TerminalFirstContextProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /s1/ }));
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1", false);
+    // Parent-controlled: no self-hosted xterm until activeKey is fed back in.
+    expect(screen.queryByTestId("terminal-view")).toBeNull();
+  });
+
+  it("hosts the parent's active shell inline in controlled mode", () => {
+    // With the parent feeding activeKey back, the section hosts that shell's
+    // TerminalView in-rail (the content half of the lifted-state contract).
+    useTerminalsMock.mockReturnValue({
+      terminals: [makeTerminal("terminal_bash_s1", "bash", "s1")],
+      isLoading: false,
+      error: null,
+    });
+    render(
+      <TerminalFirstContextProvider value={TERMINAL_FIRST_SDK_CTX}>
+        <InlineTerminalsSection
+          conversationId="conv_terminal"
+          onExpand={vi.fn()}
+          inline
+          activeKey="terminal:terminal_bash_s1"
+          onOpenShell={vi.fn()}
+          onReturnToList={vi.fn()}
+        />
+      </TerminalFirstContextProvider>,
+    );
+
+    expect(screen.getByTestId("terminal-view")).toHaveAttribute(
+      "data-terminal-id",
+      "terminal_bash_s1",
+    );
+  });
+
   it("routes native-wrapper shells to onExpand even with inline set (main-column takeover)", () => {
     // Native-CLI wrappers keep their chat-replacing UX: the shell opens
     // in the main column via MainTerminalView, not in the rail. This is

--- a/web/src/shell/InlineTerminalsSection.test.tsx
+++ b/web/src/shell/InlineTerminalsSection.test.tsx
@@ -199,7 +199,7 @@ describe("InlineTerminalsSection inline mode hosts the shell in the rail", () =>
     expect(onExpand).not.toHaveBeenCalled();
   });
 
-  it("shows a back control that returns from the hosted shell to the list", () => {
+  it("returns focus to the shell list without announcing an intentional back action", () => {
     renderInlineSection([makeTerminal("terminal_bash_s1", "bash", "s1")], vi.fn(), {
       inline: true,
       ctx: REGULAR_CTX,
@@ -208,10 +208,13 @@ describe("InlineTerminalsSection inline mode hosts the shell in the rail", () =>
     fireEvent.click(screen.getByRole("button", { name: /s1/ }));
     expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
 
-    // Back returns to the list so other shells / "+ New shell" stay reachable.
+    // Back returns keyboard users to the list without presenting an
+    // intentional navigation action as a shell failure.
     fireEvent.click(screen.getByRole("button", { name: /back to shells/i }));
     expect(screen.queryByTestId("terminal-view")).toBeNull();
     expect(screen.getByTestId("new-shell-button")).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /shell list/i })).toHaveFocus();
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
   });
 
   it("attaches the hosted shell read-only for non-owners", () => {
@@ -225,7 +228,7 @@ describe("InlineTerminalsSection inline mode hosts the shell in the rail", () =>
     expect(screen.getByTestId("terminal-view")).toHaveAttribute("data-read-only", "true");
   });
 
-  it("falls back to the list when the hosted shell disappears", () => {
+  it("focuses the list and announces when the hosted shell disappears", () => {
     const { rerender } = renderInlineSection(
       [makeTerminal("terminal_bash_s1", "bash", "s1")],
       vi.fn(),
@@ -236,7 +239,7 @@ describe("InlineTerminalsSection inline mode hosts the shell in the rail", () =>
     expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
 
     // The shell closes out from under the rail — the view drops back to
-    // the list rather than stranding an xterm on a dead terminal.
+    // the list, restores focus, and tells assistive tech what happened.
     useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
     rerender(
       <TerminalFirstContextProvider value={REGULAR_CTX}>
@@ -246,6 +249,10 @@ describe("InlineTerminalsSection inline mode hosts the shell in the rail", () =>
 
     expect(screen.queryByTestId("terminal-view")).toBeNull();
     expect(screen.getByTestId("new-shell-button")).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /shell list/i })).toHaveFocus();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "The active shell closed unexpectedly. Focus returned to the shell list.",
+    );
   });
 
   it("routes terminal-first shells to onExpand even with inline set (main-column takeover)", () => {

--- a/web/src/shell/InlineTerminalsSection.test.tsx
+++ b/web/src/shell/InlineTerminalsSection.test.tsx
@@ -78,6 +78,14 @@ const REGULAR_CTX = {
   isTerminalFirst: false,
 } as TerminalFirstContextValue;
 
+// A native-CLI wrapper session (claude-native / codex-native). These
+// keep the full-screen main-column takeover for user shells — the only
+// session shape that still routes to `onExpand` when inline is set.
+const NATIVE_WRAPPER_CTX = {
+  ...TERMINAL_FIRST_SDK_CTX,
+  isNativeWrapper: true,
+} as TerminalFirstContextValue;
+
 function renderInlineSection(
   terminals: TerminalInfo[],
   onExpand: (key: string) => void = vi.fn(),
@@ -255,13 +263,33 @@ describe("InlineTerminalsSection inline mode hosts the shell in the rail", () =>
     );
   });
 
-  it("routes terminal-first shells to onExpand even with inline set (main-column takeover)", () => {
-    // Terminal-first sessions keep their chat-replacing UX: the shell
-    // opens in the main column via MainTerminalView, not in the rail.
+  it("hosts a chat-first SDK session's user shell inline (chat stays visible)", () => {
+    // Chat-first SDK sessions (polly/debby) are terminal-first only
+    // because the runner hosts an embedded REPL. Their user-created
+    // shells belong inline beside the chat — the +New Shell fix. The
+    // REPL itself is excluded by inventoryTerminals, so every row here
+    // is a user shell that must render in-rail, not full-screen.
     const onExpand = vi.fn();
     renderInlineSection([makeTerminal("terminal_bash_s1", "bash", "s1")], onExpand, {
       inline: true,
       ctx: TERMINAL_FIRST_SDK_CTX,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /s1/ }));
+
+    const view = screen.getByTestId("terminal-view");
+    expect(view).toHaveAttribute("data-terminal-id", "terminal_bash_s1");
+    expect(onExpand).not.toHaveBeenCalled();
+  });
+
+  it("routes native-wrapper shells to onExpand even with inline set (main-column takeover)", () => {
+    // Native-CLI wrappers keep their chat-replacing UX: the shell opens
+    // in the main column via MainTerminalView, not in the rail. This is
+    // the sole session shape that still routes full-screen when inline.
+    const onExpand = vi.fn();
+    renderInlineSection([makeTerminal("terminal_bash_s1", "bash", "s1")], onExpand, {
+      inline: true,
+      ctx: NATIVE_WRAPPER_CTX,
     });
 
     fireEvent.click(screen.getByRole("button", { name: /s1/ }));

--- a/web/src/shell/InlineTerminalsSection.test.tsx
+++ b/web/src/shell/InlineTerminalsSection.test.tsx
@@ -12,6 +12,27 @@ vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
   useTerminals: vi.fn(),
 }));
 
+// Stub the xterm view so inline-mode tests can assert which terminal is
+// hosted (and its read-only flag) without dragging in the WebSocket stack.
+vi.mock("@/components/blocks/TerminalView", () => ({
+  TerminalView: ({
+    sessionId,
+    terminalId,
+    readOnly,
+  }: {
+    sessionId: string;
+    terminalId: string;
+    readOnly?: boolean;
+  }) => (
+    <div
+      data-testid="terminal-view"
+      data-session-id={sessionId}
+      data-terminal-id={terminalId}
+      data-read-only={String(readOnly ?? false)}
+    />
+  ),
+}));
+
 // These tests cover row navigation, not shell creation. The button
 // needs a QueryClient (it reads the session agent for its access
 // gate); its behavior is covered by NewTerminalButton.test.tsx. The
@@ -50,15 +71,31 @@ const TERMINAL_FIRST_SDK_CTX = {
   terminalStartingUp: false,
 } as TerminalFirstContextValue;
 
-function renderInlineSection(terminals: TerminalInfo[], onExpand: (key: string) => void = vi.fn()) {
+// A regular (non-terminal-first) session: the rail hosts shells inline
+// rather than replacing the main column. This is the desktop-fix path.
+const REGULAR_CTX = {
+  ...TERMINAL_FIRST_SDK_CTX,
+  isTerminalFirst: false,
+} as TerminalFirstContextValue;
+
+function renderInlineSection(
+  terminals: TerminalInfo[],
+  onExpand: (key: string) => void = vi.fn(),
+  opts: { inline?: boolean; readOnly?: boolean; ctx?: TerminalFirstContextValue } = {},
+) {
   useTerminalsMock.mockReturnValue({
     terminals,
     isLoading: false,
     error: null,
   });
   return render(
-    <TerminalFirstContextProvider value={TERMINAL_FIRST_SDK_CTX}>
-      <InlineTerminalsSection conversationId="conv_terminal" onExpand={onExpand} />
+    <TerminalFirstContextProvider value={opts.ctx ?? TERMINAL_FIRST_SDK_CTX}>
+      <InlineTerminalsSection
+        conversationId="conv_terminal"
+        onExpand={onExpand}
+        inline={opts.inline}
+        readOnly={opts.readOnly}
+      />
     </TerminalFirstContextProvider>,
   );
 }
@@ -134,5 +171,95 @@ describe("InlineTerminalsSection rows open shells in the main view", () => {
     // drift down as shells accumulate.
     const shellRow = screen.getByRole("button", { name: /s1/ });
     expect(row.compareDocumentPosition(shellRow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});
+
+describe("InlineTerminalsSection inline mode hosts the shell in the rail", () => {
+  it("clicking a shell row mounts its TerminalView in-rail instead of calling onExpand", () => {
+    const onExpand = vi.fn();
+    renderInlineSection(
+      [
+        makeTerminal("terminal_bash_s1", "bash", "s1"),
+        makeTerminal("terminal_worker_s2", "worker", "s2"),
+      ],
+      onExpand,
+      { inline: true, ctx: REGULAR_CTX },
+    );
+
+    // Baseline: the list is showing, no xterm yet.
+    expect(screen.queryByTestId("terminal-view")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /s1/ }));
+
+    // The shell now renders INSIDE the rail (the FileViewer-in-rail
+    // mirror) and onExpand — the full-screen overlay path — is never
+    // called on desktop.
+    const view = screen.getByTestId("terminal-view");
+    expect(view).toHaveAttribute("data-terminal-id", "terminal_bash_s1");
+    expect(onExpand).not.toHaveBeenCalled();
+  });
+
+  it("shows a back control that returns from the hosted shell to the list", () => {
+    renderInlineSection([makeTerminal("terminal_bash_s1", "bash", "s1")], vi.fn(), {
+      inline: true,
+      ctx: REGULAR_CTX,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /s1/ }));
+    expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
+
+    // Back returns to the list so other shells / "+ New shell" stay reachable.
+    fireEvent.click(screen.getByRole("button", { name: /back to shells/i }));
+    expect(screen.queryByTestId("terminal-view")).toBeNull();
+    expect(screen.getByTestId("new-shell-button")).toBeInTheDocument();
+  });
+
+  it("attaches the hosted shell read-only for non-owners", () => {
+    renderInlineSection([makeTerminal("terminal_bash_s1", "bash", "s1")], vi.fn(), {
+      inline: true,
+      readOnly: true,
+      ctx: REGULAR_CTX,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /s1/ }));
+    expect(screen.getByTestId("terminal-view")).toHaveAttribute("data-read-only", "true");
+  });
+
+  it("falls back to the list when the hosted shell disappears", () => {
+    const { rerender } = renderInlineSection(
+      [makeTerminal("terminal_bash_s1", "bash", "s1")],
+      vi.fn(),
+      { inline: true, ctx: REGULAR_CTX },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /s1/ }));
+    expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
+
+    // The shell closes out from under the rail — the view drops back to
+    // the list rather than stranding an xterm on a dead terminal.
+    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
+    rerender(
+      <TerminalFirstContextProvider value={REGULAR_CTX}>
+        <InlineTerminalsSection conversationId="conv_terminal" onExpand={vi.fn()} inline />
+      </TerminalFirstContextProvider>,
+    );
+
+    expect(screen.queryByTestId("terminal-view")).toBeNull();
+    expect(screen.getByTestId("new-shell-button")).toBeInTheDocument();
+  });
+
+  it("routes terminal-first shells to onExpand even with inline set (main-column takeover)", () => {
+    // Terminal-first sessions keep their chat-replacing UX: the shell
+    // opens in the main column via MainTerminalView, not in the rail.
+    const onExpand = vi.fn();
+    renderInlineSection([makeTerminal("terminal_bash_s1", "bash", "s1")], onExpand, {
+      inline: true,
+      ctx: TERMINAL_FIRST_SDK_CTX,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /s1/ }));
+
+    expect(onExpand).toHaveBeenCalledWith("terminal:terminal_bash_s1");
+    expect(screen.queryByTestId("terminal-view")).toBeNull();
   });
 });

--- a/web/src/shell/InlineTerminalsSection.test.tsx
+++ b/web/src/shell/InlineTerminalsSection.test.tsx
@@ -298,7 +298,9 @@ describe("InlineTerminalsSection inline mode hosts the shell in the rail", () =>
     );
 
     fireEvent.click(screen.getByRole("button", { name: /s1/ }));
-    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1");
+    // The callback carries the SOURCE conversation so the parent can reject a
+    // mutation that lands after navigation moved on (see AppShell.openShellTab).
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1", "conv_terminal");
     // Parent-controlled: no self-hosted xterm until activeKey is fed back in.
     expect(screen.queryByTestId("terminal-view")).toBeNull();
   });

--- a/web/src/shell/InlineTerminalsSection.test.tsx
+++ b/web/src/shell/InlineTerminalsSection.test.tsx
@@ -4,6 +4,7 @@ import { type TerminalInfo, useTerminals } from "@/hooks/useTerminals";
 import type { TerminalFirstContextValue } from "./TerminalFirstContext";
 import { TerminalFirstContextProvider } from "./TerminalFirstContext";
 import { InlineTerminalsSection } from "./InlineTerminalsSection";
+import { makeTerminal } from "./testTerminals";
 
 vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
   // Keep the real module (inventoryTerminals etc.) — only the
@@ -45,15 +46,6 @@ vi.mock("./NewTerminalButton", () => ({
 }));
 
 const useTerminalsMock = vi.mocked(useTerminals);
-
-function makeTerminal(id: string, name: string, session: string): TerminalInfo {
-  return {
-    id,
-    name,
-    session,
-    running: true,
-  };
-}
 
 /**
  * Minimal TerminalFirst context for a terminal-first SDK session, so
@@ -306,7 +298,7 @@ describe("InlineTerminalsSection inline mode hosts the shell in the rail", () =>
     );
 
     fireEvent.click(screen.getByRole("button", { name: /s1/ }));
-    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1", false);
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1");
     // Parent-controlled: no self-hosted xterm until activeKey is fed back in.
     expect(screen.queryByTestId("terminal-view")).toBeNull();
   });

--- a/web/src/shell/InlineTerminalsSection.test.tsx
+++ b/web/src/shell/InlineTerminalsSection.test.tsx
@@ -299,8 +299,9 @@ describe("InlineTerminalsSection inline mode hosts the shell in the rail", () =>
 
     fireEvent.click(screen.getByRole("button", { name: /s1/ }));
     // The callback carries the SOURCE conversation so the parent can reject a
-    // mutation that lands after navigation moved on (see AppShell.openShellTab).
-    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1", "conv_terminal");
+    // mutation that lands after navigation moved on (see AppShell.openShellTab),
+    // plus pendingInventory=false — selecting an existing shell, not a create.
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1", "conv_terminal", false);
     // Parent-controlled: no self-hosted xterm until activeKey is fed back in.
     expect(screen.queryByTestId("terminal-view")).toBeNull();
   });

--- a/web/src/shell/InlineTerminalsSection.tsx
+++ b/web/src/shell/InlineTerminalsSection.tsx
@@ -111,7 +111,7 @@ export function InlineTerminalsSection({
   }, [activeKey, hostInline]);
 
   // Row click: host the shell in the rail (inline) or hand it off for a
-  // full-screen takeover (mobile / terminal-first). New-shell creation
+  // full-screen takeover (mobile / native-CLI wrappers). New-shell creation
   // follows the same split so a freshly-created shell lands in the active
   // surface.
   // `pendingInventory` marks the creation path: a freshly-created shell

--- a/web/src/shell/InlineTerminalsSection.tsx
+++ b/web/src/shell/InlineTerminalsSection.tsx
@@ -74,9 +74,12 @@ interface InlineTerminalsSectionProps {
    * component (see ``pendingCreatedKeyRef``), so this exposes only the key.
    * ``source`` is the conversation the selection originated in; the parent
    * drops the mutation when navigation has since moved to another session
-   * (a pending create in A must not rewrite B's workspace).
+   * (a pending create in A must not rewrite B's workspace). ``pendingInventory``
+   * is true on the create path (the shell isn't in the inventory yet) so the
+   * parent can bridge the create→inventory gap for its off-surface cleanup —
+   * this component owns the same bridge only while it stays mounted.
    */
-  onOpenShell?: (key: string, source: string) => void;
+  onOpenShell?: (key: string, source: string, pendingInventory: boolean) => void;
   /**
    * Deselect the active shell back to the list (controlled mode).
    * `unexpected` is true when the shell vanished on its own (closed out
@@ -217,8 +220,10 @@ export function InlineTerminalsSection({
         // Tag the mutation with its source conversation. AppShell rejects the
         // whole UI mutation (file/panel clear, tab select, rail open, active
         // shell, persistence) when navigation has moved on, so a pending
-        // create in A can't rewrite B's workspace.
-        onOpenShell?.(key, source);
+        // create in A can't rewrite B's workspace. ``pendingInventory`` lets
+        // AppShell bridge the create→inventory gap for its off-surface cleanup
+        // if this section unmounts before the shell surfaces.
+        onOpenShell?.(key, source, pendingInventory);
       } else {
         setLocalActiveKey(key);
       }

--- a/web/src/shell/InlineTerminalsSection.tsx
+++ b/web/src/shell/InlineTerminalsSection.tsx
@@ -56,12 +56,18 @@ export function InlineTerminalsSection({
   const { getStatus, setTerminalConnectionState, markTerminalActive } =
     useTerminalStatuses(terminals);
 
-  // Host the shell inside the rail only for non-terminal-first sessions.
-  // Terminal-first sessions (SDK REPL / native wrappers) keep routing to
-  // `onExpand`, which opens the shell in the main column via
-  // MainTerminalView — their established, chat-replacing UX.
-  const isTerminalFirst = terminalFirstCtx?.isTerminalFirst ?? false;
-  const hostInline = inline && !isTerminalFirst;
+  // Host the shell inside the rail for every session EXCEPT native-CLI
+  // wrappers. The Shells list is already the user-shell inventory: the
+  // embedded REPL / native vendor pane is excluded by
+  // `inventoryTerminals`, so every row here is a user-created shell.
+  // Chat-first SDK sessions (polly/debby) are terminal-first only because
+  // the runner hosts an embedded REPL — their user shells belong inline
+  // beside the chat, so we gate on `isNativeWrapper`, never
+  // `isTerminalFirst`. Native wrappers keep routing to `onExpand`, which
+  // opens the shell full-screen in the main column via MainTerminalView —
+  // their established, chat-replacing UX.
+  const isNativeWrapper = terminalFirstCtx?.isNativeWrapper ?? false;
+  const hostInline = inline && !isNativeWrapper;
 
   // Inline hosting only: which shell is shown in the rail. Null shows the
   // list. A closed/disappeared shell falls back to the list below.

--- a/web/src/shell/InlineTerminalsSection.tsx
+++ b/web/src/shell/InlineTerminalsSection.tsx
@@ -44,6 +44,23 @@ interface InlineTerminalsSectionProps {
    */
   readOnly?: boolean;
   /**
+   * AppShell's single "hosts shells inline, not center" verdict, passed
+   * down so this section never recomputes it from a possibly-stale label
+   * source. When omitted (mobile drawer / unit tests) it falls back to the
+   * context-derived ``!isNativeWrapper``. Combined with ``inline`` it
+   * decides whether a row hosts in-rail or hands off to ``onExpand``.
+   */
+  hostsShellsInline?: boolean;
+  /**
+   * Whether a successful label source has settled the session's shape
+   * (native wrapper vs inline-hosting). While false the routing verdict is
+   * not yet authoritative, so shell-create is parked/disabled — starting a
+   * shell against a mislabeled default could capture the wrong host and
+   * leave a highlighted tab that renders no terminal. Default true (the
+   * self-hosting paths that don't supply it aren't shape-sensitive).
+   */
+  sessionLabelsReady?: boolean;
+  /**
    * Active shell tab key when inline hosting is CONTROLLED by the parent
    * (desktop rail). Mirrors the Files tab's `selectedFilePath`: null shows
    * the shell list, a key hosts that shell. Providing `onOpenShell` opts
@@ -55,8 +72,11 @@ interface InlineTerminalsSectionProps {
    * Select a shell (controlled mode) — the parent records the open tab and
    * sets it active. The create->inventory gap marker stays internal to this
    * component (see ``pendingCreatedKeyRef``), so this exposes only the key.
+   * ``source`` is the conversation the selection originated in; the parent
+   * drops the mutation when navigation has since moved to another session
+   * (a pending create in A must not rewrite B's workspace).
    */
-  onOpenShell?: (key: string) => void;
+  onOpenShell?: (key: string, source: string) => void;
   /**
    * Deselect the active shell back to the list (controlled mode).
    * `unexpected` is true when the shell vanished on its own (closed out
@@ -70,6 +90,8 @@ export function InlineTerminalsSection({
   onExpand,
   inline = false,
   readOnly = false,
+  hostsShellsInline,
+  sessionLabelsReady = true,
   activeKey: controlledActiveKey,
   onOpenShell,
   onReturnToList,
@@ -96,8 +118,14 @@ export function InlineTerminalsSection({
   // `isTerminalFirst`. Native wrappers keep routing to `onExpand`, which
   // opens the shell full-screen in the main column via MainTerminalView —
   // their established, chat-replacing UX.
+  // Prefer AppShell's single hostsShellsInline verdict when supplied (the
+  // controlled desktop rail) so this section can't recompute a DIFFERENT
+  // answer from a label source that resolved on a different tick. Fall back to
+  // the context-derived ``!isNativeWrapper`` only for the self-hosting paths
+  // (mobile drawer / unit tests) that don't lift the verdict.
   const isNativeWrapper = terminalFirstCtx?.isNativeWrapper ?? false;
-  const hostInline = inline && !isNativeWrapper;
+  const hostsInlineVerdict = hostsShellsInline ?? !isNativeWrapper;
+  const hostInline = inline && hostsInlineVerdict;
 
   // Inline hosting: which shell is shown in the rail. Null shows the list;
   // a closed/disappeared shell falls back to the list below. CONTROLLED
@@ -112,6 +140,16 @@ export function InlineTerminalsSection({
   const shouldFocusListRef = useRef(false);
   const pendingCreatedKeyRef = useRef<string | null>(null);
   const activeTerminal = terminals.find((t) => terminalTabKey(t) === activeKey) ?? null;
+  // Latest routing inputs, so a create callback that fires AFTER an async
+  // POST resolves re-checks the CURRENT verdict rather than the one captured
+  // when creation started. Between "New shell" click and POST completion the
+  // session labels can resolve (native wrapper revealed), flipping the
+  // routing target — reading the ref keeps a native session from capturing an
+  // inline-owned shell tab that renders no terminal.
+  const hostInlineRef = useRef(hostInline);
+  hostInlineRef.current = hostInline;
+  const conversationIdRef = useRef(conversationId);
+  conversationIdRef.current = conversationId;
 
   const returnToList = useCallback(
     (unexpected: boolean) => {
@@ -163,19 +201,29 @@ export function InlineTerminalsSection({
   // unexpected close). Selecting an existing shell clears the ref.
   const openShell = useCallback(
     (key: string, pendingInventory: boolean) => {
-      if (!hostInline) {
+      // ``pendingInventory`` is the create path — its callback runs after an
+      // async POST, so re-read the LATEST routing verdict (ref, not the value
+      // captured when the click happened). A native-wrapper label that
+      // resolved mid-flight flips the target: route full-screen via onExpand
+      // instead of capturing an inline-owned tab that renders no terminal.
+      const source = conversationIdRef.current;
+      if (!hostInlineRef.current) {
         onExpand(key);
         return;
       }
       pendingCreatedKeyRef.current = pendingInventory ? key : null;
       setAnnouncement("");
       if (controlled) {
-        onOpenShell?.(key);
+        // Tag the mutation with its source conversation. AppShell rejects the
+        // whole UI mutation (file/panel clear, tab select, rail open, active
+        // shell, persistence) when navigation has moved on, so a pending
+        // create in A can't rewrite B's workspace.
+        onOpenShell?.(key, source);
       } else {
         setLocalActiveKey(key);
       }
     },
-    [hostInline, onExpand, controlled, onOpenShell],
+    [onExpand, controlled, onOpenShell],
   );
 
   return (
@@ -235,6 +283,12 @@ export function InlineTerminalsSection({
             conversationId={conversationId}
             onCreated={(key) => openShell(key, true)}
             variant="row"
+            // Park shell-create until the routing verdict is authoritative:
+            // a shell started against a mislabeled default could complete
+            // after native labels arrive and capture the wrong host. Only
+            // gates the controlled inline rail; self-hosting paths pass
+            // sessionLabelsReady=true (their shape isn't ambiguous here).
+            disabled={hostInline && !sessionLabelsReady}
           />
           {terminals.map((t) => (
             <button

--- a/web/src/shell/InlineTerminalsSection.tsx
+++ b/web/src/shell/InlineTerminalsSection.tsx
@@ -1,13 +1,18 @@
-// Shells tab content for the right-side rail: a virtual "+ New shell"
-// row on top, then the session's shells as rows. Clicking a shell row
-// does NOT open an in-rail split — it hands the shell to `onExpand`,
-// which replaces the main session view with that shell
-// (MainTerminalView for terminal-first sessions, the full-width push
-// panel otherwise). The rail stays a lightweight index; the terminal
-// always gets the full main column.
+// Shells tab content for the right-side rail. Two modes:
+//
+//   - List mode (default, mobile drawer): a virtual "+ New shell" row on
+//     top, then the session's shells as rows. Clicking a row hands the
+//     shell to `onExpand`, which replaces the main session view with the
+//     full-screen shell (mobile) — the rail stays a lightweight index.
+//   - Inline mode (`inline`, desktop rail): clicking a row hosts the
+//     shell's `TerminalView` INSIDE the rail, exactly mirroring how the
+//     Files tab renders a FileViewer inline. Chat stays visible on the
+//     left. A back affordance returns to the list so other shells stay
+//     reachable. `onExpand` is unused here.
 
-import { TerminalIcon } from "lucide-react";
-import { useMemo } from "react";
+import { ChevronLeftIcon, TerminalIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { TerminalView } from "@/components/blocks/TerminalView";
 import { inventoryTerminals, terminalTabKey, useTerminals } from "@/hooks/useTerminals";
 import { NewTerminalButton } from "./NewTerminalButton";
 import { useTerminalFirst } from "./TerminalFirstContext";
@@ -18,9 +23,27 @@ interface InlineTerminalsSectionProps {
   conversationId: string;
   /** Open a shell in the main view, keyed by its terminal tab key. */
   onExpand: (terminalKey: string) => void;
+  /**
+   * Host the selected shell's terminal INSIDE the rail (desktop) rather
+   * than handing it to `onExpand` for a full-screen takeover (mobile).
+   * Mirrors the Files tab's inline FileViewer. Default false.
+   */
+  inline?: boolean;
+  /**
+   * Attach the inline terminal read-only — the viewer can watch but not
+   * type. Set for non-owners: a shared PTY's keystrokes carry no per-user
+   * identity, so only the owner may drive it (server-enforced). Only
+   * meaningful in inline mode. Default false.
+   */
+  readOnly?: boolean;
 }
 
-export function InlineTerminalsSection({ conversationId, onExpand }: InlineTerminalsSectionProps) {
+export function InlineTerminalsSection({
+  conversationId,
+  onExpand,
+  inline = false,
+  readOnly = false,
+}: InlineTerminalsSectionProps) {
   const { terminals: allTerminals } = useTerminals(conversationId);
   // Inventory view: the agent's own terminal (SDK REPL / native vendor
   // pane) backs the pill's Terminal view and must not appear as a
@@ -30,7 +53,68 @@ export function InlineTerminalsSection({ conversationId, onExpand }: InlineTermi
     () => inventoryTerminals(allTerminals, terminalFirstCtx?.isTerminalFirst ?? false),
     [allTerminals, terminalFirstCtx?.isTerminalFirst],
   );
-  const { getStatus } = useTerminalStatuses(terminals);
+  const { getStatus, setTerminalConnectionState, markTerminalActive } =
+    useTerminalStatuses(terminals);
+
+  // Host the shell inside the rail only for non-terminal-first sessions.
+  // Terminal-first sessions (SDK REPL / native wrappers) keep routing to
+  // `onExpand`, which opens the shell in the main column via
+  // MainTerminalView — their established, chat-replacing UX.
+  const isTerminalFirst = terminalFirstCtx?.isTerminalFirst ?? false;
+  const hostInline = inline && !isTerminalFirst;
+
+  // Inline hosting only: which shell is shown in the rail. Null shows the
+  // list. A closed/disappeared shell falls back to the list below.
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+  const activeTerminal = terminals.find((t) => terminalTabKey(t) === activeKey) ?? null;
+  useEffect(() => {
+    if (activeKey && !activeTerminal) setActiveKey(null);
+  }, [activeKey, activeTerminal]);
+
+  // Row click: host the shell in the rail (inline) or hand it off for a
+  // full-screen takeover (mobile / terminal-first). New-shell creation
+  // follows the same split so a freshly-created shell lands in the active
+  // surface.
+  const openShell = hostInline ? setActiveKey : onExpand;
+
+  if (hostInline && activeTerminal) {
+    return (
+      <div className="flex h-full min-h-0 flex-col overflow-hidden bg-card">
+        {/* Shell header — back to the list + identity, mirroring
+            MainTerminalView's chrome-free shell header. */}
+        <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-2 py-1.5">
+          <button
+            type="button"
+            aria-label="Back to shells"
+            onClick={() => setActiveKey(null)}
+            className="flex items-center gap-1 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <ChevronLeftIcon className="size-4 shrink-0" />
+          </button>
+          <span className="flex min-w-0 items-center gap-1.5 rounded-sm bg-muted px-2 py-1 text-foreground text-xs">
+            <TerminalIcon className="size-3 shrink-0" />
+            <span className="max-w-[8rem] truncate">{activeTerminal.name}</span>
+            {activeTerminal.session && (
+              <span className="shrink-0 text-muted-foreground/60">· {activeTerminal.session}</span>
+            )}
+            <TerminalStatusBadge status={getStatus(activeTerminal)} />
+          </span>
+        </div>
+        <div key={activeTerminal.id} className="flex min-h-0 flex-1 flex-col p-2">
+          <TerminalView
+            sessionId={conversationId}
+            terminalId={activeTerminal.id}
+            readOnly={readOnly}
+            transport={activeTerminal.transport}
+            onStateChange={(state) => {
+              setTerminalConnectionState(activeTerminal.id, state);
+            }}
+            onActivity={() => markTerminalActive(activeTerminal.id)}
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-card">
@@ -41,13 +125,13 @@ export function InlineTerminalsSection({ conversationId, onExpand }: InlineTermi
           shells the virtual row is the whole list — no centered
           empty-state copy. */}
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto py-1">
-        <NewTerminalButton conversationId={conversationId} onCreated={onExpand} variant="row" />
+        <NewTerminalButton conversationId={conversationId} onCreated={openShell} variant="row" />
         {terminals.map((t) => (
           <button
             key={terminalTabKey(t)}
             type="button"
             className="flex w-full items-center gap-2 px-2 py-1.5 text-left hover:bg-accent/60"
-            onClick={() => onExpand(terminalTabKey(t))}
+            onClick={() => openShell(terminalTabKey(t))}
           >
             <TerminalIcon className="size-3.5 shrink-0 text-muted-foreground" />
             {t.session && <span className="shrink-0 text-xs font-medium">{t.session}</span>}

--- a/web/src/shell/InlineTerminalsSection.tsx
+++ b/web/src/shell/InlineTerminalsSection.tsx
@@ -16,7 +16,7 @@ import { TerminalView } from "@/components/blocks/TerminalView";
 import { inventoryTerminals, terminalTabKey, useTerminals } from "@/hooks/useTerminals";
 import { NewTerminalButton } from "./NewTerminalButton";
 import { useTerminalFirst } from "./TerminalFirstContext";
-import { TerminalStatusBadge } from "./terminalStatus";
+import { TerminalIdentityChip, TerminalStatusBadge } from "./terminalStatus";
 import { useTerminalStatuses } from "./useTerminalStatuses";
 
 interface InlineTerminalsSectionProps {
@@ -83,18 +83,23 @@ export function InlineTerminalsSection({
 
   useEffect(() => {
     if (!hostInline || !activeKey) return;
-    if (activeTerminal) {
-      if (pendingCreatedKeyRef.current === activeKey) pendingCreatedKeyRef.current = null;
-      return;
-    }
     // onCreated fires before the terminals hook necessarily exposes the
-    // cache update. Keep that selection until the new shell appears.
-    if (pendingCreatedKeyRef.current === activeKey) return;
-    returnToList(true);
+    // cache update, so a freshly-created shell is briefly absent from the
+    // inventory. pending marks that gap.
+    const pending = pendingCreatedKeyRef.current === activeKey;
+    // The pending shell surfaced — drop its marker.
+    if (activeTerminal && pending) pendingCreatedKeyRef.current = null;
+    // The selection vanished without a pending marker — it closed
+    // unexpectedly, so fall back to the list.
+    if (!activeTerminal && !pending) returnToList(true);
   }, [activeKey, activeTerminal, hostInline, returnToList]);
 
+  // `returnToList` is the only setter of shouldFocusListRef, and it nulls
+  // activeKey in the same call — so when the ref is set, activeKey is
+  // already null and the list is rendered and focusable. activeKey stays
+  // in the deps to re-run once that null commit lands.
   useEffect(() => {
-    if (!hostInline || activeKey !== null || !shouldFocusListRef.current) return;
+    if (!hostInline || !shouldFocusListRef.current) return;
     shellListRef.current?.focus();
     shouldFocusListRef.current = false;
   }, [activeKey, hostInline]);
@@ -103,25 +108,18 @@ export function InlineTerminalsSection({
   // full-screen takeover (mobile / terminal-first). New-shell creation
   // follows the same split so a freshly-created shell lands in the active
   // surface.
+  // `pendingInventory` marks the creation path: a freshly-created shell
+  // is selected before the terminals hook exposes it, so record it in
+  // pendingCreatedKeyRef to bridge the create->inventory gap (the focus
+  // effect above keeps the selection instead of misreading the gap as an
+  // unexpected close). Selecting an existing shell clears the ref.
   const openShell = useCallback(
-    (key: string) => {
+    (key: string, pendingInventory: boolean) => {
       if (!hostInline) {
         onExpand(key);
         return;
       }
-      pendingCreatedKeyRef.current = null;
-      setAnnouncement("");
-      setActiveKey(key);
-    },
-    [hostInline, onExpand],
-  );
-  const openCreatedShell = useCallback(
-    (key: string) => {
-      if (!hostInline) {
-        onExpand(key);
-        return;
-      }
-      pendingCreatedKeyRef.current = key;
+      pendingCreatedKeyRef.current = pendingInventory ? key : null;
       setAnnouncement("");
       setActiveKey(key);
     },
@@ -148,16 +146,11 @@ export function InlineTerminalsSection({
             >
               <ChevronLeftIcon className="size-4 shrink-0" />
             </button>
-            <span className="flex min-w-0 items-center gap-1.5 rounded-sm bg-muted px-2 py-1 text-foreground text-xs">
-              <TerminalIcon className="size-3 shrink-0" />
-              <span className="max-w-[8rem] truncate">{activeTerminal.name}</span>
-              {activeTerminal.session && (
-                <span className="shrink-0 text-muted-foreground/60">
-                  · {activeTerminal.session}
-                </span>
-              )}
-              <TerminalStatusBadge status={getStatus(activeTerminal)} />
-            </span>
+            <TerminalIdentityChip
+              terminal={activeTerminal}
+              status={getStatus(activeTerminal)}
+              className="min-w-0"
+            />
           </div>
           <div key={activeTerminal.id} className="flex min-h-0 flex-1 flex-col p-2">
             <TerminalView
@@ -188,7 +181,7 @@ export function InlineTerminalsSection({
         >
           <NewTerminalButton
             conversationId={conversationId}
-            onCreated={openCreatedShell}
+            onCreated={(key) => openShell(key, true)}
             variant="row"
           />
           {terminals.map((t) => (
@@ -196,7 +189,7 @@ export function InlineTerminalsSection({
               key={terminalTabKey(t)}
               type="button"
               className="flex w-full items-center gap-2 px-2 py-1.5 text-left hover:bg-accent/60"
-              onClick={() => openShell(terminalTabKey(t))}
+              onClick={() => openShell(terminalTabKey(t), false)}
             >
               <TerminalIcon className="size-3.5 shrink-0 text-muted-foreground" />
               {t.session && <span className="shrink-0 text-xs font-medium">{t.session}</span>}

--- a/web/src/shell/InlineTerminalsSection.tsx
+++ b/web/src/shell/InlineTerminalsSection.tsx
@@ -9,6 +9,13 @@
 //     Files tab renders a FileViewer inline. Chat stays visible on the
 //     left. A back affordance returns to the list so other shells stay
 //     reachable. `onExpand` is unused here.
+//
+// Inline hosting is CONTROLLED: the active shell (and the open-tab set) is
+// owned by AppShell — mirroring how Files lift `selectedFilePath`/`openFiles`
+// — so the shell's identity can surface as a tab in the shared top header
+// strip (see WorkspacePanel's ShellTabsStrip) beside the open file tabs.
+// `activeKey`/`onOpenShell`/`onReturnToList` wire that up; when omitted, the
+// section stays list-only (the mobile drawer path).
 
 import { ChevronLeftIcon, TerminalIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -36,6 +43,26 @@ interface InlineTerminalsSectionProps {
    * meaningful in inline mode. Default false.
    */
   readOnly?: boolean;
+  /**
+   * Active shell tab key when inline hosting is CONTROLLED by the parent
+   * (desktop rail). Mirrors the Files tab's `selectedFilePath`: null shows
+   * the shell list, a key hosts that shell. Providing `onOpenShell` opts
+   * into controlled mode; omit both to keep the section list-only /
+   * self-hosting (mobile drawer + unit tests).
+   */
+  activeKey?: string | null;
+  /**
+   * Select a shell (controlled mode). `pendingInventory` is true for a
+   * freshly-created shell not yet in the terminals inventory. The parent
+   * records the open tab and sets it active.
+   */
+  onOpenShell?: (key: string, pendingInventory: boolean) => void;
+  /**
+   * Deselect the active shell back to the list (controlled mode).
+   * `unexpected` is true when the shell vanished on its own (closed out
+   * from under the rail) rather than via the back affordance.
+   */
+  onReturnToList?: (unexpected: boolean) => void;
 }
 
 export function InlineTerminalsSection({
@@ -43,6 +70,9 @@ export function InlineTerminalsSection({
   onExpand,
   inline = false,
   readOnly = false,
+  activeKey: controlledActiveKey,
+  onOpenShell,
+  onReturnToList,
 }: InlineTerminalsSectionProps) {
   const { terminals: allTerminals } = useTerminals(conversationId);
   // Inventory view: the agent's own terminal (SDK REPL / native vendor
@@ -69,23 +99,35 @@ export function InlineTerminalsSection({
   const isNativeWrapper = terminalFirstCtx?.isNativeWrapper ?? false;
   const hostInline = inline && !isNativeWrapper;
 
-  // Inline hosting only: which shell is shown in the rail. Null shows the
-  // list. A closed/disappeared shell falls back to the list below.
-  const [activeKey, setActiveKey] = useState<string | null>(null);
+  // Inline hosting: which shell is shown in the rail. Null shows the list;
+  // a closed/disappeared shell falls back to the list below. CONTROLLED
+  // when the parent supplies `onOpenShell` (desktop rail lifts the active
+  // shell so it can render as a top-strip tab, mirroring Files); otherwise
+  // self-hosted via local state (list-only paths + unit tests).
+  const controlled = onOpenShell !== undefined;
+  const [localActiveKey, setLocalActiveKey] = useState<string | null>(null);
+  const activeKey = controlled ? (controlledActiveKey ?? null) : localActiveKey;
   const [announcement, setAnnouncement] = useState("");
   const shellListRef = useRef<HTMLDivElement>(null);
   const shouldFocusListRef = useRef(false);
   const pendingCreatedKeyRef = useRef<string | null>(null);
   const activeTerminal = terminals.find((t) => terminalTabKey(t) === activeKey) ?? null;
 
-  const returnToList = useCallback((unexpected: boolean) => {
-    shouldFocusListRef.current = true;
-    pendingCreatedKeyRef.current = null;
-    setAnnouncement(
-      unexpected ? "The active shell closed unexpectedly. Focus returned to the shell list." : "",
-    );
-    setActiveKey(null);
-  }, []);
+  const returnToList = useCallback(
+    (unexpected: boolean) => {
+      shouldFocusListRef.current = true;
+      pendingCreatedKeyRef.current = null;
+      setAnnouncement(
+        unexpected ? "The active shell closed unexpectedly. Focus returned to the shell list." : "",
+      );
+      if (controlled) {
+        onReturnToList?.(unexpected);
+      } else {
+        setLocalActiveKey(null);
+      }
+    },
+    [controlled, onReturnToList],
+  );
 
   useEffect(() => {
     if (!hostInline || !activeKey) return;
@@ -127,9 +169,13 @@ export function InlineTerminalsSection({
       }
       pendingCreatedKeyRef.current = pendingInventory ? key : null;
       setAnnouncement("");
-      setActiveKey(key);
+      if (controlled) {
+        onOpenShell?.(key, pendingInventory);
+      } else {
+        setLocalActiveKey(key);
+      }
     },
-    [hostInline, onExpand],
+    [hostInline, onExpand, controlled, onOpenShell],
   );
 
   return (

--- a/web/src/shell/InlineTerminalsSection.tsx
+++ b/web/src/shell/InlineTerminalsSection.tsx
@@ -52,11 +52,11 @@ interface InlineTerminalsSectionProps {
    */
   activeKey?: string | null;
   /**
-   * Select a shell (controlled mode). `pendingInventory` is true for a
-   * freshly-created shell not yet in the terminals inventory. The parent
-   * records the open tab and sets it active.
+   * Select a shell (controlled mode) — the parent records the open tab and
+   * sets it active. The create->inventory gap marker stays internal to this
+   * component (see ``pendingCreatedKeyRef``), so this exposes only the key.
    */
-  onOpenShell?: (key: string, pendingInventory: boolean) => void;
+  onOpenShell?: (key: string) => void;
   /**
    * Deselect the active shell back to the list (controlled mode).
    * `unexpected` is true when the shell vanished on its own (closed out
@@ -170,7 +170,7 @@ export function InlineTerminalsSection({
       pendingCreatedKeyRef.current = pendingInventory ? key : null;
       setAnnouncement("");
       if (controlled) {
-        onOpenShell?.(key, pendingInventory);
+        onOpenShell?.(key);
       } else {
         setLocalActiveKey(key);
       }

--- a/web/src/shell/InlineTerminalsSection.tsx
+++ b/web/src/shell/InlineTerminalsSection.tsx
@@ -11,7 +11,7 @@
 //     reachable. `onExpand` is unused here.
 
 import { ChevronLeftIcon, TerminalIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TerminalView } from "@/components/blocks/TerminalView";
 import { inventoryTerminals, terminalTabKey, useTerminals } from "@/hooks/useTerminals";
 import { NewTerminalButton } from "./NewTerminalButton";
@@ -66,81 +66,147 @@ export function InlineTerminalsSection({
   // Inline hosting only: which shell is shown in the rail. Null shows the
   // list. A closed/disappeared shell falls back to the list below.
   const [activeKey, setActiveKey] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+  const shellListRef = useRef<HTMLDivElement>(null);
+  const shouldFocusListRef = useRef(false);
+  const pendingCreatedKeyRef = useRef<string | null>(null);
   const activeTerminal = terminals.find((t) => terminalTabKey(t) === activeKey) ?? null;
+
+  const returnToList = useCallback((unexpected: boolean) => {
+    shouldFocusListRef.current = true;
+    pendingCreatedKeyRef.current = null;
+    setAnnouncement(
+      unexpected ? "The active shell closed unexpectedly. Focus returned to the shell list." : "",
+    );
+    setActiveKey(null);
+  }, []);
+
   useEffect(() => {
-    if (activeKey && !activeTerminal) setActiveKey(null);
-  }, [activeKey, activeTerminal]);
+    if (!hostInline || !activeKey) return;
+    if (activeTerminal) {
+      if (pendingCreatedKeyRef.current === activeKey) pendingCreatedKeyRef.current = null;
+      return;
+    }
+    // onCreated fires before the terminals hook necessarily exposes the
+    // cache update. Keep that selection until the new shell appears.
+    if (pendingCreatedKeyRef.current === activeKey) return;
+    returnToList(true);
+  }, [activeKey, activeTerminal, hostInline, returnToList]);
+
+  useEffect(() => {
+    if (!hostInline || activeKey !== null || !shouldFocusListRef.current) return;
+    shellListRef.current?.focus();
+    shouldFocusListRef.current = false;
+  }, [activeKey, hostInline]);
 
   // Row click: host the shell in the rail (inline) or hand it off for a
   // full-screen takeover (mobile / terminal-first). New-shell creation
   // follows the same split so a freshly-created shell lands in the active
   // surface.
-  const openShell = hostInline ? setActiveKey : onExpand;
-
-  if (hostInline && activeTerminal) {
-    return (
-      <div className="flex h-full min-h-0 flex-col overflow-hidden bg-card">
-        {/* Shell header — back to the list + identity, mirroring
-            MainTerminalView's chrome-free shell header. */}
-        <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-2 py-1.5">
-          <button
-            type="button"
-            aria-label="Back to shells"
-            onClick={() => setActiveKey(null)}
-            className="flex items-center gap-1 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            <ChevronLeftIcon className="size-4 shrink-0" />
-          </button>
-          <span className="flex min-w-0 items-center gap-1.5 rounded-sm bg-muted px-2 py-1 text-foreground text-xs">
-            <TerminalIcon className="size-3 shrink-0" />
-            <span className="max-w-[8rem] truncate">{activeTerminal.name}</span>
-            {activeTerminal.session && (
-              <span className="shrink-0 text-muted-foreground/60">· {activeTerminal.session}</span>
-            )}
-            <TerminalStatusBadge status={getStatus(activeTerminal)} />
-          </span>
-        </div>
-        <div key={activeTerminal.id} className="flex min-h-0 flex-1 flex-col p-2">
-          <TerminalView
-            sessionId={conversationId}
-            terminalId={activeTerminal.id}
-            readOnly={readOnly}
-            transport={activeTerminal.transport}
-            onStateChange={(state) => {
-              setTerminalConnectionState(activeTerminal.id, state);
-            }}
-            onActivity={() => markTerminalActive(activeTerminal.id)}
-          />
-        </div>
-      </div>
-    );
-  }
+  const openShell = useCallback(
+    (key: string) => {
+      if (!hostInline) {
+        onExpand(key);
+        return;
+      }
+      pendingCreatedKeyRef.current = null;
+      setAnnouncement("");
+      setActiveKey(key);
+    },
+    [hostInline, onExpand],
+  );
+  const openCreatedShell = useCallback(
+    (key: string) => {
+      if (!hostInline) {
+        onExpand(key);
+        return;
+      }
+      pendingCreatedKeyRef.current = key;
+      setAnnouncement("");
+      setActiveKey(key);
+    },
+    [hostInline, onExpand],
+  );
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-card">
-      {/* Always a plain top-aligned list: a virtual "+ New shell" row
-          first (gated inside NewTerminalButton on the agent's terminal
-          access — leading keeps it at a fixed spot instead of drifting
-          down as shells accumulate), then the shell rows. With zero
-          shells the virtual row is the whole list — no centered
-          empty-state copy. */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto py-1">
-        <NewTerminalButton conversationId={conversationId} onCreated={openShell} variant="row" />
-        {terminals.map((t) => (
-          <button
-            key={terminalTabKey(t)}
-            type="button"
-            className="flex w-full items-center gap-2 px-2 py-1.5 text-left hover:bg-accent/60"
-            onClick={() => openShell(terminalTabKey(t))}
-          >
-            <TerminalIcon className="size-3.5 shrink-0 text-muted-foreground" />
-            {t.session && <span className="shrink-0 text-xs font-medium">{t.session}</span>}
-            <span className="truncate text-xs text-muted-foreground/70">{t.name}</span>
-            <span className="flex-1" />
-            <TerminalStatusBadge status={getStatus(t)} />
-          </button>
-        ))}
-      </div>
+      {hostInline && (
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {announcement}
+        </div>
+      )}
+      {hostInline && activeTerminal ? (
+        <>
+          {/* Shell header — back to the list + identity, mirroring
+            MainTerminalView's chrome-free shell header. */}
+          <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-2 py-1.5">
+            <button
+              type="button"
+              aria-label="Back to shells"
+              onClick={() => returnToList(false)}
+              className="flex items-center gap-1 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <ChevronLeftIcon className="size-4 shrink-0" />
+            </button>
+            <span className="flex min-w-0 items-center gap-1.5 rounded-sm bg-muted px-2 py-1 text-foreground text-xs">
+              <TerminalIcon className="size-3 shrink-0" />
+              <span className="max-w-[8rem] truncate">{activeTerminal.name}</span>
+              {activeTerminal.session && (
+                <span className="shrink-0 text-muted-foreground/60">
+                  · {activeTerminal.session}
+                </span>
+              )}
+              <TerminalStatusBadge status={getStatus(activeTerminal)} />
+            </span>
+          </div>
+          <div key={activeTerminal.id} className="flex min-h-0 flex-1 flex-col p-2">
+            <TerminalView
+              sessionId={conversationId}
+              terminalId={activeTerminal.id}
+              readOnly={readOnly}
+              transport={activeTerminal.transport}
+              onStateChange={(state) => {
+                setTerminalConnectionState(activeTerminal.id, state);
+              }}
+              onActivity={() => markTerminalActive(activeTerminal.id)}
+            />
+          </div>
+        </>
+      ) : (
+        /* Always a plain top-aligned list: a virtual "+ New shell" row
+           first (gated inside NewTerminalButton on the agent's terminal
+           access — leading keeps it at a fixed spot instead of drifting
+           down as shells accumulate), then the shell rows. With zero
+           shells the virtual row is the whole list — no centered
+           empty-state copy. */
+        <div
+          ref={hostInline ? shellListRef : undefined}
+          role={hostInline ? "region" : undefined}
+          aria-label={hostInline ? "Shell list" : undefined}
+          tabIndex={hostInline ? -1 : undefined}
+          className="flex min-h-0 flex-1 flex-col overflow-y-auto py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+        >
+          <NewTerminalButton
+            conversationId={conversationId}
+            onCreated={openCreatedShell}
+            variant="row"
+          />
+          {terminals.map((t) => (
+            <button
+              key={terminalTabKey(t)}
+              type="button"
+              className="flex w-full items-center gap-2 px-2 py-1.5 text-left hover:bg-accent/60"
+              onClick={() => openShell(terminalTabKey(t))}
+            >
+              <TerminalIcon className="size-3.5 shrink-0 text-muted-foreground" />
+              {t.session && <span className="shrink-0 text-xs font-medium">{t.session}</span>}
+              <span className="truncate text-xs text-muted-foreground/70">{t.name}</span>
+              <span className="flex-1" />
+              <TerminalStatusBadge status={getStatus(t)} />
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -150,7 +150,13 @@ describe("MainTerminalView — terminal-first SDK sessions", () => {
     expect(view).toHaveAttribute("data-read-only", "true");
   });
 
-  it("renders a rail-opened shell chrome-free: shell header + close, no agent tab", () => {
+  it("does NOT render a chrome-free shell view for a stray user-shell key (hardening)", () => {
+    // Chat-first, non-wrapper SDK sessions host user shells INLINE in the
+    // rail — they never take over the center. This hardens the center path:
+    // even if a user-shell key reaches MainTerminalView here (a stale key,
+    // a bug), ``isShellView`` gates on ``isNativeWrapper`` (false), so the
+    // chrome-free shell header + close X must NOT render — that UX belongs
+    // to native wrappers only.
     const setView = vi.fn();
     renderView({
       terminals: [REPL_TERMINAL, BASH_SHELL],
@@ -158,22 +164,15 @@ describe("MainTerminalView — terminal-first SDK sessions", () => {
       setView,
     });
 
-    // The shell replaced the view (this is the rail row's target).
+    // The terminal still mounts (the key is honored), but with no shell
+    // chrome: no identity header naming the shell, no "Close shell" X.
     expect(screen.getByTestId("terminal-view")).toHaveAttribute(
       "data-terminal-id",
       "terminal_bash_s1",
     );
-    // The header names the shell only — an agent tab ("polly"/"tui")
-    // here is the reported regression: the shell view must not imply
-    // the shell is the agent.
-    expect(screen.getByText("bash")).toBeInTheDocument();
-    expect(screen.queryByText("tui")).toBeNull();
+    expect(screen.queryByText("bash")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Close shell" })).toBeNull();
     expect(screen.queryByTestId("new-shell-button")).toBeNull();
-
-    // The close X is the way back to chat (the Chat/Terminal pill is
-    // hidden in shell view — ConnectionIndicator gates on isShellView).
-    fireEvent.click(screen.getByRole("button", { name: "Close shell" }));
-    expect(setView).toHaveBeenCalledWith("chat");
   });
 });
 

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -150,13 +150,7 @@ describe("MainTerminalView — terminal-first SDK sessions", () => {
     expect(view).toHaveAttribute("data-read-only", "true");
   });
 
-  it("does NOT render a chrome-free shell view for a stray user-shell key (hardening)", () => {
-    // Chat-first, non-wrapper SDK sessions host user shells INLINE in the
-    // rail — they never take over the center. This hardens the center path:
-    // even if a user-shell key reaches MainTerminalView here (a stale key,
-    // a bug), ``isShellView`` gates on ``isNativeWrapper`` (false), so the
-    // chrome-free shell header + close X must NOT render — that UX belongs
-    // to native wrappers only.
+  it("renders a rail-opened shell chrome-free: shell header + close, no agent tab", () => {
     const setView = vi.fn();
     renderView({
       terminals: [REPL_TERMINAL, BASH_SHELL],
@@ -164,15 +158,22 @@ describe("MainTerminalView — terminal-first SDK sessions", () => {
       setView,
     });
 
-    // The terminal still mounts (the key is honored), but with no shell
-    // chrome: no identity header naming the shell, no "Close shell" X.
+    // The shell replaced the view (this is the rail row's target).
     expect(screen.getByTestId("terminal-view")).toHaveAttribute(
       "data-terminal-id",
       "terminal_bash_s1",
     );
-    expect(screen.queryByText("bash")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Close shell" })).toBeNull();
+    // The header names the shell only — an agent tab ("polly"/"tui")
+    // here is the reported regression: the shell view must not imply
+    // the shell is the agent.
+    expect(screen.getByText("bash")).toBeInTheDocument();
+    expect(screen.queryByText("tui")).toBeNull();
     expect(screen.queryByTestId("new-shell-button")).toBeNull();
+
+    // The close X is the way back to chat (the Chat/Terminal pill is
+    // hidden in shell view — ConnectionIndicator gates on isShellView).
+    fireEvent.click(screen.getByRole("button", { name: "Close shell" }));
+    expect(setView).toHaveBeenCalledWith("chat");
   });
 });
 

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -13,12 +13,12 @@
 // single header row (identity + close X). There is no tab strip —
 // shells are enumerated and created in the rail's Shells tab.
 
-import { XIcon } from "lucide-react";
+import { TerminalIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TerminalView } from "@/components/blocks/TerminalView";
 import { AGENT_TERMINAL_IDS, terminalTabKey, useTerminals } from "@/hooks/useTerminals";
 import { useTerminalFirst } from "./TerminalFirstContext";
-import { TerminalIdentityChip } from "./terminalStatus";
+import { TerminalStatusBadge } from "./terminalStatus";
 import { useTerminalStatuses } from "./useTerminalStatuses";
 
 interface MainTerminalViewProps {
@@ -139,7 +139,14 @@ export function MainTerminalView({
             {isShellView && activeTerminal && (
               // Shell header — identity + close, nothing else.
               <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-2 pt-1 pb-2">
-                <TerminalIdentityChip terminal={activeTerminal} status={getStatus(activeTerminal)} />
+                <span className="flex items-center gap-1.5 rounded-sm bg-muted px-2 py-1 text-foreground text-xs">
+                  <TerminalIcon className="size-3 shrink-0" />
+                  <span className="max-w-[8rem] truncate">{activeTerminal.name}</span>
+                  <span className="shrink-0 text-muted-foreground/60">
+                    · {activeTerminal.session}
+                  </span>
+                  <TerminalStatusBadge status={getStatus(activeTerminal)} />
+                </span>
                 <span className="flex-1" />
                 <button
                   type="button"

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -99,12 +99,12 @@ export function MainTerminalView({
   // header row naming the shell plus a close X — no agent tab (the shell is
   // not the agent). The Chat/Terminal pill is hidden in this state too
   // (ConnectionIndicator gates on the context's `isShellView`), so the X is
-  // the way back to chat. This is the NATIVE-WRAPPER UX only — chat-first,
-  // non-wrapper sessions host user shells inline in the rail, never the
-  // center, so gate on `isNativeWrapper` (not `isTerminalFirst`) to keep a
-  // stray user-shell key from rendering chrome-free here for them.
+  // the way back to chat. This view only ever renders in the center, so a
+  // non-agent terminal here IS a center-hosted shell — a native wrapper, or a
+  // chat-first session on mobile where there's no rail — and gates on
+  // `isTerminalFirst`; on desktop the rail hosts those shells, never here.
   const isShellView =
-    (terminalFirstCtx?.isNativeWrapper ?? false) &&
+    (terminalFirstCtx?.isTerminalFirst ?? false) &&
     activeTerminal !== null &&
     !AGENT_TERMINAL_IDS.has(activeTerminal.id);
   const setSurfaceElement = useCallback(

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -95,13 +95,16 @@ export function MainTerminalView({
   }, [terminals, agentTerminals, activeKey]);
 
   const activeTerminal = terminals.find((t) => terminalTabKey(t) === activeKey) ?? null;
-  // A user shell opened from the rail takes over the pane chrome-free:
-  // a single header row naming the shell plus a close X — no agent tab
-  // (the shell is not the agent). The Chat/Terminal pill is hidden in
-  // this state too (ConnectionIndicator gates on the context's
-  // `isShellView`), so the X is the way back to chat.
+  // A center-hosted user shell takes over the pane chrome-free: a single
+  // header row naming the shell plus a close X — no agent tab (the shell is
+  // not the agent). The Chat/Terminal pill is hidden in this state too
+  // (ConnectionIndicator gates on the context's `isShellView`), so the X is
+  // the way back to chat. This is the NATIVE-WRAPPER UX only — chat-first,
+  // non-wrapper sessions host user shells inline in the rail, never the
+  // center, so gate on `isNativeWrapper` (not `isTerminalFirst`) to keep a
+  // stray user-shell key from rendering chrome-free here for them.
   const isShellView =
-    (terminalFirstCtx?.isTerminalFirst ?? false) &&
+    (terminalFirstCtx?.isNativeWrapper ?? false) &&
     activeTerminal !== null &&
     !AGENT_TERMINAL_IDS.has(activeTerminal.id);
   const setSurfaceElement = useCallback(

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -13,12 +13,12 @@
 // single header row (identity + close X). There is no tab strip —
 // shells are enumerated and created in the rail's Shells tab.
 
-import { TerminalIcon, XIcon } from "lucide-react";
+import { XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TerminalView } from "@/components/blocks/TerminalView";
 import { AGENT_TERMINAL_IDS, terminalTabKey, useTerminals } from "@/hooks/useTerminals";
 import { useTerminalFirst } from "./TerminalFirstContext";
-import { TerminalStatusBadge } from "./terminalStatus";
+import { TerminalIdentityChip } from "./terminalStatus";
 import { useTerminalStatuses } from "./useTerminalStatuses";
 
 interface MainTerminalViewProps {
@@ -139,14 +139,7 @@ export function MainTerminalView({
             {isShellView && activeTerminal && (
               // Shell header — identity + close, nothing else.
               <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-2 pt-1 pb-2">
-                <span className="flex items-center gap-1.5 rounded-sm bg-muted px-2 py-1 text-foreground text-xs">
-                  <TerminalIcon className="size-3 shrink-0" />
-                  <span className="max-w-[8rem] truncate">{activeTerminal.name}</span>
-                  <span className="shrink-0 text-muted-foreground/60">
-                    · {activeTerminal.session}
-                  </span>
-                  <TerminalStatusBadge status={getStatus(activeTerminal)} />
-                </span>
+                <TerminalIdentityChip terminal={activeTerminal} status={getStatus(activeTerminal)} />
                 <span className="flex-1" />
                 <button
                   type="button"

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2669,13 +2669,18 @@ describe("NewChatLandingScreen custom-agent sandbox gating", () => {
 // needs-setup harnesses, "Custom agents") are unreachable there. Below the
 // `md` breakpoint the picker swaps its contents in place: tapping the row
 // drills into that group's page with a Back row. jsdom's matchMedia mock
-// reports non-mobile, so these tests force the `max-width` query to match.
+// reports non-mobile, so these tests force the mobile query to match. The
+// mobile query is the logical complement of the `md` boundary
+// (`not all and (min-width: 768px)`); a plain `(min-width: 768px)` desktop
+// check stays false, so desktop consumers keep reading not-mobile.
 // ---------------------------------------------------------------------------
 
 function forceMobileViewport(): () => void {
   const real = window.matchMedia;
   window.matchMedia = ((query: string) => ({
-    matches: /max-width/.test(query),
+    // Mobile branch: the negated min-width query matches; the bare min-width
+    // desktop query does not.
+    matches: /max-width/.test(query) || /^\s*not all and/.test(query),
     media: query,
     onchange: null,
     addListener: () => {},

--- a/web/src/shell/NewTerminalButton.tsx
+++ b/web/src/shell/NewTerminalButton.tsx
@@ -49,15 +49,26 @@ interface NewTerminalButtonProps {
    * entry rather than floating in empty space.
    */
   variant?: "icon" | "row";
+  /**
+   * Park the affordance while the caller's routing verdict isn't yet
+   * authoritative — the inline rail sets this until the session labels
+   * settle so a shell can't be created against a mislabeled shape. Merged
+   * with the in-flight ``create.isPending`` gate.
+   */
+  disabled?: boolean;
 }
 
 export function NewTerminalButton({
   conversationId,
   onCreated,
   variant = "icon",
+  disabled = false,
 }: NewTerminalButtonProps) {
   const { data: agent } = useSessionAgent(conversationId);
   const create = useCreateTerminal(conversationId);
+  // Disabled while a create is in flight OR the caller hasn't cleared its
+  // routing gate (labels still pending on the inline rail).
+  const isDisabled = create.isPending || disabled;
   // Native-wrapper sessions declare the host's installed shells as their
   // terminals (default `$SHELL` first); SDK agents declare distinct-purpose
   // terminals with no default. Only the native case gets the split-button
@@ -90,7 +101,7 @@ export function NewTerminalButton({
       <button
         type="button"
         aria-label="New shell"
-        disabled={create.isPending}
+        disabled={isDisabled}
         className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-muted-foreground hover:bg-accent/60 hover:text-foreground disabled:cursor-default disabled:opacity-50"
         onClick={onTriggerClick}
       >
@@ -103,7 +114,7 @@ export function NewTerminalButton({
       <button
         type="button"
         aria-label="New shell"
-        disabled={create.isPending}
+        disabled={isDisabled}
         className="cursor-pointer rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-default disabled:opacity-50"
         onClick={onTriggerClick}
       >
@@ -159,7 +170,7 @@ export function NewTerminalButton({
       <button
         type="button"
         aria-label="Choose shell"
-        disabled={create.isPending}
+        disabled={isDisabled}
         className={
           variant === "row"
             ? "flex shrink-0 items-center px-2 py-1.5 text-muted-foreground hover:bg-accent/60 hover:text-foreground disabled:cursor-default disabled:opacity-50"

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TerminalInfo } from "@/hooks/useTerminals";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { ChangedSort } from "./FlatFileList";
 import type { RightRailTab } from "./railTabs";
@@ -49,6 +50,10 @@ afterEach(() => {
  * the spied callbacks the tests assert against (openFileViewer / onCloseFile /
  * onRightRailTabChange) alongside the render result.
  */
+function makeTerminal(id: string, name: string, session: string): TerminalInfo {
+  return { id, name, session, running: true };
+}
+
 function renderWorkspace(
   overrides: {
     rightRailTab?: RightRailTab;
@@ -57,11 +62,16 @@ function renderWorkspace(
     showBrowserTab?: boolean;
     showShellsTab?: boolean;
     permissionLevel?: number | null;
+    openShells?: TerminalInfo[];
+    activeShellKey?: string | null;
   } = {},
 ) {
   const openFileViewer = vi.fn();
   const onCloseFile = vi.fn();
   const onRightRailTabChange = vi.fn();
+  const onOpenShell = vi.fn();
+  const onCloseShell = vi.fn();
+  const onReturnToShellList = vi.fn();
   render(
     <TooltipProvider delayDuration={0}>
       <WorkspacePanel
@@ -88,6 +98,11 @@ function renderWorkspace(
         onShowScopeView={vi.fn()}
         onCommentsOpenChange={vi.fn()}
         openTerminalsPanel={vi.fn()}
+        openShells={overrides.openShells ?? []}
+        activeShellKey={overrides.activeShellKey ?? null}
+        onOpenShell={onOpenShell}
+        onCloseShell={onCloseShell}
+        onReturnToShellList={onReturnToShellList}
         permissionLevel={overrides.permissionLevel ?? null}
         filesPanelSort={"recent" as ChangedSort}
         onSortChange={vi.fn()}
@@ -98,7 +113,7 @@ function renderWorkspace(
       />
     </TooltipProvider>,
   );
-  return { openFileViewer, onCloseFile, onRightRailTabChange };
+  return { openFileViewer, onCloseFile, onRightRailTabChange, onOpenShell, onCloseShell };
 }
 
 describe("WorkspacePanel surface presentation", () => {
@@ -257,6 +272,51 @@ describe("WorkspacePanel shells tab", () => {
   it("hides the Shells tab when showShellsTab is false", () => {
     renderWorkspace({ showShellsTab: false });
     expect(screen.queryByRole("tab", { name: /shells/i })).toBeNull();
+  });
+});
+
+describe("WorkspacePanel shell identity tabs (header parity with Files)", () => {
+  it("renders a top-strip tab per open shell showing its name · session identity", () => {
+    renderWorkspace({
+      rightRailTab: "terminals",
+      showShellsTab: true,
+      openShells: [makeTerminal("terminal_bash_s1", "bash", "s1")],
+      activeShellKey: "terminal:terminal_bash_s1",
+    });
+
+    // The shell surfaces as a tab in the shared top strip (mirroring file
+    // tabs) with its identity — name and session — not just the rail content.
+    expect(screen.getByText("bash · s1")).toBeInTheDocument();
+    // And it's the active tab; the fixed Shells trigger reads inactive so both
+    // aren't highlighted at once (the sentinel that prevents that).
+    const tab = screen.getByRole("button", { name: /close bash · s1/i }).closest("[role='button']");
+    expect(tab).toHaveAttribute("aria-current", "true");
+    expect(screen.getByRole("tab", { name: /shells/i })).toHaveAttribute("data-state", "inactive");
+  });
+
+  it("selects a shell tab via onOpenShell and closes it via onCloseShell", () => {
+    const { onOpenShell, onCloseShell } = renderWorkspace({
+      rightRailTab: "terminals",
+      showShellsTab: true,
+      openShells: [
+        makeTerminal("terminal_bash_s1", "bash", "s1"),
+        makeTerminal("terminal_worker_s2", "worker", "s2"),
+      ],
+      activeShellKey: "terminal:terminal_bash_s1",
+    });
+
+    fireEvent.click(screen.getByText("worker · s2"));
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_worker_s2", false);
+
+    fireEvent.click(screen.getByRole("button", { name: /close worker · s2/i }));
+    expect(onCloseShell).toHaveBeenCalledWith("terminal:terminal_worker_s2");
+    // The x must not also activate the tab (stopPropagation).
+    expect(onOpenShell).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows no shell tabs when none are open", () => {
+    renderWorkspace({ rightRailTab: "terminals", showShellsTab: true, openShells: [] });
+    expect(screen.queryByRole("button", { name: /^Close .* · / })).toBeNull();
   });
 });
 

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -335,6 +335,49 @@ describe("WorkspacePanel shell identity tabs (header parity with Files)", () => 
     expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1");
   });
 
+  it("does not highlight the shell tab when another rail tab is displayed (highlight-desync)", () => {
+    // Regression: ``activeShellKey`` stays set so returning to the Shells tab
+    // resumes the same shell, but the tab highlight must track the DISPLAYED
+    // surface. With the Files (Agents/etc.) tab selected, the shell tab must
+    // read inactive and the fixed Files trigger active — not a stale shell tab
+    // left aria-current while other content shows.
+    renderWorkspace({
+      rightRailTab: "files",
+      showShellsTab: true,
+      openShells: [makeTerminal("terminal_bash_s1", "bash", "s1")],
+      activeShellKey: "terminal:terminal_bash_s1",
+    });
+
+    const shellTab = screen
+      .getByRole("button", { name: /close bash · s1/i })
+      .closest("[role='button']");
+    expect(shellTab).toHaveAttribute("aria-current", "false");
+    expect(screen.getByRole("tab", { name: /files/i })).toHaveAttribute("data-state", "active");
+  });
+
+  it("does not highlight the shell tab when a file is open (highlight-desync)", () => {
+    // Even on the Shells rail tab, an open file wins the content slot (FileViewer
+    // renders), so the file tab is current and the shell tab must not be.
+    renderWorkspace({
+      rightRailTab: "terminals",
+      showShellsTab: true,
+      selectedFilePath: "README.md",
+      openFiles: ["README.md"],
+      openShells: [makeTerminal("terminal_bash_s1", "bash", "s1")],
+      activeShellKey: "terminal:terminal_bash_s1",
+    });
+
+    const shellTab = screen
+      .getByRole("button", { name: /close bash · s1/i })
+      .closest("[role='button']");
+    expect(shellTab).toHaveAttribute("aria-current", "false");
+    // The open file's tab carries the highlight instead.
+    const fileTab = screen
+      .getByRole("button", { name: /close readme\.md/i })
+      .closest("[role='button']");
+    expect(fileTab).toHaveAttribute("aria-current", "true");
+  });
+
   it("renders the in-tab status as a DOT ONLY, without the status word (A2)", () => {
     renderWorkspace({
       rightRailTab: "terminals",

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -4,6 +4,7 @@ import type { TerminalInfo } from "@/hooks/useTerminals";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { ChangedSort } from "./FlatFileList";
 import type { RightRailTab } from "./railTabs";
+import { makeTerminal } from "./testTerminals";
 import { WorkspacePanel } from "./WorkspacePanel";
 
 // The rail's content children are exercised by their own suites; stub them so
@@ -50,10 +51,6 @@ afterEach(() => {
  * the spied callbacks the tests assert against (openFileViewer / onCloseFile /
  * onRightRailTabChange) alongside the render result.
  */
-function makeTerminal(id: string, name: string, session: string): TerminalInfo {
-  return { id, name, session, running: true };
-}
-
 function renderWorkspace(
   overrides: {
     rightRailTab?: RightRailTab;
@@ -306,7 +303,7 @@ describe("WorkspacePanel shell identity tabs (header parity with Files)", () => 
     });
 
     fireEvent.click(screen.getByText("worker · s2"));
-    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_worker_s2", false);
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_worker_s2");
 
     fireEvent.click(screen.getByRole("button", { name: /close worker · s2/i }));
     expect(onCloseShell).toHaveBeenCalledWith("terminal:terminal_worker_s2");
@@ -317,6 +314,39 @@ describe("WorkspacePanel shell identity tabs (header parity with Files)", () => 
   it("shows no shell tabs when none are open", () => {
     renderWorkspace({ rightRailTab: "terminals", showShellsTab: true, openShells: [] });
     expect(screen.queryByRole("button", { name: /^Close .* · / })).toBeNull();
+  });
+
+  it("shows open shell tabs even while a NON-shell rail tab is active (symmetric with files)", () => {
+    // D2: shell tabs are peers of file tabs in the shared strip — visible and
+    // switchable regardless of the selected rail tab, so one click reaches any
+    // open surface. Here the Files tab is active but the shell tab still shows.
+    const { onOpenShell } = renderWorkspace({
+      rightRailTab: "files",
+      showShellsTab: true,
+      openShells: [makeTerminal("terminal_bash_s1", "bash", "s1")],
+      activeShellKey: null,
+    });
+
+    const shellTab = screen.getByText("bash · s1");
+    expect(shellTab).toBeInTheDocument();
+    // Clicking it activates the shell inline (AppShell pulls the rail to
+    // Shells) — the same one-click switch a file tab gives.
+    fireEvent.click(shellTab);
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1");
+  });
+
+  it("renders the in-tab status as a DOT ONLY, without the status word (A2)", () => {
+    renderWorkspace({
+      rightRailTab: "terminals",
+      showShellsTab: true,
+      openShells: [makeTerminal("terminal_bash_s1", "bash", "s1")],
+      activeShellKey: "terminal:terminal_bash_s1",
+    });
+
+    // The status dot carries its label for a11y/tooltip, but the word must not
+    // render as visible text in the tab (keeps shell tabs as light as file tabs).
+    expect(screen.getByLabelText("Idle")).toBeInTheDocument();
+    expect(screen.queryByText("Idle")).toBeNull();
   });
 });
 

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -17,7 +17,15 @@ vi.mock("./FilesPanel", () => ({
   FilesPanel: () => <div data-testid="files-panel-stub" />,
 }));
 vi.mock("./InlineTerminalsSection", () => ({
-  InlineTerminalsSection: () => <div data-testid="terminals-stub" />,
+  // Echo the desktop props (inline + readOnly) so the rail's Shells tab
+  // can be proven to host the terminal inline, not route to the overlay.
+  InlineTerminalsSection: ({ inline, readOnly }: { inline?: boolean; readOnly?: boolean }) => (
+    <div
+      data-testid="terminals-stub"
+      data-inline={String(inline ?? false)}
+      data-read-only={String(readOnly ?? false)}
+    />
+  ),
 }));
 vi.mock("./SubagentsPanel", () => ({
   SubagentsPanel: () => <div data-testid="subagents-stub" />,
@@ -47,6 +55,8 @@ function renderWorkspace(
     selectedFilePath?: string | null;
     openFiles?: string[];
     showBrowserTab?: boolean;
+    showShellsTab?: boolean;
+    permissionLevel?: number | null;
   } = {},
 ) {
   const openFileViewer = vi.fn();
@@ -63,7 +73,7 @@ function renderWorkspace(
         showFilesPanel
         showBrowserTab={overrides.showBrowserTab ?? false}
         changedCount={0}
-        showShellsTab={false}
+        showShellsTab={overrides.showShellsTab ?? false}
         terminalsLength={0}
         subagentsWorking={0}
         agentCount={1}
@@ -78,7 +88,7 @@ function renderWorkspace(
         onShowScopeView={vi.fn()}
         onCommentsOpenChange={vi.fn()}
         openTerminalsPanel={vi.fn()}
-        permissionLevel={null}
+        permissionLevel={overrides.permissionLevel ?? null}
         filesPanelSort={"recent" as ChangedSort}
         onSortChange={vi.fn()}
         filesPanelFlatView={false}
@@ -219,6 +229,34 @@ describe("WorkspacePanel content area", () => {
     // slot and the viewer is unmounted.
     expect(screen.getByTestId("files-panel-stub")).toBeInTheDocument();
     expect(screen.queryByTestId("file-viewer-stub")).toBeNull();
+  });
+});
+
+describe("WorkspacePanel shells tab", () => {
+  it("hosts the shells section inline (desktop) when the Shells tab is active", () => {
+    renderWorkspace({ rightRailTab: "terminals", showShellsTab: true });
+
+    // The rail hosts the terminal inline (mirroring the Files tab's
+    // FileViewer), not via the full-screen overlay. `inline` proves the
+    // desktop path; a false value would regress to the overlay.
+    const stub = screen.getByTestId("terminals-stub");
+    expect(stub).toBeInTheDocument();
+    expect(stub).toHaveAttribute("data-inline", "true");
+    // Owner (null level) attaches read-write.
+    expect(stub).toHaveAttribute("data-read-only", "false");
+  });
+
+  it("attaches the inline shell read-only for non-owners", () => {
+    renderWorkspace({ rightRailTab: "terminals", showShellsTab: true, permissionLevel: 2 });
+
+    // A non-owner (EDIT level) watches but can't type — a shared PTY
+    // can't attribute keystrokes per-user.
+    expect(screen.getByTestId("terminals-stub")).toHaveAttribute("data-read-only", "true");
+  });
+
+  it("hides the Shells tab when showShellsTab is false", () => {
+    renderWorkspace({ showShellsTab: false });
+    expect(screen.queryByRole("tab", { name: /shells/i })).toBeNull();
   });
 });
 

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -61,6 +61,8 @@ function renderWorkspace(
     permissionLevel?: number | null;
     openShells?: TerminalInfo[];
     activeShellKey?: string | null;
+    hostsShellsInline?: boolean;
+    sessionLabelsReady?: boolean;
   } = {},
 ) {
   const openFileViewer = vi.fn();
@@ -100,6 +102,8 @@ function renderWorkspace(
         onOpenShell={onOpenShell}
         onCloseShell={onCloseShell}
         onReturnToShellList={onReturnToShellList}
+        hostsShellsInline={overrides.hostsShellsInline ?? true}
+        sessionLabelsReady={overrides.sessionLabelsReady ?? true}
         permissionLevel={overrides.permissionLevel ?? null}
         filesPanelSort={"recent" as ChangedSort}
         onSortChange={vi.fn()}
@@ -303,7 +307,8 @@ describe("WorkspacePanel shell identity tabs (header parity with Files)", () => 
     });
 
     fireEvent.click(screen.getByText("worker · s2"));
-    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_worker_s2");
+    // Strip-tab clicks carry the current conversation as the mutation source.
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_worker_s2", "conv_ws");
 
     fireEvent.click(screen.getByRole("button", { name: /close worker · s2/i }));
     expect(onCloseShell).toHaveBeenCalledWith("terminal:terminal_worker_s2");
@@ -332,7 +337,7 @@ describe("WorkspacePanel shell identity tabs (header parity with Files)", () => 
     // Clicking it activates the shell inline (AppShell pulls the rail to
     // Shells) — the same one-click switch a file tab gives.
     fireEvent.click(shellTab);
-    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1");
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1", "conv_ws");
   });
 
   it("does not highlight the shell tab when another rail tab is displayed (highlight-desync)", () => {

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -307,8 +307,9 @@ describe("WorkspacePanel shell identity tabs (header parity with Files)", () => 
     });
 
     fireEvent.click(screen.getByText("worker · s2"));
-    // Strip-tab clicks carry the current conversation as the mutation source.
-    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_worker_s2", "conv_ws");
+    // Strip-tab clicks carry the current conversation as the mutation source
+    // and pendingInventory=false (the shell is already open, not a create).
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_worker_s2", "conv_ws", false);
 
     fireEvent.click(screen.getByRole("button", { name: /close worker · s2/i }));
     expect(onCloseShell).toHaveBeenCalledWith("terminal:terminal_worker_s2");
@@ -337,7 +338,7 @@ describe("WorkspacePanel shell identity tabs (header parity with Files)", () => 
     // Clicking it activates the shell inline (AppShell pulls the rail to
     // Shells) — the same one-click switch a file tab gives.
     fireEvent.click(shellTab);
-    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1", "conv_ws");
+    expect(onOpenShell).toHaveBeenCalledWith("terminal:terminal_bash_s1", "conv_ws", false);
   });
 
   it("does not highlight the shell tab when another rail tab is displayed (highlight-desync)", () => {

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -5,9 +5,11 @@ import {
   GlobeIcon,
   ListTodoIcon,
   SquareTerminalIcon,
+  TerminalIcon,
   XIcon,
 } from "lucide-react";
 import { type ReactElement, useCallback, useEffect, useRef } from "react";
+import { type TerminalInfo, terminalTabKey } from "@/hooks/useTerminals";
 import { cn } from "@/lib/utils";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -18,6 +20,7 @@ import { FileViewer } from "./FileViewer";
 import type { ChangedSort } from "./FlatFileList";
 import { InlineTerminalsSection } from "./InlineTerminalsSection";
 import { SubagentsPanel } from "./SubagentsPanel";
+import { deriveTerminalStatus, TerminalStatusBadge } from "./terminalStatus";
 import { TodoPanel } from "./TodoPanel";
 import { type RightRailTab, TAB_BADGE_BASE } from "./railTabs";
 
@@ -138,6 +141,101 @@ function FileTabsStrip({
   );
 }
 
+// ---------------------------------------------------------------------------
+// ShellTabsStrip — open shell tabs in the top rail strip, the Shells-tab peer
+// of FileTabsStrip. Each tab shows the shell's identity (icon, name · session,
+// status dot) and an "x" close button; clicking the cell activates the shell
+// (hosting its terminal inline below), clicking the x closes it. Same box
+// metrics and hover-close treatment as FileTabsStrip so files and shells line
+// up in one strip.
+// ---------------------------------------------------------------------------
+
+function ShellTabsStrip({
+  shells,
+  activeShellKey,
+  onShellSelect,
+  onCloseShell,
+}: {
+  /** Open shells, in tab order. */
+  shells: TerminalInfo[];
+  /** Currently active shell tab key, or null when another tab is active. */
+  activeShellKey: string | null;
+  /** Activate a shell tab by key. */
+  onShellSelect: (key: string) => void;
+  /** Close a shell tab by key. */
+  onCloseShell: (key: string) => void;
+}) {
+  const activeTabRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    activeTabRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activeShellKey]);
+  return (
+    <div className="flex items-center gap-0.5">
+      {shells.map((t) => {
+        const key = terminalTabKey(t);
+        const active = key === activeShellKey;
+        // Tabs are lightweight index entries — no live bridge state here, so
+        // status is running/closed off the resource flag alone.
+        const status = deriveTerminalStatus(t, null);
+        const label = t.session ? `${t.name} · ${t.session}` : t.name;
+        return (
+          <div
+            key={key}
+            ref={active ? activeTabRef : undefined}
+            role="button"
+            tabIndex={0}
+            aria-current={active}
+            title={label}
+            onClick={() => onShellSelect(key)}
+            onAuxClick={(e) => {
+              if (e.button === 1) {
+                e.preventDefault();
+                onCloseShell(key);
+              }
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onShellSelect(key);
+              }
+            }}
+            className={cn(
+              "group/tab relative flex h-[32px] min-w-0 max-w-[320px] shrink-0 cursor-pointer items-center justify-center gap-[6px] overflow-hidden rounded-[8px] px-[12px] text-[13px] font-medium leading-5 transition-colors",
+              active
+                ? "bg-[color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))] text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <TerminalIcon className="size-4 shrink-0" />
+            <span className="min-w-0 truncate">{label}</span>
+            <TerminalStatusBadge status={status} />
+            <span
+              className={cn(
+                "absolute inset-y-0 right-[2px] flex items-center pl-[12px] pr-[4px] opacity-0 transition-opacity group-hover/tab:opacity-100",
+                active
+                  ? "[background:linear-gradient(to_right,transparent,color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))_40%)]"
+                  : "[background:linear-gradient(to_right,transparent,var(--card)_40%)]",
+              )}
+            >
+              <button
+                type="button"
+                aria-label={`Close ${label}`}
+                className="flex size-6 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCloseShell(key);
+                }}
+              >
+                <XIcon className="size-4" />
+              </button>
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 /**
  * Props for {@link WorkspacePanel}. All state lives in AppShell; this
  * component is a pure view. Handlers wrap the AppShell setters so the
@@ -216,6 +314,21 @@ interface WorkspacePanelProps {
    * (see the ``inline`` prop passed below), so this stays unused there.
    */
   openTerminalsPanel: (key: string) => void;
+  /**
+   * Open shells shown as tabs in the top strip, resolved to their terminal
+   * info — the Shells-tab peer of ``openFiles``. Mirrors how AppShell lifts
+   * the open-file set so the shell identity surfaces in the shared header.
+   */
+  openShells: TerminalInfo[];
+  /** Active shell tab key, or null when the Shells tab shows the list. */
+  activeShellKey: string | null;
+  /** Select a shell (adds/activates its tab). ``pendingInventory`` is true
+   *  for a freshly-created shell not yet in the terminal inventory. */
+  onOpenShell: (key: string, pendingInventory: boolean) => void;
+  /** Close a single open shell tab by key. */
+  onCloseShell: (key: string) => void;
+  /** Deselect the active shell tab, revealing the shell list. */
+  onReturnToShellList: (unexpected: boolean) => void;
   /** Viewer's permission level (gates edit affordances). */
   permissionLevel: number | null;
   /** Changed-files sort order, shared with the viewer's prev/next order. */
@@ -272,6 +385,11 @@ export function WorkspacePanel({
   onShowScopeView,
   onCommentsOpenChange,
   openTerminalsPanel,
+  openShells,
+  activeShellKey,
+  onOpenShell,
+  onCloseShell,
+  onReturnToShellList,
   permissionLevel,
   filesPanelSort,
   onSortChange,
@@ -327,10 +445,17 @@ export function WorkspacePanel({
           // the left in the ≥500px case and contributes its full width to the
           // outer scroller in the <500px case.
           className="shrink-0"
-          // When a file tab is active no fixed trigger should highlight, so feed
-          // the radix group a sentinel that matches none of them. The active
-          // file tab carries its own highlight (see FileTabsStrip).
-          value={selectedFilePath !== null ? "__file__" : rightRailTab}
+          // When a file OR shell tab is active no fixed trigger should
+          // highlight, so feed the radix group a sentinel that matches none of
+          // them. The active file/shell tab carries its own highlight (see
+          // FileTabsStrip / ShellTabsStrip).
+          value={
+            selectedFilePath !== null
+              ? "__file__"
+              : rightRailTab === "terminals" && activeShellKey !== null
+                ? "__shell__"
+                : rightRailTab
+          }
           onValueChange={(v) => onRightRailTabChange(v as RightRailTab)}
         >
           <TabsList variant="pill" className="gap-1">
@@ -442,6 +567,25 @@ export function WorkspacePanel({
             </div>
           </>
         )}
+        {/* Shell tabs — the Shells-tab peer of the file tabs, surfaced only
+            while the Shells tab is active (its content is the only slot that
+            hosts a shell inline). Same divider + scroll treatment as files. */}
+        {rightRailTab === "terminals" && openShells.length > 0 && (
+          <>
+            <div
+              aria-hidden
+              className="mx-[4px] hidden h-[14px] w-px shrink-0 self-center bg-border-strong @min-[500px]/rail:block"
+            />
+            <div className="flex shrink-0 items-center [scrollbar-width:thin] @min-[500px]/rail:min-w-0 @min-[500px]/rail:flex-1 @min-[500px]/rail:overflow-x-auto @min-[500px]/rail:overflow-y-hidden [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent">
+              <ShellTabsStrip
+                shells={openShells}
+                activeShellKey={activeShellKey}
+                onShellSelect={(key) => onOpenShell(key, false)}
+                onCloseShell={onCloseShell}
+              />
+            </div>
+          </>
+        )}
       </div>
       {/* Tab content — single slot. Files holds FileViewer when a
           file is open, FilesPanel otherwise; Shells hosts the active
@@ -481,6 +625,9 @@ export function WorkspacePanel({
             onExpand={openTerminalsPanel}
             inline
             readOnly={!isOwnerLevel(permissionLevel)}
+            activeKey={activeShellKey}
+            onOpenShell={onOpenShell}
+            onReturnToList={onReturnToShellList}
           />
         ) : (
           showFilesPanel && (

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -328,9 +328,11 @@ interface WorkspacePanelProps {
   /**
    * Select a shell (adds/activates its tab and hosts it inline). ``source``
    * is the conversation the selection originated in; AppShell drops the
-   * mutation if navigation has since moved on.
+   * mutation if navigation has since moved on. ``pendingInventory`` is true
+   * only on the create path (shell not yet in inventory) so AppShell can
+   * bridge the create→inventory gap for its off-surface cleanup.
    */
-  onOpenShell: (key: string, source: string) => void;
+  onOpenShell: (key: string, source: string, pendingInventory: boolean) => void;
   /**
    * AppShell's single "hosts shells inline, not center" verdict, forwarded
    * to the inline shell section so it never recomputes routing from a
@@ -616,8 +618,9 @@ export function WorkspacePanel({
                 shells={openShells}
                 activeShellKey={displayedShellKey}
                 // A strip-tab click is synchronous in the current
-                // conversation, so it is always its own source.
-                onShellSelect={(key) => onOpenShell(key, conversationId)}
+                // conversation, so it is always its own source. The shell is
+                // already open/in inventory, so it's never a pending create.
+                onShellSelect={(key) => onOpenShell(key, conversationId, false)}
                 onCloseShell={onCloseShell}
               />
             </div>

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -403,6 +403,15 @@ export function WorkspacePanel({
   const handleCloseTab = useCallback(() => {
     if (selectedFilePath !== null) onCloseFile(selectedFilePath);
   }, [onCloseFile, selectedFilePath]);
+  // Which surface is ACTUALLY on screen decides the tab highlight — not the raw
+  // ``activeShellKey``, which stays set (so returning to the Shells tab resumes
+  // the same shell) even while a file or another tab is shown. Content priority
+  // is: an open file wins, else the selected ``rightRailTab``. A shell is the
+  // displayed surface only when no file is open AND the Shells tab is selected;
+  // otherwise its tab must not read as current (the desync: a shell tab left
+  // ``aria-current`` while Files/Agents content shows).
+  const displayedShellKey =
+    selectedFilePath === null && rightRailTab === "terminals" ? activeShellKey : null;
   return (
     <aside
       aria-label="Workspace"
@@ -451,7 +460,7 @@ export function WorkspacePanel({
           value={
             selectedFilePath !== null
               ? "__file__"
-              : activeShellKey !== null
+              : displayedShellKey !== null
                 ? "__shell__"
                 : rightRailTab
           }
@@ -573,7 +582,7 @@ export function WorkspacePanel({
               />
               <ShellTabsStrip
                 shells={openShells}
-                activeShellKey={activeShellKey}
+                activeShellKey={displayedShellKey}
                 onShellSelect={onOpenShell}
                 onCloseShell={onCloseShell}
               />

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -9,6 +9,7 @@ import {
   XIcon,
 } from "lucide-react";
 import { type ReactElement, useCallback, useEffect, useRef } from "react";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { type TerminalInfo, terminalTabKey } from "@/hooks/useTerminals";
 import { cn } from "@/lib/utils";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -269,9 +270,11 @@ interface WorkspacePanelProps {
   changedCount: number;
   /**
    * Whether the Shells tab is available — AppShell's combined gate
-   * (not a native wrapper, AND either a shell exists or the agent's
-   * spec declares shell access, which makes the tab show by default
-   * with its "+ New shell" empty state).
+   * (not a claude-native sub-agent, AND either a shell exists or the
+   * agent's spec declares shell access, which makes the tab show by
+   * default with its "+ New shell" empty state). Native wrappers get the
+   * tab too; only claude-native sub-agents are excluded (parent owns the
+   * tmux pane).
    */
   showShellsTab: boolean;
   /** Number of open shells, shown as the Shells tab badge when > 0. */
@@ -322,8 +325,23 @@ interface WorkspacePanelProps {
   openShells: TerminalInfo[];
   /** Active shell tab key, or null when the Shells tab shows the list. */
   activeShellKey: string | null;
-  /** Select a shell (adds/activates its tab and hosts it inline). */
-  onOpenShell: (key: string) => void;
+  /**
+   * Select a shell (adds/activates its tab and hosts it inline). ``source``
+   * is the conversation the selection originated in; AppShell drops the
+   * mutation if navigation has since moved on.
+   */
+  onOpenShell: (key: string, source: string) => void;
+  /**
+   * AppShell's single "hosts shells inline, not center" verdict, forwarded
+   * to the inline shell section so it never recomputes routing from a
+   * possibly-stale label source.
+   */
+  hostsShellsInline: boolean;
+  /**
+   * Whether a successful label source has settled the session shape. Gates
+   * shell-create in the inline section until routing is authoritative.
+   */
+  sessionLabelsReady: boolean;
   /** Close a single open shell tab by key. */
   onCloseShell: (key: string) => void;
   /** Deselect the active shell tab, revealing the shell list. */
@@ -389,6 +407,8 @@ export function WorkspacePanel({
   onOpenShell,
   onCloseShell,
   onReturnToShellList,
+  hostsShellsInline,
+  sessionLabelsReady,
   permissionLevel,
   filesPanelSort,
   onSortChange,
@@ -403,6 +423,12 @@ export function WorkspacePanel({
   const handleCloseTab = useCallback(() => {
     if (selectedFilePath !== null) onCloseFile(selectedFilePath);
   }, [onCloseFile, selectedFilePath]);
+  // This rail is CSS-hidden below md (`hidden md:flex`) but stays MOUNTED, so
+  // its inline TerminalView + read-write PTY WebSocket would stay live under
+  // the mobile drawer/overlay path — two attachments to the same shell. Gate
+  // the inline shell host on the real breakpoint so only the visible surface
+  // holds a live PTY. Reactive: crossing the breakpoint unmounts/remounts it.
+  const isMobileViewport = useIsMobileViewport();
   // Which surface is ACTUALLY on screen decides the tab highlight — not the raw
   // ``activeShellKey``, which stays set (so returning to the Shells tab resumes
   // the same shell) even while a file or another tab is shown. Content priority
@@ -412,6 +438,18 @@ export function WorkspacePanel({
   // ``aria-current`` while Files/Agents content shows).
   const displayedShellKey =
     selectedFilePath === null && rightRailTab === "terminals" ? activeShellKey : null;
+  // The value fed to the static Tabs group. When a file OR shell tab is the
+  // displayed surface, feed a sentinel that matches no fixed trigger (the
+  // file/shell tab carries its own highlight in FileTabsStrip / ShellTabsStrip);
+  // otherwise the selected rail tab drives it. Priority: file > shell > rail.
+  let stripTabsValue: string;
+  if (selectedFilePath !== null) {
+    stripTabsValue = "__file__";
+  } else if (displayedShellKey !== null) {
+    stripTabsValue = "__shell__";
+  } else {
+    stripTabsValue = rightRailTab;
+  }
   return (
     <aside
       aria-label="Workspace"
@@ -453,17 +491,11 @@ export function WorkspacePanel({
           // the left in the ≥500px case and contributes its full width to the
           // outer scroller in the <500px case.
           className="shrink-0"
-          // When a file OR shell tab is active no fixed trigger should
-          // highlight, so feed the radix group a sentinel that matches none of
-          // them. The active file/shell tab carries its own highlight (see
-          // FileTabsStrip / ShellTabsStrip).
-          value={
-            selectedFilePath !== null
-              ? "__file__"
-              : displayedShellKey !== null
-                ? "__shell__"
-                : rightRailTab
-          }
+          // ``stripTabsValue`` (computed above) resolves file > shell > rail:
+          // a file/shell surface feeds a sentinel that matches no fixed
+          // trigger, so the active file/shell tab carries its own highlight
+          // (see FileTabsStrip / ShellTabsStrip).
+          value={stripTabsValue}
           onValueChange={(v) => onRightRailTabChange(v as RightRailTab)}
         >
           <TabsList variant="pill" className="gap-1">
@@ -583,7 +615,9 @@ export function WorkspacePanel({
               <ShellTabsStrip
                 shells={openShells}
                 activeShellKey={displayedShellKey}
-                onShellSelect={onOpenShell}
+                // A strip-tab click is synchronous in the current
+                // conversation, so it is always its own source.
+                onShellSelect={(key) => onOpenShell(key, conversationId)}
                 onCloseShell={onCloseShell}
               />
             </div>
@@ -594,9 +628,10 @@ export function WorkspacePanel({
           file is open, FilesPanel otherwise; Shells hosts the active
           shell's terminal inline (list ↔ terminal, mirroring the Files
           tab); Subagents lists the root's children + a "main" link back
-          to the parent. The Shells branch is unreachable when its tab
-          is hidden — native wrappers, claude-native sub-agents, or no
-          shell attached. */}
+          to the parent. The Shells branch is unreachable only when its
+          tab is hidden — a claude-native sub-agent, or an agent with no
+          shell and no declared shell access. (Native wrappers DO get the
+          tab; the section just routes their rows full-screen.) */}
       <div data-workspace-panel-content className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {selectedFilePath !== null ? (
           <FileViewer
@@ -623,11 +658,22 @@ export function WorkspacePanel({
           // Desktop rail: host the active shell inline, mirroring the
           // Files tab's inline FileViewer — chat stays visible. The
           // full-screen overlay path (`onExpand`) is the mobile fallback.
+          // ``inline`` drops to false while this (still-mounted but
+          // CSS-hidden) rail is below the md breakpoint, so its TerminalView
+          // and PTY WebSocket don't stay live under the mobile overlay path —
+          // only one surface holds a read-write attachment at a time.
           <InlineTerminalsSection
+            // Key by conversation so a client-side navigation unmounts this
+            // instance and cancels any per-mutation create callback bound to
+            // the previous session, rather than letting it fire against the
+            // new one.
+            key={conversationId}
             conversationId={conversationId}
             onExpand={openTerminalsPanel}
-            inline
+            inline={!isMobileViewport}
             readOnly={!isOwnerLevel(permissionLevel)}
+            hostsShellsInline={hostsShellsInline}
+            sessionLabelsReady={sessionLabelsReady}
             activeKey={activeShellKey}
             onOpenShell={onOpenShell}
             onReturnToList={onReturnToShellList}

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { BrowserPane } from "@/components/BrowserPane/BrowserPane";
+import { isOwnerLevel } from "@/lib/permissionsApi";
 import { FilesPanel } from "./FilesPanel";
 import { FileViewer } from "./FileViewer";
 import type { ChangedSort } from "./FlatFileList";
@@ -209,7 +210,11 @@ interface WorkspacePanelProps {
   /** Surface the file viewer's comments-open state up to AppShell (it
    *  widens the rail to fit the comments column). */
   onCommentsOpenChange: (open: boolean) => void;
-  /** Expand a terminal into the full-width terminals push panel. */
+  /**
+   * Expand a terminal into the full-width terminals push panel — the
+   * mobile fallback. On desktop the Shells tab hosts the terminal inline
+   * (see the ``inline`` prop passed below), so this stays unused there.
+   */
   openTerminalsPanel: (key: string) => void;
   /** Viewer's permission level (gates edit affordances). */
   permissionLevel: number | null;
@@ -439,13 +444,12 @@ export function WorkspacePanel({
         )}
       </div>
       {/* Tab content — single slot. Files holds FileViewer when a
-          file is open, FilesPanel otherwise; Shells holds the
-          list-only inline section (clicking a row opens the shell in
-          the main view — no in-rail xterm); Subagents lists the
-          root's children + a "main" link back to the parent.
-          The Shells branch is unreachable when its tab is hidden —
-          native wrappers, claude-native sub-agents, or no shell
-          attached. */}
+          file is open, FilesPanel otherwise; Shells hosts the active
+          shell's terminal inline (list ↔ terminal, mirroring the Files
+          tab); Subagents lists the root's children + a "main" link back
+          to the parent. The Shells branch is unreachable when its tab
+          is hidden — native wrappers, claude-native sub-agents, or no
+          shell attached. */}
       <div data-workspace-panel-content className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {selectedFilePath !== null ? (
           <FileViewer
@@ -469,7 +473,15 @@ export function WorkspacePanel({
         ) : rightRailTab === "todos" && todosSupported ? (
           <TodoPanel frameless />
         ) : rightRailTab === "terminals" && showShellsTab ? (
-          <InlineTerminalsSection conversationId={conversationId} onExpand={openTerminalsPanel} />
+          // Desktop rail: host the active shell inline, mirroring the
+          // Files tab's inline FileViewer — chat stays visible. The
+          // full-screen overlay path (`onExpand`) is the mobile fallback.
+          <InlineTerminalsSection
+            conversationId={conversationId}
+            onExpand={openTerminalsPanel}
+            inline
+            readOnly={!isOwnerLevel(permissionLevel)}
+          />
         ) : (
           showFilesPanel && (
             <FilesPanel

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -20,7 +20,7 @@ import { FileViewer } from "./FileViewer";
 import type { ChangedSort } from "./FlatFileList";
 import { InlineTerminalsSection } from "./InlineTerminalsSection";
 import { SubagentsPanel } from "./SubagentsPanel";
-import { deriveTerminalStatus, TerminalStatusBadge } from "./terminalStatus";
+import { deriveTerminalStatus, terminalLabel, TerminalStatusDot } from "./terminalStatus";
 import { TodoPanel } from "./TodoPanel";
 import { type RightRailTab, TAB_BADGE_BASE } from "./railTabs";
 
@@ -177,7 +177,7 @@ function ShellTabsStrip({
         // Tabs are lightweight index entries — no live bridge state here, so
         // status is running/closed off the resource flag alone.
         const status = deriveTerminalStatus(t, null);
-        const label = t.session ? `${t.name} · ${t.session}` : t.name;
+        const label = terminalLabel(t);
         return (
           <div
             key={key}
@@ -208,7 +208,7 @@ function ShellTabsStrip({
           >
             <TerminalIcon className="size-4 shrink-0" />
             <span className="min-w-0 truncate">{label}</span>
-            <TerminalStatusBadge status={status} />
+            <TerminalStatusDot status={status} />
             <span
               className={cn(
                 "absolute inset-y-0 right-[2px] flex items-center pl-[12px] pr-[4px] opacity-0 transition-opacity group-hover/tab:opacity-100",
@@ -322,9 +322,8 @@ interface WorkspacePanelProps {
   openShells: TerminalInfo[];
   /** Active shell tab key, or null when the Shells tab shows the list. */
   activeShellKey: string | null;
-  /** Select a shell (adds/activates its tab). ``pendingInventory`` is true
-   *  for a freshly-created shell not yet in the terminal inventory. */
-  onOpenShell: (key: string, pendingInventory: boolean) => void;
+  /** Select a shell (adds/activates its tab and hosts it inline). */
+  onOpenShell: (key: string) => void;
   /** Close a single open shell tab by key. */
   onCloseShell: (key: string) => void;
   /** Deselect the active shell tab, revealing the shell list. */
@@ -452,7 +451,7 @@ export function WorkspacePanel({
           value={
             selectedFilePath !== null
               ? "__file__"
-              : rightRailTab === "terminals" && activeShellKey !== null
+              : activeShellKey !== null
                 ? "__shell__"
                 : rightRailTab
           }
@@ -539,9 +538,16 @@ export function WorkspacePanel({
             )}
           </TabsList>
         </Tabs>
-        {openFiles.length > 0 && (
+        {/* Open file AND shell tabs share ONE horizontal scroll region (A1) so
+            they can't split the rail width 50/50 with competing scrollers. Both
+            are ALWAYS present (D2): open shell tabs are peers of open file tabs
+            in the shared strip, so one click switches to any open surface
+            regardless of the selected rail tab — clicking a shell tab activates
+            it inline (pulling the rail to Shells, via ``onOpenShell``), exactly
+            as a file tab pulls the rail to Files. */}
+        {(openFiles.length > 0 || openShells.length > 0) && (
           <>
-            {/* 1px divider separating the static tabs from the file tabs.
+            {/* 1px divider separating the static tabs from the open-surface tabs.
                 Only meaningful in the ≥500px case where the static tabs are
                 anchored; in the <500px whole-strip-scroll case there's no fixed
                 boundary, so hide it. */}
@@ -549,38 +555,26 @@ export function WorkspacePanel({
               aria-hidden
               className="mx-[4px] hidden h-[14px] w-px shrink-0 self-center bg-border-strong @min-[500px]/rail:block"
             />
-            {/* File-tabs region. ≥500px (rail container query): the ONLY
-                horizontal scroller (flex-1 + overflow-x-auto), so the static
-                tabs stay anchored. <500px: shrink-0 with NO overflow set — it
-                keeps its natural width and the whole row overflows into the
-                outer scroller, so the strip scrolls as one. (overflow-y-hidden
-                must stay scoped to the ≥500px case: setting it while overflow-x
-                is `visible` would force overflow-x to `auto`, turning this into
-                its own scroller and defeating the <500px whole-strip scroll.) */}
-            <div className="flex shrink-0 items-center [scrollbar-width:thin] @min-[500px]/rail:min-w-0 @min-[500px]/rail:flex-1 @min-[500px]/rail:overflow-x-auto @min-[500px]/rail:overflow-y-hidden [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent">
+            {/* Combined open-surface region — the single scroller. ≥500px (rail
+                container query): the ONLY horizontal scroller (flex-1 +
+                overflow-x-auto), so the static tabs stay anchored. <500px:
+                shrink-0 with NO overflow set — it keeps its natural width and
+                the whole row overflows into the outer scroller, so the strip
+                scrolls as one. (overflow-y-hidden must stay scoped to the ≥500px
+                case: setting it while overflow-x is `visible` would force
+                overflow-x to `auto`, turning this into its own scroller and
+                defeating the <500px whole-strip scroll.) */}
+            <div className="flex shrink-0 items-center gap-0.5 [scrollbar-width:thin] @min-[500px]/rail:min-w-0 @min-[500px]/rail:flex-1 @min-[500px]/rail:overflow-x-auto @min-[500px]/rail:overflow-y-hidden [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent">
               <FileTabsStrip
                 openFiles={openFiles}
                 activeFilePath={selectedFilePath}
                 onFileSelect={openFileViewer}
                 onCloseFile={onCloseFile}
               />
-            </div>
-          </>
-        )}
-        {/* Shell tabs — the Shells-tab peer of the file tabs, surfaced only
-            while the Shells tab is active (its content is the only slot that
-            hosts a shell inline). Same divider + scroll treatment as files. */}
-        {rightRailTab === "terminals" && openShells.length > 0 && (
-          <>
-            <div
-              aria-hidden
-              className="mx-[4px] hidden h-[14px] w-px shrink-0 self-center bg-border-strong @min-[500px]/rail:block"
-            />
-            <div className="flex shrink-0 items-center [scrollbar-width:thin] @min-[500px]/rail:min-w-0 @min-[500px]/rail:flex-1 @min-[500px]/rail:overflow-x-auto @min-[500px]/rail:overflow-y-hidden [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent">
               <ShellTabsStrip
                 shells={openShells}
                 activeShellKey={activeShellKey}
-                onShellSelect={(key) => onOpenShell(key, false)}
+                onShellSelect={onOpenShell}
                 onCloseShell={onCloseShell}
               />
             </div>

--- a/web/src/shell/terminalStatus.test.tsx
+++ b/web/src/shell/terminalStatus.test.tsx
@@ -2,7 +2,12 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { type ConnectionState } from "@/components/blocks/TerminalSession";
 import { type TerminalInfo } from "@/hooks/useTerminals";
-import { deriveTerminalStatus, TerminalStatusBadge } from "./terminalStatus";
+import {
+  deriveTerminalStatus,
+  terminalLabel,
+  TerminalStatusBadge,
+  TerminalStatusDot,
+} from "./terminalStatus";
 
 afterEach(() => {
   cleanup();
@@ -71,6 +76,28 @@ describe("TerminalStatusBadge", () => {
 
     rerender(<TerminalStatusBadge status="closed" />);
     dot = screen.getByLabelText("Closed").querySelector("span");
-    expect(dot).toHaveClass("size-1.5", "bg-black", "dark:bg-white");
+    // Softened from bg-black/dark:bg-white to a muted tone (A2).
+    expect(dot).toHaveClass("size-1.5", "bg-muted-foreground/40");
+  });
+});
+
+describe("TerminalStatusDot", () => {
+  it("renders a dot with the accessible status label but NO text word", () => {
+    render(<TerminalStatusDot status="idle" />);
+
+    // The dot carries the label for assistive tech / tooltip...
+    const dot = screen.getByLabelText("Idle");
+    expect(dot).toHaveClass("size-1.5", "bg-muted-foreground/55");
+    // ...but the word must not render as visible text (keeps tab strip compact).
+    expect(screen.queryByText("Idle")).toBeNull();
+  });
+});
+
+describe("terminalLabel", () => {
+  it("joins name and session, omitting the session when absent", () => {
+    expect(terminalLabel({ id: "t", name: "bash", session: "s1", running: true })).toBe(
+      "bash · s1",
+    );
+    expect(terminalLabel({ id: "t", name: "bash", session: "", running: true })).toBe("bash");
   });
 });

--- a/web/src/shell/terminalStatus.tsx
+++ b/web/src/shell/terminalStatus.tsx
@@ -17,8 +17,34 @@ export const STATUS_CONFIG: Record<TerminalStatus, { label: string; className: s
   idle: { label: "Idle", className: "bg-muted-foreground/55" },
   connecting: { label: "Connecting", className: "bg-amber-500 animate-pulse" },
   error: { label: "Error", className: "bg-red-500" },
-  closed: { label: "Closed", className: "bg-black dark:bg-white" },
+  // Softened from a stark solid black/white blob to a muted foreground tone so
+  // a closed dot reads as "inactive", not an alarm — especially in the compact
+  // tab strip where it sits beside busier chrome.
+  closed: { label: "Closed", className: "bg-muted-foreground/40" },
 };
+
+/** ``name · session`` identity string for a terminal (session omitted if absent). */
+export function terminalLabel(t: TerminalInfo): string {
+  return t.session ? `${t.name} · ${t.session}` : t.name;
+}
+
+/**
+ * Status DOT only (no text word) — for compact contexts like the top tab
+ * strip where the full badge's label would make tabs busier than file tabs.
+ * The accessible name is preserved via ``aria-label``/``title`` on the dot.
+ *
+ * :param status: Terminal-local display status, e.g. ``"idle"``.
+ */
+export function TerminalStatusDot({ status }: { status: TerminalStatus }) {
+  const { label, className } = STATUS_CONFIG[status];
+  return (
+    <span
+      aria-label={label}
+      title={label}
+      className={cn("inline-block size-1.5 shrink-0 rounded-full", className)}
+    />
+  );
+}
 
 /**
  * Render a visible status dot and label for a terminal tab or selector row.

--- a/web/src/shell/terminalStatus.tsx
+++ b/web/src/shell/terminalStatus.tsx
@@ -1,3 +1,4 @@
+import { TerminalIcon } from "lucide-react";
 import { type ConnectionState } from "@/components/blocks/TerminalSession";
 import { type TerminalInfo } from "@/hooks/useTerminals";
 import { cn } from "@/lib/utils";
@@ -34,6 +35,41 @@ export function TerminalStatusBadge({ status }: { status: TerminalStatus }) {
     >
       <span className={cn("inline-block size-1.5 rounded-full", className)} />
       <span>{label}</span>
+    </span>
+  );
+}
+
+/**
+ * Identity chip for a terminal's inline header: icon, name, optional
+ * session key, and status dot. Shared by the rail's inline shell header
+ * and the main-column shell header so both stay pixel-identical.
+ *
+ * :param terminal: Terminal whose name/session drive the chip.
+ * :param status: Terminal-local display status for the trailing badge.
+ * :param className: Extra classes on the outer span (e.g. ``min-w-0``).
+ */
+export function TerminalIdentityChip({
+  terminal,
+  status,
+  className,
+}: {
+  terminal: TerminalInfo;
+  status: TerminalStatus;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-1.5 rounded-sm bg-muted px-2 py-1 text-foreground text-xs",
+        className,
+      )}
+    >
+      <TerminalIcon className="size-3 shrink-0" />
+      <span className="max-w-[8rem] truncate">{terminal.name}</span>
+      {terminal.session && (
+        <span className="shrink-0 text-muted-foreground/60">· {terminal.session}</span>
+      )}
+      <TerminalStatusBadge status={status} />
     </span>
   );
 }

--- a/web/src/shell/terminalStatus.tsx
+++ b/web/src/shell/terminalStatus.tsx
@@ -41,8 +41,7 @@ export function TerminalStatusBadge({ status }: { status: TerminalStatus }) {
 
 /**
  * Identity chip for a terminal's inline header: icon, name, optional
- * session key, and status dot. Shared by the rail's inline shell header
- * and the main-column shell header so both stay pixel-identical.
+ * session key, and status dot. Used by the rail's inline shell header.
  *
  * :param terminal: Terminal whose name/session drive the chip.
  * :param status: Terminal-local display status for the trailing badge.

--- a/web/src/shell/testTerminals.ts
+++ b/web/src/shell/testTerminals.ts
@@ -1,0 +1,13 @@
+// Shared test fixture: build a TerminalInfo with sensible defaults. Used by
+// the shell suites (AppShell / InlineTerminalsSection / WorkspacePanel) so the
+// same shape is constructed one way across tests.
+import type { TerminalInfo } from "@/hooks/useTerminals";
+
+export function makeTerminal(
+  id: string,
+  name: string,
+  session: string,
+  overrides: Partial<TerminalInfo> = {},
+): TerminalInfo {
+  return { id, name, session, running: true, ...overrides };
+}


### PR DESCRIPTION
## Related issue

N/A

## Summary

The file explorer opens files **inline** in the right-hand Workspace rail (alongside chat), but opening a **shell** took over the **entire** agent screen via the full-width `TerminalsPanel` / `MainTerminalView`, hiding the chat — an inconsistent, jarring experience. This PR makes shells behave like files: hosted inline in the rail, addressable from the shared top tab strip, with chat always visible.

**Inline rail hosting (per-session-shape gate).** On **desktop (md+)**, a user-created shell now renders **inline in the Workspace rail**, mirroring the FileViewer-in-rail pattern. `InlineTerminalsSection` gains an `inline` mode: clicking a shell row hosts its `TerminalView` in-rail; the shell list and "+ New Shell" stay reachable and multiple shells work; non-owners attach read-only. The correct gate is **per-session-shape, not per-session-terminal-first**: chat-first SDK sessions (polly/debby) are labeled `omnigent.ui=terminal` only because the runner hosts an embedded REPL — they are terminal-first but still have a chat surface. Gating on `isTerminalFirst` wrongly sent their user shells full-screen. The single derived gate is now `hostsShellsInline = !isNativeWrapper`; only native-CLI wrapper sessions (`omnigent.wrapper`; claude-native/codex-native) keep the full-screen takeover.

**Files-parity top-strip tabs (symmetric switching).** Open shells lift into `AppShell` (`openShellKeys` / `activeShellKey`, peers of `openFiles` / `selectedFilePath`) and render as tabs in the shared top strip alongside file tabs, so any open shell or file is switchable in one click. Shell tabs are session-transient (reset on conversation switch); file tabs remain persisted.

**Conversation-scoped ownership (correctness).** Lifted shell state and the center path's `panelInitialKey` are both tagged with the owning `conversationId` and treated as null when the owner != current conversation. This prevents a warm A->B navigation from resolving a stale same-terminal-id key and attaching a shell's read-write WebSocket to the wrong session. Cold-reload restore is label-aware — it never treats a still-loading/errored session snapshot as authoritative, so a polly reload always lands on chat, not a headerless center shell.

**Unchanged surfaces.** The main-column embedded REPL (`MainTerminalView`) is preserved exactly for native-CLI wrapper sessions. **Mobile (< md)** keeps the existing full-screen overlay fallback — small screens have no room for a side rail.

## Test Plan

- Web unit tests (Vitest, **Node 20**), affected + surrounding suites — `src/shell/`: **1522 passed** / 2 expected-fail / 1 skipped.
  - `web/src/shell/InlineTerminalsSection.test.tsx` — inline-mode: chat-first SDK session hosts its user shell inline (chat visible); native-wrapper still routes full-screen via `onExpand`; back-to-list; read-only for non-owners; fallback when the shell disappears.
  - `web/src/shell/WorkspacePanel.test.tsx` — Shells tab hosts inline; read-only propagation; symmetric shell/file top-strip tabs; active-tab highlight tracks the displayed surface (`displayedShellKey`).
  - `web/src/shell/AppShell.test.tsx` — desktop inline path never opens the overlay (chat not hidden); cold-reload label race (loading->error->success) lands on chat; warm A->B nav with identical terminal ids never exposes the prior session's key on any render pass (rail + center paths).
  - `web/src/hooks/useTerminals.test.ts` — embedded REPL / agent panes filtered out of the rail Shells inventory.
- `tsc -b` — clean. `oxlint` on changed files — clean. `prettier --check` — clean. `pre-commit run` — passes. No `package-lock` drift.
- **Live E2E verification** via the `e2e_ui` Playwright harness (real server + runner + bash PTY + xterm, mock LLM): drove a genuine chat-first session (`omnigent.ui=terminal`, no wrapper label), opened a shell and confirmed its xterm mounts inside the Workspace rail with chat still visible and `main-terminal-view` count == 0, typed a live command, opened a second shell to show the symmetric top-strip tab, and opened a file inline to show files/shells coexistence and one-click switching.

## Demo

**Shells behave like files** — on a chat-first SDK session (`omnigent.ui=terminal`, no wrapper label — the polly/debby shape), a shell opens **inline in the right rail with chat still visible**, appears as a **tab in the shared top strip** (symmetric with file tabs, switchable in one click), and coexists with an open file in the same rail:

![Inline shell side-panel — round 4 @ 8c2c3f2e](https://raw.githubusercontent.com/btli/omnigent/demo-shell-side-panel/head-8c2c3f2e/shell-side-panel-inline-rail.gif)

Captured live via the `e2e_ui` harness (real server + runner + PTY + xterm): + New shell -> inline in rail; live `echo`; second shell -> second top-strip tab; open file -> FileViewer in the same rail with file+shell tabs coexisting. `main-terminal-view` count stayed 0 throughout.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Extended the affected Vitest suites for the per-session-shape gate (chat-first SDK user shell -> inline; native-wrapper -> full-screen), the symmetric top-strip tabs, the active-tab highlight derivation, and the conversation-ownership guarantees (cold-reload label race and warm-nav same-terminal-id race, on both the rail and center paths). Because `AppShell.test.tsx` stubs `TerminalView` (it never mounts real `MainTerminalView` / xterm), the warm-nav tests assert the conversation-owner gate outcome — the stale key is never exposed on any render pass — rather than literal WebSocket non-attachment; that runtime behavior was exercised via the live `e2e_ui` harness. Manually verified end-to-end against a live server+runner with the Playwright `e2e_ui` harness driving a genuine chat-first session (no label manipulation).

E2E: updated three standing suites to assert inline rail hosting of shells for chat-first (`hostsShellsInline`) sessions — `tests/e2e_ui/shells/test_new_shell.py`, `tests/e2e_ui/sessions/test_terminal_theme.py`, and `tests/e2e_ui/files/test_right_panel.py` — including the Chat-pill inversion (chat stays visible under inline hosting instead of being replaced). These suites previously asserted center takeover, which this change intentionally replaces; all three plus `tests/e2e_ui/shells/test_terminal_session_links.py` pass locally (10 passed). Center-hosting for native-wrapper / terminal-first sessions remains covered by the native render-parity suite (`tests/e2e_ui/messages/test_native_*_render_parity.py`) and by the `MainTerminalView` / `AppShell` unit tests added here.

## Changelog

+ Shells now open inline in the desktop Workspace rail alongside chat (like files) for chat-first sessions, with symmetric top-strip tabs for one-click switching between open shells and files, instead of taking over the whole screen; the embedded REPL and native-CLI terminal sessions are unchanged

