### PR TITLE
feat(server): shell_command event — bang-command orchestration + receipt persistence

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3099,6 +3099,32 @@ def _assert_server_port_bindable(host: str, port: int) -> None:
             ) from exc
 
 
+_SINGLE_OWNER_ERROR = (
+    "Omnigent requires a single server process per conversation: resource-event ordering is "
+    "process-local (session affinity). Refusing to start with WEB_CONCURRENCY/workers > 1 or "
+    "OMNIGENT_MULTI_REPLICA set. Run one worker and one replica, or implement a durable "
+    "cross-worker resource revision first (tracked for v0.8.0)."
+)
+
+
+def _enforce_single_owner_or_exit() -> None:
+    """Reject worker/replica settings that invalidate process-local ordering."""
+    worker_count = max(
+        int(os.environ.get("WEB_CONCURRENCY", "1")),
+        int(os.environ.get("UVICORN_WORKERS", "1")),
+        int(os.environ.get("GUNICORN_WORKERS", "1")),
+    )
+    multi_replica = os.environ.get("OMNIGENT_MULTI_REPLICA", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if worker_count > 1 or multi_replica:
+        logging.getLogger(__name__).error(_SINGLE_OWNER_ERROR)
+        click.echo(_SINGLE_OWNER_ERROR, err=True)
+        raise SystemExit(2)
+
+
 @cli.group("server", invoke_without_command=True)
 @click.option(
     "--host",
@@ -3244,7 +3270,6 @@ def server(
         # A subcommand (stop/status) handles this invocation; the body
         # below is the server path for the bare ``server`` group.
         return
-
     if background:
         # `omnigent server --background` replaces the removed `server start`
         # subcommand: ensure (or reuse) the managed detached local server and
@@ -3265,6 +3290,9 @@ def server(
             click.echo(f"  log: {_display_path(startup.log_path)}")
         return
 
+    # The single-owner guard applies to the in-process boot; the background
+    # path spawns a detached server that re-enters here and runs it there.
+    _enforce_single_owner_or_exit()
     port_source = ctx.get_parameter_source("port")
     port_was_explicit = port_source is click.core.ParameterSource.COMMANDLINE
     if port_was_explicit:

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -471,27 +471,37 @@ class ResourceEventData(BaseModel):
         ``"terminal"``, ``"file"``, ``"environment"``.
     :param resource: Full resource object dict for ``created``
         events. ``None`` for ``deleted`` events.
+    :param sequence: Process-local resource revision stamped on the
+        corresponding live event. ``None`` for legacy records.
     """
 
     event_type: str
     resource_id: str
     resource_type: str
     resource: dict[str, Any] | None = None
+    sequence: int | None = None
 
 
 class TerminalCommandData(BaseModel):
     """
-    Data payload for a runner-side terminal command (``!cmd``) observed
-    in a harness transcript (today: Claude Code's embedded TUI).
+    Data payload for a runner-side terminal command (``!cmd``).
+
+    Two producers write this item type:
+
+    * the native-bridge observer mirroring ``!cmd`` entries the vendor
+      TUI executed itself (one ``kind="input"`` and one
+      ``kind="output"`` record per invocation);
+    * the server's ``shell_command`` event, which persists ONE
+      ``kind="input"`` receipt per web-composer bang command, filling
+      the optional routing/outcome fields below.
 
     Listed in :data:`NON_CONTENT_ITEM_TYPES` so the agent loop never
     injects this as phantom content into the LLM's message history.
 
-    Claude Code writes two sibling transcript records per ``!cmd``
-    invocation: one ``<bash-input>`` record and one combined
-    ``<bash-stdout>``/``<bash-stderr>`` record. Each maps to one
-    ``terminal_command`` item with ``kind="input"`` or
-    ``kind="output"`` respectively.
+    The optional fields default to ``None`` so legacy persisted items
+    (native-bridge observer records predating receipts) deserialize
+    without backfill — the same additive-optional idiom as
+    :attr:`SlashCommandData.kind`.
 
     :param kind: ``"input"`` for the command text, ``"output"`` for
         the combined stdout/stderr result.
@@ -501,12 +511,39 @@ class TerminalCommandData(BaseModel):
         ``None`` otherwise.
     :param stderr: Captured stderr text. Present when ``kind="output"``,
         ``None`` otherwise.
+    :param action: ``"spawn"`` when the command launched a new shell,
+        ``"send"`` when routed into an existing one. ``None`` for
+        legacy native-bridge observer items.
+    :param terminal_id: Target terminal resource id, e.g.
+        ``"terminal_zsh_u-ab12cd"``.
+    :param terminal_name: Shell type for display, e.g. ``"zsh"``.
+    :param session_key: Display session key, e.g. ``"u-ab12cd"``.
+    :param status: Delivery outcome — ``"ok"`` when delivery was
+        confirmed, ``"unknown"`` when it may have occurred, and
+        ``"error"`` for definite non-delivery.
+    :param error: Human-readable failure text when ``status="error"``.
+    :param attempt_id: Client-generated idempotency key. ``None`` only
+        for legacy native-bridge records.
+    :param sequence: Authoritative resource revision for a spawn receipt.
+        ``None`` for sends and legacy records.
     """
 
     kind: Literal["input", "output"]
     input: str | None = None
     stdout: str | None = None
     stderr: str | None = None
+    action: Literal["spawn", "send"] | None = None
+    terminal_id: str | None = None
+    terminal_name: str | None = None
+    session_key: str | None = None
+    status: Literal["ok", "error", "unknown"] | None = None
+    error: str | None = None
+    attempt_id: str | None = None
+    sequence: int | None = None
+    attempt_fingerprint: str | None = None
+    terminal: dict[str, Any] | None = None
+    http_status: int | None = None
+    error_code: str | None = None
 
 
 class RoutingDecisionData(BaseModel):

--- a/omnigent/entities/session_resources.py
+++ b/omnigent/entities/session_resources.py
@@ -334,9 +334,11 @@ def resolve_terminal_entry_by_resource_id(
     """
     if terminal_registry is None:
         return None
-    for entry in terminal_registry.list_for_conversation(session_id):
-        if not entry.instance.running:
-            continue
-        if terminal_resource_id(entry.terminal_name, entry.session_key) == terminal_id:
-            return entry
-    return None
+    from omnigent.terminals.registry import ResolveSnapshot
+
+    resolved = terminal_registry.resolve_snapshot(session_id, terminal_id)
+    if not isinstance(resolved, ResolveSnapshot):
+        return None
+    if resolved.instance.retired or not resolved.instance.running:
+        return None
+    return resolved.entry

--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -23,6 +23,9 @@ class ErrorCode:
     :cvar INVALID_INPUT: Request validation failed (HTTP 400).
     :cvar ALREADY_EXISTS: Duplicate resource (HTTP 409).
     :cvar CONFLICT: Operation conflicts with current state (HTTP 409).
+    :cvar ATTEMPT_CONFLICT: An idempotency key was rebound (HTTP 409).
+    :cvar IDEMPOTENCY_CAPACITY_EXHAUSTED: A bounded idempotency ledger
+        rejected a new attempt before execution (HTTP 503).
     :cvar INTERNAL_ERROR: Unexpected server error (HTTP 500).
     :cvar HARNESS_PROTOCOL_VIOLATION: A harness emitted an SSE
         sequence that violates the Omnigent↔harness contract — e.g.
@@ -53,6 +56,8 @@ class ErrorCode:
     INVALID_INPUT = "invalid_input"
     ALREADY_EXISTS = "already_exists"
     CONFLICT = "conflict"
+    ATTEMPT_CONFLICT = "attempt_conflict"
+    IDEMPOTENCY_CAPACITY_EXHAUSTED = "idempotency_capacity_exhausted"
     INTERNAL_ERROR = "internal_error"
     HARNESS_PROTOCOL_VIOLATION = "harness_protocol_violation"
     RUNNER_UNAVAILABLE = "runner_unavailable"
@@ -70,6 +75,8 @@ _CODE_TO_HTTP_STATUS: dict[str, int] = {
     ErrorCode.INVALID_INPUT: 400,
     ErrorCode.ALREADY_EXISTS: 409,
     ErrorCode.CONFLICT: 409,
+    ErrorCode.ATTEMPT_CONFLICT: 409,
+    ErrorCode.IDEMPOTENCY_CAPACITY_EXHAUSTED: 503,
     ErrorCode.INTERNAL_ERROR: 500,
     # Harness protocol violations are server-side bugs in the
     # harness implementation — surface as 500 (no client action

--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -24,6 +24,10 @@ class ErrorCode:
     :cvar ALREADY_EXISTS: Duplicate resource (HTTP 409).
     :cvar CONFLICT: Operation conflicts with current state (HTTP 409).
     :cvar ATTEMPT_CONFLICT: An idempotency key was rebound (HTTP 409).
+    :cvar ATTEMPT_ABANDONED: The single-flight owner of an idempotent
+        attempt exited before persisting a receipt (e.g. cancelled),
+        so a concurrent duplicate waiter has no result to replay and
+        should simply retry the same request (HTTP 503).
     :cvar IDEMPOTENCY_CAPACITY_EXHAUSTED: A bounded idempotency ledger
         rejected a new attempt before execution (HTTP 503).
     :cvar INTERNAL_ERROR: Unexpected server error (HTTP 500).
@@ -57,6 +61,7 @@ class ErrorCode:
     ALREADY_EXISTS = "already_exists"
     CONFLICT = "conflict"
     ATTEMPT_CONFLICT = "attempt_conflict"
+    ATTEMPT_ABANDONED = "attempt_abandoned"
     IDEMPOTENCY_CAPACITY_EXHAUSTED = "idempotency_capacity_exhausted"
     INTERNAL_ERROR = "internal_error"
     HARNESS_PROTOCOL_VIOLATION = "harness_protocol_violation"
@@ -76,6 +81,7 @@ _CODE_TO_HTTP_STATUS: dict[str, int] = {
     ErrorCode.ALREADY_EXISTS: 409,
     ErrorCode.CONFLICT: 409,
     ErrorCode.ATTEMPT_CONFLICT: 409,
+    ErrorCode.ATTEMPT_ABANDONED: 503,
     ErrorCode.IDEMPOTENCY_CAPACITY_EXHAUSTED: 503,
     ErrorCode.INTERNAL_ERROR: 500,
     # Harness protocol violations are server-side bugs in the

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -735,6 +735,9 @@ class TerminalEnvSpec:
         default, which is control mode unless ``terminal.transport`` in
         ``~/.omnigent/config.yaml`` opts out to ``pty``. A per-attach
         ``?transport=`` query overrides both.
+    :param ready_process: Final process name that proves an arbitrary
+        configured command has handed control to its input owner. Used only
+        by explicit shell-command readiness waits.
     """
 
     command: str | None = None
@@ -752,6 +755,7 @@ class TerminalEnvSpec:
     tmux_start_on_attach: bool = False
     keep_alive_after_exit: bool = False
     terminal_transport: str | None = None
+    ready_process: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -730,6 +730,11 @@ def _parse_terminal_env_spec(data: YamlData | str | bool | None) -> TerminalEnvS
     if not isinstance(env_val, dict):
         raise TypeError("terminal 'env' must be a mapping of string -> string")
     env = {str(k): str(v) for k, v in env_val.items()}
+    ready_process = data.get("ready_process")
+    if ready_process is not None and (
+        not isinstance(ready_process, str) or not ready_process.strip()
+    ):
+        raise TypeError("terminal 'ready_process' must be a non-empty string")
 
     return TerminalEnvSpec(
         command=data.get("command", "bash"),
@@ -741,6 +746,7 @@ def _parse_terminal_env_spec(data: YamlData | str | bool | None) -> TerminalEnvS
         log_file=data.get("log_file"),
         scrollback=int(data.get("scrollback", 10000)),
         session_prefix=data.get("session_prefix", "omni_"),
+        ready_process=ready_process,
     )
 
 

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -1259,6 +1259,16 @@ class TerminalInstance:
         if not self.running:
             return {"error": "Terminal is not running"}
 
+        # ``keys`` tokens are passed to ``tmux send-keys`` as bare arguments
+        # (no ``-l``), so a token beginning with ``-``/``+`` would be parsed as
+        # a send-keys flag rather than a key name. Reject before any dispatch.
+        for key in keys.split():
+            if key.startswith(("-", "+")):
+                raise ValueError(
+                    f"Invalid tmux key name {key!r}: key names must not start "
+                    "with '-' or '+' (they would be consumed as send-keys flags)"
+                )
+
         dispatch_started = False
         try:
             if text:
@@ -1333,7 +1343,11 @@ class TerminalInstance:
         deadline: float,
         poll_interval_s: float,
     ) -> bool:
-        """Clear the acknowledged probe from the screen and pane history."""
+        """Clear the acknowledged probe from the screen and scrollback.
+
+        Sends ``C-l`` then ``clear-history`` so the typed readiness probe
+        leaves no residue in the pane or its history.
+        """
         loop = asyncio.get_running_loop()
         remaining = deadline - loop.time()
         if remaining <= 0:
@@ -1397,7 +1411,12 @@ class TerminalInstance:
         timeout_s: float,
         poll_interval_s: float,
     ) -> bool:
-        """Run one bounded shell-readiness evaluation."""
+        """Run one bounded shell-readiness evaluation.
+
+        Under the nonce contract this types a probe into the live pane and,
+        once acknowledged, clears it plus the scrollback via
+        ``_clear_shell_readiness_residue`` so the user never sees it.
+        """
         if not self.running or timeout_s <= 0:
             return False
         if self.shell_ready_nonce is None and self.ready_process is None:

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -11,6 +11,7 @@ import contextlib
 import logging
 import os
 import re
+import secrets
 import shutil
 import subprocess
 import tempfile
@@ -433,6 +434,9 @@ _IDLE_WATCHER_JOIN_TIMEOUT_S = 1.0
 # (1024 chars ≤ 4KB packed). tmux writes each invocation's bytes to the
 # pane in submission order, so the program sees one contiguous stream.
 _SEND_KEYS_LITERAL_CHARS_PER_CALL = 1024
+_SEND_KEYS_HEX_BYTES_PER_CALL = 1024
+_SHELL_READY_POLL_SECONDS = 0.025
+_SHELL_READY_STABLE_SAMPLES = 2
 
 
 class _IdleDetector:
@@ -932,6 +936,8 @@ class TerminalInstance:
         the first tmux client attaches to the session.
     :param running: Whether the tmux server is currently expected to
         be alive.
+    :param ready_process: Declared final process for arbitrary-command
+        readiness, or ``None`` when no explicit readiness contract exists.
     """
 
     name: str
@@ -974,7 +980,14 @@ class TerminalInstance:
     # attach routes via :func:`resolve_terminal_transport`; does not affect how
     # the tmux server itself is launched.
     terminal_transport: str | None = None
+    ready_process: str | None = None
+    shell_ready_nonce: str | None = None
+    _shell_ready_probe_sent: bool = field(default=False, repr=False, compare=False)
+    _shell_ready_acknowledged: bool = field(default=False, repr=False, compare=False)
     running: bool = False
+    retired: bool = False
+    owner_generation: int = 0
+    op_lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
     launch_cwd: str | None = None
     # Owned per-launch egress proxy. ``None`` when the sandbox
     # carries no ``egress_rules`` or the backend doesn't need a
@@ -1246,9 +1259,11 @@ class TerminalInstance:
         if not self.running:
             return {"error": "Terminal is not running"}
 
+        dispatch_started = False
         try:
             if text:
                 for start in range(0, len(text), _SEND_KEYS_LITERAL_CHARS_PER_CALL):
+                    dispatch_started = True
                     await self._tmux(
                         "send-keys",
                         "-l",
@@ -1261,17 +1276,221 @@ class TerminalInstance:
                 if text:
                     await asyncio.sleep(0.05)
                 for key in keys.split():
+                    dispatch_started = True
                     await self._tmux("send-keys", "-t", self.tmux_target, key)
-        except RuntimeError:
+        except (RuntimeError, OSError):
             self.running = False
+            if dispatch_started:
+                return {
+                    "error": (
+                        f"Delivery to terminal {self.name}:{self.session_key} "
+                        "could not be confirmed"
+                    ),
+                    "delivery_unknown": True,
+                }
             return {
                 "error": (
                     f"Terminal {self.name}:{self.session_key} is no longer "
                     "running (tmux server exited)"
                 )
             }
+        except asyncio.CancelledError:
+            if dispatch_started:
+                return {
+                    "error": (
+                        f"Delivery to terminal {self.name}:{self.session_key} "
+                        "could not be confirmed"
+                    ),
+                    "delivery_unknown": True,
+                }
+            raise
 
         return {"status": "sent"}
+
+    async def send_raw_bytes(self, data: bytes) -> bool:
+        """Inject one attached-client frame through tmux's byte-exact hex path."""
+        if not self.running:
+            return False
+        try:
+            for start in range(0, len(data), _SEND_KEYS_HEX_BYTES_PER_CALL):
+                chunk = data[start : start + _SEND_KEYS_HEX_BYTES_PER_CALL]
+                await self._tmux(
+                    "send-keys",
+                    "-t",
+                    self.tmux_target,
+                    "-H",
+                    *(f"{value:02x}" for value in chunk),
+                )
+        except (RuntimeError, OSError):
+            self.running = False
+            return False
+        return True
+
+    async def _clear_shell_readiness_residue(
+        self,
+        *,
+        nonce: str,
+        deadline: float,
+        poll_interval_s: float,
+    ) -> bool:
+        """Clear the acknowledged probe from the screen and pane history."""
+        loop = asyncio.get_running_loop()
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return False
+        await asyncio.wait_for(
+            self._tmux("send-keys", "-t", self.tmux_target, "C-l"),
+            timeout=remaining,
+        )
+
+        while self.running:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            snapshot = await asyncio.wait_for(
+                self._tmux_output(
+                    "capture-pane",
+                    "-t",
+                    self.tmux_target,
+                    "-p",
+                ),
+                timeout=remaining,
+            )
+            self._remember_pane_snapshot(snapshot)
+            if nonce not in _strip_ansi(snapshot):
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return False
+                await asyncio.wait_for(
+                    self._tmux("clear-history", "-t", self.tmux_target),
+                    timeout=remaining,
+                )
+                return True
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            await asyncio.sleep(min(poll_interval_s, remaining))
+        return False
+
+    async def wait_for_shell_ready(
+        self,
+        *,
+        timeout_s: float,
+        poll_interval_s: float = _SHELL_READY_POLL_SECONDS,
+    ) -> bool:
+        """Wait for an input-loop ACK or a stable declared final process."""
+        try:
+            async with asyncio.timeout(timeout_s):
+                return await self._wait_for_shell_ready_once(
+                    timeout_s=timeout_s,
+                    poll_interval_s=poll_interval_s,
+                )
+        except TimeoutError:
+            return False
+        finally:
+            if not self._shell_ready_acknowledged:
+                self._shell_ready_probe_sent = False
+
+    async def _wait_for_shell_ready_once(
+        self,
+        *,
+        timeout_s: float,
+        poll_interval_s: float,
+    ) -> bool:
+        """Run one bounded shell-readiness evaluation."""
+        if not self.running or timeout_s <= 0:
+            return False
+        if self.shell_ready_nonce is None and self.ready_process is None:
+            return False
+        if self._shell_ready_acknowledged:
+            return True
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_s
+        stable_process_samples = 0
+        probe_nonce = self.shell_ready_nonce
+        if probe_nonce is not None and not self._shell_ready_probe_sent:
+            probe_nonce = _mint_shell_ready_nonce()
+            self.shell_ready_nonce = probe_nonce
+            remaining = deadline - loop.time()
+            try:
+                probe = _direct_shell_readiness_probe(
+                    Path(self.command).name,
+                    probe_nonce,
+                )
+                await asyncio.wait_for(
+                    self._tmux(
+                        "send-keys",
+                        "-l",
+                        "-t",
+                        self.tmux_target,
+                        probe,
+                    ),
+                    timeout=remaining,
+                )
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return False
+                await asyncio.wait_for(
+                    self._tmux("send-keys", "-t", self.tmux_target, "Enter"),
+                    timeout=remaining,
+                )
+                self._shell_ready_probe_sent = True
+            except (TimeoutError, RuntimeError, OSError, ValueError):
+                return False
+
+        while self.running:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            try:
+                if probe_nonce is not None:
+                    snapshot = await asyncio.wait_for(
+                        self._tmux_output(
+                            "capture-pane",
+                            "-t",
+                            self.tmux_target,
+                            "-p",
+                            "-S",
+                            "-",
+                        ),
+                        timeout=remaining,
+                    )
+                    self._remember_pane_snapshot(snapshot)
+                    if probe_nonce in _strip_ansi(snapshot):
+                        if not await self._clear_shell_readiness_residue(
+                            nonce=probe_nonce,
+                            deadline=deadline,
+                            poll_interval_s=poll_interval_s,
+                        ):
+                            return False
+                        self._shell_ready_acknowledged = True
+                        return True
+                else:
+                    process = await asyncio.wait_for(
+                        self._tmux_output(
+                            "display-message",
+                            "-p",
+                            "-t",
+                            self.tmux_target,
+                            "#{pane_current_command}",
+                        ),
+                        timeout=remaining,
+                    )
+                    if process.strip() == self.ready_process:
+                        stable_process_samples += 1
+                        if stable_process_samples >= _SHELL_READY_STABLE_SAMPLES:
+                            return True
+                    else:
+                        stable_process_samples = 0
+            except (TimeoutError, RuntimeError, OSError):
+                return False
+
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            await asyncio.sleep(min(poll_interval_s, remaining))
+        return False
 
     async def read(self, scrollback: int = 0) -> TerminalResult:
         """Capture the terminal screen."""
@@ -1884,6 +2103,90 @@ def _shell_quote(s: str) -> str:
     return "'" + s.replace("'", "'\\''") + "'"
 
 
+def _direct_shell_args_reach_input_loop(shell_name: str, args: list[str]) -> bool:
+    """Return whether direct shell argv can reach a command-reading loop."""
+    stdin_mode = False
+    option_operand = False
+    parsing_options = True
+    for arg in args:
+        if option_operand:
+            option_operand = False
+            continue
+        if parsing_options and arg == "--":
+            parsing_options = False
+            continue
+        if parsing_options and arg == "-":
+            stdin_mode = True
+            parsing_options = False
+            continue
+        if parsing_options and arg.startswith("--"):
+            option, separator, _value = arg.partition("=")
+            if option in {
+                "--command",
+                "--dump-po-strings",
+                "--dump-strings",
+                "--help",
+                "--noexec",
+                "--pretty-print",
+                "--version",
+            }:
+                return False
+            if option in {"--init-file", "--rcfile"} and not separator:
+                option_operand = True
+            if option in {"--shinstdin", "--stdin"}:
+                stdin_mode = True
+            continue
+        if parsing_options and len(arg) > 1 and arg[0] in {"-", "+"}:
+            if arg[:2] in {"-O", "+O", "-o", "+o"}:
+                option_operand = len(arg) == 2
+                continue
+            flags = arg[1:]
+            if any(flag in flags for flag in ("c", "D", "n", "t")):
+                return False
+            if "s" in flags:
+                stdin_mode = True
+            continue
+        if not stdin_mode:
+            return False
+
+    return not option_operand and shell_name in {"bash", "zsh"}
+
+
+def terminal_spec_supports_shell_readiness(spec: TerminalEnvSpec) -> bool:
+    """Return whether *spec* has a fail-closed spawn readiness contract."""
+    if spec.ready_process is not None:
+        return True
+    shell_name = Path(spec.command or "bash").name
+    return _direct_shell_args_reach_input_loop(shell_name, list(spec.args))
+
+
+def _direct_shell_readiness_probe(shell_name: str, nonce: str) -> str:
+    """Build a nonce-free command that ACKs only at a shell input loop."""
+    encoded_nonce = "".join(f"\\0{byte:03o}" for byte in nonce.encode("ascii"))
+    if shell_name == "bash":
+        condition = "[[ ${#BASH_SOURCE[@]} -eq 0 ]]"
+    elif shell_name == "zsh":
+        condition = "[[ $ZSH_EVAL_CONTEXT == toplevel ]]"
+    else:
+        raise ValueError(f"Unsupported direct readiness shell: {shell_name}")
+    return f"if {condition}; then builtin printf '%b\\n' '{encoded_nonce}'; fi"
+
+
+def _mint_shell_ready_nonce() -> str:
+    """Mint one direct-shell readiness probe nonce."""
+    return f"OMNIGENT_SHELL_READY_{secrets.token_hex(16)}"
+
+
+def _owned_shell_ready_nonce(spec: TerminalEnvSpec) -> str | None:
+    """Mint a readiness nonce for direct shells with an input-loop contract."""
+    if spec.ready_process is not None:
+        return None
+    shell_name = Path(spec.command or "bash").name
+    if not _direct_shell_args_reach_input_loop(shell_name, list(spec.args)):
+        return None
+    return _mint_shell_ready_nonce()
+
+
 @dataclass(frozen=True)
 class TerminalCreateResult:
     """
@@ -2038,6 +2341,8 @@ def create_terminal_instance(
         tmux_start_on_attach=spec.tmux_start_on_attach,
         keep_alive_after_exit=spec.keep_alive_after_exit,
         terminal_transport=spec.terminal_transport,
+        ready_process=spec.ready_process,
+        shell_ready_nonce=_owned_shell_ready_nonce(spec),
     )
 
     return TerminalCreateResult(instance=instance, cwd=cwd)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1834,21 +1834,35 @@ class _TerminalInputAttempts:
         try:
             outcome = await operation()
         except asyncio.CancelledError:
-            outcome = _TerminalInputOutcome(
-                status_code=200,
-                body={"outcome": "delivery_unknown"},
-            )
+            # Cancellation only happens at teardown today; stamp completion so
+            # the slot stays purgeable (never a permanently-leaked, replay-
+            # poisoning entry) if that ever changes. Synchronous write, no
+            # await — safe on the single event-loop thread mid-cancellation.
+            entry = self._entries.get(key)
+            if entry is not None:
+                entry.completed_at = time.monotonic()
+            raise
+        except (ValueError, OmnigentError):
+            # These carry dedicated global handlers that answer 4xx (a
+            # flag-like ``keys`` token raises ValueError before any dispatch).
+            # Record completion so a same-id replay re-hits this failing task,
+            # then propagate instead of faking a delivery_unknown.
+            await self._mark_completed(key)
+            raise
         except Exception:
             _logger.exception("terminal input attempt failed after dispatch")
             outcome = _TerminalInputOutcome(
                 status_code=200,
                 body={"outcome": "delivery_unknown"},
             )
+        await self._mark_completed(key)
+        return outcome
+
+    async def _mark_completed(self, key: tuple[str, str]) -> None:
         async with self._lock:
             entry = self._entries.get(key)
             if entry is not None:
                 entry.completed_at = time.monotonic()
-        return outcome
 
     def _purge_expired_locked(self) -> None:
         cutoff = time.monotonic() - _TERMINAL_INPUT_ATTEMPT_TTL_SECONDS

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 import click
 import httpx
-from fastapi import FastAPI, HTTPException, Query, Request, WebSocket
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, WebSocket
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 from omnigent.entities.session_resources import (
@@ -125,12 +125,19 @@ from omnigent.runner.session_init_protocol import (
     parse_runner_session_init_envelope,
 )
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager, NoLiveHarnessError
+from omnigent.server.routes._content_type import require_json_content_type
 from omnigent.server.schemas import (
     BackgroundSessionTitleRequest,
     BackgroundSessionTitleResponse,
 )
 from omnigent.spec.skill_sources import SkillSourceContext, resolve_harness_skills
 from omnigent.spec.types import LocalToolInfo, SkillSpec
+from omnigent.terminals import (
+    AmbiguousResourceId,
+    AmbiguousResourceIdError,
+    ResolveSnapshot,
+    TerminalRegistry,
+)
 from omnigent.terminals.control_bridge import bridge_tmux_control_to_websocket
 from omnigent.terminals.ws_bridge import (
     WS_CLOSE_TERMINAL_NOT_FOUND,
@@ -1726,6 +1733,134 @@ def get_session_agent_id(session_id: str) -> str | None:
 # a single walk. Module-level so it can be tuned/patched in one place.
 _SESSION_SKILLS_CACHE_TTL_SECONDS = 60.0
 _SESSION_INIT_ENVELOPE_TTL_SECONDS = 60.0
+_TERMINAL_INPUT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
+_TERMINAL_INPUT_ATTEMPT_MAX_ENTRIES = 50_000
+
+
+async def _terminal_snapshot_is_alive(
+    registry: TerminalRegistry,
+    snapshot: ResolveSnapshot,
+) -> bool:
+    """Probe tmux only while an atomic terminal owner snapshot remains valid."""
+    return await asyncio.to_thread(
+        registry.run_fenced,
+        snapshot,
+        snapshot.instance.is_alive,
+        invalid=False,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class _TerminalInputOutcome:
+    """Exact status/body pair cached for one runner input attempt."""
+
+    status_code: int
+    body: dict[str, Any]
+
+
+@dataclasses.dataclass
+class _TerminalInputAttempt:
+    """One in-flight or completed attempt bound to its request fingerprint."""
+
+    fingerprint: tuple[str, str, str, bool]
+    task: asyncio.Task[_TerminalInputOutcome]
+    completed_at: float | None = None
+
+
+class _TerminalInputAttempts:
+    """Bounded atomic single-flight ledger for terminal input delivery."""
+
+    def __init__(self) -> None:
+        self._entries: dict[tuple[str, str], _TerminalInputAttempt] = {}
+        self._lock = asyncio.Lock()
+        self.max_entries = _TERMINAL_INPUT_ATTEMPT_MAX_ENTRIES
+
+    async def execute(
+        self,
+        *,
+        session_id: str,
+        attempt_id: str,
+        fingerprint: tuple[str, str, str, bool],
+        operation: Callable[[], Awaitable[_TerminalInputOutcome]],
+    ) -> _TerminalInputOutcome:
+        """Claim an id atomically or await its existing shielded task.
+
+        A repeated ``attempt_id`` replays the cached outcome (including
+        ``delivery_unknown``); actually retrying delivery requires a fresh
+        ``attempt_id``.
+        """
+        key = (session_id, attempt_id)
+        async with self._lock:
+            self._purge_expired_locked()
+            existing = self._entries.get(key)
+            if existing is not None:
+                if existing.fingerprint != fingerprint:
+                    return _TerminalInputOutcome(
+                        status_code=409,
+                        body={
+                            "error": {
+                                "code": "attempt_conflict",
+                                "message": "attempt_id is bound to a different terminal input",
+                            }
+                        },
+                    )
+                task = existing.task
+            else:
+                if len(self._entries) >= self.max_entries:
+                    return _TerminalInputOutcome(
+                        status_code=503,
+                        body={
+                            "error": {
+                                "code": "idempotency_capacity_exhausted",
+                                "message": "Runner input idempotency capacity is exhausted",
+                            }
+                        },
+                    )
+                task = asyncio.create_task(
+                    self._run_claimed(key, operation),
+                    name=f"terminal-input-{attempt_id}",
+                )
+                self._entries[key] = _TerminalInputAttempt(
+                    fingerprint=fingerprint,
+                    task=task,
+                )
+        return await asyncio.shield(task)
+
+    async def _run_claimed(
+        self,
+        key: tuple[str, str],
+        operation: Callable[[], Awaitable[_TerminalInputOutcome]],
+    ) -> _TerminalInputOutcome:
+        try:
+            outcome = await operation()
+        except asyncio.CancelledError:
+            outcome = _TerminalInputOutcome(
+                status_code=200,
+                body={"outcome": "delivery_unknown"},
+            )
+        except Exception:
+            _logger.exception("terminal input attempt failed after dispatch")
+            outcome = _TerminalInputOutcome(
+                status_code=200,
+                body={"outcome": "delivery_unknown"},
+            )
+        async with self._lock:
+            entry = self._entries.get(key)
+            if entry is not None:
+                entry.completed_at = time.monotonic()
+        return outcome
+
+    def _purge_expired_locked(self) -> None:
+        cutoff = time.monotonic() - _TERMINAL_INPUT_ATTEMPT_TTL_SECONDS
+        expired = [
+            key
+            for key, entry in self._entries.items()
+            if entry.completed_at is not None and entry.completed_at <= cutoff
+        ]
+        for key in expired:
+            self._entries.pop(key, None)
+        if expired:
+            _logger.info("evicted %d expired terminal input attempts", len(expired))
 
 
 class _BodyRequest:
@@ -1794,6 +1929,8 @@ def create_runner_app(
     import hmac
 
     app = FastAPI(title="omnigent-runner")
+    terminal_input_attempts = _TerminalInputAttempts()
+    app.state.terminal_input_attempts = terminal_input_attempts
 
     from omnigent.runtime import telemetry
 
@@ -7948,6 +8085,7 @@ def create_runner_app(
                 scrollback=spec.get("scrollback", 10000),
                 tmux_allow_passthrough=bool(spec.get("tmux_allow_passthrough", False)),
                 tmux_start_on_attach=bool(spec.get("tmux_start_on_attach", False)),
+                ready_process=spec.get("ready_process"),
             )
         bridge_inject = bool(body.get("bridge_inject_dir"))
         bridge_id: str | None = None
@@ -8119,6 +8257,151 @@ def create_runner_app(
             content=session_resource_view_to_dict(resource),
         )
 
+    @app.post(
+        "/v1/sessions/{session_id}/resources/terminals/{terminal_id}/input",
+        dependencies=[Depends(require_json_content_type)],
+    )
+    async def send_session_terminal_input(
+        session_id: str,
+        terminal_id: str,
+        request: Request,
+    ) -> JSONResponse:
+        """Send literal text and key chords to a running terminal.
+
+        The public server authorizes the owning user before proxying here;
+        this runner-local endpoint resolves only runner-owned terminal state.
+
+        :param session_id: Session/conversation identifier.
+        :param terminal_id: Opaque terminal resource id.
+        :param request: JSON body containing ``text`` and optional ``keys``.
+        :returns: The terminal send result or a structured error response.
+        """
+        body = await request.json()
+        text = body.get("text") if isinstance(body, dict) else None
+        keys = body.get("keys", "Enter") if isinstance(body, dict) else None
+        wait_for_ready = body.get("wait_for_ready", False) if isinstance(body, dict) else None
+        attempt_id = body.get("attempt_id") if isinstance(body, dict) else None
+        if (
+            not isinstance(text, str)
+            or not isinstance(keys, str)
+            or not isinstance(wait_for_ready, bool)
+        ):
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": {
+                        "code": "invalid_input",
+                        "message": (
+                            "'text' is required, 'text' and 'keys' must be strings, "
+                            "and 'wait_for_ready' must be a boolean"
+                        ),
+                    }
+                },
+            )
+        if attempt_id is not None and (
+            not isinstance(attempt_id, str) or not attempt_id.strip() or len(attempt_id) > 128
+        ):
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": {
+                        "code": "invalid_input",
+                        "message": (
+                            "'attempt_id' must be a non-empty string of at most 128 characters"
+                        ),
+                    }
+                },
+            )
+
+        terminal_registry = resource_registry.terminal_registry
+
+        async def _execute_input() -> _TerminalInputOutcome:
+            if terminal_registry is None:
+                return _TerminalInputOutcome(
+                    status_code=404,
+                    body={
+                        "error": {
+                            "code": "terminal_not_running",
+                            "message": f"Terminal {terminal_id!r} is not running",
+                        }
+                    },
+                )
+            resolved = terminal_registry.resolve_snapshot(session_id, terminal_id)
+            if isinstance(resolved, AmbiguousResourceId):
+                return _TerminalInputOutcome(
+                    status_code=409,
+                    body={
+                        "error": {
+                            "code": resolved.code,
+                            "message": f"Terminal {terminal_id!r} resolves to multiple entries",
+                        }
+                    },
+                )
+            if resolved is None:
+                return _TerminalInputOutcome(
+                    status_code=404,
+                    body={
+                        "error": {
+                            "code": "terminal_not_running",
+                            "message": f"Terminal {terminal_id!r} is not running",
+                        }
+                    },
+                )
+
+            from omnigent.tools.builtins.sys_terminal import send_terminal_input
+
+            try:
+                result = await asyncio.to_thread(
+                    send_terminal_input,
+                    terminal_registry,
+                    resolved,
+                    text,
+                    keys=keys,
+                    wait_for_ready=wait_for_ready,
+                )
+            except (RuntimeError, OSError, asyncio.CancelledError):
+                _logger.warning(
+                    "terminal input delivery could not be confirmed for %s/%s",
+                    session_id,
+                    terminal_id,
+                    exc_info=True,
+                )
+                return _TerminalInputOutcome(
+                    status_code=200,
+                    body={"outcome": "delivery_unknown"},
+                )
+            if result.get("delivery_unknown"):
+                return _TerminalInputOutcome(
+                    status_code=200,
+                    body={"outcome": "delivery_unknown"},
+                )
+            if "error" in result:
+                code = str(result.get("code") or "terminal_not_running")
+                return _TerminalInputOutcome(
+                    status_code=409,
+                    body={
+                        "error": {
+                            "code": code,
+                            "message": str(result["error"]),
+                        }
+                    },
+                )
+            return _TerminalInputOutcome(
+                status_code=200,
+                body={**result, "outcome": "sent"},
+            )
+
+        if attempt_id is None:
+            outcome = await _execute_input()
+        else:
+            outcome = await terminal_input_attempts.execute(
+                session_id=session_id,
+                attempt_id=attempt_id,
+                fingerprint=(terminal_id, text, keys, wait_for_ready),
+                operation=_execute_input,
+            )
+        return JSONResponse(status_code=outcome.status_code, content=outcome.body)
+
     @app.post("/v1/sessions/{session_id}/resources/terminals/{terminal_id}/transfer")
     async def transfer_session_terminal(
         session_id: str,
@@ -8142,6 +8425,19 @@ def create_runner_app(
                 source_session_id=session_id,
                 target_session_id=target_session_id,
                 terminal_id=terminal_id,
+            )
+        except AmbiguousResourceIdError as exc:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "error": {
+                        "code": "ambiguous_resource_id",
+                        "message": _client_safe_error_detail(
+                            exc,
+                            context="terminal transfer",
+                        ),
+                    }
+                },
             )
         except RuntimeError as exc:
             return JSONResponse(
@@ -8173,10 +8469,21 @@ def create_runner_app(
         session_id: str,
         terminal_id: str,
     ) -> JSONResponse:
-        closed = await resource_registry.close_terminal(
-            session_id,
-            terminal_id,
-        )
+        try:
+            closed = await resource_registry.close_terminal(
+                session_id,
+                terminal_id,
+            )
+        except AmbiguousResourceIdError as exc:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "error": {
+                        "code": "ambiguous_resource_id",
+                        "message": _client_safe_error_detail(exc, context="terminal close"),
+                    }
+                },
+            )
         if not closed:
             return JSONResponse(
                 status_code=404,
@@ -8204,9 +8511,25 @@ def create_runner_app(
         registry = resource_registry.terminal_registry
         lock = _repl_terminal_ensure_locks.setdefault(session_id, asyncio.Lock())
         async with lock:
-            existing = registry.get(session_id, _REPL_TERMINAL_NAME, _REPL_TERMINAL_SESSION_KEY)
-            if existing is None or not existing.running or not await existing.is_alive():
-                await registry.close(session_id, _REPL_TERMINAL_NAME, _REPL_TERMINAL_SESSION_KEY)
+            existing = registry.resolve_key_snapshot(
+                session_id,
+                _REPL_TERMINAL_NAME,
+                _REPL_TERMINAL_SESSION_KEY,
+            )
+            if isinstance(existing, AmbiguousResourceId):
+                return None
+            alive = (
+                await _terminal_snapshot_is_alive(registry, existing)
+                if isinstance(existing, ResolveSnapshot)
+                else False
+            )
+            if not alive:
+                # Low-level registry close, not ``close_terminal``: the
+                # resource-level scan skips entries whose ``running`` flag is
+                # already False, orphaning the activity watcher and scratch
+                # dir. ``close_snapshot`` pops and tears the instance down.
+                if isinstance(existing, ResolveSnapshot):
+                    await registry.close_snapshot(existing)
                 try:
                     repl_agent_spec = await _resolve_session_agent_spec(session_id)
                 except OmnigentError:
@@ -8235,9 +8558,21 @@ def create_runner_app(
         registry = resource_registry.terminal_registry
         lock = _qwen_terminal_ensure_locks.setdefault(session_id, asyncio.Lock())
         async with lock:
-            existing = registry.get(session_id, "qwen", "main")
-            if existing is None or not existing.running or not await existing.is_alive():
-                await registry.close(session_id, "qwen", "main")
+            existing = registry.resolve_key_snapshot(session_id, "qwen", "main")
+            if isinstance(existing, AmbiguousResourceId):
+                return None
+            alive = (
+                await _terminal_snapshot_is_alive(registry, existing)
+                if isinstance(existing, ResolveSnapshot)
+                else False
+            )
+            if not alive:
+                # Low-level registry close, not ``close_terminal``: the
+                # resource-level scan skips entries whose ``running`` flag is
+                # already False, orphaning the activity watcher and scratch
+                # dir. ``close_snapshot`` pops and tears the instance down.
+                if isinstance(existing, ResolveSnapshot):
+                    await registry.close_snapshot(existing)
                 try:
                     await _auto_create_qwen_terminal(
                         session_id,
@@ -8263,24 +8598,41 @@ def create_runner_app(
         transport: str | None = Query(default=None),
     ) -> None:
         await websocket.accept()
-        entry = resolve_terminal_entry_by_resource_id(
-            session_id,
-            terminal_id,
-            terminal_registry,
-        )
+        attach_snapshot: ResolveSnapshot | None = None
+        ambiguous_owner = False
+        if terminal_registry is not None:
+            resolved = terminal_registry.resolve_snapshot(session_id, terminal_id)
+            if isinstance(resolved, ResolveSnapshot):
+                if await _terminal_snapshot_is_alive(terminal_registry, resolved):
+                    attach_snapshot = resolved
+            elif isinstance(resolved, AmbiguousResourceId):
+                ambiguous_owner = True
+        entry = attach_snapshot.entry if attach_snapshot is not None else None
         terminal_role = (
             resource_registry.terminal_resource_role(session_id, terminal_id)
             if resource_registry is not None
             else None
         )
-        if entry is None or not entry.instance.running or not await entry.instance.is_alive():
-            if terminal_role == OMNIGENT_REPL_TERMINAL_ROLE:
+        if entry is None:
+            if ambiguous_owner:
+                entry = None
+            elif terminal_role == OMNIGENT_REPL_TERMINAL_ROLE:
                 entry = await _recreate_repl_terminal(session_id, terminal_id)
             elif terminal_role == QWEN_NATIVE_TERMINAL_ROLE:
                 entry = await _recreate_qwen_terminal(session_id, terminal_id)
             else:
                 entry = None
             if entry is None:
+                await websocket.close(
+                    code=WS_CLOSE_TERMINAL_NOT_FOUND,
+                    reason="terminal resource not found or not running",
+                )
+                return
+            if terminal_registry is not None:
+                recreated = terminal_registry.resolve_snapshot(session_id, terminal_id)
+                if isinstance(recreated, ResolveSnapshot):
+                    attach_snapshot = recreated
+            if attach_snapshot is None:
                 await websocket.close(
                     code=WS_CLOSE_TERMINAL_NOT_FOUND,
                     reason="terminal resource not found or not running",
@@ -8309,12 +8661,24 @@ def create_runner_app(
             if resolved_transport == TERMINAL_TRANSPORT_CONTROL
             else bridge_tmux_pty_to_websocket
         )
+
+        async def _send_attached_input(data: bytes) -> bool:
+            assert attach_snapshot is not None
+            assert terminal_registry is not None
+            return await asyncio.to_thread(
+                terminal_registry.run_fenced,
+                attach_snapshot,
+                lambda: attach_snapshot.instance.send_raw_bytes(data),
+                invalid=False,
+            )
+
         await bridge(
             websocket,
             socket_path=str(entry.instance.socket_path),
             tmux_target=entry.instance.tmux_target,
             read_only=read_only,
             on_client_interaction=entry.instance.note_client_interaction,
+            on_client_input=_send_attached_input,
         )
 
     async def _require_os_env(session_id: str) -> Any | None:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1758,6 +1758,24 @@ class _TerminalInputOutcome:
     body: dict[str, Any]
 
 
+_DELIVERY_UNKNOWN = _TerminalInputOutcome(
+    status_code=200,
+    body={"outcome": "delivery_unknown"},
+)
+
+
+def _terminal_not_running(terminal_id: str) -> _TerminalInputOutcome:
+    return _TerminalInputOutcome(
+        status_code=404,
+        body={
+            "error": {
+                "code": "terminal_not_running",
+                "message": f"Terminal {terminal_id!r} is not running",
+            }
+        },
+    )
+
+
 @dataclasses.dataclass
 class _TerminalInputAttempt:
     """One in-flight or completed attempt bound to its request fingerprint."""
@@ -1851,10 +1869,7 @@ class _TerminalInputAttempts:
             raise
         except Exception:
             _logger.exception("terminal input attempt failed after dispatch")
-            outcome = _TerminalInputOutcome(
-                status_code=200,
-                body={"outcome": "delivery_unknown"},
-            )
+            outcome = _DELIVERY_UNKNOWN
         await self._mark_completed(key)
         return outcome
 
@@ -8287,7 +8302,8 @@ def create_runner_app(
 
         :param session_id: Session/conversation identifier.
         :param terminal_id: Opaque terminal resource id.
-        :param request: JSON body containing ``text`` and optional ``keys``.
+        :param request: JSON body containing ``text`` and optional ``keys`` /
+            ``wait_for_ready`` fields.
         :returns: The terminal send result or a structured error response.
         """
         body = await request.json()
@@ -8331,15 +8347,7 @@ def create_runner_app(
 
         async def _execute_input() -> _TerminalInputOutcome:
             if terminal_registry is None:
-                return _TerminalInputOutcome(
-                    status_code=404,
-                    body={
-                        "error": {
-                            "code": "terminal_not_running",
-                            "message": f"Terminal {terminal_id!r} is not running",
-                        }
-                    },
-                )
+                return _terminal_not_running(terminal_id)
             resolved = terminal_registry.resolve_snapshot(session_id, terminal_id)
             if isinstance(resolved, AmbiguousResourceId):
                 return _TerminalInputOutcome(
@@ -8352,15 +8360,7 @@ def create_runner_app(
                     },
                 )
             if resolved is None:
-                return _TerminalInputOutcome(
-                    status_code=404,
-                    body={
-                        "error": {
-                            "code": "terminal_not_running",
-                            "message": f"Terminal {terminal_id!r} is not running",
-                        }
-                    },
-                )
+                return _terminal_not_running(terminal_id)
 
             from omnigent.tools.builtins.sys_terminal import send_terminal_input
 
@@ -8380,15 +8380,9 @@ def create_runner_app(
                     terminal_id,
                     exc_info=True,
                 )
-                return _TerminalInputOutcome(
-                    status_code=200,
-                    body={"outcome": "delivery_unknown"},
-                )
+                return _DELIVERY_UNKNOWN
             if result.get("delivery_unknown"):
-                return _TerminalInputOutcome(
-                    status_code=200,
-                    body={"outcome": "delivery_unknown"},
-                )
+                return _DELIVERY_UNKNOWN
             if "error" in result:
                 code = str(result.get("code") or "terminal_not_running")
                 return _TerminalInputOutcome(

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -59,6 +59,10 @@ from omnigent.runner.session_init_protocol import (
     RunnerSessionInitEnvelope,
 )
 from omnigent.spec.types import AgentSpec
+from omnigent.terminals import (
+    AmbiguousResourceId,
+    ResolveSnapshot,
+)
 
 _logger = logging.getLogger("omnigent.runner.app")
 
@@ -269,15 +273,11 @@ def _terminal_lookup_miss_reason(
     terminal_registry = resource_registry.terminal_registry
     if terminal_registry is None:
         return "terminal_registry_missing"
-    entries = terminal_registry.list_for_conversation(session_id)
-    if not entries:
-        return "session_has_no_registered_terminals"
-    registered_ids = [
-        terminal_resource_id(entry.terminal_name, entry.session_key) for entry in entries
-    ]
-    for entry in entries:
-        if terminal_resource_id(entry.terminal_name, entry.session_key) != terminal_id:
-            continue
+    resolved = terminal_registry.resolve_snapshot(session_id, terminal_id)
+    if isinstance(resolved, AmbiguousResourceId):
+        return "ambiguous_resource_id"
+    if isinstance(resolved, ResolveSnapshot):
+        entry = resolved.entry
         if not entry.instance.running:
             return (
                 "terminal_registered_but_not_running "
@@ -289,6 +289,12 @@ def _terminal_lookup_miss_reason(
             f"name={entry.terminal_name!r} session_key={entry.session_key!r} "
             f"socket={entry.instance.socket_path}"
         )
+    entries = terminal_registry.list_for_conversation(session_id)
+    if not entries:
+        return "session_has_no_registered_terminals"
+    registered_ids = [
+        terminal_resource_id(entry.terminal_name, entry.session_key) for entry in entries
+    ]
     return f"terminal_id_not_registered registered_ids={registered_ids!r}"
 
 

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -35,6 +35,12 @@ from omnigent.entities.session_resources import (
     terminal_resource_id,
     terminal_resource_view,
 )
+from omnigent.terminals.registry import (
+    AmbiguousResourceId,
+    AmbiguousResourceIdError,
+    ResolveSnapshot,
+    TerminalListEntry,
+)
 
 if TYPE_CHECKING:
     from omnigent.inner.os_env import OSEnvironment
@@ -523,27 +529,23 @@ class SessionResourceRegistry:
         """
         if self._terminal_registry is None:
             return None
+        resolved = self._terminal_registry.resolve_snapshot(session_id, terminal_id)
+        if not isinstance(resolved, ResolveSnapshot):
+            return None
 
-        for entry in self._terminal_registry.list_for_conversation(
-            session_id,
-        ):
-            if terminal_resource_id(entry.terminal_name, entry.session_key) != terminal_id:
-                continue
-            if not entry.instance.running:
-                return None
+        cache_key = f"{session_id}:{terminal_id}"
+        cached = self._is_alive_cache.get(cache_key)
 
-            cache_key = f"{session_id}:{terminal_id}"
-            cached = self._is_alive_cache.get(cache_key)
-            if cached is not None:
-                return terminal_resource_view(session_id, entry) if cached else None
-
-            alive = await entry.instance.is_alive()
-            if alive:
-                self._is_alive_cache[cache_key] = True
-            else:
-                self._is_alive_cache.pop(cache_key, None)
-                return None
-            return terminal_resource_view(session_id, entry)
+        alive = await asyncio.to_thread(
+            self._terminal_registry.run_fenced,
+            resolved,
+            lambda: bool(cached) if cached is not None else resolved.instance.is_alive(),
+            invalid=False,
+        )
+        if alive:
+            self._is_alive_cache[cache_key] = True
+            return terminal_resource_view(session_id, resolved.entry)
+        self._is_alive_cache.pop(cache_key, None)
         return None
 
     def resolve_environment(
@@ -1217,22 +1219,17 @@ class SessionResourceRegistry:
         """
         if self._terminal_registry is None:
             return False
-
-        for entry in self._terminal_registry.list_for_conversation(
-            session_id,
-        ):
-            if terminal_resource_id(entry.terminal_name, entry.session_key) == terminal_id:
-                closed = await self._terminal_registry.close(
-                    session_id,
-                    entry.terminal_name,
-                    entry.session_key,
-                )
-                if closed:
-                    with self._lock:
-                        self._terminal_roles.pop((session_id, terminal_id), None)
-                        self._terminal_lifecycles.pop((session_id, terminal_id), None)
-                return closed
-        return False
+        resolved = self._terminal_registry.resolve_snapshot(session_id, terminal_id)
+        if isinstance(resolved, AmbiguousResourceId):
+            raise AmbiguousResourceIdError(f"Terminal resource {terminal_id!r} is ambiguous")
+        if resolved is None:
+            return False
+        closed = await self._terminal_registry.close_snapshot(resolved)
+        if closed:
+            with self._lock:
+                self._terminal_roles.pop((session_id, terminal_id), None)
+                self._terminal_lifecycles.pop((session_id, terminal_id), None)
+        return closed
 
     async def transfer_terminal(
         self,
@@ -1261,40 +1258,49 @@ class SessionResourceRegistry:
         if self._terminal_registry is None:
             return None
 
-        from omnigent.terminals.registry import TerminalListEntry
-
-        for entry in self._terminal_registry.list_for_conversation(
+        resolved = self._terminal_registry.resolve_snapshot(
             source_session_id,
+            terminal_id,
+        )
+        if isinstance(resolved, AmbiguousResourceId):
+            raise AmbiguousResourceIdError(f"Terminal resource {terminal_id!r} is ambiguous")
+        if resolved is None:
+            return None
+
+        def _transfer_after_revalidation() -> (
+            tuple[
+                SessionResourceView,
+                str | None,
+                TerminalLifecycle | None,
+            ]
+            | None
         ):
-            if not entry.instance.running:
-                continue
-            if terminal_resource_id(entry.terminal_name, entry.session_key) != terminal_id:
-                continue
-            moved = self._terminal_registry.transfer(
-                source_session_id,
+            moved = self._terminal_registry.transfer_snapshot(
+                resolved,
                 target_session_id,
-                entry.terminal_name,
-                entry.session_key,
             )
             if not moved:
                 return None
+            entry = resolved.entry
+            instance = resolved.instance
             with self._lock:
                 role = self._terminal_roles.pop((source_session_id, terminal_id), None)
                 if role is not None:
                     self._terminal_roles[(target_session_id, terminal_id)] = role
-                lifecycle = self._terminal_lifecycles.pop((source_session_id, terminal_id), None)
+                lifecycle = self._terminal_lifecycles.pop(
+                    (source_session_id, terminal_id),
+                    None,
+                )
                 if lifecycle is not None:
                     self._terminal_lifecycles[(target_session_id, terminal_id)] = lifecycle
-            # Move the PTY-status memo with the pane so a post-transfer exit is
-            # classified against the right session. Don't clobber a status the
-            # target already has from its own terminal.
-            with self._lock:
                 moved_status = self._last_session_status.pop(source_session_id, None)
                 if moved_status is not None and target_session_id not in self._last_session_status:
                     self._last_session_status[target_session_id] = moved_status
             try:
-                await entry.instance.set_conversation_link(
-                    self._terminal_registry.conversation_link_for_id(target_session_id)
+                asyncio.run(
+                    instance.set_conversation_link(
+                        self._terminal_registry.conversation_link_for_id(target_session_id)
+                    )
                 )
             except (RuntimeError, OSError) as exc:
                 _logger.warning(
@@ -1302,25 +1308,37 @@ class SessionResourceRegistry:
                     target_session_id,
                     exc,
                 )
-            if lifecycle is not None:
-                self._start_terminal_activity_watcher(
-                    target_session_id,
-                    entry.terminal_name,
-                    entry.session_key,
-                    entry.instance,
-                    role,
-                    lifecycle,
-                    replace=True,
-                )
-            return terminal_resource_view(
+            view = terminal_resource_view(
                 target_session_id,
                 TerminalListEntry(
                     terminal_name=entry.terminal_name,
                     session_key=entry.session_key,
-                    instance=entry.instance,
+                    instance=instance,
                 ),
             )
-        return None
+            return view, role, lifecycle
+
+        transferred = await asyncio.to_thread(
+            self._terminal_registry.run_fenced,
+            resolved,
+            _transfer_after_revalidation,
+            invalid=None,
+        )
+        if transferred is None:
+            return None
+        view, role, lifecycle = transferred
+        if lifecycle is not None:
+            entry = resolved.entry
+            self._start_terminal_activity_watcher(
+                target_session_id,
+                entry.terminal_name,
+                entry.session_key,
+                resolved.instance,
+                role,
+                lifecycle,
+                replace=True,
+            )
+        return view
 
     async def cleanup_session(self, session_id: str) -> None:
         """Close all resources owned by a session.

--- a/omnigent/runtime/session_stream.py
+++ b/omnigent/runtime/session_stream.py
@@ -8,7 +8,8 @@ behind past the bound is disconnected so it can recover through the
 snapshot + live-tail reconnect contract. Events emitted before any
 subscriber is connected are LOST — there is no buffer and no replay.
 Clients that need to recover state across a disconnect fetch
-``GET /v1/sessions/{id}`` for the persisted history and dedupe by item id.
+``GET /v1/sessions/{id}`` for persisted history and reconcile resource
+state with the process-local ``sequence`` watermark.
 
 This module owns no per-conversation lifecycle. There is no
 ``register`` / ``unregister`` step: the first ``subscribe`` call
@@ -57,6 +58,13 @@ _subscribers: dict[
     set[tuple[asyncio.Queue[dict[str, Any] | object], asyncio.AbstractEventLoop]],
 ] = {}
 _lock = threading.Lock()
+_sequence = 0
+
+
+def current_sequence() -> int:
+    """Return the latest process-local event sequence under the stream lock."""
+    with _lock:
+        return _sequence
 
 
 def _enqueue_or_overflow(
@@ -82,10 +90,11 @@ def publish(conversation_id: str, event: dict[str, Any]) -> None:
     """
     Broadcast an event to every active subscriber of the given
     conversation (called from sync workflow thread). The event
-    payload is delivered verbatim — no sequence number or other
-    ordering field is added on the wire. Events emitted while no
-    subscriber is connected are dropped silently; reconnecting
-    clients use the snapshot endpoint, not replay.
+    payload is stamped in place with one process-global ``sequence``
+    before the subscriber snapshot is taken. Events emitted while no
+    subscriber is connected are dropped from live delivery but still
+    consume a sequence; reconnecting clients use the persisted resource
+    event log and snapshot watermark rather than stream replay.
 
     No-op when ``_subscribers`` has no entry for this
     ``conversation_id`` (typical between turns when nothing is
@@ -131,10 +140,22 @@ def publish(conversation_id: str, event: dict[str, Any]) -> None:
     pending_elicitations.record_publish(conversation_id, event)
     if suppress_live:
         return
+    global _sequence
     with _lock:
+        _sequence += 1
+        event["sequence"] = _sequence
         subs = list(_subscribers.get(conversation_id, ()))
     for queue, loop in subs:
         loop.call_soon_threadsafe(_enqueue_or_overflow, queue, event)
+
+
+def publish_best_effort(conversation_id: str, event: dict[str, Any]) -> Exception | None:
+    """Publish without allowing an SSE notification failure to escape."""
+    try:
+        publish(conversation_id, event)
+    except Exception as exc:
+        return exc
+    return None
 
 
 def close(conversation_id: str) -> None:

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -64,6 +64,15 @@ _SLASH_COMMAND_TYPE: str = "slash_command"
 _STOP_SESSION_TYPE: str = "stop_session"
 
 
+# Web-composer bang (``!``) shell command — a control event, not an
+# item type: the server orchestrates the terminal create/input proxies,
+# persists a ``terminal_command`` receipt, and starts no agent turn.
+_SHELL_COMMAND_TYPE: str = "shell_command"
+_SHELL_ATTEMPT_ID_MAX_CHARS = 128
+_SHELL_SPAWN_DIGEST_CHARS = 32
+_SHELL_COMMAND_RUNNER_POST_TIMEOUT_SECONDS = 15.0
+
+
 _EXTERNAL_ASSISTANT_MESSAGE_TYPE: str = "external_assistant_message"
 
 
@@ -345,6 +354,7 @@ _ALLOWED_EVENT_TYPES: frozenset[str] = frozenset(ITEM_TYPE_TO_DATA_CLS.keys()) |
     _APPROVAL_TYPE,
     _MCP_ELICITATION_TYPE,
     _COMPACT_TYPE,
+    _SHELL_COMMAND_TYPE,
     _STOP_SESSION_TYPE,
     _EXTERNAL_ASSISTANT_MESSAGE_TYPE,
     _EXTERNAL_CONVERSATION_ITEM_TYPE,
@@ -768,6 +778,10 @@ __all__ = [
     "_SESSION_UPDATES_MAX_WATCHED",
     "_SESSION_UPDATES_RESCAN_INTERVAL_S",
     "_SHARED_DISCOVERY_KEY",
+    "_SHELL_ATTEMPT_ID_MAX_CHARS",
+    "_SHELL_COMMAND_RUNNER_POST_TIMEOUT_SECONDS",
+    "_SHELL_COMMAND_TYPE",
+    "_SHELL_SPAWN_DIGEST_CHARS",
     "_SLASH_COMMAND_TYPE",
     "_SNAPSHOT_RUNNER_TIMEOUT_S",
     "_STOP_RUNNER_RESULT_TIMEOUT_S",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -4302,7 +4302,7 @@ async def _proxy_get_to_runner(
             body = resp.json()
             error = body.get("error", {})
             msg = error.get("message") or "runner resource endpoint failed"
-        except (ValueError, AttributeError, TypeError):
+        except (ValueError, AttributeError, TypeError, httpx.HTTPError):
             msg = "runner resource endpoint failed"
         raise HTTPException(status_code=502, detail=msg)
     return resp.json()

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -9,14 +9,16 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import json
 import secrets
 import time
 import urllib.parse
+import uuid
 from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, Literal, NoReturn, cast
 
 import httpx
 from fastapi import (
@@ -53,6 +55,7 @@ from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_plugins import (
     NativeCodingAgent,
 )
+from omnigent.inner.datamodel import TerminalEnvSpec
 from omnigent.native_coding_agents import (
     native_coding_agent_for_harness,
     native_coding_agent_for_wrapper_label,
@@ -584,7 +587,7 @@ def _publish_and_persist_resource_event(
     resource_type: str,
     conversation_store: ConversationStore,
     resource: dict[str, Any] | None = None,
-) -> None:
+) -> bool:
     """Publish an SSE event and persist it as a conversation item.
 
     Emits the event on the live session stream so connected
@@ -599,6 +602,11 @@ def _publish_and_persist_resource_event(
     :param resource_type: Kind of resource, e.g. ``"terminal"``.
     :param conversation_store: Store for persisting the item.
     :param resource: Full resource dict for created events.
+    :returns: ``True`` when the item was persisted; ``False`` when the
+        append failed and was suppressed. Most callers treat
+        persistence as best-effort and ignore this; callers that need
+        the durable record (the ``shell_command`` spawn path) must
+        check it.
     """
     from omnigent.entities.conversation import ResourceEventData
 
@@ -610,7 +618,19 @@ def _publish_and_persist_resource_event(
         sse_payload["resource_type"] = resource_type
         sse_payload["session_id"] = session_id
 
-    session_stream.publish(session_id, sse_payload)
+    publish_error = session_stream.publish_best_effort(session_id, sse_payload)
+    if publish_error is not None:
+        _logger.warning(
+            "resource-event SSE publish failed for session=%s type=%s: %s",
+            session_id,
+            event_type,
+            publish_error,
+        )
+    sequence = sse_payload.get("sequence")
+    if not isinstance(sequence, int):
+        sequence = None
+    elif event_type == "session.resource.created" and resource is not None:
+        resource["sequence"] = sequence
 
     item = NewConversationItem(
         type="resource_event",
@@ -620,6 +640,7 @@ def _publish_and_persist_resource_event(
             resource_id=resource_id,
             resource_type=resource_type,
             resource=resource,
+            sequence=sequence,
         ),
     )
     try:
@@ -630,6 +651,8 @@ def _publish_and_persist_resource_event(
             session_id,
             exc_info=True,
         )
+        return False
+    return True
 
 
 def _structured_ask_user_question(
@@ -4242,6 +4265,125 @@ async def _get_runner_client_for_resource_access_impl(
     return cast("httpx.AsyncClient | None", get_runner_client())
 
 
+async def _proxy_get_to_runner(
+    session_id: str,
+    path: str,
+    params: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Proxy a GET request to the runner and return parsed JSON.
+
+    :param session_id: Session/conversation identifier.
+    :param path: Runner-relative URL path.
+    :param params: Optional query params forwarded to the runner,
+        e.g. ``{"order": "asc"}``. ``None`` sends no query string.
+    :returns: Parsed JSON response body.
+    :raises HTTPException: 502 on runner failure.
+    """
+    runner_client = await _get_runner_client_for_resource_access(session_id)
+    if runner_client is None:
+        raise HTTPException(
+            status_code=502,
+            detail="no runner available for resource access",
+        )
+    try:
+        resp = await runner_client.get(path, params=params, timeout=10.0)
+    except (httpx.HTTPError, ConnectionError) as exc:
+        raise HTTPException(
+            status_code=502,
+            detail="runner resource endpoint unavailable",
+        ) from exc
+    if resp.status_code == 404:
+        raise OmnigentError(
+            resp.json().get("error", {}).get("message", "Resource not found"),
+            code=ErrorCode.NOT_FOUND,
+        )
+    if resp.status_code != 200:
+        try:
+            body = resp.json()
+            error = body.get("error", {})
+            msg = error.get("message") or "runner resource endpoint failed"
+        except (ValueError, AttributeError, TypeError):
+            msg = "runner resource endpoint failed"
+        raise HTTPException(status_code=502, detail=msg)
+    return resp.json()
+
+
+async def _proxy_post_to_runner(
+    session_id: str,
+    path: str,
+    body: dict[str, Any],
+) -> tuple[int, dict[str, Any]]:
+    """Proxy a POST request to the runner and return status + JSON.
+
+    :param session_id: Session/conversation identifier.
+    :param path: Runner-relative URL path.
+    :param body: JSON body to forward.
+    :returns: Tuple of (status_code, parsed_json_body).
+    :raises HTTPException: 502 on transport failure.
+    """
+    runner_client = await _get_runner_client_for_resource_access(session_id)
+    if runner_client is None:
+        raise HTTPException(
+            status_code=502,
+            detail="no runner available for resource access",
+        )
+    try:
+        resp = await runner_client.post(
+            path,
+            json=body,
+            timeout=10.0,
+        )
+    except (httpx.HTTPError, ConnectionError) as exc:
+        raise HTTPException(
+            status_code=502,
+            detail="runner resource endpoint unavailable",
+        ) from exc
+    return resp.status_code, resp.json()
+
+
+async def _create_terminal_idempotently(
+    session_id: str,
+    path: str,
+    body: dict[str, Any],
+) -> tuple[int, dict[str, Any]]:
+    """Retry one ambiguous terminal-create response with the same stable key."""
+    try:
+        return await _proxy_post_to_runner(session_id, path, body)
+    except HTTPException as exc:
+        if exc.status_code != 502:
+            raise
+        return await _proxy_post_to_runner(session_id, path, body)
+
+
+def _raise_invalid_shell_attempt_id(cause: ValueError | None = None) -> NoReturn:
+    error = OmnigentError(
+        "shell_command requires data.attempt_id as a canonical UUIDv4 string",
+        code=ErrorCode.INVALID_INPUT,
+    )
+    if cause is not None:
+        raise error from cause
+    raise error
+
+
+def _require_shell_attempt_id(value: object) -> str:
+    """Validate and return one canonical UUIDv4 shell-command attempt id."""
+    parsed: uuid.UUID | None = None
+    if isinstance(value, str) and value and len(value) <= _SHELL_ATTEMPT_ID_MAX_CHARS:
+        try:
+            parsed = uuid.UUID(value)
+        except ValueError as exc:
+            _raise_invalid_shell_attempt_id(exc)
+    if parsed is None or parsed.version != 4 or str(parsed) != value:
+        _raise_invalid_shell_attempt_id()
+    return value
+
+
+def _shell_spawn_session_key(attempt_id: str) -> str:
+    """Derive the stable 128-bit user-shell key for one attempt."""
+    digest = hashlib.sha256(attempt_id.encode()).hexdigest()
+    return f"u-{digest[:_SHELL_SPAWN_DIGEST_CHARS]}"
+
+
 async def _proxy_get_session_resources_to_runner(
     runner_client: httpx.AsyncClient,
     session_id: str,
@@ -6219,6 +6361,61 @@ def _load_agent_spec_for_session_impl(
     )
 
 
+async def _require_declared_terminal(
+    conv: Conversation,
+    terminal_name: object,
+    agent_store: AgentStore,
+) -> TerminalEnvSpec:
+    """Enforce the user-facing declared-terminal launch gate.
+
+    A user-initiated terminal launch must name a terminal from the
+    agent spec's ``terminals:`` block — the single security gate
+    shared by the terminal create route and the ``shell_command``
+    spawn path, so the two cannot drift. Callers with an exemption
+    (the create route's native-bootstrap shape) decide that BEFORE
+    calling this.
+
+    :param conv: Conversation whose agent spec declares the terminals.
+    :param terminal_name: Requested terminal name, e.g. ``"zsh"``.
+    :param agent_store: Store used to resolve the agent spec.
+    :returns: The matching declared terminal spec.
+    :raises OmnigentError: 400 when the name is not declared (or the
+        agent has no ``terminals:`` block at all).
+    """
+    spec = await asyncio.to_thread(_load_agent_spec_for_session, conv, agent_store)
+    terminal_specs = (spec.terminals or {}) if spec is not None else {}
+    declared = list(terminal_specs)
+    if not isinstance(terminal_name, str) or terminal_name not in terminal_specs:
+        raise OmnigentError(
+            (
+                f"Terminal {terminal_name!r} is not declared by this "
+                f"agent. Terminals can only be created for agents whose spec "
+                f"declares them; this agent declares: {declared or 'none'}."
+            ),
+            code=ErrorCode.INVALID_INPUT,
+        )
+    return terminal_specs[terminal_name]
+
+
+def _error_text_from_exc(exc: OmnigentError | HTTPException, fallback: str) -> str:
+    """Extract a human-readable cause from a failed runner proxy call.
+
+    The resource proxies fail two ways: the runner router raises
+    :class:`OmnigentError` before any HTTP client exists (session not
+    bound, runner offline), or the transport raises and is wrapped as
+    an :class:`HTTPException` 502. Receipts must record the cause in
+    either case.
+
+    :param exc: The exception a proxy helper raised.
+    :param fallback: Message used when the exception carries no
+        usable detail text.
+    :returns: The failure text to store on the error receipt.
+    """
+    if isinstance(exc, OmnigentError):
+        return exc.message
+    return exc.detail if isinstance(exc.detail, str) and exc.detail else fallback
+
+
 def _build_policy_engine_from_spec(*args: Any, **kwargs: Any) -> PolicyEngine:
     """Call-time proxy so a facade patch of this symbol is honored here."""
     from omnigent.server.routes import sessions as _facade
@@ -6835,7 +7032,10 @@ async def _stream_live_events(
                         f"session stream event missing string ``type`` field: {event!r}",
                     )
                 validated = _SERVER_STREAM_EVENT_ADAPTER.validate_python(event)
-                yield _format_sse(event_type, validated.model_dump())
+                wire_event = validated.model_dump()
+                if wire_event.get("sequence") is None:
+                    wire_event.pop("sequence", None)
+                yield _format_sse(event_type, wire_event)
     except session_stream.SubscriberOverflowError:
         _logger.warning(
             "session stream subscriber overflowed for %s; closing for snapshot reconnect",
@@ -8402,6 +8602,7 @@ __all__ = [
     "_consume_pre_resolved_harness_elicitation",
     "_create_and_publish_codex_child",
     "_create_session_worktree",
+    "_create_terminal_idempotently",
     "_delete_stored_session_bundle_after_failure",
     "_derive_terminal_launch_args_from_spec",
     "_descendant_sessions",
@@ -8409,6 +8610,7 @@ __all__ = [
     "_dispatch_skill_slash_command_to_runner",
     "_emit_server_routing_decision",
     "_error_item_from_sse",
+    "_error_text_from_exc",
     "_evaluate_output_policy",
     "_extract_assistant_text_from_event",
     "_extract_claude_native_runner_failure",
@@ -8478,6 +8680,8 @@ __all__ = [
     "_priced_cost_for_display",
     "_provision_managed_sandbox",
     "_proxy_get_session_resources_to_runner",
+    "_proxy_get_to_runner",
+    "_proxy_post_to_runner",
     "_prune_pre_resolved_harness_elicitations",
     "_prune_session_read_state",
     "_publish_and_persist_resource_event",
@@ -8509,6 +8713,7 @@ __all__ = [
     "_publish_status",
     "_publish_terminal_pending",
     "_query_host_runner_status",
+    "_raise_invalid_shell_attempt_id",
     "_read_state_entry",
     "_read_upload_capped",
     "_record_daily_cost",
@@ -8521,8 +8726,10 @@ __all__ = [
     "_replace_text_in_message_body",
     "_require_collaboration_mode_forward",
     "_require_cost_control_label_authority",
+    "_require_declared_terminal",
     "_require_external_status_forward",
     "_require_host_conn_for_worktree",
+    "_require_shell_attempt_id",
     "_reset_runner_resources_after_switch",
     "_reset_runner_resources_after_switch_impl",
     "_resolve_harness",
@@ -8539,6 +8746,7 @@ __all__ = [
     "_session_status_from_cache",
     "_session_status_with_child_rollup",
     "_set_read_state",
+    "_shell_spawn_session_key",
     "_signal_harness_elicitation_resolved_by_id",
     "_signal_terminal_resolved_harness_elicitation",
     "_spec_config_flag_explicitly_disabled",

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -4285,14 +4285,18 @@ async def _relay_runner_stream(
                     # (session.resource.created / .deleted) emitted by
                     # agent-tool terminal launches/closes so reconnecting
                     # clients rediscover the resource in the snapshot.
-                    # The live publish below already updates connected
-                    # clients.
+                    # The shared helper stamps and publishes before append.
                     resource_item = _resource_event_item_from_sse(session_id, event)
                     if resource_item is not None:
-                        await _relay_persist(
-                            conversation_store,
+                        resource_data = resource_item.data
+                        await asyncio.to_thread(
+                            _publish_and_persist_resource_event,
                             session_id,
-                            resource_item,
+                            resource_data.event_type,
+                            resource_data.resource_id,
+                            resource_data.resource_type,
+                            conversation_store,
+                            resource_data.resource,
                         )
                         # Self-heal the spin-up flag: a created terminal is
                         # authoritative proof the session is no longer
@@ -4301,11 +4305,12 @@ async def _relay_runner_stream(
                         # between launch and clear). Only fire on a real
                         # state change to avoid redundant stream traffic.
                         if (
-                            resource_item.data.event_type == "session.resource.created"
-                            and resource_item.data.resource_type == "terminal"
+                            resource_data.event_type == "session.resource.created"
+                            and resource_data.resource_type == "terminal"
                             and _session_terminal_pending_cache.get(session_id, False)
                         ):
                             _publish_terminal_pending(session_id, False)
+                        continue
 
                     # Intelligent-model-router decision emitted by the runner's
                     # cost advisor at turn start. Persist as a display-only

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -198,6 +198,10 @@ class _ShellCommandAttemptLedger:
         self._conversation_store = conversation_store
         self._lock = asyncio.Lock()
         self._in_flight: dict[tuple[str, str], _InFlightShellCommand] = {}
+        # Retain the fire-and-forget cleanup tasks: the event loop keeps
+        # only a weak reference, so an un-held task can be GC'd before it
+        # releases the abandoned slot, wedging duplicate waiters forever.
+        self._cleanup_tasks: set[asyncio.Task[None]] = set()
 
     def _find_receipt(self, session_id: str, attempt_id: str) -> ConversationItem | None:
         after: str | None = None
@@ -262,12 +266,26 @@ class _ShellCommandAttemptLedger:
                     self._in_flight.pop(key, None)
                     raise RuntimeError("shell-command claim requires an asyncio task")
                 owner.add_done_callback(
-                    lambda completed: asyncio.create_task(
-                        self._finish_abandoned(key, entry, completed)
-                    )
+                    lambda completed: self._schedule_finish_abandoned(key, entry, completed)
                 )
                 return None
         return await asyncio.shield(result)
+
+    def _schedule_finish_abandoned(
+        self,
+        key: tuple[str, str],
+        entry: _InFlightShellCommand,
+        owner: asyncio.Task[Any],
+    ) -> None:
+        """Spawn and retain the abandoned-owner cleanup task.
+
+        Holding a strong reference until the task finishes keeps the
+        loop from garbage-collecting it mid-run, which would otherwise
+        leave the in-flight slot un-released.
+        """
+        task = asyncio.create_task(self._finish_abandoned(key, entry, owner))
+        self._cleanup_tasks.add(task)
+        task.add_done_callback(self._cleanup_tasks.discard)
 
     async def complete(
         self,
@@ -297,7 +315,17 @@ class _ShellCommandAttemptLedger:
             if entry.result.done():
                 return
             if owner.cancelled():
-                entry.result.cancel()
+                # The owner was cancelled before persisting a receipt.
+                # Cancelling the shared future would surface as a
+                # CancelledError (HTTP 500) on innocent duplicate
+                # waiters — resolve them with a retryable error so a
+                # resend of the same attempt re-claims and executes.
+                entry.result.set_exception(
+                    OmnigentError(
+                        "shell-command attempt was abandoned before completing; retry",
+                        code=ErrorCode.ATTEMPT_ABANDONED,
+                    )
+                )
                 return
             exc = owner.exception()
             entry.result.set_exception(

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -3,24 +3,34 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import secrets
-from collections.abc import Callable
-from typing import Any
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Literal
 
 import httpx
 from fastapi import (
     APIRouter,
+    HTTPException,
     Request,
 )
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
+from sqlalchemy.exc import SQLAlchemyError
 
 from omnigent.entities import (
+    Conversation,
+    ConversationItem,
     ErrorData,
     NewConversationItem,
+    TerminalCommandData,
 )
 from omnigent.entities.conversation import (
     parse_item_data,
 )
+from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE as _HARNESS_NOT_CONFIGURED_ERROR_CODE,
@@ -80,6 +90,7 @@ from omnigent.server.schemas import (
     ElicitationRequestParams,
     ErrorDetail,
     McpServerStartup,
+    OutputItemDoneEvent,
     SessionEventInput,
 )
 from omnigent.session_lifecycle import (
@@ -94,6 +105,206 @@ from omnigent.telemetry.events import SessionDeletedEvent as _TelSessionDeletedE
 from omnigent.telemetry.events import SessionStoppedEvent as _TelSessionStoppedEvent
 from omnigent.telemetry.installation_id import get_installation_id as _get_installation_id
 from omnigent.tools.client_specified import parse_client_side_tool_specs
+
+
+def _shell_attempt_fingerprint(
+    *,
+    session_id: str,
+    action: Literal["spawn", "send"],
+    command: str,
+    terminal_name: str | None,
+    terminal_id: str | None,
+    session_key: str | None,
+) -> str:
+    """Bind one attempt id to its complete semantic shell request."""
+    canonical = json.dumps(
+        {
+            "action": action,
+            "command": command,
+            "session_id": session_id,
+            "session_key": session_key,
+            "terminal_id": terminal_id,
+            "terminal_name": terminal_name,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+@dataclass(frozen=True)
+class _ShellCommandReplay:
+    """Stored HTTP result replayed for one completed shell attempt."""
+
+    status_code: int
+    body: dict[str, Any]
+
+
+class _ShellCommandRunnerError(OmnigentError):
+    """Preserve an explicit runner status alongside its stable error code."""
+
+    def __init__(self, message: str, *, code: str, http_status: int) -> None:
+        super().__init__(message, code=code)
+        self._http_status = http_status
+
+    @property
+    def http_status(self) -> int:
+        """Return the runner's definite non-delivery status unchanged."""
+        return self._http_status
+
+
+@dataclass
+class _InFlightShellCommand:
+    """One process-local single-flight slot backed by a durable receipt."""
+
+    fingerprint: str
+    result: asyncio.Future[_ShellCommandReplay]
+
+
+def _replay_from_shell_receipt(item: ConversationItem) -> _ShellCommandReplay:
+    """Rebuild the original mutation response from a durable receipt."""
+    if not isinstance(item.data, TerminalCommandData):
+        raise TypeError("shell-command ledger resolved a non-terminal receipt")
+    data = item.data
+    if data.status == "error":
+        if data.error_code is None:
+            return _ShellCommandReplay(
+                status_code=data.http_status or 500,
+                body={"detail": data.error or "Shell command failed"},
+            )
+        return _ShellCommandReplay(
+            status_code=data.http_status or 500,
+            body={
+                "error": {
+                    "code": data.error_code or ErrorCode.INTERNAL_ERROR,
+                    "message": data.error or "Shell command failed",
+                }
+            },
+        )
+    body: dict[str, Any] = {
+        "item_id": item.id,
+        "item": item.to_api_dict(),
+        "terminal": data.terminal,
+    }
+    if data.sequence is not None:
+        body["sequence"] = data.sequence
+    return _ShellCommandReplay(status_code=200, body=body)
+
+
+class _ShellCommandAttemptLedger:
+    """Single-flight execution with durable receipt-based replay."""
+
+    def __init__(self, conversation_store: ConversationStore) -> None:
+        self._conversation_store = conversation_store
+        self._lock = asyncio.Lock()
+        self._in_flight: dict[tuple[str, str], _InFlightShellCommand] = {}
+
+    def _find_receipt(self, session_id: str, attempt_id: str) -> ConversationItem | None:
+        after: str | None = None
+        while True:
+            page = self._conversation_store.list_items(
+                session_id,
+                limit=1000,
+                after=after,
+                order="desc",
+                type="terminal_command",
+            )
+            for item in page.data:
+                if (
+                    isinstance(item.data, TerminalCommandData)
+                    and item.data.attempt_id == attempt_id
+                ):
+                    return item
+            if not page.has_more or page.last_id is None:
+                return None
+            after = page.last_id
+
+    async def wait_or_claim(
+        self,
+        *,
+        session_id: str,
+        attempt_id: str,
+        fingerprint: str,
+    ) -> _ShellCommandReplay | None:
+        """Return a replay for a duplicate, or claim the caller as owner."""
+        key = (session_id, attempt_id)
+        async with self._lock:
+            existing = self._in_flight.get(key)
+            if existing is not None:
+                if existing.fingerprint != fingerprint:
+                    raise OmnigentError(
+                        "attempt_id is already bound to a different shell command",
+                        code=ErrorCode.ATTEMPT_CONFLICT,
+                    )
+                result = existing.result
+            else:
+                receipt = await asyncio.to_thread(self._find_receipt, session_id, attempt_id)
+                if receipt is not None:
+                    data = receipt.data
+                    if (
+                        not isinstance(data, TerminalCommandData)
+                        or data.attempt_fingerprint != fingerprint
+                    ):
+                        raise OmnigentError(
+                            "attempt_id is already bound to a different shell command",
+                            code=ErrorCode.ATTEMPT_CONFLICT,
+                        )
+                    return _replay_from_shell_receipt(receipt)
+
+                result = asyncio.get_running_loop().create_future()
+                result.add_done_callback(
+                    lambda completed: None if completed.cancelled() else completed.exception()
+                )
+                entry = _InFlightShellCommand(fingerprint=fingerprint, result=result)
+                self._in_flight[key] = entry
+                owner = asyncio.current_task()
+                if owner is None:
+                    self._in_flight.pop(key, None)
+                    raise RuntimeError("shell-command claim requires an asyncio task")
+                owner.add_done_callback(
+                    lambda completed: asyncio.create_task(
+                        self._finish_abandoned(key, entry, completed)
+                    )
+                )
+                return None
+        return await asyncio.shield(result)
+
+    async def complete(
+        self,
+        *,
+        session_id: str,
+        attempt_id: str,
+        receipt: ConversationItem,
+    ) -> None:
+        """Resolve current waiters from the just-persisted durable receipt."""
+        key = (session_id, attempt_id)
+        async with self._lock:
+            entry = self._in_flight.pop(key, None)
+            if entry is not None and not entry.result.done():
+                entry.result.set_result(_replay_from_shell_receipt(receipt))
+
+    async def _finish_abandoned(
+        self,
+        key: tuple[str, str],
+        entry: _InFlightShellCommand,
+        owner: asyncio.Task[Any],
+    ) -> None:
+        """Release waiters if an owner exits before persisting a receipt."""
+        async with self._lock:
+            if self._in_flight.get(key) is not entry:
+                return
+            self._in_flight.pop(key, None)
+            if entry.result.done():
+                return
+            if owner.cancelled():
+                entry.result.cancel()
+                return
+            exc = owner.exception()
+            entry.result.set_exception(
+                exc
+                if exc is not None
+                else RuntimeError("shell-command owner exited without a durable receipt")
+            )
 
 
 def register_events_routes(
@@ -114,6 +325,509 @@ def register_events_routes(
 ) -> None:
     """Register the events, stream, and delete routes on router."""
 
+    shell_command_attempts = _ShellCommandAttemptLedger(conversation_store)
+
+    def _build_shell_command_receipt_item(
+        command: str,
+        *,
+        action: Literal["spawn", "send"],
+        terminal_id: str | None,
+        terminal_name: str | None,
+        session_key: str | None,
+        status: Literal["ok", "error", "unknown"],
+        error: str | None,
+        attempt_id: str,
+        attempt_fingerprint: str,
+        sequence: int | None,
+        terminal: dict[str, Any] | None,
+        http_status: int,
+        error_code: str | None,
+        created_by: str | None,
+    ) -> NewConversationItem:
+        """Construct one ``terminal_command`` receipt item.
+
+        Pure construction, no I/O — the only step that can raise on
+        malformed field values (e.g. a non-string ``terminal_id``
+        committed to orchestration state). Callers isolate this so a
+        construction failure can fall back to a minimal receipt WITHOUT
+        risking a double persist.
+
+        Uses a synthetic ``turn_`` response id since no agent turn
+        exists for a bang command.
+
+        :param command: Verbatim command text sent to the shell.
+        :param action: ``"spawn"`` or ``"send"``.
+        :param terminal_id: Target terminal resource id, when known.
+        :param terminal_name: Shell type for display, when known.
+        :param session_key: Display session key, when known.
+        :param status: Delivery outcome: ``"ok"``, ``"unknown"``, or
+            ``"error"``.
+        :param error: Failure text when ``status="error"``.
+        :param created_by: Authenticated actor id, or ``None`` in
+            single-user mode.
+        :returns: The unpersisted receipt item.
+        """
+        return NewConversationItem(
+            type="terminal_command",
+            response_id=f"turn_{uuid.uuid4().hex}",
+            data=TerminalCommandData(
+                kind="input",
+                input=command,
+                action=action,
+                terminal_id=terminal_id,
+                terminal_name=terminal_name,
+                session_key=session_key,
+                status=status,
+                error=error,
+                attempt_id=attempt_id,
+                sequence=sequence,
+                attempt_fingerprint=attempt_fingerprint,
+                terminal=terminal,
+                http_status=http_status,
+                error_code=error_code,
+            ),
+            created_by=created_by,
+        )
+
+    async def _dispatch_shell_command_event(
+        session_id: str,
+        conv: Conversation,
+        body: SessionEventInput,
+        *,
+        created_by: str | None,
+    ) -> JSONResponse:
+        """Execute one idempotent bang command without starting an agent turn.
+
+        ``attempt_id`` binds the request fingerprint and produces exactly
+        one durable receipt. Input success is determined only from the T1
+        ``outcome`` discriminator; ambiguous delivery becomes ``unknown``.
+        Receipt publication is best-effort after append and can never change
+        the command outcome or cause a second receipt.
+
+        :param session_id: Session/conversation identifier.
+        :param conv: Conversation row for ``session_id``.
+        :param body: Validated ``shell_command`` event body.
+        :param created_by: Authenticated actor id for attribution.
+        :returns: 200 ``{"item_id": ..., "item": <receipt>,
+            "terminal": <resource|None>, "sequence": <int?>}``.
+        :raises OmnigentError: On gate/validation failures,
+            runner-reported terminal errors, and unrouteable runners.
+        :raises HTTPException: 502 when the runner transport fails or
+            a stage hits a decode, shape, or persistence failure.
+        """
+        action = body.data.get("action")
+        if action not in ("spawn", "send"):
+            raise OmnigentError(
+                "shell_command requires data.action of 'spawn' or 'send'",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        command = body.data.get("command")
+        if not isinstance(command, str) or not command.strip():
+            raise OmnigentError(
+                "shell_command requires a non-empty string data.command",
+                code=ErrorCode.INVALID_INPUT,
+            )
+
+        attempt_id = _require_shell_attempt_id(body.data.get("attempt_id"))
+        terminal_name: str | None = None
+        session_key: str | None = None
+        terminal_id: str | None = None
+        if action == "spawn":
+            requested_name = body.data.get("terminal")
+            if not isinstance(requested_name, str) or not requested_name:
+                raise OmnigentError(
+                    "shell_command spawn requires a non-empty string data.terminal",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            terminal_name = requested_name
+            session_key = _shell_spawn_session_key(attempt_id)
+            terminal_id = terminal_resource_id(terminal_name, session_key)
+        else:
+            requested_id = body.data.get("terminal_id")
+            if not isinstance(requested_id, str) or not requested_id:
+                raise OmnigentError(
+                    "shell_command send requires a non-empty string data.terminal_id",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            terminal_id = requested_id
+
+        attempt_fingerprint = _shell_attempt_fingerprint(
+            session_id=session_id,
+            action=action,
+            command=command,
+            terminal_name=terminal_name,
+            terminal_id=terminal_id,
+            session_key=session_key,
+        )
+        replay = await shell_command_attempts.wait_or_claim(
+            session_id=session_id,
+            attempt_id=attempt_id,
+            fingerprint=attempt_fingerprint,
+        )
+        if replay is not None:
+            return JSONResponse(status_code=replay.status_code, content=replay.body)
+
+        terminals_path = f"/v1/sessions/{session_id}/resources/terminals"
+        terminal_resource: dict[str, Any] | None = None
+        terminal_created = False
+        # The attempt's one receipt. _receipt_once's guard makes any
+        # persist-then-reraise path physically unable to append twice.
+        receipt_box: list[ConversationItem] = []
+
+        async def _receipt_once(
+            status: Literal["ok", "error", "unknown"],
+            error: str | None = None,
+            *,
+            http_status: int = 200,
+            error_code: str | None = None,
+        ) -> ConversationItem:
+            """Persist this attempt's single receipt (idempotent).
+
+            Reads the orchestration state (terminal id/name/key) at
+            call time, so the receipt reflects how far the attempt got.
+
+            The exactly-once guarantee is structural: the receipt is
+            appended to ``receipt_box`` right after it persists and
+            BEFORE it publishes, so a later publish failure (or any
+            re-entry) short-circuits on the guard instead of persisting
+            a second time. The minimal-receipt fallback covers ONLY
+            item construction — never the persist/publish — so it can
+            never fire after a durable append.
+
+            :param status: Delivery outcome for the receipt.
+            :param error: Failure text when ``status="error"``.
+            :returns: The persisted receipt item.
+            """
+            if receipt_box:
+                return receipt_box[0]
+
+            raw_sequence = (
+                terminal_resource.get("sequence")
+                if action == "spawn" and terminal_resource is not None
+                else None
+            )
+            resource_sequence = raw_sequence if isinstance(raw_sequence, int) else None
+            common_receipt_args: dict[str, Any] = {
+                "action": action,
+                "status": status,
+                "attempt_id": attempt_id,
+                "attempt_fingerprint": attempt_fingerprint,
+                "sequence": resource_sequence,
+                "terminal": terminal_resource,
+                "http_status": http_status,
+                "error_code": error_code,
+                "created_by": created_by,
+            }
+
+            # Fallback scope is item CONSTRUCTION only. If building the
+            # full receipt raises (e.g. a stage committed an invalid
+            # field to orchestration state), fall back to a minimal
+            # receipt rather than lose the record entirely.
+            try:
+                item = _build_shell_command_receipt_item(
+                    command,
+                    terminal_id=terminal_id,
+                    terminal_name=terminal_name,
+                    session_key=session_key,
+                    error=error,
+                    **common_receipt_args,
+                )
+            except (ValueError, TypeError):
+                _logger.warning(
+                    "shell_command receipt construction failed for session=%s; "
+                    "persisting minimal receipt",
+                    session_id,
+                    exc_info=True,
+                )
+                fallback_error = error
+                if status == "error" and fallback_error is None:
+                    fallback_error = "shell command receipt details unavailable"
+                item = _build_shell_command_receipt_item(
+                    command,
+                    terminal_id=None,
+                    terminal_name=None,
+                    session_key=None,
+                    error=fallback_error,
+                    **common_receipt_args,
+                )
+
+            # Persist, then record in the box BEFORE publishing: a
+            # publish failure must not trigger a second append.
+            persisted = (await asyncio.to_thread(conversation_store.append, session_id, [item]))[0]
+            receipt_box.append(persisted)
+            await shell_command_attempts.complete(
+                session_id=session_id,
+                attempt_id=attempt_id,
+                receipt=persisted,
+            )
+            event = OutputItemDoneEvent(
+                type="response.output_item.done", item=persisted.to_api_dict()
+            )
+            publish_error = session_stream.publish_best_effort(
+                session_id,
+                event.model_dump(),
+            )
+            if publish_error is not None:
+                _logger.warning(
+                    "shell-command receipt SSE publish failed for session=%s attempt=%s: %s",
+                    session_id,
+                    attempt_id,
+                    publish_error,
+                )
+            return receipt_box[0]
+
+        def _partial(cause: str) -> str:
+            """Note the created-but-undelivered outcome on late spawn failures.
+
+            :param cause: The underlying failure text.
+            :returns: The receipt error text, prefixed when the shell
+                already exists (``session.resource.created`` went out).
+            """
+            if action == "spawn" and terminal_created:
+                return f"Terminal was created but the command was not delivered: {cause}"
+            return cause
+
+        async def _run_stage(stage: Callable[[], Awaitable[Any]], describe: str) -> Any:
+            """Run one orchestration stage, receipting EVERY failure class.
+
+            :param stage: The stage body to execute.
+            :param describe: Human phrase for receipt error text, e.g.
+                ``"launching the terminal"``.
+            :returns: The stage's return value.
+            :raises OmnigentError: Re-raised stage errors (status maps
+                through, e.g. gate 400 / dead shell 404/409).
+            :raises HTTPException: Re-raised transport 502s, and
+                decode/shape/persist failures normalized to 502.
+            """
+            try:
+                return await stage()
+            except (OmnigentError, HTTPException) as exc:
+                response_status = (
+                    exc.http_status if isinstance(exc, OmnigentError) else exc.status_code
+                )
+                response_code = exc.code if isinstance(exc, OmnigentError) else None
+                await _receipt_once(
+                    "error",
+                    _partial(_error_text_from_exc(exc, f"Runner unreachable while {describe}")),
+                    http_status=response_status,
+                    error_code=response_code,
+                )
+                raise
+            except (
+                ValueError,
+                TypeError,
+                AttributeError,
+                LookupError,
+                RuntimeError,
+                SQLAlchemyError,
+            ) as exc:
+                # Non-JSON body, non-object JSON, or a persistence
+                # failure (including DB-level store errors) —
+                # normalized into a receipted 502 so no attempt can
+                # exit without its receipt.
+                cause = _partial(f"Unexpected failure while {describe}: {exc}")
+                await _receipt_once("error", cause, http_status=502)
+                raise HTTPException(status_code=502, detail=cause) from exc
+
+        def _error_from_runner_body(payload: Any, fallback: str) -> tuple[str, str]:
+            """Extract (message, code) from a runner error body of any shape.
+
+            :param payload: Decoded runner response body — possibly not
+                an object at all.
+            :param fallback: Message used when the body carries none.
+            :returns: ``(message, error_code)`` for an OmnigentError.
+            """
+            detail = payload.get("error") if isinstance(payload, dict) else None
+            if not isinstance(detail, dict):
+                return fallback, ErrorCode.INTERNAL_ERROR
+            message = detail.get("message")
+            code = detail.get("code")
+            return (
+                message if isinstance(message, str) else fallback,
+                code if isinstance(code, str) else ErrorCode.INTERNAL_ERROR,
+            )
+
+        if action == "spawn":
+            if terminal_name is None or session_key is None:
+                raise RuntimeError("validated spawn routing fields are missing")
+
+            async def _gate_stage() -> None:
+                """Require a declared terminal that can ACK before creation."""
+                terminal_spec = await _require_declared_terminal(
+                    conv,
+                    terminal_name,
+                    agent_store,
+                )
+                from omnigent.inner.terminal import terminal_spec_supports_shell_readiness
+
+                if not terminal_spec_supports_shell_readiness(terminal_spec):
+                    raise OmnigentError(
+                        (
+                            f"Terminal {terminal_name!r} does not provide a shell "
+                            "readiness contract and cannot be used for shell_command spawn."
+                        ),
+                        code=ErrorCode.INVALID_INPUT,
+                    )
+
+            await _run_stage(_gate_stage, "validating the terminal type")
+
+            async def _create_stage() -> dict[str, Any]:
+                """Launch the terminal; returns the validated resource.
+
+                Success is strictly 2xx — a redirect must not count as
+                a launched terminal. The resource ``id`` is validated
+                here, BEFORE it is committed to orchestration state, so
+                a malformed value can never poison the receipt itself.
+                """
+                status_code, payload = await _create_terminal_idempotently(
+                    session_id,
+                    terminals_path,
+                    {
+                        "terminal": terminal_name,
+                        "session_key": session_key,
+                        "attempt_id": attempt_id,
+                    },
+                )
+                if not 200 <= status_code < 300:
+                    message, code = _error_from_runner_body(
+                        payload,
+                        f"Terminal launch failed (runner returned HTTP {status_code})",
+                    )
+                    raise OmnigentError(message, code=code)
+                if not isinstance(payload, dict):
+                    raise TypeError(f"expected a resource object, got {type(payload).__name__}")
+                resource_id = payload.get("id")
+                if not isinstance(resource_id, str) or not resource_id:
+                    raise TypeError(
+                        f"terminal resource id must be a non-empty string, got {resource_id!r}"
+                    )
+                return payload
+
+            created = await _run_stage(_create_stage, "launching the terminal")
+            terminal_created = True
+            terminal_id = created["id"]
+            terminal_resource = created
+
+            async def _record_stage() -> None:
+                """Announce + persist the new terminal for reconnects.
+
+                The shared helper suppresses append failures for its
+                best-effort callers; here the durable record is part of
+                the contract, so a suppressed failure is a stage
+                failure.
+                """
+                event_persisted = _publish_and_persist_resource_event(
+                    session_id,
+                    "session.resource.created",
+                    resource_id=created["id"],
+                    resource_type="terminal",
+                    conversation_store=conversation_store,
+                    resource=created,
+                )
+                if not event_persisted:
+                    raise RuntimeError("session.resource.created was not persisted")
+
+            await _run_stage(_record_stage, "recording the new terminal")
+        else:
+            if terminal_id is None:
+                raise RuntimeError("validated send terminal id is missing")
+
+            async def _resolve_stage() -> dict[str, Any]:
+                """Resolve the target terminal; returns the resource."""
+                payload = await _proxy_get_to_runner(session_id, f"{terminals_path}/{terminal_id}")
+                if not isinstance(payload, dict):
+                    raise TypeError(f"expected a resource object, got {type(payload).__name__}")
+                return payload
+
+            # Resolve the target so the receipt carries the shell's
+            # display name/key and a dead id fails before any input.
+            terminal_resource = await _run_stage(_resolve_stage, "resolving the terminal")
+            metadata = terminal_resource.get("metadata")
+            if isinstance(metadata, dict):
+                raw_name = metadata.get("terminal_name")
+                raw_key = metadata.get("session_key")
+                terminal_name = raw_name if isinstance(raw_name, str) else None
+                session_key = raw_key if isinstance(raw_key, str) else None
+
+        async def _input_stage() -> Literal["ok", "unknown"]:
+            """Deliver once and classify the runner's outcome discriminator."""
+            runner_client = await _get_runner_client_for_resource_access(session_id)
+            if runner_client is None:
+                raise HTTPException(
+                    status_code=502,
+                    detail="no runner available for resource access",
+                )
+            try:
+                input_payload: dict[str, Any] = {
+                    "attempt_id": attempt_id,
+                    "text": command,
+                    "keys": "Enter",
+                    "wait_for_ready": action == "spawn",
+                }
+                resp = await runner_client.post(
+                    f"{terminals_path}/{terminal_id}/input",
+                    json=input_payload,
+                    timeout=_SHELL_COMMAND_RUNNER_POST_TIMEOUT_SECONDS,
+                )
+            except asyncio.CancelledError:
+                return "unknown"
+            except (httpx.HTTPError, ConnectionError):
+                return "unknown"
+            if 200 <= resp.status_code < 300:
+                try:
+                    success_payload: Any = resp.json()
+                except ValueError:
+                    return "unknown"
+                if not isinstance(success_payload, dict):
+                    return "unknown"
+                outcome = success_payload.get("outcome")
+                if outcome == "sent":
+                    return "ok"
+                return "unknown"
+
+            try:
+                payload: Any = resp.json()
+            except ValueError:
+                payload = None
+            message, code = _error_from_runner_body(
+                payload,
+                f"Terminal input failed (runner returned HTTP {resp.status_code})",
+            )
+            if resp.status_code >= 500:
+                if code != ErrorCode.IDEMPOTENCY_CAPACITY_EXHAUSTED:
+                    return "unknown"
+            elif resp.status_code == 404 and code == ErrorCode.INTERNAL_ERROR:
+                code = ErrorCode.NOT_FOUND
+            elif resp.status_code == 409 and code == ErrorCode.INTERNAL_ERROR:
+                code = ErrorCode.CONFLICT
+            elif resp.status_code == 400 and code == ErrorCode.INTERNAL_ERROR:
+                code = ErrorCode.INVALID_INPUT
+            if 400 <= resp.status_code < 600:
+                raise _ShellCommandRunnerError(
+                    message,
+                    code=code,
+                    http_status=resp.status_code,
+                )
+            raise OmnigentError(message, code=code)
+
+        delivery_status = await _run_stage(_input_stage, "sending terminal input")
+
+        item = await _receipt_once(delivery_status)
+        # Explicit 200 overriding the events route's 202 default: the
+        # command has already executed and its receipt is durable —
+        # nothing was "accepted for later processing". No ``queued``
+        # field for the same reason.
+        response_content: dict[str, Any] = {
+            "item_id": item.id,
+            "item": item.to_api_dict(),
+            "terminal": terminal_resource,
+        }
+        if action == "spawn" and terminal_resource is not None:
+            sequence = terminal_resource.get("sequence")
+            if isinstance(sequence, int):
+                response_content["sequence"] = sequence
+        return JSONResponse(status_code=200, content=response_content)
+
     @router.post(
         "/sessions/{session_id}/events",
         # Internal event ingestion — hidden from the public API reference.
@@ -127,7 +841,7 @@ def register_events_routes(
         request: Request,
         session_id: str,
         body: SessionEventInput,
-    ) -> dict[str, bool | str]:
+    ) -> dict[str, Any] | JSONResponse:
         """
         Submit a session event (input message, tool output,
         approval, or interrupt).
@@ -178,6 +892,13 @@ def register_events_routes(
         - ``"external_codex_collaboration_mode_change"`` persists the
           Codex app-server collaboration mode kind as an internal session label
           (``omnigent.codex_native.collaboration_mode``).
+        - ``"shell_command"`` executes a web-composer bang (``!``)
+          command against a session shell (owner-only): ``spawn``
+          launches a declared terminal then sends the command,
+          ``send`` routes it into an existing terminal. Persists one
+          ``terminal_command`` receipt item with the outcome and
+          starts NO agent turn. Responds 200 (already executed), not
+          the route's 202 default.
         - ``"stop_session"`` terminates the live session without
           deleting the conversation (owner-only). Forwarded
           harness-agnostically to the runner, which hard-kills the
@@ -239,6 +960,7 @@ def register_events_routes(
             _MCP_ELICITATION_TYPE,
             _COMPACT_TYPE,
             _SLASH_COMMAND_TYPE,
+            _SHELL_COMMAND_TYPE,
             _STOP_SESSION_TYPE,
             _EXTERNAL_ASSISTANT_MESSAGE_TYPE,
             _EXTERNAL_CONVERSATION_ITEM_TYPE,
@@ -629,6 +1351,18 @@ def register_events_routes(
                 [item],
             )
             return {"queued": True}
+        if body.type == _SHELL_COMMAND_TYPE:
+            # Keystroke injection by another name — owner-only, matching
+            # the interactive write-attach gate in terminal_attach.py.
+            await _require_access(
+                user_id, session_id, LEVEL_OWNER, permission_store, conversation_store
+            )
+            return await _dispatch_shell_command_event(
+                session_id,
+                conv,
+                body,
+                created_by=_attribution_user(user_id),
+            )
         if body.type == _EXTERNAL_ASSISTANT_MESSAGE_TYPE:
             item_id = await _persist_external_assistant_message(
                 session_id,

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -58,6 +58,7 @@ from omnigent.server.routes._origin import require_trusted_origin
 from omnigent.server.routes._sessions.common import *
 from omnigent.server.routes._sessions.common import (
     get_server_runner_router,
+    session_stream,
     set_server_runner_router,
 )
 from omnigent.server.routes._sessions.helpers import *
@@ -222,50 +223,6 @@ def register_resources_routes(
             raise _session_not_found()
         return conv
 
-    async def _proxy_get_to_runner(
-        session_id: str,
-        path: str,
-        params: dict[str, str] | None = None,
-    ) -> dict[str, Any]:
-        """Proxy a GET request to the runner and return parsed JSON.
-
-        :param session_id: Session/conversation identifier.
-        :param path: Runner-relative URL path.
-        :param params: Optional query params forwarded to the runner,
-            e.g. ``{"order": "asc"}``. ``None`` sends no query string.
-        :returns: Parsed JSON response body.
-        :raises HTTPException: 502 on runner failure.
-        """
-        runner_client = await _get_runner_client_for_resource_access(
-            session_id,
-        )
-        if runner_client is None:
-            raise HTTPException(
-                status_code=502,
-                detail="no runner available for resource access",
-            )
-        try:
-            resp = await runner_client.get(path, params=params, timeout=10.0)
-        except (httpx.HTTPError, ConnectionError) as exc:
-            raise HTTPException(
-                status_code=502,
-                detail="runner resource endpoint unavailable",
-            ) from exc
-        if resp.status_code == 404:
-            raise OmnigentError(
-                resp.json().get("error", {}).get("message", "Resource not found"),
-                code=ErrorCode.NOT_FOUND,
-            )
-        if resp.status_code != 200:
-            try:
-                body = resp.json()
-                error = body.get("error", {})
-                msg = error.get("message") or "runner resource endpoint failed"
-            except Exception:
-                msg = "runner resource endpoint failed"
-            raise HTTPException(status_code=502, detail=msg)
-        return resp.json()
-
     async def _fs_get_with_host_fallback(
         session_id: str,
         *,
@@ -362,40 +319,6 @@ def register_resources_routes(
             # Any other host FS failure (e.g. git_status_failed 500) mirrors the
             # runner proxy, which wraps non-200/404 responses as a 502.
             raise HTTPException(status_code=502, detail=exc.message) from exc
-
-    async def _proxy_post_to_runner(
-        session_id: str,
-        path: str,
-        body: dict[str, Any],
-    ) -> tuple[int, dict[str, Any]]:
-        """Proxy a POST request to the runner and return status + JSON.
-
-        :param session_id: Session/conversation identifier.
-        :param path: Runner-relative URL path.
-        :param body: JSON body to forward.
-        :returns: Tuple of (status_code, parsed_json_body).
-        :raises HTTPException: 502 on transport failure.
-        """
-        runner_client = await _get_runner_client_for_resource_access(
-            session_id,
-        )
-        if runner_client is None:
-            raise HTTPException(
-                status_code=502,
-                detail="no runner available for resource access",
-            )
-        try:
-            resp = await runner_client.post(
-                path,
-                json=body,
-                timeout=10.0,
-            )
-        except (httpx.HTTPError, ConnectionError) as exc:
-            raise HTTPException(
-                status_code=502,
-                detail="runner resource endpoint unavailable",
-            ) from exc
-        return resp.status_code, resp.json()
 
     async def _proxy_delete_to_runner(
         session_id: str,
@@ -609,7 +532,13 @@ def register_resources_routes(
             for key, value in request.query_params.items()
             if key in ("limit", "after", "before", "order")
         }
-        return await _proxy_get_to_runner(session_id, path, params=forwarded or None)
+        resource_revision = session_stream.current_sequence()
+        payload = await _proxy_get_to_runner(session_id, path, params=forwarded or None)
+        return {
+            **payload,
+            "resource_revision": resource_revision,
+            "full_snapshot": True,
+        }
 
     @router.post(
         "/sessions/{session_id}/resources/terminals",
@@ -653,25 +582,29 @@ def register_resources_routes(
         """
         conv = await _validate_session(session_id, request, LEVEL_EDIT)
         body = await request.json()
+        if not isinstance(body, dict):
+            raise OmnigentError(
+                "Terminal create body must be a JSON object",
+                code=ErrorCode.INVALID_INPUT,
+            )
         is_native_bootstrap = (
             bool(body.get("ensure_native_terminal") or body.get("bridge_inject_dir"))
             and native_coding_agent_for_terminal_name(body.get("terminal")) is not None
             and body.get("session_key") == "main"
         )
+        attempt_id: str | None = None
+        if body.get("attempt_id") is not None:
+            attempt_id = _require_shell_attempt_id(body["attempt_id"])
+            if not is_native_bootstrap:
+                body = {
+                    **body,
+                    "attempt_id": attempt_id,
+                    "session_key": _shell_spawn_session_key(attempt_id),
+                }
         if not is_native_bootstrap:
-            spec = await asyncio.to_thread(_load_agent_spec_for_session, conv, agent_store)
-            declared = list(spec.terminals or {}) if spec is not None else []
-            if body.get("terminal") not in declared:
-                raise OmnigentError(
-                    (
-                        f"Terminal {body.get('terminal')!r} is not declared by this "
-                        f"agent. Terminals can only be created for agents whose spec "
-                        f"declares them; this agent declares: {declared or 'none'}."
-                    ),
-                    code=ErrorCode.INVALID_INPUT,
-                )
+            await _require_declared_terminal(conv, body.get("terminal"), agent_store)
         path = f"/v1/sessions/{session_id}/resources/terminals"
-        status, payload = await _proxy_post_to_runner(
+        status, payload = await _create_terminal_idempotently(
             session_id,
             path,
             body,
@@ -691,7 +624,12 @@ def register_resources_routes(
             conversation_store=conversation_store,
             resource=payload,
         )
-        return payload
+        if attempt_id is None:
+            return payload
+        return {
+            "terminal": payload,
+            "sequence": payload.get("sequence"),
+        }
 
     @router.get(
         "/sessions/{session_id}/resources/terminals/{terminal_id}",

--- a/omnigent/server/routes/terminal_attach.py
+++ b/omnigent/server/routes/terminal_attach.py
@@ -89,6 +89,7 @@ from omnigent.server.routes._auth_helpers import require_access
 from omnigent.stores import ConversationStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.terminals.control_bridge import bridge_tmux_control_to_websocket
+from omnigent.terminals.registry import ResolveSnapshot
 from omnigent.terminals.ws_bridge import (
     WS_CLOSE_INTERNAL_ERROR,
     WS_CLOSE_TERMINAL_NOT_FOUND,
@@ -153,10 +154,6 @@ def create_terminal_attach_router(
             pick the control-mode vs PTY bridge in-process. ``None`` defers to
             the terminal spec / global default.
         """
-        from omnigent.entities.session_resources import (
-            resolve_terminal_entry_by_resource_id,
-        )
-
         await _authorize_terminal_attach(
             websocket,
             session_id=session_id,
@@ -228,17 +225,26 @@ def create_terminal_attach_router(
             )
             return
 
-        entry = resolve_terminal_entry_by_resource_id(
-            session_id,
-            terminal_id,
-            terminal_registry,
-        )
-        if entry is None or not entry.instance.running or not await entry.instance.is_alive():
+        resolved = terminal_registry.resolve_snapshot(session_id, terminal_id)
+        if not isinstance(resolved, ResolveSnapshot):
             await websocket.close(
                 code=_WS_CLOSE_TERMINAL_NOT_FOUND,
                 reason="terminal resource not found or not running",
             )
             return
+
+        if not await asyncio.to_thread(
+            terminal_registry.run_fenced,
+            resolved,
+            resolved.instance.is_alive,
+            invalid=False,
+        ):
+            await websocket.close(
+                code=_WS_CLOSE_TERMINAL_NOT_FOUND,
+                reason="terminal resource not found or not running",
+            )
+            return
+        entry = resolved.entry
 
         from omnigent.inner.terminal import (
             TERMINAL_TRANSPORT_CONTROL,
@@ -265,11 +271,21 @@ def create_terminal_attach_router(
                 if resolved_transport == TERMINAL_TRANSPORT_CONTROL
                 else bridge_tmux_pty_to_websocket
             )
+
+            async def _send_attached_input(data: bytes) -> bool:
+                return await asyncio.to_thread(
+                    terminal_registry.run_fenced,
+                    resolved,
+                    lambda: resolved.instance.send_raw_bytes(data),
+                    invalid=False,
+                )
+
             await bridge(
                 websocket,
                 socket_path=str(entry.instance.socket_path),
                 tmux_target=entry.instance.tmux_target,
                 read_only=read_only,
+                on_client_input=_send_attached_input,
             )
 
     return router

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2489,13 +2489,11 @@ class _SSEEventBase(BaseModel):
 
     - ``type``: the event-type discriminator literal (defined per
       subclass so :data:`ServerStreamEvent` can dispatch).
-    - ``sequence_number``: monotonic per-stream sequence number
-      assigned by the SSE serializer at emit time
-      (``_format_sse`` in ``omnigent/server/routes/sessions.py``).
-      Producers leave it ``None``; the route serializer populates
-      it on the wire. ``None`` on session-scoped events emitted
-      directly by the runtime (the session stream does not number
-      events).
+    - ``sequence_number``: optional producer-local legacy ordering
+      field. ``None`` when that producer does not supply one.
+    - ``sequence``: process-local mutation order stamped by
+      :func:`omnigent.runtime.session_stream.publish`. ``None`` for
+      direct/legacy events that bypass that publisher.
 
     Subclasses MUST declare ``type`` as ``Literal[...]`` so the
     discriminated-union machinery can route incoming dicts. The
@@ -2507,9 +2505,11 @@ class _SSEEventBase(BaseModel):
         producer side (before serialization) and on session-scoped
         events that the runtime publishes directly without
         sequencing.
+    :param sequence: Process-local event sequence, when stamped.
     """
 
     sequence_number: int | None = None
+    sequence: int | None = None
 
     model_config = ConfigDict(extra="ignore")
 

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -845,6 +845,14 @@ def _parse_terminals(
             raise OmnigentError(
                 f"terminals.{name}.env must be a mapping", code=ErrorCode.INVALID_INPUT
             )
+        ready_process = entry.get("ready_process")
+        if ready_process is not None and (
+            not isinstance(ready_process, str) or not ready_process.strip()
+        ):
+            raise OmnigentError(
+                f"terminals.{name}.ready_process must be a non-empty string",
+                code=ErrorCode.INVALID_INPUT,
+            )
         # os_env may be a nested mapping (parsed like top-level os_env), the
         # literal string "inherit", or absent.
         raw_os_env = entry.get("os_env")
@@ -864,6 +872,7 @@ def _parse_terminals(
             session_prefix=str(entry.get("session_prefix", "omni_")),
             tmux_allow_passthrough=bool(entry.get("tmux_allow_passthrough", False)),
             tmux_start_on_attach=bool(entry.get("tmux_start_on_attach", False)),
+            ready_process=ready_process,
         )
     return terminals or None
 

--- a/omnigent/terminals/__init__.py
+++ b/omnigent/terminals/__init__.py
@@ -9,9 +9,18 @@ See ``designs/OMNIGENT_TERMINAL_BRIDGE.md`` for the design and the
 :mod:`omnigent.inner.terminal` for the underlying tmux machinery.
 """
 
-from omnigent.terminals.registry import TerminalListEntry, TerminalRegistry
+from omnigent.terminals.registry import (
+    AmbiguousResourceId,
+    AmbiguousResourceIdError,
+    ResolveSnapshot,
+    TerminalListEntry,
+    TerminalRegistry,
+)
 
 __all__ = [
+    "AmbiguousResourceId",
+    "AmbiguousResourceIdError",
+    "ResolveSnapshot",
     "TerminalListEntry",
     "TerminalRegistry",
 ]

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -52,7 +52,7 @@ import json
 import logging
 import re
 import shutil
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Final
 
@@ -312,6 +312,7 @@ async def bridge_tmux_control_to_websocket(
     tmux_target: str,
     read_only: bool,
     on_client_interaction: Callable[[], None] | None = None,
+    on_client_input: Callable[[bytes], Awaitable[bool]] | None = None,
     reader_done: asyncio.Event | None = None,
     forward_done: asyncio.Event | None = None,
 ) -> None:
@@ -332,6 +333,8 @@ async def bridge_tmux_control_to_websocket(
         interaction (connect, disconnect, each input/resize frame) so the
         idle watcher can discount client-driven repaints. See the PTY bridge
         for the full rationale.
+    :param on_client_input: Optional owner-fenced raw-input dispatcher. A
+        ``False`` result closes an attachment whose captured owner changed.
     :param reader_done: Optional test-only event set once the reader has queued
         the full backlog and the ``None`` EOF sentinel, letting a test await the
         reader draining tmux instead of sleeping. Inert (never awaited) when
@@ -490,13 +493,29 @@ async def bridge_tmux_control_to_websocket(
                             rows = int(ctl["rows"])
                         except (KeyError, TypeError, ValueError):
                             continue
+                        if on_client_input is not None and not await on_client_input(b""):
+                            with contextlib.suppress(RuntimeError):
+                                await websocket.close(
+                                    code=WS_CLOSE_TERMINAL_NOT_FOUND,
+                                    reason="terminal ownership changed",
+                                )
+                            return
                         await _send_command(f"refresh-client -C {cols}x{rows}\n".encode())
                 elif data is not None and not read_only:
                     # Stamp before sending so the next %output (the echo) takes
                     # the small interactive frame cap.
                     last_client_input_at = _monotonic()
-                    for cmd in _hex_send_keys_commands(tmux_target, data):
-                        await _send_command(cmd)
+                    if on_client_input is not None:
+                        if not await on_client_input(data):
+                            with contextlib.suppress(RuntimeError):
+                                await websocket.close(
+                                    code=WS_CLOSE_TERMINAL_NOT_FOUND,
+                                    reason="terminal ownership changed",
+                                )
+                            return
+                    else:
+                        for cmd in _hex_send_keys_commands(tmux_target, data):
+                            await _send_command(cmd)
         except WebSocketDisconnect:
             return
 

--- a/omnigent/terminals/registry.py
+++ b/omnigent/terminals/registry.py
@@ -29,9 +29,10 @@ map. Tool invocations run on background threads via
 spins up its own ``asyncio.run`` loop to drive the registry's async
 methods. An ``asyncio.Lock`` would be bound to whichever loop created
 it and would silently fail to synchronize concurrent invocations from
-different threads. The threading lock is held only for short map
-mutations (no tmux I/O underneath); slow tmux subprocess calls happen
-outside the lock.
+different threads. The registry lock is held only for short map
+mutations. Terminal operations capture a snapshot, acquire the stable
+instance-owned ``op_lock``, revalidate under the registry lock, then
+perform tmux I/O while retaining only ``op_lock``.
 """
 
 from __future__ import annotations
@@ -39,8 +40,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, TypeVar
 from urllib.parse import quote
 
 from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
@@ -91,14 +94,43 @@ class TerminalListEntry:
 
     :param terminal_name: The terminal's spec name, e.g. ``"bash"``.
     :param session_key: The per-launch session key, e.g. ``"s1"``.
-    :param instance: The live :class:`TerminalInstance`. Callers can
-        read ``.running``, ``.command``, ``.socket_path``, etc., or
-        invoke ``send`` / ``read`` directly when wrapping in tools.
+    :param instance: The :class:`TerminalInstance` at snapshot time.
+        Callers may inspect metadata; tmux operations must use an atomic
+        :class:`ResolveSnapshot` and revalidate ownership first.
     """
 
     terminal_name: str
     session_key: str
     instance: TerminalInstance
+
+
+@dataclass(frozen=True)
+class ResolveSnapshot:
+    """Atomic terminal ownership snapshot used to fence one tmux operation."""
+
+    entry: TerminalListEntry
+    instance: TerminalInstance
+    op_lock: threading.Lock
+    owner_tuple: tuple[str, str, str]
+    owner_generation: int
+
+
+@dataclass(frozen=True)
+class AmbiguousResourceId:
+    """Fail-closed result for legacy registry entries sharing one public id."""
+
+    session_id: str
+    terminal_id: str
+    code: str = "ambiguous_resource_id"
+
+
+class AmbiguousResourceIdError(RuntimeError):
+    """Raised when a mutating terminal operation receives an ambiguous id."""
+
+
+ResolveResult = ResolveSnapshot | AmbiguousResourceId | None
+_FencedResultT = TypeVar("_FencedResultT")
+_FencedInvalidT = TypeVar("_FencedInvalidT")
 
 
 class TerminalRegistry:
@@ -128,20 +160,10 @@ class TerminalRegistry:
         # Per-conversation maps make ``cleanup_conversation`` cheap
         # (one pop) and ``list_for_conversation`` direct.
         self._by_conversation: dict[str, dict[tuple[str, str], TerminalInstance]] = {}
-        # Per-instance locks keyed by the full (conv_id, name, session_key)
-        # triple. Created at launch, removed at close /
-        # cleanup_conversation. Sender / reader / closer tools acquire
-        # this around the ``asyncio.run(instance.X())`` call to serialize
-        # tmux subprocess invocations on the same instance — without it,
-        # two concurrent ``sys_terminal_send`` calls can interleave their
-        # per-keystroke tmux commands (a ``send(text=X, keys="Enter")``
-        # decomposes to ~2 subprocess calls with a 50ms ``asyncio.sleep``
-        # between them — plenty of room for another send to slip in).
-        # See ``designs/OMNIGENT_TERMINAL_BRIDGE.md`` §9.1.
-        self._instance_locks: dict[tuple[str, str, str], threading.Lock] = {}
         # Threading lock — see module docstring for the rationale.
-        # Protects both ``_by_conversation`` and ``_instance_locks``.
+        # It protects the map and every owner-generation transition.
         self._lock = threading.Lock()
+        self._shutting_down = False
 
     def conversation_link_for_id(self, conversation_id: str) -> str:
         """
@@ -204,14 +226,33 @@ class TerminalRegistry:
             tool wraps in a JSON error envelope.
         """
         key = (terminal_name, session_key)
+        existing_snapshot: ResolveSnapshot | None = None
         with self._lock:
+            if self._shutting_down:
+                raise RuntimeError("terminal registry is shutting down")
+            self._assert_resource_id_available_locked(
+                conversation_id,
+                terminal_name,
+                session_key,
+            )
             existing = self._by_conversation.get(conversation_id, {}).get(key)
-        if existing is not None and existing.running:
-            if await existing.is_alive():
-                return existing
-            await self.close(conversation_id, terminal_name, session_key)
-        elif existing is not None:
-            await self.close(conversation_id, terminal_name, session_key)
+            if existing is not None:
+                existing_snapshot = ResolveSnapshot(
+                    entry=TerminalListEntry(terminal_name, session_key, existing),
+                    instance=existing,
+                    op_lock=existing.op_lock,
+                    owner_tuple=(conversation_id, terminal_name, session_key),
+                    owner_generation=existing.owner_generation,
+                )
+        if existing_snapshot is not None:
+            if await asyncio.to_thread(
+                self.run_fenced,
+                existing_snapshot,
+                existing_snapshot.instance.is_alive,
+                invalid=False,
+            ):
+                return existing_snapshot.instance
+            await self.close_snapshot(existing_snapshot)
 
         # Lock-free section: ``create_terminal_instance`` and
         # ``launch`` may take real time (tmux spawn). Holding the
@@ -242,28 +283,37 @@ class TerminalRegistry:
                 f"terminal {terminal_name}:{session_key} exited before it became available"
             )
 
+        registration_error: RuntimeError | None = None
         with self._lock:
-            slot = self._by_conversation.setdefault(conversation_id, {})
-            # Re-check: another concurrent launch for the same key may
-            # have raced ours. Take the second-arrival policy: close
-            # ours and return the racer's. Avoids two live tmux
-            # sessions for the same key.
-            racer = slot.get(key)
-            if racer is not None and racer.running:
-                # Close ours outside the lock; racer wins.
-                instance_to_close: TerminalInstance | None = created.instance
-                winning_instance = racer
-            else:
-                slot[key] = created.instance
-                instance_to_close = None
+            if self._shutting_down:
+                shutdown_started = True
+                instance_to_close = created.instance
                 winning_instance = created.instance
-                # Allocate a per-instance lock alongside the
-                # registration. Tools fetch it via
-                # :meth:`get_instance_lock` to serialize concurrent
-                # tmux ops on this instance.
-                self._instance_locks[(conversation_id, terminal_name, session_key)] = (
-                    threading.Lock()
-                )
+            else:
+                shutdown_started = False
+                try:
+                    self._assert_resource_id_available_locked(
+                        conversation_id,
+                        terminal_name,
+                        session_key,
+                    )
+                except RuntimeError as exc:
+                    registration_error = exc
+                    instance_to_close = created.instance
+                    winning_instance = created.instance
+                else:
+                    slot = self._by_conversation.setdefault(conversation_id, {})
+                    # Re-check: another concurrent launch for the same key may
+                    # have raced ours. Take the second-arrival policy: close
+                    # ours and return the racer's.
+                    racer = slot.get(key)
+                    if racer is not None and racer.running:
+                        instance_to_close = created.instance
+                        winning_instance = racer
+                    else:
+                        slot[key] = created.instance
+                        instance_to_close = None
+                        winning_instance = created.instance
 
         if instance_to_close is not None:
             try:
@@ -275,35 +325,117 @@ class TerminalRegistry:
                     session_key,
                     conversation_id,
                 )
+        if shutdown_started:
+            raise RuntimeError("terminal registry is shutting down")
+        if registration_error is not None:
+            raise registration_error
         return winning_instance
 
-    def get_instance_lock(
+    def _assert_resource_id_available_locked(
         self,
         conversation_id: str,
         terminal_name: str,
         session_key: str,
-    ) -> threading.Lock | None:
-        """Return the per-instance lock for a registered terminal.
+    ) -> None:
+        """Reject a sanitized ``(name, key)`` collision while ``_lock`` is held."""
+        from omnigent.entities.session_resources import terminal_resource_id
 
-        Used by the ``sys_terminal_send`` / ``read`` / ``close``
-        tools to serialize tmux subprocess invocations against the
-        same instance. The lock exists from registration (in
-        :meth:`launch`) until the instance is closed (in
-        :meth:`close` or :meth:`cleanup_conversation`).
+        requested_id = terminal_resource_id(terminal_name, session_key)
+        slot = self._by_conversation.get(conversation_id, {})
+        collisions = [
+            (name, key)
+            for name, key in slot
+            if terminal_resource_id(name, key) == requested_id
+            and (name, key) != (terminal_name, session_key)
+        ]
+        if collisions:
+            raise RuntimeError(
+                f"terminal resource id {requested_id!r} collides with registered "
+                f"terminal {collisions[0][0]!r}:{collisions[0][1]!r}"
+            )
 
-        :param conversation_id: Owning conversation id.
-        :param terminal_name: Terminal spec name.
-        :param session_key: Session key from launch.
-        :returns: A :class:`threading.Lock` to acquire around
-            per-instance ops, or ``None`` if the instance was
-            never registered (or has been closed). Callers should
-            handle ``None`` by surfacing a "not running" error to
-            the LLM rather than skipping the lock — the
-            instance-not-found path means the operation can't
-            proceed at all.
-        """
+    def resolve_snapshot(
+        self,
+        session_id: str,
+        terminal_id: str,
+    ) -> ResolveResult:
+        """Resolve one public id and capture ownership atomically under ``_lock``."""
+        from omnigent.entities.session_resources import terminal_resource_id
+
         with self._lock:
-            return self._instance_locks.get((conversation_id, terminal_name, session_key))
+            matches = [
+                (name, key, instance)
+                for (name, key), instance in self._by_conversation.get(session_id, {}).items()
+                if terminal_resource_id(name, key) == terminal_id
+            ]
+            if len(matches) > 1:
+                return AmbiguousResourceId(session_id=session_id, terminal_id=terminal_id)
+            if not matches:
+                return None
+            name, key, instance = matches[0]
+            entry = TerminalListEntry(
+                terminal_name=name,
+                session_key=key,
+                instance=instance,
+            )
+            return ResolveSnapshot(
+                entry=entry,
+                instance=instance,
+                op_lock=instance.op_lock,
+                owner_tuple=(session_id, name, key),
+                owner_generation=instance.owner_generation,
+            )
+
+    def resolve_key_snapshot(
+        self,
+        session_id: str,
+        terminal_name: str,
+        session_key: str,
+    ) -> ResolveResult:
+        """Resolve a tool's name/key arguments through the public-id resolver."""
+        from omnigent.entities.session_resources import terminal_resource_id
+
+        return self.resolve_snapshot(
+            session_id,
+            terminal_resource_id(terminal_name, session_key),
+        )
+
+    def snapshot_error_code(self, snapshot: ResolveSnapshot) -> str | None:
+        """Return why a captured owner can no longer operate, or ``None``."""
+        with self._lock:
+            if not self._snapshot_mapping_matches_locked(snapshot):
+                return "terminal_moved"
+            if snapshot.instance.retired or not snapshot.instance.running:
+                return "terminal_not_running"
+            return None
+
+    def run_fenced(
+        self,
+        snapshot: ResolveSnapshot,
+        async_fn: Callable[
+            [],
+            Coroutine[Any, Any, _FencedResultT] | _FencedResultT,
+        ],
+        *,
+        invalid: _FencedInvalidT | Callable[[str], _FencedInvalidT],
+    ) -> _FencedResultT | _FencedInvalidT:
+        """Run one operation while its captured terminal owner stays valid."""
+        with snapshot.op_lock:
+            error_code = self.snapshot_error_code(snapshot)
+            if error_code is not None:
+                return invalid(error_code) if callable(invalid) else invalid
+            result = async_fn()
+            if asyncio.iscoroutine(result):
+                return asyncio.run(result)
+            return result
+
+    def _snapshot_mapping_matches_locked(self, snapshot: ResolveSnapshot) -> bool:
+        session_id, terminal_name, session_key = snapshot.owner_tuple
+        current = self._by_conversation.get(session_id, {}).get((terminal_name, session_key))
+        return (
+            current is snapshot.instance
+            and snapshot.instance.owner_generation == snapshot.owner_generation
+        )
 
     def get(
         self,
@@ -400,16 +532,42 @@ class TerminalRegistry:
         :raises RuntimeError: If the target conversation already has an
             entry with the same terminal name and session key.
         """
+        resolved = self.resolve_key_snapshot(
+            source_conversation_id,
+            terminal_name,
+            session_key,
+        )
+        if isinstance(resolved, AmbiguousResourceId):
+            raise AmbiguousResourceIdError(
+                f"Terminal resource {resolved.terminal_id!r} is ambiguous"
+            )
+        if resolved is None:
+            return False
+        with resolved.op_lock:
+            return self.transfer_snapshot(resolved, target_conversation_id)
+
+    def transfer_snapshot(
+        self,
+        snapshot: ResolveSnapshot,
+        target_conversation_id: str,
+    ) -> bool:
+        """Move a captured owner while its stable ``op_lock`` is held."""
+        if not snapshot.op_lock.locked():
+            raise RuntimeError("transfer_snapshot requires the instance operation lock")
+        source_conversation_id, terminal_name, session_key = snapshot.owner_tuple
         key = (terminal_name, session_key)
-        source_lock_key = (source_conversation_id, terminal_name, session_key)
-        target_lock_key = (target_conversation_id, terminal_name, session_key)
         with self._lock:
-            source_slot = self._by_conversation.get(source_conversation_id)
-            if source_slot is None:
+            if self._shutting_down or not self._snapshot_mapping_matches_locked(snapshot):
                 return False
-            instance = source_slot.get(key)
-            if instance is None:
+            if snapshot.instance.retired or not snapshot.instance.running:
                 return False
+            if source_conversation_id == target_conversation_id:
+                return True
+            self._assert_resource_id_available_locked(
+                target_conversation_id,
+                terminal_name,
+                session_key,
+            )
             target_slot = self._by_conversation.setdefault(target_conversation_id, {})
             if key in target_slot:
                 raise RuntimeError(
@@ -417,13 +575,12 @@ class TerminalRegistry:
                     f"conversation {target_conversation_id!r}"
                 )
 
+            snapshot.instance.owner_generation += 1
+            source_slot = self._by_conversation[source_conversation_id]
             source_slot.pop(key)
             if not source_slot:
                 self._by_conversation.pop(source_conversation_id, None)
-            target_slot[key] = instance
-
-            lock = self._instance_locks.pop(source_lock_key, None)
-            self._instance_locks[target_lock_key] = lock or threading.Lock()
+            target_slot[key] = snapshot.instance
         return True
 
     async def close(
@@ -446,33 +603,79 @@ class TerminalRegistry:
             if no live instance was found (already-closed or
             never-launched).
         """
-        key = (terminal_name, session_key)
-        with self._lock:
-            slot = self._by_conversation.get(conversation_id)
-            if slot is None:
-                return False
-            instance = slot.pop(key, None)
-            if not slot:
-                # Drop the empty per-conversation dict so memory
-                # doesn't grow with stale conversation ids.
-                self._by_conversation.pop(conversation_id, None)
-            # Drop the per-instance lock too so subsequent
-            # ``get_instance_lock`` calls return ``None`` for this
-            # closed instance (callers surface a "not running"
-            # error to the LLM).
-            self._instance_locks.pop((conversation_id, terminal_name, session_key), None)
-        if instance is None:
-            return False
-        try:
-            await asyncio.wait_for(instance.close(), timeout=_CLOSE_TIMEOUT_S)
-        except asyncio.TimeoutError:
-            logger.warning(
-                "Terminal close timed out for %s:%s in conv %s",
-                terminal_name,
-                session_key,
-                conversation_id,
+        resolved = self.resolve_key_snapshot(
+            conversation_id,
+            terminal_name,
+            session_key,
+        )
+        if isinstance(resolved, AmbiguousResourceId):
+            raise AmbiguousResourceIdError(
+                f"Terminal resource {resolved.terminal_id!r} is ambiguous"
             )
+        if resolved is None:
+            return False
+        return await self.close_snapshot(resolved)
+
+    async def close_snapshot(self, snapshot: ResolveSnapshot) -> bool:
+        """Retire and close one captured terminal without blocking the event loop."""
+        return await asyncio.to_thread(self._retire_and_close, snapshot, "Terminal close")
+
+    def _retire_and_close(
+        self,
+        snapshot: ResolveSnapshot,
+        log_prefix: str,
+    ) -> bool:
+        """Linearize retirement, then run tmux teardown under ``op_lock``."""
+        conversation_id, terminal_name, session_key = snapshot.owner_tuple
+        with snapshot.op_lock:
+            with self._lock:
+                if not self._snapshot_mapping_matches_locked(snapshot):
+                    return False
+                if snapshot.instance.retired:
+                    return False
+                snapshot.instance.retired = True
+                snapshot.instance.owner_generation += 1
+                slot = self._by_conversation[conversation_id]
+                slot.pop((terminal_name, session_key))
+                if not slot:
+                    self._by_conversation.pop(conversation_id, None)
+
+            async def _close_with_timeout() -> None:
+                await asyncio.wait_for(
+                    snapshot.instance.close(),
+                    timeout=_CLOSE_TIMEOUT_S,
+                )
+
+            try:
+                asyncio.run(_close_with_timeout())
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "%s timed out for %s:%s in conv %s",
+                    log_prefix,
+                    terminal_name,
+                    session_key,
+                    conversation_id,
+                )
         return True
+
+    def _snapshots_for_conversation_locked(
+        self,
+        conversation_id: str,
+    ) -> list[ResolveSnapshot]:
+        """Capture every exact owner in a conversation while ``_lock`` is held."""
+        return [
+            ResolveSnapshot(
+                entry=TerminalListEntry(name, key, instance),
+                instance=instance,
+                op_lock=instance.op_lock,
+                owner_tuple=(conversation_id, name, key),
+                owner_generation=instance.owner_generation,
+            )
+            for (name, key), instance in self._by_conversation.get(
+                conversation_id,
+                {},
+            ).items()
+        ]
 
     async def cleanup_conversation(self, conversation_id: str) -> None:
         """Close every terminal owned by *conversation_id*.
@@ -495,24 +698,16 @@ class TerminalRegistry:
         :param conversation_id: The conversation being torn down.
         """
         with self._lock:
-            slot = self._by_conversation.pop(conversation_id, None)
-            # Drop every per-instance lock owned by this conversation.
-            # Iterate over `slot` (the just-popped per-conv map) for the
-            # canonical (name, key) pairs.
-            if slot:
-                for name, sess in slot:
-                    self._instance_locks.pop((conversation_id, name, sess), None)
-        if not slot:
+            snapshots = self._snapshots_for_conversation_locked(conversation_id)
+        if not snapshots:
             return
-        for (name, key), instance in slot.items():
+        for snapshot in snapshots:
+            _, name, key = snapshot.owner_tuple
             try:
-                await asyncio.wait_for(instance.close(), timeout=_CLOSE_TIMEOUT_S)
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "cleanup_conversation: close timed out for %s:%s in conv %s",
-                    name,
-                    key,
-                    conversation_id,
+                await asyncio.to_thread(
+                    self._retire_and_close,
+                    snapshot,
+                    "cleanup_conversation: close",
                 )
             except Exception:
                 # We're in a workflow finally block; raising here would
@@ -533,29 +728,27 @@ class TerminalRegistry:
         a stuck instance shouldn't block the rest of Omnigent shutdown.
         """
         with self._lock:
-            slots = list(self._by_conversation.items())
-            self._by_conversation.clear()
-            # AP-shutdown clears all instance locks too — every
-            # conversation's terminals are being torn down.
-            self._instance_locks.clear()
-        for conversation_id, slot in slots:
-            for (name, key), instance in slot.items():
-                try:
-                    await asyncio.wait_for(instance.close(), timeout=_CLOSE_TIMEOUT_S)
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "shutdown: close timed out for %s:%s in conv %s",
-                        name,
-                        key,
-                        conversation_id,
-                    )
-                except Exception:
-                    logger.exception(
-                        "shutdown: close failed for %s:%s in conv %s",
-                        name,
-                        key,
-                        conversation_id,
-                    )
+            self._shutting_down = True
+            snapshots = [
+                snapshot
+                for conversation_id in tuple(self._by_conversation)
+                for snapshot in self._snapshots_for_conversation_locked(conversation_id)
+            ]
+        for snapshot in snapshots:
+            conversation_id, name, key = snapshot.owner_tuple
+            try:
+                await asyncio.to_thread(
+                    self._retire_and_close,
+                    snapshot,
+                    "shutdown: close",
+                )
+            except Exception:
+                logger.exception(
+                    "shutdown: close failed for %s:%s in conv %s",
+                    name,
+                    key,
+                    conversation_id,
+                )
 
     def active_conversation_ids(self) -> list[str]:
         """Return ids of conversations with at least one registered terminal.

--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -39,7 +39,7 @@ import struct
 import sys
 import time
 import weakref
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Final
 
@@ -510,6 +510,7 @@ async def bridge_tmux_pty_to_websocket(
     tmux_target: str,
     read_only: bool,
     on_client_interaction: Callable[[], None] | None = None,
+    on_client_input: Callable[[bytes], Awaitable[bool]] | None = None,
 ) -> None:
     """
     Bridge a tmux attach PTY to an already-accepted *websocket*.
@@ -538,6 +539,10 @@ async def bridge_tmux_pty_to_websocket(
         mis-reading them as agent activity. ``None`` (e.g. the
         server-direct attach path, which is out-of-process from the
         watcher) disables that attribution.
+    :param on_client_input: Optional owner-fenced raw-input dispatcher. The
+        runner supplies this so each frame revalidates ownership and performs
+        the complete tmux write under the instance lock. ``False`` closes the
+        stale attachment without forwarding bytes.
     """
     # Attaching is itself a client interaction: tmux resizes the window to
     # the new client, which reflows the pane. Stamp it before the bridge
@@ -647,10 +652,27 @@ async def bridge_tmux_pty_to_websocket(
                             rows = int(ctl["rows"])
                         except (KeyError, TypeError, ValueError):
                             continue
+                        if on_client_input is not None and not await on_client_input(b""):
+                            with contextlib.suppress(RuntimeError):
+                                await websocket.close(
+                                    code=WS_CLOSE_TERMINAL_NOT_FOUND,
+                                    reason="terminal ownership changed",
+                                )
+                            return
                         winsize = struct.pack("HHHH", rows, cols, 0, 0)
                         with contextlib.suppress(OSError):
                             fcntl.ioctl(master_fd, termios.TIOCSWINSZ, winsize)
                 elif data is not None and not read_only:
+                    if on_client_input is not None:
+                        last_client_input_at = _monotonic()
+                        if not await on_client_input(data):
+                            with contextlib.suppress(RuntimeError):
+                                await websocket.close(
+                                    code=WS_CLOSE_TERMINAL_NOT_FOUND,
+                                    reason="terminal ownership changed",
+                                )
+                            return
+                        continue
                     # Probe pane liveness only if we haven't checked recently (cache
                     # for ~100ms to avoid a subprocess per keystroke). When remain-on-exit
                     # keeps a dead pane alive, Ctrl-C silently fails; detect and close

--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -672,7 +672,6 @@ async def bridge_tmux_pty_to_websocket(
                                     reason="terminal ownership changed",
                                 )
                             return
-                        continue
                     # Probe pane liveness only if we haven't checked recently (cache
                     # for ~100ms to avoid a subprocess per keystroke). When remain-on-exit
                     # keeps a dead pane alive, Ctrl-C silently fails; detect and close
@@ -697,6 +696,8 @@ async def bridge_tmux_pty_to_websocket(
                                 )
                             return
                         # is_dead is False (live) or None (inconclusive) → continue
+                    if on_client_input is not None:
+                        continue
                     last_client_input_at = _monotonic()
                     await _write_all_nonblocking(loop, master_fd, data)
         except WebSocketDisconnect:

--- a/omnigent/tools/builtins/sys_terminal.py
+++ b/omnigent/tools/builtins/sys_terminal.py
@@ -31,18 +31,36 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import threading
 from dataclasses import dataclass
 from typing import Any
 
 from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
 from omnigent.inner.terminal import TerminalInstance
 from omnigent.spec.types import AgentSpec
-from omnigent.terminals import TerminalRegistry
+from omnigent.terminals import AmbiguousResourceId, ResolveSnapshot, TerminalRegistry
 from omnigent.tools.base import Tool, ToolContext
 
 _logger = logging.getLogger(__name__)
 _PLACEHOLDER_CWDS = (None, "", ".", "./")
+_SHELL_READINESS_TIMEOUT_SECONDS = 10.0
+
+
+def _fence_error(
+    error_code: str,
+    *,
+    delivery_not_attempted: bool = False,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "error": (
+            "Terminal ownership changed"
+            if error_code == "terminal_moved"
+            else "Terminal is not running"
+        ),
+        "code": error_code,
+    }
+    if delivery_not_attempted:
+        result["delivery_not_attempted"] = True
+    return result
 
 
 def _has_meaningful_cwd(cwd: str | None) -> bool:
@@ -92,7 +110,7 @@ class _ValidatedLaunchArgs:
 
 @dataclass(frozen=True)
 class _ResolvedInstance:
-    """A running :class:`TerminalInstance` plus its parsed tool args + lock.
+    """A captured running-terminal owner plus its parsed tool arguments.
 
     Returned by :func:`_resolve_running_instance` on the success
     path. Using a dataclass keeps call-sites self-documenting:
@@ -101,18 +119,13 @@ class _ResolvedInstance:
 
     :param instance: The live :class:`TerminalInstance`.
     :param parsed: The parsed JSON arguments dict for the tool.
-    :param lock: The per-instance ``threading.Lock`` from
-        :meth:`TerminalRegistry.get_instance_lock`. Callers MUST
-        acquire this around the ``asyncio.run(instance.X())`` call
-        to serialize concurrent tmux ops on the same instance —
-        without it, a ``send(text=X, keys="Enter")`` call can
-        interleave its 2 tmux subprocess invocations with another
-        thread's send. See ``designs/OMNIGENT_TERMINAL_BRIDGE.md`` §9.1.
+    :param snapshot: Atomic registry owner snapshot. Operations acquire its
+        instance-owned lock and revalidate it immediately before tmux I/O.
     """
 
     instance: TerminalInstance
     parsed: dict[str, Any]
-    lock: threading.Lock
+    snapshot: ResolveSnapshot
 
 
 def _format_launch_envelope(
@@ -454,12 +467,19 @@ def _resolve_running_instance(
     invalid = _validate_session_required_args(parsed)
     if invalid is not None:
         return json.dumps(invalid)
-    instance = registry.get(ctx.conversation_id, parsed["terminal"], parsed["session"])
-    lock = registry.get_instance_lock(ctx.conversation_id, parsed["terminal"], parsed["session"])
-    # Either the entry is missing from both (never launched / already
-    # closed) or both are present (launched and registered atomically).
-    # If only one is present, the registry's invariants are broken.
-    if instance is None or not instance.running or lock is None:
+    resolved = registry.resolve_key_snapshot(
+        ctx.conversation_id,
+        parsed["terminal"],
+        parsed["session"],
+    )
+    if isinstance(resolved, AmbiguousResourceId):
+        return json.dumps(
+            {
+                "error": f"terminal resource '{resolved.terminal_id}' is ambiguous",
+                "code": resolved.code,
+            }
+        )
+    if resolved is None:
         return json.dumps(
             {
                 "error": (
@@ -467,7 +487,78 @@ def _resolve_running_instance(
                 )
             }
         )
-    return _ResolvedInstance(instance=instance, parsed=parsed, lock=lock)
+    return _ResolvedInstance(
+        instance=resolved.instance,
+        parsed=parsed,
+        snapshot=resolved,
+    )
+
+
+def send_terminal_input(
+    registry: TerminalRegistry,
+    snapshot: ResolveSnapshot,
+    text: str | None,
+    *,
+    keys: str = "Enter",
+    wait_for_ready: bool = False,
+) -> dict[str, Any]:
+    """Revalidate one atomic owner snapshot and send under its stable lock.
+
+    Both the synchronous agent tool and async runner route use this
+    chokepoint so their tmux sends cannot drift or interleave.
+
+    :param registry: Registry that captured and revalidates the owner.
+    :param snapshot: Atomic terminal ownership snapshot.
+    :param text: Literal text passed to ``tmux send-keys -l``.
+    :param keys: Space-separated tmux key names pressed after the text.
+    :param wait_for_ready: Require the final shell readiness ACK first.
+    :returns: The terminal's send result.
+    """
+
+    async def _send() -> dict[str, Any]:
+        if wait_for_ready:
+            if (
+                snapshot.instance.shell_ready_nonce is None
+                and snapshot.instance.ready_process is None
+            ):
+                return {
+                    "error": "Terminal does not support a shell readiness contract",
+                    "code": "shell_readiness_unsupported",
+                    "delivery_not_attempted": True,
+                }
+            ready = await snapshot.instance.wait_for_shell_ready(
+                timeout_s=_SHELL_READINESS_TIMEOUT_SECONDS,
+            )
+            if not ready:
+                return {
+                    "error": "Terminal shell readiness was not acknowledged",
+                    "code": "terminal_not_ready",
+                    "delivery_not_attempted": True,
+                }
+        return await snapshot.instance.send(text, keys=keys)
+
+    return registry.run_fenced(
+        snapshot,
+        _send,
+        invalid=lambda error_code: _fence_error(
+            error_code,
+            delivery_not_attempted=True,
+        ),
+    )
+
+
+def read_terminal_output(
+    registry: TerminalRegistry,
+    snapshot: ResolveSnapshot,
+    *,
+    scrollback: int,
+) -> dict[str, Any]:
+    """Revalidate and capture one terminal pane under the instance lock."""
+    return registry.run_fenced(
+        snapshot,
+        lambda: snapshot.instance.read(scrollback=scrollback),
+        invalid=_fence_error,
+    )
 
 
 def _parse_arguments(arguments: str) -> dict[str, Any] | dict[str, str]:
@@ -852,20 +943,19 @@ class SysTerminalSendTool(Tool):
         keys = resolved.parsed.get("keys", "Enter")
         if not isinstance(keys, str):
             return json.dumps({"error": "'keys' must be a string if provided"})
-        # Hold the per-instance lock across the full ``send`` op.
-        # ``send(text=X, keys="Enter")`` issues ~2 tmux subprocess
-        # calls with a 50ms ``asyncio.sleep`` between them; without
-        # the lock, two concurrent sends interleave their commands
-        # and corrupt the shell input.
-        with resolved.lock:
-            try:
-                result = asyncio.run(resolved.instance.send(text, keys=keys))
-            except (RuntimeError, OSError) as exc:
-                # tmux send-keys subprocess failures and stale-socket
-                # errors land here. Wrap so the LLM sees a structured
-                # error and can decide whether to relaunch the terminal.
-                _logger.exception("sys_terminal_send failed")
-                return json.dumps({"error": f"send failed: {exc}"})
+        try:
+            result = send_terminal_input(
+                self._registry,
+                resolved.snapshot,
+                text,
+                keys=keys,
+            )
+        except (RuntimeError, OSError) as exc:
+            # tmux send-keys subprocess failures and stale-socket
+            # errors land here. Wrap so the LLM sees a structured
+            # error and can decide whether to relaunch the terminal.
+            _logger.exception("sys_terminal_send failed")
+            return json.dumps({"error": f"send failed: {exc}"})
         return json.dumps(result)
 
 
@@ -925,18 +1015,15 @@ class SysTerminalReadTool(Tool):
         if not isinstance(scrollback_raw, int) or scrollback_raw < 0:
             return json.dumps({"error": "'scrollback' must be a non-negative integer"})
 
-        # Hold the per-instance lock so a concurrent ``send`` can't
-        # mutate the pane mid-capture. ``capture-pane`` is one tmux
-        # call and probably atomic from tmux's view, but a send can
-        # land between two interleaved reads or between a read and
-        # whatever the LLM does next. Cheap insurance.
-        with resolved.lock:
-            try:
-                result = asyncio.run(resolved.instance.read(scrollback=scrollback_raw))
-            except (RuntimeError, OSError) as exc:
-                # tmux capture-pane subprocess failures land here.
-                _logger.exception("sys_terminal_read failed")
-                return json.dumps({"error": f"read failed: {exc}"})
+        try:
+            result = read_terminal_output(
+                self._registry,
+                resolved.snapshot,
+                scrollback=scrollback_raw,
+            )
+        except (RuntimeError, OSError) as exc:
+            _logger.exception("sys_terminal_read failed")
+            return json.dumps({"error": f"read failed: {exc}"})
         return json.dumps(result)
 
 
@@ -1059,19 +1146,24 @@ class SysTerminalCloseTool(Tool):
         terminal_name = parsed["terminal"]
         session_key = parsed["session"]
 
-        # Acquire the per-instance lock BEFORE asking the registry
-        # to close. This serializes against any in-flight send/read
-        # holding the same lock, so the actual ``instance.close()``
-        # never races with a tmux op already in progress. ``None``
-        # means the instance was already closed (or never launched);
-        # registry.close() returns False in that case anyway.
-        lock = self._registry.get_instance_lock(ctx.conversation_id, terminal_name, session_key)
+        resolved = self._registry.resolve_key_snapshot(
+            ctx.conversation_id,
+            terminal_name,
+            session_key,
+        )
+        if isinstance(resolved, AmbiguousResourceId):
+            return json.dumps(
+                {
+                    "error": f"terminal resource '{resolved.terminal_id}' is ambiguous",
+                    "code": resolved.code,
+                }
+            )
 
         def _do_close() -> bool:
             try:
-                return asyncio.run(
-                    self._registry.close(ctx.conversation_id, terminal_name, session_key)
-                )
+                if resolved is None:
+                    return False
+                return asyncio.run(self._registry.close_snapshot(resolved))
             except (RuntimeError, OSError) as exc:
                 # tmux teardown can raise when the server is already
                 # gone — surface but don't propagate.
@@ -1079,11 +1171,7 @@ class SysTerminalCloseTool(Tool):
                 raise _CloseFailed(str(exc)) from exc
 
         try:
-            if lock is not None:
-                with lock:
-                    closed = _do_close()
-            else:
-                closed = _do_close()
+            closed = _do_close()
         except _CloseFailed as exc:
             return json.dumps({"error": f"close failed: {exc}"})
 

--- a/openapi.json
+++ b/openapi.json
@@ -270,6 +270,18 @@
             "title": "Args",
             "type": "object"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -304,6 +316,18 @@
           "response": {
             "$ref": "#/components/schemas/ResponseObject",
             "description": "The final response object with `status=\"cancelled\"`."
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -585,6 +609,18 @@
             "description": "Synthetic `call_id` the SDK uses to reconcile the local task; `None` when no pending tool call row exists for the task.",
             "title": "Call Id"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -734,6 +770,18 @@
             "default": null,
             "title": "Compacted Messages"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -866,6 +914,18 @@
       "CompactionFailedEvent": {
         "description": "Conversation history compaction failed.\n\nEmitted by `omnigent/server/routes/sessions.py` when\n`compact_conversation_now()` raises. Clients that rendered a\n\"Compacting\u2026\" spinner on `CompactionInProgressEvent`\nshould dismiss it without leaving a permanent marker, since the\nconversation history was not modified.",
         "properties": {
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -894,6 +954,18 @@
       "CompactionInProgressEvent": {
         "description": "Conversation history is being compacted.\n\nEmitted by `omnigent/runtime/compaction.py` while a\ncompaction step runs so clients can render a \"summarizing\nhistory\u2026\" indicator. Wire shape matches `compaction.py:765`.",
         "properties": {
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -925,6 +997,18 @@
           "response": {
             "$ref": "#/components/schemas/ResponseObject",
             "description": "The final response object with `status=\"completed\"`."
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -1236,6 +1320,18 @@
             "$ref": "#/components/schemas/ResponseObject",
             "description": "The newly-allocated response object."
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -1280,6 +1376,18 @@
           "params": {
             "$ref": "#/components/schemas/ElicitationRequestParams",
             "description": "The MCP-shaped params block carrying the prompt and (form-mode only) the requested schema."
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -1421,6 +1529,18 @@
             "title": "Elicitation Id",
             "type": "string"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -1507,6 +1627,18 @@
             "$ref": "#/components/schemas/RetryErrorDetail",
             "description": "Classified error description."
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -1563,6 +1695,18 @@
           "response": {
             "$ref": "#/components/schemas/ResponseObject",
             "description": "The final response object with `status=\"failed\"` and `error` populated."
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -1694,6 +1838,18 @@
             "default": null,
             "description": "Sequence number of the last non- heartbeat event seen on the same stream, e.g. `42`. `None` before any user-visible event has fired (first heartbeat of the turn, before deltas land), or when the producer chose not to populate it.",
             "title": "Last Event Seq"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -1844,6 +2000,18 @@
             "$ref": "#/components/schemas/ResponseObject",
             "description": "The response object with `status=\"in_progress\"`."
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -1891,6 +2059,18 @@
           "response": {
             "$ref": "#/components/schemas/ResponseObject",
             "description": "The final response object with `status=\"incomplete\"` and `incomplete_details` populated describing the reason."
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -2329,6 +2509,18 @@
             "description": "Original filename if the annotation supplied one, e.g. `\"report.pdf\"`. `None` otherwise.",
             "title": "Filename"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -2363,6 +2555,18 @@
             "description": "The completed item dict. Heterogeneous and item-type-specific; see `omnigent/entities/conversation.py` for the per-type `*Data` shapes that drive serialization. Example for a function_call item: `{\"id\": \"fc_abc123\", \"type\": \"function_call\", \"status\": \"action_required\", \"name\": \"search.web\", \"arguments\": \"{\\\"q\\\": \\\"foo\\\"}\", \"call_id\": \"call_xyz\"}`.",
             "title": "Item",
             "type": "object"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -2436,6 +2640,18 @@
             "default": null,
             "description": "For terminal-observed streaming (claude-native), the vendor's stable per-message id, e.g. `\"2ca51d97-2f0f-493a-aed7-85a5b56c5747\"`. Lets the web UI scope an in-flight buffer to one assistant message and reconcile it against the final item. `None` for ordinary in-process task streaming, where deltas already group by the active response.",
             "title": "Message Id"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -2559,6 +2775,18 @@
             "title": "Reason",
             "type": "string"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -2660,6 +2888,18 @@
           "response": {
             "$ref": "#/components/schemas/ResponseObject",
             "description": "The response object with `status=\"queued\"`."
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -2768,6 +3008,18 @@
       "ReasoningStartedEvent": {
         "description": "Marker emitted once when a reasoning block begins.\n\nFired even when the reasoning content itself is encrypted /\nredacted (so no delta events follow), letting clients render\na \"thinking\u2026\" indicator regardless of provider verification\nstatus. Wire shape matches `omnigent/runtime/workflow.py:1350`.",
         "properties": {
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -2800,6 +3052,18 @@
             "description": "The summary text fragment, e.g. `\"Will use the search tool to gather context.\"`.",
             "title": "Delta",
             "type": "string"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -2834,6 +3098,18 @@
             "description": "The reasoning text fragment, e.g. `\"Considering the user's intent...\"`.",
             "title": "Delta",
             "type": "string"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -2891,6 +3167,18 @@
             "description": "Kind of resource, e.g. `\"terminal\"`, `\"file\"`, `\"environment\"`.",
             "title": "Resource Type",
             "type": "string"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Process-local resource revision stamped on the corresponding live event. `None` for legacy records.",
+            "title": "Sequence"
           }
         },
         "required": [
@@ -3120,6 +3408,18 @@
             "description": "Total tries allowed by the retry policy, e.g. `3`. Lets clients render \"attempt 2 of 3\".",
             "title": "Max Attempts",
             "type": "integer"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -3511,6 +3811,18 @@
             "title": "Conversation Id",
             "type": "string"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -3547,6 +3859,18 @@
             "description": "Environment whose changes were invalidated, e.g. `\"default\"`.",
             "title": "Environment Id",
             "type": "string"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -3598,6 +3922,18 @@
             "title": "Conversation Id",
             "type": "string"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -3638,6 +3974,18 @@
             "description": "The active collaboration mode string, e.g. `\"plan\"` or `\"default\"`. Category: **transient** (SSE-only). The server also writes `omnigent.codex_native.collaboration_mode` on the conversation labels, so reconnect clients restore the same state from the session snapshot.",
             "title": "Mode",
             "type": "string"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -3704,6 +4052,18 @@
             "default": null,
             "description": "Echo of `conversation_id` for consumers that key on a dedicated \"parent\" field rather than the carrier `conversation_id`. Always equal to `conversation_id`; included for forward-compat with clients that may relay these events across stream boundaries. Category: **transient** (SSE-only). The corresponding durable record of \"a child session exists\" lives in the conversation store as the child conversation row itself (`parent_conversation_id` foreign key) and the parent's tunneled `function_call` item \u2014 reconnecting clients discover children by walking the parent's persisted history, not by replaying this event.",
             "title": "Parent Session Id"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -3812,6 +4172,18 @@
       "SessionHeartbeatEvent": {
         "description": "Idle-stream keepalive on `GET /v1/sessions/{id}/stream`.\n\nEmitted by the session-stream route on a fixed cadence whenever\nthe underlying publish queue has been quiet (no turn in flight,\nno resource events). Distinct from `HeartbeatEvent`\n(`response.heartbeat`), which is per-turn and is driven by\nthe runtime workflow while a response is producing output.\n\nWhy this exists: the session stream stays open across many turns\nand through idle periods (waiting for the user to type). Without\na periodic emit, intermediate proxies, OS-level sockets, and the\nclient's SSE read-timeout can leave a half-open stream\nundetected for minutes after a network event (laptop sleep,\nWi-Fi handoff). The heartbeat puts a regular byte on the wire\nso the client's read-timeout and the server's\n`request.is_disconnected()` check both fire promptly.\n\nConsumers MAY ignore the payload entirely (the bytes crossing\nthe wire are sufficient). The optional `server_time` mirrors\n`HeartbeatEvent` for symmetry and debugging.",
         "properties": {
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -3856,6 +4228,18 @@
           "data": {
             "$ref": "#/components/schemas/SessionInputConsumedPayload",
             "description": "The decoded queued-item payload \u2014 see `SessionInputConsumedPayload`."
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -3943,6 +4327,18 @@
           "data": {
             "$ref": "#/components/schemas/SessionInterruptedPayload",
             "description": "The interrupt metadata \u2014 see `SessionInterruptedPayload`."
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -4355,6 +4751,18 @@
             "title": "Conversation Id",
             "type": "string"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -4403,6 +4811,18 @@
             "title": "Model",
             "type": "string"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -4438,6 +4858,18 @@
             "title": "Conversation Id",
             "type": "string"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -4471,6 +4903,18 @@
             "description": "The conversation whose stream delivered this event \u2014 the root or a sub-agent conversation, e.g. `\"conv_abc123\"`. Matches the streamed conversation (not necessarily the tree's root) so clients can guard events by the conversation they are viewing.",
             "title": "Conversation Id",
             "type": "string"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -4555,6 +4999,18 @@
             "description": "Reasoning effort now active for the session, e.g. `\"medium\"`, or `None` when Codex cleared to its default. Category: **transient** (SSE-only). The server also writes `reasoning_effort` on the conversation, so on reconnect clients restore the selection from the session snapshot rather than from a replayed event.",
             "title": "Reasoning Effort"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -4589,6 +5045,18 @@
             "description": "The newly created resource object.",
             "title": "Resource",
             "type": "object"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -4628,6 +5096,18 @@
             "description": "Type of the deleted resource, e.g. `\"terminal\"`, `\"file\"`.",
             "title": "Resource Type",
             "type": "string"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -5267,6 +5747,18 @@
             "description": "Failure detail when `stage == \"failed\"`, e.g. `\"managed sandbox launch failed: spend limit reached\"`. `None` otherwise. Category: **transient** (SSE-only). On reconnect, clients seed the progress indicator from the session snapshot's `sandbox_status` field, which is populated by `_session_sandbox_status_cache` at snapshot build time.",
             "title": "Error"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -5314,6 +5806,18 @@
             "description": "Session identifier, e.g. `\"conv_abc123\"`. Category: **transient** (SSE-only). On reconnect, clients seed the menu from the session snapshot's `skills` field, which is populated by the runner-skills cache at snapshot build time.",
             "title": "Conversation Id",
             "type": "string"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -5386,6 +5890,18 @@
             "description": "Optional active response id for terminal-backed integrations, e.g. `\"codex_turn_abc123\"`. Clients use it to associate coarse session status edges with the assistant bubble they describe. `None` for ordinary in-process runtime edges.",
             "title": "Response Id"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -5440,6 +5956,18 @@
             "title": "Reason",
             "type": "string"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -5491,6 +6019,18 @@
       "SessionTerminalActivityEvent": {
         "description": "A terminal's pane produced output (runner-determined activity pulse).\n\nPowers the web \"active\" badge for any terminal without a client PTY\nattach \u2014 the runner's per-terminal pane watcher emits this when the\npane content changes. Transient (a live pulse; not persisted, not in\nthe connect snapshot).",
         "properties": {
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -5541,6 +6081,18 @@
             "title": "Pending",
             "type": "boolean"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -5575,6 +6127,18 @@
             "description": "Session identifier, e.g. `\"conv_abc123\"`.",
             "title": "Conversation Id",
             "type": "string"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -5698,6 +6262,18 @@
             "description": "Session identifier.",
             "title": "Conversation Id",
             "type": "string"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -5975,8 +6551,81 @@
         "type": "object"
       },
       "TerminalCommandData": {
-        "description": "Data payload for a runner-side terminal command (`!cmd`) observed\nin a harness transcript (today: Claude Code's embedded TUI).\n\nListed in `NON_CONTENT_ITEM_TYPES` so the agent loop never\ninjects this as phantom content into the LLM's message history.\n\nClaude Code writes two sibling transcript records per `!cmd`\ninvocation: one `<bash-input>` record and one combined\n`<bash-stdout>`/`<bash-stderr>` record. Each maps to one\n`terminal_command` item with `kind=\"input\"` or\n`kind=\"output\"` respectively.",
+        "description": "Data payload for a runner-side terminal command (`!cmd`).\n\nTwo producers write this item type:\n\n* the native-bridge observer mirroring `!cmd` entries the vendor\n  TUI executed itself (one `kind=\"input\"` and one\n  `kind=\"output\"` record per invocation);\n* the server's `shell_command` event, which persists ONE\n  `kind=\"input\"` receipt per web-composer bang command, filling\n  the optional routing/outcome fields below.\n\nListed in `NON_CONTENT_ITEM_TYPES` so the agent loop never\ninjects this as phantom content into the LLM's message history.\n\nThe optional fields default to `None` so legacy persisted items\n(native-bridge observer records predating receipts) deserialize\nwithout backfill \u2014 the same additive-optional idiom as\n`SlashCommandData.kind`.",
         "properties": {
+          "action": {
+            "anyOf": [
+              {
+                "enum": [
+                  "spawn",
+                  "send"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "`\"spawn\"` when the command launched a new shell, `\"send\"` when routed into an existing one. `None` for legacy native-bridge observer items.",
+            "title": "Action"
+          },
+          "attempt_fingerprint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attempt Fingerprint"
+          },
+          "attempt_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Client-generated idempotency key. `None` only for legacy native-bridge records.",
+            "title": "Attempt Id"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Human-readable failure text when `status=\"error\"`.",
+            "title": "Error"
+          },
+          "error_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Code"
+          },
+          "http_status": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Http Status"
+          },
           "input": {
             "anyOf": [
               {
@@ -5997,6 +6646,47 @@
             ],
             "title": "Kind",
             "type": "string"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Authoritative resource revision for a spawn receipt. `None` for sends and legacy records.",
+            "title": "Sequence"
+          },
+          "session_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display session key, e.g. `\"u-ab12cd\"`.",
+            "title": "Session Key"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "ok",
+                  "error",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Delivery outcome \u2014 `\"ok\"` when delivery was confirmed, `\"unknown\"` when it may have occurred, and `\"error\"` for definite non-delivery.",
+            "title": "Status"
           },
           "stderr": {
             "anyOf": [
@@ -6021,6 +6711,42 @@
             ],
             "description": "Captured stdout text. Present when `kind=\"output\"`, `None` otherwise.",
             "title": "Stdout"
+          },
+          "terminal": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Terminal"
+          },
+          "terminal_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Target terminal resource id, e.g. `\"terminal_zsh_u-ab12cd\"`.",
+            "title": "Terminal Id"
+          },
+          "terminal_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Shell type for display, e.g. `\"zsh\"`.",
+            "title": "Terminal Name"
           }
         },
         "required": [
@@ -6041,6 +6767,18 @@
             "description": "Command stdout/stderr fragment.",
             "title": "Delta",
             "type": "string"
+          },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
           },
           "sequence_number": {
             "anyOf": [
@@ -6072,6 +6810,18 @@
       "TurnCancelledEvent": {
         "description": "Emitted when a turn is interrupted by the user or system.",
         "properties": {
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -6106,6 +6856,18 @@
       "TurnCompletedEvent": {
         "description": "Emitted when a turn finishes successfully with no pending work.",
         "properties": {
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -6146,6 +6908,18 @@
             "title": "Error",
             "type": "object"
           },
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {
@@ -6180,6 +6954,18 @@
       "TurnStartedEvent": {
         "description": "Emitted when the runner starts a new turn for a session.",
         "properties": {
+          "sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence"
+          },
           "sequence_number": {
             "anyOf": [
               {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -441,6 +441,8 @@ target-version = "py310"
 extend-exclude = [
     "omnigent/inner/databricks_mcps/google",
     "assistant-ui",
+    # Notebook preview fixtures include a deliberately malformed JSON sample.
+    "web/src/shell/__fixtures__",
     # Protobuf-generated code (DO NOT EDIT); not ours to restyle.
     "omnigent/api/**/*_pb2.py",
     "omnigent/api/**/*_pb2.pyi",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -24,10 +24,12 @@ from omnigent.cli import (
     _CLICK_SUBCOMMANDS,
     _GLOBAL_CONFIG_KEYS,
     _NATIVE_TERMINAL_DISPATCH_SPECS,
+    _SINGLE_OWNER_ERROR,
     _bundle,
     _bundled_example_path,
     _dispatch_native_terminal_harness,
     _dispatch_run,
+    _enforce_single_owner_or_exit,
     _ensure_sqlite_parent_dir,
     _expand_config_env_vars,
     _extract_global_logging_flags,
@@ -81,6 +83,13 @@ from omnigent.runner.transports.ws_tunnel.limits import (
     TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
 )
 
+_OWNER_ENV_KEYS = (
+    "WEB_CONCURRENCY",
+    "UVICORN_WORKERS",
+    "GUNICORN_WORKERS",
+    "OMNIGENT_MULTI_REPLICA",
+)
+
 
 @pytest.fixture(autouse=True)
 def _restore_logging_state() -> Iterator[None]:
@@ -112,6 +121,62 @@ def _restore_logging_state() -> Iterator[None]:
         logger.handlers = list(handlers)
         logger.setLevel(level)
         logger.propagate = propagate
+
+
+def test_single_owner_guard_allows_default_or_one_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset and explicitly single-worker environments remain supported."""
+    for key in _OWNER_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    _enforce_single_owner_or_exit()
+
+    for key in _OWNER_ENV_KEYS[:-1]:
+        monkeypatch.setenv(key, "1")
+    monkeypatch.setenv("OMNIGENT_MULTI_REPLICA", "false")
+    _enforce_single_owner_or_exit()
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("WEB_CONCURRENCY", "2"),
+        ("UVICORN_WORKERS", "2"),
+        ("GUNICORN_WORKERS", "2"),
+        ("OMNIGENT_MULTI_REPLICA", "true"),
+    ],
+)
+def test_single_owner_guard_exits_with_verbatim_message(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    key: str,
+    value: str,
+) -> None:
+    """Every declared multi-owner configuration fails before server boot."""
+    for env_key in _OWNER_ENV_KEYS:
+        monkeypatch.delenv(env_key, raising=False)
+    monkeypatch.setenv(key, value)
+    caplog.set_level(logging.ERROR, logger="omnigent.cli")
+
+    with pytest.raises(SystemExit) as exc_info:
+        _enforce_single_owner_or_exit()
+
+    assert exc_info.value.code == 2
+    assert caplog.messages == [_SINGLE_OWNER_ERROR]
+
+
+def test_server_command_refuses_web_concurrency_before_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real CLI exits non-zero and prints the guard before uvicorn starts."""
+    for env_key in _OWNER_ENV_KEYS:
+        monkeypatch.delenv(env_key, raising=False)
+    monkeypatch.setenv("WEB_CONCURRENCY", "2")
+
+    result = CliRunner().invoke(cli, ["server"])
+
+    assert result.exit_code == 2
+    assert _SINGLE_OWNER_ERROR in result.output
 
 
 def test_python_module_entrypoint_uses_unified_click_cli() -> None:

--- a/tests/entities/test_conversation_extended.py
+++ b/tests/entities/test_conversation_extended.py
@@ -137,6 +137,17 @@ def test_resource_event_deleted() -> None:
     assert red.resource is None
 
 
+def test_resource_event_sequence_round_trips() -> None:
+    red = ResourceEventData(
+        event_type="session.resource.created",
+        resource_id="terminal_bash_s1",
+        resource_type="terminal",
+        resource={"id": "terminal_bash_s1"},
+        sequence=41,
+    )
+    assert red.model_dump(exclude_none=True)["sequence"] == 41
+
+
 # ── TerminalCommandData ───────────────────────────────
 
 
@@ -162,6 +173,137 @@ def test_terminal_command_output() -> None:
 def test_terminal_command_invalid_kind() -> None:
     with pytest.raises(ValidationError):
         TerminalCommandData(kind="unknown")  # type: ignore[arg-type]
+
+
+def test_terminal_command_legacy_item_deserializes_unchanged() -> None:
+    """Persisted items predating the receipt fields need no backfill.
+
+    Native-bridge observer records carry only kind/input (or
+    kind/stdout/stderr); the receipt fields must default to ``None``
+    so old rows keep parsing after the schema gains them.
+    """
+    data = parse_item_data("terminal_command", {"kind": "input", "input": "pwd"})
+    assert isinstance(data, TerminalCommandData)
+    assert data.action is None
+    assert data.terminal_id is None
+    assert data.terminal_name is None
+    assert data.session_key is None
+    assert data.status is None
+    assert data.error is None
+    assert data.attempt_id is None
+    assert data.sequence is None
+
+
+def test_terminal_command_legacy_item_api_dict_unchanged() -> None:
+    """Legacy items render the same wire shape as before the receipt fields.
+
+    ``to_api_dict`` spreads data over the envelope with
+    ``exclude_none=True`` — absent receipt fields must not appear, and
+    the item-level lifecycle ``status`` must survive (a receipt's data
+    ``status`` would overwrite it; legacy items have none).
+    """
+    item = ConversationItem(
+        id="tc_1",
+        type="terminal_command",
+        status="completed",
+        response_id="resp_1",
+        created_at=1,
+        data=TerminalCommandData(kind="input", input="pwd"),
+    )
+    assert item.to_api_dict() == {
+        "id": "tc_1",
+        "response_id": "resp_1",
+        "type": "terminal_command",
+        "status": "completed",
+        "kind": "input",
+        "input": "pwd",
+    }
+
+
+def test_actionless_unknown_terminal_record_keeps_optional_fields_absent() -> None:
+    """Native records can carry unknown status without receipt-only fields."""
+    data = TerminalCommandData(kind="input", input="pwd", status="unknown")
+    assert data.action is None
+    assert data.model_dump(exclude_none=True) == {
+        "kind": "input",
+        "input": "pwd",
+        "status": "unknown",
+    }
+
+
+def test_terminal_command_receipt_fields_round_trip() -> None:
+    data = parse_item_data(
+        "terminal_command",
+        {
+            "kind": "input",
+            "input": "echo hi",
+            "action": "spawn",
+            "terminal_id": "terminal_zsh_u-ab12cd",
+            "terminal_name": "zsh",
+            "session_key": "u-ab12cd",
+            "status": "ok",
+        },
+    )
+    assert isinstance(data, TerminalCommandData)
+    assert data.action == "spawn"
+    assert data.terminal_id == "terminal_zsh_u-ab12cd"
+    assert data.terminal_name == "zsh"
+    assert data.session_key == "u-ab12cd"
+    assert data.status == "ok"
+    assert data.error is None
+
+
+def test_terminal_command_receipt_status_flattens_over_lifecycle_status() -> None:
+    """The receipt's delivery ``status`` wins the item-level slot on the wire.
+
+    ``to_api_dict`` spreads data fields AFTER the envelope fields, so a
+    receipt's ``status`` ("ok"/"error") lands in the top-level ``status``
+    slot, replacing the lifecycle value ("completed"). The web client
+    narrows on this exact flattening — changing it breaks receipts.
+    """
+    item = ConversationItem(
+        id="tc_2",
+        type="terminal_command",
+        status="completed",
+        response_id="turn_abc",
+        created_at=1,
+        data=TerminalCommandData(
+            kind="input",
+            input="make test",
+            action="send",
+            terminal_id="terminal_zsh_u-ab12cd",
+            terminal_name="zsh",
+            session_key="u-ab12cd",
+            status="error",
+            error="Terminal 'terminal_zsh_u-ab12cd' is not running",
+        ),
+        created_by="alice@example.com",
+    )
+    assert item.to_api_dict() == {
+        "id": "tc_2",
+        "response_id": "turn_abc",
+        "type": "terminal_command",
+        # Data ``status`` overwrote the lifecycle "completed".
+        "status": "error",
+        "kind": "input",
+        "input": "make test",
+        "action": "send",
+        "terminal_id": "terminal_zsh_u-ab12cd",
+        "terminal_name": "zsh",
+        "session_key": "u-ab12cd",
+        "error": "Terminal 'terminal_zsh_u-ab12cd' is not running",
+        "created_by": "alice@example.com",
+    }
+
+
+def test_terminal_command_rejects_invalid_action() -> None:
+    with pytest.raises(ValidationError):
+        TerminalCommandData(kind="input", input="ls", action="focus")  # type: ignore[arg-type]
+
+
+def test_terminal_command_rejects_invalid_status() -> None:
+    with pytest.raises(ValidationError):
+        TerminalCommandData(kind="input", input="ls", status="failed")  # type: ignore[arg-type]
 
 
 # ── NON_CONTENT_ITEM_TYPES ───────────────────────────

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -666,6 +666,28 @@ async def test_process_ready_path_sends_no_direct_shell_probe(tmp_path: Path) ->
     assert process_polls == terminal_mod._SHELL_READY_STABLE_SAMPLES
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_keys", ["-X", "+", "Enter -N", "C-c +5"])
+async def test_send_rejects_flag_like_key_tokens(tmp_path: Path, bad_keys: str) -> None:
+    """A key token starting with '-'/'+' is rejected before any tmux dispatch."""
+    instance = TerminalInstance(
+        name="bash",
+        session_key="flag-guard",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        command="bash",
+        running=True,
+    )
+
+    async def reject_tmux(*args: str) -> None:
+        raise AssertionError(f"flag-like key reached tmux: {args!r}")
+
+    instance._tmux = reject_tmux  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError, match="must not start with '-' or '\\+'"):
+        await instance.send("hello", keys=bad_keys)
+
+
 @pytest.mark.parametrize("keep_alive", [True, False])
 def test_create_terminal_instance_propagates_keep_alive_after_exit(
     tmp_path: Path,

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -378,6 +378,9 @@ async def _capture_launch_argv(
     monkeypatch: pytest.MonkeyPatch,
     *,
     keep_alive_after_exit: bool,
+    command: str = "bash",
+    args: list[str] | None = None,
+    shell_ready_nonce: str | None = None,
 ) -> list[str]:
     """
     Launch a terminal with mocked tmux and return the single setup argv.
@@ -385,6 +388,9 @@ async def _capture_launch_argv(
     :param tmp_path: Temporary directory for the fake tmux socket.
     :param monkeypatch: Pytest monkeypatch fixture.
     :param keep_alive_after_exit: Value for the instance's opt-in flag.
+    :param command: Pane command to launch.
+    :param args: Arguments passed to the pane command.
+    :param shell_ready_nonce: Optional direct-shell readiness nonce.
     :returns: The flattened tmux launch argv.
     """
     captured: list[list[str]] = []
@@ -414,11 +420,250 @@ async def _capture_launch_argv(
         session_key="s1",
         socket_path=tmp_path / "tmux.sock",
         private_dir=tmp_path,
+        command=command,
+        args=list(args or []),
         keep_alive_after_exit=keep_alive_after_exit,
+        shell_ready_nonce=shell_ready_nonce,
     )
     await instance.launch(cwd=tmp_path)
     assert len(captured) == 1
     return captured[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "args"),
+    [
+        ("bash", ["-f"]),
+        ("bash", ["--noprofile", "--norc"]),
+        ("bash", ["-l"]),
+        ("zsh", ["-f"]),
+        ("zsh", ["-l"]),
+    ],
+)
+async def test_direct_shell_readiness_preserves_declared_args(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    args: list[str],
+) -> None:
+    """Readiness instrumentation leaves direct-shell argv semantics intact."""
+    argv = await _capture_launch_argv(
+        tmp_path,
+        monkeypatch,
+        keep_alive_after_exit=False,
+        command=command,
+        args=args,
+        shell_ready_nonce="OMNIGENT_SHELL_READY_test",
+    )
+
+    assert " ".join([command, *args]) in argv
+
+
+@pytest.mark.parametrize(
+    ("spec", "supported"),
+    [
+        (TerminalEnvSpec(command="bash", args=["--noprofile", "--norc"]), True),
+        (TerminalEnvSpec(command="zsh", args=["-f"]), True),
+        (TerminalEnvSpec(command="bash", args=["-l"]), True),
+        (TerminalEnvSpec(command="bash", args=["-c", "echo no-loop"]), False),
+        (TerminalEnvSpec(command="zsh", args=["script.zsh"]), False),
+        (TerminalEnvSpec(command=sys.executable, args=["-c", "pass"]), False),
+        (
+            TerminalEnvSpec(
+                command=sys.executable,
+                args=["-c", "pass"],
+                ready_process="bash",
+            ),
+            True,
+        ),
+    ],
+)
+def test_terminal_spec_shell_readiness_support_is_explicit(
+    spec: TerminalEnvSpec,
+    supported: bool,
+) -> None:
+    """Only direct input-loop shells or declared final processes can be awaited."""
+    assert terminal_mod.terminal_spec_supports_shell_readiness(spec) is supported
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "guard"),
+    [
+        ("bash", "BASH_SOURCE"),
+        ("zsh", "ZSH_EVAL_CONTEXT"),
+    ],
+)
+async def test_direct_shell_readiness_requires_input_loop_ack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    guard: str,
+) -> None:
+    """The nonce appears only after the final shell executes a guarded probe."""
+    nonce = f"OMNIGENT_SHELL_READY_{'ab' * 16}"
+    monkeypatch.setattr(terminal_mod.secrets, "token_hex", lambda _size: "ab" * 16)
+    instance = TerminalInstance(
+        name=command,
+        session_key="ready",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        command=command,
+        shell_ready_nonce=nonce,
+        running=True,
+    )
+    tmux_calls: list[tuple[str, ...]] = []
+    events: list[str] = []
+    snapshots = iter(["startup still running", nonce, "fresh prompt"])
+
+    async def record_tmux(*args: str) -> None:
+        tmux_calls.append(args)
+        events.append(f"tmux:{args[0]}")
+
+    async def capture(*args: str) -> str:
+        del args
+        snapshot = next(snapshots)
+        events.append(f"capture:{snapshot}")
+        return snapshot
+
+    instance._tmux = record_tmux  # type: ignore[method-assign]
+    instance._tmux_output = capture  # type: ignore[method-assign]
+
+    assert await instance.wait_for_shell_ready(timeout_s=0.5, poll_interval_s=0)
+    assert len(tmux_calls) == 4
+    assert tmux_calls[0][:4] == ("send-keys", "-l", "-t", "main")
+    probe = tmux_calls[0][-1]
+    assert guard in probe
+    assert nonce not in probe
+    assert tmux_calls[1] == ("send-keys", "-t", "main", "Enter")
+    assert tmux_calls[2] == ("send-keys", "-t", "main", "C-l")
+    assert tmux_calls[3] == ("clear-history", "-t", "main")
+    assert events == [
+        "tmux:send-keys",
+        "tmux:send-keys",
+        "capture:startup still running",
+        f"capture:{nonce}",
+        "tmux:send-keys",
+        "capture:fresh prompt",
+        "tmux:clear-history",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_direct_shell_retry_uses_fresh_nonce_and_ignores_stale_ack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A late ACK from a timed-out probe cannot satisfy its successor."""
+    token_hexes = iter(["11" * 16, "22" * 16])
+    monkeypatch.setattr(terminal_mod.secrets, "token_hex", lambda _size: next(token_hexes))
+    instance = TerminalInstance(
+        name="bash",
+        session_key="fresh-nonce",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        command="bash",
+        shell_ready_nonce="OMNIGENT_SHELL_READY_capability",
+        running=True,
+    )
+    probe_nonces: list[str] = []
+    scrollback_snapshots: list[str] = []
+    clear_history_calls = 0
+
+    async def record_tmux(*args: str) -> None:
+        nonlocal clear_history_calls
+        if args[:2] == ("send-keys", "-l"):
+            assert instance.shell_ready_nonce is not None
+            probe_nonces.append(instance.shell_ready_nonce)
+        elif args[0] == "clear-history":
+            clear_history_calls += 1
+
+    async def capture(*args: str) -> str:
+        if "-S" not in args:
+            return "clean prompt"
+        if len(probe_nonces) == 1:
+            await asyncio.sleep(1)
+            raise AssertionError("the timed-out capture should be cancelled")
+        snapshot = probe_nonces[len(scrollback_snapshots)]
+        scrollback_snapshots.append(snapshot)
+        return snapshot
+
+    monkeypatch.setattr(instance, "_tmux", record_tmux)
+    monkeypatch.setattr(instance, "_tmux_output", capture)
+
+    assert not await instance.wait_for_shell_ready(timeout_s=0.01, poll_interval_s=0)
+    assert await instance.wait_for_shell_ready(timeout_s=0.5, poll_interval_s=0)
+
+    assert probe_nonces == [
+        f"OMNIGENT_SHELL_READY_{'11' * 16}",
+        f"OMNIGENT_SHELL_READY_{'22' * 16}",
+    ]
+    assert scrollback_snapshots == probe_nonces
+    assert clear_history_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_acknowledged_direct_shell_fast_path_sends_no_probe(tmp_path: Path) -> None:
+    """An established shell accepts readiness without injecting more bytes."""
+    instance = TerminalInstance(
+        name="bash",
+        session_key="already-ready",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        command="bash",
+        shell_ready_nonce="OMNIGENT_SHELL_READY_acknowledged",
+        _shell_ready_probe_sent=True,
+        _shell_ready_acknowledged=True,
+        running=True,
+    )
+
+    async def reject_tmux(*args: str) -> None:
+        raise AssertionError(f"already-ready shell received tmux input: {args!r}")
+
+    async def reject_capture(*args: str) -> str:
+        raise AssertionError(f"already-ready shell was polled: {args!r}")
+
+    instance._tmux = reject_tmux  # type: ignore[method-assign]
+    instance._tmux_output = reject_capture  # type: ignore[method-assign]
+
+    assert await instance.wait_for_shell_ready(timeout_s=0.5, poll_interval_s=0)
+
+
+@pytest.mark.asyncio
+async def test_process_ready_path_sends_no_direct_shell_probe(tmp_path: Path) -> None:
+    """Declared-process readiness polls metadata without injecting pane bytes."""
+    instance = TerminalInstance(
+        name="shell",
+        session_key="process-ready",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        command=sys.executable,
+        ready_process="bash",
+        running=True,
+    )
+    process_polls = 0
+
+    async def reject_tmux(*args: str) -> None:
+        raise AssertionError(f"process-ready terminal received tmux input: {args!r}")
+
+    async def capture_process(*args: str) -> str:
+        nonlocal process_polls
+        assert args == (
+            "display-message",
+            "-p",
+            "-t",
+            "main",
+            "#{pane_current_command}",
+        )
+        process_polls += 1
+        return "bash"
+
+    instance._tmux = reject_tmux  # type: ignore[method-assign]
+    instance._tmux_output = capture_process  # type: ignore[method-assign]
+
+    assert await instance.wait_for_shell_ready(timeout_s=0.5, poll_interval_s=0)
+    assert process_polls == terminal_mod._SHELL_READY_STABLE_SAMPLES
 
 
 @pytest.mark.parametrize("keep_alive", [True, False])

--- a/tests/integration/test_sys_terminal_round_trip.py
+++ b/tests/integration/test_sys_terminal_round_trip.py
@@ -71,6 +71,7 @@ import pytest
 
 from omnigent.runner import create_runner_app
 from omnigent.terminals import TerminalRegistry
+from omnigent.tools.builtins import sys_terminal as sys_terminal_module
 from tests.e2e.conftest import (
     configure_mock_llm,
     create_runner_bound_session,
@@ -355,6 +356,222 @@ async def test_runner_terminal_input_waits_past_startup_stdin_consumer(tmp_path:
                 "a 200/sent readiness result must prove the final shell, not "
                 "the startup stdin consumer, received the command"
             )
+    finally:
+        await registry.shutdown()
+
+
+async def _wait_for_exact_shell_output(
+    registry: TerminalRegistry,
+    *,
+    session_id: str,
+    terminal_name: str,
+    session_key: str,
+    marker: str,
+) -> str:
+    """Wait until a live shell pane contains ``marker`` as its own output line."""
+    instance = registry.get(session_id, terminal_name, session_key)
+    assert instance is not None
+    screens: list[str] = []
+    for _ in range(40):
+        read_result = await instance.read(scrollback=100)
+        screen = str(read_result.get("screen", ""))
+        screens.append(screen)
+        if any(line.strip() == marker for line in screen.splitlines()):
+            return screen
+        await asyncio.sleep(0.05)
+    last_screen = screens[-1] if screens else ""
+    raise AssertionError(f"shell output {marker!r} did not appear:\n{last_screen}")
+
+
+def _write_delayed_shell_wrapper(
+    tmp_path: Path,
+    *,
+    shell_name: str,
+    real_shell: str,
+    delay_s: float,
+) -> Path:
+    """Create a shell-named shim that delays before preserving the real argv."""
+    wrapper_dir = tmp_path / "delayed-shells"
+    wrapper_dir.mkdir(exist_ok=True)
+    wrapper = wrapper_dir / shell_name
+    wrapper.write_text(
+        f"#!{sys.executable}\n"
+        "import os\n"
+        "import sys\n"
+        "import time\n"
+        f"time.sleep({delay_s!r})\n"
+        f"real_shell = {real_shell!r}\n"
+        "os.execv(real_shell, [real_shell, *sys.argv[1:]])\n",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def _encoded_output_command(marker: str) -> str:
+    """Return a short shell command whose typed form omits *marker*."""
+    encoded = "".join(f"\\0{ord(char):03o}" for char in marker)
+    return f"builtin printf '%b\\n' '{encoded}'"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("shell_name", "shell_args"),
+    [
+        ("bash", ["--noprofile", "--norc"]),
+        ("zsh", ["-f"]),
+    ],
+)
+async def test_runner_terminal_input_waits_past_old_gate_for_direct_shell(
+    tmp_path: Path,
+    shell_name: str,
+    shell_args: list[str],
+) -> None:
+    """A delayed direct shell ACKs after one second and runs the command once."""
+    real_shell = shutil.which(shell_name)
+    if shutil.which("tmux") is None or real_shell is None:
+        pytest.skip(f"tmux and {shell_name} are required for live readiness coverage")
+
+    registry = TerminalRegistry()
+    app = create_runner_app(
+        terminal_registry=registry,
+        runner_workspace=tmp_path,
+        per_session_workspace=False,
+        server_client=NullServerClient(),
+    )
+    transport = httpx.ASGITransport(app=app)
+    marker = f"O{uuid.uuid4().hex[:6]}"
+    command = _encoded_output_command(marker)
+    wrapper = _write_delayed_shell_wrapper(
+        tmp_path,
+        shell_name=shell_name,
+        real_shell=real_shell,
+        delay_s=1.35,
+    )
+    session_key = f"spawn-{shell_name}"
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as client:
+            create = await client.post(
+                "/v1/sessions/conv_bang/resources/terminals",
+                json={
+                    "terminal": shell_name,
+                    "session_key": session_key,
+                    "spec": {
+                        "command": str(wrapper),
+                        "args": shell_args,
+                        "cwd": str(tmp_path),
+                    },
+                },
+            )
+            assert create.status_code == 200, create.text
+
+            instance = registry.get("conv_bang", shell_name, session_key)
+            assert instance is not None
+            assert instance.args == shell_args
+            assert instance.ready_process is None
+            assert instance.shell_ready_nonce is not None
+
+            started = time.monotonic()
+            sent = await client.post(
+                (
+                    "/v1/sessions/conv_bang/resources/terminals/"
+                    f"terminal_{shell_name}_{session_key}/input"
+                ),
+                json={
+                    "attempt_id": str(uuid.uuid4()),
+                    "text": command,
+                    "keys": "Enter",
+                    "wait_for_ready": True,
+                },
+            )
+            elapsed = time.monotonic() - started
+            assert sent.status_code == 200, sent.text
+            assert sent.json() == {"status": "sent", "outcome": "sent"}
+            assert elapsed > 1.0, "the positive ACK must arrive after the retired 1s gate"
+
+            screen = await _wait_for_exact_shell_output(
+                registry,
+                session_id="conv_bang",
+                terminal_name=shell_name,
+                session_key=session_key,
+                marker=marker,
+            )
+            assert screen.count(command) == 1, screen
+            assert sum(line.strip() == marker for line in screen.splitlines()) == 1, screen
+    finally:
+        await registry.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_runner_terminal_input_readiness_timeout_rejects_without_send(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A readiness timeout is definite non-delivery with zero input calls."""
+    if shutil.which("tmux") is None:
+        pytest.skip("tmux not installed; runner terminal input needs tmux on PATH")
+
+    monkeypatch.setattr(
+        sys_terminal_module,
+        "_SHELL_READINESS_TIMEOUT_SECONDS",
+        0.05,
+    )
+    registry = TerminalRegistry()
+    app = create_runner_app(
+        terminal_registry=registry,
+        runner_workspace=tmp_path,
+        per_session_workspace=False,
+        server_client=NullServerClient(),
+    )
+    transport = httpx.ASGITransport(app=app)
+    marker = f"BANG_TIMEOUT_MARKER_{uuid.uuid4().hex[:8]}"
+    command = f"echo {marker}"
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as client:
+            create = await client.post(
+                "/v1/sessions/conv_timeout/resources/terminals",
+                json={
+                    "terminal": "bash",
+                    "session_key": "timeout",
+                    "spec": {
+                        "command": "/bin/sh",
+                        "args": [
+                            "-c",
+                            "sleep 0.3; exec bash --noprofile --norc -i",
+                        ],
+                        "cwd": str(tmp_path),
+                        "ready_process": "never-ready",
+                    },
+                },
+            )
+            assert create.status_code == 200, create.text
+
+            instance = registry.get("conv_timeout", "bash", "timeout")
+            assert instance is not None
+            send_calls = 0
+            real_send = instance.send
+
+            async def record_send(text: str | None, *, keys: str = "Enter") -> dict[str, Any]:
+                nonlocal send_calls
+                send_calls += 1
+                return await real_send(text, keys=keys)
+
+            monkeypatch.setattr(instance, "send", record_send)
+
+            sent = await client.post(
+                "/v1/sessions/conv_timeout/resources/terminals/terminal_bash_timeout/input",
+                json={
+                    "attempt_id": str(uuid.uuid4()),
+                    "text": command,
+                    "keys": "Enter",
+                    "wait_for_ready": True,
+                },
+            )
+            assert sent.status_code == 409, sent.text
+            assert sent.json()["error"]["code"] == "terminal_not_ready"
+            assert send_calls == 0
     finally:
         await registry.shutdown()
 

--- a/tests/integration/test_sys_terminal_round_trip.py
+++ b/tests/integration/test_sys_terminal_round_trip.py
@@ -57,14 +57,20 @@ package gate is lifted in mock mode by
 
 from __future__ import annotations
 
+import asyncio
 import json
 import shutil
+import sys
+import time
 import uuid
+from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
 
+from omnigent.runner import create_runner_app
+from omnigent.terminals import TerminalRegistry
 from tests.e2e.conftest import (
     configure_mock_llm,
     create_runner_bound_session,
@@ -72,6 +78,7 @@ from tests.e2e.conftest import (
     register_inline_agent,
     send_user_message_to_session,
 )
+from tests.runner.helpers import NullServerClient
 
 
 def _list_session_items(client: httpx.Client, session_id: str) -> list[dict[str, Any]]:
@@ -229,6 +236,127 @@ def terminal_session(
         mock_llm_server_url=mock_llm_server_url,
     )
     return session_id, model_name
+
+
+@pytest.mark.asyncio
+async def test_runner_terminal_input_route_live_tmux_round_trip(tmp_path: Path) -> None:
+    """Create a real shell, POST literal input, and read its output marker."""
+    if shutil.which("tmux") is None:
+        pytest.skip("tmux not installed; runner terminal input needs tmux on PATH")
+
+    registry = TerminalRegistry()
+    app = create_runner_app(
+        terminal_registry=registry,
+        runner_workspace=tmp_path,
+        per_session_workspace=False,
+        server_client=NullServerClient(),
+    )
+    transport = httpx.ASGITransport(app=app)
+    marker = f"RUNNER_INPUT_MARKER_{uuid.uuid4().hex[:8]}"
+    output_marker = f"OUT-{marker}"
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as client:
+            create = await client.post(
+                "/v1/sessions/conv_route/resources/terminals",
+                json={
+                    "terminal": "bash",
+                    "session_key": "route",
+                    "spec": {"command": "bash", "cwd": str(tmp_path)},
+                },
+            )
+            assert create.status_code == 200, create.text
+
+            sent = await client.post(
+                "/v1/sessions/conv_route/resources/terminals/terminal_bash_route/input",
+                json={"text": f"printf 'OUT-%s\\n' {marker}"},
+            )
+            assert sent.status_code == 200, sent.text
+            assert sent.json() == {"status": "sent", "outcome": "sent"}
+
+            instance = registry.get("conv_route", "bash", "route")
+            assert instance is not None
+            screens: list[str] = []
+            for _ in range(20):
+                read_result = await instance.read()
+                screens.append(str(read_result.get("screen", "")))
+                if output_marker in screens[-1]:
+                    break
+                await asyncio.sleep(0.05)
+
+            assert output_marker in "\n".join(screens)
+    finally:
+        await registry.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_runner_terminal_input_waits_past_startup_stdin_consumer(tmp_path: Path) -> None:
+    """Startup stdin cannot swallow a command behind a false readiness ACK."""
+    if shutil.which("tmux") is None or shutil.which("bash") is None:
+        pytest.skip("tmux and bash are required for live readiness coverage")
+
+    registry = TerminalRegistry()
+    app = create_runner_app(
+        terminal_registry=registry,
+        runner_workspace=tmp_path,
+        per_session_workspace=False,
+        server_client=NullServerClient(),
+    )
+    transport = httpx.ASGITransport(app=app)
+    marker = f"READY_INPUT_MARKER_{uuid.uuid4().hex[:8]}"
+    startup = (
+        "import os,select,sys;"
+        "ready,_,_=select.select([sys.stdin],[],[],0.25);"
+        "sys.stdin.readline() if ready else None;"
+        "os.execvp('bash',['bash','--noprofile','--norc','-i'])"
+    )
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as client:
+            create = await client.post(
+                "/v1/sessions/conv_ready/resources/terminals",
+                json={
+                    "terminal": "shell",
+                    "session_key": "startup",
+                    "spec": {
+                        "command": sys.executable,
+                        "args": ["-c", startup],
+                        "cwd": str(tmp_path),
+                        "ready_process": "bash",
+                    },
+                },
+            )
+            assert create.status_code == 200, create.text
+
+            sent = await client.post(
+                "/v1/sessions/conv_ready/resources/terminals/terminal_shell_startup/input",
+                json={
+                    "attempt_id": str(uuid.uuid4()),
+                    "text": f"printf '%s\\n' {marker}",
+                    "wait_for_ready": True,
+                },
+            )
+            if sent.status_code == 409:
+                assert sent.json()["error"]["code"] == "terminal_not_ready"
+                return
+
+            assert sent.status_code == 200, sent.text
+            assert sent.json()["outcome"] == "sent"
+            instance = registry.get("conv_ready", "shell", "startup")
+            assert instance is not None
+            screens: list[str] = []
+            for _ in range(40):
+                read_result = await instance.read()
+                screens.append(str(read_result.get("screen", "")))
+                if marker in screens[-1]:
+                    break
+                await asyncio.sleep(0.05)
+            assert marker in "\n".join(screens), (
+                "a 200/sent readiness result must prove the final shell, not "
+                "the startup stdin consumer, received the command"
+            )
+    finally:
+        await registry.shutdown()
 
 
 def test_sys_terminal_basic_round_trip(
@@ -572,3 +700,130 @@ def test_sys_terminal_send_keys_drives_interactive(
         f"Enter didn't reach python's stdin; if nothing useful shows, python3 "
         f"may not be on PATH in the tmux env."
     )
+
+
+def _write_probe_residue_delayed_shell(
+    tmp_path: Path,
+    *,
+    shell_name: str,
+    real_shell: str,
+) -> Path:
+    """Create a shell-named shim that waits before preserving the real argv."""
+    wrapper_dir = tmp_path / "probe-residue-shells"
+    wrapper_dir.mkdir(exist_ok=True)
+    wrapper = wrapper_dir / shell_name
+    wrapper.write_text(
+        f"#!{sys.executable}\n"
+        "import os\n"
+        "import sys\n"
+        "import time\n"
+        "time.sleep(1.35)\n"
+        f"real_shell = {real_shell!r}\n"
+        "os.execv(real_shell, [real_shell, *sys.argv[1:]])\n",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def _probe_residue_output_command(marker: str) -> str:
+    """Return a command whose typed representation does not include *marker*."""
+    encoded = "".join(f"\\0{ord(char):03o}" for char in marker)
+    return f"builtin printf '%b\\n' '{encoded}'"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("shell_name", "shell_args"),
+    [
+        ("bash", ["--noprofile", "--norc"]),
+        ("zsh", ["-f"]),
+    ],
+)
+async def test_runner_terminal_input_cold_spawn_hides_readiness_probe(
+    tmp_path: Path,
+    shell_name: str,
+    shell_args: list[str],
+) -> None:
+    """A delayed direct shell shows only the one user command and its output."""
+    real_shell = shutil.which(shell_name)
+    if shutil.which("tmux") is None or real_shell is None:
+        pytest.skip(f"tmux and {shell_name} are required for live readiness coverage")
+
+    registry = TerminalRegistry()
+    app = create_runner_app(
+        terminal_registry=registry,
+        runner_workspace=tmp_path,
+        per_session_workspace=False,
+        server_client=NullServerClient(),
+    )
+    transport = httpx.ASGITransport(app=app)
+    marker = f"O{uuid.uuid4().hex[:6]}"
+    command = _probe_residue_output_command(marker)
+    wrapper = _write_probe_residue_delayed_shell(
+        tmp_path,
+        shell_name=shell_name,
+        real_shell=real_shell,
+    )
+    session_key = f"clean-{shell_name}"
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as client:
+            create = await client.post(
+                "/v1/sessions/conv_clean/resources/terminals",
+                json={
+                    "terminal": shell_name,
+                    "session_key": session_key,
+                    "spec": {
+                        "command": str(wrapper),
+                        "args": shell_args,
+                        "cwd": str(tmp_path),
+                    },
+                },
+            )
+            assert create.status_code == 200, create.text
+
+            instance = registry.get("conv_clean", shell_name, session_key)
+            assert instance is not None
+            nonce = instance.shell_ready_nonce
+            assert nonce is not None
+
+            started = time.monotonic()
+            sent = await client.post(
+                (
+                    "/v1/sessions/conv_clean/resources/terminals/"
+                    f"terminal_{shell_name}_{session_key}/input"
+                ),
+                json={
+                    "attempt_id": str(uuid.uuid4()),
+                    "text": command,
+                    "keys": "Enter",
+                    "wait_for_ready": True,
+                },
+            )
+            elapsed = time.monotonic() - started
+            assert sent.status_code == 200, sent.text
+            assert sent.json() == {"status": "sent", "outcome": "sent"}
+            assert elapsed > 1.0
+
+            screens: list[str] = []
+            for _ in range(40):
+                result = await instance.read(scrollback=100)
+                screen = str(result.get("screen", ""))
+                screens.append(screen)
+                if any(line.strip() == marker for line in screen.splitlines()):
+                    break
+                await asyncio.sleep(0.05)
+            else:
+                raise AssertionError(f"shell output {marker!r} did not appear:\n{screens[-1]}")
+
+            nonempty_lines = [line for line in screen.splitlines() if line.strip()]
+            assert command in nonempty_lines[0], screen
+            assert screen.count(command) == 1, screen
+            assert screen.count(marker) == 1, screen
+            assert "BASH_SOURCE" not in screen, screen
+            assert "ZSH_EVAL_CONTEXT" not in screen, screen
+            assert "OMNIGENT_SHELL_READY_" not in screen, screen
+            assert nonce not in screen, screen
+    finally:
+        await registry.shutdown()

--- a/tests/runner/test_app_sessions_native_terminal_routing.py
+++ b/tests/runner/test_app_sessions_native_terminal_routing.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -1002,7 +1001,6 @@ async def test_ensure_terminal_route_recreates_dead_registered_pane(
 
     with registry._lock:
         registry._by_conversation[sid] = {("claude", "main"): dead_instance}
-        registry._instance_locks[(sid, "claude", "main")] = threading.Lock()
 
     app = create_runner_app(
         process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
@@ -1070,7 +1068,6 @@ async def test_dead_registered_pane_close_restores_running_for_kill_server(
 
     with registry._lock:
         registry._by_conversation[sid] = {("claude", "main"): dead_instance}
-        registry._instance_locks[(sid, "claude", "main")] = threading.Lock()
 
     alive = await dead_instance.is_alive()
     assert alive is False

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import threading
 import uuid
 from collections.abc import AsyncIterator, Callable, Sequence
 from dataclasses import dataclass
@@ -38,6 +39,9 @@ from omnigent.runner.resource_registry import (
 )
 from omnigent.spec.types import AgentSpec, ExecutorSpec
 from omnigent.terminals import TerminalListEntry, TerminalRegistry
+from omnigent.tools.base import ToolContext
+from omnigent.tools.builtins import sys_terminal as sys_terminal_module
+from omnigent.tools.builtins.sys_terminal import SysTerminalReadTool, SysTerminalSendTool
 from tests.runner.helpers import NullServerClient, make_test_terminal_instance
 
 
@@ -834,6 +838,930 @@ async def test_get_terminal_returns_404_for_unknown(
     resp = await client.get("/v1/sessions/conv_abc/resources/terminals/terminal_nope_s1")
 
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_sends_under_instance_lock(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /input sends literal text with default Enter under the instance lock."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    lock = instance.op_lock
+    calls: list[tuple[str | None, str]] = []
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        assert lock.locked(), "the shared send helper must hold the per-instance lock"
+        calls.append((text, keys))
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", record_send)
+
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"text": "printf '$HOME | literal'"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "sent", "outcome": "sent"}
+    assert calls == [("printf '$HOME | literal'", "Enter")]
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_returns_404_for_unknown(
+    client: httpx.AsyncClient,
+) -> None:
+    """POST /input distinguishes an unknown resource from a stopped terminal."""
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_nope_s1/input",
+        json={"text": "echo ignored"},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "terminal_not_running"
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_returns_409_when_not_running(
+    client: httpx.AsyncClient,
+) -> None:
+    """POST /input returns 409 for a known registry entry that is stopped."""
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_stale_s3/input",
+        json={"text": "echo ignored"},
+    )
+
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_returns_409_when_send_observes_exit(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /input maps a tmux exit observed during send to 409."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+
+    async def report_exit(
+        text: str | None = None,
+        *,
+        keys: str = "Enter",
+    ) -> dict[str, str]:
+        del text, keys
+        instance.running = False
+        return {"error": "Terminal bash:s1 is no longer running"}
+
+    monkeypatch.setattr(instance, "send", report_exit)
+
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"text": "echo races with exit"},
+    )
+
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_requires_json_content_type(
+    client: httpx.AsyncClient,
+) -> None:
+    """POST /input rejects a text/plain JSON body before parsing it."""
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        content=json.dumps({"text": "echo ignored"}),
+        headers={"content-type": "text/plain"},
+    )
+
+    assert resp.status_code == 415
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_rejects_invalid_body(
+    client: httpx.AsyncClient,
+) -> None:
+    """POST /input requires string text and keys fields."""
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"text": 42, "keys": ["Enter"]},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_route_and_send_tool_share_primitive(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The agent tool and runner route delegate to the same send chokepoint."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    lock = instance.op_lock
+    calls: list[
+        tuple[TerminalRegistry, TerminalInstance, threading.Lock, str | None, str, bool]
+    ] = []
+
+    def record_send(
+        target_registry: TerminalRegistry,
+        snapshot: Any,
+        text: str | None,
+        *,
+        keys: str = "Enter",
+        wait_for_ready: bool = False,
+    ) -> dict[str, str]:
+        calls.append(
+            (
+                target_registry,
+                snapshot.instance,
+                snapshot.op_lock,
+                text,
+                keys,
+                wait_for_ready,
+            )
+        )
+        return {"status": "sent"}
+
+    # This stub proves delegation and argument identity for both callers.
+    # Lock behavior and real tmux delivery are covered by their focused tests.
+    monkeypatch.setattr(sys_terminal_module, "send_terminal_input", record_send)
+    tool = SysTerminalSendTool(registry=registry)
+    ctx = ToolContext(
+        task_id="task_parity",
+        agent_id="agent_parity",
+        workspace=tmp_path,
+        conversation_id="conv_abc",
+    )
+
+    tool_result = await asyncio.to_thread(
+        tool.invoke,
+        json.dumps(
+            {
+                "terminal": "bash",
+                "session": "s1",
+                "text": "echo parity",
+                "keys": "C-j",
+            }
+        ),
+        ctx,
+    )
+    route_result = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"text": "echo parity", "keys": "C-j"},
+    )
+
+    assert tool_result == '{"status": "sent"}'
+    assert route_result.status_code == 200
+    assert route_result.json() == {"status": "sent", "outcome": "sent"}
+    assert calls == [
+        (registry, instance, lock, "echo parity", "C-j", False),
+        (registry, instance, lock, "echo parity", "C-j", False),
+    ]
+
+
+def _attempt_id() -> str:
+    """Return one canonical attempt id for runner input tests."""
+    return str(uuid.uuid4())
+
+
+async def _post_terminal_input(
+    client: httpx.AsyncClient,
+    *,
+    attempt_id: str,
+    text: str = "echo fenced",
+) -> httpx.Response:
+    """POST one idempotent input request to the seeded bash terminal."""
+    return await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"attempt_id": attempt_id, "text": text},
+    )
+
+
+def _snapshot_for_seeded_bash(registry: TerminalRegistry) -> Any:
+    """Capture the atomic ownership snapshot for the seeded bash terminal."""
+    snapshot = registry.resolve_snapshot("conv_abc", "terminal_bash_s1")
+    assert snapshot is not None
+    assert getattr(snapshot, "code", None) != "ambiguous_resource_id"
+    return snapshot
+
+
+def _patch_stale_resolution(
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    snapshot: Any,
+) -> None:
+    """Force the route to exercise a snapshot captured before a mutation."""
+    monkeypatch.setattr(registry, "resolve_snapshot", lambda *_args: snapshot)
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_after_transfer_uses_zero_tmux_calls(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sender that lost to transfer fails closed before touching tmux."""
+    snapshot = _snapshot_for_seeded_bash(registry)
+    instance = snapshot.instance
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", record_send)
+    assert registry.transfer("conv_abc", "conv_new", "bash", "s1") is True
+    _patch_stale_resolution(registry, monkeypatch, snapshot)
+
+    response = await _post_terminal_input(client, attempt_id=_attempt_id())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "terminal_moved"
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_after_close_uses_zero_tmux_calls(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sender that lost to close fails closed before touching tmux."""
+    snapshot = _snapshot_for_seeded_bash(registry)
+    instance = snapshot.instance
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    async def close_without_tmux() -> None:
+        instance.running = False
+
+    monkeypatch.setattr(instance, "send", record_send)
+    monkeypatch.setattr(instance, "close", close_without_tmux)
+    assert await registry.close("conv_abc", "bash", "s1") is True
+    _patch_stale_resolution(registry, monkeypatch, snapshot)
+
+    response = await _post_terminal_input(client, attempt_id=_attempt_id())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "terminal_moved"
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_after_cleanup_uses_zero_tmux_calls(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sender that lost to conversation cleanup performs no tmux input."""
+    snapshot = _snapshot_for_seeded_bash(registry)
+    instance = snapshot.instance
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    async def close_without_tmux() -> None:
+        instance.running = False
+
+    monkeypatch.setattr(instance, "send", record_send)
+    monkeypatch.setattr(instance, "close", close_without_tmux)
+    await registry.cleanup_conversation("conv_abc")
+    _patch_stale_resolution(registry, monkeypatch, snapshot)
+
+    response = await _post_terminal_input(client, attempt_id=_attempt_id())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "terminal_moved"
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_after_shutdown_uses_zero_tmux_calls(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sender that lost to runner shutdown performs no tmux input."""
+    snapshot = _snapshot_for_seeded_bash(registry)
+    instance = snapshot.instance
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    async def close_without_tmux() -> None:
+        instance.running = False
+
+    monkeypatch.setattr(instance, "send", record_send)
+    monkeypatch.setattr(instance, "close", close_without_tmux)
+    await registry.shutdown()
+    _patch_stale_resolution(registry, monkeypatch, snapshot)
+
+    response = await _post_terminal_input(client, attempt_id=_attempt_id())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "terminal_moved"
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_transfer_out_and_back_rejects_aba_snapshot(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Returning the same instance to its old owner cannot revive a stale send."""
+    snapshot = _snapshot_for_seeded_bash(registry)
+    instance = snapshot.instance
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", record_send)
+    assert registry.transfer("conv_abc", "conv_new", "bash", "s1") is True
+    assert registry.transfer("conv_new", "conv_abc", "bash", "s1") is True
+    assert registry.get("conv_abc", "bash", "s1") is instance
+    _patch_stale_resolution(registry, monkeypatch, snapshot)
+
+    response = await _post_terminal_input(client, attempt_id=_attempt_id())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "terminal_moved"
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_read_after_transfer_rejects_stale_snapshot(
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A read captured by the old owner cannot expose the new owner's pane."""
+    snapshot = _snapshot_for_seeded_bash(registry)
+    instance = snapshot.instance
+    read_calls = 0
+
+    async def record_read(scrollback: int = 0) -> dict[str, object]:
+        nonlocal read_calls
+        del scrollback
+        read_calls += 1
+        return {"screen": "new-owner-secret"}
+
+    monkeypatch.setattr(instance, "read", record_read)
+    assert registry.transfer("conv_abc", "conv_new", "bash", "s1") is True
+    _patch_stale_resolution(registry, monkeypatch, snapshot)
+    tool = SysTerminalReadTool(registry=registry)
+    context = ToolContext(
+        task_id="task_read_fence",
+        agent_id="agent_read_fence",
+        workspace=tmp_path,
+        conversation_id="conv_abc",
+    )
+
+    result = json.loads(
+        await asyncio.to_thread(
+            tool.invoke,
+            json.dumps({"terminal": "bash", "session": "s1"}),
+            context,
+        )
+    )
+
+    assert result["code"] == "terminal_moved"
+    assert read_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_concurrent_duplicate_executes_once(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent identical attempt ids await one shielded send task."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    started = threading.Event()
+    release = threading.Event()
+    send_calls = 0
+
+    async def gated_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        started.set()
+        await asyncio.to_thread(release.wait)
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", gated_send)
+    attempt_id = _attempt_id()
+    first = asyncio.create_task(_post_terminal_input(client, attempt_id=attempt_id))
+    assert await asyncio.to_thread(started.wait, 2.0)
+    second = asyncio.create_task(_post_terminal_input(client, attempt_id=attempt_id))
+    release.set()
+
+    first_response, second_response = await asyncio.gather(first, second)
+
+    assert first_response.status_code == second_response.status_code == 200
+    assert (
+        first_response.json()
+        == second_response.json()
+        == {
+            "status": "sent",
+            "outcome": "sent",
+        }
+    )
+    assert send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_attempt_fingerprint_mismatch_is_conflict(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An attempt id is permanently bound to its first input fingerprint."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", record_send)
+    attempt_id = _attempt_id()
+    first = await _post_terminal_input(client, attempt_id=attempt_id, text="echo one")
+    conflict = await _post_terminal_input(client, attempt_id=attempt_id, text="echo two")
+
+    assert first.status_code == 200
+    assert conflict.status_code == 409
+    assert conflict.json()["error"]["code"] == "attempt_conflict"
+    assert send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_cancelling_first_waiter_keeps_single_flight(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling one waiter cannot cancel or unclaim the shared send."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    started = threading.Event()
+    release = threading.Event()
+    send_calls = 0
+
+    async def gated_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        started.set()
+        await asyncio.to_thread(release.wait)
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", gated_send)
+    attempt_id = _attempt_id()
+    first = asyncio.create_task(_post_terminal_input(client, attempt_id=attempt_id))
+    assert await asyncio.to_thread(started.wait, 2.0)
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    retry = asyncio.create_task(_post_terminal_input(client, attempt_id=attempt_id))
+    release.set()
+    response = await retry
+
+    assert response.status_code == 200
+    assert response.json()["outcome"] == "sent"
+    assert send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_partial_send_is_delivery_unknown_and_retry_is_noop(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text success followed by Enter failure is cached as delivery unknown."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    tmux_calls = 0
+
+    async def fail_enter(*args: str) -> None:
+        nonlocal tmux_calls
+        tmux_calls += 1
+        if tmux_calls == 2:
+            raise RuntimeError("enter response lost")
+
+    monkeypatch.setattr(instance, "_tmux", fail_enter)
+    attempt_id = _attempt_id()
+    first = await _post_terminal_input(client, attempt_id=attempt_id)
+    retry = await _post_terminal_input(client, attempt_id=attempt_id)
+
+    assert first.status_code == retry.status_code == 200
+    assert first.json() == retry.json()
+    assert first.json()["outcome"] == "delivery_unknown"
+    assert tmux_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_readiness_timeout_is_definite_and_cached(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing final-process ACK rejects before any input operation."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    instance.shell_ready_nonce = "OMNIGENT_SHELL_READY_never_seen"
+    readiness_checks = 0
+    readiness_timeouts: list[float] = []
+    send_calls = 0
+
+    async def _not_ready(*, timeout_s: float, poll_interval_s: float = 0.025) -> bool:
+        nonlocal readiness_checks
+        del poll_interval_s
+        readiness_checks += 1
+        readiness_timeouts.append(timeout_s)
+        return False
+
+    async def _record_send(
+        text: str | None = None,
+        *,
+        keys: str = "Enter",
+    ) -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "wait_for_shell_ready", _not_ready)
+    monkeypatch.setattr(instance, "send", _record_send)
+    attempt_id = _attempt_id()
+    body = {
+        "attempt_id": attempt_id,
+        "text": "echo never-dispatched",
+        "wait_for_ready": True,
+    }
+
+    first = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=body,
+    )
+    replay = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=body,
+    )
+
+    assert first.status_code == replay.status_code == 409
+    assert first.json() == replay.json()
+    assert first.json()["error"]["code"] == "terminal_not_ready"
+    assert readiness_checks == 1
+    assert readiness_timeouts == [10.0]
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("acknowledge", "expected_status", "expected_send_calls"),
+    [(True, 200, 1), (False, 409, 0)],
+)
+async def test_terminal_input_retries_incomplete_probe_without_unsafe_delivery(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    acknowledge: bool,
+    expected_status: int,
+    expected_send_calls: int,
+) -> None:
+    """An incomplete probe is retryable but never bypasses the ACK gate."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    lock = instance.op_lock
+    instance.shell_ready_nonce = "OMNIGENT_SHELL_READY_capability"
+    monkeypatch.setattr(sys_terminal_module, "_SHELL_READINESS_TIMEOUT_SECONDS", 0.05)
+    probe_sends = 0
+    probe_nonces: list[str] = []
+    clear_history_calls = 0
+    send_calls = 0
+    history_nonce: str | None = None
+
+    async def readiness_tmux(*args: str) -> None:
+        nonlocal probe_sends, clear_history_calls, history_nonce
+        assert lock.locked(), "readiness and delivery must share the instance lock"
+        if args[:2] == ("send-keys", "-l"):
+            probe_sends += 1
+            assert instance.shell_ready_nonce is not None
+            probe_nonces.append(instance.shell_ready_nonce)
+        elif args == ("send-keys", "-t", "main", "Enter"):
+            history_nonce = instance.shell_ready_nonce if acknowledge else None
+        elif args[0] == "clear-history":
+            clear_history_calls += 1
+            history_nonce = None
+            if clear_history_calls == 1:
+                await asyncio.sleep(1)
+
+    async def readiness_capture(*args: str) -> str:
+        assert lock.locked(), "readiness and delivery must share the instance lock"
+        if "-S" in args:
+            return history_nonce or "clean prompt"
+        return "clean prompt"
+
+    async def record_send(
+        text: str | None = None,
+        *,
+        keys: str = "Enter",
+    ) -> dict[str, str]:
+        nonlocal send_calls
+        assert lock.locked(), "readiness and delivery must share the instance lock"
+        assert text == "echo exactly-once"
+        assert keys == "Enter"
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "_tmux", readiness_tmux)
+    monkeypatch.setattr(instance, "_tmux_output", readiness_capture)
+    monkeypatch.setattr(instance, "send", record_send)
+    first = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={
+            "attempt_id": _attempt_id(),
+            "text": "echo exactly-once",
+            "wait_for_ready": True,
+        },
+    )
+    retry_attempt_id = _attempt_id()
+    retry_body = {
+        "attempt_id": retry_attempt_id,
+        "text": "echo exactly-once",
+        "wait_for_ready": True,
+    }
+    second = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=retry_body,
+    )
+    replay = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=retry_body,
+    )
+
+    assert first.status_code == 409
+    assert first.json()["error"]["code"] == "terminal_not_ready"
+    assert second.status_code == replay.status_code == expected_status
+    assert second.json() == replay.json()
+    if acknowledge:
+        assert second.json() == {"status": "sent", "outcome": "sent"}
+    else:
+        assert second.json()["error"]["code"] == "terminal_not_ready"
+    assert probe_sends == 2
+    assert len(set(probe_nonces)) == 2
+    assert clear_history_calls == (2 if acknowledge else 0)
+    assert history_nonce is None
+    assert send_calls == expected_send_calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("becomes_ready", "expected_status", "expected_send_calls"),
+    [(True, 200, 1), (False, 409, 0)],
+)
+async def test_terminal_input_retries_after_over_budget_readiness_evaluation(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    becomes_ready: bool,
+    expected_status: int,
+    expected_send_calls: int,
+) -> None:
+    """One over-budget probe cannot latch readiness or bypass fail-closed delivery."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    lock = instance.op_lock
+    instance.shell_ready_nonce = "OMNIGENT_SHELL_READY_over_budget"
+    monkeypatch.setattr(sys_terminal_module, "_SHELL_READINESS_TIMEOUT_SECONDS", 0.01)
+    readiness_evaluations = 0
+    send_calls = 0
+
+    async def evaluate_readiness(
+        *,
+        timeout_s: float,
+        poll_interval_s: float,
+    ) -> bool:
+        nonlocal readiness_evaluations
+        del poll_interval_s
+        assert lock.locked(), "readiness and delivery must share the instance lock"
+        assert instance._shell_ready_probe_sent is False
+        readiness_evaluations += 1
+        instance._shell_ready_probe_sent = True
+        if readiness_evaluations == 2 and becomes_ready:
+            instance._shell_ready_acknowledged = True
+            return True
+        await asyncio.sleep(timeout_s * 4)
+        if becomes_ready:
+            instance._shell_ready_acknowledged = True
+            return True
+        return False
+
+    async def record_send(
+        text: str | None = None,
+        *,
+        keys: str = "Enter",
+    ) -> dict[str, str]:
+        nonlocal send_calls
+        assert lock.locked(), "readiness and delivery must share the instance lock"
+        assert text == "echo exactly-once"
+        assert keys == "Enter"
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "_wait_for_shell_ready_once", evaluate_readiness)
+    monkeypatch.setattr(instance, "send", record_send)
+    first = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={
+            "attempt_id": _attempt_id(),
+            "text": "echo exactly-once",
+            "wait_for_ready": True,
+        },
+    )
+    retry_attempt_id = _attempt_id()
+    retry_body = {
+        "attempt_id": retry_attempt_id,
+        "text": "echo exactly-once",
+        "wait_for_ready": True,
+    }
+    second = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=retry_body,
+    )
+    replay = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=retry_body,
+    )
+
+    assert first.status_code == 409
+    assert first.json()["error"]["code"] == "terminal_not_ready"
+    assert second.status_code == replay.status_code == expected_status
+    assert second.json() == replay.json()
+    if becomes_ready:
+        assert second.json() == {"status": "sent", "outcome": "sent"}
+    else:
+        assert second.json()["error"]["code"] == "terminal_not_ready"
+    assert readiness_evaluations == 2
+    assert send_calls == expected_send_calls
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_rejects_unsupported_readiness_before_send(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A terminal with no readiness contract fails explicitly and sends nothing."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    instance.shell_ready_nonce = None
+    instance.ready_process = None
+    send_calls = 0
+
+    async def _record_send(
+        text: str | None = None,
+        *,
+        keys: str = "Enter",
+    ) -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", _record_send)
+    response = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={
+            "attempt_id": _attempt_id(),
+            "text": "echo never-dispatched",
+            "wait_for_ready": True,
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "shell_readiness_unsupported"
+    assert send_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_completed_attempt_replays_after_transfer(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A completed attempt replays before terminal ownership is re-resolved."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", record_send)
+    attempt_id = _attempt_id()
+    first = await _post_terminal_input(client, attempt_id=attempt_id)
+    assert registry.transfer("conv_abc", "conv_new", "bash", "s1") is True
+    replay = await _post_terminal_input(client, attempt_id=attempt_id)
+
+    assert first.status_code == replay.status_code == 200
+    assert first.json() == replay.json()
+    assert send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_capacity_rejects_before_execute(
+    client: httpx.AsyncClient,
+    app: FastAPI,
+    registry: TerminalRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A full attempt ledger rejects a new id without a second send."""
+    instance = registry.get("conv_abc", "bash", "s1")
+    assert instance is not None
+    app.state.terminal_input_attempts.max_entries = 1
+    send_calls = 0
+
+    async def record_send(text: str | None = None, *, keys: str = "Enter") -> dict[str, str]:
+        nonlocal send_calls
+        del text, keys
+        send_calls += 1
+        return {"status": "sent"}
+
+    monkeypatch.setattr(instance, "send", record_send)
+    first_id = _attempt_id()
+    first = await _post_terminal_input(client, attempt_id=first_id)
+    rejected = await _post_terminal_input(client, attempt_id=_attempt_id())
+    replay = await _post_terminal_input(client, attempt_id=first_id)
+
+    assert first.status_code == replay.status_code == 200
+    assert rejected.status_code == 503
+    assert rejected.json()["error"]["code"] == "idempotency_capacity_exhausted"
+    assert send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_registration_rejects_colliding_name_key(
+    registry: TerminalRegistry,
+) -> None:
+    """Sanitized name/key collisions are rejected before spawning tmux."""
+    with pytest.raises(RuntimeError, match=r"resource id.*collides"):
+        await registry.launch(
+            "conv_abc",
+            "bash ",
+            "s1",
+            TerminalEnvSpec(command="bash"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_ambiguous_resource_id_returns_409(
+    client: httpx.AsyncClient,
+    registry: TerminalRegistry,
+    tmp_path: Path,
+) -> None:
+    """A legacy colliding registry fails closed instead of choosing first."""
+    collision = _make_instance("bash ", "s1", tmp_path)
+    registry._by_conversation["conv_abc"][(collision.name, collision.session_key)] = collision
+
+    response = await _post_terminal_input(client, attempt_id=_attempt_id())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "ambiguous_resource_id"
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import threading
+import time
 import uuid
 from collections.abc import AsyncIterator, Callable, Sequence
 from dataclasses import dataclass
@@ -954,6 +955,47 @@ async def test_terminal_input_rejects_invalid_body(
 
 
 @pytest.mark.asyncio
+async def test_terminal_input_flag_like_keys_returns_400_without_attempt_id(
+    client: httpx.AsyncClient,
+) -> None:
+    """A flag-like ``keys`` token surfaces the send guard's 400 invalid_input."""
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"text": "echo hi", "keys": "-X"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_flag_like_keys_returns_400_with_attempt_id(
+    client: httpx.AsyncClient,
+) -> None:
+    """The idempotency ledger must not mask the guard's 400 as delivery_unknown.
+
+    A same-``attempt_id`` replay of the rejected request must return the same
+    400 — the ledger caches the failing task, not a fake ``delivery_unknown``.
+    """
+    attempt_id = _attempt_id()
+    body = {"attempt_id": attempt_id, "text": "echo hi", "keys": "-X"}
+
+    first = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=body,
+    )
+    assert first.status_code == 400
+    assert first.json()["error"]["code"] == "invalid_input"
+
+    replay = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json=body,
+    )
+    assert replay.status_code == 400
+    assert replay.json()["error"]["code"] == "invalid_input"
+
+
+@pytest.mark.asyncio
 async def test_terminal_input_route_and_send_tool_share_primitive(
     client: httpx.AsyncClient,
     registry: TerminalRegistry,
@@ -1360,6 +1402,44 @@ async def test_terminal_input_cancelling_first_waiter_keeps_single_flight(
     assert response.status_code == 200
     assert response.json()["outcome"] == "sent"
     assert send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_cancelled_owner_entry_stays_purgeable() -> None:
+    """A directly-cancelled owner task stamps completion so its slot is reclaimed.
+
+    ``_purge_expired_locked`` only evicts completed entries; without the
+    synchronous stamp a cancelled owner would leak its slot forever and poison
+    that attempt_id for the process lifetime.
+    """
+    from omnigent.runner.app import (
+        _TERMINAL_INPUT_ATTEMPT_TTL_SECONDS,
+        _TerminalInputAttempt,
+        _TerminalInputAttempts,
+    )
+
+    attempts = _TerminalInputAttempts()
+    key = ("conv_abc", "attempt-cancelled")
+    placeholder = asyncio.create_task(asyncio.sleep(0))
+    await placeholder
+    attempts._entries[key] = _TerminalInputAttempt(
+        fingerprint=("terminal_bash_s1", "echo hi", "Enter", False),
+        task=placeholder,
+    )
+
+    async def _cancelled_operation() -> Any:
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await attempts._run_claimed(key, _cancelled_operation)
+
+    assert attempts._entries[key].completed_at is not None
+
+    attempts._entries[key].completed_at = (
+        time.monotonic() - _TERMINAL_INPUT_ATTEMPT_TTL_SECONDS - 1
+    )
+    attempts._purge_expired_locked()
+    assert key not in attempts._entries
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -860,6 +860,16 @@ async def test_terminal_input_sends_under_instance_lock(
 
     monkeypatch.setattr(instance, "send", record_send)
 
+    async def forbid_readiness_wait(**kwargs: float) -> bool:
+        del kwargs
+        raise AssertionError("ordinary terminal input must not wait for shell readiness")
+
+    monkeypatch.setattr(
+        instance,
+        "wait_for_shell_ready",
+        forbid_readiness_wait,
+    )
+
     resp = await client.post(
         "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
         json={"text": "printf '$HOME | literal'"},
@@ -911,6 +921,7 @@ async def test_terminal_input_returns_409_when_send_observes_exit(
         text: str | None = None,
         *,
         keys: str = "Enter",
+        wait_for_ready: bool = False,
     ) -> dict[str, str]:
         del text, keys
         instance.running = False
@@ -944,10 +955,18 @@ async def test_terminal_input_requires_json_content_type(
 async def test_terminal_input_rejects_invalid_body(
     client: httpx.AsyncClient,
 ) -> None:
-    """POST /input requires string text and keys fields."""
+    """POST /input validates text, keys, and the readiness opt-in."""
     resp = await client.post(
         "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
         json={"text": 42, "keys": ["Enter"]},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+    resp = await client.post(
+        "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/input",
+        json={"text": "echo ignored", "wait_for_ready": "yes"},
     )
 
     assert resp.status_code == 400

--- a/tests/runner/test_terminal_resource_attach_ws.py
+++ b/tests/runner/test_terminal_resource_attach_ws.py
@@ -108,8 +108,8 @@ def test_runner_resource_attach_spawns_tmux_for_running_terminal(
             # ``?transport=pty`` pins this to the PTY bridge (the one that forks
             # tmux attach) independent of the global control-mode default.
             "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach?transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     # ``-r`` is absent (read_only defaulted to false) and the local
     # socket path from the registry is what's threaded in.
@@ -156,8 +156,8 @@ def test_runner_resource_attach_passes_read_only_to_tmux(
         with TestClient(app).websocket_connect(
             "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach"
             "?read_only=true&transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     assert "-r" in captured["argv"], (
         f"Expected -r with read_only=true, got argv={captured['argv']!r}"
@@ -204,18 +204,57 @@ def test_runner_resource_attach_selects_control_bridge_on_transport_query(
     base = "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach"
     client = TestClient(app)
     with contextlib.suppress(WebSocketDisconnect):
-        with client.websocket_connect(f"{base}?transport=control"):
-            pass
+        with client.websocket_connect(f"{base}?transport=control") as ws:
+            ws.receive_bytes()
     with contextlib.suppress(WebSocketDisconnect):
-        with client.websocket_connect(f"{base}?transport=pty"):
-            pass
+        with client.websocket_connect(f"{base}?transport=pty") as ws:
+            ws.receive_bytes()
     with contextlib.suppress(WebSocketDisconnect):
-        with client.websocket_connect(base):  # no query → control default
-            pass
+        with client.websocket_connect(base) as ws:  # no query → control default
+            ws.receive_bytes()
 
     assert calls == ["control", "pty", "control"], (
         f"transport query did not select the expected bridge: {calls!r}"
     )
+
+
+def test_runner_resource_attach_frame_after_transfer_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An already-attached socket cannot write after ownership transfers."""
+    registry = TerminalRegistry()
+    instance = _make_running_instance("bash", "s1", tmp_path)
+    _seed_registry(registry, "conv_abc", instance)
+    app = create_runner_app(
+        terminal_registry=registry,
+        server_client=NullServerClient(),
+    )
+    decisions: list[bool] = []
+    tmux_calls = 0
+
+    async def count_tmux(*args: str) -> None:
+        nonlocal tmux_calls
+        del args
+        tmux_calls += 1
+
+    async def fake_control(websocket, **kwargs) -> None:
+        assert registry.transfer("conv_abc", "conv_new", "bash", "s1") is True
+        on_client_input = kwargs["on_client_input"]
+        decisions.append(await on_client_input(b"x"))
+        await websocket.close()
+
+    monkeypatch.setattr(instance, "_tmux", count_tmux)
+    monkeypatch.setattr("omnigent.runner.app.bridge_tmux_control_to_websocket", fake_control)
+
+    with contextlib.suppress(WebSocketDisconnect):
+        with TestClient(app).websocket_connect(
+            "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach?transport=control"
+        ) as ws:
+            ws.receive_bytes()
+
+    assert decisions == [False]
+    assert tmux_calls == 0
 
 
 def test_runner_resource_attach_unknown_terminal_closes_4404(tmp_path: Path) -> None:
@@ -413,8 +452,8 @@ def test_runner_resource_attach_recreates_dead_repl_terminal(
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
             "/v1/sessions/conv_abc/resources/terminals/terminal_tui_main/attach?transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     # The recreate ran exactly once, for this session. [] means the
     # route still closes 4404 (the pre-fix dead-end); a wrong id means
@@ -435,8 +474,8 @@ def test_runner_resource_attach_recreates_dead_repl_terminal(
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
             "/v1/sessions/conv_abc/resources/terminals/terminal_tui_main/attach?transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     assert auto_create_sessions == ["conv_abc"]
     assert str(fresh_dir / "tui-main.sock") in attach_argvs[1]
@@ -533,8 +572,8 @@ def test_runner_resource_attach_recreates_dead_qwen_terminal(
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
             "/v1/sessions/conv_abc/resources/terminals/terminal_qwen_main/attach?transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     assert auto_create_sessions == ["conv_abc"]
     assert str(fresh_dir / "qwen-main.sock") in attach_argvs[0]
@@ -543,8 +582,8 @@ def test_runner_resource_attach_recreates_dead_qwen_terminal(
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
             "/v1/sessions/conv_abc/resources/terminals/terminal_qwen_main/attach?transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     assert auto_create_sessions == ["conv_abc"]
     assert str(fresh_dir / "qwen-main.sock") in attach_argvs[1]

--- a/tests/runtime/test_session_stream.py
+++ b/tests/runtime/test_session_stream.py
@@ -39,9 +39,13 @@ def _clean_session_stream_registry() -> None:
     test that leaks a subscriber would silently change the behavior
     of every later test by retaining the leak's slot.
     """
-    session_stream._subscribers.clear()
+    with session_stream._lock:
+        session_stream._subscribers.clear()
+        session_stream._sequence = 0
     yield
-    session_stream._subscribers.clear()
+    with session_stream._lock:
+        session_stream._subscribers.clear()
+        session_stream._sequence = 0
 
 
 async def _collect(conv_id: str, expected: int) -> list[dict[str, Any]]:
@@ -95,6 +99,22 @@ async def test_publish_without_subscriber_is_silent_noop() -> None:
     )
 
 
+def test_sequence_is_global_and_monotonic_across_producer_kinds() -> None:
+    """Relay, native-bridge, and REST-shaped events share one sequencer."""
+    events = [
+        {"type": "response.output_text.delta", "delta": "relay"},
+        {"type": "response.output_item.done", "item": {"id": "native"}},
+        {"type": "session.resource.created", "resource": {"id": "rest"}},
+        {"type": "session.resource.deleted", "resource_id": "rest"},
+    ]
+
+    for index, event in enumerate(events):
+        session_stream.publish(f"conv_{index}", event)
+
+    assert [event["sequence"] for event in events] == [1, 2, 3, 4]
+    assert session_stream.current_sequence() == 4
+
+
 @pytest.mark.asyncio
 async def test_single_subscriber_receives_events_in_order() -> None:
     """
@@ -118,9 +138,9 @@ async def test_single_subscriber_receives_events_in_order() -> None:
     # Exact ordering of i=1,2,3 — anything else means publish
     # reordered or the queue isn't FIFO.
     assert received == [
-        {"type": "e", "i": 1},
-        {"type": "e", "i": 2},
-        {"type": "e", "i": 3},
+        {"type": "e", "i": 1, "sequence": 1},
+        {"type": "e", "i": 2, "sequence": 2},
+        {"type": "e", "i": 3, "sequence": 3},
     ], (
         f"Subscriber saw {received!r}; expected i=1,2,3 in order. "
         f"A mismatch indicates either reordering inside publish or "
@@ -149,7 +169,7 @@ async def test_pre_subscribe_events_are_lost() -> None:
     await asyncio.sleep(0)
     session_stream.publish("conv_lost", {"type": "live", "i": 1})
     received = await asyncio.wait_for(task, timeout=2.0)
-    assert received == [{"type": "live", "i": 1}], (
+    assert received == [{"type": "live", "i": 1, "sequence": 2}], (
         f"Subscriber received {received!r}; expected only the "
         f"post-subscribe event. A buffered/replayed early event "
         f"would have appeared first."
@@ -178,7 +198,10 @@ async def test_multi_subscriber_fan_out_independently_delivers() -> None:
     session_stream.publish("conv_fan", {"type": "x", "i": 2})
     r1, r2 = await asyncio.wait_for(asyncio.gather(t1, t2), timeout=2.0)
     # Both subscribers see ALL events — that's the fan-out contract.
-    expected = [{"type": "x", "i": 1}, {"type": "x", "i": 2}]
+    expected = [
+        {"type": "x", "i": 1, "sequence": 1},
+        {"type": "x", "i": 2, "sequence": 2},
+    ]
     assert r1 == expected, (
         f"Subscriber 1 received {r1!r}, expected {expected!r}. "
         f"Missing events indicate a single-consumer queue regression "
@@ -219,10 +242,10 @@ async def test_close_broadcasts_done_to_all_subscribers() -> None:
     session_stream.close("conv_close")
     # Both subscribers terminate cleanly under the close sentinel.
     await asyncio.wait_for(asyncio.gather(t1, t2), timeout=2.0)
-    assert out1 == [{"type": "a", "i": 1}], (
+    assert out1 == [{"type": "a", "i": 1, "sequence": 1}], (
         f"Subscriber 1 saw {out1!r}; close should have delivered the event before terminating."
     )
-    assert out2 == [{"type": "a", "i": 1}], (
+    assert out2 == [{"type": "a", "i": 1, "sequence": 1}], (
         f"Subscriber 2 saw {out2!r}; close should have delivered the event before terminating."
     )
 
@@ -456,7 +479,7 @@ async def test_heartbeat_interleaves_with_published_events() -> None:
         # on the queue before our wait_for starts.
         await asyncio.sleep(0)
         second = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
-        assert second == {"type": "real", "i": 1}, (
+        assert second == {"type": "real", "i": 1, "sequence": 1}, (
             f"After publishing a real event, the next yield was "
             f"{second!r}; expected the real event. A heartbeat here "
             f"means the timeout path swallowed the queued item."

--- a/tests/server/integration/test_sessions_elicitation_resolve_url.py
+++ b/tests/server/integration/test_sessions_elicitation_resolve_url.py
@@ -605,10 +605,11 @@ async def test_child_codex_elicitation_bubbles_to_parent_stream(
         assert verdict.status_code == 202, verdict.text
 
         resolved_event = await parent_resolved
-        assert resolved_event == {
+        assert {k: v for k, v in resolved_event.items() if k != "sequence"} == {
             "type": "response.elicitation_resolved",
             "elicitation_id": elicitation_id,
         }
+        assert isinstance(resolved_event["sequence"], int)
 
         resp = await hook_task
         assert resp.status_code == 200, resp.text
@@ -684,10 +685,11 @@ async def test_child_policy_elicitation_bubbles_to_parent_stream(
         assert verdict.status_code == 202, verdict.text
 
         resolved_event = await parent_resolved
-        assert resolved_event == {
+        assert {k: v for k, v in resolved_event.items() if k != "sequence"} == {
             "type": "response.elicitation_resolved",
             "elicitation_id": elicitation_id,
         }
+        assert isinstance(resolved_event["sequence"], int)
 
         resp = await evaluate
         assert resp.status_code == 200, resp.text
@@ -794,10 +796,11 @@ async def test_child_mcp_elicitation_bubbles_to_parent_stream(
         assert verdict.status_code == 202, verdict.text
 
         resolved_event = await parent_resolved
-        assert resolved_event == {
+        assert {k: v for k, v in resolved_event.items() if k != "sequence"} == {
             "type": "response.elicitation_resolved",
             "elicitation_id": elicitation_id,
         }
+        assert isinstance(resolved_event["sequence"], int)
     finally:
         for task in [parent_drain, parent_resolved]:
             if task is not None and not task.done():
@@ -869,10 +872,11 @@ async def test_child_claude_ask_user_question_bubbles_to_parent_stream(
         assert verdict.status_code == 202, verdict.text
 
         resolved_event = await parent_resolved
-        assert resolved_event == {
+        assert {k: v for k, v in resolved_event.items() if k != "sequence"} == {
             "type": "response.elicitation_resolved",
             "elicitation_id": elicitation_id,
         }
+        assert isinstance(resolved_event["sequence"], int)
 
         resp = await hook_task
         assert resp.status_code == 200, resp.text

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -2912,17 +2912,35 @@ async def test_post_external_conversation_item_persists_and_streams_visible_item
     assert body["items"][1]["data"]["name"] == "Read"
     assert body["items"][2]["data"] == {"call_id": "toolu_read_1", "output": "todo contents"}
     assert body["items"][3]["data"]["role"] == "assistant"
+    # Receipt fields (action/terminal_id/…) stay None on bridge-observed
+    # items — only the server's shell_command receipts fill them.
+    _receipt_defaults = {
+        "action": None,
+        "terminal_id": None,
+        "terminal_name": None,
+        "session_key": None,
+        "status": None,
+        "error": None,
+        "attempt_id": None,
+        "attempt_fingerprint": None,
+        "sequence": None,
+        "terminal": None,
+        "http_status": None,
+        "error_code": None,
+    }
     assert body["items"][4]["data"] == {
         "kind": "input",
         "input": "pwd",
         "stdout": None,
         "stderr": None,
+        **_receipt_defaults,
     }
     assert body["items"][5]["data"] == {
         "kind": "output",
         "input": None,
         "stdout": "/tmp/project",
         "stderr": "",
+        **_receipt_defaults,
     }
 
     assert [event["type"] for _, event in published] == [

--- a/tests/server/integration/test_sessions_shell_command.py
+++ b/tests/server/integration/test_sessions_shell_command.py
@@ -15,6 +15,7 @@ terminal resource proxies use — with an ``httpx.MockTransport``.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import re
 import shutil
@@ -23,6 +24,7 @@ import time
 import uuid
 from collections.abc import AsyncIterator, Callable
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import httpx
@@ -2598,3 +2600,72 @@ async def test_shell_command_bearer_token_without_identity_denied(
     assert resp.status_code == 401, resp.text
     assert calls == []
     assert await _terminal_command_items(auth_client, sid, headers=owner_headers) == []
+
+
+# ── ledger single-flight lifecycle (unit-level) ───────────
+
+
+class _EmptyItemsStore:
+    """Conversation store stub with no prior receipts for any attempt."""
+
+    def list_items(self, *args: Any, **kwargs: Any) -> Any:
+        """Return an empty terminal_command page so no receipt replays."""
+        return SimpleNamespace(data=[], has_more=False, last_id=None)
+
+
+async def test_shell_command_ledger_retains_cleanup_task_until_done() -> None:
+    """An abandoned-owner cleanup task stays strong-referenced until done.
+
+    asyncio keeps only a weak reference to fire-and-forget tasks, so a
+    cleanup task that is not retained can be garbage-collected before it
+    releases the in-flight slot — wedging every later duplicate on that
+    attempt. The ledger must hold the task until it finishes, then drop
+    it and leave the slot free.
+    """
+    ledger = events_module._ShellCommandAttemptLedger(_EmptyItemsStore())
+
+    async def _owner() -> None:
+        claimed = await ledger.wait_or_claim(session_id="s", attempt_id="a", fingerprint="fp")
+        assert claimed is None  # this task now owns the attempt
+
+    owner = asyncio.create_task(_owner())
+    await owner
+    # Let the owner's done-callback schedule the retained cleanup task.
+    await asyncio.sleep(0)
+    assert ledger._cleanup_tasks  # strong reference held while it runs
+
+    await asyncio.gather(*ledger._cleanup_tasks)
+    assert not ledger._cleanup_tasks  # reference dropped once finished
+    assert not ledger._in_flight  # slot released
+
+
+async def test_shell_command_ledger_cancelled_owner_gives_waiters_retryable() -> None:
+    """A cancelled owner resolves duplicate waiters as retryable, not 500.
+
+    Cancelling the shared future would surface as a ``CancelledError``
+    (HTTP 500) on innocent concurrent duplicates. They must instead see
+    a retryable ``attempt_abandoned`` so a resend re-claims and runs.
+    """
+    ledger = events_module._ShellCommandAttemptLedger(_EmptyItemsStore())
+    started = asyncio.Event()
+
+    async def _owner() -> None:
+        claimed = await ledger.wait_or_claim(session_id="s", attempt_id="a", fingerprint="fp")
+        assert claimed is None
+        started.set()
+        await asyncio.sleep(3600)  # never persists a receipt
+
+    owner = asyncio.create_task(_owner())
+    await started.wait()
+    entry = ledger._in_flight[("s", "a")]  # future duplicate waiters await
+
+    owner.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await owner
+    await asyncio.gather(*ledger._cleanup_tasks)
+
+    assert not entry.result.cancelled()
+    exc = entry.result.exception()
+    assert isinstance(exc, OmnigentError)
+    assert exc.code == ErrorCode.ATTEMPT_ABANDONED
+    assert not ledger._in_flight  # slot released for a retry

--- a/tests/server/integration/test_sessions_shell_command.py
+++ b/tests/server/integration/test_sessions_shell_command.py
@@ -1,0 +1,2600 @@
+"""Integration tests for the ``shell_command`` session event.
+
+Exercises ``POST /v1/sessions/{id}/events`` with
+``type="shell_command"`` — the server-orchestrated web-composer bang
+(``!``) command: spawn/send runner proxying, ``terminal_command``
+receipt persistence (success and error), SSE publication, the
+owner-only gate, and the guarantee that NO agent turn starts.
+
+Uses the shared ``client`` fixture from ``tests/server/conftest.py``
+(real stores + mock LLM). The runner is faked by monkeypatching
+``_get_runner_client_for_resource_access`` — the same resolver the
+terminal resource proxies use — with an ``httpx.MockTransport``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import shutil
+import sys
+import time
+import uuid
+from collections.abc import AsyncIterator, Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.routes import sessions as sessions_module
+from omnigent.server.routes.sessions import routes_events as events_module
+from tests.server.helpers import build_agent_bundle, create_test_agent
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── Helpers ───────────────────────────────────────────────
+
+
+def _shell_command_data(**data: Any) -> dict[str, Any]:
+    """Add one canonical attempt id to a shell-command event body."""
+    return {"attempt_id": str(uuid.uuid4()), **data}
+
+
+def _write_delayed_shell_wrapper(
+    tmp_path: Path,
+    *,
+    shell_name: str,
+    real_shell: str,
+    delay_s: float,
+) -> Path:
+    """Create a shell-named shim that delays before preserving the real argv."""
+    wrapper_dir = tmp_path / "delayed-shells"
+    wrapper_dir.mkdir(exist_ok=True)
+    wrapper = wrapper_dir / shell_name
+    wrapper.write_text(
+        f"#!{sys.executable}\n"
+        "import os\n"
+        "import sys\n"
+        "import time\n"
+        f"time.sleep({delay_s!r})\n"
+        f"real_shell = {real_shell!r}\n"
+        "os.execv(real_shell, [real_shell, *sys.argv[1:]])\n",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def _encoded_output_command(marker: str) -> str:
+    """Return a short shell command whose typed form omits *marker*."""
+    encoded = "".join(f"\\0{ord(char):03o}" for char in marker)
+    return f"builtin printf '%b\\n' '{encoded}'"
+
+
+async def _create_session(
+    client: httpx.AsyncClient,
+    agent_id: str,
+) -> dict[str, Any]:
+    """Create a minimal session and return the JSON response.
+
+    :param client: The test HTTP client.
+    :param agent_id: Agent to bind, e.g. ``"ag_abc123"``.
+    :returns: The ``POST /v1/sessions`` response body.
+    """
+    resp = await client.post("/v1/sessions", json={"agent_id": agent_id})
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _terminal_resource(
+    session_id: str,
+    terminal_name: str,
+    session_key: str,
+    *,
+    running: bool = True,
+) -> dict[str, Any]:
+    """Build a runner-shaped terminal resource payload.
+
+    :param session_id: Owning session id.
+    :param terminal_name: Shell type, e.g. ``"zsh"``.
+    :param session_key: Session key, e.g. ``"u-ab12cd"``.
+    :param running: Whether the terminal reports as running.
+    :returns: The resource dict the runner create/get routes return.
+    """
+    return {
+        "id": f"terminal_{terminal_name}_{session_key}",
+        "object": "session.resource",
+        "type": "terminal",
+        "session_id": session_id,
+        "name": f"{terminal_name}:{session_key}",
+        "environment": "default",
+        "metadata": {
+            "terminal_name": terminal_name,
+            "session_key": session_key,
+            "running": running,
+        },
+    }
+
+
+def _install_fake_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> tuple[httpx.AsyncClient, list[httpx.Request]]:
+    """Route resource-access runner calls to an in-memory fake.
+
+    Patches ``_get_runner_client_for_resource_access`` — the resolver
+    behind the terminal create/get/input proxies — so every call lands
+    on ``handler``. Requests are recorded for call-order assertions.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param handler: Fake runner request handler.
+    :returns: ``(fake_client, recorded_requests)``. Callers must close
+        the client.
+    """
+    calls: list[httpx.Request] = []
+
+    def _recording_handler(request: httpx.Request) -> httpx.Response:
+        """Record the request, then delegate to the fake handler."""
+        calls.append(request)
+        return handler(request)
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_recording_handler),
+        base_url="http://runner",
+    )
+
+    async def _fake_resource_client(session_id: str) -> httpx.AsyncClient:
+        """Resolve every session's resource access to the fake runner."""
+        del session_id
+        return fake_runner
+
+    monkeypatch.setattr(
+        sessions_module,
+        "_get_runner_client_for_resource_access",
+        _fake_resource_client,
+    )
+    return fake_runner, calls
+
+
+def _forbid_agent_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hard-fail the test if anything tries to start an agent turn.
+
+    The resource-access fake only observes calls routed through it —
+    an accidental agent turn would go through the GENERIC runner
+    client / event dispatcher instead and slip past those assertions.
+    Spy both so any turn start explodes immediately.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+
+    def _no_generic_runner(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError(
+            "shell_command must never resolve the generic runner client "
+            "(that path forwards events and starts agent turns)"
+        )
+
+    def _no_turn_dispatch(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError(
+            "shell_command must never dispatch a session event to the runner (agent turn)"
+        )
+
+    monkeypatch.setattr(sessions_module, "_get_runner_client", _no_generic_runner)
+    monkeypatch.setattr(sessions_module, "_dispatch_session_event_to_runner", _no_turn_dispatch)
+
+
+def _capture_stream(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, Any]]]:
+    """Capture every ``session_stream.publish`` call.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: The live list publishes are appended to.
+    """
+    published: list[tuple[str, dict[str, Any]]] = []
+    real_publish = sessions_module.session_stream.publish
+
+    def _capture(session_id: str, event: dict[str, Any]) -> None:
+        real_publish(session_id, event)
+        published.append((session_id, event))
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        _capture,
+    )
+    return published
+
+
+async def _terminal_command_items(
+    client: httpx.AsyncClient,
+    session_id: str,
+    headers: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Return persisted ``terminal_command`` items for a session.
+
+    :param client: The test HTTP client.
+    :param session_id: Session/conversation identifier.
+    :param headers: Optional auth headers.
+    :returns: The flat API dicts of every persisted receipt.
+    """
+    resp = await client.get(f"/v1/sessions/{session_id}/items", headers=headers or {})
+    assert resp.status_code == 200, resp.text
+    return [item for item in resp.json()["data"] if item["type"] == "terminal_command"]
+
+
+@pytest.fixture
+def zsh_terminal_spec(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve the session's agent spec to one declaring a ``zsh`` terminal.
+
+    The ``shell_command`` spawn path gates on the spec's
+    ``terminals:`` block exactly like the terminal create route. These
+    tests run without a real bundle load, so the module's spec loader
+    is patched to a minimal spec declaring ``zsh``.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    from omnigent.inner.datamodel import TerminalEnvSpec
+    from omnigent.spec.types import AgentSpec
+
+    spec = AgentSpec(spec_version=1, terminals={"zsh": TerminalEnvSpec(command="zsh")})
+    monkeypatch.setattr(
+        sessions_module,
+        "_load_agent_spec_for_session",
+        lambda conv, agent_store: spec,
+    )
+
+
+# ── spawn: happy path + wire-shape pin ────────────────────
+
+
+async def test_shell_command_spawn_executes_and_persists_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """Spawn creates a terminal, sends the command, persists one receipt.
+
+    Pins the whole §5.2 spawn contract: declared-name gate passes,
+    server-generated ``u-`` session key, create → input runner call
+    order, ``session.resource.created`` + ``response.output_item.done``
+    on the stream, receipt fields, and — critically — NO agent turn
+    (no runner ``/events`` POST, no ``session.input.consumed``).
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Serve terminal create and input; fail anything else."""
+        if request.method == "POST" and request.url.path.endswith("/resources/terminals"):
+            body = json.loads(request.content)
+            return httpx.Response(
+                200, json=_terminal_resource(sid, body["terminal"], body["session_key"])
+            )
+        if request.method == "POST" and request.url.path.endswith("/input"):
+            return httpx.Response(200, json={"status": "sent", "outcome": "sent"})
+        return httpx.Response(500, json={"error": {"message": f"unexpected {request.url.path}"}})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    published = _capture_stream(monkeypatch)
+    _forbid_agent_turn(monkeypatch)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="spawn", terminal="zsh", command="echo hi"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    # Explicit 200, not the events route's 202 default: the command
+    # already executed — and no misleading "queued" field.
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert "queued" not in payload
+    item = payload["item"]
+    session_key = item["session_key"]
+    attempt_id = item["attempt_id"]
+    assert re.fullmatch(r"u-[0-9a-f]{32}", session_key)
+    assert session_key == sessions_module._shell_spawn_session_key(attempt_id)
+    assert payload["terminal"]["id"] == f"terminal_zsh_{session_key}"
+    assert payload["sequence"] == payload["terminal"]["sequence"]
+    assert payload["item_id"] == item["id"]
+
+    # Runner saw exactly create → input, in order — and NO /events
+    # forward: a bang command must never start an agent turn.
+    assert [(c.method, c.url.path) for c in calls] == [
+        ("POST", f"/v1/sessions/{sid}/resources/terminals"),
+        ("POST", f"/v1/sessions/{sid}/resources/terminals/terminal_zsh_{session_key}/input"),
+    ]
+    assert json.loads(calls[0].content) == {
+        "terminal": "zsh",
+        "session_key": session_key,
+        "attempt_id": attempt_id,
+    }
+    assert json.loads(calls[1].content) == {
+        "attempt_id": attempt_id,
+        "text": "echo hi",
+        "keys": "Enter",
+        "wait_for_ready": True,
+    }
+    input_timeout = calls[1].extensions["timeout"]
+    assert set(input_timeout.values()) == {15.0}
+
+    # Stream saw the new terminal, then the receipt — and nothing else
+    # (no session.input.consumed, no status edge: no turn started).
+    assert [event["type"] for _, event in published] == [
+        "session.resource.created",
+        "response.output_item.done",
+    ]
+    assert published[0][1]["resource"]["id"] == f"terminal_zsh_{session_key}"
+    assert published[0][1]["sequence"] == payload["sequence"]
+
+    # Wire-shape pin: ``to_api_dict`` flattens the data payload OVER
+    # the item envelope, so the receipt's delivery ``status`` ("ok")
+    # occupies the top-level status slot where lifecycle values
+    # ("completed") normally live. The web client narrows on exactly
+    # this shape — assert it byte-for-byte on the SSE frame AND the
+    # GET /items reload.
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    expected = {
+        "id": receipt["id"],
+        "response_id": receipt["response_id"],
+        "type": "terminal_command",
+        "status": "ok",
+        "kind": "input",
+        "input": "echo hi",
+        "action": "spawn",
+        "terminal_id": f"terminal_zsh_{session_key}",
+        "terminal_name": "zsh",
+        "session_key": session_key,
+        "attempt_id": attempt_id,
+        "sequence": payload["sequence"],
+        "attempt_fingerprint": item["attempt_fingerprint"],
+        "terminal": payload["terminal"],
+        "http_status": 200,
+    }
+    assert receipt == expected
+    assert published[1][1]["item"] == expected
+    # Synthetic turn id — no real task/response exists for a receipt.
+    assert receipt["response_id"].startswith("turn_")
+
+    # The spawn also persisted the resource_event snapshot item the
+    # create route writes, so reconnecting clients discover the shell.
+    items_resp = await client.get(f"/v1/sessions/{sid}/items")
+    resource_events = [i for i in items_resp.json()["data"] if i["type"] == "resource_event"]
+    resource_event = next(
+        item
+        for item in resource_events
+        if item["event_type"] == "session.resource.created"
+        and item["resource_id"] == f"terminal_zsh_{session_key}"
+    )
+    assert resource_event["sequence"] == payload["sequence"]
+    assert resource_event["resource"]["sequence"] == payload["sequence"]
+
+
+async def test_shell_command_spawn_real_runner_waits_for_delayed_shell_ack(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The server receipts one command only after a real runner's late ACK."""
+    real_bash = shutil.which("bash")
+    if shutil.which("tmux") is None or real_bash is None:
+        pytest.skip("tmux and bash are required for real shell-command coverage")
+
+    from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
+    from omnigent.runner import create_runner_app
+    from omnigent.spec.types import AgentSpec
+    from omnigent.terminals import TerminalRegistry
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    wrapper = _write_delayed_shell_wrapper(
+        tmp_path,
+        shell_name="bash",
+        real_shell=real_bash,
+        delay_s=1.35,
+    )
+    os_env = OSEnvSpec(
+        type="caller_process",
+        cwd=str(tmp_path),
+        sandbox=OSEnvSandboxSpec(type="none"),
+    )
+    shell_spec = TerminalEnvSpec(
+        command=str(wrapper),
+        args=["--noprofile", "--norc"],
+        os_env=os_env,
+    )
+    agent_spec = AgentSpec(
+        spec_version=1,
+        name="real-shell-command",
+        os_env=os_env,
+        terminals={"bash": shell_spec},
+    )
+    monkeypatch.setattr(
+        sessions_module,
+        "_load_agent_spec_for_session",
+        lambda conv, agent_store: agent_spec,
+    )
+
+    async def _session_handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == f"/v1/sessions/{sid}"
+        return httpx.Response(
+            200,
+            json={"id": sid, "agent_id": agent["id"], "workspace": str(tmp_path)},
+        )
+
+    async def _resolve_spec(agent_id: str, session_id: str) -> AgentSpec:
+        assert agent_id == agent["id"]
+        assert session_id == sid
+        return agent_spec
+
+    runner_server_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_session_handler),
+        base_url="http://server",
+    )
+    registry = TerminalRegistry()
+    runner_app = create_runner_app(
+        terminal_registry=registry,
+        runner_workspace=tmp_path,
+        per_session_workspace=False,
+        server_client=runner_server_client,
+        spec_resolver=_resolve_spec,
+    )
+    runner_client = httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=runner_app),
+        base_url="http://runner",
+    )
+
+    async def _real_resource_client(session_id: str) -> httpx.AsyncClient:
+        assert session_id == sid
+        return runner_client
+
+    monkeypatch.setattr(
+        sessions_module,
+        "_get_runner_client_for_resource_access",
+        _real_resource_client,
+    )
+    _forbid_agent_turn(monkeypatch)
+    marker = f"O{uuid.uuid4().hex[:6]}"
+    command = _encoded_output_command(marker)
+
+    try:
+        started = time.monotonic()
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(
+                    action="spawn",
+                    terminal="bash",
+                    command=command,
+                ),
+            },
+        )
+        elapsed = time.monotonic() - started
+
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        assert payload["item"]["status"] == "ok"
+        assert payload["item"]["input"] == command
+        assert elapsed > 1.0, "the receipt must wait past the retired 1s readiness gate"
+
+        session_key = payload["item"]["session_key"]
+        instance = registry.get(sid, "bash", session_key)
+        assert instance is not None
+        assert instance.ready_process is None
+        assert instance.shell_ready_nonce is not None
+        screens: list[str] = []
+        for _ in range(40):
+            result = await instance.read(scrollback=100)
+            screen = str(result.get("screen", ""))
+            screens.append(screen)
+            if any(line.strip() == marker for line in screen.splitlines()):
+                break
+            await asyncio.sleep(0.05)
+        screen = screens[-1] if screens else ""
+        assert screen.count(command) == 1, screen
+        assert sum(line.strip() == marker for line in screen.splitlines()) == 1, screen
+    finally:
+        await registry.shutdown()
+        await runner_client.aclose()
+        await runner_server_client.aclose()
+
+
+# ── send: happy path ──────────────────────────────────────
+
+
+async def test_shell_command_send_routes_into_existing_shell(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Send resolves the target terminal and proxies input directly.
+
+    No create call, no resource event — the receipt carries the
+    display name/key resolved from the runner's terminal metadata.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Serve terminal get and input; fail anything else."""
+        if request.method == "GET" and request.url.path.endswith(terminal_id):
+            return httpx.Response(200, json=_terminal_resource(sid, "zsh", "u-ab12cd"))
+        if request.method == "POST" and request.url.path.endswith("/input"):
+            return httpx.Response(200, json={"status": "sent", "outcome": "sent"})
+        return httpx.Response(500, json={"error": {"message": f"unexpected {request.url.path}"}})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    published = _capture_stream(monkeypatch)
+    _forbid_agent_turn(monkeypatch)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(
+                    action="send", terminal_id=terminal_id, command="make test"
+                ),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 200, resp.text
+    assert "queued" not in resp.json()
+    item = resp.json()["item"]
+    assert item["action"] == "send"
+    assert item["status"] == "ok"
+    assert item["input"] == "make test"
+    assert item["terminal_id"] == terminal_id
+    assert item["terminal_name"] == "zsh"
+    assert item["session_key"] == "u-ab12cd"
+    assert resp.json()["terminal"]["id"] == terminal_id
+
+    assert [(c.method, c.url.path) for c in calls] == [
+        ("GET", f"/v1/sessions/{sid}/resources/terminals/{terminal_id}"),
+        ("POST", f"/v1/sessions/{sid}/resources/terminals/{terminal_id}/input"),
+    ]
+    assert json.loads(calls[1].content) == {
+        "attempt_id": item["attempt_id"],
+        "text": "make test",
+        "keys": "Enter",
+        "wait_for_ready": False,
+    }
+    # Only the receipt was published — no resource event (nothing was
+    # created), no input-consumed, no status edge (no agent turn).
+    assert [event["type"] for _, event in published] == ["response.output_item.done"]
+
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    assert receipts[0] == published[0][1]["item"]
+
+
+# ── malformed payloads: 400, no receipt ───────────────────
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"command": "echo hi"},
+        {"action": "focus", "command": "echo hi"},
+        {"action": "spawn", "command": "echo hi"},
+        {"action": "spawn", "terminal": "zsh"},
+        {"action": "spawn", "terminal": "zsh", "command": "   "},
+        {"action": "spawn", "terminal": "", "command": "echo hi"},
+        {"action": "send", "command": "echo hi"},
+        {"action": "send", "terminal_id": "", "command": "echo hi"},
+    ],
+)
+async def test_shell_command_rejects_malformed_payload(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+    data: dict[str, Any],
+) -> None:
+    """Bad shapes 400 at the boundary: no runner call, no receipt.
+
+    Client-side validation would normally stop these; a request that
+    still arrives malformed gets a plain 400 — nothing was attempted
+    against a shell, so the transcript records nothing.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    fake_runner, calls = _install_fake_runner(
+        monkeypatch, lambda request: httpx.Response(200, json={})
+    )
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={"type": "shell_command", "data": data},
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "invalid_input"
+    assert calls == []
+    assert await _terminal_command_items(client, sid) == []
+
+
+@pytest.mark.parametrize(
+    "attempt_id",
+    # A frozen uuid1 literal (version 1, not the required v4) — must stay a
+    # fixed value so xdist workers collect identical parametrize ids.
+    [None, "", "not-a-uuid", "1d5a6f7c-4b8e-11ef-9a3d-0242ac130002", "A" * 129, 42],
+)
+async def test_shell_command_rejects_malformed_attempt_id(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    attempt_id: object,
+) -> None:
+    """New shell-command events require one canonical UUIDv4 attempt id."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    fake_runner, calls = _install_fake_runner(
+        monkeypatch,
+        lambda request: httpx.Response(500),
+    )
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": {
+                    "attempt_id": attempt_id,
+                    "action": "send",
+                    "terminal_id": "terminal_zsh_u-ab12cd",
+                    "command": "pwd",
+                },
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_input"
+    assert calls == []
+    assert await _terminal_command_items(client, sid) == []
+
+
+async def test_shell_command_unknown_event_type_still_rejected(
+    client: httpx.AsyncClient,
+) -> None:
+    """A typo'd event type fails the allow-list, not the dispatcher."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={"type": "shell_commands", "data": {}},
+    )
+    assert resp.status_code == 400
+    assert "Unknown event type" in resp.json()["error"]["message"]
+
+
+# ── spawn gate: undeclared terminal → 400 + error receipt ─
+
+
+async def test_shell_command_spawn_undeclared_terminal_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """The declared-name gate 400s AND records the attempt.
+
+    Unlike a malformed payload, a well-formed spawn of an undeclared
+    type is an execution attempt — the transcript gets an error
+    receipt naming the declared set, and the runner is never reached.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    fake_runner, calls = _install_fake_runner(
+        monkeypatch, lambda request: httpx.Response(200, json={})
+    )
+    published = _capture_stream(monkeypatch)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="spawn", terminal="python", command="echo hi"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_input"
+    assert "zsh" in body["error"]["message"]
+    # The gate fired BEFORE the proxy — a recorded call here means an
+    # unauthorized launch reached the runner despite the 400.
+    assert calls == []
+
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "spawn"
+    assert receipt["terminal_name"] == "python"
+    assert "not declared" in receipt["error"]
+    assert receipt["terminal_id"] == f"terminal_python_{receipt['session_key']}"
+    # The error receipt is also published live for connected viewers.
+    assert [event["type"] for _, event in published] == ["response.output_item.done"]
+    assert published[0][1]["item"]["status"] == "error"
+
+
+async def test_shell_command_spawn_unsupported_readiness_fails_before_create(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A declared command with no readiness contract never reaches create."""
+    from omnigent.inner.datamodel import TerminalEnvSpec
+    from omnigent.spec.types import AgentSpec
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    spec = AgentSpec(
+        spec_version=1,
+        terminals={
+            "batch": TerminalEnvSpec(
+                command=sys.executable,
+                args=["-c", "print('not interactive')"],
+            )
+        },
+    )
+    monkeypatch.setattr(
+        sessions_module,
+        "_load_agent_spec_for_session",
+        lambda conv, agent_store: spec,
+    )
+    fake_runner, calls = _install_fake_runner(
+        monkeypatch,
+        lambda request: httpx.Response(
+            500,
+            json={"error": {"message": f"unexpected {request.url.path}"}},
+        ),
+    )
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(
+                    action="spawn",
+                    terminal="batch",
+                    command="echo never-created",
+                ),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "invalid_input"
+    assert "readiness contract" in resp.json()["error"]["message"]
+    assert calls == []
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    assert receipts[0]["status"] == "error"
+    assert "readiness contract" in receipts[0]["error"]
+
+
+# ── send failures: dead shell 404 / 409 + error receipt ───
+
+
+async def test_shell_command_send_unknown_terminal_404_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead/unknown terminal id 404s with an error receipt recorded."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-dead00"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """404 the terminal lookup; nothing else should be called."""
+        if request.method == "GET" and request.url.path.endswith(terminal_id):
+            not_found = {"code": "not_found", "message": f"Terminal {terminal_id!r} not found"}
+            return httpx.Response(404, json={"error": not_found})
+        return httpx.Response(500, json={"error": {"message": f"unexpected {request.url.path}"}})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="send", terminal_id=terminal_id, command="pwd"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 404, resp.text
+    assert [(c.method, c.url.path) for c in calls] == [
+        ("GET", f"/v1/sessions/{sid}/resources/terminals/{terminal_id}"),
+    ]
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "send"
+    assert receipt["terminal_id"] == terminal_id
+    assert "not found" in receipt["error"]
+
+
+async def test_shell_command_send_not_running_409_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resolved-but-dead shell 409s from input with an error receipt."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Resolve the terminal, then 409 the input call."""
+        if request.method == "GET" and request.url.path.endswith(terminal_id):
+            return httpx.Response(
+                200, json=_terminal_resource(sid, "zsh", "u-ab12cd", running=False)
+            )
+        if request.method == "POST" and request.url.path.endswith("/input"):
+            return httpx.Response(
+                409,
+                json={
+                    "error": {
+                        "code": "terminal_not_running",
+                        "message": f"Terminal {terminal_id!r} is not running",
+                    }
+                },
+            )
+        return httpx.Response(500, json={"error": {"message": f"unexpected {request.url.path}"}})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="send", terminal_id=terminal_id, command="pwd"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["error"]["code"] == "terminal_not_running"
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "send"
+    # Resolution succeeded before the failure, so the receipt still
+    # carries the display fields.
+    assert receipt["terminal_name"] == "zsh"
+    assert receipt["session_key"] == "u-ab12cd"
+    assert receipt["error_code"] == "terminal_not_running"
+    assert "not running" in receipt["error"]
+    assert len(calls) == 2
+
+
+async def test_shell_command_capacity_rejection_stays_definite_non_delivery(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T1's bounded-ledger 503 is a definite rejection, not unknown."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, json=_terminal_resource(sid, "zsh", "u-ab12cd"))
+        return httpx.Response(
+            503,
+            json={
+                "error": {
+                    "code": "idempotency_capacity_exhausted",
+                    "message": "terminal input idempotency capacity exhausted",
+                }
+            },
+        )
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(
+                    action="send",
+                    terminal_id=terminal_id,
+                    command="pwd",
+                ),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == "idempotency_capacity_exhausted"
+    assert len(calls) == 2
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    assert receipts[0]["status"] == "error"
+    assert receipts[0]["error_code"] == "idempotency_capacity_exhausted"
+
+
+# ── runner unreachable: 502 + error receipt ───────────────
+
+
+async def test_shell_command_spawn_runner_unreachable_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """No reachable runner: the attempt is recorded, then 502 surfaces."""
+
+    async def _no_runner(session_id: str) -> None:
+        """Resolve no runner for any session."""
+        del session_id
+
+    monkeypatch.setattr(
+        sessions_module,
+        "_get_runner_client_for_resource_access",
+        _no_runner,
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    resp = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={
+            "type": "shell_command",
+            "data": _shell_command_data(action="spawn", terminal="zsh", command="echo hi"),
+        },
+    )
+    assert resp.status_code == 502, resp.text
+
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "spawn"
+    assert receipt["terminal_name"] == "zsh"
+    # The HTTPException 502 detail is recorded as the cause.
+    assert receipt["error"] == "no runner available for resource access"
+
+
+async def test_shell_command_send_runner_unreachable_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Send with no reachable runner records an error receipt too."""
+
+    async def _no_runner(session_id: str) -> None:
+        """Resolve no runner for any session."""
+        del session_id
+
+    monkeypatch.setattr(
+        sessions_module,
+        "_get_runner_client_for_resource_access",
+        _no_runner,
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    resp = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={
+            "type": "shell_command",
+            "data": _shell_command_data(
+                action="send", terminal_id="terminal_zsh_u-ab12cd", command="pwd"
+            ),
+        },
+    )
+    assert resp.status_code == 502, resp.text
+
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "send"
+    assert receipt["terminal_id"] == "terminal_zsh_u-ab12cd"
+    assert receipt["error"] == "no runner available for resource access"
+
+
+# ── runner router raises OmnigentError (no HTTP client) ───
+
+
+async def test_shell_command_spawn_router_error_before_create_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """An OmnigentError from the runner router (stage 1) is receipted.
+
+    In production ``client_for_session_resources()`` raises
+    ``OmnigentError`` BEFORE any HTTP client exists (session unbound,
+    runner offline). The spawn-create stage must persist the error
+    receipt and surface the router's status — not skip the receipt
+    because no ``HTTPException`` was raised.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    async def _router_offline(session_id: str) -> httpx.AsyncClient:
+        """Raise the router's no-runner error on every resolution."""
+        del session_id
+        raise OmnigentError(
+            "No runner bound for session",
+            code=ErrorCode.RUNNER_UNAVAILABLE,
+        )
+
+    monkeypatch.setattr(
+        sessions_module,
+        "_get_runner_client_for_resource_access",
+        _router_offline,
+    )
+    _forbid_agent_turn(monkeypatch)
+
+    resp = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={
+            "type": "shell_command",
+            "data": _shell_command_data(action="spawn", terminal="zsh", command="echo hi"),
+        },
+    )
+    assert resp.status_code == 503, resp.text
+
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "spawn"
+    assert receipt["terminal_name"] == "zsh"
+    # The key was already generated, so the receipt names the terminal
+    # that WOULD have been created.
+    assert re.fullmatch(r"u-[0-9a-f]{32}", receipt["session_key"])
+    assert receipt["terminal_id"] == f"terminal_zsh_{receipt['session_key']}"
+    assert receipt["error"] == "No runner bound for session"
+
+
+async def test_shell_command_spawn_router_error_after_create_persists_partial_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """A runner drop between create and input still leaves a receipt.
+
+    The terminal WAS created (``session.resource.created`` persisted,
+    shell discoverable in the rail) but the command never landed — the
+    receipt must say exactly that, or the transcript shows nothing
+    while a fresh empty shell appears.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Serve the terminal create; input is never reached."""
+        body = json.loads(request.content)
+        return httpx.Response(
+            200, json=_terminal_resource(sid, body["terminal"], body["session_key"])
+        )
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://runner",
+    )
+    resolutions = 0
+
+    async def _drops_after_create(session_id: str) -> httpx.AsyncClient:
+        """Serve the create resolution, then report the runner gone."""
+        del session_id
+        nonlocal resolutions
+        resolutions += 1
+        if resolutions == 1:
+            return fake_runner
+        raise OmnigentError(
+            "Runner disconnected",
+            code=ErrorCode.RUNNER_UNAVAILABLE,
+        )
+
+    monkeypatch.setattr(
+        sessions_module,
+        "_get_runner_client_for_resource_access",
+        _drops_after_create,
+    )
+    published = _capture_stream(monkeypatch)
+    _forbid_agent_turn(monkeypatch)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="spawn", terminal="zsh", command="echo hi"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 503, resp.text
+    assert resolutions == 2
+
+    # The terminal creation went through and was announced/persisted…
+    assert [event["type"] for _, event in published] == [
+        "session.resource.created",
+        "response.output_item.done",
+    ]
+    items_resp = await client.get(f"/v1/sessions/{sid}/items")
+    assert any(
+        i["type"] == "resource_event" and i["event_type"] == "session.resource.created"
+        for i in items_resp.json()["data"]
+    )
+    # …and the receipt records the partial outcome explicitly.
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "spawn"
+    assert re.fullmatch(r"u-[0-9a-f]{32}", receipt["session_key"])
+    assert receipt["terminal_id"] == f"terminal_zsh_{receipt['session_key']}"
+    assert receipt["error"] == (
+        "Terminal was created but the command was not delivered: Runner disconnected"
+    )
+    assert published[1][1]["item"]["id"] == receipt["id"]
+
+
+async def test_shell_command_send_router_error_after_resolve_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runner drop between send's resolve-GET and input is receipted.
+
+    The resolve succeeded, so the receipt carries the shell's display
+    fields; the input-stage router error must not bypass persistence.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Serve the terminal resolve; input is never reached."""
+        return httpx.Response(200, json=_terminal_resource(sid, "zsh", "u-ab12cd"))
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://runner",
+    )
+    resolutions = 0
+
+    async def _drops_after_resolve(session_id: str) -> httpx.AsyncClient:
+        """Serve the resolve resolution, then report the runner gone."""
+        del session_id
+        nonlocal resolutions
+        resolutions += 1
+        if resolutions == 1:
+            return fake_runner
+        raise OmnigentError(
+            "Runner disconnected",
+            code=ErrorCode.RUNNER_UNAVAILABLE,
+        )
+
+    monkeypatch.setattr(
+        sessions_module,
+        "_get_runner_client_for_resource_access",
+        _drops_after_resolve,
+    )
+    _forbid_agent_turn(monkeypatch)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="send", terminal_id=terminal_id, command="pwd"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 503, resp.text
+    assert resolutions == 2
+
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "send"
+    assert receipt["terminal_id"] == terminal_id
+    assert receipt["terminal_name"] == "zsh"
+    assert receipt["session_key"] == "u-ab12cd"
+    assert receipt["error"] == "Runner disconnected"
+
+
+# ── malformed runner responses (decode/shape) ─────────────
+
+
+async def test_shell_command_create_non_json_response_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """A non-JSON create response is a receipted 502, not a bare crash.
+
+    A proxy injecting an HTML error page into the terminal-create 200
+    raises a decode error inside the proxy helper — the stage wrapper
+    must still persist exactly one error receipt.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    fake_runner, calls = _install_fake_runner(
+        monkeypatch,
+        lambda request: httpx.Response(200, content=b"<html>not json</html>"),
+    )
+    _forbid_agent_turn(monkeypatch)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="spawn", terminal="zsh", command="echo hi"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 502, resp.text
+    assert len(calls) == 1
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "spawn"
+    assert "launching the terminal" in receipt["error"]
+    # Create never succeeded, so no partial-outcome prefix.
+    assert "was created" not in receipt["error"]
+
+
+async def test_shell_command_create_non_object_response_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """A decoded-but-non-object create body is a receipted 502."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    fake_runner, calls = _install_fake_runner(
+        monkeypatch,
+        lambda request: httpx.Response(200, json=["not", "a", "resource"]),
+    )
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="spawn", terminal="zsh", command="echo hi"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 502, resp.text
+    assert len(calls) == 1
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    assert receipts[0]["status"] == "error"
+    assert "expected a resource object" in receipts[0]["error"]
+
+
+async def test_shell_command_resolve_non_json_response_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-JSON resolve response is a receipted 502."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    fake_runner, calls = _install_fake_runner(
+        monkeypatch,
+        lambda request: httpx.Response(200, content=b"garbage"),
+    )
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="send", terminal_id=terminal_id, command="pwd"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 502, resp.text
+    assert len(calls) == 1
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "send"
+    assert receipt["terminal_id"] == terminal_id
+    assert "resolving the terminal" in receipt["error"]
+
+
+async def test_shell_command_resolve_non_object_response_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A decoded-but-non-object resolve body is a receipted 502."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    fake_runner, calls = _install_fake_runner(
+        monkeypatch,
+        lambda request: httpx.Response(200, json="just a string"),
+    )
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="send", terminal_id=terminal_id, command="pwd"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 502, resp.text
+    assert len(calls) == 1
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    assert receipts[0]["status"] == "error"
+    assert "expected a resource object" in receipts[0]["error"]
+
+
+async def test_shell_command_input_2xx_malformed_body_is_delivery_unknown(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """A 2xx input response without the discriminator is unknown."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Create normally; return non-JSON garbage from input."""
+        if request.method == "POST" and request.url.path.endswith("/resources/terminals"):
+            body = json.loads(request.content)
+            return httpx.Response(
+                200, json=_terminal_resource(sid, body["terminal"], body["session_key"])
+            )
+        if request.method == "POST" and request.url.path.endswith("/input"):
+            return httpx.Response(200, content=b"\x00 not json at all")
+        return httpx.Response(500, json={"error": {"message": f"unexpected {request.url.path}"}})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    _forbid_agent_turn(monkeypatch)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="spawn", terminal="zsh", command="echo hi"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 200, resp.text
+    assert len(calls) == 2
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "unknown"
+    assert receipt["action"] == "spawn"
+    assert "error" not in receipt
+
+
+async def test_shell_command_reads_delivery_unknown_outcome_discriminator(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T1's explicit ambiguous outcome becomes an unknown 200 receipt."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, json=_terminal_resource(sid, "zsh", "u-ab12cd"))
+        return httpx.Response(200, json={"outcome": "delivery_unknown"})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(
+                    action="send",
+                    terminal_id=terminal_id,
+                    command="deploy",
+                ),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 200
+    assert resp.json()["item"]["status"] == "unknown"
+    assert len(calls) == 2
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    assert receipts[0]["status"] == "unknown"
+
+
+async def test_shell_command_input_2xx_non_object_body_is_delivery_unknown(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 2xx non-object body cannot confirm delivery."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Resolve normally; return a JSON array from input."""
+        if request.method == "GET" and request.url.path.endswith(terminal_id):
+            return httpx.Response(200, json=_terminal_resource(sid, "zsh", "u-ab12cd"))
+        if request.method == "POST" and request.url.path.endswith("/input"):
+            return httpx.Response(200, json=["sent", "maybe"])
+        return httpx.Response(500, json={"error": {"message": f"unexpected {request.url.path}"}})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="send", terminal_id=terminal_id, command="pwd"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 200, resp.text
+    assert len(calls) == 2
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    assert receipts[0]["status"] == "unknown"
+    assert receipts[0]["action"] == "send"
+
+
+async def test_shell_command_input_error_with_non_json_body_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An input 4xx with an undecodable body still receipts cleanly.
+
+    The tolerant error decode falls back to the generic message rather
+    than crashing receipt-less on the malformed error page.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Resolve normally; 409 with an HTML body from input."""
+        if request.method == "GET" and request.url.path.endswith(terminal_id):
+            return httpx.Response(200, json=_terminal_resource(sid, "zsh", "u-ab12cd"))
+        if request.method == "POST" and request.url.path.endswith("/input"):
+            return httpx.Response(409, content=b"<html>bad gateway page</html>")
+        return httpx.Response(500, json={"error": {"message": f"unexpected {request.url.path}"}})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="send", terminal_id=terminal_id, command="pwd"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 409, resp.text
+    assert len(calls) == 2
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["error"] == "Terminal input failed (runner returned HTTP 409)"
+
+
+def _fail_resource_event_append(
+    monkeypatch: pytest.MonkeyPatch,
+    store_error: Exception,
+) -> None:
+    """Make the REAL store's append raise for resource_event items only.
+
+    Drives ``_publish_and_persist_resource_event``'s actual code path
+    (including its internal best-effort suppression), while the
+    handler's own ``terminal_command`` receipt appends still succeed —
+    replacing the helper with a stub would bypass exactly the
+    suppression under test.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param store_error: Exception the append raises for resource
+        events, e.g. ``ValueError`` (suppressed by the helper) or
+        ``SQLAlchemyError`` (escapes the helper).
+    :returns: None.
+    """
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+
+    real_append = SqlAlchemyConversationStore.append
+
+    def _selective_append(self: Any, conversation_id: str, items: Any) -> Any:
+        """Raise for resource_event items; pass everything else through."""
+        if any(getattr(item, "type", None) == "resource_event" for item in items):
+            raise store_error
+        return real_append(self, conversation_id, items)
+
+    monkeypatch.setattr(SqlAlchemyConversationStore, "append", _selective_append)
+
+
+def _spawn_create_only_handler(sid: str) -> Callable[[httpx.Request], httpx.Response]:
+    """Fake-runner handler serving ONLY the terminal create.
+
+    :param sid: Session id for the returned resource.
+    :returns: A handler for :func:`_install_fake_runner`.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Serve the terminal create; input must never be reached."""
+        if request.method == "POST" and request.url.path.endswith("/resources/terminals"):
+            body = json.loads(request.content)
+            return httpx.Response(
+                200, json=_terminal_resource(sid, body["terminal"], body["session_key"])
+            )
+        return httpx.Response(500, json={"error": {"message": f"unexpected {request.url.path}"}})
+
+    return _handler
+
+
+async def test_shell_command_resource_event_suppressed_append_failure_is_receipted(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """A store failure the shared helper SUPPRESSES still fails the stage.
+
+    ``_publish_and_persist_resource_event`` swallows ValueError from
+    the append for its best-effort callers and returns ``False``. The
+    record stage must treat that as failure — otherwise the handler
+    returns 200 with ``session.resource.created`` never persisted and
+    reconnecting clients cannot discover the shell.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    _fail_resource_event_append(monkeypatch, ValueError("append rejected"))
+    fake_runner, calls = _install_fake_runner(monkeypatch, _spawn_create_only_handler(sid))
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="spawn", terminal="zsh", command="echo hi"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 502, resp.text
+    # Only the create call — the input stage was never reached.
+    assert [(c.method, c.url.path) for c in calls] == [
+        ("POST", f"/v1/sessions/{sid}/resources/terminals"),
+    ]
+    items_resp = await client.get(f"/v1/sessions/{sid}/items")
+    all_items = items_resp.json()["data"]
+    # The resource event really is missing — and the receipt says so.
+    assert not any(item["type"] == "resource_event" for item in all_items)
+    receipts = [item for item in all_items if item["type"] == "terminal_command"]
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "spawn"
+    assert receipt["error"].startswith("Terminal was created but the command was not delivered:")
+    assert "session.resource.created was not persisted" in receipt["error"]
+
+
+async def test_shell_command_resource_event_db_error_is_receipted(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """A DB-level append error (outside the helper's net) is receipted.
+
+    ``SQLAlchemyError`` is not in the shared helper's suppression
+    tuple, so it escapes the helper — the stage wrapper's normalized
+    net must catch it and persist the partial receipt instead of
+    letting the attempt exit receipt-less.
+    """
+    from sqlalchemy.exc import SQLAlchemyError
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    _fail_resource_event_append(monkeypatch, SQLAlchemyError("db connection lost"))
+    fake_runner, calls = _install_fake_runner(monkeypatch, _spawn_create_only_handler(sid))
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="spawn", terminal="zsh", command="echo hi"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 502, resp.text
+    assert len(calls) == 1
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["error"].startswith("Terminal was created but the command was not delivered:")
+    assert "recording the new terminal" in receipt["error"]
+    assert "db connection lost" in receipt["error"]
+
+
+# ── malformed create resource fields ──────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [["not", "a", "string"], "", None],
+    ids=["list", "empty", "missing"],
+)
+async def test_shell_command_create_malformed_resource_id_persists_error_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+    bad_id: Any,
+) -> None:
+    """A create resource with a bad/missing id is a receipted 502.
+
+    The id is validated INSIDE the create stage, before it is
+    committed to orchestration state — a malformed value must produce
+    an error receipt there, never poison the receipt's own
+    construction later (which would lose the receipt entirely).
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Serve a create whose resource id is malformed."""
+        if request.method == "POST" and request.url.path.endswith("/resources/terminals"):
+            body = json.loads(request.content)
+            resource = _terminal_resource(sid, body["terminal"], body["session_key"])
+            if bad_id is None:
+                resource.pop("id")
+            else:
+                resource["id"] = bad_id
+            return httpx.Response(200, json=resource)
+        return httpx.Response(500, json={"error": {"message": f"unexpected {request.url.path}"}})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="spawn", terminal="zsh", command="echo hi"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 502, resp.text
+    # Validation failed inside the create stage: no resource event, no
+    # input call.
+    assert len(calls) == 1
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "spawn"
+    assert "resource id must be a non-empty string" in receipt["error"]
+    # The receipt keeps the pre-commit deterministic id — the bad value
+    # never reached orchestration state.
+    assert receipt["terminal_id"] == f"terminal_zsh_{receipt['session_key']}"
+
+
+async def test_shell_command_receipt_construction_failure_falls_back_to_minimal_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the full receipt cannot be built, a minimal one still persists.
+
+    ``_receipt_once`` must never lose the receipt to a validation
+    error in its own construction — it falls back to a receipt without
+    the terminal fields, keeping the action/command/outcome record.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-dead00"
+
+    real_data_cls = events_module.TerminalCommandData
+
+    class _ExplodingReceiptData(real_data_cls):  # type: ignore[valid-type,misc]
+        """Receipt payload that fails whenever terminal fields are set."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            if kwargs.get("terminal_id") is not None:
+                raise ValueError("synthetic receipt construction failure")
+            super().__init__(**kwargs)
+
+    monkeypatch.setattr(events_module, "TerminalCommandData", _ExplodingReceiptData)
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """404 the terminal resolve so the error receipt carries an id."""
+        not_found = {"code": "not_found", "message": f"Terminal {terminal_id!r} not found"}
+        return httpx.Response(404, json={"error": not_found})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="send", terminal_id=terminal_id, command="pwd"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    # The original failure status still surfaces…
+    assert resp.status_code == 404, resp.text
+    assert len(calls) == 1
+    # …and exactly one minimal receipt survived the construction crash.
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["action"] == "send"
+    assert "not found" in receipt["error"]
+    assert "terminal_id" not in receipt
+    assert "terminal_name" not in receipt
+    assert "session_key" not in receipt
+
+
+async def test_shell_command_sse_publish_failure_after_persist_stores_exactly_one_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A post-append SSE failure leaves the durable success unchanged."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Resolve the terminal, then accept the input."""
+        if request.method == "GET" and request.url.path.endswith(terminal_id):
+            return httpx.Response(200, json=_terminal_resource(sid, "zsh", "u-ab12cd"))
+        if request.method == "POST" and request.url.path.endswith("/input"):
+            return httpx.Response(200, json={"status": "sent", "outcome": "sent"})
+        return httpx.Response(500, json={"error": {"message": f"unexpected {request.url.path}"}})
+
+    def _exploding_publish(session_id: str, event: dict[str, Any]) -> None:
+        """Fail publication — after the receipt has already persisted."""
+        raise RuntimeError("session stream publish exploded")
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        _exploding_publish,
+    )
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(
+                    action="send",
+                    terminal_id=terminal_id,
+                    command="pwd",
+                ),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 200
+    assert resp.json()["item"]["status"] == "ok"
+    assert len(calls) == 2
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    assert receipts[0]["status"] == "ok"
+    assert receipts[0]["action"] == "send"
+    assert receipts[0]["id"] == resp.json()["item_id"]
+    assert "receipt SSE publish failed" in caplog.text
+
+
+async def test_shell_command_explicit_error_survives_sse_publish_failure(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A notification failure cannot replace an explicit runner error."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, json=_terminal_resource(sid, "zsh", "u-ab12cd"))
+        return httpx.Response(
+            409,
+            json={
+                "error": {
+                    "code": "terminal_not_running",
+                    "message": "terminal stopped before delivery",
+                }
+            },
+        )
+
+    def _exploding_publish(session_id: str, event: dict[str, Any]) -> None:
+        raise RuntimeError("session stream publish exploded")
+
+    monkeypatch.setattr(sessions_module.session_stream, "publish", _exploding_publish)
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(
+                    action="send",
+                    terminal_id=terminal_id,
+                    command="pwd",
+                ),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 409
+    assert len(calls) == 2
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    assert receipts[0]["status"] == "error"
+    assert "terminal stopped" in receipts[0]["error"]
+    assert "receipt SSE publish failed" in caplog.text
+
+
+async def test_shell_command_response_loss_is_unknown_and_retry_is_idempotent(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-side-effect read loss yields one unknown receipt and no resend."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+    input_side_effects = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal input_side_effects
+        if request.method == "GET":
+            return httpx.Response(200, json=_terminal_resource(sid, "zsh", "u-ab12cd"))
+        input_side_effects += 1
+        raise httpx.ReadError("runner response was lost", request=request)
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    attempt_id = str(uuid.uuid4())
+    data = _shell_command_data(
+        attempt_id=attempt_id,
+        action="send",
+        terminal_id=terminal_id,
+        command="make deploy",
+    )
+    try:
+        first = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={"type": "shell_command", "data": data},
+        )
+        replay = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={"type": "shell_command", "data": data},
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert first.status_code == replay.status_code == 200
+    assert first.json()["item"]["status"] == "unknown"
+    assert replay.json()["item_id"] == first.json()["item_id"]
+    assert input_side_effects == 1
+    assert len(calls) == 2
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    assert receipts[0]["attempt_id"] == attempt_id
+
+
+async def test_shell_command_cancellation_after_dispatch_is_unknown(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation raised by an in-flight runner call is ambiguous delivery."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    class CancellingRunner:
+        """Resolve the terminal, then cancel after the input dispatch starts."""
+
+        def __init__(self) -> None:
+            self.input_calls = 0
+
+        async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+            del url, kwargs
+            return httpx.Response(
+                200,
+                json=_terminal_resource(sid, "zsh", "u-ab12cd"),
+                request=httpx.Request("GET", "http://runner/terminal"),
+            )
+
+        async def post(self, url: str, **kwargs: Any) -> httpx.Response:
+            del url, kwargs
+            self.input_calls += 1
+            raise asyncio.CancelledError
+
+    runner = CancellingRunner()
+
+    async def _resolve_runner(session_id: str) -> CancellingRunner:
+        del session_id
+        return runner
+
+    monkeypatch.setattr(
+        sessions_module,
+        "_get_runner_client_for_resource_access",
+        _resolve_runner,
+    )
+    resp = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={
+            "type": "shell_command",
+            "data": _shell_command_data(
+                action="send",
+                terminal_id=terminal_id,
+                command="make deploy",
+            ),
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["item"]["status"] == "unknown"
+    assert runner.input_calls == 1
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    assert receipts[0]["status"] == "unknown"
+
+
+async def test_shell_command_concurrent_duplicate_produces_one_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent identical events share one execution and durable receipt."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, json=_terminal_resource(sid, "zsh", "u-ab12cd"))
+        return httpx.Response(200, json={"status": "sent", "outcome": "sent"})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    data = _shell_command_data(
+        action="send",
+        terminal_id=terminal_id,
+        command="make test",
+    )
+    try:
+        first, second = await asyncio.gather(
+            client.post(
+                f"/v1/sessions/{sid}/events",
+                json={"type": "shell_command", "data": data},
+            ),
+            client.post(
+                f"/v1/sessions/{sid}/events",
+                json={"type": "shell_command", "data": data},
+            ),
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert first.status_code == second.status_code == 200
+    assert first.json()["item_id"] == second.json()["item_id"]
+    assert len(calls) == 2
+    assert len(await _terminal_command_items(client, sid)) == 1
+
+
+async def test_shell_command_attempt_fingerprint_conflict_is_409(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One attempt id cannot be rebound to a different command."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, json=_terminal_resource(sid, "zsh", "u-ab12cd"))
+        return httpx.Response(200, json={"status": "sent", "outcome": "sent"})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    attempt_id = str(uuid.uuid4())
+    try:
+        first = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(
+                    attempt_id=attempt_id,
+                    action="send",
+                    terminal_id=terminal_id,
+                    command="pwd",
+                ),
+            },
+        )
+        conflict = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(
+                    attempt_id=attempt_id,
+                    action="send",
+                    terminal_id=terminal_id,
+                    command="whoami",
+                ),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert first.status_code == 200
+    assert conflict.status_code == 409
+    assert conflict.json()["error"]["code"] == "attempt_conflict"
+    assert len(calls) == 2
+    assert len(await _terminal_command_items(client, sid)) == 1
+
+
+async def test_shell_command_create_response_loss_reuses_one_terminal(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """A lost create response retries the same derived key and terminal."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    live_keys: set[str] = set()
+    create_calls = 0
+    input_calls = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal create_calls, input_calls
+        body = json.loads(request.content)
+        if request.url.path.endswith("/resources/terminals"):
+            create_calls += 1
+            live_keys.add(body["session_key"])
+            if create_calls == 1:
+                raise httpx.ReadError("create response lost", request=request)
+            return httpx.Response(
+                200,
+                json=_terminal_resource(sid, body["terminal"], body["session_key"]),
+            )
+        input_calls += 1
+        return httpx.Response(200, json={"status": "sent", "outcome": "sent"})
+
+    fake_runner, _calls = _install_fake_runner(monkeypatch, _handler)
+    attempt_id = str(uuid.uuid4())
+    data = _shell_command_data(
+        attempt_id=attempt_id,
+        action="spawn",
+        terminal="zsh",
+        command="echo ready",
+    )
+    try:
+        first = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={"type": "shell_command", "data": data},
+        )
+        replay = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={"type": "shell_command", "data": data},
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert first.status_code == replay.status_code == 200
+    assert first.json()["terminal"]["id"] == replay.json()["terminal"]["id"]
+    assert live_keys == {sessions_module._shell_spawn_session_key(attempt_id)}
+    assert create_calls == 2
+    assert input_calls == 1
+    assert len(await _terminal_command_items(client, sid)) == 1
+
+
+async def test_direct_and_bare_create_attempts_use_the_same_stable_key(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """The shared direct-create route is response-loss safe for bare bangs too."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    live_keys: set[str] = set()
+    create_calls = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal create_calls
+        create_calls += 1
+        body = json.loads(request.content)
+        live_keys.add(body["session_key"])
+        if create_calls == 1:
+            raise httpx.ReadError("create response lost", request=request)
+        return httpx.Response(
+            200,
+            json=_terminal_resource(sid, body["terminal"], body["session_key"]),
+        )
+
+    fake_runner, _calls = _install_fake_runner(monkeypatch, _handler)
+    attempt_id = str(uuid.uuid4())
+    body = {"attempt_id": attempt_id, "terminal": "zsh", "session_key": "u-random"}
+    try:
+        first = await client.post(
+            f"/v1/sessions/{sid}/resources/terminals",
+            json=body,
+        )
+        retry = await client.post(
+            f"/v1/sessions/{sid}/resources/terminals",
+            json=body,
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert first.status_code == retry.status_code == 200
+    assert first.json()["terminal"]["id"] == retry.json()["terminal"]["id"]
+    assert isinstance(first.json()["sequence"], int)
+    assert first.json()["sequence"] == first.json()["terminal"]["sequence"]
+    assert live_keys == {sessions_module._shell_spawn_session_key(attempt_id)}
+    assert create_calls == 3
+
+
+# ── redirects are not deliveries ──────────────────────────
+
+
+async def test_shell_command_input_redirect_is_receipted_error(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 307 from the input route is NOT a delivery.
+
+    Only strict 2xx means the command reached the shell; a redirect
+    (proxy misconfiguration) must produce an error receipt, not a
+    phantom ``ok``.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    terminal_id = "terminal_zsh_u-ab12cd"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Resolve normally; redirect the input call."""
+        if request.method == "GET" and request.url.path.endswith(terminal_id):
+            return httpx.Response(200, json=_terminal_resource(sid, "zsh", "u-ab12cd"))
+        if request.method == "POST" and request.url.path.endswith("/input"):
+            return httpx.Response(307, headers={"location": "http://elsewhere/input"})
+        return httpx.Response(500, json={"error": {"message": f"unexpected {request.url.path}"}})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="send", terminal_id=terminal_id, command="pwd"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 500, resp.text
+    assert len(calls) == 2
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["error"] == "Terminal input failed (runner returned HTTP 307)"
+
+
+async def test_shell_command_create_redirect_is_receipted_error(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """A 3xx from the terminal create is NOT a launched terminal."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    fake_runner, calls = _install_fake_runner(
+        monkeypatch,
+        lambda request: httpx.Response(
+            302, json={}, headers={"location": "http://elsewhere/terminals"}
+        ),
+    )
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="spawn", terminal="zsh", command="echo hi"),
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 500, resp.text
+    assert len(calls) == 1
+    receipts = await _terminal_command_items(client, sid)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["status"] == "error"
+    assert receipt["error"] == "Terminal launch failed (runner returned HTTP 302)"
+    # No partial prefix: the create never succeeded.
+    assert "was created" not in receipt["error"]
+
+
+# ── owner-only gate (multi-user) ──────────────────────────
+
+
+@pytest.fixture()
+def auth_app(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+) -> FastAPI:
+    """App fixture with the permission store enabled.
+
+    Mirrors the shared ``app`` fixture but wires a
+    ``SqlAlchemyPermissionStore`` + strict header auth so per-user
+    permission levels are enforced on the events route.
+
+    :param runtime_init: Fixture that initializes the runtime with a
+        mock LLM.
+    :param db_uri: Test database URI.
+    :param tmp_path: Pytest temporary directory fixture.
+    """
+    from omnigent.runtime.agent_cache import AgentCache
+    from omnigent.server.app import create_app
+    from omnigent.server.auth import UnifiedAuthProvider
+    from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+    from omnigent.stores.artifact_store.local import LocalArtifactStore
+    from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+    from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+    from omnigent.stores.permission_store.sqlalchemy_store import (
+        SqlAlchemyPermissionStore,
+    )
+
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+        comment_store=SqlAlchemyCommentStore(db_uri),
+        permission_store=SqlAlchemyPermissionStore(db_uri),
+        auth_provider=UnifiedAuthProvider(source="header", local_single_user=False),
+    )
+
+
+@pytest_asyncio.fixture()
+async def auth_client(
+    auth_app: FastAPI,
+    tmp_path: Path,
+) -> AsyncIterator[httpx.AsyncClient]:
+    """HTTP client wired to the auth-enabled FastAPI app.
+
+    :param auth_app: The permission-enforcing app fixture.
+    :param tmp_path: Pytest temporary directory fixture.
+    """
+    from omnigent.runtime import set_harness_process_manager
+    from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
+
+    pm = HarnessProcessManager(tmp_parent=tmp_path / "harness_pm")
+    await pm.start()
+    set_harness_process_manager(pm)
+
+    transport = httpx.ASGITransport(app=auth_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    set_harness_process_manager(None)
+    await pm.shutdown()
+
+
+async def test_shell_command_requires_owner_level(
+    auth_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shared editor is refused: bang commands are owner-only.
+
+    Keystroke injection matches the write-attach gate — LEVEL_EDIT
+    passes the events route's base check but must fail the
+    shell-command branch with 403, before any runner call or receipt.
+    """
+    owner = "bryan@example.com"
+    editor = "carol@example.com"
+    owner_headers = {"X-Forwarded-Email": owner}
+
+    bundle = build_agent_bundle(name="test-agent")
+    create_resp = await auth_client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        headers=owner_headers,
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    sid = create_resp.json()["session_id"]
+
+    from omnigent.server.auth import LEVEL_EDIT
+
+    grant_resp = await auth_client.put(
+        f"/v1/sessions/{sid}/permissions",
+        json={"user_id": editor, "level": LEVEL_EDIT},
+        headers=owner_headers,
+    )
+    assert grant_resp.status_code in (200, 201), grant_resp.text
+
+    fake_runner, calls = _install_fake_runner(
+        monkeypatch, lambda request: httpx.Response(200, json={})
+    )
+    try:
+        resp = await auth_client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(
+                    action="send",
+                    terminal_id="terminal_zsh_u-ab12cd",
+                    command="pwd",
+                ),
+            },
+            headers={"X-Forwarded-Email": editor},
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 403, resp.text
+    # The refusal happened before orchestration: no runner traffic and
+    # no receipt in the transcript.
+    assert calls == []
+    assert await _terminal_command_items(auth_client, sid, headers=owner_headers) == []
+
+
+async def _create_owned_session(auth_client: httpx.AsyncClient, owner: str) -> str:
+    """Create a bundled session owned by ``owner`` and return its id.
+
+    :param auth_client: Client wired to the auth-enabled app.
+    :param owner: Identity for ``X-Forwarded-Email``.
+    :returns: The new session id.
+    """
+    bundle = build_agent_bundle(name="test-agent")
+    resp = await auth_client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        headers={"X-Forwarded-Email": owner},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["session_id"]
+
+
+async def test_shell_command_owner_success_records_created_by(
+    auth_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    zsh_terminal_spec: None,
+) -> None:
+    """The session owner may run bang commands; receipts credit them.
+
+    In multi-user mode the receipt's ``created_by`` must carry the
+    authenticated owner so shared viewers can see who injected the
+    command — the audit-trail half of the owner-only gate.
+    """
+    owner = "bryan@example.com"
+    owner_headers = {"X-Forwarded-Email": owner}
+    sid = await _create_owned_session(auth_client, owner)
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Serve terminal create and input; fail anything else."""
+        if request.method == "POST" and request.url.path.endswith("/resources/terminals"):
+            body = json.loads(request.content)
+            return httpx.Response(
+                200, json=_terminal_resource(sid, body["terminal"], body["session_key"])
+            )
+        if request.method == "POST" and request.url.path.endswith("/input"):
+            return httpx.Response(200, json={"status": "sent", "outcome": "sent"})
+        return httpx.Response(500, json={"error": {"message": f"unexpected {request.url.path}"}})
+
+    fake_runner, calls = _install_fake_runner(monkeypatch, _handler)
+    _forbid_agent_turn(monkeypatch)
+    try:
+        resp = await auth_client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(action="spawn", terminal="zsh", command="echo hi"),
+            },
+            headers=owner_headers,
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["item"]["created_by"] == owner
+    assert len(calls) == 2
+
+    receipts = await _terminal_command_items(auth_client, sid, headers=owner_headers)
+    assert len(receipts) == 1
+    assert receipts[0]["created_by"] == owner
+    assert receipts[0]["status"] == "ok"
+
+
+async def test_shell_command_viewer_denied(
+    auth_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A read-only viewer is refused before the owner gate even runs.
+
+    LEVEL_READ fails the events route's base LEVEL_EDIT check — no
+    runner traffic, no receipt.
+    """
+    owner = "bryan@example.com"
+    viewer = "victor@example.com"
+    owner_headers = {"X-Forwarded-Email": owner}
+    sid = await _create_owned_session(auth_client, owner)
+
+    from omnigent.server.auth import LEVEL_READ
+
+    grant_resp = await auth_client.put(
+        f"/v1/sessions/{sid}/permissions",
+        json={"user_id": viewer, "level": LEVEL_READ},
+        headers=owner_headers,
+    )
+    assert grant_resp.status_code in (200, 201), grant_resp.text
+
+    fake_runner, calls = _install_fake_runner(
+        monkeypatch, lambda request: httpx.Response(200, json={})
+    )
+    try:
+        resp = await auth_client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(
+                    action="send",
+                    terminal_id="terminal_zsh_u-ab12cd",
+                    command="pwd",
+                ),
+            },
+            headers={"X-Forwarded-Email": viewer},
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 403, resp.text
+    assert calls == []
+    assert await _terminal_command_items(auth_client, sid, headers=owner_headers) == []
+
+
+async def test_shell_command_bearer_token_without_identity_denied(
+    auth_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A machine credential with no user identity cannot run commands.
+
+    In strict header mode an ``Authorization: Bearer`` token carries
+    no identity, so the request resolves to no user and is rejected
+    before the shell-command branch — no runner traffic, no receipt.
+    """
+    owner = "bryan@example.com"
+    owner_headers = {"X-Forwarded-Email": owner}
+    sid = await _create_owned_session(auth_client, owner)
+
+    fake_runner, calls = _install_fake_runner(
+        monkeypatch, lambda request: httpx.Response(200, json={})
+    )
+    try:
+        resp = await auth_client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "shell_command",
+                "data": _shell_command_data(
+                    action="send",
+                    terminal_id="terminal_zsh_u-ab12cd",
+                    command="pwd",
+                ),
+            },
+            headers={"Authorization": "Bearer tok_machine_credential"},
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert resp.status_code == 401, resp.text
+    assert calls == []
+    assert await _terminal_command_items(auth_client, sid, headers=owner_headers) == []

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -1014,6 +1014,7 @@ async def test_list_environments_proxies_to_runner(
 @pytest.mark.asyncio
 async def test_list_terminals_forwards_pagination_params_to_runner(
     client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """GET /resources/terminals forwards order/limit to the runner.
 
@@ -1025,12 +1026,19 @@ async def test_list_terminals_forwards_pagination_params_to_runner(
     """
     fake_runner = _FakeRunnerClient(payload={"object": "list", "data": []})
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+    monkeypatch.setattr(session_stream, "current_sequence", lambda: 73)
 
     resp = await client.get(
         "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals?order=asc&limit=1000&bogus=1",
     )
 
     assert resp.status_code == 200
+    assert resp.json() == {
+        "object": "list",
+        "data": [],
+        "resource_revision": 73,
+        "full_snapshot": True,
+    }
     assert fake_runner.calls == [
         ("GET", "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals"),
     ]
@@ -1153,6 +1161,7 @@ async def test_create_terminal_proxies_to_runner(
 
     assert resp.status_code == 200
     assert resp.json()["id"] == "terminal_bash_s1"
+    assert isinstance(resp.json()["sequence"], int)
     assert fake_runner.calls == [
         ("POST", "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals"),
     ]
@@ -2711,11 +2720,12 @@ async def test_filesystem_write_publishes_changed_files_invalidation(
         await stream.aclose()
 
     assert resp.status_code == 200
-    assert event == {
+    assert {key: value for key, value in event.items() if key != "sequence"} == {
         "type": "session.changed_files.invalidated",
         "session_id": "79b22ebd2309e48fdeb450c65611d51b",
         "environment_id": "default",
     }
+    assert isinstance(event["sequence"], int)
 
 
 @pytest.mark.asyncio
@@ -3040,6 +3050,12 @@ async def test_relay_persists_terminal_resource_created_from_runner() -> None:
     # Persisted item carries the full resource dict for snapshot replay.
     assert events[0].data.resource is not None
     assert events[0].data.resource["id"] == "terminal_zsh_s1"
+    assert isinstance(events[0].data.sequence, int)
+    assert events[0].data.resource["sequence"] == events[0].data.sequence
+    reloaded = ConversationItem.model_validate(
+        events[0].model_dump(mode="json", exclude_none=True)
+    )
+    assert reloaded.data.sequence == events[0].data.sequence
     # Resource events thread on the session id (matches the REST path).
     assert events[0].response_id == "79b22ebd2309e48fdeb450c65611d51b"
 
@@ -3076,6 +3092,7 @@ async def test_relay_persists_terminal_resource_deleted_from_runner() -> None:
     assert events[0].data.event_type == "session.resource.deleted"
     assert events[0].data.resource_id == "terminal_zsh_s1"
     assert events[0].data.resource_type == "terminal"
+    assert isinstance(events[0].data.sequence, int)
     # Delete carries no resource body.
     assert events[0].data.resource is None
 

--- a/tests/server/routes/test_terminal_attach.py
+++ b/tests/server/routes/test_terminal_attach.py
@@ -688,8 +688,8 @@ async def test_attach_terminal_local_fallback_spawns_tmux(
             # attach) independent of the global control-mode default.
             "/v1/sessions/conv_local_attach/resources/terminals/terminal_bash_s1/attach"
             "?read_only=true&transport=pty"
-        ):
-            pass
+        ) as ws:
+            ws.receive_bytes()
 
     # tmux argv must include -r (read-only) and the local socket
     # path the registry knew about. If the socket path is the wrong

--- a/tests/server/test_stream_events.py
+++ b/tests/server/test_stream_events.py
@@ -303,6 +303,7 @@ def test_session_skills_event_round_trips_through_union() -> None:
         "type": "session.skills",
         "conversation_id": "conv_abc",
         "sequence_number": None,
+        "sequence": None,
     }
     parsed = _ADAPTER.validate_python(dumped)
     # Discriminator must route to SessionSkillsEvent, not some other
@@ -323,6 +324,7 @@ def test_session_model_options_event_round_trips_through_union() -> None:
         "type": "session.model_options",
         "conversation_id": "conv_abc",
         "sequence_number": None,
+        "sequence": None,
     }
     parsed = _ADAPTER.validate_python(dumped)
     # Discriminator must route to the model-options nudge, otherwise
@@ -492,6 +494,40 @@ async def test_stream_overflow_closes_without_done_for_reconnect(
     assert len(frames) == 1
     assert frames[0].startswith("event: session.heartbeat\n")
     assert all("[DONE]" not in frame for frame in frames)
+
+
+@pytest.mark.asyncio
+async def test_stream_frames_preserve_sequence_and_omit_legacy_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stamped frames carry ``sequence`` while unstamped frames stay identical."""
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes.sessions import _stream_live_events
+
+    async def two_events(*_args: Any, **_kwargs: Any):
+        yield {"type": "session.heartbeat", "sequence": 91}
+        yield {"type": "session.heartbeat"}
+
+    class ConnectedRequest:
+        """Request stub that remains connected through both events."""
+
+        async def is_disconnected(self) -> bool:
+            return False
+
+    monkeypatch.setattr(session_stream, "subscribe", two_events)
+    frames = [
+        frame
+        async for frame in _stream_live_events(
+            ConnectedRequest(),
+            "conv_sequence",
+        )
+    ]
+    payloads = [
+        json.loads(frame.split("data: ", 1)[1]) for frame in frames if frame.startswith("event:")
+    ]
+
+    assert payloads[0]["sequence"] == 91
+    assert "sequence" not in payloads[1]
 
 
 def test_publish_session_status_helper_uses_waiting_literal() -> None:

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -25,6 +25,7 @@ from omnigent.terminals.control_bridge import (
     bridge_tmux_control_to_websocket,
     unescape_control_output,
 )
+from omnigent.terminals.ws_bridge import WS_CLOSE_TERMINAL_NOT_FOUND
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
@@ -63,6 +64,7 @@ class _FakeWebSocket:
         self.sent: list[bytes] = []
         self.close_code: int | None = None
         self.close_reason: str | None = None
+        self.close_codes: list[int] = []
         self._recv_gate = asyncio.Event()
         # Per-send delay simulates a real network so a burst backlogs behind the
         # send — the condition under which the forwarder coalesces.
@@ -84,6 +86,7 @@ class _FakeWebSocket:
     async def close(self, code: int = 1000, reason: str = "") -> None:
         self.close_code = code
         self.close_reason = reason
+        self.close_codes.append(code)
 
 
 async def _new_private_tmux(inner: str) -> tuple[Path, str]:
@@ -346,6 +349,52 @@ async def test_control_bridge_seeds_streams_and_detaches() -> None:
 
     # Kill the server → the control client's stdout closes → bridge exits.
     await _kill_and_join(sock, task)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_owner_fence_rejects_stale_input() -> None:
+    """The control transport closes before injecting a revoked frame."""
+    sock, target = await _new_private_tmux("cat")
+    marker = b"STALE-OWNER-INPUT"
+    ws = _FakeWebSocket(inbound=[{"type": "websocket.receive", "bytes": marker + b"\r"}])
+    guarded: list[bytes] = []
+
+    async def _owner_guard(data: bytes) -> bool:
+        guarded.append(data)
+        return False
+
+    try:
+        await asyncio.wait_for(
+            bridge_tmux_control_to_websocket(
+                ws,
+                socket_path=str(sock),
+                tmux_target=target,
+                read_only=False,
+                on_client_input=_owner_guard,
+            ),
+            timeout=5.0,
+        )
+        tmux = shutil.which("tmux")
+        assert tmux is not None
+        capture = await asyncio.create_subprocess_exec(
+            tmux,
+            "-S",
+            str(sock),
+            "capture-pane",
+            "-p",
+            "-t",
+            target,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await capture.communicate()
+
+        assert guarded == [marker + b"\r"]
+        assert marker not in stdout
+        assert WS_CLOSE_TERMINAL_NOT_FOUND in ws.close_codes
+    finally:
+        await _kill_tmux(sock)
 
 
 @pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")

--- a/tests/terminals/test_registry.py
+++ b/tests/terminals/test_registry.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import asyncio
 import shutil
-import threading
 from collections.abc import AsyncIterator
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -27,7 +26,11 @@ from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpe
 from omnigent.inner.terminal import TerminalCreateResult, TerminalInstance
 from omnigent.terminals import TerminalRegistry
 from omnigent.terminals import registry as registry_mod
-from omnigent.terminals.registry import TerminalListEntry, conversation_link_for_id
+from omnigent.terminals.registry import (
+    ResolveSnapshot,
+    TerminalListEntry,
+    conversation_link_for_id,
+)
 
 # ── Pure bookkeeping (no tmux) ────────────────────────────────
 
@@ -52,6 +55,69 @@ def test_get_returns_none_for_unknown_triple() -> None:
     """
     reg = TerminalRegistry()
     assert reg.get("conv_nope", "bash", "s1") is None
+
+
+def _registered_snapshot(tmp_path: Path) -> tuple[TerminalRegistry, ResolveSnapshot]:
+    reg = TerminalRegistry()
+    instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "bash.sock",
+        private_dir=tmp_path / "bash",
+        running=True,
+    )
+    reg._by_conversation["conv_a"] = {("bash", "s1"): instance}
+    snapshot = reg.resolve_key_snapshot("conv_a", "bash", "s1")
+    assert isinstance(snapshot, ResolveSnapshot)
+    return reg, snapshot
+
+
+def test_run_fenced_runs_valid_async_function(tmp_path: Path) -> None:
+    reg, snapshot = _registered_snapshot(tmp_path)
+    calls = 0
+
+    async def operation() -> str:
+        nonlocal calls
+        calls += 1
+        return "ran"
+
+    assert reg.run_fenced(snapshot, operation, invalid="invalid") == "ran"
+    assert calls == 1
+
+
+def test_run_fenced_returns_invalid_sentinel_without_running_function(
+    tmp_path: Path,
+) -> None:
+    reg, snapshot = _registered_snapshot(tmp_path)
+    sentinel = object()
+    ran = False
+
+    async def operation() -> None:
+        nonlocal ran
+        ran = True
+
+    reg._by_conversation.clear()
+
+    assert reg.run_fenced(snapshot, operation, invalid=sentinel) is sentinel
+    assert ran is False
+
+
+def test_run_fenced_holds_snapshot_lock_during_function(tmp_path: Path) -> None:
+    reg, snapshot = _registered_snapshot(tmp_path)
+
+    async def operation() -> bool:
+        return snapshot.op_lock.locked()
+
+    assert reg.run_fenced(snapshot, operation, invalid=False) is True
+
+
+def test_run_fenced_preserves_direct_value_operation(tmp_path: Path) -> None:
+    reg, snapshot = _registered_snapshot(tmp_path)
+
+    def operation() -> tuple[str, bool]:
+        return "ran", snapshot.op_lock.locked()
+
+    assert reg.run_fenced(snapshot, operation, invalid=None) == ("ran", True)
 
 
 def test_list_for_conversation_returns_empty_for_unknown_id() -> None:
@@ -201,7 +267,6 @@ async def test_launch_replaces_stale_running_entry(
         running=False,
     )
     reg._by_conversation["conv_x"] = {("shell", "s1"): stale}
-    reg._instance_locks[("conv_x", "shell", "s1")] = threading.Lock()
 
     def _fake_create_terminal_instance(*_args: object, **_kwargs: object) -> TerminalCreateResult:
         return TerminalCreateResult(instance=created, cwd=tmp_path)
@@ -218,6 +283,60 @@ async def test_launch_replaces_stale_running_entry(
     assert result is created
     assert stale.closed is True
     assert reg.get("conv_x", "shell", "s1") is created
+
+
+async def test_launch_rejects_collision_at_final_registration_and_closes_loser(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A collision racing the spawn is rejected without leaking its tmux."""
+    reg = TerminalRegistry()
+    collision = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "winner.sock",
+        private_dir=tmp_path / "winner",
+        running=True,
+    )
+
+    class _RacingTerminal(TerminalInstance):
+        closed: bool = False
+
+        async def launch(self, *, cwd: Path | None = None) -> None:
+            del cwd
+            self.running = True
+            reg._by_conversation["conv_x"] = {("bash", "s1"): collision}
+
+        async def is_alive(self) -> bool:
+            return True
+
+        async def close(self) -> None:
+            self.closed = True
+            self.running = False
+
+    created = _RacingTerminal(
+        name="bash ",
+        session_key="s1",
+        socket_path=tmp_path / "loser.sock",
+        private_dir=tmp_path / "loser",
+    )
+
+    def _fake_create_terminal_instance(*_args: object, **_kwargs: object) -> TerminalCreateResult:
+        return TerminalCreateResult(instance=created, cwd=tmp_path)
+
+    monkeypatch.setattr(registry_mod, "create_terminal_instance", _fake_create_terminal_instance)
+
+    with pytest.raises(RuntimeError, match=r"resource id.*collides"):
+        await reg.launch(
+            "conv_x",
+            "bash ",
+            "s1",
+            TerminalEnvSpec(command="bash"),
+        )
+
+    assert created.closed is True
+    assert reg.get("conv_x", "bash", "s1") is collision
+    assert reg.get("conv_x", "bash ", "s1") is None
 
 
 def test_transfer_moves_terminal_without_closing_tmux(tmp_path: Path) -> None:
@@ -237,9 +356,8 @@ def test_transfer_moves_terminal_without_closing_tmux(tmp_path: Path) -> None:
         private_dir=tmp_path / "claude",
         running=True,
     )
-    lock = threading.Lock()
+    generation = instance.owner_generation
     reg._by_conversation["conv_old"] = {("claude", "main"): instance}
-    reg._instance_locks[("conv_old", "claude", "main")] = lock
 
     moved = reg.transfer("conv_old", "conv_new", "claude", "main")
 
@@ -247,8 +365,7 @@ def test_transfer_moves_terminal_without_closing_tmux(tmp_path: Path) -> None:
     assert reg.get("conv_old", "claude", "main") is None
     assert reg.get("conv_new", "claude", "main") is instance
     assert instance.running is True
-    assert reg.get_instance_lock("conv_old", "claude", "main") is None
-    assert reg.get_instance_lock("conv_new", "claude", "main") is lock
+    assert instance.owner_generation == generation + 1
     assert reg.active_conversation_ids() == ["conv_new"]
 
 
@@ -514,39 +631,6 @@ async def test_shutdown_clears_all_conversations(
     assert reg_with_tmux.list_for_conversation("conv_b") == []
 
 
-# ── Additional pure-bookkeeping tests (no tmux) ─────────────
-
-
-def test_get_instance_lock_returns_none_for_unknown_triple() -> None:
-    """
-    ``get_instance_lock`` returns ``None`` for a triple that was never
-    registered. Callers treat ``None`` as "not running" and surface
-    an error to the LLM.
-    """
-    reg = TerminalRegistry()
-    assert reg.get_instance_lock("conv_nope", "bash", "s1") is None
-
-
-def test_get_instance_lock_returns_lock_after_manual_registration(tmp_path: Path) -> None:
-    """
-    After manually inserting an instance and its lock (as ``launch``
-    would), ``get_instance_lock`` returns the same lock object.
-    """
-    reg = TerminalRegistry()
-    lock = threading.Lock()
-    instance = TerminalInstance(
-        name="bash",
-        session_key="s1",
-        socket_path=tmp_path / "bash.sock",
-        private_dir=tmp_path / "bash",
-        running=True,
-    )
-    reg._by_conversation["conv_a"] = {("bash", "s1"): instance}
-    reg._instance_locks[("conv_a", "bash", "s1")] = lock
-
-    assert reg.get_instance_lock("conv_a", "bash", "s1") is lock
-
-
 def test_transfer_nonexistent_source_returns_false() -> None:
     """
     Transferring from a conversation that has no terminals returns
@@ -590,9 +674,7 @@ def test_transfer_cleans_up_empty_source_slot(tmp_path: Path) -> None:
         private_dir=tmp_path / "bash",
         running=True,
     )
-    lock = threading.Lock()
     reg._by_conversation["conv_old"] = {("bash", "s1"): instance}
-    reg._instance_locks[("conv_old", "bash", "s1")] = lock
 
     reg.transfer("conv_old", "conv_new", "bash", "s1")
 
@@ -671,12 +753,13 @@ def test_conversation_link_for_id_method_delegates_to_module_function() -> None:
     assert "conv_abc" in link
 
 
-async def test_close_removes_instance_lock(tmp_path: Path) -> None:
+async def test_close_retires_instance_and_unmaps_owner(tmp_path: Path) -> None:
     """
-    After ``close``, the per-instance lock is removed so
-    ``get_instance_lock`` returns ``None``. Subsequent tool calls
-    that try to acquire the lock see "not running" rather than
-    operating on a closed tmux session.
+    After ``close``, the retired instance is no longer registry-addressable.
+
+    Subsequent tool calls see "not running" rather than operating on a
+    retired tmux session, while stale snapshots retain the same lock object
+    and observe the generation transition.
     """
     reg = TerminalRegistry()
     instance = TerminalInstance(
@@ -687,14 +770,15 @@ async def test_close_removes_instance_lock(tmp_path: Path) -> None:
         running=True,
     )
     instance.close = AsyncMock()  # type: ignore[method-assign]
-    lock = threading.Lock()
     reg._by_conversation["conv_a"] = {("bash", "s1"): instance}
-    reg._instance_locks[("conv_a", "bash", "s1")] = lock
+    generation = instance.owner_generation
 
     result = await reg.close("conv_a", "bash", "s1")
 
     assert result is True
-    assert reg.get_instance_lock("conv_a", "bash", "s1") is None
+    assert reg.get("conv_a", "bash", "s1") is None
+    assert instance.retired is True
+    assert instance.owner_generation == generation + 1
     instance.close.assert_awaited_once()
 
 
@@ -718,7 +802,6 @@ async def test_close_with_timeout_still_returns_true(tmp_path: Path) -> None:
 
     instance.close = _hang_forever  # type: ignore[method-assign]
     reg._by_conversation["conv_a"] = {("bash", "s1"): instance}
-    reg._instance_locks[("conv_a", "bash", "s1")] = threading.Lock()
 
     # The close should not hang — it uses asyncio.wait_for with _CLOSE_TIMEOUT_S.
     # We patch _CLOSE_TIMEOUT_S to a tiny value so the test finishes quickly.
@@ -768,8 +851,6 @@ async def test_cleanup_conversation_tolerates_close_exception(tmp_path: Path) ->
         ("bash", "s1"): good_instance,
         ("bash", "s2"): bad_instance,
     }
-    reg._instance_locks[("conv_a", "bash", "s1")] = threading.Lock()
-    reg._instance_locks[("conv_a", "bash", "s2")] = threading.Lock()
 
     # Should not raise despite bad_instance.close() exploding.
     await reg.cleanup_conversation("conv_a")
@@ -810,8 +891,6 @@ async def test_shutdown_tolerates_close_exception(tmp_path: Path) -> None:
 
     reg._by_conversation["conv_a"] = {("bash", "s1"): bad}
     reg._by_conversation["conv_b"] = {("bash", "s1"): good}
-    reg._instance_locks[("conv_a", "bash", "s1")] = threading.Lock()
-    reg._instance_locks[("conv_b", "bash", "s1")] = threading.Lock()
 
     await reg.shutdown()
 

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -874,6 +874,72 @@ async def test_bridge_owner_fence_rejects_stale_inbound_frame(
             os.close(master_keep)
 
 
+@pytest.mark.parametrize(
+    "pane_dead",
+    [pytest.param(True, id="dead-pane"), pytest.param(False, id="live-pane")],
+)
+@pytest.mark.asyncio
+async def test_bridge_owner_fenced_input_checks_pane_liveness(
+    pane_dead: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Owner-fenced input closes dead panes without disturbing live panes."""
+    keystroke = b"x"
+    master_fd, slave_fd = os.openpty()
+    tty.setraw(slave_fd)
+    monkeypatch.setattr(pty, "fork", lambda: (999_999, master_fd))
+    monkeypatch.setattr(os, "kill", lambda *_args, **_kwargs: None)
+    probe_calls: list[tuple[str, str]] = []
+
+    async def _pane_dead(socket_path: str, tmux_target: str) -> bool:
+        probe_calls.append((socket_path, tmux_target))
+        return pane_dead
+
+    monkeypatch.setattr(ws_bridge, "_check_pane_dead_definitive", _pane_dead)
+    delivered: list[bytes] = []
+
+    async def _owner_guard(data: bytes) -> bool:
+        delivered.append(data)
+        return True
+
+    frames: list[dict[str, object]] = [{"type": "websocket.receive", "bytes": keystroke}]
+    if pane_dead:
+        frames.append({"type": "websocket.disconnect"})
+    ws = _ScriptedWebSocket(frames)
+    bridge_task = asyncio.create_task(
+        bridge_tmux_pty_to_websocket(
+            ws,
+            socket_path="/test.sock",
+            tmux_target="main",
+            read_only=False,
+            on_client_input=_owner_guard,
+        )
+    )
+    try:
+        if pane_dead:
+            await asyncio.wait_for(asyncio.shield(bridge_task), timeout=5.0)
+        else:
+            await asyncio.wait_for(ws.exhausted.wait(), timeout=5.0)
+
+        assert delivered == [keystroke]
+        assert probe_calls == [("/test.sock", "main")]
+        if pane_dead:
+            assert ws_bridge.WS_CLOSE_TERMINAL_NOT_FOUND in ws.close_codes
+        else:
+            assert ws.close_codes == []
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(slave_fd)
+        if not bridge_task.done():
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(asyncio.shield(bridge_task), timeout=5.0)
+        bridge_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await bridge_task
+        with contextlib.suppress(OSError):
+            os.close(master_fd)
+
+
 @pytest.mark.asyncio
 async def test_bridge_stamps_on_client_interaction_for_each_event(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -651,6 +651,7 @@ class _ScriptedWebSocket:
         self._park = asyncio.Event()  # never set: parks ``receive``
         self.sent: list[bytes] = []
         self.close_code: int | None = None
+        self.close_codes: list[int] = []
 
     async def send_bytes(self, data: bytes) -> None:
         """Record PTY output forwarded to the browser (unused here)."""
@@ -667,6 +668,7 @@ class _ScriptedWebSocket:
     async def close(self, code: int = 1000, reason: str = "") -> None:
         """Capture the bridge's chosen close code."""
         self.close_code = code
+        self.close_codes.append(code)
 
 
 def _slave_winsize(slave_fd: int) -> tuple[int, int]:
@@ -801,6 +803,75 @@ async def test_bridge_read_only_gates_keystrokes_but_not_resize(
             await bridge_task
         with contextlib.suppress(OSError):
             os.close(master_fd)
+
+
+@pytest.mark.parametrize(
+    "frame,expected_callback_data",
+    [
+        ({"type": "websocket.receive", "bytes": b"stale-input"}, b"stale-input"),
+        (
+            {
+                "type": "websocket.receive",
+                "text": '{"type":"resize","cols":137,"rows":41}',
+            },
+            b"",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_bridge_owner_fence_rejects_stale_inbound_frame(
+    frame: dict[str, object],
+    expected_callback_data: bytes,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A revoked attachment cannot write either input bytes or a resize."""
+    master_fd, slave_fd = os.openpty()
+    # An owner-fence rejection makes the bridge return, and its teardown closes
+    # the master fd it was handed. Hold an independent handle to the pty master
+    # so the post-fence slave assertions below aren't ioctl'ing a torn-down pty
+    # (a closed master makes the slave's TIOCGWINSZ fail EIO on Linux).
+    master_keep = os.dup(master_fd)
+    tty.setraw(slave_fd)
+    flags = fcntl.fcntl(slave_fd, fcntl.F_GETFL)
+    fcntl.fcntl(slave_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+    initial_size = _slave_winsize(slave_fd)
+    monkeypatch.setattr(pty, "fork", lambda: (999_999, master_fd))
+    monkeypatch.setattr(os, "kill", lambda *_args, **_kwargs: None)
+
+    async def _dead_session(*_args: object, **_kwargs: object) -> bool:
+        return False
+
+    monkeypatch.setattr(ws_bridge, "_tmux_session_alive", _dead_session)
+    callback_data: list[bytes] = []
+
+    async def _owner_guard(data: bytes) -> bool:
+        callback_data.append(data)
+        return False
+
+    ws = _ScriptedWebSocket([frame])
+    try:
+        await asyncio.wait_for(
+            bridge_tmux_pty_to_websocket(
+                ws,
+                socket_path="/nonexistent.sock",
+                tmux_target="main",
+                read_only=False,
+                on_client_input=_owner_guard,
+            ),
+            timeout=5.0,
+        )
+
+        assert callback_data == [expected_callback_data]
+        assert _drain(slave_fd) == b""
+        assert _slave_winsize(slave_fd) == initial_size
+        assert ws_bridge.WS_CLOSE_TERMINAL_NOT_FOUND in ws.close_codes
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(slave_fd)
+        with contextlib.suppress(OSError):
+            os.close(master_fd)
+        with contextlib.suppress(OSError):
+            os.close(master_keep)
 
 
 @pytest.mark.asyncio
@@ -952,7 +1023,7 @@ async def test_bridge_splits_pty_redraw_after_control_key_input(
     )
     try:
         await asyncio.wait_for(ws.exhausted.wait(), timeout=5.0)
-        os.write(slave_fd, redraw)
+        await _write_all_nonblocking(asyncio.get_running_loop(), slave_fd, redraw)
         await asyncio.wait_for(_wait_for_sent_bytes(ws, len(redraw)), timeout=5.0)
 
         assert all(


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #3033** (`polly/t1-terminal-input-route`). This PR's diff includes that branch's commit (`feat(runner): add terminal input route`) until #3033 merges — review only the top commit here: `feat(server): shell_command event orchestrates bang commands with receipts`.

## Related issue

N/A — part of the `!` bang-shell-commands feature stack (T2 of the spec's task breakdown; T1 is #3033).

## Summary

**Breaking change — single-owner boot guard.** The server now refuses to start when configured for horizontal scale-out, because shell_command/resource-event ordering (the resource_revision / sequence fields) is process-local and relies on session affinity to a single owner process. At boot, `_enforce_single_owner_or_exit` (`omnigent/cli.py`) computes the worker count as max(WEB_CONCURRENCY, UVICORN_WORKERS, GUNICORN_WORKERS) and exits with code 2 if that is > 1, or if `OMNIGENT_MULTI_REPLICA` is set to a truthy value (1/true/yes). `OMNIGENT_MULTI_REPLICA` is the explicit tripwire an operator sets to declare a multi-replica deployment: setting it makes the refusal deliberate and loud rather than letting ordering silently corrupt across replicas. Operators scaling horizontally must run one worker and one replica until a durable cross-worker resource-revision is implemented (tracked for v0.8.0); the error message states this. Existing single-process deployments (the default) are unaffected.


The web composer's upcoming `!` bang commands need a server-side orchestrator: something that can spawn/route a shell command through the runner AND leave an authoritative, durable record of the attempt. This adds the `shell_command` session event and the receipt schema it persists.

- **New `shell_command` control event** on `POST /v1/sessions/{id}/events` (owner-only — injecting keystrokes matches the terminal write-attach gate). `action: "spawn"` enforces the same declared-terminal gate as the create route, proxies the runner create with a fresh server-generated `u-` session key, publishes/persists `session.resource.created`, then proxies the T1 input route with the command. `action: "send"` resolves the target terminal and proxies input directly. **No agent turn starts** — nothing is forwarded as runner input.
- **`TerminalCommandData` receipt fields** (`omnigent/entities/conversation.py`): optional `action`, `terminal_id`, `terminal_name`, `session_key`, `status`, `error` — additive-optional so legacy native-bridge `terminal_command` items deserialize unchanged.
- **One receipt per attempt**: every request that reaches execution persists a single `terminal_command` item (`kind="input"`, synthetic `turn_<uuid>` response id, `created_by` from the authenticated actor) and publishes it as `response.output_item.done`. Failures (declared-name gate 400, dead shell 404/409, runner unreachable) persist an **error receipt first**, then return the error status. Malformed payloads 400 with no receipt (nothing was attempted).

```
composer  ──POST /events {type: shell_command}──▶  server (LEVEL_OWNER)
   spawn: declared-name gate → runner create (u-XXXXXX) → session.resource.created → runner input
   send:  runner GET terminal → runner input
   both:  persist terminal_command receipt {action, terminal_id, terminal_name,
          session_key, status: ok|error} → SSE response.output_item.done
          (NO agent turn, ever)
```

**ELI5**: typing `! echo hi` in the chat box will run `echo hi` in a real shell next to the conversation — without waking the AI. This PR is the server half: it opens (or finds) the shell, types the command in, and pins a small "you ran this" card into the transcript, including when it failed and why.

**Status-code note**: the `shell_command` branch intentionally returns an explicit **200** `{item_id, item, terminal}`, overriding the events route's `202` decorator default — by response time the command has already executed and its receipt is durable, so "accepted for later processing" (and a `queued` field) would misdescribe the operation.

**Failure-path guarantee**: every orchestration stage (gate, create, resource-event record, resolve, input) runs inside one `_run_stage` failure wrapper that persists the attempt's single receipt no matter HOW the stage fails — the runner router's `OmnigentError` (raised before any HTTP client exists: session unbound, runner offline/dropped), the transport-level `HTTPException` 502, a non-JSON runner/proxy body, a decoded non-object body, or a publish/persist failure after the terminal was created. An idempotent `_receipt_once` guard makes persist-then-reraise paths physically unable to double-append, and it falls back to a minimal receipt (no terminal fields) if full receipt construction ever raises — the receipt can never be lost to its own validation. Resource-event persistence is verified (the shared best-effort helper now reports whether the append happened; a suppressed store failure fails the record stage) and `SQLAlchemyError` is in the normalized net, so DB-level store errors are receipted too. The create stage validates the returned resource id as a non-empty string before committing it to orchestration state, and delivery is strictly 2xx in the create and input stages — a 3xx redirect is a receipted error, never a phantom `ok`. A spawn that fails after the create explicitly receipts "Terminal was created but the command was not delivered: …" since the shell is already discoverable in the rail.

**Input-stage delivery semantics (chosen + tested)**: the input POST talks to the resource client directly and never decodes a 2xx body — a 2xx from the runner's input route means the command reached the shell, so the receipt is `status="ok"` even when the body is malformed (success-with-unknown-result: turning it into an error would fabricate a failure for a command that ran). Only the create/resolve stages, whose bodies carry required data, treat malformed 2xx bodies as receipted 502s; input 4xx bodies decode tolerantly with a generic fallback message.

**Single-source gate**: the declared-terminal launch gate is one shared validator (`_require_declared_terminal`) used by both the terminal create route and the `shell_command` spawn path; the create route's native-bootstrap exemption stays at its call site, outside the shared check.

**Wire-shape note (pinned by tests)**: `to_api_dict` flattens the item's data payload over the envelope, so a receipt's delivery `status` (`"ok"`/`"error"`) intentionally occupies the top-level `status` slot where lifecycle values (`"completed"`) normally live. The frontend narrows on exactly this shape; tests assert it byte-for-byte on both the SSE frame and the `GET /items` reload so the contract can't silently change.

## Test Plan

- `uv run pytest tests/server/integration/test_sessions_shell_command.py` — 38 integration tests: 200 spawn (runner call order, server-generated `u-` key, resource event, exact wire shape on SSE + reload), 200 send (metadata-resolved display fields), 403 shared editor + 403 viewer + 401 identity-less bearer token (permission-store app), authenticated owner success asserting `created_by`, 400 malformed payloads (8 shapes, no receipt / no runner call), 400 undeclared terminal **with** error receipt, 404 unknown / 409 not-running dead shell **with** error receipts, runner-unreachable and router-`OmnigentError` failures at every stage (spawn-create, spawn-partial-after-create, send-after-resolve) **with** stage-accurate error receipts, non-JSON and non-object runner bodies at every stage (create/resolve → receipted 502; input 2xx → delivered success per the semantics above), input 4xx with an undecodable body, a resource-event publish failure after create (partial-outcome receipt, input never attempted), resource-event store failures driven through the REAL helper (both its suppressed class and an escaping `SQLAlchemyError`), malformed create resource ids (list/empty/missing), the minimal-receipt construction fallback, 3xx redirects on create and input, exactly-one-receipt assertions on every failure path, and no-agent-turn assertions backed by hard-fail spies on the generic runner client and the turn dispatcher.
- `uv run pytest tests/entities/test_conversation_extended.py` — legacy `terminal_command` items deserialize unchanged (fields + API dict byte-identical), receipt round-trip, status-flattening pin, invalid `action`/`status` rejected.
- Regression: `tests/runner/test_session_resources.py`, `tests/tools/builtins/test_sys_terminal.py` (T1 suites), `tests/server/integration/test_sessions_endpoints.py`, `tests/server/routes/test_session_resources.py` — 371 passed (create-route gate tests green, unmodified, against the shared validator).
- Gates: `pre-commit run --all-files` clean; `uv run ruff check omnigent tests` clean.

## Demo

N/A (non-visual backend change; the UI lands in the stack's T4).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [x] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

All handler paths of the new event are covered by the integration suite, including every error-receipt branch and the owner-only gate under a real permission store; entity-level schema compatibility is covered by unit tests. Live tmux delivery is covered by T1's round-trip test (#3033).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
<!-- polly-stack -->
### 🔗 Linked stack — Bang shell commands (`! cmd`)

Part **2 of 4**. This feature ships as four linked PRs; merge in dependency order:

1. **#3033** — runner terminal input route
2. **#3039** — server `shell_command` event + durable receipts (depends on #3033)  ⬅ **you are here (part 2)**
3. **#3034** — web bang grammar lib + `terminal_command` receipt plumbing (inert until #3041)
4. **#3041** — web composer integration: autocomplete + submit interception + execution (activating PR; carries the demo)

Lower PRs are **inert until the stack completes** — land in sequence **#3033 → #3039 → #3034 → #3041**. A cross-cutting correctness remediation (ownership fencing, end-to-end `attempt_id` idempotency, process-local resource sequencing + single-owner boot guard, client-side reconciliation) is folded into the relevant branches; see `docs/claude/BANG_SHELL_REMEDIATION_SPEC.md`.


<!-- stack-context -->
---

## 🧭 Reviewer guide — this PR is 1 of a 4-PR stack

**Part 2 of 4 — server `shell_command` orchestration + durable receipts.** Full feature: type `!` in the chat composer to run shell commands in the session's terminals (like Claude Code's `!`). It ships as four layer-sized PRs, merged in order `#3033` → `#3039` → `#3034` → `#3041`, so each is small and reviewable on its own.

- **What this PR contributes:** Adds the server `shell_command` event: owner-gated spawn/send orchestration, exactly-once receipt persistence (including error receipts), publish-ordered `sequence`, single-owner boot guard, and the readiness timeout budget that drives #3033's primitive.
- **Reviewing it in isolation:** Server handler + persistence + tests, stacked on #3033. No client hits it yet (that arrives in #3041), so it is inert until the stack completes.

### End-to-end demo — full stack

The clip shows the finished `!` bang UX: the autocomplete menu (running shells on top, new-shell types at the bottom), typing `! echo hello` **spawning a shell and running the command** with a clean receipt, targeting an existing shell, and the unknown-target error.

> **This is the behavior of the whole 4-PR stack once all of it is merged** (`#3033` → `#3039` → `#3034` → `#3041`). No single PR delivers it standalone — the lower PRs add inert capability that the top PR (#3041) activates.

Recorded live against a Docker deploy with a dialed-in runner — which is also how a spawn-readiness bug was caught and fixed (folded into #3033/#3039).

![bang shell-commands end-to-end demo](https://raw.githubusercontent.com/btli/omnigent/assets/t4-bang-demo/demo-fixed-spawn-run.gif?v=motion)

> ▶ **[Full-quality MP4](https://raw.githubusercontent.com/btli/omnigent/assets/t4-bang-demo/bang-shell-command-demo.mp4)** — crisper 1280×720 / 25fps capture. _Recorded live against a full-stack Docker deploy; spawn+run works end-to-end. Motion clip is the real result once the whole stack (#3033 → #3039 → #3034 → #3041) is merged._
