### PR TITLE
perf(db): drop the unused ix_scheduled_tasks_state index

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1436,9 +1436,6 @@ class SqlScheduledTask(OmnigentBase):
         CheckConstraint("execution_target IN (1, 2)", name="ck_scheduled_tasks_execution_target"),
         Index("ix_scheduled_tasks_created_at", "workspace_id", "created_at", "id"),
         Index("ix_scheduled_tasks_owner_user_id", "workspace_id", "owner_user_id", "id"),
-        # Covers the scheduler's read path:
-        # WHERE workspace_id + state ORDER BY created_at, id.
-        Index("ix_scheduled_tasks_state", "workspace_id", "state", "created_at", "id"),
     )
 
 

--- a/omnigent/db/migrations/versions/e5c8b1f4a2d7_drop_unused_scheduled_tasks_state_index.py
+++ b/omnigent/db/migrations/versions/e5c8b1f4a2d7_drop_unused_scheduled_tasks_state_index.py
@@ -1,0 +1,52 @@
+"""Drop the unused ix_scheduled_tasks_state index.
+
+Revision ID: e5c8b1f4a2d7
+Revises: f6d3b8a2c1e9
+Create Date: 2026-07-20 00:00:00.000000
+
+``ix_scheduled_tasks_state`` on ``scheduled_tasks``
+(``workspace_id, state, created_at, id``) does not earn its keep. Its
+per-workspace query shape (``WHERE workspace_id AND state ORDER BY created_at,
+id``, i.e. ``list_active``) has no production caller; the scheduler reads active
+tasks exactly once at boot via ``list_active_all_workspaces`` (``WHERE state
+ORDER BY workspace_id, created_at, id``), which is a near-full scan regardless.
+
+``ix_scheduled_tasks_created_at`` (``workspace_id, created_at, id``) already
+serves that boot read: a scan of it yields the exact ``ORDER BY workspace_id,
+created_at, id`` the query wants, with ``state`` applied as a residual filter.
+The residual check is free here because the store selects whole rows, so
+``state`` is already loaded; and ``scheduled_tasks`` is low-cardinality (a
+handful of tasks per user, and ``delete`` is a hard delete so no ``deleted``
+rows linger), leaving nothing meaningful to skip. So the index is pure
+write/space overhead.
+
+The ``state`` column and its ``ck_scheduled_tasks_state`` check constraint are
+unchanged -- only the index is removed.
+
+Index-only, no data change. ``DROP``/``CREATE INDEX`` is native on every
+dialect (no table rebuild). Downgrade restores the index.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "e5c8b1f4a2d7"
+down_revision: str | None = "f6d3b8a2c1e9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX = "ix_scheduled_tasks_state"
+_TABLE = "scheduled_tasks"
+
+
+def upgrade() -> None:
+    """Drop the unused (workspace_id, state, created_at, id) index."""
+    op.drop_index(_INDEX, table_name=_TABLE)
+
+
+def downgrade() -> None:
+    """Restore the (workspace_id, state, created_at, id) index."""
+    op.create_index(_INDEX, _TABLE, ["workspace_id", "state", "created_at", "id"])

--- a/tests/db/test_migration_scheduled_tasks.py
+++ b/tests/db/test_migration_scheduled_tasks.py
@@ -123,9 +123,13 @@ def test_expected_indexes(db_engine: Engine) -> None:
     assert {
         "ix_scheduled_tasks_created_at",
         "ix_scheduled_tasks_owner_user_id",
-        "ix_scheduled_tasks_state",
     } <= scheduled_tasks_idx
     assert "ix_scheduled_tasks_agent_id" not in scheduled_tasks_idx
+    # ix_scheduled_tasks_state was dropped: list_active's per-workspace shape
+    # has no production caller, and the boot-time list_active_all_workspaces
+    # scan is served by ix_scheduled_tasks_created_at with state as a residual
+    # filter (see migration e5c8b1f4a2d7).
+    assert "ix_scheduled_tasks_state" not in scheduled_tasks_idx
     runs_idx = {i["name"] for i in insp.get_indexes("scheduled_task_runs")}
     assert "ix_scheduled_task_runs_scheduled_task_id" in runs_idx
     runs_idx_cols = {


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Drop `ix_scheduled_tasks_state (workspace_id, state, created_at, id)` on `scheduled_tasks`. It has no serving query that `ix_scheduled_tasks_created_at (workspace_id, created_at, id)` doesn't already cover.
- The per-workspace state-filtered shape (`list_active`) has **no production caller** (test-only). The scheduler's one real read is boot-time `list_active_all_workspaces` (`WHERE state ORDER BY workspace_id, created_at, id`), a near-full scan the created_at index serves directly — a scan of it yields exactly that order, with `state` applied as a residual filter.
- That residual filter is effectively free here: the store selects whole rows (so `state` is already loaded), and `scheduled_tasks` is low-cardinality (a handful of tasks per user, and `delete` is a hard delete so no `deleted` rows linger) — nothing meaningful to skip. The index was pure write/space overhead.
- Index-only migration. The `state` column and its `ck_scheduled_tasks_state` check constraint are unchanged; correctness of the `state` filter comes from the `WHERE` clause, never the index.

> **Migration parent:** rebased onto fresh `main` after #2936 (the `ix_conversation_metadata_kind` drop) merged — the migration now chains linearly off `f6d3b8a2c1e9`, so it's a single Alembic head with no sibling collision.

## Test Plan

- Updated `tests/db/test_migration_scheduled_tasks.py::test_expected_indexes` to assert `ix_scheduled_tasks_state` is **absent** (mirrors the existing `ix_scheduled_tasks_agent_id` negative assertion) — this is the schema-consistency test that runs against sqlite/mysql/postgres.
- `pytest tests/stores/test_scheduled_task_store.py tests/server/scheduled/test_scheduler.py` → **45 passed**; `tests/db/test_migration_scheduled_tasks.py::test_expected_indexes` → **passed**.
- Single Alembic head: `alembic -c omnigent/db/alembic.ini heads` → `e5c8b1f4a2d7 (head)`.
- Migration rehearsal on a throwaway SQLite DB:
  - upgrade to parent `b7e4d2c9a1f3` → indexes: `created_at`, `owner_user_id`, **`state`**
  - upgrade `head` → indexes: `created_at`, `owner_user_id` (state **dropped**)
  - downgrade `-1` → indexes: `created_at`, `owner_user_id`, **`state`** (restored)

## Demo

N/A (no UI; database index change).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behaviour is unchanged — only the index is removed, so no new tests are warranted. Existing store/scheduler tests exercise `list_active` and `list_active_all_workspaces`, whose `state` filter is enforced by the `WHERE` clause (not the index). Manually verified the migration applies and reverses cleanly via an up→down SQLite rehearsal, checking the `scheduled_tasks` index set before and after each step (see Test Plan).

This pull request and its description were written by Isaac.
