### PR TITLE
Disable automatic session rename out of the box

### DIFF
--- a/omnigent/tools/builtins/session_rename.py
+++ b/omnigent/tools/builtins/session_rename.py
@@ -2,11 +2,37 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from omnigent.tools.base import Tool
 
 CLAUDE_NATIVE_SESSION_RENAME_TOOL = "mcp__omnigent__sys_session_rename"
+
+# Automatic, agent-driven session rename ("auto-title") runs on the first turn
+# of every fresh session: the model is asked to call ``sys_session_rename`` with
+# a short summary title. That is an extra model round-trip, so it ships DISABLED
+# by default. Set ``OMNIGENT_SESSION_RENAME=on`` (``1``/``true``/``yes`` also
+# work) to opt back in. This gates only the *automatic* rename — the manual
+# "Rename" item in the web sidebar is unaffected. ``session_rename_instruction``
+# and ``session_rename_allowed_tools`` are the single gate both the Claude-native
+# launcher (``omnigent/claude_native.py``) and the shared runner
+# (``omnigent/runner/app.py``) consult, so suppressing the instruction and
+# emptying the preapproval here disables the feature everywhere while keeping
+# the implementation (tool, endpoint, dispatch) in place.
+_SESSION_RENAME_TRUTHY = ("1", "true", "yes", "on")
+
+
+def _auto_rename_enabled() -> bool:
+    """Return whether the automatic first-turn session rename is enabled.
+
+    Defaults to off; opt in via the ``OMNIGENT_SESSION_RENAME`` env var. Read on
+    every call rather than cached at import so tests can flip it with
+    ``monkeypatch.setenv`` and deployments pick up changes without a reimport;
+    the helpers run once per session, so the ``os.environ`` lookup is negligible.
+    """
+    return os.environ.get("OMNIGENT_SESSION_RENAME", "").strip().lower() in _SESSION_RENAME_TRUTHY
+
 
 SESSION_RENAME_INSTRUCTION = """
 Omnigent creates each session with its title set to the user's full prompt verbatim. On the
@@ -38,9 +64,14 @@ declines the rename, or returns an error, continue the user's turn normally.
 def session_rename_allowed_tools(*, initial_session: bool) -> tuple[str, ...]:
     """Return native Claude tools preapproved for automatic session metadata.
 
+    Returns an empty tuple when automatic rename is disabled (the default; see
+    ``OMNIGENT_SESSION_RENAME``), so the rename tool is never preapproved.
+
     :param initial_session: Whether this is the session's initial model context.
     :returns: A scoped allowlist containing only the rename tool for fresh sessions.
     """
+    if not _auto_rename_enabled():
+        return ()
     return (CLAUDE_NATIVE_SESSION_RENAME_TOOL,) if initial_session else ()
 
 
@@ -50,11 +81,15 @@ def session_rename_instruction(*, initial_session: bool) -> str | None:
     The shared runner derives ``initial_session`` from persisted message history.
     Native launchers derive it from the absence of a resumed external session or
     carried fork history. Keeping the selection here gives both layers one
-    canonical gate while allowing each to use the state it owns.
+    canonical gate while allowing each to use the state it owns. Returns
+    ``None`` (no instruction injected) when automatic rename is disabled — the
+    default; set ``OMNIGENT_SESSION_RENAME=on`` to opt in.
 
     :param initial_session: Whether this is the session's initial model context.
     :returns: The rename instruction for an initial session, otherwise ``None``.
     """
+    if not _auto_rename_enabled():
+        return None
     return SESSION_RENAME_INSTRUCTION if initial_session else None
 
 

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -2713,6 +2713,7 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
     #   worktree    — the session's stored workspace (correct answer)
     runner_env = tmp_path / "runner_workspace"
     runner_env.mkdir()
+    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "on")
     bundle_dir = tmp_path / "runner-specs" / f"{session_id}-v1"
     bundle_dir.mkdir(parents=True)
     worktree = tmp_path / "repo-worktrees" / "feature-x"
@@ -14243,6 +14244,7 @@ async def test_auto_create_claude_terminal_registers_permission_hook(
     SessionStart/Stop/.../PreCompact + statusLine but no
     PermissionRequest).
     """
+    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "on")
     monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
@@ -15317,6 +15319,7 @@ async def test_auto_create_claude_terminal_forwarder_skips_replayed_transcript_o
     :param tmp_path: Pytest-provided temporary directory.
     :param monkeypatch: Pytest monkeypatch fixture.
     """
+    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "on")
     monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")

--- a/tests/runner/test_auto_title_instruction.py
+++ b/tests/runner/test_auto_title_instruction.py
@@ -1,5 +1,7 @@
 """Tests for first-turn automatic-title instruction gating."""
 
+import pytest
+
 from omnigent.runner.app import _is_first_user_turn
 from omnigent.tools.builtins.session_rename import (
     CLAUDE_NATIVE_SESSION_RENAME_TOOL,
@@ -32,8 +34,11 @@ def test_first_user_turn_requires_one_user_message_and_no_assistant() -> None:
     assert "ToolSearch" in SESSION_RENAME_INSTRUCTION
 
 
-def test_session_rename_instruction_uses_shared_initial_session_gate() -> None:
+def test_session_rename_instruction_uses_shared_initial_session_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """History and native launch paths share one instruction selector."""
+    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "on")
     assert session_rename_instruction(initial_session=True) == SESSION_RENAME_INSTRUCTION
     assert session_rename_instruction(initial_session=False) is None
 
