### PR TITLE
fix(tests): keep the untracked-cache worker out of unrelated tests

### DIFF
--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -142,7 +142,14 @@ def _patch_login_env(
     class _Completed:
         returncode: int = 0
 
+    real_run = cli_mod.subprocess.run
+
     def _fake_run(argv: list[str], **kwargs: object) -> _Completed:
+        # Patching ``cli_mod.subprocess`` swaps ``run`` on the module
+        # itself, so background threads land here too. Anything that is
+        # not the databricks CLI goes to the real runner.
+        if Path(argv[0]).name != "databricks":
+            return real_run(argv, **kwargs)
         login_calls.append(" ".join(argv[1:]))  # drop the binary path
         return _Completed()
 
@@ -351,6 +358,41 @@ def test_login_stale_cached_grant_triggers_fresh_login_and_retry(
     # The retry verify presented the freshly minted token, not the stale one.
     assert fake.requests[-1]["authorization"] == "Bearer tok-fresh"
     assert load_databricks_workspace_host(_APPS_URL) == _WORKSPACE
+
+
+def test_foreign_subprocess_calls_stay_out_of_the_login_recorder(
+    monkeypatch: pytest.MonkeyPatch, token_dir: Path
+) -> None:
+    """Only the databricks CLI reaches ``login_calls``; the rest pass through.
+
+    ``_patch_login_env`` swaps ``run`` on the ``subprocess`` module itself,
+    so every thread in the process sees the stub. A background caller
+    landing mid-test would otherwise append its argv to the recorder and
+    break the login assertions.
+    """
+    fake = _FakeHttpx(
+        responses=[
+            _response(302, headers={"location": _APPS_REDIRECT}),
+            _response(200, body={"user_id": "alice@example.com"}),
+        ]
+    )
+    login_calls = _patch_login_env(
+        monkeypatch,
+        fake_httpx=fake,
+        # No cached grant, so the flow shells out to `databricks auth login`.
+        cached_tokens=[None, "tok-fresh"],
+    )
+
+    # Stands in for a background thread shelling out mid-login.
+    probe = cli_mod.subprocess.run(["git", "--version"], capture_output=True)
+
+    result = CliRunner().invoke(cli_group, ["login", _APPS_URL])
+
+    assert result.exit_code == 0, result.output
+    assert login_calls == [f"auth login --host {_WORKSPACE}"]
+    # Delegated to the real runner rather than stubbed out from under it.
+    assert probe.returncode == 0
+    assert b"git version" in probe.stdout
 
 
 # ── ?o= workspace selector ──────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,7 @@ os.environ.setdefault("OMNIGENT_AUTH_PROVIDER", "header")
 os.environ.setdefault("OMNIGENT_LOCAL_SINGLE_USER", "1")
 
 from omnigent.db.utils import _engine_cache, _engine_lock, get_or_create_engine
+from omnigent.runtime.filesystem_registry import GitFilesystemRegistry
 from tests import _model_pools
 
 pytest_plugins = ["tests._token_usage"]
@@ -334,6 +335,42 @@ def _isolate_codex_native_state(
     """
     state_dir = tmp_path_factory.mktemp("codex-native-state")
     monkeypatch.setenv("OMNIGENT_CODEX_NATIVE_STATE_DIR", str(state_dir))
+
+
+@pytest.fixture()
+def untracked_cache_start() -> None:
+    """Opt back in to the real :meth:`GitFilesystemRegistry.start`.
+
+    Request this alongside the tests that exercise the optimization
+    worker itself; :func:`_stub_untracked_cache_start` then leaves the
+    method alone.
+
+    :returns: None.
+    """
+
+
+@pytest.fixture(autouse=True)
+def _stub_untracked_cache_start(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the git untracked-cache worker out of unrelated tests.
+
+    :meth:`GitFilesystemRegistry.start` spawns a daemon thread that shells
+    out to git. It lands at an unpredictable moment, so a test that swaps
+    the process-global ``subprocess.run`` can record the worker's argv as
+    one of its own calls and fail on an assertion about a wholly unrelated
+    command. Stubbing the method by default removes the race for every
+    such test; the worker's own tests request ``untracked_cache_start``.
+
+    :param request: Pytest request, inspected for the opt-in fixture.
+    :param monkeypatch: Pytest monkeypatch fixture; restores the method
+        at teardown.
+    :returns: None.
+    """
+    if "untracked_cache_start" in request.fixturenames:
+        return
+    monkeypatch.setattr(GitFilesystemRegistry, "start", lambda self: None)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -859,6 +859,7 @@ def test_untracked_cache_config_written_once_per_root(tmp_path: Path, monkeypatc
 def test_untracked_cache_start_runs_once_in_daemon_thread(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    untracked_cache_start: None,
 ) -> None:
     """Registry startup launches one non-blocking optimization worker."""
     registry = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
@@ -876,6 +877,29 @@ def test_untracked_cache_start_runs_once_in_daemon_thread(
 
     assert completed.wait(timeout=1)
     assert daemon_values == [True]
+
+
+def test_untracked_cache_start_is_stubbed_for_unrelated_tests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The suite-wide guard keeps the optimization worker from firing.
+
+    The worker shells out to git at an arbitrary later moment. Landing
+    inside a test that has swapped the process-global ``subprocess.run``,
+    its argv is recorded as if the test had made the call. Tests that want
+    the real worker request the ``untracked_cache_start`` fixture.
+    """
+    registry = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    started = threading.Event()
+    monkeypatch.setattr(registry, "_enable_untracked_cache", started.set)
+
+    registry.start()
+
+    assert not started.wait(timeout=0.25), (
+        "The untracked-cache worker ran in a test that did not opt in; "
+        "it can corrupt any test that patches subprocess.run."
+    )
 
 
 def test_untracked_cache_already_enabled_skips_probe(


### PR DESCRIPTION
## Related issue

N/A

## Summary

#2976 moved git untracked-cache setup off the runner startup path and into a daemon thread. That fixed a real 6-second stall, but it also made the worker fire at an unpredictable moment during a test session. A test that swaps the process-global `subprocess.run` now records the worker's argv as one of its own calls.

This is not hypothetical: it took down `Pytest (misc)` on an unrelated PR. `tests/cli/test_login_databricks.py` asserts on the argv it captured and saw a command it never issued.

```text
FAILED tests/cli/test_login_databricks.py::test_login_stale_cached_grant_triggers_fresh_login_and_retry
    [
        'auth login --host https://example.databricks.com',
  +     'config core.untrackedCache true',
    ]
```

The recorder patches `run` on the `subprocess` module object, so the stub is visible to every thread in the process, not just the code under test. 22 test files patch `subprocess.run` this way, so any of them can draw the same failure.

**ELI5:** One test says "write down every command anyone runs." A background helper runs a git command at a random moment, the test writes that down too, then fails because its list has an extra line it did not put there. This tells the helper to stay quiet while tests run.

```text
Before: test A patches subprocess.run ──┐
        registry worker thread ─── git config ──┴──> recorded as test A's call -> A fails

After:  test A patches subprocess.run ──> only databricks argv recorded
        registry worker thread ─── stubbed out for the suite (opt back in per test)
```

Two layers, so neither alone has to be perfect:

- `tests/conftest.py` stubs `GitFilesystemRegistry.start` by default. The worker's own tests request the new `untracked_cache_start` fixture to opt back in.
- `_patch_login_env` records only the databricks CLI and forwards any other argv to the real `subprocess.run`, so a foreign caller is neither captured nor silently stubbed out from under it.

No production code changes.

## Test Plan

- [x] Confirmed both new tests fail before the fix and pass after (the login one reproduces the CI diff exactly)
- [x] Ran the full `misc` CI shard on this branch and on clean `main` for an apples-to-apples comparison: **3 failed / 5375 passed on main**, **3 failed / 5376 passed here**. Same three failures on both, all local-environment artifacts of a stray empty `/tmp/.git` on my machine (the registry factory finds it and picks the git backend). With `--basetemp` outside `/tmp` all three pass.
- [x] Ran the affected suites green: `tests/test_workspace_fs.py tests/runner/ tests/cli/ tests/runtime/test_filesystem_registry.py`
- [x] Ran all repository pre-commit hooks

```bash
uv run pytest -q tests/cli/test_login_databricks.py tests/runtime/test_filesystem_registry.py
uv run pytest -q -m "not databricks" tests --ignore=tests/e2e --ignore=tests/integration \
  --ignore=tests/runtime --ignore=tests/inner --ignore=tests/tools --ignore=tests/test_errors.py \
  --ignore=tests/frontends --ignore=tests/repl --ignore=tests/terminals --ignore=tests/server \
  --ignore=tests/onboarding --ignore=tests/spec --ignore=tests/llms --ignore=tests/codex_parity \
  --ignore=tests/runner --ignore=tests/stores
uv run pre-commit run --all-files
```

## Demo

N/A — test-only change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`test_untracked_cache_start_is_stubbed_for_unrelated_tests` covers the suite-wide guard, and `test_foreign_subprocess_calls_stay_out_of_the_login_recorder` covers the recorder, asserting both that foreign argv stays out of the capture list and that it still reaches the real runner. `test_untracked_cache_start_runs_once_in_daemon_thread` keeps exercising the real `start()` through the opt-in fixture, so the guard cannot mask a regression in the worker itself.

Worth noting the repo already lints for one instance of this bug class (the `no globally-clobbering asyncio monkeypatch` pre-commit hook). A similar hook for module-object `subprocess`/`datetime` patches would catch the remaining 21 files; happy to follow up if you want it.
