### PR TITLE
perf(db): drop the unused ix_conversation_metadata_kind index

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -652,8 +652,6 @@ class SqlConversationMetadata(OmnigentBase):
             "host_id IS NULL OR workspace IS NOT NULL",
             name="ck_conversation_metadata_workspace_required_for_host",
         ),
-        # Supports list_conversations kind filter.
-        Index("ix_conversation_metadata_kind", "workspace_id", "kind", "id"),
         # Supports list_conversations_by_runner_id and get_runner_ids.
         Index("ix_conversation_metadata_runner_id", "workspace_id", "runner_id", "id"),
     )

--- a/omnigent/db/migrations/versions/f6d3b8a2c1e9_drop_unused_conversation_metadata_kind_index.py
+++ b/omnigent/db/migrations/versions/f6d3b8a2c1e9_drop_unused_conversation_metadata_kind_index.py
@@ -1,0 +1,47 @@
+"""Drop the unused ix_conversation_metadata_kind index.
+
+Revision ID: f6d3b8a2c1e9
+Revises: b7e4d2c9a1f3
+Create Date: 2026-07-20 00:00:00.000000
+
+``ix_conversation_metadata_kind`` on ``omnigent_conversation_metadata``
+(``workspace_id, kind, id``) has no serving query. ``kind`` is fully determined
+by ``parent_conversation_id`` nullness — a child always has a parent, a
+top-level session never does — so ``list_conversations`` expresses the kind
+filter on the AP ``conversations`` table (parent-nullness) and the sub-agent
+roll-up (``list_child_conversation_ids_by_parent``) rides
+``idx_conversations_parent``; neither reads the metadata ``kind`` column. It is
+also a 2-value column (``kind IN (1, 2)``), so a standalone index could never be
+selective.
+
+So the index is pure write/space overhead. The ``kind`` column and its
+``ck_conversation_metadata_kind`` check constraint are unchanged — only the index
+is removed.
+
+Index-only, no data change. ``DROP``/``CREATE INDEX`` is native on every
+dialect (no table rebuild). Downgrade restores the index.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "f6d3b8a2c1e9"
+down_revision: str | None = "b7e4d2c9a1f3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX = "ix_conversation_metadata_kind"
+_TABLE = "omnigent_conversation_metadata"
+
+
+def upgrade() -> None:
+    """Drop the unused (workspace_id, kind, id) index."""
+    op.drop_index(_INDEX, table_name=_TABLE)
+
+
+def downgrade() -> None:
+    """Restore the (workspace_id, kind, id) index."""
+    op.create_index(_INDEX, _TABLE, ["workspace_id", "kind", "id"])


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `ix_conversation_metadata_kind` on `omnigent_conversation_metadata` (`workspace_id, kind, id`) has **no serving query**. `kind` is fully determined by `parent_conversation_id` nullness — a child always has a parent, a top-level session never does — so `list_conversations` expresses the kind filter on the AP `conversations` table (parent-nullness) and the sub-agent roll-up (`list_child_conversation_ids_by_parent`) rides `idx_conversations_parent`. Neither reads the metadata `kind` column (a repo-wide search finds no query filtering/ordering on `SqlConversationMetadata.kind`).
- `kind` is also a 2-value column (`kind IN (1, 2)`), so a standalone index could never be selective.
- Removes the index from `db_models.py` (and its now-stale "Supports list_conversations kind filter" comment) and adds migration `f6d3b8a2c1e9` to drop it. The `kind` column and its `ck_conversation_metadata_kind` check constraint are untouched — only the index is removed. Net effect: less write/space overhead on the `omnigent_conversation_metadata` insert path.

## Test Plan

- `uv run pytest tests/db/` → **340 passed**, including `test_migrations_sqlite_safe.py::test_full_migration_chain_round_trips_on_sqlite`, which exercises the new migration's `upgrade` **and** `downgrade` end-to-end.
- `uv run alembic -c omnigent/db/alembic.ini heads` → single head `f6d3b8a2c1e9` (chained off `b7e4d2c9a1f3`, no branch).
- `uv run ruff check` + `uv run ruff format --check` + `uv run pre-commit run --files …` → all pass.

## Demo

N/A (no user-visible / UI change).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full-chain SQLite migration round-trip test (`test_full_migration_chain_round_trips_on_sqlite`) already applies every migration up to head and back down, so it covers the new `drop`/`create` migration in both directions. No new column, constraint, or query behavior is introduced, so no additional test is warranted.