@@ -47,9 +52,21 @@ def test_session_rename_instruction_requires_every_fresh_session() -> None:
     assert "Skip sys_session_rename only" not in SESSION_RENAME_INSTRUCTION
 
 
-def test_session_rename_allowed_tools_are_fresh_session_only() -> None:
+def test_session_rename_allowed_tools_are_fresh_session_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Claude preapproves only the silent metadata tool on fresh sessions."""
+    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "on")
     assert session_rename_allowed_tools(initial_session=True) == (
         CLAUDE_NATIVE_SESSION_RENAME_TOOL,
     )
+    assert session_rename_allowed_tools(initial_session=False) == ()
+
+
+def test_session_rename_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The automatic rename ships off out of the box (OMNIGENT_SESSION_RENAME unset)."""
+    monkeypatch.delenv("OMNIGENT_SESSION_RENAME", raising=False)
+    assert session_rename_instruction(initial_session=True) is None
+    assert session_rename_instruction(initial_session=False) is None
+    assert session_rename_allowed_tools(initial_session=True) == ()
     assert session_rename_allowed_tools(initial_session=False) == ()

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -4376,6 +4376,7 @@ async def test_prepare_claude_terminal_fresh_session_is_not_cold_resumed(
     transcript on a fresh launch — the user would type a prompt
     and see no assistant reply mirrored to the web UI.
     """
+    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "on")
 
     async def _fake_create_session(
         _client: object,


### PR DESCRIPTION
## Related issue

N/A — small feature-flag chore with no tracking issue.

## Summary

- The automatic "auto-title" rename asks the model to call `sys_session_rename` on the first turn of every fresh session — an extra model round-trip that slows every new session. It is gated behind a new `OMNIGENT_SESSION_RENAME` env var that **defaults to off**, so the feature ships disabled out of the box.
- The implementation is kept fully intact: the `SysSessionRenameTool` class, its `ToolManager` registration, the MCP/Codex config, the dispatch handler, and the `POST /v1/sessions/{id}/auto-title` endpoint all remain. Only the *trigger* is suppressed, so nothing renames automatically unless the operator opts in with `OMNIGENT_SESSION_RENAME=on` (`1`/`true`/`yes` also work).
- The manual "Rename" item in the web sidebar (user-initiated, ownership-gated) is **unaffected** — only the slow automatic path is gated.

The single chokepoint is `session_rename_instruction()` / `session_rename_allowed_tools()` in `omnigent/tools/builtins/session_rename.py`, which both the Claude-native launcher (`omnigent/claude_native.py`) and the shared runner (`omnigent/runner/app.py`) consult. Returning `None` / `()` there suppresses the first-turn instruction and empties the tool preapproval everywhere. The flag is read at call time (once per session) rather than cached at import, so it is testable via `monkeypatch.setenv` and picks up deploy changes without a reimport.

## Test Plan

- `uv run --extra dev pytest tests/runner/test_auto_title_instruction.py` — 5 passed, including a new `test_session_rename_disabled_by_default` asserting the out-of-the-box off behavior (instruction `None`, allowlist `()` for both fresh and resumed).
- Integration cases that assert the instruction/allowlist **is** injected on fresh sessions — all updated to opt in with `monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "on")`, all green:
  - `tests/runner/test_app_sessions_native.py::test_auto_create_claude_terminal_registers_permission_hook`
  - `tests/runner/test_app_sessions_native.py::test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir`
  - `tests/runner/test_app_sessions_native.py::test_auto_create_claude_terminal_forwarder_skips_replayed_transcript_on_resume` (both the `[None-False]` fresh and `[...-True]` resume params)
  - `tests/test_claude_native.py::test_prepare_claude_terminal_fresh_session_is_not_cold_resumed`
- The rename-adjacent suite that should be untouched by the gate (tool schema, dispatch, manager registration, codex app-server config, comment relay, and the `auto-title` endpoint which is POSTed to directly) — 85 passed.
- `uv run ruff check` on all four changed files: clean.

Note: 3 `test_claude_native_bridge.py` MCP-subprocess tests fail in this environment, but they are **pre-existing** — confirmed by stashing this change and reproducing the same 3 failures on the original code (a `TimeoutError: subprocess did not emit a JSON line` startup-timing issue on this machine, unrelated to this PR).

## Demo

N/A — non-visual change (a backend env-var gate; no UI behavior change, since the manual sidebar rename is untouched).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `test_session_rename_disabled_by_default` covering the new default-off path (the core of this change), and updated the two existing unit tests that assert the active path so they explicitly opt in — so both the off (default) and on (opt-in) states are pinned. The four integration tests that assert the instruction is injected on fresh sessions now opt in too, proving the gate is consulted end-to-end by both the Claude-native and shared-runner launch paths.

## Changelog

`OMNIGENT_SESSION_RENAME=on` re-enables the automatic first-turn session rename (disabled by default)
