### PR TITLE
[runner] Coalesce agent bundle into session init

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import logging
 import os
 import shutil
@@ -861,10 +862,9 @@ def _agent_cache_dest(spec_cache_root: Path, agent_id: str, version: str) -> Pat
     """
     Compute the cache directory for an agent bundle, contained to the root.
 
-    ``agent_id`` and the version header are server-provided but treated as
-    untrusted path components: path separators are stripped and the result is
-    verified to stay within *spec_cache_root* so a crafted id/version cannot
-    traverse out of the cache root (defense-in-depth against path injection).
+    ``agent_id`` and the version header are server-provided. Hash them into a
+    fixed hexadecimal component so untrusted text never becomes filesystem
+    syntax, then verify the result remains within *spec_cache_root*.
 
     :param spec_cache_root: Runner-local cache root for extracted bundles,
         e.g. ``Path("/tmp/runner-specs-xyz")``.
@@ -875,7 +875,8 @@ def _agent_cache_dest(spec_cache_root: Path, agent_id: str, version: str) -> Pat
         *spec_cache_root*.
     :raises RuntimeError: If the computed path escapes *spec_cache_root*.
     """
-    cache_key = f"{agent_id}-v{version}".replace("/", "_").replace("\\", "_")
+    cache_identity = f"{len(agent_id)}:{agent_id}{version}".encode()
+    cache_key = f"agent-{hashlib.sha256(cache_identity).hexdigest()}"
     cache_root = spec_cache_root.resolve()
     dest = (cache_root / cache_key).resolve()
     if not dest.is_relative_to(cache_root):
