### PR TITLE
fix(codex): honor custom provider env auth

### DIFF
--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -231,6 +231,22 @@ def _codex_auth_unavailable_reason() -> HarnessUnavailableReason | None:
     if routes_through_provider:
         return None
     source = _resolve_codex_auth_source()
+    # An env-key-only custom provider stays in the bridged config.toml rather
+    # than becoming a launch override, so the resolver above legitimately
+    # looks like the built-in OpenAI path. Check the declared key against the
+    # same scrubbed environment Codex receives before falling back to
+    # auth.json. This avoids both the false ``needs-auth`` report and a false
+    # green for variables that the executor would filter out.
+    from omnigent.inner.codex_executor import _clean_codex_env
+    from omnigent.onboarding.ambient import codex_config_custom_provider_env_key
+
+    provider_env_key = codex_config_custom_provider_env_key(
+        source.auth_path.with_name("config.toml")
+    )
+    if provider_env_key is not None:
+        provider_credential = _clean_codex_env().get(provider_env_key)
+        if isinstance(provider_credential, str) and provider_credential.strip():
+            return None
     if not _codex_auth_json_has_available_credential(source.auth_path):
         return HARNESS_NEEDS_AUTH
     return None

--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -317,6 +317,55 @@ def _effective_codex_model_provider(config: dict[str, object]) -> str | None:
     return None
 
 
+def _read_codex_config(config_path: Path) -> dict[str, object] | None:
+    """Read a Codex ``config.toml`` without surfacing local config errors.
+
+    :param config_path: Path to the Codex ``config.toml`` to inspect.
+    :returns: The parsed config mapping, or ``None`` when the file is missing,
+        unreadable, malformed, or not a TOML table.
+    """
+    try:
+        raw = config_path.read_bytes()
+    except OSError:
+        return None
+    try:
+        config = tomllib.loads(raw.decode("utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError):
+        return None
+    return config if isinstance(config, dict) else None
+
+
+def codex_config_custom_provider_env_key(config_path: Path) -> str | None:
+    """Return the effective custom provider's declared ``env_key``.
+
+    Codex can authenticate a custom ``model_provider`` from an environment
+    variable named by its provider table. This helper identifies that variable
+    without reading or returning its value, so callers can check the exact
+    environment they will pass to Codex.
+
+    :param config_path: Path to the Codex ``config.toml`` to inspect.
+    :returns: The non-empty ``env_key`` name, or ``None`` when the config is
+        absent/malformed, selects a built-in or undefined provider, requires
+        OpenAI login, or does not declare an ``env_key``.
+    """
+    config = _read_codex_config(config_path)
+    if config is None:
+        return None
+    provider_id = _effective_codex_model_provider(config)
+    if provider_id is None or provider_id in _CODEX_BUILTIN_PROVIDERS:
+        return None
+    providers = config.get("model_providers")
+    if not isinstance(providers, dict):
+        return None
+    table = providers.get(provider_id)
+    if not isinstance(table, dict) or table.get("requires_openai_auth") is True:
+        return None
+    env_key = table.get("env_key")
+    if not isinstance(env_key, str) or not env_key.strip():
+        return None
+    return env_key.strip()
+
+
 def codex_config_custom_provider(config_path: Path) -> CodexConfigProvider | None:
     """Detect a custom, auth-carrying default model provider in a Codex config.
 
@@ -347,15 +396,8 @@ def codex_config_custom_provider(config_path: Path) -> CodexConfigProvider | Non
         malformed, the effective provider is built-in or unset, its table
         is absent, or the table carries no self-contained auth.
     """
-    try:
-        raw = config_path.read_bytes()
-    except OSError:
-        # Missing or unreadable file — nothing configured.
-        return None
-    try:
-        config = tomllib.loads(raw.decode("utf-8"))
-    except (tomllib.TOMLDecodeError, UnicodeDecodeError):
-        # Malformed TOML — treat as not configured rather than crash setup.
+    config = _read_codex_config(config_path)
+    if config is None:
         return None
 
     provider_id = _effective_codex_model_provider(config)

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -185,6 +185,56 @@ def test_codex_auth_unavailable_reason_provider_override_available(
     assert codex_native._codex_auth_unavailable_reason() is None
 
 
+def test_codex_auth_unavailable_reason_custom_provider_env_key_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A populated custom-provider ``env_key`` works without auth.json."""
+    auth_path = tmp_path / "codex-home" / "auth.json"  # never created
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True)
+    auth_path.parent.mkdir(parents=True)
+    auth_path.with_name("config.toml").write_text(
+        """
+model_provider = "aigateway"
+
+[model_providers.aigateway]
+name = "AI Gateway"
+base_url = "https://coder.example.com/api/v2/aibridge/openai/v1"
+env_key = "OPENAI_CODER_AIGATEWAY_SESSION_TOKEN"
+wire_api = "responses"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENAI_CODER_AIGATEWAY_SESSION_TOKEN", "session-token")
+
+    assert codex_native._codex_auth_unavailable_reason() is None
+
+
+@pytest.mark.parametrize("credential", [None, "", "   "])
+def test_codex_auth_unavailable_reason_custom_provider_env_key_missing_needs_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, credential: str | None
+) -> None:
+    """A missing or empty custom-provider variable still reports needs-auth."""
+    auth_path = tmp_path / "codex-home" / "auth.json"  # never created
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True)
+    auth_path.parent.mkdir(parents=True)
+    auth_path.with_name("config.toml").write_text(
+        """
+model_provider = "aigateway"
+
+[model_providers.aigateway]
+base_url = "https://coder.example.com/openai/v1"
+env_key = "OPENAI_CODER_AIGATEWAY_SESSION_TOKEN"
+""",
+        encoding="utf-8",
+    )
+    if credential is None:
+        monkeypatch.delenv("OPENAI_CODER_AIGATEWAY_SESSION_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("OPENAI_CODER_AIGATEWAY_SESSION_TOKEN", credential)
+
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
 def test_codex_auth_unavailable_reason_resolver_failure_falls_back_to_auth_json(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #2984

## Summary

Codex readiness now resolves the effective custom provider from config.toml and checks the provider's declared env_key before falling back to auth.json. The check uses the same filtered environment passed to the Codex subprocess, so it does not report a provider as ready when its credential would be stripped at launch.

In simple terms, an authenticated gateway-backed Codex setup is no longer mistaken for a logged-out standard Codex installation.

## Test Plan

- `uv run --extra dev pytest -q tests/test_codex_native.py tests/onboarding/test_ambient.py` (253 passed)
- `uv run --extra dev ruff check omnigent/codex_native.py omnigent/onboarding/ambient.py tests/test_codex_native.py`
- `uv run --extra dev ruff format --check omnigent/codex_native.py omnigent/onboarding/ambient.py tests/test_codex_native.py`
- `pre-commit run --files omnigent/codex_native.py omnigent/onboarding/ambient.py tests/test_codex_native.py`

## Demo

The screenshot shows the actual readiness output from the PR branch for the three regression scenarios: a custom provider with a populated env key, the same provider with the env key missing, and the standard provider with a valid auth file.

![Codex readiness demo](https://raw.githubusercontent.com/yaodong-shen/omnigent/12c873f3cc011869484f08a2a1885cc3bed40162/omnigent-readiness-demo.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression coverage includes a populated custom-provider env_key, missing and empty values, and the existing standard auth.json cases.

## Changelog

Codex custom providers authenticated through env_key are now reported as available.
