### PR TITLE
feat: import OpenCode chats

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -6271,7 +6271,10 @@ def resume(
 @cli.command("import")
 @click.option(
     "--harness",
-    type=click.Choice(["claude", "codex", "kimi", "kiro", "pi", "qwen"], case_sensitive=False),
+    type=click.Choice(
+        ["claude", "codex", "kimi", "kiro", "opencode", "pi", "qwen"],
+        case_sensitive=False,
+    ),
     required=True,
     help="Local coding harness that owns the source session.",
 )
@@ -6308,13 +6311,15 @@ def import_session_command(
 
     The source transcript is converted to ordinary Omnigent items and stored
     as a normal session. Qwen, Kiro, and Kimi currently preserve visible
-    messages but not native tool activity. Use --session for one chat or --last
-    for a bounded batch. A source session can only be imported once.
+    messages but not native tool activity; OpenCode and Pi preserve exported
+    tool activity. Use --session for one chat or --last for a bounded batch. A
+    source session can only be imported once.
 
     \b
     Examples:
       omnigent import --harness claude --session <session-id>
       omnigent import --harness codex --session <session-id>
+      omnigent import --harness opencode --session <session-id>
       omnigent import --harness qwen --session <session-id>
       omnigent import --harness claude --last 10
     """
@@ -6336,7 +6341,10 @@ def import_session_command(
     source = cast(ImportSource, harness.lower())
     is_batch = recent_session_count is not None
     if recent_session_count is not None:
-        recent_ids = list_recent_local_session_ids(source, limit=recent_session_count)
+        try:
+            recent_ids = list_recent_local_session_ids(source, limit=recent_session_count)
+        except SessionImportNotFoundError as exc:
+            raise click.ClickException(str(exc)) from exc
         if not recent_ids:
             raise click.ClickException(f"No local {source} parent sessions were found")
         source_session_ids = tuple(reversed(recent_ids))

--- a/omnigent/opencode_native_forwarder.py
+++ b/omnigent/opencode_native_forwarder.py
@@ -619,7 +619,9 @@ class OpenCodeNativeForwarder:
         status = state.get("status")
         if status == "completed" and self.state.mark(self._key("tool-out", call_id)):
             await self._post_tool_output(
-                call_id, _tool_output_text(state), message_id=response_message_id
+                call_id,
+                opencode_tool_output_text(state),
+                message_id=response_message_id,
             )
         elif status == "error" and self.state.mark(self._key("tool-out", call_id)):
             error = state.get("error")
@@ -925,9 +927,9 @@ class OpenCodeNativeForwarder:
         return map_verdict_to_decision(verdict)
 
 
-def _tool_output_text(state: Mapping[str, Any]) -> str:
+def opencode_tool_output_text(state: Mapping[str, Any]) -> str:
     """
-    Extract a string tool output from a completed tool part's ``state``.
+    Extract shared durable output from a completed OpenCode tool state.
 
     :param state: The opencode tool part ``state`` (``output`` /
         ``metadata.output``).

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 from hashlib import sha256
 from pathlib import Path
 
@@ -20,6 +21,11 @@ from omnigent.kiro_native_session_forwarder import (
     kiro_cli_sessions_dir,
     parse_kiro_jsonl_line,
 )
+from omnigent.opencode_native_app_server import (
+    OpenCodeCliNotFoundError,
+    find_opencode_cli,
+)
+from omnigent.opencode_native_forwarder import opencode_tool_output_text
 from omnigent.session_import.models import (
     ImportSource,
     LocalSessionImport,
@@ -27,8 +33,10 @@ from omnigent.session_import.models import (
 )
 
 _PI_IMPORT_SESSION_ID_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?")
+_OPENCODE_IMPORT_SESSION_ID_RE = re.compile(r"ses_[A-Za-z0-9_-]+")
 _MAX_EXTERNAL_SESSION_ID_LENGTH = 128
 _MAX_RESPONSE_ID_LENGTH = 64
+_OPENCODE_COMMAND_TIMEOUT_SECONDS = 120
 
 
 def _bounded_response_id(response_id: str) -> str:
@@ -93,6 +101,43 @@ def _is_safe_pi_import_session_id(session_id: str) -> bool:
     )
 
 
+def _is_safe_opencode_import_session_id(session_id: str) -> bool:
+    """Accept native OpenCode ids without permitting CLI option injection."""
+    return (
+        len(session_id) <= _MAX_EXTERNAL_SESSION_ID_LENGTH
+        and _OPENCODE_IMPORT_SESSION_ID_RE.fullmatch(session_id) is not None
+    )
+
+
+def _run_opencode_json(
+    *arguments: str,
+    opencode_path: str | None = None,
+) -> object:
+    """Run one public OpenCode JSON command and decode stdout."""
+    try:
+        cli = find_opencode_cli(opencode_path)
+    except OpenCodeCliNotFoundError as exc:
+        raise SessionImportNotFoundError(str(exc)) from exc
+    try:
+        completed = subprocess.run(
+            [cli, *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_OPENCODE_COMMAND_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise SessionImportNotFoundError(f"OpenCode export could not run: {exc}") from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip().splitlines()
+        suffix = f": {detail[-1]}" if detail else ""
+        raise SessionImportNotFoundError(f"OpenCode command failed{suffix}")
+    try:
+        return json.loads(completed.stdout)
+    except ValueError as exc:
+        raise SessionImportNotFoundError("OpenCode returned invalid JSON") from exc
+
+
 def _qwen_session_locator(path: Path) -> str:
     """Qualify a Qwen id by project while staying within API limits."""
     project = path.parent.parent.name
@@ -139,6 +184,35 @@ def list_recent_local_session_ids(
             if path.is_file() and path.with_suffix(".json").is_file()
         ]
         return _recent_unique_session_ids(candidates, limit=limit)
+
+    if source == "opencode":
+        payload = _run_opencode_json(
+            "session",
+            "list",
+            "--format",
+            "json",
+            "--pure",
+        )
+        if not isinstance(payload, list):
+            raise SessionImportNotFoundError("OpenCode returned an invalid session list")
+        updated_by_id: dict[str, int | float] = {}
+        for entry in payload:
+            if not isinstance(entry, dict) or isinstance(entry.get("parentID"), str):
+                continue
+            session_id = entry.get("id")
+            updated = entry.get("updated")
+            if not isinstance(session_id, str) or not _is_safe_opencode_import_session_id(
+                session_id
+            ):
+                continue
+            timestamp = updated if isinstance(updated, (int, float)) else 0
+            updated_by_id[session_id] = max(updated_by_id.get(session_id, 0), timestamp)
+        ordered = sorted(
+            updated_by_id,
+            key=lambda session_id: (updated_by_id[session_id], session_id),
+            reverse=True,
+        )
+        return tuple(ordered[:limit])
 
     if source == "pi":
         configured_home = os.environ.get("PI_CODING_AGENT_DIR")
@@ -940,6 +1014,189 @@ def load_kimi_session(
     )
 
 
+def _opencode_file_content(
+    part: dict[str, object],
+    *,
+    role: str,
+) -> dict[str, object] | None:
+    """Convert one exported OpenCode file part to a durable content block."""
+    mime = part.get("mime")
+    url = part.get("url")
+    if isinstance(mime, str) and mime.startswith("image/") and isinstance(url, str) and url:
+        return {
+            "type": "input_image" if role == "user" else "output_image",
+            "image_url": url,
+        }
+    filename = part.get("filename")
+    label = filename if isinstance(filename, str) and filename else mime
+    if not isinstance(label, str) or not label:
+        label = "attachment"
+    return {
+        "type": "input_text" if role == "user" else "output_text",
+        "text": f"[attachment: {label}]",
+    }
+
+
+def _opencode_message_items(
+    message: dict[str, object],
+    *,
+    message_number: int,
+) -> tuple[NewConversationItem, ...]:
+    """Normalize one exported OpenCode message while preserving part order."""
+    info = message.get("info")
+    parts = message.get("parts")
+    if not isinstance(info, dict) or not isinstance(parts, list):
+        return ()
+    role = info.get("role")
+    if role not in {"user", "assistant"}:
+        return ()
+    message_id = info.get("id")
+    native_id = message_id if isinstance(message_id, str) and message_id else str(message_number)
+    response_id = _bounded_response_id(f"opencode:{native_id}")
+    items: list[NewConversationItem] = []
+    pending_content: list[dict[str, object]] = []
+
+    def flush_content() -> None:
+        if not pending_content:
+            return
+        data: dict[str, object] = {"role": role, "content": list(pending_content)}
+        if role == "assistant":
+            data["agent"] = "opencode-native-ui"
+        items.append(
+            NewConversationItem(
+                type="message",
+                response_id=response_id,
+                data=parse_item_data("message", data),
+            )
+        )
+        pending_content.clear()
+
+    for raw_part in parts:
+        if not isinstance(raw_part, dict):
+            continue
+        part: dict[str, object] = raw_part
+        part_type = part.get("type")
+        if part_type == "text":
+            text = part.get("text")
+            if isinstance(text, str) and text:
+                pending_content.append(
+                    {
+                        "type": "input_text" if role == "user" else "output_text",
+                        "text": text,
+                    }
+                )
+            continue
+        if part_type == "file":
+            content = _opencode_file_content(part, role=role)
+            if content is not None:
+                pending_content.append(content)
+            continue
+        if part_type == "step-finish":
+            flush_content()
+            continue
+        if part_type != "tool" or role != "assistant":
+            continue
+        flush_content()
+        call_id = part.get("callID")
+        name = part.get("tool")
+        state = part.get("state")
+        if (
+            not isinstance(call_id, str)
+            or not call_id
+            or not isinstance(name, str)
+            or not name
+            or not isinstance(state, dict)
+        ):
+            continue
+        arguments = state.get("input")
+        serialized_arguments = (
+            arguments
+            if isinstance(arguments, str)
+            else json.dumps(
+                arguments if arguments is not None else {},
+                separators=(",", ":"),
+                ensure_ascii=True,
+            )
+        )
+        items.append(
+            NewConversationItem(
+                type="function_call",
+                response_id=response_id,
+                data=parse_item_data(
+                    "function_call",
+                    {
+                        "agent": "opencode-native-ui",
+                        "name": name,
+                        "arguments": serialized_arguments,
+                        "call_id": call_id,
+                    },
+                ),
+            )
+        )
+        status = state.get("status")
+        output: str | None = None
+        if status == "completed":
+            output = opencode_tool_output_text(state)
+        elif status == "error":
+            error = state.get("error")
+            output = f"[error] {error}" if error else "[error]"
+        if output is not None:
+            items.append(
+                NewConversationItem(
+                    type="function_call_output",
+                    response_id=response_id,
+                    data=parse_item_data(
+                        "function_call_output",
+                        {"call_id": call_id, "output": output},
+                    ),
+                )
+            )
+    flush_content()
+    return tuple(items)
+
+
+def load_opencode_session(
+    session_id: str,
+    *,
+    opencode_path: str | None = None,
+) -> LocalSessionImport:
+    """Load one session through OpenCode's supported JSON export command."""
+    if not _is_safe_opencode_import_session_id(session_id):
+        raise SessionImportNotFoundError(f"OpenCode session {session_id!r} was not found")
+    payload = _run_opencode_json("export", session_id, "--pure", opencode_path=opencode_path)
+    if not isinstance(payload, dict):
+        raise SessionImportNotFoundError(
+            f"OpenCode session {session_id!r} returned an invalid export"
+        )
+    info = payload.get("info")
+    exported_id = info.get("id") if isinstance(info, dict) else None
+    if exported_id != session_id:
+        raise SessionImportNotFoundError(
+            f"OpenCode export id {exported_id!r} did not match {session_id!r}"
+        )
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        messages = []
+    items = tuple(
+        item
+        for message_number, message in enumerate(messages, start=1)
+        if isinstance(message, dict)
+        for item in _opencode_message_items(message, message_number=message_number)
+    )
+    if not items:
+        raise SessionImportNotFoundError(
+            f"OpenCode session {session_id!r} has no importable history"
+        )
+    workspace_value = info.get("directory") if isinstance(info, dict) else None
+    workspace = workspace_value.strip() if isinstance(workspace_value, str) else None
+    return LocalSessionImport(
+        source="opencode",
+        external_session_id=session_id,
+        workspace=workspace or None,
+        items=items,
+    )
+
+
 def load_local_session(source: ImportSource, session_id: str) -> LocalSessionImport:
     """Load one local session from the selected first-party harness."""
     if source == "claude":
@@ -954,6 +1211,8 @@ def load_local_session(source: ImportSource, session_id: str) -> LocalSessionImp
         return load_pi_session(session_id)
     if source == "kimi":
         return load_kimi_session(session_id)
+    if source == "opencode":
+        return load_opencode_session(session_id)
     raise ValueError(f"Unsupported import source: {source}")
 
 
@@ -964,6 +1223,7 @@ __all__ = [
     "load_kimi_session",
     "load_kiro_session",
     "load_local_session",
+    "load_opencode_session",
     "load_pi_session",
     "load_qwen_session",
 ]

--- a/omnigent/session_import/models.py
+++ b/omnigent/session_import/models.py
@@ -9,7 +9,7 @@ from typing import Literal
 from omnigent.entities import MessageData, NewConversationItem
 from omnigent.entities.conversation import synthesize_conversation_title
 
-ImportSource = Literal["claude", "codex", "kimi", "kiro", "pi", "qwen"]
+ImportSource = Literal["claude", "codex", "kimi", "kiro", "opencode", "pi", "qwen"]
 
 IMPORT_SOURCE_LABEL_KEY = "omnigent.import.source"
 IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY = "omnigent.import.external_session_id"

--- a/openapi.json
+++ b/openapi.json
@@ -1762,6 +1762,7 @@
               "codex",
               "kimi",
               "kiro",
+              "opencode",
               "pi",
               "qwen"
             ],

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -12,6 +12,7 @@ import respx
 from click.testing import CliRunner
 
 from omnigent.cli import _CLICK_SUBCOMMANDS, cli
+from omnigent.session_import.models import SessionImportNotFoundError
 
 _BASE = "http://localhost:6767"
 
@@ -134,6 +135,57 @@ def test_import_command_accepts_qwen_session(tmp_path: Path) -> None:
     assert payload["source"] == "qwen"
     assert payload["external_session_id"] == f"-repo:{session_id}"
     assert "conv_qwen" in result.output
+
+
+@respx.mock
+def test_import_command_accepts_opencode_export() -> None:
+    """The CLI accepts OpenCode and uploads its public export representation."""
+    route = respx.post(f"{_BASE}/v1/imports").mock(
+        return_value=httpx.Response(
+            201,
+            json={"session_id": "conv_opencode", "status": "imported", "item_count": 1},
+        )
+    )
+    export = {
+        "info": {"id": "ses_cli", "directory": "/repo"},
+        "messages": [
+            {
+                "info": {"id": "msg_user", "role": "user"},
+                "parts": [{"type": "text", "text": "hello"}],
+            }
+        ],
+    }
+
+    with (
+        patch("omnigent.cli._resolve_attach_server", return_value=_BASE),
+        patch("omnigent.session_import.local._run_opencode_json", return_value=export),
+    ):
+        result = CliRunner().invoke(
+            cli,
+            ["import", "--harness", "opencode", "--session", "ses_cli"],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(route.calls.last.request.content)
+    assert payload["source"] == "opencode"
+    assert payload["external_session_id"] == "ses_cli"
+    assert payload["workspace"] == "/repo"
+    assert "conv_opencode" in result.output
+
+
+def test_import_command_reports_opencode_discovery_failure() -> None:
+    """Batch discovery surfaces a missing or broken OpenCode CLI cleanly."""
+    with patch(
+        "omnigent.session_import.local._run_opencode_json",
+        side_effect=SessionImportNotFoundError("opencode CLI not found on PATH"),
+    ):
+        result = CliRunner().invoke(
+            cli,
+            ["import", "--harness", "opencode", "--last", "1"],
+        )
+
+    assert result.exit_code == 1
+    assert "opencode CLI not found on PATH" in result.output
 
 
 @respx.mock

--- a/tests/e2e/test_chat_import_e2e.py
+++ b/tests/e2e/test_chat_import_e2e.py
@@ -141,6 +141,64 @@ def _write_jsonl_import_fixture(home: Path, harness: str) -> str:
     return f"-repo:{session_id}" if harness == "qwen" else session_id
 
 
+def _write_opencode_cli_fixture(home: Path) -> tuple[Path, str]:
+    """Write a fake public OpenCode CLI and return its bin dir plus session id."""
+    session_id = "ses_import_e2e"
+    listing = [
+        {
+            "id": session_id,
+            "title": "OpenCode import",
+            "updated": 1784247215390,
+            "created": 1784247214912,
+            "directory": "/repo",
+        }
+    ]
+    export = {
+        "info": {"id": session_id, "directory": "/repo", "version": "1.17.18"},
+        "messages": [
+            {
+                "info": {"id": "msg_user", "role": "user"},
+                "parts": [{"type": "text", "text": "inspect TODO.md"}],
+            },
+            {
+                "info": {"id": "msg_assistant", "role": "assistant"},
+                "parts": [
+                    {
+                        "type": "tool",
+                        "callID": "call_1",
+                        "tool": "bash",
+                        "state": {
+                            "status": "completed",
+                            "input": {"command": "rg TODO"},
+                            "output": "TODO.md:1:item",
+                        },
+                    },
+                    {"type": "text", "text": "Done."},
+                ],
+            },
+        ],
+    }
+    bin_dir = home / "bin"
+    executable = bin_dir / "opencode"
+    bin_dir.mkdir(parents=True)
+    executable.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json\n"
+        "import sys\n"
+        f"listing = {listing!r}\n"
+        f"export = {export!r}\n"
+        "if sys.argv[1:3] == ['session', 'list']:\n"
+        "    print(json.dumps(listing))\n"
+        f"elif sys.argv[1:] == ['export', '{session_id}', '--pure']:\n"
+        "    print(json.dumps(export))\n"
+        "else:\n"
+        "    raise SystemExit(2)\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    return bin_dir, session_id
+
+
 def test_cli_imports_claude_chat_into_live_server(live_server: str, tmp_path: Path) -> None:
     """The real CLI and server create a readable session from Claude JSONL."""
     source_session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
@@ -447,3 +505,70 @@ def test_cli_imports_jsonl_harness_chat_end_to_end(
         "Done.",
     ]
     assert item_data[1]["model"] == f"{harness}-native-ui"
+
+
+def test_cli_imports_opencode_export_end_to_end(
+    live_server: str,
+    tmp_path: Path,
+) -> None:
+    """The real CLI discovers and imports OpenCode's public JSON export."""
+    bin_dir, source_session_id = _write_opencode_cli_fixture(tmp_path)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
+            "OMNIGENT_CONFIG_HOME": str(tmp_path / "config"),
+            "OMNIGENT_DATA_DIR": str(tmp_path / "omnigent-data"),
+        }
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "import",
+            "--harness",
+            "opencode",
+            "--last",
+            "1",
+            "--server",
+            live_server,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+    match = re.search(
+        rf"Imported 4 item\(s\) from {source_session_id} into (\S+)\.",
+        result.stdout,
+    )
+    assert match is not None, result.stdout
+    imported_session_id = match.group(1)
+    session = httpx.get(
+        f"{live_server}/v1/sessions/{imported_session_id}",
+        params={"include_items": "false", "include_liveness": "false"},
+        timeout=10,
+    )
+    session.raise_for_status()
+    session_data = session.json()
+    assert session_data["external_session_id"] == source_session_id
+    assert session_data["workspace"] == "/repo"
+    assert session_data["title"] == "inspect TODO.md"
+    items = httpx.get(
+        f"{live_server}/v1/sessions/{imported_session_id}/items",
+        timeout=10,
+    )
+    items.raise_for_status()
+    item_data = items.json()["data"]
+    assert [item["type"] for item in item_data] == [
+        "message",
+        "function_call",
+        "function_call_output",
+        "message",
+    ]
+    assert item_data[1]["model"] == "opencode-native-ui"

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -13,12 +13,14 @@ from omnigent.kiro_native_session_forwarder import (
     KiroConversationMessage,
     parse_kiro_jsonl_line,
 )
+from omnigent.session_import import local as local_import
 from omnigent.session_import.local import (
     list_recent_local_session_ids,
     load_claude_session,
     load_codex_session,
     load_kimi_session,
     load_kiro_session,
+    load_opencode_session,
     load_pi_session,
     load_qwen_session,
 )
@@ -166,6 +168,140 @@ def test_long_source_ids_get_distinct_bounded_response_ids(
     assert len(response_ids) == 2
     assert response_ids[0] != response_ids[1]
     assert all(len(response_id) <= 64 for response_id in response_ids)
+
+
+def test_list_recent_opencode_sessions_uses_public_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenCode batch discovery uses its supported JSON listing command."""
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(*arguments: str, opencode_path: str | None = None) -> object:
+        assert opencode_path is None
+        calls.append(arguments)
+        return [
+            {"id": "ses_old", "updated": 10, "directory": "/old"},
+            {"id": "ses_child", "updated": 30, "parentID": "ses_parent"},
+            {"id": "ses_new", "updated": 20, "directory": "/new"},
+        ]
+
+    monkeypatch.setattr(local_import, "_run_opencode_json", fake_run)
+
+    assert list_recent_local_session_ids("opencode", limit=2) == ("ses_new", "ses_old")
+    assert calls == [("session", "list", "--format", "json", "--pure")]
+
+
+def test_list_recent_opencode_sessions_rejects_schema_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A changed public listing schema reports a contract error."""
+    monkeypatch.setattr(local_import, "_run_opencode_json", lambda *arguments: {})
+
+    with pytest.raises(SessionImportNotFoundError, match="invalid session list"):
+        list_recent_local_session_ids("opencode", limit=1)
+
+
+def test_load_opencode_session_preserves_messages_files_and_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public export maps ordered parts to durable Omnigent items."""
+    export = {
+        "info": {
+            "id": "ses_import",
+            "directory": "/repo",
+            "version": "1.17.18",
+        },
+        "messages": [
+            {
+                "info": {"id": "msg_user", "role": "user"},
+                "parts": [
+                    {"type": "text", "text": "inspect TODO.md"},
+                    {
+                        "type": "file",
+                        "mime": "image/png",
+                        "url": "data:image/png;base64,AAAA",
+                    },
+                ],
+            },
+            {
+                "info": {"id": "msg_assistant", "role": "assistant"},
+                "parts": [
+                    {"type": "reasoning", "text": "private reasoning"},
+                    {"type": "text", "text": "Checking."},
+                    {
+                        "type": "tool",
+                        "callID": "call_1",
+                        "tool": "bash",
+                        "state": {
+                            "status": "completed",
+                            "input": {"command": "rg TODO"},
+                            "output": "",
+                            "metadata": {"output": "TODO.md:1:item"},
+                        },
+                    },
+                    {"type": "text", "text": "Done."},
+                ],
+            },
+        ],
+    }
+
+    def fake_run(*arguments: str, opencode_path: str | None = None) -> object:
+        assert arguments == ("export", "ses_import", "--pure")
+        assert opencode_path is None
+        return export
+
+    monkeypatch.setattr(local_import, "_run_opencode_json", fake_run)
+
+    imported = load_opencode_session("ses_import")
+    dumped = [item.data.model_dump(mode="json", exclude_none=True) for item in imported.items]
+
+    assert imported.source == "opencode"
+    assert imported.external_session_id == "ses_import"
+    assert imported.workspace == "/repo"
+    assert [item.type for item in imported.items] == [
+        "message",
+        "message",
+        "function_call",
+        "function_call_output",
+        "message",
+    ]
+    assert dumped[0] == {
+        "role": "user",
+        "content": [
+            {"type": "input_text", "text": "inspect TODO.md"},
+            {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+        ],
+    }
+    assert dumped[1]["content"] == [{"type": "output_text", "text": "Checking."}]
+    assert dumped[1]["agent"] == "opencode-native-ui"
+    assert dumped[2] == {
+        "agent": "opencode-native-ui",
+        "name": "bash",
+        "arguments": '{"command":"rg TODO"}',
+        "call_id": "call_1",
+    }
+    assert dumped[3] == {"call_id": "call_1", "output": "TODO.md:1:item"}
+    assert dumped[4]["content"] == [{"type": "output_text", "text": "Done."}]
+    assert {item.response_id for item in imported.items[1:]} == {"opencode:msg_assistant"}
+
+
+def test_load_opencode_session_rejects_invalid_or_mismatched_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unsafe CLI arguments and mismatched exports cannot claim an import id."""
+    with pytest.raises(SessionImportNotFoundError, match="was not found"):
+        load_opencode_session("--help")
+
+    monkeypatch.setattr(
+        local_import,
+        "_run_opencode_json",
+        lambda *arguments, opencode_path=None: {
+            "info": {"id": "ses_other"},
+            "messages": [],
+        },
+    )
+    with pytest.raises(SessionImportNotFoundError, match="did not match"):
+        load_opencode_session("ses_expected")
 
 
 def test_load_claude_session_normalizes_parent_transcript(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

OpenCode users can now bring existing local chats into Omnigent without binding to OpenCode's private database. Discovery and loading use the first-party CLI's public JSON contracts in `--pure` mode, which keeps the integration stable and avoids loading user plugins during import.

- Support `omnigent import --harness opencode` for one session or a bounded `--last N` parent-session batch.
- Preserve ordered user/assistant text, images and attachment references, completed/error tool calls, and tool results; reasoning remains transient, matching the live OpenCode forwarder.
- Reject unsafe IDs, mismatched exports, malformed JSON, and listing-schema drift before creating an Omnigent session.

ELI5: Omnigent asks OpenCode for its official session list and export, translates that JSON into normal chat items, then uploads it through the existing import endpoint.

```text
opencode session list / export
              |
              v
     OpenCode import adapter
              |
              v
        POST /v1/imports
```

## Test Plan

- `pytest -p no:rerunfailures -q tests/test_session_import.py tests/cli/test_import.py tests/server/routes/test_imports.py tests/server/test_openapi_drift.py --tb=short` — 48 passed.
- `pytest -p no:rerunfailures -q tests/test_opencode_native.py tests/test_opencode_native_app_server.py tests/test_opencode_native_client.py tests/test_opencode_native_forwarder.py --tb=short` — 132 passed.
- `pytest -p no:rerunfailures -q tests/e2e/test_chat_import_e2e.py --tb=short -rfs` — 8 passed against a live localhost server.
- `mypy --follow-imports=skip omnigent/session_import/local.py` — passed.
- `ruff check ...`, `ruff format --check ...`, `python scripts/dump_openapi.py --check`, `git diff --check`, and changed-file `pre-commit` — passed.
- Manually verified content-free discovery and loading against the installed first-party OpenCode 1.17.18 CLI; the adapter found one real session and normalized it successfully.

The all-repository pytest collection was also attempted, but the available shared environments lacked unrelated optional test dependencies (`databricks-sdk` in one and `respx`/`boto3` in another). No collected test failed.

## Demo

N/A — CLI/backend change covered by the live-server E2E.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Fixtures cover parent-session filtering, recency ordering, malformed listing schemas, unsafe and mismatched IDs, text/file/image normalization, reasoning omission, tool ordering, empty-output metadata fallback, CLI error reporting, API enum drift, and the complete CLI-to-server path. Manual verification inspected only session IDs, item counts/types, and workspace presence; transcript content was not printed.

## Changelog

Import existing OpenCode chats, including files and tool activity, with `omnigent import`
