### PR TITLE
Make Daytona sandboxes resumable after stop

### DIFF
--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -825,6 +825,21 @@ class SandboxLauncher(ABC):
         del sandbox_id
         return None
 
+    def exists(self, sandbox_id: str) -> bool | None:
+        """
+        Return whether the provider still has this sandbox.
+
+        Optional capability: ``None`` means the launcher cannot cheaply answer
+        or the provider could not be reached. Callers should fail closed and
+        preserve the existing sandbox binding in that case.
+
+        :param sandbox_id: The sandbox to inspect, e.g. ``"sb-a1b2c3"``.
+        :returns: ``True`` when present, ``False`` when definitively missing,
+            or ``None`` when existence is unknown.
+        """
+        del sandbox_id
+        return None
+
     def exec_foreground(self, sandbox_id: str, command: str) -> int:
         """
         Run a command in the sandbox with stdio inherited from the

--- a/omnigent/onboarding/sandboxes/daytona.py
+++ b/omnigent/onboarding/sandboxes/daytona.py
@@ -184,6 +184,7 @@ class DaytonaSandboxLauncher(SandboxLauncher):
     """
 
     provider: ClassVar[str] = "daytona"
+    can_resume: ClassVar[bool] = True
     # Daytona preview links are sandbox→public only; there is no
     # local→sandbox path for the App OAuth callback port.
     supports_local_port_forward: ClassVar[bool] = False
@@ -387,6 +388,56 @@ class DaytonaSandboxLauncher(SandboxLauncher):
             raise click.ClickException(
                 f"Could not attach to Daytona sandbox '{sandbox_id}': {exc}"
             ) from exc
