### PR TITLE
Prevent shared managed hosts from being deleted early

### DIFF
--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -2317,6 +2317,8 @@ async def terminate_managed_host(
     host: Host,
     host_store: HostStore,
     config: ManagedSandboxConfig | None,
+    *,
+    delete_host_row: bool = True,
 ) -> None:
     """
     Terminate a managed host's sandbox and delete its host row.
@@ -2335,10 +2337,14 @@ async def terminate_managed_host(
     :param config: The deployment's current sandbox config (supplies
         the launcher for the provider-side terminate), or ``None``
         when managed hosts are no longer configured.
+    :param delete_host_row: Whether to delete the host row after provider
+        termination. Set to ``False`` when the caller already claimed and
+        removed the row transactionally.
     """
     launcher = _launcher_for_teardown(host, config)
     await _terminate_sandbox_best_effort(launcher, host)
-    await asyncio.to_thread(host_store.delete_host, host.host_id)
+    if delete_host_row:
+        await asyncio.to_thread(host_store.delete_host, host.host_id)
 
 
 async def _terminate_sandbox_best_effort(

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -21593,23 +21593,41 @@ def create_sessions_router(
         # Managed-host cleanup: when the session's host is backed by a
         # server-provisioned sandbox (host_type="managed"), terminate
         # the sandbox and delete the host row — which also revokes its
-        # launch token. Best-effort by design — the provider's lifetime
-        # cap reaps stragglers. External (laptop) hosts have no
+        # launch token. The conversation row (and its subtree) is already
+        # gone, so first prove no independently surviving conversation still
+        # references this host. That reference guard prevents deleting one
+        # session from terminating another session's sandbox after a legacy,
+        # migrated, or manual shared-host binding. External (laptop) hosts have no
         # sandbox_id and are never touched.
         host_store_for_managed = getattr(request.app.state, "host_store", None)
         if conv.host_id is not None and host_store_for_managed is not None:
-            bound_host = await asyncio.to_thread(host_store_for_managed.get_host, conv.host_id)
-            if bound_host is not None and bound_host.sandbox_id is not None:
+            claimed_host = await asyncio.to_thread(
+                host_store_for_managed.claim_unbound_managed_host_for_termination,
+                conv.host_id,
+            )
+            if claimed_host is not None:
                 from omnigent.server.managed_hosts import terminate_managed_host
 
                 await terminate_managed_host(
-                    bound_host,
+                    claimed_host,
                     host_store_for_managed,
                     # Supplies the launcher for the provider-side
-                    # terminate; None (config removed since launch)
-                    # still deletes the row and revokes the token.
+                    # terminate; the claimed row is already deleted,
+                    # so its launch token is already revoked.
                     getattr(request.app.state, "sandbox_config", None),
+                    delete_host_row=False,
                 )
+            else:
+                remaining_host = await asyncio.to_thread(
+                    host_store_for_managed.get_host, conv.host_id
+                )
+                if remaining_host is not None and remaining_host.sandbox_id:
+                    _logger.info(
+                        "Keeping managed host %s after deleting session %s: "
+                        "another session still references it",
+                        conv.host_id,
+                        session_id,
+                    )
         try:
             import hashlib as _hashlib
             import time as _time

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -186,6 +186,7 @@ class HostStore:
         """
         self._engine: Engine = get_or_create_engine(storage_location)
         self._session = make_managed_session_maker(self._engine)
+        self._session_immediate = make_managed_session_maker(self._engine, immediate=True)
 
     def upsert_on_connect(
         self,
@@ -796,6 +797,49 @@ class HostStore:
                     SqlHost.host_id == host_id,
                 )
             )
+
+    def claim_unbound_managed_host_for_termination(self, host_id: str) -> Host | None:
+        """Remove and return a managed host only when no session references it.
+
+        The reference check and host-row deletion happen in one transaction.
+        Removing the row revokes its launch token before provider termination,
+        while a surviving reference leaves both the host and sandbox untouched.
+        Normal managed-session creation never shares hosts; this guard protects
+        historical, migrated, or manually bound data that does.
+
+        :param host_id: Managed host identifier.
+        :returns: A detached snapshot for provider-side termination when the
+            claim succeeded, or ``None`` when the host is absent, external, or
+            still referenced.
+        """
+        try:
+            with self._session_immediate() as session:
+                row = session.execute(
+                    select(SqlHost)
+                    .where(
+                        SqlHost.workspace_id == current_workspace_id(),
+                        SqlHost.host_id == host_id,
+                    )
+                    .with_for_update()
+                ).scalar_one_or_none()
+                if row is None or row.sandbox_id is None:
+                    return None
+                surviving_reference = session.execute(
+                    select(SqlConversationMetadata.id)
+                    .where(
+                        SqlConversationMetadata.workspace_id == current_workspace_id(),
+                        SqlConversationMetadata.host_id == host_id,
+                    )
+                    .limit(1)
+                ).scalar_one_or_none()
+                if surviving_reference is not None:
+                    return None
+                claimed = _row_to_host(row)
+                session.delete(row)
+                return claimed
+        except IntegrityError:
+            # Fail closed if a database invariant prevents the claim.
+            return None
 
     def revoke_launch_token(self, host_id: str) -> None:
         """

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -492,6 +492,127 @@ async def test_managed_session_create_end_to_end(
     del tunnels
 
 
+async def test_managed_sessions_have_distinct_sandboxes_and_independent_teardown(
+    managed_session_env: ManagedSessionEnv,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two top-level sessions never share lifecycle-owned managed compute."""
+    env = managed_session_env
+    monkeypatch.setattr("omnigent.server.managed_hosts.MANAGED_HOST_ONLINE_TIMEOUT_S", 10)
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S", 0.2
+    )
+    loop = asyncio.get_running_loop()
+    host_futures: list[asyncio.Future[ApplicationCommunicator]] = []
+
+    def _start_fake_sandbox_host(invocation: HostStartInvocation) -> None:
+        future = asyncio.run_coroutine_threadsafe(
+            _fake_sandbox_host(
+                env.app, invocation.host_id, invocation.host_name, invocation.token
+            ),
+            loop,
+        )
+        host_futures.append(asyncio.wrap_future(future, loop=loop))
+
+    fake = FakeSandboxLauncher(on_host_start=_start_fake_sandbox_host)
+    install_fake_modal_launcher(monkeypatch, fake)
+    agent = await create_test_agent(env.client, name="managed-isolation")
+
+    created_ids: list[str] = []
+    bound: list[Conversation] = []
+    for _ in range(2):
+        response = await env.client.post(
+            "/v1/sessions",
+            json={"agent_id": agent["id"], "host_type": "managed"},
+        )
+        assert response.status_code == 201, response.text
+        session_id = response.json()["id"]
+        created_ids.append(session_id)
+        bound.append(await _wait_for_managed_binding(env, session_id))
+
+    tunnels = [await future for future in host_futures]
+    first, second = bound
+    assert first.host_id is not None
+    assert second.host_id is not None
+    assert first.host_id != second.host_id
+    first_host = env.host_store.get_host(first.host_id)
+    second_host = env.host_store.get_host(second.host_id)
+    assert first_host is not None and first_host.sandbox_id == "sb-fake-1"
+    assert second_host is not None and second_host.sandbox_id == "sb-fake-2"
+
+    first_delete = await env.client.delete(f"/v1/sessions/{created_ids[0]}")
+    assert first_delete.status_code == 200, first_delete.text
+    assert fake.terminated == ["sb-fake-1"]
+    assert env.host_store.get_host(first.host_id) is None
+    assert env.host_store.get_host(second.host_id) is not None
+    assert env.conv_store.get_conversation(created_ids[1]) is not None
+
+    second_delete = await env.client.delete(f"/v1/sessions/{created_ids[1]}")
+    assert second_delete.status_code == 200, second_delete.text
+    assert fake.terminated == ["sb-fake-1", "sb-fake-2"]
+    assert env.host_store.get_host(second.host_id) is None
+    del tunnels
+
+
+async def test_deleting_one_session_never_terminates_a_still_referenced_managed_sandbox(
+    managed_session_env: ManagedSessionEnv,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Managed teardown is reference-safe across legacy/shared host bindings."""
+    env = managed_session_env
+    monkeypatch.setattr("omnigent.server.managed_hosts.MANAGED_HOST_ONLINE_TIMEOUT_S", 10)
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S", 0.2
+    )
+    loop = asyncio.get_running_loop()
+    host_futures: list[asyncio.Future[ApplicationCommunicator]] = []
+
+    def _start_fake_sandbox_host(invocation: HostStartInvocation) -> None:
+        future = asyncio.run_coroutine_threadsafe(
+            _fake_sandbox_host(
+                env.app, invocation.host_id, invocation.host_name, invocation.token
+            ),
+            loop,
+        )
+        host_futures.append(asyncio.wrap_future(future, loop=loop))
+
+    fake = FakeSandboxLauncher(on_host_start=_start_fake_sandbox_host)
+    install_fake_modal_launcher(monkeypatch, fake)
+    agent = await create_test_agent(env.client, name="managed-reference-guard")
+    created = await env.client.post(
+        "/v1/sessions",
+        json={"agent_id": agent["id"], "host_type": "managed"},
+    )
+    assert created.status_code == 201, created.text
+    owner_id = created.json()["id"]
+    owner = await _wait_for_managed_binding(env, owner_id)
+    tunnel = await host_futures[0]
+    assert owner.host_id is not None
+
+    # Model a surviving legacy/manual binding. New managed-session creates
+    # never share a host, but teardown must fail safe if historical data or an
+    # operator migration produced this shape.
+    survivor = env.conv_store.create_conversation(
+        agent_id=agent["id"],
+        host_id=owner.host_id,
+        workspace=owner.workspace,
+    )
+
+    first_delete = await env.client.delete(f"/v1/sessions/{owner_id}")
+    assert first_delete.status_code == 200, first_delete.text
+    assert fake.terminated == []
+    assert env.host_store.get_host(owner.host_id) is not None
+    surviving_row = env.conv_store.get_conversation(survivor.id)
+    assert surviving_row is not None and surviving_row.host_id == owner.host_id
+
+    # Once the final reference is deleted, the exact same sandbox is reaped.
+    final_delete = await env.client.delete(f"/v1/sessions/{survivor.id}")
+    assert final_delete.status_code == 200, final_delete.text
+    assert fake.terminated == ["sb-fake-1"]
+    assert env.host_store.get_host(owner.host_id) is None
+    del tunnel
+
+
 async def test_managed_session_create_with_repo_workspace_binds_cloned_dir(
     managed_session_env: ManagedSessionEnv,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -2008,6 +2008,31 @@ async def test_terminate_managed_host_terminates_and_deletes_row(db_uri: str) ->
     )
 
 
+async def test_terminate_managed_host_can_skip_an_already_claimed_row(db_uri: str) -> None:
+    """Reference-safe callers can run the provider side effect without a second delete."""
+    fake = FakeSandboxLauncher()
+    host_store = HostStore(db_uri)
+    host = host_store.register_managed_host(
+        host_id="f4020e77f35477cb7030f648722544db",
+        name="managed-term-claimed",
+        user_id=_OWNER,
+        token="tok-term-claimed",
+        provider="modal",
+        sandbox_id="sb-term-claimed",
+        token_expires_at=now_epoch() + 3600,
+    )
+
+    await terminate_managed_host(
+        host,
+        host_store,
+        _injected_config(fake),
+        delete_host_row=False,
+    )
+
+    assert fake.terminated == ["sb-term-claimed"]
+    assert host_store.get_host(host.host_id) is not None
+
+
 async def test_terminate_managed_host_deletes_row_even_when_terminate_fails(
     db_uri: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Related issue

N/A — this was found during a lifecycle-hardening review of managed sessions.

## Summary

Deleting a managed session currently shuts down the sandbox recorded on that session's host. New top-level managed sessions already receive separate hosts and sandboxes, but historical data, migrations, or manual bindings can leave more than one session referring to the same host. In that case, deleting either session could interrupt the other one.

This PR makes teardown reference-safe:

- After the requested session and its child sessions are deleted, Omnigent checks whether any independent session still refers to the managed host.
- If another session still uses it, the host and sandbox are preserved.
- If no references remain, Omnigent removes the host row first—revoking its launch token—and then asks the provider to terminate the sandbox.
- The provider cleanup can now skip a second host-row deletion when the database claim has already completed.

**ELI5:** Think of a sandbox as a shared office. Before switching off the lights, Omnigent now checks whether anyone else is still inside. It only closes the office after the last session has left.

```mermaid
flowchart LR
    A["Delete a managed session"] --> B["Delete that session and its children"]
    B --> C{"Does another session use this host?"}
    C -->|"Yes"| D["Keep the host and sandbox running"]
    C -->|"No"| E["Revoke the host token"]
    E --> F["Terminate the provider sandbox"]
```

## Test Plan

- Ran the complete managed-host, host-store, and host/session binding suites:
  - `uv run --extra dev pytest tests/server/test_managed_hosts.py tests/stores/test_host_store.py tests/server/integration/test_host_session_binding.py`
  - Result: **177 passed**.
- Added integration coverage proving that:
  - two top-level managed sessions receive different hosts and sandboxes;
  - deleting one does not affect the other's host, conversation, or sandbox;
  - a deliberately shared legacy binding preserves the sandbox after the first deletion and terminates it after the final reference is deleted.
- Added focused coverage for provider termination after the database row has already been claimed.
- Ran the repository checks:
  - `uv run --extra dev pre-commit run --all-files`
  - Result: all hooks passed.

## Demo

N/A — this is a backend lifecycle and data-safety change with no visual UI changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The integration tests exercise the real API route, SQL-backed stores, host registration, session binding, and teardown orchestration with a recording sandbox provider. No live cloud credentials are required.

## Changelog

Deleting a managed session no longer shuts down a sandbox that another session still uses.
