### PR TITLE
perf(db): fold conversation_id into the comments primary key

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1011,8 +1011,16 @@ class SqlComment(OmnigentBase):
         server_default="0",
         default=current_workspace_id,
     )
+    # conversation_id leads id in the PK so a conversation's comments stay
+    # contiguous for the per-conversation prefix scans that dominate reads
+    # (list_for_conversation, fingerprints, cascade delete). This subsumes the
+    # old ix_comments_conversation_id secondary index; list_for_conversation's
+    # ORDER BY created_at now filesorts the (small) per-conversation row set.
+    conversation_id: Mapped[str] = mapped_column(
+        Uuid16(),
+        primary_key=True,
+    )
     id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
-    conversation_id: Mapped[str] = mapped_column(Uuid16())
     path: Mapped[str] = mapped_column(String(4096))
     start_index: Mapped[int] = mapped_column(Integer)
     end_index: Mapped[int] = mapped_column(Integer)
@@ -1025,20 +1033,7 @@ class SqlComment(OmnigentBase):
     anchor_content: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
     created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
-    __table_args__ = (
-        CheckConstraint("status IN (1, 2)", name="ck_comments_status"),
-        # Serves list_for_conversation: WHERE workspace_id + conversation_id
-        # ORDER BY created_at, id. Folds created_at in (over a bare
-        # conversation_id index) so the sort is index-ordered; trails id to
-        # complete the PK.
-        Index(
-            "ix_comments_conversation_id",
-            "workspace_id",
-            "conversation_id",
-            "created_at",
-            "id",
-        ),
-    )
+    __table_args__ = (CheckConstraint("status IN (1, 2)", name="ck_comments_status"),)
 
 
 def policy_name_cksum(name: str) -> bytes:

--- a/omnigent/db/migrations/versions/a7f3c1b9e2d4_comments_pk_workspace_conversation_id.py
+++ b/omnigent/db/migrations/versions/a7f3c1b9e2d4_comments_pk_workspace_conversation_id.py
@@ -1,0 +1,122 @@
+"""Widen the comments primary key with conversation_id; drop its now-redundant index.
+
+Revision ID: a7f3c1b9e2d4
+Revises: c3e8f1a9d2b7
+Create Date: 2026-07-21 00:00:00.000000
+
+Widens the ``comments`` primary key from ``(workspace_id, id)`` to
+``(workspace_id, conversation_id, id)``.  ``conversation_id`` slots in between
+the tenant partition key and the comment id so a single conversation's comments
+stay contiguous under the workspace prefix, matching the per-conversation prefix
+scans that dominate comment reads (``list_for_conversation``, the fingerprint
+aggregate, and the cascade delete).  ``conversation_id`` is already NOT NULL and
+every existing row has one, so the rebuild is a pure key change with no backfill.
+
+The wider PK subsumes ``ix_comments_conversation_id``
+(``workspace_id, conversation_id, created_at, id``): the ``(workspace_id,
+conversation_id)`` prefix it shared with the PK is now covered by the PK itself,
+so the secondary index is pure write/space overhead and is dropped.  Its one
+extra job — feeding ``list_for_conversation``'s ``ORDER BY created_at, id`` an
+index-ordered scan — is given up in favour of a filesort over the (small)
+per-conversation comment set.
+
+There are no FK constraints in the schema (see ``p1a2b3c4d5e6``), so rebuilding
+the primary key is a purely local operation on this one table.
+
+SQLite note: ``batch_alter_table(recreate="always")`` rebuilds the table so the
+primary key can change (SQLite cannot alter a PK in place); the new
+``create_primary_key`` overrides the reflected key.  On PostgreSQL the existing
+named PK is dropped explicitly first (a table can hold only one primary key)
+before the wider one is added.  Both paths guard the rebuild with
+``PRAGMA foreign_keys`` on SQLite.  The index is dropped before the rebuild so
+the recreate does not carry it forward.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import warnings
+from collections.abc import Iterator, Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a7f3c1b9e2d4"
+down_revision: str | None = "c3e8f1a9d2b7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "comments"
+# Primary key before this migration and after it.
+_OLD_PK = ["workspace_id", "id"]
+_NEW_PK = ["workspace_id", "conversation_id", "id"]
+# Secondary index made redundant by the wider PK.
+_INDEX = "ix_comments_conversation_id"
+_INDEX_COLS = ["workspace_id", "conversation_id", "created_at", "id"]
+
+
+def _existing_pk_name(table: str) -> str | None:
+    """Reflect the current primary-key constraint name (PostgreSQL path)."""
+    return sa.inspect(op.get_bind()).get_pk_constraint(table).get("name")
+
+
+@contextlib.contextmanager
+def _quiet_pk_override() -> Iterator[None]:
+    """
+    Silence the expected SQLite batch-rebuild warning about the reflected
+    primary key not matching the wider one we install. The override is
+    intentional here, and this fires on every fresh DB.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r".*not matching locally specified columns.*",
+            category=sa.exc.SAWarning,
+        )
+        yield
+
+
+def _rebuild_pk(new_pk: list[str]) -> None:
+    """Drop the current ``comments`` PK and install ``new_pk``."""
+    dialect = op.get_bind().dialect.name
+    sqlite = dialect == "sqlite"
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    if dialect == "mysql":
+        # MySQL PKs are unnamed; use raw DDL so batch_alter_table does not
+        # try to add a second PRIMARY KEY before the first is dropped.
+        pk_col_list = ", ".join(f"`{c}`" for c in new_pk)
+        op.execute(
+            sa.text(
+                f"ALTER TABLE `{_TABLE}` "
+                f"DROP PRIMARY KEY, "
+                f"ADD CONSTRAINT `pk_{_TABLE}` PRIMARY KEY ({pk_col_list})"
+            )
+        )
+    else:
+        old_pk_name = None if sqlite else _existing_pk_name(_TABLE)
+        with (
+            _quiet_pk_override(),
+            op.batch_alter_table(_TABLE, recreate="always" if sqlite else "auto") as batch_op,
+        ):
+            if old_pk_name is not None:
+                batch_op.drop_constraint(old_pk_name, type_="primary")
+            batch_op.create_primary_key(f"pk_{_TABLE}", new_pk)
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))
+
+
+def upgrade() -> None:
+    """Drop the redundant index, then widen the PK with conversation_id."""
+    # Drop first so the SQLite batch recreate does not carry the index forward.
+    op.drop_index(_INDEX, table_name=_TABLE)
+    _rebuild_pk(_NEW_PK)
+
+
+def downgrade() -> None:
+    """Restore the (workspace_id, id) PK, then recreate the index."""
+    _rebuild_pk(_OLD_PK)
+    op.create_index(_INDEX, _TABLE, _INDEX_COLS)

