### PR TITLE
perf(db): consolidate policies listing indexes; drop name unique key

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1071,12 +1071,14 @@ class SqlPolicy(OmnigentBase):
     :param id: Opaque PK, e.g. ``"pol_a1b2c3..."``.
     :param name: Human-readable name. UNIQUE per session for
         session policies; globally unique for default policies
-        (``session_id IS NULL``). Uniqueness is enforced on
-        ``name_cksum`` rather than this column.
+        (``session_id IS NULL``). Uniqueness is enforced in the
+        store (application layer), not by a DB constraint, and
+        keys on ``name_cksum`` rather than this column.
     :param name_cksum: sha256 digest of ``name`` (32 bytes). The
-        name-uniqueness indexes key on this compact digest instead
-        of the wide ``VARCHAR(256)`` name. Stamped on INSERT by a
-        column default; recomputed by the store on rename.
+        store's name-uniqueness checks key on this compact digest
+        instead of the wide ``VARCHAR(256)`` name, backed by
+        ``ix_policies_name_cksum``. Stamped on INSERT by a column
+        default; recomputed by the store on rename.
     :param session_id: FK to ``conversations.id``. ``None`` for
         server-wide default policies. ``ON DELETE CASCADE`` so
         removing a session cleans up its policies.
@@ -1148,21 +1150,24 @@ class SqlPolicy(OmnigentBase):
     __table_args__ = (
         CheckConstraint("type IN (1, 2)", name="ck_policies_type"),
         CheckConstraint("scope IN (1, 2)", name="ck_policies_scope"),
-        Index("ix_policies_created_at", "workspace_id", "created_at", "id"),
-        Index("ix_policies_session_id", "workspace_id", "session_id", "id"),
-        # Name uniqueness keys on name_cksum (sha256 of name) rather than the
-        # wide name column, for a compact 32-byte index entry.
-        UniqueConstraint(
-            "workspace_id",
-            "session_id",
-            "name_cksum",
-            name="uq_policies_session_id_name_cksum",
-        ),
-        # Default policies must have unique names; session-scoped policies
-        # may reuse the same name. That "unique only within the default set"
-        # rule can't be a partial unique index (MySQL has none), so it is
-        # enforced in the store (add_default / update_default). This plain
-        # index just backs the name_cksum lookup those checks perform.
+        # One index serves both listing paths. scope leads (the global-vs-
+        # session discriminator), then session_id:
+        #   - list_defaults:     WHERE workspace_id=? AND scope='default'
+        #   - list_for_session:  WHERE workspace_id=? AND scope='session'
+        #                              AND session_id=?
+        # scope must precede session_id so the defaults query (which does not
+        # constrain session_id) can still seek. Both listings sort their small
+        # result set by created_at in memory (created_at is deliberately left
+        # out — it can't cover both sorts, see migration d4c1b9e6f3a2).
+        # Any future session_id lookup must also constrain scope to seek here.
+        Index("ix_policies_scope_session", "workspace_id", "scope", "session_id", "id"),
+        # Name uniqueness is enforced in the store, not by a DB constraint:
+        # default policies must have globally-unique names while session
+        # policies must be unique only within their session — a "unique within
+        # a subset" rule that can't be a partial unique index (MySQL has none).
+        # The store's create/update checks (session) and create_default/
+        # update_default (default) key on name_cksum; this plain index backs
+        # those lookups.
         Index("ix_policies_name_cksum", "workspace_id", "name_cksum", "id"),
     )
 

