### PR TITLE
feat: import Qwen, Kiro, Pi, and Kimi chats

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -6271,7 +6271,7 @@ def resume(
 @cli.command("import")
 @click.option(
     "--harness",
-    type=click.Choice(["claude", "codex"], case_sensitive=False),
+    type=click.Choice(["claude", "codex", "kimi", "kiro", "pi", "qwen"], case_sensitive=False),
     required=True,
     help="Local coding harness that owns the source session.",
 )
@@ -6304,16 +6304,18 @@ def import_session_command(
     recent_session_count: int | None,
     server: str | None,
 ) -> None:
-    """Import local Claude Code or Codex chats.
+    """Import chats from supported local coding harnesses.
 
     The source transcript is converted to ordinary Omnigent items and stored
-    as a normal session. Use --session for one chat or --last for a bounded
-    batch. A source session can only be imported once.
+    as a normal session. Qwen, Kiro, and Kimi currently preserve visible
+    messages but not native tool activity. Use --session for one chat or --last
+    for a bounded batch. A source session can only be imported once.
 
     \b
     Examples:
       omnigent import --harness claude --session <session-id>
       omnigent import --harness codex --session <session-id>
+      omnigent import --harness qwen --session <session-id>
       omnigent import --harness claude --last 10
     """
     import httpx

--- a/omnigent/kimi_native_forwarder.py
+++ b/omnigent/kimi_native_forwarder.py
@@ -61,8 +61,8 @@ class _ForwardState:
 
 
 @dataclass
-class _MirrorItem:
-    """One conversation item to POST, plus the line index it came from."""
+class KimiWireItem:
+    """Stable parsed-wire contract shared by forwarding and offline import."""
 
     line_no: int
     role: str
@@ -71,6 +71,9 @@ class _MirrorItem:
     # "message" (a user/assistant turn → external_conversation_item) or
     # "reasoning" (a think block → external_output_reasoning_delta).
     kind: str = "message"
+
+
+_MirrorItem = KimiWireItem
 
 
 def clear_kimi_bridge_state(bridge_dir: Path) -> None:
@@ -110,7 +113,7 @@ def _write_state(bridge_dir: Path, state: _ForwardState) -> None:
         tmp.replace(bridge_dir / _STATE_FILE)
 
 
-def _workdirs_for_sessions(kimi_home: Path) -> dict[str, str]:
+def workdirs_for_kimi_sessions(kimi_home: Path) -> dict[str, str]:
     """Map each session dir → its ``workDir`` from ``session_index.jsonl``.
 
     Returns ``{}`` when the index is absent/unreadable (a brand-new home before
@@ -138,6 +141,9 @@ def _workdirs_for_sessions(kimi_home: Path) -> dict[str, str]:
     return mapping
 
 
+_workdirs_for_sessions = workdirs_for_kimi_sessions
+
+
 def _discover_wire(kimi_home: Path, workspace: str, launch_epoch_ms: int) -> Path | None:
     """Locate the wire log for *workspace*'s newest session created at/after launch.
 
@@ -150,7 +156,7 @@ def _discover_wire(kimi_home: Path, workspace: str, launch_epoch_ms: int) -> Pat
     sessions_root = kimi_home / "sessions"
     if not sessions_root.exists():
         return None
-    workdirs = _workdirs_for_sessions(kimi_home)
+    workdirs = workdirs_for_kimi_sessions(kimi_home)
     floor_s = (launch_epoch_ms - _DISCOVER_SKEW_MS) / 1000.0
     best: tuple[float, Path] | None = None
     for wire in sessions_root.glob("*/session_*/agents/main/wire.jsonl"):
@@ -185,7 +191,7 @@ def _input_text(blocks: object) -> str:
     return "".join(parts)
 
 
-def _row_to_item(line_no: int, row: dict[str, object]) -> _MirrorItem | None:
+def _row_to_item(line_no: int, row: dict[str, object]) -> KimiWireItem | None:
     """Map one wire-log row to a conversation item, or ``None`` to skip it."""
     row_type = row.get("type")
     if row_type == "turn.prompt":
@@ -195,7 +201,7 @@ def _row_to_item(line_no: int, row: dict[str, object]) -> _MirrorItem | None:
         text = _input_text(row.get("input"))
         if not text:
             return None
-        return _MirrorItem(
+        return KimiWireItem(
             line_no=line_no,
             role="user",
             text=text,
@@ -212,11 +218,14 @@ def _row_to_item(line_no: int, row: dict[str, object]) -> _MirrorItem | None:
         response_id = f"kimi:{uuid}" if isinstance(uuid, str) and uuid else f"kimi:line:{line_no}"
         part_type = part.get("type")
         if part_type == "text":
-            text = part.get("text")
-            if not isinstance(text, str) or not text:
+            part_text = part.get("text")
+            if not isinstance(part_text, str) or not part_text:
                 return None
-            return _MirrorItem(
-                line_no=line_no, role="assistant", text=text, response_id=response_id
+            return KimiWireItem(
+                line_no=line_no,
+                role="assistant",
+                text=part_text,
+                response_id=response_id,
             )
         if part_type == "think":
             # Reasoning lives in ``part["think"]`` (not ``part["text"]``). Mirror it
@@ -225,7 +234,7 @@ def _row_to_item(line_no: int, row: dict[str, object]) -> _MirrorItem | None:
             think = part.get("think")
             if not isinstance(think, str) or not think:
                 return None
-            return _MirrorItem(
+            return KimiWireItem(
                 line_no=line_no,
                 role="assistant",
                 text=think,
@@ -236,8 +245,8 @@ def _row_to_item(line_no: int, row: dict[str, object]) -> _MirrorItem | None:
     return None
 
 
-def _read_new_items(wire_path: Path, last_line: int) -> list[_MirrorItem]:
-    """Parse wire-log lines beyond *last_line* into conversation items.
+def read_kimi_wire_items(wire_path: Path, last_line: int) -> list[KimiWireItem]:
+    """Parse wire-log lines beyond *last_line* into the stable shared contract.
 
     The wire log is append-only JSONL, so a line count is a stable high-water
     mark. Non-JSON / unrecognized lines advance the cursor without emitting.
@@ -246,7 +255,7 @@ def _read_new_items(wire_path: Path, last_line: int) -> list[_MirrorItem]:
         lines = wire_path.read_text(encoding="utf-8").splitlines()
     except OSError:
         return []
-    items: list[_MirrorItem] = []
+    items: list[KimiWireItem] = []
     for idx in range(last_line, len(lines)):
         line = lines[idx].strip()
         if not line or not line.startswith("{"):
@@ -263,13 +272,16 @@ def _read_new_items(wire_path: Path, last_line: int) -> list[_MirrorItem]:
     return items
 
 
+_read_new_items = read_kimi_wire_items
+
+
 async def _post_conversation_item(
     client: httpx.AsyncClient,
     *,
     base_url: str,
     headers: dict[str, str],
     session_id: str,
-    item: _MirrorItem,
+    item: KimiWireItem,
     agent_name: str,
 ) -> None:
     """POST one mirrored turn as an external conversation item."""
@@ -299,7 +311,7 @@ async def _post_reasoning_item(
     base_url: str,
     headers: dict[str, str],
     session_id: str,
-    item: _MirrorItem,
+    item: KimiWireItem,
 ) -> None:
     """POST one mirrored think block as a transient reasoning event.
 
@@ -347,7 +359,7 @@ async def forward_kimi_wire_to_session(
                     last_line = 0
                     _write_state(bridge_dir, _ForwardState(str(wire_path), last_line))
             if wire_path is not None and wire_path.exists():
-                items = await asyncio.to_thread(_read_new_items, wire_path, last_line)
+                items = await asyncio.to_thread(read_kimi_wire_items, wire_path, last_line)
                 for item in items:
                     try:
                         if item.kind == "reasoning":

--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -43,17 +43,23 @@ class _ForwardState:
 
 
 @dataclass(frozen=True)
-class _KiroConversationMessage:
-    """One conversation message parsed from Kiro's JSONL store."""
+class KiroConversationMessage:
+    """Stable parsed-message contract shared by forwarding and offline import."""
 
     message_id: str
     role: str
     text: str
 
 
-def _kiro_cli_sessions_dir(home: Path | None = None) -> Path:
+_KiroConversationMessage = KiroConversationMessage
+
+
+def kiro_cli_sessions_dir(home: Path | None = None) -> Path:
     """Return Kiro CLI's session directory for this user."""
     return (home or Path.home()) / ".kiro" / "sessions" / "cli"
+
+
+_kiro_cli_sessions_dir = kiro_cli_sessions_dir
 
 
 def _read_state(bridge_dir: Path) -> _ForwardState:
@@ -161,7 +167,7 @@ def _discover_kiro_session_jsonl(
     The resume/fork path doesn't reach here: when the Kiro id is already known the
     caller binds it directly via :func:`_kiro_session_jsonl_for_id`.
     """
-    root = sessions_dir or _kiro_cli_sessions_dir()
+    root = sessions_dir or kiro_cli_sessions_dir()
     if not root.is_dir():
         return None
     floor_ms = max(0, launch_epoch_ms - _DISCOVERY_SKEW_MS)
@@ -198,7 +204,7 @@ def _kiro_session_jsonl_for_id(
     sessions_dir: Path | None = None,
 ) -> Path | None:
     """Return the JSONL path for a known Kiro session id, if it is usable."""
-    root = sessions_dir or _kiro_cli_sessions_dir()
+    root = sessions_dir or kiro_cli_sessions_dir()
     metadata_path = root / f"{session_id}.json"
     jsonl_path = root / f"{session_id}.jsonl"
     if not jsonl_path.is_file():
@@ -215,9 +221,9 @@ def _kiro_session_jsonl_for_id(
 def _read_new_kiro_messages(
     jsonl_path: Path,
     byte_offset: int,
-) -> tuple[list[_KiroConversationMessage], int]:
+) -> tuple[list[KiroConversationMessage], int]:
     """Read conversation messages after *byte_offset* from Kiro's JSONL file."""
-    messages: list[_KiroConversationMessage] = []
+    messages: list[KiroConversationMessage] = []
     try:
         with jsonl_path.open("rb") as handle:
             handle.seek(byte_offset)
@@ -235,7 +241,7 @@ def _read_new_kiro_messages(
                     line = raw_line.decode("utf-8")
                 except UnicodeDecodeError:
                     continue
-                message = _parse_kiro_jsonl_line(line)
+                message = parse_kiro_jsonl_line(line)
                 if message is not None:
                     messages.append(message)
             return messages, offset
@@ -243,8 +249,8 @@ def _read_new_kiro_messages(
         return [], byte_offset
 
 
-def _parse_kiro_jsonl_line(line: str) -> _KiroConversationMessage | None:
-    """Parse one Kiro JSONL line into a mirrorable conversation message."""
+def parse_kiro_jsonl_line(line: str) -> KiroConversationMessage | None:
+    """Parse one Kiro JSONL line into the stable shared message contract."""
     try:
         record = json.loads(line)
     except ValueError:
@@ -267,7 +273,10 @@ def _parse_kiro_jsonl_line(line: str) -> _KiroConversationMessage | None:
     text = _kiro_content_text(data.get("content")).strip()
     if not text:
         return None
-    return _KiroConversationMessage(message_id=message_id, role=role, text=text)
+    return KiroConversationMessage(message_id=message_id, role=role, text=text)
+
+
+_parse_kiro_jsonl_line = parse_kiro_jsonl_line
 
 
 def _kiro_content_text(content: object) -> str:
@@ -292,7 +301,7 @@ async def _post_conversation_message(
     *,
     session_id: str,
     agent_name: str,
-    message: _KiroConversationMessage,
+    message: KiroConversationMessage,
 ) -> None:
     """POST one Kiro message as an external conversation item."""
     if message.role == "assistant":

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -12,11 +12,13 @@ from omnigent.claude_native_bridge import read_transcript_items_from_offset
 from omnigent.codex_native import _CODEX_THREAD_ID_RE, _find_codex_rollout
 from omnigent.entities import NewConversationItem, parse_item_data
 from omnigent.kimi_native_credentials import resolve_user_kimi_home
-from omnigent.kimi_native_forwarder import _read_new_items as _read_new_kimi_items
-from omnigent.kimi_native_forwarder import _workdirs_for_sessions
+from omnigent.kimi_native_forwarder import (
+    read_kimi_wire_items,
+    workdirs_for_kimi_sessions,
+)
 from omnigent.kiro_native_session_forwarder import (
-    _kiro_cli_sessions_dir,
-    _parse_kiro_jsonl_line,
+    kiro_cli_sessions_dir,
+    parse_kiro_jsonl_line,
 )
 from omnigent.session_import.models import (
     ImportSource,
@@ -26,6 +28,17 @@ from omnigent.session_import.models import (
 
 _PI_IMPORT_SESSION_ID_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?")
 _MAX_EXTERNAL_SESSION_ID_LENGTH = 128
+_MAX_RESPONSE_ID_LENGTH = 64
+
+
+def _bounded_response_id(response_id: str) -> str:
+    """Keep short native ids readable and hash long ids without collisions."""
+    if len(response_id) <= _MAX_RESPONSE_ID_LENGTH:
+        return response_id
+    harness, separator, _ = response_id.partition(":")
+    prefix = f"{harness}:sha256:" if separator else "sha256:"
+    digest_length = _MAX_RESPONSE_ID_LENGTH - len(prefix)
+    return prefix + sha256(response_id.encode()).hexdigest()[:digest_length]
 
 
 def _find_transcript(root: Path, session_id: str) -> Path | None:
@@ -83,10 +96,15 @@ def _is_safe_pi_import_session_id(session_id: str) -> bool:
 def _qwen_session_locator(path: Path) -> str:
     """Qualify a Qwen id by project while staying within API limits."""
     project = path.parent.parent.name
-    locator = f"{project}:{path.stem}"
+    session_id = path.stem
+    locator = f"{project}:{session_id}"
     if len(locator) <= _MAX_EXTERNAL_SESSION_ID_LENGTH:
         return locator
-    return f"{sha256(project.encode()).hexdigest()[:16]}:{path.stem}"
+    project_digest = sha256(project.encode()).hexdigest()[:16]
+    locator = f"{project_digest}:{session_id}"
+    if len(locator) <= _MAX_EXTERNAL_SESSION_ID_LENGTH:
+        return locator
+    return f"{project_digest}:{sha256(session_id.encode()).hexdigest()}"
 
 
 def list_recent_local_session_ids(
@@ -114,7 +132,7 @@ def list_recent_local_session_ids(
         return _recent_unique_session_ids(candidates, limit=limit)
 
     if source == "kiro":
-        root = _kiro_cli_sessions_dir()
+        root = kiro_cli_sessions_dir()
         candidates = [
             (path, path.stem)
             for path in root.glob("*.jsonl")
@@ -129,6 +147,7 @@ def list_recent_local_session_ids(
             if configured_home
             else Path.home() / ".pi" / "agent"
         )
+        # Pi stores ids in the header, so discovery intentionally reads one line per file.
         candidates = [
             (path, session_id)
             for path in (home / "sessions").rglob("*.jsonl")
@@ -394,6 +413,7 @@ def load_codex_session(
 
 def _qwen_message_data(record: dict[str, object]) -> dict[str, object] | None:
     """Convert one visible Qwen recording row to Omnigent message data."""
+    # Qwen records assistant events as type="assistant" while message.role is "model".
     record_type = record.get("type")
     if record_type == "user":
         role = "user"
@@ -501,7 +521,7 @@ def load_qwen_session(
         items.append(
             NewConversationItem(
                 type="message",
-                response_id=response_id[:64],
+                response_id=_bounded_response_id(response_id),
                 data=parse_item_data("message", data),
             )
         )
@@ -523,7 +543,7 @@ def load_kiro_session(
     kiro_home: Path | None = None,
 ) -> LocalSessionImport:
     """Load one Kiro CLI session from its metadata and JSONL transcript."""
-    root = _kiro_cli_sessions_dir(kiro_home)
+    root = kiro_cli_sessions_dir(kiro_home)
     transcript_path = next(
         (path for path in root.glob("*.jsonl") if path.is_file() and path.stem == session_id),
         None,
@@ -545,7 +565,7 @@ def load_kiro_session(
         messages = [
             message
             for line in transcript_path.read_text(encoding="utf-8").splitlines()
-            if (message := _parse_kiro_jsonl_line(line)) is not None
+            if (message := parse_kiro_jsonl_line(line)) is not None
         ]
     except OSError as exc:
         raise SessionImportNotFoundError(
@@ -554,7 +574,7 @@ def load_kiro_session(
     items = tuple(
         NewConversationItem(
             type="message",
-            response_id=f"kiro:{message.message_id}"[:64],
+            response_id=_bounded_response_id(f"kiro:{message.message_id}"),
             data=parse_item_data(
                 "message",
                 {
@@ -686,7 +706,7 @@ def _pi_message_items(record: dict[str, object]) -> tuple[NewConversationItem, .
         return (
             NewConversationItem(
                 type="message",
-                response_id=response_id[:64],
+                response_id=_bounded_response_id(response_id),
                 data=parse_item_data(
                     "message",
                     {
@@ -719,7 +739,7 @@ def _pi_message_items(record: dict[str, object]) -> tuple[NewConversationItem, .
         return (
             NewConversationItem(
                 type="function_call_output",
-                response_id=response_id[:64],
+                response_id=_bounded_response_id(response_id),
                 data=parse_item_data(
                     "function_call_output",
                     {"call_id": call_id, "output": _pi_text(message.get("content"))},
@@ -738,7 +758,7 @@ def _pi_message_items(record: dict[str, object]) -> tuple[NewConversationItem, .
         items.append(
             NewConversationItem(
                 type="message",
-                response_id=response_id[:64],
+                response_id=_bounded_response_id(response_id),
                 data=parse_item_data(
                     "message",
                     {"role": "user", "content": normalized},
@@ -762,7 +782,7 @@ def _pi_message_items(record: dict[str, object]) -> tuple[NewConversationItem, .
         items.append(
             NewConversationItem(
                 type="message",
-                response_id=response_id[:64],
+                response_id=_bounded_response_id(response_id),
                 data=parse_item_data("message", data),
             )
         )
@@ -796,10 +816,11 @@ def _pi_message_items(record: dict[str, object]) -> tuple[NewConversationItem, .
                 if isinstance(arguments, str)
                 else json.dumps(arguments if arguments is not None else {}, separators=(",", ":"))
             )
+            # Only message items support interrupted state; retain aborted-turn tool calls.
             items.append(
                 NewConversationItem(
                     type="function_call",
-                    response_id=response_id[:64],
+                    response_id=_bounded_response_id(response_id),
                     data=parse_item_data(
                         "function_call",
                         {
@@ -885,13 +906,13 @@ def load_kimi_session(
         )
     wire_path = matches[0]
     session_dir = wire_path.parent.parent.parent
-    workspace_value = _workdirs_for_sessions(home).get(str(session_dir))
+    workspace_value = workdirs_for_kimi_sessions(home).get(str(session_dir))
     workspace = workspace_value.strip() if isinstance(workspace_value, str) else None
-    mirrored = _read_new_kimi_items(wire_path, 0)
+    mirrored = read_kimi_wire_items(wire_path, 0)
     items = tuple(
         NewConversationItem(
             type="message",
-            response_id=item.response_id[:64],
+            response_id=_bounded_response_id(item.response_id),
             data=parse_item_data(
                 "message",
                 {

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -4,16 +4,28 @@ from __future__ import annotations
 
 import json
 import os
+import re
+from hashlib import sha256
 from pathlib import Path
 
 from omnigent.claude_native_bridge import read_transcript_items_from_offset
 from omnigent.codex_native import _CODEX_THREAD_ID_RE, _find_codex_rollout
 from omnigent.entities import NewConversationItem, parse_item_data
+from omnigent.kimi_native_credentials import resolve_user_kimi_home
+from omnigent.kimi_native_forwarder import _read_new_items as _read_new_kimi_items
+from omnigent.kimi_native_forwarder import _workdirs_for_sessions
+from omnigent.kiro_native_session_forwarder import (
+    _kiro_cli_sessions_dir,
+    _parse_kiro_jsonl_line,
+)
 from omnigent.session_import.models import (
     ImportSource,
     LocalSessionImport,
     SessionImportNotFoundError,
 )
+
+_PI_IMPORT_SESSION_ID_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?")
+_MAX_EXTERNAL_SESSION_ID_LENGTH = 128
 
 
 def _find_transcript(root: Path, session_id: str) -> Path | None:
@@ -47,6 +59,36 @@ def _recent_unique_session_ids(
     return tuple(ordered[:limit])
 
 
+def _pi_session_id_from_path(path: Path) -> str | None:
+    """Read a safe native session id from a Pi transcript header."""
+    try:
+        with path.open(encoding="utf-8") as handle:
+            header = json.loads(handle.readline())
+    except (OSError, ValueError):
+        return None
+    session_id = header.get("id") if isinstance(header, dict) else None
+    if not isinstance(session_id, str) or not _is_safe_pi_import_session_id(session_id):
+        return None
+    return session_id
+
+
+def _is_safe_pi_import_session_id(session_id: str) -> bool:
+    """Match Pi's safe syntax within the import API's identity limit."""
+    return (
+        len(session_id) <= _MAX_EXTERNAL_SESSION_ID_LENGTH
+        and _PI_IMPORT_SESSION_ID_RE.fullmatch(session_id) is not None
+    )
+
+
+def _qwen_session_locator(path: Path) -> str:
+    """Qualify a Qwen id by project while staying within API limits."""
+    project = path.parent.parent.name
+    locator = f"{project}:{path.stem}"
+    if len(locator) <= _MAX_EXTERNAL_SESSION_ID_LENGTH:
+        return locator
+    return f"{sha256(project.encode()).hexdigest()[:16]}:{path.stem}"
+
+
 def list_recent_local_session_ids(
     source: ImportSource,
     *,
@@ -64,23 +106,65 @@ def list_recent_local_session_ids(
         ]
         return _recent_unique_session_ids(candidates, limit=limit)
 
-    configured_home = os.environ.get("CODEX_HOME")
-    home = Path(configured_home).expanduser() if configured_home else Path.home() / ".codex"
-    rollouts: list[Path] = []
-    sessions = home / "sessions"
-    archived_sessions = home / "archived_sessions"
-    if sessions.is_dir():
-        rollouts.extend(path for path in sessions.glob("**/rollout-*.jsonl") if path.is_file())
-    if archived_sessions.is_dir():
-        rollouts.extend(
-            path for path in archived_sessions.glob("rollout-*.jsonl") if path.is_file()
+    if source == "qwen":
+        configured_home = os.environ.get("QWEN_HOME")
+        home = Path(configured_home).expanduser() if configured_home else Path.home() / ".qwen"
+        paths = [path for path in (home / "projects").glob("*/chats/*.jsonl") if path.is_file()]
+        candidates = [(path, _qwen_session_locator(path)) for path in paths]
+        return _recent_unique_session_ids(candidates, limit=limit)
+
+    if source == "kiro":
+        root = _kiro_cli_sessions_dir()
+        candidates = [
+            (path, path.stem)
+            for path in root.glob("*.jsonl")
+            if path.is_file() and path.with_suffix(".json").is_file()
+        ]
+        return _recent_unique_session_ids(candidates, limit=limit)
+
+    if source == "pi":
+        configured_home = os.environ.get("PI_CODING_AGENT_DIR")
+        home = (
+            Path(configured_home).expanduser()
+            if configured_home
+            else Path.home() / ".pi" / "agent"
         )
-    candidates = []
-    for path in rollouts:
-        session_id = path.stem[-36:]
-        if _CODEX_THREAD_ID_RE.fullmatch(session_id):
-            candidates.append((path, session_id))
-    return _recent_unique_session_ids(candidates, limit=limit)
+        candidates = [
+            (path, session_id)
+            for path in (home / "sessions").rglob("*.jsonl")
+            if path.is_file() and (session_id := _pi_session_id_from_path(path)) is not None
+        ]
+        return _recent_unique_session_ids(candidates, limit=limit)
+
+    if source == "kimi":
+        home = resolve_user_kimi_home()
+        candidates = [
+            (path, path.parent.parent.parent.name)
+            for path in (home / "sessions").glob("*/session_*/agents/main/wire.jsonl")
+            if path.is_file()
+        ]
+        return _recent_unique_session_ids(candidates, limit=limit)
+
+    if source == "codex":
+        configured_home = os.environ.get("CODEX_HOME")
+        home = Path(configured_home).expanduser() if configured_home else Path.home() / ".codex"
+        rollouts: list[Path] = []
+        sessions = home / "sessions"
+        archived_sessions = home / "archived_sessions"
+        if sessions.is_dir():
+            rollouts.extend(path for path in sessions.glob("**/rollout-*.jsonl") if path.is_file())
+        if archived_sessions.is_dir():
+            rollouts.extend(
+                path for path in archived_sessions.glob("rollout-*.jsonl") if path.is_file()
+            )
+        candidates = []
+        for path in rollouts:
+            session_id = path.stem[-36:]
+            if _CODEX_THREAD_ID_RE.fullmatch(session_id):
+                candidates.append((path, session_id))
+        return _recent_unique_session_ids(candidates, limit=limit)
+
+    raise ValueError(f"Unsupported import source: {source}")
 
 
 def _claude_workspace(transcript_path: Path) -> str | None:
@@ -308,16 +392,557 @@ def load_codex_session(
     )
 
 
+def _qwen_message_data(record: dict[str, object]) -> dict[str, object] | None:
+    """Convert one visible Qwen recording row to Omnigent message data."""
+    record_type = record.get("type")
+    if record_type == "user":
+        role = "user"
+        content_type = "input_text"
+    elif record_type == "assistant":
+        role = "assistant"
+        content_type = "output_text"
+    else:
+        return None
+    message = record.get("message")
+    if not isinstance(message, dict) or not isinstance(message.get("parts"), list):
+        return None
+    content = [
+        {"type": content_type, "text": part["text"]}
+        for part in message["parts"]
+        if isinstance(part, dict) and isinstance(part.get("text"), str) and part["text"]
+    ]
+    if not content:
+        return None
+    data: dict[str, object] = {"role": role, "content": content}
+    if role == "assistant":
+        data["agent"] = "qwen-native-ui"
+    return data
+
+
+def _qwen_active_branch(records: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Return Qwen records on the current leaf's root-to-leaf path."""
+    linked = [record for record in records if isinstance(record.get("uuid"), str)]
+    if not linked or all("parentUuid" not in record for record in linked):
+        return records
+    by_id = {record["uuid"]: record for record in linked}
+    if len(by_id) != len(linked):
+        return []
+
+    branch: list[dict[str, object]] = []
+    current = linked[-1]
+    seen: set[str] = set()
+    while True:
+        record_id = current["uuid"]
+        if not isinstance(record_id, str) or record_id in seen:
+            return []
+        seen.add(record_id)
+        branch.append(current)
+        parent_id = current.get("parentUuid")
+        if parent_id is None:
+            branch.reverse()
+            return branch
+        if not isinstance(parent_id, str) or parent_id not in by_id:
+            return []
+        current = by_id[parent_id]
+
+
+def load_qwen_session(
+    session_id: str,
+    *,
+    qwen_home: Path | None = None,
+) -> LocalSessionImport:
+    """Load one Qwen Code session from its project chat recording."""
+    configured_home = os.environ.get("QWEN_HOME")
+    home = qwen_home or (Path(configured_home).expanduser() if configured_home else None)
+    root = (home or Path.home() / ".qwen") / "projects"
+    qualified = ":" in session_id
+    matches = [
+        path
+        for path in root.glob("*/chats/*.jsonl")
+        if path.is_file()
+        and (_qwen_session_locator(path) == session_id if qualified else path.stem == session_id)
+    ]
+    if not matches:
+        raise SessionImportNotFoundError(f"Qwen Code session {session_id!r} was not found")
+    if len(matches) > 1:
+        choices = ", ".join(sorted(_qwen_session_locator(path) for path in matches))
+        raise SessionImportNotFoundError(
+            f"Qwen Code session {session_id!r} is ambiguous; use one of: {choices}"
+        )
+    transcript_path = matches[0]
+
+    records: list[dict[str, object]] = []
+    with transcript_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(record, dict):
+                continue
+            records.append(record)
+
+    workspace: str | None = None
+    items: list[NewConversationItem] = []
+    for record_number, record in enumerate(_qwen_active_branch(records), start=1):
+        if workspace is None:
+            cwd = record.get("cwd")
+            if isinstance(cwd, str) and cwd.strip():
+                workspace = cwd.strip()
+        data = _qwen_message_data(record)
+        if data is None:
+            continue
+        record_id = record.get("uuid")
+        response_id = (
+            f"qwen:{record_id}"
+            if isinstance(record_id, str) and record_id
+            else f"qwen:{record_number}"
+        )
+        items.append(
+            NewConversationItem(
+                type="message",
+                response_id=response_id[:64],
+                data=parse_item_data("message", data),
+            )
+        )
+    if not items:
+        raise SessionImportNotFoundError(
+            f"Qwen Code session {session_id!r} has no importable history"
+        )
+    return LocalSessionImport(
+        source="qwen",
+        external_session_id=_qwen_session_locator(transcript_path),
+        workspace=workspace,
+        items=tuple(items),
+    )
+
+
+def load_kiro_session(
+    session_id: str,
+    *,
+    kiro_home: Path | None = None,
+) -> LocalSessionImport:
+    """Load one Kiro CLI session from its metadata and JSONL transcript."""
+    root = _kiro_cli_sessions_dir(kiro_home)
+    transcript_path = next(
+        (path for path in root.glob("*.jsonl") if path.is_file() and path.stem == session_id),
+        None,
+    )
+    if transcript_path is None:
+        raise SessionImportNotFoundError(f"Kiro session {session_id!r} was not found")
+    metadata_path = transcript_path.with_suffix(".json")
+    if not metadata_path.is_file():
+        raise SessionImportNotFoundError(f"Kiro session {session_id!r} was not found")
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise SessionImportNotFoundError(
+            f"Kiro session {session_id!r} has unreadable metadata"
+        ) from exc
+    workspace_value = metadata.get("cwd") if isinstance(metadata, dict) else None
+    workspace = workspace_value.strip() if isinstance(workspace_value, str) else None
+    try:
+        messages = [
+            message
+            for line in transcript_path.read_text(encoding="utf-8").splitlines()
+            if (message := _parse_kiro_jsonl_line(line)) is not None
+        ]
+    except OSError as exc:
+        raise SessionImportNotFoundError(
+            f"Kiro session {session_id!r} has an unreadable transcript"
+        ) from exc
+    items = tuple(
+        NewConversationItem(
+            type="message",
+            response_id=f"kiro:{message.message_id}"[:64],
+            data=parse_item_data(
+                "message",
+                {
+                    "role": message.role,
+                    **({"agent": "kiro-native-ui"} if message.role == "assistant" else {}),
+                    "content": [
+                        {
+                            "type": "output_text" if message.role == "assistant" else "input_text",
+                            "text": message.text,
+                        }
+                    ],
+                },
+            ),
+        )
+        for message in messages
+    )
+    if not items:
+        raise SessionImportNotFoundError(f"Kiro session {session_id!r} has no importable history")
+    return LocalSessionImport(
+        source="kiro",
+        external_session_id=session_id,
+        workspace=workspace or None,
+        items=items,
+    )
+
+
+def _pi_text(content: object) -> str:
+    """Flatten Pi string or typed-text content."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    return "".join(
+        block["text"]
+        for block in content
+        if isinstance(block, dict)
+        and block.get("type") == "text"
+        and isinstance(block.get("text"), str)
+    )
+
+
+def _pi_message_content(content: object, *, role: str) -> list[dict[str, object]]:
+    """Map Pi text and user-image blocks without changing their order."""
+    content_type = "input_text" if role == "user" else "output_text"
+    if isinstance(content, str):
+        return [{"type": content_type, "text": content}] if content else []
+    if not isinstance(content, list):
+        return []
+    normalized: list[dict[str, object]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        text = block.get("text")
+        if block.get("type") == "text" and isinstance(text, str) and text:
+            normalized.append({"type": content_type, "text": text})
+            continue
+        data = block.get("data")
+        mime_type = block.get("mimeType")
+        if (
+            role == "user"
+            and block.get("type") == "image"
+            and isinstance(data, str)
+            and data
+            and isinstance(mime_type, str)
+            and mime_type.startswith("image/")
+        ):
+            normalized.append(
+                {"type": "input_image", "image_url": f"data:{mime_type};base64,{data}"}
+            )
+    return normalized
+
+
+def _pi_active_branch(records: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Return Pi entries on the current leaf's root-to-leaf path."""
+    header = next((record for record in records if record.get("type") == "session"), {})
+    version = header.get("version")
+    if not isinstance(version, int) or version < 2:
+        legacy_parent_id: str | None = None
+        migrated: list[dict[str, object]] = []
+        for index, record in enumerate(records):
+            if record.get("type") == "session":
+                migrated.append(record)
+                continue
+            entry = dict(record)
+            legacy_entry_id = f"legacy-{index}"
+            entry["id"] = legacy_entry_id
+            entry["parentId"] = legacy_parent_id
+            migrated.append(entry)
+            legacy_parent_id = legacy_entry_id
+        records = migrated
+    entries = [
+        record
+        for record in records
+        if record.get("type") != "session" and isinstance(record.get("id"), str)
+    ]
+    if not entries:
+        return []
+    if all("parentId" not in entry for entry in entries):
+        return entries
+    by_id = {entry["id"]: entry for entry in entries}
+    if len(by_id) != len(entries):
+        return []
+    branch: list[dict[str, object]] = []
+    current = entries[-1]
+    seen: set[str] = set()
+    while True:
+        entry_id = current["id"]
+        if not isinstance(entry_id, str) or entry_id in seen:
+            return []
+        seen.add(entry_id)
+        branch.append(current)
+        parent_id = current.get("parentId")
+        if parent_id is None:
+            branch.reverse()
+            return branch
+        if not isinstance(parent_id, str) or parent_id not in by_id:
+            return []
+        current = by_id[parent_id]
+
+
+def _pi_message_items(record: dict[str, object]) -> tuple[NewConversationItem, ...]:
+    """Convert one Pi message entry to visible Omnigent items."""
+    if record.get("type") == "branch_summary":
+        summary = record.get("summary")
+        if not isinstance(summary, str) or not summary:
+            return ()
+        entry_id = record.get("id")
+        response_id = f"pi:{entry_id}" if isinstance(entry_id, str) else "pi:history"
+        return (
+            NewConversationItem(
+                type="message",
+                response_id=response_id[:64],
+                data=parse_item_data(
+                    "message",
+                    {
+                        "role": "user",
+                        "is_meta": True,
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": (
+                                    "The following is a summary of a branch that this "
+                                    "conversation came back from:\n\n<summary>\n"
+                                    f"{summary}\n</summary>"
+                                ),
+                            }
+                        ],
+                    },
+                ),
+            ),
+        )
+    message = record.get("message")
+    if record.get("type") != "message" or not isinstance(message, dict):
+        return ()
+    entry_id = record.get("id")
+    response_id = f"pi:{entry_id}" if isinstance(entry_id, str) else "pi:history"
+    role = message.get("role")
+    if role == "toolResult":
+        call_id = message.get("toolCallId")
+        if not isinstance(call_id, str) or not call_id:
+            return ()
+        return (
+            NewConversationItem(
+                type="function_call_output",
+                response_id=response_id[:64],
+                data=parse_item_data(
+                    "function_call_output",
+                    {"call_id": call_id, "output": _pi_text(message.get("content"))},
+                ),
+            ),
+        )
+    if role not in {"user", "assistant"}:
+        return ()
+
+    items: list[NewConversationItem] = []
+    content = message.get("content")
+    if role == "user":
+        normalized = _pi_message_content(content, role=role)
+        if not normalized:
+            return ()
+        items.append(
+            NewConversationItem(
+                type="message",
+                response_id=response_id[:64],
+                data=parse_item_data(
+                    "message",
+                    {"role": "user", "content": normalized},
+                ),
+            )
+        )
+        return tuple(items)
+
+    interrupted = message.get("stopReason") == "aborted"
+
+    def append_assistant_text(blocks: list[dict[str, object]]) -> None:
+        if not blocks:
+            return
+        data: dict[str, object] = {
+            "role": "assistant",
+            "agent": "pi-native-ui",
+            "content": blocks,
+        }
+        if interrupted:
+            data["interrupted"] = True
+        items.append(
+            NewConversationItem(
+                type="message",
+                response_id=response_id[:64],
+                data=parse_item_data("message", data),
+            )
+        )
+
+    if isinstance(content, str):
+        append_assistant_text(_pi_message_content(content, role="assistant"))
+    elif isinstance(content, list):
+        pending_text: list[dict[str, object]] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text":
+                pending_text.extend(_pi_message_content([block], role="assistant"))
+                continue
+            if block.get("type") != "toolCall":
+                continue
+            append_assistant_text(pending_text)
+            pending_text = []
+            call_id = block.get("id")
+            name = block.get("name")
+            if (
+                not isinstance(call_id, str)
+                or not call_id
+                or not isinstance(name, str)
+                or not name
+            ):
+                continue
+            arguments = block.get("arguments")
+            serialized_arguments = (
+                arguments
+                if isinstance(arguments, str)
+                else json.dumps(arguments if arguments is not None else {}, separators=(",", ":"))
+            )
+            items.append(
+                NewConversationItem(
+                    type="function_call",
+                    response_id=response_id[:64],
+                    data=parse_item_data(
+                        "function_call",
+                        {
+                            "agent": "pi-native-ui",
+                            "name": name,
+                            "arguments": serialized_arguments,
+                            "call_id": call_id,
+                        },
+                    ),
+                )
+            )
+        append_assistant_text(pending_text)
+    return tuple(items)
+
+
+def load_pi_session(
+    session_id: str,
+    *,
+    pi_home: Path | None = None,
+) -> LocalSessionImport:
+    """Load the active branch of one Pi coding-agent JSONL session."""
+    configured_home = os.environ.get("PI_CODING_AGENT_DIR")
+    home = pi_home or (Path(configured_home).expanduser() if configured_home else None)
+    root = (home or Path.home() / ".pi" / "agent") / "sessions"
+    if not _is_safe_pi_import_session_id(session_id):
+        raise SessionImportNotFoundError(f"Pi session {session_id!r} was not found")
+    matches = [
+        path
+        for path in root.rglob("*.jsonl")
+        if path.is_file() and _pi_session_id_from_path(path) == session_id
+    ]
+    if not matches:
+        raise SessionImportNotFoundError(f"Pi session {session_id!r} was not found")
+    if len(matches) > 1:
+        raise SessionImportNotFoundError(f"Pi session {session_id!r} is ambiguous across projects")
+    transcript_path = matches[0]
+    records: list[dict[str, object]] = []
+    with transcript_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, dict):
+                records.append(record)
+    header = next((record for record in records if record.get("type") == "session"), {})
+    if header.get("id") != session_id:
+        raise SessionImportNotFoundError(
+            f"Pi session {session_id!r} has mismatched transcript metadata"
+        )
+    workspace_value = header.get("cwd")
+    workspace = workspace_value.strip() if isinstance(workspace_value, str) else None
+    items = tuple(
+        item for record in _pi_active_branch(records) for item in _pi_message_items(record)
+    )
+    if not items:
+        raise SessionImportNotFoundError(f"Pi session {session_id!r} has no importable history")
+    return LocalSessionImport(
+        source="pi",
+        external_session_id=session_id,
+        workspace=workspace or None,
+        items=items,
+    )
+
+
+def load_kimi_session(
+    session_id: str,
+    *,
+    kimi_home: Path | None = None,
+) -> LocalSessionImport:
+    """Load one Kimi Code session from its append-only wire log."""
+    home = kimi_home or resolve_user_kimi_home()
+    matches = [
+        path
+        for path in (home / "sessions").glob("*/session_*/agents/main/wire.jsonl")
+        if path.is_file() and path.parent.parent.parent.name == session_id
+    ]
+    if not matches:
+        raise SessionImportNotFoundError(f"Kimi session {session_id!r} was not found")
+    if len(matches) > 1:
+        raise SessionImportNotFoundError(
+            f"Kimi session {session_id!r} is ambiguous across workspaces"
+        )
+    wire_path = matches[0]
+    session_dir = wire_path.parent.parent.parent
+    workspace_value = _workdirs_for_sessions(home).get(str(session_dir))
+    workspace = workspace_value.strip() if isinstance(workspace_value, str) else None
+    mirrored = _read_new_kimi_items(wire_path, 0)
+    items = tuple(
+        NewConversationItem(
+            type="message",
+            response_id=item.response_id[:64],
+            data=parse_item_data(
+                "message",
+                {
+                    "role": item.role,
+                    **({"agent": "kimi-native-ui"} if item.role == "assistant" else {}),
+                    "content": [
+                        {
+                            "type": "output_text" if item.role == "assistant" else "input_text",
+                            "text": item.text,
+                        }
+                    ],
+                },
+            ),
+        )
+        for item in mirrored
+        if item.kind == "message"
+    )
+    if not items:
+        raise SessionImportNotFoundError(f"Kimi session {session_id!r} has no importable history")
+    return LocalSessionImport(
+        source="kimi",
+        external_session_id=session_id,
+        workspace=workspace or None,
+        items=items,
+    )
+
+
 def load_local_session(source: ImportSource, session_id: str) -> LocalSessionImport:
     """Load one local session from the selected first-party harness."""
     if source == "claude":
         return load_claude_session(session_id)
-    return load_codex_session(session_id)
+    if source == "codex":
+        return load_codex_session(session_id)
+    if source == "qwen":
+        return load_qwen_session(session_id)
+    if source == "kiro":
+        return load_kiro_session(session_id)
+    if source == "pi":
+        return load_pi_session(session_id)
+    if source == "kimi":
+        return load_kimi_session(session_id)
+    raise ValueError(f"Unsupported import source: {source}")
 
 
 __all__ = [
     "list_recent_local_session_ids",
     "load_claude_session",
     "load_codex_session",
+    "load_kimi_session",
+    "load_kiro_session",
     "load_local_session",
+    "load_pi_session",
+    "load_qwen_session",
 ]

--- a/omnigent/session_import/models.py
+++ b/omnigent/session_import/models.py
@@ -9,7 +9,7 @@ from typing import Literal
 from omnigent.entities import MessageData, NewConversationItem
 from omnigent.entities.conversation import synthesize_conversation_title
 
-ImportSource = Literal["claude", "codex"]
+ImportSource = Literal["claude", "codex", "kimi", "kiro", "pi", "qwen"]
 
 IMPORT_SOURCE_LABEL_KEY = "omnigent.import.source"
 IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY = "omnigent.import.external_session_id"

--- a/openapi.json
+++ b/openapi.json
@@ -1759,7 +1759,11 @@
           "source": {
             "enum": [
               "claude",
-              "codex"
+              "codex",
+              "kimi",
+              "kiro",
+              "pi",
+              "qwen"
             ],
             "title": "Source",
             "type": "string"

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -86,7 +86,7 @@ def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path:
 
 
 def test_import_command_rejects_cursor() -> None:
-    """The v0 import command accepts only Claude Code and Codex."""
+    """The import command rejects sources without a supported adapter."""
     result = CliRunner().invoke(
         cli,
         ["import", "--harness", "cursor", "--session", "cursor-session"],
@@ -94,6 +94,46 @@ def test_import_command_rejects_cursor() -> None:
 
     assert result.exit_code == 2
     assert "Invalid value for '--harness'" in result.output
+
+
+@respx.mock
+def test_import_command_accepts_qwen_session(tmp_path: Path) -> None:
+    """The public CLI accepts a newly supported JSONL harness."""
+    session_id = "019f8648-2797-7170-bf73-837f2655c47e"
+    transcript = tmp_path / ".qwen" / "projects" / "-repo" / "chats" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        json.dumps(
+            {
+                "uuid": "user-1",
+                "sessionId": session_id,
+                "type": "user",
+                "cwd": "/repo",
+                "message": {"role": "user", "parts": [{"text": "hello"}]},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    route = respx.post(f"{_BASE}/v1/imports").mock(
+        return_value=httpx.Response(
+            201,
+            json={"session_id": "conv_qwen", "status": "imported", "item_count": 1},
+        )
+    )
+
+    with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
+        result = CliRunner().invoke(
+            cli,
+            ["import", "--harness", "qwen", "--session", session_id],
+            env={"HOME": str(tmp_path), "QWEN_HOME": str(tmp_path / ".qwen")},
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(route.calls.last.request.content)
+    assert payload["source"] == "qwen"
+    assert payload["external_session_id"] == f"-repo:{session_id}"
+    assert "conv_qwen" in result.output
 
 
 @respx.mock

--- a/tests/e2e/test_chat_import_e2e.py
+++ b/tests/e2e/test_chat_import_e2e.py
@@ -10,6 +10,135 @@ import sys
 from pathlib import Path
 
 import httpx
+import pytest
+
+
+def _write_jsonl_import_fixture(home: Path, harness: str) -> str:
+    """Write one two-message native transcript and return its source id."""
+    if harness == "qwen":
+        session_id = "019f8648-2797-7170-bf73-837f2655c471"
+        transcript = home / ".qwen" / "projects" / "-repo" / "chats" / f"{session_id}.jsonl"
+        records = [
+            {
+                "uuid": "user-1",
+                "parentUuid": None,
+                "sessionId": session_id,
+                "timestamp": "2026-07-21T12:00:00Z",
+                "type": "user",
+                "cwd": "/repo",
+                "message": {"role": "user", "parts": [{"text": "inspect TODO.md"}]},
+            },
+            {
+                "uuid": "assistant-1",
+                "parentUuid": "user-1",
+                "sessionId": session_id,
+                "timestamp": "2026-07-21T12:00:01Z",
+                "type": "assistant",
+                "cwd": "/repo",
+                "message": {"role": "model", "parts": [{"text": "Done."}]},
+            },
+        ]
+    elif harness == "kiro":
+        session_id = "kiro-import-e2e"
+        root = home / ".kiro" / "sessions" / "cli"
+        transcript = root / f"{session_id}.jsonl"
+        root.mkdir(parents=True)
+        (root / f"{session_id}.json").write_text(
+            json.dumps({"cwd": "/repo", "created_at": "2026-07-21T12:00:00Z"}),
+            encoding="utf-8",
+        )
+        records = [
+            {
+                "kind": "Prompt",
+                "data": {
+                    "message_id": "user-1",
+                    "content": [{"kind": "text", "data": "inspect TODO.md"}],
+                },
+            },
+            {
+                "kind": "AssistantMessage",
+                "data": {
+                    "message_id": "assistant-1",
+                    "content": [{"kind": "text", "data": "Done."}],
+                },
+            },
+        ]
+    elif harness == "pi":
+        session_id = "019f8648-2797-7170-bf73-837f2655c472"
+        transcript = home / ".pi" / "agent" / "sessions" / "--repo--" / f"stamp_{session_id}.jsonl"
+        records = [
+            {"type": "session", "version": 3, "id": session_id, "cwd": "/repo"},
+            {
+                "type": "message",
+                "id": "11111111",
+                "parentId": None,
+                "timestamp": "2026-07-21T12:00:00Z",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "inspect TODO.md"}],
+                    "timestamp": 0,
+                },
+            },
+            {
+                "type": "message",
+                "id": "22222222",
+                "parentId": "11111111",
+                "timestamp": "2026-07-21T12:00:01Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Done."}],
+                    "api": "anthropic-messages",
+                    "provider": "anthropic",
+                    "model": "claude-sonnet",
+                    "usage": {
+                        "input": 0,
+                        "output": 0,
+                        "cacheRead": 0,
+                        "cacheWrite": 0,
+                        "totalTokens": 0,
+                        "cost": {
+                            "input": 0,
+                            "output": 0,
+                            "cacheRead": 0,
+                            "cacheWrite": 0,
+                            "total": 0,
+                        },
+                    },
+                    "stopReason": "stop",
+                    "timestamp": 0,
+                },
+            },
+        ]
+    else:
+        session_id = "session_import_e2e"
+        session_dir = home / ".kimi-code" / "sessions" / "wd_repo" / session_id
+        transcript = session_dir / "agents" / "main" / "wire.jsonl"
+        index = home / ".kimi-code" / "session_index.jsonl"
+        index.parent.mkdir(parents=True)
+        index.write_text(
+            json.dumps({"sessionDir": str(session_dir), "workDir": "/repo"}) + "\n",
+            encoding="utf-8",
+        )
+        records = [
+            {
+                "type": "turn.prompt",
+                "origin": {"kind": "user"},
+                "input": [{"type": "text", "text": "inspect TODO.md"}],
+            },
+            {
+                "type": "context.append_loop_event",
+                "event": {
+                    "type": "content.part",
+                    "uuid": "assistant-1",
+                    "part": {"type": "text", "text": "Done."},
+                },
+            },
+        ]
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+    return f"-repo:{session_id}" if harness == "qwen" else session_id
 
 
 def test_cli_imports_claude_chat_into_live_server(live_server: str, tmp_path: Path) -> None:
@@ -82,8 +211,10 @@ def test_cli_imports_claude_chat_into_live_server(live_server: str, tmp_path: Pa
         timeout=10,
     )
     session.raise_for_status()
-    assert session.json()["external_session_id"] == source_session_id
-    assert session.json()["workspace"] == "/repo"
+    session_data = session.json()
+    assert session_data["external_session_id"] == source_session_id
+    assert session_data["workspace"] == "/repo"
+    assert session_data["title"] == "inspect TODO.md"
     items = httpx.get(f"{live_server}/v1/sessions/{session_id}/items", timeout=10)
     items.raise_for_status()
     assert [item["type"] for item in items.json()["data"]] == ["message", "message"]
@@ -245,3 +376,74 @@ def test_cli_imports_recent_codex_chats_as_batch(live_server: str, tmp_path: Pat
         )
         session.raise_for_status()
         assert session.json()["external_session_id"] == source_id
+
+
+@pytest.mark.parametrize("harness", ["qwen", "kiro", "pi", "kimi"])
+def test_cli_imports_jsonl_harness_chat_end_to_end(
+    live_server: str,
+    tmp_path: Path,
+    harness: str,
+) -> None:
+    """The real CLI discovers, uploads, and serves each supported JSONL format."""
+    source_session_id = _write_jsonl_import_fixture(tmp_path, harness)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "QWEN_HOME": str(tmp_path / ".qwen"),
+            "PI_CODING_AGENT_DIR": str(tmp_path / ".pi" / "agent"),
+            "KIMI_CODE_HOME": str(tmp_path / ".kimi-code"),
+            "OMNIGENT_CONFIG_HOME": str(tmp_path / "config"),
+            "OMNIGENT_DATA_DIR": str(tmp_path / "omnigent-data"),
+        }
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "import",
+            "--harness",
+            harness,
+            "--last",
+            "1",
+            "--server",
+            live_server,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+    match = re.search(
+        rf"Imported 2 item\(s\) from {re.escape(source_session_id)} into (\S+)\.",
+        result.stdout,
+    )
+    assert match is not None, result.stdout
+    imported_session_id = match.group(1)
+    session = httpx.get(
+        f"{live_server}/v1/sessions/{imported_session_id}",
+        params={"include_items": "false", "include_liveness": "false"},
+        timeout=10,
+    )
+    session.raise_for_status()
+    session_data = session.json()
+    assert session_data["external_session_id"] == source_session_id
+    assert session_data["workspace"] == "/repo"
+    assert session_data["title"] == "inspect TODO.md"
+    items = httpx.get(
+        f"{live_server}/v1/sessions/{imported_session_id}/items",
+        timeout=10,
+    )
+    items.raise_for_status()
+    item_data = items.json()["data"]
+    assert [item["type"] for item in item_data] == ["message", "message"]
+    assert [item["role"] for item in item_data] == ["user", "assistant"]
+    assert [item["content"][0]["text"] for item in item_data] == [
+        "inspect TODO.md",
+        "Done.",
+    ]
+    assert item_data[1]["model"] == f"{harness}-native-ui"

--- a/tests/test_kimi_native_forwarder.py
+++ b/tests/test_kimi_native_forwarder.py
@@ -14,11 +14,11 @@ from pathlib import Path
 from omnigent.kimi_native_forwarder import (
     _discover_wire,
     _ForwardState,
-    _read_new_items,
     _read_state,
     _row_to_item,
     _write_state,
     clear_kimi_bridge_state,
+    read_kimi_wire_items,
 )
 
 
@@ -113,18 +113,18 @@ class TestReadNewItems:
         return p
 
     def test_parses_user_and_assistant_only(self, tmp_path: Path) -> None:
-        items = _read_new_items(self._wire(tmp_path), 0)
+        items = read_kimi_wire_items(self._wire(tmp_path), 0)
         assert [(i.role, i.text) for i in items] == [("user", "hi"), ("assistant", "hello!")]
 
     def test_offset_skips_already_seen(self, tmp_path: Path) -> None:
         wire = self._wire(tmp_path)
         # last_line past the user prompt (line 1) → only the assistant text (line 3).
-        items = _read_new_items(wire, 2)
+        items = read_kimi_wire_items(wire, 2)
         assert [(i.role, i.text) for i in items] == [("assistant", "hello!")]
         assert items[0].line_no == 3
 
     def test_missing_file_is_empty(self, tmp_path: Path) -> None:
-        assert _read_new_items(tmp_path / "nope.jsonl", 0) == []
+        assert read_kimi_wire_items(tmp_path / "nope.jsonl", 0) == []
 
 
 class TestState:

--- a/tests/test_kiro_native_session_forwarder.py
+++ b/tests/test_kiro_native_session_forwarder.py
@@ -294,7 +294,7 @@ async def test_forward_kiro_session_posts_conversation_messages(
             },
         ],
     )
-    monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
     posted: list[tuple[str, str, forwarder._KiroConversationMessage]] = []
     external_ids: list[tuple[str, str]] = []
 
@@ -425,7 +425,7 @@ async def test_forward_kiro_session_posts_cumulative_cost_once(
         ],
         model_id="auto",
     )
-    monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
     costs: list[tuple[str, float, str | None]] = []
 
     async def _fake_post_cost(
@@ -543,7 +543,7 @@ async def test_forward_kiro_session_prefers_expected_resume_session(
         bridge_dir,
         forwarder._ForwardState(session_id="stale-session", byte_offset=0),
     )
-    monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
     posted: list[forwarder._KiroConversationMessage] = []
     external_ids: list[str] = []
 
@@ -628,7 +628,7 @@ async def test_forward_kiro_session_waits_for_expected_resume_session(
             }
         ],
     )
-    monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
     posted: list[forwarder._KiroConversationMessage] = []
     external_ids: list[str] = []
 
@@ -711,7 +711,7 @@ async def test_forward_kiro_session_does_not_post_session_status(
             },
         ],
     )
-    monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
 
     posted_event_types: list[str] = []
 
@@ -785,7 +785,7 @@ async def test_forward_kiro_session_mirrors_current_model_once(
         # No metering: proves the model mirror fires at launch, before a turn's cost.
         model_id="claude-haiku-4.5",
     )
-    monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
     models: list[tuple[str, str]] = []
 
     async def _fake_post_model(client: httpx.AsyncClient, *, session_id: str, model: str) -> None:

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -8,6 +8,11 @@ from pathlib import Path
 
 import pytest
 
+from omnigent.kimi_native_forwarder import KimiWireItem, read_kimi_wire_items
+from omnigent.kiro_native_session_forwarder import (
+    KiroConversationMessage,
+    parse_kiro_jsonl_line,
+)
 from omnigent.session_import.local import (
     list_recent_local_session_ids,
     load_claude_session,
@@ -18,6 +23,149 @@ from omnigent.session_import.local import (
     load_qwen_session,
 )
 from omnigent.session_import.models import SessionImportNotFoundError
+
+
+def test_import_adapters_use_stable_forwarder_parser_contracts(tmp_path: Path) -> None:
+    """Shared Kiro and Kimi parsers expose the fields offline import consumes."""
+    kiro = parse_kiro_jsonl_line(
+        json.dumps(
+            {
+                "kind": "Prompt",
+                "data": {
+                    "message_id": "kiro-1",
+                    "content": [{"kind": "text", "data": "hello"}],
+                },
+            }
+        )
+    )
+    assert kiro == KiroConversationMessage(message_id="kiro-1", role="user", text="hello")
+
+    wire = tmp_path / "wire.jsonl"
+    wire.write_text(
+        json.dumps(
+            {
+                "type": "turn.prompt",
+                "origin": {"kind": "user"},
+                "input": [{"type": "text", "text": "hello"}],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    items = read_kimi_wire_items(wire, 0)
+    assert items == [
+        KimiWireItem(
+            line_no=0,
+            kind="message",
+            role="user",
+            text="hello",
+            response_id="kimi:turn:0",
+        )
+    ]
+
+
+@pytest.mark.parametrize("source", ["qwen", "kiro", "pi", "kimi"])
+def test_long_source_ids_get_distinct_bounded_response_ids(
+    tmp_path: Path,
+    source: str,
+) -> None:
+    """Long native entry ids remain distinct after normalization."""
+    native_ids = ("x" * 100 + "a", "x" * 100 + "b")
+    if source == "qwen":
+        home = tmp_path / "qwen"
+        session_id = "qwen-session"
+        transcript = home / "projects" / "-repo" / "chats" / f"{session_id}.jsonl"
+        records = [
+            {
+                "uuid": native_ids[0],
+                "parentUuid": None,
+                "type": "user",
+                "message": {"parts": [{"text": "first"}]},
+            },
+            {
+                "uuid": native_ids[1],
+                "parentUuid": native_ids[0],
+                "type": "assistant",
+                "message": {"parts": [{"text": "second"}]},
+            },
+        ]
+        loader = load_qwen_session
+        loader_kwargs = {"qwen_home": home}
+    elif source == "kiro":
+        home = tmp_path / "kiro"
+        session_id = "kiro-session"
+        root = home / ".kiro" / "sessions" / "cli"
+        transcript = root / f"{session_id}.jsonl"
+        root.mkdir(parents=True)
+        (root / f"{session_id}.json").write_text("{}\n", encoding="utf-8")
+        records = [
+            {
+                "kind": kind,
+                "data": {
+                    "message_id": native_id,
+                    "content": [{"kind": "text", "data": text}],
+                },
+            }
+            for kind, native_id, text in zip(
+                ("Prompt", "AssistantMessage"),
+                native_ids,
+                ("first", "second"),
+                strict=True,
+            )
+        ]
+        loader = load_kiro_session
+        loader_kwargs = {"kiro_home": home}
+    elif source == "pi":
+        home = tmp_path / "pi"
+        session_id = "pi-session"
+        transcript = home / "sessions" / "--repo--" / f"stamp_{session_id}.jsonl"
+        records = [
+            {"type": "session", "version": 3, "id": session_id},
+            {
+                "type": "message",
+                "id": native_ids[0],
+                "parentId": None,
+                "message": {"role": "user", "content": "first"},
+            },
+            {
+                "type": "message",
+                "id": native_ids[1],
+                "parentId": native_ids[0],
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "second"}],
+                },
+            },
+        ]
+        loader = load_pi_session
+        loader_kwargs = {"pi_home": home}
+    else:
+        home = tmp_path / "kimi"
+        session_id = "session_long_ids"
+        transcript = home / "sessions" / "wd_repo" / session_id / "agents" / "main" / "wire.jsonl"
+        records = [
+            {
+                "type": "context.append_loop_event",
+                "event": {
+                    "type": "content.part",
+                    "uuid": native_id,
+                    "part": {"type": "text", "text": text},
+                },
+            }
+            for native_id, text in zip(native_ids, ("first", "second"), strict=True)
+        ]
+        loader = load_kimi_session
+        loader_kwargs = {"kimi_home": home}
+
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+
+    response_ids = [item.response_id for item in loader(session_id, **loader_kwargs).items]
+    assert len(response_ids) == 2
+    assert response_ids[0] != response_ids[1]
+    assert all(len(response_id) <= 64 for response_id in response_ids)
 
 
 def test_load_claude_session_normalizes_parent_transcript(tmp_path: Path) -> None:
@@ -518,6 +666,31 @@ def test_list_recent_qwen_sessions_scans_projects(tmp_path: Path, monkeypatch) -
     recent = list_recent_local_session_ids("qwen", limit=2)
 
     assert recent == ("-new:new", "-middle:middle")
+
+
+def test_qwen_locator_bounds_an_overlong_session_stem(tmp_path: Path, monkeypatch) -> None:
+    """Canonical Qwen identity always fits the import API's 128-char limit."""
+    monkeypatch.setenv("QWEN_HOME", str(tmp_path))
+    session_id = "s" * 180
+    transcript = tmp_path / "projects" / "-repo" / "chats" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        json.dumps(
+            {
+                "uuid": "user-1",
+                "type": "user",
+                "message": {"parts": [{"text": "hello"}]},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    (locator,) = list_recent_local_session_ids("qwen", limit=1)
+    imported = load_qwen_session(locator, qwen_home=tmp_path)
+
+    assert len(locator) <= 128
+    assert imported.external_session_id == locator
 
 
 def test_load_kiro_session_uses_metadata_and_visible_messages(tmp_path: Path) -> None:

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -12,6 +12,10 @@ from omnigent.session_import.local import (
     list_recent_local_session_ids,
     load_claude_session,
     load_codex_session,
+    load_kimi_session,
+    load_kiro_session,
+    load_pi_session,
+    load_qwen_session,
 )
 from omnigent.session_import.models import SessionImportNotFoundError
 
@@ -338,3 +342,594 @@ def test_list_recent_codex_sessions_includes_archived_and_deduplicates(
     recent = list_recent_local_session_ids("codex", limit=10)
 
     assert recent == (first_id, second_id)
+
+
+def test_load_qwen_session_normalizes_recorded_messages(tmp_path: Path) -> None:
+    """A Qwen recording imports its visible user and assistant messages."""
+    session_id = "019f8648-2797-7170-bf73-837f2655c47e"
+    transcript = tmp_path / "projects" / "-repo" / "chats" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {
+            "uuid": "user-1",
+            "sessionId": session_id,
+            "type": "user",
+            "cwd": "/repo",
+            "message": {"role": "user", "parts": [{"text": "inspect TODO.md"}]},
+        },
+        {
+            "uuid": "assistant-1",
+            "sessionId": session_id,
+            "type": "assistant",
+            "cwd": "/repo",
+            "message": {"role": "model", "parts": [{"text": "Done."}]},
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records),
+        encoding="utf-8",
+    )
+
+    imported = load_qwen_session(session_id, qwen_home=tmp_path)
+
+    assert imported.source == "qwen"
+    assert imported.external_session_id == f"-repo:{session_id}"
+    assert imported.workspace == "/repo"
+    assert imported.title == "inspect TODO.md"
+    assert [item.data.model_dump()["role"] for item in imported.items] == [
+        "user",
+        "assistant",
+    ]
+    assert imported.items[1].data.model_dump()["agent"] == "qwen-native-ui"
+
+
+def test_load_qwen_session_follows_the_current_branch(tmp_path: Path) -> None:
+    """Qwen import excludes stale siblings from its linked recording."""
+    session_id = "019f8648-2797-7170-bf73-837f2655c47e"
+    transcript = tmp_path / "projects" / "-repo" / "chats" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {
+            "uuid": "root-user",
+            "parentUuid": None,
+            "type": "user",
+            "cwd": "/repo",
+            "message": {"parts": [{"text": "start"}]},
+        },
+        {
+            "uuid": "stale-assistant",
+            "parentUuid": "root-user",
+            "type": "assistant",
+            "message": {"parts": [{"text": "stale answer"}]},
+        },
+        {
+            "uuid": "active-user",
+            "parentUuid": "root-user",
+            "type": "user",
+            "message": {"parts": [{"text": "try again"}]},
+        },
+        {
+            "uuid": "active-assistant",
+            "parentUuid": "active-user",
+            "type": "assistant",
+            "message": {"parts": [{"text": "active answer"}]},
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+
+    imported = load_qwen_session(session_id, qwen_home=tmp_path)
+
+    assert [item.data.model_dump()["content"][0]["text"] for item in imported.items] == [
+        "start",
+        "try again",
+        "active answer",
+    ]
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        [
+            {
+                "uuid": "duplicate",
+                "parentUuid": None,
+                "type": "user",
+                "message": {"parts": [{"text": "first"}]},
+            },
+            {
+                "uuid": "duplicate",
+                "parentUuid": None,
+                "type": "assistant",
+                "message": {"parts": [{"text": "second"}]},
+            },
+        ],
+        [
+            {
+                "uuid": "orphan",
+                "parentUuid": "missing",
+                "type": "user",
+                "message": {"parts": [{"text": "partial"}]},
+            }
+        ],
+    ],
+)
+def test_load_qwen_session_rejects_malformed_links(
+    tmp_path: Path,
+    records: list[dict[str, object]],
+) -> None:
+    """Malformed Qwen links cannot create a permanently partial import."""
+    session_id = "019f8648-2797-7170-bf73-837f2655c47e"
+    transcript = tmp_path / "projects" / "-repo" / "chats" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+
+    with pytest.raises(SessionImportNotFoundError, match="no importable history"):
+        load_qwen_session(session_id, qwen_home=tmp_path)
+
+
+def test_load_qwen_session_qualifies_ambiguous_project_id(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Project-qualified Qwen locators keep duplicate native ids importable."""
+    session_id = "019f8648-2797-7170-bf73-837f2655c47e"
+    monkeypatch.setenv("QWEN_HOME", str(tmp_path))
+    for project in ("-repo-a", "-repo-b"):
+        transcript = tmp_path / "projects" / project / "chats" / f"{session_id}.jsonl"
+        transcript.parent.mkdir(parents=True)
+        transcript.write_text(
+            json.dumps(
+                {
+                    "uuid": f"user-{project}",
+                    "type": "user",
+                    "message": {"parts": [{"text": project}]},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    with pytest.raises(SessionImportNotFoundError, match="ambiguous; use one of"):
+        load_qwen_session(session_id, qwen_home=tmp_path)
+    locators = list_recent_local_session_ids("qwen", limit=10)
+    assert set(locators) == {f"-repo-a:{session_id}", f"-repo-b:{session_id}"}
+    imported = load_qwen_session(f"-repo-a:{session_id}", qwen_home=tmp_path)
+    assert imported.external_session_id == f"-repo-a:{session_id}"
+    assert imported.title == "-repo-a"
+
+
+def test_list_recent_qwen_sessions_scans_projects(tmp_path: Path, monkeypatch) -> None:
+    """Qwen batch discovery returns the newest recordings across projects."""
+    monkeypatch.setenv("QWEN_HOME", str(tmp_path))
+    recordings = [
+        (tmp_path / "projects" / "-old" / "chats" / "old.jsonl", 1),
+        (tmp_path / "projects" / "-new" / "chats" / "new.jsonl", 3),
+        (tmp_path / "projects" / "-middle" / "chats" / "middle.jsonl", 2),
+    ]
+    for path, modified_at in recordings:
+        path.parent.mkdir(parents=True)
+        path.touch()
+        os.utime(path, (modified_at, modified_at))
+
+    recent = list_recent_local_session_ids("qwen", limit=2)
+
+    assert recent == ("-new:new", "-middle:middle")
+
+
+def test_load_kiro_session_uses_metadata_and_visible_messages(tmp_path: Path) -> None:
+    """A Kiro session imports JSONL messages with workspace metadata."""
+    session_id = "kiro-session-1"
+    sessions = tmp_path / ".kiro" / "sessions" / "cli"
+    sessions.mkdir(parents=True)
+    (sessions / f"{session_id}.json").write_text(
+        json.dumps({"cwd": "/repo", "created_at": "2026-07-21T12:00:00Z"}),
+        encoding="utf-8",
+    )
+    records = [
+        {
+            "kind": "Prompt",
+            "data": {
+                "message_id": "user-1",
+                "content": [{"kind": "text", "data": "inspect TODO.md"}],
+            },
+        },
+        {
+            "kind": "AssistantMessage",
+            "data": {
+                "message_id": "assistant-1",
+                "content": [{"kind": "text", "data": "Done."}],
+            },
+        },
+    ]
+    (sessions / f"{session_id}.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in records),
+        encoding="utf-8",
+    )
+
+    imported = load_kiro_session(session_id, kiro_home=tmp_path)
+
+    assert imported.source == "kiro"
+    assert imported.workspace == "/repo"
+    assert imported.title == "inspect TODO.md"
+    assert [item.data.model_dump()["role"] for item in imported.items] == [
+        "user",
+        "assistant",
+    ]
+    assert imported.items[1].data.model_dump()["agent"] == "kiro-native-ui"
+
+
+def test_list_recent_kiro_sessions_requires_metadata(tmp_path: Path, monkeypatch) -> None:
+    """Kiro batch discovery orders complete metadata/transcript pairs."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    sessions = tmp_path / ".kiro" / "sessions" / "cli"
+    sessions.mkdir(parents=True)
+    for session_id, modified_at in (("old", 1), ("new", 3)):
+        (sessions / f"{session_id}.json").write_text(
+            json.dumps({"cwd": "/repo"}), encoding="utf-8"
+        )
+        transcript = sessions / f"{session_id}.jsonl"
+        transcript.touch()
+        os.utime(transcript, (modified_at, modified_at))
+    incomplete = sessions / "incomplete.jsonl"
+    incomplete.touch()
+    os.utime(incomplete, (4, 4))
+
+    recent = list_recent_local_session_ids("kiro", limit=10)
+
+    assert recent == ("new", "old")
+
+
+def test_load_pi_session_follows_the_current_branch(tmp_path: Path) -> None:
+    """Pi import follows parent links from the last entry instead of stale branches."""
+    session_id = "019f8648-2797-7170-bf73-837f2655c47e"
+    transcript = tmp_path / "sessions" / "--repo--" / f"stamp_{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {"type": "session", "version": 3, "id": session_id, "cwd": "/repo"},
+        {
+            "type": "message",
+            "id": "root-user",
+            "parentId": None,
+            "message": {"role": "user", "content": [{"type": "text", "text": "start"}]},
+        },
+        {
+            "type": "message",
+            "id": "stale-assistant",
+            "parentId": "root-user",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "stale branch"}],
+            },
+        },
+        {
+            "type": "message",
+            "id": "active-user",
+            "parentId": "root-user",
+            "message": {"role": "user", "content": "take another approach"},
+        },
+        {
+            "type": "message",
+            "id": "active-assistant",
+            "parentId": "active-user",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "active answer"}],
+            },
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+
+    imported = load_pi_session(session_id, pi_home=tmp_path)
+
+    assert imported.source == "pi"
+    assert imported.workspace == "/repo"
+    assert [item.data.model_dump()["content"][0]["text"] for item in imported.items] == [
+        "start",
+        "take another approach",
+        "active answer",
+    ]
+
+
+def test_load_pi_session_preserves_tool_calls_and_results(tmp_path: Path) -> None:
+    """Pi assistant tool blocks and tool results remain ordinary tool items."""
+    session_id = "019f8648-2797-7170-bf73-837f2655c47e"
+    transcript = tmp_path / "sessions" / "--repo--" / f"stamp_{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {"type": "session", "version": 3, "id": session_id, "cwd": "/repo"},
+        {
+            "type": "message",
+            "id": "assistant-tool",
+            "parentId": None,
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Checking."},
+                    {
+                        "type": "toolCall",
+                        "id": "call-1",
+                        "name": "bash",
+                        "arguments": {"cmd": "ls"},
+                    },
+                ],
+            },
+        },
+        {
+            "type": "message",
+            "id": "tool-result",
+            "parentId": "assistant-tool",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "call-1",
+                "content": [{"type": "text", "text": "README.md"}],
+            },
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+
+    imported = load_pi_session(session_id, pi_home=tmp_path)
+
+    assert [item.type for item in imported.items] == [
+        "message",
+        "function_call",
+        "function_call_output",
+    ]
+    assert imported.items[1].data.model_dump() == {
+        "agent": "pi-native-ui",
+        "name": "bash",
+        "arguments": '{"cmd":"ls"}',
+        "call_id": "call-1",
+    }
+    assert imported.items[2].data.model_dump() == {
+        "call_id": "call-1",
+        "output": "README.md",
+    }
+
+
+def test_load_pi_session_rejects_an_orphaned_active_leaf(tmp_path: Path) -> None:
+    """A broken Pi parent chain cannot be claimed as a partial import."""
+    session_id = "019f8648-2797-7170-bf73-837f2655c47e"
+    transcript = tmp_path / "sessions" / "--repo--" / f"stamp_{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {"type": "session", "version": 3, "id": session_id, "cwd": "/repo"},
+        {
+            "type": "message",
+            "id": "orphan",
+            "parentId": "missing",
+            "message": {"role": "user", "content": "partial"},
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+
+    with pytest.raises(SessionImportNotFoundError, match="no importable history"):
+        load_pi_session(session_id, pi_home=tmp_path)
+
+
+def test_load_pi_session_migrates_legacy_linear_history(tmp_path: Path) -> None:
+    """Pi v1 entries without tree ids import in their original linear order."""
+    session_id = "legacy.session"
+    transcript = tmp_path / "sessions" / "--repo--" / f"stamp_{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {"type": "session", "version": 1, "id": session_id, "cwd": "/repo"},
+        {"type": "message", "message": {"role": "user", "content": "hello"}},
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "hi"}],
+            },
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+
+    imported = load_pi_session(session_id, pi_home=tmp_path)
+
+    assert [item.data.model_dump()["content"][0]["text"] for item in imported.items] == [
+        "hello",
+        "hi",
+    ]
+
+
+def test_load_pi_session_preserves_images_tool_order_and_aborted_state(tmp_path: Path) -> None:
+    """Pi content retains images, tool position, and interrupted assistant state."""
+    session_id = "my-feature"
+    transcript = tmp_path / "sessions" / "--repo--" / f"stamp_{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {"type": "session", "version": 3, "id": session_id, "cwd": "/repo"},
+        {
+            "type": "message",
+            "id": "11111111",
+            "parentId": None,
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "image", "data": "AAAA", "mimeType": "image/png"},
+                    {"type": "text", "text": "inspect this"},
+                ],
+            },
+        },
+        {
+            "type": "message",
+            "id": "22222222",
+            "parentId": "11111111",
+            "message": {
+                "role": "assistant",
+                "stopReason": "aborted",
+                "content": [
+                    {"type": "text", "text": "Before."},
+                    {
+                        "type": "toolCall",
+                        "id": "call-1",
+                        "name": "bash",
+                        "arguments": {"cmd": "ls"},
+                    },
+                    {"type": "text", "text": "After."},
+                ],
+            },
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+
+    imported = load_pi_session(session_id, pi_home=tmp_path)
+
+    assert [item.type for item in imported.items] == [
+        "message",
+        "message",
+        "function_call",
+        "message",
+    ]
+    assert imported.items[0].data.model_dump()["content"] == [
+        {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+        {"type": "input_text", "text": "inspect this"},
+    ]
+    assert imported.items[1].data.model_dump()["interrupted"] is True
+    assert imported.items[3].data.model_dump()["interrupted"] is True
+
+
+def test_load_pi_session_preserves_active_branch_summary(tmp_path: Path) -> None:
+    """Pi branch summaries remain durable context for later active turns."""
+    session_id = "branch-summary"
+    transcript = tmp_path / "sessions" / "--repo--" / f"stamp_{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {"type": "session", "version": 3, "id": session_id, "cwd": "/repo"},
+        {
+            "type": "message",
+            "id": "11111111",
+            "parentId": None,
+            "message": {"role": "user", "content": "start"},
+        },
+        {
+            "type": "branch_summary",
+            "id": "22222222",
+            "parentId": "11111111",
+            "fromId": "stale-leaf",
+            "summary": "Changed auth.py and found a token race.",
+        },
+        {
+            "type": "message",
+            "id": "33333333",
+            "parentId": "22222222",
+            "message": {"role": "user", "content": "continue"},
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+
+    imported = load_pi_session(session_id, pi_home=tmp_path)
+
+    assert [item.data.is_meta for item in imported.items] == [False, True, False]
+    assert "Changed auth.py" in imported.items[1].data.model_dump()["content"][0]["text"]
+
+
+def test_list_recent_pi_sessions_scans_project_directories(tmp_path: Path, monkeypatch) -> None:
+    """Pi batch discovery extracts session UUIDs from timestamped files."""
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(tmp_path))
+    session_ids = (
+        "019f8648-2797-7170-bf73-837f2655c471",
+        "019f8648-2797-7170-bf73-837f2655c472",
+    )
+    for index, session_id in enumerate(session_ids, start=1):
+        transcript = tmp_path / "sessions" / f"--repo-{index}--" / f"stamp_{session_id}.jsonl"
+        transcript.parent.mkdir(parents=True)
+        transcript.write_text(
+            json.dumps({"type": "session", "version": 3, "id": session_id}) + "\n",
+            encoding="utf-8",
+        )
+        os.utime(transcript, (index, index))
+
+    recent = list_recent_local_session_ids("pi", limit=10)
+
+    assert recent == tuple(reversed(session_ids))
+
+
+def test_list_recent_pi_sessions_supports_custom_ids(tmp_path: Path, monkeypatch) -> None:
+    """Pi discovery reads safe custom session ids from transcript headers."""
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(tmp_path))
+    transcript = tmp_path / "sessions" / "--repo--" / "stamp_my-feature.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        json.dumps({"type": "session", "version": 3, "id": "my-feature", "cwd": "/repo"}) + "\n",
+        encoding="utf-8",
+    )
+
+    assert list_recent_local_session_ids("pi", limit=10) == ("my-feature",)
+
+
+def test_load_kimi_session_normalizes_wire_messages(tmp_path: Path) -> None:
+    """A Kimi wire log imports visible prompts and completed assistant text."""
+    session_id = "session_20260721_abc"
+    session_dir = tmp_path / "sessions" / "wd_repo" / session_id
+    wire = session_dir / "agents" / "main" / "wire.jsonl"
+    wire.parent.mkdir(parents=True)
+    (tmp_path / "session_index.jsonl").write_text(
+        json.dumps({"sessionDir": str(session_dir), "workDir": "/repo"}) + "\n",
+        encoding="utf-8",
+    )
+    records = [
+        {
+            "type": "turn.prompt",
+            "origin": {"kind": "user"},
+            "input": [{"type": "text", "text": "inspect TODO.md"}],
+        },
+        {
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "content.part",
+                "uuid": "assistant-1",
+                "part": {"type": "think", "think": "private reasoning"},
+            },
+        },
+        {
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "content.part",
+                "uuid": "assistant-1",
+                "part": {"type": "text", "text": "Done."},
+            },
+        },
+    ]
+    wire.write_text("".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8")
+
+    imported = load_kimi_session(session_id, kimi_home=tmp_path)
+
+    assert imported.source == "kimi"
+    assert imported.workspace == "/repo"
+    assert imported.title == "inspect TODO.md"
+    assert [item.data.model_dump()["role"] for item in imported.items] == [
+        "user",
+        "assistant",
+    ]
+    assert imported.items[1].data.model_dump()["agent"] == "kimi-native-ui"
+
+
+def test_list_recent_kimi_sessions_uses_wire_recency(tmp_path: Path, monkeypatch) -> None:
+    """Kimi batch discovery identifies session directories by wire-log recency."""
+    monkeypatch.setenv("KIMI_CODE_HOME", str(tmp_path))
+    for session_id, modified_at in (("session_old", 1), ("session_new", 3)):
+        wire = tmp_path / "sessions" / "wd_repo" / session_id / "agents" / "main" / "wire.jsonl"
+        wire.parent.mkdir(parents=True)
+        wire.touch()
+        os.utime(wire, (modified_at, modified_at))
+
+    recent = list_recent_local_session_ids("kimi", limit=10)
+
+    assert recent == ("session_new", "session_old")


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add local chat import and batch discovery for Qwen Code, Kiro CLI, Pi, and Kimi Code, including project-qualified Qwen identity and Pi's active branch, tools, images, interrupted turns, legacy v1 sessions, custom IDs, and branch summaries.
- Expose stable Kiro and Kimi parsing contracts shared by live forwarding and offline import.
- Keep long source response IDs collision-safe and guarantee Qwen session locators fit API limits.
- Expose all four harnesses through `omnigent import`, update the public OpenAPI enum, and disclose that Qwen/Kiro/Kimi currently import visible messages without native tool activity.

ELI5: Omnigent can now find the JSONL chat history written by four more coding assistants, translate it into normal session items, and upload it through the same import endpoint used by Claude and Codex.

```text
native JSONL -> harness adapter -> normalized Omnigent items -> POST /v1/imports
```

## Test Plan

- `pytest -p no:rerunfailures -q tests/test_session_import.py tests/cli/test_import.py tests/server/routes/test_imports.py tests/server/test_openapi_drift.py --tb=short` - 42 passed.
- `pytest -p no:rerunfailures -q tests/e2e/test_chat_import_e2e.py --tb=short -rfs` - 7 passed against a live localhost server, including Qwen, Kiro, Pi, and Kimi.
- `pytest -p no:rerunfailures -q tests/test_qwen_native_resume.py tests/test_qwen_native_forwarder.py tests/test_kiro_native_session_forwarder.py tests/test_kimi_native_forwarder.py tests/test_pi_native_resume.py --tb=short` - 96 passed, 1 environment-dependent skip.
- `mypy --follow-imports=skip omnigent/session_import/local.py` - passed. The repository's exact broader mypy invocation currently reaches pre-existing generated `routing_pb2.pyi` errors in this local environment.
- `ruff check ...`, `ruff format --check ...`, `python scripts/dump_openapi.py --check`, and `git diff --check` - passed.
- `pre-commit run --files <all six follow-up files>` - passed. The original seven-file implementation also passed its changed-file pre-commit run.

## Demo

N/A - CLI/backend change with live-server E2E coverage.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Fixtures cover vendor-shaped records, malformed links, stale branches, project identity collisions, long native IDs, missing final newlines, Pi v1 migration, custom IDs, images, tool ordering/results, interrupted turns, and branch summaries. The E2E matrix invokes the real CLI, posts to a live server, and verifies session identity, workspace, title, roles, exact text, and native agent model.

A real local Pi v3 transcript was inspected structurally and imported successfully with messages and tool activity. No local Pi v1, Qwen, Kiro, or Kimi captures were available, so those remain covered by vendor-shaped fixtures and the production parser contracts.

## Changelog

Import local Qwen, Kiro, Pi, and Kimi coding chats into Omnigent
