### PR TITLE
feat(runner): add terminal input route

### DIFF
--- a/omnigent/entities/session_resources.py
+++ b/omnigent/entities/session_resources.py
@@ -334,9 +334,11 @@ def resolve_terminal_entry_by_resource_id(
     """
     if terminal_registry is None:
         return None
-    for entry in terminal_registry.list_for_conversation(session_id):
-        if not entry.instance.running:
-            continue
-        if terminal_resource_id(entry.terminal_name, entry.session_key) == terminal_id:
-            return entry
-    return None
+    from omnigent.terminals.registry import ResolveSnapshot
+
+    resolved = terminal_registry.resolve_snapshot(session_id, terminal_id)
+    if not isinstance(resolved, ResolveSnapshot):
+        return None
+    if resolved.instance.retired or not resolved.instance.running:
+        return None
+    return resolved.entry

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -735,6 +735,9 @@ class TerminalEnvSpec:
         default, which is control mode unless ``terminal.transport`` in
         ``~/.omnigent/config.yaml`` opts out to ``pty``. A per-attach
         ``?transport=`` query overrides both.
+    :param ready_process: Final process name that proves an arbitrary
+        configured command has handed control to its input owner. Used only
+        by explicit shell-command readiness waits.
     """
 
     command: str | None = None
@@ -752,6 +755,7 @@ class TerminalEnvSpec:
     tmux_start_on_attach: bool = False
     keep_alive_after_exit: bool = False
     terminal_transport: str | None = None
+    ready_process: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -730,6 +730,11 @@ def _parse_terminal_env_spec(data: YamlData | str | bool | None) -> TerminalEnvS
     if not isinstance(env_val, dict):
         raise TypeError("terminal 'env' must be a mapping of string -> string")
     env = {str(k): str(v) for k, v in env_val.items()}
+    ready_process = data.get("ready_process")
+    if ready_process is not None and (
+        not isinstance(ready_process, str) or not ready_process.strip()
+    ):
+        raise TypeError("terminal 'ready_process' must be a non-empty string")
 
     return TerminalEnvSpec(
         command=data.get("command", "bash"),
@@ -741,6 +746,7 @@ def _parse_terminal_env_spec(data: YamlData | str | bool | None) -> TerminalEnvS
         log_file=data.get("log_file"),
         scrollback=int(data.get("scrollback", 10000)),
         session_prefix=data.get("session_prefix", "omni_"),
+        ready_process=ready_process,
     )
 
 

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -1259,6 +1259,16 @@ class TerminalInstance:
         if not self.running:
             return {"error": "Terminal is not running"}
 
+        # ``keys`` tokens are passed to ``tmux send-keys`` as bare arguments
+        # (no ``-l``), so a token beginning with ``-``/``+`` would be parsed as
+        # a send-keys flag rather than a key name. Reject before any dispatch.
+        for key in keys.split():
+            if key.startswith(("-", "+")):
+                raise ValueError(
+                    f"Invalid tmux key name {key!r}: key names must not start "
+                    "with '-' or '+' (they would be consumed as send-keys flags)"
+                )
+
         dispatch_started = False
         try:
             if text:
@@ -1333,7 +1343,11 @@ class TerminalInstance:
         deadline: float,
         poll_interval_s: float,
     ) -> bool:
-        """Clear the acknowledged probe from the screen and pane history."""
+        """Clear the acknowledged probe from the screen and scrollback.
+
+        Sends ``C-l`` then ``clear-history`` so the typed readiness probe
+        leaves no residue in the pane or its history.
+        """
         loop = asyncio.get_running_loop()
         remaining = deadline - loop.time()
         if remaining <= 0:
@@ -1397,7 +1411,12 @@ class TerminalInstance:
         timeout_s: float,
         poll_interval_s: float,
     ) -> bool:
-        """Run one bounded shell-readiness evaluation."""
+        """Run one bounded shell-readiness evaluation.
+
+        Under the nonce contract this types a probe into the live pane and,
+        once acknowledged, clears it plus the scrollback via
+        ``_clear_shell_readiness_residue`` so the user never sees it.
+        """
         if not self.running or timeout_s <= 0:
             return False
         if self.shell_ready_nonce is None and self.ready_process is None:

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -11,6 +11,7 @@ import contextlib
 import logging
 import os
 import re
+import secrets
 import shutil
 import subprocess
 import tempfile
@@ -433,6 +434,9 @@ _IDLE_WATCHER_JOIN_TIMEOUT_S = 1.0
 # (1024 chars ≤ 4KB packed). tmux writes each invocation's bytes to the
 # pane in submission order, so the program sees one contiguous stream.
 _SEND_KEYS_LITERAL_CHARS_PER_CALL = 1024
+_SEND_KEYS_HEX_BYTES_PER_CALL = 1024
+_SHELL_READY_POLL_SECONDS = 0.025
+_SHELL_READY_STABLE_SAMPLES = 2
 
 
 class _IdleDetector:
@@ -932,6 +936,8 @@ class TerminalInstance:
         the first tmux client attaches to the session.
     :param running: Whether the tmux server is currently expected to
         be alive.
+    :param ready_process: Declared final process for arbitrary-command
+        readiness, or ``None`` when no explicit readiness contract exists.
     """
 
     name: str
@@ -974,7 +980,14 @@ class TerminalInstance:
     # attach routes via :func:`resolve_terminal_transport`; does not affect how
     # the tmux server itself is launched.
     terminal_transport: str | None = None
+    ready_process: str | None = None
+    shell_ready_nonce: str | None = None
+    _shell_ready_probe_sent: bool = field(default=False, repr=False, compare=False)
+    _shell_ready_acknowledged: bool = field(default=False, repr=False, compare=False)
     running: bool = False
+    retired: bool = False
+    owner_generation: int = 0
+    op_lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
     launch_cwd: str | None = None
     # Owned per-launch egress proxy. ``None`` when the sandbox
     # carries no ``egress_rules`` or the backend doesn't need a
@@ -1246,9 +1259,11 @@ class TerminalInstance:
         if not self.running:
             return {"error": "Terminal is not running"}
 
+        dispatch_started = False
         try:
             if text:
                 for start in range(0, len(text), _SEND_KEYS_LITERAL_CHARS_PER_CALL):
+                    dispatch_started = True
                     await self._tmux(
                         "send-keys",
                         "-l",
@@ -1261,17 +1276,221 @@ class TerminalInstance:
                 if text:
                     await asyncio.sleep(0.05)
                 for key in keys.split():
+                    dispatch_started = True
                     await self._tmux("send-keys", "-t", self.tmux_target, key)
-        except RuntimeError:
+        except (RuntimeError, OSError):
             self.running = False
+            if dispatch_started:
+                return {
+                    "error": (
+                        f"Delivery to terminal {self.name}:{self.session_key} "
+                        "could not be confirmed"
+                    ),
+                    "delivery_unknown": True,
+                }
             return {
                 "error": (
                     f"Terminal {self.name}:{self.session_key} is no longer "
                     "running (tmux server exited)"
                 )
             }
+        except asyncio.CancelledError:
+            if dispatch_started:
+                return {
+                    "error": (
+                        f"Delivery to terminal {self.name}:{self.session_key} "
+                        "could not be confirmed"
+                    ),
+                    "delivery_unknown": True,
+                }
+            raise
 
         return {"status": "sent"}
+
+    async def send_raw_bytes(self, data: bytes) -> bool:
+        """Inject one attached-client frame through tmux's byte-exact hex path."""
+        if not self.running:
+            return False
+        try:
+            for start in range(0, len(data), _SEND_KEYS_HEX_BYTES_PER_CALL):
+                chunk = data[start : start + _SEND_KEYS_HEX_BYTES_PER_CALL]
+                await self._tmux(
+                    "send-keys",
+                    "-t",
+                    self.tmux_target,
+                    "-H",
+                    *(f"{value:02x}" for value in chunk),
+                )
+        except (RuntimeError, OSError):
+            self.running = False
+            return False
+        return True
+
+    async def _clear_shell_readiness_residue(
+        self,
+        *,
+        nonce: str,
+        deadline: float,
+        poll_interval_s: float,
+    ) -> bool:
+        """Clear the acknowledged probe from the screen and pane history."""
+        loop = asyncio.get_running_loop()
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return False
+        await asyncio.wait_for(
+            self._tmux("send-keys", "-t", self.tmux_target, "C-l"),
+            timeout=remaining,
+        )
+
+        while self.running:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            snapshot = await asyncio.wait_for(
+                self._tmux_output(
+                    "capture-pane",
+                    "-t",
+                    self.tmux_target,
+                    "-p",
+                ),
+                timeout=remaining,
+            )
+            self._remember_pane_snapshot(snapshot)
+            if nonce not in _strip_ansi(snapshot):
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return False
+                await asyncio.wait_for(
+                    self._tmux("clear-history", "-t", self.tmux_target),
+                    timeout=remaining,
+                )
+                return True
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            await asyncio.sleep(min(poll_interval_s, remaining))
+        return False
+
+    async def wait_for_shell_ready(
+        self,
+        *,
+        timeout_s: float,
+        poll_interval_s: float = _SHELL_READY_POLL_SECONDS,
+    ) -> bool:
+        """Wait for an input-loop ACK or a stable declared final process."""
+        try:
+            async with asyncio.timeout(timeout_s):
+                return await self._wait_for_shell_ready_once(
+                    timeout_s=timeout_s,
+                    poll_interval_s=poll_interval_s,
+                )
+        except TimeoutError:
+            return False
+        finally:
+            if not self._shell_ready_acknowledged:
+                self._shell_ready_probe_sent = False
+
+    async def _wait_for_shell_ready_once(
+        self,
+        *,
+        timeout_s: float,
+        poll_interval_s: float,
+    ) -> bool:
+        """Run one bounded shell-readiness evaluation."""
+        if not self.running or timeout_s <= 0:
+            return False
+        if self.shell_ready_nonce is None and self.ready_process is None:
+            return False
+        if self._shell_ready_acknowledged:
+            return True
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_s
+        stable_process_samples = 0
+        probe_nonce = self.shell_ready_nonce
+        if probe_nonce is not None and not self._shell_ready_probe_sent:
+            probe_nonce = _mint_shell_ready_nonce()
+            self.shell_ready_nonce = probe_nonce
+            remaining = deadline - loop.time()
+            try:
+                probe = _direct_shell_readiness_probe(
+                    Path(self.command).name,
+                    probe_nonce,
+                )
+                await asyncio.wait_for(
+                    self._tmux(
+                        "send-keys",
+                        "-l",
+                        "-t",
+                        self.tmux_target,
+                        probe,
+                    ),
+                    timeout=remaining,
+                )
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return False
+                await asyncio.wait_for(
+                    self._tmux("send-keys", "-t", self.tmux_target, "Enter"),
+                    timeout=remaining,
+                )
+                self._shell_ready_probe_sent = True
+            except (TimeoutError, RuntimeError, OSError, ValueError):
+                return False
+
+        while self.running:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            try:
+                if probe_nonce is not None:
+                    snapshot = await asyncio.wait_for(
+                        self._tmux_output(
+                            "capture-pane",
+                            "-t",
+                            self.tmux_target,
+                            "-p",
+                            "-S",
+                            "-",
+                        ),
+                        timeout=remaining,
+                    )
+                    self._remember_pane_snapshot(snapshot)
+                    if probe_nonce in _strip_ansi(snapshot):
+                        if not await self._clear_shell_readiness_residue(
+                            nonce=probe_nonce,
+                            deadline=deadline,
+                            poll_interval_s=poll_interval_s,
+                        ):
+                            return False
+                        self._shell_ready_acknowledged = True
+                        return True
+                else:
+                    process = await asyncio.wait_for(
+                        self._tmux_output(
+                            "display-message",
+                            "-p",
+                            "-t",
+                            self.tmux_target,
+                            "#{pane_current_command}",
+                        ),
+                        timeout=remaining,
+                    )
+                    if process.strip() == self.ready_process:
+                        stable_process_samples += 1
+                        if stable_process_samples >= _SHELL_READY_STABLE_SAMPLES:
+                            return True
+                    else:
+                        stable_process_samples = 0
+            except (TimeoutError, RuntimeError, OSError):
+                return False
+
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            await asyncio.sleep(min(poll_interval_s, remaining))
+        return False
 
     async def read(self, scrollback: int = 0) -> TerminalResult:
         """Capture the terminal screen."""
@@ -1884,6 +2103,90 @@ def _shell_quote(s: str) -> str:
     return "'" + s.replace("'", "'\\''") + "'"
 
 
