### PR TITLE
feat(dictation): remote worker engine for offloading speech-to-text

### DIFF
--- a/designs/server-dictation.md
+++ b/designs/server-dictation.md
@@ -97,7 +97,8 @@ connections (default 2, `OMNIGENT_DICTATION_MAX_STREAMS`).
 | `OMNIGENT_DICTATION_MODEL_DIR` | `~/.omnigent/models/dictation/asr` | dir containing `encoder*.onnx`, `decoder*.onnx`, `joiner*.onnx`, `tokens.txt` |
 | `OMNIGENT_DICTATION_PUNCT_DIR` | `~/.omnigent/models/dictation/punct` | optional online-punctuation model dir (`model*.onnx` + `bpe.vocab`) |
 | `OMNIGENT_DICTATION_MAX_STREAMS` | `2` | concurrent dictation WebSockets |
-| `OMNIGENT_DICTATION_ENGINE` | unset (`sherpa`) | engine to use by registered name; `fake` for tests |
+| `OMNIGENT_DICTATION_ENGINE` | unset (`sherpa`) | engine to use by registered name (`sherpa`, `remote`, `fake`) |
+| `OMNIGENT_DICTATION_REMOTE_URL` | unset | worker stream URL for the `remote` engine, e.g. `ws://venus:8100/v1/dictation/stream` |
 
 `scripts/fetch-dictation-models.sh` downloads a known-good pair (streaming
 Nemotron 0.6 B int8 + English online punctuation, both Apache-2.0 upstream)
@@ -132,11 +133,46 @@ recognizer output is emitted as-is), and the mic button's `lang` prop only
 affects the Web Speech path — the server path's language is decided by the
 operator's model choice.
 
-Where a mini-PC server can't run the model an operator wants at realtime, a
-follow-up adds a **remote worker**: a `RemoteDictationEngine` (registered as
-`OMNIGENT_DICTATION_ENGINE=remote`) that relays takes over this same wire
-protocol to a beefier LAN box. It slots into the registry without changing
-the route or the protocol, so it ships separately from this core PR.
+### Remote worker
+
+Where a mini-PC server can't run the model an operator wants at realtime, the
+`remote` engine relays each take to a **dictation worker** on a beefier LAN
+box. The worker is just `create_dictation_router` served on its own — it
+speaks the exact same wire protocol the browser does (PCM frames up,
+transcript events down), so no new protocol or code path was needed. The
+browser never talks to the worker; the main server authenticates the user on
+its own route, then relays over a `websockets` client.
+
+Run the worker wherever the models live (it is **unauthenticated** — bind it
+to a trusted LAN/VPN only):
+
+```
+pip install omnigent[dictation] && scripts/fetch-dictation-models.sh
+python -m omnigent.server.dictation_worker --host 0.0.0.0 --port 8100
+```
+
+Then select the `remote` engine on the main server via env vars — no CLI
+integration is required:
+
+```
+OMNIGENT_DICTATION_ENGINE=remote \
+OMNIGENT_DICTATION_REMOTE_URL=ws://<worker-host>:8100/v1/dictation/stream \
+omnigent server ...
+```
+
+`RemoteDictationEngine` registers by name like every other engine (no changes
+to the route, protocol, or selection logic). `_RemoteStream` bridges the
+worker's async push events into the synchronous handle interface via a daemon
+reader thread, and `close()` releases the worker's capacity slot promptly.
+Fallback is per take: if the worker is unreachable and local models are
+installed, a lazily-built local sherpa engine serves the take instead (its
+weights cost no RAM until the worker actually goes down); each new take
+retries the worker first.
+
+Client timeouts (`web/src/lib/dictation.ts`) are widened to exceed the
+worker's cold-load budget (`_REMOTE_READY_TIMEOUT_S` / `_REMOTE_STOP_TIMEOUT_S`
+in `dictation.py`) so a relayed take doesn't time out on the browser side just
+as the worker finishes loading its model.
 
 ### Routes — `omnigent/server/routes/dictation.py`
 

--- a/omnigent/server/dictation.py
+++ b/omnigent/server/dictation.py
@@ -17,6 +17,11 @@ Engines are looked up by name in a small registry
   model on disk; both are checked lazily so the base install carries no
   new dependencies.
 - ``sherpa`` — the same engine, named explicitly.
