### PR TITLE
fix(electron): guarantee the desktop quits after before-quit cleanup

### DIFF
--- a/web/electron/src/desktop_updater.js
+++ b/web/electron/src/desktop_updater.js
@@ -181,6 +181,10 @@ function createDesktopUpdater({
         () => autoUpdater.checkForUpdates().catch(() => {}),
         PERIODIC_CHECK_INTERVAL_MS,
       );
+      // Don't let the 6-hourly re-check keep the Node event loop alive at quit
+      // (a ref'd interval can leave the main process lingering after the
+      // windows close on some platforms).
+      if (typeof updateCheckTimer.unref === "function") updateCheckTimer.unref();
     }
   }
 

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -80,6 +80,15 @@ const POPUP_PRELOAD = path.join(__dirname, "popup_preload.js");
 const ICON_PNG = path.join(__dirname, "..", "icons", "icon.png");
 
 /**
+ * Quit-safety timeouts (see the before-quit handler near the end of this
+ * file). `let` (not const) so tests can shrink them via __test.setQuitTimeouts
+ * to exercise the force-exit safety nets without waiting seconds in real
+ * time. Production code never writes them.
+ */
+let quitCleanupTimeoutMs = 10000;
+let quitInstallFallbackMs = 3000;
+
+/**
  * Permissions the SPA legitimately needs and we auto-grant. The dictation
  * button drives the Web Speech API and a `getUserMedia` audio stream (for the
  * mic level meter); both go through Chromium's permission layer, which in
@@ -2788,6 +2797,20 @@ if (!gotLock) {
   // stop a local server it owns. The desktop owns its host connections (the
   // confirmed lifecycle), so quitting disconnects this machine. We defer the
   // quit until cleanup finishes, then re-issue it.
+  //
+  // Hard safety cap: the only thing that ever lets the quit proceed is the
+  // re-issued app.quit() in .finally — and re-issuing app.quit() after
+  // before-quit's preventDefault() is a known intermittently-unreliable
+  // Electron behavior (electron/electron#4994, #33643, #39094). If that re-issue
+  // is a no-op, or shutdown hangs (a stuck `omnigent server stop`), the app
+  // would otherwise stay up with its window still open — looking exactly like
+  // "refuses to quit". So if graceful cleanup + the re-issued quit haven't
+  // terminated the process within quitCleanupTimeoutMs, force-exit. Host
+  // children are SIGKILL'd at 4s and a normal `omnigent server stop` is sub-
+  // second, so a normal quit completes well under the cap; the cap only trips
+  // when something is genuinely stuck, and force-exiting then is strictly
+  // better than a hung app. A cut-off server stop only leaves a daemon with a
+  // pidfile that the next launch reuses or `omnigent server stop` reclaims.
   let quitCleanupDone = false;
   let quitCleanupStarted = false;
   app.on("before-quit", (event) => {
@@ -2798,14 +2821,45 @@ if (!gotLock) {
     event.preventDefault();
     if (quitCleanupStarted) return;
     quitCleanupStarted = true;
-    serverManager
-      .shutdown(resolvedCliPath())
+
+    // unref'd so the cap itself can't hold the event loop open; app.exit()
+    // bypasses before-quit/will-quit, so it's the guaranteed way out when
+    // app.quit() proves unreliable.
+    const cap = setTimeout(() => {
+      if (quitCleanupDone) return;
+      quitCleanupDone = true;
+      app.exit(0);
+    }, quitCleanupTimeoutMs);
+    if (typeof cap.unref === "function") cap.unref();
+
+    // resolvedCliPath() is evaluated inside the async IIFE so a throw (a future
+    // change to settings/CLI resolution) becomes a rejection caught below,
+    // never stranding the quit. shutdown() always settles: host children are
+    // SIGKILL'd within 4s and `omnigent server stop` has its own exec timeout.
+    (async () => {
+      const cliPath = resolvedCliPath();
+      await serverManager.shutdown(cliPath);
+    })()
       .catch(() => {})
       .finally(() => {
+        if (quitCleanupDone) return; // the hard cap already forced the exit
         quitCleanupDone = true;
+        clearTimeout(cap);
         // Hand off to a user-approved install if one is pending; otherwise
-        // complete the deferred quit.
-        if (!updater.quitAndInstallIfPending()) app.quit();
+        // complete the deferred quit. quitAndInstall() re-issues app.quit()
+        // (via setImmediate) only when it can actually install — so if the
+        // staged update is gone and install() returns false, fall back to a
+        // plain quit and then a forced exit after a short grace, rather than
+        // leave the app up waiting for an update that won't install. The
+        // installer is spawned synchronously inside quitAndInstall(), so by
+        // the time the fallback fires the update is already underway (or was
+        // never going to install) — force-exiting only ensures we quit.
+        if (updater.quitAndInstallIfPending()) {
+          const fallback = setTimeout(() => app.exit(0), quitInstallFallbackMs);
+          if (typeof fallback.unref === "function") fallback.unref();
+        } else {
+          app.quit();
+        }
       });
   });
 }

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -11,6 +11,7 @@ function loadMainHarness({
   settings = {},
   forceDevUpdateConfig = false,
   dialogResponses = [{ response: 1, checkboxChecked: false }],
+  serverShutdown = () => Promise.resolve(),
 } = {}) {
   const userData = fs.mkdtempSync(path.join(os.tmpdir(), "omnigent-update-test-"));
   fs.writeFileSync(path.join(userData, "settings.json"), JSON.stringify(settings), "utf8");
@@ -19,6 +20,7 @@ function loadMainHarness({
   const appEvents = new Map();
   const calls = {
     appQuit: 0,
+    appExit: 0,
     checkForUpdates: 0,
     downloadUpdate: 0,
     quitAndInstall: [],
@@ -68,6 +70,9 @@ function loadMainHarness({
       quit: () => {
         calls.appQuit += 1;
       },
+      exit: () => {
+        calls.appExit += 1;
+      },
       setAppUserModelId: () => {},
     },
     BrowserWindow: Object.assign(function BrowserWindow() {}, {
@@ -114,7 +119,7 @@ function loadMainHarness({
       getCliStatus: () => ({ installed: false }),
     },
     "./server_manager": {
-      shutdown: () => Promise.resolve(),
+      shutdown: () => serverShutdown(),
       onChange: () => {},
       ensureServerAuth: async () => ({ ok: true }),
       ensureHostConnected: async () => ({ ok: true }),
@@ -132,7 +137,7 @@ function loadMainHarness({
   // into the menu, the IPC surface, and the before-quit install handoff.
   const source =
     fs.readFileSync(mainPath, "utf8") +
-    "\nmodule.exports.__test = { buildMenu, registerIpc, windows, updater };";
+    '\nmodule.exports.__test = { buildMenu, registerIpc, windows, updater, setQuitTimeouts: (o) => { if (typeof (o && o.cleanup) === "number") quitCleanupTimeoutMs = o.cleanup; if (typeof (o && o.installFallback) === "number") quitInstallFallbackMs = o.installFallback; } }';
 
   const module = { exports: {} };
   const sandbox = {
@@ -143,6 +148,7 @@ function loadMainHarness({
     Buffer,
     URL,
     clearInterval,
+    clearTimeout,
     console,
     module,
     process: {
@@ -159,6 +165,7 @@ function loadMainHarness({
       return mainRequire(specifier);
     },
     setInterval,
+    setTimeout,
   };
 
   vm.runInNewContext(source, sandbox, { filename: mainPath });
@@ -395,6 +402,64 @@ describe("auto-update main-process wiring", () => {
     assert.equal(prevented, 1);
     assert.deepEqual(harness.calls.quitAndInstall, [[false, true]]);
     assert.equal(harness.calls.appQuit, 1);
+  });
+
+  it("force-exits when a pending update install doesn't re-issue app.quit", async (t) => {
+    // electron-updater's quitAndInstall() only re-issues app.quit() when it can
+    // actually install; if it can't (staged update gone, install() returned
+    // false), the before-quit handoff would otherwise leave the app up. The
+    // fallback forces an exit instead, so the app never stays up waiting for
+    // an update that won't install.
+    const harness = loadMainHarness({
+      forceDevUpdateConfig: true,
+      settings: { update_mode: "manual" },
+    });
+    t.after(harness.cleanup);
+    harness.api.updater.init();
+    harness.autoUpdater.emit("update-downloaded", { version: "0.4.0" });
+    harness.api.registerIpc();
+    await harness.ipcHandlers.get("omnigent:update-install")(harness.events.pinned);
+    assert.equal(harness.api.updater.installPending, true);
+    assert.equal(harness.calls.appQuit, 1); // installUpdateNow → app.quit()
+
+    // Shrink the fallback so the test doesn't wait 3s. quitAndInstall is a
+    // no-op in the harness (it never re-issues app.quit), simulating a failed
+    // install(), so only the fallback can quit.
+    harness.api.setQuitTimeouts({ installFallback: 10 });
+    harness.appEvents.get("before-quit")({ preventDefault: () => {} });
+    await flushPromises();
+    assert.equal(harness.calls.appQuit, 1); // still no re-issued quit
+    assert.equal(harness.calls.appExit, 0); // fallback not fired yet
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.equal(harness.calls.appExit, 1); // fallback forced the exit
+    assert.equal(harness.calls.appQuit, 1); // never re-issued
+  });
+
+  it("force-exits if before-quit cleanup hangs past the safety cap", async (t) => {
+    // A stuck shutdown (e.g. a hung `omnigent server stop`, or the known
+    // Electron hazard where re-issuing app.quit() after before-quit's
+    // preventDefault doesn't terminate) must not strand the quit. The hard cap
+    // force-exits. Here shutdown never settles, so the re-issued app.quit() in
+    // .finally never runs — only the cap can quit.
+    const harness = loadMainHarness({
+      forceDevUpdateConfig: true,
+      settings: { update_mode: "manual" },
+      serverShutdown: () => new Promise(() => {}),
+    });
+    t.after(harness.cleanup);
+    harness.api.updater.init();
+    harness.api.registerIpc();
+    harness.api.setQuitTimeouts({ cleanup: 10 });
+
+    harness.appEvents.get("before-quit")({ preventDefault: () => {} });
+    await flushPromises();
+    assert.equal(harness.calls.appQuit, 0); // shutdown hung, no re-issued quit
+    assert.equal(harness.calls.appExit, 0); // cap not fired yet
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.equal(harness.calls.appExit, 1); // cap forced the exit
+    assert.equal(harness.calls.appQuit, 0); // never re-issued
   });
 
   it("does not start the install path when no update is downloaded", async (t) => {


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The desktop shell sometimes stays running and refuses to quit because the `before-quit` handler defers the actual quit until `serverManager.shutdown()` finishes and then **re-issues `app.quit()` as the only way the quit ever proceeds**. Re-issuing `app.quit()` after `before-quit`'s `preventDefault()` is a known intermittently-unreliable Electron behavior (electron/electron#4994, #33643, #39094); when it no-ops — or `shutdown()` hangs (a stuck `omnigent server stop`, up to ~15s) — the app stays up with its window still open, which is exactly the "refuses to quit" symptom.
- Added a hard safety cap: `app.exit(0)` after a bounded timeout if graceful cleanup + the re-issued quit haven't terminated the process. Normal cleanup (<6s: host children SIGKILL'd at 4s, `omnigent server stop` sub-second) completes well under the 10s cap, so it only trips when something is genuinely stuck — force-exiting then is strictly better than a hung app.
- Hardened the handoff: evaluate `resolvedCliPath()` inside an async IIFE (a future throw becomes a rejection, never stranding the quit); add a short `app.exit(0)` fallback when a pending update install doesn't actually re-quit (electron-updater's `quitAndInstall()` only re-issues `app.quit()` when it can install); and `unref()` the periodic update-check `setInterval` so it can't keep the event loop alive at quit.

### ELI5

When you quit the Electron app, it first stops some background helpers it started (host tunnels, a local server) and *then* quits. It tells the OS "wait, don't quit yet," does the cleanup, and asks to quit again. Sometimes that second ask gets ignored by a known Electron quirk, or the cleanup itself stalls — so the app sits there with its window open, looking like it refused to quit. This adds a watchdog timer: if the app hasn't actually exited within 10 seconds, it force-quits. It also makes sure a pending auto-update can't leave the app up if the update file is gone.

```mermaid
flowchart TD
    A["Cmd-Q / app.quit"] --> B["before-quit: preventDefault"]
    B --> C["start shutdown + 10s cap timer"]
    C --> D{"shutdown settles < 10s?"}
    D -- yes --> E["re-issued app.quit"]
    D -- "no / re-quit no-op" --> F["cap fires: forced exit"]
    E --> G{"pending update?"}
    G -- no --> H["quit completes"]
    G -- yes --> I["quitAndInstall re-quits; else 3s fallback forced exit"]
    F --> Z["guaranteed exit"]
    H --> Z
    I --> Z
```

## Test Plan

- `node --check` on both edited source files; `node --test` (full Electron suite): 220/220 pass (218 pre-existing + 2 new).
- Added two regression tests in `test/update-main.test.js`:
  - **install-fallback**: a pending update whose `quitAndInstall()` no-ops (simulating a failed `install()`) still force-exits via the fallback, never leaving `appQuit` un-incremented.
  - **cleanup-cap**: a `shutdown()` that never settles still force-exits when the cap fires, with zero re-issued `app.quit()` calls.
- Tests use an injectable `__test.setQuitTimeouts({cleanup, installFallback})` (module-level `let`s, written only by tests) and an overridable `serverShutdown` harness knob so the safety nets are exercised in milliseconds rather than seconds.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The force-exit safety nets are timing-based, so they're covered by the two new unit tests with shrunken injectable timeouts. The reliable path (cleanup settles → re-issued `app.quit`) is already covered by the pre-existing "routes approved update-install through before-quit cleanup to quitAndInstall" test, which still passes unchanged. Manual end-to-end quit verification across macOS/Windows/Linux was not performed in this environment; the change is guarded by the existing happy-path test plus the two new failure-mode tests, and `app.exit(0)` is a guaranteed terminate that bypasses the unreliable quit path.

## Changelog

The desktop app now always quits within a few seconds even if its background cleanup stalls or the OS re-quit is dropped.

