### PR TITLE
fix(acp): preserve session ACP agent selection

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5790,6 +5790,7 @@ def create_runner_app(
                 cwd=await _session_runtime_cwd(conv),
                 model_override=cast(str | None, msg_body.get("model_override")),
                 session_id=conv,
+                harness_override=cast(str | None, msg_body.get("harness_override")),
             )
             from omnigent.runtime.prompt import build_instructions
 
@@ -9562,6 +9563,7 @@ async def _resolve_harness_config(
                 workdir=workdir,
                 model_override=model_override,
                 session_id=session_id,
+                harness_override=harness_override,
             )
             return harness, spawn_env
 
@@ -9664,6 +9666,7 @@ def _build_spawn_env_from_spec(
     workdir: Path | None = None,
     model_override: str | None = None,
     session_id: str | None = None,
+    harness_override: str | None = None,
 ) -> dict[str, str] | None:
     """Build spawn-env from spec — mirrors workflow.py's helpers.
 
@@ -9681,6 +9684,8 @@ def _build_spawn_env_from_spec(
         via ``--model`` in :func:`_build_claude_native_base_args`; the
         SDK harnesses have no such arg, so the override must land in the
         env var here.)
+    :param harness_override: The raw per-session harness override. Generic ACP
+        keeps its slug in the effective spec for agent selection.
     :returns: The spawn-env dict, or ``None`` for native / unknown harnesses.
     """
     # Namespaced generic-ACP ids (``acp:<slug>``) canonicalize to ``acp`` so the
