### PR TITLE
chore(lint): fix pre-existing ruff format violations on master

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -428,6 +428,11 @@ extend-exclude = [
     # Protobuf-generated code (DO NOT EDIT); not ours to restyle.
     "omnigent/api/**/*_pb2.py",
     "omnigent/api/**/*_pb2.pyi",
+    # Notebook fixtures for the file-viewer preview feature: intentionally
+    # messy edge-case content (quote styles, spacing, a deliberately broken
+    # notebook that isn't even valid JSON) that exists to be rendered, not
+    # reformatted. ruff format would rewrite them or error on the broken one.
+    "web/src/shell/__fixtures__",
 ]
 
 [tool.ruff.lint]

--- a/tests/e2e_ui/desktop/test_desktop_update.py
+++ b/tests/e2e_ui/desktop/test_desktop_update.py
@@ -120,6 +120,3 @@ def test_settings_updates_section_check_and_mode(
     check_button.click()
     page.wait_for_function("() => window.__omniUpdate.calls.includes('check')")
     assert "check" in _bridge_calls(page)
-
-
-


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two pre-existing `ruff format` violations sit on `main`. They don't fail master's push CI (which lints only changed files) but do fail every PR (which lints the full tree via `pre-commit run --all-files`), so each open PR inherits a red `Pre-commit checks`:

1. **Notebook preview fixtures** (`web/src/shell/__fixtures__/*.ipynb`, from #1848) — `ruff format` rewrites their cell contents (quote style, spacing) and outright errors on `03_broken.ipynb`, which is deliberately not valid JSON. These are intentionally-messy edge-case fixtures for the file-viewer preview feature; they exist to be rendered, not reformatted. Fix: add the directory to `ruff`'s `extend-exclude`.
2. **`tests/e2e_ui/desktop/test_desktop_update.py`** (from #2975) — three trailing blank lines `ruff format` strips. Fix: apply the format.

After both, `ruff format --check .` is clean across the tree (1965 files).

## Test Plan

```
uv run ruff format --check .   # clean — 1965 files, 0 reformats
uv run ruff check .            # clean
```

## Demo

N/A — lint/config only, no runtime behavior change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Lint configuration and formatting only — no code behavior changes, so no new tests. Verified by running `ruff format --check .` and `ruff check .` clean on the full tree.

This pull request and its description were written by Isaac.
