### PR TITLE
fix(host): forward global config to the background local server

### DIFF
--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import click
 import psutil
 
+from omnigent.config import global_config_path
 from omnigent.inner import _proc
 from omnigent.process_logging import (
     PROCESS_LOG_FILE_ENV_VAR,
@@ -661,6 +662,7 @@ def _spawn_local_server(port: int) -> _SpawnedLocalServer:
                     db_uri,
                     "--artifact-location",
                     str(artifact_path),
+                    *(["--config", str(p)] if (p := global_config_path()).exists() else []),
                 ],
                 env=child_env,
                 stdout=log_fh,


### PR DESCRIPTION
## Related issue

N/A — same bug class as #2386 (fixed in #2763), different entrypoint.

## Summary

The background local server spawned by bare `omni` (`_spawn_local_server`) launches `omnigent.cli server` with `--host/--port/--database-uri/--artifact-location` but **not** `--config`. Since `server`'s loader does `_load_config(None) -> {}`, the global `~/.omnigent/config.yaml` is never read — so the `llm:` (and `policies:`) block is invisible to the detached server, and self-hosted smart routing silently stays off (`sys_advise_models` → `router_on: false`, `/v1/info` → `smart_routing_enabled: false`).

This mirrors #2386 (the Docker entrypoint dropped `policies:`); this is the local-spawn instance of the same "non-CLI entrypoint ignores the config file" bug.

Fix: `_spawn_local_server` now forwards `--config <global_config_path()>` when that file exists (honors `OMNIGENT_CONFIG_HOME`; skipped when absent, since the CLI option requires an existing path).

## Test Plan

- `curl /v1/info` on a background server started by bare `omni`: `smart_routing_enabled: false` before, `true` after (with `OMNIGENT_SMART_ROUTING=1` + an `llm:` block in `~/.omnigent/config.yaml`).
- Confirmed the spawned server's cmdline now carries `--config ~/.omnigent/config.yaml`.
- Verified the flag is omitted (no crash) when no global config file exists.

## Demo

<img width="881" height="787" alt="image" src="https://github.com/user-attachments/assets/2ef9b186-d6ca-4292-aa7e-0118747b0a7d" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

One-line spawn-arg change; verified manually via `/v1/info` before/after and cmdline inspection. No unit test added (the spawn path shells out to a real subprocess); happy to add one asserting `--config` is in the argv if reviewers want.