### PR TITLE
perf(db): drop the unused ix_files_created_at index

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -342,7 +342,9 @@ class SqlFile(OmnigentBase):
     session_id: Mapped[str | None] = mapped_column(Uuid16(), nullable=True)
 
     __table_args__ = (
-        Index("ix_files_created_at", "workspace_id", "created_at", "id"),
+        # Files are only ever listed per session (WHERE session_id = ?),
+        # so a session-scoped composite is the only index needed. There is
+        # no session-less "all files" listing.
         Index(
             "ix_files_session_id_created_at",
             "workspace_id",

--- a/omnigent/db/migrations/versions/c3e8f1a9d2b7_drop_unused_files_created_at_index.py
+++ b/omnigent/db/migrations/versions/c3e8f1a9d2b7_drop_unused_files_created_at_index.py
@@ -1,0 +1,47 @@
+"""Drop the unused ix_files_created_at index.
+
+Revision ID: c3e8f1a9d2b7
+Revises: z9a2b3c4d5e6
+Create Date: 2026-07-21 00:00:00.000000
+
+``ix_files_created_at`` on ``files`` (``workspace_id, created_at, id``) does not
+earn its keep. It only serves a session-less listing (``WHERE workspace_id
+ORDER BY created_at, id``), and there is no such caller: every read of a
+session's files goes through ``FileStore.list(session_id=...)`` — the agent
+``list_files`` tool (in-process and runner-proxied over
+``GET /v1/sessions/{id}/resources/files``) and the session-resources route.
+Those all filter by ``session_id`` and are served by
+``ix_files_session_id_created_at`` (``workspace_id, session_id, created_at,
+id``). Global (``session_id IS NULL``) files are only ever surfaced via the
+``include_unscoped`` OR query, which also rides the session-scoped index.
+
+So ``ix_files_created_at`` is pure write/space overhead.
+``ix_files_session_id_created_at`` is unchanged.
+
+Index-only, no data change. ``DROP``/``CREATE INDEX`` is native on every
+dialect (no table rebuild). Downgrade restores the index.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "c3e8f1a9d2b7"
+down_revision: str | None = "z9a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX = "ix_files_created_at"
+_TABLE = "files"
+
+
+def upgrade() -> None:
+    """Drop the unused (workspace_id, created_at, id) index."""
+    op.drop_index(_INDEX, table_name=_TABLE)
+
+
+def downgrade() -> None:
+    """Restore the (workspace_id, created_at, id) index."""
+    op.create_index(_INDEX, _TABLE, ["workspace_id", "created_at", "id"])

--- a/omnigent/stores/file_store/__init__.py
+++ b/omnigent/stores/file_store/__init__.py
@@ -77,30 +77,26 @@ class FileStore(ABC):
     @abstractmethod
     def list(
         self,
+        session_id: str,
         limit: int = 20,
         after: str | None = None,
         before: str | None = None,
         order: str = "desc",
-        session_id: str | None = None,
         include_unscoped: bool = False,
     ) -> PagedList[StoredFile]:
         """
-        List files with cursor-based pagination.
+        List a session's files with cursor-based pagination.
 
-        When ``session_id`` is set, only files owned by that
-        session are returned. When ``None``, all files are listed
-        (legacy global behavior).
+        Always scoped to a session — there is no cross-session
+        listing (files are only ever surfaced per session).
 
+        :param session_id: Owning session whose files to list.
         :param limit: Maximum number of files to return.
         :param after: Cursor file ID for forward pagination.
         :param before: Cursor file ID for backward pagination.
         :param order: Sort direction, ``"desc"`` or ``"asc"``.
-        :param session_id: Filter to files owned by this session.
-            ``None`` lists all files.
-        :param include_unscoped: When ``True`` **and** ``session_id``
-            is set, also return files with ``session_id IS NULL``
-            (global/unscoped files). Ignored when ``session_id``
-            is ``None``.
+        :param include_unscoped: When ``True``, also return files
+            with ``session_id IS NULL`` (global/unscoped files).
         :returns: A :class:`PagedList` of :class:`StoredFile`.
         """
         ...

--- a/omnigent/stores/file_store/sqlalchemy_store.py
+++ b/omnigent/stores/file_store/sqlalchemy_store.py
@@ -106,37 +106,38 @@ class SqlAlchemyFileStore(FileStore):
 
     def list(
         self,
+        session_id: str,
         limit: int = 20,
         after: str | None = None,
         before: str | None = None,
         order: str = "desc",
-        session_id: str | None = None,
         include_unscoped: bool = False,
     ) -> PagedList[StoredFile]:
         """
-        List files with cursor-based pagination.
+        List a session's files with cursor-based pagination.
 
+        Always scoped to ``session_id`` — the query filters on it, so
+        it is served by ``ix_files_session_id_created_at``.
+
+        :param session_id: Owning session whose files to list.
         :param limit: Maximum number of files to return.
         :param after: Cursor file ID for forward pagination.
         :param before: Cursor file ID for backward pagination.
         :param order: Sort direction, ``"desc"`` or ``"asc"``.
-        :param session_id: Filter to this session's files.
-            ``None`` lists all files.
-        :param include_unscoped: When ``True`` and ``session_id``
-            is set, also return global files (``session_id IS NULL``).
+        :param include_unscoped: When ``True``, also return global
+            files (``session_id IS NULL``).
         :returns: A :class:`PagedList` of :class:`StoredFile`.
         """
         with self._session() as session:
             is_desc = order == "desc"
             sort_fn = desc if is_desc else asc
             stmt = select(SqlFile).where(SqlFile.workspace_id == current_workspace_id())
-            if session_id is not None:
-                if include_unscoped:
-                    stmt = stmt.where(
-                        or_(SqlFile.session_id == session_id, SqlFile.session_id.is_(None))
-                    )
-                else:
-                    stmt = stmt.where(SqlFile.session_id == session_id)
+            if include_unscoped:
+                stmt = stmt.where(
+                    or_(SqlFile.session_id == session_id, SqlFile.session_id.is_(None))
+                )
+            else:
+                stmt = stmt.where(SqlFile.session_id == session_id)
             if after:
                 sub = (
                     select(SqlFile.created_at)

--- a/tests/stores/test_file_store.py
+++ b/tests/stores/test_file_store.py
@@ -6,6 +6,10 @@ import pytest
 
 from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
 
+# Files are always listed per session, so pagination/ordering tests
+# scope their fixtures to a single session id.
+_SID = "94c349190e241f85a984b3df8f129696"
+
 
 @pytest.fixture()
 def file_store(db_uri: str) -> SqlAlchemyFileStore:
@@ -45,35 +49,35 @@ def test_delete(file_store: SqlAlchemyFileStore) -> None:
 
 def test_list_pagination(file_store: SqlAlchemyFileStore) -> None:
     for i in range(4):
-        file_store.create(filename=f"f{i}.txt", bytes=i)
+        file_store.create(filename=f"f{i}.txt", bytes=i, session_id=_SID)
 
-    page1 = file_store.list(limit=2)
+    page1 = file_store.list(session_id=_SID, limit=2)
     assert len(page1.data) == 2
     assert page1.has_more is True
 
-    page2 = file_store.list(limit=2, after=page1.last_id)
+    page2 = file_store.list(session_id=_SID, limit=2, after=page1.last_id)
     assert len(page2.data) == 2
     assert page2.has_more is False
 
 
 def test_list_order_asc(file_store: SqlAlchemyFileStore) -> None:
     for i in range(3):
-        file_store.create(filename=f"f{i}.txt", bytes=i)
-    page_desc = file_store.list(order="desc")
-    page_asc = file_store.list(order="asc")
+        file_store.create(filename=f"f{i}.txt", bytes=i, session_id=_SID)
+    page_desc = file_store.list(session_id=_SID, order="desc")
+    page_asc = file_store.list(session_id=_SID, order="asc")
     assert [f.id for f in page_asc.data] == list(reversed([f.id for f in page_desc.data]))
 
 
 def test_list_asc_with_after_cursor(file_store: SqlAlchemyFileStore) -> None:
     for i in range(5):
-        file_store.create(filename=f"f{i}.txt", bytes=i)
+        file_store.create(filename=f"f{i}.txt", bytes=i, session_id=_SID)
 
-    page1 = file_store.list(limit=2, order="asc")
-    page2 = file_store.list(limit=2, order="asc", after=page1.last_id)
-    page3 = file_store.list(limit=2, order="asc", after=page2.last_id)
+    page1 = file_store.list(session_id=_SID, limit=2, order="asc")
+    page2 = file_store.list(session_id=_SID, limit=2, order="asc", after=page1.last_id)
+    page3 = file_store.list(session_id=_SID, limit=2, order="asc", after=page2.last_id)
 
     all_ids = [f.id for f in page1.data + page2.data + page3.data]
-    full_asc = file_store.list(limit=100, order="asc")
+    full_asc = file_store.list(session_id=_SID, limit=100, order="asc")
     assert all_ids == [f.id for f in full_asc.data]
 
 
@@ -193,7 +197,7 @@ def test_list_include_unscoped_false_excludes_global_files(
 
 def test_list_empty(file_store: SqlAlchemyFileStore) -> None:
     """list on an empty store returns empty PagedList."""
-    page = file_store.list()
+    page = file_store.list(session_id=_SID)
     assert page.data == []
     assert page.first_id is None
     assert page.last_id is None


### PR DESCRIPTION
## Related issue

N/A

## Summary

`ix_files_created_at` on `files` (`workspace_id, created_at, id`) is an unused
index — it only serves a **session-less** listing (`WHERE workspace_id ORDER BY
created_at, id`), and nothing issues that query.

Every read of a session's files goes through `FileStore.list(session_id=...)`:
- the agent `list_files` builtin tool (in-process for SDK harnesses, and
  runner-proxied over `GET /v1/sessions/{id}/resources/files` for native
  harnesses),
- the session-resources endpoints.

All of those filter by `session_id` and are served by
`ix_files_session_id_created_at` (`workspace_id, session_id, created_at, id`).
Global (`session_id IS NULL`) files are only ever surfaced via the
`include_unscoped` OR query, which also rides the session-scoped index. The web
UI never lists files at all (it only uploads and downloads a file by id).

Since the session-less listing had no caller, this PR also removes the code path
that produced it: `FileStore.list` now **requires** `session_id` (the
`session_id=None` branch is gone), so the unindexed query is no longer
expressible. `ix_files_session_id_created_at` is unchanged.

## Test Plan

- `uv run pytest tests/db/` → **340 passed**, including
  `test_migrations_sqlite_safe.py::test_full_migration_chain_round_trips_on_sqlite`
  (exercises the new `c3e8f1a9d2b7` drop **up and down**).
- `uv run pytest tests/stores/test_file_store.py tests/tools/builtins/test_file_tools.py tests/server/routes/test_session_resources.py`
  → all pass. The store tests that previously listed globally are now
  session-scoped (same pagination/ordering coverage).
- `uv run alembic -c omnigent/db/alembic.ini heads` → single head
  (`c3e8f1a9d2b7`, chained onto `z9a2b3c4d5e6`).
- `uv run ruff check` + `uv run ruff format --check` + `pre-commit` → clean.
- Confirmed no positional `FileStore.list()` caller — all pass `session_id` by
  keyword — so making it a required leading parameter breaks no caller.

## Demo

N/A — non-visual (index/store change).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full-chain SQLite migration test round-trips every migration up and down, so
it covers the new `c3e8f1a9d2b7` drop/restore automatically. Store-level `list`
behavior is covered by `tests/stores/test_file_store.py` (updated to be
session-scoped) and the session-resources route tests.

---

This pull request and its description were written by Isaac.
