### PR TITLE
feat(electron): shell-owned desktop update overlay + banner-safe web bridge

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -3,9 +3,12 @@ name: Electron Build
 # Manually-triggered build of the Electron desktop shell (web/electron) for
 # Linux and Windows. Each platform packages on its own native runner —
 # electron-builder does not reliably cross-compile installers — and uploads the
-# installers as downloadable workflow artifacts. Unsigned: no signing creds are
+# installers PLUS the electron-updater feed manifests (latest-linux.yml /
+# latest.yml) as downloadable workflow artifacts. Unsigned: no signing creds are
 # wired here, so `CSC_IDENTITY_AUTO_DISCOVERY=false` forces an unsigned build
-# rather than failing when a cert is absent. No publishing / release upload.
+# rather than failing when a cert is absent. No publishing to a provider / no
+# release upload (`--publish never`): the artifacts are captured here for manual
+# placement onto the omnigent.ai update feed (omnigent-site repo + artifact host).
 #
 # Run it from the Actions tab (Run workflow). macOS is intentionally omitted —
 # its signed/notarized build lives elsewhere.
@@ -75,6 +78,15 @@ jobs:
         working-directory: web/electron
         run: npm ci --no-audit --no-fund
 
+      # The shell-owned update overlay reuses the web UpdateBanner component; it
+      # is built from the web app into electron/overlay/ (gitignored) and shipped
+      # by electron-builder (build.files). The build:<platform> scripts run it
+      # automatically via their `prebuild:*` hook (see web/electron/package.json)
+      # — this step only needs to install the web app's deps so that hook works.
+      - name: Install web deps (for the update overlay build)
+        working-directory: web
+        run: npm ci --no-audit --no-fund
+
       - name: Build ${{ matrix.platform }} app
         working-directory: web/electron
         env:
@@ -86,34 +98,43 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: npm run ${{ matrix.build-script }} -- --publish never
 
-      # Each distributable gets its own artifact so consumers can download just
-      # the AppImage or just the .deb without pulling down everything else.
-      # Ship only the distributables, not electron-builder's unpacked
-      # intermediates (dist/linux-unpacked, dist/win-unpacked, blockmaps).
+      # One artifact per platform bundling the COMPLETE electron-updater feed —
+      # the installer(s), the .blockmap electron-updater needs for differential
+      # downloads (referenced by path inside latest*.yml; the .deb has no
+      # blockmap since debs aren't differentially updated), and the feed
+      # manifest (latest-linux.yml / latest.yml). upload-artifact zips all
+      # matched files into a single download, so each platform yields one zip
+      # whose contents can be dropped straight onto a feed root (local HTTP
+      # server for testing, or public/_desktop/updates/ on the artifact host).
+      # Ship only the distributables + feed files, not electron-builder's
+      # unpacked intermediates (dist/*-unpacked).
+      #
+      # electron-builder writes the latest*.yml manifests to dist/ even under
+      # --publish never (a publish config exists in build.*.publish, so
+      # update-info generation runs; --publish only skips the provider upload).
+      # The manifest lists each artifact with sha512 + size + relative url.
 
-      - name: Upload Linux AppImage
+      - name: Upload Linux feed
         if: matrix.platform == 'linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: omnigent-desktop-linux-appimage
