### PR TITLE
fix(onboarding): degrade to numbered menu when termios is unavailable on Windows (#2993)

### DIFF
--- a/omnigent/onboarding/interactive.py
+++ b/omnigent/onboarding/interactive.py
@@ -401,8 +401,17 @@ def select(
     if not sys.stdin.isatty():
         return _select_fallback(title, options, default=default, selectable=mask)
 
-    import termios
-    import tty
+    try:
+        import termios
+        import tty
+    except ImportError:
+        # ``termios``/``tty`` are POSIX-only stdlib modules — the CPython
+        # build on Windows is not compiled with them, so ``import termios``
+        # raises ``ModuleNotFoundError``. Without raw-mode keypress reading
+        # there is no arrow-key loop to drive, so degrade to the numbered
+        # prompt (the same fallback the non-TTY branch above uses) instead of
+        # crashing the whole ``omnigent setup`` flow. See issue #2993.
+        return _select_fallback(title, options, default=default, selectable=mask)
 
     fd = sys.stdin.fileno()
     selected = _first_selectable(mask, default)

--- a/tests/onboarding/test_interactive.py
+++ b/tests/onboarding/test_interactive.py
@@ -464,3 +464,26 @@ def test_render_menu_compact_truncates_long_description_to_one_line() -> None:
     assert len(hint_lines) == 1
     assert "…" in hint_lines[0]
     assert len(hint_lines[0]) <= 40
+
+
+def test_select_degrades_to_fallback_when_termios_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a TTY host lacking ``termios``, ``select`` degrades instead of crashing.
+    """
+    # Report a real terminal so select() reaches the termios/tty import instead
+    # of the non-TTY numbered branch.
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    # Emulate the Windows CPython build where these modules are absent: a
+    # ``None`` entry in ``sys.modules`` makes ``import <name>`` raise
+    # ``ImportError`` (``ModuleNotFoundError`` is the concrete subclass raised
+    # on real Windows), exercising the same degrade-to-fallback except clause.
+    monkeypatch.setitem(sys.modules, "termios", None)
+    monkeypatch.setitem(sys.modules, "tty", None)
+    _feed(monkeypatch, ["2"])
+
+    chosen = interactive.select("Which provider?", ["Claude", "Codex", "Quit"])
+
+    # "2" fed to the numbered fallback selects the second option (index 1),
+    # proving select() degraded cleanly instead of raising ModuleNotFoundError.
+    assert chosen == 1


### PR DESCRIPTION
## Related issue

Closes #2993

## Summary

- On Windows, `omnigent setup` crashed with `ModuleNotFoundError: No module
  named 'termios'`. `select()` imports the POSIX-only `termios`/`tty` stdlib
  modules for its raw-mode arrow-key loop, and the Windows CPython build isn't
  compiled with them.
- `select()` already has a numbered fallback for non-TTY stdin (pipes / CI),
  but on Windows `sys.stdin.isatty()` is `True`, so it reached the import and
  crashed instead of falling back.
- Guard the import with `try/except ImportError` and route to the same
  `_select_fallback`, mirroring the existing `except termios.error` raw-mode
  degradation a few lines below.

**ELI5:** the setup menu uses arrow keys, which rely on a Mac/Linux-only
feature. On Windows that feature doesn't exist, so setup crashed. Now it
notices the feature is missing and shows a "type a number" menu instead.