### PR TITLE
[polly] Add Claude SDK goal mode

### DIFF
--- a/tests/e2e_ui/chat/test_polly_claude_goal_mode.py
+++ b/tests/e2e_ui/chat/test_polly_claude_goal_mode.py
@@ -1,0 +1,73 @@
+"""E2E: Polly sends Claude SDK goals through the normal message path."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+
+def _patch_session_as_polly_claude(page: Page, session_id: str) -> None:
+    """Expose the seeded session to the browser as top-level Polly on Claude SDK."""
+
+    def _handle(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+
+        response = route.fetch()
+        payload = response.json()
+        payload["agent_name"] = "polly"
+        payload["harness"] = "claude-sdk"
+        payload["parent_session_id"] = None
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route("**/v1/sessions/**", _handle)
+
+
+def test_polly_claude_goal_sends_native_command(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The Goal dialog validates input and posts the exact Claude slash command."""
+    base_url, session_id = seeded_session
+    _patch_session_as_polly_claude(page, session_id)
+
+    def _ack_event(route: Route) -> None:
+        route.fulfill(
+            status=202,
+            content_type="application/json",
+            body=json.dumps({"queued": True, "item_id": "ci_goal_e2e"}),
+        )
+
+    page.route(f"**/v1/sessions/{session_id}/events", _ack_event)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    goal_toggle = page.get_by_test_id("goal-toggle")
+    expect(goal_toggle).to_be_visible(timeout=15_000)
+    expect(goal_toggle).to_have_attribute("aria-label", "Start Claude goal")
+    goal_toggle.click()
+
+    start_goal = page.get_by_test_id("goal-start")
+    start_goal.click()
+    expect(page.get_by_text("Goal condition cannot be empty.")).to_be_visible()
+
+    condition = "Finish the implementation and pass all tests"
+    page.get_by_test_id("goal-condition").fill(f"  {condition}  ")
+    with page.expect_request(
+        lambda request: (
+            request.method == "POST"
+            and urlparse(request.url).path == f"/v1/sessions/{session_id}/events"
+        )
+    ) as sent:
+        start_goal.click()
+
+    body = sent.value.post_data_json
+    assert body["data"]["content"][0]["text"] == f"/goal {condition}"
+    expect(page.get_by_role("dialog", name="Goal")).to_have_count(0)

