### PR TITLE
test(cli): assert crash-report version against VERSION, not a hardcoded string

### DIFF
--- a/tests/cli/test_crash_handler.py
+++ b/tests/cli/test_crash_handler.py
@@ -23,6 +23,7 @@ import pytest
 
 from omnigent import crash_handler as ch
 from omnigent import crash_ui
+from omnigent.version import VERSION
 
 
 # --------------------------------------------------------------------------- #
@@ -66,7 +67,7 @@ def test_build_report_contains_required_fields(data_dir: Path) -> None:
     )
     assert "# Crash Report — omnigent" in report
     assert "ValueError" in report
-    assert "omnigent 0.6.0.dev0" in report or "omnigent unknown" in report  # version line
+    assert f"omnigent {VERSION}" in report or "omnigent unknown" in report  # version line
     assert "https://github.com/omnigent-ai/omnigent" in report
     assert "Source:** uncaught" in report
     assert "the frobnicator failed" in report


### PR DESCRIPTION
## Related issue

N/A

## Summary

The misc pytest shard is red on `main` (and therefore on every open PR cut from
it). `tests/cli/test_crash_handler.py::test_build_report_contains_required_fields`
hard-codes the expected version line:

```python
assert "omnigent 0.6.0.dev0" in report or "omnigent unknown" in report
```

The `0.7.0.dev0` bump (#2950) left this stale — the crash report now renders
`**Version:** omnigent 0.7.0.dev0`, so the assertion fails.

Fix: assert against `omnigent.version.VERSION` instead of a literal, so the
check tracks the real version and won't break on future bumps.

```python
from omnigent.version import VERSION
...
assert f"omnigent {VERSION}" in report or "omnigent unknown" in report
```

## Test Plan

- `uv run pytest tests/cli/test_crash_handler.py` → **21 passed** (previously
  `test_build_report_contains_required_fields` failed on the stale literal).
- Confirmed `omnigent/version.py` is `VERSION = "0.7.0.dev0"`, matching the
  report's rendered version line.

## Demo

N/A — test-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Test-only change to an existing test; the assertion now derives the expected
version from `omnigent.version.VERSION` rather than a hardcoded string, so it
stays correct across version bumps.

---

This pull request and its description were written by Isaac.
