### PR TITLE
test(server): de-flake background-title test racing the coordinator

### DIFF
--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -143,7 +143,6 @@ async def test_create_session_without_title_returns_none(
 async def test_first_message_schedules_background_semantic_title(
     client: httpx.AsyncClient,
     app: Any,
-    db_uri: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The first user turn returns normally while title generation runs separately."""
@@ -197,11 +196,9 @@ async def test_first_message_schedules_background_semantic_title(
         await fake_runner.aclose()
 
     assert response.status_code == 202, response.text
-    store = SqlAlchemyConversationStore(db_uri)
-    store.update_conversation(
-        session["id"],
-        title="please investigate the authentication timeout",
-    )
+    # The events endpoint seeds the title synchronously before returning, so the
+    # coordinator observes the expected seed and renames it. Writing our own seed
+    # here would race that rename and clobber it, so rely on the endpoint's seed.
     await asyncio.wait_for(generated.wait(), timeout=5)
     await coordinator.wait_for_idle()
     snapshot = await client.get(f"/v1/sessions/{session['id']}")


### PR DESCRIPTION
## Related issue

N/A

## Summary

Fixes the flaky `test_first_message_schedules_background_semantic_title` server-integration test (seen failing on unrelated PRs, e.g. run 29906585821).

- The test posted the first user turn and then wrote its **own** seed title via `store.update_conversation(...)`. But the `/events` endpoint already seeds the title synchronously before returning 202 (`_seed_missing_title_from_user_message`), so that manual write was a redundant second writer.
- When the manual write landed **after** the background title coordinator's rename, it clobbered `"Debug authentication timeout"` back to the prompt text — producing the intermittent `assert 'please investigate...' == 'Debug authentication timeout'` failure. The CI log even showed the rename succeeding (`renamed=True`) before the assertion failed.
- Removed the redundant manual seed (and the now-unused `db_uri` fixture) so the test relies on the endpoint's own seed, matching the passing sibling tests (`test_initial_item_...`, `test_native_user_item_...`) which never do this manual write.

## Test Plan

- Ran the previously-flaky test 15× sequentially — all passed:

  ```bash
  for i in $(seq 1 15); do uv run pytest \
    "tests/server/integration/test_sessions_endpoints.py::test_first_message_schedules_background_semantic_title" -q; done
  ```

- Ran all title-related tests to confirm no regression:

  ```bash
  uv run pytest tests/server/integration/test_sessions_endpoints.py -k title -q   # 18 passed
  ```

- Lint clean:

  ```bash
  uvx ruff check tests/server/integration/test_sessions_endpoints.py
  ```

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This change only de-flakes an existing integration test; the assertion it makes (background coordinator renames the seeded title) is unchanged. Verified manually by running the test 15× sequentially with no failures, plus the full title-test group.

## Changelog

N/A (test-only change)

This pull request and its description were written by Isaac.
