### PR TITLE
fix(web): don't queue messages while only background work is running

### DIFF
--- a/tests/e2e_ui/chat/test_send_while_background_task.py
+++ b/tests/e2e_ui/chat/test_send_while_background_task.py
@@ -1,0 +1,124 @@
+"""Sending a message while only background work is running.
+
+A claude-native turn can settle into the user-visible ``waiting`` state:
+the turn already ended and the server's turn gate is free, but background
+shells (or a still-running sub-agent) outlive it. The claude/cursor-native
+Stop hook reports this as an ``external_session_status`` edge carrying
+``status: "waiting"``, the ended turn's ``response_id``, and a positive
+``background_task_count``.
+
+The web composer must treat that as free-to-send — a new message starts a
+fresh turn immediately — NOT queue it behind the background work. The
+regression this guards: the ``waiting``+``response_id`` edge used to force
+the local send lifecycle into ``streaming``, so the composer showed
+"Send a follow-up (queued)" and held every message in the client-side
+queue strip until the background work finished.
+
+The ``waiting`` edge is published LIVE (after navigation) so it arrives via
+the SSE ``session.status`` path — the one the fix targets. Publishing it
+before navigation is not equivalent: this suite's ``openai-agents`` runner
+collapses a posted ``waiting`` to ``running`` in the snapshot projection, so
+a pre-navigation post would not reproduce the ``waiting`` state at all.
+
+Like ``test_working_indicator_background_tasks``, this drives the real
+status edge through the Sessions events route (the same path the
+claude-native forwarder posts to), so it is deterministic — no live LLM
+turn whose timing would make the assertions flaky.
+"""
+
+from __future__ import annotations
+
+import httpx
+from playwright.sync_api import Page, expect
+
+_QUEUED_STRIP = '[data-testid="composer-queued-strip"]'
+_WORKING = '[data-testid="working-indicator"]'
+_COMPOSER_PLACEHOLDER_IDLE = "Ask the agent anything…"
+
+_SEND_MSG = "sentinel-bg-send-2a9c sent while a background task runs"
+
+
+def _publish_status(
+    base_url: str,
+    session_id: str,
+    status: str,
+    *,
+    response_id: str | None = None,
+    background_task_count: int | None = None,
+) -> None:
+    """Publish a session status through the native-harness events route.
+
+    :param base_url: Base URL of the local e2e server.
+    :param session_id: Session/conversation id.
+    :param status: Session status to publish, e.g. ``"waiting"``.
+    :param response_id: Ended turn's response id, as the native Stop hook
+        attaches it. ``None`` omits the field.
+    :param background_task_count: Background shells still running as of this
+        edge. ``None`` omits the field (leaves the sticky tally untouched).
+    :returns: None.
+    """
+    data: dict[str, object] = {"status": status}
+    if response_id is not None:
+        data["response_id"] = response_id
+    if background_task_count is not None:
+        data["background_task_count"] = background_task_count
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={"type": "external_session_status", "data": data},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def _user_bubble(page: Page, text: str):
+    """Locator for the user-message bubble carrying ``text``."""
+    return page.locator('[data-testid="message-bubble"][data-role="user"]').filter(has_text=text)
+
+
+def test_message_sends_directly_while_background_task_runs(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A message sends immediately while the session is only ``waiting``.
+
+    Drives the native Stop-hook edge live (``waiting`` + ``response_id`` +
+    a positive ``background_task_count``), then asserts the composer is
+    free to send: the placeholder reads the idle prompt (not the queued
+    follow-up), sending renders the user bubble immediately, and the
+    message never lands in the client-side queued strip.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server
+        fixture.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    composer = page.get_by_label("Message the agent")
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(composer).to_be_visible()
+
+    # The turn ended but a background shell outlives it: the Stop hook posts
+    # `waiting` with the ended turn's response_id and a positive count. The
+    # working indicator stays lit ("1 background task still running").
+    _publish_status(
+        base_url,
+        session_id,
+        "waiting",
+        response_id="resp_bg_1",
+        background_task_count=1,
+    )
+    expect(page.locator(_WORKING)).to_contain_text(
+        "1 background task still running", timeout=15_000
+    )
+
+    # The composer must be free to send — NOT stuck on the queued follow-up
+    # placeholder. This is the exact regression: `waiting`+response_id used
+    # to leave the local send lifecycle "streaming", showing the queued hint.
+    expect(composer).to_have_attribute("placeholder", _COMPOSER_PLACEHOLDER_IDLE, timeout=15_000)
+
+    # Sending must dispatch directly (a fresh turn), not enqueue: the user
+    # bubble renders immediately and nothing appears in the queued strip.
+    composer.fill(_SEND_MSG)
+    page.get_by_role("button", name="Send", exact=True).click()
+    expect(_user_bubble(page, _SEND_MSG)).to_be_visible(timeout=10_000)
+    expect(page.locator(_QUEUED_STRIP)).to_have_count(0)

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1274,14 +1274,20 @@ describe("shouldQueueSend", () => {
     expect(shouldQueueSend(null, "streaming", "running", [])).toBe(false);
   });
 
-  it("queues while the session is busy (streaming or running/waiting)", () => {
+  it("queues while the session is busy (streaming or running)", () => {
     expect(shouldQueueSend("conv_a", "streaming", "idle", [])).toBe(true);
     expect(shouldQueueSend("conv_a", "idle", "running", [])).toBe(true);
-    expect(shouldQueueSend("conv_a", "idle", "waiting", [])).toBe(true);
   });
 
   it("sends directly when idle and nothing is queued for this conversation", () => {
     expect(shouldQueueSend("conv_a", "idle", "idle", [])).toBe(false);
+  });
+
+  it("sends directly on `waiting` (turn ended, only background work remains)", () => {
+    // A background shell / still-running sub-agent keeps the session in
+    // `waiting`, but the server's turn gate is already free — a new message
+    // must start a fresh turn rather than stalling in the client queue.
+    expect(shouldQueueSend("conv_a", "idle", "waiting", [])).toBe(false);
   });
 
   it("queues when idle but this conversation already has a queued message", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -474,6 +474,13 @@ export function shouldShowAuthorBadge(
  * if it reads idle: the direct-send and queue-drain paths aren't ordered, so a
  * later direct send could overtake a still-queued earlier one when status
  * flickers idle mid-queue (cursor-native). A new chat always sends.
+ *
+ * ``waiting`` is NOT busy for queueing: it means the turn already ended and the
+ * agent loop is only parked on background work (background shells / sub-agents)
+ * — the server's turn gate is already free, so a new message starts a fresh
+ * turn immediately instead of stalling behind that background work. (The
+ * "Working…" spinner and sidebar dot still treat ``waiting`` as active — those
+ * reflect background activity, which is a separate concern from send gating.)
  */
 export function shouldQueueSend(
   conversationId: string | null,
@@ -482,8 +489,7 @@ export function shouldQueueSend(
   queuedMessages: QueuedMessage[],
 ): boolean {
   if (conversationId === null) return false;
-  const isBusy =
-    status === "streaming" || sessionStatus === "running" || sessionStatus === "waiting";
+  const isBusy = status === "streaming" || sessionStatus === "running";
   const hasQueued = queuedMessages.some((m) => m.conversationId === conversationId);
   return isBusy || hasQueued;
 }

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2628,6 +2628,9 @@ describe("chatStore — background-shell tally (claude-native)", () => {
     const state = useChatStore.getState();
     expect(state.status).toBe("idle");
     expect(state.sessionStatus).toBe("waiting");
+    // The stale streaming bubble is finalized so it doesn't linger spinning —
+    // no future edge names this id to close it.
+    expect(state.activeResponse?.state).toBe("completed");
   });
 
   it("clears the shell count when a new turn starts (running edge)", () => {

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2582,6 +2582,54 @@ describe("chatStore — background-shell tally (claude-native)", () => {
     expect(state.backgroundTaskCount).toBe(0);
   });
 
+  it("frees the local send lifecycle on a Stop-derived waiting edge (with responseId)", () => {
+    // Regression: the claude/cursor-native Stop hook posts the turn-end
+    // `waiting` edge WITH the ended turn's `response_id`. It must finalize the
+    // local `status` to idle (the turn is done) so the composer sends the next
+    // message instead of queuing it — while `sessionStatus` stays `waiting` and
+    // the shell count sticks, keeping the "Working…" spinner lit.
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      status: "streaming",
+      sessionStatus: "running",
+      backgroundTaskCount: 0,
+      activeResponse: { responseId: "resp_1", state: "streaming", error: null },
+    });
+    handleSessionEvent({
+      type: "session_status",
+      conversationId: "conv_abc",
+      status: "waiting",
+      responseId: "resp_1",
+      backgroundTaskCount: 1,
+    });
+    const state = useChatStore.getState();
+    expect(state.status).toBe("idle");
+    expect(state.activeResponse?.state).toBe("completed");
+    expect(state.sessionStatus).toBe("waiting");
+    expect(state.backgroundTaskCount).toBe(1);
+  });
+
+  it("frees the local send lifecycle on a waiting edge whose id doesn't match", () => {
+    // A `waiting` edge that carries no id (or a stale one) with no tracked
+    // response must still free the send lifecycle so a message isn't stranded.
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      status: "streaming",
+      sessionStatus: "running",
+      backgroundTaskCount: 0,
+      activeResponse: { responseId: "resp_1", state: "streaming", error: null },
+    });
+    handleSessionEvent({
+      type: "session_status",
+      conversationId: "conv_abc",
+      status: "waiting",
+      backgroundTaskCount: 1,
+    });
+    const state = useChatStore.getState();
+    expect(state.status).toBe("idle");
+    expect(state.sessionStatus).toBe("waiting");
+  });
+
   it("clears the shell count when a new turn starts (running edge)", () => {
     // A `running` edge with no count means a fresh turn began; the prior
     // turn's tally is stale and must clear, mirroring the server's
@@ -8335,6 +8383,29 @@ describe("chatStore — client-side message queue", () => {
     expect(sendSpy.mock.calls[1]!.slice(0, 2)).toEqual(["second", "agent_xyz"]);
   });
 
+  // Regression: a background shell / still-running sub-agent keeps the session
+  // in `waiting` after the turn ends, but the server's turn gate is already
+  // free. The flush must NOT treat `waiting` as busy — otherwise a queued
+  // message stays stuck until full idle even though a new turn could start now.
+  it("flushes the head on `waiting` (background work outlives the turn)", async () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      boundAgentId: "agent_xyz",
+      status: "idle",
+      sessionStatus: "waiting",
+      backgroundTaskCount: 1,
+      send: sendSpy,
+      queuedMessages: [{ queueId: "q_1", text: "first", conversationId: "conv_abc" }],
+    });
+
+    useChatStore.getState().maybeFlushQueuedHead();
+    await tick();
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0]!.slice(0, 2)).toEqual(["first", "agent_xyz"]);
+    expect(useChatStore.getState().queuedMessages).toEqual([]);
+  });
+
   it("does not flush a queue owned by a different conversation", () => {
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     useChatStore.setState({
@@ -8420,7 +8491,7 @@ describe("chatStore — client-side message queue", () => {
     expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["b1"]);
   });
 
-  it("does not flush while busy (streaming or running/waiting)", () => {
+  it("does not flush while busy (streaming or running)", () => {
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     const base = {
       conversationId: "conv_abc",
@@ -8434,9 +8505,6 @@ describe("chatStore — client-side message queue", () => {
     useChatStore.getState().maybeFlushQueuedHead();
     // Server-side turn still running.
     useChatStore.setState({ ...base, status: "idle", sessionStatus: "running" });
-    useChatStore.getState().maybeFlushQueuedHead();
-    // Draining background work.
-    useChatStore.setState({ ...base, status: "idle", sessionStatus: "waiting" });
     useChatStore.getState().maybeFlushQueuedHead();
 
     expect(sendSpy).not.toHaveBeenCalled();

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -1017,14 +1017,16 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   maybeFlushQueuedHead: () => {
     const s = get();
-    // Only when fully idle: both the local send lifecycle AND the server-side
-    // session status. No agent → nothing to send to.
+    // Flush once the agent loop is free to take a turn. `waiting` is NOT busy:
+    // the turn already ended and only background work (background shells /
+    // sub-agents) outlives it, so the server accepts a new turn immediately —
+    // mirror `shouldQueueSend`. Only the local send lifecycle (`streaming`) and
+    // an actively `running` turn gate the flush. No agent → nothing to send to.
     if (
       s.conversationId === null ||
       s.boundAgentId === null ||
       s.status === "streaming" ||
-      s.sessionStatus === "running" ||
-      s.sessionStatus === "waiting"
+      s.sessionStatus === "running"
     ) {
       return;
     }
@@ -4209,10 +4211,7 @@ export function handleSessionEvent(event: StreamEvent): void {
         } else if (event.status === "running" || event.status === "failed") {
           patch.backgroundTaskCount = 0;
         }
-        if (
-          event.responseId !== undefined &&
-          (event.status === "running" || event.status === "waiting")
-        ) {
+        if (event.responseId !== undefined && event.status === "running") {
           patch.status = "streaming";
           patch.activeResponse = {
             responseId: event.responseId,
@@ -4220,7 +4219,17 @@ export function handleSessionEvent(event: StreamEvent): void {
             error: null,
           };
         }
-        if (event.status === "idle" || event.status === "failed") {
+        // `waiting` is a TURN-END edge (the turn already finished; only
+        // background work — background shells / sub-agents — outlives it). It
+        // must finalize the local send lifecycle exactly like `idle`, NOT keep
+        // it "streaming": the composer's send gate and "(queued)" placeholder
+        // key off local `status`, so leaving it streaming would queue every new
+        // message until the background work ends. The claude/cursor-native Stop
+        // hook posts `waiting` WITH the ended turn's `response_id`, so it lands
+        // here rather than via a bare PTY `idle`. `sessionStatus` stays
+        // `waiting` (set above) and `backgroundTaskCount` is untouched, so the
+        // "Working…" spinner and sidebar dot keep reflecting the background work.
+        if (event.status === "idle" || event.status === "failed" || event.status === "waiting") {
           if (event.responseId !== undefined && s.activeResponse?.responseId === event.responseId) {
             patch.status = "idle";
             if (s.activeResponse.state !== "cancelled") {
@@ -4231,6 +4240,11 @@ export function handleSessionEvent(event: StreamEvent): void {
               };
             }
           } else if (s.activeResponse === null) {
+            patch.status = "idle";
+          } else if (event.status === "waiting") {
+            // Turn ended (background work remains) but the `waiting` edge's id
+            // doesn't match the tracked response — free the send lifecycle
+            // anyway so a new message isn't stranded behind background work.
             patch.status = "idle";
           }
           // Clear ALL pending user messages on terminal status. Any

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -2689,6 +2689,14 @@ function reconnectStatusPatch(session: Session, s: ChatState): Partial<ChatState
   if (session.lastTotalTokens != null) patch.tokensUsed = session.lastTotalTokens;
   if (session.totalCostUsd != null) patch.sessionCostUsd = session.totalCostUsd;
   if (session.usageByModel != null) patch.sessionUsageByModel = session.usageByModel;
+  // `waiting` is a TURN-END snapshot (the turn finished; only background work
+  // outlives it), so it settles the local send lifecycle like `idle` — it must
+  // NOT reopen a streaming response. The server keeps `active_response_id`
+  // populated across `waiting` (it only pops on idle/failed), so grouping
+  // `waiting` with `running` below would re-open "streaming" on a reload/
+  // reconnect and strand the composer on the "(queued)" placeholder — re-queuing
+  // sends, the exact behavior this fix removes. `sessionStatus` stays `waiting`
+  // and `backgroundTaskCount` is recovered above, so the spinner survives.
   if (
     (session.status === "idle" || session.status === "failed") &&
     s.activeResponse?.state === "streaming"
@@ -2699,8 +2707,15 @@ function reconnectStatusPatch(session: Session, s: ChatState): Partial<ChatState
       error: null,
     };
     patch.status = "idle";
+  } else if (session.status === "waiting") {
+    // Turn ended, background work remains. Finalize a still-streaming response
+    // and free the local send lifecycle so the composer dispatches a new turn.
+    if (s.activeResponse?.state === "streaming") {
+      patch.activeResponse = { ...s.activeResponse, state: "completed", error: null };
+    }
+    patch.status = "idle";
   } else if (
-    (session.status === "running" || session.status === "waiting") &&
+    session.status === "running" &&
     session.activeResponseId != null &&
     s.activeResponse?.responseId !== session.activeResponseId
   ) {
@@ -4244,8 +4259,13 @@ export function handleSessionEvent(event: StreamEvent): void {
           } else if (event.status === "waiting") {
             // Turn ended (background work remains) but the `waiting` edge's id
             // doesn't match the tracked response — free the send lifecycle
-            // anyway so a new message isn't stranded behind background work.
+            // anyway so a new message isn't stranded behind background work,
+            // and finalize a still-streaming bubble so it doesn't linger with a
+            // spinner that no edge will ever close.
             patch.status = "idle";
+            if (s.activeResponse?.state === "streaming") {
+              patch.activeResponse = { ...s.activeResponse, state: "completed", error: null };
+            }
           }
           // Clear ALL pending user messages on terminal status. Any
           // message still pending when the session reaches idle was


### PR DESCRIPTION
## Related issue

N/A

## Summary

A session with a running background job (a background shell or a still-running
sub-agent) settles into the `waiting` status — the turn has already ended and
the server's turn gate is free to accept a new turn. But the frontend treated
`waiting` as *busy* and queued every new message client-side until the session
went fully idle, so users couldn't send anything while background work ran.

Two independent gates caused this:

- `shouldQueueSend` / `maybeFlushQueuedHead` treated `sessionStatus === "waiting"`
  as busy → sends queued and the queue wouldn't drain.
- The `session_status` handler grouped a `waiting` edge carrying a `response_id`
  (which the claude/cursor-native Stop hook always posts) with `running`, forcing
  local `status = "streaming"`, which never cleared while background work ran.
  The composer's "(queued)" placeholder and the send gate both key off local
  `status`, so this alone kept messages queued on native sessions.

The fix treats `waiting` as a **turn-end** edge everywhere it gates sends: drop
it from the busy checks and finalize the local send lifecycle like `idle`, while
keeping `sessionStatus = "waiting"` and `backgroundTaskCount` so the "Working…"
spinner and sidebar dot still reflect the background activity. A new message now
starts a fresh turn immediately, matching what the server already accepts.

**Scope:** this only affects sessions with background work running — a turn that
ends with no background work still settles on `idle` and behaves exactly as
before. Sending mid-turn (`running`) still queues.

## Test Plan

- `cd web && npm test` — full suite green (4240 passed).
- `cd web && npm run build` — clean.
- Added regression tests:
  - `shouldQueueSend` sends directly on `waiting`.
  - `maybeFlushQueuedHead` flushes the head on `waiting` with a background task.
  - `session_status` handler frees the local send lifecycle on a Stop-derived
    `waiting` edge (with and without a matching `responseId`).
- Manual: open a claude-native session, start a background task (e.g. a shell
  echoing every 10s). Once it settles to "1 background task still running", type
  a message — it now sends immediately instead of landing in the queued strip;
  the background spinner stays lit. Sending mid-turn still queues.

## Demo

N/A — behavioural fix; the composer placeholder reverts from "Send a follow-up
(queued)" to "Ask the agent anything…" while a background task runs.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added unit tests for both gates (`shouldQueueSend`, `maybeFlushQueuedHead`) and
the `session_status` handler's `waiting`-edge lifecycle. Manually verified on a
live claude-native session that a message sends immediately while a background
task runs and still queues mid-turn.

## Changelog

Messages send immediately when a session's only remaining work is a background job, instead of being held in the queue until it finishes

This pull request and its description were written by Isaac.