### PR TITLE
fix(android): honor system dark mode

### DIFF
--- a/web/android/app/build.gradle.kts
+++ b/web/android/app/build.gradle.kts
@@ -101,6 +101,7 @@ play {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.activity)
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.webkit)
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -313,7 +313,12 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun applyColorScheme(scheme: String) {
-        val light = scheme == "light"
+        val light =
+            when (scheme) {
+                "light" -> true
+                "dark" -> false
+                else -> return
+            }
         WindowInsetsControllerCompat(window, window.decorView).apply {
             isAppearanceLightStatusBars = light
             isAppearanceLightNavigationBars = light

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -148,9 +148,6 @@ class MainActivity : ComponentActivity() {
                     downloadFile(downloadUrl, contentDisposition, mimeType)
                 }
             }
-        // No algorithmic darkening: with targetSdk >= 33 the DayNight theme alone
-        // makes prefers-color-scheme track the OS, and darkening would invert the
-        // SPA when the user forces light mode under an OS dark theme.
         // Wrap the WebView in a FrameLayout so the floating server-switcher
         // pill can sit on top of it. The pill uses the app's brand palette
         // (values/values-night colors.xml) so it adapts to light/dark mode.

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -33,7 +33,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 
@@ -149,9 +148,9 @@ class MainActivity : ComponentActivity() {
                     downloadFile(downloadUrl, contentDisposition, mimeType)
                 }
             }
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
-            WebSettingsCompat.setAlgorithmicDarkeningAllowed(webView.settings, true)
-        }
+        // No algorithmic darkening: with targetSdk >= 33 the DayNight theme alone
+        // makes prefers-color-scheme track the OS, and darkening would invert the
+        // SPA when the user forces light mode under an OS dark theme.
         // Wrap the WebView in a FrameLayout so the floating server-switcher
         // pill can sit on top of it. The pill uses the app's brand palette
         // (values/values-night colors.xml) so it adapts to light/dark mode.

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -32,6 +32,7 @@ import androidx.core.view.MenuCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
@@ -303,10 +304,19 @@ class MainActivity : ComponentActivity() {
                 OmnigentBridgeListener(
                     notifications = notifications,
                     blobSaver = blobSaver,
+                    onColorScheme = ::applyColorScheme,
                 ),
             )
         } catch (_: IllegalArgumentException) {
             // Malformed origin rule — leave the bridge absent; the web layer falls back.
+        }
+    }
+
+    private fun applyColorScheme(scheme: String) {
+        val light = scheme == "light"
+        WindowInsetsControllerCompat(window, window.decorView).apply {
+            isAppearanceLightStatusBars = light
+            isAppearanceLightNavigationBars = light
         }
     }
 

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -136,6 +136,8 @@ class MainActivity : ComponentActivity() {
                 webViewClient =
                     OmnigentWebViewClient(
                         pinnedOrigin = { pinnedOrigin },
+                        // Full page loads briefly use OS-derived bar polarity until the SPA
+                        // reports its resolved scheme; capable SPAs override it immediately.
                         onTopLevelNavigation = ::resetColorSchemeToSystem,
                         onPageReady = ::onPageReady,
                         onLoginRequired = ::startLogin,

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -312,16 +312,10 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun applyColorScheme(scheme: String) {
-        val light =
-            when (scheme) {
-                "light" -> true
-                "dark" -> false
-                else -> return
-            }
+    private fun applyColorScheme(isLight: Boolean) {
         WindowInsetsControllerCompat(window, window.decorView).apply {
-            isAppearanceLightStatusBars = light
-            isAppearanceLightNavigationBars = light
+            isAppearanceLightStatusBars = isLight
+            isAppearanceLightNavigationBars = isLight
         }
     }
 

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import android.app.DownloadManager
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -31,6 +32,7 @@ import androidx.core.view.MenuCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 
@@ -146,6 +148,9 @@ class MainActivity : ComponentActivity() {
                     downloadFile(downloadUrl, contentDisposition, mimeType)
                 }
             }
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+            WebSettingsCompat.setAlgorithmicDarkeningAllowed(webView.settings, true)
+        }
         // Wrap the WebView in a FrameLayout so the floating server-switcher
         // pill can sit on top of it. The pill uses the app's brand palette
         // (values/values-night colors.xml) so it adapts to light/dark mode.
@@ -269,6 +274,14 @@ class MainActivity : ComponentActivity() {
 
         ensureNotificationPermission()
         webView.loadUrl(serverUrl)
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        if (::webView.isInitialized) {
+            // Notify matchMedia listeners without reloading the SPA.
+            webView.dispatchConfigurationChanged(newConfig)
+        }
     }
 
     /**

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -33,6 +33,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.webkit.ScriptHandler
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 
@@ -56,6 +57,8 @@ class MainActivity : ComponentActivity() {
     private var pendingNavigatePath: String? = null
     private var lastInsets: Insets? = null
     private var pageLoaded = false
+    private var bridgeTransportInstalled = false
+    private var bridgeScriptHandler: ScriptHandler? = null
     private var loginAttempts = 0 // capped browser-login retries; reset in onPageReady
     private var historyCleared = false // drop pre-auth/login-redirect history once
 
@@ -139,6 +142,9 @@ class MainActivity : ComponentActivity() {
                         // Full page loads briefly use OS-derived bar polarity until the SPA
                         // reports its resolved scheme; capable SPAs override it immediately.
                         onTopLevelNavigation = ::resetColorSchemeToSystem,
+                        shouldInjectBridgeAtPageReady = {
+                            bridgeTransportInstalled && bridgeScriptHandler == null
+                        },
                         onPageReady = ::onPageReady,
                         onLoginRequired = ::startLogin,
                     )
@@ -308,21 +314,36 @@ class MainActivity : ComponentActivity() {
             )
         } catch (_: IllegalArgumentException) {
             // Malformed origin rule — leave the bridge absent; the web layer falls back.
+            return
+        }
+        bridgeTransportInstalled = true
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
+            try {
+                bridgeScriptHandler =
+                    WebViewCompat.addDocumentStartJavaScript(
+                        webView,
+                        NativeBridgeScript.source,
+                        setOf(origin),
+                    )
+            } catch (_: IllegalArgumentException) {
+                // Keep the transport; onPageFinished will inject the facade instead.
+            }
         }
     }
 
-    private fun applyColorScheme(isLight: Boolean) {
+    private fun applyColorScheme(scheme: ResolvedColorScheme) {
+        val useDarkIcons = scheme == ResolvedColorScheme.LIGHT
         WindowInsetsControllerCompat(window, window.decorView).apply {
-            isAppearanceLightStatusBars = isLight
-            isAppearanceLightNavigationBars = isLight
+            isAppearanceLightStatusBars = useDarkIcons
+            isAppearanceLightNavigationBars = useDarkIcons
         }
     }
 
     private fun resetColorSchemeToSystem() {
-        val isLight =
+        val isLightMode =
             resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK !=
                 Configuration.UI_MODE_NIGHT_YES
-        applyColorScheme(isLight)
+        applyColorScheme(if (isLightMode) ResolvedColorScheme.LIGHT else ResolvedColorScheme.DARK)
     }
 
     /**
@@ -467,7 +488,10 @@ class MainActivity : ComponentActivity() {
         pendingMicRequest = null
         loginManager.shutdown()
         if (::blobSaver.isInitialized) blobSaver.shutdown()
-        if (::webView.isInitialized) webView.destroy() // releases the bridge chain
+        if (::webView.isInitialized) {
+            removeBridge()
+            webView.destroy()
+        }
         super.onDestroy()
     }
 
@@ -502,6 +526,20 @@ class MainActivity : ComponentActivity() {
         serverUrl: String,
         newOrigin: String,
     ) {
+        removeBridge()
+        pinnedOrigin = newOrigin
+        pageLoaded = false
+        historyCleared = false
+        loginAttempts = 0
+        (switchButton as? TextView)?.text = hostLabelOf(serverUrl)
+        installBridge()
+        webView.loadUrl(serverUrl)
+    }
+
+    private fun removeBridge() {
+        bridgeScriptHandler?.remove()
+        bridgeScriptHandler = null
+        bridgeTransportInstalled = false
         try {
             WebViewCompat.removeWebMessageListener(
                 webView,
@@ -510,13 +548,6 @@ class MainActivity : ComponentActivity() {
         } catch (_: Exception) {
             // Not registered (feature unsupported, or already removed) — no-op.
         }
-        pinnedOrigin = newOrigin
-        pageLoaded = false
-        historyCleared = false
-        loginAttempts = 0
-        (switchButton as? TextView)?.text = hostLabelOf(serverUrl)
-        installBridge()
-        webView.loadUrl(serverUrl)
     }
 
     /**

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -136,6 +136,7 @@ class MainActivity : ComponentActivity() {
                 webViewClient =
                     OmnigentWebViewClient(
                         pinnedOrigin = { pinnedOrigin },
+                        onTopLevelNavigation = ::resetColorSchemeToSystem,
                         onPageReady = ::onPageReady,
                         onLoginRequired = ::startLogin,
                     )
@@ -313,6 +314,13 @@ class MainActivity : ComponentActivity() {
             isAppearanceLightStatusBars = isLight
             isAppearanceLightNavigationBars = isLight
         }
+    }
+
+    private fun resetColorSchemeToSystem() {
+        val isLight =
+            resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK !=
+                Configuration.UI_MODE_NIGHT_YES
+        applyColorScheme(isLight)
     }
 
     /**

--- a/web/android/app/src/main/java/ai/omnigent/android/NativeBridgeScript.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/NativeBridgeScript.kt
@@ -203,6 +203,10 @@ object NativeBridgeScript {
 
           window.omnigentNative = Object.freeze({
             kind: "android",
+            setColorScheme(scheme) {
+              if (scheme !== "light" && scheme !== "dark") return;
+              post({ method: "setColorScheme", scheme });
+            },
             setBadgeCount(count, options) {
               // Note: unlike iOS, the native side ignores count <= 0 — Android has
               // no badge-clear API, so a previously-set badge can't be cleared

--- a/web/android/app/src/main/java/ai/omnigent/android/NativeBridgeScript.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/NativeBridgeScript.kt
@@ -91,6 +91,29 @@ object NativeBridgeScript {
             } catch (_) {}
           };
 
+          // The SPA owns its resolved theme via the root class. Watch it here so
+          // native bars stay correct even when the server cannot report changes.
+          const resolvePageColorScheme = () => {
+            const root = document.documentElement;
+            if (root?.classList.contains("dark")) return "dark";
+            if (root?.classList.contains("light")) return "light";
+            return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+          };
+          let lastPageColorScheme = null;
+          const syncPageColorScheme = () => {
+            const scheme = resolvePageColorScheme();
+            if (scheme === lastPageColorScheme) return;
+            lastPageColorScheme = scheme;
+            post({ method: "setColorScheme", scheme });
+          };
+          const colorSchemeRoot = document.documentElement;
+          const colorSchemeObserver = colorSchemeRoot ? new MutationObserver(syncPageColorScheme) : null;
+          colorSchemeObserver?.observe(colorSchemeRoot, {
+            attributes: true,
+            attributeFilter: ["class"],
+          });
+          syncPageColorScheme();
+
           const notificationCallbacks = new Set();
           // An activation is a fire-once event, but the native side may emit it
           // (cold-start tap, replayed at page-ready) BEFORE the React listener

--- a/web/android/app/src/main/java/ai/omnigent/android/NativeBridgeScript.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/NativeBridgeScript.kt
@@ -13,6 +13,8 @@ package ai.omnigent.android
  * frames on the pinned origin. `notify()` resolves `true` optimistically (as on
  * iOS) since the post is fire-and-forget. native -> web is driven by
  * `evaluateJavascript` into the `window.__omnigentNativeEmit*` functions here.
+ * Once installed, the facade emits `omnigent-native-ready` so a SPA whose
+ * first color-scheme report raced the injection can replay it.
  */
 object NativeBridgeScript {
     val source: String =
@@ -251,6 +253,7 @@ object NativeBridgeScript {
               return () => insetCallbacks.delete(callback);
             },
           });
