### PR TITLE
docs(openshell): use uv instead of pip in install instructions

### DIFF
--- a/deploy/openshell/README.md
+++ b/deploy/openshell/README.md
@@ -14,7 +14,7 @@ This guide covers the Omnigent-specific OpenShell setup:
 - configure CLI-launched or server-managed sandboxes.
 
 ```bash
-pip install 'omnigent[openshell]'
+uv pip install 'omnigent[openshell]'
 ```
 
 Omnigent uses OpenShell two ways:
@@ -404,6 +404,6 @@ upload, foreground streaming, attach, terminate, env passthrough, error handling
 and the managed-config parsing:
 
 ```bash
-pip install -e '.[openshell,dev]'
+uv pip install -e '.[openshell,dev]'
 pytest tests/onboarding/sandboxes/test_openshell.py tests/server/test_managed_hosts.py
 ```

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -5,7 +5,7 @@ Implements :class:`~omnigent.onboarding.sandboxes.base.SandboxLauncher`
 for `NVIDIA OpenShell <https://github.com/NVIDIA/openshell>`_ sandboxes
 on top of the official ``openshell`` Python SDK. Same posture as the
 Modal, Daytona, and CoreWeave launchers: the SDK is an optional
-dependency (``pip install 'omnigent[openshell]'``) imported lazily, so
+dependency (``uv pip install 'omnigent[openshell]'``) imported lazily, so
 the provider can be listed and the module probed without it.
 
 OpenShell is self-hosted: a gateway control plane manages sandbox
@@ -104,7 +104,7 @@ def _ensure_sdk() -> None:
     except ImportError as exc:
         raise click.ClickException(
             "The openshell SDK is required for the 'openshell' sandbox provider. "
-            "Install it with `pip install 'omnigent[openshell]'`, then select a "
+            "Install it with `uv pip install 'omnigent[openshell]'`, then select a "
             "gateway with `openshell gateway select <name>` (or set OPENSHELL_GATEWAY)."
         ) from exc
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Switch OpenShell install instructions from `pip` to `uv pip` in the module docstring, the `_ensure_sdk()` error message, and the deploy README.

## Test Plan

- Grep for remaining `pip install` references in openshell files — only the shared in-sandbox wheel overlay in `base.py` remains (intentional; it runs inside the prebaked image's venv).

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only change — no code behavior affected.