### PR TITLE
ci(release): skip GitHub releases for rc/dev/pre tags

### DIFF
--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -89,14 +89,14 @@ jobs:
           base="${INPUT_BASE:-}"
           proceed=false; dry_run=false
 
-          # Does the tag look like a final release (vX.Y.Z, not rc/dev/alpha/beta)?
+          # Does the tag look like a final release (vX.Y.Z, not a pre-release)?
           is_version=true
           case "$tag" in
             v[0-9]*.[0-9]*.[0-9]*) ;;
             *) is_version=false ;;
           esac
           case "$tag" in
-            *rc*|*dev*|*a[0-9]*|*b[0-9]*) is_version=false ;;
+            *rc[0-9]*|*dev[0-9]*|*pre[0-9]*) is_version=false ;;
           esac
 
           if [ "$EVENT_NAME" = "workflow_run" ]; then

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           set -euo pipefail
           if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::${TAG} is not a final vX.Y.Z tag — rc/dev/alpha/beta releases never finalize."
+            echo "::error::${TAG} is not a final vX.Y.Z tag — rc/dev/pre releases never finalize."
             exit 1
           fi
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -28,7 +28,10 @@ on:
   push:
     tags:
       # Version tags only (v0.2.0, v0.2.0rc1, …) — `v[0-9]*` avoids triggering
-      # on non-release tags like `v-infra-*`.
+      # on non-release tags like `v-infra-*`. Pre-release tags (rcN / devN /
+      # preN) still match the glob but are skipped in the job below — no
+      # GitHub release is created for them; their installable artifacts live
+      # only on PyPI, and a curated release page is reserved for the final cut.
       - "v[0-9]*"
 
 # Least privilege: creating a release requires `contents: write`; nothing here
@@ -43,9 +46,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Skip pre-release tags (rcN / devN / preN)
+        id: tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Pre-release tags (rcN / devN / preN) get NO GitHub release — they
+          # live on PyPI only, and a curated release page is reserved for the
+          # final cut. The tag glob above still matches them, so gate here.
+          # A trailing digit is required so a substring like 'dev' or 'pre' in a
+          # mistyped tag name can't trigger a skip by accident.
+          case "$TAG" in
+            *rc[0-9]*|*dev[0-9]*|*pre[0-9]*)
+              echo "Pre-release tag ${TAG} — not creating a GitHub release (rc/dev/pre releases live on PyPI only)." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+              echo "skip=true" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "skip=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: steps.tag.outputs.skip != 'true'
 
       - name: Draft release with a placeholder body
+        if: steps.tag.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
@@ -57,20 +81,11 @@ jobs:
             echo "Release $TAG already exists — skipping." | tee -a "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          # rc / dev / alpha / beta tags are flagged as pre-releases.
-          pre=""
-          case "$TAG" in
-            *rc*|*dev*|*a[0-9]*|*b[0-9]*) pre="--prerelease" ;;
-          esac
-          # $pre is intentionally UNQUOTED: it word-splits to nothing when empty,
-          # and is only ever "" or "--prerelease" (set just above, never from
-          # external input). Quoting it would pass an empty positional arg.
           gh release create "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --draft \
             --verify-tag \
             --notes "_Release notes are being drafted automatically — check back shortly._" \
-            --title "$TAG" \
-            $pre
+            --title "$TAG"
           echo "Drafted release $TAG — curated notes will be filled in by draft-release-notes.yml; review and publish from the Releases page." \
             | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/homebrew-tap-pr.yml
+++ b/.github/workflows/homebrew-tap-pr.yml
@@ -61,14 +61,14 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
           is_final=true
-          # Only final vX.Y.Z tags; exclude rc/dev/alpha/beta and the event's
-          # prerelease flag (homebrew users get stable releases from the tap).
+          # Only final vX.Y.Z tags; exclude rcN/devN/preN pre-releases and
+          # the event's prerelease flag (homebrew users get stable releases).
           case "$tag" in
             v[0-9]*.[0-9]*.[0-9]*) ;;
             *) is_final=false ;;
           esac
           case "$tag" in
-            *rc*|*dev*|*a[0-9]*|*b[0-9]*) is_final=false ;;
+            *rc[0-9]*|*dev[0-9]*|*pre[0-9]*|*a[0-9]*|*b[0-9]*) is_final=false ;;
           esac
           if [ "${PRERELEASE}" = "true" ]; then is_final=false; fi
           echo "is_final=${is_final}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -75,14 +75,14 @@ jobs:
           echo "dry_run=${dry_run}" >> "$GITHUB_OUTPUT"
 
           is_final=true
-          # Only final vX.Y.Z tags; exclude rc/dev/alpha/beta and the
-          # event's prerelease flag.
+          # Only final vX.Y.Z tags; exclude rcN/devN/preN pre-releases and
+          # the event's prerelease flag.
           case "$tag" in
             v[0-9]*.[0-9]*.[0-9]*) ;;
             *) is_final=false ;;
           esac
           case "$tag" in