+def _direct_shell_args_reach_input_loop(shell_name: str, args: list[str]) -> bool:
+    """Return whether direct shell argv can reach a command-reading loop."""
+    stdin_mode = False
+    option_operand = False
+    parsing_options = True
+    for arg in args:
+        if option_operand:
+            option_operand = False
+            continue
+        if parsing_options and arg == "--":
+            parsing_options = False
+            continue
+        if parsing_options and arg == "-":
+            stdin_mode = True
+            parsing_options = False
+            continue
+        if parsing_options and arg.startswith("--"):
+            option, separator, _value = arg.partition("=")
+            if option in {
+                "--command",
+                "--dump-po-strings",
+                "--dump-strings",
+                "--help",
+                "--noexec",
+                "--pretty-print",
+                "--version",
+            }:
+                return False
+            if option in {"--init-file", "--rcfile"} and not separator:
+                option_operand = True
+            if option in {"--shinstdin", "--stdin"}:
+                stdin_mode = True
+            continue
+        if parsing_options and len(arg) > 1 and arg[0] in {"-", "+"}:
+            if arg[:2] in {"-O", "+O", "-o", "+o"}:
+                option_operand = len(arg) == 2
+                continue
+            flags = arg[1:]
+            if any(flag in flags for flag in ("c", "D", "n", "t")):
+                return False
+            if "s" in flags:
+                stdin_mode = True
+            continue
+        if not stdin_mode:
+            return False
+
+    return not option_operand and shell_name in {"bash", "zsh"}
+
+
+def terminal_spec_supports_shell_readiness(spec: TerminalEnvSpec) -> bool:
+    """Return whether *spec* has a fail-closed spawn readiness contract."""
+    if spec.ready_process is not None:
+        return True
+    shell_name = Path(spec.command or "bash").name
+    return _direct_shell_args_reach_input_loop(shell_name, list(spec.args))
+
+
+def _direct_shell_readiness_probe(shell_name: str, nonce: str) -> str:
+    """Build a nonce-free command that ACKs only at a shell input loop."""
+    encoded_nonce = "".join(f"\\0{byte:03o}" for byte in nonce.encode("ascii"))
+    if shell_name == "bash":
+        condition = "[[ ${#BASH_SOURCE[@]} -eq 0 ]]"
+    elif shell_name == "zsh":
+        condition = "[[ $ZSH_EVAL_CONTEXT == toplevel ]]"
+    else:
+        raise ValueError(f"Unsupported direct readiness shell: {shell_name}")
+    return f"if {condition}; then builtin printf '%b\\n' '{encoded_nonce}'; fi"
+
+
+def _mint_shell_ready_nonce() -> str:
+    """Mint one direct-shell readiness probe nonce."""
+    return f"OMNIGENT_SHELL_READY_{secrets.token_hex(16)}"
+
+
+def _owned_shell_ready_nonce(spec: TerminalEnvSpec) -> str | None:
+    """Mint a readiness nonce for direct shells with an input-loop contract."""
+    if spec.ready_process is not None:
+        return None
+    shell_name = Path(spec.command or "bash").name
+    if not _direct_shell_args_reach_input_loop(shell_name, list(spec.args)):
+        return None
+    return _mint_shell_ready_nonce()
+
+
 @dataclass(frozen=True)
 class TerminalCreateResult:
     """
@@ -2038,6 +2341,8 @@ def create_terminal_instance(
         tmux_start_on_attach=spec.tmux_start_on_attach,
         keep_alive_after_exit=spec.keep_alive_after_exit,
         terminal_transport=spec.terminal_transport,
+        ready_process=spec.ready_process,
+        shell_ready_nonce=_owned_shell_ready_nonce(spec),
     )
 
     return TerminalCreateResult(instance=instance, cwd=cwd)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1834,21 +1834,35 @@ class _TerminalInputAttempts:
         try:
             outcome = await operation()
         except asyncio.CancelledError:
-            outcome = _TerminalInputOutcome(
-                status_code=200,
-                body={"outcome": "delivery_unknown"},
-            )
+            # Cancellation only happens at teardown today; stamp completion so
+            # the slot stays purgeable (never a permanently-leaked, replay-
+            # poisoning entry) if that ever changes. Synchronous write, no
+            # await — safe on the single event-loop thread mid-cancellation.
+            entry = self._entries.get(key)
+            if entry is not None:
+                entry.completed_at = time.monotonic()
+            raise
+        except (ValueError, OmnigentError):
+            # These carry dedicated global handlers that answer 4xx (a
+            # flag-like ``keys`` token raises ValueError before any dispatch).
+            # Record completion so a same-id replay re-hits this failing task,
+            # then propagate instead of faking a delivery_unknown.
+            await self._mark_completed(key)
+            raise
         except Exception:
             _logger.exception("terminal input attempt failed after dispatch")
             outcome = _TerminalInputOutcome(
                 status_code=200,
                 body={"outcome": "delivery_unknown"},
             )
+        await self._mark_completed(key)
+        return outcome
+
+    async def _mark_completed(self, key: tuple[str, str]) -> None:
         async with self._lock:
             entry = self._entries.get(key)
             if entry is not None:
                 entry.completed_at = time.monotonic()
-        return outcome
 
     def _purge_expired_locked(self) -> None:
         cutoff = time.monotonic() - _TERMINAL_INPUT_ATTEMPT_TTL_SECONDS

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 import click
 import httpx
-from fastapi import FastAPI, HTTPException, Query, Request, WebSocket
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, WebSocket
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 from omnigent.entities.session_resources import (
@@ -125,12 +125,19 @@ from omnigent.runner.session_init_protocol import (
     parse_runner_session_init_envelope,
 )
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager, NoLiveHarnessError
+from omnigent.server.routes._content_type import require_json_content_type
 from omnigent.server.schemas import (
     BackgroundSessionTitleRequest,
     BackgroundSessionTitleResponse,
 )
 from omnigent.spec.skill_sources import SkillSourceContext, resolve_harness_skills
 from omnigent.spec.types import LocalToolInfo, SkillSpec
+from omnigent.terminals import (
+    AmbiguousResourceId,
+    AmbiguousResourceIdError,
+    ResolveSnapshot,
+    TerminalRegistry,
+)
 from omnigent.terminals.control_bridge import bridge_tmux_control_to_websocket
 from omnigent.terminals.ws_bridge import (
     WS_CLOSE_TERMINAL_NOT_FOUND,
@@ -1726,6 +1733,134 @@ def get_session_agent_id(session_id: str) -> str | None:
 # a single walk. Module-level so it can be tuned/patched in one place.
 _SESSION_SKILLS_CACHE_TTL_SECONDS = 60.0
 _SESSION_INIT_ENVELOPE_TTL_SECONDS = 60.0
+_TERMINAL_INPUT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
+_TERMINAL_INPUT_ATTEMPT_MAX_ENTRIES = 50_000
+
+
+async def _terminal_snapshot_is_alive(
+    registry: TerminalRegistry,
+    snapshot: ResolveSnapshot,
+) -> bool:
+    """Probe tmux only while an atomic terminal owner snapshot remains valid."""
+    return await asyncio.to_thread(
+        registry.run_fenced,
+        snapshot,
+        snapshot.instance.is_alive,
+        invalid=False,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class _TerminalInputOutcome:
+    """Exact status/body pair cached for one runner input attempt."""
+
+    status_code: int
+    body: dict[str, Any]
+
+
+@dataclasses.dataclass
+class _TerminalInputAttempt:
+    """One in-flight or completed attempt bound to its request fingerprint."""
+
+    fingerprint: tuple[str, str, str, bool]
+    task: asyncio.Task[_TerminalInputOutcome]
+    completed_at: float | None = None
+
+
+class _TerminalInputAttempts:
+    """Bounded atomic single-flight ledger for terminal input delivery."""
+
+    def __init__(self) -> None:
+        self._entries: dict[tuple[str, str], _TerminalInputAttempt] = {}
+        self._lock = asyncio.Lock()
+        self.max_entries = _TERMINAL_INPUT_ATTEMPT_MAX_ENTRIES
+
+    async def execute(
+        self,
+        *,
+        session_id: str,
+        attempt_id: str,
+        fingerprint: tuple[str, str, str, bool],
+        operation: Callable[[], Awaitable[_TerminalInputOutcome]],
+    ) -> _TerminalInputOutcome:
+        """Claim an id atomically or await its existing shielded task.
+
+        A repeated ``attempt_id`` replays the cached outcome (including
+        ``delivery_unknown``); actually retrying delivery requires a fresh
+        ``attempt_id``.
+        """
+        key = (session_id, attempt_id)
+        async with self._lock:
+            self._purge_expired_locked()
+            existing = self._entries.get(key)
+            if existing is not None:
+                if existing.fingerprint != fingerprint:
+                    return _TerminalInputOutcome(
+                        status_code=409,
+                        body={
+                            "error": {
+                                "code": "attempt_conflict",
+                                "message": "attempt_id is bound to a different terminal input",
+                            }
+                        },
+                    )
+                task = existing.task
+            else:
+                if len(self._entries) >= self.max_entries:
+                    return _TerminalInputOutcome(
+                        status_code=503,
+                        body={
+                            "error": {
+                                "code": "idempotency_capacity_exhausted",
+                                "message": "Runner input idempotency capacity is exhausted",
+                            }
+                        },
+                    )
+                task = asyncio.create_task(
+                    self._run_claimed(key, operation),
+                    name=f"terminal-input-{attempt_id}",
+                )
+                self._entries[key] = _TerminalInputAttempt(
+                    fingerprint=fingerprint,
+                    task=task,
+                )
+        return await asyncio.shield(task)
+
+    async def _run_claimed(
+        self,
+        key: tuple[str, str],
+        operation: Callable[[], Awaitable[_TerminalInputOutcome]],
+    ) -> _TerminalInputOutcome:
+        try:
+            outcome = await operation()
+        except asyncio.CancelledError:
+            outcome = _TerminalInputOutcome(
+                status_code=200,
+                body={"outcome": "delivery_unknown"},
+            )
+        except Exception:
+            _logger.exception("terminal input attempt failed after dispatch")
+            outcome = _TerminalInputOutcome(
+                status_code=200,
+                body={"outcome": "delivery_unknown"},
+            )
+        async with self._lock:
+            entry = self._entries.get(key)
+            if entry is not None:
+                entry.completed_at = time.monotonic()
+        return outcome
+
+    def _purge_expired_locked(self) -> None:
+        cutoff = time.monotonic() - _TERMINAL_INPUT_ATTEMPT_TTL_SECONDS
+        expired = [
+            key
+            for key, entry in self._entries.items()
+            if entry.completed_at is not None and entry.completed_at <= cutoff
+        ]
+        for key in expired:
+            self._entries.pop(key, None)
+        if expired:
+            _logger.info("evicted %d expired terminal input attempts", len(expired))
 
 
 class _BodyRequest:
@@ -1794,6 +1929,8 @@ def create_runner_app(
     import hmac
 
     app = FastAPI(title="omnigent-runner")
+    terminal_input_attempts = _TerminalInputAttempts()
+    app.state.terminal_input_attempts = terminal_input_attempts
 
     from omnigent.runtime import telemetry
 
@@ -7948,6 +8085,7 @@ def create_runner_app(
                 scrollback=spec.get("scrollback", 10000),
                 tmux_allow_passthrough=bool(spec.get("tmux_allow_passthrough", False)),
                 tmux_start_on_attach=bool(spec.get("tmux_start_on_attach", False)),
+                ready_process=spec.get("ready_process"),
             )
         bridge_inject = bool(body.get("bridge_inject_dir"))
         bridge_id: str | None = None
@@ -8119,6 +8257,151 @@ def create_runner_app(
             content=session_resource_view_to_dict(resource),
         )
 
+    @app.post(
+        "/v1/sessions/{session_id}/resources/terminals/{terminal_id}/input",
+        dependencies=[Depends(require_json_content_type)],
+    )
+    async def send_session_terminal_input(
+        session_id: str,
+        terminal_id: str,
+        request: Request,
+    ) -> JSONResponse:
+        """Send literal text and key chords to a running terminal.
+
+        The public server authorizes the owning user before proxying here;
+        this runner-local endpoint resolves only runner-owned terminal state.
+
+        :param session_id: Session/conversation identifier.
+        :param terminal_id: Opaque terminal resource id.
+        :param request: JSON body containing ``text`` and optional ``keys``.
+        :returns: The terminal send result or a structured error response.
+        """
+        body = await request.json()
+        text = body.get("text") if isinstance(body, dict) else None
+        keys = body.get("keys", "Enter") if isinstance(body, dict) else None
+        wait_for_ready = body.get("wait_for_ready", False) if isinstance(body, dict) else None
+        attempt_id = body.get("attempt_id") if isinstance(body, dict) else None
+        if (
+            not isinstance(text, str)
+            or not isinstance(keys, str)
+            or not isinstance(wait_for_ready, bool)
+        ):
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": {
+                        "code": "invalid_input",
+                        "message": (
+                            "'text' is required, 'text' and 'keys' must be strings, "
+                            "and 'wait_for_ready' must be a boolean"
+                        ),
+                    }
+                },
+            )
+        if attempt_id is not None and (
+            not isinstance(attempt_id, str) or not attempt_id.strip() or len(attempt_id) > 128
+        ):
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": {
+                        "code": "invalid_input",
+                        "message": (
+                            "'attempt_id' must be a non-empty string of at most 128 characters"
+                        ),
+                    }
+                },
+            )
+
+        terminal_registry = resource_registry.terminal_registry
+
+        async def _execute_input() -> _TerminalInputOutcome:
+            if terminal_registry is None:
+                return _TerminalInputOutcome(
+                    status_code=404,
+                    body={
+                        "error": {
+                            "code": "terminal_not_running",
+                            "message": f"Terminal {terminal_id!r} is not running",
+                        }
+                    },
+                )
+            resolved = terminal_registry.resolve_snapshot(session_id, terminal_id)
+            if isinstance(resolved, AmbiguousResourceId):
+                return _TerminalInputOutcome(
+                    status_code=409,
+                    body={
+                        "error": {
+                            "code": resolved.code,
+                            "message": f"Terminal {terminal_id!r} resolves to multiple entries",
+                        }
+                    },
+                )
+            if resolved is None:
+                return _TerminalInputOutcome(
+                    status_code=404,
+                    body={
+                        "error": {
+                            "code": "terminal_not_running",
+                            "message": f"Terminal {terminal_id!r} is not running",
+                        }
+                    },
+                )
+
+            from omnigent.tools.builtins.sys_terminal import send_terminal_input
+
+            try:
+                result = await asyncio.to_thread(
+                    send_terminal_input,
+                    terminal_registry,
+                    resolved,
+                    text,
+                    keys=keys,
+                    wait_for_ready=wait_for_ready,
+                )
+            except (RuntimeError, OSError, asyncio.CancelledError):
+                _logger.warning(
+                    "terminal input delivery could not be confirmed for %s/%s",
+                    session_id,
+                    terminal_id,
+                    exc_info=True,
+                )
+                return _TerminalInputOutcome(
+                    status_code=200,
+                    body={"outcome": "delivery_unknown"},
+                )
+            if result.get("delivery_unknown"):
+                return _TerminalInputOutcome(
+                    status_code=200,
+                    body={"outcome": "delivery_unknown"},
+                )
+            if "error" in result:
+                code = str(result.get("code") or "terminal_not_running")
+                return _TerminalInputOutcome(
+                    status_code=409,
+                    body={
+                        "error": {
+                            "code": code,
+                            "message": str(result["error"]),
+                        }
+                    },
+                )
+            return _TerminalInputOutcome(
+                status_code=200,
+                body={**result, "outcome": "sent"},
+            )
+
+        if attempt_id is None:
+            outcome = await _execute_input()
+        else:
+            outcome = await terminal_input_attempts.execute(
+                session_id=session_id,
+                attempt_id=attempt_id,
+                fingerprint=(terminal_id, text, keys, wait_for_ready),
+                operation=_execute_input,
+            )
+        return JSONResponse(status_code=outcome.status_code, content=outcome.body)
+
     @app.post("/v1/sessions/{session_id}/resources/terminals/{terminal_id}/transfer")
     async def transfer_session_terminal(
         session_id: str,
@@ -8142,6 +8425,19 @@ def create_runner_app(
                 source_session_id=session_id,
                 target_session_id=target_session_id,
                 terminal_id=terminal_id,
+            )
+        except AmbiguousResourceIdError as exc:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "error": {
+                        "code": "ambiguous_resource_id",
+                        "message": _client_safe_error_detail(
+                            exc,
+                            context="terminal transfer",
+                        ),
+                    }
+                },
             )
         except RuntimeError as exc:
             return JSONResponse(
@@ -8173,10 +8469,21 @@ def create_runner_app(
         session_id: str,
         terminal_id: str,
     ) -> JSONResponse:
-        closed = await resource_registry.close_terminal(
-            session_id,
-            terminal_id,
-        )
+        try:
+            closed = await resource_registry.close_terminal(
+                session_id,
+                terminal_id,
+            )
+        except AmbiguousResourceIdError as exc:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "error": {
+                        "code": "ambiguous_resource_id",
+                        "message": _client_safe_error_detail(exc, context="terminal close"),
+                    }
+                },
+            )
         if not closed:
             return JSONResponse(
                 status_code=404,
@@ -8204,9 +8511,25 @@ def create_runner_app(
         registry = resource_registry.terminal_registry
         lock = _repl_terminal_ensure_locks.setdefault(session_id, asyncio.Lock())
         async with lock:
-            existing = registry.get(session_id, _REPL_TERMINAL_NAME, _REPL_TERMINAL_SESSION_KEY)
-            if existing is None or not existing.running or not await existing.is_alive():
-                await registry.close(session_id, _REPL_TERMINAL_NAME, _REPL_TERMINAL_SESSION_KEY)
+            existing = registry.resolve_key_snapshot(
+                session_id,
+                _REPL_TERMINAL_NAME,
+                _REPL_TERMINAL_SESSION_KEY,
+            )
+            if isinstance(existing, AmbiguousResourceId):
+                return None
+            alive = (
+                await _terminal_snapshot_is_alive(registry, existing)
+                if isinstance(existing, ResolveSnapshot)
+                else False
+            )
+            if not alive:
+                # Low-level registry close, not ``close_terminal``: the
+                # resource-level scan skips entries whose ``running`` flag is
+                # already False, orphaning the activity watcher and scratch
+                # dir. ``close_snapshot`` pops and tears the instance down.
+                if isinstance(existing, ResolveSnapshot):
+                    await registry.close_snapshot(existing)
                 try:
                     repl_agent_spec = await _resolve_session_agent_spec(session_id)
                 except OmnigentError:
@@ -8235,9 +8558,21 @@ def create_runner_app(
         registry = resource_registry.terminal_registry
         lock = _qwen_terminal_ensure_locks.setdefault(session_id, asyncio.Lock())
         async with lock:
-            existing = registry.get(session_id, "qwen", "main")
-            if existing is None or not existing.running or not await existing.is_alive():
-                await registry.close(session_id, "qwen", "main")
+            existing = registry.resolve_key_snapshot(session_id, "qwen", "main")
+            if isinstance(existing, AmbiguousResourceId):
+                return None
+            alive = (
+                await _terminal_snapshot_is_alive(registry, existing)
+                if isinstance(existing, ResolveSnapshot)
+                else False
+            )
+            if not alive:
+                # Low-level registry close, not ``close_terminal``: the
+                # resource-level scan skips entries whose ``running`` flag is
+                # already False, orphaning the activity watcher and scratch
+                # dir. ``close_snapshot`` pops and tears the instance down.
+                if isinstance(existing, ResolveSnapshot):
+                    await registry.close_snapshot(existing)
                 try:
                     await _auto_create_qwen_terminal(
                         session_id,
@@ -8263,24 +8598,41 @@ def create_runner_app(
         transport: str | None = Query(default=None),
     ) -> None:
         await websocket.accept()
-        entry = resolve_terminal_entry_by_resource_id(
-            session_id,
-            terminal_id,
-            terminal_registry,
-        )
+        attach_snapshot: ResolveSnapshot | None = None
+        ambiguous_owner = False
+        if terminal_registry is not None:
+            resolved = terminal_registry.resolve_snapshot(session_id, terminal_id)
+            if isinstance(resolved, ResolveSnapshot):
+                if await _terminal_snapshot_is_alive(terminal_registry, resolved):
+                    attach_snapshot = resolved
+            elif isinstance(resolved, AmbiguousResourceId):
+                ambiguous_owner = True
+        entry = attach_snapshot.entry if attach_snapshot is not None else None
         terminal_role = (
             resource_registry.terminal_resource_role(session_id, terminal_id)
             if resource_registry is not None
             else None
         )
-        if entry is None or not entry.instance.running or not await entry.instance.is_alive():
-            if terminal_role == OMNIGENT_REPL_TERMINAL_ROLE:
+        if entry is None:
+            if ambiguous_owner:
+                entry = None
+            elif terminal_role == OMNIGENT_REPL_TERMINAL_ROLE:
                 entry = await _recreate_repl_terminal(session_id, terminal_id)
             elif terminal_role == QWEN_NATIVE_TERMINAL_ROLE:
                 entry = await _recreate_qwen_terminal(session_id, terminal_id)
             else:
                 entry = None
             if entry is None:
+                await websocket.close(
+                    code=WS_CLOSE_TERMINAL_NOT_FOUND,
+                    reason="terminal resource not found or not running",
+                )
+                return
+            if terminal_registry is not None:
+                recreated = terminal_registry.resolve_snapshot(session_id, terminal_id)
+                if isinstance(recreated, ResolveSnapshot):
+                    attach_snapshot = recreated
+            if attach_snapshot is None:
                 await websocket.close(
                     code=WS_CLOSE_TERMINAL_NOT_FOUND,
                     reason="terminal resource not found or not running",
@@ -8309,12 +8661,24 @@ def create_runner_app(
             if resolved_transport == TERMINAL_TRANSPORT_CONTROL
             else bridge_tmux_pty_to_websocket
         )
+
+        async def _send_attached_input(data: bytes) -> bool:
+            assert attach_snapshot is not None
+            assert terminal_registry is not None
+            return await asyncio.to_thread(
+                terminal_registry.run_fenced,
+                attach_snapshot,
+                lambda: attach_snapshot.instance.send_raw_bytes(data),
+                invalid=False,
+            )
+
         await bridge(
             websocket,
             socket_path=str(entry.instance.socket_path),
             tmux_target=entry.instance.tmux_target,
             read_only=read_only,
             on_client_interaction=entry.instance.note_client_interaction,
+            on_client_input=_send_attached_input,
         )
 
     async def _require_os_env(session_id: str) -> Any | None:

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -59,6 +59,10 @@ from omnigent.runner.session_init_protocol import (
     RunnerSessionInitEnvelope,
 )
 from omnigent.spec.types import AgentSpec
+from omnigent.terminals import (
+    AmbiguousResourceId,
+    ResolveSnapshot,
+)
 
 _logger = logging.getLogger("omnigent.runner.app")
 
@@ -269,15 +273,11 @@ def _terminal_lookup_miss_reason(
     terminal_registry = resource_registry.terminal_registry
     if terminal_registry is None:
         return "terminal_registry_missing"
-    entries = terminal_registry.list_for_conversation(session_id)
-    if not entries:
-        return "session_has_no_registered_terminals"
-    registered_ids = [
-        terminal_resource_id(entry.terminal_name, entry.session_key) for entry in entries
-    ]
-    for entry in entries:
-        if terminal_resource_id(entry.terminal_name, entry.session_key) != terminal_id:
-            continue
+    resolved = terminal_registry.resolve_snapshot(session_id, terminal_id)
+    if isinstance(resolved, AmbiguousResourceId):
+        return "ambiguous_resource_id"
+    if isinstance(resolved, ResolveSnapshot):
+        entry = resolved.entry
         if not entry.instance.running:
             return (
                 "terminal_registered_but_not_running "
@@ -289,6 +289,12 @@ def _terminal_lookup_miss_reason(
             f"name={entry.terminal_name!r} session_key={entry.session_key!r} "
             f"socket={entry.instance.socket_path}"
         )
+    entries = terminal_registry.list_for_conversation(session_id)
+    if not entries:
+        return "session_has_no_registered_terminals"
+    registered_ids = [
+        terminal_resource_id(entry.terminal_name, entry.session_key) for entry in entries
+    ]
     return f"terminal_id_not_registered registered_ids={registered_ids!r}"
 
 

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -35,6 +35,12 @@ from omnigent.entities.session_resources import (
     terminal_resource_id,
     terminal_resource_view,
 )
+from omnigent.terminals.registry import (
+    AmbiguousResourceId,
+    AmbiguousResourceIdError,
+    ResolveSnapshot,
+    TerminalListEntry,
+)
 
 if TYPE_CHECKING:
     from omnigent.inner.os_env import OSEnvironment
@@ -523,27 +529,23 @@ class SessionResourceRegistry:
         """
         if self._terminal_registry is None:
             return None
+        resolved = self._terminal_registry.resolve_snapshot(session_id, terminal_id)
+        if not isinstance(resolved, ResolveSnapshot):
+            return None
 
-        for entry in self._terminal_registry.list_for_conversation(
-            session_id,
-        ):
-            if terminal_resource_id(entry.terminal_name, entry.session_key) != terminal_id:
-                continue
-            if not entry.instance.running:
-                return None
+        cache_key = f"{session_id}:{terminal_id}"
+        cached = self._is_alive_cache.get(cache_key)
 
