### PR TITLE
fix(telemetry): track sdk harness name in SessionCreatedEvent

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -13172,7 +13172,9 @@ async def _create_session_from_existing_agent(
                 _TelSessionCreatedEvent(
                     session_id=conv.id,
                     agent_id=agent.id,
-                    harness=native_agent.harness if native_agent is not None else _resolve_harness(conv),
+                    harness=native_agent.harness
+                    if native_agent is not None
+                    else _resolve_harness(conv),
                     surface=_surface,
                     installation_id=_install_id,
                     anon_user_id=_anon_uid,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -13172,7 +13172,7 @@ async def _create_session_from_existing_agent(
                 _TelSessionCreatedEvent(
                     session_id=conv.id,
                     agent_id=agent.id,
-                    harness=native_agent.harness if native_agent is not None else None,
+                    harness=native_agent.harness if native_agent is not None else _resolve_harness(conv),
                     surface=_surface,
                     installation_id=_install_id,
                     anon_user_id=_anon_uid,


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `SessionCreatedEvent` telemetry was emitting `harness: null` for SDK-based sessions (e.g. `claude-sdk`, `openai-agents`, `codex`) because only native agents expose a `harness` attribute via `native_agent`.
- Fall back to `_resolve_harness(conv)` when `native_agent` is `None` — this existing function already handles `harness_override` and spec lookup, so every harness kind is now captured in telemetry.

## Test Plan

No automated test added — the emit is already wrapped in a `try/except` that swallows telemetry errors, and `_resolve_harness` is covered by its own call sites. Verified manually that `_resolve_harness` is in scope at the call site and returns the correct harness string for SDK sessions.

## Demo

<img width="757" height="691" alt="image" src="https://github.com/user-attachments/assets/fe37e014-75ad-4731-8735-4e267bf5c9aa" />


## Type of change

- [x] Bug fix

## Test coverage

- [x] Not applicable

## Coverage notes

One-line fix using an existing helper already used throughout the module. The telemetry path is best-effort and isolated from session creation correctness.