### PR TITLE
fix(runner): bound the codex-forwarder shutdown waits so an idle runner can exit

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -87,6 +87,10 @@ _REPLAY_POST_TIMEOUT_SECONDS = 5.0
 _REPLAY_DEADLINE_SECONDS = 30.0
 _DELTA_FLUSH_INTERVAL_SECONDS = 0.05
 _DELTA_FLUSH_CHAR_THRESHOLD = 64
+# A worker cancelled at loop teardown can no longer resolve its queued markers, so an
+# unbounded wait parks the caller for good. Under the runner's 10s auto-forwarder cancel
+# budget so this resolves first.
+_DELTA_MARKER_TIMEOUT_SECONDS = 5.0
 _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE = "external_reasoning_effort_change"
 # Context-compaction progress edge. Publishes the same
 # ``response.compaction.in_progress`` / ``response.compaction.completed`` SSE
@@ -974,6 +978,21 @@ class _DeltaChunk:
     tool_call_id: str | None = None
 
 
+def _resolve_marker(done: asyncio.Future[None]) -> None:
+    """
+    Complete a queue marker's future unless a cancelled caller already settled it.
+
+    An unguarded ``set_result`` on an already-cancelled future raises
+    ``InvalidStateError``, which kills the worker; ``_ensure_worker`` only replaces a
+    ``None`` task, so the dead one is never restarted and every later flush hangs.
+
+    :param done: Future the caller is waiting on.
+    :returns: None.
+    """
+    if not done.done():
+        done.set_result(None)
+
+
 @dataclass(frozen=True)
 class _DeltaFlushBarrier:
     """
@@ -1076,12 +1095,12 @@ class _OutputTextDeltaCoalescer:
 
         :returns: None after all earlier deltas have been posted.
         """
-        if self._worker_task is None:
+        if self._worker_task is None or self._worker_task.done():
             return
         loop = asyncio.get_running_loop()
         done: asyncio.Future[None] = loop.create_future()
         self._queue.put_nowait(_DeltaFlushBarrier(done=done))
-        await done
+        await self._await_marker(done, "flush barrier")
 
     async def close(self) -> None:
         """
@@ -1091,12 +1110,51 @@ class _OutputTextDeltaCoalescer:
         """
         if self._worker_task is None:
             return
+        # A worker that already stopped will never read the marker, so skip
+        # straight to reaping it rather than waiting out the bound.
+        if self._worker_task.done():
+            self._worker_task = None
+            return
         loop = asyncio.get_running_loop()
         done: asyncio.Future[None] = loop.create_future()
         self._queue.put_nowait(_DeltaFlushStop(done=done))
-        await done
-        await self._worker_task
+        await self._await_marker(done, "stop marker")
+        # Only reap a worker that has actually finished; awaiting a wedged one
+        # would reintroduce the unbounded wait this method exists to remove.
+        if self._worker_task.done():
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._worker_task
         self._worker_task = None