-            *rc*|*dev*|*a[0-9]*|*b[0-9]*) is_final=false ;;
+            *rc[0-9]*|*dev[0-9]*|*pre[0-9]*) is_final=false ;;
           esac
           if [ "${PRERELEASE}" = "true" ]; then
             is_final=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,13 +103,13 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          # Final X.Y.Z or a PEP 440 pre-release (a/b/rc). No dev/post here.
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?$ ]]; then
+          # Final X.Y.Z or a PEP 440 pre-release (rc). No dev/post/alpha/beta here.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$ ]]; then
             echo "::error::Invalid release version: ${VERSION} (expect 0.6.0 or 0.6.0rc1)"; exit 1
           fi
           major="${VERSION%%.*}"; rest="${VERSION#*.}"; minor="${rest%%.*}"
           prerelease=false
-          case "$VERSION" in *a[0-9]*|*b[0-9]*|*rc[0-9]*) prerelease=true ;; esac
+          case "$VERSION" in *rc[0-9]*) prerelease=true ;; esac
           {
             echo "version=${VERSION}"
             echo "tag=v${VERSION}"
@@ -647,7 +647,7 @@ jobs:
             echo "     -f ref=${TAG} -f destination=pypi -f dry-run=false   # real publish"
             echo '   ```'
             if [ "$PRERELEASE" = "true" ]; then
-              echo "2. Validate the rc from PyPI (see RELEASING.md). The GitHub draft for ${TAG} stays unpublished."
+              echo "2. Validate the rc from PyPI (see RELEASING.md). No GitHub release is created for rc tags (rcs live on PyPI only) — skip straight to the next rc or the final cut."
             else
               echo "2. Merge the CHANGELOG PR, curate the ${TAG} draft notes, then dispatch finalize-release.yml (tag=${TAG})."
             fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -94,8 +94,9 @@ What it does (all idempotent):
   or run `uv lock` behind a proxy**; the workflow owns this now;
 - commits `release: v0.6.0rc1`, tags, and pushes branch + tag with the
   omnigent-ci App token, which fires the downstream automation:
-  `github-release.yml` (draft GH release, pre-release flagged),
-  `draft-release-notes.yml`, and `oss-publish-images.yml` (Docker);
+  `oss-publish-images.yml` (Docker; publishes the immutable version image tag),
+  `github-release.yml` (skips rc — no GitHub release is created for
+  pre-releases; rcs live on PyPI only), and `draft-release-notes.yml` (skips rc);
 - on the **first** cut of a cycle (rc1), dispatches `bump-version.yml`
   (post-release) — **review and merge the `main → 0.7.0.dev0` bump PR
   promptly**, so `doc-sync` keeps staging to the right docs branch.
@@ -128,7 +129,8 @@ python -m venv /tmp/omni-rc && /tmp/omni-rc/bin/pip install \
 /tmp/omni-rc/bin/omnigent --version    # expect 0.6.0rc1
 ```
 
-The rc's GitHub draft stays **unpublished** — rc drafts are never published.
+No GitHub release is created for the rc — pre-releases live on PyPI only,
+and a curated release page is reserved for the final cut.
 Need another candidate? Repeat with `0.6.0rc2` (fixes land on `release/v0.6.0`
 first, via cherry-pick PRs or direct pushes; CI runs on `release/v*` pushes).
 
@@ -186,9 +188,10 @@ can never be reused. So:
   same inputs** — every step converges (branch exists → reused; version
   stamped → no new commit; tag at the converged commit → no-op) or fails
   loudly (tag elsewhere) rather than duplicating work.
-- **Wrong commit tagged, nothing published yet:** delete the tag and draft
-  (`gh release delete vX.Y.Z`, `git push origin :refs/tags/vX.Y.Z`), then
-  re-dispatch `release.yml`.
+- **Wrong commit tagged, nothing published yet:** delete the tag and, for a
+  final `vX.Y.Z` (which has a draft), the draft too —
+  `gh release delete vX.Y.Z`, `git push origin :refs/tags/vX.Y.Z` — then
+  re-dispatch `release.yml`. (rc tags have no draft to delete.)
 - **rc is bad:** just cut the next rc — rcs are cheap and invisible to
   default installs.
 - **Prod publish partially succeeded** (e.g. two of three packages uploaded):
@@ -205,7 +208,7 @@ can never be reused. So:
 
 To exercise the whole flow end to end without touching users, release a
 deliberately **below-latest** rc on the dead `0.0` line. A below-latest rc is
-inert everywhere that matters: the GitHub draft stays unpublished, Docker
+inert everywhere that matters: no GitHub release is created for rc tags, Docker
 publishes only the immutable version image tag (`:latest` / `:latest-rc` only
 move for the highest version), the notes/site/homebrew workflows ignore rc
 tags, `bump-main` skips itself (the version sorts below main's), and a
@@ -231,8 +234,8 @@ The examples below use `0.0.1rc2`; substitute the next free number.
    ```
 
 2. **Execute**: re-run with `-f dry_run=false`. Expect `release/v0.0.0` + tag
-   `v0.0.1rc2` pushed, the tag firing the draft-release and image workflows,
-   and CI running on the branch push. If the CI gate rejects main's head
+   `v0.0.1rc2` pushed, the tag firing the image workflow (`github-release.yml`
+   runs but skips the rc — no draft), and CI running on the branch push. If the CI gate rejects main's head
    (failing or still-pending checks), that's the gate working — wait, or
    re-dispatch with `-f ref=<green sha>` / `-f skip_ci_check=true`.
    Cancelled (superseded) runs only warn.
@@ -268,11 +271,11 @@ The examples below use `0.0.1rc2`; substitute the next free number.
 Cleanup — delete everything the rehearsal minted on GitHub:
 
 ```bash
-gh release delete v0.0.1rc2 --repo omnigent-ai/omnigent --cleanup-tag --yes
 gh api -X DELETE 'repos/omnigent-ai/omnigent/git/refs/heads/release/v0.0.0'
 ```
 
-Optionally delete the rehearsal image versions from GHCR. The PyPI side needs
+No `gh release delete` is needed: pre-release tags no longer create a GitHub
+release. Optionally delete the rehearsal image versions from GHCR. The PyPI side needs
 no cleanup: the rc is invisible to default installs and only the version
 number is spent — optionally yank it (*Manage → Releases → Yank*) for
 tidiness.
@@ -300,8 +303,9 @@ git fetch origin && git checkout release/v0.6.0 && git pull
 git tag v0.6.0rc1 && git push origin release/v0.6.0 v0.6.0rc1    # explicit tag, NOT --tags
 ```
 
-Then continue from step 2 of the standard flow (secure-repo dispatches). If the
-GH draft wasn't created, `gh release create vX.Y.Z --draft --verify-tag
---title vX.Y.Z` recreates it. To re-run the notes/site halves for an existing
+Then continue from step 2 of the standard flow (secure-repo dispatches). For
+a final `vX.Y.Z`, if the GH draft wasn't created, `gh release create vX.Y.Z
+--draft --verify-tag --title vX.Y.Z` recreates it (rc tags get no draft by
+design). To re-run the notes/site halves for an existing
 tag, dispatch `draft-release-notes.yml` or `publish-changelog.yml` with the
 `tag` input; for the tap, dispatch `update-homebrew.yml`.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `github-release.yml` was firing on every `v[0-9]*` tag push and creating an unpublished **DRAFT** GitHub release for rc/dev/pre-release tags. Nothing downstream depended on those drafts — `draft-release-notes.yml` already skips rc, `finalize-release.yml` refuses rc, and the Docker/homebrew/changelog workflows fire on the tag push / `release: published` directly. The drafts just accumulated (and rehearsal rcs had to be `gh release delete`d during cleanup).
- Added a guard that **skips** the `draft-release` job for `rcN` / `devN` / `preN` tags (a trailing digit is required, so a bare substring like `dev` or `pre` in a mistyped tag can't trip it). Final `vX.Y.Z` tags still get their draft as before.
- Dropped the now-dead `alpha`/`beta` matching arms — this repo only cuts `rc` pre-releases — and aligned the same `rcN`/`devN`/`preN` pattern + comments across the other release-adjacent workflows for consistency.
- Updated `release.yml`'s Next-steps text and `RELEASING.md` so the docs match.

### What's unaffected (verified)
- **`oss-publish-images.yml`** — fires directly on `v*` tag push; Docker images still publish for rc.
- **`draft-release-notes.yml`** — already skipped rc via its own guard; still does.
- **`finalize-release.yml`** — already refused rc; still does.
- **`publish-changelog.yml` / `update-homebrew.yml` / `homebrew-tap-pr.yml`** — fire on `release: published` (never emitted for rc); also each have their own `is_final` tag guard, now aligned.

Net effect: an rc/dev/pre tag push publishes its Docker image and PyPI package (via the secure repo) as before, but the GitHub Releases page stays clean — only the final `vX.Y.Z` gets a curated, human-published release entry.

## Test Plan

- [x] All 6 modified workflows parse as valid YAML (`yaml.safe_load`).
- [x] `pre-commit` passes (yaml syntax, trailing whitespace, newline, merge-conflict checks).
- [ ] **Manual verification on the PR branch (this PR's purpose):** cut a throwaway below-latest rc on the dead `0.0` line per RELEASING.md's "Rehearsing the pipeline" section and confirm `github-release.yml` skips (job step logs "Pre-release tag ... — not creating a GitHub release") and no draft appears on the Releases page; then a final `vX.Y.Z` tag still drafts normally.

## Demo

N/A — CI/release-automation change, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Workflow YAML validation + pre-commit run locally. The behavior change is a single `case` guard in a GitHub Actions workflow, which can't be unit-tested in-repo; it's verified by the manual rehearsal rc cut listed in the Test Plan.
