### PR TITLE
perf(db): make the conversation_items position index plain (drop UNIQUE)

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -902,17 +902,17 @@ class SqlConversationItem(ConversationBase):
     created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     __table_args__ = (
-        # created_at trails for partition-readiness (unique indexes must
-        # contain the partition key). Position uniqueness is per-second at
-        # the DB level; the next_position counter under _lock_conversation
-        # is the real allocator and never reuses a position.
+        # Backs the per-conversation position-ordered scan (the dominant read).
+        # Non-unique on purpose: the real position allocator is the next_position
+        # counter advanced under _lock_conversation, which never reuses a
+        # position; the DB is not relied on to enforce it (nothing catches a
+        # collision). Being non-unique also means it needs no partition key, so
+        # created_at is left out — the PK still carries it for partition-readiness.
         Index(
             "ix_conversation_items_conversation_id_position",
             "workspace_id",
             "conversation_id",
             "position",
-            "created_at",
-            unique=True,
         ),
         # Fork-truncation looks up by workspace_id + conversation_id +
         # response_id; id trails to complete the PK.

--- a/omnigent/db/migrations/versions/c7d2e9f4a1b8_conversation_items_position_plain_index.py
+++ b/omnigent/db/migrations/versions/c7d2e9f4a1b8_conversation_items_position_plain_index.py
@@ -1,0 +1,62 @@
+"""Make the conversation_items position index plain (drop UNIQUE + created_at).
+
+Revision ID: c7d2e9f4a1b8
+Revises: a2b7c3d8e4f9
+Create Date: 2026-07-20 00:00:00.000000
+
+``ix_conversation_items_conversation_id_position`` was UNIQUE on
+``(workspace_id, conversation_id, position, created_at)``. The ``created_at``
+tail only existed because a UNIQUE index must contain the partition key — and
+with it in the key the DB no longer enforced position uniqueness anyway (only
+per epoch-second). Strict position uniqueness is owned entirely by the
+application: the ``next_position`` counter advanced under ``_lock_conversation``
+never reuses a position, and no code path catches a position IntegrityError.
+
+So the UNIQUE flag is redundant. This repoints the index to a plain
+``(workspace_id, conversation_id, position)``:
+
+- Same access path for the dominant per-conversation position-ordered scan.
+- One less uniqueness probe on the hot conversation_items insert path.
+- ``created_at`` is dropped: a non-unique index needs no partition key, so it
+  is a local index on either engine. The PK still carries ``created_at``, so
+  the table stays partition-ready.
+
+Index-only, no data change. ``DROP``/``CREATE INDEX`` is native on every
+dialect (no table rebuild). Downgrade restores the UNIQUE + ``created_at`` shape.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "c7d2e9f4a1b8"
+down_revision: str | None = "a2b7c3d8e4f9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX = "ix_conversation_items_conversation_id_position"
+_TABLE = "conversation_items"
+
+
+def upgrade() -> None:
+    """Swap the UNIQUE (…, position, created_at) index for a plain (…, position)."""
+    op.drop_index(_INDEX, table_name=_TABLE)
+    op.create_index(
+        _INDEX,
+        _TABLE,
+        ["workspace_id", "conversation_id", "position"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Restore the UNIQUE (…, position, created_at) partition-ready index."""
+    op.drop_index(_INDEX, table_name=_TABLE)
+    op.create_index(
+        _INDEX,
+        _TABLE,
+        ["workspace_id", "conversation_id", "position", "created_at"],
+        unique=True,
+    )

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -505,8 +505,14 @@ class TestSqlConversationItem:
             assert loaded.status == encode_item_status("completed")
             assert loaded.created_by is None
 
-    def test_unique_position_per_conversation(self, db_uri: str) -> None:
-        """Two items in the same conversation cannot share the same position."""
+    def test_position_not_unique_at_db_level(self, db_uri: str) -> None:
+        """Two items in one conversation may share a position at the DB level.
+
+        The position index is plain (non-unique); strict position uniqueness is
+        owned by the ``next_position`` allocator under ``_lock_conversation``, not
+        the index (see the store's concurrent-append test). Distinct ``id`` keeps
+        the PK unique, so both rows persist.
+        """
         engine = get_or_create_engine(db_uri)
         managed = make_managed_session_maker(engine)
 
@@ -514,11 +520,15 @@ class TestSqlConversationItem:
         item1 = _make_item(id="9980c8a9248139f14f4165e5d53088aa", position=0)
         item2 = _make_item(id="0fd4e86b2daa009cd9929641dbd7dab6", position=0)
 
-        with pytest.raises(IntegrityError):
-            with managed() as session:
-                session.add(conv)
-                session.add(item1)
-                session.add(item2)
+        # No IntegrityError: the DB does not enforce position uniqueness anymore.
+        with managed() as session:
+            session.add(conv)
+            session.add(item1)
+            session.add(item2)
+
+        with managed() as session:
+            count = session.query(SqlConversationItem).filter_by(conversation_id=conv.id).count()
+        assert count == 2, f"both position-0 items should persist; found {count}"
 
     def test_delete_conversation_via_orm_leaves_items_without_fk(self, db_uri: str) -> None:
         """Without DB-level FK cascade, deleting a conversation leaves its items intact.

--- a/tests/db/test_migration_conversation_items_created_at_pk.py
+++ b/tests/db/test_migration_conversation_items_created_at_pk.py
@@ -30,7 +30,6 @@ _TABLE = "conversation_items"
 _POSITION_INDEX = "ix_conversation_items_conversation_id_position"
 _HEAD_PK = ["workspace_id", "conversation_id", "id", "created_at"]
 _PRIOR_PK = ["workspace_id", "conversation_id", "id"]
-_HEAD_INDEX = ["workspace_id", "conversation_id", "position", "created_at"]
 _PRIOR_INDEX = ["workspace_id", "conversation_id", "position"]
 
 # An UPDATE targeting the items table itself (not the FTS shadow table).
@@ -54,15 +53,22 @@ def _message(text: str, response_id: str = "resp_1") -> NewConversationItem:
     )
 
 
-def test_head_pk_and_unique_index_include_created_at(tmp_path: Path) -> None:
-    """At head both the PK and the unique position index end in created_at."""
+def test_head_pk_includes_created_at_and_position_index_is_plain(tmp_path: Path) -> None:
+    """At head the PK still ends in created_at, but the position index is plain.
+
+    z8 added created_at to both the PK and the (then-UNIQUE) position index for
+    partition-readiness. A later migration (c7d2e9f4a1b8) repointed the position
+    index to a plain ``(workspace_id, conversation_id, position)`` — strict
+    position uniqueness is owned by the next_position allocator, not the DB. The
+    PK keeps created_at, so the table stays partition-ready.
+    """
     uri = f"sqlite:///{tmp_path / 'head.db'}"
     engine = get_or_create_engine(uri)
     try:
         assert _pk(engine) == _HEAD_PK
         index = _position_index(engine)
-        assert index["column_names"] == _HEAD_INDEX
-        assert index["unique"]
+        assert index["column_names"] == _PRIOR_INDEX  # created_at dropped by c7d2e9f4a1b8
+        assert not index["unique"]  # uniqueness moved to the app allocator
     finally:
         engine.dispose()
         clear_engine_cache()

--- a/tests/db/test_migration_conversation_items_position_plain_index.py
+++ b/tests/db/test_migration_conversation_items_position_plain_index.py
@@ -1,0 +1,99 @@
+"""Tests for making the conversation_items position index plain.
+
+``ix_conversation_items_conversation_id_position`` was UNIQUE on
+``(workspace_id, conversation_id, position, created_at)``. Since strict position
+uniqueness is owned by the app-level ``next_position`` allocator (the DB key only
+enforced it per epoch-second), migration ``c7d2e9f4a1b8`` drops the UNIQUE flag
+and the ``created_at`` tail, leaving a plain ``(workspace_id, conversation_id,
+position)`` index. These tests assert the post-migration shape and the downgrade.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+
+_NEW_REVISION = "c7d2e9f4a1b8"
+# Revision just before this one (its down_revision).
+_PRE_REVISION = "a2b7c3d8e4f9"
+_INDEX = "ix_conversation_items_conversation_id_position"
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Fresh SQLite DB with the full alembic chain applied (at head)."""
+    engine = get_or_create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+def _position_index(engine: Engine) -> dict:
+    idx = {i["name"]: i for i in sa.inspect(engine).get_indexes("conversation_items")}
+    assert _INDEX in idx, f"{_INDEX} missing on conversation_items."
+    return idx[_INDEX]
+
+
+def test_position_index_is_plain_at_head(db_engine: Engine) -> None:
+    """
+    At head the position index is non-unique and keyed on (ws, conv, position).
+
+    A failure means the migration didn't apply (still UNIQUE / still carries
+    created_at). The PK — which is what keeps the table partition-ready — must
+    still carry created_at.
+    """
+    idx = _position_index(db_engine)
+    assert not idx["unique"], f"{_INDEX} should be non-unique after the migration."
+    assert idx["column_names"] == [
+        "workspace_id",
+        "conversation_id",
+        "position",
+    ], f"unexpected columns: {idx['column_names']}"
+
+    pk_cols = sa.inspect(db_engine).get_pk_constraint("conversation_items")["constrained_columns"]
+    assert "created_at" in pk_cols, (
+        f"conversation_items PK must still carry created_at (partition-readiness); got {pk_cols}"
+    )
+
+
+def test_downgrade_restores_unique_created_at_index(tmp_path: Path) -> None:
+    """
+    Downgrade restores the UNIQUE ``(…, position, created_at)`` shape.
+
+    The downgrade leg is otherwise uncovered (the engine fixtures only run
+    ``upgrade head``), so this proves the chain stays reversible.
+    """
+    uri = f"sqlite:///{tmp_path / 'roundtrip.db'}"
+    cfg = _build_alembic_config(uri)
+    engine = sa.create_engine(uri)
+    try:
+        with engine.begin() as conn:
+            cfg.attributes["connection"] = conn
+            command.upgrade(cfg, _NEW_REVISION)
+        with engine.begin() as conn:
+            cfg.attributes["connection"] = conn
+            command.downgrade(cfg, _PRE_REVISION)
+
+        idx = _position_index(engine)
+        assert idx["unique"], f"downgrade must restore UNIQUE on {_INDEX}."
+        assert idx["column_names"] == [
+            "workspace_id",
+            "conversation_id",
+            "position",
+            "created_at",
+        ], f"downgrade must restore the created_at tail; got {idx['column_names']}"
+    finally:
+        engine.dispose()
+        clear_engine_cache()

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -679,20 +679,18 @@ def test_position_ordering(conversation_store: SqlAlchemyConversationStore) -> N
     assert texts == ["First", "Second"]
 
 
-def test_unique_position_constraint(
+def test_position_not_enforced_by_db(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
     """