@@ -907,7 +908,11 @@ def _materialize_agent_spec_bundle(
         except Exception:
             shutil.rmtree(dest, ignore_errors=True)
             raise
-    spec = load(dest, expand_env=expand_env, prune_invalid_sub_agents=True)
+    try:
+        spec = load(dest, expand_env=expand_env, prune_invalid_sub_agents=True)
+    except Exception:
+        shutil.rmtree(dest, ignore_errors=True)
+        raise
     return ResolvedSpec(spec=spec, workdir=dest)
 
 

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -902,7 +902,7 @@ def _materialize_agent_spec_bundle(
     # sub-agents using harnesses it does not yet understand instead of failing
     # the entire parent-agent dispatch.
     if not dest.exists():
-        dest.mkdir(parents=True)
+        dest.mkdir(parents=True, exist_ok=True)
         try:
             load(contents, dest=dest, expand_env=expand_env, prune_invalid_sub_agents=True)
         except Exception:

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -12,6 +12,7 @@ import asyncio
 import contextlib
 import logging
 import os
+import shutil
 import signal
 import sys
 import threading
@@ -32,6 +33,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from omnigent.runner.app import ResolvedSpec
+    from omnigent.runner.session_init_protocol import RunnerSessionInitAgentBundle
     from omnigent.runner.transports.ws_tunnel.serve import _ASGIApp
 
 _RUNNER_SERVER_URL_ENV_VAR = "RUNNER_SERVER_URL"
@@ -881,6 +883,59 @@ def _agent_cache_dest(spec_cache_root: Path, agent_id: str, version: str) -> Pat
     return dest
 
 
+def _materialize_agent_spec_bundle(
+    spec_cache_root: Path,
+    agent_id: str,
+    contents: bytes,
+    *,
+    version: str,
+    session_scoped: bool,
+) -> ResolvedSpec:
+    """Extract, cache, and parse agent bundle bytes supplied by any transport."""
+    from omnigent.runner.app import ResolvedSpec
+    from omnigent.spec import load
+
+    expand_env = not session_scoped
+    dest = _agent_cache_dest(spec_cache_root, agent_id, version)
+    # The server already validated the bundle. If this runner is older, prune
+    # sub-agents using harnesses it does not yet understand instead of failing
+    # the entire parent-agent dispatch.
+    if not dest.exists():
+        dest.mkdir(parents=True)
+        try:
+            load(contents, dest=dest, expand_env=expand_env, prune_invalid_sub_agents=True)
+        except Exception:
+            shutil.rmtree(dest, ignore_errors=True)
+            raise
+    spec = load(dest, expand_env=expand_env, prune_invalid_sub_agents=True)
+    return ResolvedSpec(spec=spec, workdir=dest)
+
+
+def _resolve_agent_spec_from_embedded_bundle(
+    spec_cache_root: Path,
+    agent_id: str,
+    bundle: RunnerSessionInitAgentBundle,
+) -> ResolvedSpec:
+    """Decode and materialize an agent bundle supplied during initialization."""
+    from omnigent.runner.session_init_protocol import decode_runner_session_init_agent_bundle
+
+    contents = decode_runner_session_init_agent_bundle(bundle)
+    resolved = _materialize_agent_spec_bundle(
+        spec_cache_root,
+        agent_id,
+        contents,
+        version=bundle.version,
+        session_scoped=bundle.session_scoped,
+    )
+    _logger.info(
+        "Agent spec resolved from session initialization bundle: agent=%s version=%s bytes=%d",
+        agent_id,
+        bundle.version,
+        len(contents),
+    )
+    return resolved
+
+
 async def _resolve_agent_spec_from_server(
     server_client: httpx.AsyncClient,
     spec_cache_root: Path,
@@ -906,9 +961,6 @@ async def _resolve_agent_spec_from_server(
     :raises RuntimeError: If the server returns a non-200 status
         other than 404.
     """
-    from omnigent.runner.app import ResolvedSpec
-    from omnigent.spec import load
-
     if session_id is None:
         _logger.warning(
             "spec_resolver called without session_id for agent %s; "
@@ -934,24 +986,18 @@ async def _resolve_agent_spec_from_server(
     # a missing/unknown header is treated as session-scoped (no
     # expansion). Only operator-authored template agents expand.
     session_scoped_header = resp.headers.get("X-Agent-Session-Scoped", "true").strip().lower()
-    expand_env = session_scoped_header == "false"
+    session_scoped = session_scoped_header != "false"
     # Cache key: agent id + version header. Re-extracting on
     # every dispatch would be wasteful; keying by version means
     # PUT-induced bundle bumps invalidate naturally.
     version = resp.headers.get("X-Agent-Version", "0")
-    dest = _agent_cache_dest(spec_cache_root, agent_id, version)
-    # prune_invalid_sub_agents: the server already validated this bundle
-    # before serving it, so a sub-agent that fails validation *here* means
-    # this runner is older than that server and can't run that sub-agent
-    # (e.g. it names a harness this version doesn't know). Drop the
-    # unsupported sub-agent and launch the parent with what this runner
-    # *does* support, rather than failing every dispatch of the agent.
-    # See omnigent.spec.load.
-    if not dest.exists():
-        dest.mkdir(parents=True)
-        load(resp.content, dest=dest, expand_env=expand_env, prune_invalid_sub_agents=True)
-    spec = load(dest, expand_env=expand_env, prune_invalid_sub_agents=True)
-    return ResolvedSpec(spec=spec, workdir=dest)
+    return _materialize_agent_spec_bundle(
+        spec_cache_root,
+        agent_id,
+        resp.content,
+        version=version,
+        session_scoped=session_scoped,
+    )
 
 
 def create_app(
@@ -1080,6 +1126,17 @@ def create_app(
             session_id=session_id,
         )
 
+    async def init_spec_resolver(
+        agent_id: str,
+        bundle: RunnerSessionInitAgentBundle,
+    ) -> ResolvedSpec:
+        """Materialize the agent archive coalesced into session initialization."""
+        return _resolve_agent_spec_from_embedded_bundle(
+            _spec_cache_root,
+            agent_id,
+            bundle,
+        )
+
     # Out-of-process runner owns its own TerminalRegistry.
     from omnigent.inner.terminal import reap_orphaned_terminals
     from omnigent.terminals import TerminalRegistry
@@ -1106,6 +1163,7 @@ def create_app(
     app = create_runner_app(
         process_manager=pm,
         spec_resolver=spec_resolver,
+        init_spec_resolver=init_spec_resolver,
         server_client=server_client,
         terminal_registry=_terminal_registry,
         runner_workspace=runner_workspace,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -726,7 +726,7 @@ def _codex_session_workspace(session_workspace: str | None) -> Path:
 
     Deliberately does NOT consult ``ResolvedSpec.workdir`` — in the
     out-of-process runner that is the agent-bundle extraction dir
-    (``runner-specs-<id>/ag_<id>-v<ver>``), not the repo, so using it
+    (``runner-specs-<id>/agent-<digest>``), not the repo, so using it
     stranded Codex in a temp dir with no ``.git`` (and ignored the
     worktree entirely).
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8282,6 +8282,9 @@ def create_runner_app(
     _session_snapshot_cache: dict[str, _SessionSnapshot] = {}  # session_id → snapshot
     _session_snapshot_locks: dict[str, asyncio.Lock] = {}  # session_id → snapshot fetch lock
     _session_spec_locks: dict[str, asyncio.Lock] = {}  # session_id → spec resolution lock
+    # Readers can arrive before POST /v1/sessions. Keep them behind that
+    # assignment so it alone chooses embedded vs HTTP resolution.
+    _session_init_spec_ready: dict[str, asyncio.Event] = {}
     # Full session initialization is single-flight. The key includes the
     # assignment identity so a legacy reconnect request that omits a child
     # name cannot hide a later, correctly identified sub-agent assignment.
@@ -9465,6 +9468,8 @@ def create_runner_app(
         if embedded_bundle is not None and init_spec_resolver is not None:
             try:
                 spec = await init_spec_resolver(agent_id, embedded_bundle)
+            except asyncio.CancelledError:
+                raise
             except Exception:  # noqa: BLE001 - retry through the legacy HTTP path
                 _logger.warning(
                     "Embedded agent bundle resolution failed; falling back to HTTP: "
@@ -9473,7 +9478,7 @@ def create_runner_app(
                     agent_id,
                     exc_info=True,
                 )
-        embedded_bundle = None
+        del embedded_bundle
         if spec is None and spec_resolver is not None:
             try:
                 spec = await spec_resolver(agent_id, session_id)
@@ -9636,6 +9641,10 @@ def create_runner_app(
         else:
             harness_name = "runner-test-default"
             spawn_env = None
+
+        # Release readers after the assignment caches its chosen spec source.
+        # Legacy assignments reach this point after their HTTP fetch.
+        _session_init_spec_ready.setdefault(session_id, asyncio.Event()).set()
 
         try:
             await process_manager.get_client(
@@ -10406,6 +10415,10 @@ def create_runner_app(
         )
         task = _session_init_tasks.get(key)
         if task is None:
+            spec_ready = _session_init_spec_ready.get(session_id)
+            if spec_ready is None or spec_ready.is_set():
+                spec_ready = asyncio.Event()
+                _session_init_spec_ready[session_id] = spec_ready
             task = asyncio.create_task(
                 _initialize_session(body),
                 name=f"session-init-{session_id}",
@@ -10413,6 +10426,8 @@ def create_runner_app(
             _session_init_tasks[key] = task
 
             def _drop_completed_init(done: asyncio.Task[JSONResponse]) -> None:
+                # Errors can return before the normal spec-ready point.
+                spec_ready.set()
                 if _session_init_tasks.get(key) is done:
                     _session_init_tasks.pop(key, None)
 
@@ -10635,6 +10650,7 @@ def create_runner_app(
         _session_snapshot_cache.pop(session_id, None)
         _session_snapshot_locks.pop(session_id, None)
         _session_init_envelopes.pop(session_id, None)
+        _session_init_spec_ready.pop(session_id, None)
         _session_spec_locks.pop(session_id, None)
         _session_fs_registries.pop(session_id, None)
         _session_agent_ids.pop(session_id, None)
@@ -18197,10 +18213,9 @@ def create_runner_app(
         than the unwrapped spec, so callers that need the materialized
         bundle workdir — e.g. skill discovery — can read it via
         :func:`_resolved_spec_workdir`. Resource access can happen
-        before the first turn dispatches, so the harness process
-        manager may not have loaded the session's spec yet; this reads
-        the shared :func:`_session_snapshot` for the session's
-        ``agent_id`` and reuses the normal ``spec_resolver`` path.
+        while session assignment is running. Those readers share its
+        embedded or legacy result. A reader that arrived earlier rechecks
+        after its snapshot fetch; later cache misses use the normal path.
 
         A per-session lock makes resolution single-flight: a startup
         burst of concurrent callers resolves the bundle once and the
@@ -18218,6 +18233,13 @@ def create_runner_app(
         """
         if session_id in _session_spec_cache:
             return _session_spec_cache[session_id]
+        # Share a POST /v1/sessions resolution once that assignment has arrived.
+        # Sessions without an active assignment retain cold-cache resolution.
+        spec_ready = _session_init_spec_ready.get(session_id)
+        if spec_ready is not None and not spec_ready.is_set():
+            await spec_ready.wait()
+        if session_id in _session_spec_cache:
+            return _session_spec_cache[session_id]
         if spec_resolver is None:
             _session_spec_cache[session_id] = None
             return None
@@ -18228,6 +18250,13 @@ def create_runner_app(
             if session_id in _session_spec_cache:
                 return _session_spec_cache[session_id]
             snapshot = await _session_snapshot(session_id)
+            # The assignment can arrive while the snapshot request is in flight.
+            # Rejoin it before issuing a redundant agent/contents request.
+            spec_ready = _session_init_spec_ready.get(session_id)
+            if spec_ready is not None and not spec_ready.is_set():
+                await spec_ready.wait()
+            if session_id in _session_spec_cache:
+                return _session_spec_cache[session_id]
             if not snapshot.ok:
                 raise OmnigentError(
                     f"session spec resolver: GET /v1/sessions/{session_id} "

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -9460,6 +9460,8 @@ def create_runner_app(
         embedded_bundle = (
             init_context.envelope.agent_bundle if init_context.envelope is not None else None
         )
+        if init_context.envelope is not None:
+            init_context.envelope.agent_bundle = None
         if embedded_bundle is not None and init_spec_resolver is not None:
             try:
                 spec = await init_spec_resolver(agent_id, embedded_bundle)
@@ -9471,6 +9473,7 @@ def create_runner_app(
                     agent_id,
                     exc_info=True,
                 )
+        embedded_bundle = None
         if spec is None and spec_resolver is not None:
             try:
                 spec = await spec_resolver(agent_id, session_id)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -80,6 +80,7 @@ from omnigent.runner.resource_registry import (
     TerminalLifecycle,
 )
 from omnigent.runner.session_init_protocol import (
+    RunnerSessionInitAgentBundle,
     RunnerSessionInitEnvelope,
     parse_runner_session_init_envelope,
 )
@@ -280,6 +281,7 @@ def _client_safe_error_detail(exc: BaseException, *, context: str) -> str:
 
 
 SpecResolver = Callable[[str, str | None], Awaitable[Any | None]]
+InitSpecResolver = Callable[[str, RunnerSessionInitAgentBundle], Awaitable[Any | None]]
 _NO_BODY_STATUS_CODES = {204, 304}
 _SUBAGENT_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
 _SUBAGENT_DELIVERY_DELIVERED = "delivered"
@@ -8161,6 +8163,7 @@ def create_runner_app(
     *,
     process_manager: HarnessProcessManager | None = None,
     spec_resolver: SpecResolver | None = None,
+    init_spec_resolver: InitSpecResolver | None = None,
     server_client: httpx.AsyncClient,
     terminal_registry: Any | None = None,
     resource_registry: SessionResourceRegistry | None = None,
@@ -8178,6 +8181,9 @@ def create_runner_app(
         For in-process: wraps the server's agent cache.
         For out-of-process: wraps HTTP fetch to GET /v1/agents/{id}/contents.
         ``None`` → runner falls back to body-supplied hints (test path).
+    :param init_spec_resolver: Optional callback that materializes an agent
+        archive embedded in the initialization envelope. Failures fall back to
+        ``spec_resolver`` for compatibility and resilience.
     :param server_client: httpx.AsyncClient pointed at the AP
         server's public API. Used by the runner for
         elicitation/approval forwarding.
@@ -9451,7 +9457,21 @@ def create_runner_app(
         # cache it for resource endpoints (filesystem, terminals)
         # that may fire before the first turn dispatches.
         spec = None
-        if spec_resolver is not None:
+        embedded_bundle = (
+            init_context.envelope.agent_bundle if init_context.envelope is not None else None
+        )
+        if embedded_bundle is not None and init_spec_resolver is not None:
+            try:
+                spec = await init_spec_resolver(agent_id, embedded_bundle)
+            except Exception:  # noqa: BLE001 - retry through the legacy HTTP path
+                _logger.warning(
+                    "Embedded agent bundle resolution failed; falling back to HTTP: "
+                    "session=%s agent=%s",
+                    session_id,
+                    agent_id,
+                    exc_info=True,
+                )
+        if spec is None and spec_resolver is not None:
             try:
                 spec = await spec_resolver(agent_id, session_id)
             except (httpx.HTTPError, RuntimeError, ValueError) as exc:

--- a/omnigent/runner/session_init_protocol.py
+++ b/omnigent/runner/session_init_protocol.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -10,6 +12,21 @@ from omnigent.entities import Conversation
 
 SESSION_INIT_PROTOCOL_VERSION = 2
 SESSION_INIT_PAYLOAD_KEY = "session_init"
+# Keep the base64-expanded JSON comfortably below the tunnel's 100 MiB frame
+# limit while allowing substantially larger bundles than normal agents use.
+MAX_EMBEDDED_AGENT_BUNDLE_BYTES = 16 * 1024 * 1024
+_MAX_EMBEDDED_AGENT_BUNDLE_BASE64_CHARS = 4 * ((MAX_EMBEDDED_AGENT_BUNDLE_BYTES + 2) // 3)
+
+
+class RunnerSessionInitAgentBundle(BaseModel):
+    """Agent archive embedded in the server-to-runner initialization request."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    version: str
+    name: str
+    session_scoped: bool
+    contents_base64: str
 
 
 class RunnerSessionInitSnapshot(BaseModel):
@@ -42,12 +59,48 @@ class RunnerSessionInitEnvelope(BaseModel):
     agent_id: str
     sub_agent_name: str | None = None
     snapshot: RunnerSessionInitSnapshot
+    agent_bundle: RunnerSessionInitAgentBundle | None = None
+
+
+def encode_runner_session_init_agent_bundle(
+    contents: bytes,
+    *,
+    version: str,
+    name: str,
+    session_scoped: bool,
+) -> RunnerSessionInitAgentBundle | None:
+    """Encode a bundle when it is small enough for the initialization envelope."""
+    if len(contents) > MAX_EMBEDDED_AGENT_BUNDLE_BYTES:
+        return None
+    return RunnerSessionInitAgentBundle(
+        version=version,
+        name=name,
+        session_scoped=session_scoped,
+        contents_base64=base64.b64encode(contents).decode("ascii"),
+    )
+
+
+def decode_runner_session_init_agent_bundle(
+    bundle: RunnerSessionInitAgentBundle,
+) -> bytes:
+    """Decode and size-check an initialization bundle from an untrusted peer."""
+    encoded = bundle.contents_base64
+    if len(encoded) > _MAX_EMBEDDED_AGENT_BUNDLE_BASE64_CHARS:
+        raise ValueError("embedded agent bundle exceeds the size limit")
+    try:
+        contents = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("embedded agent bundle is not valid base64") from exc
+    if len(contents) > MAX_EMBEDDED_AGENT_BUNDLE_BYTES:
+        raise ValueError("embedded agent bundle exceeds the size limit")
+    return contents
 
 
 def build_runner_session_init_payload(
     conversation: Conversation,
     *,
     server_version: str,
+    agent_bundle: RunnerSessionInitAgentBundle | None = None,
 ) -> dict[str, Any]:
     """Build the versioned initialization fields appended to the legacy body."""
     if conversation.agent_id is None:
@@ -58,6 +111,7 @@ def build_runner_session_init_payload(
         session_id=conversation.id,
         agent_id=conversation.agent_id,
         sub_agent_name=conversation.sub_agent_name,
+        agent_bundle=agent_bundle,
         snapshot=RunnerSessionInitSnapshot(
             created_at=conversation.created_at,
             updated_at=conversation.updated_at,

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1293,6 +1293,8 @@ def create_app(
     runner_session_initializer = RunnerSessionInitializer(
         tunnel_registry,
         server_version=_server_version(),
+        agent_store=agent_store,
+        artifact_store=artifact_store,
     )
     background_title_coordinator = BackgroundSessionTitleCoordinator(
         conversation_store,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -20843,11 +20843,6 @@ def create_sessions_router(
                     code=ErrorCode.RUNNER_UNAVAILABLE,
                 ) from exc
             return {"queued": True, "item_id": body.data["call_id"]}
-        # Whether the runner was initially unavailable or was woken below. In
-        # that case the session-init handshake may still be racing the first
-        # message, even if we reused the original binding instead of launching
-        # a replacement.
-        _runner_needs_session_init = False
         # Item event (message, function_call_output, etc.).
         if conv.host_id is not None and await _maybe_wake_stale_resumable_managed_sandbox(
             session_id=session_id,
@@ -20864,7 +20859,6 @@ def create_sessions_router(
             if conv_after_wake is None:
                 raise _session_not_found()
             conv = conv_after_wake
-            _runner_needs_session_init = True
         runner_client = await _get_runner_client(session_id, runner_router)
         # Managed-launch rendezvous: a ``host_type="managed"`` create
         # returns before the sandbox exists, so the first message (the
@@ -21014,10 +21008,6 @@ def create_sessions_router(
                     timeout_s=_HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S,
                     runner_exit_reports=runner_exit_reports,
                 )
-            if runner_client is None:
-                _runner_needs_session_init = False
-            else:
-                _runner_needs_session_init = True
         if runner_client is None:
             # A native terminal-session message must NOT be silently
             # dropped when no runner is reachable — the runner crashed
@@ -21073,22 +21063,16 @@ def create_sessions_router(
         if refreshed_conv is None:
             raise _session_not_found()
         conv = refreshed_conv
-        native_terminal_ready = False
-        if _runner_needs_session_init:
-            # The runner was unavailable when this request began, so its
-            # connect callback may still be racing us. Await the handshake
-            # so the terminal + transcript forwarder are watching before we
-            # inject the message — otherwise a native web message is
-            # forwarded into a TUI whose forwarder isn't attached, the
-            # round-trip never mirrors back, and the optimistic bubble
-            # sticks with no reply (host-restart bug).
-            native_terminal_ready = await _ensure_runner_session_initialized(
-                session_id,
-                conv,
-                runner_client,
-                conversation_store,
-                initializer=getattr(request.app.state, "runner_session_initializer", None),
-            )
+        # Tunnel registration precedes its connection callback. Always cross
+        # the generation-aware initialization barrier before forwarding so a
+        # newly visible runner cannot race its session assignment.
+        native_terminal_ready = await _ensure_runner_session_initialized(
+            session_id,
+            conv,
+            runner_client,
+            conversation_store,
+            initializer=getattr(request.app.state, "runner_session_initializer", None),
+        )
         await _ensure_runner_relay_ready(
             session_id,
             conv.runner_id,

--- a/omnigent/server/runner_session_init.py
+++ b/omnigent/server/runner_session_init.py
@@ -131,8 +131,6 @@ class RunnerSessionInitializer:
             if agent is None:
                 return None
             contents = self._artifact_store.get(agent.bundle_location)
-            if contents is None:
-                return None
             bundle = encode_runner_session_init_agent_bundle(
                 contents,
                 version=str(agent.version),

--- a/omnigent/server/runner_session_init.py
+++ b/omnigent/server/runner_session_init.py
@@ -3,23 +3,40 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING
 
 import httpx
 
 from omnigent.entities import Conversation
-from omnigent.runner.session_init_protocol import build_runner_session_init_payload
+from omnigent.runner.session_init_protocol import (
+    RunnerSessionInitAgentBundle,
+    build_runner_session_init_payload,
+    encode_runner_session_init_agent_bundle,
+)
 
 if TYPE_CHECKING:
     from omnigent.runner.transports.ws_tunnel.registry import TunnelRegistry
+    from omnigent.stores import AgentStore, ArtifactStore
+
+_logger = logging.getLogger(__name__)
 
 
 class RunnerSessionInitializer:
     """Share initialization readiness within one runner tunnel generation."""
 
-    def __init__(self, registry: TunnelRegistry, *, server_version: str) -> None:
+    def __init__(
+        self,
+        registry: TunnelRegistry,
+        *,
+        server_version: str,
+        agent_store: AgentStore | None = None,
+        artifact_store: ArtifactStore | None = None,
+    ) -> None:
         self._registry = registry
         self._server_version = server_version
+        self._agent_store = agent_store
+        self._artifact_store = artifact_store
         self._tasks: dict[
             tuple[str, int, str, str, str | None],
             asyncio.Task[httpx.Response],
@@ -52,14 +69,7 @@ class RunnerSessionInitializer:
         task = self._tasks.get(key)
         if task is None:
             task = asyncio.create_task(
-                runner_client.post(
-                    "/v1/sessions",
-                    json=build_runner_session_init_payload(
-                        conversation,
-                        server_version=self._server_version,
-                    ),
-                    timeout=timeout,
-                ),
+                self._post_initialization(conversation, runner_client, timeout=timeout),
                 name=f"runner-session-init-{conversation.id}",
             )
             self._tasks[key] = task
@@ -89,6 +99,60 @@ class RunnerSessionInitializer:
         if response.status_code >= 400 and self._tasks.get(key) is task:
             self._tasks.pop(key, None)
         return response
+
+    async def _post_initialization(
+        self,
+        conversation: Conversation,
+        runner_client: httpx.AsyncClient,
+        *,
+        timeout: float,
+    ) -> httpx.Response:
+        """Load optional coalesced data, then send the initialization request."""
+        agent_bundle = await asyncio.to_thread(
+            self._load_agent_bundle,
+            conversation.agent_id,
+        )
+        return await runner_client.post(
+            "/v1/sessions",
+            json=build_runner_session_init_payload(
+                conversation,
+                server_version=self._server_version,
+                agent_bundle=agent_bundle,
+            ),
+            timeout=timeout,
+        )
+
+    def _load_agent_bundle(self, agent_id: str | None) -> RunnerSessionInitAgentBundle | None:
+        """Return an embeddable archive, or omit it for the runner's HTTP fallback."""
+        if agent_id is None or self._agent_store is None or self._artifact_store is None:
+            return None
+        try:
+            agent = self._agent_store.get(agent_id)
+            if agent is None:
+                return None
+            contents = self._artifact_store.get(agent.bundle_location)
+            if contents is None:
+                return None
+            bundle = encode_runner_session_init_agent_bundle(
+                contents,
+                version=str(agent.version),
+                name=agent.name,
+                session_scoped=agent.session_id is not None,
+            )
+            if bundle is None:
+                _logger.info(
+                    "Agent bundle is too large to embed; runner will fetch it: agent=%s bytes=%d",
+                    agent_id,
+                    len(contents),
+                )
+            return bundle
+        except Exception:  # noqa: BLE001 - initialization retains the existing HTTP fallback
+            _logger.warning(
+                "Could not embed agent bundle; runner will fetch it: agent=%s",
+                agent_id,
+                exc_info=True,
+            )
+            return None
 
     def invalidate_runner(self, runner_id: str) -> None:
         """Forget completed readiness when a runner tunnel goes away."""

--- a/tests/e2e/test_host_codex_native_e2e.py
+++ b/tests/e2e/test_host_codex_native_e2e.py
@@ -896,7 +896,7 @@ def test_codex_native_worktree_session_runs_in_worktree(
 
     Regression for the bug where codex-native resolved its terminal cwd
     from ``ResolvedSpec.workdir`` — the runner's spec-bundle extraction
-    dir (``runner-specs-<id>/ag_<id>-v<ver>``) — instead of the session
+    dir (``runner-specs-<id>/agent-<digest>``) — instead of the session
     workspace. Worktree sessions therefore launched Codex in a temp dir
     with no ``.git`` and never touched the worktree, while claude-native
     worked because it reads ``OMNIGENT_RUNNER_WORKSPACE`` directly.

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -4424,12 +4424,31 @@ async def test_create_session_envelope_is_single_flight_and_skips_metadata_callb
 
 
 @pytest.mark.asyncio
-async def test_create_session_resolves_embedded_agent_bundle_without_http_fallback() -> None:
+async def test_create_session_resolves_embedded_agent_bundle_without_http_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A current runner consumes coalesced bundle data before its HTTP resolver."""
+    import omnigent.runner.app as runner_app_module
+
     harness_client = _ScriptedHarnessClient([])
     pm = _FakeProcessManager(harness_client)
     embedded_calls = 0
     http_calls = 0
+    parsed_envelopes: list[RunnerSessionInitEnvelope] = []
+
+    original_parse = runner_app_module.parse_runner_session_init_envelope
+
+    def _capture_envelope(body: dict[str, Any]) -> RunnerSessionInitEnvelope | None:
+        envelope = original_parse(body)
+        if envelope is not None:
+            parsed_envelopes.append(envelope)
+        return envelope
+
+    monkeypatch.setattr(
+        runner_app_module,
+        "parse_runner_session_init_envelope",
+        _capture_envelope,
+    )
 
     async def _init_resolver(agent_id: str, bundle: Any) -> AgentSpec:
         nonlocal embedded_calls
@@ -4480,6 +4499,8 @@ async def test_create_session_resolves_embedded_agent_bundle_without_http_fallba
     assert response.status_code == 201
     assert embedded_calls == 1
     assert http_calls == 0
+    assert len(parsed_envelopes) == 1
+    assert parsed_envelopes[0].agent_bundle is None
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -50,6 +50,7 @@ from omnigent.entities.session_resources import SessionResourceView, terminal_re
 from omnigent.inner.terminal import TerminalInstance
 from omnigent.runner import create_runner_app
 from omnigent.runner import tool_dispatch as _tool_dispatch
+from omnigent.runner._entry import _resolve_agent_spec_from_embedded_bundle
 from omnigent.runner.app import (
     _RUNNER_DISPATCHED_FIELD,
     _WAKE_POST_MAX_ATTEMPTS,
@@ -4420,6 +4421,120 @@ async def test_create_session_envelope_is_single_flight_and_skips_metadata_callb
     assert resolver_calls == 1
     assert len(pm.get_client_calls) == 1
     assert server_client.get_paths == [f"/v1/sessions/{session_id}/items"]
+
+
+@pytest.mark.asyncio
+async def test_create_session_resolves_embedded_agent_bundle_without_http_fallback() -> None:
+    """A current runner consumes coalesced bundle data before its HTTP resolver."""
+    harness_client = _ScriptedHarnessClient([])
+    pm = _FakeProcessManager(harness_client)
+    embedded_calls = 0
+    http_calls = 0
+
+    async def _init_resolver(agent_id: str, bundle: Any) -> AgentSpec:
+        nonlocal embedded_calls
+        embedded_calls += 1
+        assert agent_id == "agent_embedded"
+        assert bundle.name == "coalesced-agent"
+        assert bundle.version == "4"
+        return AgentSpec(spec_version=1, name="coalesced-agent")
+
+    async def _http_resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        nonlocal http_calls
+        del agent_id, session_id
+        http_calls += 1
+        raise AssertionError("embedded bundle unexpectedly fell back to HTTP")
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_http_resolver,
+        init_spec_resolver=_init_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        resource_registry=SessionResourceRegistry(terminal_registry=None),
+    )
+    payload = {
+        "session_id": "conv_embedded",
+        "agent_id": "agent_embedded",
+        "session_init": {
+            "protocol_version": 2,
+            "server_version": "0.6.0.dev0",
+            "session_id": "conv_embedded",
+            "agent_id": "agent_embedded",
+            "snapshot": {
+                "created_at": 1234,
+                "updated_at": 1234,
+                "labels": {},
+            },
+            "agent_bundle": {
+                "version": "4",
+                "name": "coalesced-agent",
+                "session_scoped": True,
+                "contents_base64": "YnVuZGxl",
+            },
+        },
+    }
+
+    async with _runner_client(app) as client:
+        response = await client.post("/v1/sessions", json=payload)
+
+    assert response.status_code == 201
+    assert embedded_calls == 1
+    assert http_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_create_session_falls_back_when_embedded_agent_bundle_is_invalid(
+    tmp_path: Path,
+) -> None:
+    """Corrupt coalesced data retains the established HTTP resolution path."""
+    harness_client = _ScriptedHarnessClient([])
+    pm = _FakeProcessManager(harness_client)
+    http_calls = 0
+
+    async def _invalid_init_resolver(agent_id: str, bundle: Any) -> AgentSpec:
+        return _resolve_agent_spec_from_embedded_bundle(tmp_path, agent_id, bundle)
+
+    async def _http_resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        nonlocal http_calls
+        assert agent_id == "agent_fallback"
+        assert session_id == "conv_fallback"
+        http_calls += 1
+        return AgentSpec(spec_version=1, name="fallback-agent")
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_http_resolver,
+        init_spec_resolver=_invalid_init_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        resource_registry=SessionResourceRegistry(terminal_registry=None),
+    )
+    payload = {
+        "session_id": "conv_fallback",
+        "agent_id": "agent_fallback",
+        "session_init": {
+            "protocol_version": 2,
+            "server_version": "0.6.0.dev0",
+            "session_id": "conv_fallback",
+            "agent_id": "agent_fallback",
+            "snapshot": {
+                "created_at": 1234,
+                "updated_at": 1234,
+                "labels": {},
+            },
+            "agent_bundle": {
+                "version": "4",
+                "name": "broken-agent",
+                "session_scoped": True,
+                "contents_base64": "not-valid-base64",
+            },
+        },
+    }
+
+    async with _runner_client(app) as client:
+        response = await client.post("/v1/sessions", json=payload)
+
+    assert response.status_code == 201
+    assert http_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -75,6 +75,7 @@ from omnigent.runner.app import (
     _session_labels_for_runner_spawn,
     _terminal_lookup_miss_log_state,
     _wake_post_is_retryable,
+    parse_runner_session_init_envelope,
 )
 from omnigent.runner.mcp_manager import McpSchemasResult
 from omnigent.runner.resource_registry import (
@@ -4428,15 +4429,13 @@ async def test_create_session_resolves_embedded_agent_bundle_without_http_fallba
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A current runner consumes coalesced bundle data before its HTTP resolver."""
-    import omnigent.runner.app as runner_app_module
-
     harness_client = _ScriptedHarnessClient([])
     pm = _FakeProcessManager(harness_client)
     embedded_calls = 0
     http_calls = 0
     parsed_envelopes: list[RunnerSessionInitEnvelope] = []
 
-    original_parse = runner_app_module.parse_runner_session_init_envelope
+    original_parse = parse_runner_session_init_envelope
 
     def _capture_envelope(body: dict[str, Any]) -> RunnerSessionInitEnvelope | None:
         envelope = original_parse(body)
@@ -4445,8 +4444,7 @@ async def test_create_session_resolves_embedded_agent_bundle_without_http_fallba
         return envelope
 
     monkeypatch.setattr(
-        runner_app_module,
-        "parse_runner_session_init_envelope",
+        "omnigent.runner.app.parse_runner_session_init_envelope",
         _capture_envelope,
     )
 
@@ -4501,6 +4499,208 @@ async def test_create_session_resolves_embedded_agent_bundle_without_http_fallba
     assert http_calls == 0
     assert len(parsed_envelopes) == 1
     assert parsed_envelopes[0].agent_bundle is None
+
+
+@pytest.mark.asyncio
+async def test_embedded_agent_bundle_resolution_preserves_cancellation() -> None:
+    """Cancellation cannot fall through to the legacy HTTP resolver."""
+    http_resolver_called = asyncio.Event()
+
+    async def _cancelled_init_resolver(agent_id: str, bundle: Any) -> AgentSpec:
+        del agent_id, bundle
+        raise asyncio.CancelledError
+
+    async def _http_resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        http_resolver_called.set()
+        return AgentSpec(spec_version=1, name="unexpected-http-fallback")
+
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_http_resolver,
+        init_spec_resolver=_cancelled_init_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        resource_registry=SessionResourceRegistry(terminal_registry=None),
+    )
+    payload = {
+        "session_id": "conv_cancelled_bundle",
+        "agent_id": "agent_cancelled_bundle",
+        "session_init": {
+            "protocol_version": 2,
+            "server_version": "0.6.0.dev0",
+            "session_id": "conv_cancelled_bundle",
+            "agent_id": "agent_cancelled_bundle",
+            "snapshot": {
+                "created_at": 1234,
+                "updated_at": 1234,
+                "labels": {},
+            },
+            "agent_bundle": {
+                "version": "1",
+                "name": "cancelled-agent",
+                "session_scoped": True,
+                "contents_base64": "YnVuZGxl",
+            },
+        },
+    }
+
+    async with _runner_client(app) as client:
+        with pytest.raises(asyncio.CancelledError):
+            await client.post("/v1/sessions", json=payload)
+
+    assert not http_resolver_called.is_set()
+
+
+@pytest.mark.asyncio
+async def test_spec_reader_waits_for_embedded_session_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resource reader cannot race an incoming embedded bundle with HTTP."""
+    import omnigent.model_catalog as model_catalog
+
+    monkeypatch.setattr(model_catalog, "catalog_for_spec", lambda _spec: {})
+    harness_client = _ScriptedHarnessClient([])
+    pm = _FakeProcessManager(harness_client)
+    session_id = "conv_rendezvous"
+    snapshot_entered = asyncio.Event()
+    release_snapshot = asyncio.Event()
+    embedded_resolved = asyncio.Event()
+
+    class _ServerClient:
+        async def get(self, path: str, **_kwargs: Any) -> Any:
+            if path == f"/v1/sessions/{session_id}/items":
+                return type(
+                    "Response",
+                    (),
+                    {"status_code": 200, "json": lambda self: {"data": []}},
+                )()
+            assert path == f"/v1/sessions/{session_id}"
+            snapshot_entered.set()
+            await release_snapshot.wait()
+            return type(
+                "Response",
+                (),
+                {
+                    "status_code": 200,
+                    "json": lambda self: {
+                        "created_at": 1234,
+                        "workspace": None,
+                        "agent_id": "agent_rendezvous",
+                    },
+                },
+            )()
+
+    async def _init_resolver(agent_id: str, bundle: Any) -> AgentSpec:
+        assert agent_id == "agent_rendezvous"
+        assert bundle.name == "rendezvous-agent"
+        embedded_resolved.set()
+        return AgentSpec(spec_version=1, name="rendezvous-agent")
+
+    async def _http_resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        raise AssertionError("resource reader raced session initialization")
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_http_resolver,
+        init_spec_resolver=_init_resolver,
+        server_client=_ServerClient(),  # type: ignore[arg-type]
+        resource_registry=SessionResourceRegistry(terminal_registry=None),
+    )
+    payload = {
+        "session_id": session_id,
+        "agent_id": "agent_rendezvous",
+        "session_init": {
+            "protocol_version": 2,
+            "server_version": "0.6.0.dev0",
+            "session_id": session_id,
+            "agent_id": "agent_rendezvous",
+            "snapshot": {
+                "created_at": 1234,
+                "updated_at": 1234,
+                "labels": {},
+            },
+            "agent_bundle": {
+                "version": "1",
+                "name": "rendezvous-agent",
+                "session_scoped": True,
+                "contents_base64": "YnVuZGxl",
+            },
+        },
+    }
+
+    async with _runner_client(app) as client:
+        reader = asyncio.create_task(client.get(f"/v1/sessions/{session_id}/models"))
+        await snapshot_entered.wait()
+        assert not reader.done()
+
+        init_response = await client.post("/v1/sessions", json=payload)
+        assert embedded_resolved.is_set()
+        assert not reader.done()
+
+        release_snapshot.set()
+        reader_response = await asyncio.wait_for(reader, timeout=2.0)
+
+    assert init_response.status_code == 201
+    assert reader_response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_spec_reader_waits_for_legacy_session_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An old server's assignment performs one HTTP resolution for all readers."""
+    import omnigent.model_catalog as model_catalog
+
+    monkeypatch.setattr(model_catalog, "catalog_for_spec", lambda _spec: {})
+    resolver_entered = asyncio.Event()
+    release_resolver = asyncio.Event()
+    resolver_calls = 0
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        nonlocal resolver_calls
+        assert agent_id == "agent_legacy_rendezvous"
+        assert session_id == "conv_legacy_rendezvous"
+        resolver_calls += 1
+        resolver_entered.set()
+        await release_resolver.wait()
+        return AgentSpec(spec_version=1, name="legacy-rendezvous-agent")
+
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        resource_registry=SessionResourceRegistry(terminal_registry=None),
+    )
+    session_id = "conv_legacy_rendezvous"
+
+    async with _runner_client(app) as client:
+        initialization = asyncio.create_task(
+            client.post(
+                "/v1/sessions",
+                json={
+                    "session_id": session_id,
+                    "agent_id": "agent_legacy_rendezvous",
+                },
+            )
+        )
+        await resolver_entered.wait()
+        assert resolver_calls == 1
+        calls_after_enter = resolver_calls
+
+        reader = asyncio.create_task(client.get(f"/v1/sessions/{session_id}/models"))
+        await asyncio.sleep(0)
+        assert not reader.done()
+
+        release_resolver.set()
+        init_response, reader_response = await asyncio.wait_for(
+            asyncio.gather(initialization, reader),
+            timeout=2.0,
+        )
+
+    assert init_response.status_code == 201
+    assert reader_response.status_code == 200
+    assert resolver_calls == calls_after_enter
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -1618,10 +1618,10 @@ async def test_resolve_agent_spec_from_server_caches_success_by_agent_version(
         "/v1/sessions/conv_test/agent/contents",
         "/v1/sessions/conv_test/agent/contents",
     ]
-    cache_dir = tmp_path / "ag_cached-v7"
+    cache_dir = _agent_cache_dest(tmp_path, "ag_cached", "7")
     assert cache_dir.is_dir()
     assert (cache_dir / "config.yaml").read_text() == config_bytes.decode()
-    assert [path.name for path in tmp_path.iterdir()] == ["ag_cached-v7"]
+    assert [path.name for path in tmp_path.iterdir()] == [cache_dir.name]
 
 
 def test_resolve_embedded_agent_bundle_recovers_after_invalid_archive(tmp_path: Path) -> None:
@@ -1658,7 +1658,48 @@ def test_resolve_embedded_agent_bundle_recovers_after_invalid_archive(tmp_path: 
     resolved = _resolve_agent_spec_from_embedded_bundle(tmp_path, "ag_cached", valid)
 
     assert resolved.name == "cached-agent"
-    assert (tmp_path / "ag_cached-v7" / "config.yaml").is_file()
+    assert (_agent_cache_dest(tmp_path, "ag_cached", "7") / "config.yaml").is_file()
+
+
+def test_resolve_embedded_agent_bundle_cleans_failed_cached_parse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cached-directory parse failure removes the poisoned cache entry."""
+    from omnigent import spec as spec_module
+
+    config_bytes = (
+        b"spec_version: 1\nname: cached-agent\nexecutor:\n  config:\n    harness: claude-sdk\n"
+    )
+    bundle_buf = io.BytesIO()
+    with tarfile.open(fileobj=bundle_buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name="config.yaml")
+        info.size = len(config_bytes)
+        tf.addfile(info, io.BytesIO(config_bytes))
+    bundle = encode_runner_session_init_agent_bundle(
+        bundle_buf.getvalue(),
+        version="8",
+        name="cached-agent",
+        session_scoped=True,
+    )
+    assert bundle is not None
+
+    real_load = spec_module.load
+    load_calls = 0
+
+    def _fail_cached_parse(*args: Any, **kwargs: Any) -> Any:
+        nonlocal load_calls
+        load_calls += 1
+        if load_calls == 2:
+            raise RuntimeError("cached parse failed")
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(spec_module, "load", _fail_cached_parse)
+
+    with pytest.raises(RuntimeError, match="cached parse failed"):
+        _resolve_agent_spec_from_embedded_bundle(tmp_path, "ag_cached", bundle)
+
+    assert not _agent_cache_dest(tmp_path, "ag_cached", "8").exists()
 
 
 @pytest.mark.asyncio
@@ -1922,10 +1963,10 @@ def test_agent_cache_dest_contains_traversal(tmp_path: Path, agent_id: str, vers
 
 
 def test_agent_cache_dest_normal_id_round_trips(tmp_path: Path) -> None:
-    """A normal agent id/version maps to the expected child directory.
+    """A normal agent id/version maps deterministically to one safe child.
 
-    Proves the sanitization doesn't mangle well-formed ids — only the
-    f-string shape changes for traversal inputs.
+    The opaque digest keeps the same agent/version pair stable for cache hits
+    while ensuring a version bump maps to a different directory.
 
     :param tmp_path: Cache root fixture.
     """
@@ -1933,5 +1974,11 @@ def test_agent_cache_dest_normal_id_round_trips(tmp_path: Path) -> None:
     cache_root.mkdir()
 
     dest = _agent_cache_dest(cache_root, "ag_abc123", "3")
+    repeated = _agent_cache_dest(cache_root, "ag_abc123", "3")
+    next_version = _agent_cache_dest(cache_root, "ag_abc123", "4")
 
-    assert dest == cache_root / "ag_abc123-v3"
+    assert dest == repeated
+    assert dest != next_version
+    assert dest.parent == cache_root
+    assert dest.name.startswith("agent-")
+    assert len(dest.name) == len("agent-") + 64

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -28,6 +28,7 @@ from omnigent.runner._entry import (
     _mint_managed_owner_token,
     _parent_is_orphaned,
     _parent_process_is_alive,
+    _resolve_agent_spec_from_embedded_bundle,
     _resolve_agent_spec_from_server,
     _run_inactivity_monitor,
     _run_parent_death_killer,
@@ -42,7 +43,9 @@ from omnigent.runner.identity import (
     RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
     RUNNER_TUNNEL_TOKEN_HEADER,
 )
+from omnigent.runner.session_init_protocol import encode_runner_session_init_agent_bundle
 from omnigent.runner.transports.ws_tunnel.serve import RUNNER_TUNNEL_REJECTION_PREFIX
+from omnigent.spec import ExtractionError
 
 # Force-load the MCP streamable-http client before any test monkeypatches
 # httpx.AsyncClient: the MCP SDK evaluates `httpx.AsyncClient | None` eagerly at
@@ -1619,6 +1622,43 @@ async def test_resolve_agent_spec_from_server_caches_success_by_agent_version(
     assert cache_dir.is_dir()
     assert (cache_dir / "config.yaml").read_text() == config_bytes.decode()
     assert [path.name for path in tmp_path.iterdir()] == ["ag_cached-v7"]
+
+
+def test_resolve_embedded_agent_bundle_recovers_after_invalid_archive(tmp_path: Path) -> None:
+    """A bad coalesced archive does not poison the cache used by HTTP fallback."""
+    invalid = encode_runner_session_init_agent_bundle(
+        b"not a tarball",
+        version="7",
+        name="cached-agent",
+        session_scoped=True,
+    )
+    assert invalid is not None
+
+    with pytest.raises(ExtractionError):
+        _resolve_agent_spec_from_embedded_bundle(tmp_path, "ag_cached", invalid)
+
+    assert list(tmp_path.iterdir()) == []
+
+    config_bytes = (
+        b"spec_version: 1\nname: cached-agent\nexecutor:\n  config:\n    harness: claude-sdk\n"
+    )
+    bundle_buf = io.BytesIO()
+    with tarfile.open(fileobj=bundle_buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name="config.yaml")
+        info.size = len(config_bytes)
+        tf.addfile(info, io.BytesIO(config_bytes))
+    valid = encode_runner_session_init_agent_bundle(
+        bundle_buf.getvalue(),
+        version="7",
+        name="cached-agent",
+        session_scoped=True,
+    )
+    assert valid is not None
+
+    resolved = _resolve_agent_spec_from_embedded_bundle(tmp_path, "ag_cached", valid)
+
+    assert resolved.name == "cached-agent"
+    assert (tmp_path / "ag_cached-v7" / "config.yaml").is_file()
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_runner_session_init.py
+++ b/tests/server/test_runner_session_init.py
@@ -8,7 +8,13 @@ from typing import Any
 import httpx
 import pytest
 
-from omnigent.entities import Conversation
+from omnigent.entities import Agent, Conversation
+from omnigent.runner.session_init_protocol import (
+    MAX_EMBEDDED_AGENT_BUNDLE_BYTES,
+    RunnerSessionInitAgentBundle,
+    decode_runner_session_init_agent_bundle,
+    encode_runner_session_init_agent_bundle,
+)
 from omnigent.server.runner_session_init import RunnerSessionInitializer
 
 
@@ -47,6 +53,27 @@ def _conversation() -> Conversation:
     )
 
 
+class _AgentStore:
+    def __init__(self, agent: Agent) -> None:
+        self.agent = agent
+        self.calls = 0
+
+    def get(self, agent_id: str) -> Agent | None:
+        self.calls += 1
+        return self.agent if agent_id == self.agent.id else None
+
+
+class _ArtifactStore:
+    def __init__(self, contents: bytes) -> None:
+        self.contents = contents
+        self.calls = 0
+
+    def get(self, key: str) -> bytes:
+        assert key == "agents/agent_init/bundle.tar.gz"
+        self.calls += 1
+        return self.contents
+
+
 @pytest.mark.asyncio
 async def test_initializer_shares_result_for_one_tunnel_generation() -> None:
     registry = _Registry()
@@ -75,6 +102,58 @@ async def test_initializer_shares_result_for_one_tunnel_generation() -> None:
     initializer.invalidate_runner("runner_init")
     await initializer.initialize(conversation, client, timeout=10)  # type: ignore[arg-type]
     assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_initializer_embeds_agent_bundle_inside_single_flight_request() -> None:
+    registry = _Registry()
+    client = _Client()
+    contents = b"compressed-agent-bundle"
+    agent_store = _AgentStore(
+        Agent(
+            id="agent_init",
+            created_at=1,
+            name="embedded-agent",
+            bundle_location="agents/agent_init/bundle.tar.gz",
+            version=7,
+            session_id="conv_init",
+        )
+    )
+    artifact_store = _ArtifactStore(contents)
+    initializer = RunnerSessionInitializer(  # type: ignore[arg-type]
+        registry,
+        server_version="0.6.0.dev0",
+        agent_store=agent_store,  # type: ignore[arg-type]
+        artifact_store=artifact_store,  # type: ignore[arg-type]
+    )
+
+    first = asyncio.create_task(initializer.initialize(_conversation(), client, timeout=10))  # type: ignore[arg-type]
+    await client.entered.wait()
+    second = asyncio.create_task(initializer.initialize(_conversation(), client, timeout=10))  # type: ignore[arg-type]
+    await asyncio.sleep(0)
+    client.release.set()
+    await asyncio.gather(first, second)
+
+    assert agent_store.calls == 1
+    assert artifact_store.calls == 1
+    assert len(client.calls) == 1
+    embedded = client.calls[0]["session_init"]["agent_bundle"]
+    assert embedded["version"] == "7"
+    assert embedded["name"] == "embedded-agent"
+    assert embedded["session_scoped"] is True
+    encoded = RunnerSessionInitAgentBundle.model_validate(embedded)
+    assert decode_runner_session_init_agent_bundle(encoded) == contents
+
+
+def test_oversized_agent_bundle_is_omitted() -> None:
+    bundle = encode_runner_session_init_agent_bundle(
+        b"x" * (MAX_EMBEDDED_AGENT_BUNDLE_BYTES + 1),
+        version="1",
+        name="large-agent",
+        session_scoped=False,
+    )
+
+    assert bundle is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

N/A

## Summary

Remote runner cold starts currently make a separate authenticated `GET /v1/sessions/{id}/agent/contents` request after the server has already sent the session initialization request. In measured remote runs, that redundant round trip accounted for roughly 1.2 seconds. This change embeds the existing gzip agent bundle in the versioned session-init envelope so a current server and runner can materialize it immediately.

**ELI5:** the server already has the package the runner needs. Instead of telling the runner to call back and fetch it, the server puts the package in the startup message it was sending anyway.

```mermaid
flowchart LR
    A[Server loads bound agent bundle] --> B[POST runner session init]
    B --> C{Embedded bundle supported?}
    C -->|Yes| D[Decode and populate runner cache]
    C -->|Missing, invalid, or oversized| E[Existing HTTP contents fetch]
    D --> F[Spawn harness]
    E --> F
```

- Adds an optional protocol-v2 bundle field carrying the archive, version, name, and session-scoped provenance. The field is capped at 16 MiB before base64 encoding.
- Loads and embeds the artifact inside the server's existing single-flight initialization task, keeping blocking stores off the event loop.
- Reuses the runner's existing extraction, version cache, environment-expansion policy, and unsupported-sub-agent pruning for both embedded and HTTP bundles.
- Preserves compatibility in both directions: old runners ignore the additional field, while new runners fall back to HTTP when an old server omits it. Corrupt or oversized bundles use the same fallback.

**How to review:** start with `omnigent/runner/session_init_protocol.py`, then follow the server producer in `omnigent/server/runner_session_init.py` and runner consumer in `omnigent/runner/_entry.py` / `omnigent/runner/app.py`.

**Risk / scope:** initialization messages become larger for current peers, bounded by a conservative 16 MiB raw archive limit beneath the tunnel's 100 MiB frame limit. This does not change agent bundle contents or parsing semantics.

## Test Plan

- [x] Ran all runner entry-point tests (77 passed).
- [x] Ran session-creation coverage in `test_app_sessions_native.py` (36 passed).
- [x] Ran server application tests (29 passed).
- [x] Added coverage for embedding, single-flight loading, size limits, cache cleanup, embedded resolution without HTTP, corruption fallback, and legacy missing-field behavior.
- [x] Ran the full pre-commit suite.

Verification commands:

```bash
uv run pytest -q tests/server/test_runner_session_init.py tests/runner/test_runner_entry.py
uv run pytest -q tests/runner/test_app_sessions_native.py -k 'create_session'
uv run pytest -q tests/server/test_app.py
.venv/bin/pre-commit run --all-files
```

## Demo

N/A — non-visual runner startup optimization.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new protocol and fallback branches are covered with unit and runner-app tests; no UI behavior changes.

## Changelog

New remote sessions start faster by receiving the agent bundle in runner initialization instead of fetching it separately.
