### PR TITLE
perf(db): drop the hosts token_hash unique constraint

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1257,9 +1257,6 @@ class SqlHost(OmnigentBase):
         # upsert-on-connect logic (look up by owner+name to detect host_id
         # rotation) stays consistent.
         UniqueConstraint("workspace_id", "owner", "name", name="uq_hosts_workspace_owner_name"),
-        # resolve_launch_token filters workspace_id + token_hash, so scoping
-        # the unique to the workspace keeps that lookup index-served.
-        UniqueConstraint("workspace_id", "token_hash", name="uq_hosts_token_hash"),
     )
 
 

--- a/omnigent/db/migrations/versions/f82e866d9de0_drop_hosts_token_hash_unique.py
+++ b/omnigent/db/migrations/versions/f82e866d9de0_drop_hosts_token_hash_unique.py
@@ -1,0 +1,61 @@
+"""Drop the hosts token_hash unique constraint.
+
+Revision ID: f82e866d9de0
+Revises: d4c1b9e6f3a2
+Create Date: 2026-07-21 13:00:00.000000
+
+Removes ``uq_hosts_token_hash`` (``workspace_id, token_hash``). The launch-token
+auth path no longer looks a host up by its token digest: the tunnel endpoint is
+``/hosts/{host_id}/tunnel``, so ``resolve_launch_token`` now seeks the row by the
+``(workspace_id, host_id)`` primary key and compares the stored digest to the
+presented token's digest in Python (constant-time). With the lookup keyed on the
+PK, nothing rides this constraint, and its uniqueness guarantee was never load-
+bearing — launch tokens are 256-bit ``secrets.token_urlsafe(32)`` values whose
+digests do not collide in practice.
+
+Dropping the unique constraint runs in a ``batch_alter_table``
+(``recreate="always"`` on SQLite) guarded by the ``PRAGMA foreign_keys`` toggle
+the other host migrations use. Downgrade restores the constraint.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f82e866d9de0"
+down_revision: str | None = "d4c1b9e6f3a2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Drop the (workspace_id, token_hash) unique constraint on hosts."""
+    sqlite = _is_sqlite()
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    with op.batch_alter_table("hosts", recreate="always" if sqlite else "auto") as batch_op:
+        batch_op.drop_constraint("uq_hosts_token_hash", type_="unique")
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))
+
+
+def downgrade() -> None:
+    """Restore the (workspace_id, token_hash) unique constraint on hosts."""
+    sqlite = _is_sqlite()
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    with op.batch_alter_table("hosts", recreate="always" if sqlite else "auto") as batch_op:
+        batch_op.create_unique_constraint("uq_hosts_token_hash", ["workspace_id", "token_hash"])
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -160,11 +160,13 @@ def create_host_tunnel_router(
             # presented, it must resolve — never fall through to user auth
             # (a peer that chose this header has no user identity to fall
             # back on, and falling back would let a junk token downgrade
-            # into header/anonymous auth). The token is scoped to one
-            # host_id; presenting it for any other path fails closed so a
-            # leaked token cannot register arbitrary hosts.
-            managed = await asyncio.to_thread(host_store.resolve_launch_token, managed_token)
-            if managed is None or managed.host_id != host_id:
+            # into header/anonymous auth). The token is resolved against
+            # THIS path's host_id, so presenting it for any other path
+            # fails closed — a leaked token cannot register arbitrary hosts.
+            managed = await asyncio.to_thread(
+                host_store.resolve_launch_token, host_id, managed_token
+            )
+            if managed is None:
                 await ws.close(code=4004, reason="unauthenticated")
                 return
             tunnel_owner = managed.owner

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -12,6 +12,7 @@ connection state is tracked separately in the in-memory
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import logging
 from dataclasses import dataclass
@@ -726,33 +727,43 @@ class HostStore:
             session.add(row)
             return _row_to_host(row)
 
-    def resolve_launch_token(self, token: str) -> Host | None:
+    def resolve_launch_token(self, host_id: str, token: str) -> Host | None:
         """
-        Resolve a presented launch token to its managed host, if valid.
+        Resolve a launch token presented for *host_id* to its managed host.
 
-        The host tunnel's auth path for managed hosts. Lookup is by
-        SHA-256 digest — the comparison happens inside an indexed
-        equality query on a uniformly distributed hash, which is not
-        byte-by-byte comparable from the network (the standard
-        reset-token pattern; no timing oracle on the raw token).
-        Expired tokens do not authenticate; the expiry is checked
-        atomically with the lookup.
+        The host tunnel's auth path for managed hosts, whose endpoint is
+        ``/hosts/{host_id}/tunnel`` — so the connecting peer names the
+        host it claims to be, and the token proves the claim. The row is
+        fetched by its ``(workspace_id, host_id)`` primary key and the
+        stored SHA-256 digest is compared to the presented token's digest
+        with :func:`hmac.compare_digest`, so the equality is constant-time
+        and leaks no timing oracle on the raw token. Presenting a token
+        for the wrong ``host_id`` fails closed: the named row's digest
+        won't match. Expired tokens do not authenticate.
 
-        :param token: The raw token presented by a connecting host.
+        :param host_id: The host the peer claims to be, from the tunnel
+            path, e.g. ``"host_a1b2c3d4..."``.
+        :param token: The raw token presented by the connecting host.
         :returns: The matching :class:`Host` whose token is unexpired,
-            or ``None`` when the token is unknown or expired.
+            or ``None`` when the host is unknown, the token does not match,
+            or the token is expired.
         """
         with self._session() as session:
             row = session.execute(
                 select(SqlHost).where(
                     SqlHost.workspace_id == current_workspace_id(),
-                    SqlHost.token_hash == hash_host_launch_token(token),
+                    SqlHost.host_id == host_id,
                 )
             ).scalar_one_or_none()
             # token_expires_at is written together with token_hash, so a
-            # matched row always carries it; the None arm is mypy
-            # narrowing that doubles as fail-closed.
-            if row is None or row.token_expires_at is None or row.token_expires_at < now_epoch():
+            # credentialled row always carries both; a row with either
+            # cleared (external host, or a revoked credential) never
+            # authenticates.
+            if row is None or row.token_hash is None or row.token_expires_at is None:
+                return None
+            if not hmac.compare_digest(row.token_hash, hash_host_launch_token(token)):
+                return None
+            if row.token_expires_at < now_epoch():
                 return None
             return _row_to_host(row)
 

--- a/tests/db/test_migration_hosts_token_hash.py
+++ b/tests/db/test_migration_hosts_token_hash.py
@@ -1,0 +1,66 @@
+"""Tests for the hosts token_hash drop-unique migration (f82e866d9de0).
+
+Verifies that at head ``uq_hosts_token_hash`` is gone (the launch-token auth
+path resolves by the ``(workspace_id, host_id)`` PK and matches the digest in
+Python), that ``uq_hosts_workspace_owner_name`` is untouched, and that downgrade
+restores the constraint.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Fresh SQLite database with the full migration chain applied."""
+    db_path = tmp_path / "test.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+def test_token_hash_unique_dropped_at_head(db_engine: Engine) -> None:
+    """At head the (workspace_id, token_hash) unique key is gone."""
+    uniques = {u["name"] for u in sa.inspect(db_engine).get_unique_constraints("hosts")}
+    assert "uq_hosts_token_hash" not in uniques
+    # The owner/name uniqueness that guards host_id rotation is untouched.
+    assert "uq_hosts_workspace_owner_name" in uniques
+
+
+def test_downgrade_restores_token_hash_unique(tmp_path: Path) -> None:
+    """Downgrade restores the (workspace_id, token_hash) unique constraint."""
+    db_path = tmp_path / "downgrade.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+
+    # Sanity: head state before downgrade.
+    uniques = {u["name"] for u in sa.inspect(engine).get_unique_constraints("hosts")}
+    assert "uq_hosts_token_hash" not in uniques
+
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, "d4c1b9e6f3a2")
+
+    restored = {u["name"] for u in sa.inspect(engine).get_unique_constraints("hosts")}
+    assert "uq_hosts_token_hash" in restored
+    assert "uq_hosts_workspace_owner_name" in restored
+
+    engine.dispose()
+    clear_engine_cache()

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -1174,7 +1174,7 @@ async def test_launch_success_registers_host_and_returns_workspace(db_uri: str) 
     # The token injected into the sandbox is the one whose digest was
     # stored: resolving it (the tunnel's auth path) yields this host,
     # which also proves it is unexpired.