--- a/omnigent/db/migrations/versions/d4c1b9e6f3a2_policies_scope_index_drop_unique.py
+++ b/omnigent/db/migrations/versions/d4c1b9e6f3a2_policies_scope_index_drop_unique.py
@@ -1,0 +1,101 @@
+"""Consolidate policies listing indexes; drop the name unique key.
+
+Revision ID: d4c1b9e6f3a2
+Revises: a7f3c1b9e2d4
+Create Date: 2026-07-21 12:00:00.000000
+
+Reworks the ``policies`` secondary indexes, all schema-only:
+
+- Drop ``ix_policies_created_at`` (``workspace_id, created_at, id``) and
+  ``ix_policies_session_id`` (``workspace_id, session_id, id``).
+- Add one combined ``ix_policies_scope_session``
+  (``workspace_id, scope, session_id, id``) that serves both listing paths:
+  ``list_defaults`` (``WHERE workspace_id=? AND scope='default'``) rides the
+  ``(workspace_id, scope)`` prefix, and ``list_for_session``
+  (``WHERE workspace_id=? AND scope='session' AND session_id=?``) rides the
+  full key. ``scope`` must lead ``session_id`` so the defaults query — which
+  does not constrain ``session_id`` — can still seek. ``created_at`` is left
+  out on purpose: with ``session_id`` between ``scope`` and ``id`` it cannot
+  cover the ``ORDER BY created_at, id`` for both queries, so both sort their
+  small result set in memory (as the session listing already did).
+  NOTE: ``list_for_session`` gained a ``scope='session'`` predicate so it can
+  seek this key; a ``session_id`` lookup without ``scope`` would table-scan.
+- Drop the ``uq_policies_session_id_name_cksum`` unique constraint. Session-name
+  uniqueness now lives in the store (``SqlAlchemyPolicyStore.create`` /
+  ``update``), matching how default-name uniqueness has always been enforced
+  there. ``ix_policies_name_cksum`` still backs those lookups.
+
+Dropping the unique constraint runs in a ``batch_alter_table``
+(``recreate="always"`` on SQLite) guarded by the same ``PRAGMA foreign_keys``
+toggle as the other policy migrations. ``DROP``/``CREATE INDEX`` is native on
+every dialect. Downgrade restores the two indexes and the unique key.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d4c1b9e6f3a2"
+down_revision: str | None = "a7f3c1b9e2d4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Collapse the two listing indexes into one; drop the name unique key."""
+    sqlite = _is_sqlite()
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    # Drop the changing indexes before the rebuild so batch mode doesn't copy
+    # them onto the recreated table.
+    op.drop_index("ix_policies_created_at", table_name="policies")
+    op.drop_index("ix_policies_session_id", table_name="policies")
+
+    with op.batch_alter_table("policies", recreate="always" if sqlite else "auto") as batch_op:
+        batch_op.drop_constraint("uq_policies_session_id_name_cksum", type_="unique")
+
+    op.create_index(
+        "ix_policies_scope_session",
+        "policies",
+        ["workspace_id", "scope", "session_id", "id"],
+    )
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))
+
+
+def downgrade() -> None:
+    """Restore the split listing indexes and the (session_id, name_cksum) key."""
+    sqlite = _is_sqlite()
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    op.drop_index("ix_policies_scope_session", table_name="policies")
+
+    with op.batch_alter_table("policies", recreate="always" if sqlite else "auto") as batch_op:
+        batch_op.create_unique_constraint(
+            "uq_policies_session_id_name_cksum",
+            ["workspace_id", "session_id", "name_cksum"],
+        )
+
+    op.create_index(
+        "ix_policies_session_id",
+        "policies",
+        ["workspace_id", "session_id", "id"],
+    )
+    op.create_index(
+        "ix_policies_created_at",
+        "policies",
+        ["workspace_id", "created_at", "id"],
+    )
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))

