### PR TITLE
refactor(db): merge agent_configuration back into conversations

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -659,64 +659,6 @@ class SqlConversationMetadata(OmnigentBase):
     )
 
 
-class SqlAgentConfiguration(ConversationBase):
-    """
-    SQLAlchemy model for the ``agent_configuration`` table.
-
-    The agent bound to a conversation and its per-session config
-    overrides. Paired 1-to-1 with :class:`SqlConversation` by
-    ``(workspace_id, conversation_id)``; both tables live on the
-    Conversation base, so the pair is created and deleted in one
-    transaction.
-
-    :param conversation_id: Conversation this row belongs to, e.g.
-        ``"conv_e4f5a6b7..."``.
-    :param agent_id: Agent bound to the conversation at creation
-        time. ``None`` for conversations created without an agent
-        binding.
-    :param reasoning_effort: Per-session reasoning-effort hint.
-    :param model_override: Per-session LLM model override.
-    :param cost_control_mode_override: Per-session cost-control switch.
-    :param harness_override: Per-session brain-harness override.
-    """
-
-    __tablename__ = "agent_configuration"
-
-    workspace_id: Mapped[int] = mapped_column(
-        BigInteger,
-        primary_key=True,
-        nullable=False,
-        server_default="0",
-        default=current_workspace_id,
-    )
-    conversation_id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
-    agent_id: Mapped[str | None] = mapped_column(Uuid16(), nullable=True)
-    # Per-session reasoning-effort hint, e.g. "high". Nullable;
-    # None means use the agent default.
-    reasoning_effort: Mapped[str | None] = mapped_column(String(32), nullable=True)
-    # Per-session LLM model override, e.g. "claude-opus-4-7". Nullable;
-    # None means use the agent default from the spec.
-    model_override: Mapped[str | None] = mapped_column(String(128), nullable=True)
-    # Per-session cost-control switch: "on" | "off". Nullable; None
-    # means use the spec default (see entities.Conversation).
-    cost_control_mode_override: Mapped[str | None] = mapped_column(String(8), nullable=True)
-    # Per-session brain-harness override, e.g. "pi". Nullable; None
-    # means use the spec's executor.config.harness (see entities.Conversation).
-    harness_override: Mapped[str | None] = mapped_column(String(64), nullable=True)
-
-    __table_args__ = (
-        # Agent lookups: find the conversation(s) that own a given agent.
-        # Covering: the reverse lookup and the list filters read only
-        # conversation_id, so they resolve as index-only scans.
-        Index(
-            "ix_agent_configuration_agent_id",
-            "workspace_id",
-            "agent_id",
-            "conversation_id",
-        ),
-    )
-
-
 def conversation_title_hash(title: str) -> bytes:
     """Return the 16-byte truncated sha256 digest of a conversation title.
 
@@ -744,9 +686,9 @@ class SqlConversation(ConversationBase):
     SQLAlchemy model for the ``conversations`` table.
 
     Agent Platform (AP) fields for a conversation: identity, timestamps,
-    title, hierarchy, and the next_position allocator. The agent binding
-    and per-session overrides live in :class:`SqlAgentConfiguration`; Omnigent
-    operational state in :class:`SqlConversationMetadata`.
+    title, hierarchy, the next_position allocator, and the agent binding
+    (``agent_id`` + the ``session_overrides`` JSON blob). Omnigent
+    operational state lives in :class:`SqlConversationMetadata`.
 
     :param id: Unique conversation identifier, e.g.
         ``"conv_e4f5a6b7..."``.
@@ -762,6 +704,12 @@ class SqlConversation(ConversationBase):
         conversation in the spawn tree. Equal to ``id`` for
         top-level conversations.
     :param next_position: Monotonic allocator for the next item position.
+    :param agent_id: Agent bound to the conversation at creation time.
+        ``None`` for conversations created without an agent binding.
+    :param session_overrides: Compact JSON blob of per-session config
+        overrides (reasoning_effort, model_override,
+        cost_control_mode_override, harness_override). ``None`` when the
+        session uses all agent/spec defaults.
     """
 
     __tablename__ = "conversations"
@@ -796,6 +744,17 @@ class SqlConversation(ConversationBase):
     )
     # Monotonic allocator for the next item position in this conversation.
     next_position: Mapped[int | None] = mapped_column(Integer, nullable=True, default=0)
+    # Agent bound to this conversation at creation time. NULL for conversations
+    # created without an agent binding. Indexed for the agent→conversation
+    # reverse lookup and the list filters (agent_id / has_agent_id / agent_name).
+    agent_id: Mapped[str | None] = mapped_column(Uuid16(), nullable=True)
+    # Per-session config overrides packed as a compact JSON object, e.g.
+    # ``{"model_override":"claude-opus-4-8","reasoning_effort":"high"}``. Keys:
+    # reasoning_effort, model_override, cost_control_mode_override,
+    # harness_override. NULL when the session uses all agent/spec defaults; only
+    # set keys are stored. Never filtered in SQL — read and written whole with
+    # the row (see the store's _encode/_decode_session_overrides).
+    session_overrides: Mapped[str | None] = mapped_column(String(512), nullable=True)
     # Whether the session is archived (hidden from the default sidebar). Lives
     # here on the AP table so list_conversations can filter it inline alongside
     # the created_at/updated_at sort keys, instead of pre-fetching ids from the
@@ -813,6 +772,14 @@ class SqlConversation(ConversationBase):
             "ix_conversations_root_conversation_id",
             "workspace_id",
             "root_conversation_id",
+            "id",
+        ),
+        # Agent→conversation reverse lookup and the agent_id / has_agent_id /
+        # agent_name list filters. id trails to complete the PK (index-only).
+        Index(
+            "ix_conversations_agent_id",
+            "workspace_id",
+            "agent_id",
             "id",
         ),
         # Unique index on (parent_conversation_id, title_hash) prevents two