@@ -9688,15 +9693,25 @@ def _build_spawn_env_from_spec(
     # the concrete agent's slug is read from the spec by ``_build_acp_spawn_env``.
     harness = canonicalize_harness(harness) or harness
     effective_spec = spec
+    if harness == "acp" and harness_override:
+        effective_spec = dataclasses.replace(
+            spec,
+            executor=dataclasses.replace(
+                spec.executor,
+                config={**spec.executor.config, "harness": harness_override},
+            ),
+        )
     if model_override is not None:
-        executor = getattr(spec, "executor", None)
-        if hasattr(spec, "model_copy") and hasattr(executor, "model_copy"):
+        executor = getattr(effective_spec, "executor", None)
+        if hasattr(effective_spec, "model_copy") and hasattr(executor, "model_copy"):
             copied_executor = cast(_ModelCopyValue, executor).model_copy(
                 update={"model": model_override}
             )
             effective_spec = cast(
                 AgentSpec,
-                cast(_ModelCopyValue, spec).model_copy(update={"executor": copied_executor}),
+                cast(_ModelCopyValue, effective_spec).model_copy(
+                    update={"executor": copied_executor}
+                ),
             )
     try:
         from omnigent.runtime.workflow import (

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -1820,7 +1820,10 @@ def _validated_harness_override(value: str | None, agent: Agent) -> str | None:
             f"declares executor.type {executor_type!r}",
             code=ErrorCode.INVALID_INPUT,
         )
-    return canonical
+    # Preserve the concrete ``acp:<slug>`` so the runner launches the picked
+    # agent; folding it to bare ``acp`` would drop the slug and always launch
+    # the first configured ACP agent. Non-acp overrides keep the canonical id.
+    return value if value.startswith("acp:") else canonical
 
 
 def _validated_harness_override_executor_type(agent: Agent) -> None:

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -1519,6 +1519,12 @@ async def test_resolve_harness_config_applies_harness_override(
         "      api_key: $ANTHROPIC_API_KEY\n"
         "      models:\n"
         "        default: test-default\n"
+        "acp:\n"
+        "  agents:\n"
+        "    - name: Gemini CLI\n"
+        "      command: gemini --experimental-acp\n"
+        "    - name: Goose\n"
+        "      command: goose acp\n"
     )
     spec = AgentSpec(
         spec_version=1,
@@ -1553,6 +1559,15 @@ async def test_resolve_harness_config_applies_harness_override(
     assert spawn_env is not None and "HARNESS_PI_MODEL" in spawn_env, (
         f"Expected a pi spawn-env; got keys {sorted(spawn_env or {})!r}"
     )
+
+    harness, spawn_env = await _resolve_harness_config(
+        agent_id="ag_x",
+        spec_resolver=_resolver,
+        session_id="conv_x",
+        harness_override="acp:goose",
+    )
+    assert harness == "acp"
+    assert spawn_env is not None and spawn_env["HARNESS_ACP_COMMAND"] == "goose acp"
 
 
 @pytest.mark.asyncio

--- a/tests/server/integration/test_sessions_harness_override.py
+++ b/tests/server/integration/test_sessions_harness_override.py
@@ -177,9 +177,11 @@ async def test_create_rejects_harness_override_for_non_omnigent_agent(
     assert "agents_sdk" in resp.text
 
 
+@pytest.mark.parametrize("harness_override", ["pi", "acp:goose"])
 async def test_runner_first_event_forwards_harness_override(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    harness_override: str,
 ) -> None:
     """A create-time override reaches the runner body on the first event.
 
@@ -193,7 +195,11 @@ async def test_runner_first_event_forwards_harness_override(
     agent = await create_test_agent(client)
     resp = await client.post(
         "/v1/sessions",
-        json={"agent_id": agent["id"], "initial_items": [], "harness_override": "pi"},
+        json={
+            "agent_id": agent["id"],
+            "initial_items": [],
+            "harness_override": harness_override,
+        },
     )
     assert resp.status_code == 201, resp.text
     sid = resp.json()["id"]
@@ -214,7 +220,7 @@ async def test_runner_first_event_forwards_harness_override(
         "Runner client was never POSTed to — _forward_event_to_runner "
         "did not run. Check the runner-stub wiring."
     )
-    assert captured["body"].get("harness_override") == "pi", (
+    assert captured["body"].get("harness_override") == harness_override, (
         f"First-event runner body missing the create-time harness "
         f"override; got {captured['body'].get('harness_override')!r}. The "
         f"create route did not persist harness_override before the first "


### PR DESCRIPTION
## Related issue

Closes #4855

## Summary

A per-session `acp:<slug>` override was persisted as bare `acp`, so the runner lost the selected agent and fell back to the first configured ACP entry.

This preserves the namespaced value for persistence, then copies it into the effective runner spec before ACP spawn-env resolution. Canonical `acp` identity, non-ACP aliases, spec-pinned ACP agents, and embedded ACP agents keep their existing behavior.

```text
request acp:goose -> validate as acp -> persist acp:goose -> effective spec acp:goose -> Goose
```

ELI5: Omnigent still files every generic ACP agent under the `acp` category, but now keeps the selected agent name on the session long enough to launch it.

## Test Plan

- `pytest tests/runtime/test_acp_spawn_env.py -q` — 24 passed.
- `pytest tests/runner/test_runner_dispatch.py -k resolve_harness_config_applies_harness_override -q` — 1 passed; `acp:goose` selects Goose while Gemini is configured first.
- `pytest tests/server/integration/test_sessions_harness_override.py -q` — 8 passed; `acp:goose` survives persistence and runner forwarding.
- `ruff format --check` and `ruff check` on all changed files — passed.
- `pyrefly check omnigent/runner/app.py omnigent/server/routes/_sessions/helpers.py` — 0 errors.

## Demo

Non-visual before/after reproduction used by the regression tests:

```text
ACP config order: [gemini-cli, goose]
harness_override: acp:goose

before: stored acp       -> no slug -> HARNESS_ACP_COMMAND=gemini --experimental-acp
after:  stored acp:goose -> goose   -> HARNESS_ACP_COMMAND=goose acp
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The runner regression asserts the selected `HARNESS_ACP_COMMAND`; the server integration test asserts the full `acp:<slug>` survives persistence and forwarding.

## Changelog

Picking a specific ACP agent for a session now launches that agent instead of the first one configured.
