### PR TITLE
test(crash-handler): make version assertion bump-tolerant

### DIFF
--- a/tests/cli/test_crash_handler.py
+++ b/tests/cli/test_crash_handler.py
@@ -23,6 +23,7 @@ import pytest
 
 from omnigent import crash_handler as ch
 from omnigent import crash_ui
+from omnigent.version import VERSION
 
 
 # --------------------------------------------------------------------------- #
@@ -66,7 +67,7 @@ def test_build_report_contains_required_fields(data_dir: Path) -> None:
     )
     assert "# Crash Report — omnigent" in report
     assert "ValueError" in report
-    assert "omnigent 0.6.0.dev0" in report or "omnigent unknown" in report  # version line
+    assert f"omnigent {VERSION}" in report or "omnigent unknown" in report  # version line
     assert "https://github.com/omnigent-ai/omnigent" in report
     assert "Source:** uncaught" in report
     assert "the frobnicator failed" in report


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `test_build_report_contains_required_fields` asserted the crash report contained the literal `omnigent 0.6.0.dev0`, so it broke the moment the version was bumped to `0.7.0.dev0` — and will break on every future bump.
- The assertion now reads the version from `omnigent.version.VERSION` (the same single source of truth that `crash_handler._read_version()` imports), so it tracks the real version automatically.
- The `or "omnigent unknown"` branch is preserved, keeping coverage of the `_read_version()` failure path.

## Test Plan

- Ran the previously-failing test: `uv run --extra dev pytest tests/cli/test_crash_handler.py::test_build_report_contains_required_fields -q` → passes.
- Ran the full crash-handler suite: `uv run --extra dev pytest tests/cli/test_crash_handler.py -q` → 21 passed.
- Confirmed the diff only touches the one assertion + its import; no production code changed.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This is a test-only fix. The change makes an existing unit test (`test_build_report_contains_required_fields`) version-agnostic instead of pinning a literal version string; the full existing suite (21 tests) was re-run to confirm nothing else regressed.

## Changelog