+          window.dispatchEvent(new Event("omnigent-native-ready"));
         })();
         """.trimIndent()
 }

--- a/web/android/app/src/main/java/ai/omnigent/android/OmnigentBridgeListener.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OmnigentBridgeListener.kt
@@ -1,6 +1,8 @@
 package ai.omnigent.android
 
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.webkit.WebView
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.WebMessageCompat
@@ -17,13 +19,16 @@ import org.json.JSONObject
  * structural equivalent of the iOS `isMainFrame` + frame-origin check that a
  * raw `addJavascriptInterface` bridge cannot express.
  *
- * Callbacks arrive on the UI thread, so notification calls need no hop; the
- * blob write offloads to [BlobSaver]'s own worker.
+ * Color-scheme updates are posted to the main looper; [BlobSaver] offloads
+ * writes to its own worker.
  */
 class OmnigentBridgeListener(
     private val notifications: NativeNotificationManager,
     private val blobSaver: BlobSaver,
+    private val onColorScheme: (String) -> Unit,
 ) : WebViewCompat.WebMessageListener {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
     override fun onPostMessage(
         view: WebView,
         message: WebMessageCompat,
@@ -46,6 +51,12 @@ class OmnigentBridgeListener(
             }
 
         when (json.optString("method")) {
+            "setColorScheme" -> {
+                val scheme = json.optString("scheme")
+                if (scheme != "light" && scheme != "dark") return
+                mainHandler.post { onColorScheme(scheme) }
+            }
+
             "setBadgeCount" -> {
                 notifications.setBadgeCount(
                     count = json.optInt("count", 0),

--- a/web/android/app/src/main/java/ai/omnigent/android/OmnigentBridgeListener.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OmnigentBridgeListener.kt
@@ -25,7 +25,7 @@ import org.json.JSONObject
 class OmnigentBridgeListener(
     private val notifications: NativeNotificationManager,
     private val blobSaver: BlobSaver,
-    private val onColorScheme: (isLight: Boolean) -> Unit,
+    private val onColorScheme: (ResolvedColorScheme) -> Unit,
 ) : WebViewCompat.WebMessageListener {
     private val mainHandler = Handler(Looper.getMainLooper())
 
@@ -52,13 +52,13 @@ class OmnigentBridgeListener(
 
         when (json.optString("method")) {
             "setColorScheme" -> {
-                val isLight =
+                val scheme =
                     when (json.optString("scheme")) {
-                        "light" -> true
-                        "dark" -> false
+                        "light" -> ResolvedColorScheme.LIGHT
+                        "dark" -> ResolvedColorScheme.DARK
                         else -> return
                     }
-                mainHandler.post { onColorScheme(isLight) }
+                mainHandler.post { onColorScheme(scheme) }
             }
 
             "setBadgeCount" -> {

--- a/web/android/app/src/main/java/ai/omnigent/android/OmnigentBridgeListener.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OmnigentBridgeListener.kt
@@ -25,7 +25,7 @@ import org.json.JSONObject
 class OmnigentBridgeListener(
     private val notifications: NativeNotificationManager,
     private val blobSaver: BlobSaver,
-    private val onColorScheme: (String) -> Unit,
+    private val onColorScheme: (isLight: Boolean) -> Unit,
 ) : WebViewCompat.WebMessageListener {
     private val mainHandler = Handler(Looper.getMainLooper())
 
@@ -52,9 +52,13 @@ class OmnigentBridgeListener(
 
         when (json.optString("method")) {
             "setColorScheme" -> {
-                val scheme = json.optString("scheme")
-                if (scheme != "light" && scheme != "dark") return
-                mainHandler.post { onColorScheme(scheme) }
+                val isLight =
+                    when (json.optString("scheme")) {
+                        "light" -> true
+                        "dark" -> false
+                        else -> return
+                    }
+                mainHandler.post { onColorScheme(isLight) }
             }
 
             "setBadgeCount" -> {

--- a/web/android/app/src/main/java/ai/omnigent/android/OmnigentWebViewClient.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OmnigentWebViewClient.kt
@@ -6,22 +6,20 @@ import android.net.Uri
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.webkit.WebViewFeature
 
 /**
- * Injects the [NativeBridgeScript] facade on the pinned origin, signals
- * [onPageReady] once a pinned-origin page finishes loading, and routes the OIDC
- * login flow to the system browser via [onLoginRequired].
+ * Signals [onPageReady] once a pinned-origin page finishes loading and routes
+ * the OIDC login flow to the system browser via [onLoginRequired].
  *
- * Unlike iOS's `WKUserScript(.atDocumentStart)`, Android has no pre-JS injection
- * hook; `onPageStarted` fires after the first response byte — in practice before
- * the SPA's bundle evaluates, so `window.omnigentNative` is present by the time
- * React mounts. Anything depending on the injected emit-callbacks (notification
- * replay, inset push) waits for [onPageReady].
+ * The facade is normally registered with `addDocumentStartJavaScript` in
+ * `MainActivity`. Older WebViews that support the message listener but not
+ * document-start scripts inject it after the pinned page finishes; the facade's
+ * ready event then replays any color scheme the SPA reported before injection.
  */
 class OmnigentWebViewClient(
     private val pinnedOrigin: () -> String?,
     private val onTopLevelNavigation: () -> Unit,
+    private val shouldInjectBridgeAtPageReady: () -> Boolean,
     private val onPageReady: (url: String?) -> Unit,
     private val onLoginRequired: () -> Unit,
 ) : WebViewClient() {
@@ -54,15 +52,6 @@ class OmnigentWebViewClient(
             onLoginRequired()
             return
         }
-
-        // Inject the facade ONLY on the pinned origin and only when the web
-        // message listener is supported — otherwise the web would see a dead
-        // bridge and suppress its own Web Notifications / fallbacks.
-        if (origin == pinnedOrigin() &&
-            WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
-        ) {
-            view.evaluateJavascript(NativeBridgeScript.source, null)
-        }
     }
 
     override fun onPageFinished(
@@ -70,6 +59,10 @@ class OmnigentWebViewClient(
         url: String?,
     ) {
         super.onPageFinished(view, url)
+        if (originOf(url) == pinnedOrigin() && shouldInjectBridgeAtPageReady()) {
+            view.evaluateJavascript(NativeBridgeScript.source) { onPageReady(url) }
+            return
+        }
         onPageReady(url)
     }
 

--- a/web/android/app/src/main/java/ai/omnigent/android/OmnigentWebViewClient.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OmnigentWebViewClient.kt
@@ -21,6 +21,7 @@ import androidx.webkit.WebViewFeature
  */
 class OmnigentWebViewClient(
     private val pinnedOrigin: () -> String?,
+    private val onTopLevelNavigation: () -> Unit,
     private val onPageReady: (url: String?) -> Unit,
     private val onLoginRequired: () -> Unit,
 ) : WebViewClient() {
@@ -30,6 +31,7 @@ class OmnigentWebViewClient(
         favicon: Bitmap?,
     ) {
         super.onPageStarted(view, url, favicon)
+        onTopLevelNavigation()
 
         val origin = originOf(url)
         val scheme = url?.let { Uri.parse(it).scheme?.lowercase() }

--- a/web/android/app/src/main/java/ai/omnigent/android/ResolvedColorScheme.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/ResolvedColorScheme.kt
@@ -1,0 +1,6 @@
+package ai.omnigent.android
+
+enum class ResolvedColorScheme {
+    LIGHT,
+    DARK,
+}

--- a/web/android/app/src/main/res/values-night/themes.xml
+++ b/web/android/app/src/main/res/values-night/themes.xml
@@ -2,7 +2,7 @@
 <!-- Night variant: the web UI follows the OS dark scheme, so the transparent
      bars sit over a dark page and need light icons again. -->
 <resources>
-    <style name="Theme.Omnigent" parent="@android:style/Theme.Material.Light.NoActionBar">
+    <style name="Theme.Omnigent" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>

--- a/web/android/app/src/main/res/values/themes.xml
+++ b/web/android/app/src/main/res/values/themes.xml
@@ -5,7 +5,7 @@
       The cutout mode lets the WebView extend into the display cutout so
       injected safe-area insets cover notched devices.
     -->
-    <style name="Theme.Omnigent" parent="@android:style/Theme.Material.Light.NoActionBar">
+    <style name="Theme.Omnigent" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>

--- a/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
@@ -1,8 +1,11 @@
 package ai.omnigent.android
 
 import android.content.res.Configuration
+import android.webkit.WebView
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,6 +16,14 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [35])
 class MainActivityTest {
+    @Test
+    fun `webview leaves algorithmic darkening disabled`() {
+        ServerStore(ApplicationProvider.getApplicationContext()).connect("https://example.com")
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
+
+        assertFalse(activity.webView().settings.isAlgorithmicDarkeningAllowed)
+    }
+
     @Test
     fun `configuration change preserves SPA-applied system bar polarity`() {
         // Skip onCreate to isolate the bare config-change path from WebView dispatch.
@@ -44,4 +55,11 @@ class MainActivityTest {
             .apply { isAccessible = true }
             .invoke(this, isLight)
     }
+
+    private fun MainActivity.webView(): WebView =
+        MainActivity::class
+            .java
+            .getDeclaredField("webView")
+            .apply { isAccessible = true }
+            .get(this) as WebView
 }

--- a/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
@@ -2,6 +2,7 @@ package ai.omnigent.android
 
 import android.content.res.Configuration
 import androidx.core.view.WindowInsetsControllerCompat
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,11 +14,15 @@ import org.robolectric.annotation.Config
 @Config(sdk = [35])
 class MainActivityTest {
     @Test
-    fun `configuration change preserves explicit light system bars`() {
+    fun `configuration change preserves SPA-applied system bar polarity`() {
         // Skip onCreate to isolate the bare config-change path from WebView dispatch.
         val activity = Robolectric.buildActivity(MainActivity::class.java).get()
         activity.applyColorScheme(isLight = true)
         val insetsController = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+        val statusBarsWereLight = insetsController.isAppearanceLightStatusBars
+        val navigationBarsWereLight = insetsController.isAppearanceLightNavigationBars
+        assertTrue(statusBarsWereLight)
+        assertTrue(navigationBarsWereLight)
 
         val darkConfiguration =
             Configuration(activity.resources.configuration).apply {
@@ -27,8 +32,9 @@ class MainActivityTest {
             }
         activity.onConfigurationChanged(darkConfiguration)
 
-        assertTrue(insetsController.isAppearanceLightStatusBars)
-        assertTrue(insetsController.isAppearanceLightNavigationBars)
+        // The SPA owns resolved polarity; config changes must not re-derive it from uiMode.
+        assertEquals(statusBarsWereLight, insetsController.isAppearanceLightStatusBars)
+        assertEquals(navigationBarsWereLight, insetsController.isAppearanceLightNavigationBars)
     }
 
     private fun MainActivity.applyColorScheme(isLight: Boolean) {

--- a/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
@@ -16,7 +16,7 @@ class MainActivityTest {
     fun `configuration change preserves explicit light system bars`() {
         // Skip onCreate to isolate the bare config-change path from WebView dispatch.
         val activity = Robolectric.buildActivity(MainActivity::class.java).get()
-        activity.applyColorScheme("light")
+        activity.applyColorScheme(isLight = true)
         val insetsController = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
 
         val darkConfiguration =
@@ -26,17 +26,16 @@ class MainActivityTest {
                     Configuration.UI_MODE_NIGHT_YES
             }
         activity.onConfigurationChanged(darkConfiguration)
-        activity.applyColorScheme("system")
 
         assertTrue(insetsController.isAppearanceLightStatusBars)
         assertTrue(insetsController.isAppearanceLightNavigationBars)
     }
 
-    private fun MainActivity.applyColorScheme(scheme: String) {
+    private fun MainActivity.applyColorScheme(isLight: Boolean) {
         MainActivity::class
             .java
-            .getDeclaredMethod("applyColorScheme", String::class.java)
+            .getDeclaredMethod("applyColorScheme", Boolean::class.java)
             .apply { isAccessible = true }
-            .invoke(this, scheme)
+            .invoke(this, isLight)
     }
 }

--- a/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
@@ -48,6 +48,28 @@ class MainActivityTest {
         assertEquals(navigationBarsWereLight, insetsController.isAppearanceLightNavigationBars)
     }
 
+    @Test
+    @Config(sdk = [35], qualifiers = "night")
+    fun `top level navigation resets system bars to the OS fallback`() {
+        ServerStore(ApplicationProvider.getApplicationContext()).connect("https://example.com")
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
+        val webView = activity.webView()
+        val insetsController = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+        assertEquals(
+            Configuration.UI_MODE_NIGHT_YES,
+            activity.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK,
+        )
+
+        activity.applyColorScheme(isLight = true)
+        assertTrue(insetsController.isAppearanceLightStatusBars)
+        assertTrue(insetsController.isAppearanceLightNavigationBars)
+
+        webView.webViewClient.onPageStarted(webView, "https://example.com/next", null)
+
+        assertFalse(insetsController.isAppearanceLightStatusBars)
+        assertFalse(insetsController.isAppearanceLightNavigationBars)
+    }
+
     private fun MainActivity.applyColorScheme(isLight: Boolean) {
         MainActivity::class
             .java

--- a/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
@@ -1,0 +1,42 @@
+package ai.omnigent.android
+
+import android.content.res.Configuration
+import androidx.core.view.WindowInsetsControllerCompat
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class MainActivityTest {
+    @Test
+    fun `configuration change preserves explicit light system bars`() {
+        // Skip onCreate to isolate the bare config-change path from WebView dispatch.
+        val activity = Robolectric.buildActivity(MainActivity::class.java).get()
+        activity.applyColorScheme("light")
+        val insetsController = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+
+        val darkConfiguration =
+            Configuration(activity.resources.configuration).apply {
+                uiMode =
+                    (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or
+                    Configuration.UI_MODE_NIGHT_YES
+            }
+        activity.onConfigurationChanged(darkConfiguration)
+        activity.applyColorScheme("system")
+
+        assertTrue(insetsController.isAppearanceLightStatusBars)
+        assertTrue(insetsController.isAppearanceLightNavigationBars)
+    }
+
+    private fun MainActivity.applyColorScheme(scheme: String) {
+        MainActivity::class
+            .java
+            .getDeclaredMethod("applyColorScheme", String::class.java)
+            .apply { isAccessible = true }
+            .invoke(this, scheme)
+    }
+}

--- a/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
@@ -28,8 +28,9 @@ class MainActivityTest {
     fun `configuration change preserves SPA-applied system bar polarity`() {
         // Skip onCreate to isolate the bare config-change path from WebView dispatch.
         val activity = Robolectric.buildActivity(MainActivity::class.java).get()
-        activity.applyColorScheme(isLight = true)
-        val insetsController = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+        activity.applyColorScheme(ResolvedColorScheme.LIGHT)
+        val insetsController =
+            WindowInsetsControllerCompat(activity.window, activity.window.decorView)
         val statusBarsWereLight = insetsController.isAppearanceLightStatusBars
         val navigationBarsWereLight = insetsController.isAppearanceLightNavigationBars
         assertTrue(statusBarsWereLight)
@@ -49,18 +50,34 @@ class MainActivityTest {
     }
 
     @Test
+    fun `resolved page scheme drives both system bar icon polarities`() {
+        val activity = Robolectric.buildActivity(MainActivity::class.java).get()
+        val insetsController =
+            WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+
+        activity.applyColorScheme(ResolvedColorScheme.DARK)
+        assertFalse(insetsController.isAppearanceLightStatusBars)
+        assertFalse(insetsController.isAppearanceLightNavigationBars)
+
+        activity.applyColorScheme(ResolvedColorScheme.LIGHT)
+        assertTrue(insetsController.isAppearanceLightStatusBars)
+        assertTrue(insetsController.isAppearanceLightNavigationBars)
+    }
+
+    @Test
     @Config(sdk = [35], qualifiers = "night")
     fun `top level navigation resets system bars to the OS fallback`() {
         ServerStore(ApplicationProvider.getApplicationContext()).connect("https://example.com")
         val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
         val webView = activity.webView()
-        val insetsController = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+        val insetsController =
+            WindowInsetsControllerCompat(activity.window, activity.window.decorView)
         assertEquals(
             Configuration.UI_MODE_NIGHT_YES,
             activity.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK,
         )
 
-        activity.applyColorScheme(isLight = true)
+        activity.applyColorScheme(ResolvedColorScheme.LIGHT)
         assertTrue(insetsController.isAppearanceLightStatusBars)
         assertTrue(insetsController.isAppearanceLightNavigationBars)
 
@@ -70,12 +87,12 @@ class MainActivityTest {
         assertFalse(insetsController.isAppearanceLightNavigationBars)
     }
 
-    private fun MainActivity.applyColorScheme(isLight: Boolean) {
+    private fun MainActivity.applyColorScheme(scheme: ResolvedColorScheme) {
         MainActivity::class
             .java
-            .getDeclaredMethod("applyColorScheme", Boolean::class.java)
+            .getDeclaredMethod("applyColorScheme", ResolvedColorScheme::class.java)
             .apply { isAccessible = true }
-            .invoke(this, isLight)
+            .invoke(this, scheme)
     }
 
     private fun MainActivity.webView(): WebView =

--- a/web/android/app/src/test/java/ai/omnigent/android/OmnigentBridgeListenerTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/OmnigentBridgeListenerTest.kt
@@ -63,6 +63,15 @@ class OmnigentBridgeListenerTest {
     }
 
     @Test
+    fun `setColorScheme rejects non-string schemes`() {
+        listener.handle("""{"method":"setColorScheme","scheme":123}""")
+        listener.handle("""{"method":"setColorScheme","scheme":{"value":"light"}}""")
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(emptyList<Boolean>(), appliedLightValues)
+    }
+
+    @Test
     fun `setBadgeCount message posts the badge with parsed fields`() {
         listener.handle(
             """{"method":"setBadgeCount","count":3,"navigatePath":"/inbox","title":"T","body":"B"}""",

--- a/web/android/app/src/test/java/ai/omnigent/android/OmnigentBridgeListenerTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/OmnigentBridgeListenerTest.kt
@@ -3,6 +3,7 @@ package ai.omnigent.android
 import android.app.Application
 import android.app.NotificationManager
 import android.content.Context
+import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -24,6 +25,7 @@ class OmnigentBridgeListenerTest {
     private lateinit var context: Application
     private lateinit var listener: OmnigentBridgeListener
     private lateinit var shadow: ShadowNotificationManager
+    private val appliedSchemes = mutableListOf<String>()
 
     private val badgeId = 1
 
@@ -34,11 +36,30 @@ class OmnigentBridgeListenerTest {
             OmnigentBridgeListener(
                 notifications = NativeNotificationManager(context),
                 blobSaver = BlobSaver(context),
+                onColorScheme = appliedSchemes::add,
             )
         shadow =
             shadowOf(
                 context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager,
             )
+    }
+
+    @Test
+    fun `setColorScheme applies concrete schemes`() {
+        listener.handle("""{"method":"setColorScheme","scheme":"light"}""")
+        listener.handle("""{"method":"setColorScheme","scheme":"dark"}""")
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(listOf("light", "dark"), appliedSchemes)
+    }
+
+    @Test
+    fun `setColorScheme rejects missing and unsupported schemes`() {
+        listener.handle("""{"method":"setColorScheme","scheme":"system"}""")
+        listener.handle("""{"method":"setColorScheme"}""")
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(emptyList<String>(), appliedSchemes)
     }
 
     @Test

--- a/web/android/app/src/test/java/ai/omnigent/android/OmnigentBridgeListenerTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/OmnigentBridgeListenerTest.kt
@@ -25,7 +25,7 @@ class OmnigentBridgeListenerTest {
     private lateinit var context: Application
     private lateinit var listener: OmnigentBridgeListener
     private lateinit var shadow: ShadowNotificationManager
-    private val appliedSchemes = mutableListOf<String>()
+    private val appliedLightValues = mutableListOf<Boolean>()
 
     private val badgeId = 1
 
@@ -36,7 +36,7 @@ class OmnigentBridgeListenerTest {
             OmnigentBridgeListener(
                 notifications = NativeNotificationManager(context),
                 blobSaver = BlobSaver(context),
-                onColorScheme = appliedSchemes::add,
+                onColorScheme = appliedLightValues::add,
             )
         shadow =
             shadowOf(
@@ -50,7 +50,7 @@ class OmnigentBridgeListenerTest {
         listener.handle("""{"method":"setColorScheme","scheme":"dark"}""")
         shadowOf(Looper.getMainLooper()).idle()
 
-        assertEquals(listOf("light", "dark"), appliedSchemes)
+        assertEquals(listOf(true, false), appliedLightValues)
     }
 
     @Test
@@ -59,7 +59,7 @@ class OmnigentBridgeListenerTest {
         listener.handle("""{"method":"setColorScheme"}""")
         shadowOf(Looper.getMainLooper()).idle()
 
-        assertEquals(emptyList<String>(), appliedSchemes)
+        assertEquals(emptyList<Boolean>(), appliedLightValues)
     }
 
     @Test

--- a/web/android/app/src/test/java/ai/omnigent/android/OmnigentBridgeListenerTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/OmnigentBridgeListenerTest.kt
@@ -25,7 +25,7 @@ class OmnigentBridgeListenerTest {
     private lateinit var context: Application
     private lateinit var listener: OmnigentBridgeListener
     private lateinit var shadow: ShadowNotificationManager
-    private val appliedLightValues = mutableListOf<Boolean>()
+    private val appliedSchemes = mutableListOf<ResolvedColorScheme>()
 
     private val badgeId = 1
 
@@ -36,7 +36,7 @@ class OmnigentBridgeListenerTest {
             OmnigentBridgeListener(
                 notifications = NativeNotificationManager(context),
                 blobSaver = BlobSaver(context),
-                onColorScheme = appliedLightValues::add,
+                onColorScheme = appliedSchemes::add,
             )
         shadow =
             shadowOf(
@@ -50,7 +50,10 @@ class OmnigentBridgeListenerTest {
         listener.handle("""{"method":"setColorScheme","scheme":"dark"}""")
         shadowOf(Looper.getMainLooper()).idle()
 
-        assertEquals(listOf(true, false), appliedLightValues)
+        assertEquals(
+            listOf(ResolvedColorScheme.LIGHT, ResolvedColorScheme.DARK),
+            appliedSchemes,
+        )
     }
 
     @Test
@@ -59,7 +62,7 @@ class OmnigentBridgeListenerTest {
         listener.handle("""{"method":"setColorScheme"}""")
         shadowOf(Looper.getMainLooper()).idle()
 
-        assertEquals(emptyList<Boolean>(), appliedLightValues)
+        assertEquals(emptyList<ResolvedColorScheme>(), appliedSchemes)
     }
 
     @Test
@@ -68,7 +71,7 @@ class OmnigentBridgeListenerTest {
         listener.handle("""{"method":"setColorScheme","scheme":{"value":"light"}}""")
         shadowOf(Looper.getMainLooper()).idle()
 
-        assertEquals(emptyList<Boolean>(), appliedLightValues)
+        assertEquals(emptyList<ResolvedColorScheme>(), appliedSchemes)
     }
 
     @Test

--- a/web/android/app/src/test/java/ai/omnigent/android/OmnigentWebViewClientTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/OmnigentWebViewClientTest.kt
@@ -1,0 +1,77 @@
+package ai.omnigent.android
+
+import android.content.Context
+import android.webkit.ValueCallback
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OmnigentWebViewClientTest {
+    @Test
+    fun `page start does not inject into the outgoing document`() {
+        val webView = RecordingWebView(ApplicationProvider.getApplicationContext())
+        val client = client(shouldInjectBridgeAtPageReady = false)
+
+        client.onPageStarted(webView, PINNED_URL, null)
+
+        assertNull(webView.evaluatedScript)
+    }
+
+    @Test
+    fun `fallback injects the facade before declaring the page ready`() {
+        val webView = RecordingWebView(ApplicationProvider.getApplicationContext())
+        var readyUrl: String? = null
+        val client =
+            client(shouldInjectBridgeAtPageReady = true) { url ->
+                readyUrl = url
+            }
+
+        client.onPageFinished(webView, PINNED_URL)
+
+        assertEquals(NativeBridgeScript.source, webView.evaluatedScript)
+        assertNull(readyUrl)
+
+        webView.completeEvaluation()
+        assertEquals(PINNED_URL, readyUrl)
+    }
+
+    private fun client(
+        shouldInjectBridgeAtPageReady: Boolean,
+        onPageReady: (String?) -> Unit = {},
+    ) = OmnigentWebViewClient(
+        pinnedOrigin = { PINNED_ORIGIN },
+        onTopLevelNavigation = {},
+        shouldInjectBridgeAtPageReady = { shouldInjectBridgeAtPageReady },
+        onPageReady = onPageReady,
+        onLoginRequired = {},
+    )
+
+    private class RecordingWebView(
+        context: Context,
+    ) : WebView(context) {
+        var evaluatedScript: String? = null
+        private var callback: ValueCallback<String>? = null
+
+        override fun evaluateJavascript(
+            script: String,
+            resultCallback: ValueCallback<String>?,
+        ) {
+            evaluatedScript = script
+            callback = resultCallback
+        }
+
+        fun completeEvaluation() {
+            callback?.onReceiveValue("null")
+        }
+    }
+
+    private companion object {
+        const val PINNED_ORIGIN = "https://example.com"
+        const val PINNED_URL = "$PINNED_ORIGIN/app"
+    }
+}

--- a/web/android/app/src/test/java/ai/omnigent/android/ThemeTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/ThemeTest.kt
@@ -25,7 +25,10 @@ class ThemeTest {
             (configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or nightMode
         val themedContext = context.createConfigurationContext(configuration)
         themedContext.setTheme(R.style.Theme_Omnigent)
-        val attributes = themedContext.obtainStyledAttributes(intArrayOf(android.R.attr.isLightTheme))
+        val attributes =
+            themedContext.obtainStyledAttributes(
+                intArrayOf(android.R.attr.isLightTheme),
+            )
         return try {
             attributes.getBoolean(0, false)
         } finally {

--- a/web/android/app/src/test/java/ai/omnigent/android/ThemeTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/ThemeTest.kt
@@ -1,0 +1,35 @@
+package ai.omnigent.android
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class ThemeTest {
+    @Test
+    fun themeTracksSystemNightMode() {
+        assertEquals(true, isLightTheme(Configuration.UI_MODE_NIGHT_NO))
+        assertEquals(false, isLightTheme(Configuration.UI_MODE_NIGHT_YES))
+    }
+
+    private fun isLightTheme(nightMode: Int): Boolean {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val configuration = Configuration(context.resources.configuration)
+        configuration.uiMode =
+            (configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or nightMode
+        val themedContext = context.createConfigurationContext(configuration)
+        themedContext.setTheme(R.style.Theme_Omnigent)
+        val attributes = themedContext.obtainStyledAttributes(intArrayOf(android.R.attr.isLightTheme))
+        return try {
+            attributes.getBoolean(0, false)
+        } finally {
+            attributes.recycle()
+        }
+    }
+}

--- a/web/android/gradle/libs.versions.toml
+++ b/web/android/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ agp = "8.6.1"
 kotlin = "2.0.20"
 androidxCore = "1.13.1"
 androidxActivity = "1.9.2"
+androidxAppcompat = "1.7.0"
 androidxWebkit = "1.12.1"
 junit = "4.13.2"
 robolectric = "4.14.1"
@@ -18,6 +19,7 @@ playPublisher = "3.12.1"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
 androidx-activity = { group = "androidx.activity", name = "activity-ktx", version.ref = "androidxActivity" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppcompat" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "androidxWebkit" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }

--- a/web/src/components/theme/ThemeProvider.test.tsx
+++ b/web/src/components/theme/ThemeProvider.test.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider } from "./ThemeProvider";
+
+const themeState = vi.hoisted(() => ({
+  reportColorScheme: vi.fn(),
+  resolvedTheme: "light" as string | undefined,
+}));
+
+vi.mock("@/lib/nativeBridge", () => ({
+  reportColorScheme: themeState.reportColorScheme,
+}));
+
+vi.mock("next-themes", () => ({
+  ThemeProvider: ({ children }: { children: ReactNode }) => children,
+  useTheme: () => ({ resolvedTheme: themeState.resolvedTheme }),
+}));
+
+beforeEach(() => {
+  themeState.reportColorScheme.mockClear();
+  themeState.resolvedTheme = "light";
+});
+
+afterEach(cleanup);
+
+describe("ThemeProvider native theme sync", () => {
+  it("reports the resolved scheme on mount and whenever it changes", () => {
+    const { rerender } = render(<ThemeProvider>content</ThemeProvider>);
+    expect(themeState.reportColorScheme).toHaveBeenLastCalledWith("light");
+
+    themeState.resolvedTheme = "dark";
+    rerender(<ThemeProvider>content</ThemeProvider>);
+
+    expect(themeState.reportColorScheme).toHaveBeenNthCalledWith(2, "dark");
+  });
+});

--- a/web/src/components/theme/ThemeProvider.test.tsx
+++ b/web/src/components/theme/ThemeProvider.test.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "./ThemeProvider";
 
 const themeState = vi.hoisted(() => ({
   reportColorScheme: vi.fn(),
+  theme: "system" as string | undefined,
   resolvedTheme: "light" as string | undefined,
 }));
 
@@ -15,24 +16,52 @@ vi.mock("@/lib/nativeBridge", () => ({
 
 vi.mock("next-themes", () => ({
   ThemeProvider: ({ children }: { children: ReactNode }) => children,
-  useTheme: () => ({ resolvedTheme: themeState.resolvedTheme }),
+  useTheme: () => ({ theme: themeState.theme, resolvedTheme: themeState.resolvedTheme }),
 }));
 
 beforeEach(() => {
   themeState.reportColorScheme.mockClear();
+  themeState.theme = "system";
   themeState.resolvedTheme = "light";
 });
 
 afterEach(cleanup);
 
 describe("ThemeProvider native theme sync", () => {
-  it("reports the resolved scheme on mount and whenever it changes", () => {
+  it("reports the resolved scheme with a trailing system report while in system mode", () => {
+    // Android reads the concrete scheme; Electron keeps the last report, so
+    // "system" must come after it for native OS tracking.
+    render(<ThemeProvider>content</ThemeProvider>);
+    expect(themeState.reportColorScheme.mock.calls).toEqual([["light"], ["system"]]);
+  });
+
+  it("re-reports on a resolved change in system mode, still ending on system", () => {
     const { rerender } = render(<ThemeProvider>content</ThemeProvider>);
-    expect(themeState.reportColorScheme).toHaveBeenLastCalledWith("light");
+    themeState.reportColorScheme.mockClear();
 
     themeState.resolvedTheme = "dark";
     rerender(<ThemeProvider>content</ThemeProvider>);
 
-    expect(themeState.reportColorScheme).toHaveBeenNthCalledWith(2, "dark");
+    expect(themeState.reportColorScheme.mock.calls).toEqual([["dark"], ["system"]]);
+  });
+
+  it("reports the forced scheme when system is deselected without a resolved change", () => {
+    // System with a light OS → explicit Light: resolvedTheme stays "light",
+    // but Electron must still be told so themeSource stops tracking the OS.
+    const { rerender } = render(<ThemeProvider>content</ThemeProvider>);
+    themeState.reportColorScheme.mockClear();
+
+    themeState.theme = "light";
+    rerender(<ThemeProvider>content</ThemeProvider>);
+
+    expect(themeState.reportColorScheme.mock.calls).toEqual([["light"]]);
+  });
+
+  it("reports only the concrete scheme for an explicit selection", () => {
+    themeState.theme = "dark";
+    themeState.resolvedTheme = "dark";
+    render(<ThemeProvider>content</ThemeProvider>);
+
+    expect(themeState.reportColorScheme.mock.calls).toEqual([["dark"]]);
   });
 });

--- a/web/src/components/theme/ThemeProvider.test.tsx
+++ b/web/src/components/theme/ThemeProvider.test.tsx
@@ -28,40 +28,36 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("ThemeProvider native theme sync", () => {
-  it("reports the resolved scheme with a trailing system report while in system mode", () => {
-    // Android reads the concrete scheme; Electron keeps the last report, so
-    // "system" must come after it for native OS tracking.
+  it("reports the resolved Android scheme and selected Electron system theme", () => {
     render(<ThemeProvider>content</ThemeProvider>);
-    expect(themeState.reportColorScheme.mock.calls).toEqual([["light"], ["system"]]);
+    expect(themeState.reportColorScheme).toHaveBeenCalledWith("light", "system");
   });
 
-  it("re-reports on a resolved change in system mode, still ending on system", () => {
+  it("updates Android while Electron remains on system when the OS scheme changes", () => {
     const { rerender } = render(<ThemeProvider>content</ThemeProvider>);
     themeState.reportColorScheme.mockClear();
 
     themeState.resolvedTheme = "dark";
     rerender(<ThemeProvider>content</ThemeProvider>);
 
-    expect(themeState.reportColorScheme.mock.calls).toEqual([["dark"], ["system"]]);
+    expect(themeState.reportColorScheme).toHaveBeenCalledWith("dark", "system");
   });
 
-  it("reports the forced scheme when system is deselected without a resolved change", () => {
-    // System with a light OS → explicit Light: resolvedTheme stays "light",
-    // but Electron must still be told so themeSource stops tracking the OS.
+  it("reports an explicit Electron theme when system is deselected without a resolved change", () => {
     const { rerender } = render(<ThemeProvider>content</ThemeProvider>);
     themeState.reportColorScheme.mockClear();
 
     themeState.theme = "light";
     rerender(<ThemeProvider>content</ThemeProvider>);
 
-    expect(themeState.reportColorScheme.mock.calls).toEqual([["light"]]);
+    expect(themeState.reportColorScheme).toHaveBeenCalledWith("light", "light");
   });
 
-  it("reports only the concrete scheme for an explicit selection", () => {
+  it("keeps the resolved Android scheme separate from the explicit Electron theme", () => {
     themeState.theme = "dark";
-    themeState.resolvedTheme = "dark";
+    themeState.resolvedTheme = "light";
     render(<ThemeProvider>content</ThemeProvider>);
 
-    expect(themeState.reportColorScheme.mock.calls).toEqual([["dark"]]);
+    expect(themeState.reportColorScheme).toHaveBeenCalledWith("light", "dark");
   });
 });

--- a/web/src/components/theme/ThemeProvider.tsx
+++ b/web/src/components/theme/ThemeProvider.tsx
@@ -3,17 +3,15 @@ import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
 import { reportColorScheme } from "@/lib/nativeBridge";
 
 /**
- * Mirrors the in-app theme selection onto the Electron shell (nativeTheme), so
- * the shell-owned update overlay, native dialogs, and menus follow the theme
- * switcher rather than only the OS. No-op outside Electron. Renders nothing.
+ * Mirrors the resolved in-app theme onto native shell chrome. Renders nothing.
  */
 function NativeThemeSync() {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   useEffect(() => {
-    if (theme === "light" || theme === "dark" || theme === "system") {
-      reportColorScheme(theme);
+    if (resolvedTheme === "light" || resolvedTheme === "dark") {
+      reportColorScheme(resolvedTheme);
     }
-  }, [theme]);
+  }, [resolvedTheme]);
   return null;
 }
 

--- a/web/src/components/theme/ThemeProvider.tsx
+++ b/web/src/components/theme/ThemeProvider.tsx
@@ -3,15 +3,23 @@ import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
 import { reportColorScheme } from "@/lib/nativeBridge";
 
 /**
- * Mirrors the resolved in-app theme onto native shell chrome. Renders nothing.
+ * Mirrors the in-app theme onto native shell chrome. Renders nothing.
  */
 function NativeThemeSync() {
-  const { resolvedTheme } = useTheme();
+  const { theme, resolvedTheme } = useTheme();
   useEffect(() => {
+    // Android consumes the concrete resolved scheme (system-bar icon
+    // contrast) and ignores "system"; Electron keeps whichever report comes
+    // last, so a trailing "system" lets it track the OS natively while an
+    // explicit selection leaves it forced — including system→light under a
+    // light OS, where only `theme` changes and Electron must still be told.
     if (resolvedTheme === "light" || resolvedTheme === "dark") {
       reportColorScheme(resolvedTheme);
     }
-  }, [resolvedTheme]);
+    if (theme === "system") {
+      reportColorScheme("system");
+    }
+  }, [theme, resolvedTheme]);
   return null;
 }
 

--- a/web/src/components/theme/ThemeProvider.tsx
+++ b/web/src/components/theme/ThemeProvider.tsx
@@ -8,16 +8,10 @@ import { reportColorScheme } from "@/lib/nativeBridge";
 function NativeThemeSync() {
   const { theme, resolvedTheme } = useTheme();
   useEffect(() => {
-    // Android consumes the concrete resolved scheme (system-bar icon
-    // contrast) and ignores "system"; Electron keeps whichever report comes
-    // last, so a trailing "system" lets it track the OS natively while an
-    // explicit selection leaves it forced — including system→light under a
-    // light OS, where only `theme` changes and Electron must still be told.
     if (resolvedTheme === "light" || resolvedTheme === "dark") {
-      reportColorScheme(resolvedTheme);
-    }
-    if (theme === "system") {
-      reportColorScheme("system");
+      const selectedTheme =
+        theme === "light" || theme === "dark" || theme === "system" ? theme : resolvedTheme;
+      reportColorScheme(resolvedTheme, selectedTheme);
     }
   }, [theme, resolvedTheme]);
   return null;

--- a/web/src/lib/nativeBridge.test.ts
+++ b/web/src/lib/nativeBridge.test.ts
@@ -222,6 +222,18 @@ describe("reportColorScheme", () => {
     expect(androidSetColorScheme).toHaveBeenNthCalledWith(1, "light");
     expect(androidSetColorScheme).toHaveBeenNthCalledWith(2, "dark");
   });
+
+  it("replays an explicit scheme when Android installs after the first report", () => {
+    setAndroid(false);
+    reportColorScheme("light", "light");
+    expect(androidSetColorScheme).not.toHaveBeenCalled();
+
+    setAndroid(true);
+    window.dispatchEvent(new Event("omnigent-native-ready"));
+
+    expect(androidSetColorScheme).toHaveBeenCalledOnce();
+    expect(androidSetColorScheme).toHaveBeenCalledWith("light");
+  });
 });
 
 describe("nativeNotify", () => {

--- a/web/src/lib/nativeBridge.test.ts
+++ b/web/src/lib/nativeBridge.test.ts
@@ -8,6 +8,7 @@ import {
   nativeNotify,
   onNativeNotificationActivated,
   onNativeSidebarDrag,
+  reportColorScheme,
   setBadgeCount as bridgeSetBadge,
   setNativeServerSwitcherHidden,
   supportsBrowser,
@@ -18,6 +19,7 @@ const electronSetBadge = vi.fn();
 const electronNotify = vi.fn().mockResolvedValue(true);
 const electronUnsubscribe = vi.fn();
 const electronOnNotificationActivated = vi.fn().mockReturnValue(electronUnsubscribe);
+const electronSetColorScheme = vi.fn();
 
 // The iOS WKWebView bridge mock, installed on window.omnigentNative.
 const iosSetBadge = vi.fn();
@@ -36,6 +38,7 @@ const androidSetBadge = vi.fn();
 const androidNotify = vi.fn().mockResolvedValue(true);
 const androidUnsubscribe = vi.fn();
 const androidOnNotificationActivated = vi.fn().mockReturnValue(androidUnsubscribe);
+const androidSetColorScheme = vi.fn();
 
 /**
  * Simulate running inside / outside the Electron shell via the preload key.
@@ -50,6 +53,7 @@ function setElectron(on: boolean, withClickRouting = true, withBrowser = false):
     (window as unknown as Record<string, unknown>).omnigentDesktop = {
       kind: "electron",
       setBadgeCount: (...args: unknown[]) => electronSetBadge(...args),
+      setColorScheme: (...args: unknown[]) => electronSetColorScheme(...args),
       notify: (...args: unknown[]) => electronNotify(...args),
       ...(withClickRouting
         ? {
@@ -91,6 +95,7 @@ function setAndroid(on: boolean, withClickRouting = true): void {
     (window as unknown as Record<string, unknown>).omnigentNative = {
       kind: "android",
       setBadgeCount: (...args: unknown[]) => androidSetBadge(...args),
+      setColorScheme: (...args: unknown[]) => androidSetColorScheme(...args),
       notify: (...args: unknown[]) => androidNotify(...args),
       ...(withClickRouting
         ? {
@@ -194,6 +199,28 @@ describe("supportsBrowser", () => {
   it("is false under a non-Electron native shell (iOS)", () => {
     setIOS(true);
     expect(supportsBrowser()).toBe(false);
+  });
+});
+
+describe("reportColorScheme", () => {
+  it("keeps the Electron color-scheme path intact", () => {
+    setElectron(true);
+    reportColorScheme("system");
+    expect(electronSetColorScheme).toHaveBeenCalledWith("system");
+  });
+
+  it("routes concrete schemes through the Android bridge", () => {
+    setAndroid(true);
+    reportColorScheme("light");
+    reportColorScheme("dark");
+    expect(androidSetColorScheme).toHaveBeenNthCalledWith(1, "light");
+    expect(androidSetColorScheme).toHaveBeenNthCalledWith(2, "dark");
+  });
+
+  it("does not route an unresolved system scheme to Android", () => {
+    setAndroid(true);
+    reportColorScheme("system");
+    expect(androidSetColorScheme).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/lib/nativeBridge.test.ts
+++ b/web/src/lib/nativeBridge.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -39,6 +41,19 @@ const androidNotify = vi.fn().mockResolvedValue(true);
 const androidUnsubscribe = vi.fn();
 const androidOnNotificationActivated = vi.fn().mockReturnValue(androidUnsubscribe);
 const androidSetColorScheme = vi.fn();
+
+const androidBridgeScriptSource = readFileSync(
+  resolve("android/app/src/main/java/ai/omnigent/android/NativeBridgeScript.kt"),
+  "utf8",
+);
+
+function androidColorSchemeSyncSource(): string {
+  const match = androidBridgeScriptSource.match(
+    /          const resolvePageColorScheme = \(\) => \{[\s\S]*?          syncPageColorScheme\(\);/,
+  );
+  if (!match) throw new Error("Android color-scheme sync script not found");
+  return match[0].replace(/^ {10}/gm, "");
+}
 
 /**
  * Simulate running inside / outside the Electron shell via the preload key.
@@ -235,6 +250,36 @@ describe("reportColorScheme", () => {
 
     expect(androidSetColorScheme).toHaveBeenCalledOnce();
     expect(androidSetColorScheme).toHaveBeenCalledWith("light");
+  });
+});
+
+describe("Android injected color scheme sync", () => {
+  it("re-pushes concrete schemes after live root theme changes", async () => {
+    document.documentElement.className = "light";
+    const post = vi.fn();
+    const disconnect = new Function(
+      "post",
+      `${androidColorSchemeSyncSource()}\nreturn () => colorSchemeObserver?.disconnect();`,
+    )(post) as () => void;
+
+    try {
+      expect(post).toHaveBeenLastCalledWith({ method: "setColorScheme", scheme: "light" });
+      post.mockClear();
+
+      document.documentElement.className = "dark";
+      await vi.waitFor(() => {
+        expect(post).toHaveBeenLastCalledWith({ method: "setColorScheme", scheme: "dark" });
+      });
+
+      post.mockClear();
+      document.documentElement.className = "light";
+      await vi.waitFor(() => {
+        expect(post).toHaveBeenLastCalledWith({ method: "setColorScheme", scheme: "light" });
+      });
+    } finally {
+      disconnect();
+      document.documentElement.className = "";
+    }
   });
 });
 

--- a/web/src/lib/nativeBridge.test.ts
+++ b/web/src/lib/nativeBridge.test.ts
@@ -119,6 +119,8 @@ beforeEach(() => {
 afterEach(() => {
   setElectron(false);
   setIOS(false);
+  setAndroid(true);
+  window.dispatchEvent(new Event("omnigent-native-ready"));
   setAndroid(false);
 });
 

--- a/web/src/lib/nativeBridge.test.ts
+++ b/web/src/lib/nativeBridge.test.ts
@@ -203,24 +203,24 @@ describe("supportsBrowser", () => {
 });
 
 describe("reportColorScheme", () => {
-  it("keeps the Electron color-scheme path intact", () => {
+  it("routes the selected system theme through the Electron bridge", () => {
     setElectron(true);
-    reportColorScheme("system");
+    reportColorScheme("dark", "system");
     expect(electronSetColorScheme).toHaveBeenCalledWith("system");
   });
 
-  it("routes concrete schemes through the Android bridge", () => {
-    setAndroid(true);
-    reportColorScheme("light");
-    reportColorScheme("dark");
-    expect(androidSetColorScheme).toHaveBeenNthCalledWith(1, "light");
-    expect(androidSetColorScheme).toHaveBeenNthCalledWith(2, "dark");
+  it("routes an explicit selected theme through the Electron bridge", () => {
+    setElectron(true);
+    reportColorScheme("light", "light");
+    expect(electronSetColorScheme).toHaveBeenCalledWith("light");
   });
 
-  it("does not route an unresolved system scheme to Android", () => {
+  it("routes only resolved concrete schemes through the Android bridge", () => {
     setAndroid(true);
-    reportColorScheme("system");
-    expect(androidSetColorScheme).not.toHaveBeenCalled();
+    reportColorScheme("light", "system");
+    reportColorScheme("dark", "system");
+    expect(androidSetColorScheme).toHaveBeenNthCalledWith(1, "light");
+    expect(androidSetColorScheme).toHaveBeenNthCalledWith(2, "dark");
   });
 });
 

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -59,7 +59,7 @@ interface NativeShellApi {
    * ignore it.
    */
   setBadgeCount: (count: number, activation?: BadgeActivation) => void;
-  /** Mirror the web app's resolved theme in shell-owned chrome. */
+  /** ThemeProvider sends resolved light/dark; legacy "system" reaches Electron only, never Android. */
   setColorScheme?: (scheme: "light" | "dark" | "system") => void;
   /** Fire an OS notification; resolves true when it was shown. */
   notify: (params: NativeNotifyParams) => Promise<boolean>;

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -59,6 +59,8 @@ interface NativeShellApi {
    * ignore it.
    */
   setBadgeCount: (count: number, activation?: BadgeActivation) => void;
+  /** Mirror the web app's resolved theme in shell-owned chrome. */
+  setColorScheme?: (scheme: "light" | "dark" | "system") => void;
   /** Fire an OS notification; resolves true when it was shown. */
   notify: (params: NativeNotifyParams) => Promise<boolean>;
   // Optional: a shell older than this SPA may lack notification-click routing,
@@ -143,12 +145,6 @@ export interface NativeViewModeParams {
  */
 interface ElectronDesktopApi extends NativeShellApi {
   kind: "electron";
-  /**
-   * Report the web app's resolved color scheme so the shell mirrors it via
-   * nativeTheme (keeps the shell-owned update overlay, native dialogs, and
-   * menus in sync with the in-app theme). Absent on older shells.
-   */
-  setColorScheme?: (scheme: "light" | "dark" | "system") => void;
   /**
    * Desktop auto-update bridge — CONFIG ONLY on current shells. Update
    * notifications are shell-owned (native corner overlay + Server menu); this
@@ -467,15 +463,26 @@ export function onNativeSidebarDrag(
  * descriptive text. Electron/iOS have a real icon badge and ignore it.
  */
 /**
- * Tell the Electron shell the web app's resolved color scheme so it can mirror
- * it natively (nativeTheme.themeSource). No-op outside Electron or on older
- * shells. Fire-and-forget.
+ * Tell native shell chrome the web app's resolved color scheme. Electron
+ * mirrors it via nativeTheme; Android updates system-bar icon contrast.
+ * No-op outside supported shells. Fire-and-forget.
  */
 export function reportColorScheme(scheme: "light" | "dark" | "system"): void {
-  const native = electronApi();
-  if (!native?.setColorScheme) return;
+  const electron = electronApi();
+  if (electron?.setColorScheme) {
+    try {
+      electron.setColorScheme(scheme);
+    } catch (err) {
+      console.warn("[nativeBridge] setColorScheme failed:", err);
+    }
+    return;
+  }
+
+  if (scheme === "system") return;
+  const android = nativeApi();
+  if (android?.kind !== "android" || !android.setColorScheme) return;
   try {
-    native.setColorScheme(scheme);
+    android.setColorScheme(scheme);
   } catch (err) {
     console.warn("[nativeBridge] setColorScheme failed:", err);
   }

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -117,6 +117,10 @@ interface NativeShellApi {
   onNativeInsets?: (callback: (insets: NativeInsets) => void) => () => void;
 }
 
+const ANDROID_BRIDGE_READY_EVENT = "omnigent-native-ready";
+let pendingAndroidColorScheme: "light" | "dark" | undefined;
+let waitingForAndroidBridge = false;
+
 /** Footprints (CSS px) of the native floating bars, reported by the shell. */
 export interface NativeInsets {
   /** Server switcher pill height + its top padding. */
@@ -281,6 +285,35 @@ function nativeApi(): NativeShellApi | undefined {
   const api = (window as unknown as { omnigentNative?: NativeShellApi }).omnigentNative;
   if (api?.kind === "ios" || api?.kind === "android" || api?.kind === "electron") return api;
   return electronApi();
+}
+
+function applyAndroidColorScheme(scheme: "light" | "dark"): boolean {
+  const android = nativeApi();
+  if (android?.kind !== "android" || !android.setColorScheme) return false;
+  try {
+    android.setColorScheme(scheme);
+  } catch (err) {
+    console.warn("[nativeBridge] setColorScheme failed:", err);
+  }
+  return true;
+}
+
+function queueAndroidColorScheme(scheme: "light" | "dark"): void {
+  pendingAndroidColorScheme = scheme;
+  if (typeof window === "undefined" || waitingForAndroidBridge) return;
+
+  waitingForAndroidBridge = true;
+  window.addEventListener(
+    ANDROID_BRIDGE_READY_EVENT,
+    () => {
+      waitingForAndroidBridge = false;
+      const pendingScheme = pendingAndroidColorScheme;
+      if (!pendingScheme) return;
+      if (applyAndroidColorScheme(pendingScheme)) pendingAndroidColorScheme = undefined;
+      else queueAndroidColorScheme(pendingScheme);
+    },
+    { once: true },
+  );
 }
 
 /** True when running inside the Electron desktop shell. */
@@ -482,13 +515,11 @@ export function reportColorScheme(
     return;
   }
 
-  const android = nativeApi();
-  if (android?.kind !== "android" || !android.setColorScheme) return;
-  try {
-    android.setColorScheme(resolvedScheme);
-  } catch (err) {
-    console.warn("[nativeBridge] setColorScheme failed:", err);
+  if (applyAndroidColorScheme(resolvedScheme)) {
+    pendingAndroidColorScheme = undefined;
+    return;
   }
+  queueAndroidColorScheme(resolvedScheme);
 }
 
 export async function setBadgeCount(count: number, activation?: BadgeActivation): Promise<void> {

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -59,7 +59,7 @@ interface NativeShellApi {
    * ignore it.
    */
   setBadgeCount: (count: number, activation?: BadgeActivation) => void;
-  /** ThemeProvider sends resolved light/dark; legacy "system" reaches Electron only, never Android. */
+  /** Electron receives the selected theme; Android receives resolved light/dark, never "system". */
   setColorScheme?: (scheme: "light" | "dark" | "system") => void;
   /** Fire an OS notification; resolves true when it was shown. */
   notify: (params: NativeNotifyParams) => Promise<boolean>;
@@ -463,26 +463,29 @@ export function onNativeSidebarDrag(
  * descriptive text. Electron/iOS have a real icon badge and ignore it.
  */
 /**
- * Tell native shell chrome the web app's resolved color scheme. Electron
- * mirrors it via nativeTheme; Android updates system-bar icon contrast.
+ * Tell native shell chrome the web app's color scheme. Electron receives the
+ * selected theme so system mode keeps following the OS; Android receives the
+ * resolved scheme for system-bar icon contrast.
  * No-op outside supported shells. Fire-and-forget.
  */
-export function reportColorScheme(scheme: "light" | "dark" | "system"): void {
+export function reportColorScheme(
+  resolvedScheme: "light" | "dark",
+  selectedScheme: "light" | "dark" | "system",
+): void {
   const electron = electronApi();
   if (electron?.setColorScheme) {
     try {
-      electron.setColorScheme(scheme);
+      electron.setColorScheme(selectedScheme);
     } catch (err) {
       console.warn("[nativeBridge] setColorScheme failed:", err);
     }
     return;
   }
 
-  if (scheme === "system") return;
   const android = nativeApi();
   if (android?.kind !== "android" || !android.setColorScheme) return;
   try {
-    android.setColorScheme(scheme);
+    android.setColorScheme(resolvedScheme);
   } catch (err) {
     console.warn("[nativeBridge] setColorScheme failed:", err);
   }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Use an Android DayNight host theme and forward live `uiMode` changes so `next-themes` system mode follows the OS without reloading the SPA. With `targetSdk >= 33` the DayNight theme alone makes `prefers-color-scheme` track the OS; WebView algorithmic darkening (present in an earlier revision) was dropped after emulator testing showed it inverts the SPA when the user forces light mode under an OS dark theme.
- Report the concrete `resolvedTheme` from the web app through the Android bridge and apply matching status-bar and navigation-bar icon polarity at runtime. Electron keeps receiving the selected theme (`system` included, reported last) so its `nativeTheme.themeSource` contract is unchanged — explicit selections pin it even when the resolved value does not change.
- Preserve the day/night XML system-bar values as startup and older-web-build fallbacks, with regression coverage for bridge routing, live resolved-theme updates, message validation, and DayNight resource behavior.

ELI5: the Android wrapper now follows both the phone theme and an explicit in-app light/dark choice, including the icons around the webpage.

```text
OS or app theme → next-themes resolvedTheme → Android bridge
                                              ↓
                                 status/navigation icon contrast
```

## Test Plan

- `cd web/android && ./gradlew :app:assembleDebug :app:lintDebug :app:testDebugUnitTest` (passed; includes the tightened theme-bridge tests)
- Focused Vitest for `ThemeProvider.test.tsx` and `nativeBridge.test.ts` (passed; 45 tests)
- Focused oxlint for the changed web files (passed)
- `uvx --offline pre-commit run` against the staged follow-up change (passed)
- **Emulator matrix (API 34 `google_apis` arm64 AVD, debug APK against a local `omnigent server` on `10.0.2.2`, OS theme driven via `adb shell cmd uimode night yes|no`):**
  - App theme **System**: OS light→dark→light flips the SPA live with **no reload** (text typed into the composer survives both flips; a JS marker on `window` persists) and status/navigation icon polarity follows — **passed**
  - **OS Light + app Dark** (set via Settings → Appearance): dark page with light status/navigation icons — **passed**
  - **OS Dark + app Light**: light page with dark status/navigation icons — **passed** after the algorithmic-darkening removal; with darkening enabled this case rendered the forced-light SPA algorithmically darkened with illegible dark-on-dark status icons (root `color-scheme: light` marks the page as dark-unaware, so WebView darkens it whenever the app theme is dark)

## Demo

App theme **System** — OS light → dark → light follows live, no reload (typed composer text persists), bar icons flip:

![System mode follows OS](https://raw.githubusercontent.com/btli/omnigent/demo/pr3006-theme/scenario-A.gif)

**OS Light + app Dark** — forcing Dark in Settings → Appearance; dark page, light bar icons:

![OS light, app dark](https://raw.githubusercontent.com/btli/omnigent/demo/pr3006-theme/scenario-B.gif)

**OS Dark + app Light** — forcing Light under an OS dark theme; true light page (no algorithmic inversion), dark bar icons:

![OS dark, app light](https://raw.githubusercontent.com/btli/omnigent/demo/pr3006-theme/scenario-C.gif)

MP4 versions: [scenario A](https://raw.githubusercontent.com/btli/omnigent/demo/pr3006-theme/scenario-A.mp4) · [scenario B](https://raw.githubusercontent.com/btli/omnigent/demo/pr3006-theme/scenario-B.mp4) · [scenario C](https://raw.githubusercontent.com/btli/omnigent/demo/pr3006-theme/scenario-C.mp4)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Robolectric covers DayNight resource resolution and accepts only concrete Android color-scheme messages. Vitest covers Android/Electron routing and the report contract on mount and every change: Android always receives the concrete resolved scheme, and Electron ends on the selected theme — including `system`, and including a system→light switch that changes no resolved value. The full manual matrix (System-follows-OS live without reload, OS Light + app Dark, OS Dark + app Light, including status/navigation icon polarity) was verified on an API 34 emulator running the debug APK against a local server — recordings in the Demo section. The emulator run also caught and fixed a real regression: WebView algorithmic darkening inverted the forced-light SPA under an OS dark theme, so that setting was removed.

## Changelog

Android auto theme and system-bar icons now stay readable with both device themes and explicit in-app theme overrides.
