### PR TITLE
fix(web): stop embed back-arrow double-prefixing the basename

### DIFF
--- a/web/src/lib/routing.test.tsx
+++ b/web/src/lib/routing.test.tsx
@@ -43,6 +43,17 @@ describe("basenamedRouting Link rebasing", () => {
     // Same invariant for the object form's pathname.
     expect(renderRebasedLink("/mount", { pathname: "/mount/c/abc" })).toBe("/mount/c/abc");
   });
+
+  it("does not double-prefix a based path that carries a query or hash", () => {
+    // The Settings "Back to Omnigent" link records its return target as
+    // `pathname + search` from an absolute `useLocation()`. On the home page
+    // that pathname IS the basename, so with a workspace `?o=` param it reads as
+    // `/mount?o=123` — which the guard must still recognize as already-based
+    // rather than double-prefix to `/mount/mount?o=123` (the broken back arrow).
+    expect(renderRebasedLink("/mount", "/mount?o=123")).toBe("/mount?o=123");
+    expect(renderRebasedLink("/mount", "/mount#section")).toBe("/mount#section");
+    expect(renderRebasedLink("/mount", "/mount/c/abc?o=123")).toBe("/mount/c/abc?o=123");
+  });
 });
 
 describe("rebasePath primitive", () => {
@@ -60,5 +71,15 @@ describe("rebasePath primitive", () => {
 
   it("does not double-prefix a path already under the basename", () => {
     expect(basenamedRouting("/mount").rebasePath("/mount/c/abc")).toBe("/mount/c/abc");
+  });
+
+  it("guards on the pathname alone, ignoring a trailing query or hash", () => {
+    // A based path whose pathname equals the basename plus a `?query`/`#hash`
+    // must pass through — the guard splits the query off first so it can't slip
+    // past `=== basename` and double-prefix.
+    expect(basenamedRouting("/mount").rebasePath("/mount?o=123")).toBe("/mount?o=123");
+    expect(basenamedRouting("/mount").rebasePath("/mount#top")).toBe("/mount#top");
+    // An un-based path still rebases and keeps its query intact.
+    expect(basenamedRouting("/mount").rebasePath("/c/abc?o=123")).toBe("/mount/c/abc?o=123");
   });
 });

--- a/web/src/lib/routing.tsx
+++ b/web/src/lib/routing.tsx
@@ -77,9 +77,16 @@ export const reactRouterRouting: RoutingApi = {
  */
 function rebasePath(path: string, basename: string): string {
   if (!path.startsWith("/")) return path;
+  // Guard on the pathname alone (split off any ?query / #hash): a home-page
+  // return target like `/omnigent?o=123` — pathname equals the basename plus a
+  // query — must NOT read as un-based and double-prefix to
+  // `/omnigent/omnigent?o=123`.
+  const sep = path.search(/[?#]/);
+  const pathname = sep === -1 ? path : path.slice(0, sep);
+  const rest = sep === -1 ? "" : path.slice(sep);
   // Avoid double-prefixing if already under the basename.
-  if (path === basename || path.startsWith(`${basename}/`)) return path;
-  return `${basename}${path}`;
+  if (pathname === basename || pathname.startsWith(`${basename}/`)) return path;
+  return `${basename}${pathname}${rest}`;
 }
 
 /**


### PR DESCRIPTION
## Related issue

N/A

## Summary

The Settings **"← Back to Omnigent"** link is broken in the embedded deploy: from the home page it navigates to `/omnigent/omnigent` instead of `/omnigent`.

- The link records its return target as `pathname + search` from an absolute `useLocation()`. In the embed (basename `/omnigent`, host router mounted at root) the home-page pathname **is** the basename, and the workspace URL carries `?o=<orgId>`, so it captures `"/omnigent?o=123"`.
- `rebasePath`'s "already under basename" guard tested the whole string, so `"/omnigent?o=123"` matched neither `=== "/omnigent"` (query attached) nor `startsWith("/omnigent/")` (a `?`, not a `/`) — and the basename got prepended a **second** time → `"/omnigent/omnigent?o=123"`.
- Fix: guard on the **pathname alone** — split off any `?query`/`#hash` before the check, reattach after. This repairs the back arrow and any other link that rebases a target derived from a live location; it's a no-op for the object-form `to` (whose pathname is already query-free).

Every other nav link is unaffected because they use hard-coded app-absolute targets (`/`, `/c/:id`, `/inbox`) that never equal the basename — the back arrow is the only link whose target comes from `useLocation()`, which is why it alone broke.

```
/omnigent?o=123      ->  /omnigent?o=123        (was /omnigent/omnigent?o=123)
/omnigent            ->  /omnigent
/omnigent/c/x?o=123  ->  /omnigent/c/x?o=123
/c/x?o=123           ->  /omnigent/c/x?o=123    (still rebases; query preserved)
```

## Test Plan

- Added regression tests to `web/src/lib/routing.test.tsx` (one per `describe` block) covering a based path that carries a `?query`/`#hash`. Confirmed they **fail** on the pre-fix code and **pass** with the fix.
- `web/src/lib/routing.test.tsx` + `web/src/shell/settingsNav.test.tsx`: 29/29 pass.
- `oxlint` clean on both changed files.

## Demo

N/A — the change is a URL-resolution fix (no visual change); behaviour is covered by the added unit tests. The user-visible effect is that the back arrow lands on `/omnigent` instead of `/omnigent/omnigent`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — the added unit tests exercise the fixed branch of `rebasePath` directly (verified failing pre-fix, passing post-fix).

## Changelog

Fixed the Settings "Back to Omnigent" link navigating to a doubled path (`/omnigent/omnigent`) in the embedded app

This pull request and its description were written by Isaac.
