### PR TITLE
fix(credentials): stop mislabeling OAuth Databricks profiles as malformed

### DIFF
--- a/omnigent/runtime/credentials/databricks.py
+++ b/omnigent/runtime/credentials/databricks.py
@@ -113,12 +113,19 @@ def _databricks_sdk_importable() -> bool:
     the failure message: "install the extra" vs. "fix your OAuth
     session".
 
-    :returns: ``True`` when ``databricks.sdk.config`` imports, else
-        ``False``.
+    :returns: ``True`` when ``databricks.sdk.config`` actually imports,
+        else ``False``.
     """
-    import importlib.util
-
-    return importlib.util.find_spec("databricks.sdk.config") is not None
+    # A real import (not importlib.util.find_spec): find_spec can return
+    # a spec for an SDK whose transitive deps are missing, and can even
+    # raise on a partial ``databricks`` install where the ``sdk``
+    # subpackage is absent. Import-and-catch matches what the resolver
+    # itself does and never escapes as an uncaught error.
+    try:
+        import databricks.sdk.config  # noqa: F401
+    except Exception:
+        return False
+    return True
 
 
 def _databrickscfg_path() -> Path:
@@ -177,7 +184,16 @@ class _SectionNeedsSdk(Exception):
     :class:`_SectionPresentButInvalid` lets the resolver emit an
     honest, actionable error rather than telling the user to "fix or
     remove" a perfectly valid profile.
+
+    Carries the offending section's ``auth_type`` so the resolver can
+    tailor remediation: ``databricks-cli`` (OAuth-U2M) is fixed with
+    ``databricks auth login``, whereas other SDK-only auth types
+    (``azure-cli``, metadata-service, etc.) are not.
     """
+
+    def __init__(self, message: str, auth_type: str) -> None:
+        super().__init__(message)
+        self.auth_type = auth_type
 
 
 def _read_section(config: configparser.ConfigParser, section: str) -> WorkspaceCreds | None:
@@ -253,7 +269,7 @@ def _read_section(config: configparser.ConfigParser, section: str) -> WorkspaceC
     # an actionable error about the SDK path having failed.
     auth_type = values.get("auth_type", "").strip().lower()
     if host and not token and auth_type and auth_type != "pat":
-        raise _SectionNeedsSdk(f"auth_type={auth_type!r}, no static token")
+        raise _SectionNeedsSdk(f"auth_type={auth_type!r}, no static token", auth_type)
     missing = [k for k in ("host", "token") if not values.get(k)]
     raise _SectionPresentButInvalid(
         f"section [{section}] is missing required field(s) {missing}; "
@@ -480,29 +496,39 @@ def resolve_databricks_workspace(profile: str | None) -> WorkspaceCreds:
             "and that the file exists."
         ) from None
     except _SectionNeedsSdk as exc:
-        # Well-formed OAuth profile the plaintext path can't resolve.
+        # Well-formed SDK-only profile the plaintext path can't resolve.
         # Reaching here means the SDK path (step 1) already failed. The
         # fix differs by cause: if databricks-sdk isn't even installed
         # (it lives in the `databricks` extra, not the base install),
         # tell the user to install it; otherwise the SDK is present but
-        # couldn't complete OAuth, so point at the CLI / login session.
+        # couldn't complete auth.
         if not _databricks_sdk_importable():
             remediation = (
                 "the databricks-sdk package is not installed — it ships in the "
                 "`databricks` extra, not the base install. Reinstall with the extra "
                 "(e.g. `pip install 'omnigent[databricks]'`, or `uv run --extra "
-                "databricks ...`) so OAuth profiles can be resolved."
+                "databricks ...`) so this profile can be resolved."
             )
-        else:
+        elif exc.auth_type == "databricks-cli":
+            # OAuth-U2M: the CLI-managed session is the thing to refresh.
             remediation = (
                 "the databricks-sdk path could not mint a token for it. Ensure the "
                 "`databricks` CLI is installed and on PATH, and that the OAuth "
                 f"session is valid (run `databricks auth login --profile "
                 f"{effective_profile}`). See the cli-*.log for the underlying SDK error."
             )
