### PR TITLE
fix(pi): Show Pi’s thinking trace in Omnigent Web/Desktop/Mobile for pi-native sessions.

### DIFF
--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -1126,6 +1126,7 @@ module.exports = function (pi) {
   const postedToolCalls = new Set();
   const postedToolResults = new Set();
   const postedReasoning = new Set();
+  const streamedReasoningBlocks = new Set();
   const toolCallsById = new Map();
   const pendingInterruptMs = 30_000;
   // Live streaming state for assistant text deltas. Pi emits
@@ -1388,13 +1389,19 @@ module.exports = function (pi) {
     });
   }
 
-  async function postReasoningText(text, responseId, keyHint) {
+  async function postCompletedReasoning(text, responseId, keyHint, streamed) {
     if (typeof text !== "string" || !text.trim()) return;
     const textKey = `${responseId}:text:${fingerprint(text)}`;
     const key = `${responseId}:${keyHint || fingerprint(text)}`;
     if (postedReasoning.has(key) || postedReasoning.has(textKey)) return;
     postedReasoning.add(key);
     postedReasoning.add(textKey);
+    if (!streamed) {
+      await postEvent(config, {
+        type: "external_output_reasoning_delta",
+        data: { delta: text, started: true },
+      });
+    }
     await postEvent(config, {
       type: "external_conversation_item",
       data: {
@@ -1406,6 +1413,21 @@ module.exports = function (pi) {
           content: [{ type: "reasoning_text", text }],
         },
       },
+    });
+  }
+
+  function reasoningBlockKey(responseId, contentIndex) {
+    return `${responseId}:msg:${streamingMessageOrdinal}:thinking:${contentIndex}`;
+  }
+
+  async function postReasoningDelta(update, responseId) {
+    if (typeof update.delta !== "string" || !update.delta) return;
+    const blockKey = reasoningBlockKey(responseId, update.contentIndex);
+    const started = !streamedReasoningBlocks.has(blockKey);
+    streamedReasoningBlocks.add(blockKey);
+    await postEvent(config, {
+      type: "external_output_reasoning_delta",
+      data: { delta: update.delta, started },
     });
   }
 
@@ -1475,7 +1497,13 @@ module.exports = function (pi) {
       if (block.type === "thinking") {
         const text = typeof block.thinking === "string" ? block.thinking : "";
         const key = block.thinkingSignature || `${turnOrdinal}:${index}`;
-        await postReasoningText(text, responseId, key);
+        const blockKey = reasoningBlockKey(responseId, index);
+        await postCompletedReasoning(
+          text,
+          responseId,
+          key,
+          streamedReasoningBlocks.has(blockKey),
+        );
       }
     }
   }
@@ -1563,6 +1591,7 @@ module.exports = function (pi) {
     postedToolCalls.clear();
     postedToolResults.clear();
     postedReasoning.clear();
+    streamedReasoningBlocks.clear();
     toolCallsById.clear();
     streamedTextIndex.clear();
     finalizedTextBlocks.clear();
@@ -1630,13 +1659,23 @@ module.exports = function (pi) {
       await postTextDelta(update, responseId);
       return;
     }
+    if (update.type === "thinking_delta") {
+      await postReasoningDelta(update, responseId);
+      return;
+    }
     if (update.type === "toolcall_end") {
       await postToolCall(update.toolCall, responseId);
       return;
     }
     if (update.type === "thinking_end") {
       const key = `${turnOrdinal}:${update.contentIndex}`;
-      await postReasoningText(update.content, responseId, key);
+      const blockKey = reasoningBlockKey(responseId, update.contentIndex);
+      await postCompletedReasoning(
+        update.content,
+        responseId,
+        key,
+        streamedReasoningBlocks.has(blockKey),
+      );
     }
   });
 