--- a/web/src/components/goal/CommandGoalDialog.test.tsx
+++ b/web/src/components/goal/CommandGoalDialog.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CommandGoalDialog } from "./CommandGoalDialog";
+
+afterEach(cleanup);
+
+describe("CommandGoalDialog", () => {
+  it("submits a trimmed completion condition", () => {
+    const onStartGoal = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <CommandGoalDialog
+        open
+        onOpenChange={onOpenChange}
+        readOnly={false}
+        onStartGoal={onStartGoal}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("goal-condition"), {
+      target: { value: "  All tests pass  " },
+    });
+    fireEvent.click(screen.getByTestId("goal-start"));
+
+    expect(onStartGoal).toHaveBeenCalledWith("All tests pass");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("rejects an empty condition", () => {
+    const onStartGoal = vi.fn();
+    render(
+      <CommandGoalDialog open onOpenChange={vi.fn()} readOnly={false} onStartGoal={onStartGoal} />,
+    );
+
+    fireEvent.click(screen.getByTestId("goal-start"));
+
+    expect(screen.getByText("Goal condition cannot be empty.")).toBeInTheDocument();
+    expect(onStartGoal).not.toHaveBeenCalled();
+  });
+
+  it("disables editing in read-only sessions", () => {
+    render(<CommandGoalDialog open onOpenChange={vi.fn()} readOnly onStartGoal={vi.fn()} />);
+
+    expect(screen.getByTestId("goal-condition")).toBeDisabled();
+    expect(screen.getByTestId("goal-start")).toBeDisabled();
+  });
+});

--- a/web/src/components/goal/CommandGoalDialog.tsx
+++ b/web/src/components/goal/CommandGoalDialog.tsx
@@ -1,0 +1,93 @@
+import { type FormEvent, useEffect, useState } from "react";
+import { TargetIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+
+export interface CommandGoalDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  readOnly: boolean;
+  onStartGoal: (condition: string) => void;
+}
+
+/** Start a Claude goal by sending its native slash command as the next turn. */
+export function CommandGoalDialog({
+  open,
+  onOpenChange,
+  readOnly,
+  onStartGoal,
+}: CommandGoalDialogProps) {
+  const [condition, setCondition] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setCondition("");
+      setError(null);
+    }
+  }, [open]);
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = condition.trim();
+    if (!trimmed) {
+      setError("Goal condition cannot be empty.");
+      return;
+    }
+    onStartGoal(trimmed);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <form className="contents" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <TargetIcon className="size-4" />
+              <span>Goal</span>
+            </DialogTitle>
+            <DialogDescription>
+              Claude keeps working until this condition is met. Progress and completion appear in
+              the conversation.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground" htmlFor="goal-condition">
+              Completion condition
+            </label>
+            <Textarea
+              id="goal-condition"
+              value={condition}
+              onChange={(event) => {
+                setCondition(event.currentTarget.value);
+                if (error !== null) setError(null);
+              }}
+              disabled={readOnly}
+              maxLength={4000}
+              className="min-h-28 resize-y"
+              placeholder="All tests pass and the implementation is complete"
+              data-testid="goal-condition"
+            />
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
+
+          <DialogFooter>
+            <Button type="submit" disabled={readOnly} data-testid="goal-start">
+              Start goal
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/goal/GoalControl.test.tsx
+++ b/web/src/components/goal/GoalControl.test.tsx
@@ -12,6 +12,25 @@ vi.mock("./GoalDialog", () => ({
   ),
 }));
 
