### PR TITLE
fix(ci): format desktop update test

### DIFF
--- a/tests/e2e_ui/desktop/test_desktop_update.py
+++ b/tests/e2e_ui/desktop/test_desktop_update.py
@@ -120,6 +120,3 @@ def test_settings_updates_section_check_and_mode(
     check_button.click()
     page.wait_for_function("() => window.__omniUpdate.calls.includes('check')")
     assert "check" in _bridge_calls(page)
-
-
-


### PR DESCRIPTION
## Related issue

N/A

## Summary

Main's lint workflow failed because the desktop update E2E test retained extra trailing blank lines. Apply Ruff's formatting so the all-files pre-commit check remains clean.

## Test Plan

- `.venv/bin/pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Formatting-only correction; the full all-files pre-commit suite passes.

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>