+        else:
+            # Other SDK-only auth types (azure-cli, metadata-service,
+            # oauth-m2m, etc.) — `databricks auth login` does NOT apply.
+            remediation = (
+                "the databricks-sdk path could not mint a token for it. Ensure the "
+                f"credentials for auth_type={exc.auth_type!r} are valid and available "
+                "in this environment. See the cli-*.log for the underlying SDK error."
+            )
         raise OSError(
-            f"Databricks profile [{effective_profile}] in {cfg_path} is an OAuth "
-            f"profile ({exc}), and {remediation}"
+            f"Databricks profile [{effective_profile}] in {cfg_path} is a token-less "
+            f"profile ({exc}) that only the databricks-sdk can resolve, and "
+            f"{remediation}"
         ) from exc
     except _SectionPresentButInvalid as exc:
         raise OSError(

--- a/omnigent/runtime/credentials/databricks.py
+++ b/omnigent/runtime/credentials/databricks.py
@@ -102,6 +102,25 @@ def _strip_trailing_slash(host: str) -> str:
     return host.rstrip("/")
 
 
+def _databricks_sdk_importable() -> bool:
+    """
+    Report whether the ``databricks-sdk`` Python package can be imported.
+
+    The SDK ships only in the ``databricks`` / ``all`` install extras,
+    not the base install. When it is absent, the OAuth resolution path
+    (:func:`_try_resolve_via_sdk`) is unavailable and the resolver can
+    only see plaintext ``token`` profiles. Callers use this to tailor
+    the failure message: "install the extra" vs. "fix your OAuth
+    session".
+
+    :returns: ``True`` when ``databricks.sdk.config`` imports, else
+        ``False``.
+    """
+    import importlib.util
+
+    return importlib.util.find_spec("databricks.sdk.config") is not None
+
+
 def _databrickscfg_path() -> Path:
     """
     Return the path to the Databricks config file.
@@ -145,16 +164,36 @@ class _SectionPresentButInvalid(Exception):
     """
 
 
+class _SectionNeedsSdk(Exception):
+    """
+    Raised by :func:`_read_section` when a named section EXISTS and is
+    a well-formed OAuth profile (a non-``pat`` ``auth_type`` and no
+    static ``token``) that the raw configparser path cannot resolve.
+
+    Such a profile is NOT malformed — a missing ``token`` is expected
+    for OAuth. Only the SDK path (:func:`_try_resolve_via_sdk`) can
+    mint a bearer for it, and reaching this fallback means that path
+    already failed. Signaling this separately from
+    :class:`_SectionPresentButInvalid` lets the resolver emit an
+    honest, actionable error rather than telling the user to "fix or
+    remove" a perfectly valid profile.
+    """
+
+
 def _read_section(config: configparser.ConfigParser, section: str) -> WorkspaceCreds | None:
     """
     Read ``host`` and ``token`` from a named section of a parsed config.
 
-    Three outcomes for named (non-DEFAULT) sections:
+    Four outcomes for named (non-DEFAULT) sections:
 
     - Section absent → raises :class:`_SectionAbsent`.
     - Section present and complete → returns :class:`WorkspaceCreds`.
-    - Section present but missing ``host`` or ``token`` → raises
-      :class:`_SectionPresentButInvalid`.
+    - Section present, no static ``token``, but a non-``pat``
+      ``auth_type`` (an OAuth profile) → raises
+      :class:`_SectionNeedsSdk`. Not malformed — just unresolvable by
+      this plaintext path.
+    - Section present but missing ``host`` or ``token`` with no OAuth
+      ``auth_type`` → raises :class:`_SectionPresentButInvalid`.
 
     For ``DEFAULT``: absent or incomplete → returns ``None`` (no
     further fallback exists).
@@ -167,8 +206,11 @@ def _read_section(config: configparser.ConfigParser, section: str) -> WorkspaceC
         has both fields, or ``None`` for an absent/incomplete
         ``[DEFAULT]``.
     :raises _SectionAbsent: When a named section does not exist.
+    :raises _SectionNeedsSdk: When the section is a well-formed OAuth
+        profile (non-``pat`` ``auth_type``, no static ``token``) that
+        only the SDK path can resolve.
     :raises _SectionPresentButInvalid: When the section exists but
-        is missing ``host`` or ``token``.
+        is missing ``host`` or ``token`` and is not an OAuth profile.
     """
     # ConfigParser exposes DEFAULT via .defaults(); named sections via
     # __getitem__. Read via the appropriate API to avoid accidentally
@@ -205,6 +247,13 @@ def _read_section(config: configparser.ConfigParser, section: str) -> WorkspaceC
     # falls through to None — there's nowhere further to fall back.
     if section == DEFAULT_SECTION:
         return None
+    # An OAuth profile (non-``pat`` auth_type) legitimately has no
+    # static ``token`` — only the SDK path can resolve it. Don't
+    # defame it as malformed; signal separately so the resolver emits
+    # an actionable error about the SDK path having failed.
+    auth_type = values.get("auth_type", "").strip().lower()
+    if host and not token and auth_type and auth_type != "pat":
+        raise _SectionNeedsSdk(f"auth_type={auth_type!r}, no static token")
     missing = [k for k in ("host", "token") if not values.get(k)]
     raise _SectionPresentButInvalid(
         f"section [{section}] is missing required field(s) {missing}; "
@@ -312,7 +361,9 @@ def _try_resolve_from_cfg(profile: str | None, cfg_path: Path) -> WorkspaceCreds
        to ``[DEFAULT]`` (which could be a different workspace).
     3. If the named section is PRESENT but missing required fields,
        :class:`_SectionPresentButInvalid` propagates — same fail-loud
-       treatment.
+       treatment. Exception: a well-formed OAuth profile (non-``pat``
+       ``auth_type``, no static ``token``) raises :class:`_SectionNeedsSdk`
+       instead, since it is not malformed — only the SDK path resolves it.
     4. If ``profile`` is ``None``, skip straight to ``[DEFAULT]``.
 
     :param profile: The profile name to look up, e.g. ``"dev"``.
@@ -428,6 +479,31 @@ def resolve_databricks_workspace(profile: str | None) -> WorkspaceCreds:
             "Check that the section name matches exactly (case-sensitive) "
             "and that the file exists."
         ) from None
+    except _SectionNeedsSdk as exc:
+        # Well-formed OAuth profile the plaintext path can't resolve.
+        # Reaching here means the SDK path (step 1) already failed. The
+        # fix differs by cause: if databricks-sdk isn't even installed
+        # (it lives in the `databricks` extra, not the base install),
+        # tell the user to install it; otherwise the SDK is present but
+        # couldn't complete OAuth, so point at the CLI / login session.
+        if not _databricks_sdk_importable():
+            remediation = (
+                "the databricks-sdk package is not installed — it ships in the "
+                "`databricks` extra, not the base install. Reinstall with the extra "
+                "(e.g. `pip install 'omnigent[databricks]'`, or `uv run --extra "
+                "databricks ...`) so OAuth profiles can be resolved."
+            )
+        else:
+            remediation = (
+                "the databricks-sdk path could not mint a token for it. Ensure the "
+                "`databricks` CLI is installed and on PATH, and that the OAuth "
+                f"session is valid (run `databricks auth login --profile "
+                f"{effective_profile}`). See the cli-*.log for the underlying SDK error."
+            )
+        raise OSError(
+            f"Databricks profile [{effective_profile}] in {cfg_path} is an OAuth "
+            f"profile ({exc}), and {remediation}"
+        ) from exc
     except _SectionPresentButInvalid as exc:
         raise OSError(
             f"Databricks profile [{effective_profile}] in {cfg_path} is malformed: {exc}"

--- a/tests/runtime/credentials/test_databricks.py
+++ b/tests/runtime/credentials/test_databricks.py
@@ -325,6 +325,31 @@ def test_oauth_profile_error_recommends_extra_when_sdk_absent(
     assert "databricks auth login" not in msg
 
 
+def test_non_cli_sdk_profile_does_not_recommend_databricks_auth_login(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A token-less SDK-only profile whose auth_type is NOT databricks-cli
+    # (e.g. azure-cli) must not be told to run `databricks auth login` —
+    # that command only refreshes databricks-cli OAuth-U2M sessions. The
+    # SDK is importable in the test env; the autouse fixture forces auth
+    # to fail → the "SDK present but auth failed" branch.
+    cfg = _write_cfg(
+        tmp_path,
+        "[az]\nhost = https://az.example.com\nauth_type = azure-cli\n",
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+
+    with pytest.raises(OSError) as excinfo:
+        resolve_databricks_workspace(profile="az")
+
+    msg = str(excinfo.value)
+    assert "[az]" in msg
+    assert "malformed" not in msg.lower()
+    # Names the actual auth_type; does NOT misdirect to the CLI login.
+    assert "azure-cli" in msg
+    assert "databricks auth login" not in msg
+
+
 def test_resolves_via_sdk_when_sdk_returns_creds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runtime/credentials/test_databricks.py
+++ b/tests/runtime/credentials/test_databricks.py
@@ -264,6 +264,67 @@ def test_malformed_named_section_does_not_silently_fall_back_to_default(
     assert "malformed" in msg.lower() or "token" in msg
 
 
+def test_oauth_profile_without_token_is_not_malformed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # An OAuth profile (auth_type = databricks-cli) legitimately has no
+    # static ``token`` — only the SDK path can mint one. When that path
+    # fails (autouse fixture forces the SDK to raise), the configparser
+    # fallback must NOT report the profile as "malformed" and tell the
+    # user to fix/remove it. It should raise an actionable error that
+    # points at the SDK path / OAuth session instead.
+    cfg = _write_cfg(
+        tmp_path,
+        (
+            "[oss]\nhost = https://oss.example.com\nauth_type = databricks-cli\n"
+            # NOTE: no token line — expected for OAuth
+        ),
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+
+    # SDK is importable in the test env but the autouse fixture forces
+    # authenticate() to fail → the "installed but auth failed" branch.
+    with pytest.raises(OSError) as excinfo:
+        resolve_databricks_workspace(profile="oss")
+
+    msg = str(excinfo.value)
+    assert "[oss]" in msg
+    # Must NOT defame a valid OAuth profile as malformed.
+    assert "malformed" not in msg.lower()
+    # Should steer the user toward the real fix (SDK / OAuth session).
+    assert "OAuth" in msg
+    assert "databricks auth login" in msg
+
+
+def test_oauth_profile_error_recommends_extra_when_sdk_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # When databricks-sdk is not installed (base install, no extra),
+    # the OAuth profile is unresolvable and the error must tell the user
+    # to install the `databricks` extra — not to mess with their CLI /
+    # OAuth session, which are irrelevant when the package is missing.
+    cfg = _write_cfg(
+        tmp_path,
+        "[oss]\nhost = https://oss.example.com\nauth_type = databricks-cli\n",
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    # Simulate the base install: the SDK package is not importable.
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks._databricks_sdk_importable",
+        lambda: False,
+    )
+
+    with pytest.raises(OSError) as excinfo:
+        resolve_databricks_workspace(profile="oss")
+
+    msg = str(excinfo.value)
+    assert "[oss]" in msg
+    assert "malformed" not in msg.lower()
+    # Points at the missing package / extra, not the CLI/login session.
+    assert "omnigent[databricks]" in msg
+    assert "databricks auth login" not in msg
+
+
 def test_resolves_via_sdk_when_sdk_returns_creds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Running `omnigent server --config config.yaml` with a Databricks OAuth profile (e.g. `auth_type = databricks-cli`, no static `token`) crashed with a misleading error telling the user their profile was **malformed** and to *"fix the section or remove it"*:

> Databricks profile [oss] ... is malformed: section [oss] is missing required field(s) ['token']; this looks like a malformed profile rather than a missing one. Fix the section or remove it...

That profile is perfectly valid — OAuth profiles simply have no static `token`; only the `databricks-sdk` path can mint one. The real trigger was that `databricks-sdk` ships only in the `databricks` / `all` install extras, so a base install can't resolve OAuth profiles and the configparser fallback then defamed the profile as malformed.

- `resolve_databricks_workspace` now distinguishes a well-formed OAuth profile (non-`pat` `auth_type`, no `token`) from a genuinely malformed one via a new `_SectionNeedsSdk` signal.
- The resulting `OSError` is actionable and branches on the cause: if `databricks-sdk` isn't installed it recommends `pip install 'omnigent[databricks]'` / `uv run --extra databricks ...`; if the SDK is present but auth failed it points at the `databricks` CLI / `databricks auth login`.
- The PAT fail-loud guard (token-auth profile missing its `token`) is unchanged.

## Test Plan

- `python -m pytest tests/runtime/credentials/test_databricks.py` — 17 passed.
- Reproduced the original crash, then verified both new message branches:
  - `databricks-sdk` absent (base `uv run --frozen`) → error recommends `omnigent[databricks]`.
  - `databricks-sdk` present but CLI/OAuth auth fails → error points at `databricks auth login`.
- Confirmed the happy path still resolves the `[oss]` OAuth profile when the SDK is available.

## Demo

N/A — CLI error-message change, no UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `test_oauth_profile_without_token_is_not_malformed` (SDK-present/auth-failed branch) and `test_oauth_profile_error_recommends_extra_when_sdk_absent` (SDK-missing branch), and tightened the existing OAuth assertions. Manually verified the end-to-end `omnigent server` flow reproduces the old crash and now emits the corrected message.

## Changelog

Databricks OAuth CLI profiles no longer fail with a misleading "malformed profile" error; the message now explains the real fix (install `omnigent[databricks]` or refresh the OAuth session).

This pull request and its description were written by Isaac.