-    The (conversation_id, position, created_at) tuple has a unique index.
+    The position index is plain (non-unique): the DB permits duplicate positions.
 
-    created_at joined the index for partition-readiness (unique indexes must
-    contain a partition key), so the DB safety net blocks duplicate positions
-    only within the same epoch second — which still covers the concurrent
-    double-append race. Slower duplicates are prevented by the next_position
-    allocator, not the index.
+    Strict position uniqueness is owned by the ``next_position`` allocator under
+    ``_lock_conversation`` (proven by
+    ``test_concurrent_appends_do_not_collide_on_position``), not the index — no
+    code catches a position IntegrityError. This documents that raw
+    duplicate-position inserts are accepted at the DB level.
     """
-    from sqlalchemy.exc import IntegrityError
-
     from omnigent.db.db_models import SqlConversationItem
     from omnigent.db.enum_codecs import encode_item_status, encode_item_type
     from omnigent.db.utils import generate_item_id
@@ -726,13 +724,10 @@ def test_unique_position_constraint(
             search_text="",
         )
 
-    # Same second (the double-append race shape): the index rejects it.
-    with pytest.raises(IntegrityError):
-        with conversation_store._session() as session:
-            session.add(_duplicate_position_row(existing_created_at))
-
-    # A different second slips past the index; only the next_position
-    # allocator prevents this in real appends.
+    # Neither a same-second nor a later-second duplicate is rejected now: the
+    # index is not UNIQUE, and distinct ids keep the PK unique so both persist.
+    with conversation_store._session() as session:
+        session.add(_duplicate_position_row(existing_created_at))
     with conversation_store._session() as session:
         session.add(_duplicate_position_row(existing_created_at + 1))
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

`ix_conversation_items_conversation_id_position` was **UNIQUE** on
`(workspace_id, conversation_id, position, created_at)`. Two problems:

- The `created_at` tail only existed because a UNIQUE index must contain the
  partition key (partition-readiness). With it in the key, the DB stopped
  enforcing position uniqueness meaningfully — it only blocked a duplicate
  `position` that *also* collided on the same epoch-second.
- Strict position uniqueness is already owned entirely by the application: the
  `next_position` counter, advanced under `_lock_conversation` (`SELECT … FOR
  UPDATE` on Postgres / RESERVED-txn escalation on SQLite), never reuses a
  position. **No code path catches a position `IntegrityError`** — the DB
  constraint is never relied upon.

So the `UNIQUE` flag is redundant. This repoints the index to a plain
`(workspace_id, conversation_id, position)`:

- **Reads unchanged** — this is still the only index serving the per-conversation
  position-ordered scan (the dominant read); `created_at` never helped it.
- **Cheaper writes** — one less uniqueness probe on `conversation_items` insert,
  the hottest write path (every message / tool-call / reasoning row).
- **Smaller** — `created_at` drops out (a non-unique index needs no partition
  key; it's local per-partition on both engines).
- **Still partition-ready** — the PK still carries `created_at`, which is what
  actually makes the table partitionable. Untouched.

**ELI5:** the index promised "no two items share a position in a conversation,"
but partition-readiness had already quietly downgraded that promise to
"…within the same second," and the app never needed the promise anyway (it
hands out positions from a locked counter). So we drop the fake guarantee and
keep the index as a plain lookup — smaller, faster to write, same reads.

Migration `c7d2e9f4a1b8`: index-only, native `DROP`/`CREATE INDEX`, no data
change. Downgrade restores the UNIQUE + `created_at` shape. Three tests that
asserted the old unique/`created_at` shape are updated to the new behavior
(the DB no longer enforces position uniqueness; the app allocator does).

> **Alembic head coordination:** this branches off `main` at `f4a1c8b2d3e6` and
> shares that parent with #2928. Once both are on `main` there are two heads;
> whichever merges second gets its `down_revision` bumped onto the first. Happy
> to rebase once the order is settled.

## Test Plan

```
pytest tests/db/ tests/stores/test_conversation_store.py -q   # 500 passed
```

- New per-migration test `tests/db/test_migration_conversation_items_position_plain_index.py`:
  index is non-unique on `(ws, conv, position)` at head, PK still carries
  `created_at`, downgrade restores UNIQUE + `created_at`.
- `test_migrations_sqlite_safe.py` — full chain up→down→up on SQLite.
- Updated to the new invariant: `test_db_models.py::TestSqlConversationItem`
  (two same-position rows now persist), `test_conversation_store.py`
  (`test_position_not_enforced_by_db`), and the z8 head-shape assertion in
  `test_migration_conversation_items_created_at_pk.py`.
- `test_concurrent_appends_do_not_collide_on_position` (unchanged) still proves
  the `next_position` allocator is the real guarantor.

Before merge: index-only DDL, so a fork rehearsal is optional (no backfill) —
but worth confirming `DROP`/`CREATE INDEX` timing on the real table size.

## Demo

N/A — non-visual database change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New per-migration test covers the index reshape and downgrade; existing
store/model tests updated to the new (app-enforced) invariant cover runtime
behavior; `test_migrations_sqlite_safe.py` covers upgrade/downgrade end-to-end.

This pull request and its description were written by Isaac.
