### PR TITLE
feat(projects): first-class projects in the web sidebar

### DIFF
--- a/designs/PROJECTS_PRD.md
+++ b/designs/PROJECTS_PRD.md
@@ -425,10 +425,11 @@ user's memberships would be their own private metadata.
   (P1), move/create-in-project (P2), rename (P3), delete semantics. Reorder is
   **optional** and, if added, client-only (§7.2). No label backfill here — the
   server dual-reads (§13), so first-class projects work alongside existing
-  label-projects without migrating them. Shipped as two PRs: **1a** the project
-  container (table + store + CRUD) and **1b** session membership (the
-  `project_id` column, conversation-store dual-read, and the session-move HTTP
-  surfaces) — see §12.
+  label-projects without migrating them. Shipped as three PRs: **1a** the project
+  container (table + store + CRUD), **1b** session membership (the `project_id`
+  column, conversation-store dual-read, and the session-move HTTP surfaces), and
+  the **web UI** (sidebar create/rename/delete/move against the first-class
+  entity, dual-reading label-projects) — see §12.
 - **Phase 2 — Project defaults (P4a):** default host/workspace/harness/model
   seeded into the new-chat dialog when starting a session from within a project;
   graceful degradation when host offline / not owned.
@@ -488,16 +489,47 @@ Links sessions to projects and exposes it, completing Phase 1.
   cross-DB split-DB path); route move / unfile / list, single- and multi-user
   ownership boundaries.
 
+### Done (Web UI — first-class projects in the sidebar)
+Wires the web app to the first-class entity, keeping the label path working via
+dual-read so no migration is forced. Folders are keyed by **name** (the union
+key that merges a first-class project and a like-named label-project into one
+folder), carrying the first-class `id` when one exists.
+- ✅ **List dual-read** — `GET /v1/sessions/projects` now returns the UNION of
+  first-class projects (`project_store.list`, incl. empty, with `id`) and legacy
+  label-projects (`id=None`), merged by name and sorted. Response shape changed
+  from `list[str]` to `list[{id, name}]`; owner-scoped as before.
+- ✅ **First-class CRUD client** — `web/src/lib/projectsApi.ts`
+  (`list/create/rename/delete` against `/v1/projects`); hooks `useCreateProject`,
+  `useRenameProject`, and a reworked `useDeleteProject`. `useProjects` now
+  returns `{id, name}[]`.
+- ✅ **Create empty project** — a "New project" control (`NewProjectButton`) in
+  the always-visible Projects section (My-sessions tab), even with zero
+  projects (§5.3). `POST /v1/projects`.
+- ✅ **Membership by `project_id`** — filing/moving a session (composer picker,
+  row kebab, drag-drop) PATCHes `project_id`, resolving the picked name to an id
+  and **creating the first-class row on demand** for a label-only folder. `""`
+  unfiles. Sidebar groups a folder's members by first-class id OR the legacy
+  label, and a row's "current project" dual-reads both (so pinned first-class
+  members keep their project flyout).
+- ✅ **Rename** — `PATCH /v1/projects/{id}` (O(1)); a label-only folder is
+  promoted on demand (create + re-file members). **Delete** — archives and
+  unfiles every member (clears `project_id` + `omni_project` label), then
+  deletes the container; sessions are never deleted (§5.3, §7).
+- ✅ Tests: `projectsApi` unit tests; reworked hook tests (resolve→file,
+  create-on-demand, archive+unfile+delete); sidebar/composer suites updated;
+  server union test. Empty folders read "No sessions".
+- ⬜ **Deferred (kept on the name/label path via dual-read):** the new-session
+  prefill state machine and the Settings archived-only project picker still read
+  the `omni_project` label; retiring label reads from the UI is gated on the
+  Phase 4 backfill. TS client types are not codegen-regenerated (hand-written
+  `projectsApi`).
+
 ### TODO
-- ⬜ **Web UI** — always-visible Projects sidebar section; create empty project;
-  "New session here"; session-row kebab move; rename (§5–§7). No TS client
-  types regenerated yet.
-- ⬜ **Benchmark (when the UI ships).** Once the project sidebar is wired, add a
-  `list_project_sessions` journey to `dev/benchmarks/omnigent` (mirrors the
-  existing `list_sessions` hot read path), and consider a `list_projects`
-  journey. CRUD writes (create/rename/delete) are infrequent single-row ops and
-  don't need a benchmark. Nothing to add now — the routes aren't client-facing
-  yet, so there's no user journey to protect.
+- ⬜ **Benchmark.** Now that the sidebar is wired, add a `list_project_sessions`
+  journey to `dev/benchmarks/omnigent` (mirrors the existing `list_sessions` hot
+  read path), and consider a `list_projects` journey for the sidebar's project
+  list fetch. CRUD writes (create/rename/delete) are infrequent single-row ops
+  and don't need a benchmark.
 - ⬜ **Phase 2 — project defaults (P4a)** — add a `config` JSON column (small
   add-column migration) and plumb it through the store/entity/API; seed
   host/workspace/harness/model into the new-chat dialog (§8.1).

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -15341,25 +15341,40 @@ def create_sessions_router(
     )
     async def list_session_projects(
         request: Request,
-    ) -> list[str]:
+    ) -> list[dict[str, Any]]:
         """
-        Return all project names for the authenticated user, ordered
-        alphabetically.
+        Return the caller's projects as ``{"id", "name"}`` pairs, ordered
+        alphabetically by name.
 
-        Projects are implicit: they exist while at least one session
-        has a ``conversation_labels`` row with ``key="omni_project"``.
+        Dual-reads both project representations and unions them by name:
+        - **First-class projects** (``project_store``) — carry an ``id`` and
+          appear even when empty (the whole point of the first-class entity).
+        - **Legacy label-projects** (implicit ``omni_project`` label) — exist
+          while at least one owned session carries the label; ``id`` is
+          ``None`` until such a project is promoted to first-class.
 
-        :returns: List of project names.
+        A name present in both sources collapses to one entry that keeps the
+        first-class ``id``. Filing is owner-only, so both halves are scoped to
+        the caller (label-projects to their owned sessions, first-class to
+        their owned rows) — a project shared to them but owned by another user
+        does not surface as one of their own folders.
+
+        :returns: List of ``{"id": str | None, "name": str}`` ordered by name.
         """
         user_id = _require_user(request, auth_provider)