+
+    async def _await_marker(self, done: asyncio.Future[None], marker: str) -> None:
+        """
+        Wait for the worker to resolve a queue marker.
+
+        Races the marker against the worker itself: a worker that stops will never
+        resolve it, and at loop teardown the cancellation order between the worker
+        and the caller is arbitrary, so waiting on the marker alone stalls for the
+        full bound on an ordinary shutdown.
+
+        :param done: Future the worker resolves for this marker.
+        :param marker: Marker name used in the timeout log.
+        :returns: None once resolved, once the worker stops, or once the bound elapses.
+        """
+        worker = self._worker_task
+        waiters: set[asyncio.Future[None] | asyncio.Task[None]] = {done}
+        if worker is not None:
+            waiters.add(worker)
+        await asyncio.wait(
+            waiters,
+            return_when=asyncio.FIRST_COMPLETED,
+            timeout=_DELTA_MARKER_TIMEOUT_SECONDS,
+        )
+        if not done.done() and (worker is None or not worker.done()):
+            _logger.warning(
+                "codex delta coalescer %s timed out after %.1fs (session=%s)",
+                marker,
+                _DELTA_MARKER_TIMEOUT_SECONDS,
+                self._session_id,
+            )
 
     def _ensure_worker(self) -> None:
         """
@@ -1166,10 +1224,10 @@ class _OutputTextDeltaCoalescer:
                 buffer_chunk = None
                 buffered_chars = 0
                 flush_deadline = None
-                item.done.set_result(None)
+                _resolve_marker(item.done)
                 continue
             await self._flush_buffer(buffer, chunk=buffer_chunk)
-            item.done.set_result(None)
+            _resolve_marker(item.done)
             return
 
     async def _flush_buffer(

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -15,6 +15,7 @@ only an already-mirrored value is not re-posted.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -2234,3 +2235,137 @@ def test_settle_timeout_tracks_slowest_configured_server(tmp_path: Path) -> None
         '[mcp_servers.off]\ncommand = "y"\nenabled = false\nstartup_timeout_sec = 120\n',
     )
     assert fwd._mcp_startup_settle_timeout_seconds(tmp_path) == 25.0
+
+
+def _coalescer(client: object) -> fwd._OutputTextDeltaCoalescer:
+    """Build a delta coalescer wired to ``client``."""
+    return fwd._OutputTextDeltaCoalescer(
+        client=client,
+        session_id="conv_idle",
+        flush_interval_seconds=0.05,
+        flush_char_threshold=64,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_close_returns_when_its_worker_is_cancelled() -> None:
+    """``close()`` must not park on a marker its cancelled worker can never resolve.
+
+    ``asyncio.run`` cancels every task before resuming any, so when the forwarder
+    resumes first its ``finally`` calls ``close()`` while the worker is cancelled but
+    not yet ``done()``. The marker is queued with nobody left to complete it.
+    """
+    coalescer = _coalescer(_RecordingClient())
+    coalescer._ensure_worker()
+    await asyncio.sleep(0)
+    worker = coalescer._worker_task
+    assert worker is not None
+
+    worker.cancel()
+    # Deliberately NOT awaited: this reproduces the teardown ordering where the
+    # worker is cancelled but has not run yet, which no `done()` check can catch.
+    assert not worker.done()
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    await asyncio.wait_for(coalescer.close(), timeout=fwd._DELTA_MARKER_TIMEOUT_SECONDS + 5.0)
+
+    assert coalescer._worker_task is None
+    assert loop.time() - started < fwd._DELTA_MARKER_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_close_gives_up_on_a_wedged_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A worker still alive but stuck mid-post must not hold ``close()`` forever.
+
+    This is the one case the bound exists for: the worker owns the marker, so it is
+    off the queue, and the worker is running, so racing it does not help either.
+    """
+
+    class _HangingClient:
+        """Client whose post never returns, wedging the worker inside a flush."""
+
+        def __init__(self) -> None:
+            self.entered = asyncio.Event()
+
+        async def post(self, *args: object, **kwargs: object) -> None:
+            self.entered.set()
+            await asyncio.sleep(3600)
+
+    monkeypatch.setattr(fwd, "_DELTA_MARKER_TIMEOUT_SECONDS", 0.1)
+    client = _HangingClient()
+    coalescer = _coalescer(client)
+    coalescer._ensure_worker()
+    coalescer._queue.put_nowait(fwd._DeltaChunk(message_id="m1", tool_call_id=None, delta="x"))
+    await asyncio.wait_for(client.entered.wait(), timeout=5.0)
+    worker = coalescer._worker_task
+    assert worker is not None
+
+    await asyncio.wait_for(coalescer.close(), timeout=fwd._DELTA_MARKER_TIMEOUT_SECONDS + 5.0)
+
+    # close() gave up on the bound rather than waiting out a worker still stuck in its post.
+    assert coalescer._worker_task is None
+    assert not worker.done()
+    worker.cancel()
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_worker_survives_an_already_settled_marker() -> None:
+    """Resolving a marker whose future is already settled must not kill the worker.
+
+    ``set_result`` on a settled future raises ``InvalidStateError``, and
+    ``_ensure_worker`` only replaces a ``None`` task, so a worker lost this way is
+    never restarted and every later delta is dropped without a word.
+    """
+    client = _RecordingClient()
+    coalescer = _coalescer(client)
+    coalescer._ensure_worker()
+    await asyncio.sleep(0)
+
+    settled: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    settled.cancel()
+    coalescer._queue.put_nowait(fwd._DeltaFlushBarrier(done=settled))
+    await asyncio.sleep(0.1)
+
+    assert coalescer._worker_task is not None
+    assert not coalescer._worker_task.done()
+
+    posts_before = len(client.posts)
+    coalescer._queue.put_nowait(
+        fwd._DeltaChunk(message_id="m1", tool_call_id=None, delta="still here")
+    )
+    await asyncio.wait_for(coalescer.flush(), timeout=5.0)
+    assert len(client.posts) > posts_before
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_survives_a_cancelled_flush_caller() -> None:
+    """A cancelled ``flush()`` caller must not kill the worker.
+
+    The caller's cancellation settles its own future. Resolving it again raises
+    ``InvalidStateError`` inside the worker, and ``_ensure_worker`` only replaces a
+    ``None`` task, so the dead worker was never restarted and every later delta was
+    silently dropped.
+    """
+    client = _RecordingClient()
+    coalescer = _coalescer(client)
+    coalescer._ensure_worker()
+    await asyncio.sleep(0)
+
+    pending = asyncio.ensure_future(coalescer.flush())
+    await asyncio.sleep(0)
+    pending.cancel()
+    await asyncio.gather(pending, return_exceptions=True)
+    await asyncio.sleep(0.1)
+
+    assert coalescer._worker_task is not None
+    assert not coalescer._worker_task.done()
+
+    posts_before = len(client.posts)
+    coalescer._queue.put_nowait(
+        fwd._DeltaChunk(message_id="m1", tool_call_id=None, delta="still here")
+    )
+    await asyncio.wait_for(coalescer.flush(), timeout=5.0)
+    assert len(client.posts) > posts_before


