### PR TITLE
feat(projects): session→project membership over HTTP (Phase 1b)

### DIFF
--- a/designs/PROJECTS_PRD.md
+++ b/designs/PROJECTS_PRD.md
@@ -444,11 +444,8 @@ user's memberships would be their own private metadata.
 Tracks what has actually landed vs. what remains. Updated as work ships.
 
 ### Done (Phase 1a — project container: entity + store + CRUD)
-This PR ships the project **container** only — you can create, list, rename,
-and delete empty projects. Session→project **membership** (the `project_id`
-column, conversation-store plumbing, dual-read listing) and the session-move
-HTTP surfaces are deliberately **not** here; they land in Phase 1b (next), so
-this PR ships no column or store method that nothing consumes yet.
+Shipped: the project **container** — create, list, rename, and delete empty
+projects. Session→project membership landed separately in Phase 1b (below).
 - ✅ **`projects` table** — `SqlProject` (`db_models.py`): `id` (Uuid16),
   `name`, `owner_user_id`, `created_at`, `updated_at`. Owner-scoped index; a
   UNIQUE index on `(workspace_id, owner_user_id, name)` enforces per-owner name
@@ -468,25 +465,30 @@ this PR ships no column or store method that nothing consumes yet.
 - ✅ Tests: store CRUD + owner isolation + name uniqueness (incl. DB backstop);
   route CRUD (single- + multi-user header auth); entity.
 
