### PR TITLE
perf(conv-store): batch FTS deletes in delete_conversation

### DIFF
--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -793,6 +793,26 @@ def delete_fts_by_conversation(session: Session, conversation_id: str) -> None:
         )
 
 
+def delete_fts_by_conversation_ids(session: Session, conv_ids: list[str]) -> None:
+    """
+    Remove all FTS rows for a list of conversations in a single query.
+
+    No-op when ``conv_ids`` is empty or the dialect lacks FTS5.
+
+    :param session: An active SQLAlchemy session.
+    :param conv_ids: Conversation IDs whose FTS rows should be removed.
+    """
+    if not conv_ids:
+        return
+    if session.bind and _supports_fts5(session.bind.dialect.name):
+        placeholders = ", ".join(f":cid{i}" for i in range(len(conv_ids)))
+        params = {f"cid{i}": cid for i, cid in enumerate(conv_ids)}
+        session.execute(
+            text(f"DELETE FROM {_FTS_TABLE} WHERE conversation_id IN ({placeholders})"),
+            params,
+        )
+
+
 # ── Search text extraction ─────────────────────────────
 
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -53,7 +53,7 @@ from omnigent.db.enum_codecs import (
 from omnigent.db.utils import (
     _supports_fts5,
     build_search_snippet,
-    delete_fts_by_conversation,
+    delete_fts_by_conversation_ids,
     ensure_fts_table,
     extract_search_text,
     generate_conversation_id,
@@ -3533,8 +3533,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 .all()
             )
             bound_agent_ids = candidate_agent_ids - surviving_refs
-            for conv_id in subtree_ids:
-                delete_fts_by_conversation(ap_sess, conv_id)
+            delete_fts_by_conversation_ids(ap_sess, list(subtree_ids))
             ap_sess.execute(
                 delete(SqlConversationItem).where(
                     SqlConversationItem.workspace_id == current_workspace_id(),


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- `delete_conversation` collected all subtree conversation IDs via a recursive CTE, then deleted FTS rows in a per-ID loop — N separate `DELETE FROM conversation_items_fts WHERE conversation_id = :cid` statements for a tree of depth N.
- Added `delete_fts_by_conversation_ids(session, conv_ids)` in `omnigent/db/utils.py` that issues a single `DELETE ... WHERE conversation_id IN (...)`, with a no-op guard for an empty list.
- Replaced the loop in `delete_conversation` with one call to the new function. The existing single-ID `delete_fts_by_conversation` is kept intact for other callers (tests, etc.).

## Test Plan

1. Run the existing FTS unit tests to confirm nothing regressed:
   ```
   python -m pytest tests/db/test_utils_extended.py tests/db/test_d1_fts_dialect.py -v
   ```
2. Run the conversation store tests:
   ```
   python -m pytest tests/stores/conversation_store/ -v -k "delete"
   ```
3. Optionally, enable SQLite query logging and delete a conversation with several descendants; confirm a single FTS DELETE is issued instead of one per ID.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Performance improvement
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing FTS helper tests in `tests/db/test_utils_extended.py` and `tests/db/test_d1_fts_dialect.py` exercise the delete path. The new bulk function follows the identical dialect-guard and parameterisation pattern as the existing helpers, so no new test was required. Manually verified that `delete_fts_by_conversation` still appears in those test files and is not imported in `sqlalchemy_store.py`.

## Changelog

Deleting a conversation with many descendants now issues a single FTS DELETE instead of one per descendant.