### PR TITLE
feat(scheduled tasks): run-completion tracking + run-history endpoint

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1478,4 +1478,12 @@ class SqlScheduledTaskRun(OmnigentBase):
             "scheduled_at",
             "id",
         ),
+        # Reverse lookup conversation_id -> run for the event-driven completion
+        # hook (get_running_run_by_conversation), which fires on every turn's
+        # terminal edge; without this the lookup is a full-table scan.
+        Index(
+            "ix_scheduled_task_runs_conversation_id",
+            "workspace_id",
+            "conversation_id",
+        ),
     )

--- a/omnigent/db/migrations/versions/d4f2a1b6c8e9_add_ix_scheduled_task_runs_conversation_id.py
+++ b/omnigent/db/migrations/versions/d4f2a1b6c8e9_add_ix_scheduled_task_runs_conversation_id.py
@@ -1,0 +1,44 @@
+"""Add the ``ix_scheduled_task_runs_conversation_id`` index.
+
+Revision ID: d4f2a1b6c8e9
+Revises: 72e6dceae14f
+Create Date: 2026-07-21 00:00:00.000000
+
+The event-driven run-completion hook transitions a scheduled-task run the
+instant its conversation's turn reaches a terminal state. To find the run it
+reverse-looks-up by ``conversation_id`` (``get_running_run_by_conversation``)
+on every turn-terminal edge — for interactive sessions too, not just scheduled
+ones. Without an index that is a full scan of ``scheduled_task_runs``. Index
+``(workspace_id, conversation_id)`` to make the lookup a selective point read.
+
+Creating an index is a simple operation on SQLite, PostgreSQL, and MySQL
+alike, so no table rebuild / batch mode is needed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "d4f2a1b6c8e9"
+down_revision: str | None = "72e6dceae14f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the ``ix_scheduled_task_runs_conversation_id`` index."""
+    op.create_index(
+        "ix_scheduled_task_runs_conversation_id",
+        "scheduled_task_runs",
+        ["workspace_id", "conversation_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``ix_scheduled_task_runs_conversation_id`` index."""
+    op.drop_index(
+        "ix_scheduled_task_runs_conversation_id",
+        table_name="scheduled_task_runs",
+    )

--- a/omnigent/entities/scheduled_task.py
+++ b/omnigent/entities/scheduled_task.py
@@ -97,6 +97,9 @@ class ScheduledTaskRun:
     :param error_code: Short failure classification (e.g. ``"timeout"``,
         ``"rate_limited"``) for future retry logic; ``None`` unless
         ``status == "failed"``.
+    :param workspace_id: Tenant partition key that owns this row. Carried on
+        the entity so a cross-workspace listing (the run reconciler's sweep)
+        can re-enter each run's ``workspace_scope`` before acting on it.
     """
 
     id: str
@@ -108,3 +111,4 @@ class ScheduledTaskRun:
     finished_at: int | None = None
     error: str | None = None
     error_code: str | None = None
+    workspace_id: int = 0

--- a/omnigent/entities/scheduled_task.py
+++ b/omnigent/entities/scheduled_task.py
@@ -97,9 +97,6 @@ class ScheduledTaskRun:
     :param error_code: Short failure classification (e.g. ``"timeout"``,
         ``"rate_limited"``) for future retry logic; ``None`` unless
         ``status == "failed"``.
-    :param workspace_id: Tenant partition key that owns this row. Carried on
-        the entity so a cross-workspace listing (the run reconciler's sweep)
-        can re-enter each run's ``workspace_scope`` before acting on it.
     """
 
     id: str
@@ -111,4 +108,3 @@ class ScheduledTaskRun:
     finished_at: int | None = None
     error: str | None = None
     error_code: str | None = None
-    workspace_id: int = 0

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -83,6 +83,7 @@ from omnigent.server.routes.sharing import create_sharing_router
 from omnigent.server.routes.terminal_attach import create_terminal_attach_router
 from omnigent.server.runner_session_init import RunnerSessionInitializer
 from omnigent.server.scheduled import ScheduledTaskScheduler
+from omnigent.server.scheduled.run_reconciler import ScheduledRunReconciler
 from omnigent.server.ws_origin import WebSocketOriginMiddleware
 from omnigent.stores import (
     AgentStore,
@@ -1389,6 +1390,7 @@ def create_app(
         # creates + owner-grants a session, launches its runner, and records
         # the run — all fire-and-forget so the timer re-arms immediately.
         scheduled_task_scheduler: ScheduledTaskScheduler | None = None
+        scheduled_run_reconciler: ScheduledRunReconciler | None = None
         if scheduled_task_store is not None:
             from omnigent.server.scheduled.fire import FireDeps, build_on_fire
 
@@ -1424,9 +1426,30 @@ def create_app(
                     exc,
                 )
 
+            # Run-completion backstop: the fire path records a run as
+            # ``running`` and never revisits it, so a periodic reconciler
+            # transitions completed runs to ``succeeded``/``failed`` (and
+            # force-fails stale ones). Also non-critical — a start failure
+            # must not abort boot.
+            scheduled_run_reconciler = ScheduledRunReconciler(
+                scheduled_task_store=scheduled_task_store,
+                conversation_store=conversation_store,
+            )
+            app_inst.state.scheduled_run_reconciler = scheduled_run_reconciler
+            try:
+                await scheduled_run_reconciler.start()
+            except Exception as exc:
+                _logger.exception(
+                    "scheduled run reconciler failed to start; continuing "
+                    "without run-completion tracking (%s)",
+                    exc,
+                )
+
         try:
             yield
         finally:
+            if scheduled_run_reconciler is not None:
+                scheduled_run_reconciler.stop()
             if scheduled_task_scheduler is not None:
                 scheduled_task_scheduler.stop()
             metrics_publish_task.cancel()

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -83,7 +83,6 @@ from omnigent.server.routes.sharing import create_sharing_router
 from omnigent.server.routes.terminal_attach import create_terminal_attach_router
 from omnigent.server.runner_session_init import RunnerSessionInitializer
 from omnigent.server.scheduled import ScheduledTaskScheduler
-from omnigent.server.scheduled.run_reconciler import ScheduledRunReconciler
 from omnigent.server.ws_origin import WebSocketOriginMiddleware
 from omnigent.stores import (
     AgentStore,
@@ -1390,7 +1389,6 @@ def create_app(
         # creates + owner-grants a session, launches its runner, and records
         # the run — all fire-and-forget so the timer re-arms immediately.
         scheduled_task_scheduler: ScheduledTaskScheduler | None = None
-        scheduled_run_reconciler: ScheduledRunReconciler | None = None
         if scheduled_task_store is not None:
             from omnigent.server.scheduled.fire import FireDeps, build_on_fire
 
@@ -1426,26 +1424,12 @@ def create_app(
                     exc,
                 )
 
-            # Run-completion orphan backstop. Completion itself is
-            # event-driven (persist_scheduled_run_completion fires from
-            # _publish_status the instant a fired conversation's turn ends —
-            # no poll). This startup sweep runs ONCE to reconcile runs left
-            # ``running`` by a restart mid-fire; lazy-on-read at GET
-            # /scheduled-tasks/{id}/runs covers the rest. Non-critical — a
-            # sweep failure must not abort boot.
-            scheduled_run_reconciler = ScheduledRunReconciler(
-                scheduled_task_store=scheduled_task_store,
-                conversation_store=conversation_store,
-            )
-            app_inst.state.scheduled_run_reconciler = scheduled_run_reconciler
-            try:
-                await scheduled_run_reconciler.run_startup_sweep()
-            except Exception as exc:
-                _logger.exception(
-                    "scheduled run startup sweep failed; continuing without "
-                    "orphaned-run reconciliation (%s)",
-                    exc,
-                )
+            # Run completion is event-driven (persist_scheduled_run_completion
+            # fires from _publish_status the instant a fired conversation's turn
+            # ends — no poll). The only orphan backstop is a lazy-on-read
+            # force-fail of stale ``running`` runs on the scheduled-task read
+            # endpoints (see routes/scheduled_tasks.py); there is no startup
+            # sweep and no periodic reconcile.
 
         try:
             yield

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1426,30 +1426,32 @@ def create_app(
                     exc,
                 )
 
-            # Run-completion backstop: the fire path records a run as
-            # ``running`` and never revisits it, so a periodic reconciler
-            # transitions completed runs to ``succeeded``/``failed`` (and
-            # force-fails stale ones). Also non-critical — a start failure
-            # must not abort boot.
+            # Run-completion orphan backstop. Completion itself is
+            # event-driven (persist_scheduled_run_completion fires from
+            # _publish_status the instant a fired conversation's turn ends —
+            # no poll). This startup sweep runs ONCE to reconcile runs left
+            # ``running`` by a restart mid-fire; lazy-on-read at GET
+            # /scheduled-tasks/{id}/runs covers the rest. Non-critical — a
+            # sweep failure must not abort boot.
             scheduled_run_reconciler = ScheduledRunReconciler(
                 scheduled_task_store=scheduled_task_store,
                 conversation_store=conversation_store,
             )
             app_inst.state.scheduled_run_reconciler = scheduled_run_reconciler
             try:
-                await scheduled_run_reconciler.start()
+                await scheduled_run_reconciler.run_startup_sweep()
             except Exception as exc:
                 _logger.exception(
-                    "scheduled run reconciler failed to start; continuing "
-                    "without run-completion tracking (%s)",
+                    "scheduled run startup sweep failed; continuing without "
+                    "orphaned-run reconciliation (%s)",
                     exc,
                 )
 
         try:
             yield
         finally:
-            if scheduled_run_reconciler is not None:
-                scheduled_run_reconciler.stop()
+            # The run reconciler is a one-shot startup sweep (no periodic task
+            # to cancel); only the per-job scheduler needs stopping.
             if scheduled_task_scheduler is not None:
                 scheduled_task_scheduler.stop()
             metrics_publish_task.cancel()
@@ -1579,8 +1581,11 @@ def create_app(
     set_server_runner_router(runner_router)
     # Mirror per-session live state (turn status, pending-approval count,
     # runner liveness) onto the conversations row so replicas that don't
-    # hold a session's runner tunnel serve the same sidebar fields.
-    session_live_state.configure(conversation_store)
+    # hold a session's runner tunnel serve the same sidebar fields. The
+    # scheduled-task store additionally enables the event-driven
+    # run-completion hook (persist_scheduled_run_completion) fired from
+    # _publish_status when a fired conversation's turn reaches terminal.
+    session_live_state.configure(conversation_store, scheduled_task_store)
     pending_elicitations.set_count_persist_hook(session_live_state.persist_pending_count)
 
     @app.middleware("http")

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1434,8 +1434,9 @@ def create_app(
         try:
             yield
         finally:
-            # The run reconciler is a one-shot startup sweep (no periodic task
-            # to cancel); only the per-job scheduler needs stopping.
+            # Run completion is event-driven (the _publish_status hook) plus a
+            # lazy-on-read stale backstop — there is no run-reconciler task to
+            # cancel. Only the per-job scheduler holds timers that need stopping.
             if scheduled_task_scheduler is not None:
                 scheduled_task_scheduler.stop()
             metrics_publish_task.cancel()

--- a/omnigent/server/routes/scheduled_tasks.py
+++ b/omnigent/server/routes/scheduled_tasks.py
@@ -22,7 +22,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from fastapi import APIRouter, Request
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from omnigent.entities import ScheduledTask
+from omnigent.entities import ScheduledTask, ScheduledTaskRun
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.server.auth import RESERVED_USER_LOCAL, AuthProvider
 from omnigent.server.routes._auth_helpers import require_user
@@ -110,6 +110,24 @@ def _to_response(task: ScheduledTask) -> dict[str, Any]:
         "last_run_at": task.last_run_at,
         "last_run_conversation_id": task.last_run_conversation_id,
         "updated_at": task.updated_at,
+    }
+
+
+def _run_to_response(run: ScheduledTaskRun) -> dict[str, Any]:
+    """Serialize a :class:`ScheduledTaskRun` to a JSON-safe dict.
+
+    Excludes the free-text ``error`` blob (never SQL-queried, potentially
+    large); ``error_code`` carries the queryable failure classification.
+    """
+    return {
+        "id": run.id,
+        "scheduled_task_id": run.scheduled_task_id,
+        "status": run.status,
+        "scheduled_at": run.scheduled_at,
+        "conversation_id": run.conversation_id,
+        "fired_at": run.fired_at,
+        "finished_at": run.finished_at,
+        "error_code": run.error_code,
     }
 
 
@@ -300,6 +318,24 @@ def create_scheduled_tasks_router(
         owner_id = None if owner == RESERVED_USER_LOCAL else owner
         task = _require_owned(scheduled_task_id, owner_id)
         return _to_response(task)
+
+    @router.get("/scheduled-tasks/{scheduled_task_id}/runs")
+    async def list_scheduled_task_runs(
+        request: Request,
+        scheduled_task_id: str,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """List the run history for one of the caller's scheduled tasks.
+
+        Owner-scoped: a task owned by someone else (or absent) 404s via
+        ``_require_owned``, so runs aren't enumerable across users. Runs come
+        back most-recent-first (``scheduled_at DESC``); an empty history is an
+        empty list.
+        """
+        owner = _owner(request)
+        owner_id = None if owner == RESERVED_USER_LOCAL else owner
+        _require_owned(scheduled_task_id, owner_id)
+        runs = store.list_runs(scheduled_task_id)
+        return {"runs": [_run_to_response(r) for r in runs]}
 
     @router.patch("/scheduled-tasks/{scheduled_task_id}")
     async def update_scheduled_task(

--- a/omnigent/server/routes/scheduled_tasks.py
+++ b/omnigent/server/routes/scheduled_tasks.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 import uuid
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -34,10 +33,7 @@ from omnigent.server.routes._session_create_validation import (
     validate_session_model_metadata,
 )
 from omnigent.server.scheduled.rrule import RRuleValidationError, validate_rrule
-from omnigent.server.scheduled.run_reconciler import (
-    STALE_RUN_ERROR_CODE,
-    STALE_RUN_MAX_AGE_SECONDS,
-)
+from omnigent.server.scheduled.run_reconciler import force_fail_stale_runs
 from omnigent.stores import AgentStore, ConversationStore, PermissionStore
 from omnigent.stores.scheduled_task_store import ScheduledTaskStore
 
@@ -307,10 +303,22 @@ def create_scheduled_tasks_router(
 
     @router.get("/scheduled-tasks")
     async def list_scheduled_tasks(request: Request) -> dict[str, list[dict[str, Any]]]:
-        """List the caller's scheduled tasks."""
+        """List the caller's scheduled tasks.
+
+        Lazy-on-read stale backstop: before returning, force-fail any of this
+        owner's runs still ``running`` past the 6h max age (``incomplete``), so
+        a future Tasks-list "last-run status" badge never shows a stale orphan
+        as ``running``. Pure age check — one indexed, owner-scoped query for the
+        owner's running runs, then a conditional ``update_run``; NO per-run
+        conversation I/O. Young in-flight runs are untouched, and completion of
+        a normal run is handled event-driven (the ``_publish_status`` hook), not
+        here.
+        """
         owner = _owner(request)
         owner_id = None if owner == RESERVED_USER_LOCAL else owner
         tasks = [t for t in store.list() if t.user_id == owner_id]
+        running = store.list_running_runs_for_tasks([t.id for t in tasks])
+        force_fail_stale_runs(store, running)
         return {"scheduled_tasks": [_to_response(t) for t in tasks]}
 
     @router.get("/scheduled-tasks/{scheduled_task_id}")
@@ -339,47 +347,17 @@ def create_scheduled_tasks_router(
         Lazy-on-read backstop: before listing, force-fail any of this task's
         runs still ``running`` past the 6h max age (``incomplete``). Completion
         itself is event-driven (the ``_publish_status`` hook); this only
-        catches a genuine orphan — a run whose terminal event never fired
-        (host died mid-turn) that no restart-time startup sweep has reaped yet
-        — so the "every run eventually terminal" invariant holds without a
-        background poll. A young in-flight run is untouched, and the
+        catches a genuine orphan — a run whose terminal event never fired (host
+        died mid-turn) — so the "every run eventually terminal" invariant holds
+        without a background poll or startup sweep. Pure age check (no
+        conversation I/O); a young in-flight run is untouched, and the
         conditional ``update_run`` never clobbers an already-terminal row.
         """
         owner = _owner(request)
         owner_id = None if owner == RESERVED_USER_LOCAL else owner
         _require_owned(scheduled_task_id, owner_id)
-        runs = store.list_runs(scheduled_task_id)
-        runs = _force_fail_stale_runs(runs)
+        runs = force_fail_stale_runs(store, store.list_runs(scheduled_task_id))
         return {"runs": [_run_to_response(r) for r in runs]}
-
-    def _force_fail_stale_runs(runs: list[ScheduledTaskRun]) -> list[ScheduledTaskRun]:
-        """Force-fail ``running`` runs older than the max age; return the list.
-
-        Applied on the read path (lazy-on-read backstop). Only rows past
-        :data:`STALE_RUN_MAX_AGE_SECONDS` are touched; the store's conditional
-        ``update_run`` (``WHERE status = running``) makes it idempotent and
-        safe against a run that just transitioned via the event hook. The
-        returned list reflects any transition so the response is consistent
-        with the write.
-        """
-        now = int(time.time())
-        result: list[ScheduledTaskRun] = []
-        for run in runs:
-            if run.status == "running" and (now - run.scheduled_at) >= STALE_RUN_MAX_AGE_SECONDS:
-                updated = store.update_run(
-                    run.id,
-                    status="failed",
-                    finished_at=now,
-                    error=(
-                        "scheduled run did not reach a terminal state within "
-                        f"{STALE_RUN_MAX_AGE_SECONDS}s"
-                    ),
-                    error_code=STALE_RUN_ERROR_CODE,
-                )
-                result.append(updated if updated is not None else run)
-            else:
-                result.append(run)
-        return result
 
     @router.patch("/scheduled-tasks/{scheduled_task_id}")
     async def update_scheduled_task(

--- a/omnigent/server/routes/scheduled_tasks.py
+++ b/omnigent/server/routes/scheduled_tasks.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 import uuid
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -33,6 +34,10 @@ from omnigent.server.routes._session_create_validation import (
     validate_session_model_metadata,
 )
 from omnigent.server.scheduled.rrule import RRuleValidationError, validate_rrule
+from omnigent.server.scheduled.run_reconciler import (
+    STALE_RUN_ERROR_CODE,
+    STALE_RUN_MAX_AGE_SECONDS,
+)
 from omnigent.stores import AgentStore, ConversationStore, PermissionStore
 from omnigent.stores.scheduled_task_store import ScheduledTaskStore
 
@@ -330,12 +335,51 @@ def create_scheduled_tasks_router(
         ``_require_owned``, so runs aren't enumerable across users. Runs come
         back most-recent-first (``scheduled_at DESC``); an empty history is an
         empty list.
+
+        Lazy-on-read backstop: before listing, force-fail any of this task's
+        runs still ``running`` past the 6h max age (``incomplete``). Completion
+        itself is event-driven (the ``_publish_status`` hook); this only
+        catches a genuine orphan — a run whose terminal event never fired
+        (host died mid-turn) that no restart-time startup sweep has reaped yet
+        — so the "every run eventually terminal" invariant holds without a
+        background poll. A young in-flight run is untouched, and the
+        conditional ``update_run`` never clobbers an already-terminal row.
         """
         owner = _owner(request)
         owner_id = None if owner == RESERVED_USER_LOCAL else owner
         _require_owned(scheduled_task_id, owner_id)
         runs = store.list_runs(scheduled_task_id)
+        runs = _force_fail_stale_runs(runs)
         return {"runs": [_run_to_response(r) for r in runs]}
+
+    def _force_fail_stale_runs(runs: list[ScheduledTaskRun]) -> list[ScheduledTaskRun]:
+        """Force-fail ``running`` runs older than the max age; return the list.
+
+        Applied on the read path (lazy-on-read backstop). Only rows past
+        :data:`STALE_RUN_MAX_AGE_SECONDS` are touched; the store's conditional
+        ``update_run`` (``WHERE status = running``) makes it idempotent and
+        safe against a run that just transitioned via the event hook. The
+        returned list reflects any transition so the response is consistent
+        with the write.
+        """
+        now = int(time.time())
+        result: list[ScheduledTaskRun] = []
+        for run in runs:
+            if run.status == "running" and (now - run.scheduled_at) >= STALE_RUN_MAX_AGE_SECONDS:
+                updated = store.update_run(
+                    run.id,
+                    status="failed",
+                    finished_at=now,
+                    error=(
+                        "scheduled run did not reach a terminal state within "
+                        f"{STALE_RUN_MAX_AGE_SECONDS}s"
+                    ),
+                    error_code=STALE_RUN_ERROR_CODE,
+                )
+                result.append(updated if updated is not None else run)
+            else:
+                result.append(run)
+        return result
 
     @router.patch("/scheduled-tasks/{scheduled_task_id}")
     async def update_scheduled_task(

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -5828,6 +5828,25 @@ def _publish_status(
     # deduplicated, off-loop) so replicas that don't hold this session's
     # runner tunnel serve the same sidebar status.
     session_live_state.persist_live_status(session_id, status)
+    # Event-driven scheduled-run completion. A terminal edge (idle = the turn
+    # completed; failed = it errored/disconnected) flips the conversation's
+    # still-``running`` scheduled_task_run to succeeded/failed. This is the
+    # primary FU-1 mechanism: the run transitions the instant the turn ends,
+    # driven by the same terminal event that persists live_status — no poll.
+    # The event's own ``error`` carries the failure classification, so no label
+    # re-read is needed (and none of the race that would imply). A no-op for
+    # the common case: interactive (non-scheduled) conversations have no
+    # running run, and the reverse lookup cheaply returns None. running/waiting
+    # edges are skipped entirely so the hot path pays nothing mid-turn.
+    if status == "idle":
+        session_live_state.persist_scheduled_run_completion(session_id, "succeeded")
+    elif status == "failed":
+        session_live_state.persist_scheduled_run_completion(
+            session_id,
+            "failed",
+            error_code=error.code if error is not None else None,
+            error=error.message if error is not None else None,
+        )
     # Track the in-flight response id for snapshot-based reconnect (see
     # _session_active_response_cache). A running/waiting edge that names a
     # turn opens it; any idle/failed edge closes it.

--- a/omnigent/server/scheduled/run_reconciler.py
+++ b/omnigent/server/scheduled/run_reconciler.py
@@ -1,286 +1,104 @@
-"""Scheduled-task run-completion backstop — startup sweep + lazy-on-read.
+"""Scheduled-task run-completion stale backstop (lazy-on-read only).
 
-The fire path (:mod:`omnigent.server.scheduled.fire`) creates a conversation,
-dispatches the prompt, and records a ``scheduled_task_runs`` row as
-``running`` — then returns immediately, WITHOUT waiting for the agent turn to
-finish.
+The fire path (:mod:`omnigent.server.scheduled.fire`) records a
+``scheduled_task_runs`` row as ``running`` and returns immediately, WITHOUT
+waiting for the agent turn to finish.
 
 **The PRIMARY completion mechanism is event-driven** and lives elsewhere:
 :func:`omnigent.server.session_live_state.persist_scheduled_run_completion`,
 fired from ``_publish_status`` the instant a fired conversation's turn reaches
-a terminal edge, flips the run ``running`` → ``succeeded``/``failed``. That
-handler rides the same long-lived SSE relay that already persists the
-conversation's ``live_status`` for a browserless scheduled fire, so it needs
-no live client and no periodic poll.
+a terminal edge, flips the run ``running`` → ``succeeded``/``failed``. It rides
+the same long-lived SSE relay that already persists the conversation's
+``live_status`` for a browserless scheduled fire, so it needs no live client
+and no periodic poll.
 
-This module is only the **orphan backstop** for the case the event path cannot
-cover: a run left ``running`` because the terminal event never fired or was
-lost (host died mid-turn, or the server restarted while a fire was in flight).
-It enforces the invariant "every run eventually reaches a terminal state"
-WITHOUT a recurring background poll, via two cheap catches:
+This module is the **sole orphan backstop**: a pure age-based force-fail run
+on the READ path. If a run is left ``running`` because its terminal event never
+fired (host died mid-turn, or a server restart while a fire was in flight), it
+stays ``running`` in the DB — harmless until someone looks — and the next read
+that surfaces it force-fails it. :func:`force_fail_stale_runs` is called from
+both scheduled-task read endpoints (list + detail), so a stale orphan is
+reconciled the moment it would otherwise be shown:
 
-- :meth:`ScheduledRunReconciler.run_startup_sweep` — runs ONCE per server boot
-  (wired into the lifespan). It lists every still-``running`` run across all
-  workspaces and force-fails those whose conversation is already terminal /
-  missing, or that are past :data:`STALE_RUN_MAX_AGE_SECONDS`. This catches
-  runs orphaned by a restart mid-fire.
-- lazy-on-read at ``GET /v1/scheduled-tasks/{id}/runs`` (in the route, not
-  here) — force-fails a task's runs still ``running`` past the max age when
-  run history is read.
+- ``GET /v1/scheduled-tasks/{id}/runs`` — force-fails that task's runs still
+  ``running`` past :data:`STALE_RUN_MAX_AGE_SECONDS`.
+- ``GET /v1/scheduled-tasks`` — force-fails the owner's tasks' stale ``running``
+  runs, so a future Tasks-list "last-run status" badge never shows a stale
+  orphan as ``running``.
 
-Both reuse :func:`classify_conversation_terminal_state` (reads the durable
-``live_status`` + committed transcript + failure labels the conversation left
-behind) and the idempotent, conditional :meth:`update_run`
-(``WHERE status = running``), so a run already terminal — via the event hook, a
-fire-time ``skipped``/``failed``, or the other backstop — is never clobbered.
-
-There is deliberately NO periodic sweep of any cadence: the event hook makes
-one unnecessary, and startup-sweep + lazy-on-read match how the sibling
-scheduled-task systems reconcile orphans (at a lifecycle boundary, not on a
-timer).
+This is a pure age check — NO conversation I/O on the read path. The idempotent,
+conditional :meth:`update_run` (``WHERE status = running``) means a run already
+terminal (via the event hook, a fire-time ``skipped``/``failed``, or a prior
+read) is never clobbered. There is deliberately NO startup sweep and NO periodic
+poll of any cadence: the event hook handles every normal run, and lazy-on-read
+reconciles anything a user actually views.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
-from collections.abc import Callable
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from omnigent.db.db_models import workspace_scope
-from omnigent.server.routes.sessions import (
-    _LAST_TASK_ERROR_CODE_LABEL_KEY,
-)
-
 if TYPE_CHECKING:
-    from omnigent.entities import Conversation, ScheduledTaskRun
-    from omnigent.stores import ConversationStore
+    from omnigent.entities import ScheduledTaskRun
     from omnigent.stores.scheduled_task_store import ScheduledTaskStore
 
 _logger = logging.getLogger(__name__)
 
-# A run still ``running`` longer than this — with no terminal conversation
-# state — is force-failed with ``error_code = "incomplete"`` (host died
-# mid-turn, runner never reported completion). Deliberately generous (6h) so a
-# legitimately long agent turn is never killed; a stuck-``running`` row is a
-# far milder bug than a falsely-``failed`` one. Shared by the startup sweep and
-# the lazy-on-read backstop.
+# A run still ``running`` longer than this is force-failed with
+# ``error_code = "incomplete"`` (host died mid-turn, runner never reported
+# completion). Deliberately generous (6h) so a legitimately long agent turn is
+# never killed; a stuck-``running`` row is a far milder bug than a
+# falsely-``failed`` one.
 STALE_RUN_MAX_AGE_SECONDS: int = 6 * 60 * 60
 
 # error_code recorded on the stale-run force-fail path.
 STALE_RUN_ERROR_CODE: str = "incomplete"
 
-# Conversation ``live_status`` values that mean the turn is still in flight —
-# used as a cheap pre-filter to skip the items read for clearly-running runs.
-_IN_FLIGHT_LIVE_STATUSES: frozenset[str] = frozenset({"running", "waiting"})
 
+def force_fail_stale_runs(
+    store: ScheduledTaskStore,
+    runs: list[ScheduledTaskRun],
+    *,
+    now: int | None = None,
+) -> list[ScheduledTaskRun]:
+    """Force-fail ``running`` runs older than the max age; return the list.
 
-@dataclass(frozen=True)
-class _TerminalDecision:
-    """Outcome of classifying a run's conversation.
+    The lazy-on-read orphan backstop, shared by the scheduled-task list and
+    detail read endpoints. Pure age check — NO conversation I/O. Only rows past
+    :data:`STALE_RUN_MAX_AGE_SECONDS` are touched; the store's conditional
+    :meth:`update_run` (``WHERE status = running``) makes it idempotent and safe
+    against a run that just transitioned via the event hook. Must be called
+    inside the runs' ``workspace_scope`` (the store filters every query on
+    ``current_workspace_id()``); the read endpoints already run there.
 
-    :param status: Terminal run status to set (``"succeeded"`` / ``"failed"``),
-        or ``None`` to leave the run ``running`` (turn still in flight).
-    :param error_code: Failure classification when ``status == "failed"``.
-    :param error: Human-readable failure detail when ``status == "failed"``.
+    The returned list reflects any transition (a force-failed run carries its
+    new terminal state) so a caller rendering the runs stays consistent with the
+    write; a caller that only needs the side effect can ignore the return.
+
+    :param store: The scheduled-task store to transition runs through.
+    :param runs: Candidate runs (typically a task's history, or an owner's
+        running runs).
+    :param now: Unix epoch seconds to age against; defaults to ``time.time()``.
+    :returns: ``runs`` with any stale ``running`` row replaced by its terminal
+        form.
     """
-
-    status: str | None
-    error_code: str | None = None
-    error: str | None = None
-
-
-def _latest_message_completed(conversation_store: ConversationStore, conversation_id: str) -> bool:
-    """Return whether the conversation's newest message item is ``completed``.
-
-    The relay commits assistant output as ``message`` items; the newest one
-    reaching ``status == "completed"`` is the durable, client-independent
-    signal that the dispatched turn produced a finished response.
-
-    :param conversation_store: Store to read committed items from.
-    :param conversation_id: The fired conversation to inspect.
-    :returns: ``True`` if the latest ``message`` item is ``completed``.
-    """
-    page = conversation_store.list_items(
-        conversation_id,
-        limit=1,
-        order="desc",
-        type="message",
-    )
-    if not page.data:
-        return False
-    return page.data[0].status == "completed"
-
-
-def classify_conversation_terminal_state(
-    conversation: Conversation | None,
-    conversation_store: ConversationStore,
-    conversation_id: str,
-) -> _TerminalDecision:
-    """Decide the terminal run status for a ``running`` run's conversation.
-
-    Read order (durable signals only — no live subscription required):
-
-    #. **Missing conversation** — the fired conversation was deleted. Treat as
-       terminal ``failed`` (``conversation_missing``); nothing left to await.
-    #. **Failure labels** — a ``session.status: failed`` edge persists
-       ``omnigent.last_task_error_code``; a non-empty value means the turn
-       terminally errored → ``failed`` carrying that code.
-    #. **live_status pre-filter** — ``running``/``waiting`` means still in
-       flight; leave it (unless stale, handled by the caller).
-    #. **Completed transcript** — the newest ``message`` item is ``completed``
-       → ``succeeded``.
-    #. **Otherwise** — not yet terminal; leave ``running`` (the caller applies
-       the stale-age backstop).
-
-    :param conversation: The fired conversation, or ``None`` if it no longer
-        exists.
-    :param conversation_store: Store used to read committed items.
-    :param conversation_id: The fired conversation id (for the items read).
-    :returns: A :class:`_TerminalDecision`.
-    """
-    if conversation is None:
-        return _TerminalDecision(
-            status="failed",
-            error_code="conversation_missing",
-            error="scheduled run conversation no longer exists",
-        )
-
-    error_code = (conversation.labels or {}).get(_LAST_TASK_ERROR_CODE_LABEL_KEY)
-    if error_code:
-        return _TerminalDecision(
-            status="failed",
-            error_code=error_code,
-            error="scheduled run turn reported a terminal error",
-        )
-
-    if conversation.live_status in _IN_FLIGHT_LIVE_STATUSES:
-        return _TerminalDecision(status=None)
-
-    if _latest_message_completed(conversation_store, conversation_id):
-        return _TerminalDecision(status="succeeded")
-
-    return _TerminalDecision(status=None)
-
-
-class ScheduledRunReconciler:
-    """Orphan backstop that transitions stranded ``running`` runs to terminal.
-
-    NOT a periodic poll — the primary completion path is the event hook
-    (:func:`omnigent.server.session_live_state.persist_scheduled_run_completion`).
-    This runs its sweep ONCE per boot via :meth:`run_startup_sweep` (wired into
-    the server lifespan) to catch runs orphaned by a restart mid-fire; the
-    lazy-on-read backstop in the runs route covers the rest.
-    """
-
-    def __init__(
-        self,
-        scheduled_task_store: ScheduledTaskStore,
-        conversation_store: ConversationStore,
-        *,
-        stale_max_age_seconds: int = STALE_RUN_MAX_AGE_SECONDS,
-        now: Callable[[], float] = time.time,
-    ) -> None:
-        self._scheduled_task_store = scheduled_task_store
-        self._conversation_store = conversation_store
-        self._stale_max_age = stale_max_age_seconds
-        self._now = now
-
-    async def run_startup_sweep(self) -> int:
-        """Reconcile all ``running`` runs once at server startup.
-
-        Catches runs orphaned by a server restart that happened while a fire
-        was in flight (the terminal event fired on the old process, or never).
-        A run whose conversation is already terminal/missing is transitioned to
-        the mapped status; one past the max age with no terminal state is
-        force-failed ``incomplete``; a young in-flight run is left alone for the
-        event hook to complete.
-
-        :returns: The number of runs transitioned to a terminal state.
-        """
-        transitioned = await self._sweep_running_runs()
-        _logger.info(
-            "ScheduledRunReconciler startup sweep: transitioned %d orphaned run(s)",
-            transitioned,
-        )
-        return transitioned
-
-    async def _sweep_running_runs(self) -> int:
-        """List all ``running`` runs across workspaces and reconcile each.
-
-        :returns: The number of runs transitioned to a terminal state.
-        """
-        runs = await asyncio.to_thread(
-            self._scheduled_task_store.list_runs_by_status_all_workspaces, "running"
-        )
-        transitioned = 0
-        for run in runs:
-            try:
-                if await self._reconcile_run(run):
-                    transitioned += 1
-            except Exception:
-                # One bad run must not abort the sweep.
-                _logger.exception("ScheduledRunReconciler failed to reconcile run %s", run.id)
-        return transitioned
-
-    async def _reconcile_run(self, run: ScheduledTaskRun) -> bool:
-        """Reconcile one ``running`` run against its conversation.
-
-        Runs inside the run's ``workspace_scope`` so every store query filters
-        on the owning workspace (multi-tenant), mirroring the fire path.
-
-        :param run: A run currently in ``running``.
-        :returns: ``True`` if the run was transitioned to a terminal state.
-        """
-        with workspace_scope(run.workspace_id):
-            now = int(self._now())
-            age = now - run.scheduled_at
-
-            conversation_id = run.conversation_id
-            decision = _TerminalDecision(status=None)
-            if conversation_id is not None:
-                conversation = await asyncio.to_thread(
-                    self._conversation_store.get_conversation, conversation_id
-                )
-                decision = classify_conversation_terminal_state(
-                    conversation,
-                    self._conversation_store,
-                    conversation_id,
-                )
-
-            if decision.status is None:
-                # Not yet terminal. Force-fail only if the run is stale — a
-                # host that died mid-turn will never report completion.
-                if age < self._stale_max_age:
-                    return False
-                decision = _TerminalDecision(
-                    status="failed",
-                    error_code=STALE_RUN_ERROR_CODE,
-                    error=(
-                        "scheduled run did not reach a terminal state within "
-                        f"{self._stale_max_age}s"
-                    ),
-                )
-
-            updated = await asyncio.to_thread(
-                self._scheduled_task_store.update_run,
+    ts = int(time.time()) if now is None else now
+    result: list[ScheduledTaskRun] = []
+    for run in runs:
+        if run.status == "running" and (ts - run.scheduled_at) >= STALE_RUN_MAX_AGE_SECONDS:
+            updated = store.update_run(
                 run.id,
-                status=decision.status,
-                finished_at=now,
-                error=decision.error,
-                error_code=decision.error_code,
+                status="failed",
+                finished_at=ts,
+                error=(
+                    "scheduled run did not reach a terminal state within "
+                    f"{STALE_RUN_MAX_AGE_SECONDS}s"
+                ),
+                error_code=STALE_RUN_ERROR_CODE,
             )
-            if updated is None:
-                # Already terminal (a concurrent sweep or fire-time write won).
-                return False
-            _logger.info(
-                "ScheduledRunReconciler: run %s (task %s) %s -> %s%s",
-                run.id,
-                run.scheduled_task_id,
-                "running",
-                decision.status,
-                f" ({decision.error_code})" if decision.error_code else "",
-            )
-            return True
+            result.append(updated if updated is not None else run)
+        else:
+            result.append(run)
+    return result

--- a/omnigent/server/scheduled/run_reconciler.py
+++ b/omnigent/server/scheduled/run_reconciler.py
@@ -1,0 +1,299 @@
+"""Scheduled-task run reconciler — the run-lifecycle completion backstop.
+
+The fire path (:mod:`omnigent.server.scheduled.fire`) creates a conversation,
+dispatches the prompt, and records a ``scheduled_task_runs`` row as
+``running`` — then returns immediately, WITHOUT waiting for the agent turn to
+finish. Nothing in that path ever revisits the row, so historically a run
+stayed ``running`` with ``finished_at = NULL`` forever, even after the agent
+completed.
+
+There is no durable completion callback to hang the transition on: the
+pub-sub event bus (:mod:`omnigent.runtime.session_stream`) fans terminal
+``response.*`` events only to live SSE subscribers with no durable buffer, so
+a scheduled fire (which has no attached client) would miss them, and any
+in-memory listener would not survive a server restart.
+
+This module closes the gap with a **periodic reconciliation sweep**. Every
+:data:`RECONCILE_INTERVAL_SECONDS` it lists every still-``running`` run across
+all workspaces and, for each, reads the DURABLE state its conversation left
+behind (see :func:`classify_conversation_terminal_state`):
+
+- the conversation's ``live_status`` (relay-persisted; a cheap pre-filter), and
+- the conversation's committed items + failure labels (the authoritative
+  transcript, which survives with no client attached and across restarts).
+
+A conversation whose turn has completed flips the run to ``succeeded``; an
+errored/cancelled turn flips it to ``failed`` with an ``error_code``. A run
+that has been ``running`` longer than :data:`STALE_RUN_MAX_AGE_SECONDS`
+without reaching a terminal conversation state is force-failed with
+``error_code = "incomplete"`` (the host-died-mid-turn case) so the invariant
+"every run eventually reaches a terminal state" always holds. The store's
+:meth:`update_run` is conditional (``WHERE status = running``) and idempotent,
+so a run already terminal (a fire-time ``skipped``/``failed``, or a prior
+sweep) is never clobbered and two sweeps cannot double-transition.
+
+A lower-latency relay hook (transition the run the instant the relay observes
+``response.completed``) is a possible future optimization; it is deliberately
+NOT part of this backstop, which must work without any live subscription.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from omnigent.db.db_models import workspace_scope
+from omnigent.server.routes.sessions import (
+    _LAST_TASK_ERROR_CODE_LABEL_KEY,
+)
+
+if TYPE_CHECKING:
+    from omnigent.entities import Conversation, ScheduledTaskRun
+    from omnigent.stores import ConversationStore
+    from omnigent.stores.scheduled_task_store import ScheduledTaskStore
+
+_logger = logging.getLogger(__name__)
+
+# How often the sweep runs. The RRULE floor is 1 hour, so runs are not
+# high-frequency; 60s is responsive without churning the DB. Module constant
+# so it stays tunable.
+RECONCILE_INTERVAL_SECONDS: int = 60
+
+# A run still ``running`` longer than this — with no terminal conversation
+# state — is force-failed with ``error_code = "incomplete"`` (host died
+# mid-turn, runner never reported completion). Deliberately generous (6h) so a
+# legitimately long agent turn is never killed; a stuck-``running`` row is a
+# far milder bug than a falsely-``failed`` one.
+STALE_RUN_MAX_AGE_SECONDS: int = 6 * 60 * 60
+
+# error_code recorded on the stale-run force-fail path.
+STALE_RUN_ERROR_CODE: str = "incomplete"
+
+# Conversation ``live_status`` values that mean the turn is still in flight —
+# used as a cheap pre-filter to skip the items read for clearly-running runs.
+_IN_FLIGHT_LIVE_STATUSES: frozenset[str] = frozenset({"running", "waiting"})
+
+
+@dataclass(frozen=True)
+class _TerminalDecision:
+    """Outcome of classifying a run's conversation.
+
+    :param status: Terminal run status to set (``"succeeded"`` / ``"failed"``),
+        or ``None`` to leave the run ``running`` (turn still in flight).
+    :param error_code: Failure classification when ``status == "failed"``.
+    :param error: Human-readable failure detail when ``status == "failed"``.
+    """
+
+    status: str | None
+    error_code: str | None = None
+    error: str | None = None
+
+
+def _latest_message_completed(conversation_store: ConversationStore, conversation_id: str) -> bool:
+    """Return whether the conversation's newest message item is ``completed``.
+
+    The relay commits assistant output as ``message`` items; the newest one
+    reaching ``status == "completed"`` is the durable, client-independent
+    signal that the dispatched turn produced a finished response.
+
+    :param conversation_store: Store to read committed items from.
+    :param conversation_id: The fired conversation to inspect.
+    :returns: ``True`` if the latest ``message`` item is ``completed``.
+    """
+    page = conversation_store.list_items(
+        conversation_id,
+        limit=1,
+        order="desc",
+        type="message",
+    )
+    if not page.data:
+        return False
+    return page.data[0].status == "completed"
+
+
+def classify_conversation_terminal_state(
+    conversation: Conversation | None,
+    conversation_store: ConversationStore,
+    conversation_id: str,
+) -> _TerminalDecision:
+    """Decide the terminal run status for a ``running`` run's conversation.
+
+    Read order (durable signals only — no live subscription required):
+
+    #. **Missing conversation** — the fired conversation was deleted. Treat as
+       terminal ``failed`` (``conversation_missing``); nothing left to await.
+    #. **Failure labels** — a ``session.status: failed`` edge persists
+       ``omnigent.last_task_error_code``; a non-empty value means the turn
+       terminally errored → ``failed`` carrying that code.
+    #. **live_status pre-filter** — ``running``/``waiting`` means still in
+       flight; leave it (unless stale, handled by the caller).
+    #. **Completed transcript** — the newest ``message`` item is ``completed``
+       → ``succeeded``.
+    #. **Otherwise** — not yet terminal; leave ``running`` (the caller applies
+       the stale-age backstop).
+
+    :param conversation: The fired conversation, or ``None`` if it no longer
+        exists.
+    :param conversation_store: Store used to read committed items.
+    :param conversation_id: The fired conversation id (for the items read).
+    :returns: A :class:`_TerminalDecision`.
+    """
+    if conversation is None:
+        return _TerminalDecision(
+            status="failed",
+            error_code="conversation_missing",
+            error="scheduled run conversation no longer exists",
+        )
+
+    error_code = (conversation.labels or {}).get(_LAST_TASK_ERROR_CODE_LABEL_KEY)
+    if error_code:
+        return _TerminalDecision(
+            status="failed",
+            error_code=error_code,
+            error="scheduled run turn reported a terminal error",
+        )
+
+    if conversation.live_status in _IN_FLIGHT_LIVE_STATUSES:
+        return _TerminalDecision(status=None)
+
+    if _latest_message_completed(conversation_store, conversation_id):
+        return _TerminalDecision(status="succeeded")
+
+    return _TerminalDecision(status=None)
+
+
+class ScheduledRunReconciler:
+    """Periodic backstop that transitions ``running`` runs to terminal states.
+
+    Owns its own asyncio loop, kept OFF the :class:`ScheduledTaskScheduler`
+    (which is purely per-job timers) so the scan responsibility stays
+    separate. Wire :meth:`start` / :meth:`stop` into the server lifespan next
+    to the scheduler.
+    """
+
+    def __init__(
+        self,
+        scheduled_task_store: ScheduledTaskStore,
+        conversation_store: ConversationStore,
+        *,
+        interval_seconds: int = RECONCILE_INTERVAL_SECONDS,
+        stale_max_age_seconds: int = STALE_RUN_MAX_AGE_SECONDS,
+        now: Callable[[], float] = time.time,
+    ) -> None:
+        self._scheduled_task_store = scheduled_task_store
+        self._conversation_store = conversation_store
+        self._interval = interval_seconds
+        self._stale_max_age = stale_max_age_seconds
+        self._now = now
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Start the periodic sweep loop. Idempotent."""
+        if self._task is not None and not self._task.done():
+            return
+        self._task = asyncio.ensure_future(self._loop())
+        _logger.info(
+            "ScheduledRunReconciler started (interval=%ds, stale_max_age=%ds)",
+            self._interval,
+            self._stale_max_age,
+        )
+
+    def stop(self) -> None:
+        """Cancel the sweep loop. Idempotent."""
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    async def _loop(self) -> None:
+        """Run :meth:`reconcile_once` every ``interval`` seconds until cancelled."""
+        while True:
+            try:
+                await asyncio.sleep(self._interval)
+                await self.reconcile_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # A sweep failure must not kill the loop.
+                _logger.exception("ScheduledRunReconciler sweep failed; continuing")
+
+    async def reconcile_once(self) -> int:
+        """Run a single sweep over all ``running`` runs across every workspace.
+
+        :returns: The number of runs transitioned to a terminal state.
+        """
+        runs = await asyncio.to_thread(
+            self._scheduled_task_store.list_runs_by_status_all_workspaces, "running"
+        )
+        transitioned = 0
+        for run in runs:
+            try:
+                if await self._reconcile_run(run):
+                    transitioned += 1
+            except Exception:
+                # One bad run must not abort the sweep.
+                _logger.exception("ScheduledRunReconciler failed to reconcile run %s", run.id)
+        return transitioned
+
+    async def _reconcile_run(self, run: ScheduledTaskRun) -> bool:
+        """Reconcile one ``running`` run against its conversation.
+
+        Runs inside the run's ``workspace_scope`` so every store query filters
+        on the owning workspace (multi-tenant), mirroring the fire path.
+
+        :param run: A run currently in ``running``.
+        :returns: ``True`` if the run was transitioned to a terminal state.
+        """
+        with workspace_scope(run.workspace_id):
+            now = int(self._now())
+            age = now - run.scheduled_at
+
+            conversation_id = run.conversation_id
+            decision = _TerminalDecision(status=None)
+            if conversation_id is not None:
+                conversation = await asyncio.to_thread(
+                    self._conversation_store.get_conversation, conversation_id
+                )
+                decision = classify_conversation_terminal_state(
+                    conversation,
+                    self._conversation_store,
+                    conversation_id,
+                )
+
+            if decision.status is None:
+                # Not yet terminal. Force-fail only if the run is stale — a
+                # host that died mid-turn will never report completion.
+                if age < self._stale_max_age:
+                    return False
+                decision = _TerminalDecision(
+                    status="failed",
+                    error_code=STALE_RUN_ERROR_CODE,
+                    error=(
+                        "scheduled run did not reach a terminal state within "
+                        f"{self._stale_max_age}s"
+                    ),
+                )
+
+            updated = await asyncio.to_thread(
+                self._scheduled_task_store.update_run,
+                run.id,
+                status=decision.status,
+                finished_at=now,
+                error=decision.error,
+                error_code=decision.error_code,
+            )
+            if updated is None:
+                # Already terminal (a concurrent sweep or fire-time write won).
+                return False
+            _logger.info(
+                "ScheduledRunReconciler: run %s (task %s) %s -> %s%s",
+                run.id,
+                run.scheduled_task_id,
+                "running",
+                decision.status,
+                f" ({decision.error_code})" if decision.error_code else "",
+            )
+            return True

--- a/omnigent/server/scheduled/run_reconciler.py
+++ b/omnigent/server/scheduled/run_reconciler.py
@@ -1,40 +1,43 @@
-"""Scheduled-task run reconciler — the run-lifecycle completion backstop.
+"""Scheduled-task run-completion backstop — startup sweep + lazy-on-read.
 
 The fire path (:mod:`omnigent.server.scheduled.fire`) creates a conversation,
 dispatches the prompt, and records a ``scheduled_task_runs`` row as
 ``running`` — then returns immediately, WITHOUT waiting for the agent turn to
-finish. Nothing in that path ever revisits the row, so historically a run
-stayed ``running`` with ``finished_at = NULL`` forever, even after the agent
-completed.
+finish.
 
-There is no durable completion callback to hang the transition on: the
-pub-sub event bus (:mod:`omnigent.runtime.session_stream`) fans terminal
-``response.*`` events only to live SSE subscribers with no durable buffer, so
-a scheduled fire (which has no attached client) would miss them, and any
-in-memory listener would not survive a server restart.
+**The PRIMARY completion mechanism is event-driven** and lives elsewhere:
+:func:`omnigent.server.session_live_state.persist_scheduled_run_completion`,
+fired from ``_publish_status`` the instant a fired conversation's turn reaches
+a terminal edge, flips the run ``running`` → ``succeeded``/``failed``. That
+handler rides the same long-lived SSE relay that already persists the
+conversation's ``live_status`` for a browserless scheduled fire, so it needs
+no live client and no periodic poll.
 
-This module closes the gap with a **periodic reconciliation sweep**. Every
-:data:`RECONCILE_INTERVAL_SECONDS` it lists every still-``running`` run across
-all workspaces and, for each, reads the DURABLE state its conversation left
-behind (see :func:`classify_conversation_terminal_state`):
+This module is only the **orphan backstop** for the case the event path cannot
+cover: a run left ``running`` because the terminal event never fired or was
+lost (host died mid-turn, or the server restarted while a fire was in flight).
+It enforces the invariant "every run eventually reaches a terminal state"
+WITHOUT a recurring background poll, via two cheap catches:
 
-- the conversation's ``live_status`` (relay-persisted; a cheap pre-filter), and
-- the conversation's committed items + failure labels (the authoritative
-  transcript, which survives with no client attached and across restarts).
+- :meth:`ScheduledRunReconciler.run_startup_sweep` — runs ONCE per server boot
+  (wired into the lifespan). It lists every still-``running`` run across all
+  workspaces and force-fails those whose conversation is already terminal /
+  missing, or that are past :data:`STALE_RUN_MAX_AGE_SECONDS`. This catches
+  runs orphaned by a restart mid-fire.
+- lazy-on-read at ``GET /v1/scheduled-tasks/{id}/runs`` (in the route, not
+  here) — force-fails a task's runs still ``running`` past the max age when
+  run history is read.
 
-A conversation whose turn has completed flips the run to ``succeeded``; an
-errored/cancelled turn flips it to ``failed`` with an ``error_code``. A run
-that has been ``running`` longer than :data:`STALE_RUN_MAX_AGE_SECONDS`
-without reaching a terminal conversation state is force-failed with
-``error_code = "incomplete"`` (the host-died-mid-turn case) so the invariant
-"every run eventually reaches a terminal state" always holds. The store's
-:meth:`update_run` is conditional (``WHERE status = running``) and idempotent,
-so a run already terminal (a fire-time ``skipped``/``failed``, or a prior
-sweep) is never clobbered and two sweeps cannot double-transition.
+Both reuse :func:`classify_conversation_terminal_state` (reads the durable
+``live_status`` + committed transcript + failure labels the conversation left
+behind) and the idempotent, conditional :meth:`update_run`
+(``WHERE status = running``), so a run already terminal — via the event hook, a
+fire-time ``skipped``/``failed``, or the other backstop — is never clobbered.
 
-A lower-latency relay hook (transition the run the instant the relay observes
-``response.completed``) is a possible future optimization; it is deliberately
-NOT part of this backstop, which must work without any live subscription.
+There is deliberately NO periodic sweep of any cadence: the event hook makes
+one unnecessary, and startup-sweep + lazy-on-read match how the sibling
+scheduled-task systems reconcile orphans (at a lifecycle boundary, not on a
+timer).
 """
 
 from __future__ import annotations
@@ -58,16 +61,12 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
-# How often the sweep runs. The RRULE floor is 1 hour, so runs are not
-# high-frequency; 60s is responsive without churning the DB. Module constant
-# so it stays tunable.
-RECONCILE_INTERVAL_SECONDS: int = 60
-
 # A run still ``running`` longer than this — with no terminal conversation
 # state — is force-failed with ``error_code = "incomplete"`` (host died
 # mid-turn, runner never reported completion). Deliberately generous (6h) so a
 # legitimately long agent turn is never killed; a stuck-``running`` row is a
-# far milder bug than a falsely-``failed`` one.
+# far milder bug than a falsely-``failed`` one. Shared by the startup sweep and
+# the lazy-on-read backstop.
 STALE_RUN_MAX_AGE_SECONDS: int = 6 * 60 * 60
 
 # error_code recorded on the stale-run force-fail path.
@@ -167,12 +166,13 @@ def classify_conversation_terminal_state(
 
 
 class ScheduledRunReconciler:
-    """Periodic backstop that transitions ``running`` runs to terminal states.
+    """Orphan backstop that transitions stranded ``running`` runs to terminal.
 
-    Owns its own asyncio loop, kept OFF the :class:`ScheduledTaskScheduler`
-    (which is purely per-job timers) so the scan responsibility stays
-    separate. Wire :meth:`start` / :meth:`stop` into the server lifespan next
-    to the scheduler.
+    NOT a periodic poll — the primary completion path is the event hook
+    (:func:`omnigent.server.session_live_state.persist_scheduled_run_completion`).
+    This runs its sweep ONCE per boot via :meth:`run_startup_sweep` (wired into
+    the server lifespan) to catch runs orphaned by a restart mid-fire; the
+    lazy-on-read backstop in the runs route covers the rest.
     """
 
     def __init__(
@@ -180,48 +180,35 @@ class ScheduledRunReconciler:
         scheduled_task_store: ScheduledTaskStore,
         conversation_store: ConversationStore,
         *,
-        interval_seconds: int = RECONCILE_INTERVAL_SECONDS,
         stale_max_age_seconds: int = STALE_RUN_MAX_AGE_SECONDS,
         now: Callable[[], float] = time.time,
     ) -> None:
         self._scheduled_task_store = scheduled_task_store
         self._conversation_store = conversation_store
-        self._interval = interval_seconds
         self._stale_max_age = stale_max_age_seconds
         self._now = now
-        self._task: asyncio.Task[None] | None = None
 
-    async def start(self) -> None:
-        """Start the periodic sweep loop. Idempotent."""
-        if self._task is not None and not self._task.done():
-            return
-        self._task = asyncio.ensure_future(self._loop())
+    async def run_startup_sweep(self) -> int:
+        """Reconcile all ``running`` runs once at server startup.
+
+        Catches runs orphaned by a server restart that happened while a fire
+        was in flight (the terminal event fired on the old process, or never).
+        A run whose conversation is already terminal/missing is transitioned to
+        the mapped status; one past the max age with no terminal state is
+        force-failed ``incomplete``; a young in-flight run is left alone for the
+        event hook to complete.
+
+        :returns: The number of runs transitioned to a terminal state.
+        """
+        transitioned = await self._sweep_running_runs()
         _logger.info(
-            "ScheduledRunReconciler started (interval=%ds, stale_max_age=%ds)",
-            self._interval,
-            self._stale_max_age,
+            "ScheduledRunReconciler startup sweep: transitioned %d orphaned run(s)",
+            transitioned,
         )
+        return transitioned
 
-    def stop(self) -> None:
-        """Cancel the sweep loop. Idempotent."""
-        if self._task is not None:
-            self._task.cancel()
-            self._task = None
-
-    async def _loop(self) -> None:
-        """Run :meth:`reconcile_once` every ``interval`` seconds until cancelled."""
-        while True:
-            try:
-                await asyncio.sleep(self._interval)
-                await self.reconcile_once()
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                # A sweep failure must not kill the loop.
-                _logger.exception("ScheduledRunReconciler sweep failed; continuing")
-
-    async def reconcile_once(self) -> int:
-        """Run a single sweep over all ``running`` runs across every workspace.
+    async def _sweep_running_runs(self) -> int:
+        """List all ``running`` runs across workspaces and reconcile each.
 
         :returns: The number of runs transitioned to a terminal state.
         """

--- a/omnigent/server/scheduled/run_reconciler.py
+++ b/omnigent/server/scheduled/run_reconciler.py
@@ -66,12 +66,17 @@ def force_fail_stale_runs(
     """Force-fail ``running`` runs older than the max age; return the list.
 
     The lazy-on-read orphan backstop, shared by the scheduled-task list and
-    detail read endpoints. Pure age check — NO conversation I/O. Only rows past
-    :data:`STALE_RUN_MAX_AGE_SECONDS` are touched; the store's conditional
-    :meth:`update_run` (``WHERE status = running``) makes it idempotent and safe
-    against a run that just transitioned via the event hook. Must be called
-    inside the runs' ``workspace_scope`` (the store filters every query on
-    ``current_workspace_id()``); the read endpoints already run there.
+    detail read endpoints. Pure age check — NO conversation I/O. The age is
+    measured from ``fired_at`` (when dispatch actually began), falling back to
+    ``scheduled_at`` when a run has no ``fired_at`` (never dispatched). Measuring
+    from ``fired_at`` means a run that fired late doesn't get a shortened
+    effective window — the 6h clock starts when the turn actually started, not
+    when it was scheduled. Only rows past :data:`STALE_RUN_MAX_AGE_SECONDS` are
+    touched; the store's conditional :meth:`update_run` (``WHERE status =
+    running``) makes it idempotent and safe against a run that just transitioned
+    via the event hook. Must be called inside the runs' ``workspace_scope`` (the
+    store filters every query on ``current_workspace_id()``); the read endpoints
+    already run there.
 
     The returned list reflects any transition (a force-failed run carries its
     new terminal state) so a caller rendering the runs stays consistent with the
@@ -87,7 +92,10 @@ def force_fail_stale_runs(
     ts = int(time.time()) if now is None else now
     result: list[ScheduledTaskRun] = []
     for run in runs:
-        if run.status == "running" and (ts - run.scheduled_at) >= STALE_RUN_MAX_AGE_SECONDS:
+        # Age from when dispatch began (fired_at); fall back to scheduled_at for
+        # a run that somehow never recorded a fire time.
+        age_from = run.fired_at if run.fired_at is not None else run.scheduled_at
+        if run.status == "running" and (ts - age_from) >= STALE_RUN_MAX_AGE_SECONDS:
             updated = store.update_run(
                 run.id,
                 status="failed",

--- a/omnigent/server/session_live_state.py
+++ b/omnigent/server/session_live_state.py
@@ -47,6 +47,7 @@ from omnigent.db.enum_codecs import SESSION_LIVE_STATUS
 
 if TYPE_CHECKING:
     from omnigent.stores import ConversationStore
+    from omnigent.stores.scheduled_task_store import ScheduledTaskStore
 
 _logger = logging.getLogger(__name__)
 
@@ -58,6 +59,10 @@ _logger = logging.getLogger(__name__)
 _KNOWN_LIVE_STATUSES: frozenset[str] = frozenset(SESSION_LIVE_STATUS)
 
 _store: ConversationStore | None = None
+# Scheduled-task store for the event-driven run-completion hook. Wired
+# alongside ``_store`` by :func:`configure`; ``None`` disables the hook (the
+# runner process and unit tests that never configure it are unaffected).
+_scheduled_task_store: ScheduledTaskStore | None = None
 # Single worker => writes apply in submission order (see module docstring).
 _executor: ThreadPoolExecutor | None = None
 # Last status seen per session, for dedupe — the value whose write was
@@ -69,15 +74,22 @@ _last_status: dict[str, str] = {}
 _last_pending: dict[str, int] = {}
 
 
-def configure(store: ConversationStore | None) -> None:
+def configure(
+    store: ConversationStore | None,
+    scheduled_task_store: ScheduledTaskStore | None = None,
+) -> None:
     """
-    Wire (or clear) the conversation store live-state writes go to.
+    Wire (or clear) the stores live-state writes go to.
 
     :param store: The server's conversation store, or ``None`` to
         disable persistence (tests / non-server processes).
+    :param scheduled_task_store: The server's scheduled-task store, enabling
+        the event-driven run-completion hook
+        (:func:`persist_scheduled_run_completion`); ``None`` disables it.
     """
-    global _store
+    global _store, _scheduled_task_store
     _store = store
+    _scheduled_task_store = scheduled_task_store
     _last_status.clear()
     _last_pending.clear()
 
@@ -162,6 +174,67 @@ def persist_live_status(session_id: str, status: str) -> None:
             _last_status.pop(session_id, None)
 
     _submit("live_status", _store.set_session_live_status, session_id, status, on_failure=_evict)
+
+
+def persist_scheduled_run_completion(
+    conversation_id: str,
+    run_status: str,
+    *,
+    error_code: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Transition a scheduled-task run to terminal when its turn ends.
+
+    The event-driven completion mechanism: called from ``_publish_status``
+    wherever a session reaches a durable terminal edge (``idle`` = the turn
+    completed, ``failed`` = it errored/disconnected). Most conversations are
+    not scheduled-task fires, so the reverse lookup returns ``None`` and this
+    is a cheap no-op; only a fired conversation with a still-``running`` run
+    gets transitioned.
+
+    Runs on the SAME ordered single-worker executor as
+    :func:`persist_live_status`, inside a copy of the caller's ``contextvars``
+    (see :func:`_submit`). This is load-bearing: the store filters every query
+    on ``current_workspace_id()``, and the reverse lookup + ``update_run`` must
+    resolve to the fired run's workspace — the relay call site's
+    ``workspace_scope`` reaches the worker thread exactly as it does for the
+    ``live_status`` mirror. A bare executor would run at workspace 0 and match
+    no rows on a multi-tenant replica.
+
+    Idempotent by construction: ``update_run`` is conditional on
+    ``WHERE status = running``, so a run already terminal (a fire-time
+    ``skipped``/``failed``, or the startup/lazy backstop) is never clobbered
+    and a terminal edge seen twice transitions at most once. Best-effort like
+    the other writes here — a failure logs and is dropped; the backstop
+    (startup sweep / lazy-on-read) is the durability guarantee for the rare
+    dropped-write or restart-in-flight case.
+
+    :param conversation_id: The fired conversation whose turn just ended.
+    :param run_status: Terminal run status to set — ``"succeeded"`` (turn
+        completed) or ``"failed"`` (turn errored/cancelled/disconnected).
+    :param error_code: Short failure classification when ``run_status`` is
+        ``"failed"`` (e.g. the conversation's ``last_task_error_code``).
+    :param error: Optional human-readable failure detail for ``"failed"``.
+    """
+    store = _scheduled_task_store
+    if store is None:
+        return
+
+    def _transition() -> None:
+        run = store.get_running_run_by_conversation(conversation_id)
+        if run is None:
+            # Not a scheduled fire, or its run is already terminal — nothing to
+            # do. This is the common case (interactive sessions).
+            return
+        store.update_run(
+            run.id,
+            status=run_status,
+            finished_at=int(time.time()),
+            error=error,
+            error_code=error_code,
+        )
+
+    _submit("scheduled_run_completion", _transition)
 
 
 def persist_pending_count(conversation_id: str, count: int) -> None:

--- a/omnigent/stores/scheduled_task_store/__init__.py
+++ b/omnigent/stores/scheduled_task_store/__init__.py
@@ -266,17 +266,18 @@ class ScheduledTaskStore(ABC):
         ...
 
     @abstractmethod
-    def list_runs_by_status_all_workspaces(self, status: str) -> list[ScheduledTaskRun]:
+    def list_running_runs_for_tasks(self, scheduled_task_ids: list[str]) -> list[ScheduledTaskRun]:
         """
-        List every run in ``status`` across all workspaces.
+        List ``running`` runs for the given tasks in the current workspace.
 
-        Used by the startup orphan sweep to find ``running`` runs left behind
-        by a server restart mid-fire. Mirrors
-        :meth:`ScheduledTaskStore.list_active_all_workspaces` — the caller
-        re-enters each run's ``workspace_scope`` before acting on it.
+        Powers the lazy-on-read stale backstop on the scheduled-task LIST
+        endpoint: the route resolves the owner's tasks, then this returns their
+        still-``running`` runs so the route can force-fail the ones past the max
+        age. Workspace-scoped (filters on ``current_workspace_id()``) like every
+        other read; an empty id list returns an empty list.
 
-        :param status: The run status to filter on, e.g. ``"running"``.
-        :returns: Matching :class:`ScheduledTaskRun` instances, ordered by
-            ``workspace_id ASC, scheduled_at ASC, id ASC``.
+        :param scheduled_task_ids: Task ids (already owner-scoped by the caller).
+        :returns: ``running`` :class:`ScheduledTaskRun` instances for those
+            tasks, ordered ``scheduled_at DESC, id DESC``.
         """
         ...

--- a/omnigent/stores/scheduled_task_store/__init__.py
+++ b/omnigent/stores/scheduled_task_store/__init__.py
@@ -243,12 +243,35 @@ class ScheduledTaskStore(ABC):
         ...
 
     @abstractmethod
+    def get_running_run_by_conversation(self, conversation_id: str) -> ScheduledTaskRun | None:
+        """
+        Return the ``running`` run for a conversation, or ``None``.
+
+        The event-driven completion hook (fired when a conversation's turn
+        reaches a terminal state) uses this reverse lookup to find the
+        scheduled-task run to transition. Workspace-scoped like every other
+        store read (filters on ``current_workspace_id()``), so the caller must
+        run it inside the run's ``workspace_scope``. Backed by the
+        ``ix_scheduled_task_runs_conversation_id`` index on
+        ``(workspace_id, conversation_id)``.
+
+        A conversation maps to at most one ``running`` run (a fire creates one
+        run per conversation), so this returns a single row rather than a list.
+
+        :param conversation_id: The fired conversation to look up.
+        :returns: The matching ``running`` :class:`ScheduledTaskRun`, or
+            ``None`` if the conversation has no run, or its run is already
+            terminal.
+        """
+        ...
+
+    @abstractmethod
     def list_runs_by_status_all_workspaces(self, status: str) -> list[ScheduledTaskRun]:
         """
         List every run in ``status`` across all workspaces.
 
-        Used by the run reconciler at sweep time to find ``running`` runs to
-        reconcile against their conversations. Mirrors
+        Used by the startup orphan sweep to find ``running`` runs left behind
+        by a server restart mid-fire. Mirrors
         :meth:`ScheduledTaskStore.list_active_all_workspaces` — the caller
         re-enters each run's ``workspace_scope`` before acting on it.
 

--- a/omnigent/stores/scheduled_task_store/__init__.py
+++ b/omnigent/stores/scheduled_task_store/__init__.py
@@ -208,3 +208,52 @@ class ScheduledTaskStore(ABC):
         :returns: List of :class:`ScheduledTaskRun` instances.
         """
         ...
+
+    @abstractmethod
+    def update_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        finished_at: int,
+        error: str | None = None,
+        error_code: str | None = None,
+    ) -> ScheduledTaskRun | None:
+        """
+        Transition a still-``running`` run to a terminal status.
+
+        Idempotent and conditional: the update only applies to a run whose
+        current status is ``running`` (guarded by ``WHERE status = running``),
+        so a run already advanced to a terminal state (a fire-time
+        ``skipped``/``failed``, or a prior reconciliation) is never clobbered
+        and two concurrent sweeps cannot double-transition it.
+
+        :param run_id: The run to transition.
+        :param status: The terminal status to set — ``succeeded`` or
+            ``failed``.
+        :param finished_at: Unix epoch seconds the run reached the terminal
+            state.
+        :param error: Optional failure detail (only for ``failed``).
+        :param error_code: Optional short failure classification (only for
+            ``failed``), e.g. ``"incomplete"``.
+        :returns: The updated :class:`ScheduledTaskRun` if a ``running`` run
+            was transitioned; ``None`` if no matching ``running`` run existed
+            (not found, or already terminal).
+        """
+        ...
+
+    @abstractmethod
+    def list_runs_by_status_all_workspaces(self, status: str) -> list[ScheduledTaskRun]:
+        """
+        List every run in ``status`` across all workspaces.
+
+        Used by the run reconciler at sweep time to find ``running`` runs to
+        reconcile against their conversations. Mirrors
+        :meth:`ScheduledTaskStore.list_active_all_workspaces` — the caller
+        re-enters each run's ``workspace_scope`` before acting on it.
+
+        :param status: The run status to filter on, e.g. ``"running"``.
+        :returns: Matching :class:`ScheduledTaskRun` instances, ordered by
+            ``workspace_id ASC, scheduled_at ASC, id ASC``.
+        """
+        ...

--- a/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
+++ b/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
@@ -372,17 +372,29 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
             row = session.execute(stmt).scalars().first()
             return _run_to_entity(row) if row is not None else None
 
-    def list_runs_by_status_all_workspaces(self, status: str) -> list[ScheduledTaskRun]:
-        """List every run in ``status`` across all workspaces (startup sweep)."""
+    def list_running_runs_for_tasks(self, scheduled_task_ids: list[str]) -> list[ScheduledTaskRun]:
+        """List ``running`` runs for the given tasks in the current workspace.
+
+        Powers the lazy-on-read stale backstop on the scheduled-task LIST
+        endpoint: the route resolves the owner's tasks, then this returns their
+        still-``running`` runs (one indexed, workspace-scoped query over the
+        ``scheduled_task_id`` index) so the route can force-fail the stale ones.
+        An empty ``scheduled_task_ids`` returns an empty list without a query.
+
+        :param scheduled_task_ids: Task ids (already owner-scoped by the caller).
+        :returns: ``running`` runs for those tasks, ordered
+            ``scheduled_at DESC, id DESC``.
+        """
+        if not scheduled_task_ids:
+            return []
+        running_code = encode_scheduled_task_run_status("running")
         with self._session() as session:
             stmt = (
                 select(SqlScheduledTaskRun)
-                .where(SqlScheduledTaskRun.status == encode_scheduled_task_run_status(status))
-                .order_by(
-                    asc(SqlScheduledTaskRun.workspace_id),
-                    asc(SqlScheduledTaskRun.scheduled_at),
-                    asc(SqlScheduledTaskRun.id),
-                )
+                .where(SqlScheduledTaskRun.workspace_id == current_workspace_id())
+                .where(SqlScheduledTaskRun.scheduled_task_id.in_(scheduled_task_ids))
+                .where(SqlScheduledTaskRun.status == running_code)
+                .order_by(desc(SqlScheduledTaskRun.scheduled_at), desc(SqlScheduledTaskRun.id))
             )
             rows = session.execute(stmt).scalars().all()
             return [_run_to_entity(r) for r in rows]

--- a/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
+++ b/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
@@ -80,6 +80,7 @@ def _run_to_entity(row: SqlScheduledTaskRun) -> ScheduledTaskRun:
         finished_at=row.finished_at,
         error=row.error,
         error_code=row.error_code,
+        workspace_id=row.workspace_id or DEFAULT_WORKSPACE_ID,
     )
 
 
@@ -322,6 +323,48 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
                 .where(SqlScheduledTaskRun.workspace_id == current_workspace_id())
                 .where(SqlScheduledTaskRun.scheduled_task_id == scheduled_task_id)
                 .order_by(desc(SqlScheduledTaskRun.scheduled_at), desc(SqlScheduledTaskRun.id))
+            )
+            rows = session.execute(stmt).scalars().all()
+            return [_run_to_entity(r) for r in rows]
+
+    def update_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        finished_at: int,
+        error: str | None = None,
+        error_code: str | None = None,
+    ) -> ScheduledTaskRun | None:
+        """Transition a still-``running`` run to a terminal status.
+
+        Conditional on the current status being ``running`` so an
+        already-terminal run is never clobbered and concurrent sweeps cannot
+        double-transition (see the interface docstring).
+        """
+        running_code = encode_scheduled_task_run_status("running")
+        with self._session() as session:
+            row = session.get(SqlScheduledTaskRun, (current_workspace_id(), run_id))
+            if row is None or row.status != running_code:
+                return None
+            row.status = encode_scheduled_task_run_status(status)
+            row.finished_at = finished_at
+            row.error = error
+            row.error_code = error_code
+            session.flush()
+            return _run_to_entity(row)
+
+    def list_runs_by_status_all_workspaces(self, status: str) -> list[ScheduledTaskRun]:
+        """List every run in ``status`` across all workspaces (reconciler sweep)."""
+        with self._session() as session:
+            stmt = (
+                select(SqlScheduledTaskRun)
+                .where(SqlScheduledTaskRun.status == encode_scheduled_task_run_status(status))
+                .order_by(
+                    asc(SqlScheduledTaskRun.workspace_id),
+                    asc(SqlScheduledTaskRun.scheduled_at),
+                    asc(SqlScheduledTaskRun.id),
+                )
             )
             rows = session.execute(stmt).scalars().all()
             return [_run_to_entity(r) for r in rows]

--- a/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
+++ b/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
@@ -80,7 +80,6 @@ def _run_to_entity(row: SqlScheduledTaskRun) -> ScheduledTaskRun:
         finished_at=row.finished_at,
         error=row.error,
         error_code=row.error_code,
-        workspace_id=row.workspace_id or DEFAULT_WORKSPACE_ID,
     )
 
 

--- a/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
+++ b/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
@@ -354,8 +354,26 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
             session.flush()
             return _run_to_entity(row)
 
+    def get_running_run_by_conversation(self, conversation_id: str) -> ScheduledTaskRun | None:
+        """Return the ``running`` run for a conversation, or ``None``.
+
+        Workspace-scoped reverse lookup for the event-driven completion hook;
+        backed by ``ix_scheduled_task_runs_conversation_id``. A conversation has
+        at most one ``running`` run, so ``.first()`` is exact rather than lossy.
+        """
+        running_code = encode_scheduled_task_run_status("running")
+        with self._session() as session:
+            stmt = (
+                select(SqlScheduledTaskRun)
+                .where(SqlScheduledTaskRun.workspace_id == current_workspace_id())
+                .where(SqlScheduledTaskRun.conversation_id == conversation_id)
+                .where(SqlScheduledTaskRun.status == running_code)
+            )
+            row = session.execute(stmt).scalars().first()
+            return _run_to_entity(row) if row is not None else None
+
     def list_runs_by_status_all_workspaces(self, status: str) -> list[ScheduledTaskRun]:
-        """List every run in ``status`` across all workspaces (reconciler sweep)."""
+        """List every run in ``status`` across all workspaces (startup sweep)."""
         with self._session() as session:
             stmt = (
                 select(SqlScheduledTaskRun)

--- a/tests/server/integration/test_scheduled_tasks_routes.py
+++ b/tests/server/integration/test_scheduled_tasks_routes.py
@@ -614,3 +614,82 @@ async def test_list_runs_404_for_nonowned_task(
         f"/v1/scheduled-tasks/{created['id']}/runs", headers=_headers("bob@example.com")
     )
     assert resp.status_code == 404, resp.text
+
+
+# ── lazy-on-read orphan backstop ─────────────────────────────────────────────
+
+
+async def test_list_runs_force_fails_stale_running_run(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """Reading history force-fails a run left ``running`` past the 6h max age.
+
+    The lazy-on-read backstop for a genuine orphan (terminal event never
+    fired). ``scheduled_at`` is set well beyond the max age, so the read
+    transitions it to ``failed(incomplete)`` with ``finished_at`` stamped.
+    """
+    import time
+    import uuid
+
+    from omnigent.server.scheduled.run_reconciler import STALE_RUN_MAX_AGE_SECONDS
+
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    task_id = created["id"]
+    run_id = uuid.uuid4().hex
+    stale_scheduled_at = int(time.time()) - STALE_RUN_MAX_AGE_SECONDS - 60
+    _seed_run(
+        db_uri,
+        task_id,
+        run_id,
+        status="running",
+        scheduled_at=stale_scheduled_at,
+        fired_at=stale_scheduled_at + 1,
+        finished_at=None,
+        conversation_id=uuid.uuid4().hex,
+    )
+
+    resp = await auth_client.get(f"/v1/scheduled-tasks/{task_id}/runs", headers=_headers())
+    assert resp.status_code == 200, resp.text
+    run = resp.json()["runs"][0]
+    assert run["status"] == "failed"
+    assert run["error_code"] == "incomplete"
+    assert run["finished_at"] is not None
+
+
+async def test_list_runs_leaves_young_running_run_untouched(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """A recently-fired ``running`` run is NOT force-failed on read.
+
+    Only runs past the max age are reaped; a young in-flight run is left for
+    the event hook to complete normally.
+    """
+    import time
+    import uuid
+
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    task_id = created["id"]
+    run_id = uuid.uuid4().hex
+    recent = int(time.time()) - 30  # 30s ago, well within the max age
+    _seed_run(
+        db_uri,
+        task_id,
+        run_id,
+        status="running",
+        scheduled_at=recent,
+        fired_at=recent + 1,
+        finished_at=None,
+        conversation_id=uuid.uuid4().hex,
+    )
+
+    resp = await auth_client.get(f"/v1/scheduled-tasks/{task_id}/runs", headers=_headers())
+    assert resp.status_code == 200, resp.text
+    run = resp.json()["runs"][0]
+    assert run["status"] == "running"
+    assert run["finished_at"] is None

--- a/tests/server/integration/test_scheduled_tasks_routes.py
+++ b/tests/server/integration/test_scheduled_tasks_routes.py
@@ -771,3 +771,161 @@ async def test_list_tasks_leaves_young_running_run_untouched(
     run = detail.json()["runs"][0]
     assert run["status"] == "running"
     assert run["finished_at"] is None
+
+
+# ── event-hook wiring: _publish_status -> persist_scheduled_run_completion ────
+#
+# These lock the PRIMARY completion mechanism at the _publish_status seam (not
+# by re-calling the hook directly): a real terminal edge published the way the
+# SSE relay publishes it must reach the hook and transition the run, resolving
+# under the run's workspace_scope via the shared session_live_state executor.
+# Layer exercised: the sync _publish_status(...) call (its no-subscriber
+# session_stream.publish is a no-op) → session_live_state.persist_scheduled_run_
+# completion → the ThreadPoolExecutor(max_workers=1) worker → store.update_run.
+# A full runner/relay round-trip is covered by the live E2E; this covers the
+# server-side wiring so a future _publish_status refactor can't silently break
+# scheduled-run completion.
+
+
+def _seed_running_run_for_conv(db_uri: str, conversation_id: str) -> tuple[str, str]:
+    """Create a task + a ``running`` run bound to ``conversation_id``.
+
+    :returns: ``(task_id, run_id)``.
+    """
+    import uuid
+
+    from omnigent.stores.scheduled_task_store.sqlalchemy_store import (
+        SqlAlchemyScheduledTaskStore,
+    )
+
+    store = SqlAlchemyScheduledTaskStore(db_uri)
+    task_id = uuid.uuid4().hex
+    store.create(
+        scheduled_task_id=task_id,
+        name="hook-wiring",
+        prompt="p",
+        rrule="FREQ=HOURLY;BYMINUTE=0",
+        user_id=None,
+        agent_id=uuid.uuid4().hex,
+        timezone="UTC",
+    )
+    run_id = uuid.uuid4().hex
+    store.create_run(
+        run_id=run_id,
+        scheduled_task_id=task_id,
+        status="running",
+        scheduled_at=1000,
+        conversation_id=conversation_id,
+        fired_at=1001,
+    )
+    return task_id, run_id
+
+
+def _wait_for_run_status(
+    db_uri: str, task_id: str, run_id: str, want: str, timeout_s: float = 10.0
+):  # type: ignore[no-untyped-def]
+    """Poll the store until ``run_id`` reaches ``want`` (or timeout).
+
+    The hook write lands on session_live_state's background single-worker
+    executor, so the assertion must wait for that thread rather than read
+    synchronously.
+    """
+    import time
+
+    from omnigent.stores.scheduled_task_store.sqlalchemy_store import (
+        SqlAlchemyScheduledTaskStore,
+    )
+
+    store = SqlAlchemyScheduledTaskStore(db_uri)
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        for r in store.list_runs(task_id):
+            if r.id == run_id and r.status == want:
+                return r
+        time.sleep(0.02)
+    # Return the current row (whatever status) so the caller's assert reports it.
+    for r in store.list_runs(task_id):
+        if r.id == run_id:
+            return r
+    return None
+
+
+async def test_publish_status_idle_edge_transitions_scheduled_run_to_succeeded(
+    db_uri: str,
+) -> None:
+    """A completed-turn edge through _publish_status flips the run to succeeded.
+
+    Drives the real _publish_status(conversation_id, "idle") the relay emits and
+    asserts the run transitions running -> succeeded with finished_at set, via
+    the hook + executor path (workspace_scope contract exercised, not bypassed).
+
+    Async to satisfy the module's ``pytestmark = pytest.mark.asyncio``; the body
+    is synchronous (the hook write lands on session_live_state's background
+    executor, polled below) — no awaits needed.
+    """
+    import uuid
+
+    from omnigent.server import session_live_state
+    from omnigent.server.routes.sessions import _publish_status, _session_status_cache
+    from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+    from omnigent.stores.scheduled_task_store.sqlalchemy_store import (
+        SqlAlchemyScheduledTaskStore,
+    )
+
+    conv_id = uuid.uuid4().hex
+    task_id, run_id = _seed_running_run_for_conv(db_uri, conv_id)
+
+    session_live_state.configure(
+        SqlAlchemyConversationStore(db_uri), SqlAlchemyScheduledTaskStore(db_uri)
+    )
+    try:
+        # The relay publishes "running" as the turn starts, then "idle" at the
+        # terminal (completed) edge. Drive the terminal edge.
+        _publish_status(conv_id, "idle")
+        row = _wait_for_run_status(db_uri, task_id, run_id, "succeeded")
+    finally:
+        session_live_state.configure(None)
+        _session_status_cache.pop(conv_id, None)
+
+    assert row is not None
+    assert row.status == "succeeded"
+    assert row.finished_at is not None
+    assert row.error_code is None
+
+
+async def test_publish_status_failed_edge_transitions_scheduled_run_to_failed(
+    db_uri: str,
+) -> None:
+    """A failed-turn edge through _publish_status flips the run to failed+code.
+
+    Async for the module ``pytestmark`` (see the idle-edge test); body is sync.
+    """
+    import uuid
+
+    from omnigent.server import session_live_state
+    from omnigent.server.routes.sessions import _publish_status, _session_status_cache
+    from omnigent.server.schemas import ErrorDetail
+    from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+    from omnigent.stores.scheduled_task_store.sqlalchemy_store import (
+        SqlAlchemyScheduledTaskStore,
+    )
+
+    conv_id = uuid.uuid4().hex
+    task_id, run_id = _seed_running_run_for_conv(db_uri, conv_id)
+
+    session_live_state.configure(
+        SqlAlchemyConversationStore(db_uri), SqlAlchemyScheduledTaskStore(db_uri)
+    )
+    try:
+        _publish_status(
+            conv_id, "failed", ErrorDetail(code="runner_disconnected", message="dropped")
+        )
+        row = _wait_for_run_status(db_uri, task_id, run_id, "failed")
+    finally:
+        session_live_state.configure(None)
+        _session_status_cache.pop(conv_id, None)
+
+    assert row is not None
+    assert row.status == "failed"
+    assert row.finished_at is not None
+    assert row.error_code == "runner_disconnected"

--- a/tests/server/integration/test_scheduled_tasks_routes.py
+++ b/tests/server/integration/test_scheduled_tasks_routes.py
@@ -693,3 +693,81 @@ async def test_list_runs_leaves_young_running_run_untouched(
     run = resp.json()["runs"][0]
     assert run["status"] == "running"
     assert run["finished_at"] is None
+
+
+async def test_list_tasks_force_fails_stale_running_run(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """The LIST endpoint also force-fails a stale ``running`` run (no conv read).
+
+    Reading GET /v1/scheduled-tasks reaps the owner's stale orphans so a
+    Tasks-list badge never shows one as ``running``. Verified via the detail
+    endpoint afterward (the list response itself carries no run rows yet).
+    """
+    import time
+    import uuid
+
+    from omnigent.server.scheduled.run_reconciler import STALE_RUN_MAX_AGE_SECONDS
+
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    task_id = created["id"]
+    run_id = uuid.uuid4().hex
+    stale_at = int(time.time()) - STALE_RUN_MAX_AGE_SECONDS - 60
+    _seed_run(
+        db_uri,
+        task_id,
+        run_id,
+        status="running",
+        scheduled_at=stale_at,
+        fired_at=stale_at + 1,
+        finished_at=None,
+        conversation_id=uuid.uuid4().hex,
+    )
+
+    # Hitting the LIST endpoint triggers the lazy stale backstop.
+    list_resp = await auth_client.get("/v1/scheduled-tasks", headers=_headers())
+    assert list_resp.status_code == 200, list_resp.text
+
+    # The run was force-failed as a side effect of the list read.
+    detail = await auth_client.get(f"/v1/scheduled-tasks/{task_id}/runs", headers=_headers())
+    run = detail.json()["runs"][0]
+    assert run["status"] == "failed"
+    assert run["error_code"] == "incomplete"
+    assert run["finished_at"] is not None
+
+
+async def test_list_tasks_leaves_young_running_run_untouched(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """The LIST endpoint does NOT reap a young in-flight run."""
+    import time
+    import uuid
+
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    task_id = created["id"]
+    run_id = uuid.uuid4().hex
+    recent = int(time.time()) - 30
+    _seed_run(
+        db_uri,
+        task_id,
+        run_id,
+        status="running",
+        scheduled_at=recent,
+        fired_at=recent + 1,
+        finished_at=None,
+        conversation_id=uuid.uuid4().hex,
+    )
+
+    list_resp = await auth_client.get("/v1/scheduled-tasks", headers=_headers())
+    assert list_resp.status_code == 200, list_resp.text
+
+    detail = await auth_client.get(f"/v1/scheduled-tasks/{task_id}/runs", headers=_headers())
+    run = detail.json()["runs"][0]
+    assert run["status"] == "running"
+    assert run["finished_at"] is None

--- a/tests/server/integration/test_scheduled_tasks_routes.py
+++ b/tests/server/integration/test_scheduled_tasks_routes.py
@@ -502,3 +502,115 @@ async def test_scheduler_synced_on_create_and_delete(
 
     await auth_client.delete(f"/v1/scheduled-tasks/{created['id']}", headers=_headers())
     assert scheduler.job_count == before
+
+
+# ── GET /v1/scheduled-tasks/{id}/runs (run history) ──────────────────────────
+
+
+def _seed_run(db_uri: str, task_id: str, run_id: str, **overrides: object) -> None:
+    """Seed a run row directly (the sweep/fire path writes these in prod).
+
+    Tests run at the default workspace (no tenant middleware), matching the
+    route's read scope.
+    """
+    from omnigent.stores.scheduled_task_store.sqlalchemy_store import (
+        SqlAlchemyScheduledTaskStore,
+    )
+
+    store = SqlAlchemyScheduledTaskStore(db_uri)
+    kwargs: dict[str, object] = {
+        "run_id": run_id,
+        "scheduled_task_id": task_id,
+        "status": "succeeded",
+        "scheduled_at": 1000,
+        "conversation_id": "conv_seed",
+        "fired_at": 1001,
+        "finished_at": 1002,
+    }
+    kwargs.update(overrides)
+    store.create_run(**kwargs)  # type: ignore[arg-type]
+
+
+async def test_list_runs_returns_history_for_owned_task(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """An owned task's run history comes back most-recent-first with run fields."""
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    task_id = created["id"]
+
+    import uuid
+
+    older_id = uuid.uuid4().hex
+    newer_id = uuid.uuid4().hex
+    conv_id = uuid.uuid4().hex
+    _seed_run(
+        db_uri, task_id, older_id, scheduled_at=1000, status="succeeded", conversation_id=conv_id
+    )
+    _seed_run(
+        db_uri,
+        task_id,
+        newer_id,
+        scheduled_at=2000,
+        status="failed",
+        error_code="incomplete",
+        finished_at=2002,
+        conversation_id=conv_id,
+    )
+
+    resp = await auth_client.get(f"/v1/scheduled-tasks/{task_id}/runs", headers=_headers())
+    assert resp.status_code == 200, resp.text
+    runs = resp.json()["runs"]
+    assert [r["id"] for r in runs] == [newer_id, older_id]  # scheduled_at DESC
+    newest = runs[0]
+    assert newest["status"] == "failed"
+    assert newest["error_code"] == "incomplete"
+    assert newest["finished_at"] == 2002
+    assert newest["conversation_id"] == conv_id
+    assert newest["scheduled_task_id"] == task_id
+    # The free-text error blob is not exposed on the run list.
+    assert "error" not in newest
+
+
+async def test_list_runs_empty_for_task_with_no_runs(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """A task that has never fired returns an empty run list (not a 404)."""
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    resp = await auth_client.get(f"/v1/scheduled-tasks/{created['id']}/runs", headers=_headers())
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["runs"] == []
+
+
+async def test_list_runs_404_for_nonexistent_task(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """Runs for an unknown task id 404 (owner-scoped, not enumerable)."""
+    _make_user(db_uri)
+    resp = await auth_client.get(
+        "/v1/scheduled-tasks/ffffffffffffffffffffffffffffffff/runs", headers=_headers()
+    )
+    assert resp.status_code == 404, resp.text
+
+
+async def test_list_runs_404_for_nonowned_task(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """A task owned by another user 404s its runs (no cross-user enumeration)."""
+    _make_user(db_uri, "alice@example.com")
+    _make_user(db_uri, "bob@example.com")
+    created = (
+        await auth_client.post(
+            "/v1/scheduled-tasks", json=_create_body(), headers=_headers("alice@example.com")
+        )
+    ).json()
+    # Bob asks for Alice's task runs → 404.
+    resp = await auth_client.get(
+        f"/v1/scheduled-tasks/{created['id']}/runs", headers=_headers("bob@example.com")
+    )
+    assert resp.status_code == 404, resp.text

--- a/tests/server/scheduled/test_run_reconciler.py
+++ b/tests/server/scheduled/test_run_reconciler.py
@@ -32,7 +32,6 @@ class _RunRow:
     finished_at: int | None = None
     error: str | None = None
     error_code: str | None = None
-    workspace_id: int = 0
 
 
 class _FakeScheduledTaskStore:

--- a/tests/server/scheduled/test_run_reconciler.py
+++ b/tests/server/scheduled/test_run_reconciler.py
@@ -1,8 +1,9 @@
-"""Tests for the scheduled-task run reconciler.
+"""Tests for the scheduled-task run-completion orphan backstop.
 
-Exercises the terminal-state classification matrix and the sweep's
+Exercises the terminal-state classification matrix and the startup sweep's
 transition/idempotency/stale-fallback behavior against fakes, with no live
-server or database.
+server or database. (The primary, event-driven completion path lives in
+``session_live_state`` and is covered in ``tests/server/test_session_live_state.py``.)
 """
 
 from __future__ import annotations
@@ -88,7 +89,7 @@ class _RunRow:
 
 
 class _FakeScheduledTaskStore:
-    """Fake store exposing the two methods the reconciler uses."""
+    """Fake store exposing the methods the backstop uses."""
 
     def __init__(self, runs: list[_RunRow]) -> None:
         self._runs = {r.id: r for r in runs}
@@ -96,6 +97,12 @@ class _FakeScheduledTaskStore:
 
     def list_runs_by_status_all_workspaces(self, status: str) -> list[_RunRow]:
         return [r for r in self._runs.values() if r.status == status]
+
+    def get_running_run_by_conversation(self, conversation_id: str) -> _RunRow | None:
+        for r in self._runs.values():
+            if r.conversation_id == conversation_id and r.status == "running":
+                return r
+        return None
 
     def update_run(
         self,
@@ -180,7 +187,7 @@ def test_classify_missing_conversation_is_failed() -> None:
     assert decision.error_code == "conversation_missing"
 
 
-# ── reconcile_once (sweep) ───────────────────────────────────────────────────
+# ── run_startup_sweep (orphan sweep) ─────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -191,7 +198,7 @@ async def test_reconcile_transitions_completed_run_to_succeeded() -> None:
     conv = _FakeConversation(live_status="idle")
     convs = _FakeConversationStore({"conv_ok": conv}, {"conv_ok": [_FakeItem(status="completed")]})
     rec = ScheduledRunReconciler(sched, convs, now=lambda: 1000)
-    n = await rec.reconcile_once()
+    n = await rec.run_startup_sweep()
     assert n == 1
     assert run.status == "succeeded"
     assert run.finished_at == 1000
@@ -207,7 +214,7 @@ async def test_reconcile_transitions_errored_run_to_failed() -> None:
     )
     convs = _FakeConversationStore({"conv_bad": conv})
     rec = ScheduledRunReconciler(sched, convs, now=lambda: 1000)
-    n = await rec.reconcile_once()
+    n = await rec.run_startup_sweep()
     assert n == 1
     assert run.status == "failed"
     assert run.error_code == "runner_disconnected"
@@ -222,7 +229,7 @@ async def test_reconcile_leaves_young_running_run_alone() -> None:
     conv = _FakeConversation(live_status="running")
     convs = _FakeConversationStore({"conv_young": conv})
     rec = ScheduledRunReconciler(sched, convs, now=lambda: 1000)  # age 10s
-    n = await rec.reconcile_once()
+    n = await rec.run_startup_sweep()
     assert n == 0
     assert run.status == "running"
     assert run.finished_at is None
@@ -239,7 +246,7 @@ async def test_reconcile_force_fails_stale_running_run() -> None:
     conv = _FakeConversation(live_status="running")  # still "in flight" but stale
     convs = _FakeConversationStore({"conv_stale": conv})
     rec = ScheduledRunReconciler(sched, convs, now=lambda: now)
-    n = await rec.reconcile_once()
+    n = await rec.run_startup_sweep()
     assert n == 1
     assert run.status == "failed"
     assert run.error_code == STALE_RUN_ERROR_CODE
@@ -258,7 +265,7 @@ async def test_reconcile_stale_run_still_prefers_real_terminal_state() -> None:
         {"conv_staleok": conv}, {"conv_staleok": [_FakeItem(status="completed")]}
     )
     rec = ScheduledRunReconciler(sched, convs, now=lambda: now)
-    n = await rec.reconcile_once()
+    n = await rec.run_startup_sweep()
     assert n == 1
     assert run.status == "succeeded"
     assert run.error_code is None
@@ -284,5 +291,5 @@ async def test_reconcile_idempotent_when_run_already_terminal() -> None:
         {"conv_race": conv}, {"conv_race": [_FakeItem(status="completed")]}
     )
     rec = ScheduledRunReconciler(racing, convs, now=lambda: 1000)
-    n = await rec.reconcile_once()
+    n = await rec.run_startup_sweep()
     assert n == 0  # update returned None; not counted as a transition

--- a/tests/server/scheduled/test_run_reconciler.py
+++ b/tests/server/scheduled/test_run_reconciler.py
@@ -1,0 +1,288 @@
+"""Tests for the scheduled-task run reconciler.
+
+Exercises the terminal-state classification matrix and the sweep's
+transition/idempotency/stale-fallback behavior against fakes, with no live
+server or database.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from omnigent.server.routes.sessions import _LAST_TASK_ERROR_CODE_LABEL_KEY
+from omnigent.server.scheduled.run_reconciler import (
+    STALE_RUN_ERROR_CODE,
+    STALE_RUN_MAX_AGE_SECONDS,
+    ScheduledRunReconciler,
+    classify_conversation_terminal_state,
+)
+
+# ── fakes ────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeItem:
+    """Minimal stand-in for a ConversationItem (only ``status`` is read)."""
+
+    status: str
+
+
+@dataclass
+class _FakePage:
+    """Minimal stand-in for a PagedList (only ``data`` is read)."""
+
+    data: list[_FakeItem] = field(default_factory=list)
+
+
+@dataclass
+class _FakeConversation:
+    """Minimal stand-in for a Conversation."""
+
+    live_status: str | None = None
+    labels: dict[str, str] = field(default_factory=dict)
+
+
+class _FakeConversationStore:
+    """Fake conversation store returning canned conversations + latest items."""
+
+    def __init__(
+        self,
+        conversations: dict[str, _FakeConversation | None],
+        latest_items: dict[str, list[_FakeItem]] | None = None,
+    ) -> None:
+        self._conversations = conversations
+        self._latest_items = latest_items or {}
+
+    def get_conversation(self, conversation_id: str) -> _FakeConversation | None:
+        return self._conversations.get(conversation_id)
+
+    def list_items(
+        self,
+        conversation_id: str,
+        limit: int = 100,
+        after: str | None = None,
+        before: str | None = None,
+        order: str = "asc",
+        type: str | None = None,
+    ) -> _FakePage:
+        return _FakePage(data=list(self._latest_items.get(conversation_id, [])))
+
+
+@dataclass
+class _RunRow:
+    """Mutable run row for the fake scheduled-task store."""
+
+    id: str
+    scheduled_task_id: str
+    status: str
+    scheduled_at: int
+    conversation_id: str | None = None
+    fired_at: int | None = None
+    finished_at: int | None = None
+    error: str | None = None
+    error_code: str | None = None
+    workspace_id: int = 0
+
+
+class _FakeScheduledTaskStore:
+    """Fake store exposing the two methods the reconciler uses."""
+
+    def __init__(self, runs: list[_RunRow]) -> None:
+        self._runs = {r.id: r for r in runs}
+        self.update_calls: list[tuple[str, str, str | None]] = []
+
+    def list_runs_by_status_all_workspaces(self, status: str) -> list[_RunRow]:
+        return [r for r in self._runs.values() if r.status == status]
+
+    def update_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        finished_at: int,
+        error: str | None = None,
+        error_code: str | None = None,
+    ) -> _RunRow | None:
+        self.update_calls.append((run_id, status, error_code))
+        row = self._runs.get(run_id)
+        if row is None or row.status != "running":
+            return None  # conditional WHERE status = running
+        row.status = status
+        row.finished_at = finished_at
+        row.error = error
+        row.error_code = error_code
+        return row
+
+
+def _running_run(
+    seed: str, *, scheduled_at: int = 100, conversation_id: str | None = None
+) -> _RunRow:
+    return _RunRow(
+        id=f"run_{seed}",
+        scheduled_task_id=f"task_{seed}",
+        status="running",
+        scheduled_at=scheduled_at,
+        conversation_id=conversation_id or f"conv_{seed}",
+        fired_at=scheduled_at + 1,
+    )
+
+
+# ── classify_conversation_terminal_state ─────────────────────────────────────
+
+
+def test_classify_completed_transcript_is_succeeded() -> None:
+    """A quiescent conversation whose latest message is completed → succeeded."""
+    conv = _FakeConversation(live_status="idle")
+    store = _FakeConversationStore({"c": conv}, {"c": [_FakeItem(status="completed")]})
+    decision = classify_conversation_terminal_state(conv, store, "c")
+    assert decision.status == "succeeded"
+    assert decision.error_code is None
+
+
+def test_classify_error_label_is_failed_with_code() -> None:
+    """A failure label wins over anything else → failed carrying that code."""
+    conv = _FakeConversation(
+        live_status="failed",
+        labels={_LAST_TASK_ERROR_CODE_LABEL_KEY: "runner_error"},
+    )
+    store = _FakeConversationStore({"c": conv}, {"c": [_FakeItem(status="completed")]})
+    decision = classify_conversation_terminal_state(conv, store, "c")
+    assert decision.status == "failed"
+    assert decision.error_code == "runner_error"
+
+
+def test_classify_in_flight_live_status_left_running() -> None:
+    """live_status running/waiting short-circuits to not-terminal (leave running)."""
+    for ls in ("running", "waiting"):
+        conv = _FakeConversation(live_status=ls)
+        # Even with a completed item present, the in-flight pre-filter wins:
+        store = _FakeConversationStore({"c": conv}, {"c": [_FakeItem(status="completed")]})
+        decision = classify_conversation_terminal_state(conv, store, "c")
+        assert decision.status is None
+
+
+def test_classify_quiescent_but_no_completed_item_left_running() -> None:
+    """Idle with no completed message yet → not terminal (leave running)."""
+    conv = _FakeConversation(live_status="idle")
+    store = _FakeConversationStore({"c": conv}, {"c": [_FakeItem(status="in_progress")]})
+    decision = classify_conversation_terminal_state(conv, store, "c")
+    assert decision.status is None
+
+
+def test_classify_missing_conversation_is_failed() -> None:
+    """A deleted conversation → failed(conversation_missing), nothing to await."""
+    store = _FakeConversationStore({})
+    decision = classify_conversation_terminal_state(None, store, "c")
+    assert decision.status == "failed"
+    assert decision.error_code == "conversation_missing"
+
+
+# ── reconcile_once (sweep) ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconcile_transitions_completed_run_to_succeeded() -> None:
+    """A running run whose conversation completed flips to succeeded + finished_at."""
+    run = _running_run("ok")
+    sched = _FakeScheduledTaskStore([run])
+    conv = _FakeConversation(live_status="idle")
+    convs = _FakeConversationStore({"conv_ok": conv}, {"conv_ok": [_FakeItem(status="completed")]})
+    rec = ScheduledRunReconciler(sched, convs, now=lambda: 1000)
+    n = await rec.reconcile_once()
+    assert n == 1
+    assert run.status == "succeeded"
+    assert run.finished_at == 1000
+
+
+@pytest.mark.asyncio
+async def test_reconcile_transitions_errored_run_to_failed() -> None:
+    """A running run whose conversation errored flips to failed with the code."""
+    run = _running_run("bad")
+    sched = _FakeScheduledTaskStore([run])
+    conv = _FakeConversation(
+        live_status="failed", labels={_LAST_TASK_ERROR_CODE_LABEL_KEY: "runner_disconnected"}
+    )
+    convs = _FakeConversationStore({"conv_bad": conv})
+    rec = ScheduledRunReconciler(sched, convs, now=lambda: 1000)
+    n = await rec.reconcile_once()
+    assert n == 1
+    assert run.status == "failed"
+    assert run.error_code == "runner_disconnected"
+    assert run.finished_at == 1000
+
+
+@pytest.mark.asyncio
+async def test_reconcile_leaves_young_running_run_alone() -> None:
+    """A young, still-in-flight running run is not touched."""
+    run = _running_run("young", scheduled_at=990)
+    sched = _FakeScheduledTaskStore([run])
+    conv = _FakeConversation(live_status="running")
+    convs = _FakeConversationStore({"conv_young": conv})
+    rec = ScheduledRunReconciler(sched, convs, now=lambda: 1000)  # age 10s
+    n = await rec.reconcile_once()
+    assert n == 0
+    assert run.status == "running"
+    assert run.finished_at is None
+    assert sched.update_calls == []  # never even attempted an update
+
+
+@pytest.mark.asyncio
+async def test_reconcile_force_fails_stale_running_run() -> None:
+    """A running run past the max-age with a non-terminal conv → failed(incomplete)."""
+    now = 10_000_000
+    scheduled_at = now - STALE_RUN_MAX_AGE_SECONDS - 1  # just past the threshold
+    run = _running_run("stale", scheduled_at=scheduled_at)
+    sched = _FakeScheduledTaskStore([run])
+    conv = _FakeConversation(live_status="running")  # still "in flight" but stale
+    convs = _FakeConversationStore({"conv_stale": conv})
+    rec = ScheduledRunReconciler(sched, convs, now=lambda: now)
+    n = await rec.reconcile_once()
+    assert n == 1
+    assert run.status == "failed"
+    assert run.error_code == STALE_RUN_ERROR_CODE
+    assert run.finished_at == now
+
+
+@pytest.mark.asyncio
+async def test_reconcile_stale_run_still_prefers_real_terminal_state() -> None:
+    """A stale run whose conv actually completed is succeeded, not force-failed."""
+    now = 10_000_000
+    scheduled_at = now - STALE_RUN_MAX_AGE_SECONDS - 1
+    run = _running_run("staleok", scheduled_at=scheduled_at)
+    sched = _FakeScheduledTaskStore([run])
+    conv = _FakeConversation(live_status="idle")
+    convs = _FakeConversationStore(
+        {"conv_staleok": conv}, {"conv_staleok": [_FakeItem(status="completed")]}
+    )
+    rec = ScheduledRunReconciler(sched, convs, now=lambda: now)
+    n = await rec.reconcile_once()
+    assert n == 1
+    assert run.status == "succeeded"
+    assert run.error_code is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_idempotent_when_run_already_terminal() -> None:
+    """If the conditional update finds the run already terminal, it's a no-op."""
+    # Seed a run that the fake reports as 'running' to the sweep but update_run
+    # refuses (simulating a race where another writer won first).
+    run = _running_run("race")
+
+    # Flip the row terminal AFTER the sweep lists it but BEFORE update — model
+    # the race by having update_run see a non-running status.
+    class _RacingStore(_FakeScheduledTaskStore):
+        def update_run(self, run_id: str, **kw: Any) -> _RunRow | None:
+            self._runs[run_id].status = "succeeded"  # someone else won
+            return super().update_run(run_id, **kw)
+
+    racing = _RacingStore([run])
+    conv = _FakeConversation(live_status="idle")
+    convs = _FakeConversationStore(
+        {"conv_race": conv}, {"conv_race": [_FakeItem(status="completed")]}
+    )
+    rec = ScheduledRunReconciler(racing, convs, now=lambda: 1000)
+    n = await rec.reconcile_once()
+    assert n == 0  # update returned None; not counted as a transition

--- a/tests/server/scheduled/test_run_reconciler.py
+++ b/tests/server/scheduled/test_run_reconciler.py
@@ -61,14 +61,20 @@ class _FakeScheduledTaskStore:
         return row
 
 
-def _run(seed: str, *, status: str = "running", scheduled_at: int = 100) -> _RunRow:
+def _run(
+    seed: str,
+    *,
+    status: str = "running",
+    scheduled_at: int = 100,
+    fired_at: int | None = None,
+) -> _RunRow:
     return _RunRow(
         id=f"run_{seed}",
         scheduled_task_id=f"task_{seed}",
         status=status,
         scheduled_at=scheduled_at,
         conversation_id=f"conv_{seed}",
-        fired_at=scheduled_at + 1,
+        fired_at=fired_at if fired_at is not None else scheduled_at + 1,
     )
 
 
@@ -95,6 +101,51 @@ def test_leaves_young_running_run_untouched() -> None:
     assert run.finished_at is None
     assert store.update_calls == []  # never even attempted an update
     assert out[0].status == "running"
+
+
+def test_age_measured_from_fired_at_force_fails() -> None:
+    """Age is measured from fired_at: a run fired >6h ago is force-failed."""
+    now = 10_000_000
+    # Scheduled recently but fired_at is >6h ago (e.g. a clock/late-record edge):
+    # fired_at is what counts, so this IS stale.
+    run = _run("firedstale", scheduled_at=now - 60, fired_at=now - STALE_RUN_MAX_AGE_SECONDS - 1)
+    store = _FakeScheduledTaskStore([run])
+    force_fail_stale_runs(store, [run], now=now)
+    assert run.status == "failed"
+    assert run.error_code == STALE_RUN_ERROR_CODE
+    assert run.finished_at == now
+
+
+def test_scheduled_long_ago_but_fired_recently_left_alone() -> None:
+    """A run scheduled >6h ago but fired recently is NOT force-failed.
+
+    The behavior change: the 6h window measures from fired_at (when dispatch
+    began), so a run that fired late still gets its full window and is not
+    prematurely killed.
+    """
+    now = 10_000_000
+    run = _run(
+        "firedlate",
+        scheduled_at=now - STALE_RUN_MAX_AGE_SECONDS - 3600,  # scheduled 7h+ ago
+        fired_at=now - 60,  # but only fired 60s ago
+    )
+    store = _FakeScheduledTaskStore([run])
+    force_fail_stale_runs(store, [run], now=now)
+    assert run.status == "running"
+    assert run.finished_at is None
+    assert store.update_calls == []
+
+
+def test_age_falls_back_to_scheduled_at_when_no_fired_at() -> None:
+    """A run that never recorded fired_at ages from scheduled_at (fallback)."""
+    now = 10_000_000
+    run = _run("nofire", scheduled_at=now - STALE_RUN_MAX_AGE_SECONDS - 1, fired_at=None)
+    # _run's default would set fired_at; force it None to exercise the fallback.
+    run.fired_at = None
+    store = _FakeScheduledTaskStore([run])
+    force_fail_stale_runs(store, [run], now=now)
+    assert run.status == "failed"
+    assert run.error_code == STALE_RUN_ERROR_CODE
 
 
 def test_leaves_already_terminal_run_untouched() -> None:

--- a/tests/server/scheduled/test_run_reconciler.py
+++ b/tests/server/scheduled/test_run_reconciler.py
@@ -1,75 +1,22 @@
-"""Tests for the scheduled-task run-completion orphan backstop.
+"""Tests for the scheduled-task stale-run backstop (lazy-on-read).
 
-Exercises the terminal-state classification matrix and the startup sweep's
-transition/idempotency/stale-fallback behavior against fakes, with no live
-server or database. (The primary, event-driven completion path lives in
-``session_live_state`` and is covered in ``tests/server/test_session_live_state.py``.)
+Exercises ``force_fail_stale_runs`` — the pure age-based orphan backstop the
+scheduled-task read endpoints call. Completion of a normal run is event-driven
+(``session_live_state.persist_scheduled_run_completion``, covered in
+``tests/server/test_session_live_state.py``); there is no startup sweep and no
+periodic reconcile, so this module only covers the stale force-fail policy.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
-import pytest
-
-from omnigent.server.routes.sessions import _LAST_TASK_ERROR_CODE_LABEL_KEY
 from omnigent.server.scheduled.run_reconciler import (
     STALE_RUN_ERROR_CODE,
     STALE_RUN_MAX_AGE_SECONDS,
-    ScheduledRunReconciler,
-    classify_conversation_terminal_state,
+    force_fail_stale_runs,
 )
-
-# ── fakes ────────────────────────────────────────────────────────────────────
-
-
-@dataclass
-class _FakeItem:
-    """Minimal stand-in for a ConversationItem (only ``status`` is read)."""
-
-    status: str
-
-
-@dataclass
-class _FakePage:
-    """Minimal stand-in for a PagedList (only ``data`` is read)."""
-
-    data: list[_FakeItem] = field(default_factory=list)
-
-
-@dataclass
-class _FakeConversation:
-    """Minimal stand-in for a Conversation."""
-
-    live_status: str | None = None
-    labels: dict[str, str] = field(default_factory=dict)
-
-
-class _FakeConversationStore:
-    """Fake conversation store returning canned conversations + latest items."""
-
-    def __init__(
-        self,
-        conversations: dict[str, _FakeConversation | None],
-        latest_items: dict[str, list[_FakeItem]] | None = None,
-    ) -> None:
-        self._conversations = conversations
-        self._latest_items = latest_items or {}
-
-    def get_conversation(self, conversation_id: str) -> _FakeConversation | None:
-        return self._conversations.get(conversation_id)
-
-    def list_items(
-        self,
-        conversation_id: str,
-        limit: int = 100,
-        after: str | None = None,
-        before: str | None = None,
-        order: str = "asc",
-        type: str | None = None,
-    ) -> _FakePage:
-        return _FakePage(data=list(self._latest_items.get(conversation_id, [])))
 
 
 @dataclass
@@ -89,20 +36,11 @@ class _RunRow:
 
 
 class _FakeScheduledTaskStore:
-    """Fake store exposing the methods the backstop uses."""
+    """Fake store exposing only ``update_run`` (what the backstop calls)."""
 
     def __init__(self, runs: list[_RunRow]) -> None:
         self._runs = {r.id: r for r in runs}
-        self.update_calls: list[tuple[str, str, str | None]] = []
-
-    def list_runs_by_status_all_workspaces(self, status: str) -> list[_RunRow]:
-        return [r for r in self._runs.values() if r.status == status]
-
-    def get_running_run_by_conversation(self, conversation_id: str) -> _RunRow | None:
-        for r in self._runs.values():
-            if r.conversation_id == conversation_id and r.status == "running":
-                return r
-        return None
+        self.update_calls: list[str] = []
 
     def update_run(
         self,
@@ -113,7 +51,7 @@ class _FakeScheduledTaskStore:
         error: str | None = None,
         error_code: str | None = None,
     ) -> _RunRow | None:
-        self.update_calls.append((run_id, status, error_code))
+        self.update_calls.append(run_id)
         row = self._runs.get(run_id)
         if row is None or row.status != "running":
             return None  # conditional WHERE status = running
@@ -124,172 +62,83 @@ class _FakeScheduledTaskStore:
         return row
 
 
-def _running_run(
-    seed: str, *, scheduled_at: int = 100, conversation_id: str | None = None
-) -> _RunRow:
+def _run(seed: str, *, status: str = "running", scheduled_at: int = 100) -> _RunRow:
     return _RunRow(
         id=f"run_{seed}",
         scheduled_task_id=f"task_{seed}",
-        status="running",
+        status=status,
         scheduled_at=scheduled_at,
-        conversation_id=conversation_id or f"conv_{seed}",
+        conversation_id=f"conv_{seed}",
         fired_at=scheduled_at + 1,
     )
 
 
-# ── classify_conversation_terminal_state ─────────────────────────────────────
-
-
-def test_classify_completed_transcript_is_succeeded() -> None:
-    """A quiescent conversation whose latest message is completed → succeeded."""
-    conv = _FakeConversation(live_status="idle")
-    store = _FakeConversationStore({"c": conv}, {"c": [_FakeItem(status="completed")]})
-    decision = classify_conversation_terminal_state(conv, store, "c")
-    assert decision.status == "succeeded"
-    assert decision.error_code is None
-
-
-def test_classify_error_label_is_failed_with_code() -> None:
-    """A failure label wins over anything else → failed carrying that code."""
-    conv = _FakeConversation(
-        live_status="failed",
-        labels={_LAST_TASK_ERROR_CODE_LABEL_KEY: "runner_error"},
-    )
-    store = _FakeConversationStore({"c": conv}, {"c": [_FakeItem(status="completed")]})
-    decision = classify_conversation_terminal_state(conv, store, "c")
-    assert decision.status == "failed"
-    assert decision.error_code == "runner_error"
-
-
-def test_classify_in_flight_live_status_left_running() -> None:
-    """live_status running/waiting short-circuits to not-terminal (leave running)."""
-    for ls in ("running", "waiting"):
-        conv = _FakeConversation(live_status=ls)
-        # Even with a completed item present, the in-flight pre-filter wins:
-        store = _FakeConversationStore({"c": conv}, {"c": [_FakeItem(status="completed")]})
-        decision = classify_conversation_terminal_state(conv, store, "c")
-        assert decision.status is None
-
-
-def test_classify_quiescent_but_no_completed_item_left_running() -> None:
-    """Idle with no completed message yet → not terminal (leave running)."""
-    conv = _FakeConversation(live_status="idle")
-    store = _FakeConversationStore({"c": conv}, {"c": [_FakeItem(status="in_progress")]})
-    decision = classify_conversation_terminal_state(conv, store, "c")
-    assert decision.status is None
-
-
-def test_classify_missing_conversation_is_failed() -> None:
-    """A deleted conversation → failed(conversation_missing), nothing to await."""
-    store = _FakeConversationStore({})
-    decision = classify_conversation_terminal_state(None, store, "c")
-    assert decision.status == "failed"
-    assert decision.error_code == "conversation_missing"
-
-
-# ── run_startup_sweep (orphan sweep) ─────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_reconcile_transitions_completed_run_to_succeeded() -> None:
-    """A running run whose conversation completed flips to succeeded + finished_at."""
-    run = _running_run("ok")
-    sched = _FakeScheduledTaskStore([run])
-    conv = _FakeConversation(live_status="idle")
-    convs = _FakeConversationStore({"conv_ok": conv}, {"conv_ok": [_FakeItem(status="completed")]})
-    rec = ScheduledRunReconciler(sched, convs, now=lambda: 1000)
-    n = await rec.run_startup_sweep()
-    assert n == 1
-    assert run.status == "succeeded"
-    assert run.finished_at == 1000
-
-
-@pytest.mark.asyncio
-async def test_reconcile_transitions_errored_run_to_failed() -> None:
-    """A running run whose conversation errored flips to failed with the code."""
-    run = _running_run("bad")
-    sched = _FakeScheduledTaskStore([run])
-    conv = _FakeConversation(
-        live_status="failed", labels={_LAST_TASK_ERROR_CODE_LABEL_KEY: "runner_disconnected"}
-    )
-    convs = _FakeConversationStore({"conv_bad": conv})
-    rec = ScheduledRunReconciler(sched, convs, now=lambda: 1000)
-    n = await rec.run_startup_sweep()
-    assert n == 1
-    assert run.status == "failed"
-    assert run.error_code == "runner_disconnected"
-    assert run.finished_at == 1000
-
-
-@pytest.mark.asyncio
-async def test_reconcile_leaves_young_running_run_alone() -> None:
-    """A young, still-in-flight running run is not touched."""
-    run = _running_run("young", scheduled_at=990)
-    sched = _FakeScheduledTaskStore([run])
-    conv = _FakeConversation(live_status="running")
-    convs = _FakeConversationStore({"conv_young": conv})
-    rec = ScheduledRunReconciler(sched, convs, now=lambda: 1000)  # age 10s
-    n = await rec.run_startup_sweep()
-    assert n == 0
-    assert run.status == "running"
-    assert run.finished_at is None
-    assert sched.update_calls == []  # never even attempted an update
-
-
-@pytest.mark.asyncio
-async def test_reconcile_force_fails_stale_running_run() -> None:
-    """A running run past the max-age with a non-terminal conv → failed(incomplete)."""
+def test_force_fails_stale_running_run() -> None:
+    """A run past the max age flips to failed(incomplete) with finished_at."""
     now = 10_000_000
-    scheduled_at = now - STALE_RUN_MAX_AGE_SECONDS - 1  # just past the threshold
-    run = _running_run("stale", scheduled_at=scheduled_at)
-    sched = _FakeScheduledTaskStore([run])
-    conv = _FakeConversation(live_status="running")  # still "in flight" but stale
-    convs = _FakeConversationStore({"conv_stale": conv})
-    rec = ScheduledRunReconciler(sched, convs, now=lambda: now)
-    n = await rec.run_startup_sweep()
-    assert n == 1
+    run = _run("stale", scheduled_at=now - STALE_RUN_MAX_AGE_SECONDS - 1)
+    store = _FakeScheduledTaskStore([run])
+    out = force_fail_stale_runs(store, [run], now=now)
     assert run.status == "failed"
     assert run.error_code == STALE_RUN_ERROR_CODE
     assert run.finished_at == now
+    # The returned list reflects the transition.
+    assert out[0].status == "failed"
 
 
-@pytest.mark.asyncio
-async def test_reconcile_stale_run_still_prefers_real_terminal_state() -> None:
-    """A stale run whose conv actually completed is succeeded, not force-failed."""
+def test_leaves_young_running_run_untouched() -> None:
+    """A recently-fired running run is not touched (no update attempted)."""
     now = 10_000_000
-    scheduled_at = now - STALE_RUN_MAX_AGE_SECONDS - 1
-    run = _running_run("staleok", scheduled_at=scheduled_at)
-    sched = _FakeScheduledTaskStore([run])
-    conv = _FakeConversation(live_status="idle")
-    convs = _FakeConversationStore(
-        {"conv_staleok": conv}, {"conv_staleok": [_FakeItem(status="completed")]}
-    )
-    rec = ScheduledRunReconciler(sched, convs, now=lambda: now)
-    n = await rec.run_startup_sweep()
-    assert n == 1
+    run = _run("young", scheduled_at=now - 30)  # 30s old
+    store = _FakeScheduledTaskStore([run])
+    out = force_fail_stale_runs(store, [run], now=now)
+    assert run.status == "running"
+    assert run.finished_at is None
+    assert store.update_calls == []  # never even attempted an update
+    assert out[0].status == "running"
+
+
+def test_leaves_already_terminal_run_untouched() -> None:
+    """A terminal run (even if old) is not a candidate — status gate only."""
+    now = 10_000_000
+    run = _run("done", status="succeeded", scheduled_at=now - STALE_RUN_MAX_AGE_SECONDS - 100)
+    store = _FakeScheduledTaskStore([run])
+    force_fail_stale_runs(store, [run], now=now)
     assert run.status == "succeeded"
-    assert run.error_code is None
+    assert store.update_calls == []
 
 
-@pytest.mark.asyncio
-async def test_reconcile_idempotent_when_run_already_terminal() -> None:
-    """If the conditional update finds the run already terminal, it's a no-op."""
-    # Seed a run that the fake reports as 'running' to the sweep but update_run
-    # refuses (simulating a race where another writer won first).
-    run = _running_run("race")
+def test_mixed_batch_transitions_only_stale_running() -> None:
+    """Across a batch, only stale running rows transition; others pass through."""
+    now = 10_000_000
+    stale = _run("stale", scheduled_at=now - STALE_RUN_MAX_AGE_SECONDS - 1)
+    young = _run("young", scheduled_at=now - 10)
+    done = _run("done", status="succeeded", scheduled_at=now - STALE_RUN_MAX_AGE_SECONDS - 5)
+    store = _FakeScheduledTaskStore([stale, young, done])
+    force_fail_stale_runs(store, [stale, young, done], now=now)
+    assert stale.status == "failed" and stale.error_code == STALE_RUN_ERROR_CODE
+    assert young.status == "running"
+    assert done.status == "succeeded"
+    assert store.update_calls == ["run_stale"]  # only the stale running row
 
-    # Flip the row terminal AFTER the sweep lists it but BEFORE update — model
-    # the race by having update_run see a non-running status.
+
+def test_idempotent_when_run_already_transitioned() -> None:
+    """A racing event-hook transition (update returns None) is not double-counted.
+
+    Models the event hook winning between the read that listed the run and the
+    backstop's update: the conditional ``WHERE status=running`` update returns
+    None, and the original (stale) row is passed through unchanged in the list.
+    """
+    now = 10_000_000
+    run = _run("race", scheduled_at=now - STALE_RUN_MAX_AGE_SECONDS - 1)
+
     class _RacingStore(_FakeScheduledTaskStore):
         def update_run(self, run_id: str, **kw: Any) -> _RunRow | None:
-            self._runs[run_id].status = "succeeded"  # someone else won
+            self._runs[run_id].status = "succeeded"  # event hook won first
             return super().update_run(run_id, **kw)
 
-    racing = _RacingStore([run])
-    conv = _FakeConversation(live_status="idle")
-    convs = _FakeConversationStore(
-        {"conv_race": conv}, {"conv_race": [_FakeItem(status="completed")]}
-    )
-    rec = ScheduledRunReconciler(racing, convs, now=lambda: 1000)
-    n = await rec.run_startup_sweep()
-    assert n == 0  # update returned None; not counted as a transition
+    store = _RacingStore([run])
+    out = force_fail_stale_runs(store, [run], now=now)
+    # update_run returned None (not running anymore); the row we return is the
+    # original object, whose status the racing store flipped to succeeded.
+    assert out[0].status == "succeeded"

--- a/tests/server/test_session_live_state.py
+++ b/tests/server/test_session_live_state.py
@@ -249,6 +249,123 @@ def test_unencodable_status_is_dropped_before_enqueue(
     assert recording_store.status_writes == [("conv_1", "running")]
 
 
+class _FakeScheduledTaskStore:
+    """Scheduled-task-store stand-in recording the hook's lookup + update."""
+
+    def __init__(self, running_by_conv: dict[str, str] | None = None) -> None:
+        # conversation_id -> run_id for conversations that have a running run.
+        self._running_by_conv = running_by_conv or {}
+        self.lookup_calls: list[str] = []
+        self.update_calls: list[tuple[str, str, str | None, str | None]] = []
+        self.lookup_workspaces: list[int] = []
+
+    def get_running_run_by_conversation(self, conversation_id: str):  # type: ignore[no-untyped-def]
+        from omnigent.db.db_models import current_workspace_id
+
+        self.lookup_calls.append(conversation_id)
+        self.lookup_workspaces.append(current_workspace_id())
+        run_id = self._running_by_conv.get(conversation_id)
+        if run_id is None:
+            return None
+        # Minimal object carrying only the ``id`` the hook reads.
+        return type("_Run", (), {"id": run_id})()
+
+    def update_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        finished_at: int,
+        error: str | None = None,
+        error_code: str | None = None,
+    ):  # type: ignore[no-untyped-def]
+        self.update_calls.append((run_id, status, error, error_code))
+        return type("_Run", (), {"id": run_id, "status": status})()
+
+
+def test_scheduled_run_completion_idle_transitions_to_succeeded() -> None:
+    """A terminal ``idle`` edge flips the conversation's running run to succeeded."""
+    sched = _FakeScheduledTaskStore({"conv_1": "run_1"})
+    session_live_state.configure(_RecordingStore(), sched)  # type: ignore[arg-type]
+    try:
+        session_live_state.persist_scheduled_run_completion("conv_1", "succeeded")
+        _wait_until(lambda: bool(sched.update_calls))
+    finally:
+        session_live_state.configure(None)
+    assert sched.lookup_calls == ["conv_1"]
+    assert len(sched.update_calls) == 1
+    run_id, status, error, error_code = sched.update_calls[0]
+    assert (run_id, status) == ("run_1", "succeeded")
+    assert error is None and error_code is None
+
+
+def test_scheduled_run_completion_failed_carries_error_code() -> None:
+    """A terminal ``failed`` edge flips the run to failed with the error detail."""
+    sched = _FakeScheduledTaskStore({"conv_1": "run_1"})
+    session_live_state.configure(_RecordingStore(), sched)  # type: ignore[arg-type]
+    try:
+        session_live_state.persist_scheduled_run_completion(
+            "conv_1", "failed", error_code="runner_disconnected", error="dropped"
+        )
+        _wait_until(lambda: bool(sched.update_calls))
+    finally:
+        session_live_state.configure(None)
+    assert sched.update_calls == [("run_1", "failed", "dropped", "runner_disconnected")]
+
+
+def test_scheduled_run_completion_noop_for_non_scheduled_conversation() -> None:
+    """An interactive conversation has no running run → lookup only, no update.
+
+    This is the common case: the hook fires on every terminal edge, and the
+    cheap reverse lookup returning ``None`` keeps it a no-op for the vast
+    majority of (non-scheduled) conversations.
+    """
+    sched = _FakeScheduledTaskStore({})  # no running runs
+    session_live_state.configure(_RecordingStore(), sched)  # type: ignore[arg-type]
+    try:
+        session_live_state.persist_scheduled_run_completion("conv_x", "succeeded")
+        _wait_until(lambda: bool(sched.lookup_calls))
+    finally:
+        session_live_state.configure(None)
+    assert sched.lookup_calls == ["conv_x"]
+    assert sched.update_calls == []
+
+
+def test_scheduled_run_completion_noop_without_scheduled_store() -> None:
+    """With only a conversation store wired the hook is a pure no-op.
+
+    ``configure(store)`` (no scheduled-task store) must not enqueue any work —
+    the runner process and most tests never wire one.
+    """
+    session_live_state.configure(_RecordingStore())  # type: ignore[arg-type]
+    try:
+        # No scheduled store => returns before touching the executor.
+        session_live_state.persist_scheduled_run_completion("conv_1", "succeeded")
+    finally:
+        session_live_state.configure(None)
+
+
+def test_scheduled_run_completion_runs_in_callers_workspace_scope() -> None:
+    """The lookup + update inherit the caller's ``workspace_scope``.
+
+    Same contract as the live_status mirror: the store filters on
+    ``current_workspace_id()``, so the hook's reverse lookup must resolve to
+    the fired run's workspace. Bind a non-default workspace, leave the scope
+    before the worker runs, and assert the write thread still observed it.
+    """
+    from omnigent.db.db_models import workspace_scope
+
+    sched = _FakeScheduledTaskStore({"conv_1": "run_1"})
+    session_live_state.configure(_RecordingStore(), sched)  # type: ignore[arg-type]
+    try:
+        with workspace_scope(4242):
+            session_live_state.persist_scheduled_run_completion("conv_1", "succeeded")
+        _wait_until(lambda: bool(sched.lookup_workspaces))
+    finally:
+        session_live_state.configure(None)
+    assert sched.lookup_workspaces == [4242]
+
+
 @pytest.mark.asyncio
 async def test_liveness_pass_zeroes_pending_count_for_offline_runner() -> None:
     """A stale persisted pending count can't light a phantom inbox badge.

--- a/tests/stores/test_scheduled_task_store.py
+++ b/tests/stores/test_scheduled_task_store.py
@@ -646,3 +646,148 @@ def test_delete_does_not_remove_other_tasks_runs(store: SqlAlchemyScheduledTaskS
     remaining = store.list_runs(_uid("st_b_scope"))
     assert len(remaining) == 1
     assert remaining[0].id == _uid("sr_st_b_scope")
+
+
+# ── update_run (terminal transition + idempotency) ───────────────────────────
+
+
+def _seed_running_run(store: SqlAlchemyScheduledTaskStore, seed: str) -> str:
+    """Create a task + a ``running`` run for it; return the run id."""
+    store.create(
+        scheduled_task_id=_uid(f"task_{seed}"),
+        name=seed,
+        prompt="p",
+        rrule="FREQ=MINUTELY",
+        user_id="u",
+        agent_id=_uid("ag"),
+        timezone="UTC",
+    )
+    run_id = _uid(f"run_{seed}")
+    store.create_run(
+        run_id=run_id,
+        scheduled_task_id=_uid(f"task_{seed}"),
+        status="running",
+        scheduled_at=100,
+        conversation_id=_uid(f"conv_{seed}"),
+        fired_at=101,
+    )
+    return run_id
+
+
+def test_update_run_transitions_running_to_succeeded(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """``update_run`` flips a ``running`` run to ``succeeded`` with finished_at."""
+    run_id = _seed_running_run(store, "ok")
+    updated = store.update_run(run_id, status="succeeded", finished_at=202)
+    assert updated is not None
+    assert updated.status == "succeeded"
+    assert updated.finished_at == 202
+    assert updated.error is None and updated.error_code is None
+
+
+def test_update_run_transitions_running_to_failed_with_code(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """``update_run`` flips a ``running`` run to ``failed`` carrying error detail."""
+    run_id = _seed_running_run(store, "bad")
+    updated = store.update_run(
+        run_id, status="failed", finished_at=303, error="boom", error_code="incomplete"
+    )
+    assert updated is not None
+    assert updated.status == "failed"
+    assert updated.finished_at == 303
+    assert updated.error == "boom"
+    assert updated.error_code == "incomplete"
+
+
+def test_update_run_is_idempotent_on_already_terminal(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """A second ``update_run`` on an already-terminal run is a no-op (returns None).
+
+    The conditional ``WHERE status = running`` guard means a run advanced to a
+    terminal state — by a prior sweep or a fire-time write — is never
+    clobbered, and two concurrent sweeps cannot double-transition it.
+    """
+    run_id = _seed_running_run(store, "once")
+    first = store.update_run(run_id, status="succeeded", finished_at=202)
+    assert first is not None and first.status == "succeeded"
+    # Second attempt (e.g. a racing sweep) must not overwrite it.
+    second = store.update_run(run_id, status="failed", finished_at=999, error_code="incomplete")
+    assert second is None
+    # State is unchanged from the first transition.
+    run = store.list_runs(_uid("task_once"))[0]
+    assert run.status == "succeeded"
+    assert run.finished_at == 202
+    assert run.error_code is None
+
+
+def test_update_run_unknown_run_returns_none(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """``update_run`` on a missing run id returns ``None``."""
+    assert store.update_run(_uid("nope"), status="succeeded", finished_at=1) is None
+
+
+# ── list_runs_by_status_all_workspaces (reconciler sweep source) ─────────────
+
+
+def test_list_runs_by_status_all_workspaces_spans_tenants(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """The sweep source returns ``running`` runs across every workspace.
+
+    Non-``running`` runs are excluded, so the reconciler only ever sees rows
+    it might transition.
+    """
+    with workspace_scope(11):
+        store.create(
+            scheduled_task_id=_uid("task_w11"),
+            name="w11",
+            prompt="p",
+            rrule="FREQ=MINUTELY",
+            user_id="a",
+            agent_id=_uid("ag"),
+            timezone="UTC",
+        )
+        store.create_run(
+            run_id=_uid("run_w11"),
+            scheduled_task_id=_uid("task_w11"),
+            status="running",
+            scheduled_at=100,
+        )
+        # A terminal run in the same workspace must be excluded.
+        store.create_run(
+            run_id=_uid("run_w11_done"),
+            scheduled_task_id=_uid("task_w11"),
+            status="succeeded",
+            scheduled_at=90,
+            finished_at=95,
+        )
+    with workspace_scope(22):
+        store.create(
+            scheduled_task_id=_uid("task_w22"),
+            name="w22",
+            prompt="p",
+            rrule="FREQ=MINUTELY",
+            user_id="b",
+            agent_id=_uid("ag"),
+            timezone="UTC",
+        )
+        store.create_run(
+            run_id=_uid("run_w22"),
+            scheduled_task_id=_uid("task_w22"),
+            status="running",
+            scheduled_at=200,
+        )
+
+    running = store.list_runs_by_status_all_workspaces("running")
+    ids = {r.id for r in running}
+    assert _uid("run_w11") in ids
+    assert _uid("run_w22") in ids
+    assert _uid("run_w11_done") not in ids
+    # Each carries its owning workspace_id for the reconciler's workspace_scope.
+    by_id = {r.id: r for r in running}
+    assert by_id[_uid("run_w11")].workspace_id == 11
+    assert by_id[_uid("run_w22")].workspace_id == 22

--- a/tests/stores/test_scheduled_task_store.py
+++ b/tests/stores/test_scheduled_task_store.py
@@ -791,3 +791,71 @@ def test_list_runs_by_status_all_workspaces_spans_tenants(
     by_id = {r.id: r for r in running}
     assert by_id[_uid("run_w11")].workspace_id == 11
     assert by_id[_uid("run_w22")].workspace_id == 22
+
+
+# ── get_running_run_by_conversation (event-hook reverse lookup) ───────────────
+
+
+def test_get_running_run_by_conversation_returns_running_run(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """The reverse lookup finds the ``running`` run for a conversation."""
+    run_id = _seed_running_run(store, "hook")
+    found = store.get_running_run_by_conversation(_uid("conv_hook"))
+    assert found is not None
+    assert found.id == run_id
+    assert found.status == "running"
+
+
+def test_get_running_run_by_conversation_none_when_terminal(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """Once the run is terminal the reverse lookup returns ``None`` (hook no-op).
+
+    This is what makes the event hook idempotent: a second terminal edge finds
+    no ``running`` run to transition.
+    """
+    run_id = _seed_running_run(store, "term")
+    store.update_run(run_id, status="succeeded", finished_at=202)
+    assert store.get_running_run_by_conversation(_uid("conv_term")) is None
+
+
+def test_get_running_run_by_conversation_none_for_unknown_conversation(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """An interactive (non-scheduled) conversation has no run → ``None``."""
+    assert store.get_running_run_by_conversation(_uid("conv_absent")) is None
+
+
+def test_get_running_run_by_conversation_is_workspace_scoped(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """The lookup filters on the current workspace, like every other store read.
+
+    A run seeded in workspace 11 is invisible from the default workspace and
+    visible only inside its own ``workspace_scope`` — the property the event
+    hook relies on to write to the fired run's workspace.
+    """
+    with workspace_scope(11):
+        store.create(
+            scheduled_task_id=_uid("task_ws"),
+            name="ws",
+            prompt="p",
+            rrule="FREQ=MINUTELY",
+            user_id="a",
+            agent_id=_uid("ag"),
+            timezone="UTC",
+        )
+        store.create_run(
+            run_id=_uid("run_ws"),
+            scheduled_task_id=_uid("task_ws"),
+            status="running",
+            scheduled_at=100,
+            conversation_id=_uid("conv_ws"),
+        )
+    # Default workspace cannot see the workspace-11 run.
+    assert store.get_running_run_by_conversation(_uid("conv_ws")) is None
+    # Inside its own scope it resolves.
+    with workspace_scope(11):
+        found = store.get_running_run_by_conversation(_uid("conv_ws"))
+        assert found is not None and found.id == _uid("run_ws")

--- a/tests/stores/test_scheduled_task_store.py
+++ b/tests/stores/test_scheduled_task_store.py
@@ -730,17 +730,67 @@ def test_update_run_unknown_run_returns_none(
     assert store.update_run(_uid("nope"), status="succeeded", finished_at=1) is None
 
 
-# ── list_runs_by_status_all_workspaces (reconciler sweep source) ─────────────
+# ── list_running_runs_for_tasks (lazy-on-read LIST backstop source) ──────────
 
 
-def test_list_runs_by_status_all_workspaces_spans_tenants(
+def test_list_running_runs_for_tasks_filters_status_and_tasks(
     store: SqlAlchemyScheduledTaskStore,
 ) -> None:
-    """The sweep source returns ``running`` runs across every workspace.
+    """Returns only ``running`` runs, and only for the requested tasks.
 
-    Non-``running`` runs are excluded, so the reconciler only ever sees rows
-    it might transition.
+    Powers the LIST endpoint's lazy stale backstop: the route passes the
+    owner's task ids and gets back their still-``running`` runs to age-check.
     """
+    for seed in ("a", "b"):
+        store.create(
+            scheduled_task_id=_uid(f"task_{seed}"),
+            name=seed,
+            prompt="p",
+            rrule="FREQ=MINUTELY",
+            user_id="u",
+            agent_id=_uid("ag"),
+            timezone="UTC",
+        )
+    # task_a: one running + one terminal run.
+    store.create_run(
+        run_id=_uid("run_a_running"),
+        scheduled_task_id=_uid("task_a"),
+        status="running",
+        scheduled_at=100,
+    )
+    store.create_run(
+        run_id=_uid("run_a_done"),
+        scheduled_task_id=_uid("task_a"),
+        status="succeeded",
+        scheduled_at=90,
+        finished_at=95,
+    )
+    # task_b: one running run.
+    store.create_run(
+        run_id=_uid("run_b_running"),
+        scheduled_task_id=_uid("task_b"),
+        status="running",
+        scheduled_at=200,
+    )
+
+    got = store.list_running_runs_for_tasks([_uid("task_a"), _uid("task_b")])
+    ids = {r.id for r in got}
+    assert ids == {_uid("run_a_running"), _uid("run_b_running")}  # terminal excluded
+    # Ordered scheduled_at DESC (run_b scheduled_at=200 > run_a=100).
+    assert got[0].id == _uid("run_b_running")
+
+
+def test_list_running_runs_for_tasks_empty_ids_returns_empty(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """An empty task-id list short-circuits to an empty result (no query)."""
+    assert store.list_running_runs_for_tasks([]) == []
+
+
+def test_list_running_runs_for_tasks_is_workspace_scoped(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """A task's running run is invisible from another workspace."""
     with workspace_scope(11):
         store.create(
             scheduled_task_id=_uid("task_w11"),
@@ -757,40 +807,11 @@ def test_list_runs_by_status_all_workspaces_spans_tenants(
             status="running",
             scheduled_at=100,
         )
-        # A terminal run in the same workspace must be excluded.
-        store.create_run(
-            run_id=_uid("run_w11_done"),
-            scheduled_task_id=_uid("task_w11"),
-            status="succeeded",
-            scheduled_at=90,
-            finished_at=95,
-        )
-    with workspace_scope(22):
-        store.create(
-            scheduled_task_id=_uid("task_w22"),
-            name="w22",
-            prompt="p",
-            rrule="FREQ=MINUTELY",
-            user_id="b",
-            agent_id=_uid("ag"),
-            timezone="UTC",
-        )
-        store.create_run(
-            run_id=_uid("run_w22"),
-            scheduled_task_id=_uid("task_w22"),
-            status="running",
-            scheduled_at=200,
-        )
-
-    running = store.list_runs_by_status_all_workspaces("running")
-    ids = {r.id for r in running}
-    assert _uid("run_w11") in ids
-    assert _uid("run_w22") in ids
-    assert _uid("run_w11_done") not in ids
-    # Each carries its owning workspace_id for the reconciler's workspace_scope.
-    by_id = {r.id: r for r in running}
-    assert by_id[_uid("run_w11")].workspace_id == 11
-    assert by_id[_uid("run_w22")].workspace_id == 22
+    # Default workspace cannot see the workspace-11 run.
+    assert store.list_running_runs_for_tasks([_uid("task_w11")]) == []
+    with workspace_scope(11):
+        got = store.list_running_runs_for_tasks([_uid("task_w11")])
+        assert [r.id for r in got] == [_uid("run_w11")]
 
 
 # ── get_running_run_by_conversation (event-hook reverse lookup) ───────────────


### PR DESCRIPTION
## Related issue

N/A — tracked in Linear ([OMNI-1193](https://linear.app/omnigent/issue/OMNI-1193)). Follow-up (FU-1) to #2946.

## Summary

Scheduled-task runs were recorded `running` by the fire path and never transitioned — `finished_at` stayed NULL forever even after the agent turn finished — and run history had no REST route. This closes both gaps **event-driven, with no background poll and no startup sweep**.

- **Primary — completion hook.** `session_live_state.persist_scheduled_run_completion` fires from `_publish_status` the instant a fired conversation's turn reaches a terminal edge (`idle → succeeded`, `failed → failed`+`error_code`). It rides the same long-lived SSE relay that already persists `live_status` for a browserless scheduled fire, on the same ordered single-worker executor inside a copy of the caller's `contextvars` so the run's `workspace_scope` reaches the write thread. A reverse lookup (`get_running_run_by_conversation`, backed by a new `(workspace_id, conversation_id)` index) finds the run; the idempotent conditional `update_run` (`WHERE status=running`) transitions it and never clobbers an already-terminal row. For a non-scheduled conversation the lookup returns `None` and the hook is a fire-and-forget no-op, adding nothing to turn latency.
- **Sole orphan backstop — lazy-on-read.** For the rare run left `running` because its terminal event never fired (host died mid-turn, restart while a fire was in flight), a pure age-based force-fail runs on the read path of both `GET /v1/scheduled-tasks/{id}/runs` and `GET /v1/scheduled-tasks` — force-failing runs still `running` past a 6h max age (`incomplete`). Age is measured from `fired_at` (falling back to `scheduled_at`) so a late-firing run keeps its full window. No periodic loop, no startup sweep.
- **API:** adds `GET /v1/scheduled-tasks/{id}/runs` — owner-scoped run history (404 if not owned), most-recent-first.
- **Schema:** one migration (`d4f2a1b6c8e9`) adding `ix_scheduled_task_runs_conversation_id` on `(workspace_id, conversation_id)`. The status codec and `finished_at`/`error`/`error_code` columns already existed; FU-3 / #2978 owner semantics and fire-time `_record_run` writes are unchanged.

**ELI5:** When a scheduled task runs, we used to write down "started" and never cross it off — so every run looked like it was still going forever. Now, the moment the agent finishes its turn, the same machinery that already updates the sidebar status also crosses the run off as ✅ done or ❌ failed. If a machine dies mid-run and never reports back, the next time someone opens the task list we notice the run has been "running" too long and mark it failed — so nothing stays stuck.

```mermaid
flowchart TD
    A[Scheduled task fires] --> B[Run row recorded: running]
    B --> C[Agent turn runs]
    C --> D[Turn reaches terminal edge in _publish_status]
    D --> E{persist_scheduled_run_completion:\nreverse lookup by conversation_id}
    E -->|running run found| F[update_run WHERE status=running\n→ succeeded / failed + finished_at]
    E -->|no run / non-scheduled conv| G[no-op]
    B -.->|terminal event never fired\nhost died / restart| H[Run stuck: running]
    H -.->|GET /scheduled-tasks or /runs\nage from fired_at > 6h| I[force-fail → failed incomplete]
```

## Test Plan

Automated — targeted suite **177 passed**; whole-repo `pre-commit run --all-files` all hooks passed:

```bash
.venv/bin/python -m pytest \
  tests/server/scheduled/ \
  tests/server/integration/test_scheduled_tasks_routes.py \
  tests/stores/test_scheduled_task_store.py
```

- **Hook**: completed→`succeeded` / errored→`failed`+code; idempotent no-clobber; no-op for interactive / no-store; workspace-scope propagation.
- **`_publish_status → hook` integration test**: drives the real relay seam (`_publish_status(conv, "idle"/"failed")`) and asserts the run transitions `running → succeeded`/`failed` through the executor path — locking the primary-mechanism wiring, not re-calling the hook directly.
- **Reverse lookup**: found / already-terminal→None / unknown→None / workspace-scoped.
- **`force_fail_stale_runs`**: stale-by-`fired_at`→failed; scheduled long ago but fired recently → left alone; young untouched; terminal untouched; racing→idempotent. Lazy backstop verified on both the detail and list routes.

Manual E2E — live server + connected local host, real self-rearming next-minute timer:

- **Event-driven completion**: a real fire's run flipped `running → succeeded` with `finished_at` set **~1–2s after the turn completed** (6h backstop ⇒ event-driven, not a sweep); server logs show no reconcile/sweep line.
- **Non-scheduled regression**: interactive `POST /v1/sessions` → `201`, turn ran, hook a no-op; validation negatives (bad agent → 404, bad `model_override`/`reasoning_effort` → 400).
- **Orphan backstop**: a seeded stale `running` run is force-failed `incomplete` on both `GET /runs` and `GET /scheduled-tasks`; young in-flight left alone.
- **Honest-fail**: host disconnected → `failed(no_online_host)`; a subsequent read leaves it and any succeeded run untouched (no double-transition).

**Performance — hot-path hook (benchmarked, decision: ship as-is).** The hook runs on *every* terminal edge (interactive turns included), so it was benchmarked before finalizing. It is fire-and-forget, so it adds **zero user-facing turn latency** by construction; the reverse lookup is a flat indexed point lookup (p50 ~0.64ms, constant from 1k→100k rows, `EXPLAIN` confirms the index). It adds ~0.69ms/edge to the shared `max_workers=1` executor, giving a **~1,271 terminal-edges/s backlog ceiling** — ~2 orders of magnitude above realistic sustained load (~1–10 turn-completions/s), so the worker never queues and the best-effort `live_status` mirror is never delayed. **We're proceeding without the in-memory pre-filter optimization** because that ceiling is far above any real load and the pre-filter would add restart-fragile state for no measurable gain today; it's documented as a future optimization if a single replica ever sustains >~1k edges/s.

## Demo

N/A — backend-only change, no user-visible UI.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated unit + integration coverage is described in the Test Plan (177 passed), including a `_publish_status → hook` integration test that exercises the real relay seam through the executor. The full runner/relay round-trip and real timer firing are covered by manual E2E on a live server + connected host (event-driven `running → succeeded` ~1–2s after turn completion; orphan force-fail on read; honest-fail on host disconnect) — this path needs a live runner and isn't reproducible in the hermetic test suite.

## Changelog

Scheduled-task runs now transition to a terminal state (`succeeded`/`failed`) as soon as the dispatched turn finishes, instead of staying `running` forever; run history is readable at `GET /v1/scheduled-tasks/{id}/runs`.

---
This pull request and its description were written by Isaac.