+vi.mock("./CommandGoalDialog", () => ({
+  CommandGoalDialog: ({
+    open,
+    onStartGoal,
+  }: {
+    open: boolean;
+    onStartGoal: (condition: string) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="mock-command-goal-dialog"
+      data-open={open ? "true" : "false"}
+      onClick={() => onStartGoal("All tests pass")}
+    >
+      Start
+    </button>
+  ),
+}));
+
 const GOAL: Goal = {
   objective: "Ship goal mode",
   status: "active",
@@ -51,6 +70,26 @@ describe("GoalControl", () => {
     renderControl(null);
 
     expect(screen.getByTestId("goal-toggle")).toBeDisabled();
+  });
+
+  it("starts a command-backed goal", () => {
+    const onStartGoal = vi.fn();
+    render(
+      <TooltipProvider>
+        <GoalControl
+          mode="command"
+          conversationId="conv"
+          readOnly={false}
+          onStartGoal={onStartGoal}
+          backendLabel="Claude"
+        />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("goal-toggle"));
+    expect(screen.getByTestId("mock-command-goal-dialog")).toHaveAttribute("data-open", "true");
+    fireEvent.click(screen.getByTestId("mock-command-goal-dialog"));
+    expect(onStartGoal).toHaveBeenCalledWith("All tests pass");
   });
 
   it("renders the status pill", () => {

--- a/web/src/components/goal/GoalControl.tsx
+++ b/web/src/components/goal/GoalControl.tsx
@@ -4,28 +4,37 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { Goal } from "@/lib/goalApi";
 import { cn } from "@/lib/utils";
+import { CommandGoalDialog } from "./CommandGoalDialog";
 import { GoalDialog } from "./GoalDialog";
 import { formatGoalStatus } from "./goalUtils";
 
-interface GoalControlProps {
+interface GoalControlBaseProps {
   conversationId: string | null;
   readOnly: boolean;
-  goal: Goal | null;
-  onGoalChange: (goal: Goal | null) => void;
-  /** Optional backend name used by the current Codex-only tooltip. */
+  /** Optional backend name used in the control's accessible label and tooltip. */
   backendLabel?: string;
 }
 
+interface ManagedGoalControlProps extends GoalControlBaseProps {
+  mode?: "managed";
+  goal: Goal | null;
+  onGoalChange: (goal: Goal | null) => void;
+}
+
+interface CommandGoalControlProps extends GoalControlBaseProps {
+  mode: "command";
+  onStartGoal: (condition: string) => void;
+}
+
+type GoalControlProps = ManagedGoalControlProps | CommandGoalControlProps;
+
 /** Toolbar button plus dialog for a goal-capable session. */
-export function GoalControl({
-  conversationId,
-  readOnly,
-  goal,
-  onGoalChange,
-  backendLabel,
-}: GoalControlProps) {
+export function GoalControl(props: GoalControlProps) {
+  const { conversationId, readOnly, backendLabel } = props;
   const [open, setOpen] = useState(false);
   const goalName = backendLabel ? `${backendLabel} goal` : "goal";
+  const commandMode = props.mode === "command";
+  const goal = commandMode ? null : props.goal;
 
   useEffect(() => {
     if (!conversationId) setOpen(false);
@@ -43,9 +52,11 @@ export function GoalControl({
               "h-9 gap-1.5 px-2 text-xs md:h-8",
               goal && "border border-ring/30 text-foreground",
             )}
-            disabled={!conversationId}
-            aria-pressed={goal != null}
-            aria-label={goal ? `View ${goalName}` : `Set ${goalName}`}
+            disabled={!conversationId || (commandMode && readOnly)}
+            aria-pressed={commandMode ? undefined : goal != null}
+            aria-label={
+              goal ? `View ${goalName}` : commandMode ? `Start ${goalName}` : `Set ${goalName}`
+            }
             data-testid="goal-toggle"
             data-active={goal ? "true" : undefined}
             onClick={() => setOpen(true)}
@@ -54,16 +65,27 @@ export function GoalControl({
             <span>Goal</span>
           </Button>
         </TooltipTrigger>
-        <TooltipContent>{goal ? `View ${goalName}` : `Set ${goalName}`}</TooltipContent>
+        <TooltipContent>
+          {goal ? `View ${goalName}` : commandMode ? `Start ${goalName}` : `Set ${goalName}`}
+        </TooltipContent>
       </Tooltip>
-      <GoalDialog
-        open={open}
-        onOpenChange={setOpen}
-        conversationId={conversationId}
-        readOnly={readOnly}
-        goal={goal}
-        onGoalChange={onGoalChange}
-      />
+      {commandMode ? (
+        <CommandGoalDialog
+          open={open}
+          onOpenChange={setOpen}
+          readOnly={readOnly}
+          onStartGoal={props.onStartGoal}
+        />
+      ) : (
+        <GoalDialog
+          open={open}
+          onOpenChange={setOpen}
+          conversationId={conversationId}
+          readOnly={readOnly}
+          goal={goal}
+          onGoalChange={props.onGoalChange}
+        />
+      )}
     </>
   );
 }

--- a/web/src/components/goal/index.ts
+++ b/web/src/components/goal/index.ts
@@ -1,3 +1,4 @@
+export { CommandGoalDialog } from "./CommandGoalDialog";
 export { GoalControl, GoalStatusPill } from "./GoalControl";
 export { GoalDialog } from "./GoalDialog";
 export { useGoalState } from "./useGoalState";

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -105,6 +105,27 @@ function renderWithTooltips(ui: ReactElement) {
   return render(<TooltipProvider>{ui}</TooltipProvider>);
 }
 
+describe("Composer Claude goal control", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("sends the completion condition as a Claude /goal command", () => {
+    const onSend = vi.fn();
+    useChatStore.setState({ conversationId: "conv_polly" });
+    renderWithTooltips(<Composer {...composerProps({ onSend, showClaudeGoalControl: true })} />);
+
+    fireEvent.click(screen.getByTestId("goal-toggle"));
+    fireEvent.change(screen.getByTestId("goal-condition"), {
+      target: { value: "  Finish the implementation and pass tests  " },
+    });
+    fireEvent.click(screen.getByTestId("goal-start"));
+
+    expect(onSend).toHaveBeenCalledWith("/goal Finish the implementation and pass tests");
+  });
+});
+
 describe("Composer slash-command menu", () => {
   beforeEach(() => {
     // Two skills so the menu has skill rows distinct from the built-ins.

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1134,6 +1134,7 @@ export function ChatPage() {
       codexModelOptions={codexModelOptions}
       showCodexPlanMode={shouldShowCodexPlanModeControl(capabilitySource)}
       showGoalControl={shouldShowGoalControl(capabilitySource)}
+      showClaudeGoalControl={shouldShowPollyClaudeGoalControl(activeSession)}
       costRoutingEligible={costRoutingEligible}
       subAgentLabel={subAgentLabel}
     />
@@ -1363,6 +1364,8 @@ interface MainAgentSurfaceProps {
   showCodexPlanMode: boolean;
   /** Show the session Goal control. */
   showGoalControl?: boolean;
+  /** Show Polly's Claude SDK command-backed Goal control. */
+  showClaudeGoalControl?: boolean;
   /** Session passes `isCostRoutingSession` (polly orchestrator, not a child). */
   costRoutingEligible: boolean;
   /**
@@ -1433,6 +1436,7 @@ function MainAgentSurface({
   codexModelOptions,
   showCodexPlanMode,
   showGoalControl = false,
+  showClaudeGoalControl = false,
   costRoutingEligible,
   subAgentLabel,
 }: MainAgentSurfaceProps) {
@@ -1840,6 +1844,7 @@ function MainAgentSurface({
         codexModelOptions={codexModelOptions}
         showCodexPlanMode={showCodexPlanMode}
         showGoalControl={showGoalControl}
+        showClaudeGoalControl={showClaudeGoalControl}
         isTerminalFirst={isTerminalFirst}
         isNativeWrapper={isNativeWrapper}
         reconnectHint={liveness.kind === "runner_asleep" || liveness.kind === "host_asleep"}
@@ -3360,6 +3365,8 @@ interface ComposerProps {
   showCodexPlanMode: boolean;
   /** Show the session Goal control. */
   showGoalControl?: boolean;
+  /** Show Polly's Claude SDK command-backed Goal control. */
+  showClaudeGoalControl?: boolean;
   /**
    * Terminal-first session (Chat/Terminal pill present). Presentation
    * only: tightens the composer's bottom padding to `pb-1.5` so it sits
@@ -3827,6 +3834,7 @@ export function Composer({
   codexModelOptions,
   showCodexPlanMode,
   showGoalControl = false,
+  showClaudeGoalControl = false,
   isTerminalFirst = false,
   isNativeWrapper = false,
   reconnectHint = false,
@@ -4983,6 +4991,15 @@ export function Composer({
                 backendLabel="Codex"
               />
             )}
+            {showClaudeGoalControl && (
+              <GoalControl
+                mode="command"
+                conversationId={conversationId}
+                readOnly={isReadOnly}
+                onStartGoal={(condition) => onSend(`/goal ${condition}`)}
+                backendLabel="Claude"
+              />
+            )}
             <ComposerModelEffortLabel
               showModels={showModels}
               showEffort={showEffort}
@@ -5348,6 +5365,17 @@ export function shouldShowGoalControl(
   conv: { labels?: Record<string, string | null> | null } | null | undefined,
 ): boolean {
   return isCodexNativeSession(conv);
+}
+
+/** True for top-level Polly sessions running on the Claude SDK harness. */
+export function shouldShowPollyClaudeGoalControl(
+  session: Pick<Session, "agentName" | "harness" | "parentSessionId"> | null | undefined,
+): boolean {
+  return (
+    session?.parentSessionId == null &&
+    session?.agentName?.toLowerCase() === "polly" &&
+    session?.harness === "claude-sdk"
+  );
 }
 
 /**

--- a/web/src/pages/effortLevels.test.ts
+++ b/web/src/pages/effortLevels.test.ts
@@ -7,6 +7,7 @@ import {
   shouldShowEffortPicker,
   shouldShowGoalControl,
   shouldShowModelPicker,
+  shouldShowPollyClaudeGoalControl,
 } from "./ChatPage";
 
 const CODEX_MODEL_OPTIONS: NativeModelOption[] = [
@@ -173,5 +174,38 @@ describe("shouldShowGoalControl", () => {
     );
     expect(shouldShowGoalControl({ labels: {} })).toBe(false);
     expect(shouldShowGoalControl(null)).toBe(false);
+  });
+});
+
+describe("shouldShowPollyClaudeGoalControl", () => {
+  it("returns true only for top-level Polly sessions on Claude SDK", () => {
+    expect(
+      shouldShowPollyClaudeGoalControl({
+        agentName: "polly",
+        harness: "claude-sdk",
+        parentSessionId: null,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowPollyClaudeGoalControl({
+        agentName: "polly",
+        harness: "pi",
+        parentSessionId: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowPollyClaudeGoalControl({
+        agentName: "polly",
+        harness: "claude-sdk",
+        parentSessionId: "conv_parent",
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowPollyClaudeGoalControl({
+        agentName: "claude",
+        harness: "claude-sdk",
+        parentSessionId: null,
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Related issue

N/A

## Summary

Polly should be able to enter Goal mode without introducing a server-side goal contract. Claude SDK already treats `/goal <condition>` as a session-scoped completion loop, so this keeps the first Polly version entirely in the web client and delegates lifecycle behavior to Claude.

- Show the existing Goal control only for top-level Polly sessions whose effective harness is `claude-sdk`; harness overrides and child sessions stay unchanged.
- Add a focused completion-condition dialog that sends `/goal <condition>` through the normal chat path, with no new routes, schemas, or persisted server state.
- Preserve Codex-native's existing API-backed Goal dialog and cover the Polly flow with unit, composer, and browser E2E tests.

**ELI5:** Polly's Goal button now tells Claude "keep going until this is true" using Claude's own `/goal` command. Omnigent does not build or store a second copy of Claude's goal state.

```mermaid
flowchart LR
  U["Polly Goal button"] --> D["Completion condition dialog"]
  D --> M["Normal chat message: /goal condition"]
  M --> C["Claude SDK goal loop"]
```

## Test Plan

- [x] `npm test -- src/components/goal/CommandGoalDialog.test.tsx src/components/goal/GoalControl.test.tsx src/pages/ChatPage.composer.test.tsx src/pages/effortLevels.test.ts` (`128 passed`)
- [x] `pytest tests/e2e_ui/chat/test_polly_claude_goal_mode.py -v --confcutdir=tests/e2e_ui --ui-base-url http://127.0.0.1:15173` (`1 passed`)
- [x] Targeted Oxlint on all changed TypeScript files (no errors)
- [x] Ruff check and format check for the new E2E test
- [x] Manual in-app Browser verification against a real local server, host, Polly agent, and Claude SDK runner

`npm run type-check` is locally blocked on latest main's new `rrule` dependency because this environment cannot reach the npm registry. CI installs from its normal dependency cache and will run the repository-wide check.

## Demo

Manual Browser verification exercised the complete flow: launch top-level Polly on Claude SDK, open the Goal dialog, submit a completion condition, observe the exact `/goal <condition>` user turn, and receive the requested completion response. The isolated workspace remained unchanged.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The E2E test patches a real seeded session to the exact top-level Polly + Claude SDK identity, validates empty input, and asserts that submitting a trimmed condition posts the exact plaintext `/goal <condition>` message through the normal session event endpoint. Manual verification additionally confirmed Claude SDK completed the goal in a real session.

## Changelog

Polly sessions running on Claude SDK can start Goal mode from the chat composer.
