### PR TITLE
fix(deps): restore memory extra as backwards-compat alias for hindsight

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,12 @@ cursor = ["cursor-sdk>=0.1.7"]
 # _reflect). The tools import the client lazily, so only users who enable a
 # Hindsight memory tool need this extra.
 hindsight = ["hindsight-client>=0.4.0"]
+# Backwards-compatibility alias: this extra was renamed to `hindsight` (see
+# above) in #2605. Keep `memory` pulling the same client so existing
+# `omnigent[memory]` / `--extra memory` invocations keep working.
+# TODO(0.70): remove this `memory` alias extra — it exists only to keep the
+# pre-rename install command working during the deprecation window.
+memory = ["hindsight-client>=0.4.0"]
 # Slack integration (`omni integration slack`). The @omnigent socket-mode bot
 # lives in the separate `omnigent-slack` package (heavy deps — slack_bolt /
 # aiohttp — kept out of the baseline install). The CLI launches it as a

--- a/uv.lock
+++ b/uv.lock
@@ -2975,6 +2975,9 @@ islo = [
 kubernetes = [
     { name = "kubernetes" },
 ]
+memory = [
+    { name = "hindsight-client" },
+]
 modal = [
     { name = "modal" },
 ]
@@ -3024,6 +3027,7 @@ requires-dist = [
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.68,<2" },
     { name = "hindsight-client", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = ">=0.4.0" },
+    { name = "hindsight-client", marker = "extra == 'memory'", specifier = ">=0.4.0" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "islo", marker = "extra == 'islo'", specifier = ">=0.3.5,<0.4" },
     { name = "keyring", specifier = ">=24,<26" },
@@ -3082,7 +3086,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=10.4,<15" },
     { name = "zstandard", specifier = ">=0.22,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "boxlite", "cwsandbox", "e2b", "islo", "openshell", "kubernetes", "tracing", "agents-sdk", "antigravity", "copilot", "cursor", "hindsight", "slack", "databricks", "dev"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "boxlite", "cwsandbox", "e2b", "islo", "openshell", "kubernetes", "tracing", "agents-sdk", "antigravity", "copilot", "cursor", "hindsight", "memory", "slack", "databricks", "dev"]
 
 [[package]]
 name = "omnigent-client"


### PR DESCRIPTION
## Related issue

N/A — restores backward compatibility broken by #2605.

## Summary

- In #2605 the optional-dependency extra `memory` was renamed to `hindsight` (the extra that pulls `hindsight-client` for the Hindsight long-term-memory tools) and the old `memory` name was dropped entirely — making `omnigent[memory]` / `--extra memory` silently install a nonexistent extra.
- Re-add `memory` as an alias extra pulling the same `hindsight-client` so existing install commands keep working. `memory` is kept as a real alias (not a no-op) so the tools still light up (they gate on `importlib.util.find_spec("hindsight_client")`).
- Mirrored the alias in `uv.lock` (optional-dep block, `requires-dist` marker, and `provides-extras`). Scheduled for removal in 0.70 (TODO comment in `pyproject.toml`).

## Test Plan

- `python scripts/normalize_uv_lock_registry.py --check uv.lock` → passes (lockfile stays canonical public-PyPI).
- `uv export --extra memory --no-dev` resolves `hindsight-client==0.8.3`, identical to `uv export --extra hindsight --no-dev` → the two extras pull the same package.
- `tomllib.load` validates both `pyproject.toml` and `uv.lock` parse; `memory == hindsight == ["hindsight-client>=0.4.0"]`.
- `pre-commit run normalize-uv-lock-registry` → Passed (no-op on the hand-applied lock entries).
- Existing registry/onboarding tests are unaffected — no test enumerates the full extras set, and the harness-extra sync test only checks `cursor`/`antigravity`/`copilot`.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This is a packaging/dependency change with no new runtime code path, so automated tests aren't a natural fit here. Verified manually that both extras resolve to the same installed package (`uv export --extra memory` ≡ `--extra hindsight`), the lockfile stays canonical (normalize hook passes), and both lockfiles are valid TOML. A self-referential unit test asserting `pyproject.toml` contains the line I just wrote was considered and rejected as circular (there is no `MEMORY_EXTRA` constant to tie to, the way `CURSOR_EXTRA` exists).

## Changelog

`omnigent[memory]` is restored as a backwards-compat alias for `omnigent[hindsight]` (the `memory` extra was dropped by #2605); it will be removed in 0.70.
