### PR TITLE
fix(web): closing a shell restores the previous view instead of forcing chat

### DIFF
--- a/tests/e2e_ui/shells/test_shell_close_restores_view.py
+++ b/tests/e2e_ui/shells/test_shell_close_restores_view.py
@@ -1,0 +1,197 @@
+"""E2E: leaving a user shell returns to the view it was opened from.
+
+In a terminal-first session a shell opened from the rail's **Shells** tab
+takes over the main column, and while it does the ``Chat | Terminal``
+pill is hidden (``ConnectionIndicator`` gates on ``isShellView``). That
+makes the way *out* of the shell the only thing standing between the user
+and their previous view — so it must land where they came from:
+
+* opened from **Chat** → back to chat (no terminal surface),
+* opened from the agent **Terminal** view → back to the agent terminal,
+  with the pill restored.
+
+Two exit paths reach that restore and both are covered here:
+
+1. **The header ✕** (``MainTerminalView``'s "Close shell"), which calls
+   ``exitShellView()``.
+2. **Typing ``exit``**, which kills the PTY; the runner deletes the
+   resource and the shell drops out of ``terminals``. ``AppShell``
+   notices the open panel key has gone stale and exits the shell view
+   itself. Without that, the panel key keeps pointing at the dead shell:
+   ``MainTerminalView`` falls back to rendering the agent terminal (so no
+   shell ✕) while the pill stays hidden — no way back to chat at all.
+
+The ``exit`` path is the harder assertion, because the *rendered pane*
+looks right either way (``MainTerminalView`` re-targets the agent
+terminal on its own). The pill's visibility is what separates fixed from
+broken, so that is what these tests assert.
+
+Uses the function-scoped ``terminal_session`` fixture: a runner-bound SDK
+session, which the runner makes terminal-first by auto-creating the
+Omnigent REPL terminal (``terminal_tui_main``) and stamping
+``omnigent.ui: terminal``. No chat message is ever sent — the user, not
+the agent, opens these shells.
+"""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# The agent's own terminal for an SDK session — the pane the pill's
+# "Terminal" option shows, and the restore target when a shell was opened
+# from it.
+_AGENT_TERMINAL_KEY = "terminal:terminal_tui_main"
+# A user-created ``zsh`` shell: ``createTerminal`` mints a ``u-<rand>``
+# session key, so the resource id is ``terminal_zsh_u-<rand>``.
+_USER_ZSH_KEY_RE = re.compile(r"^terminal:terminal_zsh_u-")
+
+
+def _open_new_shell(page: Page) -> None:
+    """Open the Shells tab and click the "+ New shell" row.
+
+    Scopes every lookup to the desktop "Workspace" rail so it never
+    matches the hidden mobile drawer mirroring the same controls.
+
+    :param page: Playwright page already navigated to ``/c/{id}``.
+    """
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("Shells")).click()
+    # A single declared terminal name → the row creates directly (no dropdown).
+    rail.get_by_role("button", name="New shell").click()
+
+
+def _expect_shell_took_over(page: Page):
+    """Wait for a freshly created shell to own the main column.
+
+    :param page: Playwright page with a "+ New shell" click already fired.
+    :returns: The ``main-terminal-view`` locator, focused on the shell.
+    """
+    main_terminal = page.get_by_test_id("main-terminal-view")
+    expect(main_terminal).to_be_visible(timeout=60_000)
+    expect(main_terminal).to_have_attribute("data-active-terminal", _USER_ZSH_KEY_RE)
+    # Shell view: the pill is hidden, so the header ✕ is the only way out.
+    expect(page.get_by_role("button", name="Close shell")).to_be_visible()
+    expect(page.get_by_role("button", name="Terminal", exact=True)).to_have_count(0)
+    return main_terminal
+
+
+def _open_agent_terminal_view(page: Page):
+    """Switch the pill to the agent's Terminal view and wait for it.
+
+    The "Terminal" option is disabled until the runner's REPL terminal
+    exists, so this tolerates the spin-up window.
+
+    :param page: Playwright page already navigated to ``/c/{id}``.
+    :returns: The ``main-terminal-view`` locator, focused on the agent terminal.
+    """
+    terminal_option = page.get_by_role("button", name="Terminal", exact=True)
+    expect(terminal_option).to_be_visible(timeout=60_000)
+    expect(terminal_option).to_be_enabled(timeout=60_000)
+    terminal_option.click()
+
+    main_terminal = page.get_by_test_id("main-terminal-view")
+    expect(main_terminal).to_be_visible(timeout=30_000)
+    expect(main_terminal).to_have_attribute("data-active-terminal", _AGENT_TERMINAL_KEY)
+    return main_terminal
+
+
+def test_close_shell_opened_from_chat_returns_to_chat(
+    page: Page, terminal_session: tuple[str, str]
+) -> None:
+    """A shell opened from chat closes back to chat, not the terminal.
+
+    The baseline half of the restore contract: with no prior terminal
+    view, the ✕ must leave the terminal surface entirely rather than
+    stranding the user on the agent's terminal.
+    """
+    base_url, session_id = terminal_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_new_shell(page)
+    main_terminal = _expect_shell_took_over(page)
+
+    page.get_by_role("button", name="Close shell").click()
+
+    # Back on the conversation surface: no terminal pane at all, and the
+    # pill is showing Chat.
+    expect(main_terminal).to_have_count(0)
+    expect(page.get_by_role("button", name="Chat", exact=True)).to_have_attribute(
+        "aria-pressed", "true"
+    )
+
+
+def test_close_shell_opened_from_terminal_returns_to_terminal(
+    page: Page, terminal_session: tuple[str, str]
+) -> None:
+    """A shell opened from the agent Terminal view closes back to it.
+
+    Previously the ✕ hard-coded ``setView("chat")``, so opening a shell
+    from the Terminal view and closing it silently discarded the
+    Chat-vs-Terminal choice and dumped the user into chat.
+    """
+    base_url, session_id = terminal_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+    main_terminal = _open_agent_terminal_view(page)
+
+    _open_new_shell(page)
+    _expect_shell_took_over(page)
+
+    page.get_by_role("button", name="Close shell").click()
+
+    # Back on the AGENT's terminal — still the terminal surface, with the
+    # pill restored and "Terminal" selected. A regression drops to chat,
+    # which removes `main-terminal-view` entirely.
+    expect(main_terminal).to_be_visible()
+    expect(main_terminal).to_have_attribute("data-active-terminal", _AGENT_TERMINAL_KEY)
+    expect(page.get_by_role("button", name="Terminal", exact=True)).to_have_attribute(
+        "aria-pressed", "true"
+    )
+
+
+def test_typing_exit_in_shell_restores_the_previous_view(
+    page: Page, terminal_session: tuple[str, str]
+) -> None:
+    """Typing ``exit`` leaves shell view instead of stranding the user.
+
+    The shell's PTY dies, the runner deletes the resource, and the shell
+    disappears from the terminal list. The pane then falls back to the
+    agent terminal on its own — but the open panel key still named the
+    dead shell, so the app stayed in "shell view": pill hidden, and no
+    ✕ rendered (the pane is the agent's, not a shell). Assert the pill
+    is back, which is what actually distinguishes restored from stranded.
+    """
+    base_url, session_id = terminal_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_agent_terminal_view(page)
+
+    _open_new_shell(page)
+    main_terminal = _expect_shell_took_over(page)
+
+    # Keystrokes sent before the WS attach opens are dropped, so wait for
+    # the shell's xterm to connect first.
+    terminal_view = page.get_by_test_id("terminal-view").last
+    expect(terminal_view).to_be_visible(timeout=60_000)
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+
+    # A plain container click doesn't reliably focus the WebGL canvas in
+    # headless Chromium; focus xterm's hidden input instead.
+    terminal_view.locator("textarea.xterm-helper-textarea").focus()
+    page.keyboard.type("exit")
+    page.keyboard.press("Enter")
+
+    # The dead shell drops out of the list and the view restores itself —
+    # no click needed. Back on the agent terminal with the pill usable.
+    expect(main_terminal).to_have_attribute(
+        "data-active-terminal", _AGENT_TERMINAL_KEY, timeout=30_000
+    )
+    expect(page.get_by_role("button", name="Close shell")).to_have_count(0)
+    expect(page.get_by_role("button", name="Terminal", exact=True)).to_have_attribute(
+        "aria-pressed", "true", timeout=30_000
+    )

