### PR TITLE
fix(egress): don't inject credentials on TRACE/OPTIONS + honor Max-Forwards

### DIFF
--- a/omnigent/inner/egress/proxy.py
+++ b/omnigent/inner/egress/proxy.py
@@ -60,6 +60,22 @@ _HEADER_MAX = 65536
 # ``_handle_connect`` for the request-line-smuggling rationale.
 _MIN_PRINTABLE_BYTE = 0x20
 
+# Verbs that can never legitimately need an injected credential, so the
+# proxy refuses to attach (or swap in) the real secret on them regardless
+# of the allowlist. TRACE is a loopback diagnostic — the final recipient
+# reflects the request back to the caller, so a credential injected here
+# would be echoed straight into the sandbox. OPTIONS only negotiates
+# capabilities and has no business carrying a bound-host secret. Keeping
+# this independent of the allowlist means a permissive ``* host/**`` rule
+# can't accidentally re-open the leak.
+_CREDENTIAL_INJECTION_FORBIDDEN_METHODS = frozenset({"TRACE", "OPTIONS"})
+
+# Verbs governed by ``Max-Forwards`` (RFC 7231 §5.1.2). A conformant
+# intermediary must decrement the hop count on these before forwarding and
+# answer directly once it reaches zero; the header is ignored on every
+# other method.
+_MAX_FORWARDS_METHODS = frozenset({"TRACE", "OPTIONS"})
+
 
 def _parse_http_headers(headers_raw: bytes) -> Message:
     """
@@ -595,11 +611,6 @@ class EgressProxy:
 
             logger.info("ALLOW %s https://%s%s", inner_method, host, inner_path)
 
-            content_length = int(inner_headers.get("content-length", "0"))
-            body = b""
-            if content_length > 0:
-                body = await asyncio.wait_for(tls_reader.readexactly(content_length), timeout=30)
-
             # Forward a request line re-serialized from the parsed
             # method/path rather than the raw ``inner_first`` bytes, so
             # the upstream always receives exactly the (method, path)
@@ -607,6 +618,27 @@ class EgressProxy:
             # ``_handle_http`` (``relative_line``); closes the
             # policy-vs-forwarded byte differential.
             inner_request_line = f"{inner_method} {inner_path} HTTP/1.1\r\n".encode("latin-1")
+
+            # Max-Forwards conformance (RFC 7231 §5.1.2): terminate an
+            # exhausted TRACE / OPTIONS at the proxy over the MITM tunnel
+            # (never forwarding it into the credential-injection path);
+            # decrement a positive budget on the forwarded headers.
+            terminate, inner_headers_raw = self._apply_max_forwards(
+                inner_method, inner_headers_raw
+            )
+            if terminate:
+                logger.info(
+                    "MAX-FORWARDS-TERMINATE %s https://%s%s", inner_method, host, inner_path
+                )
+                await self._send_max_forwards_reply(
+                    tls_writer, inner_method, inner_request_line, inner_headers_raw
+                )
+                return
+
+            content_length = int(inner_headers.get("content-length", "0"))
+            body = b""
+            if content_length > 0:
+                body = await asyncio.wait_for(tls_reader.readexactly(content_length), timeout=30)
 
             await self._forward_https(
                 tls_writer,
@@ -676,7 +708,7 @@ class EgressProxy:
         connect_host = pinned_ip or host
         # Swap any synthetic credential placeholder for the real secret,
         # bound to this host (rejects cross-host replay with 403).
-        rewrite = self._rewrite_authorization(host=host, headers_raw=headers_raw)
+        rewrite = self._rewrite_authorization(method=method, host=host, headers_raw=headers_raw)
         if rewrite.error is not None:
             logger.warning(
                 "BLOCKED-CREDENTIAL %s https://%s%s — %s", method, host, path, rewrite.error
@@ -802,6 +834,19 @@ class EgressProxy:
 
         logger.info("ALLOW %s http://%s%s", method, host, path)
 
+        # Max-Forwards conformance (RFC 7231 §5.1.2): a TRACE / OPTIONS
+        # request whose hop budget is exhausted terminates at the proxy —
+        # answered here as the final recipient, never forwarded (and so
+        # never reaching the credential-injection path). A positive budget
+        # is decremented on the forwarded header block.
+        terminate, headers_raw = self._apply_max_forwards(method, headers_raw)
+        if terminate:
+            logger.info("MAX-FORWARDS-TERMINATE %s http://%s%s", method, host, path)
+            await self._send_max_forwards_reply(
+                writer, method, f"{method} {path} HTTP/1.1\r\n".encode("latin-1"), headers_raw
+            )
+            return
+
         try:
             pinned_ip = await self._assert_destination_allowed(host, port)
         except PermissionError as exc:
@@ -816,7 +861,7 @@ class EgressProxy:
             body = await asyncio.wait_for(reader.readexactly(content_length), timeout=30)
 
         relative_line = f"{method} {path} HTTP/1.1\r\n".encode("latin-1")
-        rewrite = self._rewrite_authorization(host=host, headers_raw=headers_raw)
+        rewrite = self._rewrite_authorization(method=method, host=host, headers_raw=headers_raw)
         if rewrite.error is not None:
             logger.warning(
                 "BLOCKED-CREDENTIAL %s http://%s%s — %s", method, host, path, rewrite.error
@@ -1081,7 +1126,9 @@ class EgressProxy:
         except Exception:  # noqa: BLE001 — response write is best-effort
             pass
 
-    def _rewrite_authorization(self, *, host: str, headers_raw: bytes) -> _AuthRewriteResult:
+    def _rewrite_authorization(
+        self, *, method: str, host: str, headers_raw: bytes
+    ) -> _AuthRewriteResult:
         """
         Attach the real credential to a bound-host request.
 
