### PR TITLE
fix(dictation): shield stream close from disconnect cancellation

### DIFF
--- a/omnigent/server/routes/dictation.py
+++ b/omnigent/server/routes/dictation.py
@@ -60,6 +60,7 @@ import time
 from collections.abc import Callable
 from typing import Final
 
+import anyio
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, WebSocketException
 from starlette import status
 
@@ -143,8 +144,13 @@ def create_dictation_router(
                 await websocket.send_text(json.dumps({"type": "ready"}))
                 await _pump_dictation(websocket, handle)
             finally:
-                with contextlib.suppress(Exception):
-                    await asyncio.to_thread(handle.close)
+                # An abrupt disconnect tears the ASGI task down via
+                # cancellation, which would cancel this close mid-await and
+                # leak the take (the remote engine holds a worker slot until
+                # close). Shield it so cleanup always completes.
+                with anyio.CancelScope(shield=True):
+                    with contextlib.suppress(Exception):
+                        await asyncio.to_thread(handle.close)
 
     return router
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Fixes a flaky test (`test_stream_closes_take_on_abrupt_disconnect`) that was surfacing a **real resource leak**, not just test noise.

When a browser abruptly disconnects from `WS /v1/dictation/stream`, Starlette tears the ASGI task down via **cancellation**. The cleanup in the `finally` block awaited `handle.close()` *inside the already-cancelled scope*, so the cancellation fired at the `await` before the close ran — the take was never released. For the `remote` engine this leaks a worker capacity slot (`_RemoteStream.close`) until the connection eventually dies.

`contextlib.suppress(Exception)` did not protect against this: anyio cancellation is a `BaseException`, and suppressing it only hides the traceback while the close is still skipped.

The fix wraps the close in a shielded `anyio.CancelScope(shield=True)` so cleanup always completes before the outer cancellation resumes.

## Test Plan

Reproduced the race in a tight loop against the real route before fixing (~11% failure rate), then verified each candidate:

| Approach | close() runs? |
|---|---|
| original (`suppress(Exception)`) | 22/200 leaked |
| `suppress(BaseException)` | 30/300 leaked (does **not** fix) |
| `CancelScope(shield=True)` | 0/300 leaked |

- `pytest tests/server/routes/test_dictation.py` → 8 passed.
- Target test run 20× in a loop → 20/20 passed (was flaky).
- `ruff format --check` + `ruff check` → clean.

## Demo

N/A — server-side, no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

The existing `test_stream_closes_take_on_abrupt_disconnect` already asserts the take is closed on abrupt disconnect; this change makes it pass deterministically. Verified locally by running the test 20× (previously flaky, now 20/20) and reproducing the underlying leak in a loop against the real route.

## Changelog

Dictation streams now reliably release their worker slot when a browser disconnects abruptly.

This pull request and its description were written by Isaac.
