### PR TITLE
ci: only run coverage-report when all pytest shards pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,8 +414,12 @@ jobs:
     # Combines per-shard coverage into a coverage-summary artifact. Runs in the
     # unprivileged pull_request context (read-only); code-coverage.yml consumes
     # the artifact and posts the status. Report-only.
+    #
+    # Only runs when every pytest shard passed: a failed shard drops its covered
+    # lines from the combine, so coverage off partial data would be misleading —
+    # and a red run gets re-run anyway, re-triggering this.
     needs: pytest
-    if: ${{ !cancelled() && !github.event.pull_request.draft }}
+    if: ${{ success() && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The `coverage-report` job in `ci.yml` used `if: !cancelled()`, so it ran even when one or more pytest shards **failed**. A failed shard drops its covered lines from `coverage combine`, so the resulting total is computed off partial data and compared against main's baseline — misleading.
- A red pytest run gets re-run anyway, which re-triggers coverage, so computing it on the failed run has no value.
- Gate on `success()` instead, so `coverage-report` only runs when every pytest matrix shard is green.

The draft guard (`!github.event.pull_request.draft`) stays: on draft PRs `pytest` is skipped, and a skipped dependency does **not** make `success()` false, so without the guard the job could still fire on drafts.

## Test Plan

- Static review of the `needs`/`if` semantics: `success()` passes only when all `needs` (the `pytest` matrix) succeed; a skipped `needs` job (draft PRs) does not fail `success()`, so the explicit draft guard is retained.
- To verify on a live PR: fail one pytest shard deliberately and confirm `Coverage report` shows **skipped** rather than running; push a fix and confirm it runs and posts the `Coverage` status. Behavior on all-green PRs and on push-to-main is unchanged.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

CI-workflow-only change; not exercisable by the test suite. Verified by reasoning through GitHub Actions `success()` / skipped-dependency semantics as described in the Test Plan.

This pull request and its description were written by Isaac.