@@ -1731,8 +1770,8 @@ module.exports = function (pi) {
     // posted and this finalize agree on the id regardless of whether Pi
     // fires message_start.
     await finalizeStreamingMessage(responseId);
-    streamingMessageOrdinal += 1;
     await mirrorAssistantMessage(message, responseId);
+    streamingMessageOrdinal += 1;
     // ``message_end`` is the primary usage-capture site (one completed
     // assistant message per LLM call); fold its token counts into the
     // cumulative session totals and flush to the server for pricing.

--- a/tests/test_pi_native_extension.py
+++ b/tests/test_pi_native_extension.py
@@ -637,6 +637,50 @@ def test_text_deltas_post_incrementally_with_stable_id() -> None:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_thinking_deltas_post_live_reasoning(tmp_path: Path) -> None:
+    """Pi reasoning streams live and persists for history hydration."""
+    script = (
+        _STREAMING_HARNESS
+        + r"""
+(async () => {
+  await handlers.agent_start({}, ctx);
+  await handlers.turn_start({ turnIndex: 1 }, ctx);
+
+  await feed({ type: "thinking_start", contentIndex: 0 });
+  await feed({ type: "thinking_delta", contentIndex: 0, delta: "plan " });
+  await feed({ type: "thinking_delta", contentIndex: 0, delta: "step" });
+  await feed({ type: "thinking_end", contentIndex: 0, content: "plan step" });
+
+  const message = {
+    role: "assistant",
+    content: [
+      { type: "thinking", thinking: "plan step", thinkingSignature: "sig-1" },
+      { type: "text", text: "Answer" },
+    ],
+  };
+  await handlers.message_end({ message }, ctx);
+  await handlers.turn_end({ message, toolResults: [] }, ctx);
+
+  const reasoning = posted.filter((e) => e.type === "external_output_reasoning_delta");
+  assert.deepEqual(
+    reasoning.map((e) => e.data),
+    [
+      { delta: "plan ", started: true },
+      { delta: "step", started: false },
+    ],
+  );
+  const completed = items().filter((e) => e.data.item_type === "reasoning");
+  assert.equal(completed.length, 1, JSON.stringify(completed));
+  assert.deepEqual(completed[0].data.item_data.content, [
+    { type: "reasoning_text", text: "plan step" },
+  ]);
+})().catch((e) => { console.error(e && e.stack ? e.stack : e); process.exit(1); });
+"""
+    )
+    result = _run_node(script, str(_extension_path()), str(tmp_path))
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def test_multiple_text_blocks_share_one_message_preview(tmp_path: Path) -> None:
     """Multiple text blocks in one message stream under one message_id.
 

--- a/web/src/lib/conversationItems.ts
+++ b/web/src/lib/conversationItems.ts
@@ -61,6 +61,13 @@ export interface ErrorItem extends BaseItem {
   message: string;
 }
 
+export interface ReasoningItem extends BaseItem {
+  type: "reasoning";
+  model: string;
+  summary: Array<{ type: string; text: string }>;
+  content?: Array<{ type: string; text: string }>;
+}
+
 /** The provider-native tool item types the runtime persists today. */
 export const NATIVE_TOOL_ITEM_TYPES = new Set<string>([
   "web_search_call",
@@ -158,6 +165,7 @@ export type ConversationItem =
   | FunctionCallItem
   | FunctionCallOutputItem
   | ErrorItem
+  | ReasoningItem
   | NativeToolItem
   | CompactionItem
   | SlashCommandItem
@@ -179,6 +187,10 @@ export function isFunctionCallOutputItem(item: ConversationItem): item is Functi
 
 export function isErrorItem(item: ConversationItem): item is ErrorItem {
   return item.type === "error";
+}
+
+export function isReasoningItem(item: ConversationItem): item is ReasoningItem {
+  return item.type === "reasoning";
 }
 
 export function isNativeToolItem(item: ConversationItem): item is NativeToolItem {

--- a/web/src/lib/itemsToBlocks.test.ts
+++ b/web/src/lib/itemsToBlocks.test.ts
@@ -7,6 +7,7 @@ import type {
   CompactionBlock,
   ErrorBlock,
   NativeToolBlock,
+  ReasoningBlock,
   SlashCommandBlock,
   TextDone,
   ToolGroup,
@@ -174,6 +175,27 @@ describe("itemsToBlocks — flat shape", () => {
     const blocks = itemsToBlocks(items);
     const td = blocks.find((b): b is TextDone => b.type === "text_done");
     expect(td?.hasCodeBlocks).toBe(true);
+  });
+
+  it("reasoning items survive history hydration", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "rs_1",
+        response_id: "resp_1",
+        type: "reasoning",
+        status: "completed",
+        model: "Pi",
+        summary: [],
+        content: [{ type: "reasoning_text", text: "Inspect the shared path first." }],
+      },
+      assistantMessage("resp_1", "Done."),
+    ];
+    const blocks = itemsToBlocks(items);
+    const reasoning = blocks[0] as ReasoningBlock;
+    expect(reasoning.type).toBe("reasoning_block");
+    expect(reasoning.ctx.itemId).toBe("rs_1");
+    expect(reasoning.ctx.responseId).toBe("resp_1");
+    expect(reasoning.reasoningText).toBe("Inspect the shared path first.");
   });
 
   it("assistant interrupted marker is preserved on TextDone", () => {

--- a/web/src/lib/itemsToBlocks.ts
+++ b/web/src/lib/itemsToBlocks.ts
@@ -15,6 +15,7 @@ import {
   type CompactionBlock,
   type ErrorBlock,
   type NativeToolBlock,
+  type ReasoningBlock,
   type RoutingDecisionBlock,
   type SlashCommandBlock,
   type TerminalCommandBlock,
@@ -35,6 +36,7 @@ import {
   type FunctionCallOutputItem,
   type MessageItem,
   type NativeToolItem,
+  type ReasoningItem,
   type RoutingDecisionItem,
   type SlashCommandItem,
   type TerminalCommandItem,
@@ -44,6 +46,7 @@ import {
   isFunctionCallOutputItem,
   isMessageItem,
   isNativeToolItem,
+  isReasoningItem,
   isRoutingDecisionItem,
   isSlashCommandItem,
   isTerminalCommandItem,
@@ -99,6 +102,9 @@ function itemToBlock(item: ConversationItem): AnyBlock | null {
   }
   if (isErrorItem(item)) {
     return errorToBlock(item);
+  }
+  if (isReasoningItem(item)) {
+    return reasoningToBlock(item);
   }
   if (isNativeToolItem(item)) {
     return nativeToolToBlock(item);
@@ -230,6 +236,15 @@ function errorToBlock(item: ErrorItem): ErrorBlock {
     source: item.source,
     code: item.code,
     message: item.message,
+  };
+}
+
+function reasoningToBlock(item: ReasoningItem): ReasoningBlock {
+  return {
+    type: "reasoning_block",
+    ctx: ctxFor(item),
+    reasoningText: (item.content ?? []).map((block) => block.text).join("\n\n"),
+    summaryText: item.summary.map((block) => block.text).join("\n\n"),
   };
 }
 


### PR DESCRIPTION
## Related issue

N/A

## Summary
- Previously Pi reasoning/thinking trace does not show up on the Web/Desktop UI, even though it does show up through the CLI.
- This PR makes it so that thinking trace from `pi-native` sessions running on Omnigent would be exposed to the Web/Desktop/Mobile
- Forward Pi `thinking_delta` events as live reasoning output without duplicating the completed reasoning item.
- Rehydrate persisted reasoning items into web `ReasoningBlock`s so reasoning remains visible after reload.

**ELI5:** Pi previously exposed its reasoning only after it finished, and the web history path discarded persisted reasoning. This keeps one reasoning block visible both while it streams and after history reloads.

```text
Pi thinking_delta -> native bridge -> live reasoning block
Pi thinking_end   -> persisted item -> history reasoning block
```

## Test Plan

- `.venv/bin/python -m pytest tests/test_pi_native_extension.py -q`
- `npm --prefix web exec -- vitest run src/lib/itemsToBlocks.test.ts`
- `npm --prefix web run type-check`
- `.venv/bin/pre-commit run --all-files`

## Demo

Before:
<img width="1679" height="844" alt="Screenshot 2026-07-21 at 14 56 57" src="https://github.com/user-attachments/assets/638aa8a7-6f02-45c5-b9a5-84a20dfc85cd" />

After:
<img width="1670" height="834" alt="Screenshot 2026-07-21 at 15 13 38" src="https://github.com/user-attachments/assets/aa3ee1bc-e4dd-40bb-92cd-25330bf69430" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The Pi bridge test covers live reasoning deltas and deduplicated persistence; the web test covers reasoning-item history hydration.

## Changelog

Pi sessions now show reasoning while it streams and after conversation history reloads.