### PR DESCRIPTION
## Summary

`_OutputTextDeltaCoalescer.flush()` and `close()` queue a marker carrying a `Future` and then `await` it. Only the delta worker resolves those futures, and only from inside its loop. At `asyncio.run` teardown the worker and the forwarder are cancelled in the same `_cancel_all_tasks` pass, so `supervise_forwarder`'s `finally` calls `close()`, the stop marker goes on the queue, and nobody is left to complete it. `close()` never returns and the runner never exits.

This also matters beyond the hang itself: #1528 lists this as a dependency because the clean exit its resume path assumes is not always reached.

Closes #2748.

## What changed

Three parts, in `omnigent/codex_native_forwarder.py`:

1. **`_await_marker` races the marker against the worker task, bounded.** A worker that has stopped will never resolve the marker. Waiting on the marker alone is not enough, because `_cancel_all_tasks` cancels every task before resuming any and `cancel()` does not set `done()`, so the cancellation order between the worker and its caller is arbitrary. Racing the worker covers both orderings; the bound covers a worker that is wedged but still alive.
2. **`close()` only reaps a worker that actually finished.** Awaiting a wedged one reintroduced exactly the unbounded wait this is meant to remove.
3. **`_resolve_marker` guards both resolvers.** `set_result` on a settled future raises `InvalidStateError` and kills the worker, and `_ensure_worker` only replaces a `None` task, so a worker lost that way is never restarted and every later delta is dropped silently.

## What I tried and rejected

A `try/finally` drain in `_run()` that releases queued waiters on the way out. It reads like the obvious fix and it changes no outcome: at teardown no worker survives to run the `finally`, and a marker already popped off the queue is not in the queue to drain. I measured it against each failure mode before dropping it.

## Test plan

- [x] `test_delta_coalescer_close_returns_when_its_worker_is_cancelled` cancels the worker **without** awaiting it, which is the teardown ordering no `done()` check can catch.
- [x] `test_delta_coalescer_close_gives_up_on_a_wedged_worker` pins the bound, using a client whose post never returns.
- [x] `test_delta_coalescer_worker_survives_an_already_settled_marker` and `test_delta_coalescer_survives_a_cancelled_flush_caller` cover the resolver guard and confirm deltas still flow afterwards.
- [x] Each of the three parts is mutation-covered: remove any one and a test fails.
- [x] 78 pass, up from 74 on `main`, no regressions. `ruff check` and `ruff format --check` clean.
- [x] Separately reproduced all four failure modes against the real class before and after, including the teardown path 10/10.

## Notes

`_DELTA_MARKER_TIMEOUT_SECONDS = 5.0` matches `_REPLAY_POST_TIMEOUT_SECONDS` in the same file and sits under `runner/app.py`'s 10s auto-forwarder cancel budget, so it resolves first. Happy to change the value.

The issue title also asks for a hard-exit backstop in the runner entrypoint. I left it out deliberately: it is a runner-lifecycle policy change and this fix stands on its own. Glad to do it as a follow-up if you want it.

`_SessionUsageCoalescer` looks similar but is not affected. It has no worker task and no futures, so nothing else needed the same treatment.