-          path: web/electron/dist/*.AppImage
+          name: omnigent-desktop-linux
+          path: |
+            web/electron/dist/*.AppImage
+            web/electron/dist/*.AppImage.blockmap
+            web/electron/dist/*.deb
+            web/electron/dist/latest-linux.yml
           if-no-files-found: error
           retention-days: 14
 
-      - name: Upload Linux deb
-        if: matrix.platform == 'linux'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: omnigent-desktop-linux-deb
-          path: web/electron/dist/*.deb
-          if-no-files-found: error
-          retention-days: 14
-
-      - name: Upload Windows installer
+      - name: Upload Windows feed
         if: matrix.platform == 'win'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: omnigent-desktop-win
-          path: web/electron/dist/*.exe
+          path: |
+            web/electron/dist/*.exe
+            web/electron/dist/*.exe.blockmap
+            web/electron/dist/latest.yml
           if-no-files-found: error
           retention-days: 14

--- a/tests/e2e_ui/desktop/test_desktop_update.py
+++ b/tests/e2e_ui/desktop/test_desktop_update.py
@@ -1,32 +1,23 @@
-"""E2E: the desktop auto-update UI (``UpdateBanner`` + Settings → Updates).
+"""E2E: the desktop auto-update Settings surface.
 
-Auto-update is desktop-only. ``AppShell`` renders ``UpdateBanner`` above the
-routed ``Outlet`` only when ``isElectronShell()`` is true, and the banner itself
-only paints when the Electron preload exposes an update bridge
-(``window.omnigentDesktop.updates`` — see ``web/src/lib/nativeBridge.ts`` and
-``web/src/components/UpdateBanner.tsx``). The Settings → Updates section is
-gated the same way (``web/src/pages/SettingsPage.tsx``).
+Desktop update *notifications* are shell-owned (a native corner overlay the
+Electron shell renders in its own child window -- see
+``web/electron/src/update_overlay.js`` + ``web/src/update-overlay.tsx``), so
+they show regardless of the connected server's web-bundle version. The in-page
+``UpdateBanner`` is no longer mounted by ``AppShell``; the server-page preload
+is "banner-safe" (collapses available/downloaded/error-security to ``idle`` in
+``preload.js``) so no web bundle -- including older ones -- can show a duplicate.
 
-The e2e_ui harness runs the SPA in a plain Chromium browser, not Electron, so
-by default the bridge is absent and neither surface shows. To exercise the
-desktop path end to end we inject a scriptable ``window.omnigentDesktop`` stub —
-including a full ``updates`` bridge — via ``add_init_script`` *before any app
-script runs*, the same feature-detection stubbing ``browser/test_browser_tab.py``
-uses for the embedded browser. The stub records every bridge call and captures
-the live ``onStatus`` subscriber so the test can stream update-lifecycle
-statuses from Python (``window.__omniUpdate.emit(...)``), modelling the main
-process without a real electron-updater server.
-
-Interaction note: ``UpdateBanner`` mounts as the first child of ``<main>``,
-directly under the shell's ``ChatHeader`` — a full-width ``absolute top-0``
-transparent bar (no ``pointer-events: none``) that overlays the banner's band.
-A coordinate-based Playwright click on a banner button is therefore intercepted
-by that header. The banner's *rendering* across the status lifecycle is asserted
-by streaming statuses (no clicks); each action button's *handler→bridge wiring*
-is exercised with a direct ``dispatch_event("click")`` that fires the real React
-``onClick`` regardless of the floating overlay, asserting both the recorded
-bridge call and the resulting visible state change. The Settings → Updates
-controls sit well below the header band and are driven with real clicks.
+What remains in the server-rendered SPA is the Settings -> Updates section
+(``web/src/pages/SettingsPage.tsx``), which still reads/writes update
+preferences (mode, auto-install) and triggers a check over the bridge. The e2e_ui
+harness runs the SPA in a plain Chromium browser, not Electron, so we inject a
+scriptable ``window.omnigentDesktop`` stub -- including a full ``updates`` bridge
+-- via ``add_init_script`` *before any app script runs* to exercise that surface.
+The stub records every bridge call and captures the live ``onStatus`` subscriber
+so the test can stream update-lifecycle statuses from Python
+(``window.__omniUpdate.emit(...)``), modelling the main process without a real
+electron-updater server.
 
 No LLM turn is involved; the assertions are DOM- and bridge-call-based.
 """
@@ -40,11 +31,11 @@ from playwright.sync_api import Page, expect
 # detection (``isElectronShell()`` / ``updateBridge()`` in nativeBridge.ts) sees
 # a desktop shell with an update bridge. The base native methods are guarded
 # no-ops (badge/notify) so unrelated native calls don't throw under the stub;
-# the ``updates`` object is the auto-update bridge the banner + Settings drive.
+# the ``updates`` object is the auto-update bridge Settings drives.
 #
 # Every bridge call is recorded on ``window.__omniUpdate.calls`` and the live
 # ``onStatus`` subscriber is captured so the test can push new statuses via
-# ``window.__omniUpdate.emit(...)`` — modelling the main process streaming
+# ``window.__omniUpdate.emit(...)`` -- modelling the main process streaming
 # update lifecycle events without a real update server. ``getStatus`` seeds the
 # initial state each test passes in.
 _UPDATE_SHELL_INIT_SCRIPT = """
@@ -81,7 +72,7 @@ _UPDATE_SHELL_INIT_SCRIPT = """
 """
 
 # Default desktop update config the bridge reports: periodic checks, install on
-# quit, nothing skipped — the shape ``UpdateConfig`` in nativeBridge.ts expects.
+# quit, nothing skipped -- the shape ``UpdateConfig`` in nativeBridge.ts expects.
 _DEFAULT_CONFIG = '{ mode: "default", autoInstall: true, skippedVersion: null }'
 
 
@@ -102,140 +93,11 @@ def _bridge_calls(page: Page) -> list[str]:
     return page.evaluate("() => window.__omniUpdate.calls")
 
 
-def _emit_status(page: Page, status: str) -> None:
-    """Stream a new ``UpdateStatus`` to the banner via the captured subscriber.
-
-    :param status: JS object literal for the next status, e.g.
-        ``'{ state: "downloading", progress: { percent: 42 } }'``.
-    """
-    page.evaluate(f"() => window.__omniUpdate.emit({status})")
-
-
-def test_update_banner_renders_across_the_status_lifecycle(
-    page: Page,
-    seeded_session: tuple[str, str],
-) -> None:
-    """The banner mounts in the desktop shell and tracks the live status stream.
-
-    Proves the desktop-only chain the component test can't reach end to end:
-    injected bridge → ``isElectronShell()`` gate in ``AppShell`` → banner mount →
-    initial ``getStatus`` + live ``onStatus`` subscription driving per-state copy
-    and controls. Streams available → downloading → downloaded and asserts each
-    state's visible rendering (no clicks; see the module docstring).
-    """
-    base_url, session_id = seeded_session
-
-    _install_update_stub(
-        page,
-        '{ state: "available", info: { version: "9.9.9", releaseNotes: "Fixes and polish." } }',
-    )
-    page.goto(f"{base_url}/c/{session_id}")
-    expect(page.get_by_placeholder("Ask the agent anything…")).to_be_visible()
-
-    banner = page.get_by_role("region", name="Desktop update")
-
-    # Available: version copy + the three offered actions + release notes.
-    expect(banner).to_be_visible()
-    expect(banner).to_contain_text("Omnigent 9.9.9 is available.")
-    expect(banner.get_by_role("button", name="Update now")).to_be_visible()
-    expect(banner.get_by_role("button", name="Later")).to_be_visible()
-    expect(banner.get_by_role("button", name="Skip this version")).to_be_visible()
-    expect(banner.get_by_text("Release notes")).to_be_visible()
-
-    # Downloading: progress copy + progress bar; the action buttons are gone.
-    _emit_status(
-        page,
-        '{ state: "downloading", info: { version: "9.9.9" }, progress: { percent: 42 } }',
-    )
-    expect(banner).to_contain_text("Downloading Omnigent update… 42%")
-    expect(banner.get_by_role("progressbar")).to_be_visible()
-    expect(banner.get_by_role("button", name="Update now")).to_have_count(0)
-
-    # Downloaded: ready-to-install copy + the restart action.
-    _emit_status(page, '{ state: "downloaded", info: { version: "9.9.9" } }')
-    expect(banner).to_contain_text("Omnigent 9.9.9 is ready to install.")
-    expect(banner.get_by_role("button", name="Restart to update")).to_be_visible()
-
-
-def test_update_banner_actions_call_the_bridge(
-    page: Page,
-    seeded_session: tuple[str, str],
-) -> None:
-    """The banner's action buttons invoke the matching bridge calls.
-
-    Covers the available-update *action* flow: ``Update now`` → ``download()``,
-    then (after the main process streams ``downloaded``) ``Restart to update`` →
-    ``installNow()``. The buttons' handler→bridge wiring is exercised with a
-    direct click-event dispatch because the shell's transparent ``ChatHeader``
-    overlays the banner's band (see the module docstring); the resulting visible
-    state change is asserted alongside each bridge call.
-    """
-    base_url, session_id = seeded_session
-
-    _install_update_stub(
-        page,
-        '{ state: "available", info: { version: "9.9.9" } }',
-    )
-    page.goto(f"{base_url}/c/{session_id}")
-    expect(page.get_by_placeholder("Ask the agent anything…")).to_be_visible()
-
-    banner = page.get_by_role("region", name="Desktop update")
-    expect(banner).to_contain_text("Omnigent 9.9.9 is available.")
-
-    # Update now → the bridge is asked to download.
-    banner.get_by_role("button", name="Update now").dispatch_event("click")
-    page.wait_for_function("() => window.__omniUpdate.calls.includes('download')")
-    assert "download" in _bridge_calls(page)
-
-    # The main process streams the finished download; the banner swaps to the
-    # ready-to-install state (the same onStatus channel the real shell uses).
-    _emit_status(page, '{ state: "downloaded", info: { version: "9.9.9" } }')
-    restart = banner.get_by_role("button", name="Restart to update")
-    expect(restart).to_be_visible()
-
-    # Restart to update → the bridge is asked to install now.
-    restart.dispatch_event("click")
-    page.wait_for_function("() => window.__omniUpdate.calls.includes('installNow')")
-    assert "installNow" in _bridge_calls(page)
-
-
-def test_update_banner_skip_persists_and_hides(
-    page: Page,
-    seeded_session: tuple[str, str],
-) -> None:
-    """``Skip this version`` persists the skip via the bridge and hides the banner.
-
-    The banner is a standing surface, so a user must be able to dismiss a
-    version for good. Activating ``Skip this version`` calls
-    ``setConfig({ skippedVersion })`` and, once persisted, the banner stops
-    rendering that version. (Dispatch-click for the same overlay reason.)
-    """
-    base_url, session_id = seeded_session
-
-    _install_update_stub(
-        page,
-        '{ state: "available", info: { version: "9.9.9" } }',
-    )
-    page.goto(f"{base_url}/c/{session_id}")
-    expect(page.get_by_placeholder("Ask the agent anything…")).to_be_visible()
-
-    banner = page.get_by_role("region", name="Desktop update")
-    expect(banner).to_contain_text("Omnigent 9.9.9 is available.")
-
-    banner.get_by_role("button", name="Skip this version").dispatch_event("click")
-
-    # The skip is persisted through the bridge with the offered version…
-    page.wait_for_function("() => window.__omniUpdate.calls.some(c => c.startsWith('setConfig:'))")
-    assert 'setConfig:{"skippedVersion":"9.9.9"}' in _bridge_calls(page)
-    # …and the banner for that version is gone.
-    expect(page.get_by_role("region", name="Desktop update")).to_have_count(0)
-
-
 def test_settings_updates_section_check_and_mode(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Settings → Updates exposes the mode selector and a working Check button.
+    """Settings -> Updates exposes the mode selector and a working Check button.
 
     The desktop-only Updates section (``UpdatesSection`` in SettingsPage.tsx)
     reads the config from the bridge and lets the user trigger a check. Its
@@ -260,20 +122,4 @@ def test_settings_updates_section_check_and_mode(
     assert "check" in _bridge_calls(page)
 
 
-def test_no_update_banner_in_plain_browser(
-    page: Page,
-    seeded_session: tuple[str, str],
-) -> None:
-    """A plain browser tab (no Electron bridge) never shows the update banner.
 
-    Without the ``window.omnigentDesktop`` stub, ``isElectronShell()`` is false,
-    so ``AppShell`` skips the banner entirely — the gate that keeps the desktop
-    updater UI off the plain web app (which has no updater to drive). This is
-    the half of the contract only an end-to-end browser run can prove.
-    """
-    base_url, session_id = seeded_session
-
-    page.goto(f"{base_url}/c/{session_id}")
-    expect(page.get_by_placeholder("Ask the agent anything…")).to_be_visible()
-
-    expect(page.get_by_role("region", name="Desktop update")).to_have_count(0)

--- a/web/electron/.gitignore
+++ b/web/electron/.gitignore
@@ -3,3 +3,7 @@ dist/
 # The root .gitignore ignores every build/ dir, but this one holds
 # checked-in electron-builder resources (entitlements), not build output.
 !build/
+
+# Built desktop update overlay island (produced by web's build:overlay,
+# shipped into the app by electron-builder). Generated, not committed.
+overlay/

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -22,7 +22,15 @@
     "build:mac": "electron-builder --mac",
     "build:mac:release": "electron-builder --mac -c.mac.notarize=true",
     "build:linux": "electron-builder --linux",
-    "build:win": "electron-builder --win"
+    "build:win": "electron-builder --win",
+    "build:overlay": "npm --prefix ../ run build:overlay",
+    "predev": "npm run build:overlay",
+    "prestart": "npm run build:overlay",
+    "prebuild": "npm run build:overlay",
+    "prebuild:mac": "npm run build:overlay",
+    "prebuild:mac:release": "npm run build:overlay",
+    "prebuild:linux": "npm run build:overlay",
+    "prebuild:win": "npm run build:overlay"
   },
   "devDependencies": {
     "electron": "^42.3.2",
@@ -44,9 +52,8 @@
     ],
     "publish": [
       {
-        "provider": "github",
-        "owner": "omnigent-ai",
-        "repo": "omnigent"
+        "provider": "generic",
+        "url": "https://omnigent.ai/_desktop/updates/"
       }
     ],
     "afterPack": "build/afterPack.js",
@@ -54,7 +61,8 @@
       "src/**/*",
       "setup/**/*",
       "find/**/*",
