### PR TITLE
fix(host): fail runner sessions orphaned across a host reconnect (#1857)

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2373,6 +2373,73 @@ def create_app(
             _session_status_cache[session_id] = "failed"
             _publish_status(session_id, "failed", error=detail)
 
+    async def _reconcile_host_runners(host_id: str, alive_runners: list[str]) -> None:
+        """Fail sessions orphaned while a host was disconnected.
+
+        The ``host.hello`` frame carries ``runners`` - the runner ids
+        alive on the host right now. A runner the DB still has bound to
+        this host but that is absent from that list died while the tunnel
+        was down, so its session(s) never got a ``host.runner_exited``
+        report (issue #1857) and the open view spins on "running"
+        forever. Fail those sessions through the same status path a
+        reported crash uses.
+
+        Only sessions actively depending on the runner right now are
+        touched (running / waiting / starting / ready) - the states that
+        genuinely cannot proceed once the runner is gone. A finished or
+        between-turns session rests at "idle" (there is no separate
+        "completed" cache status), so "idle" is left alone rather than
+        mislabeled failed; terminal ("failed") sessions and an unknown
+        status - an empty cache after a server restart - are skipped too.
+
+        :param host_id: The reconnecting host's id.
+        :param alive_runners: Runner ids the host reports as alive.
+        """
+        from omnigent.server.routes.sessions import (
+            _publish_status,
+            _session_status_cache,
+        )
+        from omnigent.server.schemas import ErrorDetail
+
+        bound = await asyncio.to_thread(conversation_store.list_runner_ids_for_host, host_id)
+        orphaned = bound - set(alive_runners)
+        if not orphaned:
+            return
+
+        # A finished or between-turns session rests at "idle" (there is no
+        # separate "completed" status), so failing "idle" would mislabel a
+        # done session; only fail the states that cannot proceed without
+        # the runner.
+        active_statuses = {"running", "waiting", "starting", "ready"}
+        detail = ErrorDetail(
+            code="runner_lost_while_host_offline",
+            message=(
+                "Host reconnected without this runner; the session was "
+                "lost while the host was disconnected."
+            ),
+        )
+        reconciled = 0
+        for runner_id in orphaned:
+            affected = [
+                c.id
+                for c in await asyncio.to_thread(
+                    conversation_store.list_conversations_by_runner_id, runner_id
+                )
+            ]
+            for session_id in affected:
+                if _session_status_cache.get(session_id) not in active_statuses:
+                    continue
+                _session_status_cache[session_id] = "failed"
+                _publish_status(session_id, "failed", error=detail)
+                reconciled += 1
+        _logger.warning(
+            "Host %s reconnected; failed %d session(s) across %d orphaned runner(s): %s",
+            host_id,
+            reconciled,
+            len(orphaned),
+            sorted(orphaned),
+        )
+
     async def _on_runner_connect(runner_id: str) -> None:
         """Re-assign sessions and restart SSE relays on reconnect.
 
@@ -2533,6 +2600,7 @@ def create_app(
                 auth_provider=auth_provider,
                 runner_exit_reports=runner_exit_reports,
                 on_runner_exited=_on_runner_exited,
+                on_host_reconcile=_reconcile_host_runners,
                 on_host_connect=_on_hosts_changed,
                 on_host_disconnect=_on_hosts_changed,
                 on_host_update=_on_hosts_changed,

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -73,6 +73,7 @@ def create_host_tunnel_router(
     on_host_disconnect: Callable[[str, str | None], Awaitable[None]] | None = None,
     on_host_update: Callable[[str, str | None], Awaitable[None]] | None = None,
     on_runner_exited: Callable[[str, str], Awaitable[None]] | None = None,
+    on_host_reconcile: Callable[[str, list[str]], Awaitable[None]] | None = None,
     local_single_user: bool | None = None,
     runner_exit_reports: RunnerExitReports | None = None,
 ) -> APIRouter:
@@ -102,6 +103,12 @@ def create_host_tunnel_router(
         and push the cause to the open view — the only failure signal
         for a runner that crashed before connecting its tunnel (so the
         runner-tunnel ``on_runner_disconnect`` path never fires).
+    :param on_host_reconcile: Optional async callback fired once on host
+        connect with ``(host_id, runners)`` taken from the ``host.hello``
+        frame. The server wires this to fail sessions whose runner the
+        reconnecting host no longer reports - runners that died while the
+        tunnel was down and so never sent ``host.runner_exited``
+        (issue #1857).
     :param on_host_disconnect: Optional async callback fired when
         a host's tunnel closes. Receives the ``host_id``.
     :param on_host_update: Optional async callback fired when a connected
@@ -283,6 +290,18 @@ def create_host_tunnel_router(
                 ),
                 name=f"host-receive:{host_id}",
             )
+
+            # Reconcile after the loops are running so a slow reconcile
+            # (one query per orphaned runner) never delays the first
+            # heartbeat. Mirrors the on_host_connect placement below.
+            if on_host_reconcile is not None:
+                try:
+                    await on_host_reconcile(host_id, list(frame.runners))
+                except Exception:
+                    _logger.exception(
+                        "on_host_reconcile callback failed for %s",
+                        host_id,
+                    )
 
             if on_host_connect is not None:
                 try:

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1201,6 +1201,25 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def list_runner_ids_for_host(self, host_id: str) -> set[str]:
+        """
+        Return the distinct non-null runner ids bound to conversations
+        on ``host_id`` in the current workspace.
+
+        Used by the host tunnel's connect reconciliation to find runners
+        the DB still has bound that a reconnecting host no longer reports
+        in its ``host.hello`` ``runners`` list (issue #1857). Must be
+        read-after-write consistent with ``set_runner_id`` /
+        ``set_host_id`` for the same reason
+        :meth:`list_conversations_by_runner_id` is.
+
+        :param host_id: Stable host identifier, e.g.
+            ``"host_a1b2c3d4..."``.
+        :returns: Set of runner ids currently bound to the host.
+        """
+        ...
+
+    @abstractmethod
     def set_host_id(
         self,
         conversation_id: str,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2863,6 +2863,36 @@ class SqlAlchemyConversationStore(ConversationStore):
             for r in ap_rows
         ]
 
+    def list_runner_ids_for_host(self, host_id: str) -> set[str]:
+        """
+        Return the distinct non-null runner ids bound to conversations
+        on ``host_id`` in the current workspace.
+
+        Used by the host tunnel's connect reconciliation to diff the
+        DB's view of which runners a host is running against the
+        authoritative ``runners`` list in that host's ``host.hello``
+        frame. A runner the DB still has bound but the reconnecting host
+        no longer reports died while the tunnel was down (issue #1857);
+        the caller fails its still-active session(s).
+
+        :param host_id: Stable host identifier, e.g.
+            ``"host_a1b2c3d4..."``.
+        :returns: Set of runner ids currently bound to the host.
+        """
+        with self._session() as session:
+            rows = (
+                session.execute(
+                    select(SqlConversationMetadata.runner_id).where(
+                        SqlConversationMetadata.workspace_id == current_workspace_id(),
+                        SqlConversationMetadata.host_id == host_id,
+                        SqlConversationMetadata.runner_id.is_not(None),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        return {r for r in rows if r is not None}
+
     def set_host_id(
         self,
         conversation_id: str,

--- a/tests/server/integration/test_host_tunnel_route.py
+++ b/tests/server/integration/test_host_tunnel_route.py
@@ -365,6 +365,44 @@ async def test_host_tunnel_refreshes_harness_readiness_without_reconnect(
     assert updates == [_HOST_ID]
 
 
+async def test_host_tunnel_invokes_on_host_reconcile_with_runners(
+    db_uri: str,
+) -> None:
+    """The tunnel forwards the hello frame's ``runners`` to on_host_reconcile.
+
+    This is the connect-time hook the server uses to fail sessions whose
+    runner a reconnecting host no longer reports - runners that died while
+    the tunnel was down (issue #1857). The tunnel must hand over the
+    authoritative live-runner list from the ``host.hello`` frame, not an
+    empty or stale one, or the reconciliation has nothing to diff against.
+    """
+    registry = HostRegistry()
+    store = HostStore(db_uri)
+    reconciled: list[tuple[str, list[str]]] = []
+
+    async def _on_host_reconcile(host_id: str, runners: list[str]) -> None:
+        reconciled.append((host_id, runners))
+
+    app = FastAPI()
+    app.include_router(
+        create_host_tunnel_router(
+            registry,
+            store,
+            on_host_reconcile=_on_host_reconcile,
+        ),
+        prefix="/v1",
+    )
+    comm = await _connect_route(app, _TUNNEL_PATH)
+    await _send_hello_and_wait(comm, registry, runners=["runner_x", "runner_y"])
+
+    async def _wait_reconciled() -> None:
+        while not reconciled:
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(_wait_reconciled(), timeout=1.0)
+    assert reconciled == [(_HOST_ID, ["runner_x", "runner_y"])]
+
+
 async def test_host_tunnel_sets_offline_on_disconnect(
     host_app: tuple[FastAPI, HostRegistry, HostStore],
 ) -> None:

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -2529,6 +2529,45 @@ def test_set_host_id(
     assert fetched.workspace == "/Users/corey/projects/myapp"
 
 
+def test_list_runner_ids_for_host(
+    conversation_store: SqlAlchemyConversationStore,
+    db_uri: str,
+) -> None:
+    """Return exactly the distinct non-null runner ids bound to a host.
+
+    The host tunnel's connect reconciliation diffs this against the
+    ``runners`` list in the reconnecting host's ``host.hello`` frame to
+    find runners that died while the tunnel was down (issue #1857).
+    Runners on other hosts, and host-bound conversations with no runner,
+    must not leak into the result, and a runner driving two sessions
+    collapses to one entry.
+    """
+    host = "292dfcdf8a31f1319b469f4fa179ac6b"
+    other_host = "4f64b6ee625f4e8259185c35c6e63f3d"
+    _register_host(db_uri, host)
+    _register_host(db_uri, other_host)
+
+    # Two sessions on the same runner, one on a second runner - same host.
+    a1 = conversation_store.create_conversation(runner_id="runner_a", workspace="/w")
+    conversation_store.set_host_id(a1.id, host)
+    a2 = conversation_store.create_conversation(runner_id="runner_a", workspace="/w")
+    conversation_store.set_host_id(a2.id, host)
+    b = conversation_store.create_conversation(runner_id="runner_b", workspace="/w")
+    conversation_store.set_host_id(b.id, host)
+
+    # Host-bound but no runner - must be ignored.
+    none_bound = conversation_store.create_conversation(workspace="/w")
+    conversation_store.set_host_id(none_bound.id, host)
+
+    # Runner on a different host - must not leak.
+    other = conversation_store.create_conversation(runner_id="runner_c", workspace="/w")
+    conversation_store.set_host_id(other.id, other_host)
+
+    assert conversation_store.list_runner_ids_for_host(host) == {"runner_a", "runner_b"}
+    assert conversation_store.list_runner_ids_for_host(other_host) == {"runner_c"}
+    assert conversation_store.list_runner_ids_for_host("f" * 32) == set()
+
+
 def test_set_host_id_missing_conversation_raises(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:


### PR DESCRIPTION
## Related issue

Part of #1857 (the host-reconnect facet). This PR intentionally does not use a
`Closes` keyword on #1857: that issue needs more than one fix, and the other
facets are already in flight - #2067 for the host showing offline after
reconnect, and #2031 for respawning a runner that drops while the host stays
online. See the Summary for how this composes with them.

## Summary

When a host's tunnel drops and reconnects, any runner that died while the host
was disconnected is gone, but the sessions bound to it stay `running` in the
open view indefinitely. The `host.hello` frame already carries the truth: the
runners actually alive on the host (`HostHelloFrame.runners`). Today that list
is only logged (`host_tunnel.py`, "Host ... connected ... runners=%s") and never
checked against the sessions the server still believes are running.

This reconciles on connect: diff the runners the DB has bound to the host
against the frame's `runners`, and fail the sessions of runners the host no
longer reports, reusing the existing runner-exit status path so the open view
surfaces the failure instead of spinning.

- `ConversationStore.list_runner_ids_for_host(host_id)`: new read returning the
  distinct non-null runner ids bound to a host, workspace-scoped exactly like
  `list_conversations_by_runner_id`.
- `on_host_reconcile`: a new optional tunnel callback (default `None`, so every
  existing caller stays a no-op), fired once on connect with
  `(host_id, frame.runners)` after the loops start so it never delays the first
  heartbeat.
- `_reconcile_host_runners` wires them together and only fails sessions actively
  depending on the runner right now (`running` / `waiting` / `starting` /
  `ready`). A finished or between-turns session rests at `idle` (there is no
  separate `completed` status), so `idle` is left alone rather than mislabeled
  failed; terminal (`failed`) sessions and an unknown status (an empty cache
  after a server restart) are skipped too.

#2828 refreshed harness readiness on reconnect without a full reconnect, but
that is harness state, not runner sessions, so this case was still open.

> Companion to #2031 and #2067, not a duplicate. #2031 (@apple-techie)
> auto-respawns a runner whose tunnel drops while the host stays online; #2067
> (@andrewreid) fixes a host wrongly showing offline after reconnect. This is
> the third trigger: the host tunnel itself went down and came back, and a
> runner did not survive the outage. The active-status guard skips anything
> #2031 already failed, so they compose. #2067 also edits `host_tunnel.py`, so
> if it lands first this rebases onto it.

## Test Plan

```
.venv/bin/python -m pytest tests/stores/test_conversation_store.py -q            # store query, green
.venv/bin/python -m pytest tests/server/integration/test_host_tunnel_route.py -q # tunnel wiring, green
```

- `test_list_runner_ids_for_host`: the query returns only the target host's
  non-null runners, collapses a runner that drives two sessions to one entry,
  and ignores other hosts and host-bound sessions with no runner.
- `test_host_tunnel_invokes_on_host_reconcile_with_runners`: the tunnel hands
  the hello frame's `runners` to the reconcile callback.

Note on cost: the query filters on `(workspace_id, host_id)`, which the current
`(workspace_id, runner_id)` index does not cover, so it scans the workspace's
metadata partition. It runs once per host connect (a cold path, not per
message), so this stays migration-free; an index is an easy follow-up if it
matters at scale.

## Demo

N/A, non-visual server change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The reconcile itself reuses the already-covered `_on_runner_exited` status path.
The two new seams get direct tests: the store query and the tunnel-to-callback
wiring.

## Changelog

A session no longer stays stuck on "running" after its host reconnects without the runner that was driving it.
