### PR TITLE
feat(scheduled tasks): Scheduled Tasks page 

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -67,6 +67,7 @@
         "remark-breaks": "^4.0.0",
         "remark-emoji": "^5.0.2",
         "remark-gfm": "^4.0.1",
+        "rrule": "^2.8.1",
         "shadcn": "0.0.0-beta.9d3f70e54",
         "shiki": "^4.0.2",
         "streamdown": "^2.5.0",
@@ -762,6 +763,68 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@base-ui/react": {
+      "version": "1.6.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@base-ui/react/-/react-1.6.0.tgz",
+      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.3.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.3.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@base-ui/utils/-/utils-0.3.1.tgz",
+      "integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
@@ -962,6 +1025,36 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/utilities": {
@@ -1191,6 +1284,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@emoji-mart/data": {
+      "version": "1.2.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@emoji-mart/data/-/data-1.2.1.tgz",
+      "integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@emoji-mart/react": {
+      "version": "1.1.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@emoji-mart/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "emoji-mart": "^5.2",
+        "react": "^16.8 || ^17 || ^18"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -1265,6 +1376,16 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
       "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
     },
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
@@ -1377,6 +1498,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
       }
@@ -1386,28 +1508,64 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
       }
     },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.20",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@floating-ui/react/-/react-0.27.20.tgz",
+      "integrity": "sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "version": "2.1.9",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
+        "@floating-ui/dom": "^1.8.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@floating-ui/react-dom/node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom/node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "version": "0.2.12",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
     },
     "node_modules/@fontsource-variable/geist-mono": {
@@ -1417,6 +1575,19 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@giscus/react": {
+      "version": "3.1.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@giscus/react/-/react-3.1.0.tgz",
+      "integrity": "sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==",
+      "peer": true,
+      "dependencies": {
+        "giscus": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18 || ^19",
+        "react-dom": "^16 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1575,6 +1746,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@lobehub/emojilib": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@lobehub/emojilib/-/emojilib-1.0.0.tgz",
@@ -1636,6 +1824,176 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@lobehub/ui": {
+      "version": "5.20.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@lobehub/ui/-/ui-5.20.3.tgz",
+      "integrity": "sha512-HToiJe/6MmNSrhlugkKFXSPbJhDxvsbIaI0iPCnjIVC+YOtAKBOp+W6m5+SF/7R8fTTd08PA7XBes82MENhKNA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ant-design/cssinjs": "^2.1.2",
+        "@base-ui/react": "^1.6.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@emoji-mart/data": "^1.2.1",
+        "@emoji-mart/react": "^1.1.1",
+        "@emotion/is-prop-valid": "^1.4.0",
+        "@floating-ui/react": "^0.27.19",
+        "@giscus/react": "^3.1.0",
+        "@mdx-js/mdx": "^3.1.1",
+        "@mdx-js/react": "^3.1.1",
+        "@pierre/diffs": "1.2.8",
+        "@radix-ui/react-slot": "^1.2.5",
+        "@shikijs/core": "^4.2.0",
+        "@shikijs/transformers": "^4.2.0",
+        "@splinetool/runtime": "0.9.526",
+        "ahooks": "^3.9.7",
+        "antd-style": "^4.1.0",
+        "chroma-js": "^3.2.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "dayjs": "^1.11.21",
+        "emoji-mart": "^5.6.0",
+        "es-toolkit": "^1.47.0",
+        "fast-deep-equal": "^3.1.3",
+        "hast-util-to-jsx-runtime": "^2.3.6",
+        "html-url-attributes": "^3.0.1",
+        "immer": "^11.1.8",
+        "katex": "^0.16.47",
+        "leva": "^0.10.1",
+        "lucide-react": "^1.17.0",
+        "marked": "^17.0.6",
+        "mermaid": "^11.15.0",
+        "motion": "^12.40.0",
+        "numeral": "^2.0.6",
+        "polished": "^4.3.1",
+        "query-string": "^9.4.0",
+        "rc-collapse": "^4.0.0",
+        "rc-footer": "^0.6.8",
+        "rc-image": "^7.12.0",
+        "rc-input-number": "^9.5.0",
+        "rc-menu": "^9.16.1",
+        "re-resizable": "^6.11.2",
+        "react-avatar-editor": "^15.1.0",
+        "react-error-boundary": "^6.1.2",
+        "react-hotkeys-hook": "^5.3.2",
+        "react-markdown": "^10.1.0",
+        "react-merge-refs": "^3.0.2",
+        "react-rnd": "^10.5.3",
+        "react-zoom-pan-pinch": "^3.7.0",
+        "rehype-github-alerts": "^4.2.0",
+        "rehype-katex": "^7.0.1",
+        "rehype-raw": "^7.0.0",
+        "remark-breaks": "^4.0.0",
+        "remark-cjk-friendly": "^2.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-github": "^12.0.0",
+        "remark-math": "^6.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remend": "^1.3.0",
+        "shiki": "^4.2.0",
+        "shiki-stream": "^0.1.5",
+        "swr": "^2.4.1",
+        "ts-md5": "^2.0.1",
+        "unified": "^11.0.5",
+        "url-join": "^5.0.0",
+        "use-merge-value": "^1.2.0",
+        "uuid": "^13.0.2",
+        "vfile": "^6.0.3",
+        "virtua": "^0.49.1"
+      },
+      "peerDependencies": {
+        "@lobehub/fluent-emoji": "^4.0.0",
+        "@lobehub/icons": "^5.0.0",
+        "antd": "^6.1.1",
+        "motion": "^12.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/@lobehub/ui/node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@mdx-js/mdx/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://npm-proxy.cloud.databricks.com/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@mdx-js/react": {
+      "version": "3.1.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@mdx-js/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdx": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
       }
     },
     "node_modules/@mermaid-js/parser": {
@@ -2402,6 +2760,45 @@
       ],
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@pierre/diffs": {
+      "version": "1.2.8",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@pierre/diffs/-/diffs-1.2.8.tgz",
+      "integrity": "sha512-HVaWzZ1cW5GDKodivaPCN1hU05DGvoLiG/uvVBNZODD+qY2NTr36KYgATGhb79Vr8OCKNG3qATTWJEwbkMGfzA==",
+      "license": "apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@pierre/theme": "1.0.3",
+        "@shikijs/transformers": "^3.0.0",
+        "diff": "8.0.3",
+        "hast-util-to-html": "9.0.5",
+        "lru_map": "0.4.1",
+        "shiki": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/@pierre/diffs/node_modules/diff": {
+      "version": "8.0.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@pierre/theme": {
+      "version": "1.0.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@pierre/theme/-/theme-1.0.3.tgz",
+      "integrity": "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "vscode": "^1.0.0"
       }
     },
     "node_modules/@primer/octicons": {
@@ -4965,6 +5362,39 @@
         "node": ">=20"
       }
     },
+    "node_modules/@shikijs/stream": {
+      "version": "4.3.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@shikijs/stream/-/stream-4.3.1.tgz",
+      "integrity": "sha512-QsZDisEVgtvnEgLftu/Ng5JkZlPn37AJoJQY330RnFoNcRtszr0JV3ldRLjIpgvl+qPRKF4t6h1P7FQhjQj6Sw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/core": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "solid-js": "^1.9.0",
+        "svelte": "^5.0.0-0",
+        "vue": "^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@shikijs/themes": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
@@ -4972,6 +5402,20 @@
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "4.3.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@shikijs/transformers/-/transformers-4.3.1.tgz",
+      "integrity": "sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/core": "4.3.1",
+        "@shikijs/types": "4.3.1"
       },
       "engines": {
         "node": ">=20"
@@ -5020,12 +5464,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@splinetool/runtime": {
+      "version": "0.9.526",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@splinetool/runtime/-/runtime-0.9.526.tgz",
+      "integrity": "sha512-qznHbXA5aKwDbCgESAothCNm1IeEZcmNWG145p5aXj4w5uoqR1TZ9qkTHTKLTsUbHeitCwdhzmRqan1kxboLgQ==",
+      "peer": true,
+      "dependencies": {
+        "on-change": "^4.0.0",
+        "semver-compare": "^1.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stitches/react": {
+      "version": "1.2.8",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@stitches/react/-/react-1.2.8.tgz",
+      "integrity": "sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
     },
     "node_modules/@streamdown/cjk": {
       "version": "1.0.3",
@@ -6375,6 +6839,13 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/katex": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
@@ -6389,6 +6860,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.14",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@types/mdx/-/mdx-2.0.14.tgz",
+      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -6415,7 +6893,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6425,7 +6902,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6484,6 +6960,26 @@
       "optionalDependencies": {
         "d3-selection": "^3.0.0",
         "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/@vercel/oidc": {
@@ -6797,6 +7293,16 @@
         "acorn": "^8"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -6804,6 +7310,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ahooks": {
+      "version": "3.9.7",
+      "resolved": "https://npm-proxy.cloud.databricks.com/ahooks/-/ahooks-3.9.7.tgz",
+      "integrity": "sha512-S0lvzhbdlhK36RFBkGv+RbOM/dbbweym+BIHM/bwwuWVSVN5TuVErHPMWo4w0t1NDYg5KPp2iEf7Y7E5LASYiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@types/js-cookie": "^3.0.6",
+        "dayjs": "^1.9.1",
+        "intersection-observer": "^0.12.0",
+        "js-cookie": "^3.0.5",
+        "lodash": "^4.17.21",
+        "react-fast-compare": "^3.2.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.0.0",
+        "tslib": "^2.4.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/ai": {
@@ -7041,6 +7570,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -7072,6 +7611,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
     "node_modules/atomically": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
@@ -7079,6 +7628,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://npm-proxy.cloud.databricks.com/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -7490,6 +8049,13 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/chroma-js": {
+      "version": "3.2.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/chroma-js/-/chroma-js-3.2.0.tgz",
+      "integrity": "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==",
+      "license": "(BSD-3-Clause AND Apache-2.0)",
+      "peer": true
+    },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
@@ -7513,6 +8079,13 @@
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -7615,6 +8188,17 @@
       "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
       "license": "MIT"
     },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7632,6 +8216,13 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -8465,6 +9056,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/decode-uri-component": {
+      "version": "0.4.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -8688,6 +9289,13 @@
       "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
       "license": "ISC"
     },
+    "node_modules/emoji-mart": {
+      "version": "5.6.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/emoji-mart/-/emoji-mart-5.6.0.tgz",
+      "integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -8834,6 +9442,40 @@
         "benchmarks"
       ]
     },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -8880,6 +9522,37 @@
         "node": ">=4"
       }
     },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-util-is-identifier-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
@@ -8890,11 +9563,66 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://npm-proxy.cloud.databricks.com/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -9043,6 +9771,29 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend-shallow/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9178,6 +9929,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/file-selector": {
+      "version": "0.5.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/file-selector/-/file-selector-0.5.0.tgz",
+      "integrity": "sha512-s8KNnmIDTBoD0p9uJ9uD0XY38SCeBOtj0UMXyQSLg1Ypfrfj8+dAvwsLjYQkQ2GjhVtp2HrnF5cJzMhBjfD8HA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -9188,6 +9952,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/finalhandler": {
@@ -9229,6 +10006,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -9248,6 +10035,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "12.42.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fresh": {
@@ -9412,6 +10227,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://npm-proxy.cloud.databricks.com/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/giscus": {
+      "version": "1.6.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/giscus/-/giscus-1.6.0.tgz",
+      "integrity": "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lit": "^3.2.1"
       }
     },
     "node_modules/github-from-package": {
@@ -9677,6 +10512,35 @@
         "@types/hast": "^3.0.0",
         "@ungap/structured-clone": "^1.0.0",
         "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9956,6 +10820,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.11",
+      "resolved": "https://npm-proxy.cloud.databricks.com/immer/-/immer-11.1.11.tgz",
+      "integrity": "sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -10034,6 +10909,14 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/intersection-observer": {
+      "version": "0.12.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/intersection-observer/-/intersection-observer-0.12.2.tgz",
+      "integrity": "sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==",
+      "deprecated": "The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -10121,6 +11004,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -10247,6 +11143,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://npm-proxy.cloud.databricks.com/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -10320,6 +11229,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -10377,6 +11296,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://npm-proxy.cloud.databricks.com/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -10552,6 +11478,48 @@
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
       "license": "MIT"
+    },
+    "node_modules/leva": {
+      "version": "0.10.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/leva/-/leva-0.10.1.tgz",
+      "integrity": "sha512-BcjnfUX8jpmwZUz2L7AfBtF9vn4ggTH33hmeufDULbP3YgNZ/C+ss/oO3stbrqRQyaOmRwy70y7BGTGO81S3rA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@radix-ui/react-portal": "^1.1.4",
+        "@radix-ui/react-tooltip": "^1.1.8",
+        "@stitches/react": "^1.2.8",
+        "@use-gesture/react": "^10.2.5",
+        "colord": "^2.9.2",
+        "dequal": "^2.0.2",
+        "merge-value": "^1.0.0",
+        "react-colorful": "^5.5.1",
+        "react-dropzone": "^12.0.0",
+        "v8n": "^1.3.3",
+        "zustand": "^3.6.9"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/leva/node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -10845,6 +11813,40 @@
       "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "license": "MIT"
     },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -10857,6 +11859,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -10913,6 +11922,13 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "11.5.1",
@@ -10997,6 +12013,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
+      }
+    },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-table": {
@@ -11196,6 +12225,24 @@
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.1.0",
         "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -11440,6 +12487,22 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