-        # Filing into a project is owner-only, so the sidebar renders project
-        # folders only on "My sessions". Scope to owned sessions so a project
-        # owned by someone else (with a session shared to this user) doesn't
-        # surface as one of their own folders.
-        return await asyncio.to_thread(
-            conversation_store.list_projects,
-            owned_by=user_id,
-        )
+
+        def _list_union() -> list[dict[str, Any]]:
+            # First-class first so its id wins when a name exists in both.
+            by_name: dict[str, dict[str, Any]] = {}
+            if project_store is not None:
+                for proj in project_store.list(owner_user_id=user_id):
+                    by_name[proj.name] = {"id": proj.id, "name": proj.name}
+            # Legacy path: label-derived projects (id=None unless already first-class).
+            for name in conversation_store.list_projects(owned_by=user_id):
+                by_name.setdefault(name, {"id": None, "name": name})
+            return [by_name[name] for name in sorted(by_name)]
+
+        return await asyncio.to_thread(_list_union)
 
     # ── PUT /sessions/{session_id}/read-state ─────────────────────
     #

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -271,6 +271,7 @@ from omnigent.server.schemas import (
     SessionMcpStartupEvent,
     SessionModelEvent,
     SessionModelOptionsEvent,
+    SessionProjectSummary,
     SessionReasoningEffortEvent,
     SessionResourceListPage,
     SessionResourceObject,
@@ -15335,13 +15336,10 @@ def create_sessions_router(
     # would otherwise be captured by the ``{session_id}`` path param and 404
     # as a missing conversation.
 
-    @router.get(
-        "/sessions/projects",
-        response_model=None,
-    )
+    @router.get("/sessions/projects")
     async def list_session_projects(
         request: Request,
-    ) -> list[dict[str, Any]]:
+    ) -> list[SessionProjectSummary]:
         """
         Return the caller's projects as ``{"id", "name"}`` pairs, ordered
         alphabetically by name.
@@ -15359,19 +15357,19 @@ def create_sessions_router(
         their owned rows) — a project shared to them but owned by another user
         does not surface as one of their own folders.
 
-        :returns: List of ``{"id": str | None, "name": str}`` ordered by name.
+        :returns: List of :class:`SessionProjectSummary` ordered by name.
         """
         user_id = _require_user(request, auth_provider)
 
-        def _list_union() -> list[dict[str, Any]]:
+        def _list_union() -> list[SessionProjectSummary]:
             # First-class first so its id wins when a name exists in both.
-            by_name: dict[str, dict[str, Any]] = {}
+            by_name: dict[str, SessionProjectSummary] = {}
             if project_store is not None:
                 for proj in project_store.list(owner_user_id=user_id):
-                    by_name[proj.name] = {"id": proj.id, "name": proj.name}
+                    by_name[proj.name] = SessionProjectSummary(id=proj.id, name=proj.name)
             # Legacy path: label-derived projects (id=None unless already first-class).
             for name in conversation_store.list_projects(owned_by=user_id):
-                by_name.setdefault(name, {"id": None, "name": name})
+                by_name.setdefault(name, SessionProjectSummary(id=None, name=name))
             return [by_name[name] for name in sorted(by_name)]
 
         return await asyncio.to_thread(_list_union)

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -4169,6 +4169,21 @@ class ProjectList(BaseModel):
     data: list[ProjectObject]
 
 
+class SessionProjectSummary(BaseModel):
+    """One entry of ``GET /v1/sessions/projects`` — a sidebar project folder.
+
+    Dual-read union of first-class projects and legacy ``omni_project``
+    label-projects, keyed by name.
+
+    :param id: First-class project id when one exists, or ``None`` for a
+        label-only project not yet promoted to the ``projects`` table.
+    :param name: Project name (the folder's display name and union key).
+    """
+
+    id: str | None = None
+    name: str
+
+
 class CreateProjectRequest(BaseModel):
     """
     Request body for ``POST /v1/projects``.

--- a/openapi.json
+++ b/openapi.json
@@ -4409,6 +4409,33 @@
         "title": "SessionPresenceEvent",
         "type": "object"
       },
+      "SessionProjectSummary": {
+        "description": "One entry of `GET /v1/sessions/projects` \u2014 a sidebar project folder.\n\nDual-read union of first-class projects and legacy `omni_project`\nlabel-projects, keyed by name.",
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "First-class project id when one exists, or `None` for a label-only project not yet promoted to the `projects` table.",
+            "title": "Id"
+          },
+          "name": {
+            "description": "Project name (the folder's display name and union key).",
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "SessionProjectSummary",
+        "type": "object"
+      },
       "SessionReasoningEffortEvent": {
         "description": "Active reasoning-effort update from a terminal-backed integration.\n\nEmitted after an `external_reasoning_effort_change` POST from a native\nterminal forwarder when the user changes the thinking level inside the\nterminal UI. Lets the web effort picker reflect a TUI-side switch without\na reload.",
         "properties": {
@@ -8119,13 +8146,19 @@
     },
     "/v1/sessions/projects": {
       "get": {
-        "description": "Return the caller's projects as `{\"id\", \"name\"}` pairs, ordered\nalphabetically by name.\n\nDual-reads both project representations and unions them by name:\n- **First-class projects** (`project_store`) \u2014 carry an `id` and\n  appear even when empty (the whole point of the first-class entity).\n- **Legacy label-projects** (implicit `omni_project` label) \u2014 exist\n  while at least one owned session carries the label; `id` is\n  `None` until such a project is promoted to first-class.\n\nA name present in both sources collapses to one entry that keeps the\nfirst-class `id`. Filing is owner-only, so both halves are scoped to\nthe caller (label-projects to their owned sessions, first-class to\ntheir owned rows) \u2014 a project shared to them but owned by another user\ndoes not surface as one of their own folders.\n\n**Returns:** List of `{\"id\": str | None, \"name\": str}` ordered by name.",
+        "description": "Return the caller's projects as `{\"id\", \"name\"}` pairs, ordered\nalphabetically by name.\n\nDual-reads both project representations and unions them by name:\n- **First-class projects** (`project_store`) \u2014 carry an `id` and\n  appear even when empty (the whole point of the first-class entity).\n- **Legacy label-projects** (implicit `omni_project` label) \u2014 exist\n  while at least one owned session carries the label; `id` is\n  `None` until such a project is promoted to first-class.\n\nA name present in both sources collapses to one entry that keeps the\nfirst-class `id`. Filing is owner-only, so both halves are scoped to\nthe caller (label-projects to their owned sessions, first-class to\ntheir owned rows) \u2014 a project shared to them but owned by another user\ndoes not surface as one of their own folders.\n\n**Returns:** List of `SessionProjectSummary` ordered by name.",
         "operationId": "list_session_projects_v1_sessions_projects_get",
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/SessionProjectSummary"
+                  },
+                  "title": "Response List Session Projects V1 Sessions Projects Get",
+                  "type": "array"
+                }
               }
             },
             "description": "Successful Response"

--- a/openapi.json
+++ b/openapi.json
@@ -8119,7 +8119,7 @@
     },
     "/v1/sessions/projects": {
       "get": {
-        "description": "Return all project names for the authenticated user, ordered\nalphabetically.\n\nProjects are implicit: they exist while at least one session\nhas a `conversation_labels` row with `key=\"omni_project\"`.\n\n**Returns:** List of project names.",
+        "description": "Return the caller's projects as `{\"id\", \"name\"}` pairs, ordered\nalphabetically by name.\n\nDual-reads both project representations and unions them by name:\n- **First-class projects** (`project_store`) \u2014 carry an `id` and\n  appear even when empty (the whole point of the first-class entity).\n- **Legacy label-projects** (implicit `omni_project` label) \u2014 exist\n  while at least one owned session carries the label; `id` is\n  `None` until such a project is promoted to first-class.\n\nA name present in both sources collapses to one entry that keeps the\nfirst-class `id`. Filing is owner-only, so both halves are scoped to\nthe caller (label-projects to their owned sessions, first-class to\ntheir owned rows) \u2014 a project shared to them but owned by another user\ndoes not surface as one of their own folders.\n\n**Returns:** List of `{\"id\": str | None, \"name\": str}` ordered by name.",
         "operationId": "list_session_projects_v1_sessions_projects_get",
         "responses": {
           "200": {

--- a/tests/e2e_ui/sessions/test_sidebar_pinned_project_flyout.py
+++ b/tests/e2e_ui/sessions/test_sidebar_pinned_project_flyout.py
@@ -9,10 +9,11 @@ folder icon and the project name (``ConversationRow`` / ``HoverCard`` in
 Sidebar.tsx).
 
 This drives the real chain the ``Sidebar`` unit tests mock out: the live
-``PATCH /v1/sessions/{id}`` project move → the ``omni_project`` label on the
-refreshed ``GET /v1/sessions`` list → the pinned peel keeping the label →
-the hover flyout resolving the project name from it. A browser hover (which
-jsdom can't do) is what actually opens the Radix HoverCard here.
+``PATCH /v1/sessions/{id}`` project move → the ``project_id`` membership on the
+refreshed ``GET /v1/sessions`` list → the pinned peel keeping that membership →
+the hover flyout resolving the project name (``project_id`` → name via the
+project list, falling back to the legacy ``omni_project`` label). A browser
+hover (which jsdom can't do) is what actually opens the Radix HoverCard here.
 """
 
 from __future__ import annotations

--- a/tests/e2e_ui/sessions/test_sidebar_projects.py
+++ b/tests/e2e_ui/sessions/test_sidebar_projects.py
@@ -1,13 +1,14 @@
 """Browser e2e for the sidebar's session projects.
 
 Projects group conversations under named, collapsible folders inside a
-"Projects" sidebar group. Membership is stored server-side as a
-``conversation_labels`` row with the reserved key ``"omni_project"`` (no new
-table — see ``sqlalchemy_store.list_projects`` / the ``project`` filter on
-``list_conversations``). The web UI moves a session via the row kebab's
-**"Change project"** submenu (``data-testid="move-to-project"``), which calls
-``PATCH /v1/sessions/{id}`` with ``{labels:{omni_project}}`` (an empty value
-removes the label).
+"Projects" sidebar group. Membership is the first-class
+``omnigent_conversation_metadata.project_id`` (see ``projects`` table / the
+``project`` filter on ``list_conversations``, which dual-reads it alongside the
+legacy ``omni_project`` label). The web UI moves a session via the row kebab's
+submenu (``data-testid="move-to-project"``), which calls
+``PATCH /v1/sessions/{id}`` with ``{project_id}`` — resolving the picked name to
+a project id (creating the first-class row on demand for a label-only folder),
+or ``""`` to unfile.
 
 The web UI move submenu is labelled "Add to project" (unfiled) or
 "Move session" (already filed); both share ``data-testid="move-to-project"``.
@@ -105,6 +106,8 @@ def test_remove_session_from_project(
 
     Moves the row into a fresh project first, then uses the kebab's
     "Remove from <project>" item and asserts the row returns to "Sessions".
+    The folder itself stays (now a first-class project, it exists independently
+    of its members and can be empty) — only the membership is cleared.
     """
     base_url, session_id = seeded_session
     title = f"e2e-proj-rm-{uuid.uuid4().hex[:8]}"
@@ -133,10 +136,12 @@ def test_remove_session_from_project(
     project_row.get_by_test_id("conversation-actions").click()
     page.get_by_test_id("move-to-project").click()
     # The kebab item names the project it removes from ("Remove from <name>").
+    # It unfiles immediately — no confirmation, since a first-class project
+    # persists when emptied (nothing is deleted).
     page.get_by_role("menuitem", name=re.compile(rf"Remove from {re.escape(project)}")).click()
-    # Removal is confirmed (it may delete the implicit project) — accept it.
-    page.get_by_role("button", name="Remove from project", exact=True).click()
 
-    # Back under "Sessions", and the now-empty project folder is gone.
+    # Back under "Sessions". The first-class project folder persists (empty),
+    # since a first-class project exists independently of its members.
     expect(_section(page, "Sessions").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
-    expect(page.get_by_role("button", name=project, exact=True)).to_have_count(0)
+    expect(page.get_by_role("button", name=project, exact=True)).to_have_count(1)
+    expect(_section(page, project).locator(f'a[href="/c/{session_id}"]')).to_have_count(0)

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -2314,10 +2314,12 @@ async def _drive_project_prefill(base_url: str, session_id: str) -> None:
 
             async def handle_projects(route: Route) -> None:
                 # One project so exactly one folder (and pencil) renders.
+                # GET /v1/sessions/projects returns the dual-read union as
+                # {id, name} objects (id=None for a label-only project).
                 await route.fulfill(
                     status=200,
                     content_type="application/json",
-                    body=json.dumps([project]),
+                    body=json.dumps([{"id": None, "name": project}]),
                 )
 
             async def handle_worktrees(route: Route) -> None:

--- a/tests/e2e_ui/visual/test_sidebar_snapshot.py
+++ b/tests/e2e_ui/visual/test_sidebar_snapshot.py
@@ -156,7 +156,13 @@ _PROJECT_SESSIONS_BODY = {
 }
 
 # Two project folders: one expanded (seeded below), one left collapsed/empty.
-_PROJECTS_BODY = [_PROJECT_OPEN, _PROJECT_EMPTY]
+# GET /v1/sessions/projects returns the dual-read union as {id, name} objects
+# (id=None for a label-only project); "Moonshot" holds a label-filed session,
+# "Fixit" is an empty first-class project.
+_PROJECTS_BODY = [
+    {"id": None, "name": _PROJECT_OPEN},
+    {"id": "p_fixit", "name": _PROJECT_EMPTY},
+]
 
 
 @pytest.mark.visual

--- a/tests/server/routes/test_projects_crud.py
+++ b/tests/server/routes/test_projects_crud.py
@@ -151,6 +151,33 @@ async def test_delete_project(project_client: httpx.AsyncClient) -> None:
     assert second_delete.status_code == 404
 
 
+async def test_session_projects_unions_first_class_and_labels(
+    project_client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """GET /v1/sessions/projects dual-reads: first-class projects (with id,
+    even when empty) unioned with label-only projects (id=None), by name."""
+    conv_store = SqlAlchemyConversationStore(db_uri)
+
+    # An empty first-class project — invisible to the label path, must appear.
+    empty = (await project_client.post("/v1/projects", json={"name": "Empty FC"})).json()
+    # A name that exists BOTH as first-class and as a label — one entry, fc id.
+    both = (await project_client.post("/v1/projects", json={"name": "Both"})).json()
+    conv_both = conv_store.create_conversation()
+    conv_store.set_labels(conv_both.id, {"omni_project": "Both"})
+    # A label-only project — no first-class row, id=None.
+    conv_label = conv_store.create_conversation()
+    conv_store.set_labels(conv_label.id, {"omni_project": "Label Only"})
+
+    resp = await project_client.get("/v1/sessions/projects")
+    assert resp.status_code == 200
+    assert resp.json() == [
+        {"id": both["id"], "name": "Both"},
+        {"id": empty["id"], "name": "Empty FC"},
+        {"id": None, "name": "Label Only"},
+    ]
+
+
 # ── Multi-user: projects are owner-private ─────────────────────────────
 
 

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -275,7 +275,11 @@ async def test_list_projects_returns_names_sorted(
 
     resp = await client.get("/v1/sessions/projects")
     assert resp.status_code == 200
-    assert resp.json() == ["Customer X", "Sprint 42"]
+    # Label-only projects (no first-class row) list with id=None, sorted by name.
+    assert resp.json() == [
+        {"id": None, "name": "Customer X"},
+        {"id": None, "name": "Sprint 42"},
+    ]
 
 
 # ── GET /v1/sessions?project= (filter) ───────────────────────────────

--- a/tests/server/routes/test_sessions_shared_projects.py
+++ b/tests/server/routes/test_sessions_shared_projects.py
@@ -90,10 +90,11 @@ def test_shared_project_not_listed_as_recipients_own_project(db_uri: str) -> Non
     _seed_shared_project_session(db_uri)
     app = _multi_user_app(db_uri)
 
-    # Bob owns it, so it's his project.
+    # Bob owns it, so it's his project. Label-only (no first-class row here),
+    # so it lists with id=None.
     bob = TestClient(app).get("/v1/sessions/projects", headers={"X-Forwarded-Email": BOB})
     assert bob.status_code == 200
-    assert bob.json() == ["Bob Project"]
+    assert bob.json() == [{"id": None, "name": "Bob Project"}]
 
     # Alice can access the session, but doesn't own it — no folder for her.
     alice = TestClient(app).get("/v1/sessions/projects", headers={"X-Forwarded-Email": ALICE})

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -807,8 +807,11 @@ describe("useBulkStopSessions", () => {
 });
 
 describe("useProjects", () => {
-  it("GETs /v1/sessions/projects and returns the project list", async () => {
-    const projects = ["Customer X", "Sprint 42"];
+  it("GETs /v1/sessions/projects and returns the {id, name} project list", async () => {
+    const projects = [
+      { id: "p_x", name: "Customer X" },
+      { id: null, name: "Sprint 42" },
+    ];
     fetchMock.mockResolvedValueOnce(mockResponse(projects));
 
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -917,17 +920,25 @@ describe("useNewestProjectSession", () => {
 });
 
 describe("useMoveToProject", () => {
-  it("PATCHes /v1/sessions/{id} with the project label", async () => {
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({
-        id: "conv_move",
-        object: "conversation",
-        title: "t",
-        created_at: 0,
-        updated_at: 1,
-        labels: { omni_project: "Sprint 42" },
-      }),
-    );
+  it("resolves the project name to an id, then PATCHes project_id", async () => {
+    // Filing by name first lists projects to resolve the id, then PATCHes.
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({
+          object: "list",
+          data: [{ id: "p_sprint", name: "Sprint 42" }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          id: "conv_move",
+          object: "conversation",
+          title: "t",
+          created_at: 0,
+          updated_at: 1,
+          project_id: "p_sprint",
+        }),
+      );
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
@@ -936,13 +947,49 @@ describe("useMoveToProject", () => {
     result.current.mutate({ id: "conv_move", project: "Sprint 42" });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/projects");
+    const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
     expect(url).toBe("/v1/sessions/conv_move");
     expect(init.method).toBe("PATCH");
-    expect(JSON.parse(init.body as string)).toEqual({ labels: { omni_project: "Sprint 42" } });
+    expect(JSON.parse(init.body as string)).toEqual({ project_id: "p_sprint" });
   });
 
-  it("invalidates both the conversations and projects queries on success", async () => {
+  it("creates the project on demand when the name has no first-class row", async () => {
+    fetchMock
+      // No project of this name exists yet → list is empty …
+      .mockResolvedValueOnce(mockResponse({ object: "list", data: [] }))
+      // … so it's created …
+      .mockResolvedValueOnce(mockResponse({ id: "p_new", object: "project", name: "Fresh" }))
+      // … then the session is filed under the new id.
+      .mockResolvedValueOnce(
+        mockResponse({
+          id: "conv_move",
+          object: "conversation",
+          title: "t",
+          created_at: 0,
+          updated_at: 1,
+          project_id: "p_new",
+        }),
+      );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useMoveToProject(), { wrapper });
+
+    result.current.mutate({ id: "conv_move", project: "Fresh" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [createUrl, createInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(createUrl).toBe("/v1/projects");
+    expect(createInit.method).toBe("POST");
+    expect(JSON.parse(createInit.body as string)).toEqual({ name: "Fresh" });
+    const [patchUrl, patchInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    expect(patchUrl).toBe("/v1/sessions/conv_move");
+    expect(JSON.parse(patchInit.body as string)).toEqual({ project_id: "p_new" });
+  });
+
+  it("unfiles with project_id='' (no id resolution) and invalidates the lists", async () => {
+    // Unfiling clears membership directly — no project lookup needed.
     fetchMock.mockResolvedValueOnce(
       mockResponse({
         id: "conv_move",
@@ -950,7 +997,7 @@ describe("useMoveToProject", () => {
         title: "t",
         created_at: 0,
         updated_at: 1,
-        labels: {},
+        project_id: null,
       }),
     );
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -961,6 +1008,10 @@ describe("useMoveToProject", () => {
 
     result.current.mutate({ id: "conv_move", project: "" });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv_move");
+    expect(JSON.parse(init.body as string)).toEqual({ project_id: "" });
 
     // Both keys must refresh: conversations so the row re-groups into its new
     // section, projects so the sidebar list updates.
@@ -1014,8 +1065,9 @@ describe("useDeleteProject", () => {
     });
   }
 
-  it("archives every session in the project (keeping the label) and refreshes the lists", async () => {
-    // 1st call: page of project members. Then one PATCH archive per member.
+  it("archives + unfiles every member, then deletes the first-class project", async () => {
+    // 1st call: page of project members. Then one PATCH per member, then the
+    // DELETE of the first-class container.
     fetchMock
       .mockResolvedValueOnce(
         mockResponse({
@@ -1029,7 +1081,8 @@ describe("useDeleteProject", () => {
         }),
       )
       .mockResolvedValueOnce(archivedConv("conv_a"))
-      .mockResolvedValueOnce(archivedConv("conv_b"));
+      .mockResolvedValueOnce(archivedConv("conv_b"))
+      .mockResolvedValueOnce(mockResponse({ id: "p_1", object: "project.deleted", deleted: true }));
 
     const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
@@ -1037,7 +1090,7 @@ describe("useDeleteProject", () => {
       createElement(QueryClientProvider, { client: queryClient }, children);
     const { result } = renderHook(() => useDeleteProject(), { wrapper });
 
-    result.current.mutate("Sprint 42");
+    result.current.mutate({ id: "p_1", name: "Sprint 42" });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // The list fetch is filtered by project and includes archived members.
@@ -1045,9 +1098,9 @@ describe("useDeleteProject", () => {
     expect(listUrl).toContain("project=Sprint+42");
     expect(listUrl).toContain("include_archived=true");
 
-    // Each member is archived via PATCH — NOT deleted, and the project label is
-    // left intact so unarchiving restores the session to its project.
-    const patches = (fetchMock.mock.calls.slice(1) as [string, RequestInit][]).map(
+    // Each member is archived AND detached (project_id cleared + label removed)
+    // via PATCH — never deleted.
+    const patches = (fetchMock.mock.calls.slice(1, 3) as [string, RequestInit][]).map(
       ([url, init]) => ({ url, init }),
     );
     expect(patches.map((p) => p.url).sort()).toEqual([
@@ -1056,8 +1109,17 @@ describe("useDeleteProject", () => {
     ]);
     for (const { init } of patches) {
       expect(init.method).toBe("PATCH");
-      expect(JSON.parse(init.body as string)).toEqual({ archived: true });
+      expect(JSON.parse(init.body as string)).toEqual({
+        archived: true,
+        project_id: "",
+        labels: { omni_project: "" },
+      });
     }
+
+    // Finally the first-class container is removed.
+    const [delUrl, delInit] = fetchMock.mock.calls[3] as [string, RequestInit];
+    expect(delUrl).toBe("/v1/projects/p_1");
+    expect(delInit.method).toBe("DELETE");
 
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["projects"] });
@@ -1084,7 +1146,7 @@ describe("useDeleteProject", () => {
       createElement(QueryClientProvider, { client: queryClient }, children);
     const { result } = renderHook(() => useDeleteProject(), { wrapper });
 
-    result.current.mutate("Sprint 42");
+    result.current.mutate({ id: "p_1", name: "Sprint 42" });
     await waitFor(() => expect(result.current.isError).toBe(true));
 
     const err = result.current.error as unknown as {

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -951,7 +951,10 @@ describe("useMoveToProject", () => {
     const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
     expect(url).toBe("/v1/sessions/conv_move");
     expect(init.method).toBe("PATCH");
-    expect(JSON.parse(init.body as string)).toEqual({ project_id: "p_sprint" });
+    expect(JSON.parse(init.body as string)).toEqual({
+      project_id: "p_sprint",
+      labels: { omni_project: "" },
+    });
   });
 
   it("creates the project on demand when the name has no first-class row", async () => {
@@ -985,7 +988,10 @@ describe("useMoveToProject", () => {
     expect(JSON.parse(createInit.body as string)).toEqual({ name: "Fresh" });
     const [patchUrl, patchInit] = fetchMock.mock.calls[2] as [string, RequestInit];
     expect(patchUrl).toBe("/v1/sessions/conv_move");
-    expect(JSON.parse(patchInit.body as string)).toEqual({ project_id: "p_new" });
+    expect(JSON.parse(patchInit.body as string)).toEqual({
+      project_id: "p_new",
+      labels: { omni_project: "" },
+    });
   });
 
   it("unfiles with project_id='' (no id resolution) and invalidates the lists", async () => {
@@ -1011,7 +1017,10 @@ describe("useMoveToProject", () => {
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("/v1/sessions/conv_move");
-    expect(JSON.parse(init.body as string)).toEqual({ project_id: "" });
+    expect(JSON.parse(init.body as string)).toEqual({
+      project_id: "",
+      labels: { omni_project: "" },
+    });
 
     // Both keys must refresh: conversations so the row re-groups into its new
     // section, projects so the sidebar list updates.

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -842,12 +842,25 @@ export function useArchivedProjectNames() {
  * Resolve a project NAME to its first-class id, creating the `projects` row on
  * demand when only a legacy label-project of that name exists (or nothing does).
  * This is how filing/renaming a label-only folder promotes it to first-class.
+ *
+ * Create-on-demand races: two concurrent moves to the same new name can both
+ * see no existing project and both POST; the second gets a 409. Treat that as
+ * benign — re-list and return the id the winner created.
  */
 async function resolveOrCreateProjectId(name: string): Promise<string> {
   const projects = await apiListProjects();
   const existing = projects.find((p) => p.name === name);
   if (existing) return existing.id;
-  return (await apiCreateProject(name)).id;
+  try {
+    return (await apiCreateProject(name)).id;
+  } catch {
+    // Lost the create race (or a transient failure) — re-list and use the
+    // now-existing row; only rethrow if it still isn't there.
+    const after = await apiListProjects();
+    const created = after.find((p) => p.name === name);
+    if (created) return created.id;
+    throw new Error(`Could not resolve or create project "${name}"`);
+  }
 }
 
 /**
@@ -856,6 +869,12 @@ async function resolveOrCreateProjectId(name: string): Promise<string> {
  * non-empty name is resolved to its project id (creating the row on demand for
  * a label-only folder); `""` clears membership. Exported for the new-session
  * flow, which files a freshly created session under the picked project name.
+ *
+ * The legacy `omni_project` label is cleared in the same PATCH: during the
+ * dual-read transition the sidebar groups a folder by `project_id` OR that
+ * label, so leaving a stale label would keep the session in its old
+ * label-folder (and make it match two folders at once). First-class
+ * `project_id` is the single source of truth after a move.
  */
 export async function moveConversationToProject(
   id: string,
@@ -866,7 +885,8 @@ export async function moveConversationToProject(
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     // "" clears membership (unfile); a non-empty id files into that project.
-    body: JSON.stringify({ project_id: projectId }),
+    // Clear the legacy label either way so the two representations don't diverge.
+    body: JSON.stringify({ project_id: projectId, labels: { [PROJECT_LABEL_KEY]: "" } }),
   });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return (await res.json()) as Conversation;
@@ -1089,12 +1109,16 @@ export function useCreateProject() {
 }
 
 /**
- * Rename a project. First-class projects rename in O(1) via
- * `PATCH /v1/projects/{id}` (members reference the id, not the name). A
- * label-only folder (`id === null`) has no row to rename, so it is promoted to
- * first-class on demand — created under the new name — then its member
- * sessions are re-filed onto the new id and their stale `omni_project` label is
- * cleared. Members are swept via the dual-read `?project=<oldName>`.
+ * Rename a project. A first-class project renames its row via
+ * `PATCH /v1/projects/{id}`; a label-only folder (`id === null`) is promoted on
+ * demand — a row created under the new name.
+ *
+ * Either way, the folder's members are swept via the dual-read
+ * `?project=<oldName>` and re-filed onto the target `project_id` with their
+ * legacy `omni_project` label cleared. That keeps the rename coherent across
+ * both membership representations during the transition: a first-class row's
+ * members that were still matched by the legacy label don't get stranded in an
+ * `oldName` folder, and nothing ends up matching two folders at once.
  */
 export function useRenameProject() {
   const queryClient = useQueryClient();
@@ -1108,12 +1132,20 @@ export function useRenameProject() {
       oldName: string;
       newName: string;
     }) => {
+      // The target project id: rename the existing row (first-class), or
+      // create one on demand (label-only folder being promoted).
+      let projectId: string;
       if (id !== null) {
         await apiRenameProject(id, newName);
-        return;
+        projectId = id;
+      } else {
+        projectId = (await apiCreateProject(newName)).id;
       }
-      // Label-only → promote: create the row, migrate members onto it.
-      const created = await apiCreateProject(newName);
+      // Reconcile the folder's members either way. During the dual-read
+      // transition a member can still sit in the oldName folder via the legacy
+      // omni_project label; re-file each onto project_id and clear that label so
+      // the rename is coherent for both membership representations and nothing
+      // is left behind in an oldName folder.
       const memberIds = await fetchAllProjectSessionIds(oldName);
       await Promise.all(
         memberIds.map(async (sid) => {
@@ -1121,12 +1153,12 @@ export function useRenameProject() {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              project_id: created.id,
+              project_id: projectId,
               labels: { [PROJECT_LABEL_KEY]: "" },
             }),
           });
           // Surface a failed re-file: a resolved-but-4xx/5xx response would
-          // otherwise report success while leaving members unfiled.
+          // otherwise report success while leaving members behind.
           if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
         }),
       );

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -853,13 +853,16 @@ async function resolveOrCreateProjectId(name: string): Promise<string> {
   if (existing) return existing.id;
   try {
     return (await apiCreateProject(name)).id;
-  } catch {
-    // Lost the create race (or a transient failure) — re-list and use the
-    // now-existing row; only rethrow if it still isn't there.
+  } catch (err) {
+    // The create may have lost a race (a concurrent move created the same
+    // name → 409) or genuinely failed (500 / network). Distinguish the two by
+    // re-listing: if the row now exists, a racer won — use it. Otherwise the
+    // create really failed, so rethrow the ORIGINAL error rather than a generic
+    // message, so the true cause (status, network) isn't masked.
     const after = await apiListProjects();
     const created = after.find((p) => p.name === name);
     if (created) return created.id;
-    throw new Error(`Could not resolve or create project "${name}"`);
+    throw err;
   }
 }
 

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -35,6 +35,12 @@ import {
   type SessionListWireItem,
 } from "@/lib/sessionListCache";
 import { stopSession } from "@/lib/sessionsApi";
+import {
+  createProject as apiCreateProject,
+  deleteProject as apiDeleteProject,
+  listProjects as apiListProjects,
+  renameProject as apiRenameProject,
+} from "@/lib/projectsApi";
 import { useChatStore } from "@/store/chatStore";
 import type { Session } from "@/lib/types";
 import { useSessionUpdatesConnected } from "./useSessionUpdatesConnected";
@@ -160,6 +166,13 @@ export interface Conversation {
    * invalidate the parent's child-sessions cache when the child changes.
    */
   parent_session_id?: string | null;
+  /**
+   * First-class project this session is filed under (`projects.id`), or
+   * `null`/absent when unfiled. Distinct from the legacy `omni_project`
+   * label in `labels`; the sidebar groups a folder's members by EITHER this
+   * id OR the label during the dual-read transition.
+   */
+  project_id?: string | null;
 }
 
 export interface ConversationsPage {
@@ -731,14 +744,31 @@ export function usePinnedConversationBackfill(
 // without a value import cycle; re-exported here for the existing consumers.
 export { PROJECT_LABEL_KEY };
 
-/** Fetch all project names from `GET /v1/sessions/projects`. */
+/**
+ * A sidebar project folder. During the label→first-class transition a folder
+ * is keyed by `name` (the union key that merges a first-class project and a
+ * legacy label-project of the same name into one folder). `id` is the
+ * first-class project id when one exists, or `null` for a label-only project
+ * (which has no `projects` row yet). Operations that need an id
+ * (rename/delete/file) use it, promoting label-only projects on demand.
+ */
+export interface ProjectSummary {
+  id: string | null;
+  name: string;
+}
+
+/**
+ * Fetch the caller's projects from `GET /v1/sessions/projects`, which
+ * dual-reads first-class projects (with id, incl. empty ones) and legacy
+ * label-projects (id=null), unioned by name and sorted.
+ */
 export function useProjects() {
-  return useQuery<string[]>({
+  return useQuery<ProjectSummary[]>({
     queryKey: ["projects"],
     queryFn: async () => {
       const res = await authenticatedFetch("/v1/sessions/projects");
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-      return (await res.json()) as string[];
+      return (await res.json()) as ProjectSummary[];
     },
     staleTime: 30_000,
   });
@@ -808,12 +838,35 @@ export function useArchivedProjectNames() {
   });
 }
 
-async function moveConversationToProject(id: string, project: string): Promise<Conversation> {
+/**
+ * Resolve a project NAME to its first-class id, creating the `projects` row on
+ * demand when only a legacy label-project of that name exists (or nothing does).
+ * This is how filing/renaming a label-only folder promotes it to first-class.
+ */
+async function resolveOrCreateProjectId(name: string): Promise<string> {
+  const projects = await apiListProjects();
+  const existing = projects.find((p) => p.name === name);
+  if (existing) return existing.id;
+  return (await apiCreateProject(name)).id;
+}
+
+/**
+ * File a session into a project (by name) or unfile it (`project === ""`), via
+ * the first-class `project_id` membership on `PATCH /v1/sessions/{id}`. A
+ * non-empty name is resolved to its project id (creating the row on demand for
+ * a label-only folder); `""` clears membership. Exported for the new-session
+ * flow, which files a freshly created session under the picked project name.
+ */
+export async function moveConversationToProject(
+  id: string,
+  project: string,
+): Promise<Conversation> {
+  const projectId = project === "" ? "" : await resolveOrCreateProjectId(project);
   const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(id)}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
-    // Empty string signals "remove from project" (server deletes the label row).
-    body: JSON.stringify({ labels: { [PROJECT_LABEL_KEY]: project } }),
+    // "" clears membership (unfile); a non-empty id files into that project.
+    body: JSON.stringify({ project_id: projectId }),
   });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return (await res.json()) as Conversation;
@@ -956,21 +1009,36 @@ export function useNewestProjectSession(project: string | null) {
   });
 }
 
+/** Archive a session AND detach it from its project (clear project_id + the
+ * legacy omni_project label) in a single PATCH — used by "Delete project". */
+async function archiveAndUnfileConversation(id: string): Promise<Conversation> {
+  const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    // project_id="" clears first-class membership; the empty omni_project label
+    // value removes the legacy label row, so the session is fully detached.
+    body: JSON.stringify({ archived: true, project_id: "", labels: { [PROJECT_LABEL_KEY]: "" } }),
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as Conversation;
+}
+
 /**
- * Delete a whole project by ARCHIVING every session filed under it. The
- * sessions keep their `omni_project` label (so unarchiving restores them to
- * this project) and their history; they only leave the active sidebar. The
- * project is implicit and the server's project list excludes all-archived
- * projects, so the folder disappears once its last member is archived. Throws
- * `{ failed, succeeded, total }` if any session failed (e.g. a shared session
- * the user can't modify), leaving those sessions in place.
+ * Delete a project: archive AND unfile every member session, then delete the
+ * first-class `projects` row (when the folder has one). Sessions are never
+ * deleted — they are detached (project_id + omni_project label cleared) and
+ * archived, so they leave the sidebar but keep their history. Accepts the
+ * folder's `{ id, name }`: `name` drives the member sweep (dual-read
+ * `?project=`), `id` deletes the container (skipped for a label-only folder,
+ * which has none). Throws `{ failed, succeeded, total }` if any member failed
+ * (e.g. a shared session the user can't modify), leaving those in place.
  */
 export function useDeleteProject() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (project: string) => {
-      const ids = await fetchAllProjectSessionIds(project);
-      const results = await Promise.allSettled(ids.map((id) => archiveConversation(id, true)));
+    mutationFn: async ({ id, name }: ProjectSummary) => {
+      const ids = await fetchAllProjectSessionIds(name);
+      const results = await Promise.allSettled(ids.map((sid) => archiveAndUnfileConversation(sid)));
       const succeeded: string[] = [];
       const failed: string[] = [];
       for (let i = 0; i < results.length; i++) {
@@ -985,6 +1053,10 @@ export function useDeleteProject() {
         }
       }
       if (failed.length > 0) throw { failed, succeeded, total: ids.length };
+      // All members detached — remove the first-class container if present.
+      // (A label-only folder has no row; clearing the labels above already
+      // makes it vanish from the project list.)
+      if (id !== null) await apiDeleteProject(id);
       return { succeeded, failed };
     },
     onSettled: () => {
@@ -995,6 +1067,72 @@ export function useDeleteProject() {
       void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
       void queryClient.invalidateQueries({ queryKey: ["project-newest-session"] });
       // Deleting a project archives its members, growing the archived set.
+      void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });
+    },
+  });
+}
+
+/**
+ * Create an empty first-class project (`POST /v1/projects`). This is the
+ * capability the label model can't express — a project with no members. The
+ * server rejects a duplicate name (409); the error message is surfaced to the
+ * caller for inline display.
+ */
+export function useCreateProject() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) => apiCreateProject(name),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+}
+
+/**
+ * Rename a project. First-class projects rename in O(1) via
+ * `PATCH /v1/projects/{id}` (members reference the id, not the name). A
+ * label-only folder (`id === null`) has no row to rename, so it is promoted to
+ * first-class on demand — created under the new name — then its member
+ * sessions are re-filed onto the new id and their stale `omni_project` label is
+ * cleared. Members are swept via the dual-read `?project=<oldName>`.
+ */
+export function useRenameProject() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      oldName,
+      newName,
+    }: {
+      id: string | null;
+      oldName: string;
+      newName: string;
+    }) => {
+      if (id !== null) {
+        await apiRenameProject(id, newName);
+        return;
+      }
+      // Label-only → promote: create the row, migrate members onto it.
+      const created = await apiCreateProject(newName);
+      const memberIds = await fetchAllProjectSessionIds(oldName);
+      await Promise.all(
+        memberIds.map((sid) =>
+          authenticatedFetch(`/v1/sessions/${encodeURIComponent(sid)}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              project_id: created.id,
+              labels: { [PROJECT_LABEL_KEY]: "" },
+            }),
+          }),
+        ),
+      );
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      void queryClient.invalidateQueries({ queryKey: ["projects"] });
+      void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
+      void queryClient.invalidateQueries({ queryKey: ["project-newest-session"] });
       void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });
     },
   });

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -1116,16 +1116,19 @@ export function useRenameProject() {
       const created = await apiCreateProject(newName);
       const memberIds = await fetchAllProjectSessionIds(oldName);
       await Promise.all(
-        memberIds.map((sid) =>
-          authenticatedFetch(`/v1/sessions/${encodeURIComponent(sid)}`, {
+        memberIds.map(async (sid) => {
+          const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sid)}`, {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
               project_id: created.id,
               labels: { [PROJECT_LABEL_KEY]: "" },
             }),
-          }),
-        ),
+          });
+          // Surface a failed re-file: a resolved-but-4xx/5xx response would
+          // otherwise report success while leaving members unfiled.
+          if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+        }),
       );
     },
     onSuccess: () => {

--- a/web/src/lib/projectsApi.test.ts
+++ b/web/src/lib/projectsApi.test.ts
@@ -1,0 +1,88 @@
+// Unit tests for `projectsApi.ts` — the `/v1/projects` first-class CRUD
+// client. Happy-path requests with a mocked `fetch`, plus error-path coverage
+// that surfaces the server's structured `{error: {message}}` shape.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProject, deleteProject, listProjects, renameProject } from "./projectsApi";
+
+function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: "OK",
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("listProjects", () => {
+  it("GETs /v1/projects and returns the data array", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ object: "list", data: [{ id: "p_1", name: "A" }] }),
+    );
+    const result = await listProjects();
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/projects");
+    expect(result).toEqual([{ id: "p_1", name: "A" }]);
+  });
+});
+
+describe("createProject", () => {
+  it("POSTs the name and returns the project", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ id: "p_1", name: "New" }));
+    const result = await createProject("New");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/projects");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ name: "New" });
+    expect(result.id).toBe("p_1");
+  });
+
+  it("surfaces the server error message on a duplicate name (409)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse(
+        { error: { message: "A project named 'New' already exists" } },
+        {
+          ok: false,
+          status: 409,
+        },
+      ),
+    );
+    await expect(createProject("New")).rejects.toThrow("already exists");
+  });
+});
+
+describe("renameProject", () => {
+  it("PATCHes /v1/projects/{id} with the new name (url-encoded id)", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ id: "p a", name: "Renamed" }));
+    await renameProject("p a", "Renamed");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/projects/p%20a");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({ name: "Renamed" });
+  });
+});
+
+describe("deleteProject", () => {
+  it("DELETEs /v1/projects/{id}", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ deleted: true }));
+    await deleteProject("p_1");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/projects/p_1");
+    expect(init.method).toBe("DELETE");
+  });
+
+  it("throws on non-2xx", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 404 }));
+    await expect(deleteProject("missing")).rejects.toThrow();
+  });
+});

--- a/web/src/lib/projectsApi.ts
+++ b/web/src/lib/projectsApi.ts
@@ -1,0 +1,83 @@
+// Typed client for the `/v1/projects` first-class projects CRUD
+// (`omnigent/server/routes/projects.py`). Projects are owner-private
+// containers that group sessions and exist independently of their members —
+// so they can be empty, renamed, and deleted without touching sessions.
+//
+// Session→project membership lives on the session, not here: file/unfile a
+// session with `PATCH /v1/sessions/{id}` `{ project_id }` (see sessionsApi).
+//
+// All requests go through the existing Vite `/v1` proxy. TS surface is
+// camelCase-friendly, but the project shape is already flat snake_case-free
+// (`id`, `name`), so no boundary conversion is needed.
+
+import { authenticatedFetch } from "./identity";
+
+/** A first-class project. Mirrors the `ProjectObject` response shape. */
+export interface Project {
+  id: string;
+  name: string;
+  /** Owner user id; `null` in single-user / OSS mode. */
+  owner_user_id?: string | null;
+  created_at?: number;
+  updated_at?: number | null;
+}
+
+interface ProjectListResponse {
+  object: "list";
+  data: Project[];
+}
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: { message?: string }; message?: string };
+    return body.error?.message ?? body.message ?? `${res.status} ${res.statusText}`;
+  } catch {
+    return `${res.status} ${res.statusText}`;
+  }
+}
+
+/** List the caller's projects (owner-scoped), oldest first. */
+export async function listProjects(): Promise<Project[]> {
+  const res = await authenticatedFetch("/v1/projects");
+  if (!res.ok) throw new Error(await readError(res));
+  const body = (await res.json()) as ProjectListResponse;
+  return body.data;
+}
+
+/**
+ * Create an empty project. Rejects with the server's message on a duplicate
+ * name (409) so callers can surface it inline.
+ */
+export async function createProject(name: string): Promise<Project> {
+  const res = await authenticatedFetch("/v1/projects", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) throw new Error(await readError(res));
+  return (await res.json()) as Project;
+}
+
+/** Rename a project (O(1) — members reference the id, not the name string). */
+export async function renameProject(id: string, name: string): Promise<Project> {
+  const res = await authenticatedFetch(`/v1/projects/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) throw new Error(await readError(res));
+  return (await res.json()) as Project;
+}
+
+/**
+ * Delete a project. Only the container is removed; member sessions are kept
+ * (never cascade-deleted). Their `project_id` is left dangling server-side, but
+ * the dual-read listing joins against the (now-absent) project, so they surface
+ * as unfiled. Returns 404 if not found / not owned.
+ */
+export async function deleteProject(id: string): Promise<void> {
+  const res = await authenticatedFetch(`/v1/projects/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) throw new Error(await readError(res));
+}

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1751,11 +1751,14 @@ describe("NewChatLandingScreen", () => {
   });
 
   it("files a pre-filled project chip's selection, and invalidates project sessions", async () => {
-    // Both the create POST and the follow-up label PATCH read .ok / .json.
-    authenticatedFetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({ id: "conv_new" }),
-    } as unknown as Response);
+    // Sequence: create POST → list projects (resolve name→id) → PATCH project_id.
+    authenticatedFetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "conv_new" }) } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ object: "list", data: [{ id: "p_docs", name: "docs" }] }),
+      } as Response)
+      .mockResolvedValue({ ok: true, json: async () => ({ id: "conv_new" }) } as Response);
     const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
     // The chip only renders when a project is pre-selected (e.g. via the
     // sidebar's per-project pencil), so land with `?project=`.
