### PR TITLE
fix(codex): fall back to the runner workspace when no explicit cwd is set

### DIFF
--- a/omnigent/inner/codex_harness.py
+++ b/omnigent/inner/codex_harness.py
@@ -38,8 +38,8 @@ Env vars read at startup:
   ``HARNESS_CODEX_GATEWAY`` (the gateway path pins its own
   generated provider).
 - ``HARNESS_CODEX_CWD``: working directory the executor launches
-  the Codex CLI in. ``None`` falls back to the subprocess's
-  inherited cwd.
+  the Codex CLI in. ``None`` falls back to ``OMNIGENT_RUNNER_WORKSPACE``
+  if set, then to the subprocess's inherited cwd.
 - ``OMNIGENT_CODEX_PATH``: absolute path to a ``codex`` CLI binary.
   ``None`` searches ``PATH``. (Legacy ``HARNESS_CODEX_PATH`` still honored,
   deprecated.)
@@ -288,7 +288,7 @@ def _build_codex_executor() -> Executor:
     agent_name_raw = os.environ.get(_ENV_AGENT_NAME, "").strip()
     agent_name = agent_name_raw or None
     return CodexExecutor(
-        cwd=os.environ.get(_ENV_CWD),
+        cwd=os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE") or None,
         os_env=_resolve_os_env(),
         model=os.environ.get(_ENV_MODEL),
         codex_path=resolve_harness_path("codex"),

--- a/tests/inner/test_codex_harness.py
+++ b/tests/inner/test_codex_harness.py
@@ -142,6 +142,76 @@ def test_executor_factory_reads_env_vars(
     assert os_env_value.sandbox.type == "none"
 
 
+def test_executor_factory_cwd_falls_back_to_runner_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Locks the harness half of the contract asserted by
+    ``tests/runtime/test_spawn_env_cwd.py::test_builder_omits_cwd_when_none``:
+    when the builder omits ``HARNESS_CODEX_CWD``, the harness falls back
+    to ``OMNIGENT_RUNNER_WORKSPACE``. Mirrors the claude-sdk / kimi / pi /
+    hermes harnesses.
+    """
+    monkeypatch.delenv("HARNESS_CODEX_CWD", raising=False)
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", "/home/bobby/code/agents")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, *, cwd: str | None, **_kwargs: Any) -> None:
+        captured["cwd"] = cwd
+
+    with patch(
+        "omnigent.inner.codex_harness.CodexExecutor.__init__",
+        _fake_init,
+    ):
+        codex_harness._build_codex_executor()
+
+    assert captured["cwd"] == "/home/bobby/code/agents"
+
+
+def test_executor_factory_explicit_cwd_wins_over_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``HARNESS_CODEX_CWD`` takes precedence over the
+    ``OMNIGENT_RUNNER_WORKSPACE`` fallback."""
+    monkeypatch.setenv("HARNESS_CODEX_CWD", "/tmp/explicit")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", "/home/bobby/code/agents")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, *, cwd: str | None, **_kwargs: Any) -> None:
+        captured["cwd"] = cwd
+
+    with patch(
+        "omnigent.inner.codex_harness.CodexExecutor.__init__",
+        _fake_init,
+    ):
+        codex_harness._build_codex_executor()
+
+    assert captured["cwd"] == "/tmp/explicit"
+
+
+def test_executor_factory_blank_cwd_env_vars_pass_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty cwd env vars normalize to ``None`` rather than an empty
+    string, so the executor reaches its own inherited-cwd fallback."""
+    monkeypatch.setenv("HARNESS_CODEX_CWD", "")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", "")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, *, cwd: str | None, **_kwargs: Any) -> None:
+        captured["cwd"] = cwd
+
+    with patch(
+        "omnigent.inner.codex_harness.CodexExecutor.__init__",
+        _fake_init,
+    ):
+        codex_harness._build_codex_executor()
+
+    assert captured["cwd"] is None
+
+
 def test_executor_factory_decodes_os_env_json(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #2855

## Summary

The codex harness wrap read only `HARNESS_CODEX_CWD`. When the spawn env omits that var, `CodexExecutor` gets `cwd=None` and falls through to `os.getcwd()`, which is the runner daemon's launch directory (`omnigent/host/connect.py` spawns the runner with no `cwd=`, and nothing `os.chdir`s afterward). Seven sibling harnesses (acp, claude-sdk, goose, hermes, kimi, pi, qwen) already fall back to `OMNIGENT_RUNNER_WORKSPACE` first. This adds the same rung to codex.

The contract is already written down: `tests/runtime/test_spawn_env_cwd.py::test_builder_omits_cwd_when_none` asserts each builder omits its `HARNESS_*_CWD` var when no cwd is resolved, "so the harness applies its own `OMNIGENT_RUNNER_WORKSPACE` / inherited-cwd fallback". codex is in that test's builder list but never held up the harness half of it.

Being upfront about scope: every current production caller threads a cwd through `_session_runtime_cwd`, so this changes no observed behavior today. It closes the documented contract gap and covers a caller that omits the var. That is the same basis on which #339 landed the fallback for `pi` and the claude-sdk half of #1951 landed it for claude-sdk.

`cursor_harness.py` and `copilot_harness.py` have the same shape and the same gap. I left them out to keep this reviewable. Happy to fold them in here or file a follow-up, whichever you prefer. Note those two advertise an `os_env.cwd` rung in their harness docstrings that codex does not, so they need a docstring update alongside the change rather than just the `or` clause.

## Test Plan

- `pytest tests/inner/test_codex_harness.py tests/runtime/test_spawn_env_cwd.py` → 48 passed.
- Fail-without-fix proven: reverting only the production line makes `test_executor_factory_cwd_falls_back_to_runner_workspace` fail with `assert None == '/home/bobby/code/agents'`.
- Mutation-checked each part of the changed line. Dropping the `OMNIGENT_RUNNER_WORKSPACE` rung fails test 1; dropping the trailing `or None` fails test 3; swapping precedence fails test 2.
- Full `tests/inner` run compared against a clean-`main` baseline: identical failure set (32, all pre-existing Windows/POSIX cases), so no regressions.
- `ruff format --check` and `ruff check` clean.

Tests were run on Windows. The pre-existing failures in that directory are unix-socket, symlink, chmod and tmux cases that do not run there.

## Demo

N/A, non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Three unit tests: the workspace fallback, explicit-cwd precedence, and empty-env-var normalization. Each is pinned by a distinct mutation of the changed line.