-    resolved = host_store.resolve_launch_token(start.token)
+    resolved = host_store.resolve_launch_token(start.host_id, start.token)
     assert resolved is not None
     assert resolved.host_id == result.host_id
     # Nothing was torn down on the success path.
@@ -1475,7 +1475,10 @@ async def test_launch_online_timeout_terminates_and_deletes_host(
     assert host_store.list_hosts(_OWNER) == []
     # The start command DID run (the failure was registration, not
     # startup), so its minted token exists — and must be dead.
-    assert host_store.resolve_launch_token(fake.host_starts[0].token) is None
+    assert (
+        host_store.resolve_launch_token(fake.host_starts[0].host_id, fake.host_starts[0].token)
+        is None
+    )
 
 
 async def test_launch_with_repo_clones_into_workspace(db_uri: str) -> None:
@@ -1601,7 +1604,9 @@ class _EntrypointFakeLauncher(FakeSandboxLauncher):
             }
         )
         # The token was registered before start_host, so it resolves now.
-        self.token_resolved_at_start = self._host_store.resolve_launch_token(token) is not None
+        self.token_resolved_at_start = (
+            self._host_store.resolve_launch_token(host_id, token) is not None
+        )
         # Simulate the host's entrypoint dialing back over the tunnel.
         self._host_store.upsert_on_connect(host_id=host_id, name=host_name, owner=_OWNER)
         return f"/home/omnigent/workspace/{repo_name}" if repo_name else "/home/omnigent/workspace"
