### PR TITLE
perf(db): drop conversations title-unique index + title_hash column

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -36,11 +36,6 @@ from omnigent.db.compression import CompressedText
 # BINARY(32) there — an exact fit for the digest and fully indexable.
 _CKSUM32 = LargeBinary(32).with_variant(MySQLBinary(32), "mysql")
 
-# 16-byte (truncated sha256) digest column, same rationale as _CKSUM32 but half
-# the width. 128 bits of collision resistance is ample for a per-parent unique
-# key, so the conversation title hash uses this narrower form.
-_CKSUM16 = LargeBinary(16).with_variant(MySQLBinary(16), "mysql")
-
 
 # Hex length of a bare uuid4 id, the canonical Python-side form.
 _UUID_HEX_LEN = 32
@@ -659,28 +654,6 @@ class SqlConversationMetadata(OmnigentBase):
     )
 
 
-def conversation_title_hash(title: str) -> bytes:
-    """Return the 16-byte truncated sha256 digest of a conversation title.
-
-    ``ix_conversations_parent_title_unique`` keys on this instead of a wide
-    512-char title prefix, so the unique index stays a fixed 16 bytes. The full
-    title is hashed verbatim (no normalization), so two titles collide iff their
-    digests do — uniqueness is exact and case-sensitive.
-    """
-    return hashlib.sha256(title.encode("utf-8")).digest()[:16]
-
-
-def _default_conversation_title_hash(context: Any) -> bytes:
-    """Column default: derive ``title_hash`` from the bound ``title`` on INSERT.
-
-    ``title`` carries a ``server_default=""``, so an INSERT that omits it leaves
-    ``title`` out of the bound params — fall back to ``""`` to match the stored
-    value. Column defaults do not fire on UPDATE, so the store recomputes it
-    explicitly on the rename paths.
-    """
-    return conversation_title_hash(context.get_current_parameters().get("title") or "")
-
-
 class SqlConversation(ConversationBase):
     """
     SQLAlchemy model for the ``conversations`` table.
@@ -726,14 +699,6 @@ class SqlConversation(ConversationBase):
     created_at: Mapped[int] = mapped_column(Integer)
     updated_at: Mapped[int] = mapped_column(Integer)
     title: Mapped[str] = mapped_column(String(768), nullable=False, server_default="")
-    # Fixed-width sha256(title)[:16] mirror of ``title`` that the unique index
-    # keys on instead of a wide title prefix. The ORM default stamps it on INSERT
-    # and the store recomputes it on rename, so every app-created row has a hash;
-    # it is nullable only so raw-SQL inserts (tests/tooling that bypass the ORM
-    # default) don't have to supply it.
-    title_hash: Mapped[bytes | None] = mapped_column(
-        _CKSUM16, nullable=True, default=_default_conversation_title_hash
-    )
     parent_conversation_id: Mapped[str | None] = mapped_column(
         Uuid16(),
         nullable=True,
@@ -782,18 +747,10 @@ class SqlConversation(ConversationBase):
             "agent_id",
             "id",
         ),
-        # Unique index on (parent_conversation_id, title_hash) prevents two
-        # same-named children under the same parent. Keys on the fixed-width
-        # title_hash rather than a wide title prefix. NULLs are distinct in a
-        # unique index, so top-level conversations (NULL parent) are exempt.
-        Index(
-            "ix_conversations_parent_title_unique",
-            "workspace_id",
-            "parent_conversation_id",
-            "title_hash",
-            unique=True,
-        ),
-        # Composite index for child-session listing.
+        # Child-session listing, and the per-parent title lookup that backs the
+        # application-level (parent, title) uniqueness check in create_conversation
+        # (no DB unique constraint: the check seeks this parent's children here and
+        # filters title as a residual).
         Index(
             "idx_conversations_parent",
             "workspace_id",

--- a/omnigent/db/migrations/versions/72e6dceae14f_drop_conversations_title_hash.py
+++ b/omnigent/db/migrations/versions/72e6dceae14f_drop_conversations_title_hash.py
@@ -1,0 +1,148 @@
+"""Drop the per-parent title-uniqueness index and the ``title_hash`` column.
+
+Revision ID: 72e6dceae14f
+Revises: b3c1a2d4e5f6
+Create Date: 2026-07-21 00:00:00.000000
+
+``conversations`` enforced per-parent child-title uniqueness with a UNIQUE index
+on ``(workspace_id, parent_conversation_id, title_hash)``, where ``title_hash``
+was a fixed 16-byte ``sha256(title)[:16]`` mirror of ``title`` maintained solely
+to key that index. Uniqueness now lives in application code
+(``create_conversation`` does a per-parent ``(parent, title)`` existence check
+before inserting), so both the index and the column are removed. Reads that used
+to touch the unique index — the runner's find-or-create pre-check and the new
+create-time check — are served by ``idx_conversations_parent``
+(``workspace_id, parent_conversation_id, ...``), which seeks the parent's
+children and filters ``title`` as a residual.
+
+The column drop uses ``batch_alter_table`` so SQLite (which needs a table
+rebuild for ``DROP COLUMN`` on older versions) is handled uniformly. On SQLite
+the DESC-ordered ``idx_conversations_parent`` is dropped and recreated
+explicitly around the rebuild so its column sort order is not lost to batch
+reflection; MySQL/Postgres drop the column with native ``ALTER`` and leave every
+other index untouched.
+
+Downgrade re-adds ``title_hash`` (nullable), back-fills
+``title_hash = sha256(title)[:16]`` in Python (keyset-batched to bound memory —
+SQLite has no ``sha256()`` SQL function), and restores the UNIQUE index on it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import BINARY as MySQLBinary
+
+revision: str = "72e6dceae14f"
+down_revision: str | None = "b3c1a2d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# BYTEA/BLOB elsewhere, BINARY(16) on MySQL (BLOB is not indexable there).
+_CKSUM16 = sa.LargeBinary(length=16).with_variant(MySQLBinary(16), "mysql")
+
+_UNIQUE_INDEX = "ix_conversations_parent_title_unique"
+_PARENT_INDEX = "idx_conversations_parent"
+_BACKFILL_BATCH = 1000
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def _title_hash(title: str) -> bytes:
+    """First 16 bytes of sha256(title) (kept self-contained in the migration)."""
+    return hashlib.sha256(title.encode("utf-8")).digest()[:16]
+
+
+def _create_parent_index() -> None:
+    """Recreate ``idx_conversations_parent`` with its DESC ordering intact."""
+    op.create_index(
+        _PARENT_INDEX,
+        "conversations",
+        [
+            "workspace_id",
+            "parent_conversation_id",
+            sa.text("created_at DESC"),
+            sa.text("id DESC"),
+        ],
+    )
+
+
+def _backfill_title_hash() -> None:
+    """Compute ``title_hash`` for every existing row in Python, keyset-batched.
+
+    Pages by the ``(workspace_id, id)`` primary key so memory stays bounded to
+    one batch regardless of table size (unlike a single ``fetchall``).
+    """
+    bind = op.get_bind()
+    last_ws: int | None = None
+    last_id: object = None
+    while True:
+        if last_ws is None:
+            rows = bind.execute(
+                sa.text(
+                    "SELECT workspace_id, id, title FROM conversations "
+                    "ORDER BY workspace_id, id LIMIT :lim"
+                ),
+                {"lim": _BACKFILL_BATCH},
+            ).fetchall()
+        else:
+            rows = bind.execute(
+                sa.text(
+                    "SELECT workspace_id, id, title FROM conversations "
+                    "WHERE workspace_id > :ws OR (workspace_id = :ws AND id > :id) "
+                    "ORDER BY workspace_id, id LIMIT :lim"
+                ),
+                {"ws": last_ws, "id": last_id, "lim": _BACKFILL_BATCH},
+            ).fetchall()
+        if not rows:
+            break
+        for workspace_id, conv_id, title in rows:
+            bind.execute(
+                sa.text(
+                    "UPDATE conversations SET title_hash = :h "
+                    "WHERE workspace_id = :ws AND id = :id"
+                ),
+                {"h": _title_hash(title or ""), "ws": workspace_id, "id": conv_id},
+            )
+        last_ws, last_id = rows[-1][0], rows[-1][1]
+        if len(rows) < _BACKFILL_BATCH:
+            break
+
+
+def upgrade() -> None:
+    """Drop the unique index, then the ``title_hash`` column."""
+    sqlite = _is_sqlite()
+    op.drop_index(_UNIQUE_INDEX, table_name="conversations")
+
+    if sqlite:
+        # The table rebuild would reflect and re-emit idx_conversations_parent,
+        # losing its DESC column ordering; drop it first and recreate it by hand.
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+        op.drop_index(_PARENT_INDEX, table_name="conversations")
+        with op.batch_alter_table("conversations", recreate="always") as batch_op:
+            batch_op.drop_column("title_hash")
+        _create_parent_index()
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))
+    else:
+        # Batch (never on the bare op proxy) so the SQLite-safe-DDL guard passes;
+        # on MySQL/Postgres "auto" mode issues a native ALTER ... DROP COLUMN with
+        # no table rebuild, leaving every other index untouched.
+        with op.batch_alter_table("conversations") as batch_op:
+            batch_op.drop_column("title_hash")
+
+
+def downgrade() -> None:
+    """Restore ``title_hash`` (back-filled) and the UNIQUE index on it."""
+    op.add_column("conversations", sa.Column("title_hash", _CKSUM16, nullable=True))
+    _backfill_title_hash()
+    op.create_index(
+        _UNIQUE_INDEX,
+        "conversations",
+        ["workspace_id", "parent_conversation_id", "title_hash"],
+        unique=True,
+    )

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -36,7 +36,6 @@ from omnigent.db.db_models import (
     SqlPolicy,
     SqlSessionPermission,
     SqlUserDailyCost,
-    conversation_title_hash,
     current_workspace_id,
     uuid_to_bytes,
 )
