### PR TITLE
fix(ci): install web dependencies with matching peer mode

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -85,7 +85,7 @@ jobs:
       # — this step only needs to install the web app's deps so that hook works.
       - name: Install web deps (for the update overlay build)
         working-directory: web
-        run: npm ci --no-audit --no-fund
+        run: npm ci --legacy-peer-deps --no-audit --no-fund
 
       - name: Build ${{ matrix.platform }} app
         working-directory: web/electron


### PR DESCRIPTION
## Related issue

N/A

## Summary

The Electron build workflow could not install the web dependencies because it used strict peer resolution against a lockfile generated with legacy peer handling. Use `--legacy-peer-deps` consistently with the web lockfile generation and other web CI jobs.

## Test Plan

- `cd web && npx --yes --package npm@11.12.1 npm ci --legacy-peer-deps --no-audit --no-fund`
- `cd web && npm run build:overlay`
- `uv run pre-commit run --files .github/workflows/electron-build.yml`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the install with CI's pinned npm 11.12.1 and built the update overlay successfully. This workflow-only correction does not require a new automated test.

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>