+- ``remote`` — relays takes to a dictation worker on another machine
+  (``OMNIGENT_DICTATION_REMOTE_URL``), so a small main server can borrow
+  a beefier LAN box's CPU. Falls back to the local sherpa engine (when
+  models are installed) if the worker is unreachable. See
+  :class:`RemoteDictationEngine` and ``dictation_worker.py``.
 - ``fake`` — a deterministic scripted engine used by tests and the
   Playwright e2e suite; no native dependency, no models, no microphone.
 
@@ -65,11 +70,14 @@ the default locations.
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import json
 import logging
 import os
 import re
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -81,12 +89,20 @@ ENGINE_ENV = "OMNIGENT_DICTATION_ENGINE"
 MODEL_DIR_ENV = "OMNIGENT_DICTATION_MODEL_DIR"
 PUNCT_DIR_ENV = "OMNIGENT_DICTATION_PUNCT_DIR"
 MAX_STREAMS_ENV = "OMNIGENT_DICTATION_MAX_STREAMS"
+#: Worker stream URL for the ``remote`` engine, e.g.
+#: ``ws://venus:8100/v1/dictation/stream``.
+REMOTE_URL_ENV = "OMNIGENT_DICTATION_REMOTE_URL"
 
 #: Built-in engine names. The default (empty ``OMNIGENT_DICTATION_ENGINE``)
 #: resolves to the sherpa engine.
 ENGINE_SHERPA = "sherpa"
 ENGINE_FAKE = "fake"
+ENGINE_REMOTE = "remote"
 _DEFAULT_ENGINE = ENGINE_SHERPA
+
+#: Worker handshake budget: covers a cold model load on the worker side.
+_REMOTE_READY_TIMEOUT_S = 30.0
+_REMOTE_STOP_TIMEOUT_S = 10.0
 
 #: The one PCM format the stream route accepts: 16 kHz mono s16le.
 SAMPLE_RATE = 16000
@@ -96,6 +112,7 @@ _BYTES_PER_SECOND = SAMPLE_RATE * 2
 REASON_EXTRA_NOT_INSTALLED = "extra_not_installed"
 REASON_MODELS_MISSING = "models_missing"
 REASON_UNKNOWN_ENGINE = "unknown_engine"
+REASON_REMOTE_URL_MISSING = "remote_url_missing"
 
 DEFAULT_MAX_STREAMS = 2
 
@@ -455,6 +472,186 @@ class _SherpaStream:
         """No-op: the recognizer stream frees with the handle."""
 
 