-      "icons/**/*"
+      "icons/**/*",
+      "overlay/**/*"
     ],
     "extraResources": [
       {
@@ -86,7 +94,7 @@
       "publish": [
         {
           "provider": "generic",
-          "url": "https://diksk5m140cfbma7.public.blob.vercel-storage.com/mac/"
+          "url": "https://omnigent.ai/_desktop/updates/"
         }
       ]
     },
@@ -122,7 +130,7 @@
       "publish": [
         {
           "provider": "generic",
-          "url": "https://diksk5m140cfbma7.public.blob.vercel-storage.com/linux/"
+          "url": "https://omnigent.ai/_desktop/updates/"
         }
       ]
     },
@@ -134,7 +142,7 @@
       "publish": [
         {
           "provider": "generic",
-          "url": "https://diksk5m140cfbma7.public.blob.vercel-storage.com/win/"
+          "url": "https://omnigent.ai/_desktop/updates/"
         }
       ]
     }

--- a/web/electron/src/desktop_updater.js
+++ b/web/electron/src/desktop_updater.js
@@ -11,8 +11,10 @@
 //
 // Design notes preserved from the original inline implementation:
 //   - Updates are gated on a usable feed: a packaged build, or a dev build with
-//     `OMNIGENT_FORCE_DEV_UPDATE_CONFIG=1` (surfaced here as `forceDevUpdateConfig`).
-//     Manual actions in an unusable feed reject with a friendly dev message.
+//     `forceDevUpdateConfig` set (main.js derives it from !app.isPackaged, so
+//     dev always uses dev-app-update.yml and a packaged build can never be
+//     redirected to it). Manual actions in an unusable feed reject with a
+//     friendly dev message.
 //   - `autoDownload` is always off; downloads and installs are explicit and
 //     each privileged IPC action re-confirms with a native dialog (a cached
 //     hosting grant must not silently authorize an update action).