--- a/web/src/hooks/useTerminals.test.ts
+++ b/web/src/hooks/useTerminals.test.ts
@@ -15,7 +15,9 @@ import {
   fetchTerminals,
   inventoryTerminals,
   isAgentTerminalKey,
+  PANEL_NO_TERMINAL_KEY,
   PENDING_RECONCILE_INTERVAL_MS,
+  shellViewIsStale,
   terminalInfoFromResource,
   terminalsReconcileInterval,
   terminalTabKey,
@@ -490,6 +492,43 @@ describe("terminalTabKey", () => {
     };
     const after: TerminalInfo = { ...before, name: "bash-renamed", session: "s2" };
     expect(terminalTabKey(before)).toBe(terminalTabKey(after));
+  });
+});
+
+describe("shellViewIsStale", () => {
+  const shell: TerminalInfo = {
+    id: "terminal_bash_s1",
+    name: "bash",
+    session: "s1",
+    running: true,
+  };
+  const agent: TerminalInfo = {
+    id: "terminal_claude_main",
+    name: "claude",
+    session: "main",
+    running: true,
+  };
+  const shellKey = terminalTabKey(shell); // "terminal:terminal_bash_s1"
+
+  it("is false while the shell still exists (the normal open-shell state)", () => {
+    expect(shellViewIsStale(shellKey, [agent, shell])).toBe(false);
+  });
+
+  it("is true once the shell leaves the list (user typed `exit`) — drives the #479 auto-exit", () => {
+    expect(shellViewIsStale(shellKey, [agent])).toBe(true);
+  });
+
+  it("is false for chat (null) and the no-target sentinel", () => {
+    expect(shellViewIsStale(null, [agent, shell])).toBe(false);
+    expect(shellViewIsStale(PANEL_NO_TERMINAL_KEY, [agent, shell])).toBe(false);
+  });
+
+  it("is false for the agent terminal — it's the pill's Terminal view, never a stale shell", () => {
+    expect(shellViewIsStale(terminalTabKey(agent), [agent])).toBe(false);
+  });
+
+  it("is false while the list is empty (loading / offline) so a pending restore isn't clobbered", () => {
+    expect(shellViewIsStale(shellKey, [])).toBe(false);
   });
 });
 

