### PR TITLE
chore(electron): bump desktop shell to 0.6.0

### DIFF
--- a/web/electron/package-lock.json
+++ b/web/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omnigent-desktop-electron",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omnigent-desktop-electron",
-      "version": "0.3.0",
+      "version": "0.6.0",
       "dependencies": {
         "electron-updater": "^6.3.9",
         "js-yaml": "^4.2.0"

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnigent-desktop-electron",
   "productName": "Omnigent",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "description": "Omnigent desktop shell (Electron edition) — a thin native wrapper around the server-served web UI.",
   "private": true,
   "main": "src/main.js",


### PR DESCRIPTION
## Related issue

N/A

## Summary

Bump the Omnigent Electron desktop shell (`omnigent-desktop-electron`) version from 0.3.0 to 0.6.0 in `web/electron/package.json` and its lockfile. The shell reads its version dynamically via Electron's `app.getVersion()` (sourced from `package.json#version`), so this updates the About dialog and the auto-updater's version comparison; there are no code or behavior changes.

## Test Plan

- Confirmed `web/electron/package.json` and `web/electron/package-lock.json` version fields are consistent (both `0.6.0`) and both files still parse as valid JSON (`node -e`).
- Verified no other reference to the shell version exists under `web/electron/` — `main.js`, the auto-updater (`desktop_updater.js`), and the electron-builder config all derive the version dynamically from `package.json#version`, so nothing else needs updating.
- No build/run change to exercise; the bump takes effect at the next packaged release.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

This is a metadata-only version bump: no source, config, or behavior changes. The version string is read dynamically by Electron's `app.getVersion()` from `package.json#version` (About dialog + auto-updater feed comparison) and substituted via `${version}` in electron-builder artifact names, so it is exercised at build/release time rather than by unit tests. The existing updater tests use a hardcoded incoming version (`0.4.0`) and are unaffected.
