### PR TITLE
fix(server): key HostRegistry by (workspace_id, host_id)

### DIFF
--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -22,7 +22,7 @@ from typing import Any, Protocol
 
 from cachetools import TTLCache
 
-from omnigent.db.db_models import InvalidUuidError, uuid_to_bytes
+from omnigent.db.db_models import InvalidUuidError, current_workspace_id, uuid_to_bytes
 from omnigent.host.frames import HostHelloFrame
 
 _logger = logging.getLogger(__name__)
@@ -163,6 +163,11 @@ class WebSocketLike(Protocol):
 class HostConnection:
     """Per-host state while the tunnel is open.
 
+    :param workspace_id: Tenant partition the tunnel belongs to,
+        mirroring the ``hosts`` table's ``(workspace_id, host_id)`` PK.
+        Captured at register time so ``send_text``'s replaced-connection
+        guard keys on the full ``(workspace_id, host_id)`` without
+        reading request context from the long-lived sender loop.
     :param host_id: Stable host identifier, e.g.
         ``"host_a1b2c3d4..."``.
     :param ws: The live WebSocket to this host.
@@ -224,6 +229,7 @@ class HostConnection:
         ``error_code``, and ``error``.
     """
 
+    workspace_id: int
     host_id: str
     ws: WebSocketLike
     hello: HostHelloFrame
@@ -274,7 +280,9 @@ class HostRegistry:
     def __init__(self) -> None:
         """Initialize an empty host registry."""
         self._lock = threading.RLock()
-        self._hosts: dict[str, HostConnection] = {}
+        # Keyed by (workspace_id, host_id) to mirror the hosts-table PK:
+        # one stable host_id can be live in more than one workspace.
+        self._hosts: dict[tuple[int, str], HostConnection] = {}
 
     def register(
         self,
@@ -282,24 +290,38 @@ class HostRegistry:
         ws: WebSocketLike,
         hello: HostHelloFrame,
         owner: str | None,
+        workspace_id: int | None = None,
     ) -> HostConnection:
         """Register a host connection (newest wins).
 
-        If ``host_id`` is already registered (stale connection),
-        the old connection is replaced and its outbound queue is
-        poisoned with ``None`` so the sender loop exits.
+        If ``(workspace_id, host_id)`` is already registered (stale
+        connection), the old connection is replaced and its outbound
+        queue is poisoned with ``None`` so the sender loop exits.
+
+        Scoping the key by workspace means the same stable ``host_id``
+        (a laptop's config id) connecting to two workspaces is tracked
+        as two independent connections rather than one evicting the
+        other — matching the ``hosts`` table's ``(workspace_id,
+        host_id)`` PK.
 
         :param host_id: Stable host identifier, e.g.
             ``"host_a1b2c3d4..."``.
         :param ws: The live WebSocket.
         :param hello: The hello frame from the host.
         :param owner: Authenticated user ID, or ``None``.
+        :param workspace_id: Tenant partition the connection belongs to.
+            Defaults to the request-bound :func:`current_workspace_id`
+            (``0`` in single-tenant deployments); captured into the
+            connection so ``send_text`` need not read request context
+            from the sender loop.
         :returns: The new :class:`HostConnection`. Its ``host_id`` is
             the canonical form (see :func:`_canonical_host_id`).
         """
+        ws_id = current_workspace_id() if workspace_id is None else workspace_id
         host_id = _canonical_host_id(host_id)
         now = time.time()
         conn = HostConnection(
+            workspace_id=ws_id,
             host_id=host_id,
             ws=ws,
             hello=hello,
@@ -309,67 +331,84 @@ class HostRegistry:
             last_frame_at=now,
         )
         with self._lock:
-            old = self._hosts.get(host_id)
+            key = (ws_id, host_id)
+            old = self._hosts.get(key)
             if old is not None:
                 _logger.info(
-                    "replacing stale host connection: %s",
+                    "replacing stale host connection: ws=%s host=%s",
+                    ws_id,
                     host_id,
                 )
                 old.outbound_queue.put_nowait(None)
-            self._hosts[host_id] = conn
+            self._hosts[key] = conn
         return conn
 
-    def deregister(self, host_id: str) -> None:
+    def deregister(self, host_id: str, workspace_id: int | None = None) -> None:
         """Remove a host connection.
 
-        No-op if ``host_id`` is not registered.
+        No-op if ``(workspace_id, host_id)`` is not registered.
 
         :param host_id: Host identifier to remove, in any accepted
             spelling (see :func:`_canonical_host_id`).
+        :param workspace_id: Tenant partition; defaults to
+            :func:`current_workspace_id`.
         """