+
+    def resume(self, sandbox_id: str) -> None:
+        """Resume a stopped sandbox without replacing its persistent workspace."""
+        handle = self._resolve(sandbox_id)
+        import daytona
+
+        try:
+            handle.refresh_data()
+            if handle.state != daytona.SandboxState.STARTED:
+                click.echo(f"▸ Resuming Daytona sandbox '{sandbox_id}'")
+                handle.start()
+        except daytona.DaytonaError as exc:
+            raise click.ClickException(
+                f"Could not resume Daytona sandbox '{sandbox_id}': {exc}"
+            ) from exc
+
+    def is_running(self, sandbox_id: str) -> bool | None:
+        """Return Daytona's current running state for a managed sandbox."""
+        _ensure_sdk()
+        import daytona
+
+        try:
+            handle = self._daytona().get(sandbox_id)
+            handle.refresh_data()
+        except daytona.DaytonaNotFoundError:
+            self._sandboxes.pop(sandbox_id, None)
+            return False
+        except daytona.DaytonaError:
+            return None
+        self._sandboxes[sandbox_id] = handle
+        if handle.state == daytona.SandboxState.STARTED:
+            return True
+        if handle.state == daytona.SandboxState.STOPPED:
+            return False
+        return None
+
+    def exists(self, sandbox_id: str) -> bool | None:
+        """Return whether Daytona still has the provider-side sandbox object."""
+        _ensure_sdk()
+        import daytona
+
+        try:
+            handle = self._daytona().get(sandbox_id)
+        except daytona.DaytonaNotFoundError:
+            self._sandboxes.pop(sandbox_id, None)
+            return False
+        except daytona.DaytonaError:
+            return None
+        self._sandboxes[sandbox_id] = handle
+        return True
 
     def keep_alive(self, sandbox_id: str) -> None:
         """

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -2194,6 +2194,17 @@ def host_sandbox_is_running(
     return launcher.is_running(host.sandbox_id)
 
 
+def host_sandbox_exists(
+    host: Host,
+    config: ManagedSandboxConfig | None,
+) -> bool | None:
+    """Ask the matched provider whether this managed sandbox still exists."""
+    launcher = _launcher_for_teardown(host, config)
+    if launcher is None or host.sandbox_id is None:
+        return None
+    return launcher.exists(host.sandbox_id)
+
+
 # ── Managed-host wake (resume a dormant host on demand) ─────────────────────
 
 # Per-host resume single-flight: one in-flight resume per host_id on this

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -180,6 +180,7 @@ from omnigent.server.managed_hosts import (
     ManagedSandboxConfig,
     RepoWorkspace,
     host_resume_supported,
+    host_sandbox_exists,
     host_sandbox_is_running,
 )
 from omnigent.server.mcp_pool import ServerMcpPool
@@ -7203,7 +7204,8 @@ async def _maybe_relaunch_managed_sandbox(
         # uses (host_resume_supported). Both run in the background through this
         # same tracker, so the message parks on the rendezvous either way; only
         # the provision step differs.
-        if host_resume_supported(host, sandbox_config):
+        sandbox_exists = await asyncio.to_thread(host_sandbox_exists, host, sandbox_config)
+        if host_resume_supported(host, sandbox_config) and sandbox_exists is not False:
             _kick_managed_wake(
                 session_id=session_id,
                 conv=conv,

--- a/tests/onboarding/sandboxes/test_daytona.py
+++ b/tests/onboarding/sandboxes/test_daytona.py
@@ -302,6 +302,8 @@ class _FakeDaytonaState:
     :param create_raises: Exception ``create`` raises instead of
         provisioning (e.g. a canned SDK authorization error), or
         ``None`` for normal creation.
+    :param get_raises: Exception ``get`` raises instead of resolving a
+        sandbox, or ``None`` for normal lookup.
     :param delete_raises: Exceptions successive ``delete`` calls raise
         before succeeding (popped front-first) — models the live
         "Sandbox state change in progress" conflict window.
@@ -312,6 +314,7 @@ class _FakeDaytonaState:
     deleted: list[str] = field(default_factory=list)
     client_count: int = 0
     create_raises: Exception | None = None
+    get_raises: Exception | None = None
     delete_raises: list[Exception] = field(default_factory=list)
 
 
@@ -357,6 +360,8 @@ def _install_fake_daytona(monkeypatch: pytest.MonkeyPatch) -> _FakeDaytonaState:
 
         def get(self, sandbox_id: str) -> _FakeSandbox:
             """Resolve a live sandbox or raise the not-found error."""
+            if state.get_raises is not None:
+                raise state.get_raises
             sandbox = state.sandboxes.get(sandbox_id)
             if sandbox is None:
                 raise _FakeNotFoundError(sandbox_id)
@@ -724,6 +729,58 @@ def test_attach_unknown_sandbox_fails_with_hint(fake_daytona: _FakeDaytonaState)
     """A vanished sandbox surfaces as a clear error naming the id."""
     with pytest.raises(click.ClickException, match="dt-gone"):
         DaytonaSandboxLauncher().attach("dt-gone")
+
+
+def test_resume_starts_stopped_sandbox_in_place(fake_daytona: _FakeDaytonaState) -> None:
+    """A managed wake starts the same Daytona sandbox instead of replacing it."""
+    launcher = DaytonaSandboxLauncher()
+    sandbox_id = launcher.provision("a")
+    sandbox = fake_daytona.sandboxes[sandbox_id]
+    sandbox.state = _FakeSandboxState.STOPPED
+
+    launcher.resume(sandbox_id)
+
+    assert launcher.can_resume is True
+    assert sandbox.refresh_data_calls == 1
+    assert sandbox.start_calls == 1
+    assert sandbox_id in fake_daytona.sandboxes
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        (_FakeSandboxState.STARTED, True),
+        (_FakeSandboxState.STOPPED, False),
+    ],
+)
+def test_is_running_reports_daytona_state(
+    fake_daytona: _FakeDaytonaState,
+    state: _FakeSandboxState,
+    expected: bool,
+) -> None:
+    """Managed liveness follows the refreshed provider state."""
+    launcher = DaytonaSandboxLauncher()
+    sandbox_id = launcher.provision("a")
+    fake_daytona.sandboxes[sandbox_id].state = state
+
+    assert launcher.is_running(sandbox_id) is expected
+    assert fake_daytona.sandboxes[sandbox_id].refresh_data_calls == 1
+
+
+def test_exists_distinguishes_deleted_from_unreachable(
+    fake_daytona: _FakeDaytonaState,
+) -> None:
+    """Only a definite not-found response permits replacement provisioning."""
+    launcher = DaytonaSandboxLauncher()
+    sandbox_id = launcher.provision("a")
+
+    assert launcher.exists(sandbox_id) is True
+
+    fake_daytona.sandboxes.pop(sandbox_id)
+    assert launcher.exists(sandbox_id) is False
+
+    fake_daytona.get_raises = _FakeDaytonaError("provider unavailable")
+    assert launcher.exists(sandbox_id) is None
 
 
 def test_keep_alive_disables_autostop(fake_daytona: _FakeDaytonaState) -> None:

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -1122,6 +1122,73 @@ async def test_resumable_managed_wake_ignores_stale_db_liveness(
     assert calls == ["wake"]
 
 
+async def test_deleted_resumable_sandbox_relaunches_instead_of_waking(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deleted provider object gets a replacement sandbox on the next message."""
+    from omnigent.server.routes import sessions as sessions_module
+
+    host_store = HostStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    host_id = "ef26926f4b091f61b11fb1c646314b3e"
+    host_store.register_managed_host(
+        host_id=host_id,
+        name="managed-deleted-islo",
+        user_id=RESERVED_USER_LOCAL,
+        token="tok-deleted-islo",
+        provider="islo",
+        sandbox_id="sb-deleted-islo",
+        token_expires_at=9_999_999_999,
+    )
+    conv = conv_store.create_conversation(
+        agent_id=None,
+        host_id=host_id,
+        workspace="/root/workspace",
+    )
+    fake = FakeSandboxLauncher(can_resume=True)
+    fake.provider = "islo"  # type: ignore[misc]
+    fake.exists = lambda _sandbox_id: False  # type: ignore[method-assign]
+    config = ManagedSandboxConfig(
+        server_url="https://managed-test.example.com",
+        launcher_factory=lambda: fake,
+        token_ttl_s=3600,
+        provider="islo",
+    )
+    tracker = ManagedLaunchTracker()
+    calls: list[str] = []
+
+    def _finish_relaunch(**kwargs: object) -> None:
+        del kwargs
+        calls.append("relaunch")
+        tracker.begin(conv.id)
+        tracker.finish(conv.id)
+
+    def _unexpected_wake(**kwargs: object) -> None:
+        del kwargs
+        calls.append("wake")
+
+    monkeypatch.setattr(sessions_module, "_kick_managed_relaunch", _finish_relaunch)
+    monkeypatch.setattr(sessions_module, "_kick_managed_wake", _unexpected_wake)
+    app_state = SimpleNamespace(
+        host_store=host_store,
+        sandbox_config=config,
+        managed_launches=tracker,
+        host_registry=SimpleNamespace(get=lambda _host_id: None),
+    )
+
+    assert (
+        await sessions_module._maybe_relaunch_managed_sandbox(
+            session_id=conv.id,
+            conv=conv,
+            app_state=app_state,
+            conversation_store=conv_store,
+        )
+        is True
+    )
+    assert calls == ["relaunch"]
+
+
 async def test_resumable_managed_wake_drops_fresh_local_tunnels_when_provider_paused(
     db_uri: str,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Related issue

N/A — this was found while testing managed-session recovery against Daytona.

## Summary

Daytona sandboxes can be stopped without losing their files, but Omnigent did not previously advertise or use that restart capability. As a result, returning to a stopped managed session could fail instead of waking the existing workspace.

This PR teaches the shared sandbox lifecycle to distinguish three outcomes:

- **Stopped:** restart the same Daytona sandbox and keep its files.
- **Deleted:** create a replacement sandbox on the next message.
- **Temporarily unreachable:** keep the current binding and fail safely rather than risk replacing a workspace that may still exist.

**ELI5:** A sleeping workspace should be woken up, not thrown away. Omnigent now asks Daytona whether the workspace is asleep, gone, or temporarily unavailable before deciding what to do.

```mermaid
flowchart LR
    A["User sends a message"] --> B{"Does the sandbox still exist?"}
    B -->|"Yes or unknown"| C["Wake the same sandbox"]
    B -->|"Definitely deleted"| D["Provision a replacement"]
    C --> E["Keep the existing workspace and files"]
```

The lifecycle check is exposed through the provider-neutral `SandboxLauncher` interface, so the session router does not need Daytona-specific API knowledge.

## Test Plan

- Ran the complete Daytona launcher and managed host/session binding suites:
  - `uv run --extra dev pytest tests/onboarding/sandboxes/test_daytona.py tests/server/integration/test_host_session_binding.py`
  - Result: **50 passed**.
- Covered waking a stopped sandbox in place, running/stopped status reporting, deleted-sandbox detection, temporary provider errors, and deleted-object routing to relaunch.
- Ran the repository checks:
  - `uv run --extra dev pre-commit run --all-files`
  - Result: all hooks passed.

## Demo

N/A — this is a backend lifecycle change with no visual UI changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The Daytona API boundary is tested with the repository's explicit fake SDK, including not-found and transient-error responses. The integration test verifies that a definitively deleted resumable sandbox selects replacement provisioning instead of the wake path.

## Changelog

Messages sent to a stopped Daytona-backed session now wake its existing workspace, while deleted sandboxes are replaced safely.