+### Done (Phase 1b — session membership over HTTP)
+Links sessions to projects and exposes it, completing Phase 1.
+- ✅ **Membership column + migration** — nullable `project_id` (Uuid16) on
+  `SqlConversationMetadata` (no DB FK, Rule R032; `NULL` = unfiled) via
+  `c2d3e4f5a6b7`, an add-column migration chained after `b1c2d3e4f5a6`, plus
+  `ix_conversation_metadata_project_id` and `Conversation.project_id`.
+- ✅ **Conversation-store ops** — `set_conversation_project()` (file / move /
+  unfile by id) and a **name-based dual-read** `list_conversations(project=…)`
+  filter: a session is "in project `<name>`" if it has EITHER the first-class
+  membership (`metadata.project_id` → the caller's project of that name) OR the
+  legacy `omni_project` label with that value; `""` = unfiled. Cross-DB-safe;
+  the prefetch is bounded to the caller's permission-scoped ids so the `IN` /
+  `NOT IN` list can't grow past their own sessions. This is the §13 dual-read
+  made real, so there is no coexisting pair of filters to reconcile later.
+- ✅ **Session routes** — `PATCH /v1/sessions/{id}` files/unfiles by id
+  (owner-only; target-project ownership validated → 404 otherwise) and
+  `GET /v1/sessions?project=<name>` lists a project's sessions (owner-scoped);
+  `project_id` surfaced on `SessionResponse` / `SessionListItem`; `openapi.json`
+  regenerated.
+- ✅ Tests: store membership ops + name-based dual-read (incl. unfiled and the
+  cross-DB split-DB path); route move / unfile / list, single- and multi-user
+  ownership boundaries.
+
 ### TODO
-- ⬜ **Phase 1b — session membership over HTTP.** Link sessions to projects and
-  expose it (completes Phase 1). Built and green on a follow-up branch; rebases
-  onto this once it merges. Covers:
-  - **Membership column + migration** — nullable `project_id` (Uuid16) on
-    `SqlConversationMetadata` (no DB FK, Rule R032; `NULL` = unfiled) via a
-    small add-column migration chained after `b1c2d3e4f5a6`, plus
-    `Conversation.project_id`.
-  - **Conversation-store ops** — `set_conversation_project()` (file / move /
-    unfile by id) and a **name-based dual-read** `list_conversations(project=…)`
-    filter: a session is "in project `<name>`" if it has EITHER the first-class
-    membership (`metadata.project_id` → the caller's project of that name) OR
-    the legacy `omni_project` label with that value; `""` = unfiled.
-    Cross-DB-safe. This is the §13 dual-read made real, so there is no
-    coexisting pair of filters to reconcile later.
-  - **Session routes** — `PATCH /v1/sessions/{id}` files/unfiles by id
-    (owner-only; target-project ownership validated → 404 otherwise) and
-    `GET /v1/sessions?project=<name>` lists a project's sessions (owner-scoped);
-    `project_id` surfaced on `SessionResponse` / `SessionListItem`.
 - ⬜ **Web UI** — always-visible Projects sidebar section; create empty project;
   "New session here"; session-row kebab move; rename (§5–§7). No TS client
   types regenerated yet.

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -642,6 +642,10 @@ class SqlConversationMetadata(OmnigentBase):
     live_status: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
     # Outstanding elicitation (approval-prompt) count; NULL = never written.
     pending_elicitation_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # First-class project membership. Relates to projects.id; no DB FK
+    # (Rule R032). NULL = unfiled. Coexists with the implicit ``omni_project``
+    # label via the store's dual-read until labels are consolidated.
+    project_id: Mapped[str | None] = mapped_column(Uuid16(), nullable=True)
 
     __table_args__ = (
         CheckConstraint("kind IN (1, 2)", name="ck_conversation_metadata_kind"),
@@ -651,6 +655,8 @@ class SqlConversationMetadata(OmnigentBase):
         ),
         # Supports list_conversations_by_runner_id and get_runner_ids.
         Index("ix_conversation_metadata_runner_id", "workspace_id", "runner_id", "id"),
+        # "list sessions in project X" + per-project counts (GROUP BY project_id).
+        Index("ix_conversation_metadata_project_id", "workspace_id", "project_id", "id"),
     )
 
 

--- a/omnigent/db/migrations/versions/c2d3e4f5a6b7_add_project_id_to_conversation_metadata.py
+++ b/omnigent/db/migrations/versions/c2d3e4f5a6b7_add_project_id_to_conversation_metadata.py
@@ -1,0 +1,56 @@
+"""add project_id to omnigent_conversation_metadata
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1c2d3e4f5a6
+Create Date: 2026-07-22 00:00:00.000000
+
+Phase 1b of the projects feature (see ``designs/PROJECTS_PRD.md``): links
+sessions to first-class projects. Adds a nullable ``project_id`` (Uuid16) to
+``omnigent_conversation_metadata`` — the session→project membership pointer.
+``NULL`` means unfiled. ``b1c2d3e4f5a6`` created the ``projects`` container;
+this migration adds the column that references it, alongside the store/route
+code that reads and writes it, so no column ships unused.
+
+Additive. There are no foreign-key constraints (schema Rule R032): the
+project relationship is enforced by the application, not the database. The
+column coexists with the implicit ``omni_project`` label via the store's
+dual-read, so existing label-projects keep working with no backfill.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from omnigent.db.db_models import Uuid16
+
+revision: str = "c2d3e4f5a6b7"
+down_revision: str | None = "b1c2d3e4f5a6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``project_id`` and its owner-scoped list index."""
+    with op.batch_alter_table("omnigent_conversation_metadata") as batch_op:
+        batch_op.add_column(sa.Column("project_id", Uuid16(), nullable=True))
+    # Backs "list sessions in project X" and per-project counts
+    # (GROUP BY project_id) scoped to the tenant partition.
+    op.create_index(
+        "ix_conversation_metadata_project_id",
+        "omnigent_conversation_metadata",
+        ["workspace_id", "project_id", "id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the index and ``project_id`` column."""
+    op.drop_index(
+        "ix_conversation_metadata_project_id",
+        table_name="omnigent_conversation_metadata",
+    )
+    with op.batch_alter_table("omnigent_conversation_metadata") as batch_op:
+        batch_op.drop_column("project_id")

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -180,6 +180,9 @@ class Conversation:
         listing (and the sidebar), surfacing only when the caller
         passes ``include_archived=True``. ``False`` for normal
         sessions; toggled via ``PATCH /v1/sessions/{id}``.
+    :param project_id: The first-class project this session is filed
+        under, or ``None`` if unfiled. Owner-private membership; see
+        ``designs/PROJECTS_PRD.md``.
     :param search_snippet: Transient, list-only excerpt of the chat
         content that matched a ``search_query`` — set by
         ``list_conversations`` whenever the query hit an item's body (even
@@ -218,6 +221,7 @@ class Conversation:
     # outstanding approval-prompt count (None = never written).
     live_status: str | None = None
     pending_elicitation_count: int | None = None
+    project_id: str | None = None
     # Transient: populated only by list_conversations on a content search;
     # never read from or written to the DB.
     search_snippet: str | None = None

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2216,6 +2216,9 @@ def create_app(
             # workspace over the host tunnel when the runner is offline
             # (the file panel stays live without waking the agent).
             host_registry=host_registry,
+            # Validates target-project ownership when PATCH /v1/sessions/{id}
+            # files a session into a project (owner-private membership).
+            project_store=project_store,
         ),
         prefix="/v1",
         tags=["sessions"],

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -16410,9 +16410,11 @@ def create_sessions_router(
                 )
             target_project_id = body.project_id
             if target_project_id == "":
-                await asyncio.to_thread(
+                unfiled = await asyncio.to_thread(
                     conversation_store.set_conversation_project, session_id, None
                 )
+                if not unfiled:
+                    raise _session_not_found()
             else:
                 if project_store is None:
                     raise OmnigentError(

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -16398,7 +16398,17 @@ def create_sessions_router(
         # into another owner's (or a missing) project is rejected as NOT_FOUND
         # — the same 404 the projects API returns, so we don't leak existence.
         if set_project:
-            target_project_id = body.project_id or ""
+            # ``""`` unfiles; a non-empty id files. Explicit JSON ``null`` is
+            # not a valid value here (omitting the field is how you leave
+            # membership unchanged), so reject it rather than treating it as a
+            # destructive unfile.
+            if body.project_id is None:
+                raise OmnigentError(
+                    'project_id must be a project id or "" to unfile; '
+                    "omit the field to leave membership unchanged",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            target_project_id = body.project_id
             if target_project_id == "":
                 await asyncio.to_thread(
                     conversation_store.set_conversation_project, session_id, None

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -307,6 +307,7 @@ from omnigent.stores.conversation_store import (
 from omnigent.stores.file_store import FileStore
 from omnigent.stores.host_store import Host, HostStore
 from omnigent.stores.permission_store import PermissionStore
+from omnigent.stores.project_store import ProjectStore
 from omnigent.telemetry import emit as _tel_emit
 from omnigent.telemetry.events import SessionCreatedEvent as _TelSessionCreatedEvent
 from omnigent.telemetry.events import SessionDeletedEvent as _TelSessionDeletedEvent
@@ -2395,6 +2396,7 @@ def _build_session_list_item(
         # push-stream path leaves it None (no query in flight there).
         search_snippet=conv.search_snippet,
         parent_session_id=conv.parent_conversation_id,
+        project_id=conv.project_id,
     )
 
 
@@ -2845,6 +2847,7 @@ def _build_session_response(
         # is not replayed on the SSE stream). Populated for native-terminal
         # sessions whose forwarder stamps a turn id; ``None`` otherwise.
         active_response_id=_session_active_response_cache.get(conv.id),
+        project_id=conv.project_id,
     )
 
 
@@ -14742,6 +14745,7 @@ def create_sessions_router(
     runner_tunnel_tokens: frozenset[str] | None = None,
     runner_exit_reports: RunnerExitReports | None = None,
     host_registry: HostRegistry | None = None,
+    project_store: ProjectStore | None = None,
 ) -> APIRouter:
     """
     Factory that builds the sessions router.
@@ -14802,6 +14806,10 @@ def create_sessions_router(
         the runner is offline, so the file panel stays live without
         waking the agent. ``None`` disables the fallback (the endpoints
         then 503 on an offline runner, as before).
+    :param project_store: Store for first-class projects. Required to
+        validate ownership when ``PATCH /v1/sessions/{id}`` files a
+        session into a project. ``None`` disables the move-into-project
+        action (a non-empty ``project_id`` is then rejected as unsupported).
     :returns: A configured :class:`APIRouter` exposing the
         ``/sessions`` endpoints.
     """
@@ -15456,6 +15464,8 @@ def create_sessions_router(
         # A specific project folder ("My sessions"-only) must show only the
         # viewer's own sessions — a session shared with them but filed under a
         # like-named project belongs on "Shared with me", not in this folder.
+        # Passing owned_by here also scopes the dual-read's first-class half:
+        # the store resolves the project NAME to the caller's own project id.
         # The flat list (project=None) and Unfiled (project="") stay unscoped so
         # shared sessions still surface for the "Shared with me" tab.
         owned_by = user_id if project else None
@@ -16050,6 +16060,11 @@ def create_sessions_router(
             registered; 404 if no session exists.
         """
         user_id = _get_user_id(request, auth_provider)
+        # Filing into a project is owner-only: projects are owner-private, so a
+        # session's membership is the owner organizing their own sessions — an
+        # editor must not move it. Presence is the signal (``""`` unfiles), so
+        # gate on model_fields_set, not a non-None value.
+        set_project = "project_id" in body.model_fields_set
         # Archiving/unarchiving is an owner-only lifecycle action: it pairs
         # with a client-driven, owner-gated stop, so an editor must not be
         # able to archive a session (hiding it, and via the client stopping
@@ -16057,7 +16072,7 @@ def create_sessions_router(
         # endpoint needs only edit. Owner implies edit, so a single check at
         # the level the request actually requires gates both — no redundant
         # second permission-store read for archive/unarchive.
-        required_level = LEVEL_OWNER if body.archived is not None else LEVEL_EDIT
+        required_level = LEVEL_OWNER if (body.archived is not None or set_project) else LEVEL_EDIT
         await _require_access(
             user_id, session_id, required_level, permission_store, conversation_store
         )
@@ -16378,6 +16393,34 @@ def create_sessions_router(
                     str(exc),
                     code=ErrorCode.INVALID_INPUT,
                 ) from exc
+        # File into a first-class project (owner-only, gated above). ``""``
+        # unfiles; a non-empty id must name a project the caller owns. Filing
+        # into another owner's (or a missing) project is rejected as NOT_FOUND
+        # — the same 404 the projects API returns, so we don't leak existence.
+        if set_project:
+            target_project_id = body.project_id or ""
+            if target_project_id == "":
+                await asyncio.to_thread(
+                    conversation_store.set_conversation_project, session_id, None
+                )
+            else:
+                if project_store is None:
+                    raise OmnigentError(
+                        "Filing a session into a project is not supported by this server",
+                        code=ErrorCode.INVALID_INPUT,
+                    )
+                owned = await asyncio.to_thread(
+                    project_store.get, target_project_id, owner_user_id=user_id
+                )
+                if owned is None:
+                    raise OmnigentError("Project not found", code=ErrorCode.NOT_FOUND)
+                filed = await asyncio.to_thread(
+                    conversation_store.set_conversation_project,
+                    session_id,
+                    target_project_id,
+                )
+                if not filed:
+                    raise _session_not_found()
         level = await _get_permission_level(user_id, session_id, permission_store)
         return await _get_session_snapshot(
             conversation_store,

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1840,6 +1840,11 @@ class SessionResponse(BaseModel):
     # opening the session mid-startup sees the startup band.
     mcp_startup: dict[str, McpServerStartup] | None = None
     active_response_id: str | None = None
+    # First-class project this session is filed under, or ``None`` when
+    # unfiled. Distinct from the legacy ``omni_project`` label (surfaced in
+    # ``labels``); set/cleared via ``PATCH /v1/sessions/{id}`` and filtered on
+    # ``GET /v1/sessions?project=``.
+    project_id: str | None = None
 
 
 class UpdateSessionRequest(BaseModel):
@@ -1909,6 +1914,13 @@ class UpdateSessionRequest(BaseModel):
         session from the default sidebar listing), ``False`` unarchives,
         ``None`` leaves unchanged. Owner-only (unlike ``title``, which
         needs only edit access).
+    :param project_id: File this session into a first-class project (see
+        ``designs/PROJECTS_PRD.md``). A non-empty id moves the session into
+        that project; the empty string ``""`` unfiles it. ``None`` (field
+        omitted) leaves membership unchanged. Owner-only: because projects
+        are owner-private, only the session owner may file it, and only into
+        a project they own — the server verifies both. Independent of the
+        legacy ``omni_project`` label, which is set via ``labels``.
     """
 
     runner_id: str | None = None
@@ -1921,6 +1933,7 @@ class UpdateSessionRequest(BaseModel):
     external_session_id: str | None = None
     terminal_launch_args: list[str] | None = None
     archived: bool | None = None
+    project_id: str | None = None
     silent: bool = False
 
     model_config = ConfigDict(extra="forbid")
@@ -2239,6 +2252,10 @@ class SessionListItem(BaseModel):
     viewer_unread: bool = False
     search_snippet: str | None = None
     parent_session_id: str | None = None
+    # First-class project this session is filed under, or ``None`` when
+    # unfiled. Lets the sidebar group sessions by project without a follow-up
+    # GET. Distinct from the legacy ``omni_project`` label in ``labels``.
+    project_id: str | None = None
 
 
 class SessionList(BaseModel):

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1916,10 +1916,11 @@ class UpdateSessionRequest(BaseModel):
         needs only edit access).
     :param project_id: File this session into a first-class project (see
         ``designs/PROJECTS_PRD.md``). A non-empty id moves the session into
-        that project; the empty string ``""`` unfiles it. ``None`` (field
-        omitted) leaves membership unchanged. Owner-only: because projects
-        are owner-private, only the session owner may file it, and only into
-        a project they own — the server verifies both. Independent of the
+        that project; the empty string ``""`` unfiles it. **Omitting** the
+        field leaves membership unchanged; an explicit ``null`` is rejected
+        (400) so it can't silently unfile. Owner-only: because projects are
+        owner-private, only the session owner may file it, and only into a
+        project they own — the server verifies both. Independent of the
         legacy ``omni_project`` label, which is set via ``labels``.
     """
 

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -644,12 +644,16 @@ class ConversationStore(ABC):
             conversations are excluded. When ``True``, archived and
             non-archived conversations are both returned (the caller
             groups them). Powers the sidebar's "Show archived" toggle.
-        :param project: When set to a non-empty string, only return
-            sessions that have a ``conversation_labels`` row with
-            ``key="omni_project"`` and ``value=project`` (the sidebar's
-            per-project folder fetch). When set to an empty string
-            ``""``, only return sessions with NO project label (unfiled
-            sessions). ``None`` disables the filter.
+        :param project: Filter by project NAME, dual-reading the
+            first-class projects entity and the legacy ``omni_project``
+            label (the sidebar's per-project folder fetch). A non-empty
+            string returns sessions that EITHER have a first-class
+            membership (``metadata.project_id`` → ``owned_by``'s project of
+            this name) OR carry the ``omni_project`` label with this value.
+            ``""`` returns sessions with NEITHER (unfiled). ``None`` disables
+            the filter. The name→id resolution is owner-scoped (projects are
+            owner-private), so pass ``owned_by`` alongside a specific name.
+            See ``designs/PROJECTS_PRD.md``.
         :param title: When set, only return conversations whose
             ``title`` matches exactly. ``None`` disables the filter.
             Powers the ``(agent, title)`` child-session lookup in
@@ -899,6 +903,26 @@ class ConversationStore(ABC):
             ``{"input_tokens": 1500, "output_tokens": 350,
             "total_tokens": 1850}``. May carry a nested ``"by_model"``
             sub-dict (per-model token/cost buckets), hence ``Any``.
+        """
+        ...
+
+    @abstractmethod
+    def set_conversation_project(
+        self,
+        conversation_id: str,
+        project_id: str | None,
+    ) -> bool:
+        """
+        File a conversation into a first-class project (or unfile it).
+
+        Sets ``omnigent_conversation_metadata.project_id``; ``None`` unfiles
+        the session. The first-class counterpart to moving a session between
+        ``omni_project`` labels (see ``designs/PROJECTS_PRD.md``).
+
+        :param conversation_id: The conversation to update, e.g. ``"conv_abc"``.
+        :param project_id: The project id to file under, or ``None`` to unfile.
+        :returns: ``True`` if a metadata row was updated; ``False`` if the
+            conversation has no metadata row.
         """
         ...
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2251,19 +2251,26 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversationLabel.key == PROJECT_LABEL_KEY,
                 )
                 if project == "":
-                    # Unfiled: no first-class membership AND no label. Bound the
-                    # prefetch to qualifying_ids (when permission-scoped) so the
-                    # NOT IN list stays capped to the caller's own sessions.
+                    # Unfiled: no first-class membership AND no label.
                     first_class_stmt = select(SqlConversationMetadata.id).where(
                         SqlConversationMetadata.workspace_id == current_workspace_id(),
                         SqlConversationMetadata.project_id.is_not(None),
                     )
-                    if qualifying_ids is not None:
-                        first_class_stmt = first_class_stmt.where(
-                            SqlConversationMetadata.id.in_(qualifying_ids)
-                        )
-                    with self._session() as meta_sess:
-                        first_class_filed = list(meta_sess.execute(first_class_stmt).scalars())
+                    if self._conv_engine is self._engine:
+                        # Single-DB: metadata is colocated with conversations, so
+                        # push the exclusion down as a NOT IN subquery — no need to
+                        # pull every filed id into Python.
+                        first_class_filed: Any = first_class_stmt
+                    else:
+                        # Split-DB: metadata lives elsewhere, so prefetch the ids.
+                        # Bound to qualifying_ids (when permission-scoped) so the
+                        # NOT IN list stays capped to the caller's own sessions.
+                        if qualifying_ids is not None:
+                            first_class_stmt = first_class_stmt.where(
+                                SqlConversationMetadata.id.in_(qualifying_ids)
+                            )
+                        with self._session() as meta_sess:
+                            first_class_filed = list(meta_sess.execute(first_class_stmt).scalars())
                     stmt = stmt.where(
                         SqlConversation.id.not_in(first_class_filed),
                         SqlConversation.id.not_in(label_filed),

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2277,10 +2277,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                     )
                 else:
                     # Resolve the owner's project of this name → its member ids
-                    # (one join). No such project yields an empty list, so the
+                    # (one join). No such project yields an empty match, so the
                     # filter collapses to the label match alone (v1 behaviour).
-                    # Bound to qualifying_ids (when permission-scoped) to cap the
-                    # IN list to the caller's own sessions.
                     member_stmt = (
                         select(SqlConversationMetadata.id)
                         .join(
@@ -2294,15 +2292,24 @@ class SqlAlchemyConversationStore(ConversationStore):
                             SqlProject.name == project,
                         )
                     )
-                    if qualifying_ids is not None:
-                        member_stmt = member_stmt.where(
-                            SqlConversationMetadata.id.in_(qualifying_ids)
-                        )
-                    with self._session() as meta_sess:
-                        member_ids = list(meta_sess.execute(member_stmt).scalars())
+                    if self._conv_engine is self._engine:
+                        # Single-DB: metadata + projects are colocated with
+                        # conversations, so use the SELECT as an IN subquery — no
+                        # need to pull member ids into Python.
+                        member_match: Any = member_stmt
+                    else:
+                        # Split-DB: resolve member ids first, bounded to
+                        # qualifying_ids (when permission-scoped) so the IN list
+                        # stays capped to the caller's own sessions.
+                        if qualifying_ids is not None:
+                            member_stmt = member_stmt.where(
+                                SqlConversationMetadata.id.in_(qualifying_ids)
+                            )
+                        with self._session() as meta_sess:
+                            member_match = list(meta_sess.execute(member_stmt).scalars())
                     stmt = stmt.where(
                         or_(
-                            SqlConversation.id.in_(member_ids),
+                            SqlConversation.id.in_(member_match),
                             SqlConversation.id.in_(
                                 label_filed.where(SqlConversationLabel.value == project)
                             ),

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -34,6 +34,7 @@ from omnigent.db.db_models import (
     SqlConversationLabel,
     SqlConversationMetadata,
     SqlPolicy,
+    SqlProject,
     SqlSessionPermission,
     SqlUserDailyCost,
     current_workspace_id,
@@ -209,6 +210,7 @@ def _to_conversation(
             else None
         ),
         pending_elicitation_count=meta.pending_elicitation_count if meta else None,
+        project_id=meta.project_id if meta else None,
     )
 
 
@@ -1298,6 +1300,34 @@ class SqlAlchemyConversationStore(ConversationStore):
                 .values(session_usage=json.dumps(usage))
             )
 
+    def set_conversation_project(
+        self,
+        conversation_id: str,
+        project_id: str | None,
+    ) -> bool:
+        """
+        File a conversation into a first-class project (or unfile it).
+
+        Sets ``omnigent_conversation_metadata.project_id``. ``None`` unfiles the
+        session. The first-class counterpart to moving a session between
+        ``omni_project`` labels.
+
+        :param conversation_id: The conversation to update, e.g. ``"conv_abc"``.
+        :param project_id: The project id to file under, or ``None`` to unfile.
+        :returns: ``True`` if a metadata row was updated; ``False`` if the
+            conversation has no metadata row.
+        """
+        with self._session() as session:
+            result = session.execute(
+                update(SqlConversationMetadata)
+                .where(
+                    SqlConversationMetadata.workspace_id == current_workspace_id(),
+                    SqlConversationMetadata.id == conversation_id,
+                )
+                .values(project_id=project_id)
+            )
+            return result.rowcount > 0
+
     def increment_session_usage(
         self,
         conversation_id: str,
@@ -2075,12 +2105,14 @@ class SqlAlchemyConversationStore(ConversationStore):
         :param include_archived: When ``False`` (default), exclude
             rows where ``archived`` is true. When ``True``, include
             archived rows alongside non-archived ones.
-        :param project: When set to a non-empty string, only return
-            sessions that have a ``conversation_labels`` row with
-            ``key="omni_project"`` and ``value=project``. When set to an
-            empty string ``""``, only return sessions with NO project
-            label (i.e., unfiled sessions). ``None`` disables the
-            filter.
+        :param project: Filter by project NAME, dual-reading both storage
+            paths. A non-empty string returns sessions that EITHER have a
+            first-class membership (``metadata.project_id`` → ``owned_by``'s
+            project of this name) OR carry the legacy ``omni_project`` label
+            with this value. ``""`` returns sessions with NEITHER (unfiled).
+            ``None`` disables the filter. The name→id resolution is scoped to
+            ``owned_by`` (projects are owner-private), so pass ``owned_by``
+            alongside a specific name for the first-class half to resolve.
         :param owned_by: When set, restrict to sessions the user owns
             (an ``owner``-level grant) — stricter than ``accessible_by``,
             which also matches sessions merely shared with them. Powers
@@ -2208,25 +2240,65 @@ class SqlAlchemyConversationStore(ConversationStore):
                 )
                 stmt = stmt.where(or_(title_match, content_match))
             if project is not None:
+                # Dual-read by project NAME: a session is "in <name>" if it has
+                # EITHER the first-class membership (metadata.project_id → the
+                # owner's project of that name) OR the legacy ``omni_project``
+                # label. The label is colocated on the AP DB (inline subquery);
+                # projects + metadata are on the Omnigent DB, so member ids are
+                # resolved there first, then combined with the label subquery.
+                label_filed = select(SqlConversationLabel.conversation_id).where(
+                    SqlConversationLabel.workspace_id == current_workspace_id(),
+                    SqlConversationLabel.key == PROJECT_LABEL_KEY,
+                )
                 if project == "":
-                    # Unfiled: sessions with no project label at all.
-                    stmt = stmt.where(
-                        SqlConversation.id.not_in(
-                            select(SqlConversationLabel.conversation_id).where(
-                                SqlConversationLabel.workspace_id == current_workspace_id(),
-                                SqlConversationLabel.key == PROJECT_LABEL_KEY,
-                            )
+                    # Unfiled: no first-class membership AND no label. Bound the
+                    # prefetch to qualifying_ids (when permission-scoped) so the
+                    # NOT IN list stays capped to the caller's own sessions.
+                    first_class_stmt = select(SqlConversationMetadata.id).where(
+                        SqlConversationMetadata.workspace_id == current_workspace_id(),
+                        SqlConversationMetadata.project_id.is_not(None),
+                    )
+                    if qualifying_ids is not None:
+                        first_class_stmt = first_class_stmt.where(
+                            SqlConversationMetadata.id.in_(qualifying_ids)
                         )
+                    with self._session() as meta_sess:
+                        first_class_filed = list(meta_sess.execute(first_class_stmt).scalars())
+                    stmt = stmt.where(
+                        SqlConversation.id.not_in(first_class_filed),
+                        SqlConversation.id.not_in(label_filed),
                     )
                 else:
-                    # Specific project: session must have this project label.
+                    # Resolve the owner's project of this name → its member ids
+                    # (one join). No such project yields an empty list, so the
+                    # filter collapses to the label match alone (v1 behaviour).
+                    # Bound to qualifying_ids (when permission-scoped) to cap the
+                    # IN list to the caller's own sessions.
+                    member_stmt = (
+                        select(SqlConversationMetadata.id)
+                        .join(
+                            SqlProject,
+                            SqlConversationMetadata.project_id == SqlProject.id,
+                        )
+                        .where(
+                            SqlConversationMetadata.workspace_id == current_workspace_id(),
+                            SqlProject.workspace_id == current_workspace_id(),
+                            SqlProject.owner_user_id == owned_by,
+                            SqlProject.name == project,
+                        )
+                    )
+                    if qualifying_ids is not None:
+                        member_stmt = member_stmt.where(
+                            SqlConversationMetadata.id.in_(qualifying_ids)
+                        )
+                    with self._session() as meta_sess:
+                        member_ids = list(meta_sess.execute(member_stmt).scalars())
                     stmt = stmt.where(
-                        SqlConversation.id.in_(
-                            select(SqlConversationLabel.conversation_id).where(
-                                SqlConversationLabel.workspace_id == current_workspace_id(),
-                                SqlConversationLabel.key == PROJECT_LABEL_KEY,
-                                SqlConversationLabel.value == project,
-                            )
+                        or_(
+                            SqlConversation.id.in_(member_ids),
+                            SqlConversation.id.in_(
+                                label_filed.where(SqlConversationLabel.value == project)
+                            ),
                         )
                     )
             if after:

--- a/openapi.json
+++ b/openapi.json
@@ -6206,7 +6206,7 @@
                 "type": "null"
               }
             ],
-            "description": "File this session into a first-class project (see `designs/PROJECTS_PRD.md`). A non-empty id moves the session into that project; the empty string `\"\"` unfiles it. `None` (field omitted) leaves membership unchanged. Owner-only: because projects are owner-private, only the session owner may file it, and only into a project they own \u2014 the server verifies both. Independent of the legacy `omni_project` label, which is set via `labels`.",
+            "description": "File this session into a first-class project (see `designs/PROJECTS_PRD.md`). A non-empty id moves the session into that project; the empty string `\"\"` unfiles it. **Omitting** the field leaves membership unchanged; an explicit `null` is rejected (400) so it can't silently unfile. Owner-only: because projects are owner-private, only the session owner may file it, and only into a project they own \u2014 the server verifies both. Independent of the legacy `omni_project` label, which is set via `labels`.",
             "title": "Project Id"
           },
           "reasoning_effort": {

--- a/openapi.json
+++ b/openapi.json
@@ -4121,6 +4121,17 @@
             "description": "The requesting user's numeric permission level on this session: `1` = read, `2` = edit, `3` = manage. `None` when permissions are disabled.",
             "title": "Permission Level"
           },
+          "project_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project Id"
+          },
           "reasoning_effort": {
             "anyOf": [
               {
@@ -4918,6 +4929,17 @@
             ],
             "description": "The requesting user's numeric permission level on this session: `1` = read, `2` = edit, `3` = manage. `None` when permissions are disabled (single-user mode without a permission store).",
             "title": "Permission Level"
+          },
+          "project_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project Id"
           },
           "reasoning_effort": {
             "anyOf": [
@@ -6174,6 +6196,18 @@
             ],
             "description": "Per-session LLM model override, e.g. `\"claude-opus-4-7\"`. The value is forwarded as-is to the executor at turn start; the server does not enumerate valid models. Clear aliases such as `\"default\"`, `\"off\"`, or `\"reset\"` remove the override (matching the REPL's `/model` semantics). `None` leaves unchanged.",
             "title": "Model Override"
+          },
+          "project_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "File this session into a first-class project (see `designs/PROJECTS_PRD.md`). A non-empty id moves the session into that project; the empty string `\"\"` unfiles it. `None` (field omitted) leaves membership unchanged. Owner-only: because projects are owner-private, only the session owner may file it, and only into a project they own \u2014 the server verifies both. Independent of the legacy `omni_project` label, which is set via `labels`.",
+            "title": "Project Id"
           },
           "reasoning_effort": {
             "anyOf": [

--- a/tests/server/routes/test_sessions_project_membership.py
+++ b/tests/server/routes/test_sessions_project_membership.py
@@ -136,6 +136,22 @@ def test_file_into_nonexistent_project_404(db_uri: str) -> None:
     assert resp.status_code == 404
 
 
+def test_explicit_null_project_id_is_rejected(db_uri: str) -> None:
+    """A present-but-null project_id is invalid: only "" unfiles, and omitting
+    the field leaves membership unchanged — so null must not silently unfile."""
+    _ensure_agent(db_uri)
+    conv = SqlAlchemyConversationStore(db_uri).create_conversation(title="s", agent_id=AGENT_ID)
+    client = TestClient(_single_user_app(db_uri))
+    project = client.post("/v1/projects", json={"name": "Work"}).json()
+    client.patch(f"/v1/sessions/{conv.id}", json={"project_id": project["id"]})
+
+    resp = client.patch(f"/v1/sessions/{conv.id}", json={"project_id": None})
+    assert resp.status_code == 400
+    # Membership is untouched — the invalid PATCH didn't unfile it.
+    snap = client.get(f"/v1/sessions/{conv.id}")
+    assert snap.json()["project_id"] == project["id"]
+
+
 def test_project_filter_excludes_other_projects(db_uri: str) -> None:
     """?project=<name> returns only that project's members, not another's."""
     _ensure_agent(db_uri)

--- a/tests/server/routes/test_sessions_project_membership.py
+++ b/tests/server/routes/test_sessions_project_membership.py
@@ -1,0 +1,302 @@
+"""Tests for filing sessions into first-class projects via the sessions API.
+
+Exercises the two HTTP surfaces added on top of the projects Stage-1 store:
+
+- ``PATCH /v1/sessions/{id}`` with ``project_id`` — move a session into a
+  project (non-empty id), unfile it (``""``), leave unchanged (omitted). Filing
+  is by project **id** (the client holds it after create/list).
+- ``GET /v1/sessions?project=<name>`` — list a project's member sessions by
+  **name**, dual-reading the first-class entity and the legacy ``omni_project``
+  label; ``?project=`` (empty) lists unfiled sessions. The name→id resolution is
+  server-side, so the client passes only the name it renders in the sidebar.
+
+Both are owner-scoped because projects are owner-private: only the session
+owner may file it, and only into a project they own. The multi-user tests use
+header auth to prove the ownership boundary holds — a caller can neither file a
+session into another owner's project nor into a session they only have
+edit/read access to.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from omnigent.errors import OmnigentError
+from omnigent.server.auth import (
+    LEVEL_EDIT,
+    LEVEL_OWNER,
+    UnifiedAuthProvider,
+)
+from omnigent.server.routes.projects import create_projects_router
+from omnigent.server.routes.sessions import create_sessions_router
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.permission_store.sqlalchemy_store import (
+    SqlAlchemyPermissionStore,
+)
+from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
+
+ALICE = "alice@example.com"
+BOB = "bob@example.com"
+AGENT_ID = "087b7cb7ac30abf4debfaa578d052ec6"
+
+
+def _ensure_agent(db_uri: str) -> None:
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    if agent_store.get(AGENT_ID) is None:
+        agent_store.create(
+            agent_id=AGENT_ID,
+            name="test-agent",
+            bundle_location=f"{AGENT_ID}/bundle",
+        )
+
+
+# ── Single-user mode (no auth) ───────────────────────────────────────────
+
+
+def _single_user_app(db_uri: str) -> FastAPI:
+    """Build an app (no auth provider) mounting sessions + projects at ``/v1``."""
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def _handle(request: Request, exc: OmnigentError) -> JSONResponse:
+        del request
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    project_store = SqlAlchemyProjectStore(db_uri)
+    app.include_router(
+        create_sessions_router(
+            conversation_store=SqlAlchemyConversationStore(db_uri),
+            agent_store=SqlAlchemyAgentStore(db_uri),
+            project_store=project_store,
+        ),
+        prefix="/v1",
+    )
+    app.include_router(create_projects_router(project_store=project_store), prefix="/v1")
+    return app
+
+
+def test_file_and_unfile_session_single_user(db_uri: str) -> None:
+    """PATCH project_id files the session; project_id="" unfiles it."""
+    _ensure_agent(db_uri)
+    conv = SqlAlchemyConversationStore(db_uri).create_conversation(title="s", agent_id=AGENT_ID)
+    client = TestClient(_single_user_app(db_uri))
+
+    project = client.post("/v1/projects", json={"name": "Work"}).json()
+
+    # File it (by id — the client holds the id after create).
+    resp = client.patch(f"/v1/sessions/{conv.id}", json={"project_id": project["id"]})
+    assert resp.status_code == 200
+    assert resp.json()["project_id"] == project["id"]
+
+    # Listing by project NAME returns it (dual-read resolves the name → id).
+    listed = client.get("/v1/sessions?project=Work")
+    assert [s["id"] for s in listed.json()["data"]] == [conv.id]
+
+    # Unfile it.
+    resp = client.patch(f"/v1/sessions/{conv.id}", json={"project_id": ""})
+    assert resp.status_code == 200
+    assert resp.json()["project_id"] is None
+
+    # No longer in the project; now shows under unfiled (project="").
+    assert client.get("/v1/sessions?project=Work").json()["data"] == []
+    unfiled = client.get("/v1/sessions?project=")
+    assert conv.id in [s["id"] for s in unfiled.json()["data"]]
+
+
+def test_omitting_project_id_leaves_membership_unchanged(db_uri: str) -> None:
+    """A PATCH that doesn't mention project_id must not clear the filing."""
+    _ensure_agent(db_uri)
+    conv = SqlAlchemyConversationStore(db_uri).create_conversation(title="s", agent_id=AGENT_ID)
+    client = TestClient(_single_user_app(db_uri))
+    project = client.post("/v1/projects", json={"name": "Work"}).json()
+    client.patch(f"/v1/sessions/{conv.id}", json={"project_id": project["id"]})
+
+    # A title-only PATCH leaves project membership intact.
+    resp = client.patch(f"/v1/sessions/{conv.id}", json={"title": "renamed"})
+    assert resp.status_code == 200
+    assert resp.json()["project_id"] == project["id"]
+
+
+def test_file_into_nonexistent_project_404(db_uri: str) -> None:
+    """Filing into a project id that doesn't exist is rejected (404)."""
+    _ensure_agent(db_uri)
+    conv = SqlAlchemyConversationStore(db_uri).create_conversation(title="s", agent_id=AGENT_ID)
+    client = TestClient(_single_user_app(db_uri))
+    resp = client.patch(
+        f"/v1/sessions/{conv.id}", json={"project_id": "ffffffffffffffffffffffffffffffff"}
+    )
+    assert resp.status_code == 404
+
+
+def test_project_filter_excludes_other_projects(db_uri: str) -> None:
+    """?project=<name> returns only that project's members, not another's."""
+    _ensure_agent(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    a = conv_store.create_conversation(title="a", agent_id=AGENT_ID)
+    b = conv_store.create_conversation(title="b", agent_id=AGENT_ID)
+    client = TestClient(_single_user_app(db_uri))
+    p1 = client.post("/v1/projects", json={"name": "P1"}).json()
+    client.post("/v1/projects", json={"name": "P2"})
+    client.patch(f"/v1/sessions/{a.id}", json={"project_id": p1["id"]})
+    # File b under P2 by name via the legacy label, to prove the dual-read OR
+    # branch surfaces label members under the same ?project= filter.
+    conv_store.set_labels(b.id, {"omni_project": "P2"})
+
+    assert [s["id"] for s in client.get("/v1/sessions?project=P1").json()["data"]] == [a.id]
+    assert [s["id"] for s in client.get("/v1/sessions?project=P2").json()["data"]] == [b.id]
+
+
+def test_project_filter_dual_reads_label_and_entity(db_uri: str) -> None:
+    """Under one ?project=<name>, both a first-class member and a legacy
+    label member surface together (the dual-read OR)."""
+    _ensure_agent(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    entity_member = conv_store.create_conversation(title="entity", agent_id=AGENT_ID)
+    label_member = conv_store.create_conversation(title="label", agent_id=AGENT_ID)
+    client = TestClient(_single_user_app(db_uri))
+    project = client.post("/v1/projects", json={"name": "Work"}).json()
+    client.patch(f"/v1/sessions/{entity_member.id}", json={"project_id": project["id"]})
+    conv_store.set_labels(label_member.id, {"omni_project": "Work"})
+
+    listed = client.get("/v1/sessions?project=Work").json()["data"]
+    assert {s["id"] for s in listed} == {entity_member.id, label_member.id}
+
+
+# ── Multi-user mode (header auth) — ownership boundary ───────────────────
+
+
+def _multi_user_app(db_uri: str) -> FastAPI:
+    """Build a header-auth app mounting sessions + projects at ``/v1``."""
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def _handle(request: Request, exc: OmnigentError) -> JSONResponse:
+        del request
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    auth = UnifiedAuthProvider(source="header")
+    project_store = SqlAlchemyProjectStore(db_uri)
+    app.include_router(
+        create_sessions_router(
+            conversation_store=SqlAlchemyConversationStore(db_uri),
+            agent_store=SqlAlchemyAgentStore(db_uri),
+            auth_provider=auth,
+            permission_store=SqlAlchemyPermissionStore(db_uri),
+            project_store=project_store,
+        ),
+        prefix="/v1",
+    )
+    app.include_router(
+        create_projects_router(project_store=project_store, auth_provider=auth),
+        prefix="/v1",
+    )
+    return app
+
+
+def _seed_owned_session(db_uri: str, owner: str, title: str = "s") -> str:
+    """Create a session owned by ``owner`` (owner-level grant). Returns its id."""
+    conv = SqlAlchemyConversationStore(db_uri).create_conversation(title=title, agent_id=AGENT_ID)
+    perms = SqlAlchemyPermissionStore(db_uri)
+    perms.ensure_user(owner)
+    perms.grant(owner, conv.id, LEVEL_OWNER)
+    return conv.id
+
+
+def _hdr(user: str) -> dict[str, str]:
+    return {"X-Forwarded-Email": user}
+
+
+def test_owner_can_file_own_session_into_own_project(db_uri: str) -> None:
+    """The happy path under header auth: Alice files her session into her project."""
+    _ensure_agent(db_uri)
+    conv_id = _seed_owned_session(db_uri, ALICE)
+    client = TestClient(_multi_user_app(db_uri))
+    project = client.post("/v1/projects", json={"name": "Alice"}, headers=_hdr(ALICE)).json()
+
+    resp = client.patch(
+        f"/v1/sessions/{conv_id}", json={"project_id": project["id"]}, headers=_hdr(ALICE)
+    )
+    assert resp.status_code == 200
+    assert resp.json()["project_id"] == project["id"]
+    listed = client.get("/v1/sessions?project=Alice", headers=_hdr(ALICE))
+    assert [s["id"] for s in listed.json()["data"]] == [conv_id]
+
+
+def test_cannot_file_into_another_owners_project(db_uri: str) -> None:
+    """Alice owns the session but the target project is Bob's — rejected 404,
+    and the session stays unfiled."""
+    _ensure_agent(db_uri)
+    conv_id = _seed_owned_session(db_uri, ALICE)
+    client = TestClient(_multi_user_app(db_uri))
+    bob_project = client.post("/v1/projects", json={"name": "Bob"}, headers=_hdr(BOB)).json()
+
+    resp = client.patch(
+        f"/v1/sessions/{conv_id}",
+        json={"project_id": bob_project["id"]},
+        headers=_hdr(ALICE),
+    )
+    assert resp.status_code == 404
+    # Still unfiled — the rejected filing had no side effect.
+    snap = client.get(f"/v1/sessions/{conv_id}", headers=_hdr(ALICE))
+    assert snap.json()["project_id"] is None
+
+
+def test_editor_cannot_file_shared_session(db_uri: str) -> None:
+    """Bob owns the session and shares EDIT with Alice; Alice may not file it
+    into her own project — filing is owner-only."""
+    _ensure_agent(db_uri)
+    conv_id = _seed_owned_session(db_uri, BOB)
+    perms = SqlAlchemyPermissionStore(db_uri)
+    perms.ensure_user(ALICE)
+    perms.grant(ALICE, conv_id, LEVEL_EDIT)
+    client = TestClient(_multi_user_app(db_uri))
+    alice_project = client.post("/v1/projects", json={"name": "Alice"}, headers=_hdr(ALICE)).json()
+
+    resp = client.patch(
+        f"/v1/sessions/{conv_id}",
+        json={"project_id": alice_project["id"]},
+        headers=_hdr(ALICE),
+    )
+    # Edit access is below owner, so the owner-only gate rejects with 403.
+    assert resp.status_code == 403
+
+
+def test_project_listing_is_owner_scoped(db_uri: str) -> None:
+    """A session shared to Alice but filed by its owner Bob must not surface in
+    Alice's ?project= listing, even when Alice has her own like-named project.
+    The name→id resolution is owner-scoped, so "Shared" resolves to Alice's own
+    (empty) project, never Bob's."""
+    _ensure_agent(db_uri)
+    conv_id = _seed_owned_session(db_uri, BOB)
+    perms = SqlAlchemyPermissionStore(db_uri)
+    perms.ensure_user(ALICE)
+    perms.grant(ALICE, conv_id, LEVEL_EDIT)
+    client = TestClient(_multi_user_app(db_uri))
+    bob_project = client.post("/v1/projects", json={"name": "Shared"}, headers=_hdr(BOB)).json()
+    # Alice owns a distinct project that happens to share the name.
+    client.post("/v1/projects", json={"name": "Shared"}, headers=_hdr(ALICE))
+    client.patch(
+        f"/v1/sessions/{conv_id}",
+        json={"project_id": bob_project["id"]},
+        headers=_hdr(BOB),
+    )
+
+    # Bob sees his member session under his "Shared".
+    bob_list = client.get("/v1/sessions?project=Shared", headers=_hdr(BOB))
+    assert [s["id"] for s in bob_list.json()["data"]] == [conv_id]
+
+    # Alice, asking for "Shared", resolves to HER project — the shared session
+    # (Bob's) does not surface: the listing is owner-scoped.
+    alice_list = client.get("/v1/sessions?project=Shared", headers=_hdr(ALICE))
+    assert alice_list.json()["data"] == []

--- a/tests/server/routes/test_sessions_project_membership.py
+++ b/tests/server/routes/test_sessions_project_membership.py
@@ -152,6 +152,15 @@ def test_explicit_null_project_id_is_rejected(db_uri: str) -> None:
     assert snap.json()["project_id"] == project["id"]
 
 
+def test_unfile_unknown_session_404(db_uri: str) -> None:
+    """Unfiling a session with no metadata row is a 404, mirroring the file
+    path — a PATCH that changed nothing must not report success."""
+    _ensure_agent(db_uri)
+    client = TestClient(_single_user_app(db_uri))
+    resp = client.patch("/v1/sessions/" + "f" * 32, json={"project_id": ""})
+    assert resp.status_code == 404
+
+
 def test_project_filter_excludes_other_projects(db_uri: str) -> None:
     """?project=<name> returns only that project's members, not another's."""
     _ensure_agent(db_uri)

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -4774,6 +4774,65 @@ def test_list_conversations_project_none_disables_filter(
     assert ids >= {filed.id, unfiled.id}
 
 
+def test_set_conversation_project_files_and_unfiles(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """``set_conversation_project`` sets and clears first-class membership."""
+    project_id = "b" * 32
+    conv = conversation_store.create_conversation()
+    assert conv.project_id is None
+
+    filed = conversation_store.set_conversation_project(conv.id, project_id)
+    assert filed is True
+    assert conversation_store.get_conversation(conv.id).project_id == project_id
+
+    # Unfile.
+    unfiled = conversation_store.set_conversation_project(conv.id, None)
+    assert unfiled is True
+    assert conversation_store.get_conversation(conv.id).project_id is None
+
+
+def test_set_conversation_project_unknown_session_returns_false(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Filing a non-existent session updates nothing and returns ``False``."""
+    result = conversation_store.set_conversation_project("f" * 32, "b" * 32)
+    assert result is False
+
+
+def test_list_conversations_filters_by_project_name_dual_read(
+    conversation_store: SqlAlchemyConversationStore,
+    db_uri: str,
+) -> None:
+    """``list_conversations(project="Name")`` dual-reads by project NAME:
+    a session matches if it has EITHER the first-class membership (its
+    ``metadata.project_id`` points at the owner's project of that name) OR the
+    legacy ``omni_project`` label with that value. ``""`` returns sessions in
+    NEITHER (unfiled)."""
+    from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
+
+    project_store = SqlAlchemyProjectStore(db_uri)
+    # Single-user: null owner. The route passes owned_by=None to match.
+    project = project_store.create("c" * 32, "Work", None)
+
+    first_class = conversation_store.create_conversation(title="first-class")
+    labelled = conversation_store.create_conversation(title="labelled")
+    unfiled = conversation_store.create_conversation(title="unfiled")
+    # One member via the first-class entity, one via the legacy label — both
+    # under the same name "Work".
+    conversation_store.set_conversation_project(first_class.id, project.id)
+    conversation_store.set_labels(labelled.id, {"omni_project": "Work"})
+
+    members = conversation_store.list_conversations(project="Work", owned_by=None)
+    assert {c.id for c in members.data} == {first_class.id, labelled.id}
+
+    unfiled_page = conversation_store.list_conversations(project="", owned_by=None)
+    unfiled_ids = {c.id for c in unfiled_page.data}
+    assert unfiled.id in unfiled_ids
+    assert first_class.id not in unfiled_ids
+    assert labelled.id not in unfiled_ids
+
+
 def test_list_projects_owned_by_excludes_shared_only_projects(
     conversation_store: SqlAlchemyConversationStore,
     db_uri: str,

--- a/tests/stores/test_conversation_store_split_db.py
+++ b/tests/stores/test_conversation_store_split_db.py
@@ -286,6 +286,56 @@ def test_set_external_session_id(store: SqlAlchemyConversationStore) -> None:
     assert updated.external_session_id == "ext-uuid-123"
 
 
+# ── project membership ─────────────────────────────────
+
+
+def test_set_conversation_project_lands_in_omnigent_db(
+    omnigent_db: Path, store: SqlAlchemyConversationStore
+) -> None:
+    """``project_id`` is written to the metadata row in the Omnigent DB."""
+    project_id = "b" * 32
+    conv = store.create_conversation(title="filed")
+    filed = store.set_conversation_project(conv.id, project_id)
+    assert filed is True
+
+    stored = _col(omnigent_db, "omnigent_conversation_metadata", "project_id", f"id=X'{conv.id}'")
+    assert stored == [project_id]
+    # Reads back through the entity (which merges both DBs).
+    assert store.get_conversation(conv.id).project_id == project_id
+
+
+def test_list_conversations_project_name_filter_crosses_dbs(
+    store: SqlAlchemyConversationStore,
+    omnigent_db: Path,
+) -> None:
+    """The dual-read ``project`` (by name) filter resolves the first-class
+    member ids from the Omnigent DB (``projects`` JOIN ``conversation_metadata``,
+    both colocated there) and ORs them with the ``omni_project`` label on the AP
+    DB — the cross-DB path a single-DB test can't exercise.
+    """
+    from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
+
+    # projects lives on the Omnigent DB, so create it against that URI.
+    project_store = SqlAlchemyProjectStore(f"sqlite:///{omnigent_db}")
+    project = project_store.create("c" * 32, "Work", None)
+
+    first_class = store.create_conversation(title="first-class")
+    labelled = store.create_conversation(title="labelled")
+    unfiled = store.create_conversation(title="loose")
+    store.set_conversation_project(first_class.id, project.id)
+    store.set_labels(labelled.id, {"omni_project": "Work"})
+
+    members = store.list_conversations(project="Work", owned_by=None)
+    assert {c.id for c in members.data} == {first_class.id, labelled.id}
+
+    # Empty string means "unfiled" — the loose session, excluding both members,
+    # even though first-class membership lives in the other physical DB.
+    unfiled_ids = {c.id for c in store.list_conversations(project="", owned_by=None).data}
+    assert unfiled.id in unfiled_ids
+    assert first_class.id not in unfiled_ids
+    assert labelled.id not in unfiled_ids
+
+
 # ── conversation items ─────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A — follow-up to #2765 (Phase 1a).

## Summary

Completes **Phase 1** of the projects feature (see `designs/PROJECTS_PRD.md`) by linking sessions to first-class projects and exposing it over HTTP. #2765 shipped the empty **container** (table + CRUD); this PR adds the **membership** pointer and the move/list surfaces that read it — so no column or store method ships unused.

- **Migration `c2d3e4f5a6b7`** (chained after `b1c2d3e4f5a6`): nullable `project_id` (Uuid16) on `omnigent_conversation_metadata` + `ix_conversation_metadata_project_id`. Additive, no backfill, no DB FK (Rule R032); `NULL` = unfiled.
- **Conversation store**: `set_conversation_project()` (file/move/unfile by id); `list_conversations(project=<name>)` is now a **name-based dual-read** — a session is "in `<name>`" if it has EITHER the first-class membership (`metadata.project_id` → the owner's project of that name) OR the legacy `omni_project` label; `""` = unfiled.
- **Routes**: `PATCH /v1/sessions/{id}` files/unfiles by id (owner-only; target-project ownership validated → 404, no existence leak); `GET /v1/sessions?project=<name>` lists owner-scoped; `project_id` surfaced on `SessionResponse`/`SessionListItem`; `openapi.json` regenerated.

**ELI5:** #2765 let you make empty project folders. This PR lets you actually *put sessions in them* (and take them out), and lists a folder's sessions — while the old label-based projects keep working unchanged, because the listing reads both.

### Backward compatibility
The one change to existing behavior is `?project=` becoming a dual-read. It's compatible by construction: with no first-class members (nothing has called `PATCH project_id` yet), the first-class half resolves to an empty set and the filter collapses to the prior label-only behavior. No existing session is reclassified.

The Copilot scaling comments from #2765 are addressed here: the first-class prefetch is intersected with the caller's permission-scoped ids, so the `IN`/`NOT IN` list can't grow past their own sessions.

## Test Plan

```bash
python -m pytest \
  tests/server/routes/test_sessions_project_membership.py \
  tests/stores/test_conversation_store.py -k "project or set_conversation" \
  tests/stores/test_conversation_store_split_db.py -k project \
  tests/db/test_migrations_sqlite_safe.py
```

- 9 route tests: PATCH move/unfile, omit-leaves-unchanged, file-into-nonexistent→404, dual-read, and single-/multi-user ownership boundaries (can't file into another owner's project, editor can't file a shared session, listing is owner-scoped).
- Store tests: `set_conversation_project` files/unfiles/unknown-returns-False; name-based dual-read (first-class + label under one name; `""` unfiled).
- Split-DB tests: `project_id` lands in the Omnigent DB; the dual-read resolves member ids cross-DB and ORs with the AP-DB label.
- Full migration chain round-trips on SQLite (exercises `c2d3e4f5a6b7`).

Full suites green: 170 conversation-store + 71 route/store/split-DB. pre-commit clean.

## Demo

N/A — API-level only; no web UI in this PR (Web UI is still TODO in the PRD, TS client types not regenerated).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated coverage above.

## Changelog

Sessions can now be filed into first-class projects via `PATCH /v1/sessions/{id}` and listed with `GET /v1/sessions?project=<name>`, which dual-reads first-class membership and legacy project labels.

This pull request and its description were written by Isaac.