@@ -900,6 +899,30 @@ class SqlAlchemyConversationStore(ConversationStore):
             if parent_conversation_id is not None and not title:
                 title = f"untitled:{new_id}"
             with self._conv_session() as ap_sess:
+                # Application-level (parent, title) uniqueness — there is no DB
+                # unique constraint. Only children are scoped; top-level sessions
+                # (NULL parent) may reuse titles freely. The SELECT seeks this
+                # parent's children via idx_conversations_parent and filters
+                # title as a residual. Best-effort: a concurrent same-name create
+                # can still race past this check, yielding a duplicate child
+                # rather than an error (the common repeat-send path is served by
+                # the runner's find-or-create pre-check, so this fires only on a
+                # genuine collision).
+                if parent_conversation_id is not None:
+                    duplicate = ap_sess.execute(
+                        select(SqlConversation.id)
+                        .where(
+                            SqlConversation.workspace_id == current_workspace_id(),
+                            SqlConversation.parent_conversation_id == parent_conversation_id,
+                            SqlConversation.title == (title or ""),
+                        )
+                        .limit(1)
+                    ).first()
+                    if duplicate is not None:
+                        raise NameAlreadyExistsError(
+                            f"sub-agent name already exists under parent "
+                            f"{parent_conversation_id!r}: title={title!r}"
+                        )
                 row = SqlConversation(
                     id=new_id,
                     created_at=now,
@@ -926,21 +949,17 @@ class SqlAlchemyConversationStore(ConversationStore):
                 meta_sess.add(meta)
             return _to_conversation(row, meta)
         except IntegrityError as exc:
-            # Translate the unique-index violation into a
-            # clean exception type the spawn/send tools can map
-            # to a name_already_exists tool error. Other integrity
-            # violations (FK, check constraints) re-raise.
+            # Translate a caller-supplied-id PK collision into a clean exception
+            # type. Per-parent title uniqueness is enforced by the SELECT above,
+            # not a DB constraint, so only the id PK violation is handled here;
+            # other integrity violations (FK, check constraints) re-raise.
             #
             # Detection prefers the PK constraint name (Postgres/MySQL surface it
             # directly), and falls back on SQLite's failed-column signature:
             #   Postgres → "pk_conversations" (repo naming convention; the stock
             #     "conversations_pkey" is kept as a defensive fallback)
             #   MySQL    → duplicate entry ... for key '...PRIMARY'
-            #   SQLite   → "conversations.id" (dotted) — appears only in the
-            #     "UNIQUE constraint failed: …" clause, never in the INSERT
-            #     column list, so it cleanly separates from the title-uniqueness
-            #     index (which names title_hash, not id).
-            # id is checked before title. Other integrity violations re-raise.
+            #   SQLite   → "conversations.id" (dotted) in the failed-UNIQUE clause.
             msg = str(exc).lower()
             is_id_unique_violation = conversation_id is not None and (
                 "pk_conversations" in msg
@@ -954,14 +973,6 @@ class SqlAlchemyConversationStore(ConversationStore):
             if is_id_unique_violation:
                 raise ConversationAlreadyExistsError(
                     f"conversation id {conversation_id!r} already exists"
-                ) from exc
-            is_title_unique_violation = "ix_conversations_parent_title_unique" in msg or (
-                "unique" in msg and "parent_conversation_id" in msg and "title" in msg
-            )
-            if is_title_unique_violation:
-                raise NameAlreadyExistsError(
-                    f"sub-agent name already exists under parent "
-                    f"{parent_conversation_id!r}: title={title!r}"
                 ) from exc
             raise
 
@@ -2427,8 +2438,6 @@ class SqlAlchemyConversationStore(ConversationStore):
             ap_changed = False
             if title is not None:
                 row.title = title or ""
-                # Column default only fires on INSERT; keep the hash in sync here.
-                row.title_hash = conversation_title_hash(row.title)
                 ap_changed = True
             # Read-modify-write the override blob so partial updates preserve the
             # keys they don't touch. Only re-encode when something actually changed.
@@ -2502,10 +2511,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversation.id == conversation_id,
                     SqlConversation.title == expected_title,
                 )
-                # Bulk UPDATE bypasses the column default, so stamp the hash here.
                 .values(
                     title=title,
-                    title_hash=conversation_title_hash(title),
                     updated_at=now_epoch(),
                 )
             )

