### PR TITLE
Add databricks_cli secretless credential proxy type

### DIFF
--- a/designs/SANDBOX_CREDENTIAL_PROXY.md
+++ b/designs/SANDBOX_CREDENTIAL_PROXY.md
@@ -106,6 +106,7 @@ swap-on-access:
 | `https_basic` | `Authorization: Basic b64(user:<real>)` | swap-on-access (optional `env:`) | Generic Basic auth; `username` defaults to `x-access-token`. |
 | `git_https` | `Authorization: Basic b64(user:<real>)` | swap-on-access | Preset for git-over-HTTPS; nothing in the sandbox. |
 | `gh_basic` | Basic for git host, `token` for api host | swap-on-access for git; `GH_TOKEN`/`GITHUB_TOKEN` env for api | Preset for GitHub CLI + git; defaults to `github.com` + `api.github.com`. |
+| `databricks_cli` | `Authorization: Bearer <real>` per workspace host | placeholder `.databrickscfg` file (one `oa_cred_*` per profile) | Preset for the Databricks CLI; takes `profiles` (+ optional `default`). See below. |
 
 Common fields: `target`/`targets` (host + optional path glob — only the
 host binds the credential; path scoping is delegated to `egress_rules`),
@@ -152,6 +153,54 @@ parser) that rejects unknown keys, enforces exactly one source key, and
 checks POSIX env-var names — then converts to the `CredentialSourceSpec`
 dataclass the runtime consumes.
 
+### `databricks_cli` — profile-keyed, refreshing, file-materialized
+
+The Databricks CLI is a fifth type that differs from the four host-keyed
+primitives above:
+
+- **Profile-keyed, not host-keyed.** It takes `profiles: [name, ...]`
+  (and optional `default`) instead of `target`/`targets`/`source`. The
+  workspace host behind each profile is only known once the parent
+  resolves it, so profiles are carried on `DatabricksProxySpec` rather
+  than in the host-keyed `entries` list. Only the listed profiles are
+  proxied; every other profile is invisible to the sandbox.
+- **File materialization, not env injection.** The CLI gates on a local
+  credential (like `gh`) and `DATABRICKS_HOST`/`DATABRICKS_TOKEN` carry
+  only one workspace, so per-profile selection needs a config file. The
+  parent writes a placeholder-only `.databrickscfg` into the sandbox
+  scratch dir — one `[profile]` section per profile with the real `host`
+  and a synthetic `token = oa_cred_*` — and points `DATABRICKS_CONFIG_FILE`
+  at it (and `DATABRICKS_CONFIG_PROFILE` when `default` is set). The CLI
+  emits `Authorization: Bearer oa_cred_*`, which the proxy swaps per host.
+- **Refreshing secret.** Databricks profiles are usually OAuth
+  (`auth_type = databricks-cli`) with a ~1h token, so the rewrite rule
+  holds a `DatabricksProfileTokenProvider` (via the SDK) instead of a
+  static secret. The proxy calls `rule.resolve_secret()` on each swap; the
+  provider re-mints via `Config.authenticate()` at most once per throttle
+  window (the SDK caches in-memory and only re-shells near expiry), so a
+  long session survives token expiry. The provider requires the
+  `databricks` extra and fails loud if it is missing.
+- **Egress is operator-listed.** Reaching a workspace requires its host in
+  `egress_rules` (`* <host>/**`), the same as every other credential-proxy
+  type. The proxy does not widen egress on its own — an earlier draft
+  auto-added resolved hosts, but that was dropped to keep egress behavior
+  consistent across types (the operator declares every reachable host).
+- **Linux only.** The `databricks` CLI is a Go binary and Go on macOS
+  ignores `SSL_CERT_FILE`, so `databricks_cli` is rejected on
+  `darwin_seatbelt` (same rationale as `gh_basic`); use `linux_bwrap`.
+
+```yaml
+os_env:
+  sandbox:
+    type: linux_bwrap
+    egress_rules:
+      - "* pypi.org/**"
+    credential_proxy:
+      - type: databricks_cli
+        profiles: [dbc-adb7b1a3-9097, oss]
+        default: dbc-adb7b1a3-9097
+```
+
 ## Internal model
 
 `omnigent/inner/datamodel.py`:
@@ -162,8 +211,11 @@ dataclass the runtime consumes.
   type compiles down to: `host`, `scheme` (`basic`/`bearer`/`token`),
   `source`, `username | None`, `inject_env: list[str]` (empty for
   swap-on-access; populated only by the opt-in `env` shim).
-- `CredentialProxySpec` — list of entries; attached to
+- `CredentialProxySpec` — list of entries plus an optional
+  `databricks: DatabricksProxySpec`; attached to
   `OSEnvSandboxSpec.credential_proxy`.
+- `DatabricksProxySpec` / `DatabricksProfileBinding` — the profile list
+  (+ `default`, `config_env`) for the `databricks_cli` type.
 
 The parser (`omnigent/spec/parser.py`, `_parse_credential_proxy`)
 validates each raw entry with a pydantic boundary model