@@ -1104,11 +1151,24 @@ class EgressProxy:
         left untouched (and suppresses injection), so the proxy never
         clobbers an unrelated credential a tool deliberately sent.
 
+        No injection or swap happens on the loopback/diagnostic verbs in
+        :data:`_CREDENTIAL_INJECTION_FORBIDDEN_METHODS` (``TRACE`` /
+        ``OPTIONS``) — TRACE would reflect the injected secret back into
+        the sandbox, and neither verb can legitimately carry a bound-host
+        credential. The headers are forwarded untouched so any synthetic
+        placeholder the sandbox holds (a harmless fake) passes through
+        without being upgraded to the real secret.
+
+        :param method: HTTP method (case-insensitive), e.g. ``"GET"``.
         :param host: Upstream request host (case-insensitive).
         :param headers_raw: Raw HTTP header block (CRLF-separated).
         :returns: An :class:`_AuthRewriteResult` carrying either the
             (possibly rewritten / injected) headers or a rejection reason.
         """
+        if method.upper() in _CREDENTIAL_INJECTION_FORBIDDEN_METHODS:
+            # Independent of the allowlist and of whether a rule binds this
+            # host: these verbs never receive the real credential.
+            return _AuthRewriteResult(headers=headers_raw, error=None)
         if not self._cred_by_host:
             return _AuthRewriteResult(headers=headers_raw, error=None)
 
@@ -1372,3 +1432,114 @@ class EgressProxy:
         del msg["Keep-Alive"]
         msg["Connection"] = "close"
         return msg.as_bytes(policy=email.policy.HTTP)
+
+    @staticmethod
+    def _apply_max_forwards(method: str, headers_raw: bytes) -> tuple[bool, bytes]:
+        """
+        Enforce ``Max-Forwards`` (RFC 7231 §5.1.2) for TRACE / OPTIONS.
+
+        ``Max-Forwards`` bounds how many intermediaries a TRACE or OPTIONS
+        request may traverse. A conformant intermediary that receives one
+        of these verbs MUST inspect the header before forwarding:
+
+        - value ``0`` (or a malformed value): the proxy is the final
+          recipient and MUST NOT forward — it answers directly.
+        - value ``> 0``: decrement by one, then forward.
+
+        The header is ignored on every other method, so those requests
+        pass through untouched.
+
+        :param method: HTTP method (upper-case), e.g. ``"TRACE"``.
+        :param headers_raw: Raw request header block (CRLF-separated).
+        :returns: ``(terminate, headers)``. ``terminate`` is ``True`` when
+            the proxy must answer as the final recipient (the caller must
+            not forward upstream); otherwise ``headers`` is the block to
+            forward, with ``Max-Forwards`` decremented when it was present.
+        """
+        if method not in _MAX_FORWARDS_METHODS:
+            return False, headers_raw
+        msg = _parse_http_headers(headers_raw)
+        raw = msg.get("Max-Forwards")
+        if raw is None:
+            # No hop limit expressed — forward as a transparent hop.
+            return False, headers_raw
+        try:
+            remaining = int(raw.strip())
+        except ValueError:
+            # A malformed count is treated as exhausted: terminate at the
+            # proxy rather than forward an ambiguous hop budget upstream.
+            remaining = 0
+        if remaining <= 0:
+            return True, headers_raw
+        del msg["Max-Forwards"]
+        msg["Max-Forwards"] = str(remaining - 1)
+        return False, msg.as_bytes(policy=email.policy.HTTP)
+
+    @staticmethod
+    def _build_trace_echo(request_line: bytes, headers_raw: bytes) -> bytes:
+        """
+        Reflect a TRACE request as a ``message/http`` payload.
+
+        RFC 7231 §4.3.8 has the final recipient echo the received request
+        so the client can see what arrived. We drop the headers that could
+        carry a secret (``Authorization`` / ``Cookie`` /
+        ``Proxy-Authorization``) so the reflection can never hand a
+        credential back to the caller — the exact leak this hardening
+        exists to prevent.
+
+        :param request_line: The origin-form request line to echo, e.g.
+            ``b"TRACE /path HTTP/1.1\\r\\n"``.
+        :param headers_raw: Raw request header block (CRLF-separated).
+        :returns: The ``message/http`` body: the request line followed by
+            the (sensitive-stripped) header block.
+        """
+        msg = _parse_http_headers(headers_raw)
+        del msg["Authorization"]
+        del msg["Cookie"]
+        del msg["Proxy-Authorization"]
+        return request_line + msg.as_bytes(policy=email.policy.HTTP)
+
+    async def _send_max_forwards_reply(
+        self,
+        writer: asyncio.StreamWriter,
+        method: str,
+        request_line: bytes,
+        headers_raw: bytes,
+    ) -> None:
+        """
+        Answer a TRACE / OPTIONS request as the final recipient.
+
+        Called when ``Max-Forwards`` reached zero and the proxy must halt
+        the request instead of forwarding (see :meth:`_apply_max_forwards`).
+        TRACE reflects the received message (``message/http``) with any
+        sensitive headers stripped; OPTIONS reports the proxy's own
+        communication options via ``Allow``.
+
+        :param writer: Stream to write the response to (the plaintext
+            client writer, or the MITM ``tls_writer`` inside CONNECT).
+        :param method: ``"TRACE"`` or ``"OPTIONS"`` (upper-case).
+        :param request_line: Origin-form request line, echoed for TRACE.
+        :param headers_raw: Raw request header block, echoed for TRACE.
+        """
+        if method == "TRACE":
+            body = self._build_trace_echo(request_line, headers_raw)
+            resp = (
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: message/http\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"Connection: close\r\n"
+                b"\r\n" + body
+            )
+        else:  # OPTIONS
+            resp = (
+                b"HTTP/1.1 200 OK\r\n"
+                b"Allow: GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS, TRACE\r\n"
+                b"Content-Length: 0\r\n"
+                b"Connection: close\r\n"
+                b"\r\n"
+            )
+        try:
+            writer.write(resp)
+            await writer.drain()
+        except Exception:  # noqa: BLE001 — response write is best-effort
+            pass

--- a/omnigent/inner/egress/proxy.py
+++ b/omnigent/inner/egress/proxy.py
@@ -1449,14 +1449,16 @@ class EgressProxy:
         The header is ignored on every other method, so those requests
         pass through untouched.
 
-        :param method: HTTP method (upper-case), e.g. ``"TRACE"``.
+        :param method: HTTP method (case-insensitive), e.g. ``"TRACE"``.
         :param headers_raw: Raw request header block (CRLF-separated).
         :returns: ``(terminate, headers)``. ``terminate`` is ``True`` when
             the proxy must answer as the final recipient (the caller must
             not forward upstream); otherwise ``headers`` is the block to
             forward, with ``Max-Forwards`` decremented when it was present.
         """
