### PR TITLE
fix(web): move host-offline reconnect prompt into the composer host badge

### DIFF
--- a/web/src/components/HostBadge.test.tsx
+++ b/web/src/components/HostBadge.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HostBadge, resolveHostBadge } from "./HostBadge";
@@ -216,6 +216,39 @@ describe("HostBadge", () => {
     useSessionHostOnlineMock.mockReturnValue(null);
     render(<HostBadge sessionId="conv_1" />);
     expect(screen.getByTestId("host-badge").textContent).toBe("mac-laptop, status unknown");
+  });
+
+  it("renders a clickable reconnect affordance in the badge slot when onReconnect is set", () => {
+    // host_offline moves the reconnect prompt up into the host badge: the
+    // passive name + dot is replaced by a button carrying the host-offline
+    // copy, and clicking it opens the reconnect help.
+    useHostsMock.mockReturnValue({
+      data: [
+        {
+          host_id: "host_a1b2",
+          name: "mac-laptop",
+          owner: "alice",
+          status: "offline",
+          sandbox_provider: null,
+        },
+      ],
+    });
+    useSessionHostOnlineMock.mockReturnValue(false);
+    const onReconnect = vi.fn();
+    render(<HostBadge sessionId="conv_1" onReconnect={onReconnect} />);
+    const badge = screen.getByTestId("host-badge");
+    expect(badge.tagName).toBe("BUTTON");
+    expect(badge.textContent).toMatch(/Host is offline/);
+    fireEvent.click(badge);
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing when onReconnect is set but the session isn't host-bound", () => {
+    // The reconnect affordance still gates on there being a host to reconnect
+    // to — an unbound session has no badge slot to host it.
+    useSessionMock.mockReturnValue({ session: { hostId: null }, isLoading: false, error: null });
+    render(<HostBadge sessionId="conv_1" onReconnect={vi.fn()} />);
+    expect(screen.queryByTestId("host-badge")).toBeNull();
   });
 
   it("shows unknown while the host list is still loading", () => {

--- a/web/src/components/HostBadge.tsx
+++ b/web/src/components/HostBadge.tsx
@@ -1,3 +1,5 @@
+import { MonitorOff as MonitorOffIcon } from "lucide-react";
+
 import { useHosts } from "@/hooks/useHosts";
 import type { Host } from "@/hooks/useHosts";
 import { useSession } from "@/hooks/useSession";
@@ -62,8 +64,20 @@ const STATUS_WORD: Record<HostBadgeStatus, string> = {
  * session isn't host-bound — same self-contained shape as PresenceAvatars.
  * Shows the friendly host name (or sandbox-provider label) plus a status
  * circle: green online, red offline, neutral while liveness is still unknown.
+ *
+ * When `onReconnect` is set the session is unreachable because its host is
+ * offline (`host_offline` liveness): the badge becomes a clickable "Host is
+ * offline — click to reconnect" affordance in the same slot, replacing the
+ * passive name + dot. This is what moves the reconnect prompt up beside the
+ * host instead of a separate banner below the composer.
  */
-export function HostBadge({ sessionId }: { sessionId: string }) {
+export function HostBadge({
+  sessionId,
+  onReconnect,
+}: {
+  sessionId: string;
+  onReconnect?: () => void;
+}) {
   const { session } = useSession(sessionId);
   const hostId = session?.hostId ?? null;
   // Keep sandbox hosts so managed sessions resolve to a provider label.
@@ -84,6 +98,22 @@ export function HostBadge({ sessionId }: { sessionId: string }) {
 
   const badge = resolveHostBadge({ hostId, host, online });
   if (!badge) return null;
+
+  if (onReconnect) {
+    return (
+      <button
+        type="button"
+        data-testid="host-badge"
+        onClick={onReconnect}
+        className="flex min-w-0 items-center gap-1.5 text-xs text-destructive underline-offset-2 hover:underline"
+        title="Host is offline — click to reconnect"
+      >
+        <span aria-hidden className="size-2 shrink-0 rounded-full bg-destructive" />
+        <MonitorOffIcon className="size-3.5 shrink-0" aria-hidden />
+        <span className="truncate">Host is offline — click to reconnect</span>
+      </button>
+    );
+  }
 
   return (
     <div

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -68,17 +68,18 @@ describe("ConnectionIndicator", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("shows the host-offline reconnect affordance", () => {
-    // WHY: a host_offline session is unreachable — the only way back is the
-    // clickable reconnect banner with the host-specific copy.
-    render(
+  it("renders nothing for a non-terminal-first host_offline session (badge owns the affordance)", () => {
+    // WHY: the reconnect prompt for host_offline moved up into the composer's
+    // host badge (ComposerStatusLine), where the host is already named — so
+    // this band suppresses itself for a non-terminal-first session. The badge
+    // renders the clickable "Host is offline — click to reconnect" instead.
+    const { container } = render(
       <ConnectionIndicator
         liveness={{ kind: "host_offline", isOwner: true }}
         onShowReconnectHelp={onShowReconnectHelp}
       />,
     );
-    const btn = screen.getByTestId("disconnected-indicator");
-    expect(btn).toHaveTextContent(/Host is offline/);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it("shows agent-disconnected copy for a local-stranded runner", () => {

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -82,21 +82,6 @@ describe("ConnectionIndicator", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("keeps the host_offline banner for a sub-agent session (its composer hides the badge)", () => {
-    // WHY: a sub-agent session's composer suppresses the host badge (the
-    // header's child slot owns that row), so the badge can't carry the
-    // reconnect affordance. The banner must stay or the session has no way
-    // back — the regression Polly flagged.
-    render(
-      <ConnectionIndicator
-        liveness={{ kind: "host_offline", isOwner: true }}
-        onShowReconnectHelp={onShowReconnectHelp}
-        isSubAgentSession
-      />,
-    );
-    expect(screen.getByTestId("disconnected-indicator")).toHaveTextContent(/Host is offline/);
-  });
-
   it("shows agent-disconnected copy for a local-stranded runner", () => {
     // WHY: local_stranded is the other unreachable branch and must read as the
     // agent dropping, not the host.

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -82,6 +82,21 @@ describe("ConnectionIndicator", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it("keeps the host_offline banner for a sub-agent session (its composer hides the badge)", () => {
+    // WHY: a sub-agent session's composer suppresses the host badge (the
+    // header's child slot owns that row), so the badge can't carry the
+    // reconnect affordance. The banner must stay or the session has no way
+    // back — the regression Polly flagged.
+    render(
+      <ConnectionIndicator
+        liveness={{ kind: "host_offline", isOwner: true }}
+        onShowReconnectHelp={onShowReconnectHelp}
+        isSubAgentSession
+      />,
+    );
+    expect(screen.getByTestId("disconnected-indicator")).toHaveTextContent(/Host is offline/);
+  });
+
   it("shows agent-disconnected copy for a local-stranded runner", () => {
     // WHY: local_stranded is the other unreachable branch and must read as the
     // agent dropping, not the host.

--- a/web/src/pages/ChatPage.statusLine.test.tsx
+++ b/web/src/pages/ChatPage.statusLine.test.tsx
@@ -337,33 +337,18 @@ describe("Composer status line (branch + context ring)", () => {
     expect(onShowReconnectHelp).toHaveBeenCalledTimes(1);
   });
 
-  it("hides the passive host badge on a sub-agent session", () => {
+  it("hides the host badge on a sub-agent session", () => {
     // A child session repurposes the header's left slot for the back
-    // affordance, so the passive host name badge stays hidden there as it did
-    // before (the offline-reconnect case below is the exception).
+    // affordance, so the host badge stays hidden there as it did before. Sub-
+    // agents are never host-bound (host_id is null), so they can't be
+    // host_offline anyway — a stranded child is local_stranded, handled by the
+    // banner elsewhere.
     bindHost("mac-laptop");
     useChatStore.setState({ gitBranch: "geist" });
     renderComposer({ subAgentLabel: "check-eligibility" });
 
     expect(screen.queryByTestId("host-badge")).toBeNull();
     expect(screen.getByTestId("composer-git-branch")).toBeInTheDocument();
-  });
-
-  it("still shows the offline reconnect badge on a sub-agent session", () => {
-    // A sub-agent host_offline session gets the SAME reconnect path as a
-    // normal session — the badge carries the affordance even though its
-    // passive name badge is otherwise hidden, so the child isn't left with no
-    // way back.
-    bindHost("mac-laptop");
-    useSessionHostOnlineMock.mockReturnValue(false);
-    const onShowReconnectHelp = vi.fn();
-    renderComposer({ subAgentLabel: "check-eligibility", hostOffline: true, onShowReconnectHelp });
-
-    const badge = screen.getByTestId("host-badge");
-    expect(badge.tagName).toBe("BUTTON");
-    expect(badge).toHaveTextContent(/Host is offline/);
-    badge.click();
-    expect(onShowReconnectHelp).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/web/src/pages/ChatPage.statusLine.test.tsx
+++ b/web/src/pages/ChatPage.statusLine.test.tsx
@@ -320,6 +320,23 @@ describe("Composer status line (branch + context ring)", () => {
     );
   });
 
+  it("turns the host badge into a clickable reconnect prompt for an offline host", () => {
+    // host_offline surfaces the reconnect affordance in the host badge (in
+    // place of the old banner below the composer): the tray shows even with
+    // no branch/ring, and clicking the badge opens the reconnect help.
+    bindHost("mac-laptop");
+    useSessionHostOnlineMock.mockReturnValue(false);
+    const onShowReconnectHelp = vi.fn();
+    renderComposer({ hostOffline: true, onShowReconnectHelp });
+
+    expect(statusLine()).not.toBeNull();
+    const badge = screen.getByTestId("host-badge");
+    expect(badge.tagName).toBe("BUTTON");
+    expect(badge).toHaveTextContent(/Host is offline/);
+    badge.click();
+    expect(onShowReconnectHelp).toHaveBeenCalledTimes(1);
+  });
+
   it("hides the host badge on a sub-agent session", () => {
     // A child session repurposes the header's left slot for the back
     // affordance, so the host badge stays hidden there as it did before.

--- a/web/src/pages/ChatPage.statusLine.test.tsx
+++ b/web/src/pages/ChatPage.statusLine.test.tsx
@@ -337,15 +337,33 @@ describe("Composer status line (branch + context ring)", () => {
     expect(onShowReconnectHelp).toHaveBeenCalledTimes(1);
   });
 
-  it("hides the host badge on a sub-agent session", () => {
+  it("hides the passive host badge on a sub-agent session", () => {
     // A child session repurposes the header's left slot for the back
-    // affordance, so the host badge stays hidden there as it did before.
+    // affordance, so the passive host name badge stays hidden there as it did
+    // before (the offline-reconnect case below is the exception).
     bindHost("mac-laptop");
     useChatStore.setState({ gitBranch: "geist" });
     renderComposer({ subAgentLabel: "check-eligibility" });
 
     expect(screen.queryByTestId("host-badge")).toBeNull();
     expect(screen.getByTestId("composer-git-branch")).toBeInTheDocument();
+  });
+
+  it("still shows the offline reconnect badge on a sub-agent session", () => {
+    // A sub-agent host_offline session gets the SAME reconnect path as a
+    // normal session — the badge carries the affordance even though its
+    // passive name badge is otherwise hidden, so the child isn't left with no
+    // way back.
+    bindHost("mac-laptop");
+    useSessionHostOnlineMock.mockReturnValue(false);
+    const onShowReconnectHelp = vi.fn();
+    renderComposer({ subAgentLabel: "check-eligibility", hostOffline: true, onShowReconnectHelp });
+
+    const badge = screen.getByTestId("host-badge");
+    expect(badge.tagName).toBe("BUTTON");
+    expect(badge).toHaveTextContent(/Host is offline/);
+    badge.click();
+    expect(onShowReconnectHelp).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1676,6 +1676,7 @@ function MainAgentSurface({
           liveness={liveness}
           onShowReconnectHelp={onShowReconnectHelp}
           surfaceFrontmost={surfaceFrontmost}
+          isSubAgentSession={subAgentLabel != null}
         />
       </>
     );
@@ -1868,6 +1869,7 @@ function MainAgentSurface({
         liveness={liveness}
         onShowReconnectHelp={onShowReconnectHelp}
         surfaceFrontmost={surfaceFrontmost}
+        isSubAgentSession={subAgentLabel != null}
       />
     </>
   );
@@ -2542,12 +2544,17 @@ export function ConnectionIndicator({
   liveness,
   onShowReconnectHelp,
   surfaceFrontmost = true,
+  isSubAgentSession = false,
 }: {
   liveness: SessionLiveness;
   onShowReconnectHelp: () => void;
   // Whether the chat/terminal surface is frontmost (not under a drawer). Gates
   // the native iOS bar so it doesn't float over an opened sidebar/panel.
   surfaceFrontmost?: boolean;
+  // Whether the open session is a sub-agent (child). Its composer hides the
+  // host badge (the header's child slot owns that row), so the badge can't
+  // carry the host-offline reconnect affordance — keep the banner here.
+  isSubAgentSession?: boolean;
 }) {
   const terminalFirst = useTerminalFirst();
   const keyboardVisible = useIOSNativeKeyboardVisible(
@@ -2589,13 +2596,16 @@ export function ConnectionIndicator({
   }
   if (unreachable) {
     // A `host_offline` session moves the reconnect affordance up into the
-    // composer's host badge (ComposerStatusLine), where the host is already
-    // named — so render nothing here whenever that composer is on screen.
-    // The composer is hidden only in the terminal-first *terminal* view (the
-    // PTY owns the surface); there the banner still carries the affordance.
-    // `local_stranded` keeps the banner everywhere (no host, hence no badge).
+    // composer's host badge (ComposerStatusLine) — so render nothing here
+    // whenever that badge is actually on screen. Two ways it isn't: the
+    // terminal-first *terminal* view (the PTY owns the surface, no composer),
+    // and a sub-agent session (its composer hides the host badge — the
+    // header's child slot owns that row). In both, keep the banner so the
+    // affordance survives. `local_stranded` keeps the banner everywhere (no
+    // host, hence no badge).
     const composerOnScreen = !(terminalFirst?.isTerminalFirst && terminalFirst.view === "terminal");
-    if (liveness.kind === "host_offline" && composerOnScreen) {
+    const badgeCarriesAffordance = composerOnScreen && !isSubAgentSession;
+    if (liveness.kind === "host_offline" && badgeCarriesAffordance) {
       return null;
     }
     return (

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1676,7 +1676,6 @@ function MainAgentSurface({
           liveness={liveness}
           onShowReconnectHelp={onShowReconnectHelp}
           surfaceFrontmost={surfaceFrontmost}
-          isSubAgentSession={subAgentLabel != null}
         />
       </>
     );
@@ -1869,7 +1868,6 @@ function MainAgentSurface({
         liveness={liveness}
         onShowReconnectHelp={onShowReconnectHelp}
         surfaceFrontmost={surfaceFrontmost}
-        isSubAgentSession={subAgentLabel != null}
       />
     </>
   );
@@ -2544,17 +2542,12 @@ export function ConnectionIndicator({
   liveness,
   onShowReconnectHelp,
   surfaceFrontmost = true,
-  isSubAgentSession = false,
 }: {
   liveness: SessionLiveness;
   onShowReconnectHelp: () => void;
   // Whether the chat/terminal surface is frontmost (not under a drawer). Gates
   // the native iOS bar so it doesn't float over an opened sidebar/panel.
   surfaceFrontmost?: boolean;
-  // Whether the open session is a sub-agent (child). Its composer hides the
-  // host badge (the header's child slot owns that row), so the badge can't
-  // carry the host-offline reconnect affordance — keep the banner here.
-  isSubAgentSession?: boolean;
 }) {
   const terminalFirst = useTerminalFirst();
   const keyboardVisible = useIOSNativeKeyboardVisible(
@@ -2596,16 +2589,15 @@ export function ConnectionIndicator({
   }
   if (unreachable) {
     // A `host_offline` session moves the reconnect affordance up into the
-    // composer's host badge (ComposerStatusLine) — so render nothing here
-    // whenever that badge is actually on screen. Two ways it isn't: the
-    // terminal-first *terminal* view (the PTY owns the surface, no composer),
-    // and a sub-agent session (its composer hides the host badge — the
-    // header's child slot owns that row). In both, keep the banner so the
-    // affordance survives. `local_stranded` keeps the banner everywhere (no
-    // host, hence no badge).
+    // composer's host badge (ComposerStatusLine), where the host is already
+    // named — so render nothing here whenever that composer is on screen
+    // (sub-agent sessions included; their badge carries it just like a normal
+    // session's). The composer is hidden only in the terminal-first *terminal*
+    // view (the PTY owns the surface); there the banner still carries the
+    // affordance. `local_stranded` keeps the banner everywhere (no host, hence
+    // no badge).
     const composerOnScreen = !(terminalFirst?.isTerminalFirst && terminalFirst.view === "terminal");
-    const badgeCarriesAffordance = composerOnScreen && !isSubAgentSession;
-    if (liveness.kind === "host_offline" && badgeCarriesAffordance) {
+    if (liveness.kind === "host_offline" && composerOnScreen) {
       return null;
     }
     return (
@@ -3678,10 +3670,12 @@ function ComposerStatusLine({
   // contextWindow > 0: the SSE path validates it but the snapshot path doesn't, and 0/0 → "NaN%".
   const showRing =
     !!conversationId && contextWindow != null && contextWindow > 0 && tokensUsed != null;
-  // The offline-host affordance lives in the host badge, so the tray must
-  // render even when every other slot is empty (an unreachable session often
-  // has no branch/ring/harness yet).
-  const showReconnect = showHost && !!onHostReconnect;
+  // The offline-host reconnect affordance lives in the host badge. It renders
+  // even for sub-agent sessions — they get the same reconnect path as a normal
+  // session, unlike the passive name badge (`showHost`) which stays hidden for
+  // a child. The tray must render for it even when every other slot is empty
+  // (an unreachable session often has no branch/ring/harness yet).
+  const showReconnect = !!conversationId && !!onHostReconnect;
   if (!showBranch && !showPlanMode && !showGoal && !showRing && !showHarness && !showReconnect)
     return null;
 
@@ -3705,7 +3699,7 @@ function ComposerStatusLine({
           so the right cluster stays pinned right even when both are absent;
           each item truncates to an ellipsis so the tray never wraps. */}
       <div className="flex min-w-0 flex-1 items-center gap-3 text-xs text-muted-foreground">
-        {showHost && conversationId && (
+        {(showHost || showReconnect) && conversationId && (
           <HostBadge sessionId={conversationId} onReconnect={onHostReconnect} />
         )}
         {showBranch && (

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3670,12 +3670,13 @@ function ComposerStatusLine({
   // contextWindow > 0: the SSE path validates it but the snapshot path doesn't, and 0/0 → "NaN%".
   const showRing =
     !!conversationId && contextWindow != null && contextWindow > 0 && tokensUsed != null;
-  // The offline-host reconnect affordance lives in the host badge. It renders
-  // even for sub-agent sessions — they get the same reconnect path as a normal
-  // session, unlike the passive name badge (`showHost`) which stays hidden for
-  // a child. The tray must render for it even when every other slot is empty
-  // (an unreachable session often has no branch/ring/harness yet).
-  const showReconnect = !!conversationId && !!onHostReconnect;
+  // The offline-host reconnect affordance lives in the host badge, so the tray
+  // must render even when every other slot is empty (an unreachable session
+  // often has no branch/ring/harness yet). Gated by `showHost`: only host-bound
+  // sessions can be `host_offline`, and sub-agents (which hide the badge) are
+  // never host-bound — a stranded child is `local_stranded`, which keeps its
+  // banner elsewhere.
+  const showReconnect = showHost && !!onHostReconnect;
   if (!showBranch && !showPlanMode && !showGoal && !showRing && !showHarness && !showReconnect)
     return null;
 
@@ -3699,7 +3700,7 @@ function ComposerStatusLine({
           so the right cluster stays pinned right even when both are absent;
           each item truncates to an ellipsis so the tray never wraps. */}
       <div className="flex min-w-0 flex-1 items-center gap-3 text-xs text-muted-foreground">
-        {(showHost || showReconnect) && conversationId && (
+        {showHost && conversationId && (
           <HostBadge sessionId={conversationId} onReconnect={onHostReconnect} />
         )}
         {showBranch && (

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1854,6 +1854,8 @@ function MainAgentSurface({
           !sandboxLaunching &&
           (liveness.kind === "host_offline" || liveness.kind === "local_stranded")
         }
+        hostOffline={!sandboxLaunching && liveness.kind === "host_offline"}
+        onShowReconnectHelp={onShowReconnectHelp}
         costRoutingVerdict={costRoutingVerdict}
         costRoutingEligible={costRoutingEligible}
         subAgentLabel={subAgentLabel}
@@ -2586,6 +2588,16 @@ export function ConnectionIndicator({
     return null;
   }
   if (unreachable) {
+    // A `host_offline` session moves the reconnect affordance up into the
+    // composer's host badge (ComposerStatusLine), where the host is already
+    // named — so render nothing here whenever that composer is on screen.
+    // The composer is hidden only in the terminal-first *terminal* view (the
+    // PTY owns the surface); there the banner still carries the affordance.
+    // `local_stranded` keeps the banner everywhere (no host, hence no badge).
+    const composerOnScreen = !(terminalFirst?.isTerminalFirst && terminalFirst.view === "terminal");
+    if (liveness.kind === "host_offline" && composerOnScreen) {
+      return null;
+    }
     return (
       <button
         type="button"
@@ -3389,6 +3401,15 @@ interface ComposerProps {
    * banner below is the only affordance.
    */
   unreachable?: boolean;
+  /**
+   * The session is host-bound to an offline, non-resumable host
+   * (`host_offline`): the composer's host badge turns into a clickable
+   * "Host is offline — click to reconnect" affordance (see HostBadge's
+   * `onReconnect`), replacing the separate banner below the composer.
+   */
+  hostOffline?: boolean;
+  /** Open the reconnect help dialog — wired to the host badge when `hostOffline`. */
+  onShowReconnectHelp?: () => void;
   /** Latest parsed advisor verdict for the cost-routing pill; `null`/omitted when none. */
   costRoutingVerdict?: CostRoutingVerdict | null;
   /** Session passes `isCostRoutingSession` (polly orchestrator, not a child); see that predicate. */
@@ -3609,10 +3630,18 @@ function ComposerStatusLine({
   harnessLabel,
   goal,
   isSubAgentSession,
+  onHostReconnect,
 }: {
   harnessLabel: string | null;
   goal: Goal | null;
   isSubAgentSession: boolean;
+  /**
+   * When set (`host_offline` liveness), the host badge becomes a clickable
+   * "Host is offline — click to reconnect" affordance. Also forces the tray
+   * to render even when it would otherwise be empty, so the prompt is always
+   * visible for an unreachable host.
+   */
+  onHostReconnect?: () => void;
 }) {
   const conversationId = useChatStore((s) => s.conversationId);
   const contextWindow = useChatStore((s) => s.contextWindow);
@@ -3639,7 +3668,12 @@ function ComposerStatusLine({
   // contextWindow > 0: the SSE path validates it but the snapshot path doesn't, and 0/0 → "NaN%".
   const showRing =
     !!conversationId && contextWindow != null && contextWindow > 0 && tokensUsed != null;
-  if (!showBranch && !showPlanMode && !showGoal && !showRing && !showHarness) return null;
+  // The offline-host affordance lives in the host badge, so the tray must
+  // render even when every other slot is empty (an unreachable session often
+  // has no branch/ring/harness yet).
+  const showReconnect = showHost && !!onHostReconnect;
+  if (!showBranch && !showPlanMode && !showGoal && !showRing && !showHarness && !showReconnect)
+    return null;
 
   return (
     <div
@@ -3661,7 +3695,9 @@ function ComposerStatusLine({
           so the right cluster stays pinned right even when both are absent;
           each item truncates to an ellipsis so the tray never wraps. */}
       <div className="flex min-w-0 flex-1 items-center gap-3 text-xs text-muted-foreground">
-        {showHost && conversationId && <HostBadge sessionId={conversationId} />}
+        {showHost && conversationId && (
+          <HostBadge sessionId={conversationId} onReconnect={onHostReconnect} />
+        )}
         {showBranch && (
           <span className="flex min-w-0 items-center gap-1.5">
             <GitBranchIcon className="size-3.5 shrink-0" />
@@ -3801,6 +3837,8 @@ export function Composer({
   reconnectHint = false,
   sandboxAsleepHint = false,
   unreachable = false,
+  hostOffline = false,
+  onShowReconnectHelp,
   costRoutingVerdict = null,
   costRoutingEligible = false,
   subAgentLabel = null,
@@ -5003,6 +5041,7 @@ export function Composer({
         harnessLabel={harnessLabel}
         goal={goal}
         isSubAgentSession={subAgentLabel != null}
+        onHostReconnect={hostOffline ? onShowReconnectHelp : undefined}
       />
     </form>
   );

--- a/web/src/pages/ConnectionIndicator.test.tsx
+++ b/web/src/pages/ConnectionIndicator.test.tsx
@@ -148,10 +148,23 @@ describe("ConnectionIndicator", () => {
     expect(screen.queryByRole("group", { name: /view mode/i })).toBeNull();
   });
 
-  it("uses host-specific wording for a host_offline session", () => {
-    renderWithContext({ kind: "host_offline", isOwner: true }, makeCtx());
+  it("keeps the host-offline banner in the terminal-first TERMINAL view (no composer badge there)", () => {
+    // In the terminal view the PTY owns the surface — the composer's host
+    // badge isn't on screen, so the banner still carries the reconnect copy.
+    renderWithContext({ kind: "host_offline", isOwner: true }, makeCtx({ view: "terminal" }));
     const button = screen.getByTestId("disconnected-indicator");
     expect(button).toHaveTextContent(/host is offline/i);
+  });
+
+  it("suppresses the host-offline banner in the chat view (composer badge owns it)", () => {
+    // The chat view shows the composer, whose host badge becomes the clickable
+    // reconnect affordance — so this band must not double up the banner.
+    const { container } = renderWithContext(
+      { kind: "host_offline", isOwner: true },
+      makeCtx({ view: "chat" }),
+    );
+    expect(screen.queryByTestId("disconnected-indicator")).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it("renders NOTHING for a runner_asleep NON-terminal-first session — composer stays open", () => {


### PR DESCRIPTION
## Related issue

N/A

## Summary

When a session's host went offline, the "Host is offline — click to reconnect" prompt rendered as a **banner below the composer**, separate from the composer's host badge where the host is already named — so it read as duplicated chrome.

- The composer's host badge now becomes the reconnect affordance: on `host_offline`, it turns into a clickable red "Host is offline — click to reconnect" control in place of the passive host name + status dot.
- `ConnectionIndicator` suppresses its banner for `host_offline` whenever the composer (and its badge) is on screen — i.e. everywhere except the terminal-first **terminal** view, where the PTY owns the surface and the badge isn't visible, so the banner still carries the affordance there.
- `local_stranded` keeps the banner everywhere (no host bound → no badge to host the affordance).

## Test Plan

- `cd web && npm test` — full suite green (4303 passed, 3 expected-fail, 1 skipped).
- `cd web && npm run build` — `tsc -b` + vite build clean.
- Updated/added unit tests: `HostBadge.test.tsx` (clickable offline badge + host-bound gating), `ChatPage.statusLine.test.tsx` (offline badge wired through the Composer), `ConnectionIndicator.test.tsx` (banner kept in terminal view, suppressed in chat view), `ChatPage.indicators.test.tsx` (non-terminal-first `host_offline` renders nothing).
- Manual: opened a claude-native session, took the host offline, confirmed the badge shows the reconnect prompt in chat view with no bottom banner, and the banner remains in the terminal view.

## Demo

<img width="769" height="154" alt="image" src="https://github.com/user-attachments/assets/b7bb0d06-3df3-40a1-825d-2c46ebb37532" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: with a host-bound claude-native session forced offline (`host_offline` liveness), confirmed in chat view the host badge renders the clickable "Host is offline — click to reconnect" control and the separate below-composer banner no longer appears; flipping to the terminal view still shows the banner (no composer badge there). Automated unit tests cover the badge affordance and the banner suppression/retention branches.

## Changelog

The "Host is offline — click to reconnect" prompt now appears in the composer's host badge instead of a separate banner below the composer

This pull request and its description were written by Isaac.