+    },
+    "node_modules/merge-value": {
+      "version": "1.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/merge-value/-/merge-value-1.0.0.tgz",
+      "integrity": "sha512-fJMmvat4NeKz63Uv9iHWcPDjCWcCkoiRoajRTEO8hlhUC6rwaHg0QCF9hBOTjZmm4JuglPckPSTtcuJL5kp0TQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-value": "^2.0.6",
+        "is-extendable": "^1.0.0",
+        "mixin-deep": "^1.2.0",
+        "set-value": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -11771,6 +12834,113 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
@@ -11812,6 +12982,34 @@
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
       }
     },
     "node_modules/micromark-factory-space": {
@@ -12014,6 +13212,32 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
@@ -12262,6 +13486,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -12296,6 +13534,50 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.42.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/motion/-/motion-12.42.2.tgz",
+      "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "framer-motion": "^12.42.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.42.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -12523,6 +13805,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/numeral": {
+      "version": "2.0.6",
+      "resolved": "https://npm-proxy.cloud.databricks.com/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -12565,6 +13857,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-change": {
+      "version": "4.0.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/on-change/-/on-change-4.0.2.tgz",
+      "integrity": "sha512-cMtCyuJmTx/bg2HCpHo3ZLeF7FZnBOapLqZHr2AlLeJ5Ul0Zu2mUJJz051Fdwu/Et2YW04ZD+TtU+gVy0ACNCA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/on-change?sponsor=1"
       }
     },
     "node_modules/on-finished": {
@@ -13213,6 +14518,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/property-information": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
@@ -13411,6 +14735,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/query-string": {
+      "version": "9.4.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/query-string/-/query-string-9.4.1.tgz",
+      "integrity": "sha512-lSyJeN3RuaG7DZGWThtYRhk96+kEyZ/+doZpERuWbjeFL+Ok3vEat/swU498rAI0NcVt5/RJp8UDuLz7FckxrA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "decode-uri-component": "^0.4.1",
+        "filter-obj": "^5.1.0",
+        "split-on-first": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -13564,6 +14906,283 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/rc-collapse": {
+      "version": "4.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rc-collapse/-/rc-collapse-4.0.0.tgz",
+      "integrity": "sha512-SwoOByE39/3oIokDs/BnkqI+ltwirZbP8HZdq1/3SkPSBi7xDdvWHTp7cpNI9ullozkR6mwTWQi6/E/9huQVrA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "rc-motion": "^2.3.4",
+        "rc-util": "^5.27.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-dialog": {
+      "version": "9.6.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rc-dialog/-/rc-dialog-9.6.0.tgz",
+      "integrity": "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/portal": "^1.0.0-8",
+        "classnames": "^2.2.6",
+        "rc-motion": "^2.3.0",
+        "rc-util": "^5.21.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-dialog/node_modules/@rc-component/portal": {
+      "version": "1.1.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@rc-component/portal/-/portal-1.1.2.tgz",
+      "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-footer": {
+      "version": "0.6.8",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rc-footer/-/rc-footer-0.6.8.tgz",
+      "integrity": "sha512-JBZ+xcb6kkex8XnBd4VHw1ZxjV6kmcwUumSHaIFdka2qzMCo7Klcy4sI6G0XtUpG/vtpislQCc+S9Bc+NLHYMg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/rc-image": {
+      "version": "7.12.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rc-image/-/rc-image-7.12.0.tgz",
+      "integrity": "sha512-cZ3HTyyckPnNnUb9/DRqduqzLfrQRyi+CdHjdqgsyDpI3Ln5UX1kXnAhPBSJj9pVRzwRFgqkN7p9b6HBDjmu/Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "@rc-component/portal": "^1.0.2",
+        "classnames": "^2.2.6",
+        "rc-dialog": "~9.6.0",
+        "rc-motion": "^2.6.2",
+        "rc-util": "^5.34.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-image/node_modules/@rc-component/portal": {
+      "version": "1.1.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@rc-component/portal/-/portal-1.1.2.tgz",
+      "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-input": {
+      "version": "1.8.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rc-input/-/rc-input-1.8.0.tgz",
+      "integrity": "sha512-KXvaTbX+7ha8a/k+eg6SYRVERK0NddX8QX7a7AnRvUa/rEH0CNMlpcBzBkhI0wp2C8C4HlMoYl8TImSN+fuHKA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.18.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/rc-input-number": {
+      "version": "9.5.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rc-input-number/-/rc-input-number-9.5.0.tgz",
+      "integrity": "sha512-bKaEvB5tHebUURAEXw35LDcnRZLq3x1k7GxfAqBMzmpHkDGzjAtnUL8y4y5N15rIFIg5IJgwr211jInl3cipag==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/mini-decimal": "^1.0.1",
+        "classnames": "^2.2.5",
+        "rc-input": "~1.8.0",
+        "rc-util": "^5.40.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-menu": {
+      "version": "9.16.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rc-menu/-/rc-menu-9.16.1.tgz",
+      "integrity": "sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "2.x",
+        "rc-motion": "^2.4.3",
+        "rc-overflow": "^1.3.1",
+        "rc-util": "^5.27.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-menu/node_modules/@rc-component/portal": {
+      "version": "1.1.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@rc-component/portal/-/portal-1.1.2.tgz",
+      "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-menu/node_modules/@rc-component/trigger": {
+      "version": "2.3.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/@rc-component/trigger/-/trigger-2.3.1.tgz",
+      "integrity": "sha512-ORENF39PeXTzM+gQEshuk460Z8N4+6DkjpxlpE7Q3gYy1iBpLrx0FOJz3h62ryrJZ/3zCAUIkT1Pb/8hHWpb3A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "@rc-component/portal": "^1.1.0",
+        "classnames": "^2.3.2",
+        "rc-motion": "^2.0.0",
+        "rc-resize-observer": "^1.3.1",
+        "rc-util": "^5.44.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-motion": {
+      "version": "2.9.5",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rc-motion/-/rc-motion-2.9.5.tgz",
+      "integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.44.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-overflow": {
+      "version": "1.5.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rc-overflow/-/rc-overflow-1.5.0.tgz",
+      "integrity": "sha512-Lm/v9h0LymeUYJf0x39OveU52InkdRXqnn2aYXfWmo8WdOonIKB2kfau+GF0fWq6jPgtdO9yMqveGcK6aIhJmg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.37.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-resize-observer": {
+      "version": "1.4.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz",
+      "integrity": "sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.44.1",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util": {
+      "version": "5.44.4",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rc-util/-/rc-util-5.44.4.tgz",
+      "integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/re-resizable": {
+      "version": "6.11.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/re-resizable/-/re-resizable-6.11.2.tgz",
+      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -13574,6 +15193,28 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-avatar-editor": {
+      "version": "15.1.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/react-avatar-editor/-/react-avatar-editor-15.1.0.tgz",
+      "integrity": "sha512-Zto7u9l6Wd5LPPtjeFJ+7uwoT4bs01OSgkN2kxD18lWl8IiZ0GY3nWCbKPx4qIU7Au1vENsMJm19rfVWHHayaQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^0.14.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.8.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/react-colorful/-/react-colorful-5.8.0.tgz",
+      "integrity": "sha512-Wy9OzPfjSN9bF12OB8N7UQvlsZ0I+7wHxpN+bV5BjNQGxOj6IiwkRjevJK9yOBjJWGQvAaf1OXtn8rUeEatAng==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {
@@ -13588,6 +15229,56 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.7.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/react-draggable/-/react-draggable-4.7.0.tgz",
+      "integrity": "sha512-kTpANmKWVnFXiZ76Ag2ZowiFStuBYnJ606PI1TbUsOg29/400/JNIxI9+CuenhiAqFuXWJffz6F4UI3R51kUug==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-dropzone": {
+      "version": "12.1.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/react-dropzone/-/react-dropzone-12.1.0.tgz",
+      "integrity": "sha512-iBYHA1rbopIvtzokEX4QubO6qk5IF/x3BtKGu74rF2JkQDXnwC4uO/lHKpaw4PJIV6iIAYOlwLv2FpiGyqHNog==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.5.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.1.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/react-error-boundary/-/react-error-boundary-6.1.2.tgz",
+      "integrity": "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-hook-form": {
       "version": "7.80.0",
@@ -13649,6 +15340,25 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-merge-refs": {
+      "version": "3.0.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/react-merge-refs/-/react-merge-refs-3.0.2.tgz",
+      "integrity": "sha512-MSZAfwFfdbEvwkKWP5EI5chuLYnNUxNS7vyS0i1Jp+wtd8J4Ga2ddzhaE68aMol2Z4vCnRM/oGOo1a3V75UPlw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-pdf": {
@@ -13727,6 +15437,29 @@
         }
       }
     },
+    "node_modules/react-rnd": {
+      "version": "10.5.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/react-rnd/-/react-rnd-10.5.3.tgz",
+      "integrity": "sha512-s/sIT3pGZnQ+57egijkTp9mizjIWrJz68Pq6yd+F/wniFY3IriML18dUXnQe/HP9uMiJ+9MAp44hljG99fZu6Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "re-resizable": "^6.11.2",
+        "react-draggable": "^4.5.0",
+        "tslib": "2.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-rnd/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD",
+      "peer": true
+    },
     "node_modules/react-router": {
       "version": "6.30.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
@@ -13781,6 +15514,21 @@
         }
       }
     },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "3.7.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
+      "integrity": "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -13819,6 +15567,77 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/redent": {
@@ -13911,6 +15730,22 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14024,6 +15859,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-github": {
+      "version": "12.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/remark-github/-/remark-github-12.0.0.tgz",
+      "integrity": "sha512-ByefQKFN184LeiGRCabfl7zUJsdlMYWEhiLX1gpmQ11yFg6xSuOTW7LVCv0oc1x+YvUMJW23NU36sJX2RWGgvg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "to-vfile": "^8.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-math": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
@@ -14034,6 +15888,21 @@
         "mdast-util-math": "^3.0.0",
         "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14124,6 +15993,20 @@
       "engines": {
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -14286,6 +16169,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -14376,6 +16268,19 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
@@ -14396,6 +16301,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -14447,6 +16359,32 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
       "integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
       "license": "MIT"
+    },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/set-value/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -14594,6 +16532,36 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/shiki-stream": {
+      "version": "0.1.5",
+      "resolved": "https://npm-proxy.cloud.databricks.com/shiki-stream/-/shiki-stream-0.1.5.tgz",
+      "integrity": "sha512-DzkqVlqf02Tp4zTFNgJp+3rOG2RkuoONBq+Pm2sHslAlJ5M0QbR1devn4dr9SgcBTrtHTf6Rqyj3wVJi0g16Bw==",
+      "deprecated": "shiki-stream is now @shikijs/stream, please migrate by renaming the package",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/stream": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "solid-js": "^1.9.0",
+        "vue": "^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/side-channel": {
@@ -14778,6 +16746,46 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/split-on-first": {
+      "version": "3.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/split-on-first/-/split-on-first-3.0.0.tgz",
+      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/stackback": {
@@ -15063,6 +17071,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -15096,6 +17118,13 @@
         "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -15122,7 +17151,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
       "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -15257,6 +17285,20 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/to-vfile": {
+      "version": "8.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/to-vfile/-/to-vfile-8.0.0.tgz",
+      "integrity": "sha512-IcmH1xB5576MJc9qcfEC/m/nQCFt3fzMHz45sSlgJyTWjRbKW1HAkJpuf3DgE57YzIlZcwcBZA5ENQbBo4aLkg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -15330,6 +17372,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.10"
+      }
+    },
+    "node_modules/ts-md5": {
+      "version": "2.0.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/ts-md5/-/ts-md5-2.0.1.tgz",
+      "integrity": "sha512-yF35FCoEOFBzOclSkMNEUbFQZuv89KEQ+5Xz03HrMSGUGB1+r+El+JiGOFwsP4p9RFNzwlrydYoTLvPOuICl9w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-morph": {
@@ -15434,7 +17486,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15537,6 +17589,20 @@
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
       "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -15762,6 +17828,13 @@
         "uuid": "dist-node/bin/uuid"
       }
     },
+    "node_modules/v8n": {
+      "version": "1.5.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/v8n/-/v8n-1.5.1.tgz",
+      "integrity": "sha512-LdabyT4OffkyXFCe9UT+uMkxNBs5rcTVuZClvxQr08D5TUgo1OFKkoT65qYRCsiKBl/usHjpXvP4hHMzzDRj3A==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
@@ -15820,6 +17893,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/virtua": {
+      "version": "0.49.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/virtua/-/virtua-0.49.3.tgz",
+      "integrity": "sha512-k1Yn988Vz/L40uDtEWPjfdVo15Suumh4tU4/z5Srs0elNcU9DgBskqdh3llpHyAlXrCeHWTfcclYvY1uU4MmIg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0",
+        "solid-js": ">=1.0",
+        "svelte": ">=5.0",
+        "vue": ">=3.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/web/package.json
+++ b/web/package.json
@@ -78,6 +78,7 @@
     "remark-breaks": "^4.0.0",
     "remark-emoji": "^5.0.2",
     "remark-gfm": "^4.0.1",
+    "rrule": "^2.8.1",
     "shadcn": "0.0.0-beta.9d3f70e54",
     "shiki": "^4.0.2",
     "streamdown": "^2.5.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ const ApprovePage = lazy(() =>
   import("@/pages/ApprovePage").then((m) => ({ default: m.ApprovePage })),
 );
 const InboxPage = lazy(() => import("@/pages/InboxPage").then((m) => ({ default: m.InboxPage })));
+const TasksPage = lazy(() => import("@/pages/TasksPage").then((m) => ({ default: m.TasksPage })));
 const SettingsPage = lazy(() =>
   import("@/pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
 );
@@ -119,6 +120,7 @@ function App({ basename }: AppProps = {}) {
           <Route path={prefix || "/"} element={<ChatPage />} />
           <Route path={`${prefix}/c/:conversationId`} element={<ChatPage />} />
           <Route path={`${prefix}/inbox`} element={<InboxPage />} />
+          <Route path={`${prefix}/tasks`} element={<TasksPage />} />
           {/* Settings renders into the chat outlet so the conversations
               sidebar stays put — entering settings only swaps the card's
               content (the section nav) and the main area. The active section

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -1,0 +1,453 @@
+// Tests for the manual create dialog: submit stays disabled until the required
+// fields are filled, the workspace-without-host pairing rule surfaces inline,
+// and a valid submit calls the create mutation with the RRULE built from the
+// schedule fields (host/workspace omitted when unset).
+//
+// The agent/host hooks and the create mutation are mocked; WorkspacePicker is
+// stubbed (its filesystem browsing is out of scope here).
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CreateScheduledTaskDialog,
+  isInsidePopper,
+  shouldGuardDialogDismiss,
+} from "./CreateScheduledTaskDialog";
+import * as agentsHook from "@/hooks/useAvailableAgents";
+import * as hostsHook from "@/hooks/useHosts";
+import * as scheduledHooks from "@/hooks/useScheduledTasks";
+import type { AvailableAgent } from "@/hooks/useAvailableAgents";
+
+vi.mock("@/hooks/useAvailableAgents", () => ({ useAvailableAgents: vi.fn() }));
+vi.mock("@/hooks/useHosts", () => ({ useHosts: vi.fn() }));
+vi.mock("@/hooks/useScheduledTasks", () => ({ useCreateScheduledTask: vi.fn() }));
+vi.mock("@/lib/agentLabels", () => ({ useBrainHarnessLabels: () => ({}) }));
+vi.mock("@/shell/WorkspacePicker", () => ({
+  WorkspacePicker: ({ onNavigate }: { onNavigate?: (p: string) => void }) => (
+    <button type="button" onClick={() => onNavigate?.("/home/me/repo")}>
+      pick-workspace
+    </button>
+  ),
+}));
+
+// Stub the heavy shared picker: expose buttons that drive the exact callbacks
+// the dialog wires (select an entry, set model/effort knobs, toggle open state)
+// so we can test the dialog's selection→payload mapping + dismiss-guard without
+// the real Radix menu / QueryClient. Two entries mirror the two mapping cases:
+// a bare harness (claude-native-ui) and a plain agent (polly).
+vi.mock("@/shell/NewChatDialog", () => ({
+  AgentHarnessPicker: ({
+    onSelectAgent,
+    setPickedModel,
+    setPickedEffort,
+    onOpenChange,
+    effectiveAgentId,
+    agentLabel,
+    host,
+  }: {
+    onSelectAgent: (a: AvailableAgent) => void;
+    setPickedModel: (m: string) => void;
+    setPickedEffort: (e: string) => void;
+    onOpenChange?: (open: boolean) => void;
+    effectiveAgentId: string | null;
+    agentLabel: string;
+    host?: { host_id: string } | null;
+  }) => (
+    <div
+      data-testid="agent-picker-stub"
+      data-effective={effectiveAgentId ?? ""}
+      // Surface the host the dialog feeds the picker for badge computation, so
+      // a test can assert it's populated even when no host is pinned.
+      data-badge-host={host?.host_id ?? ""}
+    >
+      <span>{agentLabel}</span>
+      <button
+        type="button"
+        data-testid="pick-harness-claude"
+        onClick={() =>
+          onSelectAgent({
+            id: "ag_claude_native",
+            name: "claude-native-ui",
+            display_name: "Claude Code",
+            description: null,
+            harness: "claude-native",
+            skills: [],
+          })
+        }
+      >
+        pick claude harness
+      </button>
+      <button
+        type="button"
+        data-testid="pick-agent-polly"
+        onClick={() =>
+          onSelectAgent({
+            id: "ag_1",
+            name: "polly",
+            display_name: "Polly",
+            description: null,
+            harness: "claude-sdk",
+            skills: [],
+          })
+        }
+      >
+        pick polly
+      </button>
+      <button type="button" data-testid="pick-model" onClick={() => setPickedModel("opus")}>
+        set model
+      </button>
+      <button type="button" data-testid="pick-effort" onClick={() => setPickedEffort("high")}>
+        set effort
+      </button>
+      <button type="button" data-testid="picker-open" onClick={() => onOpenChange?.(true)}>
+        open
+      </button>
+      <button type="button" data-testid="picker-close" onClick={() => onOpenChange?.(false)}>
+        close
+      </button>
+    </div>
+  ),
+}));
+
+// nativeAgentHasCapability(claude-native, "permissionMode") must be true so the
+// model/effort knobs map onto the payload; polly (claude-sdk) has no knobs.
+vi.mock("@/lib/nativeCodingAgents", async (orig) => {
+  const actual = await orig<typeof import("@/lib/nativeCodingAgents")>();
+  return {
+    ...actual,
+    isNativeCodingAgent: (a: AvailableAgent) => a?.name === "claude-native-ui",
+    nativeAgentHasCapability: (a: AvailableAgent | undefined | null, cap: string) =>
+      a?.name === "claude-native-ui" && cap === "permissionMode",
+  };
+});
+
+const AGENTS: AvailableAgent[] = [
+  {
+    id: "ag_1",
+    name: "polly",
+    display_name: "Polly",
+    description: null,
+    harness: "claude-sdk",
+    skills: [],
+  },
+  {
+    id: "ag_claude_native",
+    name: "claude-native-ui",
+    display_name: "Claude Code",
+    description: null,
+    harness: "claude-native",
+    skills: [],
+  },
+];
+
+const mutateAsync = vi.fn();
+
+beforeEach(() => {
+  mutateAsync.mockReset().mockResolvedValue({ id: "st_new" });
+  vi.mocked(agentsHook.useAvailableAgents).mockReturnValue({
+    data: AGENTS,
+  } as unknown as ReturnType<typeof agentsHook.useAvailableAgents>);
+  vi.mocked(hostsHook.useHosts).mockReturnValue({
+    data: [{ host_id: "host_1", name: "laptop", owner: "me", status: "online" }],
+  } as unknown as ReturnType<typeof hostsHook.useHosts>);
+  vi.mocked(scheduledHooks.useCreateScheduledTask).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+  } as unknown as ReturnType<typeof scheduledHooks.useCreateScheduledTask>);
+});
+
+afterEach(() => cleanup());
+
+function renderDialog(onOpenChange: (open: boolean) => void = vi.fn()) {
+  return render(<CreateScheduledTaskDialog open onOpenChange={onOpenChange} />);
+}
+
+describe("agent picker readiness (needs-setup badges)", () => {
+  it("feeds the picker a fallback online host so 'needs setup' badges show with no host pinned", () => {
+    renderDialog();
+    // Fresh state: no host pinned, but the dialog still passes the first online
+    // host to the picker for badge computation (badgeHost fallback) so the
+    // "needs setup" affordance isn't invisible until the user picks a host.
+    const picker = screen.getByTestId("agent-picker-stub");
+    expect(picker.getAttribute("data-badge-host")).toBe("host_1");
+  });
+});
+
+describe("CreateScheduledTaskDialog validation", () => {
+  it("keeps submit disabled until name + prompt are set (agent defaults to the first)", () => {
+    renderDialog();
+    const submit = screen.getByTestId("create-scheduled-task-submit");
+    // Agent is never blank — the picker resolves a default (first agent) — so
+    // only name + prompt gate submit.
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "Nightly" } });
+    expect(submit).toBeDisabled();
+    fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "Do it" } });
+    expect(submit).toBeEnabled();
+  });
+});
+
+describe("CreateScheduledTaskDialog prefill (seed-on-open + reset)", () => {
+  it("seeds Name + Prompt from initialName/initialPrompt when opened", () => {
+    render(
+      <CreateScheduledTaskDialog
+        open
+        onOpenChange={vi.fn()}
+        initialName="Daily morning brief"
+        initialPrompt="Summarize overnight activity."
+      />,
+    );
+    expect((screen.getByTestId("task-name-input") as HTMLInputElement).value).toBe(
+      "Daily morning brief",
+    );
+    expect((screen.getByTestId("task-prompt-input") as HTMLTextAreaElement).value).toBe(
+      "Summarize overnight activity.",
+    );
+  });
+
+  it("starts EMPTY when opened with no initial values (manual path)", () => {
+    render(<CreateScheduledTaskDialog open onOpenChange={vi.fn()} />);
+    expect((screen.getByTestId("task-name-input") as HTMLInputElement).value).toBe("");
+    expect((screen.getByTestId("task-prompt-input") as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("does not clobber user edits while the dialog stays open", () => {
+    const { rerender } = render(
+      <CreateScheduledTaskDialog open onOpenChange={vi.fn()} initialName="Seed" />,
+    );
+    fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "Edited" } });
+    // A re-render with the SAME open+props must not re-seed over the edit.
+    rerender(<CreateScheduledTaskDialog open onOpenChange={vi.fn()} initialName="Seed" />);
+    expect((screen.getByTestId("task-name-input") as HTMLInputElement).value).toBe("Edited");
+  });
+
+  it("reseeds on a fresh open, and a no-prefill reopen starts empty (no stale leak)", () => {
+    const { rerender } = render(
+      <CreateScheduledTaskDialog open={false} onOpenChange={vi.fn()} initialName="First" />,
+    );
+    // Open with "First".
+    rerender(<CreateScheduledTaskDialog open onOpenChange={vi.fn()} initialName="First" />);
+    expect((screen.getByTestId("task-name-input") as HTMLInputElement).value).toBe("First");
+
+    // Close (resetForm clears), then reopen with NO prefill → empty.
+    rerender(<CreateScheduledTaskDialog open={false} onOpenChange={vi.fn()} />);
+    rerender(<CreateScheduledTaskDialog open onOpenChange={vi.fn()} />);
+    expect((screen.getByTestId("task-name-input") as HTMLInputElement).value).toBe("");
+  });
+});
+
+describe("CreateScheduledTaskDialog submit", () => {
+  it("submits required fields with the built RRULE and omits host/workspace when unset", async () => {
+    renderDialog();
+    fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "Nightly" } });
+    fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "Do it" } });
+
+    const submit = screen.getByTestId("create-scheduled-task-submit");
+    await waitFor(() => expect(submit).toBeEnabled());
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    const arg = mutateAsync.mock.calls[0][0];
+    expect(arg).toMatchObject({
+      name: "Nightly",
+      prompt: "Do it",
+      // Default agent = first after sortAgentsForDisplay (harness rows rank
+      // first, so the Claude Code harness is the default) — matches NewChatDialog.
+      agentId: "ag_claude_native",
+      // Default schedule model is daily at 09:00.
+      rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+    });
+    expect(arg).not.toHaveProperty("hostId");
+    expect(arg).not.toHaveProperty("workspace");
+    // Timezone has no visible control but is still inferred + sent: a non-empty
+    // IANA-ish string (whatever the test env's local zone resolves to).
+    expect(typeof arg.timezone).toBe("string");
+    expect(arg.timezone.length).toBeGreaterThan(0);
+  });
+
+  it("maps a bare-harness pick to its agent_id, no model/effort (harness has no knobs)", async () => {
+    renderDialog();
+    fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "N" } });
+    fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
+    // Pick the Claude Code harness row; set model/effort — but for a bare
+    // harness that supports the model knobs they DO apply (claude-native).
+    fireEvent.click(screen.getByTestId("pick-harness-claude"));
+    fireEvent.click(screen.getByTestId("pick-model"));
+    fireEvent.click(screen.getByTestId("pick-effort"));
+    fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    const arg = mutateAsync.mock.calls[0][0];
+    expect(arg.agentId).toBe("ag_claude_native");
+    expect(arg.modelOverride).toBe("opus");
+    expect(arg.reasoningEffort).toBe("high");
+  });
+
+  it("drops model/effort for an agent pick that has no model knobs (polly)", async () => {
+    renderDialog();
+    fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "N" } });
+    fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
+    // Set model/effort first, then pick Polly (claude-sdk — no knobs) so the
+    // supports-knobs gate drops them.
+    fireEvent.click(screen.getByTestId("pick-model"));
+    fireEvent.click(screen.getByTestId("pick-effort"));
+    fireEvent.click(screen.getByTestId("pick-agent-polly"));
+    fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    const arg = mutateAsync.mock.calls[0][0];
+    expect(arg.agentId).toBe("ag_1");
+    expect(arg).not.toHaveProperty("modelOverride");
+    expect(arg).not.toHaveProperty("reasoningEffort");
+  });
+
+  it("does not render a visible timezone picker (inferred silently)", () => {
+    renderDialog();
+    expect(screen.queryByTestId("task-timezone-trigger")).toBeNull();
+  });
+
+  it("renders the Time field as a 15-minute-slot dropdown (96 options, no free input)", async () => {
+    renderDialog();
+    const timeField = screen.getByTestId("schedule-time");
+    // It's a Select trigger (combobox), not a free-form <input type=time>.
+    expect(timeField.getAttribute("type")).not.toBe("time");
+    fireEvent.keyDown(timeField, { key: "Enter" });
+    const options = await screen.findAllByRole("option");
+    expect(options).toHaveLength(96);
+    // First and last slots span the day at 15-min granularity.
+    expect(options[0]).toHaveTextContent("12:00 AM");
+    expect(options[options.length - 1]).toHaveTextContent("11:45 PM");
+  });
+
+  it("picking a time slot flows into the submitted RRULE", async () => {
+    renderDialog();
+    fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "T" } });
+    fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
+    // Agent defaults to the first (polly); just pick 2:30 PM from the Time dropdown.
+    fireEvent.keyDown(screen.getByTestId("schedule-time"), { key: "Enter" });
+    fireEvent.click(await screen.findByRole("option", { name: "2:30 PM" }));
+
+    const submit = screen.getByTestId("create-scheduled-task-submit");
+    await waitFor(() => expect(submit).toBeEnabled());
+    fireEvent.click(submit);
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    // Default preset is Daily → 14:30.
+    expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=DAILY;BYHOUR=14;BYMINUTE=30");
+  });
+
+  it("Hourly preset shows a minute-only dropdown of 15-min slots", async () => {
+    renderDialog();
+    fireEvent.keyDown(screen.getByTestId("schedule-preset-trigger"), { key: "Enter" });
+    fireEvent.click(await screen.findByRole("option", { name: "Hourly" }));
+    fireEvent.keyDown(screen.getByTestId("schedule-minute"), { key: "Enter" });
+    const options = (await screen.findAllByRole("option")).map((o) => o.textContent);
+    expect(options).toEqual([":00", ":15", ":30", ":45"]);
+  });
+
+  it("offers exactly the four v1 frequency presets — no Custom entry point", async () => {
+    renderDialog();
+    // Open the frequency Select (keyboard is the reliable jsdom path).
+    fireEvent.keyDown(screen.getByTestId("schedule-preset-trigger"), { key: "Enter" });
+    const options = (await screen.findAllByRole("option")).map((o) => o.textContent);
+    expect(options).toEqual(["Hourly", "Daily", "Weekdays", "Weekly"]);
+    expect(options).not.toContain("Custom");
+    // The Custom-only sub-controls must never be in the DOM in v1.
+    expect(screen.queryByTestId("custom-freq-trigger")).toBeNull();
+    expect(screen.queryByTestId("custom-interval")).toBeNull();
+    expect(screen.queryByTestId("schedule-month-trigger")).toBeNull();
+  });
+
+  it("does not render the 'Reads as' schedule preview (removed in v1)", () => {
+    renderDialog();
+    expect(screen.queryByTestId("schedule-preview")).toBeNull();
+    expect(screen.queryByText(/Reads as:/i)).toBeNull();
+  });
+});
+
+describe("nested-Select does not dismiss the Dialog (isInsidePopper guard)", () => {
+  // The guard's decision is pure DOM: is the interaction target inside a Radix
+  // popper / Select portal? Unit-test that directly — jsdom can't faithfully
+  // reproduce Radix's pointer-capture portal outside-click, so the full
+  // "click an option → dialog stays open" path is covered by the live pane
+  // verification (see the task report), not here.
+  it("treats a click inside a Select portal as inside-popper", () => {
+    const content = document.createElement("div");
+    content.setAttribute("data-slot", "select-content");
+    const option = document.createElement("div");
+    option.setAttribute("role", "option");
+    content.appendChild(option);
+    document.body.appendChild(content);
+    expect(isInsidePopper(option)).toBe(true);
+
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-radix-popper-content-wrapper", "");
+    const inner = document.createElement("span");
+    wrapper.appendChild(inner);
+    document.body.appendChild(wrapper);
+    expect(isInsidePopper(inner)).toBe(true);
+
+    const listbox = document.createElement("div");
+    listbox.setAttribute("role", "listbox");
+    document.body.appendChild(listbox);
+    expect(isInsidePopper(listbox)).toBe(true);
+  });
+
+  it("treats the real backdrop (outside any popper) as NOT inside-popper", () => {
+    const backdrop = document.createElement("div");
+    document.body.appendChild(backdrop);
+    expect(isInsidePopper(backdrop)).toBe(false);
+    expect(isInsidePopper(null)).toBe(false);
+    expect(isInsidePopper(document.body)).toBe(false);
+  });
+});
+
+describe("shouldGuardDialogDismiss (backdrop click closes; select-dismiss guarded)", () => {
+  function overlayTarget(): Element {
+    const overlay = document.createElement("div");
+    overlay.setAttribute("data-slot", "dialog-overlay");
+    document.body.appendChild(overlay);
+    return overlay;
+  }
+  function popperTarget(): Element {
+    const content = document.createElement("div");
+    content.setAttribute("data-slot", "select-content");
+    const inner = document.createElement("div");
+    content.appendChild(inner);
+    document.body.appendChild(content);
+    return inner;
+  }
+
+  it("does NOT guard a genuine backdrop-overlay click → dialog dismisses", () => {
+    const target = overlayTarget();
+    // Even while a Select is open / just closed / inside grace, a backdrop click
+    // must dismiss (the bug was this being swallowed).
+    expect(shouldGuardDialogDismiss(target, { selectOpen: true, msSinceSelectClose: 0 })).toBe(
+      false,
+    );
+    expect(shouldGuardDialogDismiss(target, { selectOpen: false, msSinceSelectClose: 10 })).toBe(
+      false,
+    );
+  });
+
+  it("guards a click INSIDE a popper (option pick) → dialog stays open", () => {
+    expect(
+      shouldGuardDialogDismiss(popperTarget(), { selectOpen: false, msSinceSelectClose: 9999 }),
+    ).toBe(true);
+  });
+
+  it("guards while a Select is open, and within the grace window after it closes", () => {
+    const plain = document.createElement("div");
+    document.body.appendChild(plain);
+    // Select currently open → guarded.
+    expect(shouldGuardDialogDismiss(plain, { selectOpen: true, msSinceSelectClose: 9999 })).toBe(
+      true,
+    );
+    // Trailing focus-outside within grace → guarded.
+    expect(shouldGuardDialogDismiss(plain, { selectOpen: false, msSinceSelectClose: 50 })).toBe(
+      true,
+    );
+    // Well after grace, not in a popper, no select → NOT guarded (would dismiss).
+    expect(shouldGuardDialogDismiss(plain, { selectOpen: false, msSinceSelectClose: 500 })).toBe(
+      false,
+    );
+  });
+});

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -1,0 +1,535 @@
+// The "Set up manually" create dialog for a scheduled task. Fully wires the
+// form to POST /v1/scheduled-tasks via useCreateScheduledTask, invalidating the
+// list and closing on success. Reuses the existing agent picker
+// (useAvailableAgents), host picker (useHosts), and directory picker
+// (WorkspacePicker) rather than reinventing them.
+//
+// Field contract mirrors omnigent/server/routes/scheduled_tasks.py:
+//   REQUIRED: name, prompt, rrule (built from the ScheduleFields model),
+//     agent_id. OPTIONAL: timezone (default UTC), model_override,
+//     reasoning_effort, host_id + workspace (validated as a pair — a workspace
+//     without a host is rejected client- and server-side).
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Loader2Icon, TriangleAlertIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/scheduled/Label";
+import { ScheduleFields } from "@/components/scheduled/ScheduleFields";
+import { WorkspacePicker } from "@/shell/WorkspacePicker";
+import { AgentHarnessPicker } from "@/shell/NewChatDialog";
+import { useAvailableAgents, type AvailableAgent } from "@/hooks/useAvailableAgents";
+import { useHosts } from "@/hooks/useHosts";
+import { useCreateScheduledTask } from "@/hooks/useScheduledTasks";
+import { useBrainHarnessLabels } from "@/lib/agentLabels";
+import { isNativeCodingAgent, nativeAgentHasCapability } from "@/lib/nativeCodingAgents";
+import { sortAgentsForDisplay } from "@/lib/agentGrouping";
+import {
+  buildRRule,
+  DEFAULT_SCHEDULE_MODEL,
+  validateSchedule,
+  type ScheduleModel,
+} from "@/lib/scheduleBuilder";
+import { ScheduledTaskApiError } from "@/lib/scheduledTasksApi";
+import { localTimezone } from "@/lib/timezones";
+
+// Agents hidden from the scheduled-task picker (mirrors NewChatDialog's set):
+// superseded / SDK-only harnesses that shouldn't be user-pickable here.
+const HIDDEN_PICKER_AGENTS = new Set(["nessie", "kimi", "kimi-code"]);
+
+export function CreateScheduledTaskDialog({
+  open,
+  onOpenChange,
+  initialName,
+  initialPrompt,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Seed values applied to Name/Prompt when the dialog opens (e.g. from a
+   *  "More ideas" suggestion chip). Omitted → the fields start empty. */
+  initialName?: string;
+  initialPrompt?: string;
+}) {
+  const { data: agents } = useAvailableAgents({ enabled: open });
+  const { data: hosts } = useHosts({ enabled: open });
+  const brainHarnessLabels = useBrainHarnessLabels();
+  const createMutation = useCreateScheduledTask();
+
+  const [name, setName] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [schedule, setSchedule] = useState<ScheduleModel>(DEFAULT_SCHEDULE_MODEL);
+
+  // ── Agent / harness picker (shared with NewChatDialog) ─────────────────────
+  // The picker's "Harnesses" (Claude Code / Codex / Pi …) and "Agents"
+  // (Polly / Debby / custom) rows are all real AvailableAgents with ids, so a
+  // single `pickedAgentId` covers both cases — for a bare-harness pick it's the
+  // `*-native-ui` agent's id, exactly what the interactive dialog sends. The
+  // per-entry model/effort knobs (claude-native only) ride along as
+  // model_override / reasoning_effort. The picker also surfaces permission /
+  // approval / cursor mode + a harness override, but the scheduled-task API has
+  // NO field for those — so we hold them in local state to satisfy the picker's
+  // props and DROP them from the create body (flagged to the lead).
+  const [pickedAgentId, setPickedAgentId] = useState<string | null>(null);
+  const [pickedModel, setPickedModel] = useState("");
+  const [pickedEffort, setPickedEffort] = useState("");
+  const [pickedHarness, setPickedHarness] = useState<string | null>(null);
+  // Mode knobs the picker requires as props; not sent to the scheduled API.
+  const [permissionMode, setPermissionMode] = useState("default");
+  const [approvalMode, setApprovalMode] = useState("default");
+  const [cursorExecMode, setCursorExecMode] = useState("default");
+  const [bypassSandbox, setBypassSandbox] = useState(false);
+
+  const agentList = useMemo(
+    () => sortAgentsForDisplay((agents ?? []).filter((a) => !HIDDEN_PICKER_AGENTS.has(a.name))),
+    [agents],
+  );
+  const harnessEntries = useMemo(
+    () => agentList.filter((a) => isNativeCodingAgent(a)),
+    [agentList],
+  );
+  const agentEntries = useMemo(() => agentList.filter((a) => !isNativeCodingAgent(a)), [agentList]);
+  // Resolve the effective selection: the explicit pick if it's still in the
+  // list, else the first agent (so the picker always has a concrete value).
+  const effectiveAgentId =
+    (agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ?? null;
+  const selectedAgent = agentList.find((a) => a.id === effectiveAgentId);
+  const agentLabel = selectedAgent ? selectedAgent.display_name : "Select agent";
+  // Model/effort knobs only apply to agents that expose the permission-mode
+  // submenu (claude-native), mirroring NewChatDialog's `agentSupportsPermissionMode`.
+  const agentSupportsModelKnobs = nativeAgentHasCapability(selectedAgent, "permissionMode");
+
+  function handleSelectAgent(agent: AvailableAgent) {
+    setPickedAgentId(agent.id);
+  }
+
+  // ── Nested-Select dismiss guard ───────────────────────────────────────────
+  // The agent/host/schedule Selects portal their dropdown OUTSIDE DialogContent.
+  // Two dismiss paths leak through to the Dialog and close the whole modal:
+  //   (a) picking an option — the closing pointerdown lands in the popper;
+  //   (b) clicking empty modal body (or the trigger) while a Select is open —
+  //       the target is the dialog body, and the portal ALSO emits a
+  //       focus-outside as it unmounts.
+  // Target-sniffing (isInsidePopper) only covers (a). To cover (b) too, track
+  // whether ANY Select is open, and keep the guard armed for a short grace
+  // window after it closes so the trailing pointerup/focus transition that
+  // Radix reports as "interact outside" is absorbed. See `guardDialogDismiss`.
+  const selectOpenCountRef = useRef(0);
+  const selectClosedAtRef = useRef(0);
+  function handleSelectOpenChange(isOpen: boolean) {
+    if (isOpen) {
+      selectOpenCountRef.current += 1;
+    } else {
+      selectOpenCountRef.current = Math.max(0, selectOpenCountRef.current - 1);
+      selectClosedAtRef.current = Date.now();
+    }
+  }
+  /** preventDefault the Dialog's outside-dismiss ONLY for the narrow nested-Select
+   * cases — a click inside a popper (path a) or while a Select is open (path b),
+   * plus a short grace window for the trailing focus-outside a Select emits as it
+   * unmounts. A genuine click on the backdrop OVERLAY always dismisses: its target
+   * is the overlay itself (never a popper), so we let it through even inside the
+   * grace window — this is the fix for backdrop-click-to-close being swallowed.
+   * Escape + Cancel are unaffected (they don't route through this guard). */
+  function guardDialogDismiss(event: { target: EventTarget | null; preventDefault: () => void }) {
+    if (
+      shouldGuardDialogDismiss(event.target, {
+        selectOpen: selectOpenCountRef.current > 0,
+        msSinceSelectClose: Date.now() - selectClosedAtRef.current,
+      })
+    ) {
+      event.preventDefault();
+    }
+  }
+  // Optional pinned host/workspace. "" = unset (server resolves at fire time).
+  const [hostId, setHostId] = useState<string>("");
+  const [workspace, setWorkspace] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+
+  // Seed Name/Prompt on the closed→open transition ONLY. Keying off the
+  // transition (not `open` being true) means we never clobber the user's edits
+  // while the dialog stays open. Each fresh open is AUTHORITATIVE — the fields
+  // are set to the initial values, or cleared to "" when none are supplied — so
+  // a stale prefill can never leak into a subsequent manual open regardless of
+  // how the prior instance was closed, and switching chips reseeds.
+  const wasOpen = useRef(false);
+  useEffect(() => {
+    if (open && !wasOpen.current) {
+      setName(initialName ?? "");
+      setPrompt(initialPrompt ?? "");
+    }
+    wasOpen.current = open;
+  }, [open, initialName, initialPrompt]);
+
+  const hostOptions = hosts ?? [];
+  // The resolved Host for the pinned id, or undefined when none is pinned.
+  const selectedHost = hostId === "" ? undefined : hostOptions.find((h) => h.host_id === hostId);
+  // Host whose `configured_harnesses` drives the picker's "needs setup" badges.
+  // Host is OPTIONAL on scheduled tasks (post-FU-3: unset = resolve the connected
+  // host at fire time), so we must NOT require the user to pin one before the
+  // readiness affordance appears. Fall back to the first ONLINE host for badge
+  // computation only — this does NOT change the form's `hostId` value (which
+  // stays "" = resolve-at-fire); it just gives the picker a readiness map so
+  // unconfigured agents show "needs setup" immediately, matching how the
+  // interactive New Chat dialog auto-selects the first online host on mount.
+  const badgeHost =
+    selectedHost ?? hostOptions.find((h) => h.status === "online") ?? hostOptions[0];
+
+  // A workspace is only valid with a host — mirror the server's pairing rule so
+  // the user gets inline feedback instead of a 400.
+  const workspaceWithoutHost = workspace.trim() !== "" && hostId === "";
+  // Block submit on an invalid schedule (bad interval, empty multi-select) so
+  // the form never posts an RRULE the server's validate_rrule would 400.
+  const scheduleInvalid = validateSchedule(schedule) !== null;
+  const canSubmit =
+    name.trim() !== "" &&
+    prompt.trim() !== "" &&
+    effectiveAgentId !== null &&
+    !workspaceWithoutHost &&
+    !scheduleInvalid &&
+    !createMutation.isPending;
+
+  function resetForm() {
+    setName("");
+    setPrompt("");
+    setPickedAgentId(null);
+    setPickedModel("");
+    setPickedEffort("");
+    setPickedHarness(null);
+    setPermissionMode("default");
+    setApprovalMode("default");
+    setCursorExecMode("default");
+    setBypassSandbox(false);
+    setSchedule(DEFAULT_SCHEDULE_MODEL);
+    setHostId("");
+    setWorkspace("");
+    setError(null);
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) resetForm();
+    onOpenChange(next);
+  }
+
+  async function handleSubmit() {
+    if (effectiveAgentId === null) return;
+    setError(null);
+    try {
+      await createMutation.mutateAsync({
+        name: name.trim(),
+        prompt: prompt.trim(),
+        rrule: buildRRule(schedule),
+        // Both a bare-harness pick and an agent pick resolve to a real agent id
+        // here (harness rows are the `*-native-ui` agents), matching what the
+        // interactive dialog sends as `agent_id`.
+        agentId: effectiveAgentId,
+        // Model / effort ride along ONLY for agents that expose the model-knob
+        // submenu (claude-native), mirroring NewChatDialog. An unselected ("")
+        // knob is omitted so the agent keeps its own configured model. The
+        // picker's permission/approval/cursor mode + harness override have NO
+        // scheduled-task API field, so they are intentionally NOT sent.
+        ...(agentSupportsModelKnobs && pickedModel ? { modelOverride: pickedModel } : {}),
+        ...(agentSupportsModelKnobs && pickedEffort ? { reasoningEffort: pickedEffort } : {}),
+        // Timezone is inferred from the browser (Intl) and not user-editable in
+        // v1 — a picker can be added later if cross-timezone scheduling is
+        // needed. Still sent so the server evaluates the RRULE in the user's
+        // local zone rather than defaulting to UTC.
+        timezone: localTimezone(),
+        // Send the host/workspace pair only when a host was pinned. A pinned
+        // host with no workspace is allowed (server defaults to the host home).
+        ...(hostId !== "" ? { hostId } : {}),
+        ...(hostId !== "" && workspace.trim() !== "" ? { workspace: workspace.trim() } : {}),
+      });
+      handleOpenChange(false);
+    } catch (err) {
+      setError(
+        err instanceof ScheduledTaskApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : "Couldn't create the scheduled task.",
+      );
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="max-h-[90vh] overflow-y-auto sm:max-w-lg"
+        data-testid="create-scheduled-task-dialog"
+        // Keep a nested Select's dismiss (pick an option, OR click empty modal
+        // body / trigger while it's open) from closing the whole Dialog. See
+        // `guardDialogDismiss` — it covers both the popper-target path and the
+        // Select-open + focus-outside path, while leaving real backdrop clicks
+        // and Escape to close as normal.
+        onPointerDownOutside={guardDialogDismiss}
+        onInteractOutside={guardDialogDismiss}
+      >
+        <DialogHeader>
+          <DialogTitle>New scheduled task</DialogTitle>
+          <DialogDescription>
+            Runs an agent session on a recurring schedule. Fires on a connected host.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-1">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="task-name">Name</Label>
+            <Input
+              id="task-name"
+              value={name}
+              placeholder="Nightly triage"
+              data-testid="task-name-input"
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="task-prompt">Prompt</Label>
+            <Textarea
+              id="task-prompt"
+              value={prompt}
+              rows={4}
+              placeholder="What should the agent do each time it runs?"
+              data-testid="task-prompt-input"
+              // No native resize grip — match the clean styling of the other fields.
+              className="resize-none"
+              onChange={(e) => setPrompt(e.target.value)}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            {/* "Runs with" — the unified picker offers BOTH harnesses (Claude
+                Code / Codex / Pi …) and agents (Polly / Debby), so "Agent" would
+                be misleading. */}
+            <Label>Runs with</Label>
+            {/* Shared unified picker (same component the interactive NewChatDialog
+                uses): a "Harnesses" section (Claude Code / Codex / Pi …) + an
+                "Agents" section (Polly / Debby / custom), with per-entry
+                model/effort knobs. onOpenChange feeds the dialog's dismiss guard
+                so opening the picker doesn't close the modal. Custom-agent
+                creation, sandbox, and the mode knobs that scheduled-tasks can't
+                persist are wired to no-ops / dropped (see handleSubmit). */}
+            <div data-testid="task-agent-picker">
+              <AgentHarnessPicker
+                agentEntries={agentEntries}
+                harnessEntries={harnessEntries}
+                brainHarnessLabels={brainHarnessLabels}
+                effectiveAgentId={effectiveAgentId}
+                agentLabel={agentLabel}
+                hasAgents={agentList.length > 0}
+                // Drives the per-row "needs setup" badges from
+                // host.configured_harnesses. Uses the pinned host if any, else
+                // falls back to the first online host so the badges show in the
+                // fresh/default state (host is optional here — see `badgeHost`).
+                host={badgeHost}
+                onSelectAgent={handleSelectAgent}
+                pendingAgent={null}
+                pendingAgentId="__unused_pending_agent__"
+                onSelectPending={() => {}}
+                // TODO(OMNI-1193): "Create custom agent" is a no-op here. The
+                // interactive flow (NewChatDialog) opens CreateAgentDialog, holds
+                // the returned bundle as a PENDING agent, and only PERSISTS it at
+                // session-create time via the multipart createBundledSession
+                // (which also mints a session). A scheduled task needs a concrete
+                // `agent_id` up front and has no session to ride, and there is no
+                // standalone "persist agent bundle → agent_id" endpoint yet — so
+                // wiring this correctly is blocked on backend support (a persist
+                // route, or a bundle-aware POST /v1/scheduled-tasks). Left inert
+                // rather than forking a flow that creates a phantom session.
+                onCreateCustomAgent={() => {}}
+                sandboxSelected={false}
+                permissionMode={permissionMode}
+                approvalMode={approvalMode}
+                cursorExecMode={cursorExecMode}
+                bypassSandbox={bypassSandbox}
+                pickedModel={pickedModel}
+                pickedEffort={pickedEffort}
+                pickedHarness={pickedHarness}
+                setPermissionMode={setPermissionMode}
+                setApprovalMode={setApprovalMode}
+                setCursorExecMode={setCursorExecMode}
+                setBypassSandbox={setBypassSandbox}
+                setPickedModel={setPickedModel}
+                setPickedEffort={setPickedEffort}
+                setPickedHarness={(h) => setPickedHarness(h)}
+                onOpenChange={handleSelectOpenChange}
+                // Bound the dropdown height so it scrolls in the modal instead
+                // of running off the bottom of the screen (the trigger sits near
+                // the top of a tall dialog, unlike the composer footer). Width
+                // matches the interactive picker so the "needs setup" pills +
+                // agent descriptions fit without cramping (the shared default is
+                // only min-w-64; pin a comfortable fixed width like interactive).
+                contentClassName="max-h-80 w-80"
+                // Full-width trigger → left-align the menu's edge to it.
+                contentAlign="start"
+                // Match the sibling <Select> fields (Frequency / host): full
+                // width, bordered, h-8, normal foreground text — not the compact
+                // muted ghost styling the composer footer uses.
+                triggerClassName="h-8 w-full justify-between rounded-lg border border-input bg-transparent px-2.5 text-foreground hover:bg-transparent hover:text-foreground dark:bg-input/30"
+                triggerLabelClassName="max-w-none text-sm"
+              />
+            </div>
+          </div>
+
+          <ScheduleFields
+            model={schedule}
+            onChange={setSchedule}
+            onSelectOpenChange={handleSelectOpenChange}
+          />
+
+          {/* Timezone is inferred from the browser (localTimezone via Intl) and
+              intentionally has no visible control in v1 — it's still sent in the
+              create payload so the schedule evaluates in the user's local zone. */}
+
+          {/* Optional host + workspace pin. Left unset, the server resolves the
+              owner's connected host and its home directory at fire time. */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="task-host">Host (optional)</Label>
+            <Select
+              value={hostId === "" ? UNSET_HOST : hostId}
+              onValueChange={(v) => {
+                const next = v === UNSET_HOST ? "" : v;
+                setHostId(next);
+                // Clearing the host invalidates any pinned workspace.
+                if (next === "") setWorkspace("");
+              }}
+              onOpenChange={handleSelectOpenChange}
+            >
+              <SelectTrigger id="task-host" data-testid="task-host-trigger">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent position="popper" align="start">
+                <SelectItem value={UNSET_HOST}>Resolve at fire time</SelectItem>
+                {hostOptions.map((host) => (
+                  <SelectItem key={host.host_id} value={host.host_id}>
+                    {host.name} {host.status === "offline" ? "(offline)" : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-[11px] text-muted-foreground">
+              Leave unset to run on your connected host when the task fires.
+            </p>
+          </div>
+
+          {hostId !== "" && (
+            <div className="flex flex-col gap-1.5">
+              <Label>Workspace (optional)</Label>
+              <p className="text-[11px] text-muted-foreground">
+                Defaults to the host&apos;s home directory. Pick a directory to pin it.
+              </p>
+              <div className="h-56 overflow-hidden rounded-md border border-border">
+                <WorkspacePicker
+                  hostId={hostId}
+                  onNavigate={setWorkspace}
+                  initialPath={workspace || undefined}
+                />
+              </div>
+              {workspace && (
+                <p className="truncate font-mono text-[11px] text-muted-foreground">{workspace}</p>
+              )}
+            </div>
+          )}
+
+          {workspaceWithoutHost && (
+            <p
+              className="flex items-center gap-1.5 text-xs text-destructive"
+              data-testid="workspace-without-host-error"
+            >
+              <TriangleAlertIcon className="size-3.5 shrink-0" />
+              Pick a host before pinning a workspace.
+            </p>
+          )}
+
+          {error && (
+            <div
+              role="alert"
+              data-testid="create-error"
+              className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive"
+            >
+              <TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            data-testid="create-scheduled-task-submit"
+          >
+            {createMutation.isPending && <Loader2Icon className="mr-1 size-4 animate-spin" />}
+            Create task
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Sentinel Select value for "no pinned host" — Radix Select disallows "". */
+const UNSET_HOST = "__unset_host__";
+
+/**
+ * True when an event target lives inside a Radix popper / Select portal (which
+ * renders outside the DialogContent subtree). Used to distinguish a click that
+ * merely closes a nested Select from a genuine outside-click on the backdrop, so
+ * the former doesn't dismiss the whole Dialog.
+ *
+ * Exported for unit testing (the full portal outside-click is hard to reproduce
+ * faithfully in jsdom — see the dialog test).
+ */
+export function isInsidePopper(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    target.closest(
+      '[data-radix-popper-content-wrapper], [data-slot="select-content"], [role="listbox"]',
+    ) !== null
+  );
+}
+
+/** True when the event target is the Dialog's backdrop overlay itself. A real
+ *  backdrop click must always dismiss, so the guard lets it through. */
+export function isBackdropOverlay(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest('[data-slot="dialog-overlay"]') !== null;
+}
+
+/**
+ * Pure decision for whether to SWALLOW the Dialog's outside-dismiss. Returns
+ * true → preventDefault (dialog stays open); false → let it dismiss.
+ *
+ * A genuine backdrop-overlay click ALWAYS dismisses (returns false), even during
+ * the grace window — this is the fix for backdrop-click-to-close being swallowed.
+ * Otherwise we swallow only the narrow nested-Select cases: a Select currently
+ * open, the trailing focus-outside within `graceMs` of a Select closing, or a
+ * click that landed inside a popper. Exported pure so it's unit-testable without
+ * Radix's portal machinery.
+ */
+export function shouldGuardDialogDismiss(
+  target: EventTarget | null,
+  opts: { selectOpen: boolean; msSinceSelectClose: number; graceMs?: number },
+): boolean {
+  if (isBackdropOverlay(target)) return false;
+  const graceMs = opts.graceMs ?? 150;
+  return opts.selectOpen || opts.msSinceSelectClose < graceMs || isInsidePopper(target);
+}

--- a/web/src/components/scheduled/CreateWithOmnigentDialog.tsx
+++ b/web/src/components/scheduled/CreateWithOmnigentDialog.tsx
@@ -1,0 +1,53 @@
+// Placeholder for the "Create with Omnigent" flow — a conversational path where
+// the user describes the task in natural language and the agent proposes the
+// name / prompt / schedule.
+//
+// TODO(UI-2): This is intentionally a STUB. The full conversational create flow
+// is built in the UI-2 task; this dialog only exists so the "New task" menu's
+// first option is wired and discoverable now. Do not add real behavior here —
+// UI-2 owns it.
+
+import { SparklesIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+export function CreateWithOmnigentDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid="create-with-omnigent-dialog" className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <SparklesIcon className="size-4 text-primary" />
+            Create with Omnigent
+          </DialogTitle>
+          <DialogDescription>
+            Describe a recurring task in plain language and Omnigent will draft the schedule and
+            prompt for you.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="rounded-md border border-dashed border-border bg-muted/30 px-4 py-8 text-center text-sm text-muted-foreground">
+          Coming soon. For now, use{" "}
+          <span className="font-medium text-foreground">Set up manually</span> to create a task.
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/scheduled/Label.tsx
+++ b/web/src/components/scheduled/Label.tsx
@@ -1,0 +1,14 @@
+// Small shared form label for the scheduled-tasks forms. The repo has no shadcn
+// `label` primitive; other forms (RegisterPage) hand-roll a `<label>` with
+// `text-sm font-medium leading-none`, so this centralizes that one style for the
+// several fields the create dialog renders.
+
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/utils";
+
+export function Label({ className, ...props }: ComponentPropsWithoutRef<"label">) {
+  return (
+    // eslint-disable-next-line jsx-a11y/label-has-associated-control -- callers pass htmlFor
+    <label className={cn("text-sm font-medium leading-none", className)} {...props} />
+  );
+}

--- a/web/src/components/scheduled/ScheduleFields.tsx
+++ b/web/src/components/scheduled/ScheduleFields.tsx
@@ -1,0 +1,253 @@
+// The schedule-builder sub-form used by the manual create dialog.
+//
+// v1 top-level frequency: Hourly, Daily, Weekdays, Weekly. Each is a simple
+// preset — Hourly takes no inputs, Daily/Weekdays take a time, Weekly adds a
+// weekday multi-select. Emits its state up as a ScheduleModel; the parent turns
+// it into an RRULE via buildRRule and gates submit on validateSchedule.
+//
+// TODO(UI-2): the "Custom" entry point (interval + Monthly/Yearly, with the
+// day-of-month / month controls) is deferred. Its model fields, buildRRule
+// cases, and scheduleText/nextRun handling for INTERVAL / BYMONTH /
+// multi-BYMONTHDAY / yearly are intentionally KEPT in the lib files
+// (scheduleBuilder.ts, scheduleText.ts) so they stay robust and UI-2 can wire a
+// Custom sub-form back in — they're just not reachable from this v1 UI.
+
+import { Label } from "@/components/scheduled/Label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import {
+  WEEKDAY_CODES,
+  validateSchedule,
+  type ScheduleModel,
+  type SchedulePreset,
+  type WeekdayCode,
+} from "@/lib/scheduleBuilder";
+import { formatClockTime } from "@/lib/scheduleText";
+
+// v1 presets only — "custom" is deferred to UI-2 (see file header) and is
+// deliberately absent from this list, so it's unreachable from the dropdown.
+const PRESET_OPTIONS: { value: SchedulePreset; label: string }[] = [
+  { value: "hourly", label: "Hourly" },
+  { value: "daily", label: "Daily" },
+  { value: "weekdays", label: "Weekdays" },
+  { value: "weekly", label: "Weekly" },
+];
+
+/** Time-of-day is constrained to 15-minute slots (no free typing). */
+const MINUTE_SLOTS = [0, 15, 30, 45] as const;
+
+/** Every 15-minute slot across the day (96 options), for the Time dropdown. */
+const TIME_SLOTS: { hour: number; minute: number }[] = Array.from({ length: 96 }, (_, i) => ({
+  hour: Math.floor(i / 4),
+  minute: (i % 4) * 15,
+}));
+
+const WEEKDAY_LABELS: Record<WeekdayCode, string> = {
+  MO: "Mon",
+  TU: "Tue",
+  WE: "Wed",
+  TH: "Thu",
+  FR: "Fri",
+  SA: "Sat",
+  SU: "Sun",
+};
+
+export function ScheduleFields({
+  model,
+  onChange,
+  onSelectOpenChange,
+}: {
+  model: ScheduleModel;
+  onChange: (next: ScheduleModel) => void;
+  /** Forwarded to the frequency Select's onOpenChange so the parent Dialog can
+   * keep an open Select from dismissing the whole modal. Optional. */
+  onSelectOpenChange?: (open: boolean) => void;
+}) {
+  // Time-of-day is meaningless for the hourly preset (fires every hour); it
+  // shows a minute-only input instead.
+  const isHourly = model.preset === "hourly";
+  const showWeekdays = model.preset === "weekly";
+
+  const error = validateSchedule(model);
+
+  function toggleWeekday(code: WeekdayCode) {
+    const has = model.weekdays.includes(code);
+    const next = has ? model.weekdays.filter((c) => c !== code) : [...model.weekdays, code];
+    onChange({ ...model, weekdays: next });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="schedule-preset">Frequency</Label>
+        <Select
+          value={model.preset}
+          onValueChange={(value) => onChange({ ...model, preset: value as SchedulePreset })}
+          onOpenChange={onSelectOpenChange}
+        >
+          <SelectTrigger id="schedule-preset" data-testid="schedule-preset-trigger">
+            <SelectValue />
+          </SelectTrigger>
+          {/* position="popper" opens the list anchored BELOW the trigger (auto-
+              flips up when no room) so it never overlaps the field label above,
+              unlike the default item-aligned mode. align="start" lines the
+              dropdown's left edge up with the trigger (Radix defaults to
+              center, which shifts it left). */}
+          <SelectContent position="popper" align="start">
+            {PRESET_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {showWeekdays && (
+        <div className="flex flex-col gap-1.5">
+          <Label>On days</Label>
+          <div className="flex flex-wrap gap-1.5" role="group" aria-label="Weekdays">
+            {WEEKDAY_CODES.map((code) => {
+              const selected = model.weekdays.includes(code);
+              return (
+                <button
+                  key={code}
+                  type="button"
+                  aria-pressed={selected}
+                  data-testid={`weekday-${code}`}
+                  onClick={() => toggleWeekday(code)}
+                  className={cn(
+                    "h-8 min-w-11 rounded-md border px-2 text-xs font-medium transition-colors",
+                    selected
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border bg-background text-muted-foreground hover:bg-muted",
+                  )}
+                >
+                  {WEEKDAY_LABELS[code]}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="schedule-time">{isHourly ? "Minute" : "Time"}</Label>
+        {isHourly ? (
+          // Hourly fires every hour; only the minute-of-hour matters. Constrain
+          // to 15-min slots (0/15/30/45) via a dropdown — no free typing.
+          <Select
+            value={String(snapMinute(model.minute))}
+            onValueChange={(v) => onChange({ ...model, minute: Number(v) })}
+            onOpenChange={onSelectOpenChange}
+          >
+            <SelectTrigger id="schedule-time" data-testid="schedule-minute" className="w-28">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent position="popper" align="start">
+              {MINUTE_SLOTS.map((m) => (
+                <SelectItem key={m} value={String(m)}>
+                  {`:${pad(m)}`}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          // Time-of-day constrained to 15-min slots (96/day) via a dropdown.
+          // Value encodes "H:M"; labels use the same 12h clock as the list rows.
+          <Select
+            value={`${snapHour(model)}:${snapMinute(model.minute)}`}
+            onValueChange={(v) => {
+              const [h, m] = v.split(":");
+              onChange({ ...model, hour: Number(h), minute: Number(m) });
+            }}
+            onOpenChange={(next) => {
+              onSelectOpenChange?.(next);
+              // Radix scrolls the SELECTED slot into view on open (even in
+              // popper mode), so a 9:00 AM default would land mid-list and hide
+              // 12:00 AM. Pin the viewport to the top so the list always starts
+              // at 12:00 AM (index 0), per product. Radix's scroll-into-view
+              // runs in a layout effect + a follow-up frame after open, so we
+              // pin on a short interval for a few ticks to reliably win the
+              // race regardless of machine speed, then stop.
+              if (next) {
+                let ticks = 0;
+                const pinTop = () => {
+                  document
+                    .querySelectorAll<HTMLElement>("[data-radix-select-viewport]")
+                    .forEach((vp) => {
+                      vp.scrollTop = 0;
+                    });
+                };
+                const timer = setInterval(() => {
+                  pinTop();
+                  if (++ticks >= 6) clearInterval(timer);
+                }, 16);
+                pinTop();
+              }
+            }}
+          >
+            <SelectTrigger id="schedule-time" data-testid="schedule-time" className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            {/* position="popper" + align="start" opens the list below the
+                trigger, left-aligned. We also reset the viewport scroll to top
+                on open (see onOpenChange) so the list starts at 12:00 AM (index
+                0) rather than scrolled to the selected slot. max-h ≈ 12 rows
+                (~28px each) so the 96 slots scroll inside the popover. */}
+            <SelectContent position="popper" align="start" className="max-h-[21rem]">
+              {TIME_SLOTS.map((slot) => (
+                <SelectItem
+                  key={`${slot.hour}:${slot.minute}`}
+                  value={`${slot.hour}:${slot.minute}`}
+                >
+                  {formatClockTime(slot.hour, slot.minute)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+
+      {/* TODO(UI-2): the human-readable "Reads as: <scheduleText>" preview was
+          removed from v1 per product. describeSchedule/buildRRule stay in the
+          lib for the list rows + a future preview; only the inline validation
+          error renders here now. */}
+      {error && (
+        <p className="text-xs text-destructive" data-testid="schedule-error">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Zero-pad a number to two digits (minute labels, e.g. ":05"). */
+function pad(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
+/**
+ * Snap a stored minute onto the nearest 15-min slot (0/15/30/45) so the Select's
+ * controlled value always matches one of its options — otherwise a model minute
+ * left off-grid (e.g. from the default 0, or a future preset) would show a blank
+ * trigger. Rounds to nearest; 53 → 45, 8 → 15.
+ */
+function snapMinute(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  const slot = Math.round(Math.min(59, Math.max(0, n)) / 15) * 15;
+  return slot === 60 ? 45 : slot;
+}
+
+/** The stored hour clamped to 0–23 for the Time dropdown's value. */
+function snapHour(model: ScheduleModel): number {
+  const h = model.hour;
+  if (!Number.isFinite(h)) return 0;
+  return Math.min(23, Math.max(0, Math.trunc(h)));
+}

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -1,0 +1,136 @@
+// One row in the Tasks list, rendered as a FLAT list row (no card chrome — no
+// border/background/shadow box, no per-row divider). Layout: bold task title on
+// line 1 (+ a small "Paused" pill when paused), a single muted subline on line 2
+// with the human-readable schedule and, for active rows, the next-run
+// ("Weekdays at 8:00 AM · Next run in 15h"). Paused rows show the schedule only
+// (no "· Paused" suffix) and are NOT dimmed — the title stays fully legible and
+// the pill is the sole paused signal. A hover-revealed ellipsis (⋯) action menu
+// (Pause/Resume + Delete) sits on the right. No leading or trailing status
+// circles — the ⋯ menu is the only affordance.
+
+import { useMemo, useState } from "react";
+import { MoreHorizontalIcon, PauseIcon, PlayIcon, Trash2Icon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { describeSchedule, nextRunAtMs, nextRunLabel } from "@/lib/scheduleText";
+import type { ScheduledTask } from "@/lib/scheduledTasksApi";
+
+export function ScheduledTaskRow({
+  task,
+  onPauseToggle,
+  onDelete,
+  busy,
+}: {
+  task: ScheduledTask;
+  onPauseToggle: (task: ScheduledTask) => void;
+  onDelete: (task: ScheduledTask) => void;
+  busy: boolean;
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const paused = task.state === "paused";
+  const scheduleText = useMemo(() => describeSchedule(task.rrule), [task.rrule]);
+  // Recompute next-run relative to now on each render (the list re-renders on
+  // the 60s poll and on any mutation, which is frequent enough for an "in Xh").
+  const nextRun = useMemo(
+    () => (paused ? null : nextRunAtMs(task.rrule, task.timezone)),
+    [paused, task.rrule, task.timezone],
+  );
+
+  // The subtitle is the same for active and paused rows: schedule + next-run.
+  // The paused signal is the pill next to the title, NOT a "· Paused" suffix
+  // and NOT row-wide dimming (both removed — the suffix was redundant and heavy
+  // dimming failed AA contrast on the title). Paused rows still show the
+  // schedule; `nextRun` is null when paused so the label reads "Paused" only if
+  // nextRunLabel says so — but we drop the next-run clause entirely for paused.
+  const secondaryLine = paused ? scheduleText : `${scheduleText} · ${nextRunLabel(nextRun)}`;
+
+  return (
+    <div
+      data-testid="scheduled-task-row"
+      data-state={task.state}
+      className={cn(
+        // Flat row — NO card chrome (no border/bg/shadow box) and no per-row
+        // divider. `group relative` so the absolutely-positioned ⋯ trigger can
+        // hover-reveal; vertical padding gives the flat-list spacing.
+        // `-mx-2 rounded-lg` + `hover:bg-muted/50` gives a subtle FULL-ROW hover
+        // highlight (like the sidebar conversation rows) that extends past the
+        // content while keeping the title aligned with the page. `pl-2` (left
+        // content inset) is mirrored by the ⋯ button's `right-2` inset so the
+        // two edges are symmetric within the highlight; `pr-10` keeps the text
+        // clear of the inset button. Paused rows are NOT dimmed — the title must
+        // stay legible (AA); the "Paused" pill is the sole signal.
+        "group relative -mx-2 flex items-center gap-3 rounded-lg py-3 pr-10 pl-2 transition-colors hover:bg-muted/50",
+      )}
+    >
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm font-semibold">{task.name}</span>
+          {paused && (
+            <span
+              data-testid="task-paused-pill"
+              className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+            >
+              Paused
+            </span>
+          )}
+        </span>
+        <span className="truncate text-xs text-muted-foreground" data-testid="task-schedule-line">
+          {secondaryLine}
+        </span>
+      </div>
+
+      {/* Hover-revealed ellipsis menu, mirroring the sidebar conversation-row
+          action button: absolute-positioned on the right, hidden until the row
+          is hovered / focused, and kept surfaced while the menu is open via
+          `aria-expanded`. */}
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Actions for ${task.name}`}
+            data-testid="task-row-menu"
+            disabled={busy}
+            className={cn(
+              "-translate-y-1/2 absolute top-1/2 right-2 transition-opacity",
+              "md:opacity-0 md:group-hover:opacity-100 md:group-has-[:focus-visible]:opacity-100",
+              "md:aria-expanded:opacity-100",
+            )}
+          >
+            <MoreHorizontalIcon className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={() => onPauseToggle(task)} data-testid="task-pause-toggle">
+            {paused ? (
+              <>
+                <PlayIcon className="size-4" />
+                Resume
+              </>
+            ) : (
+              <>
+                <PauseIcon className="size-4" />
+                Pause
+              </>
+            )}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            variant="destructive"
+            onSelect={() => onDelete(task)}
+            data-testid="task-delete"
+          >
+            <Trash2Icon className="size-4" />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/web/src/components/scheduled/suggestions.ts
+++ b/web/src/components/scheduled/suggestions.ts
@@ -1,0 +1,47 @@
+// Static "Suggestions" shown below the scheduled-tasks list.
+//
+// NOTE: This list is hardcoded PENDING a suggestions backend endpoint. There is
+// no /v1/scheduled-tasks/suggestions route today; when one lands, replace this
+// module with a hook that fetches it. Selecting a suggestion is wired to
+// prefill the manual create dialog (name + prompt); the schedule is left at the
+// form default for the user to confirm.
+
+import type { LucideIcon } from "lucide-react";
+import { BugIcon, NewspaperIcon } from "lucide-react";
+
+export interface ScheduledTaskSuggestion {
+  id: string;
+  icon: LucideIcon;
+  /** Short chip label (1-2 words) shown on the pill. The fuller name used for
+   *  the created task lives in `prefill.name`, not here. */
+  title: string;
+  description: string;
+  /** Prefill applied to the manual create dialog when the suggestion is picked. */
+  prefill: { name: string; prompt: string };
+}
+
+export const SCHEDULED_TASK_SUGGESTIONS: ScheduledTaskSuggestion[] = [
+  // Chips render in array order — "Daily brief" first, then "Issue triage".
+  {
+    id: "daily-brief",
+    icon: NewspaperIcon,
+    title: "Daily brief",
+    description: "Every morning, summarize overnight activity into a short brief.",
+    prefill: {
+      name: "Daily morning brief",
+      prompt:
+        "Put together a short morning brief: summarize new issues, pull requests, and notable activity since yesterday, and call out anything that needs my attention today.",
+    },
+  },
+  {
+    id: "morning-triage",
+    icon: BugIcon,
+    title: "Issue triage",
+    description: "Every weekday morning, summarize new issues and flag anything urgent.",
+    prefill: {
+      name: "Morning issue triage",
+      prompt:
+        "Review issues opened since yesterday. Summarize the important ones and flag anything that looks urgent or is blocking a release.",
+    },
+  },
+];

--- a/web/src/hooks/useScheduledTasks.test.tsx
+++ b/web/src/hooks/useScheduledTasks.test.tsx
@@ -1,0 +1,102 @@
+// Tests for the scheduled-tasks React-Query hooks: the list query shape and the
+// invalidate-on-success contract of the create / update / delete mutations.
+// The API client is mocked so we assert on hook wiring, not HTTP.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "@/lib/scheduledTasksApi";
+import {
+  SCHEDULED_TASKS_KEY,
+  useCreateScheduledTask,
+  useDeleteScheduledTask,
+  useScheduledTasks,
+  useUpdateScheduledTask,
+} from "./useScheduledTasks";
+
+vi.mock("@/lib/scheduledTasksApi", () => ({
+  listScheduledTasks: vi.fn(),
+  createScheduledTask: vi.fn(),
+  updateScheduledTask: vi.fn(),
+  deleteScheduledTask: vi.fn(),
+}));
+
+const TASK: api.ScheduledTask = {
+  id: "st_1",
+  name: "Nightly triage",
+  prompt: "Triage",
+  rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+  ownerUserId: null,
+  agentId: "ag_1",
+  timezone: "UTC",
+  createdAt: 1,
+  updatedAt: 2,
+  modelOverride: null,
+  reasoningEffort: null,
+  workspace: null,
+  hostId: null,
+  state: "active",
+  lastRunAt: null,
+  lastRunConversationId: null,
+};
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper };
+}
+
+beforeEach(() => {
+  vi.mocked(api.listScheduledTasks).mockResolvedValue([TASK]);
+  vi.mocked(api.createScheduledTask).mockResolvedValue(TASK);
+  vi.mocked(api.updateScheduledTask).mockResolvedValue({ ...TASK, state: "paused" });
+  vi.mocked(api.deleteScheduledTask).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useScheduledTasks", () => {
+  it("returns the list from the API", async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useScheduledTasks(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([TASK]);
+  });
+});
+
+describe("mutations invalidate the list", () => {
+  it("create invalidates SCHEDULED_TASKS_KEY", async () => {
+    const { queryClient, wrapper } = makeWrapper();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useCreateScheduledTask(), { wrapper });
+    await result.current.mutateAsync({
+      name: "n",
+      prompt: "p",
+      rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      agentId: "ag_1",
+    });
+    expect(spy).toHaveBeenCalledWith({ queryKey: SCHEDULED_TASKS_KEY });
+  });
+
+  it("update invalidates the list", async () => {
+    const { queryClient, wrapper } = makeWrapper();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUpdateScheduledTask(), { wrapper });
+    await result.current.mutateAsync({ id: "st_1", input: { state: "paused" } });
+    expect(spy).toHaveBeenCalledWith({ queryKey: SCHEDULED_TASKS_KEY });
+  });
+
+  it("delete invalidates the list", async () => {
+    const { queryClient, wrapper } = makeWrapper();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useDeleteScheduledTask(), { wrapper });
+    await result.current.mutateAsync("st_1");
+    expect(spy).toHaveBeenCalledWith({ queryKey: SCHEDULED_TASKS_KEY });
+  });
+});

--- a/web/src/hooks/useScheduledTasks.ts
+++ b/web/src/hooks/useScheduledTasks.ts
@@ -1,0 +1,104 @@
+// TanStack Query hooks over the `/v1/scheduled-tasks` client: a `useQuery` for
+// the list + run history, and `useMutation`s for create / update / delete. Each
+// mutation invalidates the list query on success so the Tasks page reflects the
+// change without a manual refetch. Mirrors the pattern in `useConversations.ts`
+// (invalidate-on-success), but the scheduled-tasks list reads the DB directly
+// (no async search index), so a plain invalidate can't resurrect a just-deleted
+// row — no patch-in-place gymnastics are needed here.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createScheduledTask,
+  deleteScheduledTask,
+  listScheduledTaskRuns,
+  listScheduledTasks,
+  updateScheduledTask,
+  type CreateScheduledTaskInput,
+  type ScheduledTask,
+  type ScheduledTaskRun,
+  type UpdateScheduledTaskInput,
+} from "@/lib/scheduledTasksApi";
+
+/** Query key for the caller's scheduled-tasks list. */
+export const SCHEDULED_TASKS_KEY = ["scheduled-tasks"] as const;
+
+/** Query key for one task's run history. */
+export function scheduledTaskRunsKey(id: string): readonly unknown[] {
+  return ["scheduled-task-runs", id];
+}
+
+/**
+ * The caller's scheduled tasks. There is no push stream for scheduled tasks, so
+ * a 30 s stale window keeps quick remounts cheap and a 60 s background poll
+ * catches out-of-band changes (a task created from the agent tool, or a run
+ * that just fired) without hammering the server.
+ */
+export function useScheduledTasks() {
+  return useQuery<ScheduledTask[]>({
+    queryKey: SCHEDULED_TASKS_KEY,
+    queryFn: listScheduledTasks,
+    staleTime: 30_000,
+    // POLLING CONTRACT — read before reusing this hook.
+    // The 60s interval only runs while a component that mounts this hook is
+    // mounted; TanStack Query tears the interval down on unmount. Today the sole
+    // consumer is TasksPage, which is route-scoped and lazy-loaded at /tasks — so
+    // polling happens ONLY while the user is on the Scheduled Tasks page and
+    // stops the moment they navigate away.
+    // GUARD RAIL: do NOT mount this hook in a persistent / always-rendered spot
+    // (sidebar, global layout, an app-shell badge). That would silently turn a
+    // page-scoped poll into app-wide 60s background traffic. If you need a
+    // persistent scheduled-tasks indicator, add a SEPARATE lightweight query
+    // (no short refetchInterval, or a much longer one) — don't reuse this one.
+    refetchInterval: 60_000,
+  });
+}
+
+/**
+ * One task's run history (most-recent-first). `enabled` gates the fetch so an
+ * unexpanded row costs nothing.
+ */
+export function useScheduledTaskRuns(id: string, enabled: boolean = true) {
+  return useQuery<ScheduledTaskRun[]>({
+    queryKey: scheduledTaskRunsKey(id),
+    queryFn: () => listScheduledTaskRuns(id),
+    enabled,
+    staleTime: 30_000,
+  });
+}
+
+/** Create a scheduled task, then refresh the list. */
+export function useCreateScheduledTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateScheduledTaskInput) => createScheduledTask(input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: SCHEDULED_TASKS_KEY });
+    },
+  });
+}
+
+/** Update a task (pause/reactivate/rename/reschedule), then refresh the list. */
+export function useUpdateScheduledTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: UpdateScheduledTaskInput }) =>
+      updateScheduledTask(id, input),
+    onSuccess: (updated) => {
+      void queryClient.invalidateQueries({ queryKey: SCHEDULED_TASKS_KEY });
+      // A schedule/state change can shift the run history too (e.g. a
+      // just-reactivated task), so refresh that task's runs if they're loaded.
+      void queryClient.invalidateQueries({ queryKey: scheduledTaskRunsKey(updated.id) });
+    },
+  });
+}
+
+/** Delete a task, then refresh the list. */
+export function useDeleteScheduledTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteScheduledTask(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: SCHEDULED_TASKS_KEY });
+    },
+  });
+}

--- a/web/src/lib/scheduleBuilder.ts
+++ b/web/src/lib/scheduleBuilder.ts
@@ -1,0 +1,176 @@
+// Build an RFC-5545 RRULE string from the manual create form's schedule model,
+// and validate it against the form's constraints before submit.
+//
+// Top-level presets (the frequency dropdown): Hourly, Daily, Weekdays, Weekly,
+// Custom. Monthly and Yearly are reachable ONLY under Custom (a sub-frequency
+// selector with an interval + specifics). The server validates the final rule
+// (`validate_rrule`), including a 1-hour-minimum-interval floor
+// (MIN_INTERVAL_SECONDS=3600); this module enforces the same floor client-side
+// (Custom Hourly INTERVAL ≥ 1) plus positive-integer intervals and non-empty
+// multi-selects, so the form never submits a rule the server would reject.
+
+/** The frequency dropdown's top-level options. */
+export type SchedulePreset = "hourly" | "daily" | "weekdays" | "weekly" | "custom";
+
+/** The frequency sub-selector shown under the "custom" preset. */
+export type CustomFreq = "hourly" | "daily" | "weekly" | "monthly" | "yearly";
+
+/** Weekday codes as used by RRULE `BYDAY` (MO..SU), in calendar order. */
+export const WEEKDAY_CODES = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"] as const;
+export type WeekdayCode = (typeof WEEKDAY_CODES)[number];
+
+/** Months 1–12 for the Custom Yearly `BYMONTH`. */
+export const MONTHS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
+
+/** The manual form's schedule inputs. Fields not relevant to the active
+ * preset/custom-frequency are simply ignored by `buildRRule`. */
+export interface ScheduleModel {
+  preset: SchedulePreset;
+  /** Hour of day 0–23 (ignored for hourly). */
+  hour: number;
+  /** Minute of hour 0–59. */
+  minute: number;
+  /** Selected weekdays for the `weekly` preset and Custom Weekly. */
+  weekdays: WeekdayCode[];
+  /** Sub-frequency when `preset === "custom"`. */
+  customFreq: CustomFreq;
+  /** Recurrence interval (every X units) for Custom; positive integer. */
+  interval: number;
+  /** Days-of-month (1–31) for Custom Monthly / Yearly (multi-select). */
+  monthDays: number[];
+  /** Month 1–12 for Custom Yearly. */
+  month: number;
+}
+
+export const DEFAULT_SCHEDULE_MODEL: ScheduleModel = {
+  preset: "daily",
+  hour: 9,
+  minute: 0,
+  weekdays: ["MO"],
+  customFreq: "daily",
+  interval: 1,
+  monthDays: [1],
+  month: 1,
+};
+
+/**
+ * Build the canonical RRULE string for a schedule model. Produces a plain
+ * `RRULE:`-less rule body (e.g. `FREQ=WEEKLY;BYDAY=MO,TU;BYHOUR=8;BYMINUTE=0`).
+ * The time-of-day is encoded via `BYHOUR`/`BYMINUTE` (no DTSTART) so the rule
+ * carries no absolute anchor and the server localizes it in the task's tz.
+ */
+export function buildRRule(model: ScheduleModel): string {
+  const { hour, minute } = model;
+  switch (model.preset) {
+    case "hourly":
+      // Every hour on the minute — meets the 1h floor exactly.
+      return "FREQ=HOURLY;BYMINUTE=0";
+    case "daily":
+      return `FREQ=DAILY;BYHOUR=${hour};BYMINUTE=${minute}`;
+    case "weekdays":
+      return `FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=${hour};BYMINUTE=${minute}`;
+    case "weekly": {
+      const byday = normalizeWeekdays(model.weekdays).join(",") || "MO";
+      return `FREQ=WEEKLY;BYDAY=${byday};BYHOUR=${hour};BYMINUTE=${minute}`;
+    }
+    case "custom":
+      return buildCustomRRule(model);
+    default:
+      return `FREQ=DAILY;BYHOUR=${hour};BYMINUTE=${minute}`;
+  }
+}
+
+function buildCustomRRule(model: ScheduleModel): string {
+  const { hour, minute } = model;
+  const interval = clampInterval(model.interval);
+  switch (model.customFreq) {
+    case "hourly":
+      // every X hours at minute Y
+      return `FREQ=HOURLY;INTERVAL=${interval};BYMINUTE=${minute}`;
+    case "daily":
+      return `FREQ=DAILY;INTERVAL=${interval};BYHOUR=${hour};BYMINUTE=${minute}`;
+    case "weekly": {
+      const byday = normalizeWeekdays(model.weekdays).join(",") || "MO";
+      return `FREQ=WEEKLY;INTERVAL=${interval};BYDAY=${byday};BYHOUR=${hour};BYMINUTE=${minute}`;
+    }
+    case "monthly": {
+      const days = normalizeMonthDays(model.monthDays).join(",") || "1";
+      return `FREQ=MONTHLY;INTERVAL=${interval};BYMONTHDAY=${days};BYHOUR=${hour};BYMINUTE=${minute}`;
+    }
+    case "yearly": {
+      const days = normalizeMonthDays(model.monthDays).join(",") || "1";
+      const month = clampMonth(model.month);
+      return `FREQ=YEARLY;INTERVAL=${interval};BYMONTH=${month};BYMONTHDAY=${days};BYHOUR=${hour};BYMINUTE=${minute}`;
+    }
+    default:
+      return `FREQ=DAILY;INTERVAL=${interval};BYHOUR=${hour};BYMINUTE=${minute}`;
+  }
+}
+
+/**
+ * Validate the schedule model against the form's constraints. Returns a
+ * human-readable error string when invalid (shown inline + gates submit), or
+ * `null` when the model is OK. Mirrors the server's rejection reasons so a bad
+ * schedule fails fast in the form rather than as a 400.
+ */
+export function validateSchedule(model: ScheduleModel): string | null {
+  // Multi-selects must have at least one selection.
+  if (model.preset === "weekly" && model.weekdays.length === 0) {
+    return "Pick at least one day of the week.";
+  }
+  if (model.preset === "custom") {
+    if (!Number.isInteger(model.interval) || model.interval < 1) {
+      return "Interval must be a whole number of at least 1.";
+    }
+    // 1-hour floor: a sub-hour cadence is only reachable via Custom Hourly with
+    // INTERVAL < 1, which the interval check above already blocks. Guard the
+    // hourly case explicitly for a clear message.
+    if (model.customFreq === "hourly" && model.interval < 1) {
+      return "Hourly tasks must run at most once per hour (interval ≥ 1).";
+    }
+    if (model.customFreq === "weekly" && model.weekdays.length === 0) {
+      return "Pick at least one day of the week.";
+    }
+    if (
+      (model.customFreq === "monthly" || model.customFreq === "yearly") &&
+      model.monthDays.length === 0
+    ) {
+      return "Pick at least one day of the month.";
+    }
+  }
+  return null;
+}
+
+/** Sort weekday codes into calendar order (MO..SU), dropping duplicates. */
+function normalizeWeekdays(codes: WeekdayCode[]): WeekdayCode[] {
+  const seen = new Set(codes);
+  return WEEKDAY_CODES.filter((c) => seen.has(c));
+}
+
+/**
+ * Sort day-of-month values ascending, drop dups, and clamp each to 1–31. We
+ * allow the full 1–31 range (not a conservative ≤28) and let the server / rrule
+ * handle short months — a `BYMONTHDAY=31` simply doesn't fire in February,
+ * which is the standard RRULE semantic and matches user expectations.
+ */
+function normalizeMonthDays(days: number[]): number[] {
+  const cleaned = days.map((d) => clampMonthDay(d)).filter((d): d is number => d != null);
+  return [...new Set(cleaned)].sort((a, b) => a - b);
+}
+
+function clampInterval(n: number): number {
+  if (!Number.isFinite(n)) return 1;
+  return Math.max(1, Math.trunc(n));
+}
+
+function clampMonthDay(day: number): number | null {
+  if (!Number.isFinite(day)) return null;
+  const d = Math.trunc(day);
+  if (d < 1 || d > 31) return null;
+  return d;
+}
+
+function clampMonth(m: number): number {
+  if (!Number.isFinite(m)) return 1;
+  return Math.min(12, Math.max(1, Math.trunc(m)));
+}

--- a/web/src/lib/scheduleText.test.ts
+++ b/web/src/lib/scheduleText.test.ts
@@ -1,0 +1,333 @@
+// Tests for the client-side schedule text + next-run derivation, and the RRULE
+// builder + validation that feed them. Covers every shape the create form can
+// produce: the simple presets (Hourly/Daily/Weekdays/Weekly) and all five
+// Custom frequencies (with INTERVAL, multi weekday/month-day selects, and
+// yearly BYMONTH), plus the 1-hour-floor validation.
+
+import { describe, expect, it } from "vitest";
+import { describeSchedule, formatClockTime, nextRunAtMs, nextRunLabel } from "./scheduleText";
+import {
+  buildRRule,
+  DEFAULT_SCHEDULE_MODEL,
+  validateSchedule,
+  type ScheduleModel,
+} from "./scheduleBuilder";
+
+/** Convenience: a model with overrides on top of the default. */
+function model(overrides: Partial<ScheduleModel>): ScheduleModel {
+  return { ...DEFAULT_SCHEDULE_MODEL, ...overrides };
+}
+
+describe("formatClockTime", () => {
+  it("formats 12-hour times with AM/PM", () => {
+    expect(formatClockTime(8, 0)).toBe("8:00 AM");
+    expect(formatClockTime(0, 0)).toBe("12:00 AM");
+    expect(formatClockTime(12, 30)).toBe("12:30 PM");
+    expect(formatClockTime(13, 5)).toBe("1:05 PM");
+    expect(formatClockTime(23, 59)).toBe("11:59 PM");
+  });
+});
+
+describe("buildRRule — simple presets", () => {
+  it("hourly (no inputs)", () => {
+    expect(buildRRule(model({ preset: "hourly" }))).toBe("FREQ=HOURLY;BYMINUTE=0");
+  });
+
+  it("daily (time only)", () => {
+    expect(buildRRule(model({ preset: "daily", hour: 9, minute: 0 }))).toBe(
+      "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+    );
+  });
+
+  it("weekdays (Mon–Fri + time)", () => {
+    expect(buildRRule(model({ preset: "weekdays", hour: 8, minute: 0 }))).toBe(
+      "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=8;BYMINUTE=0",
+    );
+  });
+
+  it("weekly (multi weekday, sorted to calendar order)", () => {
+    expect(
+      buildRRule(model({ preset: "weekly", weekdays: ["FR", "MO"], hour: 8, minute: 0 })),
+    ).toBe("FREQ=WEEKLY;BYDAY=MO,FR;BYHOUR=8;BYMINUTE=0");
+  });
+
+  it("weekly falls back to MO when the (invalid) empty set is built", () => {
+    // validateSchedule blocks submit, but buildRRule must still emit a legal rule.
+    expect(buildRRule(model({ preset: "weekly", weekdays: [], hour: 8, minute: 0 }))).toBe(
+      "FREQ=WEEKLY;BYDAY=MO;BYHOUR=8;BYMINUTE=0",
+    );
+  });
+});
+
+describe("buildRRule — custom frequencies with INTERVAL", () => {
+  it("custom hourly: every X hours at minute Y", () => {
+    expect(
+      buildRRule(model({ preset: "custom", customFreq: "hourly", interval: 2, minute: 15 })),
+    ).toBe("FREQ=HOURLY;INTERVAL=2;BYMINUTE=15");
+  });
+
+  it("custom daily: every X days at h:m", () => {
+    expect(
+      buildRRule(
+        model({ preset: "custom", customFreq: "daily", interval: 3, hour: 9, minute: 30 }),
+      ),
+    ).toBe("FREQ=DAILY;INTERVAL=3;BYHOUR=9;BYMINUTE=30");
+  });
+
+  it("custom weekly: every X weeks on <days> at h:m", () => {
+    expect(
+      buildRRule(
+        model({
+          preset: "custom",
+          customFreq: "weekly",
+          interval: 2,
+          weekdays: ["MO", "WE", "FR"],
+          hour: 8,
+          minute: 0,
+        }),
+      ),
+    ).toBe("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR;BYHOUR=8;BYMINUTE=0");
+  });
+
+  it("custom monthly: every X months on <multi days> at h:m", () => {
+    expect(
+      buildRRule(
+        model({
+          preset: "custom",
+          customFreq: "monthly",
+          interval: 3,
+          monthDays: [15, 1],
+          hour: 6,
+          minute: 0,
+        }),
+      ),
+    ).toBe("FREQ=MONTHLY;INTERVAL=3;BYMONTHDAY=1,15;BYHOUR=6;BYMINUTE=0");
+  });
+
+  it("custom yearly: every X years in month Y on <multi days> at h:m", () => {
+    expect(
+      buildRRule(
+        model({
+          preset: "custom",
+          customFreq: "yearly",
+          interval: 2,
+          month: 3,
+          monthDays: [1],
+          hour: 9,
+          minute: 0,
+        }),
+      ),
+    ).toBe("FREQ=YEARLY;INTERVAL=2;BYMONTH=3;BYMONTHDAY=1;BYHOUR=9;BYMINUTE=0");
+  });
+
+  it("clamps a bad interval up to 1 in the built rule", () => {
+    expect(buildRRule(model({ preset: "custom", customFreq: "daily", interval: 0 }))).toContain(
+      "INTERVAL=1",
+    );
+  });
+
+  it("allows day-of-month up to 31 (short months handled by rrule)", () => {
+    expect(
+      buildRRule(model({ preset: "custom", customFreq: "monthly", interval: 1, monthDays: [31] })),
+    ).toContain("BYMONTHDAY=31");
+  });
+});
+
+describe("validateSchedule — 1-hour floor + required selections", () => {
+  it("accepts every simple preset", () => {
+    expect(validateSchedule(model({ preset: "hourly" }))).toBeNull();
+    expect(validateSchedule(model({ preset: "daily" }))).toBeNull();
+    expect(validateSchedule(model({ preset: "weekdays" }))).toBeNull();
+    expect(validateSchedule(model({ preset: "weekly", weekdays: ["MO"] }))).toBeNull();
+  });
+
+  it("rejects an empty weekly weekday set", () => {
+    expect(validateSchedule(model({ preset: "weekly", weekdays: [] }))).toMatch(
+      /at least one day/i,
+    );
+  });
+
+  it("rejects a sub-1 interval (the 1h floor) on custom hourly", () => {
+    expect(
+      validateSchedule(model({ preset: "custom", customFreq: "hourly", interval: 0 })),
+    ).toMatch(/at least 1/i);
+  });
+
+  it("rejects a non-integer / <1 interval for any custom frequency", () => {
+    expect(validateSchedule(model({ preset: "custom", customFreq: "daily", interval: 0 }))).toMatch(
+      /at least 1/i,
+    );
+    expect(
+      validateSchedule(model({ preset: "custom", customFreq: "daily", interval: 1.5 })),
+    ).toMatch(/whole number/i);
+  });
+
+  it("accepts a valid custom hourly interval (>=1 → within the floor)", () => {
+    expect(
+      validateSchedule(model({ preset: "custom", customFreq: "hourly", interval: 1 })),
+    ).toBeNull();
+    expect(
+      validateSchedule(model({ preset: "custom", customFreq: "hourly", interval: 6 })),
+    ).toBeNull();
+  });
+
+  it("requires at least one custom weekly weekday and monthly/yearly day", () => {
+    expect(
+      validateSchedule(
+        model({ preset: "custom", customFreq: "weekly", interval: 1, weekdays: [] }),
+      ),
+    ).toMatch(/at least one day/i);
+    expect(
+      validateSchedule(
+        model({ preset: "custom", customFreq: "monthly", interval: 1, monthDays: [] }),
+      ),
+    ).toMatch(/at least one day of the month/i);
+    expect(
+      validateSchedule(
+        model({ preset: "custom", customFreq: "yearly", interval: 1, monthDays: [] }),
+      ),
+    ).toMatch(/at least one day of the month/i);
+  });
+});
+
+describe("describeSchedule", () => {
+  it("collapses the Mon–Fri set to Weekdays", () => {
+    expect(describeSchedule("FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=8;BYMINUTE=0")).toBe(
+      "Weekdays at 8:00 AM",
+    );
+  });
+
+  it("renders a daily rule", () => {
+    expect(describeSchedule("FREQ=DAILY;BYHOUR=9;BYMINUTE=0")).toBe("Every day at 9:00 AM");
+  });
+
+  it("renders a specific weekly day and a multi-day set", () => {
+    expect(describeSchedule("FREQ=WEEKLY;BYDAY=MO;BYHOUR=14;BYMINUTE=30")).toBe(
+      "Weekly on Monday at 2:30 PM",
+    );
+    expect(describeSchedule("FREQ=WEEKLY;BYDAY=MO,FR;BYHOUR=8;BYMINUTE=0")).toBe(
+      "Weekly on Monday and Friday at 8:00 AM",
+    );
+  });
+
+  it("renders weekends", () => {
+    expect(describeSchedule("FREQ=WEEKLY;BYDAY=SA,SU;BYHOUR=10;BYMINUTE=0")).toBe(
+      "Weekends at 10:00 AM",
+    );
+  });
+
+  it("renders plain hourly and interval-hourly", () => {
+    expect(describeSchedule("FREQ=HOURLY;BYMINUTE=0")).toBe("Hourly");
+    expect(describeSchedule("FREQ=HOURLY;INTERVAL=2;BYMINUTE=15")).toBe("Every 2 hours at :15");
+  });
+
+  it("renders interval daily / weekly", () => {
+    expect(describeSchedule("FREQ=DAILY;INTERVAL=3;BYHOUR=9;BYMINUTE=30")).toBe(
+      "Every 3 days at 9:30 AM",
+    );
+    expect(describeSchedule("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE;BYHOUR=8;BYMINUTE=0")).toBe(
+      "Every 2 weeks on Monday and Wednesday at 8:00 AM",
+    );
+  });
+
+  it("renders monthly with single + multi day, plain + interval", () => {
+    expect(describeSchedule("FREQ=MONTHLY;BYMONTHDAY=1;BYHOUR=6;BYMINUTE=0")).toBe(
+      "Monthly on the 1st at 6:00 AM",
+    );
+    expect(describeSchedule("FREQ=MONTHLY;INTERVAL=3;BYMONTHDAY=1,15;BYHOUR=6;BYMINUTE=0")).toBe(
+      "Every 3 months on the 1st and 15th at 6:00 AM",
+    );
+  });
+
+  it("renders yearly with month + day, plain + interval", () => {
+    expect(describeSchedule("FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=1;BYHOUR=9;BYMINUTE=0")).toBe(
+      "Yearly in March on the 1st at 9:00 AM",
+    );
+    expect(
+      describeSchedule("FREQ=YEARLY;INTERVAL=2;BYMONTH=12;BYMONTHDAY=25;BYHOUR=9;BYMINUTE=0"),
+    ).toBe("Every 2 years in December on the 25th at 9:00 AM");
+  });
+
+  it("falls back to the raw rule for an unparseable string", () => {
+    expect(describeSchedule("not a rule")).toBe("not a rule");
+  });
+
+  it("round-trips every builder output to non-empty readable text", () => {
+    const cases: ScheduleModel[] = [
+      model({ preset: "hourly" }),
+      model({ preset: "daily" }),
+      model({ preset: "weekdays" }),
+      model({ preset: "weekly", weekdays: ["TU", "TH"] }),
+      model({ preset: "custom", customFreq: "hourly", interval: 4, minute: 0 }),
+      model({ preset: "custom", customFreq: "daily", interval: 2 }),
+      model({ preset: "custom", customFreq: "weekly", interval: 2, weekdays: ["MO"] }),
+      model({ preset: "custom", customFreq: "monthly", interval: 1, monthDays: [1, 15] }),
+      model({ preset: "custom", customFreq: "yearly", interval: 1, month: 6, monthDays: [1] }),
+    ];
+    for (const m of cases) {
+      const text = describeSchedule(buildRRule(m));
+      expect(text.length).toBeGreaterThan(0);
+      // Never leaks the raw FREQ= rule as the "readable" text.
+      expect(text.startsWith("FREQ=")).toBe(false);
+    }
+  });
+});
+
+describe("nextRunAtMs", () => {
+  it("computes the next daily occurrence after now", () => {
+    // 2026-01-01 06:00 UTC; a 9:00 UTC daily rule fires later the same day.
+    const now = new Date("2026-01-01T06:00:00Z");
+    const next = nextRunAtMs("FREQ=DAILY;BYHOUR=9;BYMINUTE=0", "UTC", now);
+    expect(next).not.toBeNull();
+    const d = new Date(next!);
+    expect(d.getUTCHours()).toBe(9);
+    expect(d.getUTCDate()).toBe(1);
+  });
+
+  it("rolls to the next day when today's time has passed", () => {
+    const now = new Date("2026-01-01T12:00:00Z");
+    const next = nextRunAtMs("FREQ=DAILY;BYHOUR=9;BYMINUTE=0", "UTC", now);
+    expect(new Date(next!).getUTCDate()).toBe(2);
+  });
+
+  it("handles interval-daily (every 3 days)", () => {
+    const now = new Date("2026-01-01T00:00:00Z");
+    const next = nextRunAtMs("FREQ=DAILY;INTERVAL=3;BYHOUR=9;BYMINUTE=0", "UTC", now);
+    expect(next).not.toBeNull();
+    expect(new Date(next!).getUTCHours()).toBe(9);
+  });
+
+  it("handles yearly with BYMONTH + BYMONTHDAY", () => {
+    const now = new Date("2026-01-01T00:00:00Z");
+    const next = nextRunAtMs("FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=1;BYHOUR=9;BYMINUTE=0", "UTC", now);
+    expect(next).not.toBeNull();
+    const d = new Date(next!);
+    expect(d.getUTCMonth()).toBe(2); // March (0-indexed)
+    expect(d.getUTCDate()).toBe(1);
+  });
+
+  it("handles multi-day monthly (picks the nearest upcoming day)", () => {
+    const now = new Date("2026-01-10T00:00:00Z");
+    const next = nextRunAtMs("FREQ=MONTHLY;BYMONTHDAY=1,15;BYHOUR=9;BYMINUTE=0", "UTC", now);
+    expect(next).not.toBeNull();
+    // Next after the 10th is the 15th of the same month.
+    expect(new Date(next!).getUTCDate()).toBe(15);
+  });
+
+  it("returns null for an unparseable rule", () => {
+    expect(nextRunAtMs("garbage", "UTC")).toBeNull();
+  });
+});
+
+describe("nextRunLabel", () => {
+  const now = new Date("2026-01-01T00:00:00Z");
+  it("labels sub-hour, hour, and day ranges", () => {
+    expect(nextRunLabel(now.getTime() + 30 * 60_000, now)).toBe("Next run in 30m");
+    expect(nextRunLabel(now.getTime() + 15 * 3_600_000, now)).toBe("Next run in 15h");
+    expect(nextRunLabel(now.getTime() + 3 * 86_400_000, now)).toBe("Next run in 3d");
+  });
+
+  it("handles no upcoming run", () => {
+    expect(nextRunLabel(null, now)).toBe("No upcoming runs");
+  });
+});

--- a/web/src/lib/scheduleText.ts
+++ b/web/src/lib/scheduleText.ts
@@ -1,0 +1,356 @@
+// Client-side derivation of the two human-readable schedule strings the Tasks
+// list shows for each task: a schedule summary ("Weekdays at 8:00 AM") and a
+// next-run relative label ("Next run in 15h"). Both are computed from the
+// stored RFC-5545 RRULE + IANA timezone — there is no backend next-run
+// endpoint, by design.
+//
+// We use the `rrule` library only for the next-occurrence math (parsing the
+// rule and stepping to the next firing). The summary text is hand-formatted:
+// rrule's own `.toText()` produces "every week on Monday, Tuesday, …" which is
+// verbose and doesn't collapse the weekday set to "Weekdays" the way the design
+// calls for.
+
+import { RRule, rrulestr } from "rrule";
+
+// A fixed, far-past UTC anchor for occurrence generation. The scheduled-task
+// RRULEs carry no DTSTART (the time-of-day lives in BYHOUR/BYMINUTE), and
+// without an explicit dtstart rrule.js defaults the anchor to the module's
+// import-time `new Date()`, which would make `.after` generate occurrences from
+// today rather than honoring the caller's `now`. Anchoring to a stable past
+// date makes BY* rules fully determine the schedule. Matches the server's
+// fixed-deterministic-anchor approach.
+const OCCURRENCE_ANCHOR = new Date(Date.UTC(2000, 0, 1, 0, 0, 0));
+
+/** Days-of-week bit set helpers. RRule weekday order is MO..SU (0..6). */
+const WEEKDAYS = [RRule.MO, RRule.TU, RRule.WE, RRule.TH, RRule.FR].map((d) => d.weekday);
+const ALL_DAYS = [RRule.MO, RRule.TU, RRule.WE, RRule.TH, RRule.FR, RRule.SA, RRule.SU].map(
+  (d) => d.weekday,
+);
+
+const DAY_LABELS: Record<number, string> = {
+  [RRule.MO.weekday]: "Monday",
+  [RRule.TU.weekday]: "Tuesday",
+  [RRule.WE.weekday]: "Wednesday",
+  [RRule.TH.weekday]: "Thursday",
+  [RRule.FR.weekday]: "Friday",
+  [RRule.SA.weekday]: "Saturday",
+  [RRule.SU.weekday]: "Sunday",
+};
+
+/**
+ * Format an hour/minute pair as a 12-hour clock time, e.g. `8:00 AM`,
+ * `12:30 PM`. Falls back to `midnight` semantics via the standard 12-hour
+ * convention (0 → 12 AM).
+ */
+export function formatClockTime(hour: number, minute: number): string {
+  const period = hour < 12 ? "AM" : "PM";
+  const h12 = hour % 12 === 0 ? 12 : hour % 12;
+  const mm = minute.toString().padStart(2, "0");
+  return `${h12}:${mm} ${period}`;
+}
+
+/** Parse an RRULE string into an `RRule`, or `null` if it can't be parsed. */
+function tryParse(rrule: string): RRule | null {
+  try {
+    const parsed = rrulestr(rrule);
+    // rrulestr can return an RRuleSet for multi-rule strings; the scheduled-task
+    // backend stores a single RRULE, so we only handle the RRule case for text.
+    return parsed instanceof RRule ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+/**
+ * Human-readable summary of an RRULE's recurrence. Handles every shape the
+ * create form can produce — the simple presets and all five Custom
+ * frequencies, including INTERVAL (>1), multi-day BYMONTHDAY, and yearly
+ * BYMONTH — e.g.:
+ *   - "Weekdays at 8:00 AM"
+ *   - "Every day at 9:00 AM"
+ *   - "Weekly on Monday and Friday at 2:30 PM"
+ *   - "Every 2 hours at :15"
+ *   - "Every 3 months on the 1st and 15th at 6:00 AM"
+ *   - "Every 2 years in March on the 1st at 9:00 AM"
+ *
+ * Falls back to the library's `.toText()` (then the raw rule) for anything this
+ * formatter doesn't special-case, so a valid-but-unusual rule still renders
+ * something readable rather than blank.
+ */
+export function describeSchedule(rrule: string): string {
+  const rule = tryParse(rrule);
+  if (!rule) return rrule;
+  const o = rule.origOptions;
+  // BYHOUR/BYMINUTE come back as number | number[] | null | undefined.
+  const hour = firstOf(o.byhour) ?? 0;
+  const minute = firstOf(o.byminute) ?? 0;
+  const timeSuffix = ` at ${formatClockTime(hour, minute)}`;
+  const days = normalizeWeekdays(o.byweekday);
+  const interval = typeof o.interval === "number" && o.interval > 1 ? o.interval : 1;
+
+  if (o.freq === RRule.HOURLY) {
+    // Time-of-day is meaningless hourly; show the minute offset instead.
+    const min = `:${minute.toString().padStart(2, "0")}`;
+    if (interval > 1) return `Every ${interval} hours at ${min}`;
+    return "Hourly";
+  }
+
+  if (o.freq === RRule.DAILY) {
+    if (interval > 1) return `Every ${interval} days${timeSuffix}`;
+    return `Every day${timeSuffix}`;
+  }
+
+  if (o.freq === RRule.WEEKLY) {
+    const dayText = weekdayText(days);
+    if (interval > 1) {
+      // "Every 2 weeks on Monday…" — a named weekday set reads better than the
+      // Weekdays/Weekends shorthands once an interval is involved.
+      const on = days.length > 0 ? ` on ${dayLabelList(days)}` : "";
+      return `Every ${interval} weeks${on}${timeSuffix}`;
+    }
+    if (days.length === 0) return `Weekly${timeSuffix}`;
+    return `${dayText}${timeSuffix}`;
+  }
+
+  if (o.freq === RRule.MONTHLY) {
+    const monthDays = normalizeNums(o.bymonthday);
+    const on = monthDays.length > 0 ? ` on the ${ordinalList(monthDays)}` : "";
+    if (interval > 1) return `Every ${interval} months${on}${timeSuffix}`;
+    return `Monthly${on}${timeSuffix}`;
+  }
+
+  if (o.freq === RRule.YEARLY) {
+    const monthNums = normalizeNums(o.bymonth);
+    const monthDays = normalizeNums(o.bymonthday);
+    const inMonth =
+      monthNums.length > 0
+        ? ` in ${monthNums
+            .map((m) => MONTH_NAMES[m - 1])
+            .filter(Boolean)
+            .join(", ")}`
+        : "";
+    const on = monthDays.length > 0 ? ` on the ${ordinalList(monthDays)}` : "";
+    if (interval > 1) return `Every ${interval} years${inMonth}${on}${timeSuffix}`;
+    return `Yearly${inMonth}${on}${timeSuffix}`;
+  }
+
+  // Anything else: defer to the library's text, then the raw rule.
+  try {
+    return capitalize(rule.toText());
+  } catch {
+    return rrule;
+  }
+}
+
+/** Weekday-set phrasing for the interval-1 weekly case (with shorthands). */
+function weekdayText(days: number[]): string {
+  if (sameSet(days, WEEKDAYS)) return "Weekdays";
+  if (sameSet(days, ALL_DAYS)) return "Every day";
+  if (sameSet(days, [RRule.SA.weekday, RRule.SU.weekday])) return "Weekends";
+  return `Weekly on ${dayLabelList(days)}`;
+}
+
+function dayLabelList(days: number[]): string {
+  return joinList(days.map((d) => DAY_LABELS[d]).filter(Boolean));
+}
+
+/**
+ * The next firing of `rrule` after `now`, as an epoch-ms timestamp, or `null`
+ * when the rule has no future occurrence (or can't be parsed).
+ *
+ * Timezone handling: the backend evaluates the rule in the task's IANA
+ * `timezone`, but the `rrule` lib computes in "floating" wall-clock time with no
+ * zone. We compute the next occurrence in the rule's own frame, then shift it by
+ * the offset between the task timezone and the viewer's local zone at that
+ * instant, so "8:00 AM America/New_York" resolves to the correct absolute
+ * moment regardless of where the viewer sits. This mirrors how the server's
+ * `python-dateutil` evaluation localizes the rule.
+ */
+export function nextRunAtMs(
+  rrule: string,
+  timezone: string,
+  now: Date = new Date(),
+): number | null {
+  const base = tryParse(rrule);
+  if (!base) return null;
+  // Rebuild with a fixed dtstart so occurrence generation is anchored
+  // deterministically (see OCCURRENCE_ANCHOR) rather than to import-time now.
+  let rule: RRule;
+  try {
+    rule = new RRule({ ...base.origOptions, dtstart: OCCURRENCE_ANCHOR });
+  } catch {
+    return null;
+  }
+  // rrule's `.after` treats the DTSTART/occurrences as UTC-naive wall times.
+  // Query against a "now" that is itself the current wall time in the task's
+  // timezone, so the comparison happens in the rule's frame.
+  const nowInTz = shiftWallClock(now, timezone);
+  let occurrence: Date | null;
+  try {
+    occurrence = rule.after(nowInTz, false);
+  } catch {
+    return null;
+  }
+  if (!occurrence) return null;
+  // `occurrence` is a wall-clock time in the task timezone, expressed as a naive
+  // Date (its UTC fields hold the tz-local Y/M/D H:M). Convert back to a real
+  // absolute instant by subtracting the tz offset at that wall time.
+  return wallClockToInstantMs(occurrence, timezone);
+}
+
+/**
+ * "Next run in Xh" / "in Xm" / "in Xd" relative label from a next-run
+ * timestamp, or a fixed fallback when there is no upcoming run.
+ */
+export function nextRunLabel(nextRunMs: number | null, now: Date = new Date()): string {
+  if (nextRunMs == null) return "No upcoming runs";
+  const diffMs = nextRunMs - now.getTime();
+  if (diffMs <= 0) return "Next run due now";
+  const minutes = Math.round(diffMs / 60_000);
+  if (minutes < 60) return `Next run in ${minutes}m`;
+  const hours = Math.round(diffMs / 3_600_000);
+  if (hours < 48) return `Next run in ${hours}h`;
+  const days = Math.round(diffMs / 86_400_000);
+  return `Next run in ${days}d`;
+}
+
+// ── internals ────────────────────────────────────────────────────────────────
+
+function firstOf(v: number | number[] | null | undefined): number | null {
+  if (v == null) return null;
+  return Array.isArray(v) ? (v.length > 0 ? v[0]! : null) : v;
+}
+
+/** Normalize a scalar-or-array RRULE option (e.g. bymonthday, bymonth) to a
+ * sorted, de-duped number[]. */
+function normalizeNums(v: number | number[] | null | undefined): number[] {
+  if (v == null) return [];
+  const arr = Array.isArray(v) ? v : [v];
+  const nums = arr.filter((n): n is number => typeof n === "number");
+  return [...new Set(nums)].sort((a, b) => a - b);
+}
+
+/** English ordinal for a day-of-month, e.g. 1 → "1st", 22 → "22nd". */
+function ordinal(n: number): string {
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
+  switch (n % 10) {
+    case 1:
+      return `${n}st`;
+    case 2:
+      return `${n}nd`;
+    case 3:
+      return `${n}rd`;
+    default:
+      return `${n}th`;
+  }
+}
+
+/** "1st", "1st and 15th", "1st, 15th, and 28th". */
+function ordinalList(days: number[]): string {
+  return joinList(days.map(ordinal));
+}
+
+/**
+ * Normalize rrule's `byweekday` (which can be a Weekday, number, or arrays of
+ * either, in any order) into a sorted array of weekday indices (0=MO..6=SU).
+ */
+function normalizeWeekdays(byweekday: RRule["origOptions"]["byweekday"]): number[] {
+  if (byweekday == null) return [];
+  const arr = Array.isArray(byweekday) ? byweekday : [byweekday];
+  const nums = arr
+    .map((d) => (typeof d === "number" ? d : (d as { weekday: number }).weekday))
+    .filter((n): n is number => typeof n === "number");
+  return [...new Set(nums)].sort((a, b) => a - b);
+}
+
+function sameSet(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false;
+  const sb = [...b].sort((x, y) => x - y);
+  const sa = [...a].sort((x, y) => x - y);
+  return sa.every((v, i) => v === sb[i]);
+}
+
+function joinList(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1);
+}
+
+/**
+ * The offset in minutes between UTC and `timezone` at instant `date`
+ * (positive when the zone is behind UTC, matching `Date.getTimezoneOffset`).
+ * Uses `Intl` so it's DST-correct for the given instant.
+ */
+function tzOffsetMinutes(date: Date, timezone: string): number {
+  try {
+    const dtf = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      hour12: false,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    const parts = dtf.formatToParts(date);
+    const map: Record<string, number> = {};
+    for (const p of parts) {
+      if (p.type !== "literal") map[p.type] = Number(p.value);
+    }
+    // Wall-clock time in the target zone, as if it were UTC.
+    const asUtc = Date.UTC(
+      map.year!,
+      map.month! - 1,
+      map.day!,
+      map.hour === 24 ? 0 : map.hour!,
+      map.minute!,
+      map.second!,
+    );
+    return (date.getTime() - asUtc) / 60_000;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Represent `date` as the naive wall-clock time in `timezone` (a Date whose UTC
+ * fields hold the zone-local Y/M/D H:M:S), so it can be fed to rrule's
+ * zone-naive `.after`.
+ */
+function shiftWallClock(date: Date, timezone: string): Date {
+  const offset = tzOffsetMinutes(date, timezone);
+  return new Date(date.getTime() - offset * 60_000);
+}
+
+/**
+ * Inverse of {@link shiftWallClock}: given a naive wall-clock Date in
+ * `timezone`, return the real absolute instant (epoch ms).
+ */
+function wallClockToInstantMs(wallDate: Date, timezone: string): number {
+  // The offset at the wall instant is a close approximation of the offset at the
+  // real instant; a single correction pass handles the common case. (DST-edge
+  // firings are within an hour, well inside the "Xh" rounding the label uses.)
+  const offset = tzOffsetMinutes(wallDate, timezone);
+  return wallDate.getTime() + offset * 60_000;
+}

--- a/web/src/lib/scheduledTasksApi.test.ts
+++ b/web/src/lib/scheduledTasksApi.test.ts
@@ -1,0 +1,213 @@
+// Unit tests for `scheduledTasksApi.ts` — happy-path requests with a mocked
+// `fetch`, snake↔camel conversion at the boundary, the optional-field omission
+// rules on create/update, and the typed error path.
+//
+// Mirrors the `sessionsApi.test.ts` pattern: one fetchMock per test,
+// vi.stubGlobal/unstubAllGlobals around it.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ScheduledTaskApiError,
+  createScheduledTask,
+  deleteScheduledTask,
+  getScheduledTask,
+  listScheduledTaskRuns,
+  listScheduledTasks,
+  updateScheduledTask,
+} from "./scheduledTasksApi";
+
+function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: "OK",
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const TASK_WIRE = {
+  id: "st_1",
+  name: "Nightly triage",
+  prompt: "Triage new issues",
+  rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+  owner_user_id: "alice",
+  agent_id: "ag_1",
+  timezone: "America/New_York",
+  created_at: 1_700_000_000,
+  updated_at: 1_700_000_100,
+  model_override: null,
+  reasoning_effort: null,
+  workspace: null,
+  host_id: null,
+  state: "active",
+  last_run_at: null,
+  last_run_conversation_id: null,
+};
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("listScheduledTasks", () => {
+  it("GETs /v1/scheduled-tasks and camelCases the rows", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ scheduled_tasks: [TASK_WIRE] }));
+    const tasks = await listScheduledTasks();
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/scheduled-tasks");
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      id: "st_1",
+      name: "Nightly triage",
+      ownerUserId: "alice",
+      agentId: "ag_1",
+      timezone: "America/New_York",
+      state: "active",
+      hostId: null,
+      workspace: null,
+    });
+  });
+
+  it("returns [] when the server omits the key", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    await expect(listScheduledTasks()).resolves.toEqual([]);
+  });
+});
+
+describe("getScheduledTask", () => {
+  it("GETs /v1/scheduled-tasks/{id} and encodes the id", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(TASK_WIRE));
+    const task = await getScheduledTask("st 1");
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/scheduled-tasks/st%201");
+    expect(task.id).toBe("st_1");
+  });
+});
+
+describe("listScheduledTaskRuns", () => {
+  it("GETs the runs subpath and camelCases run rows", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        runs: [
+          {
+            id: "run_1",
+            scheduled_task_id: "st_1",
+            status: "succeeded",
+            scheduled_at: 1_700_000_000,
+            conversation_id: "conv_1",
+            fired_at: 1_700_000_005,
+            finished_at: 1_700_000_050,
+            error_code: null,
+          },
+        ],
+      }),
+    );
+    const runs = await listScheduledTaskRuns("st_1");
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/scheduled-tasks/st_1/runs");
+    expect(runs[0]).toMatchObject({
+      id: "run_1",
+      scheduledTaskId: "st_1",
+      status: "succeeded",
+      conversationId: "conv_1",
+      firedAt: 1_700_000_005,
+      finishedAt: 1_700_000_050,
+      errorCode: null,
+    });
+  });
+});
+
+describe("createScheduledTask", () => {
+  it("POSTs required fields and omits unset optionals", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(TASK_WIRE));
+    await createScheduledTask({
+      name: "Nightly triage",
+      prompt: "Triage new issues",
+      rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      agentId: "ag_1",
+    });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/v1/scheduled-tasks");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({
+      name: "Nightly triage",
+      prompt: "Triage new issues",
+      rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      agent_id: "ag_1",
+    });
+    // Optional keys must be absent, not null.
+    expect(body).not.toHaveProperty("host_id");
+    expect(body).not.toHaveProperty("workspace");
+    expect(body).not.toHaveProperty("timezone");
+  });
+
+  it("includes the host/workspace pair and timezone when provided", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(TASK_WIRE));
+    await createScheduledTask({
+      name: "n",
+      prompt: "p",
+      rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      agentId: "ag_1",
+      timezone: "UTC",
+      hostId: "host_1",
+      workspace: "/home/me/repo",
+    });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.timezone).toBe("UTC");
+    expect(body.host_id).toBe("host_1");
+    expect(body.workspace).toBe("/home/me/repo");
+  });
+});
+
+describe("updateScheduledTask", () => {
+  it("PATCHes only the fields present in the input", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ ...TASK_WIRE, state: "paused" }));
+    const updated = await updateScheduledTask("st_1", { state: "paused" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/v1/scheduled-tasks/st_1");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body)).toEqual({ state: "paused" });
+    expect(updated.state).toBe("paused");
+  });
+});
+
+describe("deleteScheduledTask", () => {
+  it("DELETEs /v1/scheduled-tasks/{id}", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ deleted: true, id: "st_1" }));
+    await deleteScheduledTask("st_1");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/v1/scheduled-tasks/st_1");
+    expect(init.method).toBe("DELETE");
+  });
+});
+
+describe("error path", () => {
+  it("throws a ScheduledTaskApiError carrying the server code + message", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse(
+        { error: { code: "invalid_input", message: "invalid rrule: fires only once" } },
+        { ok: false, status: 400 },
+      ),
+    );
+    await expect(
+      createScheduledTask({ name: "n", prompt: "p", rrule: "bad", agentId: "ag_1" }),
+    ).rejects.toMatchObject({
+      name: "ScheduledTaskApiError",
+      status: 400,
+      code: "invalid_input",
+      message: "invalid rrule: fires only once",
+    });
+  });
+
+  it("falls back to the status line on a non-error-shaped body", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse("nope", { ok: false, status: 500 }));
+    const err = await listScheduledTasks().catch((e) => e);
+    expect(err).toBeInstanceOf(ScheduledTaskApiError);
+    expect(err.status).toBe(500);
+    expect(err.code).toBeNull();
+  });
+});

--- a/web/src/lib/scheduledTasksApi.ts
+++ b/web/src/lib/scheduledTasksApi.ts
@@ -1,0 +1,286 @@
+// Hand-written client for the six `/v1/scheduled-tasks` endpoints, mirroring
+// `omnigent/server/routes/scheduled_tasks.py`. Follows the same conventions as
+// the sibling `sessionsApi.ts`: requests go through the Vite `/v1` proxy, the
+// wire is snake_case while the TS surface is camelCase, and non-OK responses
+// throw a typed error carrying the server's machine-readable `code`.
+//
+// A scheduled task is a saved prompt that fires an agent session on a recurring
+// RFC-5545 RRULE schedule. `host_id` / `workspace` are optional (post-FU-3):
+// omit both and the server resolves the owner's connected host + its home dir
+// at fire time; supply them only as a validated pair.
+
+import { authenticatedFetch } from "./identity";
+
+/** Lifecycle state of a scheduled task. `paused` tasks don't fire. */
+export type ScheduledTaskState = "active" | "paused";
+
+/** Terminal + in-flight statuses a single run can hold. */
+export type ScheduledTaskRunStatus =
+  | "scheduled"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "skipped"
+  | "incomplete";
+
+/**
+ * A scheduled task, camelCased from the server's `_to_response` shape. The
+ * server preserves the JSON key `owner_user_id` for the owning user even though
+ * the DB column is `user_id`; it's surfaced here as `ownerUserId`.
+ */
+export interface ScheduledTask {
+  id: string;
+  name: string;
+  prompt: string;
+  /** RFC-5545 recurrence rule, e.g. `FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=8;BYMINUTE=0`. */
+  rrule: string;
+  /** Owning user, or `null` in single-user / auth-disabled deployments. */
+  ownerUserId: string | null;
+  agentId: string;
+  /** IANA timezone the RRULE is evaluated in, e.g. `America/Los_Angeles`. */
+  timezone: string;
+  createdAt: number;
+  updatedAt: number;
+  modelOverride: string | null;
+  reasoningEffort: string | null;
+  /** Pinned absolute workspace, or `null` (server defaults to the host home). */
+  workspace: string | null;
+  /** Pinned host, or `null` (server resolves the connected host at fire time). */
+  hostId: string | null;
+  state: ScheduledTaskState;
+  /** Epoch seconds of the last fire, or `null` if it has never fired. */
+  lastRunAt: number | null;
+  lastRunConversationId: string | null;
+}
+
+/** One run of a scheduled task, camelCased from `_run_to_response`. */
+export interface ScheduledTaskRun {
+  id: string;
+  scheduledTaskId: string;
+  status: ScheduledTaskRunStatus;
+  scheduledAt: number;
+  conversationId: string | null;
+  firedAt: number | null;
+  finishedAt: number | null;
+  /** Queryable failure classification, e.g. `no_online_host`; `null` on success. */
+  errorCode: string | null;
+}
+
+/** Body for `POST /v1/scheduled-tasks`. */
+export interface CreateScheduledTaskInput {
+  name: string;
+  prompt: string;
+  rrule: string;
+  agentId: string;
+  timezone?: string;
+  modelOverride?: string | null;
+  reasoningEffort?: string | null;
+  /** Optional pinned workspace; only valid together with `hostId`. */
+  workspace?: string | null;
+  /** Optional pinned host. */
+  hostId?: string | null;
+}
+
+/**
+ * Body for `PATCH /v1/scheduled-tasks/{id}`. Every field is optional; only the
+ * fields present are changed. The server rejects nulling an already-set
+ * `workspace` / `hostId` — send a new value or leave the field unset.
+ */
+export interface UpdateScheduledTaskInput {
+  name?: string;
+  prompt?: string;
+  rrule?: string;
+  timezone?: string;
+  modelOverride?: string | null;
+  reasoningEffort?: string | null;
+  workspace?: string;
+  hostId?: string;
+  state?: ScheduledTaskState;
+}
+
+/** Wire shape of a task row (snake_case), matching `_to_response`. */
+interface ScheduledTaskWire {
+  id: string;
+  name: string;
+  prompt: string;
+  rrule: string;
+  owner_user_id: string | null;
+  agent_id: string;
+  timezone: string;
+  created_at: number;
+  updated_at: number;
+  model_override: string | null;
+  reasoning_effort: string | null;
+  workspace: string | null;
+  host_id: string | null;
+  state: ScheduledTaskState;
+  last_run_at: number | null;
+  last_run_conversation_id: string | null;
+}
+
+/** Wire shape of a run row (snake_case), matching `_run_to_response`. */
+interface ScheduledTaskRunWire {
+  id: string;
+  scheduled_task_id: string;
+  status: ScheduledTaskRunStatus;
+  scheduled_at: number;
+  conversation_id: string | null;
+  fired_at: number | null;
+  finished_at: number | null;
+  error_code: string | null;
+}
+
+/**
+ * A typed HTTP error carrying the server's machine-readable `code`, so callers
+ * can branch on the failure kind (e.g. `invalid_input` for a bad RRULE) rather
+ * than string-matching the message. Mirrors `ApiError` in `sessionsApi.ts`;
+ * kept local so this module has no cross-import on the sessions client.
+ */
+export class ScheduledTaskApiError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+  constructor(message: string, status: number, code: string | null) {
+    super(message);
+    this.name = "ScheduledTaskApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+/**
+ * Build a {@link ScheduledTaskApiError} from a non-OK response, preferring the
+ * server's `error.message` / `error.code` (the `OmnigentError` shape) over the
+ * bare status line.
+ */
+async function errorFromResponse(res: Response): Promise<ScheduledTaskApiError> {
+  let message = `${res.status} ${res.statusText}`;
+  let code: string | null = null;
+  try {
+    const body = (await res.json()) as { error?: { code?: string; message?: string } };
+    if (body.error?.message) message = body.error.message;
+    if (body.error?.code) code = body.error.code;
+  } catch {
+    // Non-JSON / empty body — keep the status-line fallback.
+  }
+  return new ScheduledTaskApiError(message, res.status, code);
+}
+
+async function readJsonOrThrow<T>(res: Response): Promise<T> {
+  if (!res.ok) throw await errorFromResponse(res);
+  return (await res.json()) as T;
+}
+
+function taskFromWire(wire: ScheduledTaskWire): ScheduledTask {
+  return {
+    id: wire.id,
+    name: wire.name,
+    prompt: wire.prompt,
+    rrule: wire.rrule,
+    ownerUserId: wire.owner_user_id,
+    agentId: wire.agent_id,
+    timezone: wire.timezone,
+    createdAt: wire.created_at,
+    updatedAt: wire.updated_at,
+    modelOverride: wire.model_override,
+    reasoningEffort: wire.reasoning_effort,
+    workspace: wire.workspace,
+    hostId: wire.host_id,
+    state: wire.state,
+    lastRunAt: wire.last_run_at,
+    lastRunConversationId: wire.last_run_conversation_id,
+  };
+}
+
+function runFromWire(wire: ScheduledTaskRunWire): ScheduledTaskRun {
+  return {
+    id: wire.id,
+    scheduledTaskId: wire.scheduled_task_id,
+    status: wire.status,
+    scheduledAt: wire.scheduled_at,
+    conversationId: wire.conversation_id,
+    firedAt: wire.fired_at,
+    finishedAt: wire.finished_at,
+    errorCode: wire.error_code,
+  };
+}
+
+/** List the caller's scheduled tasks (owner-scoped server-side). */
+export async function listScheduledTasks(): Promise<ScheduledTask[]> {
+  const res = await authenticatedFetch("/v1/scheduled-tasks");
+  const body = await readJsonOrThrow<{ scheduled_tasks: ScheduledTaskWire[] }>(res);
+  return (body.scheduled_tasks ?? []).map(taskFromWire);
+}
+
+/** Fetch one of the caller's scheduled tasks (404 if not owned). */
+export async function getScheduledTask(id: string): Promise<ScheduledTask> {
+  const res = await authenticatedFetch(`/v1/scheduled-tasks/${encodeURIComponent(id)}`);
+  return taskFromWire(await readJsonOrThrow<ScheduledTaskWire>(res));
+}
+
+/** List a task's run history, most-recent-first (404 if not owned). */
+export async function listScheduledTaskRuns(id: string): Promise<ScheduledTaskRun[]> {
+  const res = await authenticatedFetch(`/v1/scheduled-tasks/${encodeURIComponent(id)}/runs`);
+  const body = await readJsonOrThrow<{ runs: ScheduledTaskRunWire[] }>(res);
+  return (body.runs ?? []).map(runFromWire);
+}
+
+/**
+ * Create a scheduled task. Only the fields the user actually set are sent, so
+ * the server applies its own defaults (`timezone` → UTC) and the optional
+ * host/workspace pair is omitted entirely when unset (server resolves the
+ * connected host at fire time).
+ */
+export async function createScheduledTask(input: CreateScheduledTaskInput): Promise<ScheduledTask> {
+  const body: Record<string, unknown> = {
+    name: input.name,
+    prompt: input.prompt,
+    rrule: input.rrule,
+    agent_id: input.agentId,
+  };
+  if (input.timezone !== undefined) body.timezone = input.timezone;
+  if (input.modelOverride != null) body.model_override = input.modelOverride;
+  if (input.reasoningEffort != null) body.reasoning_effort = input.reasoningEffort;
+  if (input.workspace != null) body.workspace = input.workspace;
+  if (input.hostId != null) body.host_id = input.hostId;
+  const res = await authenticatedFetch("/v1/scheduled-tasks", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return taskFromWire(await readJsonOrThrow<ScheduledTaskWire>(res));
+}
+
+/**
+ * Update mutable fields of a task (pause/reactivate/rename/reschedule). Only
+ * the keys present in `input` are sent, matching the server's
+ * `exclude_unset` semantics.
+ */
+export async function updateScheduledTask(
+  id: string,
+  input: UpdateScheduledTaskInput,
+): Promise<ScheduledTask> {
+  const body: Record<string, unknown> = {};
+  if (input.name !== undefined) body.name = input.name;
+  if (input.prompt !== undefined) body.prompt = input.prompt;
+  if (input.rrule !== undefined) body.rrule = input.rrule;
+  if (input.timezone !== undefined) body.timezone = input.timezone;
+  if (input.modelOverride !== undefined) body.model_override = input.modelOverride;
+  if (input.reasoningEffort !== undefined) body.reasoning_effort = input.reasoningEffort;
+  if (input.workspace !== undefined) body.workspace = input.workspace;
+  if (input.hostId !== undefined) body.host_id = input.hostId;
+  if (input.state !== undefined) body.state = input.state;
+  const res = await authenticatedFetch(`/v1/scheduled-tasks/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return taskFromWire(await readJsonOrThrow<ScheduledTaskWire>(res));
+}
+
+/** Delete a task so it no longer fires. */
+export async function deleteScheduledTask(id: string): Promise<void> {
+  const res = await authenticatedFetch(`/v1/scheduled-tasks/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) throw await errorFromResponse(res);
+}

--- a/web/src/lib/timezones.ts
+++ b/web/src/lib/timezones.ts
@@ -1,0 +1,63 @@
+// Timezone options for the scheduled-task create form. Uses the platform's IANA
+// zone list when available (`Intl.supportedValuesOf`), falling back to a small
+// curated list on older engines that lack it. The server validates the chosen
+// value against the full IANA database, so this list only needs to be usable,
+// not exhaustive.
+
+/** The viewer's local IANA timezone, or `UTC` if it can't be resolved. */
+export function localTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+const FALLBACK_ZONES = [
+  "UTC",
+  "America/Los_Angeles",
+  "America/Denver",
+  "America/Chicago",
+  "America/New_York",
+  "America/Sao_Paulo",
+  "Europe/London",
+  "Europe/Berlin",
+  "Europe/Paris",
+  "Europe/Moscow",
+  "Asia/Kolkata",
+  "Asia/Singapore",
+  "Asia/Shanghai",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+];
+
+/**
+ * The timezone options to offer, always including `UTC` and `ensure` (the
+ * currently-selected value) so a preselected local/uncommon zone is never
+ * missing from the list.
+ *
+ * NOTE: not currently called — v1 infers the timezone from the browser
+ * (`localTimezone`) with no visible picker. Retained for the future
+ * cross-timezone picker (see the comment in CreateScheduledTaskDialog).
+ */
+export function commonTimezones(ensure?: string): string[] {
+  let zones: string[];
+  try {
+    // `supportedValuesOf` is ES2023; guard for older runtimes/tests.
+    const supported = (
+      Intl as unknown as { supportedValuesOf?: (key: string) => string[] }
+    ).supportedValuesOf?.("timeZone");
+    zones = supported && supported.length > 0 ? [...supported] : [...FALLBACK_ZONES];
+  } catch {
+    zones = [...FALLBACK_ZONES];
+  }
+  const set = new Set(zones);
+  set.add("UTC");
+  if (ensure) set.add(ensure);
+  return [...set].sort((a, b) => {
+    // UTC first, then alphabetical.
+    if (a === "UTC") return -1;
+    if (b === "UTC") return 1;
+    return a.localeCompare(b);
+  });
+}

--- a/web/src/pages/TasksPage.test.tsx
+++ b/web/src/pages/TasksPage.test.tsx
@@ -1,0 +1,340 @@
+// Tests for the Scheduled tasks page (`/tasks`): list rendering, the
+// Active/Paused filter + search, the Paused badge/dimming, the New task
+// dropdown's two options, and the pause/delete row actions dispatching the
+// mutation hooks.
+//
+// The scheduled-tasks hooks are mocked at their seam; the create dialogs are
+// stubbed to a marker so we assert the menu opens the right one without
+// exercising their internals (covered by their own tests).
+
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TasksPage } from "./TasksPage";
+import * as hooks from "@/hooks/useScheduledTasks";
+import type { ScheduledTask } from "@/lib/scheduledTasksApi";
+
+vi.mock("@/hooks/useScheduledTasks", () => ({
+  useScheduledTasks: vi.fn(),
+  useUpdateScheduledTask: vi.fn(),
+  useDeleteScheduledTask: vi.fn(),
+}));
+
+// Stub the create dialog — its internals are covered separately; here we only
+// need to know it opened and WHICH prefill (initialName/initialPrompt) TasksPage
+// passed, so we can assert chip-click seeds it and manual open does not.
+vi.mock("@/components/scheduled/CreateScheduledTaskDialog", () => ({
+  CreateScheduledTaskDialog: ({
+    open,
+    initialName,
+    initialPrompt,
+  }: {
+    open: boolean;
+    initialName?: string;
+    initialPrompt?: string;
+  }) =>
+    open ? (
+      <div
+        data-testid="manual-dialog-open"
+        data-initial-name={initialName ?? ""}
+        data-initial-prompt={initialPrompt ?? ""}
+      />
+    ) : null,
+}));
+vi.mock("@/components/scheduled/CreateWithOmnigentDialog", () => ({
+  CreateWithOmnigentDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="omnigent-dialog-open" /> : null,
+}));
+
+function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: "st_1",
+    name: "Nightly triage",
+    prompt: "Triage",
+    rrule: "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=8;BYMINUTE=0",
+    ownerUserId: null,
+    agentId: "ag_1",
+    timezone: "UTC",
+    createdAt: 1,
+    updatedAt: 2,
+    modelOverride: null,
+    reasoningEffort: null,
+    workspace: null,
+    hostId: null,
+    state: "active",
+    lastRunAt: null,
+    lastRunConversationId: null,
+    ...overrides,
+  };
+}
+
+const mutate = vi.fn();
+const deleteMutate = vi.fn();
+
+function setTasks(tasks: ScheduledTask[], state: { isLoading?: boolean; isError?: boolean } = {}) {
+  vi.mocked(hooks.useScheduledTasks).mockReturnValue({
+    data: tasks,
+    isLoading: state.isLoading ?? false,
+    isError: state.isError ?? false,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof hooks.useScheduledTasks>);
+}
+
+beforeEach(() => {
+  mutate.mockReset();
+  deleteMutate.mockReset();
+  vi.mocked(hooks.useUpdateScheduledTask).mockReturnValue({
+    mutate,
+    isPending: false,
+    variables: undefined,
+  } as unknown as ReturnType<typeof hooks.useUpdateScheduledTask>);
+  vi.mocked(hooks.useDeleteScheduledTask).mockReturnValue({
+    mutate: deleteMutate,
+    isPending: false,
+    variables: undefined,
+  } as unknown as ReturnType<typeof hooks.useDeleteScheduledTask>);
+});
+
+afterEach(() => cleanup());
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <TasksPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("TasksPage list", () => {
+  it("renders the title, subtitle and task rows with schedule text", () => {
+    setTasks([task()]);
+    renderPage();
+    expect(screen.getByText("Scheduled tasks")).toBeInTheDocument();
+    expect(screen.getByText(/Run agent sessions on a recurring schedule/i)).toBeInTheDocument();
+    const row = screen.getByTestId("scheduled-task-row");
+    expect(within(row).getByText("Nightly triage")).toBeInTheDocument();
+    // Schedule text is derived client-side from the RRULE.
+    expect(within(row).getByTestId("task-schedule-line").textContent).toContain(
+      "Weekdays at 8:00 AM",
+    );
+  });
+
+  it("paused rows: pill only — no dimming, no '· Paused' suffix, no status circle", () => {
+    setTasks([task({ id: "st_2", name: "Paused one", state: "paused" })]);
+    renderPage();
+    const row = screen.getByTestId("scheduled-task-row");
+    expect(row).toHaveAttribute("data-state", "paused");
+    // NOT dimmed — the title must stay legible (AA). The pill is the sole signal.
+    expect(row.className).not.toContain("opacity-60");
+    // Small "Paused" pill next to the title.
+    expect(within(row).getByTestId("task-paused-pill")).toBeInTheDocument();
+    // No leading/trailing status circles — the ⋯ menu is the sole affordance
+    // (hover-revealed, so no resume glyph on the row).
+    expect(within(row).queryByTestId("task-resume-glyph")).toBeNull();
+    // Subline is just the schedule — no "· Paused" suffix, no next-run clause.
+    const line = within(row).getByTestId("task-schedule-line").textContent ?? "";
+    expect(line).toContain("Weekdays at 8:00 AM");
+    expect(line).not.toContain("Paused");
+    expect(line).not.toContain("Next run");
+  });
+
+  it("resumes a paused task via the row menu (Resume label reflects state)", () => {
+    setTasks([task({ id: "st_2", state: "paused" })]);
+    renderPage();
+    fireEvent.pointerDown(screen.getByTestId("task-row-menu"), { button: 0 });
+    // Paused → the toggle item reads "Resume".
+    expect(screen.getByTestId("task-pause-toggle")).toHaveTextContent("Resume");
+    fireEvent.click(screen.getByTestId("task-pause-toggle"));
+    expect(mutate).toHaveBeenCalledWith({ id: "st_2", input: { state: "active" } });
+  });
+
+  it("shows the empty state when there are no tasks", () => {
+    setTasks([]);
+    renderPage();
+    expect(screen.getByTestId("tasks-empty-state")).toBeInTheDocument();
+    expect(screen.getByText("No scheduled tasks yet")).toBeInTheDocument();
+  });
+
+  it("shows the two v1 suggestions as 'More ideas' chips (icon + title, no description)", () => {
+    setTasks([]);
+    renderPage();
+    // "All" is the default tab → the section is visible with the muted label.
+    const suggestions = screen.getByTestId("tasks-suggestions");
+    expect(within(suggestions).getByText("More ideas")).toBeInTheDocument();
+    // Exactly two chips, in array order: "Daily brief" first, "Issue triage" second.
+    const chips = within(suggestions).getAllByTestId(/^suggestion-/);
+    expect(chips).toHaveLength(2);
+    expect(chips.map((c) => c.getAttribute("data-testid"))).toEqual([
+      "suggestion-daily-brief",
+      "suggestion-morning-triage",
+    ]);
+    const triage = within(suggestions).getByTestId("suggestion-morning-triage");
+    expect(triage).toBeInTheDocument();
+    // Chip shows the SHORT label (1-2 words), not the fuller prefill name...
+    expect(triage).toHaveTextContent("Issue triage");
+    // ...but NOT the description (chips are icon + title only now).
+    expect(triage).not.toHaveTextContent("summarize new issues");
+    expect(within(suggestions).getByTestId("suggestion-daily-brief")).toBeInTheDocument();
+    // The removed weekly/niche ones are gone.
+    expect(within(suggestions).queryByTestId("suggestion-dependency-audit")).toBeNull();
+    expect(within(suggestions).queryByTestId("suggestion-changelog-digest")).toBeNull();
+  });
+
+  it("hides the Suggestions when a specific filter (Active/Paused) is selected", () => {
+    setTasks([]);
+    renderPage();
+    // Visible on the default "All" tab.
+    expect(screen.getByTestId("tasks-suggestions")).toBeInTheDocument();
+
+    // Selecting "Active" hides Suggestions...
+    fireEvent.click(screen.getByTestId("tasks-filter-active"));
+    expect(screen.queryByTestId("tasks-suggestions")).toBeNull();
+
+    // ...and so does "Paused"...
+    fireEvent.click(screen.getByTestId("tasks-filter-paused"));
+    expect(screen.queryByTestId("tasks-suggestions")).toBeNull();
+
+    // ...while switching back to "All" shows it again (live toggle).
+    fireEvent.click(screen.getByTestId("tasks-filter-all"));
+    expect(screen.getByTestId("tasks-suggestions")).toBeInTheDocument();
+  });
+});
+
+describe("sort order", () => {
+  it("orders ACTIVE by soonest next-run first, PAUSED last", () => {
+    // Pin now to midnight UTC so daily BYHOUR next-runs are deterministic:
+    // 06:00 fires before 18:00 today; the paused task must sink to the bottom
+    // regardless of its (earlier) schedule.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    try {
+      setTasks([
+        // Given in a deliberately "wrong" order to prove the sort runs.
+        task({ id: "p", name: "Paused early", state: "paused", rrule: "FREQ=DAILY;BYHOUR=1" }),
+        task({ id: "late", name: "Active late", state: "active", rrule: "FREQ=DAILY;BYHOUR=18" }),
+        task({ id: "soon", name: "Active soon", state: "active", rrule: "FREQ=DAILY;BYHOUR=6" }),
+      ]);
+      renderPage();
+      const names = screen
+        .getAllByTestId("scheduled-task-row")
+        .map((r) => r.querySelector(".font-semibold")?.textContent);
+      expect(names).toEqual(["Active soon", "Active late", "Paused early"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("filtering + search", () => {
+  it("filters to Active / Paused via the tabs", () => {
+    setTasks([
+      task({ id: "a", name: "Active task", state: "active" }),
+      task({ id: "p", name: "Paused task", state: "paused" }),
+    ]);
+    renderPage();
+    expect(screen.getAllByTestId("scheduled-task-row")).toHaveLength(2);
+
+    fireEvent.click(screen.getByTestId("tasks-filter-paused"));
+    let rows = screen.getAllByTestId("scheduled-task-row");
+    expect(rows).toHaveLength(1);
+    expect(within(rows[0]).getByText("Paused task")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("tasks-filter-active"));
+    rows = screen.getAllByTestId("scheduled-task-row");
+    expect(rows).toHaveLength(1);
+    expect(within(rows[0]).getByText("Active task")).toBeInTheDocument();
+  });
+
+  it("filters by name via the search box", () => {
+    setTasks([task({ id: "a", name: "Nightly triage" }), task({ id: "b", name: "PR sweep" })]);
+    renderPage();
+    fireEvent.change(screen.getByTestId("tasks-search"), { target: { value: "sweep" } });
+    const rows = screen.getAllByTestId("scheduled-task-row");
+    expect(rows).toHaveLength(1);
+    expect(within(rows[0]).getByText("PR sweep")).toBeInTheDocument();
+  });
+});
+
+describe("New task button", () => {
+  it("opens the manual create dialog directly (no dropdown)", () => {
+    setTasks([]);
+    renderPage();
+    // "Create with Omnigent" is hidden for now (TODO(UI-2)), leaving one create
+    // path — so the button opens the manual dialog directly rather than a menu.
+    fireEvent.click(screen.getByTestId("new-task-button"));
+    expect(screen.getByTestId("manual-dialog-open")).toBeInTheDocument();
+  });
+
+  it("does not offer a 'Create with Omnigent' entry point", () => {
+    setTasks([]);
+    renderPage();
+    // No dropdown, no Omnigent item — the stub dialog is unreachable from the UI.
+    fireEvent.pointerDown(screen.getByTestId("new-task-button"), { button: 0 });
+    expect(screen.queryByTestId("new-task-omnigent")).toBeNull();
+    expect(screen.queryByTestId("new-task-manual")).toBeNull();
+    expect(screen.queryByTestId("omnigent-dialog-open")).toBeNull();
+  });
+});
+
+describe("suggestion prefill", () => {
+  it("seeds the dialog with the picked suggestion's name + prompt", () => {
+    setTasks([]);
+    renderPage();
+    fireEvent.click(screen.getByTestId("suggestion-daily-brief"));
+    const dialog = screen.getByTestId("manual-dialog-open");
+    // The fuller prefill.name/prompt are passed (NOT the short chip label).
+    expect(dialog.getAttribute("data-initial-name")).toBe("Daily morning brief");
+    expect(dialog.getAttribute("data-initial-prompt")).toContain("morning brief");
+  });
+
+  it("opens EMPTY from the plain 'New task' button (no prefill)", () => {
+    setTasks([]);
+    renderPage();
+    fireEvent.click(screen.getByTestId("new-task-button"));
+    const dialog = screen.getByTestId("manual-dialog-open");
+    expect(dialog.getAttribute("data-initial-name")).toBe("");
+    expect(dialog.getAttribute("data-initial-prompt")).toBe("");
+  });
+
+  it("reseeds when switching chips, and does not leak a stale prefill into a manual open", () => {
+    setTasks([]);
+    renderPage();
+
+    // Open from one chip → seeded.
+    fireEvent.click(screen.getByTestId("suggestion-daily-brief"));
+    expect(screen.getByTestId("manual-dialog-open").getAttribute("data-initial-name")).toBe(
+      "Daily morning brief",
+    );
+
+    // The stub dialog reports open via the `open` prop; simulate a close by
+    // clicking a different chip (reseed) — the new suggestion's values win.
+    fireEvent.click(screen.getByTestId("suggestion-morning-triage"));
+    expect(screen.getByTestId("manual-dialog-open").getAttribute("data-initial-name")).toBe(
+      "Morning issue triage",
+    );
+
+    // Now the plain manual open must be EMPTY — no stale prefill from the chips.
+    fireEvent.click(screen.getByTestId("new-task-button"));
+    expect(screen.getByTestId("manual-dialog-open").getAttribute("data-initial-name")).toBe("");
+  });
+});
+
+describe("row actions", () => {
+  it("pauses an active task via the row menu (Pause label reflects state)", () => {
+    setTasks([task({ id: "st_1", state: "active" })]);
+    renderPage();
+    fireEvent.pointerDown(screen.getByTestId("task-row-menu"), { button: 0 });
+    // Active → the toggle item reads "Pause".
+    expect(screen.getByTestId("task-pause-toggle")).toHaveTextContent("Pause");
+    fireEvent.click(screen.getByTestId("task-pause-toggle"));
+    expect(mutate).toHaveBeenCalledWith({ id: "st_1", input: { state: "paused" } });
+  });
+
+  it("deletes a task via the row menu", () => {
+    setTasks([task({ id: "st_1" })]);
+    renderPage();
+    fireEvent.pointerDown(screen.getByTestId("task-row-menu"), { button: 0 });
+    fireEvent.click(screen.getByTestId("task-delete"));
+    expect(deleteMutate).toHaveBeenCalledWith("st_1");
+  });
+});

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -1,0 +1,358 @@
+/**
+ * Scheduled tasks page (`/tasks`) — the list of the user's recurring agent
+ * tasks, a search + Active/Paused filter, a "New task" dropdown (Create with
+ * Omnigent / Set up manually), and a static Suggestions section below.
+ *
+ * Data comes from `useScheduledTasks` (GET /v1/scheduled-tasks). Pause/resume
+ * and delete go through the update/delete mutations, which invalidate the list.
+ * The human-readable schedule and next-run text are computed client-side from
+ * each task's stored RRULE (`scheduleText`) — there is no backend next-run
+ * endpoint.
+ */
+
+import { useMemo, useState } from "react";
+import {
+  CalendarClockIcon,
+  ChevronDownIcon,
+  Loader2Icon,
+  PlusIcon,
+  SearchIcon,
+  SparklesIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { PageScroll } from "@/components/PageScroll";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { CreateScheduledTaskDialog } from "@/components/scheduled/CreateScheduledTaskDialog";
+import { CreateWithOmnigentDialog } from "@/components/scheduled/CreateWithOmnigentDialog";
+import { ScheduledTaskRow } from "@/components/scheduled/ScheduledTaskRow";
+import {
+  SCHEDULED_TASK_SUGGESTIONS,
+  type ScheduledTaskSuggestion,
+} from "@/components/scheduled/suggestions";
+import {
+  useDeleteScheduledTask,
+  useScheduledTasks,
+  useUpdateScheduledTask,
+} from "@/hooks/useScheduledTasks";
+import type { ScheduledTask } from "@/lib/scheduledTasksApi";
+import { nextRunAtMs } from "@/lib/scheduleText";
+import { cn } from "@/lib/utils";
+
+type FilterTab = "all" | "active" | "paused";
+
+const FILTER_TABS: { value: FilterTab; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "paused", label: "Paused" },
+];
+
+export function TasksPage() {
+  const { data: tasks, isLoading, isError, refetch } = useScheduledTasks();
+  const updateMutation = useUpdateScheduledTask();
+  const deleteMutation = useDeleteScheduledTask();
+
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<FilterTab>("all");
+  const [manualOpen, setManualOpen] = useState(false);
+  const [omnigentOpen, setOmnigentOpen] = useState(false);
+  // Prefill for the manual create dialog when opened from a "More ideas" chip.
+  // Null → the normal manual path (empty fields). Cleared on dialog close so a
+  // stale prefill never leaks into a subsequent plain "New task" open.
+  const [prefill, setPrefill] = useState<ScheduledTaskSuggestion["prefill"] | null>(null);
+
+  function openManual() {
+    setPrefill(null);
+    setManualOpen(true);
+  }
+
+  function openFromSuggestion(s: ScheduledTaskSuggestion) {
+    setPrefill(s.prefill);
+    setManualOpen(true);
+  }
+
+  function handleManualOpenChange(next: boolean) {
+    setManualOpen(next);
+    if (!next) setPrefill(null);
+  }
+
+  const filtered = useMemo(() => {
+    const all = tasks ?? [];
+    const q = search.trim().toLowerCase();
+    const matches = all.filter((t) => {
+      if (filter === "active" && t.state !== "active") return false;
+      if (filter === "paused" && t.state !== "paused") return false;
+      if (q && !t.name.toLowerCase().includes(q)) return false;
+      return true;
+    });
+    // Sort: ACTIVE first (soonest next-run at the top), PAUSED last. The
+    // least-actionable (paused) rows sink to the bottom rather than leading the
+    // list. Active rows with no computable next-run sort after those that have
+    // one; paused rows keep a stable name order among themselves.
+    return matches.slice().sort((a, b) => {
+      const aPaused = a.state === "paused";
+      const bPaused = b.state === "paused";
+      if (aPaused !== bPaused) return aPaused ? 1 : -1;
+      if (aPaused && bPaused) return a.name.localeCompare(b.name);
+      const aNext = nextRunAtMs(a.rrule, a.timezone);
+      const bNext = nextRunAtMs(b.rrule, b.timezone);
+      if (aNext == null && bNext == null) return a.name.localeCompare(b.name);
+      if (aNext == null) return 1;
+      if (bNext == null) return -1;
+      return aNext - bNext;
+    });
+  }, [tasks, search, filter]);
+
+  // A per-task busy flag so a row's menu disables while its own mutation runs.
+  const busyId =
+    updateMutation.isPending && updateMutation.variables
+      ? updateMutation.variables.id
+      : deleteMutation.isPending
+        ? (deleteMutation.variables as string | undefined)
+        : undefined;
+
+  function handlePauseToggle(task: ScheduledTask) {
+    updateMutation.mutate({
+      id: task.id,
+      input: { state: task.state === "paused" ? "active" : "paused" },
+    });
+  }
+
+  function handleDelete(task: ScheduledTask) {
+    deleteMutation.mutate(task.id);
+  }
+
+  return (
+    <PageScroll contentClassName="px-6">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-2xl font-semibold">Scheduled tasks</h1>
+          <p className="text-sm text-muted-foreground">
+            Run agent sessions on a recurring schedule. Tasks fire on a connected host.
+          </p>
+        </div>
+        {/* Only one create path is live right now ("Set up manually"), so the
+            "New task" button opens that dialog directly rather than showing a
+            one-item dropdown. TODO(UI-2): re-enable the "Create with Omnigent"
+            entry point and restore the two-option dropdown (NewTaskMenu). */}
+        <Button data-testid="new-task-button" className="shrink-0" onClick={openManual}>
+          New task
+        </Button>
+      </div>
+
+      {/* Search + filter tabs. `gap-5` gives the filter-tab row clear separation
+          from the search input (was gap-3 — too tight). No "Mark all as read"
+          control: there is no unread model for scheduled tasks in this build, so
+          it would act on nothing. Restore it if run-result unread state lands. */}
+      <div className="mb-4 flex flex-col gap-5">
+        <div className="relative">
+          <SearchIcon className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search scheduled tasks…"
+            data-testid="tasks-search"
+            className="pl-9"
+          />
+        </div>
+        {/* Codex-style tabs: the ACTIVE tab keeps a subtle resting background
+            pill + full-strength foreground — NO bold weight anywhere. Inactive
+            tabs are plain muted text with a subtle hover highlight. The
+            distinction is background + color, not font weight. */}
+        <div role="tablist" aria-label="Filter tasks" className="flex items-center gap-1">
+          {FILTER_TABS.map((tab) => (
+            <button
+              key={tab.value}
+              type="button"
+              role="tab"
+              aria-selected={filter === tab.value}
+              data-testid={`tasks-filter-${tab.value}`}
+              onClick={() => setFilter(tab.value)}
+              className={cn(
+                "rounded-md px-3 py-1 text-sm font-medium transition-colors",
+                filter === tab.value
+                  ? "bg-muted text-foreground"
+                  : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isError ? (
+        <div
+          role="alert"
+          data-testid="tasks-load-error"
+          className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm"
+        >
+          <TriangleAlertIcon className="size-4 shrink-0 text-destructive" />
+          <span className="flex-1">Couldn’t load scheduled tasks.</span>
+          <Button variant="outline" size="sm" onClick={() => void refetch()}>
+            Retry
+          </Button>
+        </div>
+      ) : isLoading ? (
+        <div className="flex items-center gap-2 py-12 text-sm text-muted-foreground">
+          <Loader2Icon className="size-4 animate-spin" />
+          Loading scheduled tasks…
+        </div>
+      ) : filtered.length === 0 ? (
+        <EmptyState hasAny={(tasks ?? []).length > 0} onCreate={openManual} />
+      ) : (
+        // Flat list — no boxed cards, and NO per-row hairline dividers (the row
+        // padding alone gives the spacing). The only divider on the page is the
+        // one before the Suggestions section (see SuggestionsSection).
+        <div className="flex flex-col" data-testid="tasks-list">
+          {filtered.map((task) => (
+            <ScheduledTaskRow
+              key={task.id}
+              task={task}
+              busy={busyId === task.id}
+              onPauseToggle={handlePauseToggle}
+              onDelete={handleDelete}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Suggestions show ONLY on the "All" tab and are hidden once a specific
+          filter ("Active" / "Paused") is selected, per the product spec ("when
+          all isn't selected, suggestions should disappear"). Driven by the same
+          `filter` state as the list, so switching tabs toggles it live. */}
+      {filter === "all" && <SuggestionsSection onPick={openFromSuggestion} />}
+
+      <CreateScheduledTaskDialog
+        open={manualOpen}
+        onOpenChange={handleManualOpenChange}
+        initialName={prefill?.name}
+        initialPrompt={prefill?.prompt}
+      />
+      {/* TODO(UI-2): stub kept wired but currently unreachable — nothing opens
+          it while the "Create with Omnigent" menu entry is hidden. Restore the
+          NewTaskMenu entry point (which calls setOmnigentOpen(true)) in UI-2. */}
+      <CreateWithOmnigentDialog open={omnigentOpen} onOpenChange={setOmnigentOpen} />
+    </PageScroll>
+  );
+}
+
+/**
+ * The "New task" split button: a caret dropdown with the two create paths.
+ *
+ * TODO(UI-2): currently NOT rendered — while "Create with Omnigent" is hidden,
+ * the "New task" button opens the Set-up-manually dialog directly (see the
+ * header above). Restore this dropdown (and the `onCreateWithOmnigent` wiring)
+ * when the Omnigent create flow lands in UI-2.
+ *
+ * Exported (rather than deleted) so it's retained for UI-2 and doesn't trip
+ * `noUnusedLocals` while it has no in-module caller.
+ */
+export function NewTaskMenu({
+  onCreateWithOmnigent,
+  onSetUpManually,
+}: {
+  onCreateWithOmnigent: () => void;
+  onSetUpManually: () => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button data-testid="new-task-button" className="shrink-0 gap-1.5">
+          <PlusIcon className="size-4" />
+          New task
+          <ChevronDownIcon className="size-3.5 opacity-70" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuItem
+          onSelect={onCreateWithOmnigent}
+          data-testid="new-task-omnigent"
+          className="gap-2 py-2"
+        >
+          <SparklesIcon className="size-4 text-primary" />
+          <div className="flex flex-col">
+            <span className="text-sm">Create with Omnigent</span>
+            <span className="text-[11px] text-muted-foreground">Describe it in plain language</span>
+          </div>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onSelect={onSetUpManually}
+          data-testid="new-task-manual"
+          className="gap-2 py-2"
+        >
+          <CalendarClockIcon className="size-4 text-muted-foreground" />
+          <div className="flex flex-col">
+            <span className="text-sm">Set up manually</span>
+            <span className="text-[11px] text-muted-foreground">Fill in the schedule yourself</span>
+          </div>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function EmptyState({ hasAny, onCreate }: { hasAny: boolean; onCreate: () => void }) {
+  return (
+    <div
+      className="flex flex-col items-center gap-2 py-16 text-center"
+      data-testid="tasks-empty-state"
+    >
+      <CalendarClockIcon className="size-8 text-muted-foreground/50" />
+      <p className="text-sm font-medium">
+        {hasAny ? "No tasks match your filters" : "No scheduled tasks yet"}
+      </p>
+      <p className="max-w-sm text-xs text-muted-foreground">
+        {hasAny
+          ? "Try a different search or filter."
+          : "Create a task to run an agent session automatically on a recurring schedule."}
+      </p>
+      {!hasAny && (
+        <Button size="sm" className="mt-2 gap-1.5" onClick={onCreate}>
+          <PlusIcon className="size-4" />
+          New task
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/** Static suggestions rendered below the list. See `suggestions.ts` for the TODO. */
+function SuggestionsSection({ onPick }: { onPick: (s: ScheduledTaskSuggestion) => void }) {
+  return (
+    // The single divider on the page: a `border-t` separating the task list
+    // from the section. `mt-4 pt-4` keeps the gap tight.
+    <div className="mt-4 border-t border-border/60 pt-4" data-testid="tasks-suggestions">
+      {/* Muted section label, sized as a proper section header (text-sm) — a
+          step up from text-xs while staying secondary in color. */}
+      <h2 className="mb-2 text-sm font-medium text-muted-foreground">More ideas</h2>
+      {/* Compact chips that wrap onto multiple lines. Each chip is an icon +
+          TITLE only (no description) — a bordered, hoverable pill. Clicking a
+          chip prefills/creates the task, same as the old row. Icons are neutral
+          (muted) inside the neutral chip, matching the reference. */}
+      <div className="flex flex-wrap gap-2">
+        {SCHEDULED_TASK_SUGGESTIONS.map((s) => {
+          const Icon = s.icon;
+          return (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => onPick(s)}
+              data-testid={`suggestion-${s.id}`}
+              className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <Icon className="size-4 shrink-0 text-muted-foreground" />
+              <span className="truncate">{s.title}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/shell/CommandPalette.tsx
+++ b/web/src/shell/CommandPalette.tsx
@@ -19,6 +19,7 @@
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
 import {
+  CalendarClockIcon,
   InboxIcon,
   type LucideIcon,
   PanelLeftIcon,
@@ -133,6 +134,13 @@ export function CommandPalette({
         icon: InboxIcon,
         keywords: ["notifications", "comments", "needs response"],
         run: () => navigate("/inbox"),
+      },
+      {
+        id: "go-tasks",
+        label: "Go to Scheduled tasks",
+        icon: CalendarClockIcon,
+        keywords: ["scheduled", "recurring", "cron", "automation", "schedule"],
+        run: () => navigate("/tasks"),
       },
       {
         id: "go-settings",

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1288,7 +1288,7 @@ function PickerSectionHeader({ children }: { children: ReactNode }) {
  * BEFORE selecting, so the harness-switch reseed effect in the screen reads it
  * back as the same value and doesn't clobber the choice.
  */
-function AgentHarnessPicker({
+export function AgentHarnessPicker({
   agentEntries,
   harnessEntries,
   brainHarnessLabels,
@@ -1316,6 +1316,11 @@ function AgentHarnessPicker({
   setPickedModel,
   setPickedEffort,
   setPickedHarness,
+  onOpenChange,
+  contentClassName,
+  triggerClassName,
+  triggerLabelClassName,
+  contentAlign,
 }: {
   agentEntries: AvailableAgent[];
   harnessEntries: AvailableAgent[];
@@ -1344,6 +1349,27 @@ function AgentHarnessPicker({
   setPickedModel: (model: string) => void;
   setPickedEffort: (effort: string) => void;
   setPickedHarness: (harness: string | null, agentId?: string) => void;
+  /** Notified when the picker dropdown opens/closes. Optional — lets a host
+   * (e.g. the scheduled-task Dialog) forward this into its outside-click
+   * dismiss guard so opening the picker doesn't close the surrounding modal. */
+  onOpenChange?: (open: boolean) => void;
+  /** Extra classes for the dropdown content. Optional — the landing composer
+   * relies on the default `available-height` cap (its trigger sits at the
+   * bottom of the screen), but a caller whose trigger sits at the TOP of a tall
+   * modal (the scheduled-task dialog) passes a tighter `max-h-*` so the list
+   * scrolls in a bounded popover instead of spanning the viewport. tailwind-merge
+   * lets the passed max-h win over the default. */
+  contentClassName?: string;
+  /** Extra classes for the trigger Button + its label span. Optional — the
+   * landing composer uses the default compact ghost styling; a caller inside a
+   * form (the scheduled-task dialog) passes Select-trigger-matching classes so
+   * the trigger lines up with sibling <Select> fields (full width, border,
+   * h-8). tailwind-merge lets these override the defaults. */
+  triggerClassName?: string;
+  triggerLabelClassName?: string;
+  /** DropdownMenu content alignment. Defaults to "end" (composer footer). A
+   * full-width-trigger caller (scheduled dialog) passes "start" to left-align. */
+  contentAlign?: "start" | "center" | "end";
 }) {
   // Controlled so clicking a knobbed row can commit the pick and close the
   // menu (see the sub-trigger onClick below) without diving into the submenu.
@@ -1633,6 +1659,7 @@ function AgentHarnessPicker({
       open={open}
       onOpenChange={(next) => {
         setOpen(next);
+        onOpenChange?.(next);
         if (next) {
           // Lock the open direction to whichever side has more room for the
           // tall list, so the later drill-in (shorter page) can't flip it.
@@ -1660,23 +1687,35 @@ function AgentHarnessPicker({
           data-testid="new-chat-landing-agent-select"
           // Drop the Button's focus-visible ring/border that otherwise shows
           // when focus returns to the trigger after a pick.
-          className="h-8 gap-1.5 px-2.5 font-normal text-muted-foreground hover:text-foreground focus-visible:border-transparent focus-visible:ring-0"
+          className={cn(
+            "h-8 gap-1.5 px-2.5 font-normal text-muted-foreground hover:text-foreground focus-visible:border-transparent focus-visible:ring-0",
+            triggerClassName,
+          )}
         >
-          <span className="max-w-[12rem] truncate text-xs text-foreground">
+          <span
+            className={cn("max-w-[12rem] truncate text-xs text-foreground", triggerLabelClassName)}
+          >
             {hasAgents ? agentLabel : "No agents"}
           </span>
           <ChevronDownIcon className="size-3.5 opacity-60" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        align="end"
+        // Composer footer trigger is narrow + bottom-right, so `end` aligns the
+        // menu's right edge to it. A caller with a full-width trigger (the
+        // scheduled dialog) passes `align="start"` so the menu's LEFT edge lines
+        // up with the trigger instead of shifting to the right.
+        align={contentAlign ?? "end"}
         // Desktop keeps the default collision handling (the content never
         // resizes there — knobs live in hover flyouts). On mobile we force the
         // measured side and disable flipping so the in-place page swap holds
         // its direction; `--radix-..-available-height` still caps + scrolls it.
         side={isMobile ? mobileSide : "bottom"}
         avoidCollisions={!isMobile}
-        className="max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-64 max-w-[calc(100vw-2rem)] overflow-y-auto p-1"
+        className={cn(
+          "max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-64 max-w-[calc(100vw-2rem)] overflow-y-auto p-1",
+          contentClassName,
+        )}
       >
         {showMobileKnobs && mobileKnobsAgent ? (
           // Mobile knobs page: the selected agent's run-config knobs shown in

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -254,6 +254,38 @@ describe("Sidebar session list", () => {
     expect(label.className).toContain("max-md:hidden");
   });
 
+  it("renders the 'Scheduled' nav row directly under 'New session' and routes to /tasks", () => {
+    mockConversations(THREE_TYPE_CONVERSATIONS);
+    renderSidebar();
+
+    const scheduled = screen.getByTestId("scheduled-tasks-nav");
+    // Full-width nav ROW (a link), labeled just "Scheduled", pointing at /tasks —
+    // not the old top-right icon button.
+    expect(scheduled).toHaveAttribute("href", "/tasks");
+    expect(scheduled).toHaveTextContent("Scheduled");
+    // The removed icon-button version must be gone.
+    expect(screen.queryByTestId("scheduled-tasks-button")).toBeNull();
+
+    // It sits as the second item in the top nav group: after "New session",
+    // before the search box. Compare document order.
+    const newSession = screen.getByTestId("new-chat-button");
+    const search = screen.getByTestId("sidebar-search-button");
+    expect(newSession.compareDocumentPosition(scheduled) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(scheduled.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  it("marks the 'Scheduled' nav row active when on /tasks", () => {
+    mockConversations(THREE_TYPE_CONVERSATIONS);
+    renderSidebar(true, "/tasks");
+
+    // Active/selected state uses the same `bg-muted` treatment as "New session".
+    expect(screen.getByTestId("scheduled-tasks-nav").className).toContain("bg-muted");
+  });
+
   it("does NOT close the sidebar when the footer Settings is tapped", () => {
     // No onNavClick on the footer Settings link: on mobile the overlay stays
     // open and swaps to the settings section list rather than collapsing onto

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   AlertTriangleIcon,
   ArchiveIcon,
   ArchiveRestoreIcon,
+  CalendarClockIcon,
   CheckIcon,
   CheckIcon as CheckMarkIcon,
   ChevronLeftIcon,
@@ -208,13 +209,19 @@ interface SidebarProps {
  * which is `inbox` in both standalone and embedded modes. Conversation ids are
  * `conv_…`-prefixed, so a chat route's leaf can never collide with `inbox`.
  */
-function useActiveNavItem(): { isNewChatPage: boolean; isInboxPage: boolean } {
+function useActiveNavItem(): {
+  isNewChatPage: boolean;
+  isInboxPage: boolean;
+  isTasksPage: boolean;
+} {
   const { conversationId: activeConversationId } = useParams<{ conversationId: string }>();
-  const isInboxPage = useLocation().pathname.split("/").filter(Boolean).at(-1) === "inbox";
-  // Exclude inbox: it also has no `:conversationId`, so it would otherwise
-  // light up the "New session" button.
-  const isNewChatPage = activeConversationId == null && !isInboxPage;
-  return { isNewChatPage, isInboxPage };
+  const leaf = useLocation().pathname.split("/").filter(Boolean).at(-1);
+  const isInboxPage = leaf === "inbox";
+  const isTasksPage = leaf === "tasks";
+  // Exclude inbox/tasks: they also have no `:conversationId`, so they would
+  // otherwise light up the "New session" button.
+  const isNewChatPage = activeConversationId == null && !isInboxPage && !isTasksPage;
+  return { isNewChatPage, isInboxPage, isTasksPage };
 }
 
 /**
@@ -362,7 +369,7 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
   }
 
   // Which top-level nav button to highlight for the current route.
-  const { isNewChatPage, isInboxPage } = useActiveNavItem();
+  const { isNewChatPage, isInboxPage, isTasksPage } = useActiveNavItem();
 
   // On /settings the card keeps its chrome but swaps the conversation list
   // for the settings section nav (see settingsNav.tsx) — entering settings
@@ -563,6 +570,26 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
               >
                 <SquarePenIcon className="size-4 text-foreground" />
                 New session
+              </Link>
+            </Button>
+            {/* "Scheduled" — recurring agent runs (/tasks). Second row in the
+            top nav group, directly under "New session" and above search. Same
+            full-width nav-row treatment as "New session"; a Link so
+            cmd/middle-click opens a new tab. */}
+            <Button
+              asChild
+              className={cn(
+                // Flush under "New session" (no top margin) so the two rows read
+                // as one tight nav group — matches the mockup.
+                "w-full justify-start gap-1 px-2 text-sm",
+                isTasksPage && "bg-muted font-semibold",
+              )}
+              variant="ghost"
+              data-testid="scheduled-tasks-nav"
+            >
+              <Link to="/tasks" onClick={onNavClick}>
+                <CalendarClockIcon className="size-4 text-foreground" />
+                Scheduled
               </Link>
             </Button>
             {selectionMode ? (


### PR DESCRIPTION
## Related issue

<!-- Tracked in Linear (OMNI-1193). No GitHub issue to auto-close. -->
N/A — tracked in Linear ([OMNI-1193](https://linear.app/omnigent/issue/OMNI-1193)). UI-1 follow-up to the merged Scheduled Tasks backend (fire path #2720, run-completion tracking).

## Summary

Adds the **Scheduled Tasks page** (`/tasks`) — the first user-facing UI for the Scheduled Tasks / Routines feature whose backend (RRULE schema, scheduler, fire path, run-completion tracking) already merged. Greenfield frontend; the API client is hand-written over the existing `/v1/scheduled-tasks` REST surface.

- **List + create.** A route-scoped, lazy-loaded flat list of scheduled tasks with a create dialog. Data layer is `scheduledTasksApi.ts` + TanStack-Query hooks (`useScheduledTasks`); the create dialog reuses the Radix `Dialog` primitive and the shared `AgentHarnessPicker` from `NewChatDialog` (agent / harness / model / host pickers, including the "needs setup" harness badges).
- **Flat-list rows.** Bold title + a single muted subline (`Weekdays at 8:00 AM · Next run in 15h`); active tasks sorted by soonest next-run, paused last. Paused state is a single "Paused" pill (no dimming, no redundant suffix — keeps the title AA-legible). Full-row hover highlight + a hover-revealed `⋯` menu (Pause/Resume + Delete) wired to the PATCH/DELETE mutations.
- **"More ideas" suggestion chips.** A wrapping row of compact icon+title chips (Daily brief → Issue triage) that prefill the create dialog's name/prompt on click; each fresh open is authoritative so no stale prefill leaks across opens.
- **Next-run label is frontend-derived** from the RRULE (`scheduleText.ts`), refreshed by the list query's 60s `refetchInterval` — **page-scoped only** (documented guard-rail: don't mount the hook in a persistent location or it becomes app-wide polling).

**ELI5:** This is the screen where you see your scheduled tasks, create new ones, and pause or delete them. Each row shows when it runs next (worked out in the browser from the schedule rule), tasks that are paused get a little "Paused" tag, and there's a row of quick-start "ideas" that pre-fill the create form when you click them. The countdown only refreshes while you're actually looking at this page.

```mermaid
flowchart TD
    A[/tasks route · lazy TasksPage/] --> B[useScheduledTasks · GET /v1/scheduled-tasks · refetchInterval 60s]
    B --> C[Flat list · active-by-next-run, paused last]
    C --> D[ScheduledTaskRow: title + schedule·next-run subline]
    D --> E[hover ⋯ menu → Pause/Resume PATCH · Delete DELETE]
    C --> F["More ideas" chips]
    F --> G[openFromSuggestion → seed name/prompt]
    C --> H[New task button → openManual → empty form]
    G --> I[CreateScheduledTaskDialog · Radix Dialog + AgentHarnessPicker]
    H --> I
    I --> J[useCreateScheduledTask · POST /v1/scheduled-tasks]
```

## Test Plan

Automated — full web suite green; scheduled-task suite specifically **87 passed** (5 files):

```bash
cd web
npm run type-check          # 0 errors
npm run test                # 4355 passed / 3 expected-fail / 2 skipped (253 files)
npx oxlint                  # exit 0 (3 pre-existing warnings, none in new code)
npx prettier --check .      # clean
```

- **Rows**: active-first-by-next-run then paused-last sort; paused shows pill only (no dimming / no "· Paused"); hover `⋯` menu Pause/Resume label reflects state; Delete removes the row.
- **Suggestions**: "More ideas" header + chips render (title only, not the fuller prefill name); chip click seeds the dialog name/prompt; manual open is empty; switching chips reseeds; manual-after-chip has no stale prefill.
- **Create dialog**: seeds from `initialName`/`initialPrompt`; authoritative reseed on each fresh open; does not clobber mid-open edits; `shouldGuardDialogDismiss` dismisses on a real backdrop click while still swallowing the narrow nested-Select case.
- **schedule text**: `nextRunAtMs` / `nextRunLabel` / `describeSchedule` over RRULE + timezone.

Manual — dev server + real backend with a connected host: created/paused/resumed/deleted tasks end-to-end (verified backend list mutated, not just optimistic UI); "needs setup" harness badges render in the fresh form once a host is connected; both light and dark themes verified via DOM computed-styles.

## Demo

<!-- Screenshot surface was unavailable in the agent browser pane this session; verified via DOM computed-styles + geometry in both themes. Screenshots to be attached on PR open. -->
_Screenshots to be attached (light + dark) — the Scheduled Tasks list, hover `⋯` menu, and the "More ideas" create-dialog prefill._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Component/unit coverage (Vitest + RTL) is described in the Test Plan — 87 scheduled-task tests covering row sort/paused/menu, suggestion prefill seed/reseed/no-leak, dialog dismiss guard, and the RRULE schedule-text helpers. Manual verification on a live server + connected host covers the full create/pause/resume/delete round-trip and the host-dependent "needs setup" badges, which need a real backend and aren't reproducible in the hermetic suite. **Known deferral:** "Create custom agent" in the agent picker is intentionally inert (`TODO(OMNI-1193)`) — persisting a new agent needs a standalone bundle-persist endpoint that doesn't exist yet; wiring it through session-create would spawn a phantom session. Tracked as a backend follow-up.

## Changelog

New Scheduled Tasks page to view, create, pause/resume, and delete scheduled tasks, with quick-start suggestion chips that prefill the create form.

---
This pull request and its description were written by Isaac.