### PR TITLE
fix(tests): read crash-report version dynamically so a bump can't break it

### DIFF
--- a/tests/cli/test_crash_handler.py
+++ b/tests/cli/test_crash_handler.py
@@ -23,6 +23,7 @@ import pytest
 
 from omnigent import crash_handler as ch
 from omnigent import crash_ui
+from omnigent.version import VERSION
 
 
 # --------------------------------------------------------------------------- #
@@ -66,7 +67,7 @@ def test_build_report_contains_required_fields(data_dir: Path) -> None:
     )
     assert "# Crash Report — omnigent" in report
     assert "ValueError" in report
-    assert "omnigent 0.6.0.dev0" in report or "omnigent unknown" in report  # version line
+    assert f"omnigent {VERSION}" in report or "omnigent unknown" in report  # version line
     assert "https://github.com/omnigent-ai/omnigent" in report
     assert "Source:** uncaught" in report
     assert "the frobnicator failed" in report


### PR DESCRIPTION
## Related issue

N/A, cleanup of a CI regression from #2950.

## Summary

`tests/cli/test_crash_handler.py` hardcoded `omnigent 0.6.0.dev0`, so #2950's bump to `0.7.0.dev0` turned it red on every open PR. It now asserts against `omnigent.version.VERSION`, the same source the crash report reads, so future bumps stay green.

## Test Plan

```
uv run pytest tests/cli/test_crash_handler.py -q
```

Verified red on current main, green with this change.

## Demo

N/A, test-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Test-only change to the assertion; the fixed test is its own coverage.
