### PR TITLE
perf(db): consolidate scheduled_tasks listing into one user-scoped index

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1471,8 +1471,16 @@ class SqlScheduledTask(OmnigentBase):
     __table_args__ = (
         CheckConstraint("state IN (1, 2, 3)", name="ck_scheduled_tasks_state"),
         CheckConstraint("execution_target IN (1, 2)", name="ck_scheduled_tasks_execution_target"),
-        Index("ix_scheduled_tasks_created_at", "workspace_id", "created_at", "id"),
-        Index("ix_scheduled_tasks_user_id", "workspace_id", "user_id", "id"),
+        # One user-scoped listing index. Covers "a user's tasks ordered by
+        # created_at" (GET /scheduled-tasks) as a covered seek; the scheduler's
+        # state scan reads whole rows regardless of any index.
+        Index(
+            "ix_scheduled_tasks_user_scope",
+            "workspace_id",
+            "user_id",
+            "created_at",
+            "id",
+        ),
     )
 
 

--- a/omnigent/db/migrations/versions/f4664ca64ea8_consolidate_scheduled_tasks_user_scope_index.py
+++ b/omnigent/db/migrations/versions/f4664ca64ea8_consolidate_scheduled_tasks_user_scope_index.py
@@ -1,0 +1,60 @@
+"""Consolidate scheduled_tasks listing into one user-scoped index.
+
+Revision ID: f4664ca64ea8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-07-21 00:00:00.000000
+
+``scheduled_tasks`` carried two secondary indexes:
+
+- ``ix_scheduled_tasks_created_at`` (``workspace_id, created_at, id``)
+- ``ix_scheduled_tasks_user_id``    (``workspace_id, user_id, id``)
+
+The only per-request read is "list a user's tasks" (``GET /scheduled-tasks``):
+``WHERE workspace_id AND user_id ORDER BY created_at, id``. The user index was
+never used for it — the route filtered ``user_id`` in Python — so it was pure
+write/space overhead; and the ``created_at`` index served only the sort, forcing
+a scan of every owner's rows in the workspace with ``user_id`` as a residual
+filter.
+
+Replace both with a single ``ix_scheduled_tasks_user_scope``
+(``workspace_id, user_id, created_at, id``). With the ``user_id`` filter pushed
+into SQL, this is a covered seek for the per-user listing: it reads only the
+caller's rows, already in ``created_at, id`` order (no filesort). The
+scheduler-boot read (``list_active_all_workspaces``: ``WHERE state ORDER BY
+workspace_id, created_at, id``) uses neither index for its ``state`` filter and
+is a near-full scan once per process start regardless; its ordering only feeds
+independent per-task timer arming, so scanning unordered costs nothing.
+
+Index-only, no data change. ``DROP``/``CREATE INDEX`` is native on every
+dialect (no table rebuild). Downgrade restores the two original indexes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "f4664ca64ea8"
+down_revision: str | None = "c2d3e4f5a6b7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "scheduled_tasks"
+_MERGED = "ix_scheduled_tasks_user_scope"
+_CREATED_AT = "ix_scheduled_tasks_created_at"
+_USER_ID = "ix_scheduled_tasks_user_id"
+
+
+def upgrade() -> None:
+    """Fold the created_at + user_id indexes into one user-scoped index."""
+    op.drop_index(_USER_ID, table_name=_TABLE)
+    op.drop_index(_CREATED_AT, table_name=_TABLE)
+    op.create_index(_MERGED, _TABLE, ["workspace_id", "user_id", "created_at", "id"])
+
+
+def downgrade() -> None:
+    """Restore the separate created_at and user_id indexes."""
+    op.drop_index(_MERGED, table_name=_TABLE)
+    op.create_index(_CREATED_AT, _TABLE, ["workspace_id", "created_at", "id"])
+    op.create_index(_USER_ID, _TABLE, ["workspace_id", "user_id", "id"])

--- a/tests/db/test_migration_scheduled_tasks.py
+++ b/tests/db/test_migration_scheduled_tasks.py
@@ -120,15 +120,24 @@ def test_expected_indexes(db_engine: Engine) -> None:
     """Both tables expose the indexes that back the read paths."""
     insp = sa.inspect(db_engine)
     scheduled_tasks_idx = {i["name"] for i in insp.get_indexes("scheduled_tasks")}
-    assert {
-        "ix_scheduled_tasks_created_at",
-        "ix_scheduled_tasks_user_id",
-    } <= scheduled_tasks_idx
+    assert "ix_scheduled_tasks_user_scope" in scheduled_tasks_idx
+    scheduled_tasks_idx_cols = {
+        i["name"]: list(i["column_names"]) for i in insp.get_indexes("scheduled_tasks")
+    }
+    assert scheduled_tasks_idx_cols["ix_scheduled_tasks_user_scope"] == [
+        "workspace_id",
+        "user_id",
+        "created_at",
+        "id",
+    ]
     assert "ix_scheduled_tasks_agent_id" not in scheduled_tasks_idx
-    # ix_scheduled_tasks_state was dropped: list_active's per-workspace shape
-    # has no production caller, and the boot-time list_active_all_workspaces
-    # scan is served by ix_scheduled_tasks_created_at with state as a residual
-    # filter (see migration e5c8b1f4a2d7).
+    # The separate created_at + user_id listing indexes were folded into the
+    # single user-scope index above: with the user_id filter pushed into SQL the
+    # per-user list is a covered seek, and the boot scan reads whole rows
+    # regardless (see migration f4664ca64ea8).
+    assert "ix_scheduled_tasks_created_at" not in scheduled_tasks_idx
+    assert "ix_scheduled_tasks_user_id" not in scheduled_tasks_idx
+    # ix_scheduled_tasks_state was dropped earlier (see migration e5c8b1f4a2d7).
     assert "ix_scheduled_tasks_state" not in scheduled_tasks_idx
     runs_idx = {i["name"] for i in insp.get_indexes("scheduled_task_runs")}
     assert "ix_scheduled_task_runs_scheduled_task_id" in runs_idx

--- a/tests/db/test_migration_unify_user_id.py
+++ b/tests/db/test_migration_unify_user_id.py
@@ -75,12 +75,16 @@ def test_scheduled_tasks_user_id_column_at_head(db_engine: Engine) -> None:
 
 
 def test_scheduled_tasks_index_renamed(db_engine: Engine) -> None:
-    """The scheduled_tasks owner index is ``ix_scheduled_tasks_user_id`` at head."""
+    """At head the scheduled_tasks owner index is the consolidated user-scope index.
+
+    This revision renamed ``ix_scheduled_tasks_owner_user_id`` to
+    ``ix_scheduled_tasks_user_id``; migration f4664ca64ea8 then folded it with the
+    created_at listing index into ``ix_scheduled_tasks_user_scope``.
+    """
     idx = {i["name"] for i in sa.inspect(db_engine).get_indexes("scheduled_tasks")}
-    assert "ix_scheduled_tasks_user_id" in idx, f"Expected ix_scheduled_tasks_user_id; found {idx}"
-    assert "ix_scheduled_tasks_owner_user_id" not in idx, (
-        f"ix_scheduled_tasks_owner_user_id should be gone; found {idx}"
-    )
+    assert "ix_scheduled_tasks_user_scope" in idx, idx
+    assert "ix_scheduled_tasks_user_id" not in idx
+    assert "ix_scheduled_tasks_owner_user_id" not in idx
 
 
 def test_downgrade_restores_old_names(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

`scheduled_tasks` carried two secondary indexes — `ix_scheduled_tasks_created_at` `(workspace_id, created_at, id)` and `ix_scheduled_tasks_user_id` `(workspace_id, user_id, id)`. The only per-request read is "list a user's tasks" (`GET /scheduled-tasks`): `WHERE workspace_id AND user_id ORDER BY created_at, id`. The user index was never used for it — the route filtered `user_id` in Python — so it was pure write/space overhead; and the `created_at` index served only the sort, forcing a scan of every owner's rows in the workspace.

- Fold both into a single **`ix_scheduled_tasks_user_scope` `(workspace_id, user_id, created_at, id)`** (migration `f4664ca64ea8`, off the current head `b3c1a2d4e5f6`).
- Add `ScheduledTaskStore.list_for_user(user_id)` and switch the route to it, pushing the owner filter into SQL (`user_id=None` → `IS NULL` for the single-user/OSS case). The per-user listing is now a covered seek — it reads only the caller's rows, already `created_at, id`-ordered — instead of a full-workspace scan filtered in application memory.
- The scheduler-boot read (`list_active_all_workspaces`) uses neither index for its `state` filter and runs a near-full scan once per process start regardless; its ordering only feeds independent per-task timer arming, so dropping the `created_at`-ordered scan costs nothing.

Index-only migration, no data change; downgrade restores both original indexes.

## Test Plan

- `tests/db/test_migration_scheduled_tasks.py` and `tests/db/test_migration_unify_user_id.py` — updated the expected-index assertions to the consolidated index; `test_downgrade_restores_old_names` exercises the new migration's upgrade **and** downgrade chain.
- `tests/stores/test_scheduled_task_store.py` — added `test_list_for_user_filters_by_owner` (per-user isolation, `None` → `IS NULL`, and state-agnostic: active + paused both returned).
- `tests/server/integration/test_scheduled_tasks_routes.py`, `test_scheduler_lifespan.py`, `tests/server/scheduled/test_fire.py` — pass unchanged (route now hits `list_for_user`).
- 95 tests pass; `ruff check` + `ruff format` clean.

```
cd omnigent && python -m pytest \
  tests/db/test_migration_scheduled_tasks.py \
  tests/db/test_migration_unify_user_id.py \
  tests/stores/test_scheduled_task_store.py \
  tests/server/integration/test_scheduled_tasks_routes.py
```

## Demo

N/A — non-visual (DB index + query-path change).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a store-level unit test for the new `list_for_user` filter (owner isolation + `IS NULL` + state-agnostic) and updated the two migration index-expectation tests. The route and scheduler paths are covered by the existing integration suites, which pass against the new query.

This pull request and its description were written by Isaac.
