### PR TITLE
perf(store): batch FTS inserts in append and fork_conversation

### DIFF
--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -792,20 +792,26 @@ def insert_fts_bulk(
         return
     if not (session.bind and _supports_fts5(session.bind.dialect.name)):
         return
-    placeholders = ", ".join(f"(:item_id_{i}, :cid_{i}, :st_{i})" for i in range(len(rows)))
-    params: dict[str, str] = {}
-    for i, (item_id, conversation_id, search_text) in enumerate(rows):
-        params[f"item_id_{i}"] = item_id
-        params[f"cid_{i}"] = conversation_id
-        params[f"st_{i}"] = search_text
-    session.execute(
-        text(
-            f"INSERT INTO {_FTS_TABLE}"
-            f"(item_id, conversation_id, search_text) "
-            f"VALUES {placeholders}"
-        ),
-        params,
-    )
+    # 3 params per row; keep total < 999 (SQLite's safe SQLITE_MAX_VARIABLE_NUMBER
+    # on pre-3.32 builds). Newer SQLite raised the limit to 32766, but chunking at
+    # 300 is safe on all versions.
+    _CHUNK_SIZE = 300
+    for chunk_start in range(0, len(rows), _CHUNK_SIZE):
+        chunk = rows[chunk_start : chunk_start + _CHUNK_SIZE]
+        placeholders = ", ".join(f"(:item_id_{i}, :cid_{i}, :st_{i})" for i in range(len(chunk)))
+        params: dict[str, str] = {}
+        for i, (item_id, conversation_id, search_text) in enumerate(chunk):
+            params[f"item_id_{i}"] = item_id
+            params[f"cid_{i}"] = conversation_id
+            params[f"st_{i}"] = search_text
+        session.execute(
+            text(
+                f"INSERT INTO {_FTS_TABLE}"
+                f"(item_id, conversation_id, search_text) "
+                f"VALUES {placeholders}"
+            ),
+            params,
+        )
 
 
 def delete_fts_by_conversation(session: Session, conversation_id: str) -> None:

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -775,6 +775,39 @@ def insert_fts(
         )
 
 
+def insert_fts_bulk(
+    session: Session,
+    rows: list[tuple[str, str, str]],
+) -> None:
+    """
+    Dual-write multiple rows into the FTS5 table in a single INSERT.
+
+    On dialects without FTS5 this is a no-op. An empty ``rows`` list is also
+    a no-op.
+
+    :param session: An active SQLAlchemy session.
+    :param rows: Each tuple is ``(item_id, conversation_id, search_text)``.
+    """
+    if not rows:
+        return
+    if not (session.bind and _supports_fts5(session.bind.dialect.name)):
+        return
+    placeholders = ", ".join(f"(:item_id_{i}, :cid_{i}, :st_{i})" for i in range(len(rows)))
+    params: dict[str, str] = {}
+    for i, (item_id, conversation_id, search_text) in enumerate(rows):
+        params[f"item_id_{i}"] = item_id
+        params[f"cid_{i}"] = conversation_id
+        params[f"st_{i}"] = search_text
+    session.execute(
+        text(
+            f"INSERT INTO {_FTS_TABLE}"
+            f"(item_id, conversation_id, search_text) "
+            f"VALUES {placeholders}"
+        ),
+        params,
+    )
+
+
 def delete_fts_by_conversation(session: Session, conversation_id: str) -> None:
     """
     Remove all FTS rows for a conversation (SQLite-family dialects only).

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3216,7 +3216,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 items_query = items_query.where(SqlConversationItem.position <= cutoff_position)
             source_items = session.execute(items_query).scalars().all()
 
-            fts_rows = []
+            fts_rows: list[tuple[str, str, str]] = []
             for pos, src_item in enumerate(source_items):
                 # src_item.type/status are int codes copied verbatim to the new
                 # row; only generate_item_id needs the decoded string type.

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -60,7 +60,7 @@ from omnigent.db.utils import (
     generate_item_id,
     get_or_create_conversation_engine,
     get_or_create_engine,
-    insert_fts,
+    insert_fts_bulk,
     make_managed_session_maker,
     now_epoch,
     strip_nul_bytes,
@@ -1845,6 +1845,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     + 1
                 )
 
+            fts_rows: list[tuple[str, str, str]] = []
             for item in items:
                 position = next_pos
                 next_pos += 1
@@ -1869,7 +1870,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     created_by=item.created_by,
                 )
                 session.add(row)
-                insert_fts(session, item_id, conversation_id, search)
+                fts_rows.append((item_id, conversation_id, search))
                 persisted.append(
                     ConversationItem(
                         id=row.id,
@@ -1884,6 +1885,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                         created_by=item.created_by,
                     )
                 )
+            insert_fts_bulk(session, fts_rows)
 
             # Persist the advanced counter so the next append reads it instead
             # of scanning; this also lazily backfills a pre-counter conversation.
@@ -3214,6 +3216,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 items_query = items_query.where(SqlConversationItem.position <= cutoff_position)
             source_items = session.execute(items_query).scalars().all()
 
+            fts_rows = []
             for pos, src_item in enumerate(source_items):
                 # src_item.type/status are int codes copied verbatim to the new
                 # row; only generate_item_id needs the decoded string type.
@@ -3231,12 +3234,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                     created_by=src_item.created_by,
                 )
                 session.add(new_item)
-                insert_fts(
-                    session,
-                    new_item_id,
-                    new_conv.id,
-                    src_item.search_text or "",
-                )
+                fts_rows.append((new_item_id, new_conv.id, src_item.search_text or ""))
+            insert_fts_bulk(session, fts_rows)
 
             # The clone copied len(source_items) items at dense positions
             # 0..N-1, so its position allocator starts at N. Seed it from the


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `append` and `fork_conversation` in `SqlAlchemyConversationStore` called `insert_fts` once per item inside their copy/append loops, producing N+1 raw SQL `INSERT INTO conversation_items_fts` statements for every batch of items.
- Added `insert_fts_bulk(session, rows)` in `omnigent/db/utils.py` that collects all `(item_id, conversation_id, search_text)` tuples and issues a single multi-row `INSERT` (no-op on empty list or non-FTS5 dialects).
- Replaced the per-item `insert_fts` calls in both `append` and `fork_conversation` with a single `insert_fts_bulk` call after each loop. `insert_fts` is kept intact for any single-item callers.

## Test Plan

1. Run the existing store unit tests:
   ```
   cd /Users/tomu.hirata/omnigent
   .venv/bin/pytest tests/stores/ -x -q
   ```
2. Verify FTS search still works after appending items:
   - Start a local server (`omnigent serve`)
   - Create a session, send several messages
   - Use the search API to confirm items are indexed

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change
- [x] Performance improvement

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change is a pure query-batching refactor with identical semantics: same rows written, same session, same dialect guard. Existing store tests exercise the FTS write path. Manual verification confirmed FTS results are unaffected.