@@ -1770,18 +1773,18 @@ describe("NewChatLandingScreen", () => {
     });
     fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
 
-    // Create POST first, then a PATCH that sets the omni_project label on the
-    // freshly-created session id.
-    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(2));
-    const [createUrl] = authenticatedFetchMock.mock.calls[0];
-    expect(createUrl).toBe("/v1/sessions");
-    const [patchUrl, patchInit] = authenticatedFetchMock.mock.calls[1];
+    // Create POST, then the name→id resolution, then a PATCH that files the
+    // freshly-created session via first-class project_id.
+    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(3));
+    expect(authenticatedFetchMock.mock.calls[0][0]).toBe("/v1/sessions");
+    expect(authenticatedFetchMock.mock.calls[1][0]).toBe("/v1/projects");
+    const [patchUrl, patchInit] = authenticatedFetchMock.mock.calls[2];
     expect(patchUrl).toBe("/v1/sessions/conv_new");
     expect((patchInit as RequestInit).method).toBe("PATCH");
     const patchBody = JSON.parse((patchInit as RequestInit).body as string) as {
-      labels: Record<string, string>;
+      project_id: string;
     };
-    expect(patchBody.labels).toEqual({ omni_project: "docs" });
+    expect(patchBody.project_id).toBe("p_docs");
 
     // The target folder fetches its own paginated list (useProjectSessions),
     // so filing the new session must invalidate it — otherwise the row only
