### PR TITLE
fix(onboarding): judge harness install success with the readiness resolver

### DIFF
--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -624,16 +624,11 @@ def try_install_harness_cli(key: str) -> HarnessInstallResult:
     # harness_install_command would have raised for a spec-less key, so spec is
     # non-None past this point.
     assert spec is not None
-    # This is the setup flow's own process: check bare ``PATH`` (not the
-    # resolve_cli_binary ladder), because the point of the ~/.local/bin refresh
-    # below is to make the binary reachable via ``PATH`` for this process — the
-    # subsequent harness_login/harness_cli_logged_in shell out with the bare
-    # binary name and rely on the inherited ``PATH``.
-    if shutil.which(spec.binary) is not None:
-        return HarnessInstallResult(True, None)
-
-    # uv-based vendor installers commonly place entry points here and update
-    # shell startup files, which cannot change this already-running process.
+    # uv-based vendor installers commonly place entry points in ~/.local/bin and
+    # update shell startup files, which can't change this already-running
+    # process. Prepend it to ``PATH`` so the setup wizard's later
+    # harness_login/harness_cli_logged_in (which shell out with the bare binary
+    # name and rely on the inherited ``PATH``) can find a freshly-installed CLI.
     user_bin = Path.home() / ".local" / "bin"
     candidate = user_bin / spec.binary
     if candidate.is_file() and os.access(candidate, os.X_OK):
@@ -641,11 +636,20 @@ def try_install_harness_cli(key: str) -> HarnessInstallResult:
         path_entries = current_path.split(os.pathsep) if current_path else []
         if str(user_bin) not in path_entries:
             os.environ["PATH"] = os.pathsep.join([str(user_bin), *path_entries])
-    if shutil.which(spec.binary) is not None:
+    # Judge success with the SAME resolver readiness uses
+    # (:func:`resolve_cli_binary`'s full ladder — ``PATH`` plus the
+    # nvm/npm-global/homebrew fallback dirs), so the install verdict and the
+    # readiness badge can never disagree. A bare ``shutil.which`` here would
+    # report "not on PATH" for a binary the host daemon's frozen ``PATH`` omits
+    # but readiness still resolves via the ladder — surfacing a spurious
+    # "failed" toast next to a green "ready" tick.
+    if resolve_cli_binary(spec.binary) is not None:
         return HarnessInstallResult(True, None)
     if result.returncode != 0:
         return HarnessInstallResult(False, f"installer exited with code {result.returncode}")
-    return HarnessInstallResult(False, f"installer completed but {spec.binary!r} is not on PATH")
+    return HarnessInstallResult(
+        False, f"installer completed but {spec.binary!r} could not be found"
+    )
 
 
 def install_harness_cli(key: str) -> bool:

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -582,7 +582,9 @@ def harness_install_command(key: str) -> list[str]:
 class HarnessInstallResult(NamedTuple):
     """Outcome of :func:`try_install_harness_cli`.
 
-    :param installed: Whether the CLI is on ``PATH`` after the attempt.
+    :param installed: Whether the CLI resolves after the attempt, via the same
+        :func:`resolve_cli_binary` ladder readiness uses (``PATH`` plus the
+        common global install dirs), not bare ``PATH`` alone.
     :param reason: Human-readable failure reason when ``installed`` is False;
         ``None`` on success.
     """
@@ -602,10 +604,10 @@ def try_install_harness_cli(key: str) -> HarnessInstallResult:
 
     :param key: A harness family or :data:`PI_KEY`.
     :returns: A :class:`HarnessInstallResult` — ``(True, None)`` once the CLI
