### PR TITLE
[runner] Defer Git untracked-cache setup

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8749,6 +8749,7 @@ def create_runner_app(
 
     if runner_workspace is not None:
         filesystem_registry = create_filesystem_registry(watch_path=runner_workspace)
+        filesystem_registry.start()
     else:
         filesystem_registry = None
     app.state.filesystem_registry = filesystem_registry
@@ -8993,6 +8994,7 @@ def create_runner_app(
             return filesystem_registry
 
         registry = create_filesystem_registry(watch_path=session_ws_path)
+        registry.start()
         _session_fs_registries[session_id] = registry
         return registry
 

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -23,6 +23,7 @@ defines the full public interface.
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import fnmatch
 import logging
@@ -31,8 +32,14 @@ import subprocess
 import threading
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows has no flock.
+    fcntl = None  # type: ignore[assignment]
 
 _logger = logging.getLogger(__name__)
 
@@ -193,6 +200,58 @@ def _find_git_root(path: Path) -> Path | None:
         if parent == current:
             return None
         current = parent
+
+
+def _git_common_dir(git_root: Path) -> Path:
+    """Return the Git directory shared by a repository and its worktrees."""
+    git_entry = git_root / ".git"
+    if git_entry.is_dir():
+        return git_entry.resolve()
+    try:
+        marker = git_entry.read_text(encoding="utf-8").strip()
+    except OSError:
+        return git_entry
+    if not marker.startswith("gitdir:"):
+        return git_entry
+    git_dir = Path(marker.removeprefix("gitdir:").strip())
+    if not git_dir.is_absolute():
+        git_dir = git_root / git_dir
+    git_dir = git_dir.resolve()
+    try:
+        common_marker = (git_dir / "commondir").read_text(encoding="utf-8").strip()
+    except OSError:
+        return git_dir
+    common_dir = Path(common_marker)
+    if not common_dir.is_absolute():
+        common_dir = git_dir / common_dir
+    return common_dir.resolve()
+
+
+@contextlib.contextmanager
+def _untracked_cache_repo_lock(git_root: Path) -> Iterator[None]:
+    """Serialize the optional untracked-cache setup across runner processes."""
+    if fcntl is None:
+        yield
+        return
+    fd: int | None = None
+    lock_path = _git_common_dir(git_root) / "omnigent-untracked-cache.lock"
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except OSError:
+        _logger.debug("could not lock untracked-cache setup for %s", git_root, exc_info=True)
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            fd = None
+    try:
+        yield
+    finally:
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            with contextlib.suppress(OSError):
+                os.close(fd)
 
 
 def _normalize_path(path: str, cwd: Path) -> str | None:
@@ -699,13 +758,10 @@ class AgentEditFilesystemRegistry(FilesystemRegistry):
 class GitFilesystemRegistry(FilesystemRegistry):
     """Filesystem registry backed by ``git status`` and ``git show``.
 
-    Used when the workspace is inside a git repository.  No background thread
-    is started.  :meth:`list_changed_files` and :meth:`get_changed_file`
-    always reflect the current working-tree state (staged + unstaged changes
-    and untracked files relative to HEAD).  Because git tracks changes from
-    HEAD rather than from a point in time, results are not scoped to a
-    conversation start time and include changes made by any process (agent
-    tool calls, shell commands, external editors, etc.).
+    Used when the workspace is inside a git repository. :meth:`start` launches
+    optional untracked-cache setup in a daemon thread; change queries remain
+    correct before it completes. :meth:`list_changed_files` and
+    :meth:`get_changed_file` always reflect the current working-tree state.
 
     :param watch_path: The workspace directory, e.g.
         ``Path("/home/user/project")``.
@@ -721,7 +777,20 @@ class GitFilesystemRegistry(FilesystemRegistry):
         """
         super().__init__(watch_path)
         self._git_root = git_root
-        self._enable_untracked_cache()
+        self._optimization_start_lock = threading.Lock()
+        self._optimization_started = False
+
+    def start(self) -> None:
+        """Start optional Git performance setup without blocking the caller."""
+        with self._optimization_start_lock:
+            if self._optimization_started:
+                return
+            self._optimization_started = True
+        threading.Thread(
+            target=self._enable_untracked_cache,
+            name="omnigent-git-untracked-cache",
+            daemon=True,
+        ).start()
 
     def _enable_untracked_cache(self) -> None:
         """Best-effort ``core.untrackedCache=true`` on this repo.
@@ -742,38 +811,89 @@ class GitFilesystemRegistry(FilesystemRegistry):
         filesystem) are ignored since the setting is a pure speedup with no
         behavioral effect.
         """
-        root_key = str(self._git_root)
+        root_key = str(self._git_root.resolve())
         with _untracked_cache_lock:
             if root_key in _untracked_cache_enabled:
                 return
             _untracked_cache_enabled.add(root_key)
-        try:
-            # Read-only probe: exit 0 iff the filesystem's mtime is reliable
-            # enough for the untracked cache to be correct here.
-            probe = subprocess.run(
-                ["git", "update-index", "--test-untracked-cache"],
-                cwd=root_key,
-                capture_output=True,
-                timeout=_git_timeout_seconds(),
-            )
-            if probe.returncode != 0:
-                _logger.debug(
-                    "GitFilesystemRegistry: untracked cache unsupported in %s; not enabling",
-                    self._git_root,
-                )
+        with _untracked_cache_repo_lock(self._git_root):
+            if self._untracked_cache_is_enabled():
                 return
-            subprocess.run(
-                ["git", "config", "core.untrackedCache", "true"],
-                cwd=root_key,
+            self._probe_and_enable_untracked_cache()
+
+    def _untracked_cache_is_enabled(self) -> bool:
+        """Return whether the shared repository config already enables the cache."""
+        started_at = time.perf_counter()
+        try:
+            result = subprocess.run(
+                ["git", "config", "--bool", "--get", "core.untrackedCache"],
+                cwd=str(self._git_root),
                 capture_output=True,
                 timeout=_git_timeout_seconds(),
             )
         except (subprocess.TimeoutExpired, OSError):
-            _logger.debug(
-                "GitFilesystemRegistry: could not enable core.untrackedCache in %s",
+            _logger.info(
+                "git untracked-cache config check failed: git_root=%s elapsed_ms=%.1f",
                 self._git_root,
-                exc_info=True,
+                (time.perf_counter() - started_at) * 1000,
             )
+            return False
+        enabled = result.returncode == 0 and result.stdout.strip().lower() == b"true"
+        _logger.info(
+            "git untracked-cache config checked: git_root=%s elapsed_ms=%.1f enabled=%s",
+            self._git_root,
+            (time.perf_counter() - started_at) * 1000,
+            enabled,
+        )
+        return enabled
+
+    def _probe_and_enable_untracked_cache(self) -> None:
+        """Probe filesystem support and enable the optional Git index extension."""
+        probe_started_at = time.perf_counter()
+        try:
+            probe = subprocess.run(
+                ["git", "update-index", "--test-untracked-cache"],
+                cwd=str(self._git_root),
+                capture_output=True,
+                timeout=_git_timeout_seconds(),
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            _logger.info(
+                "git untracked-cache probe failed: git_root=%s elapsed_ms=%.1f",
+                self._git_root,
+                (time.perf_counter() - probe_started_at) * 1000,
+            )
+            return
+        _logger.info(
+            "git untracked-cache probe completed: git_root=%s elapsed_ms=%.1f returncode=%d",
+            self._git_root,
+            (time.perf_counter() - probe_started_at) * 1000,
+            probe.returncode,
+        )
+        if probe.returncode != 0:
+            return
+
+        config_started_at = time.perf_counter()
+        try:
+            config = subprocess.run(
+                ["git", "config", "core.untrackedCache", "true"],
+                cwd=str(self._git_root),
+                capture_output=True,
+                timeout=_git_timeout_seconds(),
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            _logger.info(
+                "git untracked-cache config failed: git_root=%s elapsed_ms=%.1f",
+                self._git_root,
+                (time.perf_counter() - config_started_at) * 1000,
+            )
+            return
+        _logger.info(
+            "git untracked-cache config completed: git_root=%s elapsed_ms=%.1f returncode=%d",
+            self._git_root,
+            (time.perf_counter() - config_started_at) * 1000,
+            config.returncode,
+        )
 
     def list_changed_files(self, conversation_id: str, *, limit: int) -> list[dict[str, Any]]:
         """Return all uncommitted changes in the working tree, newest first.

--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -88,6 +88,7 @@ class WorkspaceReader:
         # way the runner chooses it, so git workspaces get git-status
         # semantics and everything else degrades to an empty list.
         self._registry = create_filesystem_registry(self._root)
+        self._registry.start()
 
     # ── Path confinement ──────────────────────────────────────────
 

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -11,8 +11,10 @@ Events are injected via :func:`_inject`, which calls :meth:`record_change` on
 the registry so tests exercise the same code path as real tool calls.
 """
 
+import logging
 import os
 import subprocess
+import threading
 from pathlib import Path
 
 import pytest
@@ -777,16 +779,17 @@ def test_skip_dir_pathspecs_anchored_to_workspace_subdir(tmp_path: Path) -> None
     assert ":(exclude)node_modules" not in specs
 
 
-def test_untracked_cache_enabled_on_init(tmp_path: Path) -> None:
-    """The registry enables ``core.untrackedCache`` on the repo at construction.
+def test_untracked_cache_enable_helper_sets_repo_config(tmp_path: Path) -> None:
+    """The background helper enables ``core.untrackedCache`` when supported.
 
     This is the large-repo ``git status`` speedup (upstream git ≥ 2.8); the
-    registry sets it best-effort on init. Verifies the config lands.
+    The runner invokes it asynchronously after constructing the registry.
     """
     env = _git_env()
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
 
-    GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    registry = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    registry._enable_untracked_cache()
 
     result = subprocess.run(
         ["git", "config", "--get", "core.untrackedCache"],
@@ -814,8 +817,8 @@ def test_untracked_cache_failure_does_not_break_init(tmp_path: Path, monkeypatch
 
     monkeypatch.setattr("omnigent.runtime.filesystem_registry.subprocess.run", _raise_oserror)
 
-    # Construction must not raise even though the config subprocess fails.
-    GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    registry = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    registry._enable_untracked_cache()
 
 
 def test_untracked_cache_config_written_once_per_root(tmp_path: Path, monkeypatch) -> None:
@@ -845,11 +848,104 @@ def test_untracked_cache_config_written_once_per_root(tmp_path: Path, monkeypatc
     monkeypatch.setattr(fsr.subprocess, "run", _counting_run)
 
     for _ in range(3):
-        GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+        registry = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+        registry._enable_untracked_cache()
 
     assert len(config_calls) == 1, (
         f"Expected core.untrackedCache config write exactly once, got {len(config_calls)}."
     )
+
+
+def test_untracked_cache_start_runs_once_in_daemon_thread(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Registry startup launches one non-blocking optimization worker."""
+    registry = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    completed = threading.Event()
+    daemon_values: list[bool] = []
+
+    def _record_worker() -> None:
+        daemon_values.append(threading.current_thread().daemon)
+        completed.set()
+
+    monkeypatch.setattr(registry, "_enable_untracked_cache", _record_worker)
+
+    registry.start()
+    registry.start()
+
+    assert completed.wait(timeout=1)
+    assert daemon_values == [True]
+
+
+def test_untracked_cache_already_enabled_skips_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runner waiting on another process re-checks config and exits."""
+    from omnigent.runtime import filesystem_registry as fsr
+
+    monkeypatch.setattr(fsr, "_untracked_cache_enabled", set())
+    calls: list[tuple[str, ...]] = []
+
+    def _enabled_config(args, **_kwargs):
+        calls.append(tuple(args))
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=b"true\n", stderr=b"")
+
+    monkeypatch.setattr(fsr.subprocess, "run", _enabled_config)
+    registry = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+
+    registry._enable_untracked_cache()
+
+    assert calls == [("git", "config", "--bool", "--get", "core.untrackedCache")]
+
+
+def test_git_common_dir_resolves_linked_worktree(tmp_path: Path) -> None:
+    """Worktrees coordinate through a lock in their shared Git directory."""
+    from omnigent.runtime.filesystem_registry import _git_common_dir
+
+    common_dir = tmp_path / "repo" / ".git"
+    worktree_git_dir = common_dir / "worktrees" / "feature"
+    worktree_git_dir.mkdir(parents=True)
+    (worktree_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    workspace = tmp_path / "feature"
+    workspace.mkdir()
+    (workspace / ".git").write_text(f"gitdir: {worktree_git_dir}\n", encoding="utf-8")
+
+    assert _git_common_dir(workspace) == common_dir.resolve()
+
+
+def test_untracked_cache_logs_probe_and_config_timings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Startup diagnostics time the probe and config subprocesses separately."""
+    from omnigent.runtime import filesystem_registry as fsr
+
+    monkeypatch.setattr(fsr, "_untracked_cache_enabled", set())
+    readings = iter((10.0, 10.001, 10.001, 10.007, 10.007, 10.009))
+    monkeypatch.setattr(fsr.time, "perf_counter", lambda: next(readings))
+    monkeypatch.setattr(
+        fsr.subprocess,
+        "run",
+        lambda args, **_kwargs: subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=b"",
+            stderr=b"",
+        ),
+    )
+
+    with caplog.at_level(logging.INFO, logger=fsr.__name__):
+        registry = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+        registry._enable_untracked_cache()
+
+    assert caplog.messages == [
+        f"git untracked-cache config checked: git_root={tmp_path} elapsed_ms=1.0 enabled=False",
+        f"git untracked-cache probe completed: git_root={tmp_path} elapsed_ms=6.0 returncode=0",
+        f"git untracked-cache config completed: git_root={tmp_path} elapsed_ms=2.0 returncode=0",
+    ]
 
 
 def test_untracked_cache_not_enabled_when_probe_fails(tmp_path: Path, monkeypatch) -> None:
@@ -880,7 +976,8 @@ def test_untracked_cache_not_enabled_when_probe_fails(tmp_path: Path, monkeypatc
 
     monkeypatch.setattr(fsr.subprocess, "run", _probe_fails_run)
 
-    GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    registry = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    registry._enable_untracked_cache()
 
     assert config_calls == [], (
         f"Expected no config write when the probe fails, got {config_calls}."


### PR DESCRIPTION
## Related issue

N/A

## Summary

Runner startup synchronously ran `git update-index --test-untracked-cache` while constructing the filesystem registry. On a large repository that filesystem probe took about six seconds, preventing the runner from opening its tunnel even though untracked-cache setup is an optional optimization.

This moves the probe to an idempotent daemon thread and coordinates concurrent runners with a repository-level file lock. Linked worktrees resolve their shared Git directory and use the same lock; after acquiring it, each process rechecks `core.untrackedCache` so only the first runner performs the expensive probe. Platforms without `flock` may repeat the background work, but runner startup remains non-blocking.

**ELI5:** Starting a runner no longer waits for Git to inspect the whole workspace. The runner connects immediately while that optional housekeeping happens in the background.

```text
Before: runner -> create filesystem registry -> Git probe (~6.1s) -> tunnel
After:  runner -> create filesystem registry -----------------------> tunnel
                   \-> background lock -> config recheck -> optional Git probe
```

Measured locally with a cold Claude-native session:

- Pre-tunnel startup: **6,597.0 ms → 431.3 ms** (**93.5% faster**, ~15.3×)
- Filesystem registry construction: **6,077.8 ms → 0.2 ms**
- Runner start to first harness event: approximately **1.08 seconds**

## Test Plan

- [x] Ran the affected filesystem, workspace-reader, and runner lifecycle suite: 163 passed
- [x] Ran all repository pre-commit hooks
- [x] Manually created a cold runner and confirmed the tunnel connected before background Git optimization completed

## Demo

N/A — backend performance change. Timing evidence is included in the Summary.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover idempotent asynchronous startup, already-enabled configuration, worktree common-directory resolution, failure degradation, and probe/config timing. Manual verification used a cold local runner and compared the phase timings against the synchronous baseline.

Verification commands:

```bash
uv run pytest -q tests/runtime/test_filesystem_registry.py tests/test_workspace_fs.py tests/runner/test_runner_entry.py
uv run pre-commit run --all-files
```

## Changelog

Runner startup no longer waits several seconds for Git's optional untracked-file cache probe.
