### PR TITLE
Pin Polly orchestrator to Opus 4.8

### DIFF
--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -19,14 +19,11 @@ spawn: true
 # Orchestrator "brain": Claude Agent SDK. polly writes no code itself — it
 # delegates ALL coding work (investigation, implementation, review) to the
 # claude_code / codex / opencode / cursor / hermes / pi sub-agents, doing only non-code authoring (docs /
-# Markdown / text edits, skills) itself. No model/profile is pinned, so the
-# brain runs on whatever Claude provider is configured as the default
-# (`omnigent setup --no-internal-beta`) — an Anthropic API key, a Claude
-# subscription, an OpenAI-compatible gateway, or a Databricks workspace. With
-# no model named the claude-sdk harness resolves the configured provider's
-# default Claude model (the bundled catalog default is claude-opus-4-8).
+# Markdown / text edits, skills) itself. The brain is pinned to Opus 4.8 through
+# the configured Databricks model.
 executor:
   type: omnigent
+  model: databricks-claude-opus-4-8
   context_window: 1000000
   config:
     harness: claude-sdk


### PR DESCRIPTION
## Related issue

N/A

## Summary

Pin Polly's orchestrator executor to `databricks-claude-opus-4-8` so its brain starts on Opus 4.8 instead of relying on the configured Claude default.

## Test Plan

- Ran `git diff --check`.
- Parsed `examples/polly/config.yaml` with PyYAML.
- Asserted that `executor.model` equals `databricks-claude-opus-4-8`.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Confirmed the YAML parses successfully and the resulting executor model value is exactly `databricks-claude-opus-4-8`. This configuration-only change does not alter executable code.

## Changelog

Polly's orchestrator now starts on Opus 4.8.