### PR TITLE
feat(web): poll subagent tree lists as a staleness floor

### DIFF
--- a/tests/e2e_ui/agents/test_agents_tab.py
+++ b/tests/e2e_ui/agents/test_agents_tab.py
@@ -15,9 +15,10 @@ multi-agent case where the badge and rows grow once sub-agents exist.
 
 from __future__ import annotations
 
+import json
 import re
 
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page, Route, expect
 
 from tests.e2e_ui.conftest import open_right_rail
 
@@ -52,3 +53,43 @@ def test_agents_tab_lists_lone_agent(
     # and a lone agent has no sub-agent rows beneath it.
     expect(rail.locator(_SUBAGENT_MAIN_ROW)).to_be_visible(timeout=30_000)
     expect(rail.locator(_SUBAGENT_ROW)).to_have_count(0)
+
+
+def test_agents_tab_polls_for_new_child(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A child created without a stream event appears on the poll floor."""
+    base_url, session_id = seeded_session
+    request_count = 0
+
+    def child_sessions(route: Route) -> None:
+        nonlocal request_count
+        request_count += 1
+        children = []
+        if request_count > 1:
+            children.append(
+                {
+                    "id": "conv_polled_child",
+                    "title": "researcher:polled",
+                    "tool": "researcher",
+                    "session_name": "polled",
+                    "current_task_status": "completed",
+                    "busy": False,
+                    "last_message_preview": None,
+                    "pending_elicitations_count": 0,
+                }
+            )
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"object": "list", "data": children}),
+        )
+
+    page.route(f"**/v1/sessions/{session_id}/child_sessions", child_sessions)
+    page.goto(f"{base_url}/c/{session_id}")
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("^Agents")).click()
+    expect(rail.locator(_SUBAGENT_ROW)).to_have_count(0)
+    expect(rail.locator(_SUBAGENT_ROW)).to_have_count(1, timeout=20_000)

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -686,13 +686,15 @@ describe("SubagentsPanel", () => {
     expect(row.querySelector('[data-icon="pi"]')).toBeNull();
   });
 
-  it("fetches child sessions without polling (push-driven via watch-set)", () => {
+  it("polls the child-sessions list at the tree's staleness-floor interval", () => {
+    // The stream only pushes ``session.child_session.updated`` for the
+    // streamed session's direct children — the rest of the tree has no
+    // live channel — so every list in the rail refetches on a poll floor.
     useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
 
     renderPanel({ rootSessionId: "conv_root" });
 
-    expect(useChildSessionsMock).toHaveBeenCalledWith("conv_root");
-    expect(useChildSessionsMock).not.toHaveBeenCalledWith("conv_root", expect.any(Number));
+    expect(useChildSessionsMock).toHaveBeenLastCalledWith("conv_root", 15_000);
   });
 
   it("highlights the main row when conversationId === rootSessionId (on the parent)", () => {
@@ -1456,8 +1458,8 @@ describe("SubagentsPanel", () => {
     ).toEqual(["c1", "c2", "c3"]);
     // The depth-3 row's child query is disabled (null id) instead of
     // fetching c3's children.
-    expect(useChildSessionsMock).toHaveBeenCalledWith(null);
-    expect(useChildSessionsMock).not.toHaveBeenCalledWith("c3");
+    expect(useChildSessionsMock).toHaveBeenCalledWith(null, expect.any(Number));
+    expect(useChildSessionsMock).not.toHaveBeenCalledWith("c3", expect.any(Number));
   });
 
   it("highlights the active grandchild row", () => {

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -101,7 +101,15 @@ interface SubagentsPanelProps {
 type ViewMode = "list" | "graph";
 
 export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanelProps) {
-  const { children, isLoading, error } = useChildSessions(rootSessionId);
+  // Every list in the tree polls at TREE_POLL_MS as a staleness floor;
+  // stream pushes remain the fast path. The stream only carries
+  // ``session.child_session.updated`` for the *streamed* (active)
+  // session's direct children — deeper levels, and the whole tree when
+  // the user is viewing a descendant, have no live channel, so without
+  // the poll their status would freeze at the snapshot. A child can be
+  // busy even when its parent is "idle" (parent parked awaiting the
+  // child); the poll + stream together surface that.
+  const { children, isLoading, error } = useChildSessions(rootSessionId, TREE_POLL_MS);
   const [addOpen, setAddOpen] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [collapsedRows, setCollapsedRows] = useState<Record<string, boolean>>({});
@@ -110,7 +118,8 @@ export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanel
   };
 
   // Loading/error states only surface when there's no cached data to
-  // show alongside the "main" row.
+  // show alongside the "main" row. Once any data is available we
+  // render the list and let polling refresh it transparently.
   if (isLoading && children.length === 0) {
     return (
       <div className="flex h-full flex-1 items-center justify-center px-4 py-8 text-center text-xs text-muted-foreground bg-card">
@@ -692,6 +701,11 @@ function MainRow({ rootSessionId, isActive }: { rootSessionId: string; isActive:
   );
 }
 
+// Staleness-floor poll interval for every child list in the tree. See
+// the comment in SubagentsPanel — only the streamed session's direct
+// children get live pushes, so the rest of the tree relies on this.
+const TREE_POLL_MS = 15_000;
+
 // Indentation: depth 1 keeps the original 24px gutter (pl-6); each
 // further level steps in by another 14px so the connector glyphs read
 // as a tree.
@@ -730,7 +744,10 @@ function SubagentRow({
   // This child's own sub-agents, rendered as the next tree level.
   // Disabled (null id) at the depth cap so the fan-out of fetches is
   // bounded; ``useChildSessions`` skips the query entirely for null.
-  const { children: grandchildren } = useChildSessions(depth < MAX_TREE_DEPTH ? child.id : null);
+  const { children: grandchildren } = useChildSessions(
+    depth < MAX_TREE_DEPTH ? child.id : null,
+    TREE_POLL_MS,
+  );
   const hasGrandchildren = grandchildren.length > 0;
   const ToggleIcon = collapsed ? ChevronRightIcon : ChevronDownIcon;
   return (


### PR DESCRIPTION
Follow-up to #975, as invited. The polling piece was written for that PR but lost in a rebase before merge.

The stream only pushes session.child_session.updated for the streamed session's direct children, so deeper tree levels (and the whole tree when the user is viewing a descendant) had no live channel and froze at their snapshot. Every child list in the rail now refetches on a 15s poll floor (TREE_POLL_MS) while stream pushes remain the fast path. useChildSessions already supports pollMs on main; this wires it in.

All 62 SubagentsPanel tests pass, including updated poll-floor expectations.