### PR TITLE
fix(onboarding): accept application-mode arrow keys in setup menus

### DIFF
--- a/omnigent/onboarding/interactive.py
+++ b/omnigent/onboarding/interactive.py
@@ -468,7 +468,9 @@ def select(
 
                 if _select.select([fd], [], [], 0.05)[0]:
                     nxt = os.read(fd, 1)
-                    if nxt == b"[":
+                    # b"[" is normal cursor mode, b"O" application cursor
+                    # mode (DECCKM) — terminals send either for ↑/↓.
+                    if nxt in (b"[", b"O"):
                         arrow = os.read(fd, 1)
                         if arrow == b"A":  # Up
                             selected = _step_selectable(mask, selected, -1)

--- a/omnigent/onboarding/wizard.py
+++ b/omnigent/onboarding/wizard.py
@@ -90,7 +90,9 @@ def _arrow_menu(
         if ch == b"\x1b":
             if _select.select([fd], [], [], 0.05)[0]:
                 ch2 = os.read(fd, 1)
-                if ch2 == b"[":
+                # b"[" is normal cursor mode, b"O" application cursor mode
+                # (DECCKM) — terminals send either for ↑/↓.
+                if ch2 in (b"[", b"O"):
                     ch3 = os.read(fd, 1)
                     if ch3 == b"A":
                         return "up"

--- a/omnigent/repl/_theme_picker.py
+++ b/omnigent/repl/_theme_picker.py
@@ -347,7 +347,9 @@ def startup_theme_picker(
                 if next_c is None:
                     # Bare Escape — accept current.
                     break
-                if next_c == "[":
+                # "[" is normal cursor mode, "O" application cursor mode
+                # (DECCKM) — terminals send either for ↑/↓.
+                if next_c in ("[", "O"):
                     arrow = _read_raw_byte_timeout(fd, timeout=0.05)
                     if arrow == "A":  # Up
                         selected = (selected - 1) % len(_ITEMS)

--- a/tests/onboarding/test_interactive.py
+++ b/tests/onboarding/test_interactive.py
@@ -1,15 +1,15 @@
 """Tests for the shared onboarding interactive selectors.
 
 :mod:`omnigent.onboarding.interactive` provides the theme-picker-styled
-``select`` arrow-key menu and the ``prompt_text`` text input. The
-raw-termios TTY path cannot be exercised in a headless test runner (no
-controlling terminal), so these tests cover the **non-TTY numbered
-fallback** — the path pipes, CI, and the CLI test suite actually hit.
-
-Each test forces a non-TTY by monkeypatching ``sys.stdin.isatty`` to
-``False`` and feeds input via ``click``'s isolated input stream, then
-asserts on the returned index / string so a regression in the fallback
+``select`` arrow-key menu and the ``prompt_text`` text input. Most tests
+here cover the **non-TTY numbered fallback** — the path pipes, CI, and the
+CLI test suite actually hit — by monkeypatching ``sys.stdin.isatty`` to
+``False`` and feeding input via ``click``'s isolated input stream, then
+asserting on the returned index / string so a regression in the fallback
 parsing surfaces here.
+
+The raw-termios TTY path has no controlling terminal in a headless runner,
+so the tests that need one stand up a pty (see :func:`_select_over_pty`).
 """
 
 from __future__ import annotations
@@ -464,3 +464,76 @@ def test_render_menu_compact_truncates_long_description_to_one_line() -> None:
     assert len(hint_lines) == 1
     assert "…" in hint_lines[0]
     assert len(hint_lines[0]) <= 40
+
+
+def _select_over_pty(monkeypatch: pytest.MonkeyPatch, keys: bytes) -> int:
+    """Run :func:`select` against a real pty, feeding it *keys*.
+
+    ``openpty`` gives the raw-termios path the controlling terminal a
+    headless runner otherwise lacks, so the ↑/↓ escape-sequence parsing
+    can be exercised directly. ``setcbreak`` flushes pending input, so the
+    keys are written from a helper thread only once the menu has switched
+    the pty into cbreak mode.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param keys: Raw bytes to deliver as keystrokes, e.g. ``b"\\x1b[B\\r"``.
+    :returns: The index :func:`select` returned.
+    """
+    import os
+    import pty
+    import threading
+    import tty
+
+    ready = threading.Event()
+    real_setcbreak = tty.setcbreak
+
+    def _setcbreak_then_signal(fd: int, when: int = tty.TCSAFLUSH) -> None:
+        real_setcbreak(fd, when)
+        ready.set()
+
+    monkeypatch.setattr(tty, "setcbreak", _setcbreak_then_signal)
+
+    controller, follower = pty.openpty()
+
+    def _send() -> None:
+        ready.wait(timeout=10)
+        os.write(controller, keys)
+
+    writer = threading.Thread(target=_send, daemon=True)
+    try:
+        stdin = os.fdopen(follower, "rb", buffering=0)
+        monkeypatch.setattr(sys, "stdin", stdin)
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        writer.start()
+        return interactive.select("Pick", ["Claude", "Codex", "Quit"])
+    finally:
+        writer.join(timeout=10)
+        os.close(controller)
+
+
+@pytest.mark.parametrize(
+    ("introducer", "label"),
+    [(b"[", "normal cursor mode"), (b"O", "application cursor mode")],
+)
+def test_select_arrow_keys_work_in_both_cursor_modes(
+    monkeypatch: pytest.MonkeyPatch,
+    introducer: bytes,
+    label: str,
+) -> None:
+    """↑/↓ move the cursor whether the terminal sends ``ESC [ A`` or ``ESC O A``.
+
+    A terminal left in application cursor mode (DECCKM, what the ``smkx``
+    terminfo capability turns on) sends ``ESC O A``/``ESC O B`` for the
+    arrows. Dropping that form leaves the menu looking frozen — Esc and
+    Enter still respond, but the selection never moves.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param introducer: The escape-sequence introducer under test.
+    :param label: The cursor mode *introducer* corresponds to.
+    :returns: None.
+    """
+    # Down, down, up → lands on index 1; Enter confirms.
+    keys = b"\x1b" + introducer + b"B" + b"\x1b" + introducer + b"B"
+    keys += b"\x1b" + introducer + b"A" + b"\r"
+
+    assert _select_over_pty(monkeypatch, keys) == 1, label


### PR DESCRIPTION
## Related issue

Closes #2988

## Summary

Terminals in application cursor mode (DECCKM, what the `smkx` terminfo capability turns on) send `ESC O A`/`ESC O B` for the arrow keys instead of `ESC [ A`/`ESC [ B`. The hand-rolled key readers only matched the latter and silently dropped the former, so `omni setup` looked frozen: Esc and Enter still responded, but the selection never moved.

Three readers parse escape sequences by hand and all had the same gap: `onboarding/interactive.py` (the one `omni setup` reaches), `onboarding/wizard.py`, and `repl/_theme_picker.py`. Each now accepts both introducers. Both sequences are three bytes, so the surrounding read logic is unchanged.

## Test Plan

- New unit test `test_select_arrow_keys_work_in_both_cursor_modes` in `tests/onboarding/test_interactive.py`, parametrized over both introducers. It drives the raw-termios path over a `pty`, since the existing tests only covered the non-TTY numbered fallback. Fails on the `ESC O` case before the fix, passes after.
- `uv run pytest tests/onboarding tests/repl`: green, apart from one pre-existing failure in `test_repl.py::test_build_startup_header_creds_line_hints_first_available` that also fails on `main` in my environment.
- `uv run pre-commit run --files <changed files>`: clean.
- Manually on Ghostty 1.3.1 with `TERM=xterm-ghostty`: `printf '\033[?1h'; omni setup` navigates with the fix, does nothing without it.

## Demo

N/A, terminal key handling with no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test covers `interactive.select()`, the reader behind the reported failure. The identical one-line change in `wizard.py` and `_theme_picker.py` is covered by manual verification only. Happy to add a pty test to those suites too if you want them locked down.

## Changelog

Arrow keys now work in `omni setup` on terminals using application cursor mode