--- a/omnigent/server/routes/session_policies.py
+++ b/omnigent/server/routes/session_policies.py
@@ -297,7 +297,9 @@ def create_session_policies_router(
             unchanged.
         :returns: The updated policy as a serialized dict.
         :raises OmnigentError: 401/403 if the user lacks edit
-            permission, or 404 if the policy is not found.
+            permission, 404 if the policy is not found, or 409 if
+            renaming would collide with another policy in this
+            session.
         """
         user_id = get_user_id(request, auth_provider)
         if permission_store is not None:
@@ -331,13 +333,19 @@ def create_session_policies_router(
                         f"must add custom handlers via the 'policy_modules' config.",
                         code=ErrorCode.INVALID_INPUT,
                     )
-        policy = store.update(
-            policy_id,
-            session_id,
-            name=body.name,
-            handler=body.handler,
-            enabled=body.enabled,
-        )
+        try:
+            policy = store.update(
+                policy_id,
+                session_id,
+                name=body.name,
+                handler=body.handler,
+                enabled=body.enabled,
+            )
+        except IntegrityError as exc:
+            raise OmnigentError(
+                f"Policy with name '{body.name}' already exists in this session",
+                code=ErrorCode.CONFLICT,
+            ) from exc
         if policy is None:
             raise OmnigentError("Policy not found", code=ErrorCode.NOT_FOUND)
         invalidate_session_policy_specs_cache(session_id)

--- a/omnigent/stores/policy_store/sqlalchemy_store.py
+++ b/omnigent/stores/policy_store/sqlalchemy_store.py
@@ -89,6 +89,10 @@ class SqlAlchemyPolicyStore(PolicyStore):
         """Insert a new session-scoped policy.
 
         Raises ``IntegrityError`` on ``(session_id, name)`` collision.
+        Session-name uniqueness is enforced here in the application
+        layer (the table carries no unique constraint) so names are
+        unique within a session while different sessions may reuse a
+        name.
         """
         row = SqlPolicy(
             id=policy_id,
@@ -103,6 +107,22 @@ class SqlAlchemyPolicyStore(PolicyStore):
             enabled=enabled,
         )
         with self._session() as session:
+            existing = (
+                session.execute(
+                    select(SqlPolicy)
+                    .where(SqlPolicy.workspace_id == current_workspace_id())
+                    .where(SqlPolicy.session_id == session_id)
+                    .where(SqlPolicy.name_cksum == policy_name_cksum(name))
+                )
+                .scalars()
+                .first()
+            )
+            if existing is not None:
+                raise IntegrityError(
+                    "Duplicate session policy name",
+                    params={"name": name},
+                    orig=Exception(f"UNIQUE constraint: name={name!r}"),
+                )
             session.add(row)
             session.flush()
             return _to_entity(row)
@@ -116,11 +136,20 @@ class SqlAlchemyPolicyStore(PolicyStore):
             return _to_entity(row)
 
     def list_for_session(self, session_id: str) -> list[Policy]:
-        """List policies for a session ordered by ``created_at ASC``."""
+        """List policies for a session ordered by ``created_at ASC``.
+
+        Filters on ``scope='session'`` in addition to ``session_id`` —
+        redundant for correctness (a real ``session_id`` never matches a
+        default, which has ``session_id IS NULL``) but required so the
+        query can seek ``ix_policies_scope_session`` (scope leads
+        session_id in that key). Without it the planner falls back to a
+        full workspace scan.
+        """
         with self._session() as session:
             stmt = (
                 select(SqlPolicy)
                 .where(SqlPolicy.workspace_id == current_workspace_id())
+                .where(SqlPolicy.scope == encode_policy_scope("session"))
                 .where(SqlPolicy.session_id == session_id)
                 .order_by(asc(SqlPolicy.created_at), asc(SqlPolicy.id))
             )
@@ -146,6 +175,26 @@ class SqlAlchemyPolicyStore(PolicyStore):
                 return None
             changed = False
             if name is not None and row.name != name:
+                # Session-name uniqueness is enforced here in the application
+                # layer (no unique constraint on the table), so this check is
+                # the guard, not just a nicer error.
+                conflict = (
+                    session.execute(
+                        select(SqlPolicy)
+                        .where(SqlPolicy.workspace_id == current_workspace_id())
+                        .where(SqlPolicy.session_id == session_id)
+                        .where(SqlPolicy.name_cksum == policy_name_cksum(name))
+                        .where(SqlPolicy.id != policy_id)
+                    )
+                    .scalars()
+                    .first()
+                )
+                if conflict is not None:
+                    raise IntegrityError(
+                        "Duplicate session policy name",
+                        params={"name": name},
+                        orig=Exception(f"UNIQUE constraint: name={name!r}"),
+                    )
                 row.name = name
                 # Column defaults don't fire on UPDATE — recompute the digest.
                 row.name_cksum = policy_name_cksum(name)
@@ -186,10 +235,8 @@ class SqlAlchemyPolicyStore(PolicyStore):
 
         Raises ``IntegrityError`` on name collision among defaults.
 
-        SQLite treats NULLs as distinct in composite unique
-        constraints, so the ``(session_id, name_cksum)`` constraint
-        does not enforce uniqueness among default policies.
-        This method checks for duplicates explicitly (by name digest).
+        The table carries no unique constraint, so default-name
+        uniqueness is enforced here explicitly (by name digest).
         """
 
         row = SqlPolicy(
@@ -206,9 +253,8 @@ class SqlAlchemyPolicyStore(PolicyStore):
             created_by=created_by,
         )
         with self._session() as session:
-            # Explicit uniqueness check: SQLite treats NULLs as
-            # distinct in composite unique constraints, so
-            # (NULL, name) won't collide with another (NULL, name).
+            # Default-name uniqueness is enforced here (no DB constraint):
+            # scan for an existing default with the same name digest.
             existing = (
                 session.execute(
                     select(SqlPolicy)

--- a/openapi.json
+++ b/openapi.json
@@ -9562,7 +9562,7 @@
         ]
       },
       "patch": {
-        "description": "Update a session policy's mutable fields.\n\n`type` is immutable \u2014 the caller must delete and\nre-create to change it. Requires `LEVEL_EDIT`.\n\n**Parameters**\n\n- `body` \u2014 Fields to update; `None` fields are left unchanged.\n\n**Returns:** The updated policy as a serialized dict.\n\n**Raises**\n\n- `OmnigentError` \u2014 401/403 if the user lacks edit permission, or 404 if the policy is not found.",
+        "description": "Update a session policy's mutable fields.\n\n`type` is immutable \u2014 the caller must delete and\nre-create to change it. Requires `LEVEL_EDIT`.\n\n**Parameters**\n\n- `body` \u2014 Fields to update; `None` fields are left unchanged.\n\n**Returns:** The updated policy as a serialized dict.\n\n**Raises**\n\n- `OmnigentError` \u2014 401/403 if the user lacks edit permission, 404 if the policy is not found, or 409 if renaming would collide with another policy in this session.",
         "operationId": "update_policy_v1_sessions__session_id__policies__policy_id__patch",
         "parameters": [
           {

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -788,12 +788,22 @@ class TestSqlPolicy:
             assert loaded.enabled is True
             assert loaded.session_id is None
 
-    def test_unique_constraint_session_name(self, db_uri: str) -> None:
-        """Two policies in the same session cannot share the same name."""
-        engine = get_or_create_engine(db_uri)
-        managed = make_managed_session_maker(engine)
+    def test_session_name_uniqueness_not_db_enforced(self, db_uri: str) -> None:
+        """Session-name uniqueness lives in the store, not a DB constraint.
 
-        conv = _make_conversation()
+        The ``(session_id, name_cksum)`` unique key was dropped
+        (migration d4c1b9e6f3a2), so the raw table accepts two session
+        policies that share a name. ``SqlAlchemyPolicyStore.create`` is
+        the guard (see ``tests/stores/test_session_policy_store.py``).
+        """
+        import sqlalchemy as sa
+
+        engine = get_or_create_engine(db_uri)
+
+        uniques = {u["name"] for u in sa.inspect(engine).get_unique_constraints("policies")}
+        assert "uq_policies_session_id_name_cksum" not in uniques
+
+        managed = make_managed_session_maker(engine)
         p1 = SqlPolicy(
             id="12a6858438cb1aa1b9e00dc79bb04dd9",
             name="guard",
@@ -812,11 +822,18 @@ class TestSqlPolicy:
             type=encode_policy_type("python"),
             handler="mod:fn2",
         )
-        with pytest.raises(IntegrityError):
-            with managed() as session:
-                session.add(conv)
-                session.add(p1)
-                session.add(p2)
+        # No IntegrityError: the DB permits the duplicate now.
+        with managed() as session:
+            session.add(p1)
+            session.add(p2)
+
+        with managed() as session:
+            rows = (
+                session.execute(sa.select(SqlPolicy).where(SqlPolicy.name == "guard"))
+                .scalars()
+                .all()
+            )
+            assert len(rows) == 2
 
 
 # ── SqlHost ───────────────────────────────────────────

--- a/tests/db/test_migration_policy_name_cksum.py
+++ b/tests/db/test_migration_policy_name_cksum.py
@@ -58,12 +58,10 @@ def test_name_indexes_key_on_checksum(db_engine: Engine) -> None:
     assert "ix_policies_default_name" not in indexes
 
     uniques = {u["name"]: u for u in inspector.get_unique_constraints("policies")}
-    assert "uq_policies_session_id_name_cksum" in uniques
-    assert uniques["uq_policies_session_id_name_cksum"]["column_names"] == [
-        "workspace_id",
-        "session_id",
-        "name_cksum",
-    ]
+    # The (session_id, name_cksum) unique key was dropped (d4c1b9e6f3a2);
+    # session-name uniqueness now lives in the store, keyed on name_cksum
+    # via the plain ix_policies_name_cksum index checked above.
+    assert "uq_policies_session_id_name_cksum" not in uniques
     assert "uq_policies_session_id_name" not in uniques
 
 

--- a/tests/db/test_migration_policy_scope_index.py
+++ b/tests/db/test_migration_policy_scope_index.py
@@ -1,0 +1,83 @@
+"""Tests for the policies index consolidation / drop-unique migration (d4c1b9e6f3a2)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Fresh SQLite database with the full migration chain applied."""
+    db_path = tmp_path / "test.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+def test_combined_scope_session_index_replaces_split_indexes(db_engine: Engine) -> None:
+    """At head the created_at + session_id indexes collapse into one combined key."""
+    indexes = {i["name"]: i for i in sa.inspect(db_engine).get_indexes("policies")}
+
+    assert "ix_policies_created_at" not in indexes
+    assert "ix_policies_session_id" not in indexes
+    assert "ix_policies_scope_session" in indexes
+    assert not indexes["ix_policies_scope_session"]["unique"]
+    # scope leads session_id (defaults query only constrains scope); PK
+    # columns bracket it — workspace_id first, id last.
+    assert indexes["ix_policies_scope_session"]["column_names"] == [
+        "workspace_id",
+        "scope",
+        "session_id",
+        "id",
+    ]
+
+
+def test_session_name_unique_constraint_dropped(db_engine: Engine) -> None:
+    """The (session_id, name_cksum) unique key is gone; the store guards names."""
+    uniques = {u["name"] for u in sa.inspect(db_engine).get_unique_constraints("policies")}
+    assert "uq_policies_session_id_name_cksum" not in uniques
+
+
+def test_downgrade_restores_split_indexes_and_unique(tmp_path: Path) -> None:
+    """Downgrade drops the combined index and restores the split indexes + key."""
+    db_path = tmp_path / "downgrade.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+
+    # Sanity: head state before downgrade.
+    indexes = {i["name"] for i in sa.inspect(engine).get_indexes("policies")}
+    assert "ix_policies_scope_session" in indexes
+    assert "ix_policies_session_id" not in indexes
+    assert "ix_policies_created_at" not in indexes
+
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, "a7f3c1b9e2d4")
+
+    inspector = sa.inspect(engine)
+    index_names = {i["name"] for i in inspector.get_indexes("policies")}
+    assert "ix_policies_scope_session" not in index_names
+    assert "ix_policies_session_id" in index_names
+    assert "ix_policies_created_at" in index_names
+
+    uniques = {u["name"] for u in inspector.get_unique_constraints("policies")}
+    assert "uq_policies_session_id_name_cksum" in uniques
+
+    engine.dispose()
+    clear_engine_cache()

--- a/tests/stores/test_session_policy_store.py
+++ b/tests/stores/test_session_policy_store.py
@@ -271,6 +271,54 @@ def test_update_changes_name(
     assert updated.updated_at > 0
 
 
+def test_update_duplicate_name_raises(
+    store: SqlAlchemyPolicyStore,
+    session_id: str,
+) -> None:
+    """Renaming onto another policy's name in the same session raises IntegrityError."""
+    store.create(
+        policy_id="1c7d1c2f6e2f4a0b8d3e5f6a7b8c9d0e",
+        session_id=session_id,
+        name="first",
+        type="python",
+        handler="mod.func",
+    )
+    store.create(
+        policy_id="2d8e2d3f7f3f5b1c9e4f6a7b8c9d0e1f",
+        session_id=session_id,
+        name="second",
+        type="python",
+        handler="mod.func2",
+    )
+    with pytest.raises(IntegrityError):
+        store.update("2d8e2d3f7f3f5b1c9e4f6a7b8c9d0e1f", session_id, name="first")
+
+
+def test_update_same_name_different_sessions_ok(
+    store: SqlAlchemyPolicyStore,
+    session_id: str,
+    other_session_id: str,
+) -> None:
+    """A rename may collide with a name used in a different session."""
+    store.create(
+        policy_id="3e9f3e4a8a405c2daf5a6b7c8d9e0f1a",
+        session_id=other_session_id,
+        name="shared",
+        type="python",
+        handler="mod.func",
+    )
+    store.create(
+        policy_id="4fa04f5b9b516d3eb06b7c8d9e0f1a2b",
+        session_id=session_id,
+        name="local",
+        type="python",
+        handler="mod.func2",
+    )
+    updated = store.update("4fa04f5b9b516d3eb06b7c8d9e0f1a2b", session_id, name="shared")
+    assert updated is not None
+    assert updated.name == "shared"
+
+
 def test_update_changes_enabled(
     store: SqlAlchemyPolicyStore,
     session_id: str,


### PR DESCRIPTION
## Related issue

N/A — internal DB index/perf change.

## Summary

Reworks the `policies` table's secondary indexes and moves name uniqueness into
the store:

- **Collapse two listing indexes into one.** Drop `ix_policies_created_at`
  (matched no query) and `ix_policies_session_id`, replacing both with a single
  combined `ix_policies_scope_session (workspace_id, scope, session_id, id)`.
  `scope` leads `session_id` so the defaults fetch can seek the prefix and the
  session fetch can seek the full key.
- **Fix the global-policy fetch.** `list_defaults` (`WHERE workspace_id=? AND
  scope='default'`) previously had no scope-aware index and scanned every
  session-policy row to find the handful of global policies. It now seeks the
  new index. `list_for_session` gained a `scope='session'` predicate — required
  so it can reach `session_id` in the combined key (without it the planner
  table-scans; see Test Plan). `created_at` is deliberately left out of the key:
  with `session_id` between `scope` and `id` it can't cover the `ORDER BY
  created_at, id` for both queries, so both sort their small result set in
  memory (as the session listing already did).
- **Drop the `uq_policies_session_id_name_cksum` unique constraint;** enforce
  session-name uniqueness in the store (`create`/`update`), mirroring how
  default-name uniqueness has always been enforced there. The session-policy
  PATCH route now returns 409 on a rename collision (previously an unhandled
  constraint error).

Net: one fewer index maintained per write, no DB uniqueness constraint, same
seek performance on both reads. Migration `d4c1b9e6f3a2` (off `z9a2b3c4d5e6`).

<details>
<summary>EXPLAIN QUERY PLAN evidence</summary>

```
list_defaults    : SEARCH policies USING INDEX ix_policies_scope_session (workspace_id=? AND scope=?)         + TEMP B-TREE (tiny sort)
list_for_session : SEARCH policies USING INDEX ix_policies_scope_session (workspace_id=? AND scope=? AND session_id=?) + TEMP B-TREE (tiny sort)
```

Without the `scope='session'` predicate, `list_for_session` falls back to
`sqlite_autoindex_policies_1 (workspace_id=?)` — a full workspace scan.
</details>

## Test Plan

```
pytest tests/db/test_migration_policy_scope_index.py \
       tests/db/test_migration_policy_name_cksum.py \
       tests/stores/test_session_policy_store.py \
       tests/db/test_db_models.py::TestSqlPolicy \
       tests/server/integration/test_policy_crud_e2e.py
```

- All of the above pass (65 tests).
- Alembic: single head `d4c1b9e6f3a2`; full `upgrade head → downgrade
  z9a2b3c4d5e6 → upgrade head` round-trip verified — downgrade restores both
  split indexes and the unique key.
- `EXPLAIN QUERY PLAN` on the real store queries confirms both listings seek the
  combined index (evidence above).
- `ruff format --check` / `ruff check` clean.

## Demo

N/A — non-visual (DB schema / store change).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `tests/db/test_migration_policy_scope_index.py` (index consolidation +
unique-drop, upgrade and downgrade) and store rename-collision tests; updated
`test_migration_policy_name_cksum` (unique key now absent at head) and
`test_db_models` (session-name uniqueness no longer DB-enforced). Manual
verification = the `EXPLAIN QUERY PLAN` checks and the alembic round-trip
described in the Test Plan.

This pull request and its description were written by Isaac.