@@ -1811,10 +1814,13 @@ describe("NewChatLandingScreen", () => {
   it("pre-fills the project chip from the ?project= query param", async () => {
     // The sidebar's per-project "new session" pencil lands here with the
     // project pre-selected — the chip reflects it with no interaction.
-    authenticatedFetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({ id: "conv_new" }),
-    } as unknown as Response);
+    authenticatedFetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "conv_new" }) } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ object: "list", data: [{ id: "p_sprint", name: "Sprint 42" }] }),
+      } as Response)
+      .mockResolvedValue({ ok: true, json: async () => ({ id: "conv_new" }) } as Response);
     renderLanding({}, "/?project=Sprint%2042");
 
     await waitFor(() =>
@@ -1829,13 +1835,13 @@ describe("NewChatLandingScreen", () => {
     });
     fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
 
-    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(2));
-    const [patchUrl, patchInit] = authenticatedFetchMock.mock.calls[1];
+    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(3));
+    const [patchUrl, patchInit] = authenticatedFetchMock.mock.calls[2];
     expect(patchUrl).toBe("/v1/sessions/conv_new");
     const patchBody = JSON.parse((patchInit as RequestInit).body as string) as {
-      labels: Record<string, string>;
+      project_id: string;
     };
-    expect(patchBody.labels).toEqual({ omni_project: "Sprint 42" });
+    expect(patchBody.project_id).toBe("p_sprint");
   });
 
   it.each([

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -138,7 +138,11 @@ import { useHostWorktrees } from "@/hooks/useHostWorktrees";
 import { useNativeServerSwitcherForMainSurface } from "@/hooks/useNativeServerSwitcher";
 import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
 import type { Conversation } from "@/hooks/useConversations";
-import { useNewestProjectSession, useProjects, PROJECT_LABEL_KEY } from "@/hooks/useConversations";
+import {
+  useNewestProjectSession,
+  useProjects,
+  moveConversationToProject,
+} from "@/hooks/useConversations";
 import { FileMentionMenu } from "@/components/FileMentionMenu";
 import { useMentionBrowser } from "@/hooks/useMentionBrowser";
 import {
@@ -814,7 +818,7 @@ function LandingProjectPicker({
   }, [creatingNew]);
 
   const filtered = search
-    ? projects.filter((name) => name.toLowerCase().includes(search.toLowerCase()))
+    ? projects.filter((p) => p.name.toLowerCase().includes(search.toLowerCase()))
     : projects;
 
   function pick(project: string) {
@@ -874,10 +878,10 @@ function LandingProjectPicker({
             <span className="flex-1 truncate">No project</span>
             {value === "" && <CheckIcon className="size-3.5 shrink-0 text-primary" />}
           </button>
-          {filtered.map((name) => (
-            <button key={name} type="button" className={itemClass} onClick={() => pick(name)}>
-              <span className="flex-1 truncate">{name}</span>
-              {value === name && <CheckIcon className="size-3.5 shrink-0 text-primary" />}
+          {filtered.map((p) => (
+            <button key={p.name} type="button" className={itemClass} onClick={() => pick(p.name)}>
+              <span className="flex-1 truncate">{p.name}</span>
+              {value === p.name && <CheckIcon className="size-3.5 shrink-0 text-primary" />}
             </button>
           ))}
           {filtered.length === 0 && !creatingNew && (
@@ -3069,17 +3073,15 @@ export function NewChatLandingScreen() {
         }
         data = (await res.json()) as { id: string };
       }
-      // File the new session under the chosen project (an implicit collection
-      // stored as a conversation_labels row). Awaited so the conversations
-      // refetch below already sees the label; non-fatal if it fails — the
-      // session is created either way, just unfiled.
+      // File the new session under the chosen project (first-class membership).
+      // Awaited so the conversations refetch below already reflects it;
+      // non-fatal if it fails — the session is created either way, just unfiled.
       if (selectedProject) {
         try {
-          await authenticatedFetch(`/v1/sessions/${data.id}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ labels: { [PROJECT_LABEL_KEY]: selectedProject } }),
-          });
+          // File via first-class project_id; the helper resolves the picked
+          // name to a project id, creating an empty project on demand when the
+          // name is new or label-only.
+          await moveConversationToProject(data.id, selectedProject);
           void queryClient.invalidateQueries({ queryKey: ["projects"] });
           // Refetch the target project folder's own paginated list so the new
           // session shows up immediately (the folder fetches via

--- a/web/src/shell/NewProjectButton.tsx
+++ b/web/src/shell/NewProjectButton.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { PlusIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useCreateProject } from "@/hooks/useConversations";
+
+/**
+ * "New project" control in the Projects group header. Opens a dialog that
+ * creates an EMPTY first-class project (`POST /v1/projects`) — the capability
+ * the legacy label model can't express. On success the new folder is expanded
+ * (via `onCreated`) so the user can immediately file sessions into it.
+ */
+export function NewProjectButton({ onCreated }: { onCreated: (name: string) => void }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const createProject = useCreateProject();
+
+  const submit = () => {
+    const trimmed = name.trim();
+    if (trimmed === "") return;
+    createProject.mutate(trimmed, {
+      onSuccess: (project) => {
+        setOpen(false);
+        setName("");
+        onCreated(project.name);
+      },
+    });
+  };
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="New project"
+            data-testid="new-project"
+            onClick={(e) => {
+              e.stopPropagation();
+              setName("");
+              setOpen(true);
+            }}
+          >
+            <PlusIcon className="size-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">New project</TooltipContent>
+      </Tooltip>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent onClick={(e) => e.stopPropagation()}>
+          <DialogHeader>
+            <DialogTitle>New project</DialogTitle>
+            <DialogDescription>
+              Create an empty project, then file sessions into it from a session's menu.
+            </DialogDescription>
+          </DialogHeader>
+          <input
+            autoFocus
+            className="w-full rounded-md border bg-transparent px-3 py-2 text-sm outline-none"
+            placeholder="Project name…"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                submit();
+              }
+            }}
+          />
+          {createProject.isError && (
+            <p className="text-sm text-destructive" role="alert">
+              {(createProject.error as Error).message}
+            </p>
+          )}
+          <DialogFooter className="border-t-0 bg-transparent">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setOpen(false)}
+              disabled={createProject.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              data-testid="new-project-confirm"
+              disabled={createProject.isPending || name.trim() === ""}
+              onClick={submit}
+            >
+              {createProject.isPending ? "Creating…" : "Create"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/shell/Sidebar.archive.test.tsx
+++ b/web/src/shell/Sidebar.archive.test.tsx
@@ -42,6 +42,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useProjects: () => ({ data: [] }),
   useMoveToProject: () => ({ mutate: vi.fn() }),
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.bulkActionLayout.test.tsx
+++ b/web/src/shell/Sidebar.bulkActionLayout.test.tsx
@@ -48,6 +48,8 @@ vi.mock("@/hooks/useConversations", () => ({
   }),
   useMoveToProject: () => ({ mutate: vi.fn() }),
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.delete.test.tsx
+++ b/web/src/shell/Sidebar.delete.test.tsx
@@ -40,6 +40,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useProjects: () => ({ data: [] }),
   useMoveToProject: () => ({ mutate: vi.fn() }),
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.pinnedAutoExpand.test.tsx
+++ b/web/src/shell/Sidebar.pinnedAutoExpand.test.tsx
@@ -26,10 +26,12 @@ vi.mock("@/hooks/useConversations", () => ({
   usePinnedConversationBackfill: () => [],
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useStopSession: () => ({ mutate: vi.fn() }),
-  useProjects: () => ({ data: ["Repro 2506"] }),
+  useProjects: () => ({ data: [{ id: "p_repro", name: "Repro 2506" }] }),
   useProjectSessions: vi.fn(),
   useMoveToProject: () => ({ mutate: vi.fn() }),
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.projectHeaderChevron.test.tsx
+++ b/web/src/shell/Sidebar.projectHeaderChevron.test.tsx
@@ -36,7 +36,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useStopSession: () => ({ mutate: vi.fn() }),
   // One project so a folder header renders. Empty projects are not filtered
   // out, so no conversations are needed to exercise the header layout.
-  useProjects: () => ({ data: ["My Project"] }),
+  useProjects: () => ({ data: [{ id: "p_my", name: "My Project" }] }),
   useProjectSessions: () => ({
     data: undefined,
     isLoading: false,
@@ -46,6 +46,8 @@ vi.mock("@/hooks/useConversations", () => ({
   }),
   useMoveToProject: () => ({ mutate: vi.fn() }),
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -52,7 +52,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
-  useProjects: () => ({ data: mocks.projects }),
+  useProjects: () => ({ data: mocks.projects.map((name: string) => ({ id: `p_${name}`, name })) }),
   // A non-empty `useProjects` renders a project folder, which queries its
   // sessions — return the collapsed (disabled) shape so the folder is inert
   // (this suite keeps its test row unfiled; the picker only needs the name).
@@ -67,6 +67,8 @@ vi.mock("@/hooks/useConversations", () => ({
   }),
   useMoveToProject: () => mocks.moveToProject,
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -62,7 +62,7 @@ vi.mock("@/hooks/useConversations", () => ({
   usePinnedConversationBackfill: () => [],
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useStopSession: () => ({ mutate: vi.fn() }),
-  useProjects: () => ({ data: projectsMock }),
+  useProjects: () => ({ data: projectsMock.map((name: string) => ({ id: `p_${name}`, name })) }),
   useProjectSessions: (project: string, enabled: boolean) => {
     const override = projectSessionsMock.current[project];
     const rows = !enabled
@@ -88,6 +88,8 @@ vi.mock("@/hooks/useConversations", () => ({
   },
   useMoveToProject: () => ({ mutate: vi.fn() }),
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: vi.fn(() => Promise.resolve([] as string[])),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.stop.test.tsx
+++ b/web/src/shell/Sidebar.stop.test.tsx
@@ -39,6 +39,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useProjects: () => ({ data: [] }),
   useMoveToProject: () => ({ mutate: vi.fn() }),
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.subagentHighlight.test.tsx
+++ b/web/src/shell/Sidebar.subagentHighlight.test.tsx
@@ -37,6 +37,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useProjectSessions: () => ({ data: undefined, isLoading: false, isError: false, error: null }),
   useMoveToProject: () => ({ mutate: vi.fn() }),
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -30,8 +30,9 @@ const {
   deleteProjectSpy: vi.fn(),
   renameProjectSpy: vi.fn(),
   createProjectSpy: vi.fn(),
-  // Server-side "ids in this project" check that gates the remove
-  // confirmation. Defaults to "no other sessions"; tests override per case.
+  // Stub for the exported fetchProjectSessionIds helper (kept so the module
+  // mock stays complete). Remove-from-project no longer gates on a
+  // last-session check, so nothing in these tests depends on its value.
   fetchProjectSessionIdsMock: vi.fn(() => Promise.resolve([] as string[])),
   // Latest conversations handed to the global-list mock. The useProjectSessions
   // mock derives each folder's rows from this by label, mirroring the server's

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -19,6 +19,8 @@ const {
   projectsMock,
   moveToProjectSpy,
   deleteProjectSpy,
+  renameProjectSpy,
+  createProjectSpy,
   fetchProjectSessionIdsMock,
   conversationsRef,
   projectSessionsMock,
@@ -26,6 +28,8 @@ const {
   projectsMock: [] as string[],
   moveToProjectSpy: vi.fn(),
   deleteProjectSpy: vi.fn(),
+  renameProjectSpy: vi.fn(),
+  createProjectSpy: vi.fn(),
   // Server-side "ids in this project" check that gates the remove
   // confirmation. Defaults to "no other sessions"; tests override per case.
   fetchProjectSessionIdsMock: vi.fn(() => Promise.resolve([] as string[])),
@@ -56,7 +60,11 @@ vi.mock("@/hooks/useConversations", () => ({
   // Project feature: the sidebar reads the project list to build project
   // sections, and rows fire useMoveToProject from the kebab menu. Both must
   // be stubbed or the Sidebar throws on render.
-  useProjects: () => ({ data: projectsMock }),
+  // Tests push project NAMES into projectsMock; expose them as first-class
+  // {id, name} folders (synthetic id per name) to match useProjects' shape.
+  useProjects: () => ({
+    data: projectsMock.map((name: string) => ({ id: `p_${name}`, name })),
+  }),
   // Each project folder fetches its own sessions (server-side ?project=). Derive
   // them from the global-list fixture by label so existing tests keep seeding
   // project sessions there. Single page, no pagination, in this mock.
@@ -85,6 +93,8 @@ vi.mock("@/hooks/useConversations", () => ({
   },
   useMoveToProject: () => ({ mutate: moveToProjectSpy }),
   useDeleteProject: () => ({ mutate: deleteProjectSpy, isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: renameProjectSpy, isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: createProjectSpy, isPending: false, isError: false }),
   fetchProjectSessionIds: fetchProjectSessionIdsMock,
   PROJECT_LABEL_KEY: "omni_project",
 }));
@@ -918,10 +928,13 @@ describe("Sidebar project sections", () => {
     fireEvent.click(await screen.findByTestId("delete-project"));
 
     // The confirmation makes clear it removes every session, then fires the
-    // delete with the project name.
+    // delete with the folder's { id, name }.
     expect(screen.getByText(/all of its sessions/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Delete project" }));
-    expect(deleteProjectSpy).toHaveBeenCalledWith("Customer X", expect.anything());
+    expect(deleteProjectSpy).toHaveBeenCalledWith(
+      { id: "p_Customer X", name: "Customer X" },
+      expect.anything(),
+    );
   });
 });
 
@@ -1085,16 +1098,17 @@ describe("Sidebar move-to-project action", () => {
     expect(moveToProjectSpy).toHaveBeenCalledWith({ id: "conv_move", project: "Sprint 42" });
   });
 
-  it("confirms removal only when it's the project's last session", async () => {
+  it("removes a session from its project immediately, with no confirmation", async () => {
+    // A first-class project persists when emptied, so removing a session never
+    // deletes anything — it just unfiles, even if it's the last member. No
+    // last-session check, no confirmation dialog.
     projectsMock.push("Sprint 42");
     mockConversations([
       conv("conv_filed", "Claude Code", { labels: { omni_project: "Sprint 42" } }),
     ]);
-    // Server reports this is the only session in the project.
-    fetchProjectSessionIdsMock.mockResolvedValue(["conv_filed"]);
     renderSidebar();
 
-    // Expand the project folder, open the filed row's kebab → Change project.
+    // Expand the project folder, open the filed row's kebab → project submenu.
     fireEvent.click(screen.getByRole("button", { name: "Sprint 42" }));
     const row = screen.getByRole("link", { name: /conv_filed/ }).closest("li")!;
     fireEvent.pointerDown(within(row).getByRole("button", { name: "Conversation actions" }), {
@@ -1103,40 +1117,8 @@ describe("Sidebar move-to-project action", () => {
     });
     fireEvent.click(await screen.findByTestId("move-to-project"));
 
-    // Last session → "Remove from <project>" opens a confirmation that says the
-    // project will be removed too; it does NOT remove immediately.
+    // "Remove from <project>" unfiles immediately (project: "") — no dialog.
     fireEvent.click(await screen.findByRole("menuitem", { name: /Remove from Sprint 42/ }));
-    expect(await screen.findByText(/the project will be removed as well/i)).toBeInTheDocument();
-    expect(moveToProjectSpy).not.toHaveBeenCalled();
-
-    // Confirming fires the removal with an empty project (server deletes the
-    // label; the implicit project vanishes with its last session).
-    fireEvent.click(screen.getByRole("button", { name: "Remove from project" }));
-    expect(moveToProjectSpy).toHaveBeenCalledWith(
-      { id: "conv_filed", project: "" },
-      expect.anything(),
-    );
-  });
-
-  it("removes without confirmation when other sessions remain in the project", async () => {
-    projectsMock.push("Sprint 42");
-    mockConversations([
-      conv("conv_filed", "Claude Code", { labels: { omni_project: "Sprint 42" } }),
-    ]);
-    // Server reports another session is still in the project.
-    fetchProjectSessionIdsMock.mockResolvedValue(["conv_filed", "conv_other"]);
-    renderSidebar();
-
-    fireEvent.click(screen.getByRole("button", { name: "Sprint 42" }));
-    const row = screen.getByRole("link", { name: /conv_filed/ }).closest("li")!;
-    fireEvent.pointerDown(within(row).getByRole("button", { name: "Conversation actions" }), {
-      button: 0,
-      ctrlKey: false,
-    });
-    fireEvent.click(await screen.findByTestId("move-to-project"));
-    fireEvent.click(await screen.findByRole("menuitem", { name: /Remove from Sprint 42/ }));
-
-    // Not the last session → removes straight away, no confirmation dialog.
     await waitFor(() =>
       expect(moveToProjectSpy).toHaveBeenCalledWith({ id: "conv_filed", project: "" }),
     );

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -5,7 +5,9 @@ import {
   type MouseEvent,
   type ReactNode,
   type RefObject,
+  createContext,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -169,6 +171,12 @@ const TIME_MARKER_SLOT_CLASS =
 // gentler gray in light mode (a gentler glow in dark mode) and reads as "active
 // area" without the heavy fill. Pair with `transition-colors` so it eases in.
 const DROP_TARGET_HIGHLIGHT = "bg-primary/5";
+
+// Maps a first-class project id → its name, provided once at the list level so
+// each row resolves its ``project_id`` to a folder name without its own
+// ``useProjects()`` subscription. Keeps row renders O(1) and avoids spinning up
+// a query observer per row (which would also re-run on every project mutation).
+const ProjectNamesContext = createContext<Map<string, string>>(new Map());
 
 /**
  * Which session tab the sidebar is showing. ``"mine"`` is the viewer's own
@@ -990,6 +998,16 @@ function ConversationList({
   // and/or the legacy omni_project label, unioned server-side.
   const { data: projects = [] } = useProjects();
 
+  // id → name for the rows' project_id lookup, built once here and shared via
+  // context so a row doesn't subscribe to useProjects() itself.
+  const projectNamesById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of projects) {
+      if (p.id !== null) map.set(p.id, p.name);
+    }
+    return map;
+  }, [projects]);
+
   // Each ProjectFolder registers its actually-rendered conversation IDs here
   // (synchronously during render) so shift-select ranges use the real rendered
   // order, not the global paginated list which can diverge.
@@ -1415,217 +1433,219 @@ function ConversationList({
   // alone (Linear-style) — no icons or counts in the headers, no divider
   // rules between groups.
   return (
-    <DndContext
-      sensors={sensors}
-      collisionDetection={pointerWithin}
-      // Always-measure so the transient "remove from project" zone (mounted at
-      // drag start) is registered as a drop target without a stale layout cache.
-      measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-      onDragCancel={() => setActiveDrag(null)}
-    >
-      <div className="flex flex-col gap-3">
-        {/* Removing a filed session from its project means dropping it back
+    <ProjectNamesContext.Provider value={projectNamesById}>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={pointerWithin}
+        // Always-measure so the transient "remove from project" zone (mounted at
+        // drag start) is registered as a drop target without a stale layout cache.
+        measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={() => setActiveDrag(null)}
+      >
+        <div className="flex flex-col gap-3">
+          {/* Removing a filed session from its project means dropping it back
             onto the flat "Chats" list — so the Chats section itself is the
             ungroup target (wrapped below). This top strip is only a FALLBACK
             for when there are no ungrouped chats yet, so the Chats section
             isn't rendered and there'd otherwise be nowhere to drop. */}
-        {!showShared && activeDrag?.project != null && sections.sessions.length === 0 && (
-          <UngroupDropZone />
-        )}
-        {totalVisible === 0 ? (
-          <>
-            <p className="px-2 py-1 text-muted-foreground text-xs">{emptyMessage}</p>
-            {/* The list is one paginated stream ordered by updated_at across
+          {!showShared && activeDrag?.project != null && sections.sessions.length === 0 && (
+            <UngroupDropZone />
+          )}
+          {totalVisible === 0 ? (
+            <>
+              <p className="px-2 py-1 text-muted-foreground text-xs">{emptyMessage}</p>
+              {/* The list is one paginated stream ordered by updated_at across
               owned + shared sessions, so the current tab can be empty on the
               loaded window while its sessions live on a later page. Keep the
               sentinel mounted so pagination continues instead of stranding the
               user on a false "empty" state. */}
-            {hasMorePages && (
-              <InfiniteScrollSentinel
-                hasMore={hasMorePages}
-                isFetching={isFetchingNextPage}
-                fetchMore={fetchNextPage}
-                scrollRoot={scrollContainerRef}
-              />
-            )}
-          </>
-        ) : (
-          <>
-            {sections.pinned.length > 0 && (
-              // Drop a session here to pin it — pin-precedence then floats it
-              // out of any project into this section. Active only while dragging
-              // an unpinned session; outline-only highlight.
-              <PinDropZone active={activeDrag != null && !activeDrag.isPinned}>
-                <ConversationSection
-                  title="Pinned"
-                  conversations={sections.pinned}
-                  pinnedConversationIds={pinnedConversationIds}
-                  collapsed={effectiveCollapsedSections.includes("Pinned")}
-                  onToggleCollapsed={() => effectiveToggleSectionCollapsed("Pinned")}
-                  onRowClick={onRowClick}
-                  onTogglePinned={onTogglePinned}
-                  selectionMode={selectionMode}
-                  selectedIds={selectedIds}
-                  onToggleSelected={onToggleSelected}
-                  onProjectAssigned={expandProject}
+              {hasMorePages && (
+                <InfiniteScrollSentinel
+                  hasMore={hasMorePages}
+                  isFetching={isFetchingNextPage}
+                  fetchMore={fetchNextPage}
+                  scrollRoot={scrollContainerRef}
                 />
-              </PinDropZone>
-            )}
-            {/* Projects: a "Projects" group header, with each project rendered as
-              a collapsible folder row nested beneath it. Folders default
-              collapsed; an empty folder shows "No sessions". The folder icon marks
-              a project row; the group/section headers carry no icon or count.
-              Shown on the "mine" tab even with zero projects, so "New project"
-              (create-empty) is discoverable — projects are a My-sessions tool. */}
-            {activeTab !== "shared" && (
-              <SectionGroup
-                title="Projects"
-                collapsed={effectiveCollapsedSections.includes("Projects")}
-                onToggleCollapsed={() => effectiveToggleSectionCollapsed("Projects")}
-                headerAction={(() => {
-                  const allNames = sections.projectGroups.map((g) => g.name);
-                  // "New project" is always available (even when collapsed) so
-                  // the create-empty flow is reachable; the expand/revert control
-                  // is only meaningful when there are folders and the group is open.
-                  const showExpandControls =
-                    !effectiveCollapsedSections.includes("Projects") && allNames.length > 0;
-                  // Once every folder is open the only useful move is to undo it,
-                  // so the control flips to "revert" — which restores the set open
-                  // before "Expand all", or collapses everything when there's no
-                  // real last state (folders opened by hand). Otherwise it expands.
-                  const allExpanded =
-                    allNames.length > 0 && allNames.every((n) => expandedProjects.includes(n));
-                  return (
-                    <div className="flex items-center">
-                      {showExpandControls &&
-                        (allExpanded ? (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon-sm"
-                                aria-label="Collapse to previous"
-                                data-testid="revert-projects"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  revertProjects();
-                                }}
-                              >
-                                <Minimize2Icon className="size-3.5" />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom">Collapse to previous</TooltipContent>
-                          </Tooltip>
-                        ) : (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon-sm"
-                                aria-label="Expand all"
-                                data-testid="expand-all-projects"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  expandAllProjects(allNames);
-                                }}
-                              >
-                                <Maximize2Icon className="size-3.5" />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom">Expand all</TooltipContent>
-                          </Tooltip>
-                        ))}
-                      <NewProjectButton onCreated={expandProject} />
-                    </div>
-                  );
-                })()}
-              >
-                {sections.projectGroups.map((group) => (
-                  <ProjectFolder
-                    key={group.name}
-                    name={group.name}
-                    projectId={group.id}
-                    expanded={expandedProjects.includes(group.name)}
-                    // Best-effort marker from the globally-loaded window: a
-                    // collapsed folder hasn't fetched its own sessions yet.
-                    marker={projectMarkerState(group.conversations)}
-                    onToggleCollapsed={() => toggleProjectExpanded(group.name)}
+              )}
+            </>
+          ) : (
+            <>
+              {sections.pinned.length > 0 && (
+                // Drop a session here to pin it — pin-precedence then floats it
+                // out of any project into this section. Active only while dragging
+                // an unpinned session; outline-only highlight.
+                <PinDropZone active={activeDrag != null && !activeDrag.isPinned}>
+                  <ConversationSection
+                    title="Pinned"
+                    conversations={sections.pinned}
                     pinnedConversationIds={pinnedConversationIds}
-                    activeOverride={activeOverride}
-                    scrollRoot={scrollContainerRef}
+                    collapsed={effectiveCollapsedSections.includes("Pinned")}
+                    onToggleCollapsed={() => effectiveToggleSectionCollapsed("Pinned")}
                     onRowClick={onRowClick}
                     onTogglePinned={onTogglePinned}
                     selectionMode={selectionMode}
                     selectedIds={selectedIds}
                     onToggleSelected={onToggleSelected}
                     onProjectAssigned={expandProject}
-                    projectRenderedIdsRef={projectRenderedIdsRef}
                   />
-                ))}
-                {sections.projectGroups.length === 0 &&
-                  !effectiveCollapsedSections.includes("Projects") && (
-                    <p className="px-3 py-1.5 text-xs text-muted-foreground">
-                      No projects yet. Create one to group your sessions.
-                    </p>
-                  )}
-              </SectionGroup>
-            )}
-            {sections.sessions.length > 0 && (
-              // Drop a session here to send it to the flat "Chats" list — where
-              // unfiled, unpinned sessions live. Active while dragging a filed
-              // session (removes it from its project) or a pinned one (unpins
-              // it), since both have somewhere to land here.
-              <ChatsDropZone
-                active={activeDrag != null && (activeDrag.project != null || activeDrag.isPinned)}
-              >
-                <ConversationSection
-                  title="Sessions"
-                  conversations={sections.sessions}
-                  pinnedConversationIds={pinnedConversationIds}
-                  collapsed={effectiveCollapsedSections.includes("Chats")}
-                  onToggleCollapsed={() => effectiveToggleSectionCollapsed("Chats")}
-                  onRowClick={onRowClick}
-                  onTogglePinned={onTogglePinned}
-                  selectionMode={selectionMode}
-                  selectedIds={selectedIds}
-                  onToggleSelected={onToggleSelected}
-                  onProjectAssigned={expandProject}
-                />
-              </ChatsDropZone>
-            )}
-            {/* Both tabs render this same Pinned / Projects / Sessions tree;
+                </PinDropZone>
+              )}
+              {/* Projects: a "Projects" group header, with each project rendered as
+              a collapsible folder row nested beneath it. Folders default
+              collapsed; an empty folder shows "No sessions". The folder icon marks
+              a project row; the group/section headers carry no icon or count.
+              Shown on the "mine" tab even with zero projects, so "New project"
+              (create-empty) is discoverable — projects are a My-sessions tool. */}
+              {activeTab !== "shared" && (
+                <SectionGroup
+                  title="Projects"
+                  collapsed={effectiveCollapsedSections.includes("Projects")}
+                  onToggleCollapsed={() => effectiveToggleSectionCollapsed("Projects")}
+                  headerAction={(() => {
+                    const allNames = sections.projectGroups.map((g) => g.name);
+                    // "New project" is always available (even when collapsed) so
+                    // the create-empty flow is reachable; the expand/revert control
+                    // is only meaningful when there are folders and the group is open.
+                    const showExpandControls =
+                      !effectiveCollapsedSections.includes("Projects") && allNames.length > 0;
+                    // Once every folder is open the only useful move is to undo it,
+                    // so the control flips to "revert" — which restores the set open
+                    // before "Expand all", or collapses everything when there's no
+                    // real last state (folders opened by hand). Otherwise it expands.
+                    const allExpanded =
+                      allNames.length > 0 && allNames.every((n) => expandedProjects.includes(n));
+                    return (
+                      <div className="flex items-center">
+                        {showExpandControls &&
+                          (allExpanded ? (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  aria-label="Collapse to previous"
+                                  data-testid="revert-projects"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    revertProjects();
+                                  }}
+                                >
+                                  <Minimize2Icon className="size-3.5" />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent side="bottom">Collapse to previous</TooltipContent>
+                            </Tooltip>
+                          ) : (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  aria-label="Expand all"
+                                  data-testid="expand-all-projects"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    expandAllProjects(allNames);
+                                  }}
+                                >
+                                  <Maximize2Icon className="size-3.5" />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent side="bottom">Expand all</TooltipContent>
+                            </Tooltip>
+                          ))}
+                        <NewProjectButton onCreated={expandProject} />
+                      </div>
+                    );
+                  })()}
+                >
+                  {sections.projectGroups.map((group) => (
+                    <ProjectFolder
+                      key={group.name}
+                      name={group.name}
+                      projectId={group.id}
+                      expanded={expandedProjects.includes(group.name)}
+                      // Best-effort marker from the globally-loaded window: a
+                      // collapsed folder hasn't fetched its own sessions yet.
+                      marker={projectMarkerState(group.conversations)}
+                      onToggleCollapsed={() => toggleProjectExpanded(group.name)}
+                      pinnedConversationIds={pinnedConversationIds}
+                      activeOverride={activeOverride}
+                      scrollRoot={scrollContainerRef}
+                      onRowClick={onRowClick}
+                      onTogglePinned={onTogglePinned}
+                      selectionMode={selectionMode}
+                      selectedIds={selectedIds}
+                      onToggleSelected={onToggleSelected}
+                      onProjectAssigned={expandProject}
+                      projectRenderedIdsRef={projectRenderedIdsRef}
+                    />
+                  ))}
+                  {sections.projectGroups.length === 0 &&
+                    !effectiveCollapsedSections.includes("Projects") && (
+                      <p className="px-3 py-1.5 text-xs text-muted-foreground">
+                        No projects yet. Create one to group your sessions.
+                      </p>
+                    )}
+                </SectionGroup>
+              )}
+              {sections.sessions.length > 0 && (
+                // Drop a session here to send it to the flat "Chats" list — where
+                // unfiled, unpinned sessions live. Active while dragging a filed
+                // session (removes it from its project) or a pinned one (unpins
+                // it), since both have somewhere to land here.
+                <ChatsDropZone
+                  active={activeDrag != null && (activeDrag.project != null || activeDrag.isPinned)}
+                >
+                  <ConversationSection
+                    title="Sessions"
+                    conversations={sections.sessions}
+                    pinnedConversationIds={pinnedConversationIds}
+                    collapsed={effectiveCollapsedSections.includes("Chats")}
+                    onToggleCollapsed={() => effectiveToggleSectionCollapsed("Chats")}
+                    onRowClick={onRowClick}
+                    onTogglePinned={onTogglePinned}
+                    selectionMode={selectionMode}
+                    selectedIds={selectedIds}
+                    onToggleSelected={onToggleSelected}
+                    onProjectAssigned={expandProject}
+                  />
+                </ChatsDropZone>
+              )}
+              {/* Both tabs render this same Pinned / Projects / Sessions tree;
               `sections` is scoped to the active tab's conversations (owned vs.
               shared), and Projects is empty on the Shared tab. */}
-            {/* Archived sessions are no longer listed here — they live on the
+              {/* Archived sessions are no longer listed here — they live on the
               Settings page ("Archived chats"), reachable from the footer. */}
-            {/* Infinite-scroll sentinel for the global list. Pagination extends
+              {/* Infinite-scroll sentinel for the global list. Pagination extends
               the Chats list, so it hides with a collapsed Chats group — a loader
               under a collapsed group reads orphaned. */}
-            {!effectiveCollapsedSections.includes("Chats") && (
-              <InfiniteScrollSentinel
-                hasMore={hasMorePages}
-                isFetching={isFetchingNextPage}
-                fetchMore={fetchNextPage}
-                scrollRoot={scrollContainerRef}
-              />
-            )}
-          </>
-        )}
-      </div>
-      {/* The dragged row's preview follows the pointer (rendered in a portal),
+              {!effectiveCollapsedSections.includes("Chats") && (
+                <InfiniteScrollSentinel
+                  hasMore={hasMorePages}
+                  isFetching={isFetchingNextPage}
+                  fetchMore={fetchNextPage}
+                  scrollRoot={scrollContainerRef}
+                />
+              )}
+            </>
+          )}
+        </div>
+        {/* The dragged row's preview follows the pointer (rendered in a portal),
           a compact card showing the session's title. */}
-      <DragOverlay dropAnimation={null}>
-        {activeDrag ? (
-          <div className="pointer-events-none max-w-[16rem] truncate rounded-md border bg-card-solid px-3 py-2 text-sm shadow-lg">
-            {activeDrag.label}
-          </div>
-        ) : null}
-      </DragOverlay>
-    </DndContext>
+        <DragOverlay dropAnimation={null}>
+          {activeDrag ? (
+            <div className="pointer-events-none max-w-[16rem] truncate rounded-md border bg-card-solid px-3 py-2 text-sm shadow-lg">
+              {activeDrag.label}
+            </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    </ProjectNamesContext.Provider>
   );
 }
 
@@ -2436,12 +2456,11 @@ function ConversationRow({
   // The session's current project NAME, or null when unfiled — drives the
   // kebab submenu label ("Add to project" vs "Move session") and the pinned
   // flyout. Dual-read: prefer the first-class membership (project_id → name via
-  // the cached project list), falling back to the legacy omni_project label.
-  const { data: projectList = [] } = useProjects();
+  // the list-level map from context — no per-row query), falling back to the
+  // legacy omni_project label.
+  const projectNamesById = useContext(ProjectNamesContext);
   const firstClassProjectName =
-    conversation.project_id != null
-      ? projectList.find((p) => p.id === conversation.project_id)?.name
-      : undefined;
+    conversation.project_id != null ? projectNamesById.get(conversation.project_id) : undefined;
   const currentProject = firstClassProjectName ?? conversation.labels?.[PROJECT_LABEL_KEY] ?? null;
   // Pinned sessions are lifted OUT of their project folder into the flat
   // "Pinned" section, so the row no longer shows which project it belongs to.

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3223,59 +3223,58 @@ function ProjectFolderMenu({
           <DialogHeader>
             <DialogTitle>Rename project</DialogTitle>
           </DialogHeader>
-          <input
-            autoFocus
-            className="w-full rounded-md border bg-transparent px-3 py-2 text-sm outline-none"
-            value={renameValue}
-            onChange={(e) => setRenameValue(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                (e.currentTarget.closest("form") ?? e.currentTarget)
-                  .querySelector<HTMLButtonElement>('[data-testid="rename-project-confirm"]')
-                  ?.click();
+          {/* A <form> so Enter in the input submits natively (Radix Dialog
+              doesn't wrap children in one) instead of relying on a manual
+              key handler + button lookup. */}
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              const newName = renameValue.trim();
+              if (newName === "" || newName === projectName) {
+                setRenameOpen(false);
+                setMenuOpen(false);
+                return;
               }
-            }}
-          />
-          {renameProject.isError && (
-            <p className="text-sm text-destructive" role="alert">
-              {(renameProject.error as Error).message}
-            </p>
-          )}
-          <DialogFooter className="border-t-0 bg-transparent">
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => setRenameOpen(false)}
-              disabled={renameProject.isPending}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              data-testid="rename-project-confirm"
-              disabled={renameProject.isPending || renameValue.trim() === ""}
-              onClick={() => {
-                const newName = renameValue.trim();
-                if (newName === "" || newName === projectName) {
-                  setRenameOpen(false);
-                  setMenuOpen(false);
-                  return;
-                }
-                renameProject.mutate(
-                  { id: projectId, oldName: projectName, newName },
-                  {
-                    onSuccess: () => {
-                      setRenameOpen(false);
-                      setMenuOpen(false);
-                    },
+              renameProject.mutate(
+                { id: projectId, oldName: projectName, newName },
+                {
+                  onSuccess: () => {
+                    setRenameOpen(false);
+                    setMenuOpen(false);
                   },
-                );
-              }}
-            >
-              {renameProject.isPending ? "Renaming…" : "Rename"}
-            </Button>
-          </DialogFooter>
+                },
+              );
+            }}
+          >
+            <input
+              autoFocus
+              className="w-full rounded-md border bg-transparent px-3 py-2 text-sm outline-none"
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+            />
+            {renameProject.isError && (
+              <p className="text-sm text-destructive" role="alert">
+                {(renameProject.error as Error).message}
+              </p>
+            )}
+            <DialogFooter className="border-t-0 bg-transparent">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setRenameOpen(false)}
+                disabled={renameProject.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                data-testid="rename-project-confirm"
+                disabled={renameProject.isPending || renameValue.trim() === ""}
+              >
+                {renameProject.isPending ? "Renaming…" : "Rename"}
+              </Button>
+            </DialogFooter>
+          </form>
         </DialogContent>
       </Dialog>
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -101,7 +101,7 @@ import {
   useConversations,
   useMoveToProject,
   useDeleteProject,
-  fetchProjectSessionIds,
+  useRenameProject,
   PROJECT_LABEL_KEY,
   usePinnedConversationBackfill,
   useRenameConversation,
@@ -137,6 +137,7 @@ import { usePinnedSessionHotkeys } from "@/hooks/usePinnedSessionHotkeys";
 import { absoluteTime, relativeTime } from "@/lib/relativeTime";
 import { MOD_KEY } from "@/components/KeyboardShortcutsDialog";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
+import { NewProjectButton } from "./NewProjectButton";
 import { SettingsSidebarBody, useSettingsRoute, useTrackSettingsReturn } from "./settingsNav";
 import {
   type ActiveChatOverride,
@@ -779,6 +780,7 @@ function InfiniteScrollSentinel({
  */
 function ProjectFolder({
   name,
+  projectId,
   expanded,
   marker,
   onToggleCollapsed,
@@ -794,6 +796,8 @@ function ProjectFolder({
   projectRenderedIdsRef,
 }: {
   name: string;
+  /** First-class project id, or null for a label-only folder. */
+  projectId: string | null;
   expanded: boolean;
   marker: SessionState | null;
   onToggleCollapsed: () => void;
@@ -872,9 +876,11 @@ function ProjectFolder({
         selectedIds={selectedIds}
         onToggleSelected={onToggleSelected}
         onProjectAssigned={onProjectAssigned}
-        emptyMessage={loadingFirstPage ? undefined : "No chats"}
+        emptyMessage={loadingFirstPage ? undefined : "No sessions"}
         indentRows
-        headerAction={<ProjectFolderActions projectName={name} onNavigate={onRowClick} />}
+        headerAction={
+          <ProjectFolderActions projectName={name} projectId={projectId} onNavigate={onRowClick} />
+        }
         footer={
           loadingFirstPage ? (
             <p className="px-2 py-1 pl-5 text-muted-foreground text-xs">Loading…</p>
@@ -980,8 +986,9 @@ function ConversationList({
     [conversationsQuery.data],
   );
 
-  // Project names for grouping sessions by their reserved project label.
-  const { data: projectNames = [] } = useProjects();
+  // Project folders ({ id, name }) for grouping sessions — first-class id
+  // and/or the legacy omni_project label, unioned server-side.
+  const { data: projects = [] } = useProjects();
 
   // Each ProjectFolder registers its actually-rendered conversation IDs here
   // (synchronously during render) so shift-select ranges use the real rendered
@@ -1037,22 +1044,26 @@ function ConversationList({
     // owner-only), so the Shared tab renders no folders. On "mine" each folder
     // holds its non-pinned, non-archived sessions; a pinned member is excluded
     // (it lives under Pinned), so pinning a project's last session leaves the
-    // folder showing "No chats".
+    // folder showing "No sessions".
     const filedIds = new Set<string>();
-    const projectGroups: { name: string; conversations: Conversation[] }[] =
+    const projectGroups: { id: string | null; name: string; conversations: Conversation[] }[] =
       activeTab === "shared"
         ? []
-        : projectNames.map((name) => {
+        : projects.map(({ id, name }) => {
+            // Dual-read membership: a session belongs to this folder if it has
+            // the first-class id OR the legacy omni_project label of this name.
             const inProject = tabScoped.filter(
-              (c) => c.labels?.[PROJECT_LABEL_KEY] === name && !pinnedIdSet.has(c.id),
+              (c) =>
+                ((id !== null && c.project_id === id) || c.labels?.[PROJECT_LABEL_KEY] === name) &&
+                !pinnedIdSet.has(c.id),
             );
             inProject.forEach((c) => filedIds.add(c.id));
-            return { name, conversations: sortByUpdatedAtDesc(inProject, activeOverride) };
+            return { id, name, conversations: sortByUpdatedAtDesc(inProject, activeOverride) };
           });
     // NOTE: empty projects are intentionally NOT filtered out. A project comes
     // from the server project list (useProjects), so it can have zero *loaded*
     // conversations — either genuinely empty or because its chats live on an
-    // unloaded page. We render it as a folder with a "No chats" placeholder
+    // unloaded page. We render it as a folder with a "No sessions" placeholder
     // rather than hiding it (matches the target sidebar layout).
 
     // Sessions: the remainder of the tab's slice — not pinned, not filed.
@@ -1071,7 +1082,7 @@ function ConversationList({
     pinnedSet,
     pinnedConversationIds,
     activeOverride,
-    projectNames,
+    projects,
     activeTab,
     viewerId,
   ]);
@@ -1187,15 +1198,6 @@ function ConversationList({
     project: string | null;
     isPinned: boolean;
   } | null>(null);
-  // A drop-to-ungroup that turned out to remove the project's last session —
-  // held here to confirm (the implicit project vanishes with it), mirroring the
-  // kebab's "Remove from project" flow. `unpin` carries through whether the
-  // dragged session was also pinned (and so must be unpinned to leave Pinned).
-  const [pendingUngroup, setPendingUngroup] = useState<{
-    id: string;
-    project: string;
-    unpin: boolean;
-  } | null>(null);
   // Mouse: a small drag threshold so a plain click still navigates / opens the
   // kebab. Touch: a press-and-hold delay so scrolling the list isn't hijacked
   // into a drag. Keyboard users use the kebab menu instead (no KeyboardSensor).
@@ -1241,25 +1243,10 @@ function ConversationList({
         return;
       }
       if (action.kind === "ungroup") {
-        const unpin = action.unpin;
-        // Removing a project's LAST session deletes the implicit project, so
-        // confirm that case (server-side check, accurate regardless of the
-        // loaded window); otherwise remove silently. Mirrors the kebab flow.
-        void (async () => {
-          let isLastSession = true;
-          try {
-            const ids = await fetchProjectSessionIds(action.project);
-            isLastSession = ids.every((id) => id === dragged.id);
-          } catch {
-            isLastSession = true;
-          }
-          if (isLastSession) {
-            setPendingUngroup({ id: dragged.id, project: action.project, unpin });
-          } else {
-            moveToProject.mutate({ id: dragged.id, project: "" });
-            if (unpin) onTogglePinned(dragged.id);
-          }
-        })();
+        // Unfile silently — a first-class project persists when emptied, so
+        // dragging out its last session deletes nothing. Mirrors the kebab flow.
+        moveToProject.mutate({ id: dragged.id, project: "" });
+        if (action.unpin) onTogglePinned(dragged.id);
       }
     },
     [activeDrag, moveToProject, expandProject, onTogglePinned],
@@ -1415,7 +1402,7 @@ function ConversationList({
   // Archived sessions are surfaced on the Settings page, not here, so they
   // don't count toward the sidebar's empty-state threshold. Each project
   // counts itself (not just its loaded chats) so an empty project still
-  // renders its "Projects" header + "No chats" folder rather than the global
+  // renders its "Projects" header + "No sessions" folder rather than the global
   // empty-state message. `sections` is tab-scoped, so this counts the active
   // tab only (Projects is empty on the Shared tab).
   const totalVisible =
@@ -1488,65 +1475,72 @@ function ConversationList({
             )}
             {/* Projects: a "Projects" group header, with each project rendered as
               a collapsible folder row nested beneath it. Folders default
-              collapsed; an empty folder shows "No chats". The folder icon marks
-              a project row; the group/section headers carry no icon or count. */}
-            {sections.projectGroups.length > 0 && (
+              collapsed; an empty folder shows "No sessions". The folder icon marks
+              a project row; the group/section headers carry no icon or count.
+              Shown on the "mine" tab even with zero projects, so "New project"
+              (create-empty) is discoverable — projects are a My-sessions tool. */}
+            {activeTab !== "shared" && (
               <SectionGroup
                 title="Projects"
                 collapsed={effectiveCollapsedSections.includes("Projects")}
                 onToggleCollapsed={() => effectiveToggleSectionCollapsed("Projects")}
                 headerAction={(() => {
-                  // The "Projects" group itself is collapsed: its folders aren't
-                  // rendered, so expand-all / revert would be a no-op — show no
-                  // control at all.
-                  if (effectiveCollapsedSections.includes("Projects")) return null;
                   const allNames = sections.projectGroups.map((g) => g.name);
+                  // "New project" is always available (even when collapsed) so
+                  // the create-empty flow is reachable; the expand/revert control
+                  // is only meaningful when there are folders and the group is open.
+                  const showExpandControls =
+                    !effectiveCollapsedSections.includes("Projects") && allNames.length > 0;
                   // Once every folder is open the only useful move is to undo it,
                   // so the control flips to "revert" — which restores the set open
                   // before "Expand all", or collapses everything when there's no
                   // real last state (folders opened by hand). Otherwise it expands.
-                  const allExpanded = allNames.every((n) => expandedProjects.includes(n));
-                  if (allExpanded) {
-                    return (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon-sm"
-                            aria-label="Collapse to previous"
-                            data-testid="revert-projects"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              revertProjects();
-                            }}
-                          >
-                            <Minimize2Icon className="size-3.5" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom">Collapse to previous</TooltipContent>
-                      </Tooltip>
-                    );
-                  }
+                  const allExpanded =
+                    allNames.length > 0 && allNames.every((n) => expandedProjects.includes(n));
                   return (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-sm"
-                          aria-label="Expand all"
-                          data-testid="expand-all-projects"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            expandAllProjects(allNames);
-                          }}
-                        >
-                          <Maximize2Icon className="size-3.5" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">Expand all</TooltipContent>
-                    </Tooltip>
+                    <div className="flex items-center">
+                      {showExpandControls &&
+                        (allExpanded ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-sm"
+                                aria-label="Collapse to previous"
+                                data-testid="revert-projects"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  revertProjects();
+                                }}
+                              >
+                                <Minimize2Icon className="size-3.5" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom">Collapse to previous</TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-sm"
+                                aria-label="Expand all"
+                                data-testid="expand-all-projects"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  expandAllProjects(allNames);
+                                }}
+                              >
+                                <Maximize2Icon className="size-3.5" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom">Expand all</TooltipContent>
+                          </Tooltip>
+                        ))}
+                      <NewProjectButton onCreated={expandProject} />
+                    </div>
                   );
                 })()}
               >
@@ -1554,6 +1548,7 @@ function ConversationList({
                   <ProjectFolder
                     key={group.name}
                     name={group.name}
+                    projectId={group.id}
                     expanded={expandedProjects.includes(group.name)}
                     // Best-effort marker from the globally-loaded window: a
                     // collapsed folder hasn't fetched its own sessions yet.
@@ -1571,6 +1566,12 @@ function ConversationList({
                     projectRenderedIdsRef={projectRenderedIdsRef}
                   />
                 ))}
+                {sections.projectGroups.length === 0 &&
+                  !effectiveCollapsedSections.includes("Projects") && (
+                    <p className="px-3 py-1.5 text-xs text-muted-foreground">
+                      No projects yet. Create one to group your sessions.
+                    </p>
+                  )}
               </SectionGroup>
             )}
             {sections.sessions.length > 0 && (
@@ -1624,53 +1625,6 @@ function ConversationList({
           </div>
         ) : null}
       </DragOverlay>
-      {/* Confirm a drag-to-ungroup that removes the project's last session (the
-          implicit project disappears with it). Mirrors the kebab's dialog. */}
-      <Dialog
-        open={pendingUngroup != null}
-        onOpenChange={(open) => {
-          if (!open) setPendingUngroup(null);
-        }}
-      >
-        <DialogContent onClick={(e) => e.stopPropagation()}>
-          <DialogHeader>
-            <DialogTitle>Remove from project?</DialogTitle>
-            <DialogDescription>
-              This is the only session in{" "}
-              <span className="break-all font-medium">{pendingUngroup?.project}</span>, so{" "}
-              <span className="font-medium">the project will be removed as well</span>. The session
-              itself is kept.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => setPendingUngroup(null)}
-              disabled={moveToProject.isPending}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              disabled={moveToProject.isPending}
-              onClick={() => {
-                if (!pendingUngroup) return;
-                moveToProject.mutate(
-                  { id: pendingUngroup.id, project: "" },
-                  { onSuccess: () => setPendingUngroup(null) },
-                );
-                // A pinned session must also be unpinned to leave Pinned and
-                // land in the flat list.
-                if (pendingUngroup.unpin) onTogglePinned(pendingUngroup.id);
-              }}
-            >
-              Remove from project
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </DndContext>
   );
 }
@@ -2075,7 +2029,6 @@ function ConversationMenuItems({
   setIsEditing,
   setStopOpen,
   setDeleteOpen,
-  setRemoveProjectOpen,
   setMenuOpen,
   runArchive,
 }: {
@@ -2104,7 +2057,6 @@ function ConversationMenuItems({
   setIsEditing: (editing: boolean) => void;
   setStopOpen: (open: boolean) => void;
   setDeleteOpen: (open: boolean) => void;
-  setRemoveProjectOpen: (open: boolean) => void;
   // Closes the controlled kebab after a project pick; a no-op for the
   // (uncontrolled) context menu, which Radix closes on select automatically.
   setMenuOpen: (open: boolean) => void;
@@ -2130,26 +2082,10 @@ function ConversationMenuItems({
       onProjectAssigned?.(project);
       return;
     }
-    // Removing: only confirm when this is the project's LAST session (removing
-    // it would delete the implicit project). Otherwise remove silently. The
-    // check is server-side so it's accurate regardless of the loaded window.
-    void (async () => {
-      let isLastSession = true;
-      if (currentProject) {
-        try {
-          const ids = await fetchProjectSessionIds(currentProject);
-          isLastSession = ids.every((id) => id === conversation.id);
-        } catch {
-          // If the check fails, fall back to confirming.
-          isLastSession = true;
-        }
-      }
-      if (isLastSession) {
-        setRemoveProjectOpen(true);
-      } else {
-        moveToProject.mutate({ id: conversation.id, project: "" });
-      }
-    })();
+    // Removing just unfiles the session (project_id=""). No confirmation: a
+    // first-class project persists when emptied, so removal deletes nothing —
+    // the folder stays and can be deleted explicitly from its own kebab.
+    moveToProject.mutate({ id: conversation.id, project: "" });
   };
 
   // Mobile project sub-view: replaces the entire menu body in place (the
@@ -2461,9 +2397,6 @@ function ConversationRow({
   const [isEditing, setIsEditing] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [stopOpen, setStopOpen] = useState(false);
-  // True while confirming "Remove from project" — implicit projects vanish when
-  // their last session leaves, so the removal is confirmed to make that explicit.
-  const [removeProjectOpen, setRemoveProjectOpen] = useState(false);
   // The kebab menu is controlled so the project submenu can close the whole
   // menu after a pick (a plain click inside the submenu wouldn't otherwise).
   const [menuOpen, setMenuOpen] = useState(false);
@@ -2500,9 +2433,16 @@ function ConversationRow({
       runnerId: conversation.runner_id,
     }) && runnerOnline !== false;
 
-  // The session's current project (reserved label), or null when unfiled —
-  // drives the kebab submenu label ("Add to project" vs "Change project").
-  const currentProject = conversation.labels?.[PROJECT_LABEL_KEY] ?? null;
+  // The session's current project NAME, or null when unfiled — drives the
+  // kebab submenu label ("Add to project" vs "Move session") and the pinned
+  // flyout. Dual-read: prefer the first-class membership (project_id → name via
+  // the cached project list), falling back to the legacy omni_project label.
+  const { data: projectList = [] } = useProjects();
+  const firstClassProjectName =
+    conversation.project_id != null
+      ? projectList.find((p) => p.id === conversation.project_id)?.name
+      : undefined;
+  const currentProject = firstClassProjectName ?? conversation.labels?.[PROJECT_LABEL_KEY] ?? null;
   // Pinned sessions are lifted OUT of their project folder into the flat
   // "Pinned" section, so the row no longer shows which project it belongs to.
   // For those rows only, surface the project in a hover flyout. Non-pinned
@@ -2710,7 +2650,6 @@ function ConversationRow({
     setIsEditing,
     setStopOpen,
     setDeleteOpen,
-    setRemoveProjectOpen,
     runArchive,
   };
 
@@ -3047,42 +2986,6 @@ function ConversationRow({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <Dialog open={removeProjectOpen} onOpenChange={setRemoveProjectOpen}>
-        <DialogContent onClick={(e) => e.stopPropagation()}>
-          <DialogHeader>
-            <DialogTitle>Remove from project?</DialogTitle>
-            <DialogDescription>
-              This is the only session in{" "}
-              <span className="break-all font-medium">{currentProject}</span>, so{" "}
-              <span className="font-medium">the project will be removed as well</span>. The session
-              itself is kept.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => setRemoveProjectOpen(false)}
-              disabled={moveToProject.isPending}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              disabled={moveToProject.isPending}
-              onClick={() =>
-                moveToProject.mutate(
-                  { id: conversation.id, project: "" },
-                  { onSuccess: () => setRemoveProjectOpen(false) },
-                )
-              }
-            >
-              Remove from project
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </li>
   );
 }
@@ -3219,16 +3122,19 @@ function ArchivingRow({ label }: { label: string }) {
  */
 function ProjectFolderActions({
   projectName,
+  projectId,
   onNavigate,
 }: {
   projectName: string;
+  /** First-class project id, or null for a label-only folder. */
+  projectId: string | null;
   /** Plain-left-click nav handler — closes the mobile overlay so the
       pre-filed new-session page isn't left hidden behind the sidebar. */
   onNavigate: (e: MouseEvent<HTMLAnchorElement>) => void;
 }) {
   return (
     <div className="flex items-center">
-      <ProjectFolderMenu projectName={projectName} />
+      <ProjectFolderMenu projectName={projectName} projectId={projectId} />
       <Button
         asChild
         type="button"
@@ -3256,15 +3162,24 @@ function ProjectFolderActions({
 // ── ProjectFolderMenu ─────────────────────────────────────────────────────────
 
 /**
- * The kebab on a project-folder header. Currently just "Delete project", which
- * removes every session filed under the project (the implicit project then
- * disappears). Confirmation is required since it deletes sessions, not just the
- * grouping.
+ * The kebab on a project-folder header: "Rename project" (O(1) via
+ * `PATCH /v1/projects/{id}` for a first-class project; promotes a label-only
+ * folder on demand) and "Delete project" (archives + unfiles all members, then
+ * removes the container). Delete is confirmed since it archives sessions.
  */
-function ProjectFolderMenu({ projectName }: { projectName: string }) {
+function ProjectFolderMenu({
+  projectName,
+  projectId,
+}: {
+  projectName: string;
+  projectId: string | null;
+}) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [renameValue, setRenameValue] = useState(projectName);
   const deleteProject = useDeleteProject();
+  const renameProject = useRenameProject();
 
   return (
     <>
@@ -3284,6 +3199,16 @@ function ProjectFolderMenu({ projectName }: { projectName: string }) {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="min-w-40 [&_[role=menuitem]]:text-xs">
           <DropdownMenuItem
+            data-testid="rename-project"
+            onSelect={() => {
+              setRenameValue(projectName);
+              setRenameOpen(true);
+            }}
+          >
+            <PencilIcon className="size-3.5" />
+            Rename project
+          </DropdownMenuItem>
+          <DropdownMenuItem
             data-testid="delete-project"
             variant="destructive"
             onSelect={() => setDeleteOpen(true)}
@@ -3293,17 +3218,77 @@ function ProjectFolderMenu({ projectName }: { projectName: string }) {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <DialogContent onClick={(e) => e.stopPropagation()}>
+          <DialogHeader>
+            <DialogTitle>Rename project</DialogTitle>
+          </DialogHeader>
+          <input
+            autoFocus
+            className="w-full rounded-md border bg-transparent px-3 py-2 text-sm outline-none"
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                (e.currentTarget.closest("form") ?? e.currentTarget)
+                  .querySelector<HTMLButtonElement>('[data-testid="rename-project-confirm"]')
+                  ?.click();
+              }
+            }}
+          />
+          {renameProject.isError && (
+            <p className="text-sm text-destructive" role="alert">
+              {(renameProject.error as Error).message}
+            </p>
+          )}
+          <DialogFooter className="border-t-0 bg-transparent">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setRenameOpen(false)}
+              disabled={renameProject.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              data-testid="rename-project-confirm"
+              disabled={renameProject.isPending || renameValue.trim() === ""}
+              onClick={() => {
+                const newName = renameValue.trim();
+                if (newName === "" || newName === projectName) {
+                  setRenameOpen(false);
+                  setMenuOpen(false);
+                  return;
+                }
+                renameProject.mutate(
+                  { id: projectId, oldName: projectName, newName },
+                  {
+                    onSuccess: () => {
+                      setRenameOpen(false);
+                      setMenuOpen(false);
+                    },
+                  },
+                );
+              }}
+            >
+              {renameProject.isPending ? "Renaming…" : "Rename"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <DialogContent onClick={(e) => e.stopPropagation()}>
           <DialogHeader>
             <DialogTitle>Delete project?</DialogTitle>
             <DialogDescription>
-              This archives the project{" "}
+              This deletes the project{" "}
               <span className="rounded bg-muted px-1 py-0.5 font-mono text-[0.95em] break-all">
                 {projectName}
               </span>{" "}
-              and <span className="font-medium">all of its sessions</span>. Their history is kept.
-              You can find and restore them anytime from Settings.
+              and archives <span className="font-medium">all of its sessions</span>. Their history
+              is kept. You can find and restore them anytime from Settings.
             </DialogDescription>
           </DialogHeader>
           {deleteProject.isError && (
@@ -3325,12 +3310,15 @@ function ProjectFolderMenu({ projectName }: { projectName: string }) {
               variant="destructive"
               disabled={deleteProject.isPending}
               onClick={() => {
-                deleteProject.mutate(projectName, {
-                  onSuccess: () => {
-                    setDeleteOpen(false);
-                    setMenuOpen(false);
+                deleteProject.mutate(
+                  { id: projectId, name: projectName },
+                  {
+                    onSuccess: () => {
+                      setDeleteOpen(false);
+                      setMenuOpen(false);
+                    },
                   },
-                });
+                );
               }}
             >
               {deleteProject.isPending ? "Deleting…" : "Delete project"}
@@ -3374,7 +3362,7 @@ function ProjectPickerMenu({
   }, [creatingNew]);
 
   const filtered = search
-    ? projects.filter((name) => name.toLowerCase().includes(search.toLowerCase()))
+    ? projects.filter((p) => p.name.toLowerCase().includes(search.toLowerCase()))
     : projects;
 
   function handleNewProjectCommit() {
@@ -3403,10 +3391,10 @@ function ProjectPickerMenu({
         />
       </div>
       <div className="max-h-48 overflow-y-auto">
-        {filtered.map((name) => (
-          <C.Item key={name} className="px-2 py-1" onSelect={() => onSelect(name)}>
-            <span className="flex-1 truncate text-left">{name}</span>
-            {currentProject === name && (
+        {filtered.map((p) => (
+          <C.Item key={p.name} className="px-2 py-1" onSelect={() => onSelect(p.name)}>
+            <span className="flex-1 truncate text-left">{p.name}</span>
+            {currentProject === p.name && (
               <CheckMarkIcon className="size-3.5 shrink-0 text-primary" />
             )}
           </C.Item>


### PR DESCRIPTION
## Related issue

N/A — completes the projects feature (follows #2765 Phase 1a + #3053 Phase 1b).

## Summary

Wires the web app to the **first-class projects entity** shipped in #2765/#3053, while keeping the legacy `omni_project` label path working via **dual-read** so no migration is forced. This unlocks the capability the label model never could — **empty projects** — plus O(1) rename and non-destructive delete.

Folders are keyed by **name** (the union key that merges a first-class project and a like-named label-project into one folder), carrying the first-class `id` when one exists.

**ELI5:** #2765/#3053 gave the backend real project "folders" you can create empty and file sessions into by id. This PR makes the sidebar actually *use* them — a "New project" button, rename, delete, drag/kebab to file sessions — while old label-based projects keep showing up unchanged.

- **Backend:** `GET /v1/sessions/projects` now dual-reads — unions first-class projects (`project_store.list`, incl. empty, with `id`) and legacy label-projects (`id=None`), merged by name. Response shape `list[str]` → `list[{id, name}]` (owner-scoped as before); `openapi.json` regenerated.
- **Frontend:** typed `/v1/projects` CRUD client (`projectsApi.ts`); `useProjects` → `{id, name}[]`; new `useCreateProject`/`useRenameProject`; reworked `useDeleteProject` (archive + unfile every member, then delete the container — sessions are never deleted). Filing/moving files via `project_id`, resolving the picked name to an id and **creating the first-class row on demand** for a label-only folder; `""` unfiles. Sidebar folders keyed by `{id, name}`, members matched by `project_id` OR the legacy label; a row's current-project dual-reads `project_id`→name so a **pinned first-class member keeps its project flyout**; "New project" (create-empty) extracted to `NewProjectButton.tsx`; empty folders read "No sessions".

### Behavior notes
- `?project=` becoming a dual-read is backward-compatible: with no first-class members yet, the filter collapses to the prior label-only behavior — no existing session is reclassified.
- "Remove from project" now unfiles **silently** (no confirmation): a first-class project persists when emptied, so removal deletes nothing.

## Test Plan

```bash
# backend
python -m pytest tests/server/routes/test_projects_crud.py \
  tests/server/routes/test_sessions_crud.py tests/server/routes/test_sessions_shared_projects.py -q
# web (vitest)
cd web && node node_modules/vitest/vitest.mjs run \
  src/lib/projectsApi.test.ts src/hooks/useConversations.test.ts \
  src/shell/Sidebar.test.tsx src/shell/NewChatDialog.test.tsx
# e2e (Playwright, local)
uv run pytest tests/e2e_ui/sessions/test_sidebar_projects.py -m "not visual"
```

- Backend: 36 route tests pass (incl. new `test_session_projects_unions_first_class_and_labels`).
- Web: 311 vitest tests pass across the changed suites (new `projectsApi.test.ts`; reworked move/delete/union tests; all 10 Sidebar variants). Typecheck + prettier clean.
- E2E: `test_sidebar_projects.py` (move into new project; remove-from-project silent unfile with persistent folder) passes locally in Chromium.

## Demo

_UI / frontend change — screen recording to be attached._ The visible changes: a **"New project"** button in the always-visible Projects sidebar section (creates an empty project), a **Rename** item in the folder kebab, delete now archives + unfiles (folder removed, sessions kept), and drag/kebab filing via the first-class entity.

> Note: the visual-snapshot baseline (`tests/e2e_ui/visual/test_sidebar_snapshot.py`) likely needs regenerating via the pinned Docker renderer — the "New project" button and "No sessions" copy change pixels in the Projects header. The fixture shape was updated in this PR; the baseline PNG is not regenerable outside that gate.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated coverage above (unit + route + e2e). The visual-snapshot baseline regen is called out in Demo and runs in the separate pinned-runner gate.

## Changelog

The sidebar now uses first-class projects: create empty projects, rename and delete them, and file sessions into them — while existing label-based projects keep working.

This pull request and its description were written by Isaac.