### PR TITLE
fix(managed): retry sandbox terminate on the cleanup path before giving up

### DIFF
--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -173,6 +173,17 @@ PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset(
 MANAGED_HOST_ONLINE_TIMEOUT_S = 120
 _ONLINE_POLL_INTERVAL_S = 1.0
 
+# Bounded retry for the provider-side sandbox terminate on the cleanup path.
+# The terminate call can fail transiently — a channel blip, a provider 5xx, a
+# not-yet-settled sandbox — and until it succeeds the sandbox keeps running
+# (and, for quota-bearing providers, keeps consuming quota) after its session
+# and host row are gone, with nothing left pointing at it to retry. So retry a
+# few times with linear backoff before giving up, and when we do give up, log
+# an ERROR loud enough to alert/grep on rather than a warning that reads as
+# routine. Small + bounded: teardown must not block on a wedged provider.
+_TERMINATE_MAX_ATTEMPTS = 3
+_TERMINATE_RETRY_BACKOFF_S = 2.0
+
 # Launch-token lifetime for the YAML modal path: Modal's 24h sandbox
 # cap plus an hour of slack, so a live sandbox can always
 # re-authenticate its tunnel across reconnects, while a token leaked
@@ -2359,27 +2370,68 @@ async def _terminate_sandbox_best_effort(
         launcher is available (logged, nothing terminated).
     :param host: The host whose ``sandbox_id`` names the sandbox.
     """
-    if launcher is not None and host.sandbox_id is not None:
-        try:
-            await asyncio.to_thread(launcher.terminate, host.sandbox_id)
-        except Exception:  # noqa: BLE001 — deliberate broad catch: this is a
-            # provider-API boundary on a cleanup path. The provider SDK can
-            # fail here in many shapes (auth/config ClickException, network
-            # errors, SDK-internal exceptions), the sandbox may already be
-            # gone past its lifetime cap, and NONE of those may block the
-            # caller's remaining cleanup (deleting the host row / revoking
-            # the launch token), which only we can do.
-            _logger.warning(
-                "Failed to terminate managed sandbox %s (provider=%s) for host %s",
-                host.sandbox_id,
-                host.sandbox_provider,
-                host.host_id,
-                exc_info=True,
-            )
-    else:
+    if launcher is None or host.sandbox_id is None:
         _logger.warning(
             "No launcher available for managed sandbox provider %s; "
             "sandbox %s must be deleted with the provider's own tooling",
             host.sandbox_provider,
             host.sandbox_id,
         )
+        return
+
+    from omnigent.onboarding.sandboxes.base import SandboxCapabilityError
+
+    # Retry the provider terminate before giving up. A single swallowed failure
+    # here orphans the sandbox: the caller deletes the host row next, after which
+    # nothing points at the sandbox and no later session-delete can ever reach
+    # it — it runs (and, for quota-bearing providers, holds quota) until an
+    # out-of-band sweep reclaims it. Retrying rescues the common transient case
+    # (channel blip, provider 5xx, not-yet-settled sandbox).
+    for attempt in range(1, _TERMINATE_MAX_ATTEMPTS + 1):
+        try:
+            await asyncio.to_thread(launcher.terminate, host.sandbox_id)
+            return
+        except SandboxCapabilityError:
+            # The provider has no programmatic terminate — retrying can't help
+            # and this is expected for such providers; the row-delete /
+            # token-revoke the caller does next is the whole teardown. Not an
+            # error.
+            _logger.info(
+                "Managed sandbox provider %s does not support programmatic "
+                "termination; sandbox %s left to the provider's own tooling",
+                host.sandbox_provider,
+                host.sandbox_id,
+            )
+            return
+        except Exception:  # deliberate broad catch: this is a
+            # provider-API boundary on a cleanup path. The provider SDK can fail
+            # here in many shapes (auth/config ClickException, network errors,
+            # SDK-internal exceptions); none may block the caller's remaining
+            # cleanup, which only we can do. Retry, then report loudly.
+            if attempt < _TERMINATE_MAX_ATTEMPTS:
+                _logger.warning(
+                    "Failed to terminate managed sandbox %s (provider=%s) for host %s "
+                    "on attempt %d/%d; retrying",
+                    host.sandbox_id,
+                    host.sandbox_provider,
+                    host.host_id,
+                    attempt,
+                    _TERMINATE_MAX_ATTEMPTS,
+                    exc_info=True,
+                )
+                await asyncio.sleep(_TERMINATE_RETRY_BACKOFF_S * attempt)
+            else:
+                # Exhausted retries: the sandbox is now an orphan (the caller
+                # deletes the host row next). Log ERROR — not warning — so this
+                # is alertable/greppable, since only an out-of-band sweep can
+                # reclaim it from here.
+                _logger.error(
+                    "Failed to terminate managed sandbox %s (provider=%s) for host %s "
+                    "after %d attempts; sandbox is orphaned and must be reclaimed "
+                    "out of band",
+                    host.sandbox_id,
+                    host.sandbox_provider,
+                    host.host_id,
+                    _TERMINATE_MAX_ATTEMPTS,
+                    exc_info=True,
+                )

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -16,6 +16,7 @@ from omnigent.db.utils import now_epoch
 from omnigent.onboarding.sandboxes.base import render_host_config_write_command
 from omnigent.onboarding.sandboxes.e2b import managed_token_ttl_s as e2b_managed_token_ttl_s
 from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server import managed_hosts
 from omnigent.server.app import create_app
 from omnigent.server.managed_hosts import (
     BOXLITE_MANAGED_TOKEN_TTL_S,
@@ -2018,8 +2019,14 @@ async def test_terminate_managed_host_deletes_row_even_when_terminate_fails(
     """
     fake = FakeSandboxLauncher()
 
+    # Zero the retry backoff so the (now-retried) failure path doesn't sleep.
+    monkeypatch.setattr(managed_hosts, "_TERMINATE_RETRY_BACKOFF_S", 0.0)
+    attempts = 0
+
     def _explode(sandbox_id: str) -> None:
         """Simulate a provider API failure during termination."""
+        nonlocal attempts
+        attempts += 1
         raise click.ClickException("provider unavailable")
 
     monkeypatch.setattr(fake, "terminate", _explode)
@@ -2036,10 +2043,82 @@ async def test_terminate_managed_host_deletes_row_even_when_terminate_fails(
 
     await terminate_managed_host(host, host_store, _injected_config(fake))
 
+    # Retried up to the cap before giving up, then deleted the row anyway.
+    assert attempts == managed_hosts._TERMINATE_MAX_ATTEMPTS
     assert host_store.get_host("057e7fa3f1cdb40c0ec393a3d42affc7") is None
     assert (
         host_store.resolve_launch_token("057e7fa3f1cdb40c0ec393a3d42affc7", "tok-term-2") is None
     )
+
+
+async def test_terminate_managed_host_retries_then_succeeds(
+    db_uri: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A transient provider failure is retried; a later attempt that
+    succeeds terminates the sandbox (no orphan, no ERROR).
+    """
+    monkeypatch.setattr(managed_hosts, "_TERMINATE_RETRY_BACKOFF_S", 0.0)
+    fake = FakeSandboxLauncher()
+    calls: list[str] = []
+
+    def _flaky(sandbox_id: str) -> None:
+        calls.append(sandbox_id)
+        if len(calls) == 1:
+            raise click.ClickException("transient channel blip")
+
+    monkeypatch.setattr(fake, "terminate", _flaky)
+    host_store = HostStore(db_uri)
+    host = host_store.register_managed_host(
+        host_id="a1a2a3a4a5a6a7a8a9a0b1b2b3b4b5b6",
+        name="managed-term-flaky",
+        user_id=_OWNER,
+        token="tok-term-flaky",
+        provider="modal",
+        sandbox_id="sb-term-flaky",
+        token_expires_at=now_epoch() + 3600,
+    )
+
+    await terminate_managed_host(host, host_store, _injected_config(fake))
+
+    assert calls == ["sb-term-flaky", "sb-term-flaky"]  # failed once, retried, succeeded
+    assert host_store.get_host("a1a2a3a4a5a6a7a8a9a0b1b2b3b4b5b6") is None
+
+
+async def test_terminate_managed_host_does_not_retry_capability_error(
+    db_uri: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A provider with no programmatic terminate (``SandboxCapabilityError``)
+    is not retried — the row-delete/token-revoke is the whole teardown.
+    """
+    from omnigent.onboarding.sandboxes.base import SandboxCapabilityError
+
+    monkeypatch.setattr(managed_hosts, "_TERMINATE_RETRY_BACKOFF_S", 0.0)
+    fake = FakeSandboxLauncher()
+    calls = 0
+
+    def _unsupported(sandbox_id: str) -> None:
+        nonlocal calls
+        calls += 1
+        raise SandboxCapabilityError("no programmatic terminate")
+
+    monkeypatch.setattr(fake, "terminate", _unsupported)
+    host_store = HostStore(db_uri)
+    host = host_store.register_managed_host(
+        host_id="c1c2c3c4c5c6c7c8c9c0d1d2d3d4d5d6",
+        name="managed-term-cap",
+        user_id=_OWNER,
+        token="tok-term-cap",
+        provider="modal",
+        sandbox_id="sb-term-cap",
+        token_expires_at=now_epoch() + 3600,
+    )
+
+    await terminate_managed_host(host, host_store, _injected_config(fake))
+
+    assert calls == 1  # not retried
+    assert host_store.get_host("c1c2c3c4c5c6c7c8c9c0d1d2d3d4d5d6") is None
 
 
 async def test_terminate_managed_host_skips_mismatched_provider(db_uri: str) -> None:


### PR DESCRIPTION
## What & why

`_terminate_sandbox_best_effort` swallowed a single provider `terminate` failure with a `WARNING`, and the caller (`terminate_managed_host` / launch-failure cleanup / relaunch) then deleted the host row **anyway**. When that terminate fails transiently — a channel blip, a provider 5xx, a not-yet-settled sandbox — the sandbox is **orphaned**: the host row is gone, so nothing points at the sandbox anymore, no later session-delete can reach it, and it keeps running (and, for quota-bearing providers, keeps consuming quota) until an out-of-band sweep reclaims it.

We hit this in production on a quota-bearing provider: managed sandboxes accumulated against a per-(workspace, user) quota until creates started failing, and the CP-side logs showed the terminate had silently failed once and was never retried.

## Change

In `_terminate_sandbox_best_effort`:
- **Retry** the provider `terminate` up to `_TERMINATE_MAX_ATTEMPTS` (3) with linear backoff (`_TERMINATE_RETRY_BACKOFF_S`) before giving up — this rescues the common transient case.
- On exhaustion, log an **ERROR** ("sandbox is orphaned and must be reclaimed out of band") rather than a `WARNING` that reads as routine, so the leak is alertable/greppable.
- A `SandboxCapabilityError` (provider has no programmatic terminate) is **not** retried and **not** an error — the row-delete / token-revoke the caller does next is the whole teardown for those providers.

Still best-effort by design: teardown never blocks on, or raises from, a wedged provider — the host row and launch token are always cleaned up regardless. This does **not** change the ordering (row is still deleted after the terminate attempt); it only makes the terminate itself robust and its permanent failure loud.

## Tests

`tests/server/test_managed_hosts.py`:
- the existing `test_terminate_managed_host_deletes_row_even_when_terminate_fails` now also asserts the terminate was retried up to the cap (backoff monkeypatched to `0.0` so the test doesn't sleep);
- `test_terminate_managed_host_retries_then_succeeds` — a transient failure followed by a successful attempt terminates the sandbox (no orphan);
- `test_terminate_managed_host_does_not_retry_capability_error` — `SandboxCapabilityError` is not retried.

All 9 `-k terminate` tests pass (`uv run --frozen --extra dev pytest tests/server/test_managed_hosts.py -k terminate`); `ruff check` + `ruff format --check` clean on both files.