### PR TITLE
fix(telemetry): resolve harness from agent_cache instead of _globals._agent_store

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -13275,13 +13275,26 @@ async def _create_session_from_existing_agent(
             _host_install_id: str | None = None
             if _hr is not None and conv.host_id is not None:
                 _host_install_id = _hr.get_host_installation_id(conv.host_id)
+            # Resolve harness directly from the in-scope agent + cache so
+            # the result is independent of _globals._agent_store (which is
+            # only set when the server is started via the CLI).
+            _tel_harness: str | None
+            if native_agent is not None:
+                _tel_harness = native_agent.harness
+            elif conv.harness_override:
+                _tel_harness = conv.harness_override
+            else:
+                _tel_loaded = agent_cache.load(
+                    agent.id,
+                    agent.bundle_location,
+                    expand_env=agent.session_id is None,
+                )
+                _tel_harness = _spec_harness(_tel_loaded.spec)
             _tel_emit(
                 _TelSessionCreatedEvent(
                     session_id=conv.id,
                     agent_id=agent.id,
-                    harness=native_agent.harness
-                    if native_agent is not None
-                    else _resolve_harness(conv),
+                    harness=_tel_harness,
                     surface=_surface,
                     installation_id=_install_id,
                     anon_user_id=_anon_uid,

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -495,3 +495,146 @@ def test_build_record_promotes_host_installation_id() -> None:
     assert data["host_installation_id"] == "host-inst-abc"
     params = json.loads(data["params"]) if data["params"] else {}
     assert "host_installation_id" not in params
+
+
+# ── _resolve_harness ─────────────────────────────────────────────────────────
+
+
+def test_resolve_harness_none_when_conv_is_none() -> None:
+    """``None`` conversation → ``None``."""
+    from omnigent.server.routes.sessions import _resolve_harness
+
+    assert _resolve_harness(None) is None
+
+
+def test_resolve_harness_uses_harness_override() -> None:
+    """``conv.harness_override`` is returned immediately, no store lookup."""
+    from unittest.mock import MagicMock
+
+    from omnigent.server.routes.sessions import _resolve_harness
+
+    conv = MagicMock()
+    conv.harness_override = "claude-sdk"
+    assert _resolve_harness(conv) == "claude-sdk"
+
+
+def test_resolve_harness_none_when_agent_store_uninitialized() -> None:
+    """``_agent_store is None`` (runtime not started) → ``None``."""
+    from unittest.mock import MagicMock, patch
+
+    from omnigent.server.routes.sessions import _resolve_harness
+
+    conv = MagicMock()
+    conv.harness_override = None
+    conv.agent_id = "ag_abc"
+
+    with patch("omnigent.runtime._globals._agent_store", None):
+        assert _resolve_harness(conv) is None
+
+
+def test_resolve_harness_none_when_agent_not_in_store() -> None:
+    """Agent id present but not found in the store → ``None``."""
+    from unittest.mock import MagicMock, patch
+
+    from omnigent.server.routes.sessions import _resolve_harness
+
+    conv = MagicMock()
+    conv.harness_override = None
+    conv.agent_id = "ag_missing"
+
+    mock_store = MagicMock()
+    mock_store.get.return_value = None
+
+    with patch("omnigent.runtime._globals._agent_store", mock_store):
+        assert _resolve_harness(conv) is None
+
+
+def test_resolve_harness_sdk_via_config_key() -> None:
+    """Executor with ``config["harness"] = "claude-sdk"`` → ``"claude-sdk"``."""
+    from unittest.mock import MagicMock, patch
+
+    from omnigent.server.routes.sessions import _resolve_harness
+
+    conv = MagicMock()
+    conv.harness_override = None
+    conv.agent_id = "ag_sdk"
+    conv.sub_agent_name = None
+
+    executor = MagicMock()
+    executor.config = {"harness": "claude-sdk"}
+    executor.type = "omnigent"
+
+    spec = MagicMock()
+    spec.executor = executor
+    spec.sub_agents = []
+
+    loaded = MagicMock()
+    loaded.spec = spec
+
+    mock_store = MagicMock()
+    mock_store.get.return_value = MagicMock(
+        id="ag_sdk", bundle_location="ag_sdk/bundle", session_id=None
+    )
+
+    mock_cache = MagicMock()
+    mock_cache.load.return_value = loaded
+
+    with (
+        patch("omnigent.runtime._globals._agent_store", mock_store),
+        patch("omnigent.runtime.get_agent_cache", return_value=mock_cache),
+    ):
+        assert _resolve_harness(conv) == "claude-sdk"
+
+
+def test_resolve_harness_sdk_via_executor_type() -> None:
+    """Executor with no ``config["harness"]`` falls back to ``executor.type``."""
+    from unittest.mock import MagicMock, patch
+
+    from omnigent.server.routes.sessions import _resolve_harness
+
+    conv = MagicMock()
+    conv.harness_override = None
+    conv.agent_id = "ag_sdk2"
+    conv.sub_agent_name = None
+
+    executor = MagicMock()
+    executor.config = {}  # no harness key
+    executor.type = "claude-sdk"
+
+    spec = MagicMock()
+    spec.executor = executor
+    spec.sub_agents = []
+
+    loaded = MagicMock()
+    loaded.spec = spec
+
+    mock_store = MagicMock()
+    mock_store.get.return_value = MagicMock(
+        id="ag_sdk2", bundle_location="ag_sdk2/bundle", session_id=None
+    )
+
+    mock_cache = MagicMock()
+    mock_cache.load.return_value = loaded
+
+    with (
+        patch("omnigent.runtime._globals._agent_store", mock_store),
+        patch("omnigent.runtime.get_agent_cache", return_value=mock_cache),
+    ):
+        assert _resolve_harness(conv) == "claude-sdk"
+
+
+def test_resolve_harness_returns_none_on_exception() -> None:
+    """Any exception inside the resolver degrades to ``None`` (never raises)."""
+    from unittest.mock import MagicMock, patch
+
+    from omnigent.server.routes.sessions import _resolve_harness
+
+    conv = MagicMock()
+    conv.harness_override = None
+    conv.agent_id = "ag_boom"
+
+    mock_store = MagicMock()
+    mock_store.get.side_effect = OSError("disk read error")
+
+    with patch("omnigent.runtime._globals._agent_store", mock_store):
+        assert _resolve_harness(conv) is None


### PR DESCRIPTION
## Related issue

N/A

## Summary

`SessionCreatedEvent` was emitting `harness: null` for all SDK sessions (claude-sdk, openai-agents, codex, etc.) in server deployments not started via the CLI.

Root cause: the telemetry block called `_resolve_harness(conv)`, which routes through `_globals._agent_store`. That global is only populated by `runtime.init()`, called from the CLI path. In other deployment configurations the global is `None`, so `_resolve_harness` silently returns `None`.

Fix: in `create_session`, resolve the harness directly from the `agent` and `agent_cache` that are already dependency-injected into the request handler — both are always available regardless of how the server starts. Uses the existing `_spec_harness()` helper for the executor-type lookup, mirroring the native-agent path.

## Test Plan

```
python -m pytest tests/test_telemetry.py -v
```

Also added 7 unit tests for `_resolve_harness` covering:
- `None` conv → `None`
- `harness_override` short-circuits store lookup
- `_agent_store is None` (uninitialized runtime) → `None`
- agent not found in store → `None`
- executor `config["harness"]` key → resolved harness name
- executor `type` fallback → resolved harness name
- unexpected exception → `None` (never raises)

## Demo

N/A

## Type of change

- [x] Bug fix
- [x] Test / CI

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

The bug was silent (no error, just a null field), so there is no runtime error to catch in manual testing. The new unit tests cover all branches of `_resolve_harness` and document its known limitation (depends on CLI-initialized globals).

## Changelog

Fixed SDK session telemetry always recording `harness: null` in server deployments not started via the CLI.