+class RemoteDictationEngine:
+    """Relays dictation takes to a remote worker over WebSocket.
+
+    The worker is anything speaking the ``/v1/dictation/stream`` wire
+    protocol — another omnigent server or the standalone
+    ``python -m omnigent.server.dictation_worker``. Lets a small main
+    server (a mini-PC) borrow a beefier LAN box for recognition.
+
+    Fallback happens per take, at stream creation: if the worker is
+    unreachable, the lazily-built local engine (when models are
+    installed) serves the take instead. A worker dying mid-take fails
+    that take; the next one retries the worker.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        fallback_factory: Callable[[], DictationEngine] | None = None,
+    ) -> None:
+        """
+        :param url: Worker stream URL, e.g.
+            ``ws://venus:8100/v1/dictation/stream``.
+        :param fallback_factory: Builds the local fallback engine on
+            first use (lazy — its model weights cost ~real RAM), or
+            ``None`` when no local model is installed.
+        """
+        self._url = url
+        self._fallback_factory = fallback_factory
+        self._fallback: DictationEngine | None = None
+        self._fallback_lock = threading.Lock()
+
+    def create_stream(self) -> DictationStreamHandle:
+        """Connect a take to the worker, or to the local fallback."""
+        try:
+            return _RemoteStream(self._url)
+        except Exception:
+            if self._fallback_factory is None:
+                raise
+            _logger.warning(
+                "dictation worker unreachable at %s; using local fallback engine",
+                self._url,
+                exc_info=True,
+            )
+            with self._fallback_lock:
+                if self._fallback is None:
+                    self._fallback = self._fallback_factory()
+            return self._fallback.create_stream()
+
+
+class _RemoteStream:
+    """One relayed take: raw PCM up, transcript events down.
+
+    A daemon reader thread folds the worker's ``partial``/``final``
+    events into state that :meth:`feed_pcm16` returns on each call, so
+    the relay presents the same synchronous handle interface the local
+    engines do. The worker returns display-ready text already, so the
+    relay just forwards it.
+    """
+
+    def __init__(self, url: str) -> None:
+        from websockets.sync.client import connect
+
+        self._ws = connect(url, open_timeout=5)
+        try:
+            deadline = time.monotonic() + _REMOTE_READY_TIMEOUT_S
+            while True:
+                message = self._ws.recv(timeout=max(0.1, deadline - time.monotonic()))
+                if not isinstance(message, str):
+                    continue
+                event = json.loads(message)
+                if event.get("type") == "ready":
+                    break
+                if event.get("type") == "error":
+                    raise RuntimeError(f"dictation worker error: {event.get('message')}")
+        except BaseException:
+            self._ws.close()
+            raise
+        self._lock = threading.Lock()
+        self._partial = ""
+        self._finals: list[str] = []
+        self._tail = ""
+        self._dead = False
+        self._stopped = threading.Event()
+        threading.Thread(target=self._read_loop, daemon=True).start()
+
+    def _read_loop(self) -> None:
+        try:
+            while True:
+                message = self._ws.recv()
+                if not isinstance(message, str):
+                    continue
+                try:
+                    event = json.loads(message)
+                except ValueError:
+                    continue
+                kind = event.get("type")
+                with self._lock:
+                    if kind == "partial":
+                        self._partial = str(event.get("text", ""))
+                    elif kind == "final":
+                        self._finals.append(str(event.get("text", "")))
+                        self._partial = ""
+                    elif kind == "stopped":
+                        self._tail = str(event.get("text", ""))
+                        break
+                    elif kind == "error":
+                        self._dead = True
+                        break
+        except Exception:  # noqa: BLE001 - any transport failure kills the take
+            with self._lock:
+                self._dead = True
+        self._stopped.set()
+
+    def feed_pcm16(self, data: bytes) -> DictationUpdate:
+        """Ship a chunk to the worker; return its latest transcript state."""
+        with self._lock:
+            if self._dead:
+                raise RuntimeError("dictation worker connection lost")
+        self._ws.send(data)
+        with self._lock:
+            finalized = " ".join(t for t in self._finals if t).strip() or None
+            self._finals.clear()
+            return DictationUpdate(partial=self._partial, finalized=finalized)
+
+    def finish(self) -> str:
+        """Ask the worker to flush; return its tail utterance."""
+        with contextlib.suppress(Exception):
+            self._ws.send(json.dumps({"type": "stop"}))
+        self._stopped.wait(timeout=_REMOTE_STOP_TIMEOUT_S)
+        self.close()
+        with self._lock:
+            return self._tail
+
+    def close(self) -> None:
+        """Close the worker socket, releasing its capacity slot.
+
+        Also unblocks the reader thread's ``recv``. Idempotent — the
+        sync websockets client tolerates repeated ``close`` calls.
+        """
+        with contextlib.suppress(Exception):
+            self._ws.close()
+
+
+def _remote_url() -> str:
+    """The configured worker stream URL (may be empty)."""
+    return os.environ.get(REMOTE_URL_ENV, "").strip()
+
+
+def _remote_available() -> tuple[bool, str | None]:
+    """Availability probe for the remote engine.
+
+    A configured worker counts as available without probing it — the
+    worker may be briefly down or still booting, and the stream route
+    degrades cleanly (local fallback, or an error frame) when a take
+    actually starts.
+    """
+    if not _remote_url():
+        return False, REASON_REMOTE_URL_MISSING
+    return True, None
+
+
+def _build_remote_engine() -> RemoteDictationEngine:
+    """Factory for the remote engine, with a lazy local fallback.
+
+    Local models, when installed, back the worker up. The fallback
+    factory is lazy so its ~650 MB of weights cost no RAM unless the
+    worker actually goes down.
+    """
+    url = _remote_url()
+    if not url:
+        raise RuntimeError(f"dictation unavailable: {REASON_REMOTE_URL_MISSING}")
+    fallback = (
+        (lambda: SherpaDictationEngine(_asr_dir(), _punct_dir()))
+        if _sherpa_available()[0]
+        else None
+    )
+    return RemoteDictationEngine(url, fallback_factory=fallback)
+
+
 #: Scripted transcript the fake engine reveals; asserted verbatim by the
 #: server route tests and the Playwright e2e test.
 FAKE_SCRIPT = "server dictation smoke test transcript"
@@ -522,4 +719,5 @@ register_engine(
     lambda: SherpaDictationEngine(_asr_dir(), _punct_dir()),
     available=_sherpa_available,
 )
+register_engine(ENGINE_REMOTE, _build_remote_engine, available=_remote_available)
 register_engine(ENGINE_FAKE, FakeDictationEngine)

--- a/omnigent/server/dictation_worker.py
+++ b/omnigent/server/dictation_worker.py
@@ -1,0 +1,70 @@
+"""Standalone dictation worker: serves only ``WS /v1/dictation/stream``.
+
+Lets a machine with spare CPU do speech-to-text for an omnigent server
+that can't keep up with the model it wants (designs/server-dictation.md,
+"Hardware sizing"). The main server selects the ``remote`` engine and
+points ``OMNIGENT_DICTATION_REMOTE_URL`` at this worker; it relays takes
+over the same wire protocol the browser speaks, so the worker needs no
+new code — it is ``create_dictation_router`` served on its own. The
+browser never talks to the worker directly.
+
+Run it wherever the models live::
+
+    pip install omnigent[dictation]
+    scripts/fetch-dictation-models.sh
+    python -m omnigent.server.dictation_worker --host 0.0.0.0 --port 8100
+
+Then start the main server pointed at it::
+
+    OMNIGENT_DICTATION_ENGINE=remote \\
+    OMNIGENT_DICTATION_REMOTE_URL=ws://<worker-host>:8100/v1/dictation/stream \\
+    omnigent server ...
+
+The same ``OMNIGENT_DICTATION_*`` env vars configure the worker itself
+(model dirs, stream cap, fake engine for tests).
+
+Security: the worker has NO authentication — it accepts raw audio from
+anyone who can reach the port and returns transcripts. Bind it to a
+trusted network (LAN/VPN) only; the main server enforces user auth on
+its own dictation route before relaying.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from collections.abc import Sequence
+
+from fastapi import FastAPI
+
+from omnigent.server.routes.dictation import create_dictation_router
+
+
+def create_worker_app() -> FastAPI:
+    """Build the single-route worker app."""
+    app = FastAPI(title="omnigent dictation worker")
+    app.include_router(create_dictation_router(), prefix="/v1")
+    return app
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point: parse args and serve until interrupted."""
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="bind address; use a LAN/VPN address for a remote main server "
+        "(the worker is unauthenticated — never expose it publicly)",
+    )
+    parser.add_argument("--port", type=int, default=8100)
+    args = parser.parse_args(argv)
+
+    import uvicorn
+
+    logging.basicConfig(level=logging.INFO)
+    uvicorn.run(create_worker_app(), host=args.host, port=args.port, log_level="info")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/server/test_dictation_remote.py
+++ b/tests/server/test_dictation_remote.py
@@ -1,0 +1,139 @@
+"""Tests for the remote dictation engine and the standalone worker.
+
+Spins a real ``dictation_worker`` app (uvicorn on an ephemeral loopback
+port, fake engine injected via env) and drives :class:`RemoteDictationEngine`
+against it over actual TCP — the same relay path a beelink-class server
+uses to borrow a beefier box's CPU. No sherpa dependency: the worker
+runs the fake engine.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Iterator
+
+import pytest
+import uvicorn
+
+from omnigent.server import dictation
+
+
+@pytest.fixture(autouse=True)
+def _fake_engine_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The spawned worker (same process) must resolve the fake engine."""
+    monkeypatch.setenv(dictation.ENGINE_ENV, dictation.ENGINE_FAKE)
+    monkeypatch.delenv(dictation.REMOTE_URL_ENV, raising=False)
+    monkeypatch.setattr(dictation, "_engine", None)
+
+
+@pytest.fixture
+def worker_url() -> Iterator[str]:
+    """Run the real worker app on an ephemeral port; yield its stream URL."""
+    from omnigent.server.dictation_worker import create_worker_app
+
+    config = uvicorn.Config(create_worker_app(), host="127.0.0.1", port=0, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 15
+    while not server.started:
+        if time.monotonic() > deadline:
+            raise RuntimeError("worker did not start")
+        time.sleep(0.05)
+    port = server.servers[0].sockets[0].getsockname()[1]
+    yield f"ws://127.0.0.1:{port}/v1/dictation/stream"
+    server.should_exit = True
+    thread.join(timeout=10)
+
+
+_WORD = b"\x00" * (dictation.SAMPLE_RATE * 2 // 10)  # 100 ms per fake word
+_WORDS = dictation.FAKE_SCRIPT.split()
+
+
+def _drain_partial(handle: dictation.DictationStreamHandle, expected: str) -> None:
+    """Poll feeds until the relayed partial catches up (reader is async)."""
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        update = handle.feed_pcm16(b"")
+        if update.partial == expected:
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"partial never reached {expected!r}")
+
+
+def test_remote_engine_relays_partials_and_finish(worker_url: str) -> None:
+    """PCM up, partial state down, stop-flush returns the tail."""
+    engine = dictation.RemoteDictationEngine(worker_url)
+    handle = engine.create_stream()
+    handle.feed_pcm16(_WORD * 3)
+    # The worker throttles partial emission (~150 ms); poll until the
+    # 3-word partial arrives.
+    _drain_partial(handle, " ".join(_WORDS[:3]))
+    assert handle.finish() == " ".join(_WORDS[:3])
+
+
+def test_remote_engine_relays_finalized_utterances(worker_url: str) -> None:
+    """A worker 'final' event surfaces as DictationUpdate.finalized."""
+    engine = dictation.RemoteDictationEngine(worker_url)
+    handle = engine.create_stream()
+    handle.feed_pcm16(_WORD * len(_WORDS))
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        update = handle.feed_pcm16(b"")
+        if update.finalized:
+            assert update.finalized == dictation.FAKE_SCRIPT
+            break
+        time.sleep(0.05)
+    else:
+        raise AssertionError("finalized never arrived")
+    assert handle.finish() == ""
+
+
+def test_remote_stream_close_releases_worker_slot(worker_url: str) -> None:
+    """close() frees the worker's capacity slot for later takes.
+
+    Three sequential takes against a worker capped at two concurrent
+    streams: without the close, the third handshake would be rejected
+    with the 1013 at-capacity close.
+    """
+    engine = dictation.RemoteDictationEngine(worker_url)
+    for _ in range(3):
+        handle = engine.create_stream()
+        handle.feed_pcm16(_WORD)
+        handle.close()
+
+
+def test_remote_engine_falls_back_when_worker_down() -> None:
+    """Unreachable worker + local fallback → the take still serves."""
+    engine = dictation.RemoteDictationEngine(
+        "ws://127.0.0.1:9/v1/dictation/stream",  # port 9: nothing listens
+        fallback_factory=dictation.FakeDictationEngine,
+    )
+    handle = engine.create_stream()
+    update = handle.feed_pcm16(_WORD * 2)
+    assert update.partial == " ".join(_WORDS[:2])
+
+
+def test_remote_engine_raises_without_fallback() -> None:
+    """Unreachable worker and no local models → the take fails loudly."""
+    engine = dictation.RemoteDictationEngine("ws://127.0.0.1:9/v1/dictation/stream")
+    with pytest.raises(OSError):
+        engine.create_stream()
+
+
+def test_remote_unavailable_without_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Selecting remote without a worker URL is unavailable, not a crash."""
+    monkeypatch.setenv(dictation.ENGINE_ENV, dictation.ENGINE_REMOTE)
+    monkeypatch.delenv(dictation.REMOTE_URL_ENV, raising=False)
+    assert dictation.engine_availability() == (False, dictation.REASON_REMOTE_URL_MISSING)
+
+
+def test_remote_engine_selected_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OMNIGENT_DICTATION_ENGINE=remote + a URL selects the relay engine."""
+    monkeypatch.setenv(dictation.ENGINE_ENV, dictation.ENGINE_REMOTE)
+    monkeypatch.setenv(dictation.REMOTE_URL_ENV, "ws://example:8100/v1/dictation/stream")
+    monkeypatch.setattr(dictation, "_engine", None)
+    assert dictation.engine_availability() == (True, None)
+    engine = dictation.get_engine()
+    assert isinstance(engine, dictation.RemoteDictationEngine)

--- a/web/src/lib/dictation.ts
+++ b/web/src/lib/dictation.ts
@@ -70,11 +70,15 @@ export function parseDictationEvent(raw: string): DictationEvent | null {
 }
 
 // Client budgets must exceed the server's own worst cases or takes fail
-// spuriously right when they'd have succeeded. The dominant cost is the
-// first take's engine construction, which loads the model weights (seconds
-// on a cold server); the stop budget just needs to outlast the tail flush.
-const READY_TIMEOUT_MS = 20_000;
-const STOP_TIMEOUT_MS = 5_000;
+// spuriously right when they'd have succeeded:
+// - ready: engine construction loads model weights on the first take, and
+//   the remote-relay path allows the worker 30 s for its own cold load
+//   (_REMOTE_READY_TIMEOUT_S in omnigent/server/dictation.py).
+// - stop: the relay waits up to 10 s (_REMOTE_STOP_TIMEOUT_S) for the
+//   worker to flush the tail; resolving earlier would drop the user's
+//   last words even though they were transcribed moments later.
+const READY_TIMEOUT_MS = 40_000;
+const STOP_TIMEOUT_MS = 15_000;
 
 // How long stop() waits for the worklet to post its final partial chunk
 // before tearing the audio graph down. Message-port turnaround is


### PR DESCRIPTION
## Related issue

N/A — follow-up to #2093 (server-side streaming dictation), now merged.

## Summary

Adds the **remote dictation worker** that was split out of #2093 to keep that
PR focused on local speech-to-text. It reintroduces the offload path as a
first-class **registered engine** (using the engine registry #2093 landed),
not a special-cased branch:

- **`remote` engine** — `OMNIGENT_DICTATION_ENGINE=remote` +
  `OMNIGENT_DICTATION_REMOTE_URL=ws://<worker>:8100/v1/dictation/stream`. It
  relays each take to a dictation worker over the *same* wire protocol the
  browser speaks (PCM frames up, transcript events down), so a small main
  server can borrow a beefier LAN box's CPU. Selection is pure env var — no
  CLI integration, matching how niche this deployment is.
- **Standalone worker** — `python -m omnigent.server.dictation_worker`: it's
  just `create_dictation_router` served on its own. **Unauthenticated →
  LAN/VPN only**; the main server enforces user auth on its own route before
  relaying.
- **Per-take local fallback** — if the worker is unreachable and local sherpa
  models are installed, the take is served locally (fallback engine built
  lazily so its weights cost no RAM until needed).
- Web client `ready`/`stop` timeouts widened to outlast the worker's cold-load.

`websockets` is already a core dependency, so **no new package**. The engine
slots into the registry with **no changes to the route, protocol, or selection
logic** from #2093 — the whole change is +458 / −11 across 5 files.

## Test Plan

- `pytest tests/server/test_dictation_remote.py` — **7 passed**. The suite
  spins a real worker (uvicorn on an ephemeral loopback port, fake engine) and
  drives `RemoteDictationEngine` against it over actual TCP: partial relay,
  finalized utterances, stop-flush tail, `close()` releasing the worker slot,
  local fallback when the worker is down, loud failure with no fallback,
  availability + name-selection.
- Full dictation suite green alongside it against merged `main` (engine + route
  + remote = **27 passed**); `ruff` clean.
- Relies on the fake engine, so it needs no sherpa models and runs in CI.

## Demo

N/A — server/protocol change, no UI surface. (The composer mic button behaves
identically; only the server's transcription backend changes.)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the standalone worker locally
(`python -m omnigent.server.dictation_worker`) and confirmed a main server
with `OMNIGENT_DICTATION_ENGINE=remote` relays takes to it and falls back to
the local sherpa engine when the worker is stopped mid-session. Automated
coverage exercises the relay over real TCP against a spawned worker.

## Changelog

Offload dictation speech-to-text to a remote worker with
`OMNIGENT_DICTATION_ENGINE=remote`

This pull request and its description were written by Isaac.