@@ -79,7 +81,7 @@ function isUpdateSecurityError(message) {
  *   The origin a window is pinned to (used for the consent dialog copy).
  * @param {string} deps.iconPath Absolute path to the app icon PNG.
  * @param {boolean} [deps.forceDevUpdateConfig] Force the dev feed on in an
- *   unpackaged build (from `OMNIGENT_FORCE_DEV_UPDATE_CONFIG=1`).
+ *   unpackaged build (main.js sets this from !app.isPackaged).
  * @returns {{
  *   getConfig: () => { mode: string, autoInstall: boolean, skippedVersion: string | null },
  *   setConfig: (patch?: object) => { mode: string, autoInstall: boolean, skippedVersion: string | null },
@@ -252,6 +254,21 @@ function createDesktopUpdater({
   }
 
   /**
+   * Start downloading the available update. Feed-gated like the other actions.
+   * Used by the trusted shell update overlay (the server-page IPC calls
+   * `autoUpdater.downloadUpdate()` inline behind its own consent dialog).
+   *
+   * @returns {Promise<void>}
+   */
+  function downloadUpdate() {
+    if (!canUseFeed()) {
+      reportUnavailableInDev();
+      return Promise.reject(unavailableInDevError());
+    }
+    return autoUpdater.downloadUpdate().then(() => undefined);
+  }
+
+  /**
    * Native, per-action consent for a privileged update control. The IPC gate
    * only proves the call came FROM the pinned server's page — not that the USER
    * asked for it — so download/install/config changes re-confirm here. Returns
@@ -396,6 +413,7 @@ function createDesktopUpdater({
     getStatus,
     init,
     checkForUpdates,
+    downloadUpdate,
     installUpdateNow,
     registerIpc,
     quitAndInstallIfPending,

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -23,6 +23,7 @@ const {
   dialog,
   ipcMain,
   nativeImage,
+  nativeTheme,
   screen,
   session,
   shell,
@@ -30,6 +31,7 @@ const {
 } = require("electron");
 const { autoUpdater } = require("electron-updater");
 const { createDesktopUpdater } = require("./desktop_updater");
+const { createUpdateOverlay } = require("./update_overlay");
 const fs = require("node:fs");
 const path = require("node:path");
 const { pathToFileURL } = require("node:url");
@@ -54,6 +56,10 @@ const SETUP_PAGE_URL = pathToFileURL(SETUP_PAGE);
 
 /** Absolute path to the bundled find-in-page bar page. */
 const FIND_PAGE = path.join(__dirname, "..", "find", "index.html");
+// Built by web's `build:overlay` into electron/overlay/ (shipped by
+// electron-builder). Shell-owned so the update UI is independent of the
+// connected server's web-bundle version.
+const UPDATE_OVERLAY_PAGE = path.join(__dirname, "..", "overlay", "update-overlay.html");
 
 /** The find bar's file:// URL, for verifying IPC sender frames. */
 const FIND_PAGE_URL = pathToFileURL(FIND_PAGE);
@@ -623,7 +629,24 @@ const updater = createDesktopUpdater({
   isPinnedOriginSender,
   pinnedOrigin,
   iconPath: ICON_PNG,
-  forceDevUpdateConfig: process.env.OMNIGENT_FORCE_DEV_UPDATE_CONFIG === "1",
+  // Dev builds always use the local dev feed (dev-app-update.yml ->
+  // 127.0.0.1:8765); packaged builds always use the baked app-update.yml.
+  // Tying this to !app.isPackaged — not an env var — closes a redirect attack:
+  // an OMNIGENT_FORCE_DEV_UPDATE_CONFIG-style env var could otherwise point a
+  // packaged (production) app at an untrusted HTTP local feed and push a
+  // malicious update. A packaged build can never be redirected to the dev feed.
+  forceDevUpdateConfig: !app.isPackaged,
+});
+
+// Shell-owned update toast: renders the reused web UpdateBanner in a transparent
+// corner window so it shows even against servers running old omnigent web.
+const updateOverlay = createUpdateOverlay({
+  BrowserWindow,
+  ipcMain,
+  nativeTheme,
+  updater,
+  overlayPage: UPDATE_OVERLAY_PAGE,
+  preloadPath: path.join(__dirname, "update_overlay_preload.js"),
 });
 
 // ---------------------------------------------------------------------------
@@ -1019,6 +1042,7 @@ function createWindow(targetUrl, opts = {}) {
   // treated as "no server configured" rather than crashing window creation.
   const destinationOrigin = serverUrl ? originOf(serverUrl) : null;
   const destination = destinationOrigin ? loadUrl : null;
+  updateOverlay.ensureOverlay(win);
   windows.set(win, {
     // Pin to the destination's origin up front; setup-page windows stay
     // unpinned (null) until the user connects them.
@@ -1696,8 +1720,8 @@ function buildMenu() {
     {
       id: "new_window",
       label: "New Window",
-      // Standard new-window accelerator; the role-based File menu below
-      // doesn't include one, so we own it here.
+      // Own the standard new-window accelerator here — there is no
+      // role-based File menu in this app.
       accelerator: "CmdOrCtrl+N",
       click: () => newWindow(),
     },
@@ -1714,6 +1738,68 @@ function buildMenu() {
       label: "Change Server…",
       click: () => changeServer(),
     },
+    { type: "separator" },
+    // Manual update check, surfaced as a production item here so shipped
+    // .app users can trigger it from the menubar. Download/install still
+    // flows through the in-app Settings UI / UpdateBanner (and the native
+    // consent dialog when driven from a server page).
+    {
+      id: "check_for_updates",
+      label: "Check for Updates…",
+      click: async () => {
+        // Surface the two silent outcomes of a manual menubar check with a
+        // native dialog: "no update" (otherwise only the renderer banner
+        // hears it, which the user may not be looking at) and "check failed"
+        // (the promise rejects and was previously swallowed). An available
+        // update is left to the in-app UpdateBanner to avoid a double notify.
+        try {
+          await updater.checkForUpdates({ manual: true });
+          const status = updater.getStatus();
+          if (status.state === "none") {
+            await dialog.showMessageBox(activeWindow(), {
+              type: "info",
+              title: "Omnigent",
+              message: "You're up to date!",
+              detail: `Omnigent ${app.getVersion()} is the latest version.`,
+              buttons: ["OK"],
+            });
+          }
+        } catch (err) {
+          await dialog.showMessageBox(activeWindow(), {
+            type: "warning",
+            title: "Omnigent",
+            message: "Couldn't check for updates",
+            detail: String(err?.message ?? err),
+            buttons: ["OK"],
+          });
+        }
+      },
+    },
+    {
+      id: "restart_to_update",
+      label: "Restart to Update",
+      click: async () => {
+        // Production install path: the UpdateBanner toast is dismissible (and
+        // a user may have closed it), so the menubar must still offer a way to
+        // install a downloaded update. installUpdateNow() quits the app to
+        // hand off to the installer; it returns false when nothing is ready
+        // (e.g. the toast was for an update since skipped or not downloaded),
+        // which we surface with a native dialog instead of silently no-op'ing.
+        if (!updater.installUpdateNow()) {
+          await dialog.showMessageBox(activeWindow(), {
+            type: "info",
+            title: "Omnigent",
+            message: "No update is ready to install",
+            detail: "Check for updates first, then download the new version.",
+            buttons: ["OK"],
+          });
+        }
+      },
+    },
+    { type: "separator" },
+    // `role: "close"` carries the standard CmdOrCtrl+W shortcut and closes
+    // the focused window. There is no File menu, so Close lives under Server.
+    { role: "close", label: "Close Window" },
   ];
 
   // Our custom Server menu, inserted right after the leftmost menu — index 1
@@ -1723,68 +1809,6 @@ function buildMenu() {
     submenu: serverSubmenu,
   });
 
-  template.push({
-    label: "Updates",
-    submenu: [
-      {
-        id: "check_for_updates",
-        label: "Check for Updates…",
-        click: () => {
-          updater.checkForUpdates({ manual: true }).catch(() => {});
-        },
-      },
-      {
-        id: "restart_to_update",
-        label: "Restart to Update",
-        click: () => {
-          if (updater.getStatus().state === "downloaded") updater.installUpdateNow();
-        },
-      },
-    ],
-  });
-
-  // Notifications menu (macOS only — sound playback uses `afplay`): an on/off
-  // switch for the notification sound plus a picker of macOS system sounds.
-  // Selections persist in settings.json and are read live by the notify
-  // handler, so a change applies to the next notification without a relaunch.
-  if (isMac) {
-    /** @type {Electron.MenuItemConstructorOptions[]} */
-    const soundChoices = systemSoundNames().map((name) => ({
-      id: `notification_sound_${name}`,
-      label: name,
-      type: "radio",
-      checked: currentNotificationSoundName() === name,
-      click: () => {
-        const settings = loadSettings();
-        settings.notification_sound_name = name;
-        saveSettings(settings);
-        // Pick-to-preview: play the choice immediately so the user hears it,
-        // even when the sound is currently toggled off.
-        playSystemSound(name);
-      },
-    }));
-    template.push({
-      label: "Notifications",
-      submenu: [
-        {
-          id: "notification_sound_enabled",
-          label: "Play Notification Sound",
-          type: "checkbox",
-          checked: notificationSoundEnabled(),
-          click: (item) => {
-            const settings = loadSettings();
-            settings.notification_sound_enabled = item.checked;
-            saveSettings(settings);
-          },
-        },
-        { type: "separator" },
-        { label: "Sound", submenu: soundChoices },
-      ],
-    });
-  }
-
-  // Standard roles — these carry the predefined keyboard shortcuts.
-  template.push({ role: "fileMenu" });
   // The Edit roles (Undo/Redo/Cut/Copy/Paste/Select All) carry the platform
   // text-editing shortcuts; hand-rolled here instead of `role: "editMenu"`
   // only so Find… can live where users expect it.
@@ -1812,14 +1836,13 @@ function buildMenu() {
       },
     ],
   });
-  // Same items as `role: "viewMenu"`, hand-rolled so Toggle Developer
-  // Tools (and its accelerator) can be dropped from release builds.
+  // Standard View roles (Reload/zoom/fullscreen). Developer Tools lives in
+  // the Debug menu (dev only), so this menu is identical in dev and release.
   template.push({
     label: "View",
     submenu: [
       { role: "reload" },
       { role: "forceReload" },
-      ...(app.isPackaged ? [] : [{ role: "toggleDevTools" }]),
       { type: "separator" },
       { role: "resetZoom" },
       { role: "zoomIn" },
@@ -1829,6 +1852,59 @@ function buildMenu() {
     ],
   });
   template.push({ role: "windowMenu" });
+
+  // Debug menu (dev only, !app.isPackaged): consolidates every debug-only /
+  // non-production affordance behind a single top-level menu — the macOS
+  // notification-sound settings (sound playback uses `afplay`, so macOS-only)
+  // and the developer tools. Restart-to-update now lives in the production
+  // Server menu (it's a needed install path, not a debug affordance, once the
+  // UpdateBanner toast is dismissible). Hidden in the shipped .app. Placed
+  // last so it never displaces the standard menus users expect.
+  if (!app.isPackaged) {
+    /** @type {Electron.MenuItemConstructorOptions[]} */
+    const debugSubmenu = [];
+
+    // macOS notification-sound settings: an on/off switch plus a picker of
+    // system sounds. Selections persist in settings.json and are read live by
+    // the notify handler, so a change applies to the next notification without
+    // a relaunch. macOS-only because playback uses `afplay`.
+    if (isMac) {
+      /** @type {Electron.MenuItemConstructorOptions[]} */
+      const soundChoices = systemSoundNames().map((name) => ({
+        id: `notification_sound_${name}`,
+        label: name,
+        type: "radio",
+        checked: currentNotificationSoundName() === name,
+        click: () => {
+          const settings = loadSettings();
+          settings.notification_sound_name = name;
+          saveSettings(settings);
+          // Pick-to-preview: play the choice immediately so the user hears it,
+          // even when the sound is currently toggled off.
+          playSystemSound(name);
+        },
+      }));
+      debugSubmenu.push(
+        { type: "separator" },
+        {
+          id: "notification_sound_enabled",
+          label: "Play Notification Sound",
+          type: "checkbox",
+          checked: notificationSoundEnabled(),
+          click: (item) => {
+            const settings = loadSettings();
+            settings.notification_sound_enabled = item.checked;
+            saveSettings(settings);
+          },
+        },
+        { label: "Sound", submenu: soundChoices },
+      );
+    }
+
+    debugSubmenu.push({ type: "separator" }, { role: "toggleDevTools" });
+
+    template.push({ label: "Debug", submenu: debugSubmenu });
+  }
 
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
@@ -2309,6 +2385,19 @@ function registerIpc() {
   // Updater IPC surface (get/set config, get status, check/download/install).
   // The module owns the handlers and their trusted-sender + consent gates.
   updater.registerIpc();
+  updateOverlay.registerIpc();
+
+  // Mirror the web app's in-app theme onto the native side so the update
+  // overlay, native dialogs, and menus track the theme switcher (not just the
+  // OS). Value-validated; the worst a page can do is toggle appearance. Still
+  // gated to a pinned server page like every other privileged channel, so a
+  // foreign page can't drive the shell's native appearance.
+  ipcMain.on("omnigent:set-color-scheme", (event, scheme) => {
+    if (!isPinnedOriginSender(event)) return;
+    if (scheme === "light" || scheme === "dark" || scheme === "system") {
+      nativeTheme.themeSource = scheme;
+    }
+  });
 
   // SPA → start / stop / restart this machine's host daemon for the window's
   // own server (the host selection menu's "connect this machine" action).

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -16,6 +16,23 @@
 
 const { contextBridge, ipcRenderer } = require("electron");
 
+// Collapse the update states the in-page UpdateBanner renders on
+// (available / downloaded / error-security) to `idle` so the server page can
+// never show a banner — that UI is shell-owned (the corner overlay). Kept here
+// (not main) so it applies uniformly to getStatus + every onStatus push, and
+// so error-security still reaches Settings as idle+lastError (which it shows).
+function bannerSafe(status) {
+  if (
+    status &&
+    (status.state === "available" ||
+      status.state === "downloaded" ||
+      status.state === "error-security")
+  ) {
+    return status.lastError ? { state: "idle", lastError: status.lastError } : { state: "idle" };
+  }
+  return status;
+}
+
 // Native integrations for the SPA: a dock/taskbar badge and OS notifications.
 // Numbers/strings only so the values survive contextBridge's structured-clone
 // boundary.
@@ -123,26 +140,36 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
    * setup page, so a connected server can't repoint the CLI at an arbitrary one.
    */
   resetCliPath: () => ipcRenderer.invoke("omnigent:cli-reset-path"),
+  // Update bridge for the server page — CONFIG ONLY, by design. Desktop update
+  // NOTIFICATIONS are owned by the shell now (a native corner overlay with its
+  // own preload + the Server menu). This bridge stays so Settings can still
+  // read/write update preferences (mode, auto-install) and trigger a check, but
+  // it is BANNER-SAFE: `bannerSafe()` collapses the states the in-page
+  // UpdateBanner renders on (available / downloaded / error-security) down to
+  // `idle` before the page sees them. That means NO web bundle — including
+  // older shipped ones that still mount the in-page banner — can show a
+  // (duplicate) banner, while Settings still gets check progress and errors
+  // (error-security is forwarded as idle+lastError, which Settings surfaces).
   updates: {
     getConfig: () => ipcRenderer.invoke("omnigent:get-update-config"),
-    getStatus: () => ipcRenderer.invoke("omnigent:get-update-status"),
+    getStatus: () => ipcRenderer.invoke("omnigent:get-update-status").then(bannerSafe),
     check: () => ipcRenderer.invoke("omnigent:update-check"),
     download: () => ipcRenderer.invoke("omnigent:update-download"),
     installNow: () => ipcRenderer.invoke("omnigent:update-install"),
     setConfig: (patch) => ipcRenderer.invoke("omnigent:set-update-config", patch),
-    /**
-     * Subscribe to update status changes. The renderer should read getStatus()
-     * first to replay any startup event that fired before subscription.
-     * Returns an unsubscribe function.
-     * @param {(status: unknown) => void} callback
-     * @returns {() => void}
-     */
     onStatus: (callback) => {
-      const listener = (_event, status) => callback(status);
+      const listener = (_event, status) => callback(bannerSafe(status));
       ipcRenderer.on("omnigent:update-status", listener);
       return () => ipcRenderer.removeListener("omnigent:update-status", listener);
     },
   },
+  /**
+   * Report the web app's resolved color scheme so the shell can mirror it via
+   * `nativeTheme.themeSource` — keeping the update overlay, native dialogs, and
+   * menus in sync with the in-app theme switcher (not just the OS setting).
+   * @param {"light" | "dark" | "system"} scheme
+   */
+  setColorScheme: (scheme) => ipcRenderer.send("omnigent:set-color-scheme", scheme),
 
   // ── Embedded browser pane ──────────────────────────────────────────────
   // The relay hook (web/src/hooks/useBrowserAgentRelay.ts) drives a native

--- a/web/electron/src/update_overlay.js
+++ b/web/electron/src/update_overlay.js
@@ -1,0 +1,203 @@
+// Shell-owned desktop update overlay window.
+//
+// Renders the SAME web `UpdateBanner` component (built into electron/overlay/
+// by web's `build:overlay`) inside a transparent, frameless child window
+// anchored to the bottom-right of a shell window — so the update UI ships with
+// the desktop app and appears regardless of the connected server's web-bundle
+// version (an old server without UpdateBanner must still be able to tell the
+// user the desktop app is out of date).
+//
+// The overlay is a TRUSTED surface: its `omnigent:overlay-*` IPC drives the
+// updater directly (no pinned-origin gate, no per-action consent dialog — the
+// server-page IPC keeps those). The window sizes itself to the card via the
+// height the overlay reports, and hides when the card renders nothing.
+
+"use strict";
+
+const OVERLAY_WIDTH = 344; // 320px card + 12px shadow gutter each side
+const OVERLAY_INSET = 12;
+
+/**
+ * @param {object} deps
+ * @param {typeof import("electron").BrowserWindow} deps.BrowserWindow
+ * @param {import("electron").IpcMain} deps.ipcMain
+ * @param {import("electron").NativeTheme} deps.nativeTheme
+ * @param {{ getConfig: Function, getStatus: Function, setConfig: Function,
+ *   checkForUpdates: Function, downloadUpdate: Function, installUpdateNow: Function }} deps.updater
+ * @param {string} deps.overlayPage Absolute path to the built overlay HTML.
+ * @param {string} deps.preloadPath Absolute path to update_overlay_preload.js.
+ */
+function createUpdateOverlay({
+  BrowserWindow,
+  ipcMain,
+  nativeTheme,
+  updater,
+  overlayPage,
+  preloadPath,
+}) {
+  /** @type {Map<Electron.BrowserWindow, Electron.BrowserWindow>} parent -> overlay */
+  const overlays = new Map();
+  /** @type {WeakMap<Electron.BrowserWindow, number>} overlay -> last reported height */
+  const heights = new WeakMap();
+
+  function overlayForSender(event) {
+    for (const ov of overlays.values()) {
+      if (!ov.isDestroyed() && ov.webContents === event.sender) return ov;
+    }
+    return null;
+  }
+
+  function parentOf(overlay) {
+    for (const [parent, ov] of overlays) {
+      if (ov === overlay) return parent;
+    }
+    return null;
+  }
+
+  function position(parent, overlay, height) {
+    if (!parent || parent.isDestroyed() || overlay.isDestroyed()) return;
+    const content = parent.getContentBounds();
+    overlay.setBounds({
+      x: content.x + content.width - OVERLAY_WIDTH - OVERLAY_INSET,
+      y: content.y + content.height - height - OVERLAY_INSET,
+      width: OVERLAY_WIDTH,
+      height,
+    });
+  }
+
+  /** Create (once) the overlay window for a shell window and load the card. */
+  function ensureOverlay(parent) {
+    const existing = overlays.get(parent);
+    if (existing && !existing.isDestroyed()) return existing;
+
+    const overlay = new BrowserWindow({
+      parent,
+      frame: false,
+      resizable: false,
+      movable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      skipTaskbar: true,
+      transparent: true,
+      hasShadow: false, // the card draws its own shadow
+      show: false,
+      width: OVERLAY_WIDTH,
+      height: 1,
+      webPreferences: {
+        preload: preloadPath,
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    });
+    overlays.set(parent, overlay);
+
+    // The ?theme= URL param is only a pre-paint hint to avoid a flash before
+    // the renderer subscribes; it's stale after a reload (the URL is fixed at
+    // creation time from the OS theme, not the in-app theme that may have been
+    // pushed via setColorScheme since). did-finish-load fires on every load —
+    // including Cmd+R reloads — so push the LIVE theme here to correct it.
+    const theme = nativeTheme.shouldUseDarkColors ? "dark" : "light";
+    void overlay.loadFile(overlayPage, { search: `theme=${theme}` });
+    overlay.webContents.on("did-finish-load", () => {
+      if (overlay.isDestroyed()) return;
+      overlay.webContents.send(
+        "omnigent:overlay-theme",
+        nativeTheme.shouldUseDarkColors ? "dark" : "light",
+      );
+    });
+
+    const reposition = () => position(parent, overlay, heights.get(overlay) ?? 1);
+    parent.on("resize", reposition);
+    parent.on("move", reposition);
+    // Electron does NOT auto-close child windows when their parent closes, so
+    // tear the overlay down explicitly — otherwise a transparent, skipTaskbar
+    // child is orphaned with live IPC handlers and a dangling Map entry.
+    const onParentClosed = () => {
+      if (!overlay.isDestroyed()) overlay.destroy();
+    };
+    parent.on("closed", onParentClosed);
+    overlay.on("closed", () => {
+      overlays.delete(parent);
+      if (!parent.isDestroyed()) {
+        parent.removeListener("resize", reposition);
+        parent.removeListener("move", reposition);
+        parent.removeListener("closed", onParentClosed);
+      }
+    });
+    return overlay;
+  }
+
+  function registerIpc() {
+    // The overlay reports its rendered card height; 0 => nothing to show.
+    //
+    // We must NOT hide() the window when empty: a hidden BrowserWindow suspends
+    // its renderer, so its ResizeObserver stops firing and the card could never
+    // report a height again to re-appear (e.g. after a transient "checking"
+    // state collapses it). Instead keep the window shown but collapse it to an
+    // invisible, click-through 1px sliver, which keeps layout — and the
+    // ResizeObserver — alive so it expands again the moment there's content.
+    ipcMain.on("omnigent:overlay-height", (event, height) => {
+      const overlay = overlayForSender(event);
+      if (!overlay) return;
+      const h = Math.max(0, Math.round(Number(height) || 0));
+      heights.set(overlay, h);
+      const parent = parentOf(overlay);
+      if (h > 0) {
+        position(parent, overlay, h);
+        overlay.setIgnoreMouseEvents(false);
+      } else {
+        position(parent, overlay, 1);
+        overlay.setIgnoreMouseEvents(true, { forward: true });
+      }
+      if (!overlay.isVisible()) overlay.showInactive();
+    });
+
+    // Trusted updater controls for the overlay page only.
+    const guard = (event) => {
+      if (!overlayForSender(event)) {
+        throw new Error("update overlay IPC is only available to the shell overlay page");
+      }
+    };
+    ipcMain.handle("omnigent:overlay-get-update-config", (event) => {
+      guard(event);
+      return updater.getConfig();
+    });
+    ipcMain.handle("omnigent:overlay-get-update-status", (event) => {
+      guard(event);
+      return updater.getStatus();
+    });
+    ipcMain.handle("omnigent:overlay-update-check", async (event) => {
+      guard(event);
+      await updater.checkForUpdates({ manual: true });
+    });
+    ipcMain.handle("omnigent:overlay-update-download", async (event) => {
+      guard(event);
+      await updater.downloadUpdate();
+    });
+    ipcMain.handle("omnigent:overlay-update-install", (event) => {
+      guard(event);
+      if (!updater.installUpdateNow()) {
+        throw new Error("No downloaded update is ready to install.");
+      }
+    });
+    ipcMain.handle("omnigent:overlay-set-update-config", (event, patch) => {
+      guard(event);
+      return updater.setConfig(patch);
+    });
+
+    // Keep the card's theme in sync with the OS/app appearance.
+    nativeTheme.on("updated", () => {
+      const theme = nativeTheme.shouldUseDarkColors ? "dark" : "light";
+      for (const overlay of overlays.values()) {
+        if (!overlay.isDestroyed()) {
+          overlay.webContents.send("omnigent:overlay-theme", theme);
+        }
+      }
+    });
+  }
+
+  return { ensureOverlay, registerIpc };
+}
+
+module.exports = { createUpdateOverlay, OVERLAY_WIDTH, OVERLAY_INSET };

--- a/web/electron/src/update_overlay_preload.js
+++ b/web/electron/src/update_overlay_preload.js
@@ -1,0 +1,47 @@
+// Preload for the desktop update overlay (electron/overlay/update-overlay.html).
+//
+// The overlay is a bundled, TRUSTED shell surface — unlike the remote server
+// page — so it drives the updater over its own `omnigent:overlay-*` channels
+// (main verifies the sender frame), bypassing the server-page IPC that requires
+// a pinned origin + per-action consent dialog. Clicking the shell's own toast
+// IS the user's consent.
+//
+// It exposes `window.omnigentDesktop` in the exact shape the web
+// `updateBridge()` reads (kind + `updates`), so the reused `UpdateBanner`
+// component works unchanged, plus a tiny `omnigentUpdateOverlay` used only to
+// report the card's height back to the shell so it can size the window.
+
+"use strict";
+
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("omnigentDesktop", {
+  kind: "electron",
+  updates: {
+    getConfig: () => ipcRenderer.invoke("omnigent:overlay-get-update-config"),
+    getStatus: () => ipcRenderer.invoke("omnigent:overlay-get-update-status"),
+    check: () => ipcRenderer.invoke("omnigent:overlay-update-check"),
+    download: () => ipcRenderer.invoke("omnigent:overlay-update-download"),
+    installNow: () => ipcRenderer.invoke("omnigent:overlay-update-install"),
+    setConfig: (patch) => ipcRenderer.invoke("omnigent:overlay-set-update-config", patch),
+    onStatus: (callback) => {
+      // Reuse the shell's existing broadcast (sent to every window).
+      const listener = (_event, status) => callback(status);
+      ipcRenderer.on("omnigent:update-status", listener);
+      return () => ipcRenderer.removeListener("omnigent:update-status", listener);
+    },
+  },
+});
+
+contextBridge.exposeInMainWorld("omnigentUpdateOverlay", {
+  /** Report the rendered card height (px) so the shell can size/show/hide the
+   *  transparent overlay window. 0 means nothing to show — the shell hides it. */
+  reportHeight: (height) =>
+    ipcRenderer.send("omnigent:overlay-height", Math.max(0, Math.ceil(height))),
+  /** Subscribe to OS/app appearance changes so the card can restyle live. */
+  onTheme: (callback) => {
+    const listener = (_event, theme) => callback(theme);
+    ipcRenderer.on("omnigent:overlay-theme", listener);
+    return () => ipcRenderer.removeListener("omnigent:overlay-theme", listener);
+  },
+});

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -94,6 +94,7 @@ function loadMainHarness({
     nativeImage: {
       createFromPath: () => ({ isEmpty: () => true }),
     },
+    nativeTheme: { shouldUseDarkColors: false, on: () => {} },
     screen: {},
     session: { defaultSession: {} },
     shell: {},
@@ -149,7 +150,11 @@ function loadMainHarness({
       ...process,
       env: {
         ...process.env,
-        ...(forceDevUpdateConfig ? { OMNIGENT_FORCE_DEV_UPDATE_CONFIG: "1" } : {}),
+        // No OMNIGENT_FORCE_DEV_UPDATE_CONFIG injection: main.js now derives
+        // forceDevUpdateConfig from !app.isPackaged (always true in this
+        // harness), not an env var. The harness still controls the
+        // autoUpdater.forceDevUpdateConfig property directly (above) for tests
+        // that exercise the feed-unavailable path without calling init().
       },
     },
     require: (specifier) => {

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,8 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "build:overlay": "vite build --config vite.update-overlay.config.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/web/src/components/UpdateBanner.test.tsx
+++ b/web/src/components/UpdateBanner.test.tsx
@@ -59,9 +59,8 @@ describe("UpdateBanner", () => {
     });
     render(<UpdateBanner />);
 
-    expect(await screen.findByText("Omnigent 0.4.0 is available.")).toBeInTheDocument();
+    expect(await screen.findByText("Omnigent 0.4.0 is available")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Update now" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Later" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Skip this version" })).toBeInTheDocument();
     expect(screen.getByText("Release notes")).toBeInTheDocument();
     expect(vi.mocked(bridge.getStatus).mock.invocationCallOrder[0]).toBeLessThan(
@@ -74,11 +73,9 @@ describe("UpdateBanner", () => {
     expect(screen.queryByRole("button", { name: "Skip this version" })).toBeNull();
 
     emit({ state: "downloaded", info: { version: "0.4.0" } });
-    expect(await screen.findByText("Omnigent 0.4.0 is ready to install.")).toBeInTheDocument();
+    expect(await screen.findByText("Omnigent 0.4.0 is ready to install")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Restart to update" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Later — install on next quit" }),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Installs automatically on next quit.")).toBeInTheDocument();
   });
 
   it("does not promise install-on-quit when auto install is off", async () => {
@@ -92,9 +89,9 @@ describe("UpdateBanner", () => {
 
     render(<UpdateBanner />);
 
-    expect(await screen.findByText("Omnigent 0.4.0 is ready to install.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Later" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Later — install on next quit" })).toBeNull();
+    expect(await screen.findByText("Omnigent 0.4.0 is ready to install")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Restart to update" })).toBeInTheDocument();
+    expect(screen.queryByText("Installs automatically on next quit.")).toBeNull();
   });
 
   it("unsubscribes from update status events when it unmounts", async () => {
@@ -104,7 +101,7 @@ describe("UpdateBanner", () => {
     });
 
     const { unmount } = render(<UpdateBanner />);
-    expect(await screen.findByText("Omnigent 0.4.0 is available.")).toBeInTheDocument();
+    expect(await screen.findByText("Omnigent 0.4.0 is available")).toBeInTheDocument();
 
     unmount();
 
@@ -123,12 +120,12 @@ describe("UpdateBanner", () => {
     vi.mocked(bridge.setConfig).mockResolvedValueOnce(skippedConfig);
 
     render(<UpdateBanner />);
-    expect(await screen.findByText("Omnigent 0.4.0 is available.")).toBeInTheDocument();
+    expect(await screen.findByText("Omnigent 0.4.0 is available")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Skip this version" }));
     await waitFor(() => {
       expect(bridge.setConfig).toHaveBeenCalledWith({ skippedVersion: "0.4.0" });
-      expect(screen.queryByText("Omnigent 0.4.0 is available.")).toBeNull();
+      expect(screen.queryByText("Omnigent 0.4.0 is available")).toBeNull();
     });
   });
 });

--- a/web/src/components/UpdateBanner.tsx
+++ b/web/src/components/UpdateBanner.tsx
@@ -14,7 +14,16 @@ function formatPercent(percent: number | undefined): number {
   return Math.max(0, Math.min(100, Math.round(percent)));
 }
 
-export function UpdateBanner() {
+/**
+ * Desktop update toast.
+ *
+ * `variant` controls only the outer chrome so the SAME component serves two
+ * hosts: `floating` (default) pins it bottom-right for the in-page web build;
+ * `bare` drops the fixed positioning so the Electron shell can mount it inside
+ * its own corner overlay window (which owns position/size). See
+ * web/src/update-overlay.tsx + the shell's update overlay window.
+ */
+export function UpdateBanner({ variant = "floating" }: { variant?: "floating" | "bare" } = {}) {
   const bridge = updateBridge();
   const [status, setStatus] = useState<UpdateStatus | null>(null);
   const [skippedVersion, setSkippedVersion] = useState<string | null | "loading">("loading");
@@ -108,95 +117,128 @@ export function UpdateBanner() {
   const releaseNotes = visibleStatus.info?.releaseNotes;
   const progress =
     visibleStatus.state === "downloading" ? formatPercent(visibleStatus.progress?.percent) : 0;
+  const isError = visibleStatus.state === "error-security";
+  const Icon = isError
+    ? AlertTriangleIcon
+    : visibleStatus.state === "downloaded"
+      ? RotateCcwIcon
+      : DownloadIcon;
 
   return (
     <div
-      role={visibleStatus.state === "error-security" ? "status" : "region"}
+      role={isError ? "status" : "region"}
       aria-label="Desktop update"
       className={cn(
-        "border-b border-border bg-background/95 px-4 py-2 shadow-sm backdrop-blur",
-        visibleStatus.state === "error-security" && "bg-muted/70",
+        "rounded-xl border border-border bg-background p-3.5 text-sm shadow-lg",
+        // `floating`: pin bottom-right for the in-page web build. `bare`: fill
+        // the shell's overlay window, which supplies position + size itself.
+        variant === "floating"
+          ? "fixed right-4 bottom-4 z-50 w-80 max-w-[calc(100vw-2rem)] animate-in fade-in-0 slide-in-from-bottom-2 duration-200"
+          : "w-full",
       )}
     >
-      <div className="mx-auto flex max-w-5xl flex-wrap items-center gap-x-3 gap-y-2 text-sm">
-        {visibleStatus.state === "error-security" ? (
-          <AlertTriangleIcon className="size-4 text-muted-foreground" aria-hidden="true" />
-        ) : visibleStatus.state === "downloaded" ? (
-          <RotateCcwIcon className="size-4 text-primary" aria-hidden="true" />
-        ) : (
-          <DownloadIcon className="size-4 text-primary" aria-hidden="true" />
-        )}
+      <div className="flex items-start gap-3">
+        <div
+          className={cn(
+            "mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full",
+            isError
+              ? "bg-amber-500/10 text-amber-600 dark:text-amber-500"
+              : "bg-primary/10 text-primary",
+          )}
+        >
+          <Icon className="size-4" aria-hidden="true" />
+        </div>
 
         <div className="min-w-0 flex-1">
           {visibleStatus.state === "available" && (
-            <span>Omnigent {visibleStatus.info?.version ?? "update"} is available.</span>
+            <p className="font-medium text-foreground">
+              Omnigent {visibleStatus.info?.version ?? "update"} is available
+            </p>
           )}
           {visibleStatus.state === "downloading" && (
-            <div className="flex flex-col gap-1">
-              <span>Downloading Omnigent update… {progress}%</span>
+            <>
+              <p className="font-medium text-foreground">
+                Downloading Omnigent update… {progress}%
+              </p>
               <Progress
                 value={progress}
-                className="h-1.5 max-w-80"
+                className="mt-2 h-1.5"
                 aria-label="Update download progress"
               />
-            </div>
+            </>
           )}
           {visibleStatus.state === "downloaded" && (
-            <span>Omnigent {visibleStatus.info?.version ?? "update"} is ready to install.</span>
+            <>
+              <p className="font-medium text-foreground">
+                Omnigent {visibleStatus.info?.version ?? "update"} is ready to install
+              </p>
+              {autoInstall && (
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Installs automatically on next quit.
+                </p>
+              )}
+            </>
           )}
-          {visibleStatus.state === "error-security" && (
-            <span>
-              Last update check failed
-              {visibleStatus.lastError ? `: ${visibleStatus.lastError}` : "."}
-            </span>
+          {isError && (
+            <>
+              <p className="font-medium text-foreground">Update check failed</p>
+              {visibleStatus.lastError && (
+                <p className="mt-0.5 line-clamp-3 text-xs text-muted-foreground">
+                  {visibleStatus.lastError}
+                </p>
+              )}
+            </>
+          )}
+
+          {releaseNotes && visibleStatus.state !== "downloading" && (
+            <details className="mt-1.5 text-xs text-muted-foreground">
+              <summary className="cursor-pointer select-none text-foreground hover:underline">
+                Release notes
+              </summary>
+              <div className="mt-1 max-h-32 overflow-auto whitespace-pre-wrap">{releaseNotes}</div>
+            </details>
+          )}
+
+          {visibleStatus.state === "available" && (
+            <div className="mt-3 flex items-center gap-2">
+              <Button
+                size="sm"
+                onClick={() => void onDownload()}
+                loading={busyAction === "download"}
+              >
+                Update now
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void onSkip()}
+                loading={busyAction === "skip"}
+                disabled={!version}
+              >
+                Skip this version
+              </Button>
+            </div>
+          )}
+
+          {visibleStatus.state === "downloaded" && (
+            <div className="mt-3 flex items-center gap-2">
+              <Button size="sm" onClick={() => void onInstall()} loading={busyAction === "install"}>
+                Restart to update
+              </Button>
+            </div>
           )}
         </div>
 
-        {visibleStatus.state === "available" && (
-          <div className="flex flex-wrap items-center gap-2">
-            <Button size="sm" onClick={() => void onDownload()} loading={busyAction === "download"}>
-              Update now
-            </Button>
-            <Button variant="ghost" size="sm" onClick={() => setHiddenVersion(version)}>
-              Later
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => void onSkip()}
-              loading={busyAction === "skip"}
-              disabled={!version}
-            >
-              Skip this version
-            </Button>
-          </div>
-        )}
-
-        {visibleStatus.state === "downloaded" && (
-          <div className="flex flex-wrap items-center gap-2">
-            <Button size="sm" onClick={() => void onInstall()} loading={busyAction === "install"}>
-              Restart to update
-            </Button>
-            <Button variant="ghost" size="sm" onClick={() => setHiddenVersion(version)}>
-              {autoInstall ? "Later — install on next quit" : "Later"}
-            </Button>
-          </div>
-        )}
-
-        {releaseNotes && visibleStatus.state !== "downloading" && (
-          <details className="basis-full text-xs text-muted-foreground">
-            <summary className="cursor-pointer select-none text-foreground">Release notes</summary>
-            <div className="mt-1 whitespace-pre-wrap">{releaseNotes}</div>
-          </details>
-        )}
-
-        {visibleStatus.state === "error-security" && (
+        {(isError ||
+          visibleStatus.state === "available" ||
+          visibleStatus.state === "downloaded") && (
           <Button
             type="button"
             variant="ghost"
             size="icon-xs"
-            aria-label="Dismiss update warning"
-            onClick={() => setHiddenVersion(version ?? "error-security")}
+            aria-label="Dismiss"
+            className="-mt-1 -mr-1 shrink-0"
+            onClick={() => setHiddenVersion(isError ? "error-security" : (version ?? null))}
           >
             <XIcon className="size-3.5" />
           </Button>

--- a/web/src/components/theme/ThemeProvider.tsx
+++ b/web/src/components/theme/ThemeProvider.tsx
@@ -1,5 +1,21 @@
-import type { ReactNode } from "react";
-import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { type ReactNode, useEffect } from "react";
+import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
+import { reportColorScheme } from "@/lib/nativeBridge";
+
+/**
+ * Mirrors the in-app theme selection onto the Electron shell (nativeTheme), so
+ * the shell-owned update overlay, native dialogs, and menus follow the theme
+ * switcher rather than only the OS. No-op outside Electron. Renders nothing.
+ */
+function NativeThemeSync() {
+  const { theme } = useTheme();
+  useEffect(() => {
+    if (theme === "light" || theme === "dark" || theme === "system") {
+      reportColorScheme(theme);
+    }
+  }, [theme]);
+  return null;
+}
 
 /**
  * App-wide theme provider configured for Tailwind's `.dark` class variant.
@@ -20,6 +36,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       disableTransitionOnChange
       storageKey="web-theme"
     >
+      <NativeThemeSync />
       {children}
     </NextThemesProvider>
   );

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -143,7 +143,20 @@ export interface NativeViewModeParams {
  */
 interface ElectronDesktopApi extends NativeShellApi {
   kind: "electron";
-  /** Desktop auto-update bridge, absent on shells older than the updater work. */
+  /**
+   * Report the web app's resolved color scheme so the shell mirrors it via
+   * nativeTheme (keeps the shell-owned update overlay, native dialogs, and
+   * menus in sync with the in-app theme). Absent on older shells.
+   */
+  setColorScheme?: (scheme: "light" | "dark" | "system") => void;
+  /**
+   * Desktop auto-update bridge — CONFIG ONLY on current shells. Update
+   * notifications are shell-owned (native corner overlay + Server menu); this
+   * bridge is used for update preferences (mode, auto-install) + check. The
+   * shell delivers it "banner-safe": status values that would trigger the
+   * in-page UpdateBanner (available/downloaded/error-security) are collapsed to
+   * idle, so the web never shows a (duplicate) banner. Absent on older shells.
+   */
   updates?: ElectronUpdateBridge;
   /** Current server origin + recent servers, or null on a foreign page. */
   getServerPicker?: () => Promise<ServerPickerInfo | null>;
@@ -453,6 +466,21 @@ export function onNativeSidebarDrag(
  * tray notification: it makes that notification open a target and show
  * descriptive text. Electron/iOS have a real icon badge and ignore it.
  */
+/**
+ * Tell the Electron shell the web app's resolved color scheme so it can mirror
+ * it natively (nativeTheme.themeSource). No-op outside Electron or on older
+ * shells. Fire-and-forget.
+ */
+export function reportColorScheme(scheme: "light" | "dark" | "system"): void {
+  const native = electronApi();
+  if (!native?.setColorScheme) return;
+  try {
+    native.setColorScheme(scheme);
+  } catch (err) {
+    console.warn("[nativeBridge] setColorScheme failed:", err);
+  }
+}
+
 export async function setBadgeCount(count: number, activation?: BadgeActivation): Promise<void> {
   const native = nativeApi();
   if (!native) return;

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -15,7 +15,6 @@ import { readFilesPanelPreferences, writeFilesPanelPreferences } from "@/lib/fil
 import { derivePermissionLevel, isOwnerLevel } from "@/lib/permissionsApi";
 import {
   isAndroidShell,
-  isElectronShell,
   isIOSShell,
   isMacElectronShell,
   onNativeSidebarDrag,
@@ -67,7 +66,6 @@ import { useChatStore } from "@/store/chatStore";
 import { livenessRowFromSession, useSessionLiveness } from "@/hooks/useSessionLiveness";
 import { useResizableInlinePanel } from "@/hooks/useResizableInlinePanel";
 import { ChatHeader } from "./ChatHeader";
-import { UpdateBanner } from "@/components/UpdateBanner";
 import { ExecutionLogsPanel } from "./ExecutionLogsPanel";
 import { FileViewer } from "./FileViewer";
 import { FileViewerContext } from "./FileViewerContext";
@@ -1321,7 +1319,6 @@ export function AppShell() {
                   }}
                 />
                 <main className="relative flex min-h-0 min-w-0 flex-1 flex-col">
-                  {isElectronShell() && <UpdateBanner />}
                   <Outlet />
                 </main>
 

--- a/web/src/update-overlay.tsx
+++ b/web/src/update-overlay.tsx
@@ -1,0 +1,46 @@
+// Standalone entry for the desktop update overlay.
+//
+// The Electron shell owns the auto-update UI so it works regardless of the
+// connected server's web-bundle version (an old server that predates
+// UpdateBanner must not leave the desktop app unable to say it's out of date).
+// This entry mounts the SAME `UpdateBanner` component — reused, not duplicated —
+// into a bundle the shell ships and loads in a transparent corner window.
+//
+// It talks to the shell's updater over the native bridge exposed by the
+// overlay's preload (window.omnigentNative.updates), identical to the in-page
+// build; only the outer chrome differs (`variant="bare"`, since the shell
+// window supplies position/size).
+
+import { createRoot } from "react-dom/client";
+import { UpdateBanner } from "./components/UpdateBanner";
+import "./index.css";
+
+// Theme: the shell passes `?theme=dark|light` (from nativeTheme). Fall back to
+// the OS preference so the card matches the app in either case.
+const params = new URLSearchParams(window.location.search);
+const theme = params.get("theme");
+const dark =
+  theme === "dark" ||
+  (theme !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+document.documentElement.classList.toggle("dark", dark);
+
+const container = document.getElementById("update-overlay-root");
+if (container) {
+  createRoot(container).render(<UpdateBanner variant="bare" />);
+
+  // Report the rendered height so the shell can size the transparent window to
+  // the card (0 when UpdateBanner renders nothing → shell hides the window).
+  const overlay = (
+    window as unknown as {
+      omnigentUpdateOverlay?: {
+        reportHeight?: (h: number) => void;
+        onTheme?: (cb: (theme: string) => void) => void;
+      };
+    }
+  ).omnigentUpdateOverlay;
+  const report = () => overlay?.reportHeight?.(container.getBoundingClientRect().height);
+  new ResizeObserver(report).observe(container);
+  report();
+
+  overlay?.onTheme?.((next) => document.documentElement.classList.toggle("dark", next === "dark"));
+}

--- a/web/update-overlay.html
+++ b/web/update-overlay.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Omnigent Update</title>
+    <style>
+      /* The overlay lives in a transparent, frameless shell window sized to the
+         card, so the page itself paints nothing — only the UpdateBanner card
+         (its own bg/border/shadow) is visible. */
+      html,
+      body {
+        margin: 0;
+        background: transparent;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="update-overlay-root"></div>
+    <script type="module" src="/src/update-overlay.tsx"></script>
+  </body>
+</html>

--- a/web/vite.update-overlay.config.ts
+++ b/web/vite.update-overlay.config.ts
@@ -1,0 +1,43 @@
+// Build for the desktop update overlay island.
+//
+// Produces a tiny standalone page (update-overlay.html + hashed JS/CSS) that
+// mounts the SHARED `UpdateBanner` component (see src/update-overlay.tsx). The
+// output lands directly in the Electron shell package (`electron/overlay/`) so
+// electron-builder ships it and the shell can load it in a corner window —
+// making the update UI independent of the connected server's web-bundle
+// version. Run via `bun run build:overlay` (or npm); the shell build depends on
+// this output existing (see electron/package.json build.files + the
+// electron-build workflow).
+//
+// Kept separate from the main app build (vite.config.ts) so it emits no PWA
+// service worker / manifest and writes to the shell dir rather than dist/.
+
+import path from "node:path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  // Assets are loaded from a file:// page in the shell, so reference them
+  // relatively rather than from the server root.
+  base: "./",
+  // The overlay is a single self-contained card — it has no use for the web
+  // app's public/ assets (PWA icons, favicon). Disable publicDir so Vite doesn't
+  // copy ~150KB of orphan PWA images into electron/overlay/, which would then
+  // be shipped by electron-builder's `build.files: overlay/**/*`.
+  publicDir: false,
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  build: {
+    // Ship straight into the Electron package so electron-builder picks it up.
+    outDir: path.resolve(__dirname, "./electron/overlay"),
+    emptyOutDir: true,
+    rollupOptions: {
+      input: path.resolve(__dirname, "./update-overlay.html"),
+    },
+  },
+});


### PR DESCRIPTION
## Related issue

N/A

## Summary

Desktop update UX is moved out of the server-rendered web bundle into the
Electron shell, so an update notification shows regardless of the connected
server's web-bundle version (an older server that predates the in-page banner
no longer leaves the desktop app unable to say it's out of date).

- Shell-owned overlay: a transparent, frameless child window (per shell window)
  renders the SAME `UpdateBanner` component (reused, not duplicated) built into
  `electron/overlay/` via a standalone Vite entry. It sizes to the card via
  ResizeObserver height reports and collapses to a 1px click-through sliver when
  empty (never `hide()`, so the renderer keeps laying out and can re-appear).
- Banner-safe server-page bridge: `preload.js` collapses
  available/downloaded/error-security to `idle`, so no web bundle — including
  older ones still mounting the in-page banner — can show a duplicate; Settings
  still reads/writes update prefs and surfaces check errors.
- Menus: "Check for Updates…" (with native up-to-date / failed dialogs) lives
  under Server; Restart to Update + notification sounds + DevTools fold into a
  dev-only Debug menu.
- Security: `forceDevUpdateConfig` is derived from `!app.isPackaged` (env var
  removed) so a packaged build can never be redirected to the HTTP dev feed.
- In-app theme is mirrored to `nativeTheme` (setColorScheme IPC) so the overlay,
  native dialogs, and menus follow the theme switcher, not just the OS.
- Feed: publish provider points at the omnigent.ai generic feed; the build
  workflow uploads `latest-linux.yml` / `latest.yml`. The overlay is built
  automatically before dev/packaging via `prebuild:*` hooks.

## Test Plan

- `npm test` in web/electron — 218 pass.
- `npx vitest run` for UpdateBanner / SettingsPage / settingsNav — pass.
- `npx tsc -b` clean; `npm run build:overlay` produces the island.
- Manual: ran the unpackaged app against a local fake feed (127.0.0.1:8765
  advertising 0.6.1); confirmed the overlay appears, re-appears across repeated
  checks (root-caused a hidden-window ResizeObserver stall and fixed it), the
  in-page top banner stays suppressed, and "Check for Updates…" shows the native
  up-to-date / failure dialogs.

## Demo

N/A — desktop overlay; verified manually (see Test Plan). No media captured in
this environment.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the updater main-process wiring and the UpdateBanner states.
The windowed overlay (positioning, show/collapse, theme) was verified manually
against a local fake feed, since it can't be exercised headlessly.

## Changelog

Desktop update notifications now appear in a native corner toast that works
regardless of the connected server's version.

