### PR TITLE
fix(codex): keep provider keys out of process argv

### DIFF
--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -1139,10 +1139,6 @@ async def _prepare_codex_terminal(
                 thread_id=thread_id,
                 remote_url=codex_ws_url,
                 env=codex_terminal_env(app_server),
-                # Give the --remote TUI the same provider overrides as
-                # the app-server so it resolves the Omnigent provider
-                # and skips the OpenAI-login onboarding screen.
-                config_overrides=tuple(app_server.config_overrides),
             )
             terminal_id = launched_terminal.terminal_id
             _update_startup_progress(startup_progress, "Codex terminal ready.")
@@ -2371,7 +2367,6 @@ async def _launch_codex_terminal(
     thread_id: str | None,
     remote_url: str,
     env: dict[str, str],
-    config_overrides: tuple[str, ...] = (),
 ) -> LaunchedCodexTerminal:
     """
     Launch the server-backed Codex terminal resource.
@@ -2385,19 +2380,12 @@ async def _launch_codex_terminal(
     :param remote_url: App-server transport the Codex TUI attaches to
         via ``--remote``, e.g. ``"ws://127.0.0.1:9876"``.
     :param env: Environment overrides for the terminal process.
-    :param config_overrides: Codex ``-c`` provider/model overrides to
-        apply to the ``--remote`` TUI so it resolves the same provider
-        as the app-server (and skips the OpenAI-login onboarding
-        screen). See :func:`build_codex_remote_args`. Empty for a plain
-        Codex-login launch. E.g.
-        ``('model_provider="omnigent_databricks"',)``.
     :returns: Launched terminal resource details.
     """
     terminal_args = build_codex_remote_args(
         codex_args=codex_args,
         thread_id=thread_id,
         remote_url=remote_url,
-        config_overrides=config_overrides,
     )
     body = {
         "terminal": _TERMINAL_NAME,

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -34,6 +34,7 @@ from omnigent.codex_native_process_registry import (
 )
 from omnigent.inner import _proc
 from omnigent.inner.codex_executor import (
+    _apply_codex_config_overrides,
     _clean_codex_env,
     _codex_cli_version,
     _codex_home_config_source_from_env,
@@ -532,7 +533,8 @@ class CodexNativeAppServer:
     :param socket_path: Codex app-server Unix socket path.
     :param codex_home: Private per-session ``CODEX_HOME`` path.
     :param env: Environment for the app-server subprocess.
-    :param config_overrides: Codex ``-c`` config override values.
+    :param config_overrides: Generated Codex settings written to the private
+        session ``config.toml`` before startup.
     :param developer_instructions: Optional framework-owned instructions
         appended to the private session config before app-server startup.
     :param cwd: Working directory for the app-server process.
@@ -604,9 +606,9 @@ class CodexNativeAppServer:
             self.codex_home,
             _codex_home_config_source_from_env(),
         )
+        _apply_codex_config_overrides(self.codex_home, self.config_overrides)
         # Write the MCP server config into config.toml so the app-server
-        # discovers it at config load. The -c overrides may not be honored
-        # by `codex app-server`, so we write directly to the file.
+        # discovers it at config load.
         _inject_mcp_server_config(self.codex_home, self.bridge_dir, self.python_executable)
         if self.pinned_model:
             _pin_codex_config_model(self.codex_home, self.pinned_model)
@@ -659,8 +661,6 @@ class CodexNativeAppServer:
             "--listen",
             resolved_listen,
         ]
-        for override in self.config_overrides:
-            argv.extend(["-c", override])
         proc_env = {**self.env, "CODEX_HOME": str(self.codex_home)}
         self.process_owner_lock = acquire_codex_native_process_owner_lock()
         try:
@@ -1172,9 +1172,8 @@ def build_codex_native_server(
         runs. ``None`` uses :data:`sys.executable`.
     :param codex_path: Optional executable override. ``None`` searches
         ``PATH``.
-    :param extra_config_overrides: Additional ``-c`` config overrides
-        appended after Databricks routing overrides, e.g. MCP server
-        registration for the Omnigent tool relay.
+    :param extra_config_overrides: Additional generated Codex settings
+        applied after Databricks routing settings.
     :param developer_instructions: Optional framework-owned instructions
         appended to Codex's private per-session config.
     :param bypass_sandbox: When ``True``, append config overrides that put
@@ -1255,7 +1254,7 @@ class NativeCodexLaunch:
     Resolved by :func:`resolve_native_codex_launch` so a native Codex
     session honors ``configure harnesses`` like the in-process codex harness.
 
-    :param config_overrides: Codex ``-c`` overrides that route through a
+    :param config_overrides: Codex settings that route through a
         generic provider (``model_provider`` + base_url + auth + wire);
         empty for the Databricks-profile and CLI-login paths.
     :param model: Model id to pin, or ``None`` to keep Codex's default.
@@ -1280,7 +1279,7 @@ def codex_session_meta_model_provider(launch: NativeCodexLaunch) -> str:
     silently dropping the carried history. The correct value is whatever
     provider the launch itself routes through:
 
-    - a ``model_provider`` ``-c`` override (cli-config / key / gateway /
+    - a generated ``model_provider`` setting (cli-config / key / gateway /
       local providers) pins it explicitly — the override value is a TOML
       basic string, which is also valid JSON;
     - a Databricks profile launch carries no override here; the provider
@@ -1311,12 +1310,12 @@ def _codex_provider_launch(entry: ProviderEntry, model: str | None) -> NativeCod
     - a ``databricks`` entry routes via its ucode profile (the Databricks
       branch of :func:`build_native_codex_app` turns the profile into config
       overrides), so the launch carries ``profile`` and empty overrides;
-    - a ``cli-config`` entry routes via a single ``model_provider`` ``-c``
-      override pinning the custom provider its ``~/.codex/config.toml``
+    - a ``cli-config`` entry routes via a generated ``model_provider`` setting
+      pinning the custom provider its ``~/.codex/config.toml``
       defines (the provider table + credential live in that file, which the
       native server bridges into the session ``CODEX_HOME``);
-    - a ``key`` / ``gateway`` / ``local`` entry routes via a generated
-      ``model_provider`` ``-c`` override (base_url + bearer-token auth command
+    - a ``key`` / ``gateway`` / ``local`` entry routes via generated
+      provider settings (base_url + bearer-token auth command
       + wire protocol).
 
     Returns ``None`` when *entry* cannot route Codex on its own — a
@@ -1349,7 +1348,7 @@ def _codex_provider_launch(entry: ProviderEntry, model: str | None) -> NativeCod
     if entry.kind == CLI_CONFIG_KIND:
         # Pin the config.toml-defined provider by name; its table (and
         # credential) ride along via the bridged config.toml. json.dumps
-        # yields a valid TOML basic string for the -c override value.
+        # yields a valid TOML basic string for the generated setting.
         return NativeCodexLaunch(
             config_overrides=[f"model_provider={json.dumps(entry.model_provider)}"],
             model=model,
@@ -1498,7 +1497,7 @@ def resolve_native_codex_launch(*, model: str | None) -> NativeCodexLaunch:
     Codex session route through ``omnigent setup``:
 
     1. an explicit per-family default provider →
-       - ``key`` / ``gateway`` / ``local`` → provider ``-c`` overrides
+       - ``key`` / ``gateway`` / ``local`` → generated provider settings
          (base_url + token + wire), ``profile=None``;
        - ``databricks`` → the ucode profile path (its profile);
        - ``subscription`` → the Codex CLI's own stored login (no overrides)
@@ -1739,7 +1738,6 @@ def build_codex_remote_args(
     codex_args: tuple[str, ...],
     thread_id: str | None,
     remote_url: str,
-    config_overrides: tuple[str, ...] = (),
     bypass_sandbox: bool = False,
 ) -> list[str]:
     """
@@ -1753,20 +1751,10 @@ def build_codex_remote_args(
     (``"ws://IP:PORT"``, the host-spawned runner path — see
     :class:`CodexNativeAppServer` ``listen_url``).
 
-    The ``config_overrides`` are the same ``-c key=value`` provider/model
-    overrides the app-server is launched with. The ``--remote`` TUI is a
-    *separate* process that loads its own config from ``CODEX_HOME`` and
-    does NOT inherit the app-server's ``-c`` flags; without them it falls
-    back to the built-in OpenAI provider, whose ``requires_openai_auth``
-    is ``true``, so the TUI renders the first-run "Sign in with ChatGPT"
-    onboarding screen and never creates a thread. On a host-spawned
-    (web-UI-driven) session there is nobody at the terminal to dismiss
-    that screen, so ``wait_for_thread_started`` times out and the session
-    hangs in ``running`` with no response. Passing the provider overrides
-    through makes the TUI resolve the Omnigent provider
-    (``requires_openai_auth = false``), skip onboarding, and start the
-    thread immediately. Codex global ``-c`` flags must precede the
-    ``resume`` subcommand, so they are emitted first.
+    The TUI is a separate process, but it shares the app-server's private
+    ``CODEX_HOME``. Generated provider settings are materialized in that
+    home's ``config.toml`` before either process starts, so no provider
+    configuration or credential is passed in this command line.
 
     :param codex_args: Raw Codex CLI args that precede the attach flags,
         e.g. ``("--model", "gpt-5.4-mini")``. Empty when the thread's own
@@ -1777,11 +1765,6 @@ def build_codex_remote_args(
     :param remote_url: App-server endpoint the TUI attaches to, e.g.
         ``"unix:///home/user/.omnigent/codex-native/x/app-server.sock"``
         or ``"ws://127.0.0.1:9876"``.
-    :param config_overrides: Codex ``-c`` config override values to apply
-        to the TUI, e.g.
-        ``('model="databricks-gpt-5-5"', 'model_provider="omnigent_databricks"')``.
-        Each is emitted as a ``-c <value>`` global flag. Empty for a
-        plain Codex-login launch that needs no provider routing.
     :param bypass_sandbox: When ``True``, emit a single
         ``--dangerously-bypass-approvals-and-sandbox`` flag and strip any
         conflicting ``--sandbox`` / ``--ask-for-approval`` pairs from
@@ -1792,9 +1775,6 @@ def build_codex_remote_args(
         the granular flags untouched. See issue #657.
     :returns: Codex argv tail after the executable.
     """
-    override_args: list[str] = []
-    for override in config_overrides:
-        override_args.extend(["-c", override])
     if bypass_sandbox:
         # Strip the conflicting granular flags, then prepend one canonical
         # bypass flag (a global flag, so it precedes any ``resume``).
@@ -1802,8 +1782,8 @@ def build_codex_remote_args(
     else:
         passthrough = list(codex_args)
     if thread_id is None:
-        return [*override_args, *passthrough, "--remote", remote_url]
-    return [*override_args, *passthrough, "resume", "--remote", remote_url, thread_id]
+        return [*passthrough, "--remote", remote_url]
+    return [*passthrough, "resume", "--remote", remote_url, thread_id]
 
 
 def _terminate_process_tree(process: asyncio.subprocess.Process) -> None:

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, TypeAlias
 
+import tomlkit
+
 from omnigent._platform import resolve_cli_binary
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.reasoning_effort import CODEX_EFFORTS, validate_effort
@@ -77,6 +79,10 @@ CodexToolResult: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
 
 # Content passed to ``enqueue_message`` — arbitrary user-supplied payload.
 CodexEnqueuedContent: TypeAlias = Any  # type: ignore[explicit-any]
+
+CodexConfigTable: TypeAlias = (
+    tomlkit.TOMLDocument | tomlkit.items.Table | tomlkit.items.InlineTable
+)
 
 # Tool-server callback provided by ``Session._wire_sdk_executor``. Takes a
 # tool name + args dict and returns either a result dict directly or a
@@ -744,6 +750,69 @@ def _populate_codex_home_config(target_dir: Path, source_dir: Path) -> None:
         shutil.copy2(source_file, dest_path)
 
 
+def _merge_codex_config_table(target: CodexConfigTable, source: CodexConfigTable) -> None:
+    """Recursively merge a parsed Codex config fragment into *target*."""
+    for key, value in source.items():
+        existing = target.get(key)
+        table_types = (tomlkit.items.Table, tomlkit.items.InlineTable)
+        if isinstance(existing, table_types) and isinstance(value, table_types):
+            _merge_codex_config_table(existing, value)
+        else:
+            target[key] = value
+
+
+def _apply_codex_config_overrides(codex_home: Path, overrides: Iterable[str]) -> None:
+    """Persist generated Codex overrides in the private session config.
+
+    Codex configuration may contain provider credentials. Writing those
+    values to the private ``CODEX_HOME`` keeps them out of subprocess argv,
+    process listings, and command-line telemetry.
+
+    :param codex_home: Private per-session Codex home directory.
+    :param overrides: Codex ``key=value`` TOML fragments to merge.
+    :raises ValueError: If an override is not valid TOML.
+    :raises RuntimeError: If the existing private config is not valid TOML.
+    """
+    override_list = list(overrides)
+    if not override_list:
+        return
+
+    config_path = codex_home / "config.toml"
+    try:
+        existing = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+        document = tomlkit.parse(existing) if existing else tomlkit.document()
+    except (OSError, tomlkit.exceptions.ParseError):
+        raise RuntimeError("Could not read the private Codex configuration") from None
+
+    for override in override_list:
+        try:
+            fragment = tomlkit.parse(override)
+        except tomlkit.exceptions.ParseError:
+            raise ValueError("Invalid generated Codex configuration override") from None
+        _merge_codex_config_table(document, fragment)
+
+    codex_home.mkdir(mode=0o700, parents=True, exist_ok=True)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=codex_home,
+            prefix=".config.toml.",
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            temp_file.write(tomlkit.dumps(document))
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.chmod(temp_path, 0o600)
+        os.replace(temp_path, config_path)
+    finally:
+        if temp_path is not None:
+            with suppress(FileNotFoundError):
+                temp_path.unlink()
+
+
 def _databricks_codex_base_url(host: str) -> str:
     """Return the Unity AI Gateway Codex Responses base URL for *host*."""
     return f"{host.rstrip('/')}/ai-gateway/codex/v1"
@@ -1254,14 +1323,16 @@ class _CodexAppServerSession:
             self._codex_home_dir,
             _codex_home_config_source_from_env(),
         )
+        _apply_codex_config_overrides(
+            self._codex_home_dir,
+            self._codex_config_overrides,
+        )
         # Override CODEX_HOME so Codex stores its data (including conversation
         # history) in a private temp directory rather than the user's ~/.codex/.
         # This prevents subagent sessions from polluting the user's Codex history.
         proc_env = {**self._env, "CODEX_HOME": str(self._codex_home_dir)}
         try:
             argv = [self._codex_path, "app-server"]
-            for override in self._codex_config_overrides:
-                argv.extend(["-c", override])
             self._proc = await _create_subprocess_exec(
                 *argv,
                 stdin=asyncio.subprocess.PIPE,
@@ -2079,7 +2150,7 @@ class CodexExecutor(Executor):
             ``None`` falls back to ``DATABRICKS_CONFIG_PROFILE`` then the
             first valid profile.
         :param model_provider_override: A codex ``model_provider`` id to pin
-            via a ``-c`` override, e.g. ``"openai"`` (force the built-in
+            in the private session config, e.g. ``"openai"`` (force the built-in
             provider so a custom default in the user's ``~/.codex/config.toml``
             cannot shadow a subscription) or ``"Databricks"`` (a custom
             ``[model_providers.X]`` table from that same file, which this
@@ -2163,7 +2234,7 @@ class CodexExecutor(Executor):
         self._env.update(self._retry_policy.codex_cli.env())
         self._codex_config_overrides: list[str] = []
         if model_provider_override is not None and gateway:
-            # Both would fight over model_provider in the -c overrides; the
+            # Both would fight over model_provider in the generated config; the
             # AP producer must emit exactly one routing mechanism.
             raise OSError(
                 "CodexExecutor received both gateway=True and "
@@ -2172,7 +2243,7 @@ class CodexExecutor(Executor):
             )
         if model_provider_override is not None:
             # Pin the provider by name. json.dumps yields a valid TOML basic
-            # string (proper quoting/escaping) for the -c override value.
+            # string with proper quoting and escaping.
             self._codex_config_overrides.append(
                 f"model_provider={json.dumps(model_provider_override)}"
             )

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -3828,13 +3828,6 @@ async def _auto_create_codex_terminal(
                     thread_id=launch_config.external_session_id,
                     remote_url=codex_ws_url,
                     bypass_sandbox=launch_config.bypass_sandbox,
-                    # The --remote TUI loads its own config and does not
-                    # inherit the app-server's -c flags; pass the same
-                    # provider/model overrides so it resolves the
-                    # Omnigent provider instead of falling back to the
-                    # OpenAI built-in (which would force the first-run
-                    # login screen and block thread creation).
-                    config_overrides=tuple(app_server.config_overrides),
                 ),
                 env=codex_terminal_env(app_server),
                 # Match the local ``omnigent codex`` terminal scrollback.

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -16,12 +16,14 @@ import pytest
 from omnigent.inner.codex_executor import (
     _TURN_EVENT_WARN_SECONDS,
     CodexExecutor,
+    _apply_codex_config_overrides,
     _build_initial_prompt,
     _codex_cli_version,
     _CodexAppServerSession,
     _databricks_codex_config_overrides,
     _dynamic_tool_result_payload,
     _prompt_for_turn,
+    _provider_codex_config_overrides,
     _to_codex_input_items,
 )
 from omnigent.inner.executor import (
@@ -2130,6 +2132,60 @@ def test_populate_codex_skills_from_bundle_none_leaves_no_dir(tmp_path: Path) ->
 # ---------------------------------------------------------------------------
 
 
+def test_apply_codex_config_overrides_preserves_config_and_locks_permissions(
+    tmp_path: Path,
+) -> None:
+    """Generated settings merge into a mode-0600 private config."""
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    config_path = codex_home / "config.toml"
+    config_path.write_text(
+        (
+            '# keep this comment\nmodel = "old"\n'
+            'model_providers={user_provider={name="User"}}\n'
+            "[features]\nuser_feature = true\n"
+        ),
+        encoding="utf-8",
+    )
+    secret = "sk-private-sentinel"
+
+    _apply_codex_config_overrides(
+        codex_home,
+        [
+            'model="new"',
+            "features.generated=true",
+            *_provider_codex_config_overrides(
+                model=None,
+                base_url="https://provider.invalid/v1",
+                auth_command=f"printf %s {secret}",
+                wire_api="responses",
+            ),
+        ],
+    )
+
+    rendered = config_path.read_text(encoding="utf-8")
+    assert "# keep this comment" in rendered
+    assert 'model = "new"' in rendered
+    assert "user_feature = true" in rendered
+    assert "generated = true" in rendered
+    assert "user_provider" in rendered
+    assert secret in rendered
+    assert config_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_apply_codex_config_overrides_redacts_invalid_secret(
+    tmp_path: Path,
+) -> None:
+    """A malformed generated override is not echoed in its exception."""
+    codex_home = tmp_path / "codex-home"
+    secret = "sk-invalid-sentinel"
+
+    with pytest.raises(ValueError) as exc_info:
+        _apply_codex_config_overrides(codex_home, [f'key="{secret}'])
+
+    assert secret not in str(exc_info.value)
+
+
 def test_populate_codex_home_config_symlinks_auth_and_config(tmp_path: Path) -> None:
     """``auth.json`` is symlinked; ``config.toml`` is copied (not symlinked).
 
@@ -2307,6 +2363,55 @@ def test_app_server_start_uses_real_home_for_private_inherited_codex_home(
         assert fake_proc.terminated
 
     _run(_t())
+
+
+def test_app_server_start_keeps_provider_secret_out_of_argv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Embedded Codex materializes provider auth only in private config."""
+    source_home = tmp_path / "source-home"
+    source_home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(source_home))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    secret = "sk-embedded-argv-sentinel"
+    captured_argv: tuple[object, ...] | None = None
+
+    async def _t() -> None:
+        fake_proc = _FakeProcess()
+
+        async def _fake_create_subprocess_exec(*args, **kwargs):
+            nonlocal captured_argv
+            captured_argv = args
+            config_path = Path(kwargs["env"]["CODEX_HOME"]) / "config.toml"
+            assert secret in config_path.read_text(encoding="utf-8")
+            assert config_path.stat().st_mode & 0o777 == 0o600
+            return fake_proc
+
+        session = _CodexAppServerSession(
+            codex_path="/bin/codex",
+            cwd=str(workspace),
+            env={},
+            tool_executor=None,
+            codex_config_overrides=_provider_codex_config_overrides(
+                model="test-model",
+                base_url="https://provider.invalid/v1",
+                auth_command=f"printf %s {secret}",
+                wire_api="responses",
+            ),
+        )
+        session._request = AsyncMock(return_value={"result": {}})
+        with patch(
+            "omnigent.inner.codex_executor._create_subprocess_exec",
+            new=_fake_create_subprocess_exec,
+        ):
+            await session.start()
+            await session.close()
+
+    _run(_t())
+
+    assert captured_argv == ("/bin/codex", "app-server")
+    assert secret not in "\0".join(str(arg) for arg in captured_argv)
 
 
 def test_app_server_start_preserves_custom_home_from_inherited_private_symlink(

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -775,69 +775,21 @@ def test_build_codex_remote_args_passes_transport_verbatim(
     )
 
 
-@pytest.mark.parametrize(
-    ("thread_id", "expected"),
-    [
-        # Fresh thread: -c overrides precede the bare --remote attach.
-        (
-            None,
-            [
-                "-c",
-                'model="databricks-gpt-5-5"',
-                "-c",
-                'model_provider="omnigent_databricks"',
-                "--remote",
-                "ws://127.0.0.1:9876",
-            ],
-        ),
-        # Resume: -c overrides are global flags and MUST precede the
-        # ``resume`` subcommand (codex rejects globals placed after it).
-        (
-            "thread_host",
-            [
-                "-c",
-                'model="databricks-gpt-5-5"',
-                "-c",
-                'model_provider="omnigent_databricks"',
-                "resume",
-                "--remote",
-                "ws://127.0.0.1:9876",
-                "thread_host",
-            ],
-        ),
-    ],
-)
-def test_build_codex_remote_args_emits_config_overrides_before_subcommand(
-    thread_id: str | None,
-    expected: list[str],
-) -> None:
-    """
-    ``build_codex_remote_args`` emits each ``config_overrides`` entry as a
-    ``-c <value>`` global flag ahead of the attach flags.
-
-    The ``--remote`` TUI is a separate process that does not inherit the
-    app-server's ``-c`` flags; without these the TUI falls back to the
-    OpenAI built-in provider (``requires_openai_auth = true``), renders
-    the first-run login onboarding screen, and never creates a thread —
-    so a host-spawned session hangs in ``running`` with no response.
-    Asserting the exact argv (not just membership) guards two things at
-    once: that the overrides are forwarded at all, and that they land
-    *before* the ``resume`` subcommand — codex treats ``-c`` as a global
-    option and rejects it when placed after a subcommand, which would
-    abort TUI startup and reintroduce the hang.
-    """
-    assert (
-        codex_native_app_server.build_codex_remote_args(
-            codex_args=(),
-            thread_id=thread_id,
-            remote_url="ws://127.0.0.1:9876",
-            config_overrides=(
-                'model="databricks-gpt-5-5"',
-                'model_provider="omnigent_databricks"',
-            ),
-        )
-        == expected
+def test_build_codex_remote_args_contains_no_config_overrides() -> None:
+    """The remote TUI reads provider settings from its private CODEX_HOME."""
+    args = codex_native_app_server.build_codex_remote_args(
+        codex_args=(),
+        thread_id="thread_host",
+        remote_url="ws://127.0.0.1:9876",
     )
+
+    assert args == [
+        "resume",
+        "--remote",
+        "ws://127.0.0.1:9876",
+        "thread_host",
+    ]
+    assert "-c" not in args
 
 
 @pytest.mark.parametrize(

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -23,7 +24,10 @@ from omnigent.codex_native_app_server import (
     trust_native_policy_hooks,
 )
 from omnigent.codex_native_hook import _EVALUATE_POLICY_TIMEOUT_S
-from omnigent.inner.codex_executor import _populate_codex_home_config
+from omnigent.inner.codex_executor import (
+    _populate_codex_home_config,
+    _provider_codex_config_overrides,
+)
 
 
 def test_sync_developer_instructions_preserves_and_restores_user_config(tmp_path: Path) -> None:
@@ -515,6 +519,53 @@ async def test_start_writes_fresh_mcp_config_without_leading_blanks(
             "sys_session_rename": {"approval_mode": "approve"},
         },
     }
+
+
+async def test_start_keeps_provider_secret_out_of_native_argv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Native app-server reads provider auth from its private config."""
+    real_codex_home = tmp_path / "real-codex-home"
+    real_codex_home.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    codex_home = tmp_path / "codex-home"
+    monkeypatch.setenv("CODEX_HOME", str(real_codex_home))
+    _disable_codex_startup_rpc(monkeypatch)
+    secret = "sk-native-argv-sentinel"
+    subprocess_calls: list[tuple[object, ...]] = []
+    real_create_subprocess_exec = asyncio.create_subprocess_exec
+
+    async def _capture_create_subprocess_exec(*args: object, **kwargs: object):
+        subprocess_calls.append(args)
+        return await real_create_subprocess_exec(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _capture_create_subprocess_exec)
+    server = CodexNativeAppServer(
+        codex_path=sys.executable,
+        socket_path=tmp_path / "codex.sock",
+        codex_home=codex_home,
+        env={},
+        config_overrides=_provider_codex_config_overrides(
+            model="test-model",
+            base_url="https://provider.invalid/v1",
+            auth_command=f"printf %s {secret}",
+            wire_api="responses",
+        ),
+        cwd=workspace,
+        bridge_dir=tmp_path / "bridge",
+    )
+
+    await server.start()
+    try:
+        app_server_argv = next(call for call in subprocess_calls if "app-server" in call)
+        assert secret not in "\0".join(str(arg) for arg in app_server_argv)
+        assert "-c" not in app_server_argv
+        config_path = codex_home / "config.toml"
+        assert secret in config_path.read_text(encoding="utf-8")
+        assert config_path.stat().st_mode & 0o777 == 0o600
+    finally:
+        await server.close()
 
 
 async def test_untrusted_hook_is_trusted_via_batchwrite() -> None:


### PR DESCRIPTION
## Related issue

[GHSA-8g8f-vxv3-8cp9](https://github.com/omnigent-ai/omnigent/security/advisories/GHSA-8g8f-vxv3-8cp9)

## Summary

- Materialize generated Codex provider settings in the private per-session
  `CODEX_HOME/config.toml` with mode `0600`.
- Stop forwarding generated provider settings, including authentication
  commands, through embedded app-server, native app-server, and remote-TUI
  command-line arguments.
- Preserve existing user TOML settings and comments while applying generated
  settings atomically.

ELI5: provider credentials previously traveled inside the command used to
start Codex, where process listings could see them. Codex now reads those
settings from its private session configuration instead.

```text
Before: provider credential -> Codex -c argv -> app server / remote TUI
After:  provider credential -> private 0600 config -> app server / remote TUI
```

## Test Plan

- `uv run python -m pytest -q tests/inner/test_codex_executor.py tests/test_codex_native_app_server.py tests/test_codex_native.py tests/test_native_codex_provider.py`
  - 333 passed
- `uv run pre-commit run --all-files`
  - all hooks passed
- Regression tests use sentinel credentials and verify they are absent from
  embedded app-server, native app-server, and remote-TUI argv.

## Demo

N/A — non-visual security fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Sentinel tests cover the shared TOML materialization helper and all three
affected Codex argv paths. Existing provider-routing tests verify that model,
provider, and web-search settings retain their behavior.

## Changelog

Codex provider credentials no longer appear in subprocess command lines.
