### PR TITLE
fix(runner): do not memoize a session workspace from a failed snapshot

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8880,6 +8880,10 @@ def create_runner_app(
         """
         if session_id not in _session_workspace_cache:
             snapshot = await _session_snapshot(session_id)
+            # A failed fetch carries no workspace. Memoizing its ``None``
+            # would pin the session to the global workspace for its lifetime.
+            if not snapshot.ok:
+                return None
             _session_workspace_cache[session_id] = snapshot.workspace
         return _session_workspace_cache.get(session_id)
 
@@ -17871,7 +17875,10 @@ def create_runner_app(
             return
         snapshot = await _session_snapshot(session_id)
         _session_start_cache[session_id] = snapshot.created_at
-        _session_workspace_cache[session_id] = snapshot.workspace
+        # Only memoize a workspace the server actually returned; a failed
+        # fetch is re-resolved lazily by _session_workspace_value.
+        if snapshot.ok:
+            _session_workspace_cache[session_id] = snapshot.workspace
 
     async def _resolve_session_spec_entry(session_id: str) -> Any | None:
         """

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import subprocess
 import uuid
 from collections.abc import AsyncIterator, Callable, Sequence
 from dataclasses import dataclass
@@ -25,7 +26,7 @@ from omnigent.entities.session_resources import (
     terminal_resource_view,
 )
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
-from omnigent.inner.os_env import EditEntry, OpResult, OSEnvironment
+from omnigent.inner.os_env import EditEntry, OpResult, OSEnvironment, create_os_environment
 from omnigent.inner.terminal import TerminalInstance
 from omnigent.runner import create_runner_app
 from omnigent.runner import resource_registry as resource_registry_mod
@@ -2114,6 +2115,140 @@ async def test_unbound_agent_snapshot_is_not_cached_and_retries(
     # The bundle resolved only once the agent had bound.
     assert resolver_count == 1, (
         f"expected one bundle resolution (after binding), got {resolver_count}"
+    )
+
+
+def _git_env() -> dict[str, str]:
+    """Build an env dict with dummy git identity.
+
+    :returns: Copy of the current environment with GIT_AUTHOR_* and
+        GIT_COMMITTER_* set to safe dummy values.
+    """
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+
+@pytest.mark.asyncio
+async def test_failed_snapshot_does_not_latch_session_workspace(
+    tmp_path: Path,
+) -> None:
+    """A transient non-200 snapshot does not latch the session onto the
+    runner's global workspace: a later read resolves the real worktree.
+
+    The workspace projection is memoized separately from the snapshot
+    itself, so a single failed fetch used to pin ``workspace=None`` for
+    the session's lifetime. Everything keyed off it (the filesystem
+    registry here, the harness cwd in production) then silently read the
+    global ``runner_workspace`` instead of the session's git worktree,
+    with no later fetch to recover from.
+
+    :param tmp_path: Temporary root holding both git workspaces.
+    :returns: None.
+    """
+    env = _git_env()
+    conv = "conv_latch"
+
+    # Runner's global workspace: a clean git repo, so reading it yields
+    # no changed files and is distinguishable from the worktree.
+    runner_ws = tmp_path / "workspace"
+    runner_ws.mkdir()
+    subprocess.run(["git", "init"], cwd=runner_ws, check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=runner_ws,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+    # Session's server-stored workspace: a separate git repo standing in
+    # for a worktree, carrying one uncommitted file as the marker.
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    subprocess.run(["git", "init"], cwd=worktree, check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    (worktree / "agent_change.py").write_text("# written by agent")
+
+    server_reachable = False
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        """
+        Stub Omnigent server: fail every snapshot until it is reachable.
+
+        :param request: Outbound request from the runner.
+        :returns: 503 while unreachable, then the bound snapshot naming
+            the worktree as the session workspace.
+        """
+        if request.method == "GET" and request.url.path == f"/v1/sessions/{conv}":
+            if not server_reachable:
+                return httpx.Response(503, json={})
+            return httpx.Response(
+                200,
+                json={
+                    "id": conv,
+                    "agent_id": "ag_latch",
+                    "created_at": 1000,
+                    "workspace": str(worktree),
+                },
+            )
+        return httpx.Response(200, json={})
+
+    # The session's OS env is pre-seeded, so the filesystem endpoints run
+    # without a spec resolver and the snapshot is fetched lazily.
+    os_env = create_os_environment(
+        OSEnvSpec(
+            type="caller_process",
+            cwd=str(worktree),
+            sandbox=OSEnvSandboxSpec(type="none"),
+        ),
+    )
+    assert os_env is not None
+    registry = SessionResourceRegistry()
+    registry._primary_envs[conv] = os_env
+
+    server_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    )
+    app = create_runner_app(
+        resource_registry=registry,
+        runner_workspace=runner_ws,
+        server_client=server_client,
+    )
+    changes_url = f"/v1/sessions/{conv}/resources/environments/{DEFAULT_ENVIRONMENT_ID}/changes"
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as c:
+            during_outage = await c.get(changes_url)
+            server_reachable = True
+            after_recovery = await c.get(changes_url)
+    finally:
+        await server_client.aclose()
+
+    # While the server is down the read still succeeds off the global
+    # workspace fallback, which is clean and so reports nothing.
+    assert during_outage.status_code == 200, during_outage.text
+    assert during_outage.json()["data"] == []
+    assert after_recovery.status_code == 200, after_recovery.text
+    paths = [entry["path"] for entry in after_recovery.json()["data"]]
+    # The marker only exists in the worktree. Its absence means the failed
+    # fetch memoized workspace=None and the session is stuck on the global
+    # runner workspace with no fetch left to recover it.
+    assert "agent_change.py" in paths, (
+        f"expected the worktree's changed file after recovery, got {paths}; "
+        f"empty means the transient failure latched workspace=None and the "
+        f"session stayed pinned to the global runner workspace"
     )
 
 


### PR DESCRIPTION
## Related issue

Closes #3016

## Summary

`_session_snapshot` deliberately refuses to cache an incomplete or failed snapshot so spec resolution can retry until the agent binds, and `test_failed_session_snapshot_is_not_cached_and_retries` guards that. The workspace projection cache defeated it one layer up: `_session_workspace_value` and `_ensure_session_registered` both wrote `snapshot.workspace` unconditionally, so one transient non-200 pinned `workspace=None` for the session's lifetime.

After that, `_session_runtime_cwd` returns the global runner workspace instead of the session's worktree, and the harness process manager bakes the subprocess env at first spawn, so the session never recovers. Nothing short of deleting the session clears it, since the reset-agent-cache path evicts `_session_snapshot_cache` but not the projections.

Both writes are now guarded on `snapshot.ok`. `created_at` stays unconditional in `_ensure_session_registered` because its wall-time fallback is documented behavior there and is display-only.

Both guards are needed. `_session_start_cache` doubles as the early-return sentinel in `_ensure_session_registered`, so once `created_at` is set that function never runs again and its guard alone would get no second chance. The lazy re-resolve in `_session_workspace_value` is what actually recovers the workspace.

## Test Plan

- `test_failed_snapshot_does_not_latch_session_workspace` mirrors the two existing retry tests in the same file. It stands up a runner whose global workspace and session workspace are different git repos, fails the session GET for the whole first request window, then recovers and asserts the session reads the worktree's changed file rather than the clean global repo.
- Fail-without-fix proven by stashing only `omnigent/runner/app.py` and re-running: the new test fails, the two neighbouring tests still pass.
- Full `tests/runner` run compared against a clean-`main` baseline: 80 failures with the change vs 81 without, and the set difference in the regression direction is empty. The one test that differs (`test_parent_idle_with_stuck_wake_flag_posts_recovery_wake`) is order-dependent and passes standalone on both trees, so I am not claiming it.
- `ruff format --check` and `ruff check` clean.

Tests were run on Windows. The pre-existing failures in `tests/runner` are unix-socket, symlink, chmod and tmux cases that do not run there.

## Demo

N/A, non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

One regression test covering the transient-failure path end to end through a real endpoint. Verified to fail on the unfixed tree.

## Changelog

A transient server hiccup no longer pins a session to the wrong working directory for the rest of the conversation.