-        if method not in _MAX_FORWARDS_METHODS:
+        # Normalize here so the guard holds even if a future caller forgets
+        # to upper-case the verb (both current callers already do).
+        if method.upper() not in _MAX_FORWARDS_METHODS:
             return False, headers_raw
         msg = _parse_http_headers(headers_raw)
         raw = msg.get("Max-Forwards")
@@ -1515,6 +1517,11 @@ class EgressProxy:
         sensitive headers stripped; OPTIONS reports the proxy's own
         communication options via ``Allow``.
 
+        Any request body (e.g. an ``OPTIONS`` with ``Content-Length``) is
+        intentionally left undrained: the reply sets ``Connection: close``
+        and the caller tears the connection down, so leftover bytes are
+        discarded rather than mistaken for a pipelined request.
+
         :param writer: Stream to write the response to (the plaintext
             client writer, or the MITM ``tls_writer`` inside CONNECT).
         :param method: ``"TRACE"`` or ``"OPTIONS"`` (upper-case).
@@ -1531,6 +1538,10 @@ class EgressProxy:
                 b"\r\n" + body
             )
         else:  # OPTIONS
+            # This ``Allow`` list is intentionally static and proxy-scoped:
+            # it advertises the verbs the proxy itself answers for as the
+            # final recipient of a ``Max-Forwards: 0`` request, NOT the
+            # origin's capabilities (which are never queried on this path).
             resp = (
                 b"HTTP/1.1 200 OK\r\n"
                 b"Allow: GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS, TRACE\r\n"

--- a/tests/inner/egress/test_proxy.py
+++ b/tests/inner/egress/test_proxy.py
@@ -1501,10 +1501,19 @@ class _CapturedRequest:
         can assert the proxy collapsed any client-supplied
         ``Connection`` / ``Keep-Alive`` headers into exactly one
         ``close`` rather than forwarding duplicates.
+    :param max_forwards: The ``Max-Forwards`` header value the upstream
+        received (as sent, e.g. ``"2"``), or ``None`` when the request
+        carried no such header — lets a test assert the proxy decremented
+        the hop count on a forwarded TRACE / OPTIONS.
+    :param method: The request method the upstream received, e.g.
+        ``"GET"`` or ``"TRACE"``, or ``None`` when the request line could
+        not be parsed.
     """
 
     authorization: str | None
     connection: list[str] = field(default_factory=list)
+    max_forwards: str | None = None
+    method: str | None = None
 
 
 async def _start_capturing_upstream(captured: list[_CapturedRequest]) -> asyncio.Server:
@@ -1523,12 +1532,26 @@ async def _start_capturing_upstream(captured: list[_CapturedRequest]) -> asyncio
         head = await reader.readuntil(b"\r\n\r\n")
         auth: str | None = None
         connection: list[str] = []
-        for line in head.split(b"\r\n"):
+        max_forwards: str | None = None
+        lines = head.split(b"\r\n")
+        method: str | None = None
+        if lines and lines[0]:
+            method = lines[0].split(b" ", 1)[0].decode("latin-1")
+        for line in lines:
             if line[:14].lower() == b"authorization:":
                 auth = line.partition(b":")[2].strip().decode("latin-1")
             elif line[:11].lower() == b"connection:":
                 connection.append(line.partition(b":")[2].strip().decode("latin-1").lower())
-        captured.append(_CapturedRequest(authorization=auth, connection=connection))
+            elif line[:13].lower() == b"max-forwards:":
+                max_forwards = line.partition(b":")[2].strip().decode("latin-1")
+        captured.append(
+            _CapturedRequest(
+                authorization=auth,
+                connection=connection,
+                max_forwards=max_forwards,
+                method=method,
+            )
+        )
         writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
         await writer.drain()
         writer.close()
@@ -1558,6 +1581,48 @@ async def _proxied_http_get(
         f"GET http://127.0.0.1:{upstream_port}/probe HTTP/1.1\r\n"
         f"Host: 127.0.0.1:{upstream_port}\r\n"
         f"{auth_line}"
+        "Connection: close\r\n"
+        "\r\n"
+    ).encode("latin-1")
+    writer.write(request)
+    await writer.drain()
+    response = await asyncio.wait_for(reader.read(4096), timeout=5)
+    writer.close()
+    with contextlib.suppress(Exception):
+        await writer.wait_closed()
+    return response
+
+
+async def _proxied_http_request(
+    *,
+    proxy_port: int,
+    upstream_port: int,
+    method: str,
+    authorization: str | None = None,
+    extra_headers: str = "",
+) -> bytes:
+    """Send one plain-HTTP request of an arbitrary method through the proxy.
+
+    A generalization of :func:`_proxied_http_get` used by the TRACE /
+    OPTIONS and ``Max-Forwards`` tests, where the method and extra headers
+    (e.g. ``"Max-Forwards: 0\\r\\n"``) matter.
+
+    :param proxy_port: Loopback TCP port the proxy listens on.
+    :param upstream_port: Port of the local capturing upstream.
+    :param method: HTTP method to send, e.g. ``"TRACE"`` or ``"OPTIONS"``.
+    :param authorization: Raw ``Authorization`` value to send, or ``None``
+        to omit the header (the swap-on-access client shape).
+    :param extra_headers: Additional header lines, each CRLF-terminated,
+        inserted verbatim before the ``Connection: close`` line.
+    :returns: The raw response bytes the client received from the proxy.
+    """
+    reader, writer = await asyncio.open_connection("127.0.0.1", proxy_port)
+    auth_line = f"Authorization: {authorization}\r\n" if authorization is not None else ""
+    request = (
+        f"{method} http://127.0.0.1:{upstream_port}/probe HTTP/1.1\r\n"
+        f"Host: 127.0.0.1:{upstream_port}\r\n"
+        f"{auth_line}"
+        f"{extra_headers}"
         "Connection: close\r\n"
         "\r\n"
     ).encode("latin-1")
@@ -1838,6 +1903,407 @@ async def test_credential_rewrite_injects_on_access_without_header(
     # The proxy synthesized the Authorization header from the rule — the
     # client sent none.
     assert captured[0].authorization == "Bearer real-secret-value"
+
+
+# ---------------------------------------------------------------------------
+# Credential injection is refused on loopback/diagnostic verbs (TRACE /
+# OPTIONS) and the proxy is a conformant Max-Forwards intermediary. TRACE
+# reflects the request back to the caller, so injecting a bound-host secret
+# there would echo it straight into the sandbox — the leak this hardening
+# closes. The guard is independent of the allowlist: even a permissive
+# ``* host/**`` rule never attaches (or swaps in) the real credential on
+# these verbs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["TRACE", "OPTIONS"])
+async def test_credential_not_injected_on_loopback_method(
+    ca_paths: tuple[Path, Path, Path],
+    method: str,
+) -> None:
+    """Swap-on-access never fires on TRACE / OPTIONS.
+
+    A bare request to a bound host would normally get the real credential
+    attached (see ``test_credential_rewrite_injects_on_access_without_header``).
+    On a loopback/diagnostic verb it must NOT — the upstream must receive
+    no ``Authorization`` header at all. A regression here would let a TRACE
+    reflect the injected secret back into the sandbox.
+    """
+    cert_path, key_path, _ = ca_paths
+    rule = CredentialRewriteRule(
+        host="127.0.0.1",
+        scheme="bearer",
+        real_secret="real-secret-value",
+        synthetic=None,
+        username=None,
+    )
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+        credential_rewrites=[rule],
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        # No Max-Forwards header, so the request is forwarded to the
+        # upstream (the termination path is covered separately) — letting
+        # us assert on exactly what crossed the proxy boundary.
+        response = await _proxied_http_request(
+            proxy_port=proxy_port,
+            upstream_port=upstream_port,
+            method=method,
+            authorization=None,
+        )
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert b"200 OK" in response, f"Request did not complete: {response[:200]!r}"
+    assert len(captured) == 1
+    assert captured[0].method == method
+    # The real credential was NOT injected on the loopback/diagnostic verb.
+    assert captured[0].authorization is None
+    assert b"real-secret-value" not in response
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["TRACE", "OPTIONS"])
+async def test_synthetic_not_swapped_on_loopback_method(
+    ca_paths: tuple[Path, Path, Path],
+    method: str,
+) -> None:
+    """A synthetic placeholder is NOT upgraded to the real secret on TRACE / OPTIONS.
+
+    Even for the correct bound host, the placeholder swap is suppressed on
+    these verbs. The (harmless, fake) placeholder passes through unchanged;
+    the real secret is never emitted, so a reflected TRACE can only echo a
+    dummy value.
+    """
+    cert_path, key_path, _ = ca_paths
+    synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}loopbackplaceholder"
+    rule = CredentialRewriteRule(
+        host="127.0.0.1",
+        scheme="bearer",
+        synthetic=synthetic,
+        real_secret="real-secret-value",
+        username=None,
+    )
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+        credential_rewrites=[rule],
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        response = await _proxied_http_request(
+            proxy_port=proxy_port,
+            upstream_port=upstream_port,
+            method=method,
+            authorization=f"Bearer {synthetic}",
+        )
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert b"200 OK" in response, f"Request did not complete: {response[:200]!r}"
+    assert len(captured) == 1
+    # The placeholder passed through untouched — never swapped for the real
+    # secret on a loopback/diagnostic verb.
+    assert captured[0].authorization == f"Bearer {synthetic}"
+    assert "real-secret-value" not in (captured[0].authorization or "")
+
+
+@pytest.mark.asyncio
+async def test_max_forwards_zero_terminates_trace_at_proxy(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    """TRACE with ``Max-Forwards: 0`` is answered by the proxy, not forwarded.
+
+    RFC 7231 §5.1.2: an intermediary that receives ``Max-Forwards: 0`` on
+    TRACE MUST act as the final recipient. The proxy replies 200
+    ``message/http`` and never contacts the upstream — so credential
+    injection (which runs on the forward path) can't fire, and the
+    reflected body carries no secret.
+    """
+    cert_path, key_path, _ = ca_paths
+    rule = CredentialRewriteRule(
+        host="127.0.0.1",
+        scheme="bearer",
+        real_secret="real-secret-value",
+        synthetic=None,
+        username=None,
+    )
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+        credential_rewrites=[rule],
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        response = await _proxied_http_request(
+            proxy_port=proxy_port,
+            upstream_port=upstream_port,
+            method="TRACE",
+            authorization=None,
+            extra_headers="Max-Forwards: 0\r\n",
+        )
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert b"200 OK" in response, f"Proxy did not answer TRACE: {response[:200]!r}"
+    assert b"message/http" in response
+    # The upstream was never contacted — the request stopped at the proxy.
+    assert captured == []
+    # The reflected request line is echoed, and no injected secret appears.
+    assert b"TRACE /probe HTTP/1.1" in response
+    assert b"real-secret-value" not in response
+
+
+@pytest.mark.asyncio
+async def test_max_forwards_zero_terminates_options_at_proxy(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    """OPTIONS with ``Max-Forwards: 0`` is answered by the proxy with ``Allow``.
+
+    The proxy responds as the final recipient (200 with an ``Allow``
+    header advertising its options) and never forwards upstream.
+    """
+    cert_path, key_path, _ = ca_paths
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        response = await _proxied_http_request(
+            proxy_port=proxy_port,
+            upstream_port=upstream_port,
+            method="OPTIONS",
+            extra_headers="Max-Forwards: 0\r\n",
+        )
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert b"200 OK" in response, f"Proxy did not answer OPTIONS: {response[:200]!r}"
+    assert b"Allow:" in response
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_max_forwards_positive_is_decremented_on_forward(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    """A positive ``Max-Forwards`` on TRACE is decremented before forwarding.
+
+    RFC 7231 §5.1.2: when the value is greater than zero the intermediary
+    forwards with the value reduced by one. The upstream must therefore see
+    ``Max-Forwards: 2`` for a request that arrived with ``3``.
+    """
+    cert_path, key_path, _ = ca_paths
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        response = await _proxied_http_request(
+            proxy_port=proxy_port,
+            upstream_port=upstream_port,
+            method="TRACE",
+            extra_headers="Max-Forwards: 3\r\n",
+        )
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert b"200 OK" in response, f"Request did not complete: {response[:200]!r}"
+    assert len(captured) == 1
+    assert captured[0].method == "TRACE"
+    # Decremented by exactly one on the forwarded request.
+    assert captured[0].max_forwards == "2"
+
+
+@pytest.mark.asyncio
+async def test_max_forwards_ignored_on_non_applicable_method(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    """``Max-Forwards`` on a GET is ignored, and injection still fires.
+
+    The header only governs TRACE / OPTIONS (RFC 7231 §5.1.2). A GET
+    carrying ``Max-Forwards`` must be forwarded unchanged (value intact),
+    and swap-on-access credential injection must still run — proving the
+    Max-Forwards machinery didn't disturb the normal forward path.
+    """
+    cert_path, key_path, _ = ca_paths
+    rule = CredentialRewriteRule(
+        host="127.0.0.1",
+        scheme="bearer",
+        real_secret="real-secret-value",
+        synthetic=None,
+        username=None,
+    )
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+        credential_rewrites=[rule],
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        response = await _proxied_http_request(
+            proxy_port=proxy_port,
+            upstream_port=upstream_port,
+            method="GET",
+            authorization=None,
+            extra_headers="Max-Forwards: 5\r\n",
+        )
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert b"200 OK" in response, f"Request did not complete: {response[:200]!r}"
+    assert len(captured) == 1
+    # Value forwarded untouched (not decremented) on a non-applicable verb.
+    assert captured[0].max_forwards == "5"
+    # And normal swap-on-access injection still happened.
+    assert captured[0].authorization == "Bearer real-secret-value"
+
+
+# ---------------------------------------------------------------------------
+# Unit coverage for the Max-Forwards / no-inject helpers (no network).
+# ---------------------------------------------------------------------------
+
+
+def test_apply_max_forwards_ignores_non_applicable_method() -> None:
+    """Non TRACE/OPTIONS methods bypass Max-Forwards entirely (headers unchanged)."""
+    headers = b"Host: example.com\r\nMax-Forwards: 3\r\n\r\n"
+    terminate, out = EgressProxy._apply_max_forwards("GET", headers)
+    assert terminate is False
+    assert out == headers
+
+
+def test_apply_max_forwards_missing_header_forwards_unchanged() -> None:
+    """A TRACE without Max-Forwards is forwarded as a transparent hop."""
+    headers = b"Host: example.com\r\n\r\n"
+    terminate, out = EgressProxy._apply_max_forwards("TRACE", headers)
+    assert terminate is False
+    assert out == headers
+
+
+def test_apply_max_forwards_zero_terminates() -> None:
+    """Max-Forwards: 0 halts the request at the proxy."""
+    headers = b"Host: example.com\r\nMax-Forwards: 0\r\n\r\n"
+    terminate, _out = EgressProxy._apply_max_forwards("TRACE", headers)
+    assert terminate is True
+
+
+def test_apply_max_forwards_positive_decrements() -> None:
+    """A positive Max-Forwards is decremented by one on the forwarded block."""
+    headers = b"Host: example.com\r\nMax-Forwards: 4\r\n\r\n"
+    terminate, out = EgressProxy._apply_max_forwards("OPTIONS", headers)
+    assert terminate is False
+    assert b"Max-Forwards: 3" in out
+    assert b"Max-Forwards: 4" not in out
+
+
+def test_apply_max_forwards_malformed_terminates() -> None:
+    """A malformed Max-Forwards is treated as exhausted (fail closed)."""
+    headers = b"Host: example.com\r\nMax-Forwards: notanumber\r\n\r\n"
+    terminate, _out = EgressProxy._apply_max_forwards("TRACE", headers)
+    assert terminate is True
+
+
+def test_build_trace_echo_strips_sensitive_headers() -> None:
+    """The reflected TRACE body echoes the request but drops secret-bearing headers."""
+    request_line = b"TRACE /path HTTP/1.1\r\n"
+    headers = (
+        b"Host: example.com\r\n"
+        b"Authorization: Bearer super-secret\r\n"
+        b"Cookie: session=abc\r\n"
+        b"Proxy-Authorization: Basic zzz\r\n"
+        b"User-Agent: probe\r\n"
+        b"\r\n"
+    )
+    body = EgressProxy._build_trace_echo(request_line, headers)
+    assert b"TRACE /path HTTP/1.1" in body
+    assert b"Host: example.com" in body
+    assert b"User-Agent: probe" in body
+    # None of the secret-bearing headers (or their values) survive.
+    assert b"Authorization" not in body
+    assert b"super-secret" not in body
+    assert b"Cookie" not in body
+    assert b"session=abc" not in body
+    assert b"Proxy-Authorization" not in body
+
+
+@pytest.mark.parametrize("method", ["TRACE", "OPTIONS", "trace", "options"])
+def test_rewrite_authorization_skips_forbidden_methods(
+    ca_paths: tuple[Path, Path, Path],
+    method: str,
+) -> None:
+    """``_rewrite_authorization`` never injects on TRACE / OPTIONS (any case)."""
+    cert_path, key_path, _ = ca_paths
+    rule = CredentialRewriteRule(
+        host="127.0.0.1",
+        scheme="bearer",
+        real_secret="real-secret-value",
+        synthetic=None,
+        username=None,
+    )
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        credential_rewrites=[rule],
+    )
+    headers = b"Host: 127.0.0.1\r\n\r\n"
+    result = proxy._rewrite_authorization(method=method, host="127.0.0.1", headers_raw=headers)
+    assert result.error is None
+    assert b"Authorization" not in result.headers
+    assert b"real-secret-value" not in result.headers
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

N/A

## Summary

The credential proxy injected the real bound-host secret keyed only on the request host, ignoring the HTTP method. `TRACE` is a loopback diagnostic whose final recipient reflects the request back to the caller, so a `TRACE` to a bound host would get the real credential attached and then **echoed straight back into the sandbox** — a credential leak. `OPTIONS` similarly has no business carrying a bound-host secret.

- **Never inject/swap credentials on `TRACE`/`OPTIONS`**, independent of the egress allowlist. `_rewrite_authorization` now short-circuits these verbs before any host lookup or synthetic-placeholder swap, so even a permissive `* host/**` rule can't re-open the gap. A synthetic placeholder (a harmless fake) passes through untouched; the real secret is never emitted.
- **Behave as a conformant `Max-Forwards` intermediary** (RFC 7231 §5.1.2): for `TRACE`/`OPTIONS`, answer as the final recipient when `Max-Forwards` reaches `0` (TRACE returns `200 message/http` with `Authorization`/`Cookie`/`Proxy-Authorization` stripped; OPTIONS returns `200` + `Allow`) — never forwarding into the injection path — and decrement a positive budget before forwarding. The header is ignored on all other methods.

Wired into both the plain-HTTP path (`_handle_http`) and the MITM CONNECT path (`_handle_connect`), after the allowlist check so disallowed methods still get a `403`.

Impact on non–credential-proxy users: none for part 1 (nothing to inject). For part 2, ordinary `TRACE`/`OPTIONS` investigation still works — a request with no `Max-Forwards` (or `>= 1`) is forwarded to the site; only `Max-Forwards: 0` is answered by the proxy, which is the correct semantics for an intermediary.

## Test Plan

```bash
uv run --extra dev python -m pytest tests/inner/egress/test_proxy.py -p no:randomly \
  -k "max_forwards or loopback or forbidden or trace_echo or synthetic_not_swapped or not_injected"
# 20 passed

uv run --extra dev python -m pytest tests/inner/egress/test_proxy.py tests/inner/test_credential_proxy.py tests/inner/egress/test_rules.py -p no:randomly
```

New coverage in `tests/inner/egress/test_proxy.py`:
- No injection on `TRACE`/`OPTIONS` (swap-on-access and synthetic-placeholder shapes).
- `Max-Forwards: 0` terminates `TRACE` (echo, no upstream contact, no secret in body) and `OPTIONS` (`Allow` header).
- `Max-Forwards: 3` decremented to `2` on forward; `Max-Forwards` ignored on `GET` (value intact, normal injection still fires).
- Unit tests for `_apply_max_forwards` (non-applicable method, missing header, zero, positive, malformed) and `_build_trace_echo` sensitive-header stripping.

All pass. (Pre-existing, unrelated: `test_proxy_start_unix` fails locally on macOS with `AF_UNIX path too long` due to the temp-dir path length.)

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the unit tests listed above.

## Changelog

Credential proxy no longer attaches injected credentials to TRACE/OPTIONS requests, and the egress proxy now honors Max-Forwards as a conformant intermediary.