--- a/web/src/hooks/useTerminals.test.ts
+++ b/web/src/hooks/useTerminals.test.ts
@@ -17,6 +17,7 @@ import {
   isAgentTerminalKey,
   PANEL_NO_TERMINAL_KEY,
   PENDING_RECONCILE_INTERVAL_MS,
+  restoredShellExitView,
   shellViewIsStale,
   terminalInfoFromResource,
   terminalsReconcileInterval,
@@ -529,6 +530,22 @@ describe("shellViewIsStale", () => {
 
   it("is false while the list is empty (loading / offline) so a pending restore isn't clobbered", () => {
     expect(shellViewIsStale(shellKey, [])).toBe(false);
+  });
+});
+
+describe("restoredShellExitView", () => {
+  it("returns chat only when the prior view was chat (null)", () => {
+    expect(restoredShellExitView(null)).toBe("chat");
+  });
+
+  it("returns terminal when the prior view was the agent terminal", () => {
+    expect(restoredShellExitView("terminal:terminal_claude_main")).toBe("terminal");
+  });
+
+  it("returns terminal for the no-target sentinel (Terminal open before any terminal existed)", () => {
+    // PANEL_NO_TERMINAL_KEY is the empty string — falsy, so it must not be
+    // lumped in with the chat (null) case and routed back to chat.
+    expect(restoredShellExitView(PANEL_NO_TERMINAL_KEY)).toBe("terminal");
   });
 });
 

--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -120,6 +120,28 @@ export function shellViewIsStale(panelKey: string | null, terminals: TerminalInf
 }
 
 /**
+ * The view to restore when leaving a shell, given the last non-shell
+ * panel key that was showing before the shell took over.
+ *
+ * ``null`` means the user came from chat. Both the agent-terminal key and
+ * :data:`PANEL_NO_TERMINAL_KEY` (the Terminal view open with no specific
+ * target — e.g. Terminal picked before any terminal existed) mean the
+ * user came from the Terminal surface, so both restore ``"terminal"``.
+ * The empty-string sentinel is falsy, so it must be matched explicitly
+ * rather than lumped in with the chat (null) case.
+ *
+ * :param prevNonShellKey: Last non-shell panel key, or null for chat.
+ * :returns: The view the pill's ``setView`` should restore.
+ */
+export function restoredShellExitView(prevNonShellKey: string | null): "chat" | "terminal" {
+  if (prevNonShellKey === null) return "chat";
+  if (prevNonShellKey === PANEL_NO_TERMINAL_KEY || isAgentTerminalKey(prevNonShellKey)) {
+    return "terminal";
+  }
+  return "chat";
+}
+
+/**
  * Project the terminal list down to the session's *inventory* — the
  * shells shown in the right-rail Shells tab, its count badge, and the
  * mobile menu entry.

--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -99,6 +99,27 @@ export function isAgentTerminalKey(terminalKey: string): boolean {
 }
 
 /**
+ * Whether a terminal-first shell view has gone stale — the open panel key
+ * still points at a user shell that no longer exists in *terminals* (e.g.
+ * the user typed ``exit`` and the runner deleted the resource). Callers
+ * exit the shell view when this is true so the user isn't stranded with
+ * the Chat/Terminal pill hidden and no shell close button (issue #479).
+ *
+ * Returns ``false`` for chat (``null``), the agent terminal, the
+ * "open with no target" sentinel, and while the list is empty
+ * (loading / offline) so a pending restore isn't clobbered.
+ *
+ * :param panelKey: The open panel key (:func:`terminalTabKey` value), or null.
+ * :param terminals: The current terminal list.
+ */
+export function shellViewIsStale(panelKey: string | null, terminals: TerminalInfo[]): boolean {
+  if (!panelKey || panelKey === PANEL_NO_TERMINAL_KEY) return false;
+  if (isAgentTerminalKey(panelKey)) return false;
+  if (terminals.length === 0) return false;
+  return !terminals.some((t) => terminalTabKey(t) === panelKey);
+}
+
+/**
  * Project the terminal list down to the session's *inventory* — the
  * shells shown in the right-rail Shells tab, its count badge, and the
  * mobile menu entry.

--- a/web/src/pages/ConnectionIndicator.test.tsx
+++ b/web/src/pages/ConnectionIndicator.test.tsx
@@ -22,6 +22,7 @@ function makeCtx(overrides: Partial<TerminalFirstContextValue> = {}): TerminalFi
     view: "chat",
     terminalViewKey: null,
     setView: vi.fn(),
+    exitShellView: vi.fn(),
     terminalsAvailable: true,
     terminalStartingUp: false,
     ...overrides,

--- a/web/src/pages/RunnerStartingIndicator.test.tsx
+++ b/web/src/pages/RunnerStartingIndicator.test.tsx
@@ -21,6 +21,7 @@ function makeCtx(overrides: Partial<TerminalFirstContextValue> = {}): TerminalFi
     view: "chat",
     terminalViewKey: null,
     setView: vi.fn(),
+    exitShellView: vi.fn(),
     terminalsAvailable: false,
     terminalStartingUp: false,
     ...overrides,

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -49,6 +49,7 @@ import {
   inventoryTerminals,
   isAgentTerminalKey,
   PANEL_NO_TERMINAL_KEY,
+  shellViewIsStale,
   terminalTabKey,
   useTerminals,
 } from "@/hooks/useTerminals";
@@ -1179,13 +1180,9 @@ export function AppShell() {
   // Auto-exit shell view when the active shell leaves the terminal list
   // (e.g. the user typed `exit`, so the runner deleted the resource):
   // restore the prior view instead of stranding the user with the pill
-  // hidden and no shell ✕ to click (issue #479). Skip while the list is
-  // empty (loading / offline) so we don't clobber a pending restore.
+  // hidden and no shell ✕ to click (issue #479).
   useEffect(() => {
-    if (!terminalFirst || !panelInitialKey) return;
-    if (isAgentTerminalKey(panelInitialKey) || panelInitialKey === PANEL_NO_TERMINAL_KEY) return;
-    if (terminals.length === 0) return;
-    if (!terminals.some((t) => terminalTabKey(t) === panelInitialKey)) exitShellView();
+    if (terminalFirst && shellViewIsStale(panelInitialKey, terminals)) exitShellView();
   }, [terminalFirst, panelInitialKey, terminals, exitShellView]);
 
   // `terminals` is already runner-accurate (useTerminals empties it when the

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -229,6 +229,15 @@ export function AppShell() {
     () => readFilesPanelPreferences().sort,
   );
   const [panelInitialKey, setPanelInitialKeyState] = useState<string | null>(null);
+  // Remember the last non-shell view (chat = null, or the agent terminal)
+  // so closing a user shell returns there instead of a hard-coded
+  // destination. Opening a shell overwrites `panelInitialKey` with the
+  // shell key; this ref keeps whatever was showing just before that.
+  const lastNonShellKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    const inShell = !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
+    if (!inShell) lastNonShellKeyRef.current = panelInitialKey;
+  }, [panelInitialKey]);
   const [executionLogsKey, setExecutionLogsKey] = useState<string | null>(null);
   const [filesPanelOpen, setFilesPanelOpen] = useState(false);
   // Mobile-only full-screen drawers for the rail tabs that have no desktop
@@ -1157,6 +1166,16 @@ export function AppShell() {
     [terminalFirst, terminals, setPanelInitialKey],
   );
 
+  // Close (✕) affordance for a user-shell view: return to whatever was
+  // showing before the shell took over — the agent terminal if we came
+  // from it, otherwise chat. `setView` resolves the agent terminal
+  // robustly (and falls back to chat when none is open).
+  const exitShellView = useCallback(() => {
+    const prev = lastNonShellKeyRef.current;
+    if (prev && isAgentTerminalKey(prev)) setView("terminal");
+    else setView("chat");
+  }, [setView]);
+
   // `terminals` is already runner-accurate (useTerminals empties it when the
   // runner is offline), so a non-empty list means an openable PTY.
   const terminalsAvailable = terminals.length > 0;
@@ -1197,6 +1216,7 @@ export function AppShell() {
       view: panelOpen ? "terminal" : "chat",
       terminalViewKey: panelInitialKey,
       setView,
+      exitShellView,
       terminalsAvailable,
       terminalStartingUp,
     }),
@@ -1208,6 +1228,7 @@ export function AppShell() {
       panelOpen,
       panelInitialKey,
       setView,
+      exitShellView,
       terminalsAvailable,
       terminalStartingUp,
     ],

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1176,6 +1176,18 @@ export function AppShell() {
     else setView("chat");
   }, [setView]);
 
+  // Auto-exit shell view when the active shell leaves the terminal list
+  // (e.g. the user typed `exit`, so the runner deleted the resource):
+  // restore the prior view instead of stranding the user with the pill
+  // hidden and no shell ✕ to click (issue #479). Skip while the list is
+  // empty (loading / offline) so we don't clobber a pending restore.
+  useEffect(() => {
+    if (!terminalFirst || !panelInitialKey) return;
+    if (isAgentTerminalKey(panelInitialKey) || panelInitialKey === PANEL_NO_TERMINAL_KEY) return;
+    if (terminals.length === 0) return;
+    if (!terminals.some((t) => terminalTabKey(t) === panelInitialKey)) exitShellView();
+  }, [terminalFirst, panelInitialKey, terminals, exitShellView]);
+
   // `terminals` is already runner-accurate (useTerminals empties it when the
   // runner is offline), so a non-empty list means an openable PTY.
   const terminalsAvailable = terminals.length > 0;

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -49,6 +49,7 @@ import {
   inventoryTerminals,
   isAgentTerminalKey,
   PANEL_NO_TERMINAL_KEY,
+  restoredShellExitView,
   shellViewIsStale,
   terminalTabKey,
   useTerminals,
@@ -1172,9 +1173,7 @@ export function AppShell() {
   // from it, otherwise chat. `setView` resolves the agent terminal
   // robustly (and falls back to chat when none is open).
   const exitShellView = useCallback(() => {
-    const prev = lastNonShellKeyRef.current;
-    if (prev && isAgentTerminalKey(prev)) setView("terminal");
-    else setView("chat");
+    setView(restoredShellExitView(lastNonShellKeyRef.current));
   }, [setView]);
 
   // Auto-exit shell view when the active shell leaves the terminal list

--- a/web/src/shell/InlineTerminalsSection.test.tsx
+++ b/web/src/shell/InlineTerminalsSection.test.tsx
@@ -46,6 +46,7 @@ const TERMINAL_FIRST_SDK_CTX = {
   view: "chat",
   terminalViewKey: null,
   setView: () => {},
+  exitShellView: () => {},
   terminalsAvailable: true,
   terminalStartingUp: false,
 } as TerminalFirstContextValue;

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -57,12 +57,12 @@ const BASH_SHELL: TerminalInfo = {
  * TerminalFirst context for the two session shapes under test — the
  * terminal-first SDK session and the native wrapper; both render the
  * agent terminal chrome-free and shells via the shell view.
- * `setView` is a spy so the shell view's close affordance is
+ * `exitShellView` is a spy so the shell view's close affordance is
  * assertable.
  */
 function makeCtx(
   isNativeWrapper: boolean,
-  setView: (view: "chat" | "terminal") => void = () => {},
+  exitShellView: () => void = () => {},
 ): TerminalFirstContextValue {
   return {
     isClaudeNative: isNativeWrapper,
@@ -71,7 +71,8 @@ function makeCtx(
     isShellView: false,
     view: "terminal",
     terminalViewKey: null,
-    setView,
+    setView: () => {},
+    exitShellView,
     terminalsAvailable: true,
     terminalStartingUp: false,
   } as TerminalFirstContextValue;
@@ -82,17 +83,17 @@ function renderView({
   isNativeWrapper = false,
   initialTerminalKey = null,
   readOnly = false,
-  setView,
+  exitShellView,
 }: {
   terminals: TerminalInfo[];
   isNativeWrapper?: boolean;
   initialTerminalKey?: string | null;
   readOnly?: boolean;
-  setView?: (view: "chat" | "terminal") => void;
+  exitShellView?: () => void;
 }) {
   useTerminalsMock.mockReturnValue({ terminals, isLoading: false, error: null });
   return render(
-    <TerminalFirstContextProvider value={makeCtx(isNativeWrapper, setView)}>
+    <TerminalFirstContextProvider value={makeCtx(isNativeWrapper, exitShellView)}>
       <MainTerminalView
         conversationId="conv_sdk"
         initialTerminalKey={initialTerminalKey}
@@ -151,11 +152,11 @@ describe("MainTerminalView — terminal-first SDK sessions", () => {
   });
 
   it("renders a rail-opened shell chrome-free: shell header + close, no agent tab", () => {
-    const setView = vi.fn();
+    const exitShellView = vi.fn();
     renderView({
       terminals: [REPL_TERMINAL, BASH_SHELL],
       initialTerminalKey: "terminal:terminal_bash_s1",
-      setView,
+      exitShellView,
     });
 
     // The shell replaced the view (this is the rail row's target).
@@ -170,10 +171,12 @@ describe("MainTerminalView — terminal-first SDK sessions", () => {
     expect(screen.queryByText("tui")).toBeNull();
     expect(screen.queryByTestId("new-shell-button")).toBeNull();
 
-    // The close X is the way back to chat (the Chat/Terminal pill is
-    // hidden in shell view — ConnectionIndicator gates on isShellView).
+    // The close X delegates to exitShellView, which restores the pre-shell
+    // view (chat or the agent terminal — AppShell owns which). The
+    // Chat/Terminal pill is hidden in shell view (ConnectionIndicator gates
+    // on isShellView), so this ✕ is the way out.
     fireEvent.click(screen.getByRole("button", { name: "Close shell" }));
-    expect(setView).toHaveBeenCalledWith("chat");
+    expect(exitShellView).toHaveBeenCalled();
   });
 });
 
@@ -210,22 +213,22 @@ describe("MainTerminalView — native wrapper sessions", () => {
       session: "main",
       running: true,
     };
-    const setView = vi.fn();
+    const exitShellView = vi.fn();
     renderView({
       terminals: [claudePane, BASH_SHELL],
       isNativeWrapper: true,
       initialTerminalKey: "terminal:terminal_bash_s1",
-      setView,
+      exitShellView,
     });
 
     // Same shell-view contract as SDK sessions: shell header only, no
-    // vendor-pane tab, X back to chat.
+    // vendor-pane tab, X delegates to exitShellView (restore prior view).
     expect(screen.getByTestId("terminal-view")).toHaveAttribute(
       "data-terminal-id",
       "terminal_bash_s1",
     );
     expect(screen.queryByText("claude")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Close shell" }));
-    expect(setView).toHaveBeenCalledWith("chat");
+    expect(exitShellView).toHaveBeenCalled();
   });
 });

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -99,7 +99,8 @@ export function MainTerminalView({
   // a single header row naming the shell plus a close X — no agent tab
   // (the shell is not the agent). The Chat/Terminal pill is hidden in
   // this state too (ConnectionIndicator gates on the context's
-  // `isShellView`), so the X is the way back to chat.
+  // `isShellView`), so the X is the way out — back to whatever showed
+  // before the shell took over (chat or the agent terminal).
   const isShellView =
     (terminalFirstCtx?.isTerminalFirst ?? false) &&
     activeTerminal !== null &&
@@ -151,7 +152,7 @@ export function MainTerminalView({
                 <button
                   type="button"
                   aria-label="Close shell"
-                  onClick={() => terminalFirstCtx?.setView("chat")}
+                  onClick={() => terminalFirstCtx?.exitShellView()}
                   className="cursor-pointer rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
                 >
                   <XIcon className="size-3.5" />

--- a/web/src/shell/NewTerminalButton.test.tsx
+++ b/web/src/shell/NewTerminalButton.test.tsx
@@ -39,6 +39,7 @@ function terminalFirstCtx(isNativeWrapper: boolean): TerminalFirstContextValue {
     view: "chat",
     terminalViewKey: null,
     setView: () => {},
+    exitShellView: () => {},
     terminalsAvailable: true,
     terminalStartingUp: false,
   } as TerminalFirstContextValue;

--- a/web/src/shell/TerminalFirstContext.tsx
+++ b/web/src/shell/TerminalFirstContext.tsx
@@ -60,6 +60,14 @@ export interface TerminalFirstContextValue {
   /** Switch view. `"terminal"` opens the terminal surface. */
   setView: (view: TerminalFirstView) => void;
   /**
+   * Leave the current user-shell view, returning to whatever was showing
+   * before the shell took over the main view — the agent terminal if that
+   * was the prior view, otherwise chat. The shell view's close (✕)
+   * affordance calls this so closing a shell never strands the user on a
+   * hard-coded destination.
+   */
+  exitShellView: () => void;
+  /**
    * True when a terminal exists AND is reachable (the runner is online) —
    * i.e. there's a PTY the "Terminal" pill can open right now. False on a
    * stopped/offline runner, which greys the button.


### PR DESCRIPTION
## Related issue

Closes #479

## Summary

In a terminal-first session, opening a user shell from the **Shells** rail
takes over the main view. Closing it (the ✕) always called `setView("chat")`,
so you were dropped into **chat** — even when you had opened the shell from the
agent **Terminal** view. And while a shell owns the view the `Chat | Terminal`
pill is hidden (`isShellView`), so the ✕ was the *only* way back. Net effect:
closing a shell silently discarded your Chat-vs-Terminal pill state.

This PR remembers the last non-shell view and restores it on close:

- `AppShell` tracks the last non-shell view in `lastNonShellKeyRef` (chat =
  `null`, or the agent-terminal key) and exposes a new `exitShellView()` on
  `TerminalFirstContext`.
- `MainTerminalView`'s ✕ calls `exitShellView()` instead of hard-coding chat.
- Came from chat → back to chat; came from the agent terminal → back to the
  agent terminal (the pill reappears there). Shell→shell chains keep the
  original pre-chain view.
- The same restore runs when the shell dies on its own (the user types
  `exit`): `AppShell` watches for the open panel key going stale
  (`shellViewIsStale`) and exits shell view itself. That path is the actual
  #479 scenario — the pane silently falls back to the agent terminal while the
  pill stays hidden, so there is no way back to chat at all.

This is the same root cause as #479 (closing a shell strands the view); the
shipped 0.6.0 release exhibits it too.

## Test Plan

- `npx tsc -b` — clean.
- `npx vitest run` on the touched suites (`MainTerminalView`, `NewTerminalButton`,
  `InlineTerminalsSection`, `ConnectionIndicator`, `RunnerStartingIndicator`) —
  **46 passed**. `MainTerminalView.test.tsx` now asserts the ✕ delegates to
  `exitShellView` rather than a hard-coded `setView("chat")`.
- `uv run pytest tests/e2e_ui/shells/` — **7 passed** (3 new + the 3 existing
  `test_new_shell` cases + `test_terminal_session_links`, all green).
- **The new e2e tests were verified to actually fail without the fix.** Reverted
  the four changed sources to `main`, rebuilt the UI, re-ran: the came-from-chat
  case passes (unchanged behaviour — it is the control), and both new-behaviour
  cases fail. The typed-`exit` one fails with *no* `Chat | Terminal` pill
  present on the page, which is precisely the stranding this PR fixes.
- Manual, via the Vite dev server against a live claude-native session: open a
  shell from the Shells rail from **Chat** → ✕ returns to Chat; open a shell
  from the agent **Terminal** view → ✕ returns to the agent terminal with the
  `Chat | Terminal` pill restored.

### New e2e coverage

`tests/e2e_ui/shells/test_shell_close_restores_view.py`, on the existing
`terminal_session` fixture (a runner-bound SDK session, which the runner makes
terminal-first by auto-creating the Omnigent REPL terminal and stamping
`omnigent.ui: terminal`):

| Test | Drives | Asserts |
| --- | --- | --- |
| `test_close_shell_opened_from_chat_returns_to_chat` | chat → shell → ✕ | terminal surface gone, pill shows **Chat** |
| `test_close_shell_opened_from_terminal_returns_to_terminal` | Terminal → shell → ✕ | still on `terminal_tui_main`, pill shows **Terminal** |
| `test_typing_exit_in_shell_restores_the_previous_view` | Terminal → shell → type `exit` | view restores with **no click**, pill is back |

The `exit` test asserts on the *pill*, not the rendered pane: `MainTerminalView`
re-targets the agent terminal on its own either way, so pane identity looks
correct even when broken. Pill visibility is what separates restored from
stranded.

## Demo

**Before** — closing a shell dumps you into Chat even when you opened it from Terminal:

https://github.com/user-attachments/assets/93159181-d50c-4173-8998-f1c3d3c03f86

**After** — closing a shell returns you to the view you came from (Terminal → Terminal, and chat -> chat):

https://github.com/user-attachments/assets/71d3c1fe-bd71-4703-b00a-1738e1d4329b


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Three layers, no overlap:

- **Unit (`MainTerminalView.test.tsx`)** — the ✕ delegates to `exitShellView`
  rather than a hard-coded `setView("chat")`.
- **Unit (`useTerminals.test.ts`)** — the two pure helpers the state machine
  rests on: `shellViewIsStale` (shell present / gone via `exit` / chat / agent
  terminal / empty-list guard) and `restoredShellExitView` (all three branches,
  including the `PANEL_NO_TERMINAL_KEY` empty string, which is falsy and so must
  not be lumped in with the `null` = chat case).
- **E2E (`tests/e2e_ui/shells/test_shell_close_restores_view.py`)** — the wiring
  the unit tests can't reach: `lastNonShellKeyRef` capture, the auto-exit effect,
  and pill visibility, driven end-to-end against a real runner + PTY. Proven
  non-vacuous by re-running against the pre-fix sources (see Test Plan).

## Changelog

Closing a shell now returns you to the view you came from (chat or the agent terminal) instead of always dropping into chat