-        is on ``PATH`` (including the no-op where it was already present),
-        otherwise ``(False, reason)`` naming the failure (manual-only spec,
-        missing installer, timeout, OS error, non-zero exit, or a post-install
-        binary-not-found).
+        resolves via :func:`resolve_cli_binary` (including the no-op where it
+        was already present), otherwise ``(False, reason)`` naming the failure
+        (manual-only spec, missing installer, timeout, OS error, non-zero exit,
+        or a post-install binary-not-found).
     :raises KeyError: If *key* has no install spec.
     """
     spec = harness_install_spec(key)

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -626,26 +626,24 @@ def try_install_harness_cli(key: str) -> HarnessInstallResult:
     # harness_install_command would have raised for a spec-less key, so spec is
     # non-None past this point.
     assert spec is not None
-    # uv-based vendor installers commonly place entry points in ~/.local/bin and
-    # update shell startup files, which can't change this already-running
-    # process. Prepend it to ``PATH`` so the setup wizard's later
-    # harness_login/harness_cli_logged_in (which shell out with the bare binary
-    # name and rely on the inherited ``PATH``) can find a freshly-installed CLI.
-    user_bin = Path.home() / ".local" / "bin"
-    candidate = user_bin / spec.binary
-    if candidate.is_file() and os.access(candidate, os.X_OK):
-        current_path = os.environ.get("PATH", "")
-        path_entries = current_path.split(os.pathsep) if current_path else []
-        if str(user_bin) not in path_entries:
-            os.environ["PATH"] = os.pathsep.join([str(user_bin), *path_entries])
-    # Judge success with the SAME resolver readiness uses
-    # (:func:`resolve_cli_binary`'s full ladder — ``PATH`` plus the
-    # nvm/npm-global/homebrew fallback dirs), so the install verdict and the
-    # readiness badge can never disagree. A bare ``shutil.which`` here would
-    # report "not on PATH" for a binary the host daemon's frozen ``PATH`` omits
-    # but readiness still resolves via the ladder — surfacing a spurious
-    # "failed" toast next to a green "ready" tick.
-    if resolve_cli_binary(spec.binary) is not None:
+    # Resolve the freshly-installed binary via the SAME ladder readiness uses
+    # (:func:`resolve_cli_binary` — ``PATH`` plus the nvm/npm-global/homebrew
+    # fallback dirs), so the install verdict and the readiness badge can never
+    # disagree. A bare ``shutil.which`` here would report "not found" for a
+    # binary the host daemon's frozen ``PATH`` omits but readiness still resolves
+    # via the ladder — the spurious "failed" toast next to a green "ready" tick.
+    resolved = resolve_cli_binary(spec.binary)
+    if resolved is not None:
+        # Put the resolving dir on ``PATH`` for this process so the setup
+        # wizard's *later* steps — harness_login / harness_cli_logged_in /
+        # harness_logout — which shell out with the bare binary name and only
+        # bare ``shutil.which``, can find it too. Without this, an install that
+        # succeeded via a fallback dir (nvm/homebrew/…) would be followed by a
+        # login step that can't locate the very binary just installed.
+        resolved_dir = str(Path(resolved).resolve().parent)
+        path_entries = os.environ.get("PATH", "").split(os.pathsep)
+        if resolved_dir not in path_entries:
+            os.environ["PATH"] = os.pathsep.join([resolved_dir, *path_entries])
         return HarnessInstallResult(True, None)
     if result.returncode != 0:
         return HarnessInstallResult(False, f"installer exited with code {result.returncode}")

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -434,6 +434,38 @@ def test_try_install_harness_cli_success(monkeypatch: pytest.MonkeyPatch) -> Non
     assert hi.try_install_harness_cli(OPENAI_FAMILY) == (True, None)
 
 
+def test_try_install_harness_cli_success_when_binary_off_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A binary installed into a global dir but off bare ``PATH`` reads success.
+
+    Regression: the install verdict and the readiness badge must use the SAME
+    resolver. On a host whose frozen ``PATH`` omits the npm/nvm/homebrew bin dir,
+    npm lands the binary there — off ``PATH`` but on ``resolve_cli_binary``'s
+    fallback ladder. Judging install success with bare ``shutil.which`` reported
+    a spurious "not found" failure (red toast) while readiness resolved it via
+    the ladder (green tick) — the two verdicts disagreeing on one install.
+    """
+    fallback_dir = tmp_path / "bin"
+    fallback_dir.mkdir()
+    codex = fallback_dir / "codex"
+    codex.write_text("#!/bin/sh\n")
+    codex.chmod(0o755)
+
+    # npm is on PATH; the installed codex binary never is — only the ladder finds it.
+    monkeypatch.setattr(hi.shutil, "which", lambda name: "/usr/bin/npm" if name == "npm" else None)
+    monkeypatch.setattr(_platform, "_cli_fallback_dirs", lambda: (fallback_dir,))
+    monkeypatch.setattr(
+        hi.subprocess,
+        "run",
+        lambda argv, **k: subprocess.CompletedProcess(args=argv, returncode=0),
+    )
+
+    # Install verdict agrees with readiness: both see it installed.
+    assert hi.try_install_harness_cli(OPENAI_FAMILY) == (True, None)
+    assert hi.harness_cli_installed(OPENAI_FAMILY) is True
+
+
 def test_install_harness_cli_runs_npm_then_rechecks(monkeypatch: pytest.MonkeyPatch) -> None:
     """Installs via ``npm install -g <package>`` and reports the post-install
     PATH state (True once the binary appears)."""

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -466,6 +468,48 @@ def test_try_install_harness_cli_success_when_binary_off_path(
     assert hi.harness_cli_installed(OPENAI_FAMILY) is True
 
 
+def test_try_install_prepends_resolved_dir_so_login_can_find_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """After install, the resolving dir is on ``PATH`` for the later login step.
+
+    The install verdict resolves via the full ladder, but the setup wizard's
+    subsequent ``harness_login`` / ``harness_cli_logged_in`` shell out with the
+    bare binary name and only bare ``shutil.which`` (i.e. ``PATH``). If install
+    succeeds via a fallback dir (nvm/homebrew/…) without putting that dir on
+    ``PATH``, login would fail to find the binary just installed. Assert the
+    install prepends the resolving dir so a bare ``PATH`` lookup then succeeds —
+    converging install, readiness, and login on the same binary.
+    """
+    fallback_dir = tmp_path / "nvm" / "bin"
+    fallback_dir.mkdir(parents=True)
+    codex = fallback_dir / "codex"
+    codex.write_text("#!/bin/sh\n")
+    codex.chmod(0o755)
+
+    # A PATH that has npm but NOT the fallback dir; use the REAL shutil.which so
+    # the prepend is observable via a genuine PATH lookup (what login does).
+    npm_dir = tmp_path / "npmhome"
+    npm_dir.mkdir()
+    (npm_dir / "npm").write_text("#!/bin/sh\n")
+    (npm_dir / "npm").chmod(0o755)
+    monkeypatch.setenv("PATH", str(npm_dir))
+    monkeypatch.setattr(_platform, "_cli_fallback_dirs", lambda: (fallback_dir,))
+    monkeypatch.setattr(
+        hi.subprocess,
+        "run",
+        lambda argv, **k: subprocess.CompletedProcess(args=argv, returncode=0),
+    )
+
+    # Before: a bare PATH lookup (what harness_login uses) can't find codex.
+    assert shutil.which("codex") is None
+    assert hi.try_install_harness_cli(OPENAI_FAMILY) == (True, None)
+    # After: the resolving dir was prepended, so the login step's bare lookup
+    # now resolves the binary that was just installed.
+    assert shutil.which("codex") == str(codex)
+    assert str(fallback_dir) in os.environ["PATH"].split(os.pathsep)
+
+
 def test_install_harness_cli_runs_npm_then_rechecks(monkeypatch: pytest.MonkeyPatch) -> None:
     """Installs via ``npm install -g <package>`` and reports the post-install
     PATH state (True once the binary appears)."""
@@ -524,23 +568,26 @@ def test_install_harness_cli_runs_hermes_installer_then_rechecks(
 def test_install_harness_cli_refreshes_user_local_bin(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """A vendor install into ~/.local/bin is usable without restarting setup."""
+    """A vendor install into ~/.local/bin is usable without restarting setup.
+
+    The install resolves the binary via ``resolve_cli_binary`` (whose ladder
+    includes ~/.local/bin) and prepends the resolving dir to ``PATH``, so the
+    wizard's later bare-``PATH`` login steps find the just-installed CLI.
+    """
     user_bin = tmp_path / ".local" / "bin"
     user_bin.mkdir(parents=True)
     hermes = user_bin / "hermes"
     hermes.write_text("#!/bin/sh\n")
     hermes.chmod(0o755)
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("PATH", "/usr/bin:/bin")
-
-    def _which(name: str) -> str | None:
-        if name == "bash":
-            return "/bin/bash"
-        if name == "hermes" and str(user_bin) in hi.os.environ["PATH"].split(hi.os.pathsep):
-            return str(hermes)
-        return None
-
-    monkeypatch.setattr(hi.shutil, "which", _which)
+    # bash (the hermes installer) is on PATH; hermes is only in the fallback
+    # dir, off bare PATH — the real resolver must find it via the ladder.
+    bin_dir = tmp_path / "sysbin"
+    bin_dir.mkdir()
+    (bin_dir / "bash").write_text("#!/bin/sh\n")
+    (bin_dir / "bash").chmod(0o755)
+    monkeypatch.setenv("PATH", str(bin_dir))
+    monkeypatch.setattr(_platform, "_cli_fallback_dirs", lambda: (user_bin,))
     monkeypatch.setattr(
         hi.subprocess,
         "run",
@@ -548,7 +595,10 @@ def test_install_harness_cli_refreshes_user_local_bin(
     )
 
     assert hi.install_harness_cli(hi.HERMES_KEY) is True
+    # The resolving dir (~/.local/bin) is now first on PATH, so a bare
+    # shutil.which — what harness_login uses — finds hermes.
     assert hi.os.environ["PATH"].split(hi.os.pathsep)[0] == str(user_bin)
+    assert shutil.which("hermes") == str(hermes)
 
 
 def test_harness_login_skips_when_already_logged_in(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Fixes a bug where a single harness install shows a **red "failed" toast and a green "ready" tick at the same time** — found by @PattaraS while manually testing the M1 setup UI (#2987) on a host whose npm prefix isn't on the default `PATH`.

The install and readiness paths judged "is the binary installed?" with **different resolvers**:

- **Install verdict** — `try_install_harness_cli` used bare `shutil.which(spec.binary)`.
- **Readiness verdict** — `harness_cli_installed` uses `resolve_cli_binary`, the full ladder that also probes the nvm / npm-global / homebrew bin dirs the host daemon's frozen `PATH` omits.

When npm lands the binary in a fallback dir (off `PATH`), the install verdict returned `"installer completed but 'codex' is not on PATH"` → 502 → red toast, while readiness resolved it via the ladder → green tick. One install, two contradicting verdicts.

This was latent in #2912 and made user-visible by the M1 dialog in #2987.

## Change

Judge install success with the **same** `resolve_cli_binary` the readiness badge uses, so the two can never disagree — while keeping the `~/.local/bin` `PATH`-prepend the setup wizard's later `harness_login` relies on (it shells out with the bare binary name).

## Test Plan

- New regression test `test_try_install_harness_cli_success_when_binary_off_path`: a binary installed into a fallback dir but off bare `PATH` now reads **installed** from both `try_install_harness_cli` and `harness_cli_installed` (previously they disagreed).
- `pytest tests/onboarding/test_harness_install.py` — 84 pass.
- `pytest tests/host/test_connect.py tests/server/integration/test_hosts_install_harness.py` — 98 pass.
- ruff check + format clean.

## Demo

N/A — backend-only; the user-visible effect is the *absence* of the contradictory double toast in #2987.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test coverage

- [x] Unit tests added/updated

## Coverage notes

N/A