--- a/omnigent/db/migrations/versions/b7e4d2c9a1f3_merge_agent_configuration_into_conversations.py
+++ b/omnigent/db/migrations/versions/b7e4d2c9a1f3_merge_agent_configuration_into_conversations.py
@@ -1,0 +1,271 @@
+"""Merge agent_configuration back into conversations.
+
+Revision ID: b7e4d2c9a1f3
+Revises: c7d2e9f4a1b8
+Create Date: 2026-07-20 00:00:00.000000
+
+Reverses ``bb2c3d4e5f6a``: the 1-to-1 ``agent_configuration`` companion table
+is folded back onto ``conversations``. The agent binding (``agent_id``) returns
+as a first-class indexed column, and the four per-session overrides
+(reasoning_effort, model_override, cost_control_mode_override, harness_override)
+collapse into a single nullable ``session_overrides`` JSON blob (``VARCHAR(512)``)
+that is ``NULL`` when the session uses all agent/spec defaults.
+
+The overrides were never filtered in SQL — only ever read/written alongside the
+conversation — so a blob loses no query capability while dropping a table, an
+extra INSERT, a JOIN, and the paired-row repair/fork/delete plumbing. ``agent_id``
+stays a real column so the agent→conversation reverse lookup and the
+``agent_id`` / ``has_agent_id`` / ``agent_name`` list filters remain index-backed
+(``ix_conversations_agent_id``).
+
+Data copy (both directions in Python, keyset-batched by primary key to bound
+memory): SQL JSON construction is not portable, and — more importantly — the
+copy must not rely on column-to-column type coercion. ``bb2c3d4e5f6a`` created
+``agent_configuration.agent_id`` / ``conversation_id`` as ``VARCHAR`` even though
+``conversations`` stores ids as 16 raw bytes (``Uuid16``); a SQL
+``UPDATE … SET binary_col = (SELECT varchar_col …)`` would fail on Postgres/MySQL
+(binary vs varchar), invisibly to SQLite. So every id is normalised to 16 bytes
+in Python (:func:`_as_uuid_bytes`) before it is bound into a binary column,
+making the migration correct regardless of the source column's declared type or
+stored form.
+
+Column type by dialect: ``agent_id`` is ``Uuid16`` (16 raw bytes) — ``BYTEA``
+(Postgres) / ``BLOB`` (SQLite), ``BINARY(16)`` on MySQL. ``session_overrides``
+is a plain bounded ``VARCHAR(512)`` (the length is a cap, not a preallocation;
+NULL/short blobs cost only their bytes).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from omnigent.db.db_models import Uuid16, uuid_to_bytes
+
+revision: str = "b7e4d2c9a1f3"
+down_revision: str | None = "c7d2e9f4a1b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Fixed key order so the encoded object is stable across writes. Mirrors the
+# store's _SESSION_OVERRIDE_KEYS (kept self-contained in the migration).
+_OVERRIDE_KEYS = (
+    "reasoning_effort",
+    "model_override",
+    "cost_control_mode_override",
+    "harness_override",
+)
+_BACKFILL_BATCH = 1000
+
+
+def _as_uuid_bytes(value: object) -> bytes | None:
+    """Normalise a stored id to the 16 raw bytes a ``Uuid16`` column holds.
+
+    Accepts whatever the driver returns for the source column, regardless of
+    its declared type: ``None``; 16 raw bytes / ``memoryview`` (binary column);
+    or a 32-char hex string, optionally dashed / legacy-prefixed, possibly
+    delivered as ``bytes`` (varchar column). This lets the copy target a binary
+    column on every dialect without relying on implicit type coercion.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        raw = bytes(value)
+        if len(raw) == 16:
+            return raw
+        # A varchar id surfaced as bytes (e.g. hex text) — decode then normalise.
+        return uuid_to_bytes(raw.decode("ascii"))
+    return uuid_to_bytes(value)  # str / uuid.UUID
+
+
+def _encode_overrides(values: dict[str, str | None]) -> str | None:
+    """Pack set overrides into a compact JSON blob, or ``None`` when all unset."""
+    data = {key: values[key] for key in _OVERRIDE_KEYS if values.get(key) is not None}
+    return json.dumps(data, separators=(",", ":")) if data else None
+
+
+def _backfill_binding_and_overrides() -> None:
+    """Copy ``agent_configuration`` onto ``conversations`` (agent_id + blob).
+
+    Pages over ``agent_configuration`` by its ``(workspace_id, conversation_id)``
+    primary key so memory stays bounded to one batch. Only rows that carry a
+    binding or at least one override trigger an UPDATE; all-default rows keep both
+    columns NULL. Ids are normalised to bytes so the binary ``conversations``
+    columns are written correctly on every dialect.
+    """
+    bind = op.get_bind()
+    last_ws: int | None = None
+    last_id: object = None
+    while True:
+        if last_ws is None:
+            rows = bind.execute(
+                sa.text(
+                    "SELECT workspace_id, conversation_id, agent_id, reasoning_effort,"
+                    " model_override, cost_control_mode_override, harness_override"
+                    " FROM agent_configuration"
+                    " ORDER BY workspace_id, conversation_id LIMIT :lim"
+                ),
+                {"lim": _BACKFILL_BATCH},
+            ).fetchall()
+        else:
+            rows = bind.execute(
+                sa.text(
+                    "SELECT workspace_id, conversation_id, agent_id, reasoning_effort,"
+                    " model_override, cost_control_mode_override, harness_override"
+                    " FROM agent_configuration"
+                    " WHERE workspace_id > :ws"
+                    "    OR (workspace_id = :ws AND conversation_id > :id)"
+                    " ORDER BY workspace_id, conversation_id LIMIT :lim"
+                ),
+                {"ws": last_ws, "id": last_id, "lim": _BACKFILL_BATCH},
+            ).fetchall()
+        if not rows:
+            break
+        for ws, conv_id, agent_id, reasoning, model, cost, harness in rows:
+            agent_bytes = _as_uuid_bytes(agent_id)
+            blob = _encode_overrides(
+                {
+                    "reasoning_effort": reasoning,
+                    "model_override": model,
+                    "cost_control_mode_override": cost,
+                    "harness_override": harness,
+                }
+            )
+            if agent_bytes is not None or blob is not None:
+                bind.execute(
+                    sa.text(
+                        "UPDATE conversations SET agent_id = :aid, session_overrides = :so"
+                        " WHERE workspace_id = :ws AND id = :id"
+                    ),
+                    {"aid": agent_bytes, "so": blob, "ws": ws, "id": _as_uuid_bytes(conv_id)},
+                )
+        last_ws, last_id = rows[-1][0], rows[-1][1]
+        if len(rows) < _BACKFILL_BATCH:
+            break
+
+
+def _restore_agent_configuration_overrides() -> None:
+    """Downgrade: fan ``conversations.session_overrides`` back out to columns.
+
+    Pages over ``conversations`` by its ``(workspace_id, id)`` primary key,
+    parses each blob, and writes the four override columns onto the (already
+    inserted, 1-to-1) ``agent_configuration`` rows.
+    """
+    bind = op.get_bind()
+    last_ws: int | None = None
+    last_id: object = None
+    while True:
+        if last_ws is None:
+            rows = bind.execute(
+                sa.text(
+                    "SELECT workspace_id, id, session_overrides FROM conversations"
+                    " WHERE session_overrides IS NOT NULL"
+                    " ORDER BY workspace_id, id LIMIT :lim"
+                ),
+                {"lim": _BACKFILL_BATCH},
+            ).fetchall()
+        else:
+            rows = bind.execute(
+                sa.text(
+                    "SELECT workspace_id, id, session_overrides FROM conversations"
+                    " WHERE session_overrides IS NOT NULL"
+                    "   AND (workspace_id > :ws OR (workspace_id = :ws AND id > :id))"
+                    " ORDER BY workspace_id, id LIMIT :lim"
+                ),
+                {"ws": last_ws, "id": last_id, "lim": _BACKFILL_BATCH},
+            ).fetchall()
+        if not rows:
+            break
+        for ws, conv_id, blob in rows:
+            data = json.loads(blob) if blob else {}
+            bind.execute(
+                sa.text(
+                    "UPDATE agent_configuration SET"
+                    " reasoning_effort = :reasoning_effort,"
+                    " model_override = :model_override,"
+                    " cost_control_mode_override = :cost_control_mode_override,"
+                    " harness_override = :harness_override"
+                    " WHERE workspace_id = :ws AND conversation_id = :id"
+                ),
+                {
+                    "reasoning_effort": data.get("reasoning_effort"),
+                    "model_override": data.get("model_override"),
+                    "cost_control_mode_override": data.get("cost_control_mode_override"),
+                    "harness_override": data.get("harness_override"),
+                    "ws": ws,
+                    "id": _as_uuid_bytes(conv_id),
+                },
+            )
+        last_ws, last_id = rows[-1][0], rows[-1][1]
+        if len(rows) < _BACKFILL_BATCH:
+            break
+
+
+def upgrade() -> None:
+    """
+    1. Add ``agent_id`` and ``session_overrides`` to ``conversations`` (nullable).
+    2. Copy the binding + overrides across in Python (byte-normalised ids).
+    3. Create ``ix_conversations_agent_id``; drop ``ix_agent_configuration_agent_id``.
+    4. Drop the ``agent_configuration`` table.
+
+    Adding nullable columns is native DDL on every dialect, so no table rebuild
+    / ``batch_alter_table`` is needed on the upgrade path.
+    """
+    op.add_column("conversations", sa.Column("agent_id", Uuid16(), nullable=True))
+    op.add_column("conversations", sa.Column("session_overrides", sa.String(512), nullable=True))
+
+    _backfill_binding_and_overrides()
+
+    op.create_index(
+        "ix_conversations_agent_id",
+        "conversations",
+        ["workspace_id", "agent_id", "id"],
+    )
+    op.drop_index("ix_agent_configuration_agent_id", table_name="agent_configuration")
+    op.drop_table("agent_configuration")
+
+
+def downgrade() -> None:
+    """Recreate ``agent_configuration``, copy the binding + overrides back, and
+    drop the merged columns from ``conversations``.
+
+    The recreated table uses ``Uuid16`` (binary) id columns — matching
+    ``conversations`` — so the ``INSERT … SELECT`` binding copy is a clean
+    binary-to-binary move on every dialect (the original split declared these
+    ``VARCHAR``; binary is the consistent, coercion-free choice here).
+    """
+    op.create_table(
+        "agent_configuration",
+        sa.Column("workspace_id", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("conversation_id", Uuid16(), nullable=False),
+        sa.Column("agent_id", Uuid16(), nullable=True),
+        sa.Column("reasoning_effort", sa.String(32), nullable=True),
+        sa.Column("model_override", sa.String(128), nullable=True),
+        sa.Column("cost_control_mode_override", sa.String(8), nullable=True),
+        sa.Column("harness_override", sa.String(64), nullable=True),
+        sa.PrimaryKeyConstraint("workspace_id", "conversation_id"),
+    )
+    op.create_index(
+        "ix_agent_configuration_agent_id",
+        "agent_configuration",
+        ["workspace_id", "agent_id", "conversation_id"],
+    )
+
+    # One agent_configuration row per conversation, agent_id carried directly
+    # (binary→binary, so no coercion needed).
+    op.execute(
+        """
+        INSERT INTO agent_configuration (workspace_id, conversation_id, agent_id)
+        SELECT workspace_id, id, agent_id FROM conversations
+        """
+    )
+    _restore_agent_configuration_overrides()
+
+    op.drop_index("ix_conversations_agent_id", table_name="conversations")
+    # DROP COLUMN needs batch_alter_table on older SQLite.
+    with op.batch_alter_table("conversations") as batch_op:
+        batch_op.drop_column("session_overrides")
+        batch_op.drop_column("agent_id")

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import IntegrityError
 from omnigent.db.converters import sql_agent_to_entity
 from omnigent.db.db_models import (
     SqlAgent,
-    SqlAgentConfiguration,
+    SqlConversation,
     current_workspace_id,
 )
 from omnigent.db.enum_codecs import encode_agent_kind
@@ -63,10 +63,10 @@ class SqlAlchemyAgentStore(AgentStore):
         """
         Reverse-lookup the conversation bound to a session-scoped agent.
 
-        ``agent_configuration.agent_id`` is the sole link (the agent row
-        carries no back-pointer), and the ``agent_configuration`` table lives
-        in the AP DB — so this must run on the conversation engine, not
-        the Omnigent engine that owns the ``agents`` table.
+        ``conversations.agent_id`` is the sole link (the agent row carries no
+        back-pointer), and the ``conversations`` table lives in the AP DB — so
+        this must run on the conversation engine, not the Omnigent engine that
+        owns the ``agents`` table.
 
         :param agent_id: Agent identifier, e.g. ``"ag_abc123"``.
         :returns: Owning conversation id, or ``None`` when no
@@ -74,10 +74,10 @@ class SqlAlchemyAgentStore(AgentStore):
         """
         with self._conv_session() as conv_sess:
             return conv_sess.execute(
-                select(SqlAgentConfiguration.conversation_id)
+                select(SqlConversation.id)
                 .where(
-                    SqlAgentConfiguration.workspace_id == current_workspace_id(),
-                    SqlAgentConfiguration.agent_id == agent_id,
+                    SqlConversation.workspace_id == current_workspace_id(),
+                    SqlConversation.agent_id == agent_id,
                 )
                 .limit(1)
             ).scalar_one_or_none()

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -28,7 +28,6 @@ from omnigent.db.converters import sql_agent_to_entity
 from omnigent.db.db_models import (
     LABEL_VALUE_MAX_LEN,
     SqlAgent,
-    SqlAgentConfiguration,
     SqlComment,
     SqlConversation,
     SqlConversationItem,
@@ -94,16 +93,60 @@ from omnigent.stores.conversation_store import (
 
 _logger = logging.getLogger(__name__)
 
+# Per-session config overrides packed into the ``conversations.session_overrides``
+# JSON blob. Order is fixed so the encoded object is stable across writes.
+_SESSION_OVERRIDE_KEYS = (
+    "reasoning_effort",
+    "model_override",
+    "cost_control_mode_override",
+    "harness_override",
+)
+
+
+def _encode_session_overrides(overrides: dict[str, str | None]) -> str | None:
+    """Pack the set per-session overrides into a compact JSON blob.
+
+    Omits keys whose value is ``None`` and returns ``None`` when nothing is
+    set, so a session on all agent/spec defaults stores SQL ``NULL`` rather
+    than an empty object. Only the four :data:`_SESSION_OVERRIDE_KEYS` are
+    considered; any other keys in *overrides* are ignored.
+
+    :param overrides: Mapping of override key to value (missing / ``None``
+        values mean "unset").
+    :returns: Compact JSON object string, or ``None`` when no override is set.
+    """
+    data = {
+        key: overrides[key] for key in _SESSION_OVERRIDE_KEYS if overrides.get(key) is not None
+    }
+    return json.dumps(data, separators=(",", ":")) if data else None
+
+
+def _decode_session_overrides(raw: str | None) -> dict[str, str | None]:
+    """Unpack the ``session_overrides`` blob to a full override dict.
+
+    Every one of the four :data:`_SESSION_OVERRIDE_KEYS` is present in the
+    result (unset keys read back as ``None``) so read-modify-write callers can
+    treat the dict uniformly regardless of which overrides were stored.
+
+    :param raw: The stored JSON blob, or ``None``.
+    :returns: Dict keyed by every override name, value ``None`` when unset.
+    """
+    data: dict[str, Any] = json.loads(raw) if raw else {}
+    return {key: data.get(key) for key in _SESSION_OVERRIDE_KEYS}
+
 
 def _to_conversation(
     row: SqlConversation,
     meta: SqlConversationMetadata | None = None,
     labels: dict[str, str] | None = None,
-    agent_config: SqlAgentConfiguration | None = None,
 ) -> Conversation:
     """
-    Convert a :class:`SqlConversation` ORM row (plus optional metadata
-    and agent-configuration rows) to a :class:`Conversation` entity.
+    Convert a :class:`SqlConversation` ORM row (plus optional metadata) to a
+    :class:`Conversation` entity.
+
+    The agent binding (``agent_id``) and per-session overrides live on the
+    conversation row itself — the latter packed in the ``session_overrides``
+    JSON blob, unpacked here via :func:`_decode_session_overrides`.
 
     :param row: The SQLAlchemy ORM row to convert.
     :param meta: Optional metadata row from
@@ -116,20 +159,15 @@ def _to_conversation(
         ``None`` rather than forcing a second query); this
         maps to an empty dict on the entity. Populated
         callers pass the JOINed ``{key: value}`` map.
-    :param agent_config: Optional paired row from ``agent_configuration``.
-        When ``None``, the agent binding and all per-session
-        overrides default to ``None``.
     :returns: A :class:`Conversation` dataclass instance.
     """
-    import json
-
     session_state: dict[str, Any] = {}
     if meta and meta.session_state:
         session_state = json.loads(meta.session_state)
     session_usage: dict[str, Any] = {}
     if meta and meta.session_usage:
         session_usage = json.loads(meta.session_usage)
-    agent_config = agent_config
+    overrides = _decode_session_overrides(row.session_overrides)
     return Conversation(
         id=row.id,
         created_at=row.created_at,
@@ -142,18 +180,16 @@ def _to_conversation(
         kind="sub_agent" if row.parent_conversation_id is not None else "default",
         parent_conversation_id=row.parent_conversation_id,
         root_conversation_id=row.root_conversation_id,
-        agent_id=agent_config.agent_id if agent_config else None,
+        agent_id=row.agent_id,
         runner_id=meta.runner_id if meta else None,
         host_id=meta.host_id if meta else None,
         labels=labels if labels is not None else {},
         session_state=session_state,
         session_usage=session_usage,
-        reasoning_effort=agent_config.reasoning_effort if agent_config else None,
-        model_override=agent_config.model_override if agent_config else None,
-        cost_control_mode_override=agent_config.cost_control_mode_override
-        if agent_config
-        else None,
-        harness_override=agent_config.harness_override if agent_config else None,
+        reasoning_effort=overrides["reasoning_effort"],
+        model_override=overrides["model_override"],
+        cost_control_mode_override=overrides["cost_control_mode_override"],
+        harness_override=overrides["harness_override"],
         sub_agent_name=meta.sub_agent_name if meta else None,
         external_session_id=meta.external_session_id if meta else None,
         # NULL → None; a stored JSON array (e.g. ``"[]"`` or
@@ -183,12 +219,14 @@ def _new_session_conversation_row(
     title: str | None,
     parent_conversation_id: str | None = None,
     root_conversation_id: str | None = None,
+    agent_id: str | None = None,
+    session_overrides: str | None = None,
 ) -> SqlConversation:
     """
     Build the AP conversation row for atomic session creation.
 
-    The agent binding and per-session overrides live in the paired
-    :func:`_new_agent_configuration_row`; Omnigent operational fields
+    The agent binding (``agent_id``) and the per-session override blob
+    (``session_overrides``) live on this row; Omnigent operational fields
     (runner_id, host_id, workspace, terminal_launch_args, kind, etc.)
     in :func:`_new_session_metadata_row`.
 
@@ -201,6 +239,10 @@ def _new_session_conversation_row(
     :param root_conversation_id: Root of the spawn tree. Required
         when ``parent_conversation_id`` is set; ``None`` for
         top-level rows where the root mirrors the primary key.
+    :param agent_id: Optional agent binding. ``None`` leaves it NULL.
+    :param session_overrides: Optional pre-encoded per-session override
+        JSON blob (see :func:`_encode_session_overrides`). ``None`` leaves
+        it NULL.
     :returns: Unsaved :class:`SqlConversation` row.
     """
     # Sub-agent children must have a unique title per parent.
@@ -217,38 +259,8 @@ def _new_session_conversation_row(
         # primary key so tree-scoped lookups treat it as its own
         # root. Child rows inherit their parent's root.
         root_conversation_id=root_conversation_id or conversation_id,
-    )
-
-
-def _new_agent_configuration_row(
-    conversation_id: str,
-    agent_id: str | None = None,
-    reasoning_effort: str | None = None,
-    model_override: str | None = None,
-    cost_control_mode_override: str | None = None,
-    harness_override: str | None = None,
-) -> SqlAgentConfiguration:
-    """
-    Build the agent-configuration row paired with a new conversation.
-
-    Lives on the Conversation base, so callers add it in the same
-    transaction as the :class:`SqlConversation` row.
-
-    :param conversation_id: New conversation id, e.g. ``"conv_abc123"``.
-    :param agent_id: Optional agent binding. ``None`` leaves it NULL.
-    :param reasoning_effort: Optional per-session reasoning-effort hint.
-    :param model_override: Optional per-session LLM model override.
-    :param cost_control_mode_override: Optional cost-control switch.
-    :param harness_override: Optional brain-harness override.
-    :returns: Unsaved :class:`SqlAgentConfiguration` row.
-    """
-    return SqlAgentConfiguration(
-        conversation_id=conversation_id,
         agent_id=agent_id,
-        reasoning_effort=reasoning_effort,
-        model_override=model_override,
-        cost_control_mode_override=cost_control_mode_override,
-        harness_override=harness_override,
+        session_overrides=session_overrides,
     )
 
 
@@ -316,18 +328,16 @@ def _new_session_agent_row(
 def _created_session_from_rows(
     conversation_row: SqlConversation,
     meta_row: SqlConversationMetadata | None,
-    agent_config_row: SqlAgentConfiguration | None,
     agent_row: SqlAgent,
     labels: dict[str, str] | None,
 ) -> CreatedSession:
     """
     Convert committed session creation rows to store entities.
 
-    :param conversation_row: Inserted conversation row.
+    :param conversation_row: Inserted conversation row (carries the agent
+        binding + per-session override blob).
     :param meta_row: Inserted metadata row, or ``None`` when not yet
         persisted (entity defaults apply).
-    :param agent_config_row: Inserted agent-configuration row, or ``None``
-        when not yet persisted (entity defaults apply).
     :param agent_row: Inserted session-scoped agent row.
     :param labels: Labels written during creation, or ``None``.
     :returns: :class:`CreatedSession` with entity objects.
@@ -337,7 +347,6 @@ def _created_session_from_rows(
             conversation_row,
             meta_row,
             labels if labels is not None else {},
-            agent_config_row,
         ),
         agent=sql_agent_to_entity(agent_row, session_id=conversation_row.id),
     )
@@ -738,31 +747,6 @@ class SqlAlchemyConversationStore(ConversationStore):
                 SqlConversationMetadata, (current_workspace_id(), conversation_id)
             )
 
-    @staticmethod
-    def _fetch_agent_configurations(
-        session: Session, conversation_ids: list[str]
-    ) -> dict[str, SqlAgentConfiguration]:
-        """
-        Bulk-fetch agent-configuration rows keyed by conversation id.
-
-        Runs on the caller's Conversation-DB session (``agent_configuration``
-        is on the Conversation base), so callers batch it beside the
-        conversation-row and label fetches in one snapshot.
-        """
-        if not conversation_ids:
-            return {}
-        rows = (
-            session.execute(
-                select(SqlAgentConfiguration).where(
-                    SqlAgentConfiguration.workspace_id == current_workspace_id(),
-                    SqlAgentConfiguration.conversation_id.in_(conversation_ids),
-                )
-            )
-            .scalars()
-            .all()
-        )
-        return {r.conversation_id: r for r in rows}
-
     def _lock_conversation(self, session: Session, conversation_id: str) -> None:
         """
         Acquire a row-level lock on the conversation to serialize
@@ -923,11 +907,9 @@ class SqlAlchemyConversationStore(ConversationStore):
                     title=title or "",
                     parent_conversation_id=parent_conversation_id,
                     root_conversation_id=root_id,
+                    agent_id=agent_id,
                 )
                 ap_sess.add(row)
-                # Same DB as conversations, so the pair commits atomically.
-                agent_config = _new_agent_configuration_row(new_id, agent_id=agent_id)
-                ap_sess.add(agent_config)
             meta = SqlConversationMetadata(
                 id=new_id,
                 kind=encode_conversation_kind(kind),
@@ -942,46 +924,32 @@ class SqlAlchemyConversationStore(ConversationStore):
             )
             with self._session() as meta_sess:
                 meta_sess.add(meta)
-            return _to_conversation(row, meta, agent_config=agent_config)
+            return _to_conversation(row, meta)
         except IntegrityError as exc:
             # Translate the unique-index violation into a
             # clean exception type the spawn/send tools can map
             # to a name_already_exists tool error. Other integrity
             # violations (FK, check constraints) re-raise.
             #
-            # Detection prefers the specific index name (Postgres
-            # surfaces it directly), and falls back to the
-            # ``parent_conversation_id`` + ``title`` column
-            # signature (SQLite tends to format the message that
-            # way). This is narrower than a generic "unique"
-            # check, which would misclassify any future unique
-            # constraint added to the conversations table.
+            # Detection prefers the PK constraint name (Postgres/MySQL surface it
+            # directly), and falls back on SQLite's failed-column signature:
+            #   Postgres → "pk_conversations" (repo naming convention; the stock
+            #     "conversations_pkey" is kept as a defensive fallback)
+            #   MySQL    → duplicate entry ... for key '...PRIMARY'
+            #   SQLite   → "conversations.id" (dotted) — appears only in the
+            #     "UNIQUE constraint failed: …" clause, never in the INSERT
+            #     column list, so it cleanly separates from the title-uniqueness
+            #     index (which names title_hash, not id).
+            # id is checked before title. Other integrity violations re-raise.
             msg = str(exc).lower()
             is_id_unique_violation = conversation_id is not None and (
-                "conversations_pkey" in msg
-                or "agent_configuration_pkey" in msg
+                "pk_conversations" in msg
+                or "conversations_pkey" in msg
                 or (
                     "duplicate entry" in msg
-                    and (
-                        "for key 'primary'" in msg
-                        or "for key 'conversations.primary'" in msg
-                        or "for key 'agent_configuration.primary'" in msg
-                    )
+                    and ("for key 'primary'" in msg or "for key 'conversations.primary'" in msg)
                 )
-                or (
-                    "unique" in msg
-                    and (
-                        (
-                            "conversations.workspace_id" in msg
-                            and "conversations.id" in msg
-                            and "parent_conversation_id" not in msg
-                        )
-                        or (
-                            "agent_configuration.workspace_id" in msg
-                            and "agent_configuration.conversation_id" in msg
-                        )
-                    )
-                )
+                or ("unique" in msg and "conversations.id" in msg)
             )
             if is_id_unique_violation:
                 raise ConversationAlreadyExistsError(
@@ -1001,13 +969,9 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         Fetch a conversation by its unique ID.
 
-        Issues two queries inside one session:
-
-        1. A single LEFT OUTER JOIN of ``conversations`` +
-           ``agent_configuration`` (same PK, same DB) so both rows
-           arrive in one round-trip instead of two serial
-           ``session.get`` calls.
-        2. A label fetch on ``conversation_labels``.
+        Issues two queries inside one session: the conversation row
+        (which carries the agent binding + per-session override blob) and
+        a label fetch on ``conversation_labels``.
 
         :param conversation_id: Unique conversation identifier,
             e.g. ``"conv_abc123"``.
@@ -1015,25 +979,11 @@ class SqlAlchemyConversationStore(ConversationStore):
             ``None``.
         """
         with self._conv_session() as session:
-            result = session.execute(
-                select(SqlConversation, SqlAgentConfiguration)
-                .outerjoin(
-                    SqlAgentConfiguration,
-                    (SqlAgentConfiguration.workspace_id == SqlConversation.workspace_id)
-                    & (SqlAgentConfiguration.conversation_id == SqlConversation.id),
-                )
-                .where(
-                    SqlConversation.workspace_id == current_workspace_id(),
-                    SqlConversation.id == conversation_id,
-                )
-            ).first()
-            if result is None:
+            row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
+            if row is None:
                 return None
-            row, agent_config = result
             meta = self._get_meta(session, conversation_id)
-            return _to_conversation(
-                row, meta, _fetch_labels(session, conversation_id), agent_config
-            )
+            return _to_conversation(row, meta, _fetch_labels(session, conversation_id))
 
     def find_imported_conversation(
         self,
@@ -1181,7 +1131,6 @@ class SqlAlchemyConversationStore(ConversationStore):
             # too — _to_conversation reads ORM columns, which would raise
             # DetachedInstanceError once the session closes.
             labels_by_conv = _fetch_labels_bulk(session, [row.id for row in rows])
-            configs_by_id = self._fetch_agent_configurations(session, [row.id for row in rows])
         meta_rows = []
         if rows:
             row_ids = [r.id for r in rows]
@@ -1202,7 +1151,6 @@ class SqlAlchemyConversationStore(ConversationStore):
                 row,
                 meta_by_id.get(row.id),
                 labels_by_conv.get(row.id, {}),
-                configs_by_id.get(row.id),
             )
             for row in rows
         }
@@ -2212,17 +2160,10 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversation.root_conversation_id == root_conversation_id,
                 )
             if has_agent_id is True:
-                stmt = stmt.where(
-                    SqlConversation.id.in_(
-                        select(SqlAgentConfiguration.conversation_id).where(
-                            SqlAgentConfiguration.workspace_id == current_workspace_id(),
-                            SqlAgentConfiguration.agent_id.is_not(None),
-                        )
-                    )
-                )
+                stmt = stmt.where(SqlConversation.agent_id.is_not(None))
             if agent_name is not None:
                 # Agents live in the Omnigent DB — resolve to IDs first, then
-                # filter via agent_configuration (same DB as conversations).
+                # filter on the conversations.agent_id column directly.
                 with self._session() as agent_sess:
                     agent_ids_for_name = list(
                         agent_sess.execute(
@@ -2234,26 +2175,11 @@ class SqlAlchemyConversationStore(ConversationStore):
                         .scalars()
                         .all()
                     )
-                stmt = stmt.where(
-                    SqlConversation.id.in_(
-                        select(SqlAgentConfiguration.conversation_id).where(
-                            SqlAgentConfiguration.workspace_id == current_workspace_id(),
-                            SqlAgentConfiguration.agent_id.in_(agent_ids_for_name),
-                        )
-                    )
-                )
+                stmt = stmt.where(SqlConversation.agent_id.in_(agent_ids_for_name))
             if agent_id is not None:
-                # Conversations without an agent binding (legacy rows)
-                # correctly return no results: their agent_configuration row has
-                # agent_id NULL.
-                stmt = stmt.where(
-                    SqlConversation.id.in_(
-                        select(SqlAgentConfiguration.conversation_id).where(
-                            SqlAgentConfiguration.workspace_id == current_workspace_id(),
-                            SqlAgentConfiguration.agent_id == agent_id,
-                        )
-                    )
-                )
+                # Conversations without an agent binding (legacy rows) correctly
+                # return no results: their agent_id column is NULL.
+                stmt = stmt.where(SqlConversation.agent_id == agent_id)
             if title is not None:
                 stmt = stmt.where(SqlConversation.title == title)
             if search_query:
@@ -2317,9 +2243,9 @@ class SqlAlchemyConversationStore(ConversationStore):
             if has_more:
                 rows = rows[:limit]
             row_ids = [r.id for r in rows]
-            # Fetch labels and agent-configuration rows for all returned
-            # conversations in single IN-clause queries so the list-path is
-            # O(1) queries regardless of page size.
+            # Fetch labels for all returned conversations in a single IN-clause
+            # query so the list-path is O(1) queries regardless of page size.
+            # The agent binding + overrides ride on each conversation row.
             labels_by_conv = _fetch_labels_bulk(session, row_ids)
             # On a content search, fetch a preview excerpt of the matching
             # chat text so the UI can show *where* each session matched (the
@@ -2329,11 +2255,8 @@ class SqlAlchemyConversationStore(ConversationStore):
             snippets = (
                 _fetch_search_snippets(session, row_ids, search_query) if search_query else {}
             )
-            configs_by_id = self._fetch_agent_configurations(session, row_ids)
             # Build AP-only entities; metadata fetched separately below.
-            ap_entities = [
-                (r, labels_by_conv.get(r.id, {}), configs_by_id.get(r.id)) for r in rows
-            ]
+            ap_entities = [(r, labels_by_conv.get(r.id, {})) for r in rows]
 
         # Fetch metadata from Omnigent DB and merge.
         meta_by_id: dict[str, SqlConversationMetadata] = {}
@@ -2352,8 +2275,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 # Access .id inside the session to avoid DetachedInstanceError.
                 meta_by_id = {m.id: m for m in meta_rows}
                 convs = [
-                    _to_conversation(r, meta_by_id.get(r.id), labels, agent_config)
-                    for r, labels, agent_config in ap_entities
+                    _to_conversation(r, meta_by_id.get(r.id), labels) for r, labels in ap_entities
                 ]
         else:
             convs = []
@@ -2496,50 +2418,45 @@ class SqlAlchemyConversationStore(ConversationStore):
             if the conversation does not exist.
         """
         now = now_epoch()
-        # Two separate transactions: AP (conversation + agent_configuration rows,
-        # same DB) and Omnigent (metadata).
+        # Two transactions: AP (the conversation row, which carries the agent
+        # binding + per-session override blob) and Omnigent (metadata).
         with self._conv_session() as ap_sess:
             row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
             if not row:
                 return None
-            agent_config = ap_sess.get(
-                SqlAgentConfiguration, (current_workspace_id(), conversation_id)
-            )
-            if agent_config is None:
-                # Repair a conversation missing its paired agent_configuration
-                # row; same transaction, so the pair stays consistent.
-                _logger.warning(
-                    "conversation %s has no agent_configuration row; recreating it",
-                    conversation_id,
-                )
-                agent_config = _new_agent_configuration_row(conversation_id)
-                ap_sess.add(agent_config)
             ap_changed = False
             if title is not None:
                 row.title = title or ""
                 # Column default only fires on INSERT; keep the hash in sync here.
                 row.title_hash = conversation_title_hash(row.title)
                 ap_changed = True
+            # Read-modify-write the override blob so partial updates preserve the
+            # keys they don't touch. Only re-encode when something actually changed.
+            overrides = _decode_session_overrides(row.session_overrides)
+            overrides_changed = False
             if _unset_reasoning_effort:
-                agent_config.reasoning_effort = None
-                ap_changed = True
+                overrides["reasoning_effort"] = None
+                overrides_changed = True
             elif reasoning_effort is not None:
-                agent_config.reasoning_effort = reasoning_effort
-                ap_changed = True
+                overrides["reasoning_effort"] = reasoning_effort
+                overrides_changed = True
             if _unset_model_override:
-                agent_config.model_override = None
-                ap_changed = True
+                overrides["model_override"] = None
+                overrides_changed = True
             elif model_override is not None:
-                agent_config.model_override = model_override
-                ap_changed = True
+                overrides["model_override"] = model_override
+                overrides_changed = True
             if _unset_cost_control_mode_override:
-                agent_config.cost_control_mode_override = None
-                ap_changed = True
+                overrides["cost_control_mode_override"] = None
+                overrides_changed = True
             elif cost_control_mode_override is not None:
-                agent_config.cost_control_mode_override = cost_control_mode_override
-                ap_changed = True
+                overrides["cost_control_mode_override"] = cost_control_mode_override
+                overrides_changed = True
             if harness_override is not None:
-                agent_config.harness_override = harness_override
+                overrides["harness_override"] = harness_override
+                overrides_changed = True
+            if overrides_changed:
+                row.session_overrides = _encode_session_overrides(overrides)
                 ap_changed = True
             if archived is not None:
                 # archived lives on the AP conversations row; a visible state change.
@@ -2857,11 +2774,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 .scalars()
                 .all()
             )
-            configs_by_id = self._fetch_agent_configurations(ap_sess, [r.id for r in ap_rows])
-        return [
-            _to_conversation(r, meta_by_id.get(r.id), agent_config=configs_by_id.get(r.id))
-            for r in ap_rows
-        ]
+        return [_to_conversation(r, meta_by_id.get(r.id)) for r in ap_rows]
 
     def set_host_id(
         self,
@@ -3068,15 +2981,11 @@ class SqlAlchemyConversationStore(ConversationStore):
             title,
             parent_conversation_id=parent_conversation_id,
             root_conversation_id=root_conversation_id,
-        )
-        agent_config_row = _new_agent_configuration_row(
-            conversation_id,
             agent_id=agent_id,
-            reasoning_effort=reasoning_effort,
+            session_overrides=_encode_session_overrides({"reasoning_effort": reasoning_effort}),
         )
         with self._conv_session() as ap_sess:
             ap_sess.add(conversation_row)
-            ap_sess.add(agent_config_row)
             if labels:
                 _upsert_labels(ap_sess, conversation_id, labels, now)
 
@@ -3099,9 +3008,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             session.add(meta_row)
             session.flush()
 
-        return _created_session_from_rows(
-            conversation_row, meta_row, agent_config_row, agent_row, labels
-        )
+        return _created_session_from_rows(conversation_row, meta_row, agent_row, labels)
 
     def fork_conversation(
         self,
@@ -3219,9 +3126,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             source = session.get(SqlConversation, (current_workspace_id(), source_conversation_id))
             if source is None:
                 raise LookupError(f"conversation not found: {source_conversation_id!r}")
-            source_config = session.get(
-                SqlAgentConfiguration, (current_workspace_id(), source_conversation_id)
-            )
+            source_overrides = _decode_session_overrides(source.session_overrides)
 
             fork_title = (
                 title
@@ -3233,6 +3138,22 @@ class SqlAlchemyConversationStore(ConversationStore):
                 )
             )
             creating_clone = cloned_agent_bundle_location is not None
+            # Model-family-bound overrides (reasoning_effort, model_override, and
+            # — same gate — harness_override) copy only when copy_model_settings.
+            # cost_control_mode_override is intentionally never carried onto a fork.
+            fork_overrides = _encode_session_overrides(
+                {
+                    "reasoning_effort": (
+                        source_overrides["reasoning_effort"] if copy_model_settings else None
+                    ),
+                    "model_override": (
+                        source_overrides["model_override"] if copy_model_settings else None
+                    ),
+                    "harness_override": (
+                        source_overrides["harness_override"] if copy_model_settings else None
+                    ),
+                }
+            )
             new_conv = SqlConversation(
                 id=new_conv_id,
                 created_at=now,
@@ -3242,34 +3163,12 @@ class SqlAlchemyConversationStore(ConversationStore):
                 # root mirrors its own id (matches the
                 # ``_new_session_conversation_row`` invariant).
                 root_conversation_id=new_conv_id,
+                # An explicit agent_id (clone or existing) beats inheriting the
+                # source's binding.
+                agent_id=(agent_id if agent_id is not None else source.agent_id),
+                session_overrides=fork_overrides,
             )
             session.add(new_conv)
-            # Paired agent-configuration row: an explicit agent_id (clone or
-            # existing) beats inheriting the source's binding.
-            new_config = _new_agent_configuration_row(
-                new_conv_id,
-                agent_id=(
-                    agent_id
-                    if agent_id is not None
-                    else (source_config.agent_id if source_config else None)
-                ),
-                reasoning_effort=(
-                    source_config.reasoning_effort
-                    if copy_model_settings and source_config
-                    else None
-                ),
-                model_override=(
-                    source_config.model_override if copy_model_settings and source_config else None
-                ),
-                # The brain-harness override is family-bound like the model,
-                # so it follows the same copy gate.
-                harness_override=(
-                    source_config.harness_override
-                    if copy_model_settings and source_config
-                    else None
-                ),
-            )
-            session.add(new_config)
 
             # Resolve the truncation cutoff: the position of the LAST item
             # of the selected response, so the fork never ends mid-turn.
@@ -3347,7 +3246,7 @@ class SqlAlchemyConversationStore(ConversationStore):
 
             # Cloned agent: the row itself is written to the Omnigent DB after
             # the AP session commits (see the block below the with-statement);
-            # the fork's binding already lives on new_config.agent_id.
+            # the fork's binding already lives on new_conv.agent_id.
             if creating_clone:
                 assert (
                     agent_id is not None
@@ -3443,7 +3342,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     )
                 )
 
-        return _to_conversation(new_conv, fork_meta, fork_labels, new_config)
+        return _to_conversation(new_conv, fork_meta, fork_labels)
 
     def switch_conversation_agent(
         self,
@@ -3502,24 +3401,21 @@ class SqlAlchemyConversationStore(ConversationStore):
         if previous_builtin_id is not None:
             upserts[SWITCH_PREVIOUS_BUILTIN_LABEL_KEY] = previous_builtin_id
 
-        # AP holds conversation+labels+agent_configuration; Omnigent holds
-        # agent+metadata. Read old_agent_id from AP before overwriting it.
+        # AP holds the conversation (agent binding + overrides) + labels;
+        # Omnigent holds agent+metadata. Read old_agent_id before overwriting it.
         with self._conv_session() as ap_sess:
             row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
             if row is None:
                 raise LookupError(f"conversation not found: {conversation_id!r}")
-            agent_config = ap_sess.get(
-                SqlAgentConfiguration, (current_workspace_id(), conversation_id)
-            )
-            if agent_config is None:
-                agent_config = _new_agent_configuration_row(conversation_id)
-                ap_sess.add(agent_config)
-            old_agent_id = agent_config.agent_id
-            agent_config.agent_id = new_agent_id
+            old_agent_id = row.agent_id
+            row.agent_id = new_agent_id
+            overrides = _decode_session_overrides(row.session_overrides)
             if not copy_model_settings:
-                agent_config.model_override = None
-                agent_config.reasoning_effort = None
-            agent_config.harness_override = None
+                overrides["model_override"] = None
+                overrides["reasoning_effort"] = None
+            # The brain-harness override never survives a rebind.
+            overrides["harness_override"] = None
+            row.session_overrides = _encode_session_overrides(overrides)
             row.updated_at = now
 
             existing = _fetch_labels(ap_sess, conversation_id)
@@ -3614,10 +3510,10 @@ class SqlAlchemyConversationStore(ConversationStore):
             # should only be removed when ALL its referrers are deleted.
             candidate_agent_ids = set(
                 ap_sess.execute(
-                    select(SqlAgentConfiguration.agent_id).where(
-                        SqlAgentConfiguration.workspace_id == current_workspace_id(),
-                        SqlAgentConfiguration.conversation_id.in_(subtree_ids),
-                        SqlAgentConfiguration.agent_id.is_not(None),
+                    select(SqlConversation.agent_id).where(
+                        SqlConversation.workspace_id == current_workspace_id(),
+                        SqlConversation.id.in_(subtree_ids),
+                        SqlConversation.agent_id.is_not(None),
                     )
                 )
                 .scalars()
@@ -3627,10 +3523,10 @@ class SqlAlchemyConversationStore(ConversationStore):
             # subtree being deleted.
             surviving_refs = set(
                 ap_sess.execute(
-                    select(SqlAgentConfiguration.agent_id).where(
-                        SqlAgentConfiguration.workspace_id == current_workspace_id(),
-                        SqlAgentConfiguration.agent_id.in_(candidate_agent_ids),
-                        SqlAgentConfiguration.conversation_id.not_in(subtree_ids),
+                    select(SqlConversation.agent_id).where(
+                        SqlConversation.workspace_id == current_workspace_id(),
+                        SqlConversation.agent_id.in_(candidate_agent_ids),
+                        SqlConversation.id.not_in(subtree_ids),
                     )
                 )
                 .scalars()
@@ -3649,12 +3545,6 @@ class SqlAlchemyConversationStore(ConversationStore):
                 delete(SqlConversationLabel).where(
                     SqlConversationLabel.workspace_id == current_workspace_id(),
                     SqlConversationLabel.conversation_id.in_(subtree_ids),
-                )
-            )
-            ap_sess.execute(
-                delete(SqlAgentConfiguration).where(
-                    SqlAgentConfiguration.workspace_id == current_workspace_id(),
-                    SqlAgentConfiguration.conversation_id.in_(subtree_ids),
                 )
             )
             ap_sess.execute(

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -16,7 +16,6 @@ from sqlalchemy.exc import IntegrityError, OperationalError
 from omnigent.db.db_models import (
     SqlAccountToken,
     SqlAgent,
-    SqlAgentConfiguration,
     SqlComment,
     SqlConversation,
     SqlConversationItem,
@@ -70,6 +69,8 @@ def _make_conversation(
     root_conversation_id: str | None = None,
     title: str | None = None,
     archived: bool = False,
+    agent_id: str | None = None,
+    session_overrides: str | None = None,
 ) -> SqlConversation:
     return SqlConversation(
         id=id,
@@ -79,14 +80,9 @@ def _make_conversation(
         root_conversation_id=root_conversation_id or id,
         title=title,
         archived=archived,
+        agent_id=agent_id,
+        session_overrides=session_overrides,
     )
-
-
-def _make_agent_configuration(
-    conversation_id: str = "a9930027fd3e2e979e65844f7af7bf88",
-    agent_id: str | None = None,
-) -> SqlAgentConfiguration:
-    return SqlAgentConfiguration(conversation_id=conversation_id, agent_id=agent_id)
 
 
 def _make_metadata(
@@ -357,9 +353,8 @@ class TestSqlConversation:
             loaded = session.get(SqlConversation, (0, "a9930027fd3e2e979e65844f7af7bf88"))
             assert loaded is not None
             assert loaded.title == "Hello World"
-            # Identity/hierarchy columns only; kind/archived live on
-            # SqlConversationMetadata, agent binding + overrides on
-            # SqlAgentConfiguration.
+            # kind lives on SqlConversationMetadata; the agent binding
+            # (agent_id) and per-session override blob live on the row itself.
             assert loaded.root_conversation_id == "a9930027fd3e2e979e65844f7af7bf88"
             assert loaded.next_position == 0
 
@@ -368,17 +363,15 @@ class TestSqlConversation:
         managed = make_managed_session_maker(engine)
 
         conv = _make_conversation()
-        agent_config = _make_agent_configuration()
         with managed() as session:
             session.add(conv)
-            session.add(agent_config)
 
         with managed() as session:
-            loaded = session.get(SqlAgentConfiguration, (0, "a9930027fd3e2e979e65844f7af7bf88"))
+            loaded = session.get(SqlConversation, (0, "a9930027fd3e2e979e65844f7af7bf88"))
             assert loaded is not None
-            assert loaded.reasoning_effort is None
-            assert loaded.model_override is None
+            # Agent binding + overrides default to NULL on a bare conversation.
             assert loaded.agent_id is None
+            assert loaded.session_overrides is None
 
     def test_metadata_kind_and_archived(self, db_uri: str) -> None:
         """kind lives on SqlConversationMetadata; archived on SqlConversation."""

--- a/tests/db/test_migration_agents_session_id.py
+++ b/tests/db/test_migration_agents_session_id.py
@@ -48,16 +48,15 @@ def test_agents_session_id_index_removed(db_engine: Engine) -> None:
     assert "ix_agents_session_id" not in index_names
 
 
-def test_ix_agent_configuration_agent_id_added(db_engine: Engine) -> None:
-    """The agent-lookup index lives on agent_configuration at head.
+def test_ix_conversations_agent_id_present(db_engine: Engine) -> None:
+    """The agent-lookup index lives back on conversations at head.
 
-    ix_conversations_agent_id moved there when the agent binding split
-    out of conversations.
+    The agent binding merged back onto conversations (dropping the
+    agent_configuration table), so the index is ix_conversations_agent_id.
     """
+    assert "agent_configuration" not in set(sa.inspect(db_engine).get_table_names())
     conv_indexes = {i["name"] for i in sa.inspect(db_engine).get_indexes("conversations")}
-    assert "ix_conversations_agent_id" not in conv_indexes
-    ra_indexes = {i["name"] for i in sa.inspect(db_engine).get_indexes("agent_configuration")}
-    assert "ix_agent_configuration_agent_id" in ra_indexes
+    assert "ix_conversations_agent_id" in conv_indexes
 
 
 def test_agents_name_index_exists(db_engine: Engine) -> None:
@@ -122,7 +121,7 @@ def test_session_agent_kind_stored_and_read(db_engine: Engine) -> None:
 
 
 def test_agents_session_id_fk_accepts_existing_session(db_engine: Engine) -> None:
-    """agent_configuration.agent_id (forward pointer) accepts a valid agent id."""
+    """conversations.agent_id (forward pointer) accepts a valid agent id."""
     with db_engine.begin() as conn:
         conn.execute(
             sa.text(
@@ -137,35 +136,28 @@ def test_agents_session_id_fk_accepts_existing_session(db_engine: Engine) -> Non
                 "loc": "552f255351da28d9c68a67cc9758840d/bundle",
             },
         )
-        # The agent binding lives on agent_configuration, paired 1:1 with
-        # the conversations row.
+        # The agent binding lives on the conversations row itself.
         conn.execute(
             sa.text(
                 "INSERT INTO conversations"
-                " (id, created_at, updated_at, root_conversation_id)"
-                " VALUES (:id, :ts, :ts, :id)"
-            ),
-            {"id": "e6c4a1ce71909cfba7d30a314c5f94ee", "ts": 1700000002},
-        )
-        conn.execute(
-            sa.text(
-                "INSERT INTO agent_configuration (conversation_id, agent_id)"
-                " VALUES (:id, :agent_id)"
+                " (id, created_at, updated_at, root_conversation_id, agent_id)"
+                " VALUES (:id, :ts, :ts, :id, :agent_id)"
             ),
             {
                 "id": "e6c4a1ce71909cfba7d30a314c5f94ee",
+                "ts": 1700000002,
                 "agent_id": "552f255351da28d9c68a67cc9758840d",
             },
         )
         stored = conn.execute(
-            sa.text("SELECT agent_id FROM agent_configuration WHERE conversation_id = :id"),
+            sa.text("SELECT agent_id FROM conversations WHERE id = :id"),
             {"id": "e6c4a1ce71909cfba7d30a314c5f94ee"},
         ).scalar_one()
     assert stored == "552f255351da28d9c68a67cc9758840d"
 
 
 def test_agents_session_id_fk_rejects_missing_session(db_engine: Engine) -> None:
-    """Without DB FK, agent_configuration.agent_id accepts any value including nonexistent agents.
+    """Without DB FK, conversations.agent_id accepts any value including nonexistent agents.
 
     Referential integrity is now the application's responsibility.
     """
@@ -174,29 +166,17 @@ def test_agents_session_id_fk_rejects_missing_session(db_engine: Engine) -> None
         conn.execute(
             sa.text(
                 "INSERT INTO conversations"
-                " (id, created_at, updated_at, root_conversation_id)"
-                " VALUES (:id, :ts, :ts, :id)"
-            ),
-            {"id": "5eca720dc2bc6cdc3a99028d7bd0f917", "ts": 1700000002},
-        )
-        conn.execute(
-            sa.text(
-                "INSERT INTO agent_configuration (conversation_id, agent_id)"
-                " VALUES (:id, :agent_id)"
+                " (id, created_at, updated_at, root_conversation_id, agent_id)"
+                " VALUES (:id, :ts, :ts, :id, :agent_id)"
             ),
             {
                 "id": "5eca720dc2bc6cdc3a99028d7bd0f917",
+                "ts": 1700000002,
                 "agent_id": "5ff5b2e31fe10beb80134394037b17b0",
             },
         )
     # Clean up
     with db_engine.begin() as conn:
-        conn.execute(
-            sa.text(
-                "DELETE FROM agent_configuration "
-                "WHERE conversation_id = '5eca720dc2bc6cdc3a99028d7bd0f917'"
-            )
-        )
         conn.execute(
             sa.text("DELETE FROM conversations WHERE id = '5eca720dc2bc6cdc3a99028d7bd0f917'")
         )
@@ -365,21 +345,16 @@ def test_agents_session_id_downgrade_round_trip(tmp_path: Path) -> None:
                 " 'my-session', '372d0296768feff7262c605c5553d1da/b', 1, 2)"
             )
         )
+        # agent_id lives back on conversations at head (the agent_configuration
+        # table was merged away). The downgrade chain moves it out to
+        # agent_configuration and back before the older downgrades read it.
         conn.execute(
             sa.text(
                 "INSERT INTO conversations"
-                " (workspace_id, id, created_at, updated_at, root_conversation_id, title)"
+                " (workspace_id, id, created_at, updated_at, root_conversation_id, title,"
+                " agent_id)"
                 " VALUES (0, '8e32600337d08f59ad381caf96a90659', 3, 3,"
-                " '8e32600337d08f59ad381caf96a90659', '')"
-            )
-        )
-        # agent_id lives on agent_configuration at head; the bb2c3d4e5f6a
-        # downgrade restores it to conversations before the older
-        # downgrades read it.
-        conn.execute(
-            sa.text(
-                "INSERT INTO agent_configuration (workspace_id, conversation_id, agent_id)"
-                " VALUES (0, '8e32600337d08f59ad381caf96a90659',"
+                " '8e32600337d08f59ad381caf96a90659', '',"
                 " '372d0296768feff7262c605c5553d1da')"
             )
         )

--- a/tests/db/test_migration_merge_agent_configuration.py
+++ b/tests/db/test_migration_merge_agent_configuration.py
@@ -1,0 +1,186 @@
+"""Tests for the agent_configuration merge migration (b7e4d2c9a1f3).
+
+Reverses the earlier split: the agent_configuration companion table folds back
+onto conversations as an indexed ``agent_id`` column plus a ``session_overrides``
+JSON blob.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import command
+
+from omnigent.db.db_models import uuid_to_bytes
+from omnigent.db.utils import _build_alembic_config, clear_engine_cache
+
+# Revision before the merge (agent_configuration still exists) and the merge itself.
+_PRE_MERGE = "a2b7c3d8e4f9"
+_MERGE = "b7e4d2c9a1f3"
+
+_CONV_BOUND = "a9930027fd3e2e979e65844f7af7bf88"
+_CONV_DEFAULT = "b0041138ae4f3fa8af76955a8b086c99"
+_AGENT = "112c4ebea353b873df12de9d02f539ab"
+
+
+def _upgrade(uri: str, engine: sa.Engine, revision: str) -> None:
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.upgrade(config, revision)
+
+
+def _downgrade(uri: str, engine: sa.Engine, revision: str) -> None:
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, revision)
+
+
+def _seed(engine: sa.Engine) -> None:
+    """One conversation with an agent + overrides, one on all defaults."""
+    with engine.begin() as conn:
+        for cid in (_CONV_BOUND, _CONV_DEFAULT):
+            conn.execute(
+                sa.text(
+                    "INSERT INTO conversations (workspace_id, id, created_at, updated_at,"
+                    " title, root_conversation_id) VALUES (0, :id, 1, 1, :t, :id)"
+                ),
+                {"id": uuid_to_bytes(cid), "t": f"conv {cid[:6]}"},
+            )
+        conn.execute(
+            sa.text(
+                "INSERT INTO agent_configuration (workspace_id, conversation_id, agent_id,"
+                " reasoning_effort, model_override, cost_control_mode_override, harness_override)"
+                " VALUES (0, :cid, :aid, 'high', 'claude-opus-4-8', NULL, NULL)"
+            ),
+            {"cid": uuid_to_bytes(_CONV_BOUND), "aid": uuid_to_bytes(_AGENT)},
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO agent_configuration (workspace_id, conversation_id, agent_id)"
+                " VALUES (0, :cid, NULL)"
+            ),
+            {"cid": uuid_to_bytes(_CONV_DEFAULT)},
+        )
+
+
+def test_merge_upgrade_folds_binding_and_overrides(tmp_path: Path) -> None:
+    """Upgrade drops the table, copies agent_id, and packs overrides into a blob."""
+    uri = f"sqlite:///{tmp_path / 'merge.db'}"
+    engine = sa.create_engine(uri)
+    try:
+        _upgrade(uri, engine, _PRE_MERGE)
+        _seed(engine)
+        _upgrade(uri, engine, _MERGE)
+
+        insp = sa.inspect(engine)
+        assert "agent_configuration" not in set(insp.get_table_names())
+        cols = {c["name"] for c in insp.get_columns("conversations")}
+        assert {"agent_id", "session_overrides"} <= cols
+        conv_indexes = {i["name"] for i in insp.get_indexes("conversations")}
+        assert "ix_conversations_agent_id" in conv_indexes
+
+        with engine.begin() as conn:
+            aid, blob = conn.execute(
+                sa.text("SELECT agent_id, session_overrides FROM conversations WHERE id = :id"),
+                {"id": uuid_to_bytes(_CONV_BOUND)},
+            ).one()
+            assert bytes(aid) == uuid_to_bytes(_AGENT)
+            # Only the set overrides are stored; unset ones are omitted.
+            assert json.loads(blob) == {
+                "reasoning_effort": "high",
+                "model_override": "claude-opus-4-8",
+            }
+
+            aid2, blob2 = conn.execute(
+                sa.text("SELECT agent_id, session_overrides FROM conversations WHERE id = :id"),
+                {"id": uuid_to_bytes(_CONV_DEFAULT)},
+            ).one()
+            # All-default session keeps both NULL.
+            assert aid2 is None and blob2 is None
+    finally:
+        clear_engine_cache()
+
+
+def test_merge_copies_varchar_stored_agent_id(tmp_path: Path) -> None:
+    """A hex-string agent_id (the Postgres/MySQL VARCHAR form) copies as bytes.
+
+    The split migration declared agent_configuration.agent_id as VARCHAR, so on
+    a non-SQLite fork the source holds a hex string. The migration must still
+    land the correct 16 raw bytes in the binary conversations.agent_id column —
+    this is the coercion the hardened Python copy handles.
+    """
+    uri = f"sqlite:///{tmp_path / 'merge_varchar.db'}"
+    engine = sa.create_engine(uri)
+    try:
+        _upgrade(uri, engine, _PRE_MERGE)
+        with engine.begin() as conn:
+            conn.execute(
+                sa.text(
+                    "INSERT INTO conversations (workspace_id, id, created_at, updated_at,"
+                    " title, root_conversation_id) VALUES (0, :id, 1, 1, 't', :id)"
+                ),
+                {"id": uuid_to_bytes(_CONV_BOUND)},
+            )
+            # agent_id + conversation_id inserted as plain hex strings, not bytes.
+            conn.execute(
+                sa.text(
+                    "INSERT INTO agent_configuration (workspace_id, conversation_id, agent_id)"
+                    " VALUES (0, :cid, :aid)"
+                ),
+                {"cid": _CONV_BOUND, "aid": _AGENT},
+            )
+        _upgrade(uri, engine, _MERGE)
+
+        with engine.begin() as conn:
+            aid = conn.execute(
+                sa.text("SELECT agent_id FROM conversations WHERE id = :id"),
+                {"id": uuid_to_bytes(_CONV_BOUND)},
+            ).scalar_one()
+            assert bytes(aid) == uuid_to_bytes(_AGENT)
+    finally:
+        clear_engine_cache()
+
+
+def test_merge_round_trip_restores_agent_configuration(tmp_path: Path) -> None:
+    """Downgrade recreates the table and fans the blob back out to columns."""
+    uri = f"sqlite:///{tmp_path / 'merge_rt.db'}"
+    engine = sa.create_engine(uri)
+    try:
+        _upgrade(uri, engine, _PRE_MERGE)
+        _seed(engine)
+        _upgrade(uri, engine, _MERGE)
+        _downgrade(uri, engine, _PRE_MERGE)
+
+        insp = sa.inspect(engine)
+        assert "agent_configuration" in set(insp.get_table_names())
+        cols = {c["name"] for c in insp.get_columns("conversations")}
+        assert "agent_id" not in cols and "session_overrides" not in cols
+
+        with engine.begin() as conn:
+            row = conn.execute(
+                sa.text(
+                    "SELECT agent_id, reasoning_effort, model_override,"
+                    " cost_control_mode_override, harness_override"
+                    " FROM agent_configuration WHERE conversation_id = :cid"
+                ),
+                {"cid": uuid_to_bytes(_CONV_BOUND)},
+            ).one()
+            assert bytes(row[0]) == uuid_to_bytes(_AGENT)
+            assert row[1] == "high"
+            assert row[2] == "claude-opus-4-8"
+            assert row[3] is None and row[4] is None
+
+            row2 = conn.execute(
+                sa.text(
+                    "SELECT agent_id, reasoning_effort FROM agent_configuration"
+                    " WHERE conversation_id = :cid"
+                ),
+                {"cid": uuid_to_bytes(_CONV_DEFAULT)},
+            ).one()
+            assert row2[0] is None and row2[1] is None
+    finally:
+        clear_engine_cache()

--- a/tests/stores/test_conversation_store_split_db.py
+++ b/tests/stores/test_conversation_store_split_db.py
@@ -351,12 +351,10 @@ def test_delete_conversation_subtree_cleans_both_dbs(
     parent = store.create_conversation(title="parent")
     store.create_conversation(kind="sub_agent", title="child", parent_conversation_id=parent.id)
     assert _count(conv_db, "conversations") == 2
-    assert _count(conv_db, "agent_configuration") == 2
     assert _count(omnigent_db, "omnigent_conversation_metadata") == 2
 
     asyncio.run(store.delete_conversation(parent.id))
     assert _count(conv_db, "conversations") == 0
-    assert _count(conv_db, "agent_configuration") == 0
     assert _count(omnigent_db, "omnigent_conversation_metadata") == 0
 
 
@@ -435,10 +433,10 @@ def test_agent_store_resolves_session_id_across_dbs(
         agent_description=None,
         title="split session",
     )
-    # Agent row lands in the Omnigent DB; the binding in the AP DB's
-    # agent_configuration table.
+    # Agent row lands in the Omnigent DB; the binding on the AP DB's
+    # conversations.agent_id column.
     assert _count(omnigent_db, "agents") == 1
-    assert _col(conv_db, "agent_configuration", "agent_id") == ["112c4ebea353b873df12de9d02f539ab"]
+    assert _col(conv_db, "conversations", "agent_id") == ["112c4ebea353b873df12de9d02f539ab"]
 
     agent_store = SqlAlchemyAgentStore(
         f"sqlite:///{omnigent_db}",
@@ -524,7 +522,7 @@ def test_delete_conversation_deletes_session_scoped_agent(
 
     asyncio.run(store.delete_conversation(created.conversation.id))
     assert _count(omnigent_db, "agents") == 0
-    assert _count(conv_db, "agent_configuration") == 0
+    assert _count(conv_db, "conversations") == 0
 
 
 def test_delete_conversation_keeps_template_agent(


### PR DESCRIPTION
## Related issue

N/A

## Summary

`agent_configuration` was a 1-to-1 companion table split out of `conversations` a
week ago (`bb2c3d4e5f6a`). It never earned its keep: same database, always created
1:1 (it needed "repair a missing row" logic), and every read path fetched it
anyway. This folds it back onto `conversations`:

- **`agent_id`** returns as a first-class **indexed** column (`ix_conversations_agent_id`), so the agent→conversation reverse lookup and the `agent_id` / `has_agent_id` / `agent_name` list filters stay index-backed.
- The four per-session overrides (`reasoning_effort`, `model_override`, `cost_control_mode_override`, `harness_override`) collapse into one nullable **`session_overrides` `VARCHAR(512)` JSON blob**, `NULL` when the session uses all agent/spec defaults. They were never filtered in SQL, so a blob loses no query capability.

Net effect: drops a table, an extra INSERT, the `get_conversation` JOIN, and the paired-row repair/fork/delete plumbing (**−181 lines** of store code). Reverses `bb2c3d4e5f6a`.

While here, fixed a latent bug: the caller-supplied-id → `ConversationAlreadyExistsError` translation had been relying on the `agent_configuration` INSERT failing first; with that table gone it's re-keyed on the dotted `conversations.id` token in the constraint error (SQLite), which never appears in the INSERT column list.

Migration `b7e4d2c9a1f3` (reverses `bb2c3d4e5f6a`): adds the columns, copies the binding + overrides in Python (keyset-batched), restores the index, drops the table. Fully reversible. Ids are normalised to bytes in Python before the copy, so it is correct on SQLite/Postgres/MySQL regardless of the source column's declared type (the split declared it `VARCHAR`; `conversations` stores ids as raw bytes) — a column-to-column SQL copy would have failed on Postgres/MySQL.

## Test Plan

```
.venv/bin/python -m pytest \
  tests/db/test_migration_merge_agent_configuration.py \
  tests/db/test_migration_agents_session_id.py \
  tests/db/test_db_models.py \
  tests/stores/test_conversation_store.py \
  tests/stores/test_conversation_store_split_db.py \
  tests/stores/test_agent_store.py
```

- New `test_migration_merge_agent_configuration.py` covers upgrade, full up/down round-trip, **and** the varchar-stored-`agent_id` case (the Postgres/MySQL form the byte-normalisation targets).
- Existing conversation/agent/split-DB store suites updated and green (229 store tests + migration/model tests).
- `pre-commit run --files ...` clean; single alembic head confirmed (`b7e4d2c9a1f3`).

## Demo

N/A — schema/store refactor, no UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added migration tests (upgrade, round-trip, varchar-source copy) and updated the
model / conversation-store / split-DB / agent-store suites to the merged schema.
The SQLite round-trip proves the reversible data copy; the byte-normalisation is
what makes the copy dialect-safe on Postgres/MySQL.

This pull request and its description were written by Isaac.