--- a/tests/db/test_migration_conversations_title_hash.py
+++ b/tests/db/test_migration_conversations_title_hash.py
@@ -6,6 +6,11 @@ Per-parent child-title uniqueness used to key a UNIQUE index on the wide
 it, so entries are a fixed 16 bytes. Uniqueness semantics are unchanged: two
 titles collide iff their digests do. These tests assert the post-migration
 shape, the backfill, and that the downgrade restores the title-keyed index.
+
+These pin to ``a2b7c3d8e4f9`` explicitly, not head: a later migration
+(``72e6dceae14f``) drops the column and index once uniqueness moved into
+application code, so the column is absent at head. Head-state coverage lives in
+``test_migration_drop_conversations_title_hash.py``.
 """
 
 from __future__ import annotations
@@ -22,7 +27,6 @@ from sqlalchemy.engine import Engine
 from omnigent.db.utils import (
     _build_alembic_config,
     clear_engine_cache,
-    get_or_create_engine,
 )
 
 _NEW_REVISION = "a2b7c3d8e4f9"
@@ -37,11 +41,17 @@ def _title_hash(title: str) -> bytes:
 
 @pytest.fixture
 def db_engine(tmp_path: Path) -> Iterator[Engine]:
-    """Fresh SQLite DB with the full alembic chain applied (at head)."""
-    engine = get_or_create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    """Fresh SQLite DB migrated to ``a2b7c3d8e4f9`` (where title_hash exists)."""
+    uri = f"sqlite:///{tmp_path / 'test.db'}"
+    cfg = _build_alembic_config(uri)
+    engine = sa.create_engine(uri)
+    with engine.begin() as conn:
+        cfg.attributes["connection"] = conn
+        command.upgrade(cfg, _NEW_REVISION)
     try:
         yield engine
     finally:
+        engine.dispose()
         clear_engine_cache()
 
 

--- a/tests/db/test_migration_drop_conversations_title_hash.py
+++ b/tests/db/test_migration_drop_conversations_title_hash.py
@@ -1,0 +1,138 @@
+"""Tests for migration ``72e6dceae14f`` (drop title_hash + the unique index).
+
+Per-parent child-title uniqueness moved into application code
+(``create_conversation`` seeks the parent's children before inserting), so the
+UNIQUE index ``ix_conversations_parent_title_unique`` and the ``title_hash``
+column that keyed it are removed. These assert the head shape (both gone,
+``idx_conversations_parent`` preserved with its DESC ordering) and that the
+downgrade restores the column, its backfill, and the index.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+
+_REVISION = "72e6dceae14f"
+_PRE_REVISION = "b3c1a2d4e5f6"
+_UNIQUE_INDEX = "ix_conversations_parent_title_unique"
+_PARENT_INDEX = "idx_conversations_parent"
+
+
+def _title_hash(title: str) -> bytes:
+    return hashlib.sha256(title.encode("utf-8")).digest()[:16]
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Fresh SQLite DB with the full alembic chain applied (at head)."""
+    engine = get_or_create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+def test_title_hash_column_gone_at_head(db_engine: Engine) -> None:
+    """``conversations.title_hash`` is absent once the migration has applied."""
+    cols = {c["name"] for c in sa.inspect(db_engine).get_columns("conversations")}
+    assert "title_hash" not in cols, f"title_hash should be dropped at head: {cols}"
+
+
+def test_unique_index_gone_at_head(db_engine: Engine) -> None:
+    """The per-parent title UNIQUE index is dropped; uniqueness is app-level."""
+    idx = {i["name"] for i in sa.inspect(db_engine).get_indexes("conversations")}
+    assert _UNIQUE_INDEX not in idx, f"{_UNIQUE_INDEX} should be gone: {sorted(idx)}"
+
+
+def test_parent_index_preserved_at_head(db_engine: Engine) -> None:
+    """``idx_conversations_parent`` survives the column drop (SQLite rebuild)."""
+    idx = {i["name"]: i for i in sa.inspect(db_engine).get_indexes("conversations")}
+    assert _PARENT_INDEX in idx, f"{_PARENT_INDEX} missing: {sorted(idx)}"
+    assert idx[_PARENT_INDEX]["column_names"] == [
+        "workspace_id",
+        "parent_conversation_id",
+        "created_at",
+        "id",
+    ], idx[_PARENT_INDEX]["column_names"]
+
+
+def test_parent_index_keeps_desc_ordering(tmp_path: Path) -> None:
+    """The rebuilt ``idx_conversations_parent`` keeps its ``DESC`` sort order.
+
+    SQLAlchemy's SQLite reflection doesn't surface column sort direction, so
+    assert against the raw DDL in ``sqlite_master`` instead.
+    """
+    uri = f"sqlite:///{tmp_path / 'ddl.db'}"
+    cfg = _build_alembic_config(uri)
+    engine = sa.create_engine(uri)
+    try:
+        with engine.begin() as conn:
+            cfg.attributes["connection"] = conn
+            command.upgrade(cfg, _REVISION)
+        with engine.connect() as conn:
+            ddl = conn.execute(
+                sa.text("SELECT sql FROM sqlite_master WHERE type='index' AND name = :n"),
+                {"n": _PARENT_INDEX},
+            ).scalar_one()
+        assert "created_at DESC" in ddl and "id DESC" in ddl, ddl
+    finally:
+        engine.dispose()
+        clear_engine_cache()
+
+
+def test_downgrade_restores_hash_index_and_backfills(tmp_path: Path) -> None:
+    """Downgrade re-adds ``title_hash`` (back-filled) and the UNIQUE index."""
+    uri = f"sqlite:///{tmp_path / 'roundtrip.db'}"
+    cfg = _build_alembic_config(uri)
+    engine = sa.create_engine(uri)
+    conv_id = "94c349190e241f85a984b3df8f129696"
+    title = "coder:legacy session"
+    try:
+        with engine.begin() as conn:
+            cfg.attributes["connection"] = conn
+            command.upgrade(cfg, _REVISION)
+            # Seed a row at head (no title_hash) to prove the backfill.
+            conn.execute(
+                sa.text(
+                    "INSERT INTO conversations "
+                    "(workspace_id, id, created_at, updated_at, root_conversation_id, title) "
+                    "VALUES (0, :id, 1, 1, :id, :t)"
+                ),
+                {"id": conv_id, "t": title},
+            )
+        with engine.begin() as conn:
+            cfg.attributes["connection"] = conn
+            command.downgrade(cfg, _PRE_REVISION)
+
+        insp = sa.inspect(engine)
+        cols = {c["name"] for c in insp.get_columns("conversations")}
+        assert "title_hash" in cols, "downgrade must restore title_hash."
+        idx = {i["name"]: i for i in insp.get_indexes("conversations")}
+        assert idx[_UNIQUE_INDEX]["unique"], f"{_UNIQUE_INDEX} must be UNIQUE again."
+        assert idx[_UNIQUE_INDEX]["column_names"] == [
+            "workspace_id",
+            "parent_conversation_id",
+            "title_hash",
+        ], idx[_UNIQUE_INDEX]["column_names"]
+        with engine.connect() as conn:
+            stored = conn.execute(
+                sa.text("SELECT title_hash FROM conversations WHERE id = :id"),
+                {"id": conv_id},
+            ).scalar_one()
+        assert bytes(stored) == _title_hash(title), "backfilled hash != sha256(title)[:16]"
+    finally:
+        engine.dispose()
+        clear_engine_cache()

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -1987,7 +1987,7 @@ def test_create_conversation_with_parent_pointer_and_title(
 def test_create_duplicate_title_under_same_parent_raises(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """G36: partial unique index rejects ``(parent_id, title)`` duplicates."""
+    """The app-level ``(parent, title)`` check rejects sibling duplicates."""
     from omnigent.stores.conversation_store import NameAlreadyExistsError
 
     parent = conversation_store.create_conversation()
@@ -1996,11 +1996,10 @@ def test_create_duplicate_title_under_same_parent_raises(
         title="coder:auth",
         parent_conversation_id=parent.id,
     )
-    # Without the partial unique index + IntegrityError-to-
-    # NameAlreadyExistsError translation, the second create
-    # would either succeed silently (creating a duplicate row)
-    # or raise a raw sqlalchemy IntegrityError that would leak
-    # through to the LLM as an opaque error.
+    # There is no DB unique constraint: create_conversation seeks this parent's
+    # children and raises NameAlreadyExistsError when the title is already taken,
+    # so a duplicate sub-agent name surfaces cleanly instead of creating a
+    # second ambiguous row.
     with pytest.raises(NameAlreadyExistsError):
         conversation_store.create_conversation(
             kind="sub_agent",
@@ -2012,7 +2011,7 @@ def test_create_duplicate_title_under_same_parent_raises(
 def test_create_same_title_under_different_parents_succeeds(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """The unique constraint is per-parent — ``(p1, "auth")`` and ``(p2, "auth")`` coexist."""
+    """Uniqueness is per-parent — ``(p1, "auth")`` and ``(p2, "auth")`` coexist."""
     p1 = conversation_store.create_conversation()
     p2 = conversation_store.create_conversation()
     conversation_store.create_conversation(
@@ -2022,9 +2021,8 @@ def test_create_same_title_under_different_parents_succeeds(
     conversation_store.create_conversation(
         kind="sub_agent", title="coder:auth", parent_conversation_id=p2.id
     )
-    # Both children must exist; if the unique constraint were
-    # global (not partial-by-parent), the second create would
-    # raise.
+    # Both children must exist; the app-level check scopes to a single parent,
+    # so a same-title child under a different parent is never a collision.
     p1_children = conversation_store.list_conversations(
         kind="sub_agent",
         parent_conversation_id=p1.id,
@@ -2042,11 +2040,10 @@ def test_create_same_title_under_different_parents_succeeds(
 def test_create_null_parent_allows_duplicate_titles(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """Top-level conversations (NULL parent) are NOT subject to the unique constraint."""
-    # Both conversations share title="" and parent=None. The unique index on
-    # (parent_conversation_id, title) still allows this: a NULL in any indexed
-    # column makes the key distinct, so top-level rows never collide even
-    # without a WHERE predicate.
+    """Top-level conversations (NULL parent) are NOT subject to the uniqueness check."""
+    # Both conversations share title="" and parent=None. The app-level check in
+    # create_conversation only runs when parent_conversation_id is set, so
+    # top-level rows may share a title freely.
     a = conversation_store.create_conversation()
     b = conversation_store.create_conversation()
     assert a.id != b.id


### PR DESCRIPTION
## Related issue

N/A

## Summary

Per-parent child-title uniqueness was enforced by a UNIQUE index on
`(workspace_id, parent_conversation_id, title_hash)`, where `title_hash` was a
16-byte `sha256(title)[:16]` mirror of `title` maintained **solely** to key that
index. Reads never touched it — the runner's find-or-create pre-check filters on
`title`, whose 3rd index column was `title_hash` — so the index was pure write
amplification and the column was dead weight.

- Move the check into `create_conversation`: a per-parent `(parent, title)`
  existence `SELECT` served by the existing `idx_conversations_parent`, raising
  `NameAlreadyExistsError` on a hit. Only children are scoped; top-level (NULL
  parent) sessions may reuse titles freely, exactly as before.
- Drop the UNIQUE index, the `title_hash` column, both hash helpers, the
  `_CKSUM16` alias, the ORM default, the two rename-path recomputes, and the
  store's `IntegrityError`→title translation (the id-PK branch stays).
- Migration `72e6dceae14f`. SQLite drops/recreates `idx_conversations_parent` by
  hand around the batch rebuild so its `DESC` ordering survives; MySQL/Postgres
  use native `DROP COLUMN`. Downgrade re-adds `title_hash`, back-fills it in
  Python (keyset-batched), and restores the unique index.

**Trade-off (intentional):** the DB index was the atomic backstop for concurrent
same-name spawns — and tool calls within a turn dispatch concurrently, so a
fan-out emitting two same-named children could hit it. The app check is
best-effort, so that rare race now yields a stranded duplicate child + a wasted
runner instead of a clean error. Bounded (the continue-lookup targets the newest;
no data corruption), and the common repeat-send path is unaffected (served by the
runner's find-or-create pre-check).

## Test Plan

```bash
uv run alembic -c omnigent/db/alembic.ini heads          # single head: 72e6dceae14f
uv run --extra dev python -m pytest \
  tests/db/test_migration_drop_conversations_title_hash.py \
  tests/db/test_migration_conversations_title_hash.py \
  tests/stores/test_conversation_store.py
```

- New `test_migration_drop_conversations_title_hash.py`: asserts head shape
  (column + unique index gone, `idx_conversations_parent` preserved with its
  `DESC` DDL) and a full downgrade round-trip (column + backfill + index
  restored).
- `test_migration_conversations_title_hash.py` re-pinned to revision
  `a2b7c3d8e4f9` (head no longer has the column).
- `176 passed` on `test_conversation_store.py` (duplicate-raises, cross-parent,
  and NULL-parent-exempt cases updated to the app-level mechanism).
- Server sub-agent title-collision + idempotency integration tests and
  `test_sys_session.py` pass unchanged.
- Manual SQLite round-trip (upgrade → downgrade → re-upgrade) with index/DDL
  inspection confirms the `DESC` ordering and all sibling indexes survive.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the migration upgrade/downgrade/re-upgrade on SQLite and
inspected `sqlite_master` to confirm `idx_conversations_parent` keeps its
`created_at DESC, id DESC` ordering after the column drop, the unique index and
`title_hash` are gone at head, no row data is lost, and the downgrade backfill
matches `sha256(title)[:16]`. MySQL/Postgres paths (native `DROP COLUMN`) are
covered by the stores-mysql / stores-postgres CI shards.