+        ws_id = current_workspace_id() if workspace_id is None else workspace_id
         with self._lock:
-            self._hosts.pop(_canonical_host_id(host_id), None)
+            self._hosts.pop((ws_id, _canonical_host_id(host_id)), None)
 
-    def get(self, host_id: str) -> HostConnection | None:
+    def get(self, host_id: str, workspace_id: int | None = None) -> HostConnection | None:
         """Look up a live host connection.
 
         :param host_id: Host identifier, in any accepted spelling
             (see :func:`_canonical_host_id`).
+        :param workspace_id: Tenant partition; defaults to
+            :func:`current_workspace_id`.
         :returns: The :class:`HostConnection` if online,
             otherwise ``None``.
         """
+        ws_id = current_workspace_id() if workspace_id is None else workspace_id
         with self._lock:
-            return self._hosts.get(_canonical_host_id(host_id))
+            return self._hosts.get((ws_id, _canonical_host_id(host_id)))
 
-    def online_host_ids(self) -> list[str]:
-        """Return IDs of all currently connected hosts.
+    def online_host_ids(self, workspace_id: int | None = None) -> list[str]:
+        """Return IDs of all hosts connected in one workspace.
 
-        :returns: List of host_id strings.
+        :param workspace_id: Tenant partition; defaults to
+            :func:`current_workspace_id`.
+        :returns: List of host_id strings live in the workspace.
         """
+        ws_id = current_workspace_id() if workspace_id is None else workspace_id
         with self._lock:
-            return list(self._hosts.keys())
+            return [hid for (ws, hid) in self._hosts if ws == ws_id]
 
-    def is_host_telemetry_opted_out(self, host_id: str) -> bool:
+    def is_host_telemetry_opted_out(self, host_id: str, workspace_id: int | None = None) -> bool:
         """Return whether the host has opted out of telemetry.
 
         :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
+        :param workspace_id: Tenant partition; defaults to
+            :func:`current_workspace_id`.
         :returns: ``True`` when the host sent ``telemetry_opt_out=True``
             in its hello frame.  Defaults to ``False`` when the host is
             offline or unknown.
         """
-        conn = self.get(host_id)
+        conn = self.get(host_id, workspace_id)
         if conn is None:
             return False
         return conn.hello.telemetry_opt_out
 
-    def get_host_installation_id(self, host_id: str) -> str | None:
+    def get_host_installation_id(
+        self, host_id: str, workspace_id: int | None = None
+    ) -> str | None:
         """Return the installation ID the host advertised in its hello frame.
 
         :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
+        :param workspace_id: Tenant partition; defaults to
+            :func:`current_workspace_id`.
         :returns: The host's installation ID, or ``None`` when offline or
             not set.
         """
-        conn = self.get(host_id)
+        conn = self.get(host_id, workspace_id)
         if conn is None:
             return None
         return conn.hello.installation_id
@@ -391,7 +430,7 @@ class HostRegistry:
             replaced (the outbound queue was poisoned).
         """
         with self._lock:
-            current = self._hosts.get(conn.host_id)
+            current = self._hosts.get((conn.workspace_id, conn.host_id))
             if current is not conn:
                 raise ConnectionError(f"host {conn.host_id!r} connection was replaced")
 

--- a/tests/server/test_host_registry.py
+++ b/tests/server/test_host_registry.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 
 import pytest
 
+from omnigent.db.db_models import workspace_scope
 from omnigent.host.frames import HostHelloFrame
 from omnigent.server.host_registry import HostRegistry, RunnerExitReports
 
