### PR TITLE
docs(readme): add telemetry disclosure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,17 @@ Polly at [`examples/polly/`](https://github.com/omnigent-ai/omnigent/tree/main/e
 
 ---
 
+## Telemetry
+
+Omnigent collects anonymized usage data (telemetry) by default. This data
+contains no sensitive or personally identifiable information. If you're using
+Omnigent through a managed service or distribution, please consult your managed
+service agreement to determine any data collection that may impact your use of
+the service. To opt out, follow our instructions in
+[Usage Telemetry](https://omnigent.ai/docs/deploy/telemetry).
+
+---
+
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](https://github.com/omnigent-ai/omnigent/blob/main/CONTRIBUTING.md) for how to set up your environment, run the checks, and open a pull request.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a **Telemetry** section to the README disclosing that Omnigent collects
  anonymized usage data by default, with no sensitive or personally
  identifiable information.
- Link to the [Usage Telemetry](https://omnigent.ai/docs/deploy/telemetry)
  docs page for opt-out instructions, and note that managed-service users
  should consult their service agreement.

## Test Plan

- Previewed the rendered markdown locally; verified the section sits between
  "Write your own agent" and "Contributing" and the docs link points to
  https://omnigent.ai/docs/deploy/telemetry.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Docs-only change; verified by reading the rendered README diff.