@@ -186,9 +238,13 @@ backend allow-list, and the `gh_basic`-on-macOS guard.
   - `helper_env_updates` — synthetic values for each `inject_env` var
     (empty for swap-on-access entries),
   - `rewrites: list[CredentialRewriteRule]` — `(host, scheme,
-    real_secret, synthetic | None, username)` for the proxy. `synthetic`
-    is `None` for swap-on-access entries; it is minted (and the matching
-    placeholder injected) only when the entry sets `env`.
+    real_secret | secret_provider, synthetic | None, username)` for the
+    proxy. `synthetic` is `None` for swap-on-access entries; it is minted
+    (and the matching placeholder injected) only when the entry sets `env`
+    (or, for `databricks_cli`, per proxied profile). A rule carries either
+    a static `real_secret` or a refreshing `secret_provider` — the proxy
+    calls `rule.resolve_secret()` — plus, for `databricks_cli`,
+    `sandbox_files` (the placeholder `.databrickscfg`).
 
 The real secret lives **only** in the parent process and the proxy's
 in-memory rewrite table. It is never serialized into the

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -203,6 +203,40 @@ same YAML works across platforms. For the full set of sandbox options, how to
 share one policy across `sys_os_*` and terminals, and how to set up network
 egress rules, see the `sandbox:` examples below and the sandbox source under `omnigent/inner/`.
 
+### Secretless credential proxy
+
+`sandbox.credential_proxy` lets sandboxed tools authenticate to external hosts
+without the real secret ever entering the sandbox: the mandatory L7 egress proxy
+attaches the credential on the way out. It requires `egress_rules` and a
+network-isolating backend (`linux_bwrap` or `darwin_seatbelt`). See
+`designs/SANDBOX_CREDENTIAL_PROXY.md` for the full type table.
+
+The `databricks_cli` type proxies the Databricks CLI. List the profiles to
+proxy; only those are materialized into the sandbox (with placeholder tokens)
+and swapped by the proxy. As with every other credential-proxy type, you must
+list each workspace host in `egress_rules` yourself — the proxy does not widen
+egress on its own. OAuth tokens are refreshed for the life of the session.
+Requires the `databricks` extra and `linux_bwrap` (the Go CLI ignores
+`SSL_CERT_FILE` on macOS, so `darwin_seatbelt` is rejected).
+
+```yaml
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: linux_bwrap
+    egress_rules:
+      - "* pypi.org/**"                              # your other egress needs
+      - "* dbc-adb7b1a3-9097.cloud.databricks.com/**"  # the proxied workspace
+    credential_proxy:
+      - type: databricks_cli
+        profiles: [dbc-adb7b1a3-9097, oss]
+        default: dbc-adb7b1a3-9097   # optional; sets DATABRICKS_CONFIG_PROFILE
+```
+
+Inside the sandbox, `databricks --profile dbc-adb7b1a3-9097 current-user me`
+works; the sandbox holds only `oa_cred_*` placeholders, never a live token.
+
 ## Tools
 
 Tools are declared under `tools` by name.

--- a/omnigent/inner/credential_proxy.py
+++ b/omnigent/inner/credential_proxy.py
@@ -30,12 +30,18 @@ from __future__ import annotations
 import os
 import secrets
 import subprocess
+import threading
+import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import urlsplit
 
+from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.inner.datamodel import (
     CredentialProxySpec,
     CredentialSourceSpec,
+    DatabricksProxySpec,
 )
 
 # Prefix on every minted placeholder. The proxy uses it to recognise a
@@ -74,13 +80,67 @@ class CredentialRewriteRule:
         placeholder will appear in requests).
     :param username: Basic-auth username emitted when ``scheme="basic"``,
         e.g. ``"x-access-token"``. ``None`` for ``bearer`` / ``token``.
+    :param real_secret: A static real credential. Used when
+        :attr:`secret_provider` is ``None`` (the ``env`` / ``file`` /
+        ``command`` sources resolve once at helper start).
+    :param secret_provider: A zero-arg callable returning the *current*
+        real credential, re-resolved on each swap. Used for sources whose
+        secret expires and must be refreshed for long sessions (e.g. a
+        Databricks OAuth profile). Takes precedence over
+        :attr:`real_secret` when set.
     """
 
     host: str
     scheme: str
-    real_secret: str
+    real_secret: str | None = None
     synthetic: str | None = None
     username: str | None = None
+    secret_provider: Callable[[], str] | None = None
+
+    def resolve_secret(self) -> str:
+        """
+        Return the current real credential for this rule.
+
+        Prefers :attr:`secret_provider` (refreshing sources) and falls
+        back to the static :attr:`real_secret`.
+
+        :returns: The real upstream credential the proxy should attach.
+        :raises ValueError: If neither a provider nor a static secret is
+            configured (a malformed rule).
+        """
+        if self.secret_provider is not None:
+            return self.secret_provider()
+        if self.real_secret is not None:
+            return self.real_secret
+        raise ValueError(
+            f"credential rewrite for host {self.host!r} has neither a static secret nor a provider"
+        )
+
+
+@dataclass
+class MaterializedFile:
+    """A file the parent writes into the sandbox scratch dir at start.
+
+    Used by the ``databricks_cli`` policy to place a ``.databrickscfg``
+    that lists the proxied profiles with **placeholder** tokens (never a
+    real secret). The parent writes :attr:`content` to
+    ``<scratch>/<name>`` and, when :attr:`env_var` is set, points that
+    environment variable at the absolute path so the tool discovers it.
+
+    :param name: File name relative to the sandbox scratch directory,
+        e.g. ``"databrickscfg"``.
+    :param content: Full file contents (placeholders only — no real
+        secret ever lands in the sandbox).
+    :param mode: POSIX file mode, e.g. ``0o600``.
+    :param env_var: Environment variable pointed at the written file's
+        absolute path, e.g. ``"DATABRICKS_CONFIG_FILE"``. ``None`` to
+        write the file without exporting a pointer.
+    """
+
+    name: str
+    content: str
+    mode: int = 0o600
+    env_var: str | None = None
 
 
 @dataclass
@@ -94,10 +154,13 @@ class CredentialProxyRuntime:
         Empty when every entry uses pure swap-on-access.
     :param rewrites: Host-scoped real-credential rewrite rules the egress
         proxy enforces.
+    :param sandbox_files: Placeholder-only files the parent materializes
+        into the sandbox scratch dir (e.g. a ``.databrickscfg``).
     """
 
     helper_env_updates: dict[str, str] = field(default_factory=dict)
     rewrites: list[CredentialRewriteRule] = field(default_factory=list)
+    sandbox_files: list[MaterializedFile] = field(default_factory=list)
 
 
 def prepare_credential_proxy_runtime(
@@ -127,6 +190,9 @@ def prepare_credential_proxy_runtime(
     runtime = CredentialProxyRuntime()
     if spec is None:
         return runtime
+
+    if spec.databricks is not None:
+        _prepare_databricks_runtime(spec.databricks, runtime)
 
     for entry in spec.entries:
         real_secret = _resolve_secret(entry.source, parent_env=parent_env)
@@ -209,9 +275,220 @@ def _resolve_secret(source: CredentialSourceSpec, *, parent_env: dict[str, str])
     raise ValueError(f"unsupported credential_proxy source kind: {source.kind!r}")
 
 
+# Default seconds between re-authentications for a Databricks profile. The
+# OAuth token lives ~1h and the SDK refreshes it in-memory near expiry, so a
+# short throttle keeps per-request overhead negligible while still picking up
+# a refreshed token well before it expires.
+_DATABRICKS_REFRESH_INTERVAL_SECONDS = 60.0
+
+
+class DatabricksProfileTokenProvider:
+    """Refreshing bearer-token source for one ``~/.databrickscfg`` profile.
+
+    Resolves a Databricks workspace profile via the ``databricks`` SDK in
+    the (trusted) parent. The workspace URL / host are read once from the
+    profile at construction; the bearer token is minted lazily on first
+    use and re-minted via ``Config.authenticate()`` at most once per
+    :attr:`_refresh_interval` so a long agent session survives OAuth
+    access-token expiry (the SDK caches in-memory and only re-shells the
+    CLI near expiry). Thread-safe: the egress proxy resolves from its own
+    event-loop thread.
+
+    The real token never leaves the parent — only a synthetic placeholder
+    is written into the sandbox ``.databrickscfg``.
+    """
+
+    def __init__(
+        self,
+        profile: str,
+        *,
+        refresh_interval: float = _DATABRICKS_REFRESH_INTERVAL_SECONDS,
+        config_factory: Callable[[str], object] | None = None,
+        authenticate: Callable[[object], str] | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """
+        Build a provider for *profile*, resolving its workspace host now.
+
+        :param profile: The ``~/.databrickscfg`` profile (section) name.
+        :param refresh_interval: Minimum seconds between re-authentications.
+        :param config_factory: Test seam returning an object exposing a
+            ``host`` attribute for *profile* (defaults to the SDK ``Config``).
+        :param authenticate: Test seam minting a bearer from the config
+            object (defaults to ``Config.authenticate()`` unpacking).
+        :param clock: Monotonic clock, injectable for tests.
+        :raises OmnigentError: If the SDK is unavailable or the profile has
+            no ``host``.
+        """
+        self.profile = profile
+        self._refresh_interval = refresh_interval
+        self._authenticate = authenticate or _databricks_authenticate
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._token: str | None = None
+        self._next_refresh = 0.0
+
+        factory = config_factory or _databricks_config
+        self._config = factory(profile)
+        host = getattr(self._config, "host", None)
+        if not host or not str(host).strip():
+            raise OmnigentError(
+                f"Databricks profile {profile!r} has no 'host'; add it to "
+                "~/.databrickscfg (e.g. `databricks auth login --profile "
+                f"{profile}`).",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        self.workspace_url = str(host).strip().rstrip("/")
+        hostname = urlsplit(self.workspace_url).hostname
+        if not hostname:
+            raise OmnigentError(
+                f"Databricks profile {profile!r} host {self.workspace_url!r} is not a valid URL.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        self.hostname = hostname.lower()
+
+    def resolve(self) -> str:
+        """
+        Return the current bearer token, re-minting past the throttle window.
+
+        :returns: A live workspace bearer token.
+        :raises OmnigentError: If authentication fails.
+        """
+        with self._lock:
+            now = self._clock()
+            if self._token is not None and now < self._next_refresh:
+                return self._token
+            token = self._authenticate(self._config)
+            if not token:
+                raise OmnigentError(
+                    f"Databricks profile {self.profile!r} produced an empty token.",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            self._token = token
+            self._next_refresh = now + self._refresh_interval
+            return token
+
+
+def _databricks_config(profile: str) -> object:
+    """
+    Build a ``databricks.sdk.config.Config`` for *profile* (SDK required).
+
+    :param profile: The ``~/.databrickscfg`` profile name.
+    :returns: A configured SDK ``Config`` instance.
+    :raises OmnigentError: If the ``databricks`` extra is not installed or
+        the profile cannot be loaded.
+    """
+    try:
+        from databricks.sdk.config import Config
+    except ImportError as exc:
+        raise OmnigentError(
+            "os_env.sandbox.credential_proxy type 'databricks_cli' requires the "
+            "Databricks SDK. Install the 'databricks' extra (e.g. "
+            "`pip install omnigent[databricks]`).",
+            code=ErrorCode.INVALID_INPUT,
+        ) from exc
+    try:
+        return Config(profile=profile)
+    except Exception as exc:
+        raise OmnigentError(
+            f"Failed to load Databricks profile {profile!r}: {exc}",
+            code=ErrorCode.INVALID_INPUT,
+        ) from exc
+
+
+def _databricks_authenticate(config: object) -> str:
+    """
+    Mint a fresh bearer from an SDK ``Config`` via ``authenticate()``.
+
+    :param config: An SDK ``Config`` instance.
+    :returns: The bearer token (``Authorization`` value minus ``Bearer ``).
+    :raises OmnigentError: If authentication fails or returns a non-Bearer
+        scheme.
+    """
+    try:
+        headers = config.authenticate()  # type: ignore[attr-defined]
+    except Exception as exc:
+        raise OmnigentError(
+            f"Databricks authentication failed: {exc}",
+            code=ErrorCode.INVALID_INPUT,
+        ) from exc
+    auth = (headers or {}).get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        raise OmnigentError(
+            "Databricks authentication returned a non-Bearer scheme; only "
+            "Bearer tokens (PAT / OAuth) are supported by the credential proxy.",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    return auth.removeprefix("Bearer ").strip()
+
+
+def _prepare_databricks_runtime(
+    spec: DatabricksProxySpec,
+    runtime: CredentialProxyRuntime,
+    *,
+    provider_factory: Callable[[str], DatabricksProfileTokenProvider] | None = None,
+) -> None:
+    """
+    Resolve Databricks profiles into rewrite rules + a placeholder cfg.
+
+    For each profile the parent resolves the workspace host, mints one
+    ``oa_cred_*`` placeholder, and adds a refreshing bearer rewrite rule
+    bound to that host. A ``.databrickscfg`` naming every profile with its
+    placeholder token is materialized into the sandbox. Reaching the
+    workspace still requires the operator to list its host in
+    ``egress_rules`` — the same as every other credential-proxy type.
+
+    :param spec: The parsed Databricks proxy policy.
+    :param runtime: The runtime being assembled (mutated in place).
+    :param provider_factory: Test seam building a provider per profile.
+    :raises OmnigentError: If a profile can't be resolved or two profiles
+        resolve to the same workspace host (they'd collide in the proxy's
+        host-keyed rewrite table).
+    """
+    factory = provider_factory or DatabricksProfileTokenProvider
+    sections: list[str] = []
+    seen_hosts: dict[str, str] = {}
+    for binding in spec.profiles:
+        provider = factory(binding.profile)
+        host = provider.hostname
+        if host in seen_hosts:
+            raise OmnigentError(
+                f"Databricks profiles {seen_hosts[host]!r} and "
+                f"{binding.profile!r} both resolve to workspace host {host!r}; "
+                "the credential proxy binds one credential per host. Proxy only "
+                "one profile per workspace.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        seen_hosts[host] = binding.profile
+        synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}{secrets.token_urlsafe(24)}"
+        runtime.rewrites.append(
+            CredentialRewriteRule(
+                host=host,
+                scheme="bearer",
+                secret_provider=provider.resolve,
+                synthetic=synthetic,
+            )
+        )
+        sections.append(
+            f"[{binding.profile}]\nhost = {provider.workspace_url}\ntoken = {synthetic}\n"
+        )
+    runtime.sandbox_files.append(
+        MaterializedFile(
+            name="databrickscfg",
+            content="\n".join(sections),
+            mode=0o600,
+            env_var=spec.config_env,
+        )
+    )
+    if spec.default is not None:
+        runtime.helper_env_updates["DATABRICKS_CONFIG_PROFILE"] = spec.default
+
+
 __all__ = [
     "SYNTHETIC_CREDENTIAL_PREFIX",
     "CredentialProxyRuntime",
     "CredentialRewriteRule",
+    "DatabricksProfileTokenProvider",
+    "MaterializedFile",
     "prepare_credential_proxy_runtime",
 ]

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -451,15 +451,59 @@ class CredentialProxyEntry:
 
 
 @dataclass
+class DatabricksProfileBinding:
+    """One Databricks ``~/.databrickscfg`` profile to proxy.
+
+    The host and OAuth/PAT token behind a profile are resolved in the
+    parent at runtime (via the ``databricks`` SDK) — never at parse time
+    and never inside the sandbox. The sandbox only ever sees a synthetic
+    ``oa_cred_*`` placeholder written into a materialized ``.databrickscfg``.
+
+    :param profile: The profile (section) name in ``~/.databrickscfg``,
+        e.g. ``"dbc-adb7b1a3-9097"``. Selected in the sandbox with
+        ``databricks --profile <name>`` (or as the default profile).
+    """
+
+    profile: str
+
+
+@dataclass
+class DatabricksProxySpec:
+    """Secretless proxy policy for the Databricks CLI.
+
+    Unlike the four host-keyed credential types, Databricks profiles bind
+    to a workspace host that is only known once the parent resolves the
+    profile at runtime, so they are carried here rather than in
+    :attr:`CredentialProxySpec.entries`.
+
+    :param profiles: The profiles to proxy. Only these profiles are
+        materialized into the sandbox ``.databrickscfg`` and swapped by
+        the egress proxy; every other profile is invisible to the sandbox.
+    :param default: Optional profile used when the CLI is invoked without
+        ``--profile`` (exported as ``DATABRICKS_CONFIG_PROFILE``). Must be
+        one of :attr:`profiles`.
+    :param config_env: Environment variable pointed at the materialized
+        config file (the Databricks CLI honors ``DATABRICKS_CONFIG_FILE``).
+    """
+
+    profiles: list[DatabricksProfileBinding]
+    default: str | None = None
+    config_env: str = "DATABRICKS_CONFIG_FILE"
+
+
+@dataclass
 class CredentialProxySpec:
     """Secretless credential-proxy policy for a sandbox.
 
     :param entries: Normalized per-host credential bindings. The real
         secrets stay in the parent; the sandbox only ever sees synthetic
         placeholders that the egress proxy rewrites.
+    :param databricks: Optional Databricks-CLI proxy policy (a list of
+        profiles). Resolved to per-workspace-host bindings at runtime.
     """
 
     entries: list[CredentialProxyEntry]
+    databricks: DatabricksProxySpec | None = None
 
 
 @dataclass

--- a/omnigent/inner/egress/proxy.py
+++ b/omnigent/inner/egress/proxy.py
@@ -27,6 +27,7 @@ import asyncio
 import base64
 import binascii
 import email.policy
+import functools
 import hmac
 import ipaddress
 import logging
@@ -708,7 +709,9 @@ class EgressProxy:
         connect_host = pinned_ip or host
         # Swap any synthetic credential placeholder for the real secret,
         # bound to this host (rejects cross-host replay with 403).
-        rewrite = self._rewrite_authorization(method=method, host=host, headers_raw=headers_raw)
+        rewrite = await self._rewrite_authorization_async(
+            method=method, host=host, headers_raw=headers_raw
+        )
         if rewrite.error is not None:
             logger.warning(
                 "BLOCKED-CREDENTIAL %s https://%s%s — %s", method, host, path, rewrite.error
@@ -861,7 +864,9 @@ class EgressProxy:
             body = await asyncio.wait_for(reader.readexactly(content_length), timeout=30)
 
         relative_line = f"{method} {path} HTTP/1.1\r\n".encode("latin-1")
-        rewrite = self._rewrite_authorization(method=method, host=host, headers_raw=headers_raw)
+        rewrite = await self._rewrite_authorization_async(
+            method=method, host=host, headers_raw=headers_raw
+        )
         if rewrite.error is not None:
             logger.warning(
                 "BLOCKED-CREDENTIAL %s http://%s%s — %s", method, host, path, rewrite.error
@@ -1126,6 +1131,34 @@ class EgressProxy:
         except Exception:  # noqa: BLE001 — response write is best-effort
             pass
 
+    async def _rewrite_authorization_async(
+        self, *, method: str, host: str, headers_raw: bytes
+    ) -> _AuthRewriteResult:
+        """
+        Async wrapper around :meth:`_rewrite_authorization`.
+
+        A refreshing credential source (e.g. a Databricks OAuth profile)
+        may re-mint a token via a blocking SDK/CLI call when its throttle
+        window elapses. That would stall the proxy's event loop, so the
+        rewrite runs in the default executor. The common case — no
+        credential rules configured — short-circuits inline with no
+        executor hop.
+
+        :param method: HTTP method (case-insensitive), e.g. ``"GET"``.
+        :param host: Upstream request host (case-insensitive).
+        :param headers_raw: Raw HTTP header block (CRLF-separated).
+        :returns: The rewrite result.
+        """
+        if not self._cred_by_host:
+            return _AuthRewriteResult(headers=headers_raw, error=None)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            functools.partial(
+                self._rewrite_authorization, method=method, host=host, headers_raw=headers_raw
+            ),
+        )
+
     def _rewrite_authorization(
         self, *, method: str, host: str, headers_raw: bytes
     ) -> _AuthRewriteResult:
@@ -1262,10 +1295,11 @@ class EgressProxy:
             ``"Basic <base64(username:real)>"``.
         :raises ValueError: If the rule carries an unsupported scheme.
         """
+        real_secret = rule.resolve_secret()
         if rule.scheme == "bearer":
-            return f"Bearer {rule.real_secret}"
+            return f"Bearer {real_secret}"
         if rule.scheme == "token":
-            return f"token {rule.real_secret}"
+            return f"token {real_secret}"
         if rule.scheme == "basic":
             # The parser always populates ``username`` for Basic
             # bindings; fail loud rather than invent one if a malformed
@@ -1274,7 +1308,7 @@ class EgressProxy:
                 raise ValueError(
                     f"basic credential rewrite for host {rule.host!r} is missing a username"
                 )
-            pair = f"{rule.username}:{rule.real_secret}".encode()
+            pair = f"{rule.username}:{real_secret}".encode()
             return "Basic " + base64.b64encode(pair).decode("ascii")
         raise ValueError(f"unsupported credential rewrite scheme: {rule.scheme!r}")
 

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -30,6 +30,7 @@ from .async_utils import run_sync_on_thread
 from .credential_proxy import (
     CredentialProxyRuntime,
     CredentialRewriteRule,
+    MaterializedFile,
     prepare_credential_proxy_runtime,
 )
 from .datamodel import CredentialProxySpec, OSEnvSpec
@@ -259,6 +260,33 @@ def _build_credential_proxy_parent_env(
     return resolved
 
 
+def _write_credential_proxy_files(
+    env: dict[str, str],
+    files: Sequence[MaterializedFile],
+    tmpdir: Path,
+) -> None:
+    """
+    Write placeholder-only credential-proxy files into the sandbox scratch dir.
+
+    Each file carries only synthetic ``oa_cred_*`` placeholders (never a
+    real secret), so writing it into the sandbox-visible scratch dir is
+    safe. When a file declares an ``env_var``, that variable is pointed at
+    the written file's absolute path so the tool discovers it (e.g.
+    ``DATABRICKS_CONFIG_FILE``).
+
+    :param env: The helper spawn env; pointer vars are set in place.
+    :param files: The files to materialize.
+    :param tmpdir: The sandbox scratch directory (a write root bound into
+        the sandbox).
+    """
+    for spec in files:
+        path = tmpdir / spec.name
+        path.write_text(spec.content, encoding="utf-8")
+        os.chmod(path, spec.mode)
+        if spec.env_var is not None:
+            env[spec.env_var] = str(path)
+
+
 @dataclass
 class OSEnvironment(ABC):
     """Base OS environment interface."""
@@ -441,6 +469,11 @@ class _HelperProcessClient:
                     parent_env=credential_parent_env,
                 )
                 env.update(credential_runtime.helper_env_updates)
+                # Materialize placeholder-only config files (e.g. a
+                # ``.databrickscfg`` listing proxied profiles with
+                # ``oa_cred_*`` tokens) into the scratch dir and point the
+                # tool at them. No real secret is written to the sandbox.
+                _write_credential_proxy_files(env, credential_runtime.sandbox_files, self._tmpdir)
 
         # Start L7 egress proxy if rules are configured. The proxy
         # listens on a Unix socket in the scratch tmpdir; the helper
@@ -711,8 +744,9 @@ class _HelperProcessClient:
         # ``require_auth=True`` because we have an inherited config
         # FD to deliver the token out of band — see the in-process
         # token injection in :func:`_run_helper`.
+        rules = list(self._egress_rules or [])
         handle = start_egress_proxy(
-            rules=self._egress_rules or [],
+            rules=rules,
             tmpdir=self._tmpdir,
             allow_private_destinations=self._egress_allow_private_destinations,
             require_auth=True,

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -18,6 +18,8 @@ from omnigent.inner.datamodel import (
     CredentialProxyEntry,
     CredentialProxySpec,
     CredentialSourceSpec,
+    DatabricksProfileBinding,
+    DatabricksProxySpec,
     OSEnvSandboxSpec,
     OSEnvSpec,
     TerminalEnvSpec,
@@ -1304,12 +1306,14 @@ class _CredentialProxyItemModel(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    type: Literal["https_bearer", "https_basic", "git_https", "gh_basic"]
-    source: _CredentialSourceModel
+    type: Literal["https_bearer", "https_basic", "git_https", "gh_basic", "databricks_cli"]
+    source: _CredentialSourceModel | None = None
     target: str | None = None
     targets: list[str] | None = None
     env: str | None = None
     username: str | None = None
+    profiles: list[str] | None = None
+    default: str | None = None
 
     @field_validator("env")
     @classmethod
@@ -1348,12 +1352,23 @@ class _CredentialProxyItemModel(BaseModel):
         ``targets``; ``gh_basic`` allows neither (it defaults to the
         GitHub git + API hosts) but not both. The ``env`` shim is only
         meaningful for the ``https_*`` primitives, and ``username`` only
-        applies to the Basic schemes.
+        applies to the Basic schemes. ``databricks_cli`` is profile-keyed:
+        it takes ``profiles`` (+ optional ``default``) and none of the
+        host-keyed fields (``source`` is implicit — the profile).
 
         :returns: ``self`` once validated.
         :raises ValueError: On a cardinality violation or a per-type
             option that does not apply.
         """
+        if self.type == "databricks_cli":
+            return self._check_databricks_cli()
+        # The host-keyed types resolve their secret from an explicit source.
+        if self.source is None:
+            raise ValueError("source is required")
+        if self.profiles is not None:
+            raise ValueError(f"{self.type} does not accept 'profiles'")
+        if self.default is not None:
+            raise ValueError(f"{self.type} does not accept 'default'")
         has_target = self.target is not None
         has_targets = self.targets is not None
         if has_targets and not self.targets:
@@ -1367,6 +1382,44 @@ class _CredentialProxyItemModel(BaseModel):
             raise ValueError(f"{self.type} does not accept an 'env' injection shim")
         if self.username is not None and self.type == "https_bearer":
             raise ValueError("https_bearer does not accept a 'username'")
+        return self
+
+    def _check_databricks_cli(self) -> _CredentialProxyItemModel:
+        """
+        Validate a ``databricks_cli`` entry.
+
+        The Databricks CLI is profile-keyed: it takes a non-empty
+        ``profiles`` list and an optional ``default`` (which must be one of
+        the listed profiles). The host-keyed fields (``source`` — resolved
+        from the profile — ``target``/``targets``, ``env``, ``username``)
+        do not apply and are rejected so typos fail loud.
+
+        :returns: ``self`` once validated.
+        :raises ValueError: On a missing/empty/duplicate profile, a
+            ``default`` outside ``profiles``, or a host-keyed field set.
+        """
+        for name, value in (
+            ("source", self.source),
+            ("target", self.target),
+            ("targets", self.targets),
+            ("env", self.env),
+            ("username", self.username),
+        ):
+            if value is not None:
+                raise ValueError(f"databricks_cli does not accept {name!r}")
+        if not self.profiles:
+            raise ValueError("databricks_cli requires a non-empty 'profiles' list")
+        seen: set[str] = set()
+        for profile in self.profiles:
+            if not profile or not profile.strip():
+                raise ValueError("databricks_cli 'profiles' entries must be non-empty strings")
+            if profile in seen:
+                raise ValueError(f"databricks_cli lists profile {profile!r} more than once")
+            seen.add(profile)
+        if self.default is not None and self.default not in self.profiles:
+            raise ValueError(
+                f"databricks_cli 'default' {self.default!r} must be one of 'profiles'"
+            )
         return self
 
 
@@ -1440,6 +1493,9 @@ def _parse_credential_proxy(raw: object) -> CredentialProxySpec | None:
     if not raw:
         return None
     entries: list[CredentialProxyEntry] = []
+    databricks_profiles: list[DatabricksProfileBinding] = []
+    databricks_default: str | None = None
+    databricks_seen: set[str] = set()
     for i, item in enumerate(raw):
         try:
             model = _CredentialProxyItemModel.model_validate(item)
@@ -1449,6 +1505,16 @@ def _parse_credential_proxy(raw: object) -> CredentialProxySpec | None:
                 f"{_format_validation_error(exc)}",
                 code=ErrorCode.INVALID_INPUT,
             ) from exc
+        if model.type == "databricks_cli":
+            databricks_default = _merge_databricks_cli(
+                model,
+                profiles=databricks_profiles,
+                seen=databricks_seen,
+                current_default=databricks_default,
+                index=i,
+            )
+            continue
+        assert model.source is not None  # guaranteed by the model validator
         source = model.source.to_spec()
         if model.type == "gh_basic":
             entries.extend(_normalize_gh_basic(model, source=source, index=i))
@@ -1458,12 +1524,11 @@ def _parse_credential_proxy(raw: object) -> CredentialProxySpec | None:
             entries.extend(_normalize_https_basic(model, source=source, index=i))
         else:  # git_https
             entries.extend(_normalize_git_https(model, source=source, index=i))
-    if not entries:
-        return None
     # Fail loud on conflicting host bindings. The egress proxy keys its
     # rewrite table by host, so two entries binding the same host would
     # silently last-win (one credential dropped). Reject it at parse time
-    # rather than picking a binding nondeterministically.
+    # rather than picking a binding nondeterministically. (Databricks
+    # hosts are resolved at runtime, so their collision guard lives there.)
     seen_hosts: dict[str, str] = {}
     for entry in entries:
         host_key = entry.host.lower()
@@ -1476,7 +1541,65 @@ def _parse_credential_proxy(raw: object) -> CredentialProxySpec | None:
                 code=ErrorCode.INVALID_INPUT,
             )
         seen_hosts[host_key] = entry.host
-    return CredentialProxySpec(entries=entries)
+    databricks = (
+        DatabricksProxySpec(profiles=databricks_profiles, default=databricks_default)
+        if databricks_profiles
+        else None
+    )
+    if not entries and databricks is None:
+        return None
+    return CredentialProxySpec(entries=entries, databricks=databricks)
+
+
+def _merge_databricks_cli(
+    model: _CredentialProxyItemModel,
+    *,
+    profiles: list[DatabricksProfileBinding],
+    seen: set[str],
+    current_default: str | None,
+    index: int,
+) -> str | None:
+    """
+    Merge one validated ``databricks_cli`` entry into the shared profile list.
+
+    Multiple ``databricks_cli`` entries are allowed and coalesced into a
+    single :class:`DatabricksProxySpec`. Profile names must be unique
+    across every entry (each profile maps to one materialized cfg section
+    and one workspace-host binding), and at most one ``default`` may be
+    declared in total.
+
+    :param model: The validated entry; ``profiles`` is non-empty and
+        ``default`` (if set) is one of them.
+    :param profiles: Accumulator of bindings, mutated in place.
+    :param seen: Accumulator of profile names already claimed.
+    :param current_default: The default declared by a prior entry, or
+        ``None``.
+    :param index: Entry index for error messages.
+    :returns: The (possibly updated) default profile name.
+    :raises OmnigentError: On a duplicate profile across entries or a
+        second conflicting ``default``.
+    """
+    assert model.profiles is not None  # guaranteed by the model validator
+    for profile in model.profiles:
+        if profile in seen:
+            raise OmnigentError(
+                f"os_env.sandbox.credential_proxy[{index}] lists Databricks "
+                f"profile {profile!r} which is already proxied by another "
+                "databricks_cli entry; each profile may appear once.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        seen.add(profile)
+        profiles.append(DatabricksProfileBinding(profile=profile))
+    if model.default is not None:
+        if current_default is not None and current_default != model.default:
+            raise OmnigentError(
+                "os_env.sandbox.credential_proxy declares conflicting "
+                f"databricks_cli defaults ({current_default!r} and "
+                f"{model.default!r}); declare at most one default profile.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        return model.default
+    return current_default
 
 
 def _credential_proxy_macos_unsupported_reason(
@@ -1502,16 +1625,30 @@ def _credential_proxy_macos_unsupported_reason(
     the original ``type`` keeps this check independent of how the presets
     normalize into bindings.
 
+    ``databricks_cli`` fails on macOS for the same reason — the ``databricks``
+    CLI is also a Go binary — so it is rejected here too.
+
     :param credential_proxy: Parsed credential-proxy spec, or ``None`` when the
         ``credential_proxy:`` field is absent.
     :param sandbox_type: Resolved sandbox backend, e.g. ``"darwin_seatbelt"``
         (macOS) or ``"linux_bwrap"`` (Linux).
     :returns: A human-readable rejection message when a ``gh_basic`` (i.e. a
-        ``token``-scheme) binding is configured on ``darwin_seatbelt``, else
-        ``None``.
+        ``token``-scheme) binding or a ``databricks_cli`` policy is configured
+        on ``darwin_seatbelt``, else ``None``.
     """
     if credential_proxy is None or sandbox_type != "darwin_seatbelt":
         return None
+    if credential_proxy.databricks is not None:
+        return (
+            "os_env.sandbox.credential_proxy type 'databricks_cli' does not work "
+            "on macOS (sandbox.type=darwin_seatbelt). The 'databricks' CLI is a Go "
+            "binary, and Go on macOS verifies TLS against the system keychain "
+            "(Security.framework) and ignores SSL_CERT_FILE -- the environment "
+            "variable the egress MITM proxy uses to publish its CA to sandboxed "
+            "tools. Every 'databricks' call would fail with 'certificate is not "
+            "trusted'. Use sandbox.type=linux_bwrap (Go honors SSL_CERT_FILE on "
+            "Linux)."
+        )
     if not any(entry.scheme == "token" for entry in credential_proxy.entries):
         return None
     return (

--- a/tests/inner/egress/test_proxy.py
+++ b/tests/inner/egress/test_proxy.py
@@ -1700,6 +1700,63 @@ async def test_credential_rewrite_swaps_bearer_and_token(
 
 
 @pytest.mark.asyncio
+async def test_credential_rewrite_swaps_via_refreshing_provider(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    """A rule with a ``secret_provider`` resolves the live token per swap.
+
+    This is the Databricks-CLI shape: the real bearer expires, so the rule
+    carries a provider (not a static secret). The upstream must receive the
+    provider's current value, proving ``resolve_secret()`` is called on the
+    swap path (and thus long sessions pick up a refreshed token).
+    """
+    cert_path, key_path, _ = ca_paths
+    synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}dbx123"
+    calls = {"n": 0}
+
+    def provider() -> str:
+        calls["n"] += 1
+        return f"live-token-{calls['n']}"
+
+    rule = CredentialRewriteRule(
+        host="127.0.0.1",
+        scheme="bearer",
+        synthetic=synthetic,
+        secret_provider=provider,
+    )
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+        credential_rewrites=[rule],
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        response = await _proxied_http_get(
+            proxy_port=proxy_port,
+            upstream_port=upstream_port,
+            authorization=f"Bearer {synthetic}",
+        )
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert b"200 OK" in response, f"Request did not complete: {response[:200]!r}"
+    assert len(captured) == 1
+    # The provider was invoked and its live token (not the synthetic)
+    # reached upstream.
+    assert calls["n"] == 1
+    assert captured[0].authorization == "Bearer live-token-1"
+    assert synthetic not in (captured[0].authorization or "")
+
+
+@pytest.mark.asyncio
 async def test_credential_rewrite_swaps_basic_password(
     ca_paths: tuple[Path, Path, Path],
 ) -> None:

--- a/tests/inner/sandbox/test_egress_e2e.py
+++ b/tests/inner/sandbox/test_egress_e2e.py
@@ -1154,6 +1154,129 @@ def test_credential_proxy_https_bearer_swaps_injected_env_token(
     assert real_secret not in injected
 
 
+class _FakeDatabricksConfig:
+    """Stand-in SDK ``Config`` exposing a ``host`` + a static token."""
+
+    def __init__(self, host: str, token: str) -> None:
+        self.host = host
+        self._token = token
+
+    def authenticate(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._token}"}
+
+
+def _databricks_cfg_probe(target_url: str) -> str:
+    """
+    Build a probe that authenticates using the materialized Databricks config.
+
+    It reads the placeholder token from ``DATABRICKS_CONFIG_FILE`` (the
+    file the parent materialized into the sandbox), sends it as a Bearer
+    header through ``HTTP_PROXY`` to *target_url*, and prints
+    ``STATUS <code>``. This mirrors how the ``databricks`` CLI would emit
+    ``Authorization: Bearer <placeholder>`` from its config file.
+
+    :param target_url: Absolute http URL of the local upstream.
+    :returns: Python source for use with :func:`_python_probe_argv`.
+    """
+    return "\n".join(
+        [
+            "import os, base64, http.client, configparser",
+            "from urllib.parse import urlparse",
+            "cfg = configparser.ConfigParser()",
+            "cfg.read(os.environ['DATABRICKS_CONFIG_FILE'])",
+            "token = cfg['prof']['token']",
+            "p = urlparse(os.environ['HTTP_PROXY'])",
+            "headers = {'Connection': 'close', 'Authorization': 'Bearer ' + token}",
+            "if p.username and p.password:",
+            "    creds = f'{p.username}:{p.password}'.encode()",
+            "    headers['Proxy-Authorization'] = 'Basic ' + base64.b64encode(creds).decode()",
+            "conn = http.client.HTTPConnection(p.hostname, p.port, timeout=30)",
+            f"conn.request('GET', '{target_url}', headers=headers)",
+            "resp = conn.getresponse()",
+            "print('STATUS', resp.status)",
+            "conn.close()",
+        ]
+    )
+
+
+def test_credential_proxy_databricks_cli_materializes_cfg_and_swaps(
+    tmp_path: Path,
+    active_sandbox_spec_factory: Callable[..., OSEnvSandboxSpec],
+    sandbox_pythonpath_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    databricks_cli: placeholder cfg is materialized and the proxy swaps the token.
+
+    Full path: a ``databricks_cli`` policy resolves the (faked) profile to
+    a local upstream host + real token, materializes a placeholder-only
+    Databricks config and points ``DATABRICKS_CONFIG_FILE`` at it. The
+    operator lists the workspace host in ``egress_rules`` (same as every
+    other credential-proxy type — the proxy does NOT widen egress on its
+    own). The probe reads the placeholder token from that cfg and sends it
+    as a Bearer through the proxy; the upstream must receive the REAL
+    token. We assert:
+
+    - the upstream got the real token (swap fired via the refreshing
+      provider);
+    - the sandbox cfg holds only the ``oa_cred_*`` placeholder, never the
+      real token.
+    """
+    from omnigent.inner.datamodel import DatabricksProfileBinding, DatabricksProxySpec
+
+    real_token = "dbx-real-oauth-token-7c2"
+    upstream = _CapturingUpstream()
+    host_url = f"http://127.0.0.1:{upstream.port}"
+    monkeypatch.setattr(
+        "omnigent.inner.credential_proxy._databricks_config",
+        lambda _profile: _FakeDatabricksConfig(host_url, real_token),
+    )
+    monkeypatch.setattr(
+        "omnigent.inner.credential_proxy._databricks_authenticate",
+        lambda config: config.authenticate()["Authorization"].removeprefix("Bearer "),
+    )
+
+    spec = active_sandbox_spec_factory(
+        # The operator must list the workspace host explicitly — the
+        # credential proxy does not auto-add it (consistent with the
+        # other credential-proxy types).
+        egress_rules=["* 127.0.0.1/**"],
+        egress_allow_private_destinations=True,
+        credential_proxy=CredentialProxySpec(
+            entries=[],
+            databricks=DatabricksProxySpec(profiles=[DatabricksProfileBinding(profile="prof")]),
+        ),
+    )
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(tmp_path), sandbox=spec)
+    )
+    probe = _databricks_cfg_probe(f"{host_url}/probe")
+    try:
+        result = run_async(os_env.shell(_python_probe_argv(probe)))
+        cfg_dump = run_async(os_env.shell('cat "$DATABRICKS_CONFIG_FILE"'))
+    finally:
+        os_env.close()
+        upstream.close()
+
+    assert result["exit_code"] == 0, (
+        f"Probe failed. stdout={result.get('stdout')!r} stderr={result.get('stderr')!r}"
+    )
+    assert "STATUS 200" in result["stdout"], (
+        f"Did not reach upstream (the workspace host listed in egress_rules "
+        f"must make 127.0.0.1 reachable): {result['stdout']!r}"
+    )
+    assert upstream.captured == [f"Bearer {real_token}"], (
+        "Upstream MUST receive the real token after the proxy swap. "
+        f"Captured: {upstream.captured!r}."
+    )
+    # The materialized cfg carries only the placeholder — never the real token.
+    assert f"host = {host_url}" in cfg_dump["stdout"]
+    assert SYNTHETIC_CREDENTIAL_PREFIX in cfg_dump["stdout"]
+    assert real_token not in cfg_dump["stdout"], (
+        f"real token leaked into the sandbox Databricks config: {cfg_dump['stdout']!r}"
+    )
+
+
 # Module guard so the helpers don't trigger lint warnings about
 # unused module-level imports when no test in this file references
 # them directly.

--- a/tests/inner/test_credential_proxy.py
+++ b/tests/inner/test_credential_proxy.py
@@ -16,14 +16,20 @@ from pathlib import Path
 
 import pytest
 
+from omnigent.errors import OmnigentError
 from omnigent.inner.credential_proxy import (
     SYNTHETIC_CREDENTIAL_PREFIX,
+    CredentialProxyRuntime,
+    DatabricksProfileTokenProvider,
+    _prepare_databricks_runtime,
     prepare_credential_proxy_runtime,
 )
 from omnigent.inner.datamodel import (
     CredentialProxyEntry,
     CredentialProxySpec,
     CredentialSourceSpec,
+    DatabricksProfileBinding,
+    DatabricksProxySpec,
 )
 
 
@@ -236,3 +242,136 @@ def test_gh_basic_shape_injects_env_for_api_host_only() -> None:
     assert git_rule.synthetic is None
     assert git_rule.real_secret == "ghp_real"
     assert set(runtime.helper_env_updates) == {"GH_TOKEN", "GITHUB_TOKEN"}
+
+
+# ---------------------------------------------------------------------------
+# databricks_cli
+# ---------------------------------------------------------------------------
+
+
+class _FakeConfig:
+    """Stand-in for ``databricks.sdk.config.Config`` in provider tests."""
+
+    def __init__(self, host: str, tokens: list[str]) -> None:
+        self.host = host
+        self._tokens = tokens
+        self.authenticate_calls = 0
+
+    def authenticate(self) -> dict[str, str]:
+        idx = min(self.authenticate_calls, len(self._tokens) - 1)
+        self.authenticate_calls += 1
+        return {"Authorization": f"Bearer {self._tokens[idx]}"}
+
+
+def test_databricks_provider_resolves_host_and_refreshes() -> None:
+    """The provider reads the host once and re-mints past the throttle window.
+
+    Within the throttle window ``resolve()`` returns the cached token
+    (one ``authenticate()`` call); once the window elapses it re-mints,
+    which is what keeps a long session alive across OAuth expiry.
+    """
+    fake = _FakeConfig("https://ws.cloud.databricks.com/", ["tok-1", "tok-2"])
+    clock = {"now": 0.0}
+    provider = DatabricksProfileTokenProvider(
+        "prof",
+        refresh_interval=100.0,
+        config_factory=lambda _p: fake,
+        clock=lambda: clock["now"],
+    )
+    assert provider.hostname == "ws.cloud.databricks.com"
+    assert provider.workspace_url == "https://ws.cloud.databricks.com"
+
+    assert provider.resolve() == "tok-1"
+    clock["now"] = 50.0  # still inside the window -> cached, no re-mint
+    assert provider.resolve() == "tok-1"
+    assert fake.authenticate_calls == 1
+    clock["now"] = 150.0  # past the window -> re-mint
+    assert provider.resolve() == "tok-2"
+    assert fake.authenticate_calls == 2
+
+
+def test_databricks_provider_requires_host() -> None:
+    """A profile without a ``host`` fails loud rather than binding nothing."""
+    with pytest.raises(OmnigentError, match="no 'host'"):
+        DatabricksProfileTokenProvider("prof", config_factory=lambda _p: _FakeConfig("", []))
+
+
+def test_databricks_provider_missing_sdk_fails_loud() -> None:
+    """The default factory raises a clear error when the SDK is absent."""
+    try:
+        import databricks.sdk.config  # noqa: F401
+    except ImportError:
+        with pytest.raises(OmnigentError, match="requires the Databricks SDK"):
+            DatabricksProfileTokenProvider("prof")
+    else:
+        pytest.skip("databricks SDK is installed; missing-SDK path not exercisable")
+
+
+def test_databricks_runtime_materializes_placeholder_cfg() -> None:
+    """Two profiles produce two host-bound rules + a placeholder cfg file.
+
+    The materialized ``.databrickscfg`` must carry only ``oa_cred_*``
+    placeholders (never a live token) and name each profile's real host,
+    and the rewrites bind per host with a refreshing provider.
+    """
+    spec = DatabricksProxySpec(
+        profiles=[
+            DatabricksProfileBinding(profile="wsA"),
+            DatabricksProfileBinding(profile="wsB"),
+        ],
+        default="wsA",
+    )
+    hosts = {
+        "wsA": "https://a.cloud.databricks.com",
+        "wsB": "https://b.cloud.databricks.com",
+    }
+
+    def factory(profile: str) -> DatabricksProfileTokenProvider:
+        return DatabricksProfileTokenProvider(
+            profile,
+            config_factory=lambda _p, h=hosts[profile]: _FakeConfig(h, [f"live-{profile}"]),
+        )
+
+    runtime = CredentialProxyRuntime()
+    _prepare_databricks_runtime(spec, runtime, provider_factory=factory)
+
+    assert {r.host for r in runtime.rewrites} == {
+        "a.cloud.databricks.com",
+        "b.cloud.databricks.com",
+    }
+    for rule in runtime.rewrites:
+        assert rule.scheme == "bearer"
+        assert rule.synthetic and rule.synthetic.startswith(SYNTHETIC_CREDENTIAL_PREFIX)
+        # The rule resolves the live token lazily via the provider.
+        assert rule.resolve_secret().startswith("live-")
+
+    assert runtime.helper_env_updates["DATABRICKS_CONFIG_PROFILE"] == "wsA"
+
+    assert len(runtime.sandbox_files) == 1
+    cfg = runtime.sandbox_files[0]
+    assert cfg.env_var == "DATABRICKS_CONFIG_FILE"
+    assert cfg.mode == 0o600
+    assert "[wsA]" in cfg.content and "[wsB]" in cfg.content
+    assert "host = https://a.cloud.databricks.com" in cfg.content
+    # Placeholders only — no live token ever lands in the sandbox file.
+    assert "live-wsA" not in cfg.content and "live-wsB" not in cfg.content
+    assert cfg.content.count(SYNTHETIC_CREDENTIAL_PREFIX) == 2
+
+
+def test_databricks_runtime_rejects_same_host_profiles() -> None:
+    """Two profiles on the same workspace host collide in the host-keyed table."""
+    spec = DatabricksProxySpec(
+        profiles=[
+            DatabricksProfileBinding(profile="p1"),
+            DatabricksProfileBinding(profile="p2"),
+        ]
+    )
+
+    def factory(profile: str) -> DatabricksProfileTokenProvider:
+        return DatabricksProfileTokenProvider(
+            profile,
+            config_factory=lambda _p: _FakeConfig("https://same.cloud.databricks.com", ["t"]),
+        )
+
+    with pytest.raises(OmnigentError, match="resolve to workspace host"):
+        _prepare_databricks_runtime(spec, CredentialProxyRuntime(), provider_factory=factory)

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -3449,13 +3449,105 @@ def test_parse_credential_proxy_https_env_optional(tmp_path: Path) -> None:
     assert entry.inject_env == []
 
 
+def test_parse_credential_proxy_databricks_cli(tmp_path: Path) -> None:
+    """A ``databricks_cli`` entry parses into a profile-keyed policy.
+
+    Unlike the host-keyed types it lands on ``credential_proxy.databricks``
+    (not ``entries``), preserving the profile list and default. If this
+    broke, the runtime would never materialize the ``.databrickscfg`` or
+    resolve the profiles.
+    """
+    config = _credential_proxy_config(
+        [
+            {
+                "type": "databricks_cli",
+                "profiles": ["dbc-adb7b1a3-9097", "oss"],
+                "default": "dbc-adb7b1a3-9097",
+            }
+        ]
+    )
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    proxy = spec.os_env.sandbox.credential_proxy
+    assert proxy is not None
+    assert proxy.entries == []
+    assert proxy.databricks is not None
+    assert [b.profile for b in proxy.databricks.profiles] == ["dbc-adb7b1a3-9097", "oss"]
+    assert proxy.databricks.default == "dbc-adb7b1a3-9097"
+
+
+@pytest.mark.parametrize(
+    "entry,match",
+    [
+        # ``default`` must name one of the listed profiles.
+        (
+            {"type": "databricks_cli", "profiles": ["a"], "default": "b"},
+            r"'default' 'b' must be one of 'profiles'",
+        ),
+        # Empty ``profiles`` list.
+        ({"type": "databricks_cli", "profiles": []}, r"non-empty 'profiles' list"),
+        # A host-keyed field doesn't apply.
+        (
+            {"type": "databricks_cli", "profiles": ["a"], "target": "h.example.com"},
+            r"databricks_cli does not accept 'target'",
+        ),
+        # ``source`` doesn't apply (resolved from the profile).
+        (
+            {"type": "databricks_cli", "profiles": ["a"], "source": {"env": "X"}},
+            r"databricks_cli does not accept 'source'",
+        ),
+        # Duplicate profile within one entry.
+        (
+            {"type": "databricks_cli", "profiles": ["a", "a"]},
+            r"more than once",
+        ),
+    ],
+)
+def test_parse_credential_proxy_databricks_cli_fail_loud(
+    tmp_path: Path, entry: dict[str, object], match: str
+) -> None:
+    """Malformed ``databricks_cli`` entries fail loudly at parse time."""
+    config = _credential_proxy_config([entry])
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match=match):
+        parse(tmp_path)
+
+
+def test_parse_credential_proxy_databricks_cli_rejected_on_macos(tmp_path: Path) -> None:
+    """``databricks_cli`` is rejected on macOS (``darwin_seatbelt``).
+
+    The ``databricks`` CLI is a Go binary and Go on macOS ignores
+    ``SSL_CERT_FILE`` (the var the egress MITM proxy uses to publish its
+    CA), so every call would fail with an opaque TLS error. Fail loud at
+    parse time instead.
+    """
+    config = {
+        "spec_version": 1,
+        "name": "cred-proxy-dbx-macos",
+        "os_env": {
+            "type": "caller_process",
+            "cwd": ".",
+            "sandbox": {
+                "type": "darwin_seatbelt",
+                "egress_rules": ["* corp.example.com/**"],
+                "credential_proxy": [{"type": "databricks_cli", "profiles": ["a"]}],
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match=r"databricks_cli' does not work\s+on macOS"):
+        parse(tmp_path)
+
+
 @pytest.mark.parametrize(
     "entries,match",
     [
         # Unknown ``type`` — caught by the pydantic ``Literal``.
         ([{"type": "bogus", "source": {"env": "X"}}], r"type: Input should be"),
-        # Missing ``source`` — pydantic ``Field required``.
-        ([{"type": "https_bearer", "target": "h.example.com"}], r"source: Field required"),
+        # Missing ``source`` — required for the host-keyed types (the
+        # field is optional at the pydantic layer because ``databricks_cli``
+        # forbids it, so the requirement is enforced in the model validator).
+        ([{"type": "https_bearer", "target": "h.example.com"}], r"source is required"),
         # ``source`` as a bare string (the old surface) is now rejected —
         # it must be a nested ``{env|file|command: ...}`` mapping.
         (


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds a `databricks_cli` `credential_proxy` type so sandboxed tools can use the
Databricks CLI without the real OAuth/PAT token ever entering the sandbox.

- The operator lists which `~/.databrickscfg` profiles to proxy. Each is
  materialized into the sandbox as a **placeholder-only** `.databrickscfg`
  (an `oa_cred_*` token) with `DATABRICKS_CONFIG_FILE` / `DATABRICKS_CONFIG_PROFILE`
  pointed at it; the mandatory L7 egress proxy swaps the placeholder for the
  real token on the way out. The real secret never lands in the sandbox.
- OAuth profiles mint ~1h tokens, so a refreshing `DatabricksProfileTokenProvider`
  re-mints via the databricks SDK for the life of the session.
  `CredentialRewriteRule` gains an optional `secret_provider` and the proxy
  resolves the secret per-swap (offloaded via `run_in_executor`).
- Requires the `databricks` extra and `linux_bwrap`. The `databricks` CLI is a
  Go binary and Go ignores `SSL_CERT_FILE` on macOS, so `darwin_seatbelt` is
  rejected at parse time (same rationale as `gh_basic`).
- Egress stays **operator-listed**: the workspace host must be named in
  `egress_rules`, consistent with every other `credential_proxy` type (the proxy
  does not widen egress on its own).

## Test Plan

Automated (Linux, `linux_bwrap`):

- `pytest tests/spec/test_parser.py tests/inner/test_credential_proxy.py tests/inner/egress/test_proxy.py -k "databricks or credential or refreshing_provider"` — parser validation, token-provider refresh, placeholder materialization, per-swap secret resolution.
- `pytest "tests/inner/sandbox/test_egress_e2e.py::test_credential_proxy_databricks_cli_materializes_cfg_and_swaps[linux_bwrap]"` — real bwrap sandbox + real MITM proxy: placeholder cfg materialized, token swapped upstream, real token never in the sandbox cfg.

Manual, full end-to-end on a Linux host against a real workspace:

1. `omnigent run agent.yaml -p "…run: databricks current-user me -p <profile> --output json"` where `agent.yaml` declares `sandbox.type: linux_bwrap` with `credential_proxy: [{type: databricks_cli, profiles: [<profile>]}]` and lists the workspace host in `egress_rules`.
2. The agent's shell tool runs the real `databricks` Go CLI inside the sandbox; the sandbox `.databrickscfg` holds only `oa_cred_*`; the proxy swaps it and the workspace returns the real user identity (HTTP 200).
3. Verified the Go CLI honors `SSL_CERT_FILE` on Linux (succeeds with it, `x509: certificate signed by unknown authority` without it) — the reason this type is Linux-only.
4. Verified egress is enforced and not auto-widened: with only `pypi.org` in `egress_rules` the workspace is blocked; adding the workspace host makes it reachable.

## Demo

N/A — non-visual (CLI / sandbox behavior).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit/integration/e2e added for parsing, the refreshing token provider,
placeholder materialization, per-swap secret resolution, and the full
`linux_bwrap` sandbox swap path. Manual verification (above) ran the real
`databricks` Go CLI inside a live `linux_bwrap` sandbox against a real
workspace via `omnigent run`, confirming the token swap end to end and that
the real token never enters the sandbox. The `darwin_seatbelt` rejection is
covered by a parser test; the CLI-in-sandbox swap itself can only run on Linux.

## Changelog

New `databricks_cli` credential-proxy type lets sandboxed agents use the Databricks CLI without the real token entering the sandbox
