### PR TITLE
perf(runtime): bump default idle-reap window to 1 hour

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -98,7 +98,7 @@ _SOCKET_MODE = 0o600
 # Per §Deployment knobs vs spec self-containment, this is a
 # deployment-level capacity knob — operators may tune; specs MUST
 # NOT depend on a specific value.
-_DEFAULT_IDLE_TIMEOUT_S = 30 * 60  # 30 minutes
+_DEFAULT_IDLE_TIMEOUT_S = 60 * 60  # 1 hour
 
 # How often the idle reaper wakes up to check for stale entries.
 # Picking 1/30th of the timeout keeps reaping reasonably prompt
@@ -115,7 +115,7 @@ def _resolve_harness_idle_timeout_s() -> float:
     """Resolve the harness idle-reap window in seconds.
 
     Honors :envvar:`OMNIGENT_HARNESS_IDLE_TIMEOUT_S` (``0`` disables reaping);
-    otherwise the 30-minute default. An unparseable or negative value logs a
+    otherwise the 1-hour default. An unparseable or negative value logs a
     warning and falls back to the default rather than failing the runner at
     boot — an env typo shouldn't take the runner down.
     """
@@ -526,7 +526,7 @@ class HarnessProcessManager:
 
     :param idle_timeout_s: Seconds of inactivity after which a
         subprocess gets reaped. Deployment-level capacity knob;
-        defaults to 30 minutes. Specs MUST NOT depend on a
+        defaults to 1 hour. Specs MUST NOT depend on a
         specific value.
     :param reaper_interval_s: Seconds between idle-reaper passes.
         Defaults to 60.
@@ -546,7 +546,7 @@ class HarnessProcessManager:
         tmp_parent: Path | None = None,
     ) -> None:
         # ``None`` (the default at both construction sites) resolves from the
-        # OMNIGENT_HARNESS_IDLE_TIMEOUT_S env var, else the 30-minute default.
+        # OMNIGENT_HARNESS_IDLE_TIMEOUT_S env var, else the 1-hour default.
         self._idle_timeout_s = (
             idle_timeout_s if idle_timeout_s is not None else _resolve_harness_idle_timeout_s()
         )

--- a/omnigent/terminals/pane_reaper.py
+++ b/omnigent/terminals/pane_reaper.py
@@ -65,8 +65,8 @@ NATIVE_PANE_TERMINAL_NAMES: frozenset[str] = frozenset(
 )
 
 # Default idle window before an unused native pane is reaped. Mirrors
-# ``HarnessProcessManager``'s 30-minute SDK-proxy default for consistency.
-_DEFAULT_IDLE_TIMEOUT_S = 30 * 60
+# ``HarnessProcessManager``'s 1-hour SDK-proxy default for consistency.
+_DEFAULT_IDLE_TIMEOUT_S = 60 * 60
 _DEFAULT_REAPER_INTERVAL_S = 60.0
 _IDLE_TIMEOUT_ENV = "OMNIGENT_NATIVE_PANE_IDLE_TIMEOUT_S"
 
@@ -91,7 +91,7 @@ def resolve_native_pane_idle_timeout_s() -> float:
     """Resolve the native-pane idle window in seconds.
 
     Honors :envvar:`OMNIGENT_NATIVE_PANE_IDLE_TIMEOUT_S` (``0`` disables pane
-    reaping); otherwise the 30-minute default. An unparseable or negative value
+    reaping); otherwise the 1-hour default. An unparseable or negative value
     logs a warning and falls back to the default rather than failing the runner
     at boot — an env typo shouldn't take the runner down or (worse) make the
     reaper act on a bogus window.


### PR DESCRIPTION
## Related issue

N/A

## Summary

Bumps the default idle-reap window from **30 minutes to 1 hour** for the two inner reapers so short lulls between turns don't tear down live sessions:

- `_DEFAULT_IDLE_TIMEOUT_S` in `omnigent/runtime/harnesses/process_manager.py` — SDK-proxy harness subprocesses.
- `_DEFAULT_IDLE_TIMEOUT_S` in `omnigent/terminals/pane_reaper.py` — native CLI tmux panes (mirrors the harness default for consistency).

The runner-level watchdog (`_DEFAULT_RUNNER_IDLE_TIMEOUT_S`) was already at 1 hour, so the outer watchdog now consistently outlives the inner reapers it contains. Both bumped defaults remain overridable via `OMNIGENT_HARNESS_IDLE_TIMEOUT_S` / `OMNIGENT_NATIVE_PANE_IDLE_TIMEOUT_S`, and specs must not depend on the specific value. Doc/comment references to "30 minutes" were updated to "1 hour".

## Test Plan

Ran the affected suites — all pass:

```
python -m pytest tests/terminals/test_pane_reaper.py \
  tests/runtime/harnesses/test_process_manager_idle_config.py \
  tests/runner/test_runner_entry.py -q
# 95 passed
```

Existing tests exercise env-var overrides (explicit `1800` values) and the default-resolution paths, so the constant change is covered.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — existing unit tests in the suites above cover default resolution and env overrides.

This pull request and its description were written by Isaac.