@@ -1708,9 +1713,9 @@ async def test_relaunch_rolls_sandbox_generation_under_same_host(db_uri: str) ->
     # revoked by the re-arm (its digest no longer matches anything).
     gen2_token = fake.host_starts[1].token
     assert gen2_token != gen1_token
-    resolved = host_store.resolve_launch_token(gen2_token)
+    resolved = host_store.resolve_launch_token(fake.host_starts[1].host_id, gen2_token)
     assert resolved is not None and resolved.host_id == first.host_id
-    assert host_store.resolve_launch_token(gen1_token) is None
+    assert host_store.resolve_launch_token(fake.host_starts[0].host_id, gen1_token) is None
 
 
 async def test_relaunch_failure_keeps_host_row_and_revokes_token(db_uri: str) -> None:
@@ -1755,7 +1760,10 @@ async def test_relaunch_failure_keeps_host_row_and_revokes_token(db_uri: str) ->
     # cleanup (revoke_launch_token — covered directly in the host-store
     # suite). Gen 1's raw token is the only one observable here (the
     # failed start never executed), so assert on it.
-    assert host_store.resolve_launch_token(fake.host_starts[0].token) is None
+    assert (
+        host_store.resolve_launch_token(fake.host_starts[0].host_id, fake.host_starts[0].token)
+        is None
+    )
 
 
 async def test_relaunch_rejects_unconfigured_provider(db_uri: str) -> None:
@@ -1867,8 +1875,8 @@ async def test_resume_managed_host_wakes_same_sandbox_and_refreshes_token(db_uri
     assert woke.sandbox_id == "sb-fake-1"
     second_token = fake.host_starts[1].token
     assert second_token != first_token
-    assert host_store.resolve_launch_token(first_token) is None
-    resolved = host_store.resolve_launch_token(second_token)
+    assert host_store.resolve_launch_token(fake.host_starts[0].host_id, first_token) is None
+    resolved = host_store.resolve_launch_token(fake.host_starts[1].host_id, second_token)
     assert resolved is not None and resolved.host_id == first.host_id
 
 
@@ -1898,8 +1906,13 @@ async def test_resume_managed_host_force_wakes_fresh_online_row(db_uri: str) -> 
 
     assert fake.resumed == ["sb-resume-force"]
     assert len(fake.host_starts) == 1
-    assert host_store.resolve_launch_token("tok-resume-force") is None
-    resolved = host_store.resolve_launch_token(fake.host_starts[0].token)
+    assert (
+        host_store.resolve_launch_token("62d4405ba38711fe34bebfeb5a7adaf2", "tok-resume-force")
+        is None
+    )
+    resolved = host_store.resolve_launch_token(
+        "62d4405ba38711fe34bebfeb5a7adaf2", fake.host_starts[0].token
+    )
     assert resolved is not None and resolved.host_id == "62d4405ba38711fe34bebfeb5a7adaf2"
 
 
@@ -1927,7 +1940,10 @@ async def test_resume_managed_host_noops_for_non_resumable_provider(db_uri: str)
     assert host is not None
     assert host.status == "offline"
     assert host.sandbox_id == "sb-resume-noop"
-    assert host_store.resolve_launch_token("tok-resume-noop") is not None
+    assert (
+        host_store.resolve_launch_token("249d058fbcde7b2ce941479cdb8c82d7", "tok-resume-noop")
+        is not None
+    )
 
 
 async def test_resume_managed_host_failure_preserves_existing_row_and_token(db_uri: str) -> None:
@@ -1956,7 +1972,10 @@ async def test_resume_managed_host_failure_preserves_existing_row_and_token(db_u
     assert host is not None
     assert host.status == "offline"
     assert host.sandbox_id == "sb-resume-fail"
-    assert host_store.resolve_launch_token("tok-resume-fail") is not None
+    assert (
+        host_store.resolve_launch_token("efbef7dede7be6577770cbb1287992f2", "tok-resume-fail")
+        is not None
+    )
 
 
 # ── terminate_managed_host ──────────────────────────────────
@@ -1984,7 +2003,9 @@ async def test_terminate_managed_host_terminates_and_deletes_row(db_uri: str) ->
 
     assert fake.terminated == ["sb-term-1"]
     assert host_store.get_host("62a91eb065624754c6a6dfb5869dd7e8") is None
-    assert host_store.resolve_launch_token("tok-term-1") is None
+    assert (
+        host_store.resolve_launch_token("62a91eb065624754c6a6dfb5869dd7e8", "tok-term-1") is None
+    )
 
 
 async def test_terminate_managed_host_deletes_row_even_when_terminate_fails(
@@ -2016,7 +2037,9 @@ async def test_terminate_managed_host_deletes_row_even_when_terminate_fails(
     await terminate_managed_host(host, host_store, _injected_config(fake))
 
     assert host_store.get_host("057e7fa3f1cdb40c0ec393a3d42affc7") is None
-    assert host_store.resolve_launch_token("tok-term-2") is None
+    assert (
+        host_store.resolve_launch_token("057e7fa3f1cdb40c0ec393a3d42affc7", "tok-term-2") is None
+    )
 
 
 async def test_terminate_managed_host_skips_mismatched_provider(db_uri: str) -> None:
@@ -2044,7 +2067,9 @@ async def test_terminate_managed_host_skips_mismatched_provider(db_uri: str) -> 
     # No cross-provider terminate was attempted.
     assert fake.terminated == []
     assert host_store.get_host("487212fd2b157b6ab6a6d6d3ef06ce5b") is None
-    assert host_store.resolve_launch_token("tok-term-3") is None
+    assert (
+        host_store.resolve_launch_token("487212fd2b157b6ab6a6d6d3ef06ce5b", "tok-term-3") is None
+    )
 
     # config=None behaves the same: row deleted, nothing terminated.
     host2 = host_store.register_managed_host(

--- a/tests/stores/test_host_store.py
+++ b/tests/stores/test_host_store.py
@@ -710,7 +710,7 @@ def test_register_managed_host_and_resolve_token_roundtrip(db_uri: str) -> None:
         token_expires_at=now_epoch() + 3600,
     )
 
-    resolved = store.resolve_launch_token("raw-launch-token-1")
+    resolved = store.resolve_launch_token("e932ccae9eeb8f2a86f7ebfc5089c28d", "raw-launch-token-1")
     assert resolved is not None
     assert resolved.host_id == "e932ccae9eeb8f2a86f7ebfc5089c28d"
     assert resolved.name == "managed-m1"
@@ -739,8 +739,13 @@ def test_resolve_launch_token_rejects_unknown_and_expired(db_uri: str) -> None:
         token_expires_at=now_epoch() - 1,
     )
 
-    assert store.resolve_launch_token("no-such-token") is None
-    assert store.resolve_launch_token("raw-launch-token-2") is None
+    # Unknown host id: nothing to resolve.
+    assert store.resolve_launch_token("00000000000000000000000000000000", "no-such-token") is None
+    # Known host, but its token is already expired.
+    assert (
+        store.resolve_launch_token("e5e05ec590da46a0e27bb138d343ffe7", "raw-launch-token-2")
+        is None
+    )
 
 
 def test_register_managed_host_relaunch_rotates_credential(db_uri: str) -> None:
@@ -778,8 +783,11 @@ def test_register_managed_host_relaunch_rotates_credential(db_uri: str) -> None:
     assert second.sandbox_id == "sb-gen2"
     # Generation-1 token is revoked by the overwrite; generation-2
     # resolves to the same host now backed by the new sandbox.
-    assert store.resolve_launch_token("generation-1-token") is None
-    resolved = store.resolve_launch_token("generation-2-token")
+    assert (
+        store.resolve_launch_token("a687a760841c785578a03f4677f8db3c", "generation-1-token")
+        is None
+    )
+    resolved = store.resolve_launch_token("a687a760841c785578a03f4677f8db3c", "generation-2-token")
     assert resolved is not None
     assert resolved.host_id == "a687a760841c785578a03f4677f8db3c"
     assert resolved.sandbox_id == "sb-gen2"
@@ -813,7 +821,10 @@ def test_managed_columns_survive_connect(db_uri: str) -> None:
     assert connected.sandbox_provider == "modal"
     assert connected.sandbox_id == "sb-m4"
     # The credential still resolves after connect.
-    assert store.resolve_launch_token("raw-launch-token-4") is not None
+    assert (
+        store.resolve_launch_token("d55a61010459cea88ed2af0fe916139b", "raw-launch-token-4")
+        is not None
+    )
 
 
 def test_delete_host_removes_row_and_revokes_token(db_uri: str) -> None:
@@ -835,7 +846,10 @@ def test_delete_host_removes_row_and_revokes_token(db_uri: str) -> None:
 
     store.delete_host("dcf4eb5fc0b04985ec45f79cfda95566")
     assert store.get_host("dcf4eb5fc0b04985ec45f79cfda95566") is None
-    assert store.resolve_launch_token("raw-launch-token-5") is None
+    assert (
+        store.resolve_launch_token("dcf4eb5fc0b04985ec45f79cfda95566", "raw-launch-token-5")
+        is None
+    )
     assert store.list_hosts("alice@example.com") == []
     # Second delete is a no-op, not an error.
     store.delete_host("dcf4eb5fc0b04985ec45f79cfda95566")
@@ -860,13 +874,19 @@ def test_revoke_launch_token_keeps_row_but_stops_resolution(db_uri: str) -> None
     )
     # Sanity: the token resolves before the revoke — without this, a
     # broken register would make the post-revoke assertion vacuous.
-    assert store.resolve_launch_token("raw-launch-token-revoke") is not None
+    assert (
+        store.resolve_launch_token("f59827fa9468170e62cf28104d2a5251", "raw-launch-token-revoke")
+        is not None
+    )
 
     store.revoke_launch_token("f59827fa9468170e62cf28104d2a5251")
 
     # The credential is dead but the row (and its managed binding)
     # survives — a deleted row here would null the session's host_id.
-    assert store.resolve_launch_token("raw-launch-token-revoke") is None
+    assert (
+        store.resolve_launch_token("f59827fa9468170e62cf28104d2a5251", "raw-launch-token-revoke")
+        is None
+    )
     host = store.get_host("f59827fa9468170e62cf28104d2a5251")
     assert host is not None
     assert host.sandbox_provider == "modal"
@@ -935,8 +955,9 @@ def test_register_managed_host_refuses_cross_owner_recredential(db_uri: str) -> 
 
     # Alice's credential and binding are untouched; Bob's token never
     # became valid.
-    resolved = store.resolve_launch_token("alice-token-7")
+    resolved = store.resolve_launch_token("58f80f7592c6a72ba121eb5aedde8a82", "alice-token-7")
     assert resolved is not None
     assert resolved.owner == "alice@example.com"
     assert resolved.sandbox_id == "sb-m7"
-    assert store.resolve_launch_token("bob-token-7") is None
+    # Bob's token never armed Alice's host: it does not match the stored digest.
+    assert store.resolve_launch_token("58f80f7592c6a72ba121eb5aedde8a82", "bob-token-7") is None


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Drops the `uq_hosts_token_hash` unique constraint (`workspace_id, token_hash`)
  on the `hosts` table. The managed-host launch-token auth path no longer needs a
  digest-keyed index.
- The host tunnel endpoint is `/hosts/{host_id}/tunnel`, so the connecting peer
  already names the host it claims to be. `HostStore.resolve_launch_token(token)`
  becomes `resolve_launch_token(host_id, token)`: it seeks the row by the
  `(workspace_id, host_id)` primary key and compares the stored SHA-256 digest to
  the presented token's digest with `hmac.compare_digest` — constant-time, so the
  "no timing oracle on the raw token" property the old DB-equality lookup relied on
  is preserved.
- The constraint's uniqueness was never load-bearing: launch tokens are 256-bit
  `secrets.token_urlsafe(32)` values whose digests do not collide in practice, and
  nothing rides the constraint now that the lookup keys on the PK.

The tunnel caller (`host_tunnel.py`) passes the path `host_id` and drops the now
tautological `managed.host_id != host_id` check — resolving *by* `host_id` makes it
inherent. Presenting a token for the wrong host_id still fails closed (the named
row's digest won't match).

Migration `f82e866d9de0` parents off the current head `d4c1b9e6f3a2`; downgrade
restores the constraint.

## Test Plan

- New `tests/db/test_migration_hosts_token_hash.py`: at head `uq_hosts_token_hash`
  is gone (and `uq_hosts_workspace_owner_name` untouched); downgrade restores it.
- Updated `resolve_launch_token` call sites to thread `host_id` through
  `tests/stores/test_host_store.py` and `tests/server/test_managed_hosts.py`.
- Ran locally (SQLite): `test_host_store.py` (33), `test_managed_hosts.py` +
  `test_db_models.py::TestSqlHost` (128), `test_host_tunnel_route.py` integration
  (16) — including `test_managed_token_authenticates_as_record_owner` and the
  wrong/expired/cross-path refusal cases — and the new migration test (2). All green.
- `ruff format --check`, `ruff check`, and `pre-commit run --files` all clean.
  Single alembic head confirmed.

## Demo

N/A — schema/auth-path change, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the added migration test and the updated store / route tests above.
