### PR TITLE
Add rahulrav1 to maintainers

### DIFF
--- a/.github/MAINTAINER
+++ b/.github/MAINTAINER
@@ -15,6 +15,7 @@ mahesh-venkatachalam
 mateiz
 newfront
 PattaraS
+rahulrav1
 SabhyaC26
 serena-ruan
 shivam5


### PR DESCRIPTION
## What & why

Adds `rahulrav1` to the canonical maintainer roster in `.github/MAINTAINER`.

`.github/MAINTAINER` is the single source of truth for who can approve merges. It is read by the `maintainer-approval`, `oss-regen-on-comment`, and `polly-review-approval-dispatch` workflows (via `.github/scripts/merge-ready/load-maintainers.sh`) and gates:

- the **Maintainer Approval** required check,
- the `skip-security-scan` waiver,
- `e2e-approved`.

This PR grants `rahulrav1` those permissions. The entry is inserted in alphabetical position (between `PattaraS` and `SabhyaC26`), consistent with the existing ordering.

## Scope notes

- **`.github/areas.json` was intentionally NOT modified.** That file defines code-area ownership / reviewer routing for specific paths; no area was specified for `rahulrav1`, so none was assigned. Being in `MAINTAINER` without owning an area is valid (e.g. `hzub` is currently in the same state). The invariant enforced by `areas.test.js` — every area owner must also be in `MAINTAINER` — continues to hold.
- **`.github/workflows/auto-assign-reviewer.fixture.json` was intentionally NOT modified.** It is a frozen test fixture explicitly marked `do NOT sync with areas.json`; editing it as a source of truth would break `auto-assign-reviewer.test.js`.
- Unrelated local changes to `uv.lock` and `web/package-lock.json` were left out of this commit to keep the PR scoped to a single line.

## Test plan

- [ ] CI `maintainer-approval` / `areas` checks pass
- [ ] Confirm `rahulrav1` resolves as a maintainer via `load-maintainers.sh` against the updated `MAINTAINER` file