-            cache_key = f"{session_id}:{terminal_id}"
-            cached = self._is_alive_cache.get(cache_key)
-            if cached is not None:
-                return terminal_resource_view(session_id, entry) if cached else None
-
-            alive = await entry.instance.is_alive()
-            if alive:
-                self._is_alive_cache[cache_key] = True
-            else:
-                self._is_alive_cache.pop(cache_key, None)
-                return None
-            return terminal_resource_view(session_id, entry)
+        alive = await asyncio.to_thread(
+            self._terminal_registry.run_fenced,
+            resolved,
+            lambda: bool(cached) if cached is not None else resolved.instance.is_alive(),
+            invalid=False,
+        )
+        if alive:
+            self._is_alive_cache[cache_key] = True
+            return terminal_resource_view(session_id, resolved.entry)
+        self._is_alive_cache.pop(cache_key, None)
         return None
 
     def resolve_environment(
@@ -1217,22 +1219,17 @@ class SessionResourceRegistry:
         """
         if self._terminal_registry is None:
             return False
-
-        for entry in self._terminal_registry.list_for_conversation(
-            session_id,
-        ):
-            if terminal_resource_id(entry.terminal_name, entry.session_key) == terminal_id:
-                closed = await self._terminal_registry.close(
-                    session_id,
-                    entry.terminal_name,
-                    entry.session_key,
-                )
-                if closed:
-                    with self._lock:
-                        self._terminal_roles.pop((session_id, terminal_id), None)
-                        self._terminal_lifecycles.pop((session_id, terminal_id), None)
-                return closed
-        return False
+        resolved = self._terminal_registry.resolve_snapshot(session_id, terminal_id)
+        if isinstance(resolved, AmbiguousResourceId):
+            raise AmbiguousResourceIdError(f"Terminal resource {terminal_id!r} is ambiguous")
+        if resolved is None:
+            return False
+        closed = await self._terminal_registry.close_snapshot(resolved)
+        if closed:
+            with self._lock:
+                self._terminal_roles.pop((session_id, terminal_id), None)
+                self._terminal_lifecycles.pop((session_id, terminal_id), None)
+        return closed
 
     async def transfer_terminal(
         self,
@@ -1261,40 +1258,49 @@ class SessionResourceRegistry:
         if self._terminal_registry is None:
             return None
 
-        from omnigent.terminals.registry import TerminalListEntry
-
-        for entry in self._terminal_registry.list_for_conversation(
+        resolved = self._terminal_registry.resolve_snapshot(
             source_session_id,
+            terminal_id,
+        )
+        if isinstance(resolved, AmbiguousResourceId):
+            raise AmbiguousResourceIdError(f"Terminal resource {terminal_id!r} is ambiguous")
+        if resolved is None:
+            return None
+
+        def _transfer_after_revalidation() -> (
+            tuple[
+                SessionResourceView,
+                str | None,
+                TerminalLifecycle | None,
+            ]
+            | None
         ):
-            if not entry.instance.running:
-                continue
-            if terminal_resource_id(entry.terminal_name, entry.session_key) != terminal_id:
-                continue
-            moved = self._terminal_registry.transfer(
-                source_session_id,
+            moved = self._terminal_registry.transfer_snapshot(
+                resolved,
                 target_session_id,
-                entry.terminal_name,
-                entry.session_key,
             )
             if not moved:
                 return None
+            entry = resolved.entry
+            instance = resolved.instance
             with self._lock:
                 role = self._terminal_roles.pop((source_session_id, terminal_id), None)
                 if role is not None:
                     self._terminal_roles[(target_session_id, terminal_id)] = role
-                lifecycle = self._terminal_lifecycles.pop((source_session_id, terminal_id), None)
+                lifecycle = self._terminal_lifecycles.pop(
+                    (source_session_id, terminal_id),
+                    None,
+                )
                 if lifecycle is not None:
                     self._terminal_lifecycles[(target_session_id, terminal_id)] = lifecycle
-            # Move the PTY-status memo with the pane so a post-transfer exit is
-            # classified against the right session. Don't clobber a status the
-            # target already has from its own terminal.
-            with self._lock:
                 moved_status = self._last_session_status.pop(source_session_id, None)
                 if moved_status is not None and target_session_id not in self._last_session_status:
                     self._last_session_status[target_session_id] = moved_status
             try:
-                await entry.instance.set_conversation_link(
-                    self._terminal_registry.conversation_link_for_id(target_session_id)
+                asyncio.run(
+                    instance.set_conversation_link(
+                        self._terminal_registry.conversation_link_for_id(target_session_id)
+                    )
                 )
             except (RuntimeError, OSError) as exc:
                 _logger.warning(
@@ -1302,25 +1308,37 @@ class SessionResourceRegistry:
                     target_session_id,
                     exc,
                 )
-            if lifecycle is not None:
-                self._start_terminal_activity_watcher(
-                    target_session_id,
-                    entry.terminal_name,
-                    entry.session_key,
-                    entry.instance,
-                    role,
-                    lifecycle,
-                    replace=True,
-                )
-            return terminal_resource_view(
+            view = terminal_resource_view(
                 target_session_id,
                 TerminalListEntry(
                     terminal_name=entry.terminal_name,
                     session_key=entry.session_key,
-                    instance=entry.instance,
+                    instance=instance,
                 ),
             )
-        return None
+            return view, role, lifecycle
+
+        transferred = await asyncio.to_thread(
+            self._terminal_registry.run_fenced,
+            resolved,
+            _transfer_after_revalidation,
+            invalid=None,
+        )
+        if transferred is None:
+            return None
+        view, role, lifecycle = transferred
+        if lifecycle is not None:
+            entry = resolved.entry
+            self._start_terminal_activity_watcher(
+                target_session_id,
+                entry.terminal_name,
+                entry.session_key,
+                resolved.instance,
+                role,
+                lifecycle,
+                replace=True,
+            )
+        return view
 
     async def cleanup_session(self, session_id: str) -> None:
         """Close all resources owned by a session.

--- a/omnigent/server/routes/terminal_attach.py
+++ b/omnigent/server/routes/terminal_attach.py
@@ -89,6 +89,7 @@ from omnigent.server.routes._auth_helpers import require_access
 from omnigent.stores import ConversationStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.terminals.control_bridge import bridge_tmux_control_to_websocket
+from omnigent.terminals.registry import ResolveSnapshot
 from omnigent.terminals.ws_bridge import (
     WS_CLOSE_INTERNAL_ERROR,
     WS_CLOSE_TERMINAL_NOT_FOUND,
@@ -153,10 +154,6 @@ def create_terminal_attach_router(
             pick the control-mode vs PTY bridge in-process. ``None`` defers to
             the terminal spec / global default.
         """
-        from omnigent.entities.session_resources import (
-            resolve_terminal_entry_by_resource_id,
-        )
-
         await _authorize_terminal_attach(
             websocket,
             session_id=session_id,
@@ -228,17 +225,26 @@ def create_terminal_attach_router(
             )
             return
 
-        entry = resolve_terminal_entry_by_resource_id(
-            session_id,
-            terminal_id,
-            terminal_registry,
-        )
-        if entry is None or not entry.instance.running or not await entry.instance.is_alive():
+        resolved = terminal_registry.resolve_snapshot(session_id, terminal_id)
+        if not isinstance(resolved, ResolveSnapshot):
             await websocket.close(
                 code=_WS_CLOSE_TERMINAL_NOT_FOUND,
                 reason="terminal resource not found or not running",
             )
             return
+
+        if not await asyncio.to_thread(
+            terminal_registry.run_fenced,
+            resolved,
+            resolved.instance.is_alive,
+            invalid=False,
+        ):
+            await websocket.close(
+                code=_WS_CLOSE_TERMINAL_NOT_FOUND,
+                reason="terminal resource not found or not running",
+            )
+            return
+        entry = resolved.entry
 
         from omnigent.inner.terminal import (
             TERMINAL_TRANSPORT_CONTROL,
@@ -265,11 +271,21 @@ def create_terminal_attach_router(
                 if resolved_transport == TERMINAL_TRANSPORT_CONTROL
                 else bridge_tmux_pty_to_websocket
             )
+
+            async def _send_attached_input(data: bytes) -> bool:
+                return await asyncio.to_thread(
+                    terminal_registry.run_fenced,
+                    resolved,
+                    lambda: resolved.instance.send_raw_bytes(data),
+                    invalid=False,
+                )
+
             await bridge(
                 websocket,
                 socket_path=str(entry.instance.socket_path),
                 tmux_target=entry.instance.tmux_target,
                 read_only=read_only,
+                on_client_input=_send_attached_input,
             )
 
     return router

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -845,6 +845,14 @@ def _parse_terminals(
             raise OmnigentError(
                 f"terminals.{name}.env must be a mapping", code=ErrorCode.INVALID_INPUT
             )
+        ready_process = entry.get("ready_process")
+        if ready_process is not None and (
+            not isinstance(ready_process, str) or not ready_process.strip()
+        ):
+            raise OmnigentError(
+                f"terminals.{name}.ready_process must be a non-empty string",
+                code=ErrorCode.INVALID_INPUT,
+            )
         # os_env may be a nested mapping (parsed like top-level os_env), the
         # literal string "inherit", or absent.
         raw_os_env = entry.get("os_env")
@@ -864,6 +872,7 @@ def _parse_terminals(
             session_prefix=str(entry.get("session_prefix", "omni_")),
             tmux_allow_passthrough=bool(entry.get("tmux_allow_passthrough", False)),
             tmux_start_on_attach=bool(entry.get("tmux_start_on_attach", False)),
+            ready_process=ready_process,
         )
     return terminals or None
 

--- a/omnigent/terminals/__init__.py
+++ b/omnigent/terminals/__init__.py
@@ -9,9 +9,18 @@ See ``designs/OMNIGENT_TERMINAL_BRIDGE.md`` for the design and the
 :mod:`omnigent.inner.terminal` for the underlying tmux machinery.
 """
 
-from omnigent.terminals.registry import TerminalListEntry, TerminalRegistry
+from omnigent.terminals.registry import (
+    AmbiguousResourceId,
+    AmbiguousResourceIdError,
+    ResolveSnapshot,
+    TerminalListEntry,
+    TerminalRegistry,
+)
 
 __all__ = [
+    "AmbiguousResourceId",
+    "AmbiguousResourceIdError",
+    "ResolveSnapshot",
     "TerminalListEntry",
     "TerminalRegistry",
 ]

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -52,7 +52,7 @@ import json
 import logging
 import re
 import shutil
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Final
 
@@ -312,6 +312,7 @@ async def bridge_tmux_control_to_websocket(
     tmux_target: str,
     read_only: bool,
     on_client_interaction: Callable[[], None] | None = None,
+    on_client_input: Callable[[bytes], Awaitable[bool]] | None = None,
     reader_done: asyncio.Event | None = None,
     forward_done: asyncio.Event | None = None,
 ) -> None:
@@ -332,6 +333,8 @@ async def bridge_tmux_control_to_websocket(
         interaction (connect, disconnect, each input/resize frame) so the
         idle watcher can discount client-driven repaints. See the PTY bridge
         for the full rationale.
+    :param on_client_input: Optional owner-fenced raw-input dispatcher. A
+        ``False`` result closes an attachment whose captured owner changed.
     :param reader_done: Optional test-only event set once the reader has queued
         the full backlog and the ``None`` EOF sentinel, letting a test await the
         reader draining tmux instead of sleeping. Inert (never awaited) when
@@ -490,13 +493,29 @@ async def bridge_tmux_control_to_websocket(
                             rows = int(ctl["rows"])
                         except (KeyError, TypeError, ValueError):
                             continue
+                        if on_client_input is not None and not await on_client_input(b""):
+                            with contextlib.suppress(RuntimeError):
+                                await websocket.close(
+                                    code=WS_CLOSE_TERMINAL_NOT_FOUND,
+                                    reason="terminal ownership changed",
+                                )
+                            return
                         await _send_command(f"refresh-client -C {cols}x{rows}\n".encode())
                 elif data is not None and not read_only:
                     # Stamp before sending so the next %output (the echo) takes
                     # the small interactive frame cap.
                     last_client_input_at = _monotonic()
-                    for cmd in _hex_send_keys_commands(tmux_target, data):
-                        await _send_command(cmd)
+                    if on_client_input is not None:
+                        if not await on_client_input(data):
+                            with contextlib.suppress(RuntimeError):
+                                await websocket.close(
+                                    code=WS_CLOSE_TERMINAL_NOT_FOUND,
+                                    reason="terminal ownership changed",
+                                )
+                            return
+                    else:
+                        for cmd in _hex_send_keys_commands(tmux_target, data):
+                            await _send_command(cmd)
         except WebSocketDisconnect:
             return
 

--- a/omnigent/terminals/registry.py
+++ b/omnigent/terminals/registry.py
@@ -29,9 +29,10 @@ map. Tool invocations run on background threads via
 spins up its own ``asyncio.run`` loop to drive the registry's async
 methods. An ``asyncio.Lock`` would be bound to whichever loop created
 it and would silently fail to synchronize concurrent invocations from
-different threads. The threading lock is held only for short map
-mutations (no tmux I/O underneath); slow tmux subprocess calls happen
-outside the lock.
+different threads. The registry lock is held only for short map
+mutations. Terminal operations capture a snapshot, acquire the stable
+instance-owned ``op_lock``, revalidate under the registry lock, then
+perform tmux I/O while retaining only ``op_lock``.
 """
 
 from __future__ import annotations
@@ -39,8 +40,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, TypeVar
 from urllib.parse import quote
 
 from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
@@ -91,14 +94,43 @@ class TerminalListEntry:
 
     :param terminal_name: The terminal's spec name, e.g. ``"bash"``.
     :param session_key: The per-launch session key, e.g. ``"s1"``.
-    :param instance: The live :class:`TerminalInstance`. Callers can
-        read ``.running``, ``.command``, ``.socket_path``, etc., or
-        invoke ``send`` / ``read`` directly when wrapping in tools.
+    :param instance: The :class:`TerminalInstance` at snapshot time.
+        Callers may inspect metadata; tmux operations must use an atomic
+        :class:`ResolveSnapshot` and revalidate ownership first.
     """
 
     terminal_name: str
     session_key: str
     instance: TerminalInstance
+
+
+@dataclass(frozen=True)
+class ResolveSnapshot:
+    """Atomic terminal ownership snapshot used to fence one tmux operation."""
+
+    entry: TerminalListEntry
+    instance: TerminalInstance
+    op_lock: threading.Lock
+    owner_tuple: tuple[str, str, str]
+    owner_generation: int
+
+
+@dataclass(frozen=True)
+class AmbiguousResourceId:
+    """Fail-closed result for legacy registry entries sharing one public id."""
+
+    session_id: str
+    terminal_id: str
+    code: str = "ambiguous_resource_id"
+
+
+class AmbiguousResourceIdError(RuntimeError):
+    """Raised when a mutating terminal operation receives an ambiguous id."""
+
+
+ResolveResult = ResolveSnapshot | AmbiguousResourceId | None
+_FencedResultT = TypeVar("_FencedResultT")
+_FencedInvalidT = TypeVar("_FencedInvalidT")
 
 
 class TerminalRegistry:
@@ -128,20 +160,10 @@ class TerminalRegistry:
         # Per-conversation maps make ``cleanup_conversation`` cheap
         # (one pop) and ``list_for_conversation`` direct.
         self._by_conversation: dict[str, dict[tuple[str, str], TerminalInstance]] = {}
-        # Per-instance locks keyed by the full (conv_id, name, session_key)
-        # triple. Created at launch, removed at close /
-        # cleanup_conversation. Sender / reader / closer tools acquire
-        # this around the ``asyncio.run(instance.X())`` call to serialize
-        # tmux subprocess invocations on the same instance — without it,
-        # two concurrent ``sys_terminal_send`` calls can interleave their
-        # per-keystroke tmux commands (a ``send(text=X, keys="Enter")``
-        # decomposes to ~2 subprocess calls with a 50ms ``asyncio.sleep``
-        # between them — plenty of room for another send to slip in).
-        # See ``designs/OMNIGENT_TERMINAL_BRIDGE.md`` §9.1.
-        self._instance_locks: dict[tuple[str, str, str], threading.Lock] = {}
         # Threading lock — see module docstring for the rationale.
-        # Protects both ``_by_conversation`` and ``_instance_locks``.
+        # It protects the map and every owner-generation transition.
         self._lock = threading.Lock()
+        self._shutting_down = False
 
     def conversation_link_for_id(self, conversation_id: str) -> str:
         """
@@ -204,14 +226,33 @@ class TerminalRegistry:
             tool wraps in a JSON error envelope.
         """
         key = (terminal_name, session_key)
+        existing_snapshot: ResolveSnapshot | None = None
         with self._lock:
+            if self._shutting_down:
+                raise RuntimeError("terminal registry is shutting down")
+            self._assert_resource_id_available_locked(
+                conversation_id,
+                terminal_name,
+                session_key,
+            )
             existing = self._by_conversation.get(conversation_id, {}).get(key)
-        if existing is not None and existing.running:
-            if await existing.is_alive():
-                return existing
-            await self.close(conversation_id, terminal_name, session_key)
-        elif existing is not None:
-            await self.close(conversation_id, terminal_name, session_key)
+            if existing is not None:
+                existing_snapshot = ResolveSnapshot(
+                    entry=TerminalListEntry(terminal_name, session_key, existing),
+                    instance=existing,
+                    op_lock=existing.op_lock,
+                    owner_tuple=(conversation_id, terminal_name, session_key),
+                    owner_generation=existing.owner_generation,
+                )
+        if existing_snapshot is not None:
+            if await asyncio.to_thread(
+                self.run_fenced,
+                existing_snapshot,
+                existing_snapshot.instance.is_alive,
+                invalid=False,
+            ):
+                return existing_snapshot.instance
+            await self.close_snapshot(existing_snapshot)
 
         # Lock-free section: ``create_terminal_instance`` and
         # ``launch`` may take real time (tmux spawn). Holding the
@@ -242,28 +283,37 @@ class TerminalRegistry:
                 f"terminal {terminal_name}:{session_key} exited before it became available"
             )
 
+        registration_error: RuntimeError | None = None
         with self._lock:
-            slot = self._by_conversation.setdefault(conversation_id, {})
-            # Re-check: another concurrent launch for the same key may
-            # have raced ours. Take the second-arrival policy: close
-            # ours and return the racer's. Avoids two live tmux
-            # sessions for the same key.
-            racer = slot.get(key)
-            if racer is not None and racer.running:
-                # Close ours outside the lock; racer wins.
-                instance_to_close: TerminalInstance | None = created.instance
-                winning_instance = racer
-            else:
-                slot[key] = created.instance
-                instance_to_close = None
+            if self._shutting_down:
+                shutdown_started = True
+                instance_to_close = created.instance
                 winning_instance = created.instance
-                # Allocate a per-instance lock alongside the
-                # registration. Tools fetch it via
-                # :meth:`get_instance_lock` to serialize concurrent
-                # tmux ops on this instance.
-                self._instance_locks[(conversation_id, terminal_name, session_key)] = (
-                    threading.Lock()
-                )
+            else:
+                shutdown_started = False
+                try:
+                    self._assert_resource_id_available_locked(
+                        conversation_id,
+                        terminal_name,
+                        session_key,
+                    )
+                except RuntimeError as exc:
+                    registration_error = exc
+                    instance_to_close = created.instance
+                    winning_instance = created.instance
+                else:
+                    slot = self._by_conversation.setdefault(conversation_id, {})
+                    # Re-check: another concurrent launch for the same key may
+                    # have raced ours. Take the second-arrival policy: close
+                    # ours and return the racer's.
+                    racer = slot.get(key)
+                    if racer is not None and racer.running:
+                        instance_to_close = created.instance
+                        winning_instance = racer
+                    else:
+                        slot[key] = created.instance
+                        instance_to_close = None
+                        winning_instance = created.instance
 
         if instance_to_close is not None:
             try:
@@ -275,35 +325,117 @@ class TerminalRegistry:
                     session_key,
                     conversation_id,
                 )
+        if shutdown_started:
+            raise RuntimeError("terminal registry is shutting down")
+        if registration_error is not None:
+            raise registration_error
         return winning_instance
 
-    def get_instance_lock(
+    def _assert_resource_id_available_locked(
         self,
         conversation_id: str,
         terminal_name: str,
         session_key: str,
-    ) -> threading.Lock | None:
-        """Return the per-instance lock for a registered terminal.
+    ) -> None:
+        """Reject a sanitized ``(name, key)`` collision while ``_lock`` is held."""
+        from omnigent.entities.session_resources import terminal_resource_id
 
-        Used by the ``sys_terminal_send`` / ``read`` / ``close``
-        tools to serialize tmux subprocess invocations against the
-        same instance. The lock exists from registration (in
-        :meth:`launch`) until the instance is closed (in
-        :meth:`close` or :meth:`cleanup_conversation`).
+        requested_id = terminal_resource_id(terminal_name, session_key)
+        slot = self._by_conversation.get(conversation_id, {})
+        collisions = [
+            (name, key)
+            for name, key in slot
+            if terminal_resource_id(name, key) == requested_id
+            and (name, key) != (terminal_name, session_key)
+        ]
+        if collisions:
+            raise RuntimeError(
+                f"terminal resource id {requested_id!r} collides with registered "
+                f"terminal {collisions[0][0]!r}:{collisions[0][1]!r}"
+            )
 
-        :param conversation_id: Owning conversation id.
-        :param terminal_name: Terminal spec name.
-        :param session_key: Session key from launch.
-        :returns: A :class:`threading.Lock` to acquire around
-            per-instance ops, or ``None`` if the instance was
-            never registered (or has been closed). Callers should
-            handle ``None`` by surfacing a "not running" error to
-            the LLM rather than skipping the lock — the
-            instance-not-found path means the operation can't
-            proceed at all.
-        """
+    def resolve_snapshot(
+        self,
+        session_id: str,
+        terminal_id: str,
+    ) -> ResolveResult:
+        """Resolve one public id and capture ownership atomically under ``_lock``."""
+        from omnigent.entities.session_resources import terminal_resource_id
+
         with self._lock:
-            return self._instance_locks.get((conversation_id, terminal_name, session_key))
+            matches = [
+                (name, key, instance)
+                for (name, key), instance in self._by_conversation.get(session_id, {}).items()
+                if terminal_resource_id(name, key) == terminal_id
+            ]
+            if len(matches) > 1:
+                return AmbiguousResourceId(session_id=session_id, terminal_id=terminal_id)
+            if not matches:
+                return None
+            name, key, instance = matches[0]
+            entry = TerminalListEntry(
+                terminal_name=name,
+                session_key=key,
+                instance=instance,
+            )
+            return ResolveSnapshot(
+                entry=entry,
+                instance=instance,
+                op_lock=instance.op_lock,
+                owner_tuple=(session_id, name, key),
+                owner_generation=instance.owner_generation,
+            )
+
+    def resolve_key_snapshot(
+        self,
+        session_id: str,
+        terminal_name: str,
+        session_key: str,
+    ) -> ResolveResult:
+        """Resolve a tool's name/key arguments through the public-id resolver."""
+        from omnigent.entities.session_resources import terminal_resource_id
+
+        return self.resolve_snapshot(
+            session_id,
+            terminal_resource_id(terminal_name, session_key),
+        )
+
+    def snapshot_error_code(self, snapshot: ResolveSnapshot) -> str | None:
+        """Return why a captured owner can no longer operate, or ``None``."""
+        with self._lock:
+            if not self._snapshot_mapping_matches_locked(snapshot):
+                return "terminal_moved"
+            if snapshot.instance.retired or not snapshot.instance.running:
+                return "terminal_not_running"
+            return None
+
+    def run_fenced(
+        self,
+        snapshot: ResolveSnapshot,
+        async_fn: Callable[
+            [],
+            Coroutine[Any, Any, _FencedResultT] | _FencedResultT,
+        ],
+        *,
+        invalid: _FencedInvalidT | Callable[[str], _FencedInvalidT],
+    ) -> _FencedResultT | _FencedInvalidT:
+        """Run one operation while its captured terminal owner stays valid."""
+        with snapshot.op_lock:
+            error_code = self.snapshot_error_code(snapshot)
+            if error_code is not None:
+                return invalid(error_code) if callable(invalid) else invalid
+            result = async_fn()
+            if asyncio.iscoroutine(result):
+                return asyncio.run(result)
+            return result
+
+    def _snapshot_mapping_matches_locked(self, snapshot: ResolveSnapshot) -> bool:
+        session_id, terminal_name, session_key = snapshot.owner_tuple
+        current = self._by_conversation.get(session_id, {}).get((terminal_name, session_key))
+        return (
+            current is snapshot.instance
+            and snapshot.instance.owner_generation == snapshot.owner_generation
+        )
 
     def get(
         self,
@@ -400,16 +532,42 @@ class TerminalRegistry:
         :raises RuntimeError: If the target conversation already has an
             entry with the same terminal name and session key.
         """
+        resolved = self.resolve_key_snapshot(
+            source_conversation_id,
+            terminal_name,
+            session_key,
+        )
+        if isinstance(resolved, AmbiguousResourceId):
+            raise AmbiguousResourceIdError(
+                f"Terminal resource {resolved.terminal_id!r} is ambiguous"
+            )
+        if resolved is None:
+            return False
+        with resolved.op_lock:
+            return self.transfer_snapshot(resolved, target_conversation_id)
+
+    def transfer_snapshot(
+        self,
+        snapshot: ResolveSnapshot,
+        target_conversation_id: str,
+    ) -> bool:
+        """Move a captured owner while its stable ``op_lock`` is held."""
+        if not snapshot.op_lock.locked():
+            raise RuntimeError("transfer_snapshot requires the instance operation lock")
+        source_conversation_id, terminal_name, session_key = snapshot.owner_tuple
         key = (terminal_name, session_key)
-        source_lock_key = (source_conversation_id, terminal_name, session_key)
-        target_lock_key = (target_conversation_id, terminal_name, session_key)
         with self._lock:
-            source_slot = self._by_conversation.get(source_conversation_id)
-            if source_slot is None:
+            if self._shutting_down or not self._snapshot_mapping_matches_locked(snapshot):
                 return False
-            instance = source_slot.get(key)
-            if instance is None:
+            if snapshot.instance.retired or not snapshot.instance.running:
                 return False
+            if source_conversation_id == target_conversation_id:
+                return True
+            self._assert_resource_id_available_locked(
+                target_conversation_id,
+                terminal_name,
+                session_key,
+            )
             target_slot = self._by_conversation.setdefault(target_conversation_id, {})
             if key in target_slot:
                 raise RuntimeError(
@@ -417,13 +575,12 @@ class TerminalRegistry:
                     f"conversation {target_conversation_id!r}"
                 )
 
+            snapshot.instance.owner_generation += 1
+            source_slot = self._by_conversation[source_conversation_id]
             source_slot.pop(key)
             if not source_slot:
                 self._by_conversation.pop(source_conversation_id, None)
-            target_slot[key] = instance
-
-            lock = self._instance_locks.pop(source_lock_key, None)
-            self._instance_locks[target_lock_key] = lock or threading.Lock()
+            target_slot[key] = snapshot.instance
         return True
 
     async def close(
@@ -446,33 +603,79 @@ class TerminalRegistry:
             if no live instance was found (already-closed or
             never-launched).
         """
-        key = (terminal_name, session_key)
-        with self._lock:
-            slot = self._by_conversation.get(conversation_id)
-            if slot is None:
-                return False
-            instance = slot.pop(key, None)
-            if not slot:
-                # Drop the empty per-conversation dict so memory
-                # doesn't grow with stale conversation ids.
-                self._by_conversation.pop(conversation_id, None)
-            # Drop the per-instance lock too so subsequent
-            # ``get_instance_lock`` calls return ``None`` for this
-            # closed instance (callers surface a "not running"
-            # error to the LLM).
-            self._instance_locks.pop((conversation_id, terminal_name, session_key), None)
-        if instance is None:
-            return False
-        try:
-            await asyncio.wait_for(instance.close(), timeout=_CLOSE_TIMEOUT_S)
-        except asyncio.TimeoutError:
-            logger.warning(
-                "Terminal close timed out for %s:%s in conv %s",
-                terminal_name,
-                session_key,
-                conversation_id,
+        resolved = self.resolve_key_snapshot(
+            conversation_id,
+            terminal_name,
+            session_key,
+        )
+        if isinstance(resolved, AmbiguousResourceId):
+            raise AmbiguousResourceIdError(
+                f"Terminal resource {resolved.terminal_id!r} is ambiguous"
             )
+        if resolved is None:
+            return False
+        return await self.close_snapshot(resolved)
+
+    async def close_snapshot(self, snapshot: ResolveSnapshot) -> bool:
+        """Retire and close one captured terminal without blocking the event loop."""
+        return await asyncio.to_thread(self._retire_and_close, snapshot, "Terminal close")
+
+    def _retire_and_close(
+        self,
+        snapshot: ResolveSnapshot,
+        log_prefix: str,
+    ) -> bool:
+        """Linearize retirement, then run tmux teardown under ``op_lock``."""
+        conversation_id, terminal_name, session_key = snapshot.owner_tuple
+        with snapshot.op_lock:
+            with self._lock:
+                if not self._snapshot_mapping_matches_locked(snapshot):
+                    return False
+                if snapshot.instance.retired:
+                    return False
+                snapshot.instance.retired = True
+                snapshot.instance.owner_generation += 1
+                slot = self._by_conversation[conversation_id]
+                slot.pop((terminal_name, session_key))
+                if not slot:
+                    self._by_conversation.pop(conversation_id, None)
+
+            async def _close_with_timeout() -> None:
+                await asyncio.wait_for(
+                    snapshot.instance.close(),
+                    timeout=_CLOSE_TIMEOUT_S,
+                )
+
+            try:
+                asyncio.run(_close_with_timeout())
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "%s timed out for %s:%s in conv %s",
+                    log_prefix,
+                    terminal_name,
+                    session_key,
+                    conversation_id,
+                )
         return True
+
+    def _snapshots_for_conversation_locked(
+        self,
+        conversation_id: str,
+    ) -> list[ResolveSnapshot]:
+        """Capture every exact owner in a conversation while ``_lock`` is held."""
+        return [
+            ResolveSnapshot(
+                entry=TerminalListEntry(name, key, instance),
+                instance=instance,
+                op_lock=instance.op_lock,
+                owner_tuple=(conversation_id, name, key),
+                owner_generation=instance.owner_generation,
+            )
+            for (name, key), instance in self._by_conversation.get(
+                conversation_id,
+                {},
+            ).items()
+        ]
 
     async def cleanup_conversation(self, conversation_id: str) -> None:
         """Close every terminal owned by *conversation_id*.
@@ -495,24 +698,16 @@ class TerminalRegistry:
         :param conversation_id: The conversation being torn down.
         """
         with self._lock:
-            slot = self._by_conversation.pop(conversation_id, None)
-            # Drop every per-instance lock owned by this conversation.
-            # Iterate over `slot` (the just-popped per-conv map) for the
-            # canonical (name, key) pairs.
-            if slot:
-                for name, sess in slot:
-                    self._instance_locks.pop((conversation_id, name, sess), None)
-        if not slot:
+            snapshots = self._snapshots_for_conversation_locked(conversation_id)
+        if not snapshots:
             return
-        for (name, key), instance in slot.items():
+        for snapshot in snapshots:
+            _, name, key = snapshot.owner_tuple
             try:
-                await asyncio.wait_for(instance.close(), timeout=_CLOSE_TIMEOUT_S)
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "cleanup_conversation: close timed out for %s:%s in conv %s",
-                    name,
-                    key,
-                    conversation_id,
+                await asyncio.to_thread(
+                    self._retire_and_close,
+                    snapshot,
+                    "cleanup_conversation: close",
                 )
             except Exception:
                 # We're in a workflow finally block; raising here would
@@ -533,29 +728,27 @@ class TerminalRegistry:
         a stuck instance shouldn't block the rest of Omnigent shutdown.
         """
         with self._lock:
-            slots = list(self._by_conversation.items())
-            self._by_conversation.clear()
-            # AP-shutdown clears all instance locks too — every
-            # conversation's terminals are being torn down.
-            self._instance_locks.clear()
-        for conversation_id, slot in slots:
-            for (name, key), instance in slot.items():
-                try:
-                    await asyncio.wait_for(instance.close(), timeout=_CLOSE_TIMEOUT_S)
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "shutdown: close timed out for %s:%s in conv %s",
-                        name,
-                        key,
-                        conversation_id,
-                    )
-                except Exception:
-                    logger.exception(
-                        "shutdown: close failed for %s:%s in conv %s",
-                        name,
-                        key,
-                        conversation_id,
-                    )
+            self._shutting_down = True
+            snapshots = [
+                snapshot
+                for conversation_id in tuple(self._by_conversation)
+                for snapshot in self._snapshots_for_conversation_locked(conversation_id)
+            ]
+        for snapshot in snapshots:
+            conversation_id, name, key = snapshot.owner_tuple
+            try:
+                await asyncio.to_thread(
+                    self._retire_and_close,
+                    snapshot,
+                    "shutdown: close",
+                )
+            except Exception:
+                logger.exception(
+                    "shutdown: close failed for %s:%s in conv %s",
+                    name,
+                    key,
+                    conversation_id,
+                )
 
     def active_conversation_ids(self) -> list[str]:
         """Return ids of conversations with at least one registered terminal.

--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -39,7 +39,7 @@ import struct
 import sys
 import time
 import weakref
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Final
 
@@ -510,6 +510,7 @@ async def bridge_tmux_pty_to_websocket(
     tmux_target: str,
     read_only: bool,
     on_client_interaction: Callable[[], None] | None = None,
+    on_client_input: Callable[[bytes], Awaitable[bool]] | None = None,
 ) -> None:
     """
     Bridge a tmux attach PTY to an already-accepted *websocket*.
@@ -538,6 +539,10 @@ async def bridge_tmux_pty_to_websocket(
         mis-reading them as agent activity. ``None`` (e.g. the
         server-direct attach path, which is out-of-process from the
         watcher) disables that attribution.
+    :param on_client_input: Optional owner-fenced raw-input dispatcher. The
+        runner supplies this so each frame revalidates ownership and performs
+        the complete tmux write under the instance lock. ``False`` closes the
+        stale attachment without forwarding bytes.
     """
     # Attaching is itself a client interaction: tmux resizes the window to
     # the new client, which reflows the pane. Stamp it before the bridge
@@ -647,10 +652,27 @@ async def bridge_tmux_pty_to_websocket(
                             rows = int(ctl["rows"])
                         except (KeyError, TypeError, ValueError):
                             continue
+                        if on_client_input is not None and not await on_client_input(b""):
+                            with contextlib.suppress(RuntimeError):
+                                await websocket.close(
+                                    code=WS_CLOSE_TERMINAL_NOT_FOUND,
+                                    reason="terminal ownership changed",
+                                )
+                            return
                         winsize = struct.pack("HHHH", rows, cols, 0, 0)
                         with contextlib.suppress(OSError):
                             fcntl.ioctl(master_fd, termios.TIOCSWINSZ, winsize)
                 elif data is not None and not read_only:
+                    if on_client_input is not None:
+                        last_client_input_at = _monotonic()
+                        if not await on_client_input(data):
+                            with contextlib.suppress(RuntimeError):
+                                await websocket.close(
+                                    code=WS_CLOSE_TERMINAL_NOT_FOUND,
+                                    reason="terminal ownership changed",
+                                )
+                            return
+                        continue
                     # Probe pane liveness only if we haven't checked recently (cache
                     # for ~100ms to avoid a subprocess per keystroke). When remain-on-exit
                     # keeps a dead pane alive, Ctrl-C silently fails; detect and close

--- a/omnigent/tools/builtins/sys_terminal.py
+++ b/omnigent/tools/builtins/sys_terminal.py
@@ -31,18 +31,36 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import threading
 from dataclasses import dataclass
 from typing import Any
 
 from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
 from omnigent.inner.terminal import TerminalInstance
 from omnigent.spec.types import AgentSpec
-from omnigent.terminals import TerminalRegistry
+from omnigent.terminals import AmbiguousResourceId, ResolveSnapshot, TerminalRegistry
 from omnigent.tools.base import Tool, ToolContext
 
 _logger = logging.getLogger(__name__)
 _PLACEHOLDER_CWDS = (None, "", ".", "./")
+_SHELL_READINESS_TIMEOUT_SECONDS = 10.0
+
+
+def _fence_error(
+    error_code: str,
+    *,
+    delivery_not_attempted: bool = False,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "error": (
+            "Terminal ownership changed"
+            if error_code == "terminal_moved"
+            else "Terminal is not running"
+        ),
+        "code": error_code,
+    }
+    if delivery_not_attempted:
+        result["delivery_not_attempted"] = True
+    return result
 
 
 def _has_meaningful_cwd(cwd: str | None) -> bool:
@@ -92,7 +110,7 @@ class _ValidatedLaunchArgs:
 
 @dataclass(frozen=True)
 class _ResolvedInstance:
-    """A running :class:`TerminalInstance` plus its parsed tool args + lock.
+    """A captured running-terminal owner plus its parsed tool arguments.
 
     Returned by :func:`_resolve_running_instance` on the success
     path. Using a dataclass keeps call-sites self-documenting:
@@ -101,18 +119,13 @@ class _ResolvedInstance:
 
     :param instance: The live :class:`TerminalInstance`.
     :param parsed: The parsed JSON arguments dict for the tool.
-    :param lock: The per-instance ``threading.Lock`` from
-        :meth:`TerminalRegistry.get_instance_lock`. Callers MUST
-        acquire this around the ``asyncio.run(instance.X())`` call
-        to serialize concurrent tmux ops on the same instance —
-        without it, a ``send(text=X, keys="Enter")`` call can
-        interleave its 2 tmux subprocess invocations with another
-        thread's send. See ``designs/OMNIGENT_TERMINAL_BRIDGE.md`` §9.1.
+    :param snapshot: Atomic registry owner snapshot. Operations acquire its
+        instance-owned lock and revalidate it immediately before tmux I/O.
     """
 
     instance: TerminalInstance
     parsed: dict[str, Any]
-    lock: threading.Lock
+    snapshot: ResolveSnapshot
 
 
 def _format_launch_envelope(
@@ -454,12 +467,19 @@ def _resolve_running_instance(
     invalid = _validate_session_required_args(parsed)
     if invalid is not None:
         return json.dumps(invalid)
-    instance = registry.get(ctx.conversation_id, parsed["terminal"], parsed["session"])
-    lock = registry.get_instance_lock(ctx.conversation_id, parsed["terminal"], parsed["session"])
-    # Either the entry is missing from both (never launched / already
-    # closed) or both are present (launched and registered atomically).
-    # If only one is present, the registry's invariants are broken.
-    if instance is None or not instance.running or lock is None:
+    resolved = registry.resolve_key_snapshot(
+        ctx.conversation_id,
+        parsed["terminal"],
+        parsed["session"],
+    )
+    if isinstance(resolved, AmbiguousResourceId):
+        return json.dumps(
+            {
+                "error": f"terminal resource '{resolved.terminal_id}' is ambiguous",
+                "code": resolved.code,
+            }
+        )
+    if resolved is None:
         return json.dumps(
             {
                 "error": (
@@ -467,7 +487,78 @@ def _resolve_running_instance(
                 )
             }
         )
-    return _ResolvedInstance(instance=instance, parsed=parsed, lock=lock)
+    return _ResolvedInstance(
+        instance=resolved.instance,
+        parsed=parsed,
+        snapshot=resolved,
+    )
+
+
+def send_terminal_input(
+    registry: TerminalRegistry,
+    snapshot: ResolveSnapshot,
+    text: str | None,
+    *,
+    keys: str = "Enter",
+    wait_for_ready: bool = False,
+) -> dict[str, Any]:
+    """Revalidate one atomic owner snapshot and send under its stable lock.
+
+    Both the synchronous agent tool and async runner route use this
+    chokepoint so their tmux sends cannot drift or interleave.
+
+    :param registry: Registry that captured and revalidates the owner.
+    :param snapshot: Atomic terminal ownership snapshot.
+    :param text: Literal text passed to ``tmux send-keys -l``.
+    :param keys: Space-separated tmux key names pressed after the text.
+    :param wait_for_ready: Require the final shell readiness ACK first.
+    :returns: The terminal's send result.
+    """
+
+    async def _send() -> dict[str, Any]:
+        if wait_for_ready:
+            if (
+                snapshot.instance.shell_ready_nonce is None
+                and snapshot.instance.ready_process is None
+            ):
+                return {
+                    "error": "Terminal does not support a shell readiness contract",
+                    "code": "shell_readiness_unsupported",
+                    "delivery_not_attempted": True,
+                }
+            ready = await snapshot.instance.wait_for_shell_ready(
+                timeout_s=_SHELL_READINESS_TIMEOUT_SECONDS,
+            )
+            if not ready:
+                return {
+                    "error": "Terminal shell readiness was not acknowledged",
+                    "code": "terminal_not_ready",
+                    "delivery_not_attempted": True,
+                }
+        return await snapshot.instance.send(text, keys=keys)
+
+    return registry.run_fenced(
+        snapshot,
+        _send,
+        invalid=lambda error_code: _fence_error(
+            error_code,
+            delivery_not_attempted=True,
+        ),
+    )
+
+
+def read_terminal_output(
+    registry: TerminalRegistry,
+    snapshot: ResolveSnapshot,
+    *,
+    scrollback: int,
+) -> dict[str, Any]:
+    """Revalidate and capture one terminal pane under the instance lock."""
+    return registry.run_fenced(
+        snapshot,
+        lambda: snapshot.instance.read(scrollback=scrollback),
+        invalid=_fence_error,
+    )
 
 
 def _parse_arguments(arguments: str) -> dict[str, Any] | dict[str, str]:
@@ -852,20 +943,19 @@ class SysTerminalSendTool(Tool):
         keys = resolved.parsed.get("keys", "Enter")
         if not isinstance(keys, str):
             return json.dumps({"error": "'keys' must be a string if provided"})
-        # Hold the per-instance lock across the full ``send`` op.
-        # ``send(text=X, keys="Enter")`` issues ~2 tmux subprocess
-        # calls with a 50ms ``asyncio.sleep`` between them; without
-        # the lock, two concurrent sends interleave their commands
-        # and corrupt the shell input.
-        with resolved.lock:
-            try:
-                result = asyncio.run(resolved.instance.send(text, keys=keys))
-            except (RuntimeError, OSError) as exc:
-                # tmux send-keys subprocess failures and stale-socket
-                # errors land here. Wrap so the LLM sees a structured
-                # error and can decide whether to relaunch the terminal.
-                _logger.exception("sys_terminal_send failed")
-                return json.dumps({"error": f"send failed: {exc}"})
+        try:
+            result = send_terminal_input(
+                self._registry,
+                resolved.snapshot,
+                text,
+                keys=keys,
+            )
+        except (RuntimeError, OSError) as exc:
+            # tmux send-keys subprocess failures and stale-socket
+            # errors land here. Wrap so the LLM sees a structured
+            # error and can decide whether to relaunch the terminal.
+            _logger.exception("sys_terminal_send failed")
+            return json.dumps({"error": f"send failed: {exc}"})
         return json.dumps(result)
 
 
@@ -925,18 +1015,15 @@ class SysTerminalReadTool(Tool):
         if not isinstance(scrollback_raw, int) or scrollback_raw < 0:
             return json.dumps({"error": "'scrollback' must be a non-negative integer"})
 
-        # Hold the per-instance lock so a concurrent ``send`` can't
-        # mutate the pane mid-capture. ``capture-pane`` is one tmux
-        # call and probably atomic from tmux's view, but a send can
-        # land between two interleaved reads or between a read and
-        # whatever the LLM does next. Cheap insurance.
-        with resolved.lock:
-            try:
-                result = asyncio.run(resolved.instance.read(scrollback=scrollback_raw))
-            except (RuntimeError, OSError) as exc:
-                # tmux capture-pane subprocess failures land here.
-                _logger.exception("sys_terminal_read failed")
-                return json.dumps({"error": f"read failed: {exc}"})
+        try:
+            result = read_terminal_output(
+                self._registry,
+                resolved.snapshot,
+                scrollback=scrollback_raw,
+            )
+        except (RuntimeError, OSError) as exc:
+            _logger.exception("sys_terminal_read failed")
+            return json.dumps({"error": f"read failed: {exc}"})
         return json.dumps(result)
 
 
@@ -1059,19 +1146,24 @@ class SysTerminalCloseTool(Tool):
         terminal_name = parsed["terminal"]
         session_key = parsed["session"]
 
-        # Acquire the per-instance lock BEFORE asking the registry
-        # to close. This serializes against any in-flight send/read
-        # holding the same lock, so the actual ``instance.close()``
-        # never races with a tmux op already in progress. ``None``
-        # means the instance was already closed (or never launched);
-        # registry.close() returns False in that case anyway.
-        lock = self._registry.get_instance_lock(ctx.conversation_id, terminal_name, session_key)
+        resolved = self._registry.resolve_key_snapshot(
+            ctx.conversation_id,
+            terminal_name,
+            session_key,
+        )
+        if isinstance(resolved, AmbiguousResourceId):
+            return json.dumps(
+                {
+                    "error": f"terminal resource '{resolved.terminal_id}' is ambiguous",
+                    "code": resolved.code,
+                }
+            )
 
         def _do_close() -> bool:
             try:
-                return asyncio.run(
-                    self._registry.close(ctx.conversation_id, terminal_name, session_key)
-                )
+                if resolved is None:
+                    return False
+                return asyncio.run(self._registry.close_snapshot(resolved))
             except (RuntimeError, OSError) as exc:
                 # tmux teardown can raise when the server is already
                 # gone — surface but don't propagate.
@@ -1079,11 +1171,7 @@ class SysTerminalCloseTool(Tool):
                 raise _CloseFailed(str(exc)) from exc
 
         try:
-            if lock is not None:
-                with lock:
-                    closed = _do_close()
-            else:
-                closed = _do_close()
+            closed = _do_close()
         except _CloseFailed as exc:
             return json.dumps({"error": f"close failed: {exc}"})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -441,6 +441,8 @@ target-version = "py310"
 extend-exclude = [
     "omnigent/inner/databricks_mcps/google",
     "assistant-ui",
+    # Notebook preview fixtures include a deliberately malformed JSON sample.
+    "web/src/shell/__fixtures__",
     # Protobuf-generated code (DO NOT EDIT); not ours to restyle.
     "omnigent/api/**/*_pb2.py",
     "omnigent/api/**/*_pb2.pyi",

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -666,6 +666,28 @@ async def test_process_ready_path_sends_no_direct_shell_probe(tmp_path: Path) ->
     assert process_polls == terminal_mod._SHELL_READY_STABLE_SAMPLES
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_keys", ["-X", "+", "Enter -N", "C-c +5"])
+async def test_send_rejects_flag_like_key_tokens(tmp_path: Path, bad_keys: str) -> None:
+    """A key token starting with '-'/'+' is rejected before any tmux dispatch."""
+    instance = TerminalInstance(
+        name="bash",
+        session_key="flag-guard",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        command="bash",
+        running=True,
+    )
+
+    async def reject_tmux(*args: str) -> None:
+        raise AssertionError(f"flag-like key reached tmux: {args!r}")
+
+    instance._tmux = reject_tmux  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError, match="must not start with '-' or '\\+'"):
+        await instance.send("hello", keys=bad_keys)
+
+
 @pytest.mark.parametrize("keep_alive", [True, False])
 def test_create_terminal_instance_propagates_keep_alive_after_exit(
     tmp_path: Path,

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -378,6 +378,9 @@ async def _capture_launch_argv(
     monkeypatch: pytest.MonkeyPatch,
     *,
     keep_alive_after_exit: bool,
+    command: str = "bash",
+    args: list[str] | None = None,
+    shell_ready_nonce: str | None = None,
 ) -> list[str]:
     """
     Launch a terminal with mocked tmux and return the single setup argv.
@@ -385,6 +388,9 @@ async def _capture_launch_argv(
     :param tmp_path: Temporary directory for the fake tmux socket.
     :param monkeypatch: Pytest monkeypatch fixture.
     :param keep_alive_after_exit: Value for the instance's opt-in flag.
+    :param command: Pane command to launch.
+    :param args: Arguments passed to the pane command.
+    :param shell_ready_nonce: Optional direct-shell readiness nonce.
     :returns: The flattened tmux launch argv.
     """
     captured: list[list[str]] = []
@@ -414,11 +420,250 @@ async def _capture_launch_argv(
         session_key="s1",
         socket_path=tmp_path / "tmux.sock",
         private_dir=tmp_path,
+        command=command,
+        args=list(args or []),
         keep_alive_after_exit=keep_alive_after_exit,
+        shell_ready_nonce=shell_ready_nonce,
     )
     await instance.launch(cwd=tmp_path)
     assert len(captured) == 1
     return captured[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "args"),
+    [
+        ("bash", ["-f"]),
+        ("bash", ["--noprofile", "--norc"]),
+        ("bash", ["-l"]),
+        ("zsh", ["-f"]),
+        ("zsh", ["-l"]),
+    ],
+)
+async def test_direct_shell_readiness_preserves_declared_args(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    args: list[str],
+) -> None:
+    """Readiness instrumentation leaves direct-shell argv semantics intact."""
+    argv = await _capture_launch_argv(
+        tmp_path,
+        monkeypatch,
+        keep_alive_after_exit=False,
+        command=command,
+        args=args,
+        shell_ready_nonce="OMNIGENT_SHELL_READY_test",
+    )
+
+    assert " ".join([command, *args]) in argv
+
+
+@pytest.mark.parametrize(
+    ("spec", "supported"),
+    [
+        (TerminalEnvSpec(command="bash", args=["--noprofile", "--norc"]), True),
+        (TerminalEnvSpec(command="zsh", args=["-f"]), True),
+        (TerminalEnvSpec(command="bash", args=["-l"]), True),
+        (TerminalEnvSpec(command="bash", args=["-c", "echo no-loop"]), False),
+        (TerminalEnvSpec(command="zsh", args=["script.zsh"]), False),
+        (TerminalEnvSpec(command=sys.executable, args=["-c", "pass"]), False),
+        (
+            TerminalEnvSpec(
+                command=sys.executable,
+                args=["-c", "pass"],
+                ready_process="bash",
+            ),
+            True,
+        ),
+    ],
+)
+def test_terminal_spec_shell_readiness_support_is_explicit(
+    spec: TerminalEnvSpec,
+    supported: bool,
+) -> None:
+    """Only direct input-loop shells or declared final processes can be awaited."""
+    assert terminal_mod.terminal_spec_supports_shell_readiness(spec) is supported
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "guard"),
+    [
+        ("bash", "BASH_SOURCE"),
+        ("zsh", "ZSH_EVAL_CONTEXT"),
+    ],
+)
+async def test_direct_shell_readiness_requires_input_loop_ack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    guard: str,
+) -> None:
+    """The nonce appears only after the final shell executes a guarded probe."""
+    nonce = f"OMNIGENT_SHELL_READY_{'ab' * 16}"
+    monkeypatch.setattr(terminal_mod.secrets, "token_hex", lambda _size: "ab" * 16)
+    instance = TerminalInstance(
+        name=command,
+        session_key="ready",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        command=command,
+        shell_ready_nonce=nonce,
+        running=True,
+    )
+    tmux_calls: list[tuple[str, ...]] = []
+    events: list[str] = []
+    snapshots = iter(["startup still running", nonce, "fresh prompt"])
+
+    async def record_tmux(*args: str) -> None:
+        tmux_calls.append(args)
+        events.append(f"tmux:{args[0]}")
+
+    async def capture(*args: str) -> str:
+        del args
+        snapshot = next(snapshots)
+        events.append(f"capture:{snapshot}")
+        return snapshot
+
+    instance._tmux = record_tmux  # type: ignore[method-assign]
+    instance._tmux_output = capture  # type: ignore[method-assign]
+
+    assert await instance.wait_for_shell_ready(timeout_s=0.5, poll_interval_s=0)
+    assert len(tmux_calls) == 4
+    assert tmux_calls[0][:4] == ("send-keys", "-l", "-t", "main")
+    probe = tmux_calls[0][-1]
+    assert guard in probe
+    assert nonce not in probe
+    assert tmux_calls[1] == ("send-keys", "-t", "main", "Enter")
+    assert tmux_calls[2] == ("send-keys", "-t", "main", "C-l")
+    assert tmux_calls[3] == ("clear-history", "-t", "main")
+    assert events == [
+        "tmux:send-keys",
+        "tmux:send-keys",
+        "capture:startup still running",
+        f"capture:{nonce}",
+        "tmux:send-keys",
+        "capture:fresh prompt",
+        "tmux:clear-history",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_direct_shell_retry_uses_fresh_nonce_and_ignores_stale_ack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A late ACK from a timed-out probe cannot satisfy its successor."""
+    token_hexes = iter(["11" * 16, "22" * 16])
+    monkeypatch.setattr(terminal_mod.secrets, "token_hex", lambda _size: next(token_hexes))
+    instance = TerminalInstance(
+        name="bash",
+        session_key="fresh-nonce",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        command="bash",
+        shell_ready_nonce="OMNIGENT_SHELL_READY_capability",
+        running=True,
+    )
+    probe_nonces: list[str] = []
+    scrollback_snapshots: list[str] = []
+    clear_history_calls = 0
+
+    async def record_tmux(*args: str) -> None:
+        nonlocal clear_history_calls
+        if args[:2] == ("send-keys", "-l"):
+            assert instance.shell_ready_nonce is not None
+            probe_nonces.append(instance.shell_ready_nonce)
+        elif args[0] == "clear-history":
+            clear_history_calls += 1
+
+    async def capture(*args: str) -> str:
+        if "-S" not in args:
+            return "clean prompt"
+        if len(probe_nonces) == 1:
+            await asyncio.sleep(1)
+            raise AssertionError("the timed-out capture should be cancelled")
+        snapshot = probe_nonces[len(scrollback_snapshots)]
+        scrollback_snapshots.append(snapshot)
+        return snapshot
+
+    monkeypatch.setattr(instance, "_tmux", record_tmux)
+    monkeypatch.setattr(instance, "_tmux_output", capture)
+
+    assert not await instance.wait_for_shell_ready(timeout_s=0.01, poll_interval_s=0)
+    assert await instance.wait_for_shell_ready(timeout_s=0.5, poll_interval_s=0)
+
+    assert probe_nonces == [
+        f"OMNIGENT_SHELL_READY_{'11' * 16}",
+        f"OMNIGENT_SHELL_READY_{'22' * 16}",
+    ]
+    assert scrollback_snapshots == probe_nonces
+    assert clear_history_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_acknowledged_direct_shell_fast_path_sends_no_probe(tmp_path: Path) -> None:
+    """An established shell accepts readiness without injecting more bytes."""
+    instance = TerminalInstance(
+        name="bash",
+        session_key="already-ready",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        command="bash",
+        shell_ready_nonce="OMNIGENT_SHELL_READY_acknowledged",
+        _shell_ready_probe_sent=True,
+        _shell_ready_acknowledged=True,
+        running=True,
+    )
+
+    async def reject_tmux(*args: str) -> None:
+        raise AssertionError(f"already-ready shell received tmux input: {args!r}")
+
+    async def reject_capture(*args: str) -> str:
+        raise AssertionError(f"already-ready shell was polled: {args!r}")
+
+    instance._tmux = reject_tmux  # type: ignore[method-assign]
+    instance._tmux_output = reject_capture  # type: ignore[method-assign]
+
+    assert await instance.wait_for_shell_ready(timeout_s=0.5, poll_interval_s=0)
+
+
+@pytest.mark.asyncio
+async def test_process_ready_path_sends_no_direct_shell_probe(tmp_path: Path) -> None:
+    """Declared-process readiness polls metadata without injecting pane bytes."""
+    instance = TerminalInstance(
+        name="shell",
+        session_key="process-ready",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        command=sys.executable,
+        ready_process="bash",
+        running=True,
+    )
+    process_polls = 0
+
+    async def reject_tmux(*args: str) -> None:
+        raise AssertionError(f"process-ready terminal received tmux input: {args!r}")
+
+    async def capture_process(*args: str) -> str:
+        nonlocal process_polls
+        assert args == (
+            "display-message",
+            "-p",
+            "-t",
+            "main",
+            "#{pane_current_command}",
+        )
+        process_polls += 1
+        return "bash"
+
+    instance._tmux = reject_tmux  # type: ignore[method-assign]
+    instance._tmux_output = capture_process  # type: ignore[method-assign]
+
+    assert await instance.wait_for_shell_ready(timeout_s=0.5, poll_interval_s=0)
+    assert process_polls == terminal_mod._SHELL_READY_STABLE_SAMPLES
 
 
 @pytest.mark.parametrize("keep_alive", [True, False])

--- a/tests/integration/test_sys_terminal_round_trip.py
+++ b/tests/integration/test_sys_terminal_round_trip.py
@@ -57,14 +57,20 @@ package gate is lifted in mock mode by
 
 from __future__ import annotations
 
+import asyncio
 import json
 import shutil
+import sys
+import time
 import uuid
+from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
 
+from omnigent.runner import create_runner_app
+from omnigent.terminals import TerminalRegistry
 from tests.e2e.conftest import (
     configure_mock_llm,
     create_runner_bound_session,
@@ -72,6 +78,7 @@ from tests.e2e.conftest import (
     register_inline_agent,
     send_user_message_to_session,
 )
+from tests.runner.helpers import NullServerClient
 
 
 def _list_session_items(client: httpx.Client, session_id: str) -> list[dict[str, Any]]:
@@ -229,6 +236,127 @@ def terminal_session(
         mock_llm_server_url=mock_llm_server_url,
     )
     return session_id, model_name
+
+
+@pytest.mark.asyncio
+async def test_runner_terminal_input_route_live_tmux_round_trip(tmp_path: Path) -> None:
+    """Create a real shell, POST literal input, and read its output marker."""
+    if shutil.which("tmux") is None:
+        pytest.skip("tmux not installed; runner terminal input needs tmux on PATH")
+
+    registry = TerminalRegistry()
+    app = create_runner_app(
+        terminal_registry=registry,
+        runner_workspace=tmp_path,
+        per_session_workspace=False,
+        server_client=NullServerClient(),
+    )
+    transport = httpx.ASGITransport(app=app)
+    marker = f"RUNNER_INPUT_MARKER_{uuid.uuid4().hex[:8]}"
+    output_marker = f"OUT-{marker}"
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as client:
+            create = await client.post(
+                "/v1/sessions/conv_route/resources/terminals",
+                json={
+                    "terminal": "bash",
+                    "session_key": "route",
+                    "spec": {"command": "bash", "cwd": str(tmp_path)},
+                },
+            )
+            assert create.status_code == 200, create.text
+
+            sent = await client.post(
+                "/v1/sessions/conv_route/resources/terminals/terminal_bash_route/input",
+                json={"text": f"printf 'OUT-%s\\n' {marker}"},
+            )
+            assert sent.status_code == 200, sent.text
+            assert sent.json() == {"status": "sent", "outcome": "sent"}
+
+            instance = registry.get("conv_route", "bash", "route")
+            assert instance is not None
+            screens: list[str] = []
+            for _ in range(20):
+                read_result = await instance.read()
+                screens.append(str(read_result.get("screen", "")))
+                if output_marker in screens[-1]:
+                    break
+                await asyncio.sleep(0.05)
+
+            assert output_marker in "\n".join(screens)
+    finally:
+        await registry.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_runner_terminal_input_waits_past_startup_stdin_consumer(tmp_path: Path) -> None:
+    """Startup stdin cannot swallow a command behind a false readiness ACK."""
+    if shutil.which("tmux") is None or shutil.which("bash") is None:
+        pytest.skip("tmux and bash are required for live readiness coverage")
+
+    registry = TerminalRegistry()
+    app = create_runner_app(
+        terminal_registry=registry,
+        runner_workspace=tmp_path,
+        per_session_workspace=False,
+        server_client=NullServerClient(),
+    )
+    transport = httpx.ASGITransport(app=app)
+    marker = f"READY_INPUT_MARKER_{uuid.uuid4().hex[:8]}"
+    startup = (
+        "import os,select,sys;"
+        "ready,_,_=select.select([sys.stdin],[],[],0.25);"
+        "sys.stdin.readline() if ready else None;"
+        "os.execvp('bash',['bash','--noprofile','--norc','-i'])"
+    )
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as client:
+            create = await client.post(
+                "/v1/sessions/conv_ready/resources/terminals",
+                json={
+                    "terminal": "shell",
+                    "session_key": "startup",
+                    "spec": {
+                        "command": sys.executable,
+                        "args": ["-c", startup],
+                        "cwd": str(tmp_path),
+                        "ready_process": "bash",
+                    },
+                },
+            )
+            assert create.status_code == 200, create.text
+
+            sent = await client.post(
+                "/v1/sessions/conv_ready/resources/terminals/terminal_shell_startup/input",
+                json={
+                    "attempt_id": str(uuid.uuid4()),
+                    "text": f"printf '%s\\n' {marker}",
+                    "wait_for_ready": True,
+                },
+            )
+            if sent.status_code == 409:
+                assert sent.json()["error"]["code"] == "terminal_not_ready"
+                return
+
+            assert sent.status_code == 200, sent.text
+            assert sent.json()["outcome"] == "sent"
+            instance = registry.get("conv_ready", "shell", "startup")
+            assert instance is not None
+            screens: list[str] = []
+            for _ in range(40):
+                read_result = await instance.read()
+                screens.append(str(read_result.get("screen", "")))
+                if marker in screens[-1]:
+                    break
+                await asyncio.sleep(0.05)
+            assert marker in "\n".join(screens), (
+                "a 200/sent readiness result must prove the final shell, not "
+                "the startup stdin consumer, received the command"
+            )
+    finally:
+        await registry.shutdown()
 
 
 def test_sys_terminal_basic_round_trip(
@@ -572,3 +700,130 @@ def test_sys_terminal_send_keys_drives_interactive(
         f"Enter didn't reach python's stdin; if nothing useful shows, python3 "
         f"may not be on PATH in the tmux env."
     )
+
+
+def _write_probe_residue_delayed_shell(
+    tmp_path: Path,
+    *,
+    shell_name: str,
+    real_shell: str,
+) -> Path:
+    """Create a shell-named shim that waits before preserving the real argv."""
+    wrapper_dir = tmp_path / "probe-residue-shells"
+    wrapper_dir.mkdir(exist_ok=True)
+    wrapper = wrapper_dir / shell_name
+    wrapper.write_text(
+        f"#!{sys.executable}\n"
+        "import os\n"
+        "import sys\n"
+        "import time\n"
+        "time.sleep(1.35)\n"
+        f"real_shell = {real_shell!r}\n"
+        "os.execv(real_shell, [real_shell, *sys.argv[1:]])\n",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def _probe_residue_output_command(marker: str) -> str:
+    """Return a command whose typed representation does not include *marker*."""
+    encoded = "".join(f"\\0{ord(char):03o}" for char in marker)
+    return f"builtin printf '%b\\n' '{encoded}'"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("shell_name", "shell_args"),
+    [
+        ("bash", ["--noprofile", "--norc"]),
+        ("zsh", ["-f"]),
+    ],
+)
+async def test_runner_terminal_input_cold_spawn_hides_readiness_probe(
+    tmp_path: Path,
+    shell_name: str,
+    shell_args: list[str],
+) -> None:
+    """A delayed direct shell shows only the one user command and its output."""
+    real_shell = shutil.which(shell_name)
+    if shutil.which("tmux") is None or real_shell is None:
+        pytest.skip(f"tmux and {shell_name} are required for live readiness coverage")
+
+    registry = TerminalRegistry()
+    app = create_runner_app(
+        terminal_registry=registry,
+        runner_workspace=tmp_path,
+        per_session_workspace=False,
+        server_client=NullServerClient(),
+    )
+    transport = httpx.ASGITransport(app=app)
+    marker = f"O{uuid.uuid4().hex[:6]}"
+    command = _probe_residue_output_command(marker)
+    wrapper = _write_probe_residue_delayed_shell(
+        tmp_path,
+        shell_name=shell_name,
+        real_shell=real_shell,
+    )
+    session_key = f"clean-{shell_name}"
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as client:
+            create = await client.post(
+                "/v1/sessions/conv_clean/resources/terminals",
+                json={
+                    "terminal": shell_name,
+                    "session_key": session_key,
+                    "spec": {
+                        "command": str(wrapper),
+                        "args": shell_args,
+                        "cwd": str(tmp_path),
+                    },
+                },
+            )
+            assert create.status_code == 200, create.text
+
+            instance = registry.get("conv_clean", shell_name, session_key)
+            assert instance is not None
+            nonce = instance.shell_ready_nonce
+            assert nonce is not None
+
+            started = time.monotonic()
+            sent = await client.post(
+                (
+                    "/v1/sessions/conv_clean/resources/terminals/"
+                    f"terminal_{shell_name}_{session_key}/input"
+                ),
+                json={
+                    "attempt_id": str(uuid.uuid4()),
+                    "text": command,
+                    "keys": "Enter",
+                    "wait_for_ready": True,
+                },
+            )
+            elapsed = time.monotonic() - started
+            assert sent.status_code == 200, sent.text
+            assert sent.json() == {"status": "sent", "outcome": "sent"}
+            assert elapsed > 1.0
+
+            screens: list[str] = []
+            for _ in range(40):
+                result = await instance.read(scrollback=100)
+                screen = str(result.get("screen", ""))
+                screens.append(screen)
+                if any(line.strip() == marker for line in screen.splitlines()):
+                    break
+                await asyncio.sleep(0.05)
+            else:
+                raise AssertionError(f"shell output {marker!r} did not appear:\n{screens[-1]}")
+
+            nonempty_lines = [line for line in screen.splitlines() if line.strip()]
+            assert command in nonempty_lines[0], screen
+            assert screen.count(command) == 1, screen
+            assert screen.count(marker) == 1, screen
+            assert "BASH_SOURCE" not in screen, screen
+            assert "ZSH_EVAL_CONTEXT" not in screen, screen
+            assert "OMNIGENT_SHELL_READY_" not in screen, screen
+            assert nonce not in screen, screen
+    finally:
+        await registry.shutdown()

--- a/tests/runner/test_app_sessions_native_terminal_routing.py
+++ b/tests/runner/test_app_sessions_native_terminal_routing.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -1002,7 +1001,6 @@ async def test_ensure_terminal_route_recreates_dead_registered_pane(
 
     with registry._lock:
         registry._by_conversation[sid] = {("claude", "main"): dead_instance}
-        registry._instance_locks[(sid, "claude", "main")] = threading.Lock()
 
     app = create_runner_app(
         process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
@@ -1070,7 +1068,6 @@ async def test_dead_registered_pane_close_restores_running_for_kill_server(
 
     with registry._lock:
         registry._by_conversation[sid] = {("claude", "main"): dead_instance}
-        registry._instance_locks[(sid, "claude", "main")] = threading.Lock()
 
     alive = await dead_instance.is_alive()
     assert alive is False

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import threading
 import uuid
 from collections.abc import AsyncIterator, Callable, Sequence
 from dataclasses import dataclass
@@ -38,6 +39,9 @@ from omnigent.runner.resource_registry import (
 )
 from omnigent.spec.types import AgentSpec, ExecutorSpec
 from omnigent.terminals import TerminalListEntry, TerminalRegistry
+from omnigent.tools.base import ToolContext
+from omnigent.tools.builtins import sys_terminal as sys_terminal_module
+from omnigent.tools.builtins.sys_terminal import SysTerminalReadTool, SysTerminalSendTool
 from tests.runner.helpers import NullServerClient, make_test_terminal_instance
 
 
@@ -834,6 +838,930 @@ async def test_get_terminal_returns_404_for_unknown(
     resp = await client.get("/v1/sessions/conv_abc/resources/terminals/terminal_nope_s1")
 
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_sends_under_instance_lock(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /input sends literal text with default Enter under the instance lock."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    lock = instance.op_lock
+    calls: list[tuple[str | None, str]] = []
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        assert lock.locked(), "the shared send helper must hold the per-instance lock"
+        calls.append((text, keys))
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", record_send)
+
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"text": "printf '$HOME | literal'"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "sent", "outcome": "sent"}
+    assert calls == [("printf '$HOME | literal'", "Enter")]
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_returns_404_for_unknown(
+    client: httpx.AsyncClient,
+) -> None:
+    """POST /input distinguishes an unknown resource from a stopped terminal."""
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_nope_s1/input",
+        json={"text": "echo ignored"},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "terminal_not_running"
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_returns_409_when_not_running(
+    client: httpx.AsyncClient,
+) -> None:
+    """POST /input returns 409 for a known registry entry that is stopped."""
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_stale_s3/input",
+        json={"text": "echo ignored"},
+    )
+
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_returns_409_when_send_observes_exit(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /input maps a tmux exit observed during send to 409."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+
+    async def report_exit(
+        text: str | None = None,
+        *,
+        keys: str = "Enter",
+    ) -> dict[str, str]:
+        del text, keys
+        instance.running = False
+        return {"error": "Terminal bash:s1 is no longer running"}
+
+    monkeypatch.setattr(instance, "send", report_exit)
+
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"text": "echo races with exit"},
+    )
+
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_requires_json_content_type(
+    client: httpx.AsyncClient,
+) -> None:
+    """POST /input rejects a text/plain JSON body before parsing it."""
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        content=json.dumps({"text": "echo ignored"}),
+        headers={"content-type": "text/plain"},
+    )
+
+    assert resp.status_code == 415
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_rejects_invalid_body(
+    client: httpx.AsyncClient,
+) -> None:
+    """POST /input requires string text and keys fields."""
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"text": 42, "keys": ["Enter"]},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_route_and_send_tool_share_primitive(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The agent tool and runner route delegate to the same send chokepoint."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    lock = instance.op_lock
+    calls: list[
+        tuple[TerminalRegistry, TerminalInstance, threading.Lock, str | None, str, bool]
+    ] = []
+
+    def record_send(
+        target_registry: TerminalRegistry,
+        snapshot: Any,
+        text: str | None,
+        *,
+        keys: str = "Enter",
+        wait_for_ready: bool = False,
+    ) -> dict[str, str]:
+        calls.append(
+            (
+                target_registry,
+                snapshot.instance,
+                snapshot.op_lock,
+                text,
+                keys,
+                wait_for_ready,
+            )
+        )
+        return {"status": "sent"}
+
+    # This stub proves delegation and argument identity for both callers.
+    # Lock behavior and real tmux delivery are covered by their focused tests.
+    monkeypatch.setattr(sys_terminal_module, "send_terminal_input", record_send)
+    tool = SysTerminalSendTool(registry=registry)
+    ctx = ToolContext(
+        task_id="task_parity",
+        agent_id="agent_parity",
+        workspace=tmp_path,
+        conversation_id="conv_abc",
+    )
+
+    tool_result = await asyncio.to_thread(
+        tool.invoke,
+        json.dumps(
+            {
+                "terminal": "bash",
+                "session": "s1",
+                "text": "echo parity",
+                "keys": "C-j",
+            }
+        ),
+        ctx,
+    )
+    route_result = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"text": "echo parity", "keys": "C-j"},
+    )
+
+    assert tool_result == '{"status": "sent"}'
+    assert route_result.status_code == 200
+    assert route_result.json() == {"status": "sent", "outcome": "sent"}
+    assert calls == [
+        (registry, instance, lock, "echo parity", "C-j", False),
+        (registry, instance, lock, "echo parity", "C-j", False),
+    ]
+
+
+def _attempt_id() -> str:
+    """Return one canonical attempt id for runner input tests."""
+    return str(uuid.uuid4())
+
+
+async def _post_terminal_input(
+    client: httpx.AsyncClient,
+    *,
+    attempt_id: str,
+    text: str = "echo fenced",
+) -> httpx.Response:
+    """POST one idempotent input request to the seeded bash terminal."""
+    return await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"attempt_id": attempt_id, "text": text},
+    )
+
+
+def _snapshot_for_seeded_bash(registry: TerminalRegistry) -> Any:
+    """Capture the atomic ownership snapshot for the seeded bash terminal."""
+    snapshot = registry.resolve_snapshot("conv_abc", "terminal_bash_s1")
+    assert snapshot is not None
+    assert getattr(snapshot, "code", None) != "ambiguous_resource_id"
+    return snapshot
+
+
+def _patch_stale_resolution(
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    snapshot: Any,
+) -> None:
+    """Force the route to exercise a snapshot captured before a mutation."""
+    monkeypatch.setattr(registry, "resolve_snapshot", lambda *_args: snapshot)
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_after_transfer_uses_zero_tmux_calls(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sender that lost to transfer fails closed before touching tmux."""
+    snapshot = _snapshot_for_seeded_bash(registry)
+    instance = snapshot.instance
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", record_send)
+    assert registry.transfer("conv_abc", "conv_new", "bash", "s1") is True
+    _patch_stale_resolution(registry, monkeypatch, snapshot)
+
+    response = await _post_terminal_input(client, attempt_id=_attempt_id())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "terminal_moved"
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_after_close_uses_zero_tmux_calls(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sender that lost to close fails closed before touching tmux."""
+    snapshot = _snapshot_for_seeded_bash(registry)
+    instance = snapshot.instance
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    async def close_without_tmux() -> None:
+        instance.running = False
+
+    monkeypatch.setattr(instance, "send", record_send)
+    monkeypatch.setattr(instance, "close", close_without_tmux)
+    assert await registry.close("conv_abc", "bash", "s1") is True
+    _patch_stale_resolution(registry, monkeypatch, snapshot)
+
+    response = await _post_terminal_input(client, attempt_id=_attempt_id())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "terminal_moved"
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_after_cleanup_uses_zero_tmux_calls(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sender that lost to conversation cleanup performs no tmux input."""
+    snapshot = _snapshot_for_seeded_bash(registry)
+    instance = snapshot.instance
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    async def close_without_tmux() -> None:
+        instance.running = False
+
+    monkeypatch.setattr(instance, "send", record_send)
+    monkeypatch.setattr(instance, "close", close_without_tmux)
+    await registry.cleanup_conversation("conv_abc")
+    _patch_stale_resolution(registry, monkeypatch, snapshot)
+
+    response = await _post_terminal_input(client, attempt_id=_attempt_id())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "terminal_moved"
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_after_shutdown_uses_zero_tmux_calls(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sender that lost to runner shutdown performs no tmux input."""
+    snapshot = _snapshot_for_seeded_bash(registry)
+    instance = snapshot.instance
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    async def close_without_tmux() -> None:
+        instance.running = False
+
+    monkeypatch.setattr(instance, "send", record_send)
+    monkeypatch.setattr(instance, "close", close_without_tmux)
+    await registry.shutdown()
+    _patch_stale_resolution(registry, monkeypatch, snapshot)
+
+    response = await _post_terminal_input(client, attempt_id=_attempt_id())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "terminal_moved"
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_transfer_out_and_back_rejects_aba_snapshot(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Returning the same instance to its old owner cannot revive a stale send."""
+    snapshot = _snapshot_for_seeded_bash(registry)
+    instance = snapshot.instance
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", record_send)
+    assert registry.transfer("conv_abc", "conv_new", "bash", "s1") is True
+    assert registry.transfer("conv_new", "conv_abc", "bash", "s1") is True
+    assert registry.get("conv_abc", "bash", "s1") is instance
+    _patch_stale_resolution(registry, monkeypatch, snapshot)
+
+    response = await _post_terminal_input(client, attempt_id=_attempt_id())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "terminal_moved"
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_read_after_transfer_rejects_stale_snapshot(
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A read captured by the old owner cannot expose the new owner's pane."""
+    snapshot = _snapshot_for_seeded_bash(registry)
+    instance = snapshot.instance
+    read_calls = 0
+
+    async def record_read(scrollback: int = 0) -> dict[str, object]:
+        nonlocal read_calls
+        del scrollback
+        read_calls += 1
+        return {"screen": "new-owner-secret"}
+
+    monkeypatch.setattr(instance, "read", record_read)
+    assert registry.transfer("conv_abc", "conv_new", "bash", "s1") is True
+    _patch_stale_resolution(registry, monkeypatch, snapshot)
+    tool = SysTerminalReadTool(registry=registry)
+    context = ToolContext(
+        task_id="task_read_fence",
+        agent_id="agent_read_fence",
+        workspace=tmp_path,
+        conversation_id="conv_abc",
+    )
+
+    result = json.loads(
+        await asyncio.to_thread(
+            tool.invoke,
+            json.dumps({"terminal": "bash", "session": "s1"}),
+            context,
+        )
+    )
+
+    assert result["code"] == "terminal_moved"
+    assert read_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_concurrent_duplicate_executes_once(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent identical attempt ids await one shielded send task."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    started = threading.Event()
+    release = threading.Event()
+    send_calls = 0
+
+    async def gated_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        started.set()
+        await asyncio.to_thread(release.wait)
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", gated_send)
+    attempt_id = _attempt_id()
+    first = asyncio.create_task(_post_terminal_input(client, attempt_id=attempt_id))
+    assert await asyncio.to_thread(started.wait, 2.0)
+    second = asyncio.create_task(_post_terminal_input(client, attempt_id=attempt_id))
+    release.set()
+
+    first_response, second_response = await asyncio.gather(first, second)
+
+    assert first_response.status_code == second_response.status_code == 200
+    assert (
+        first_response.json()
+        == second_response.json()
+        == {
+            "status": "sent",
+            "outcome": "sent",
+        }
+    )
+    assert send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_attempt_fingerprint_mismatch_is_conflict(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An attempt id is permanently bound to its first input fingerprint."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", record_send)
+    attempt_id = _attempt_id()
+    first = await _post_terminal_input(client, attempt_id=attempt_id, text="echo one")
+    conflict = await _post_terminal_input(client, attempt_id=attempt_id, text="echo two")
+
+    assert first.status_code == 200
+    assert conflict.status_code == 409
+    assert conflict.json()["error"]["code"] == "attempt_conflict"
+    assert send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_cancelling_first_waiter_keeps_single_flight(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling one waiter cannot cancel or unclaim the shared send."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    started = threading.Event()
+    release = threading.Event()
+    send_calls = 0
+
+    async def gated_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        started.set()
+        await asyncio.to_thread(release.wait)
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", gated_send)
+    attempt_id = _attempt_id()
+    first = asyncio.create_task(_post_terminal_input(client, attempt_id=attempt_id))
+    assert await asyncio.to_thread(started.wait, 2.0)
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    retry = asyncio.create_task(_post_terminal_input(client, attempt_id=attempt_id))
+    release.set()
+    response = await retry
+
+    assert response.status_code == 200
+    assert response.json()["outcome"] == "sent"
+    assert send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_partial_send_is_delivery_unknown_and_retry_is_noop(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text success followed by Enter failure is cached as delivery unknown."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    tmux_calls = 0
+
+    async def fail_enter(*args: str) -> None:
+        nonlocal tmux_calls
+        tmux_calls += 1
+        if tmux_calls == 2:
+            raise RuntimeError("enter response lost")
+
+    monkeypatch.setattr(instance, "_tmux", fail_enter)
+    attempt_id = _attempt_id()
+    first = await _post_terminal_input(client, attempt_id=attempt_id)
+    retry = await _post_terminal_input(client, attempt_id=attempt_id)
+
+    assert first.status_code == retry.status_code == 200
+    assert first.json() == retry.json()
+    assert first.json()["outcome"] == "delivery_unknown"
+    assert tmux_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_readiness_timeout_is_definite_and_cached(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing final-process ACK rejects before any input operation."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    instance.shell_ready_nonce = "OMNIGENT_SHELL_READY_never_seen"
+    readiness_checks = 0
+    readiness_timeouts: list[float] = []
+    send_calls = 0
+
+    async def _not_ready(*, timeout_s: float, poll_interval_s: float = 0.025) -> bool:
+        nonlocal readiness_checks
+        del poll_interval_s
+        readiness_checks += 1
+        readiness_timeouts.append(timeout_s)
+        return False
+
+    async def _record_send(
+        text: str | None = None,
+        *,
+        keys: str = "Enter",
+    ) -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "wait_for_shell_ready", _not_ready)
+    monkeypatch.setattr(instance, "send", _record_send)
+    attempt_id = _attempt_id()
+    body = {
+        "attempt_id": attempt_id,
+        "text": "echo never-dispatched",
+        "wait_for_ready": True,
+    }
+
+    first = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=body,
+    )
+    replay = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=body,
+    )
+
+    assert first.status_code == replay.status_code == 409
+    assert first.json() == replay.json()
+    assert first.json()["error"]["code"] == "terminal_not_ready"
+    assert readiness_checks == 1
+    assert readiness_timeouts == [10.0]
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("acknowledge", "expected_status", "expected_send_calls"),
+    [(True, 200, 1), (False, 409, 0)],
+)
+async def test_terminal_input_retries_incomplete_probe_without_unsafe_delivery(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    acknowledge: bool,
+    expected_status: int,
+    expected_send_calls: int,
+) -> None:
+    """An incomplete probe is retryable but never bypasses the ACK gate."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    lock = instance.op_lock
+    instance.shell_ready_nonce = "OMNIGENT_SHELL_READY_capability"
+    monkeypatch.setattr(sys_terminal_module, "_SHELL_READINESS_TIMEOUT_SECONDS", 0.05)
+    probe_sends = 0
+    probe_nonces: list[str] = []
+    clear_history_calls = 0
+    send_calls = 0
+    history_nonce: str | None = None
+
+    async def readiness_tmux(*args: str) -> None:
+        nonlocal probe_sends, clear_history_calls, history_nonce
+        assert lock.locked(), "readiness and delivery must share the instance lock"
+        if args[:2] == ("send-keys", "-l"):
+            probe_sends += 1
+            assert instance.shell_ready_nonce is not None
+            probe_nonces.append(instance.shell_ready_nonce)
+        elif args == ("send-keys", "-t", "main", "Enter"):
+            history_nonce = instance.shell_ready_nonce if acknowledge else None
+        elif args[0] == "clear-history":
+            clear_history_calls += 1
+            history_nonce = None
+            if clear_history_calls == 1:
+                await asyncio.sleep(1)
+
+    async def readiness_capture(*args: str) -> str:
+        assert lock.locked(), "readiness and delivery must share the instance lock"
+        if "-S" in args:
+            return history_nonce or "clean prompt"
+        return "clean prompt"
+
+    async def record_send(
+        text: str | None = None,
+        *,
+        keys: str = "Enter",
+    ) -> dict[str, str]:
+        nonlocal send_calls
+        assert lock.locked(), "readiness and delivery must share the instance lock"
+        assert text == "echo exactly-once"
+        assert keys == "Enter"
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "_tmux", readiness_tmux)
+    monkeypatch.setattr(instance, "_tmux_output", readiness_capture)
+    monkeypatch.setattr(instance, "send", record_send)
+    first = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={
+            "attempt_id": _attempt_id(),
+            "text": "echo exactly-once",
+            "wait_for_ready": True,
+        },
+    )
+    retry_attempt_id = _attempt_id()
+    retry_body = {
+        "attempt_id": retry_attempt_id,
+        "text": "echo exactly-once",
+        "wait_for_ready": True,
+    }
+    second = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=retry_body,
+    )
+    replay = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=retry_body,
+    )
+
+    assert first.status_code == 409
+    assert first.json()["error"]["code"] == "terminal_not_ready"
+    assert second.status_code == replay.status_code == expected_status
+    assert second.json() == replay.json()
+    if acknowledge:
+        assert second.json() == {"status": "sent", "outcome": "sent"}
+    else:
+        assert second.json()["error"]["code"] == "terminal_not_ready"
+    assert probe_sends == 2
+    assert len(set(probe_nonces)) == 2
+    assert clear_history_calls == (2 if acknowledge else 0)
+    assert history_nonce is None
+    assert send_calls == expected_send_calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("becomes_ready", "expected_status", "expected_send_calls"),
+    [(True, 200, 1), (False, 409, 0)],
+)
+async def test_terminal_input_retries_after_over_budget_readiness_evaluation(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    becomes_ready: bool,
+    expected_status: int,
+    expected_send_calls: int,
+) -> None:
+    """One over-budget probe cannot latch readiness or bypass fail-closed delivery."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    lock = instance.op_lock
+    instance.shell_ready_nonce = "OMNIGENT_SHELL_READY_over_budget"
+    monkeypatch.setattr(sys_terminal_module, "_SHELL_READINESS_TIMEOUT_SECONDS", 0.01)
+    readiness_evaluations = 0
+    send_calls = 0
+
+    async def evaluate_readiness(
+        *,
+        timeout_s: float,
+        poll_interval_s: float,
+    ) -> bool:
+        nonlocal readiness_evaluations
+        del poll_interval_s
+        assert lock.locked(), "readiness and delivery must share the instance lock"
+        assert instance._shell_ready_probe_sent is False
+        readiness_evaluations += 1
+        instance._shell_ready_probe_sent = True
+        if readiness_evaluations == 2 and becomes_ready:
+            instance._shell_ready_acknowledged = True
+            return True
+        await asyncio.sleep(timeout_s * 4)
+        if becomes_ready:
+            instance._shell_ready_acknowledged = True
+            return True
+        return False
+
+    async def record_send(
+        text: str | None = None,
+        *,
+        keys: str = "Enter",
+    ) -> dict[str, str]:
+        nonlocal send_calls
+        assert lock.locked(), "readiness and delivery must share the instance lock"
+        assert text == "echo exactly-once"
+        assert keys == "Enter"
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "_wait_for_shell_ready_once", evaluate_readiness)
+    monkeypatch.setattr(instance, "send", record_send)
+    first = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={
+            "attempt_id": _attempt_id(),
+            "text": "echo exactly-once",
+            "wait_for_ready": True,
+        },
+    )
+    retry_attempt_id = _attempt_id()
+    retry_body = {
+        "attempt_id": retry_attempt_id,
+        "text": "echo exactly-once",
+        "wait_for_ready": True,
+    }
+    second = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=retry_body,
+    )
+    replay = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=retry_body,
+    )
+
+    assert first.status_code == 409
+    assert first.json()["error"]["code"] == "terminal_not_ready"
+    assert second.status_code == replay.status_code == expected_status
+    assert second.json() == replay.json()
+    if becomes_ready:
+        assert second.json() == {"status": "sent", "outcome": "sent"}
+    else:
+        assert second.json()["error"]["code"] == "terminal_not_ready"
+    assert readiness_evaluations == 2
+    assert send_calls == expected_send_calls
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_rejects_unsupported_readiness_before_send(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A terminal with no readiness contract fails explicitly and sends nothing."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    instance.shell_ready_nonce = None
+    instance.ready_process = None
+    send_calls = 0
+
+    async def _record_send(
+        text: str | None = None,
+        *,
+        keys: str = "Enter",
+    ) -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", _record_send)
+    response = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={
+            "attempt_id": _attempt_id(),
+            "text": "echo never-dispatched",
+            "wait_for_ready": True,
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "shell_readiness_unsupported"
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_completed_attempt_replays_after_transfer(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A completed attempt replays before terminal ownership is re-resolved."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", record_send)
+    attempt_id = _attempt_id()
+    first = await _post_terminal_input(client, attempt_id=attempt_id)
+    assert registry.transfer("conv_abc", "conv_new", "bash", "s1") is True
+    replay = await _post_terminal_input(client, attempt_id=attempt_id)
+
+    assert first.status_code == replay.status_code == 200
+    assert first.json() == replay.json()
+    assert send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_capacity_rejects_before_execute(
+    client: httpx.AsyncClient,
+    app: FastAPI,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A full attempt ledger rejects a new id without a second send."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    app.state.terminal_input_attempts.max_entries = 1
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", record_send)
+    first_id = _attempt_id()
+    first = await _post_terminal_input(client, attempt_id=first_id)
+    rejected = await _post_terminal_input(client, attempt_id=_attempt_id())
+    replay = await _post_terminal_input(client, attempt_id=first_id)
+
+    assert first.status_code == replay.status_code == 200
+    assert rejected.status_code == 503
+    assert rejected.json()["error"]["code"] == "idempotency_capacity_exhausted"
+    assert send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_registration_rejects_colliding_name_key(
+    registry: TerminalRegistry,
+) -> None:
+    """Sanitized name/key collisions are rejected before spawning tmux."""
+    with pytest.raises(RuntimeError, match=r"resource id.*collides"):
+        await registry.launch(
+            "conv_abc",
+            "bash ",
+            "s1",
+            TerminalEnvSpec(command="bash"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_ambiguous_resource_id_returns_409(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    tmp_path: Path,
+) -> None:
+    """A legacy colliding registry fails closed instead of choosing first."""
+    collision = _make_instance("bash ", "s1", tmp_path)
+    registry._by_conversation["conv_abc"][(collision.name, collision.session_key)] = collision
+
+    response = await _post_terminal_input(client, attempt_id=_attempt_id())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "ambiguous_resource_id"
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import threading
+import time
 import uuid
 from collections.abc import AsyncIterator, Callable, Sequence
 from dataclasses import dataclass
@@ -954,6 +955,47 @@ async def test_terminal_input_rejects_invalid_body(
 
 
 @pytest.mark.asyncio
+async def test_terminal_input_flag_like_keys_returns_400_without_attempt_id(
+    client: httpx.AsyncClient,
+) -> None:
+    """A flag-like ``keys`` token surfaces the send guard's 400 invalid_input."""
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"text": "echo hi", "keys": "-X"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_flag_like_keys_returns_400_with_attempt_id(
+    client: httpx.AsyncClient,
+) -> None:
+    """The idempotency ledger must not mask the guard's 400 as delivery_unknown.
+
+    A same-``attempt_id`` replay of the rejected request must return the same
+    400 — the ledger caches the failing task, not a fake ``delivery_unknown``.
+    """
+    attempt_id = _attempt_id()
+    body = {"attempt_id": attempt_id, "text": "echo hi", "keys": "-X"}
+
+    first = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=body,
+    )
+    assert first.status_code == 400
+    assert first.json()["error"]["code"] == "invalid_input"
+
+    replay = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=body,
+    )
+    assert replay.status_code == 400
+    assert replay.json()["error"]["code"] == "invalid_input"
+
+
+@pytest.mark.asyncio
 async def test_terminal_input_route_and_send_tool_share_primitive(
     client: httpx.AsyncClient,
     registry: TerminalRegistry,
@@ -1360,6 +1402,44 @@ async def test_terminal_input_cancelling_first_waiter_keeps_single_flight(
     assert response.status_code == 200
     assert response.json()["outcome"] == "sent"
     assert send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_cancelled_owner_entry_stays_purgeable() -> None:
+    """A directly-cancelled owner task stamps completion so its slot is reclaimed.
+
+    ``_purge_expired_locked`` only evicts completed entries; without the
+    synchronous stamp a cancelled owner would leak its slot forever and poison
+    that attempt_id for the process lifetime.
+    """
+    from omnigent.runner.app import (
+        _TERMINAL_INPUT_ATTEMPT_TTL_SECONDS,
+        _TerminalInputAttempt,
+        _TerminalInputAttempts,
+    )
+
+    attempts = _TerminalInputAttempts()
+    key = ("conv_abc", "attempt-cancelled")
+    placeholder = asyncio.create_task(asyncio.sleep(0))
+    await placeholder
+    attempts._entries[key] = _TerminalInputAttempt(
+        fingerprint=("terminal_bash_s1", "echo hi", "Enter", False),
+        task=placeholder,
+    )
+
+    async def _cancelled_operation() -> Any:
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await attempts._run_claimed(key, _cancelled_operation)
+
+    assert attempts._entries[key].completed_at is not None
+
+    attempts._entries[key].completed_at = (
+        time.monotonic() - _TERMINAL_INPUT_ATTEMPT_TTL_SECONDS - 1
+    )
+    attempts._purge_expired_locked()
+    assert key not in attempts._entries
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_terminal_resource_attach_ws.py
+++ b/tests/runner/test_terminal_resource_attach_ws.py
@@ -108,8 +108,8 @@ def test_runner_resource_attach_spawns_tmux_for_running_terminal(
             # ``?transport=pty`` pins this to the PTY bridge (the one that forks
             # tmux attach) independent of the global control-mode default.
             "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach?transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     # ``-r`` is absent (read_only defaulted to false) and the local
     # socket path from the registry is what's threaded in.
@@ -156,8 +156,8 @@ def test_runner_resource_attach_passes_read_only_to_tmux(
         with TestClient(app).websocket_connect(
             "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach"
             "?read_only=true&transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     assert "-r" in captured["argv"], (
         f"Expected -r with read_only=true, got argv={captured['argv']!r}"
@@ -204,18 +204,57 @@ def test_runner_resource_attach_selects_control_bridge_on_transport_query(
     base = "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach"
     client = TestClient(app)
     with contextlib.suppress(WebSocketDisconnect):
-        with client.websocket_connect(f"{base}?transport=control"):
-            pass
+        with client.websocket_connect(f"{base}?transport=control") as ws:
+            ws.receive_bytes()
     with contextlib.suppress(WebSocketDisconnect):
-        with client.websocket_connect(f"{base}?transport=pty"):
-            pass
+        with client.websocket_connect(f"{base}?transport=pty") as ws:
+            ws.receive_bytes()
     with contextlib.suppress(WebSocketDisconnect):
-        with client.websocket_connect(base):  # no query → control default
-            pass
+        with client.websocket_connect(base) as ws:  # no query → control default
+            ws.receive_bytes()
 
     assert calls == ["control", "pty", "control"], (
         f"transport query did not select the expected bridge: {calls!r}"
     )
+
+
+def test_runner_resource_attach_frame_after_transfer_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An already-attached socket cannot write after ownership transfers."""
+    registry = TerminalRegistry()
+    instance = _make_running_instance("bash", "s1", tmp_path)
+    _seed_registry(registry, "conv_abc", instance)
+    app = create_runner_app(
+        terminal_registry=registry,
+        server_client=NullServerClient(),
+    )
+    decisions: list[bool] = []
+    tmux_calls = 0
+
+    async def count_tmux(*args: str) -> None:
+        nonlocal tmux_calls
+        del args
+        tmux_calls += 1
+
+    async def fake_control(websocket, **kwargs) -> None:
+        assert registry.transfer("conv_abc", "conv_new", "bash", "s1") is True
+        on_client_input = kwargs["on_client_input"]
+        decisions.append(await on_client_input(b"x"))
+        await websocket.close()
+
+    monkeypatch.setattr(instance, "_tmux", count_tmux)
+    monkeypatch.setattr("omnigent.runner.app.bridge_tmux_control_to_websocket", fake_control)
+
+    with contextlib.suppress(WebSocketDisconnect):
+        with TestClient(app).websocket_connect(
+            "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach?transport=control"
+        ) as ws:
+            ws.receive_bytes()
+
+    assert decisions == [False]
+    assert tmux_calls == 0
 
 
 def test_runner_resource_attach_unknown_terminal_closes_4404(tmp_path: Path) -> None:
@@ -413,8 +452,8 @@ def test_runner_resource_attach_recreates_dead_repl_terminal(
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
             "/v1/sessions/conv_abc/resources/terminals/terminal_tui_main/attach?transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     # The recreate ran exactly once, for this session. [] means the
     # route still closes 4404 (the pre-fix dead-end); a wrong id means
@@ -435,8 +474,8 @@ def test_runner_resource_attach_recreates_dead_repl_terminal(
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
             "/v1/sessions/conv_abc/resources/terminals/terminal_tui_main/attach?transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     assert auto_create_sessions == ["conv_abc"]
     assert str(fresh_dir / "tui-main.sock") in attach_argvs[1]
@@ -533,8 +572,8 @@ def test_runner_resource_attach_recreates_dead_qwen_terminal(
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
             "/v1/sessions/conv_abc/resources/terminals/terminal_qwen_main/attach?transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     assert auto_create_sessions == ["conv_abc"]
     assert str(fresh_dir / "qwen-main.sock") in attach_argvs[0]
@@ -543,8 +582,8 @@ def test_runner_resource_attach_recreates_dead_qwen_terminal(
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
             "/v1/sessions/conv_abc/resources/terminals/terminal_qwen_main/attach?transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     assert auto_create_sessions == ["conv_abc"]
     assert str(fresh_dir / "qwen-main.sock") in attach_argvs[1]

--- a/tests/server/routes/test_terminal_attach.py
+++ b/tests/server/routes/test_terminal_attach.py
@@ -688,8 +688,8 @@ async def test_attach_terminal_local_fallback_spawns_tmux(
             # attach) independent of the global control-mode default.
             "/v1/sessions/conv_local_attach/resources/terminals/terminal_bash_s1/attach"
             "?read_only=true&transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     # tmux argv must include -r (read-only) and the local socket
     # path the registry knew about. If the socket path is the wrong

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -25,6 +25,7 @@ from omnigent.terminals.control_bridge import (
     bridge_tmux_control_to_websocket,
     unescape_control_output,
 )
+from omnigent.terminals.ws_bridge import WS_CLOSE_TERMINAL_NOT_FOUND
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
@@ -63,6 +64,7 @@ class _FakeWebSocket:
         self.sent: list[bytes] = []
         self.close_code: int | None = None
         self.close_reason: str | None = None
+        self.close_codes: list[int] = []
         self._recv_gate = asyncio.Event()
         # Per-send delay simulates a real network so a burst backlogs behind the
         # send — the condition under which the forwarder coalesces.
@@ -84,6 +86,7 @@ class _FakeWebSocket:
     async def close(self, code: int = 1000, reason: str = "") -> None:
         self.close_code = code
         self.close_reason = reason
+        self.close_codes.append(code)
 
 
 async def _new_private_tmux(inner: str) -> tuple[Path, str]:
@@ -346,6 +349,52 @@ async def test_control_bridge_seeds_streams_and_detaches() -> None:
 
     # Kill the server → the control client's stdout closes → bridge exits.
     await _kill_and_join(sock, task)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_owner_fence_rejects_stale_input() -> None:
+    """The control transport closes before injecting a revoked frame."""
+    sock, target = await _new_private_tmux("cat")
+    marker = b"STALE-OWNER-INPUT"
+    ws = _FakeWebSocket(inbound=[{"type": "websocket.receive", "bytes": marker + b"\r"}])
+    guarded: list[bytes] = []
+
+    async def _owner_guard(data: bytes) -> bool:
+        guarded.append(data)
+        return False
+
+    try:
+        await asyncio.wait_for(
+            bridge_tmux_control_to_websocket(
+                ws,
+                socket_path=str(sock),
+                tmux_target=target,
+                read_only=False,
+                on_client_input=_owner_guard,
+            ),
+            timeout=5.0,
+        )
+        tmux = shutil.which("tmux")
+        assert tmux is not None
+        capture = await asyncio.create_subprocess_exec(
+            tmux,
+            "-S",
+            str(sock),
+            "capture-pane",
+            "-p",
+            "-t",
+            target,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await capture.communicate()
+
+        assert guarded == [marker + b"\r"]
+        assert marker not in stdout
+        assert WS_CLOSE_TERMINAL_NOT_FOUND in ws.close_codes
+    finally:
+        await _kill_tmux(sock)
 
 
 @pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")

--- a/tests/terminals/test_registry.py
+++ b/tests/terminals/test_registry.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import asyncio
 import shutil
-import threading
 from collections.abc import AsyncIterator
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -27,7 +26,11 @@ from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpe
 from omnigent.inner.terminal import TerminalCreateResult, TerminalInstance
 from omnigent.terminals import TerminalRegistry
 from omnigent.terminals import registry as registry_mod
-from omnigent.terminals.registry import TerminalListEntry, conversation_link_for_id
+from omnigent.terminals.registry import (
+    ResolveSnapshot,
+    TerminalListEntry,
+    conversation_link_for_id,
+)
 
 # ── Pure bookkeeping (no tmux) ────────────────────────────────
 
@@ -52,6 +55,69 @@ def test_get_returns_none_for_unknown_triple() -> None:
     """
     reg = TerminalRegistry()
     assert reg.get("conv_nope", "bash", "s1") is None
+
+
+def _registered_snapshot(tmp_path: Path) -> tuple[TerminalRegistry, ResolveSnapshot]:
+    reg = TerminalRegistry()
+    instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "bash.sock",
+        private_dir=tmp_path / "bash",
+        running=True,
+    )
+    reg._by_conversation["conv_a"] = {("bash", "s1"): instance}
+    snapshot = reg.resolve_key_snapshot("conv_a", "bash", "s1")
+    assert isinstance(snapshot, ResolveSnapshot)
+    return reg, snapshot
+
+
+def test_run_fenced_runs_valid_async_function(tmp_path: Path) -> None:
+    reg, snapshot = _registered_snapshot(tmp_path)
+    calls = 0
+
+    async def operation() -> str:
+        nonlocal calls
+        calls += 1
+        return "ran"
+
+    assert reg.run_fenced(snapshot, operation, invalid="invalid") == "ran"
+    assert calls == 1
+
+
+def test_run_fenced_returns_invalid_sentinel_without_running_function(
+    tmp_path: Path,
+) -> None:
+    reg, snapshot = _registered_snapshot(tmp_path)
+    sentinel = object()
+    ran = False
+
+    async def operation() -> None:
+        nonlocal ran
+        ran = True
+
+    reg._by_conversation.clear()
+
+    assert reg.run_fenced(snapshot, operation, invalid=sentinel) is sentinel
+    assert ran is False
+
+
+def test_run_fenced_holds_snapshot_lock_during_function(tmp_path: Path) -> None:
+    reg, snapshot = _registered_snapshot(tmp_path)
+
+    async def operation() -> bool:
+        return snapshot.op_lock.locked()
+
+    assert reg.run_fenced(snapshot, operation, invalid=False) is True
+
+
+def test_run_fenced_preserves_direct_value_operation(tmp_path: Path) -> None:
+    reg, snapshot = _registered_snapshot(tmp_path)
+
+    def operation() -> tuple[str, bool]:
+        return "ran", snapshot.op_lock.locked()
+
+    assert reg.run_fenced(snapshot, operation, invalid=None) == ("ran", True)
 
 
 def test_list_for_conversation_returns_empty_for_unknown_id() -> None:
@@ -201,7 +267,6 @@ async def test_launch_replaces_stale_running_entry(
         running=False,
     )
     reg._by_conversation["conv_x"] = {("shell", "s1"): stale}
-    reg._instance_locks[("conv_x", "shell", "s1")] = threading.Lock()
 
     def _fake_create_terminal_instance(*_args: object, **_kwargs: object) -> TerminalCreateResult:
         return TerminalCreateResult(instance=created, cwd=tmp_path)
@@ -218,6 +283,60 @@ async def test_launch_replaces_stale_running_entry(
     assert result is created
     assert stale.closed is True
     assert reg.get("conv_x", "shell", "s1") is created
+
+
+async def test_launch_rejects_collision_at_final_registration_and_closes_loser(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A collision racing the spawn is rejected without leaking its tmux."""
+    reg = TerminalRegistry()
+    collision = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "winner.sock",
+        private_dir=tmp_path / "winner",
+        running=True,
+    )
+
+    class _RacingTerminal(TerminalInstance):
+        closed: bool = False
+
+        async def launch(self, *, cwd: Path | None = None) -> None:
+            del cwd
+            self.running = True
+            reg._by_conversation["conv_x"] = {("bash", "s1"): collision}
+
+        async def is_alive(self) -> bool:
+            return True
+
+        async def close(self) -> None:
+            self.closed = True
+            self.running = False
+
+    created = _RacingTerminal(
+        name="bash ",
+        session_key="s1",
+        socket_path=tmp_path / "loser.sock",
+        private_dir=tmp_path / "loser",
+    )
+
+    def _fake_create_terminal_instance(*_args: object, **_kwargs: object) -> TerminalCreateResult:
+        return TerminalCreateResult(instance=created, cwd=tmp_path)
+
+    monkeypatch.setattr(registry_mod, "create_terminal_instance", _fake_create_terminal_instance)
+
+    with pytest.raises(RuntimeError, match=r"resource id.*collides"):
+        await reg.launch(
+            "conv_x",
+            "bash ",
+            "s1",
+            TerminalEnvSpec(command="bash"),
+        )
+
+    assert created.closed is True
+    assert reg.get("conv_x", "bash", "s1") is collision
+    assert reg.get("conv_x", "bash ", "s1") is None
 
 
 def test_transfer_moves_terminal_without_closing_tmux(tmp_path: Path) -> None:
@@ -237,9 +356,8 @@ def test_transfer_moves_terminal_without_closing_tmux(tmp_path: Path) -> None:
         private_dir=tmp_path / "claude",
         running=True,
     )
-    lock = threading.Lock()
+    generation = instance.owner_generation
     reg._by_conversation["conv_old"] = {("claude", "main"): instance}
-    reg._instance_locks[("conv_old", "claude", "main")] = lock
 
     moved = reg.transfer("conv_old", "conv_new", "claude", "main")
 
@@ -247,8 +365,7 @@ def test_transfer_moves_terminal_without_closing_tmux(tmp_path: Path) -> None:
     assert reg.get("conv_old", "claude", "main") is None
     assert reg.get("conv_new", "claude", "main") is instance
     assert instance.running is True
-    assert reg.get_instance_lock("conv_old", "claude", "main") is None
-    assert reg.get_instance_lock("conv_new", "claude", "main") is lock
+    assert instance.owner_generation == generation + 1
     assert reg.active_conversation_ids() == ["conv_new"]
 
 
@@ -514,39 +631,6 @@ async def test_shutdown_clears_all_conversations(
     assert reg_with_tmux.list_for_conversation("conv_b") == []
 
 
-# ── Additional pure-bookkeeping tests (no tmux) ─────────────
-
-
-def test_get_instance_lock_returns_none_for_unknown_triple() -> None:
-    """
-    ``get_instance_lock`` returns ``None`` for a triple that was never
-    registered. Callers treat ``None`` as "not running" and surface
-    an error to the LLM.
-    """
-    reg = TerminalRegistry()
-    assert reg.get_instance_lock("conv_nope", "bash", "s1") is None
-
-
-def test_get_instance_lock_returns_lock_after_manual_registration(tmp_path: Path) -> None:
-    """
-    After manually inserting an instance and its lock (as ``launch``
-    would), ``get_instance_lock`` returns the same lock object.
-    """
-    reg = TerminalRegistry()
-    lock = threading.Lock()
-    instance = TerminalInstance(
-        name="bash",
-        session_key="s1",
-        socket_path=tmp_path / "bash.sock",
-        private_dir=tmp_path / "bash",
-        running=True,
-    )
-    reg._by_conversation["conv_a"] = {("bash", "s1"): instance}
-    reg._instance_locks[("conv_a", "bash", "s1")] = lock
-
-    assert reg.get_instance_lock("conv_a", "bash", "s1") is lock
-
-
 def test_transfer_nonexistent_source_returns_false() -> None:
     """
     Transferring from a conversation that has no terminals returns
@@ -590,9 +674,7 @@ def test_transfer_cleans_up_empty_source_slot(tmp_path: Path) -> None:
         private_dir=tmp_path / "bash",
         running=True,
     )
-    lock = threading.Lock()
     reg._by_conversation["conv_old"] = {("bash", "s1"): instance}
-    reg._instance_locks[("conv_old", "bash", "s1")] = lock
 
     reg.transfer("conv_old", "conv_new", "bash", "s1")
 
@@ -671,12 +753,13 @@ def test_conversation_link_for_id_method_delegates_to_module_function() -> None:
     assert "conv_abc" in link
 
 
-async def test_close_removes_instance_lock(tmp_path: Path) -> None:
+async def test_close_retires_instance_and_unmaps_owner(tmp_path: Path) -> None:
     """
-    After ``close``, the per-instance lock is removed so
-    ``get_instance_lock`` returns ``None``. Subsequent tool calls
-    that try to acquire the lock see "not running" rather than
-    operating on a closed tmux session.
+    After ``close``, the retired instance is no longer registry-addressable.
+
+    Subsequent tool calls see "not running" rather than operating on a
+    retired tmux session, while stale snapshots retain the same lock object
+    and observe the generation transition.
     """
     reg = TerminalRegistry()
     instance = TerminalInstance(
@@ -687,14 +770,15 @@ async def test_close_removes_instance_lock(tmp_path: Path) -> None:
         running=True,
     )
     instance.close = AsyncMock()  # type: ignore[method-assign]
-    lock = threading.Lock()
     reg._by_conversation["conv_a"] = {("bash", "s1"): instance}
-    reg._instance_locks[("conv_a", "bash", "s1")] = lock
+    generation = instance.owner_generation
 
     result = await reg.close("conv_a", "bash", "s1")
 
     assert result is True
-    assert reg.get_instance_lock("conv_a", "bash", "s1") is None
+    assert reg.get("conv_a", "bash", "s1") is None
+    assert instance.retired is True
+    assert instance.owner_generation == generation + 1
     instance.close.assert_awaited_once()
 
 
@@ -718,7 +802,6 @@ async def test_close_with_timeout_still_returns_true(tmp_path: Path) -> None:
 
     instance.close = _hang_forever  # type: ignore[method-assign]
     reg._by_conversation["conv_a"] = {("bash", "s1"): instance}
-    reg._instance_locks[("conv_a", "bash", "s1")] = threading.Lock()
 
     # The close should not hang — it uses asyncio.wait_for with _CLOSE_TIMEOUT_S.
     # We patch _CLOSE_TIMEOUT_S to a tiny value so the test finishes quickly.
@@ -768,8 +851,6 @@ async def test_cleanup_conversation_tolerates_close_exception(tmp_path: Path) ->
         ("bash", "s1"): good_instance,
         ("bash", "s2"): bad_instance,
     }
-    reg._instance_locks[("conv_a", "bash", "s1")] = threading.Lock()
-    reg._instance_locks[("conv_a", "bash", "s2")] = threading.Lock()
 
     # Should not raise despite bad_instance.close() exploding.
     await reg.cleanup_conversation("conv_a")
@@ -810,8 +891,6 @@ async def test_shutdown_tolerates_close_exception(tmp_path: Path) -> None:
 
     reg._by_conversation["conv_a"] = {("bash", "s1"): bad}
     reg._by_conversation["conv_b"] = {("bash", "s1"): good}
-    reg._instance_locks[("conv_a", "bash", "s1")] = threading.Lock()
-    reg._instance_locks[("conv_b", "bash", "s1")] = threading.Lock()
 
     await reg.shutdown()
 

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -651,6 +651,7 @@ class _ScriptedWebSocket:
         self._park = asyncio.Event()  # never set: parks ``receive``
         self.sent: list[bytes] = []
         self.close_code: int | None = None
+        self.close_codes: list[int] = []
 
     async def send_bytes(self, data: bytes) -> None:
         """Record PTY output forwarded to the browser (unused here)."""
@@ -667,6 +668,7 @@ class _ScriptedWebSocket:
     async def close(self, code: int = 1000, reason: str = "") -> None:
         """Capture the bridge's chosen close code."""
         self.close_code = code
+        self.close_codes.append(code)
 
 
 def _slave_winsize(slave_fd: int) -> tuple[int, int]:
@@ -801,6 +803,75 @@ async def test_bridge_read_only_gates_keystrokes_but_not_resize(
             await bridge_task
         with contextlib.suppress(OSError):
             os.close(master_fd)
+
+
+@pytest.mark.parametrize(
+    "frame,expected_callback_data",
+    [
+        ({"type": "websocket.receive", "bytes": b"stale-input"}, b"stale-input"),
+        (
+            {
+                "type": "websocket.receive",
+                "text": '{"type":"resize","cols":137,"rows":41}',
+            },
+            b"",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_bridge_owner_fence_rejects_stale_inbound_frame(
+    frame: dict[str, object],
+    expected_callback_data: bytes,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A revoked attachment cannot write either input bytes or a resize."""
+    master_fd, slave_fd = os.openpty()
+    # An owner-fence rejection makes the bridge return, and its teardown closes
+    # the master fd it was handed. Hold an independent handle to the pty master
+    # so the post-fence slave assertions below aren't ioctl'ing a torn-down pty
+    # (a closed master makes the slave's TIOCGWINSZ fail EIO on Linux).
+    master_keep = os.dup(master_fd)
+    tty.setraw(slave_fd)
+    flags = fcntl.fcntl(slave_fd, fcntl.F_GETFL)
+    fcntl.fcntl(slave_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+    initial_size = _slave_winsize(slave_fd)
+    monkeypatch.setattr(pty, "fork", lambda: (999_999, master_fd))
+    monkeypatch.setattr(os, "kill", lambda *_args, **_kwargs: None)
+
+    async def _dead_session(*_args: object, **_kwargs: object) -> bool:
+        return False
+
+    monkeypatch.setattr(ws_bridge, "_tmux_session_alive", _dead_session)
+    callback_data: list[bytes] = []
+
+    async def _owner_guard(data: bytes) -> bool:
+        callback_data.append(data)
+        return False
+
+    ws = _ScriptedWebSocket([frame])
+    try:
+        await asyncio.wait_for(
+            bridge_tmux_pty_to_websocket(
+                ws,
+                socket_path="/nonexistent.sock",
+                tmux_target="main",
+                read_only=False,
+                on_client_input=_owner_guard,
+            ),
+            timeout=5.0,
+        )
+
+        assert callback_data == [expected_callback_data]
+        assert _drain(slave_fd) == b""
+        assert _slave_winsize(slave_fd) == initial_size
+        assert ws_bridge.WS_CLOSE_TERMINAL_NOT_FOUND in ws.close_codes
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(slave_fd)
+        with contextlib.suppress(OSError):
+            os.close(master_fd)
+        with contextlib.suppress(OSError):
+            os.close(master_keep)
 
 
 @pytest.mark.asyncio
@@ -952,7 +1023,7 @@ async def test_bridge_splits_pty_redraw_after_control_key_input(
     )
     try:
         await asyncio.wait_for(ws.exhausted.wait(), timeout=5.0)
-        os.write(slave_fd, redraw)
+        await _write_all_nonblocking(asyncio.get_running_loop(), slave_fd, redraw)
         await asyncio.wait_for(_wait_for_sent_bytes(ws, len(redraw)), timeout=5.0)
 
         assert all(


### PR DESCRIPTION
## Related issue

N/A

## Summary

The shell-command backend needs a runner-owned way to inject terminal input without duplicating the agent tool's tmux locking behavior. This change:

- factors the locked `TerminalInstance.send` call into one shared helper used by both callers;
- adds `POST /v1/sessions/{session_id}/resources/terminals/{terminal_id}/input` with JSON validation and 200/404/409 responses; and
- keeps the existing `sys_terminal_send` success envelope byte-for-byte unchanged.

ELI5: both entrances now funnel through the same locked door before typing into tmux.

```text
sys_terminal_send ─┐
                   ├─> shared send helper ─> instance lock ─> tmux send-keys
runner POST /input ┘
```

## Test Plan

- `pre-commit run --all-files` — passed.
- `uv run ruff check omnigent tests` — passed.
- `uv run pytest tests/runner/test_session_resources.py tests/tools/builtins/test_sys_terminal.py tests/integration/test_sys_terminal_round_trip.py -q` — 73 passed, including a real tmux create → input → read marker round-trip.
- `uv run ruff check` — attempted; Ruff 0.15.16 reports three unchanged `web/src/shell/__fixtures__/*.ipynb` baseline errors, including the intentionally invalid `03_broken.ipynb`. No frontend or lint-suppression changes are included in this backend-only PR.

## Demo

N/A — non-visual backend change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Route tests cover JSON validation, 200/404/409 status behavior, lock ownership, mid-send terminal exit, exact agent-tool output, and shared-helper parity. The integration suite creates a real bash tmux terminal, posts an echo command to the new route, and reads the marker from the pane.

## Changelog

Runner terminal resources can now accept literal input through a serialized API route.


---
<!-- polly-stack -->
### 🔗 Linked stack — Bang shell commands (`! cmd`)

Part **1 of 4**. This feature ships as four linked PRs; merge in dependency order:

1. **#3033** — runner terminal input route  ⬅ **you are here (part 1)**
2. **#3039** — server `shell_command` event + durable receipts (depends on #3033)
3. **#3034** — web bang grammar lib + `terminal_command` receipt plumbing (inert until #3041)
4. **#3041** — web composer integration: autocomplete + submit interception + execution (activating PR; carries the demo)

Lower PRs are **inert until the stack completes** — land in sequence **#3033 → #3039 → #3034 → #3041**. A cross-cutting correctness remediation (ownership fencing, end-to-end `attempt_id` idempotency, process-local resource sequencing + single-owner boot guard, client-side reconciliation) is folded into the relevant branches; see `docs/claude/BANG_SHELL_REMEDIATION_SPEC.md`.


<!-- stack-context -->
---

## 🧭 Reviewer guide — this PR is 1 of a 4-PR stack

**Part 1 of 4 — runner input route + shell-readiness primitive.** Full feature: type `!` in the chat composer to run shell commands in the session's terminals (like Claude Code's `!`). It ships as four layer-sized PRs, merged in order `#3033` → `#3039` → `#3034` → `#3041`, so each is small and reviewable on its own.

- **What this PR contributes:** Adds the runner-side `POST .../terminals/{id}/input` primitive (owner-fenced `tmux send-keys` through a shared chokepoint) and the shell-readiness handshake that makes spawn-then-run reliable — a nonce emitted only from the final shell input loop, fail-closed on genuine timeout.
- **Reviewing it in isolation:** Self-contained runner change + unit/live-tmux tests. It exposes a capability but nothing calls it until the server orchestration in #3039 lands, so merged alone it is inert but safe.

### End-to-end demo — full stack

The clip shows the finished `!` bang UX: the autocomplete menu (running shells on top, new-shell types at the bottom), typing `! echo hello` **spawning a shell and running the command** with a clean receipt, targeting an existing shell, and the unknown-target error.

> **This is the behavior of the whole 4-PR stack once all of it is merged** (`#3033` → `#3039` → `#3034` → `#3041`). No single PR delivers it standalone — the lower PRs add inert capability that the top PR (#3041) activates.

Recorded live against a Docker deploy with a dialed-in runner — which is also how a spawn-readiness bug was caught and fixed (folded into #3033/#3039).

![bang shell-commands end-to-end demo](https://raw.githubusercontent.com/btli/omnigent/assets/t4-bang-demo/demo-fixed-spawn-run.gif?v=motion)

> ▶ **[Full-quality MP4](https://raw.githubusercontent.com/btli/omnigent/assets/t4-bang-demo/bang-shell-command-demo.mp4)** — crisper 1280×720 / 25fps capture. _Recorded live against a full-stack Docker deploy; spawn+run works end-to-end. Motion clip is the real result once the whole stack (#3033 → #3039 → #3034 → #3041) is merged._