--- a/omnigent/stores/comment_store/sqlalchemy_store.py
+++ b/omnigent/stores/comment_store/sqlalchemy_store.py
@@ -6,7 +6,7 @@ import uuid
 
 from sqlalchemy import delete, func, select
 
-from omnigent.db.db_models import SqlComment, current_workspace_id, normalize_uuid
+from omnigent.db.db_models import SqlComment, current_workspace_id
 from omnigent.db.enum_codecs import decode_comment_status, encode_comment_status
 from omnigent.db.utils import (
     get_or_create_engine,
@@ -59,8 +59,10 @@ class SqlAlchemyCommentStore(CommentStore):
     def get(self, comment_id: str, conversation_id: str) -> Comment | None:
         """Fetch a single comment by id, scoped to a conversation. See base class for contract."""
         with self._session() as session:
-            row = session.get(SqlComment, (current_workspace_id(), comment_id))
-            if row is None or row.conversation_id != normalize_uuid(conversation_id):
+            # conversation_id is part of the PK, so the lookup itself enforces
+            # the conversation scoping — a wrong conversation simply misses.
+            row = session.get(SqlComment, (current_workspace_id(), conversation_id, comment_id))
+            if row is None:
                 return None
             return _to_entity(row)
 
@@ -126,8 +128,8 @@ class SqlAlchemyCommentStore(CommentStore):
     ) -> Comment | None:
         """Update a comment's fields, scoped to a conversation. See base class for contract."""
         with self._session() as session:
-            row = session.get(SqlComment, (current_workspace_id(), comment_id))
-            if row is None or row.conversation_id != normalize_uuid(conversation_id):
+            row = session.get(SqlComment, (current_workspace_id(), conversation_id, comment_id))
+            if row is None:
                 return None
             if status is not None:
                 row.status = encode_comment_status(status)
@@ -140,8 +142,8 @@ class SqlAlchemyCommentStore(CommentStore):
     def delete(self, comment_id: str, conversation_id: str) -> Comment | None:
         """Delete a single comment by id, scoped to a conversation. See base class for contract."""
         with self._session() as session:
-            row = session.get(SqlComment, (current_workspace_id(), comment_id))
-            if row is None or row.conversation_id != normalize_uuid(conversation_id):
+            row = session.get(SqlComment, (current_workspace_id(), conversation_id, comment_id))
+            if row is None:
                 return None
             entity = _to_entity(row)
             session.delete(row)

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -716,7 +716,10 @@ class TestSqlComment:
             session.add(comment)
 
         with managed() as session:
-            loaded = session.get(SqlComment, (0, "cccccccccccccccccccccccccccccc01"))
+            loaded = session.get(
+                SqlComment,
+                (0, "a9930027fd3e2e979e65844f7af7bf88", "cccccccccccccccccccccccccccccc01"),
+            )
             assert loaded is not None
             assert loaded.path == "src/App.tsx"
             assert loaded.body == "Looks good!"
@@ -746,7 +749,10 @@ class TestSqlComment:
             session.add(comment)
 
         with managed() as session:
-            loaded = session.get(SqlComment, (0, "cccccccccccccccccccccccccccccc02"))
+            loaded = session.get(
+                SqlComment,
+                (0, "a9930027fd3e2e979e65844f7af7bf88", "cccccccccccccccccccccccccccccc02"),
+            )
             assert loaded is not None
             assert loaded.anchor_content is None
             assert loaded.created_by is None

--- a/tests/db/test_migration_workspace_id.py
+++ b/tests/db/test_migration_workspace_id.py
@@ -50,6 +50,9 @@ _LATER_PK_OVERRIDES: dict[str, list[str]] = {
     # between workspace_id and id; z8a2b3c4d5e6 appended created_at for
     # partition-readiness.
     "conversation_items": ["workspace_id", "conversation_id", "id", "created_at"],
+    # a7f3c1b9e2d4 widened comments to insert conversation_id between
+    # workspace_id and id (dropping the now-redundant conversation index).
+    "comments": ["workspace_id", "conversation_id", "id"],
 }
 
 

--- a/tests/server/test_identity_migration.py
+++ b/tests/server/test_identity_migration.py
@@ -164,7 +164,10 @@ def test_remap_repoints_comments_policies_tokens_hosts(db_uri: str) -> None:
 
     with Session(engine) as s:
         assert (
-            s.get(SqlComment, (0, "747618b4b2dd94383e50ddf180ceddc3")).created_by
+            s.get(
+                SqlComment,
+                (0, "8af356d908005a65f872c246158c6293", "747618b4b2dd94383e50ddf180ceddc3"),
+            ).created_by
             == "alice@example.com"
         )
         assert (


### PR DESCRIPTION
## Related issue

N/A

## Summary

Fold `conversation_id` into the `comments` primary key and drop the secondary
index it made redundant.

- **PK**: `(workspace_id, id)` → `(workspace_id, conversation_id, id)`.
  `conversation_id` slots between the tenant key and the comment id so a
  conversation's comments are contiguous under the workspace prefix — matching
  the per-conversation reads that dominate comment access.
- **Index dropped**: `ix_comments_conversation_id`
  `(workspace_id, conversation_id, created_at, id)`. Its
  `(workspace_id, conversation_id)` prefix is now carried by the PK itself, so
  it backed `list_for_conversation`, the fingerprint aggregate, and the cascade
  delete purely as write/space overhead. Its one extra job — feeding
  `list_for_conversation`'s `ORDER BY created_at, id` an index-ordered scan — is
  given up for a filesort over the small per-conversation comment set.
- **Store**: `get` / `update_comment` / `delete` already receive
  `conversation_id`, so they now key on the full PK tuple instead of fetching by
  `(workspace_id, id)` and filtering `conversation_id` in Python — the lookup
  itself enforces the conversation scoping.
- **Migration** `a7f3c1b9e2d4` (off `z9a2b3c4d5e6`) is a pure key change:
  `conversation_id` is already `NOT NULL` and populated, so no backfill.
  Batch-recreate on SQLite, raw `DROP/ADD PRIMARY KEY` on MySQL,
  drop-constraint + create on PostgreSQL — same idiom as the `conversation_items`
  PK widen.

> **Note for reviewers / merge order:** #2954 also parents a migration off
> `z9a2b3c4d5e6`. Whichever of the two merges second will create two Alembic
> heads on `main` and needs re-parenting onto the other.

## Test Plan

Run against the branch:

```
pytest tests/stores/test_comment_store.py \
       tests/db/test_migrations_sqlite_safe.py \
       tests/db/test_migration_workspace_id.py \
       tests/db/test_migration_comments_updated_at.py \
       tests/tools/builtins/test_list_comments.py \
       tests/tools/builtins/test_update_comment.py \
       tests/server/routes/test_comments_crud.py \
       tests/server/integration/test_comments_routes.py \
       tests/entities/test_comment.py tests/runner/test_comment_relay.py
```

- **128 passed (+1 xfail).**
- `test_full_migration_chain_round_trips_on_sqlite` exercises the migration
  up → down → up.
- `test_downgrade_removes_workspace_id_and_restores_pk` exercises the full
  downgrade chain through the new migration.
- `test_workspace_id_leads_the_primary_key[comments]` confirms the new PK
  (via the added `_LATER_PK_OVERRIDES` entry).
- `test_update_comment_wrong_conversation_is_noop` confirms PK-based scoping
  still rejects wrong-conversation access.
- Explicit check: at migration head, `comments` PK is
  `(workspace_id, conversation_id, id)` with zero secondary indexes, and the
  ORM model agrees.
- `ruff format --check` + `ruff check` clean.

## Demo

N/A — schema/store change, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

<!-- Existing comment store, tool, route, integration, and migration suites
     already cover the CRUD paths and PK/downgrade behaviour; the one test
     addition (_LATER_PK_OVERRIDES entry) extends the migration PK-lead check. -->

## Coverage notes

N/A — covered by existing suites plus the migration PK-lead check update.