@@ -185,6 +186,69 @@ def test_get_returns_none_for_unknown() -> None:
     """
     registry = HostRegistry()
     assert registry.get("host_nonexistent") is None
+
+
+def test_same_host_id_isolated_across_workspaces() -> None:
+    """
+    The same stable host_id connecting to two workspaces is tracked as
+    two independent connections — neither evicts the other.
+
+    A laptop's config.yaml host_id is stable, so a multi-workspace user
+    presents the same id to workspace A and workspace B. Keyed on
+    host_id alone, the second connect would poison the first's outbound
+    queue and ``send_text`` would route workspace A's frames to
+    workspace B's tunnel. Keyed on (workspace_id, host_id) — mirroring
+    the hosts-table PK — both stay live and isolated.
+    """
+    registry = HostRegistry()
+    host_id = "00112233445566778899aabbccddeeff"
+
+    with workspace_scope(111):
+        conn_a = registry.register(host_id, FakeWebSocket(), _make_hello(), owner="alice")
+    with workspace_scope(222):
+        conn_b = registry.register(host_id, FakeWebSocket(), _make_hello(), owner="alice")
+
+    # Distinct connections, neither evicted.
+    assert conn_a is not conn_b
+    assert conn_a.workspace_id == 111
+    assert conn_b.workspace_id == 222
+    with workspace_scope(111):
+        assert registry.get(host_id) is conn_a
+    with workspace_scope(222):
+        assert registry.get(host_id) is conn_b
+
+    # Workspace B's connect did NOT poison workspace A's outbound queue.
+    assert conn_a.outbound_queue.empty()
+
+    # send_text routes to the right workspace's tunnel (no "replaced" error).
+    registry.send_text(conn_a, "a")
+    registry.send_text(conn_b, "b")
+    assert conn_a.outbound_queue.get_nowait() == "a"
+    assert conn_b.outbound_queue.get_nowait() == "b"
+
+    # Deregister is workspace-scoped: removing A leaves B live.
+    with workspace_scope(111):
+        registry.deregister(host_id)
+        assert registry.get(host_id) is None
+    with workspace_scope(222):
+        assert registry.get(host_id) is conn_b
+
+
+def test_online_host_ids_scoped_to_workspace() -> None:
+    """
+    online_host_ids returns only the requesting workspace's hosts, so
+    one tenant never sees another's connected host ids.
+    """
+    registry = HostRegistry()
+    with workspace_scope(111):
+        registry.register("host_a", FakeWebSocket(), _make_hello(), owner="alice")
+    with workspace_scope(222):
+        registry.register("host_b", FakeWebSocket(), _make_hello(), owner="bob")
+
+    with workspace_scope(111):
+        assert registry.online_host_ids() == ["host_a"]
+    with workspace_scope(222):
+        assert registry.online_host_ids() == ["host_b"]
 
 
 # ── RunnerExitReports ───────────────────────────────────


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The in-memory `HostRegistry` keyed live connections by `host_id` alone,
  but a `host_id` is only unique **within a workspace** — the `hosts` table PK
  is `(workspace_id, host_id)`.
- A BYO/local host has a **stable** `~/.omnigent/config.yaml` `host_id`, so a
  user who belongs to multiple workspaces and points that host at more than one
  presents the same `host_id` to each. Keyed on `host_id` alone, the second
  workspace's connect treated the first's healthy tunnel as stale: it evicted
  the entry (newest-wins) and poisoned the first connection's outbound queue, so
  that workspace's host operations then failed with `"connection was replaced"`.
  Without host-tunnel replica affinity, routing could also resolve the wrong
  workspace's tunnel for the same `host_id`.
- Key the registry by `(workspace_id, host_id)` to mirror the DB PK. The
  workspace defaults to `current_workspace_id()` — `0` in single-tenant/OSS, so
  behavior there is unchanged — and is captured into `HostConnection` at
  register time so the long-lived sender loop's `send_text` guard never reads
  request context. Every call site is already request-scoped, so no call-site
  changes are needed; the change is contained to `host_registry.py`.

## Test Plan

- `pytest tests/server/test_host_registry.py` — **16 passed**, including two new
  tests:
  - `test_same_host_id_isolated_across_workspaces` — the same `host_id` in
    workspaces 111 and 222 yields two distinct connections; neither is evicted
    or poisoned, `send_text` routes to the correct workspace's tunnel, and
    `deregister` is workspace-scoped.
  - `test_online_host_ids_scoped_to_workspace` — one tenant never sees another's
    connected host ids.
- Regression (default workspace-0 path unchanged):
  `pytest tests/server/integration/test_hosts_api.py tests/server/integration/test_host_session_binding.py tests/server/test_managed_hosts.py tests/stores/test_host_store.py`
  — pass.
- `pre-commit run --files omnigent/server/host_registry.py tests/server/test_host_registry.py`
  — clean.

## Demo

N/A (no UI change)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The single-tenant/OSS path (workspace `0`) is exercised by all existing host
tests unchanged; the multi-workspace behavior is covered by the two new unit
tests above using `workspace_scope`.

This pull request and its description were written by Isaac.
