### PR TITLE
Add a provider-neutral remote sandbox runtime

### DIFF
--- a/omnigent/onboarding/sandboxes/__init__.py
+++ b/omnigent/onboarding/sandboxes/__init__.py
@@ -58,6 +58,7 @@ _LAUNCHERS: dict[str, str] = {
     "lakebox": "omnigent.onboarding.sandboxes.lakebox:LakeboxLauncher",
     "modal": "omnigent.onboarding.sandboxes.modal:ModalSandboxLauncher",
     "daytona": "omnigent.onboarding.sandboxes.daytona:DaytonaSandboxLauncher",
+    "remote": "omnigent.onboarding.sandboxes.remote:RemoteSandboxLauncher",
     "boxlite": "omnigent.onboarding.sandboxes.boxlite:BoxliteSandboxLauncher",
     # CoreWeave Sandbox via the official cwsandbox SDK (the
     # `omnigent[cwsandbox]` extra), imported lazily like modal/daytona.

--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -409,6 +409,14 @@ class SandboxLauncher(ABC):
     # of being silently revived onto an empty workspace.
     can_resume: ClassVar[bool] = False
 
+    def set_launch_context(self, *, owner: str, session_id: str | None) -> None:
+        """Bind authenticated launch metadata to this launcher instance.
+
+        Providers that delegate provisioning to an external control plane can
+        override this hook. Direct providers ignore it by default.
+        """
+        del owner, session_id
+
     @abstractmethod
     def prepare(self) -> None:
         """

--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -656,6 +656,19 @@ class SandboxLauncher(ABC):
         """
         raise self._capability_error("configure keep-alive")
 
+    def set_activity(self, sandbox_id: str, *, active: bool) -> None:
+        """Tell a lifecycle-aware provider whether the sandbox has active work.
+
+        The default is deliberately a no-op: most providers either infer
+        activity themselves or do not expose a policy hook. Managed remote
+        controllers can override this to protect a long-running turn from an
+        idle timer and restore the normal idle policy when the turn finishes.
+
+        :param sandbox_id: Target sandbox.
+        :param active: ``True`` while a turn or background task is running.
+        """
+        del sandbox_id, active
+
     @abstractmethod
     def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
         """

--- a/omnigent/onboarding/sandboxes/remote.py
+++ b/omnigent/onboarding/sandboxes/remote.py
@@ -17,6 +17,10 @@ from omnigent.onboarding.sandboxes.base import RemoteCommandResult, SandboxLaunc
 DEFAULT_TOKEN_ENV = "OMNIGENT_REMOTE_SANDBOX_TOKEN"
 _RESUME_TIMEOUT_S = 15 * 60
 _RESUME_POLL_INTERVAL_S = 2
+_MAX_RESPONSE_BYTES = 1024 * 1024
+_MAX_ERROR_BYTES = 4096
+_RETRYABLE_STATUS_CODES = frozenset({429, 502, 503, 504})
+_RETRY_DELAYS_S = (0.25, 1.0)
 
 
 class RemoteSandboxLauncher(SandboxLauncher):
@@ -75,6 +79,7 @@ class RemoteSandboxLauncher(SandboxLauncher):
                 "env": env,
             },
             timeout=15 * 60,
+            retryable=True,
         )
         runtime = self._mapping(body.get("runtime"), "runtime")
         runtime_id = runtime.get("id")
@@ -108,13 +113,23 @@ class RemoteSandboxLauncher(SandboxLauncher):
         return completed
 
     def terminate(self, sandbox_id: str) -> None:
-        self._request("DELETE", f"/api/v1/sandbox-runtimes/{sandbox_id}")
+        self._request("DELETE", f"/api/v1/sandbox-runtimes/{sandbox_id}", retryable=True)
+
+    def set_activity(self, sandbox_id: str, *, active: bool) -> None:
+        self._request(
+            "POST",
+            f"/api/v1/sandbox-runtimes/{sandbox_id}/activity",
+            {"active": active},
+            timeout=30,
+            retryable=True,
+        )
 
     def resume(self, sandbox_id: str) -> None:
         self._request(
             "POST",
             f"/api/v1/sandbox-runtimes/{sandbox_id}/resume",
             timeout=30,
+            retryable=True,
         )
         deadline = time.monotonic() + _RESUME_TIMEOUT_S
         while time.monotonic() < deadline:
@@ -152,7 +167,7 @@ class RemoteSandboxLauncher(SandboxLauncher):
 
     def _runtime(self, sandbox_id: str) -> Mapping[str, object] | None:
         try:
-            body = self._request("GET", f"/api/v1/sandbox-runtimes/{sandbox_id}")
+            body = self._request("GET", f"/api/v1/sandbox-runtimes/{sandbox_id}", retryable=True)
         except click.ClickException as exc:
             if "(404)" in exc.message:
                 return None
@@ -166,6 +181,7 @@ class RemoteSandboxLauncher(SandboxLauncher):
         body: Mapping[str, object] | None = None,
         *,
         timeout: int = 90,
+        retryable: bool = False,
     ) -> Mapping[str, object]:
         token = os.environ.get(self._token_env)
         if not token:
@@ -184,16 +200,30 @@ class RemoteSandboxLauncher(SandboxLauncher):
                 "X-Sandbox-Runtime-API-Version": "1",
             },
         )
-        try:
-            with urlopen(request, timeout=timeout) as response:
-                raw = response.read()
-        except HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace")[:500]
-            raise click.ClickException(
-                f"remote sandbox controller request failed ({exc.code}): {detail}"
-            ) from exc
-        except (URLError, TimeoutError, OSError) as exc:
-            raise click.ClickException(f"remote sandbox controller is unavailable: {exc}") from exc
+        attempts = len(_RETRY_DELAYS_S) + 1 if retryable else 1
+        raw = b""
+        for attempt in range(attempts):
+            try:
+                with urlopen(request, timeout=timeout) as response:
+                    raw = self._read_bounded(response, _MAX_RESPONSE_BYTES)
+                break
+            except HTTPError as exc:
+                if exc.code in _RETRYABLE_STATUS_CODES and attempt + 1 < attempts:
+                    time.sleep(_RETRY_DELAYS_S[attempt])
+                    continue
+                detail = self._read_bounded(exc, _MAX_ERROR_BYTES).decode(
+                    "utf-8", errors="replace"
+                )
+                raise click.ClickException(
+                    f"remote sandbox controller request failed ({exc.code}): {detail}"
+                ) from exc
+            except (URLError, TimeoutError, OSError) as exc:
+                if attempt + 1 < attempts:
+                    time.sleep(_RETRY_DELAYS_S[attempt])
+                    continue
+                raise click.ClickException(
+                    f"remote sandbox controller is unavailable: {exc}"
+                ) from exc
         if not raw:
             return {}
         try:
@@ -201,6 +231,18 @@ class RemoteSandboxLauncher(SandboxLauncher):
         except ValueError as exc:
             raise click.ClickException("remote sandbox controller returned invalid JSON") from exc
         return self._mapping(value, "response")
+
+    @staticmethod
+    def _read_bounded(response: object, limit: int) -> bytes:
+        read = getattr(response, "read", None)
+        if not callable(read):
+            raise click.ClickException("remote sandbox controller returned an invalid response")
+        raw = read(limit + 1)
+        if len(raw) > limit:
+            raise click.ClickException(
+                f"remote sandbox controller response exceeded {limit} bytes"
+            )
+        return raw
 
     @staticmethod
     def _mapping(value: object, name: str) -> Mapping[str, object]:

--- a/omnigent/onboarding/sandboxes/remote.py
+++ b/omnigent/onboarding/sandboxes/remote.py
@@ -107,28 +107,6 @@ class RemoteSandboxLauncher(SandboxLauncher):
             )
         return completed
 
-    def run_background(
-        self,
-        sandbox_id: str,
-        command: str,
-        *,
-        log_path: str = "/tmp/omnigent-host.log",
-    ) -> RemoteCommandResult:
-        del log_path
-        self._ensure_running(sandbox_id)
-        body = self._request(
-            "POST",
-            f"/api/v1/sandbox-runtimes/{sandbox_id}/commands",
-            {"command": command, "detached": True},
-            timeout=30,
-        )
-        result = self._mapping(body.get("result"), "command result")
-        return RemoteCommandResult(
-            returncode=int(result.get("exitCode") or 0),
-            stdout=str(result.get("stdout") or "launched\n"),
-            stderr=str(result.get("stderr") or ""),
-        )
-
     def terminate(self, sandbox_id: str) -> None:
         self._request("DELETE", f"/api/v1/sandbox-runtimes/{sandbox_id}")
 

--- a/omnigent/onboarding/sandboxes/remote.py
+++ b/omnigent/onboarding/sandboxes/remote.py
@@ -1,0 +1,201 @@
+"""Managed sandbox launcher backed by an external runtime controller."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping, Sequence
+from typing import ClassVar
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import click
+
+from omnigent.onboarding.sandboxes.base import RemoteCommandResult, SandboxLauncher
+
+DEFAULT_TOKEN_ENV = "OMNIGENT_REMOTE_SANDBOX_TOKEN"
+
+
+class RemoteSandboxLauncher(SandboxLauncher):
+    """Delegate managed sandbox primitives to a versioned HTTP control plane."""
+
+    provider: ClassVar[str] = "remote"
+    supports_cli_bootstrap: ClassVar[bool] = False
+    can_resume: ClassVar[bool] = True
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        token_env: str | None = None,
+        env: Sequence[str] | None = None,
+    ) -> None:
+        self._url = url.rstrip("/")
+        self._token_env = token_env or DEFAULT_TOKEN_ENV
+        self._env_names = tuple(env or ())
+        self._owner: str | None = None
+        self._session_id: str | None = None
+
+    def set_launch_context(self, *, owner: str, session_id: str | None) -> None:
+        self._owner = owner
+        self._session_id = session_id
+
+    def prepare(self) -> None:
+        if not self._url.startswith(("https://", "http://localhost", "http://127.0.0.1")):
+            raise click.ClickException(
+                "remote sandbox controller URL must use HTTPS (or localhost for development)"
+            )
+        if not os.environ.get(self._token_env):
+            raise click.ClickException(
+                f"remote sandbox controller token is not set in {self._token_env}"
+            )
+        if self._owner is None or self._session_id is None:
+            raise click.ClickException("remote sandbox launch context is incomplete")
+
+    def provision(self, name: str) -> str:
+        self.prepare()
+        env: dict[str, str] = {}
+        for env_name in self._env_names:
+            value = os.environ.get(env_name)
+            if value is None:
+                raise click.ClickException(
+                    f"sandbox.remote.env names '{env_name}' but it is not set"
+                )
+            env[env_name] = value
+        body = self._request(
+            "POST",
+            "/api/v1/sandbox-runtimes",
+            {
+                "name": name,
+                "owner": self._owner,
+                "sessionId": self._session_id,
+                "env": env,
+            },
+            timeout=15 * 60,
+        )
+        runtime = self._mapping(body.get("runtime"), "runtime")
+        runtime_id = runtime.get("id")
+        if not isinstance(runtime_id, str) or not runtime_id:
+            raise click.ClickException("remote sandbox controller returned no runtime id")
+        return runtime_id
+
+    def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
+        body = self._request(
+            "POST",
+            f"/api/v1/sandbox-runtimes/{sandbox_id}/commands",
+            {"command": command, "timeoutSeconds": 15 * 60},
+            timeout=16 * 60,
+        )
+        result = self._mapping(body.get("result"), "command result")
+        exit_code = result.get("exitCode")
+        if exit_code is not None and not isinstance(exit_code, int):
+            raise click.ClickException("remote sandbox controller returned an invalid exit code")
+        stdout = result.get("stdout", "")
+        stderr = result.get("stderr", "")
+        if not isinstance(stdout, str) or not isinstance(stderr, str):
+            raise click.ClickException("remote sandbox controller returned invalid command output")
+        completed = RemoteCommandResult(returncode=exit_code or 0, stdout=stdout, stderr=stderr)
+        if check and completed.returncode != 0:
+            detail = stderr.strip() or stdout.strip() or "no output"
+            raise click.ClickException(
+                f"remote command failed in sandbox '{sandbox_id}' "
+                f"(exit {completed.returncode}): {detail}"
+            )
+        return completed
+
+    def run_background(
+        self,
+        sandbox_id: str,
+        command: str,
+        *,
+        log_path: str = "/tmp/omnigent-host.log",
+    ) -> RemoteCommandResult:
+        del log_path
+        body = self._request(
+            "POST",
+            f"/api/v1/sandbox-runtimes/{sandbox_id}/commands",
+            {"command": command, "detached": True},
+            timeout=30,
+        )
+        result = self._mapping(body.get("result"), "command result")
+        return RemoteCommandResult(
+            returncode=int(result.get("exitCode") or 0),
+            stdout=str(result.get("stdout") or "launched\n"),
+            stderr=str(result.get("stderr") or ""),
+        )
+
+    def terminate(self, sandbox_id: str) -> None:
+        self._request("DELETE", f"/api/v1/sandbox-runtimes/{sandbox_id}")
+
+    def resume(self, sandbox_id: str) -> None:
+        self._request("POST", f"/api/v1/sandbox-runtimes/{sandbox_id}/resume")
+
+    def is_running(self, sandbox_id: str) -> bool | None:
+        runtime = self._runtime(sandbox_id)
+        return None if runtime is None else runtime.get("state") == "running"
+
+    def exists(self, sandbox_id: str) -> bool | None:
+        runtime = self._runtime(sandbox_id)
+        return runtime is not None and runtime.get("state") != "deleted"
+
+    def _runtime(self, sandbox_id: str) -> Mapping[str, object] | None:
+        try:
+            body = self._request("GET", f"/api/v1/sandbox-runtimes/{sandbox_id}")
+        except click.ClickException as exc:
+            if "(404)" in exc.message:
+                return None
+            raise
+        return self._mapping(body.get("runtime"), "runtime")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body: Mapping[str, object] | None = None,
+        *,
+        timeout: int = 90,
+    ) -> Mapping[str, object]:
+        token = os.environ.get(self._token_env)
+        if not token:
+            raise click.ClickException(
+                f"remote sandbox controller token is not set in {self._token_env}"
+            )
+        data = json.dumps(body).encode() if body is not None else None
+        request = Request(
+            f"{self._url}{path}",
+            method=method,
+            data=data,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "X-Sandbox-Runtime-API-Version": "1",
+            },
+        )
+        try:
+            with urlopen(request, timeout=timeout) as response:
+                raw = response.read()
+        except HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:500]
+            raise click.ClickException(
+                f"remote sandbox controller request failed ({exc.code}): {detail}"
+            ) from exc
+        except (URLError, TimeoutError, OSError) as exc:
+            raise click.ClickException(
+                f"remote sandbox controller is unavailable: {exc}"
+            ) from exc
+        if not raw:
+            return {}
+        try:
+            value = json.loads(raw)
+        except ValueError as exc:
+            raise click.ClickException(
+                "remote sandbox controller returned invalid JSON"
+            ) from exc
+        return self._mapping(value, "response")
+
+    @staticmethod
+    def _mapping(value: object, name: str) -> Mapping[str, object]:
+        if not isinstance(value, dict):
+            raise click.ClickException(f"remote sandbox controller returned an invalid {name}")
+        return value

--- a/omnigent/onboarding/sandboxes/remote.py
+++ b/omnigent/onboarding/sandboxes/remote.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from collections.abc import Mapping, Sequence
 from typing import ClassVar
 from urllib.error import HTTPError, URLError
@@ -14,6 +15,8 @@ import click
 from omnigent.onboarding.sandboxes.base import RemoteCommandResult, SandboxLauncher
 
 DEFAULT_TOKEN_ENV = "OMNIGENT_REMOTE_SANDBOX_TOKEN"
+_RESUME_TIMEOUT_S = 15 * 60
+_RESUME_POLL_INTERVAL_S = 2
 
 
 class RemoteSandboxLauncher(SandboxLauncher):
@@ -80,6 +83,7 @@ class RemoteSandboxLauncher(SandboxLauncher):
         return runtime_id
 
     def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
+        self._ensure_running(sandbox_id)
         body = self._request(
             "POST",
             f"/api/v1/sandbox-runtimes/{sandbox_id}/commands",
@@ -111,6 +115,7 @@ class RemoteSandboxLauncher(SandboxLauncher):
         log_path: str = "/tmp/omnigent-host.log",
     ) -> RemoteCommandResult:
         del log_path
+        self._ensure_running(sandbox_id)
         body = self._request(
             "POST",
             f"/api/v1/sandbox-runtimes/{sandbox_id}/commands",
@@ -128,7 +133,29 @@ class RemoteSandboxLauncher(SandboxLauncher):
         self._request("DELETE", f"/api/v1/sandbox-runtimes/{sandbox_id}")
 
     def resume(self, sandbox_id: str) -> None:
-        self._request("POST", f"/api/v1/sandbox-runtimes/{sandbox_id}/resume")
+        self._request(
+            "POST",
+            f"/api/v1/sandbox-runtimes/{sandbox_id}/resume",
+            timeout=30,
+        )
+        deadline = time.monotonic() + _RESUME_TIMEOUT_S
+        while time.monotonic() < deadline:
+            runtime = self._runtime(sandbox_id)
+            if runtime is None:
+                raise click.ClickException(
+                    f"remote sandbox runtime '{sandbox_id}' disappeared while waking"
+                )
+            state = runtime.get("state")
+            if state == "running":
+                return
+            if state in {"deleted", "error"}:
+                raise click.ClickException(
+                    f"remote sandbox runtime '{sandbox_id}' could not wake (state: {state})"
+                )
+            time.sleep(_RESUME_POLL_INTERVAL_S)
+        raise click.ClickException(
+            f"remote sandbox runtime '{sandbox_id}' did not wake within 15 minutes"
+        )
 
     def is_running(self, sandbox_id: str) -> bool | None:
         runtime = self._runtime(sandbox_id)
@@ -137,6 +164,13 @@ class RemoteSandboxLauncher(SandboxLauncher):
     def exists(self, sandbox_id: str) -> bool | None:
         runtime = self._runtime(sandbox_id)
         return runtime is not None and runtime.get("state") != "deleted"
+
+    def _ensure_running(self, sandbox_id: str) -> None:
+        runtime = self._runtime(sandbox_id)
+        if runtime is None:
+            raise click.ClickException(f"remote sandbox runtime '{sandbox_id}' was not found")
+        if runtime.get("state") != "running":
+            self.resume(sandbox_id)
 
     def _runtime(self, sandbox_id: str) -> Mapping[str, object] | None:
         try:
@@ -181,17 +215,13 @@ class RemoteSandboxLauncher(SandboxLauncher):
                 f"remote sandbox controller request failed ({exc.code}): {detail}"
             ) from exc
         except (URLError, TimeoutError, OSError) as exc:
-            raise click.ClickException(
-                f"remote sandbox controller is unavailable: {exc}"
-            ) from exc
+            raise click.ClickException(f"remote sandbox controller is unavailable: {exc}") from exc
         if not raw:
             return {}
         try:
             value = json.loads(raw)
         except ValueError as exc:
-            raise click.ClickException(
-                "remote sandbox controller returned invalid JSON"
-            ) from exc
+            raise click.ClickException("remote sandbox controller returned invalid JSON") from exc
         return self._mapping(value, "response")
 
     @staticmethod

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1886,6 +1886,7 @@ async def launch_managed_host(
     config: ManagedSandboxConfig,
     owner: str,
     host_store: HostStore,
+    session_id: str | None = None,
     repo: RepoWorkspace | None = None,
     on_stage: Callable[[str], None] | None = None,
 ) -> ManagedHostLaunch:
@@ -1909,6 +1910,8 @@ async def launch_managed_host(
     :param host_store: Persistent host registrations — receives the
         pre-registered host row and is polled for the sandbox host
         coming online.
+    :param session_id: Canonical session id for provider-side ownership
+        metadata, when the launch is associated with a session.
     :param repo: Parsed repository-URL workspace to clone into the
         sandbox as the session's working directory, or ``None`` for
         an empty workspace. Private repositories authenticate via the
@@ -1961,6 +1964,7 @@ async def relaunch_managed_host(
     config: ManagedSandboxConfig,
     host: Host,
     host_store: HostStore,
+    session_id: str | None = None,
     repo: RepoWorkspace | None = None,
     on_stage: Callable[[str], None] | None = None,
 ) -> ManagedHostLaunch:
@@ -1987,6 +1991,8 @@ async def relaunch_managed_host(
     :param host: The existing managed host row to relaunch
         (``sandbox_provider`` set; callers guard on that).
     :param host_store: Persistent host registrations.
+    :param session_id: Canonical session id for provider-side ownership
+        metadata, when the relaunch is associated with a session.
     :param repo: Repository to re-clone as the workspace, or ``None``
         for an empty workspace.
     :param on_stage: Progress observer forwarded to
@@ -2234,6 +2240,53 @@ def host_sandbox_is_running(
     if launcher is None or host.sandbox_id is None:
         return None
     return launcher.is_running(host.sandbox_id)
+
+
+def host_sandbox_exists(
+    host: Host,
+    config: ManagedSandboxConfig | None,
+) -> bool | None:
+    """Ask the matched provider whether the recorded sandbox still exists."""
+    launcher = _launcher_for_teardown(host, config)
+    if launcher is None or host.sandbox_id is None:
+        return None
+    return launcher.exists(host.sandbox_id)
+
+
+async def set_managed_host_activity(
+    host_id: str,
+    host_store: HostStore,
+    config: ManagedSandboxConfig | None,
+    *,
+    active: bool,
+) -> None:
+    """Propagate turn activity to a lifecycle-aware managed sandbox.
+
+    This is best-effort by design: publishing a model status edge must never
+    fail because an optional provider policy endpoint is unavailable. The
+    platform-owned remote launcher uses the signal to extend the provider
+    safety timer while work is active and restore the normal idle timer once
+    the session is quiescent.
+    """
+    host = await asyncio.to_thread(host_store.get_host, host_id)
+    if host is None or host.sandbox_id is None:
+        return
+    launcher = _launcher_for_teardown(host, config)
+    if launcher is None:
+        return
+    try:
+        await asyncio.to_thread(
+            launcher.set_activity,
+            host.sandbox_id,
+            active=active,
+        )
+    except Exception:  # noqa: BLE001 -- optional provider boundary must soft-fail
+        _logger.warning(
+            "Could not update activity policy for managed host %s (sandbox %s)",
+            host_id,
+            host.sandbox_id,
+            exc_info=True,
+        )
 
 
 # ── Managed-host wake (resume a dormant host on demand) ─────────────────────

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -160,10 +160,21 @@ SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset(
         "e2b",
         "openshell",
         "kubernetes",
+        "remote",
     }
 )
 PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset(
-    {"modal", "daytona", "boxlite", "cwsandbox", "islo", "e2b", "openshell", "kubernetes"}
+    {
+        "modal",
+        "daytona",
+        "boxlite",
+        "cwsandbox",
+        "islo",
+        "e2b",
+        "openshell",
+        "kubernetes",
+        "remote",
+    }
 )
 
 # How long a managed launch waits for the sandboxed host to register
@@ -217,6 +228,10 @@ OPENSHELL_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 # reconnects while still expiring tokens of Pods nobody deleted. A relaunch
 # mints a fresh token (and the per-Pod token Secret is replaced).
 KUBERNETES_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
+
+# Remote controllers own the backing provider lifecycle. Keep Omnigent's host
+# token bounded while allowing a stopped runtime to resume in place.
+REMOTE_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 
 # The cwsandbox launch-token TTL is NOT a constant: CW Sandbox's lifetime is
 # operator-overridable (OMNIGENT_CWSANDBOX_MAX_LIFETIME_S), so the TTL is
@@ -833,6 +848,13 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
             resources=_parse_kubernetes_resources(raw),
         )
         token_ttl_s = KUBERNETES_MANAGED_TOKEN_TTL_S
+    elif provider == "remote":
+        launcher_factory = _remote_launcher_factory(
+            url=_parse_provider_string(raw, "remote", "url"),
+            token_env=_parse_provider_string(raw, "remote", "token_env"),
+            env=_parse_provider_env(raw, "remote"),
+        )
+        token_ttl_s = REMOTE_MANAGED_TOKEN_TTL_S
     else:
         launcher_factory = _unsupported_launcher_factory(provider)
         # Never consulted (the factory rejects before any token is
@@ -944,6 +966,24 @@ def _daytona_launcher_factory(
         from omnigent.onboarding.sandboxes.daytona import DaytonaSandboxLauncher
 
         return DaytonaSandboxLauncher(image=image, env=env)
+
+    return _build
+
+
+def _remote_launcher_factory(
+    *,
+    url: str | None,
+    token_env: str | None,
+    env: list[str] | None,
+) -> Callable[[], SandboxLauncher]:
+    """Build a launcher that delegates lifecycle operations over HTTP."""
+    if url is None:
+        raise ValueError("server config 'sandbox.remote.url' is required")
+
+    def _build() -> SandboxLauncher:
+        from omnigent.onboarding.sandboxes.remote import RemoteSandboxLauncher
+
+        return RemoteSandboxLauncher(url=url, token_env=token_env, env=env)
 
     return _build
 
@@ -1888,6 +1928,7 @@ async def launch_managed_host(
         startup, or registration fails.
     """
     launcher = config.launcher_factory()
+    launcher.set_launch_context(owner=owner, session_id=session_id)
     host_id = uuid.uuid4().hex
     # Visible label in the host picker; (owner, name) is the hosts
     # table PK, so embed the host_id's leading hex for uniqueness
@@ -1965,6 +2006,7 @@ async def relaunch_managed_host(
                 "was launched with is no longer configured on this server"
             ),
         )
+    launcher.set_launch_context(owner=host.user_id, session_id=session_id)
     # The old generation is normally already dead (that is why we are
     # here), but terminate defensively so a transient tunnel outage
     # can never leave two live sandboxes claiming one host identity.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -181,6 +181,7 @@ from omnigent.server.managed_hosts import (
     RepoWorkspace,
     host_resume_supported,
     host_sandbox_is_running,
+    set_managed_host_activity,
 )
 from omnigent.server.mcp_pool import ServerMcpPool
 from omnigent.server.permissions import check_session_access
@@ -6944,6 +6945,7 @@ async def _provision_managed_sandbox(
                 config=sandbox_config,
                 host=relaunch_host,
                 host_store=host_store,
+                session_id=session_id,
                 repo=repo,
                 on_stage=_on_stage,
             )
@@ -6951,6 +6953,7 @@ async def _provision_managed_sandbox(
             config=sandbox_config,
             owner=owner,
             host_store=host_store,
+            session_id=session_id,
             repo=repo,
             on_stage=_on_stage,
         )
@@ -20734,6 +20737,18 @@ def create_sessions_router(
                 response_id=response_id,
                 background_task_count=bg_count,
             )
+            host_store = getattr(request.app.state, "host_store", None)
+            sandbox_config = getattr(request.app.state, "sandbox_config", None)
+            if conv.host_id is not None and host_store is not None:
+                await set_managed_host_activity(
+                    conv.host_id,
+                    host_store,
+                    sandbox_config,
+                    active=(
+                        status in {"running", "waiting"}
+                        or _session_background_task_count_cache.get(session_id, 0) > 0
+                    ),
+                )
             forward_body = body.model_dump()
             forward_body["data"] = await _enrich_idle_status_with_subagent_output(
                 forward_body["data"], status, session_id, conversation_store

--- a/tests/onboarding/sandboxes/test_remote.py
+++ b/tests/onboarding/sandboxes/test_remote.py
@@ -81,6 +81,38 @@ def test_run_uses_controller_command_endpoint_and_preserves_output(
     assert result.stdout == "hello\n"
 
 
+def test_background_run_uses_the_shared_durable_shell_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payloads: list[dict[str, object]] = []
+
+    def _urlopen(request: Request, *, timeout: int) -> _Response:
+        del timeout
+        if request.method == "GET":
+            return _Response({"runtime": {"id": "runtime_abc", "state": "running"}})
+        payloads.append(json.loads(request.data or b"{}"))
+        return _Response({"result": {"exitCode": 0, "stdout": "launched\n", "stderr": ""}})
+
+    monkeypatch.setenv("OMNIGENT_REMOTE_SANDBOX_TOKEN", "runtime-secret")
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.remote.urlopen", _urlopen)
+    launcher = RemoteSandboxLauncher(url="https://platform.example.com")
+
+    result = launcher.run_background(
+        "runtime_abc",
+        "FOO=bar omnigent host --server https://omnigent.example.com",
+    )
+
+    assert result.stdout == "launched\n"
+    assert payloads == [
+        {
+            "command": "setsid nohup sh -c "
+            "'FOO=bar omnigent host --server https://omnigent.example.com' "
+            "> /tmp/omnigent-host.log 2>&1 < /dev/null & echo launched",
+            "timeoutSeconds": 15 * 60,
+        }
+    ]
+
+
 def test_stopped_runtime_is_resumed_through_the_controller(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/onboarding/sandboxes/test_remote.py
+++ b/tests/onboarding/sandboxes/test_remote.py
@@ -1,0 +1,105 @@
+"""Tests for the external sandbox runtime controller adapter."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.request import Request
+
+import pytest
+
+from omnigent.onboarding.sandboxes.remote import RemoteSandboxLauncher
+
+
+class _Response:
+    def __init__(self, body: dict[str, object] | None = None) -> None:
+        self._body = json.dumps(body).encode() if body is not None else b""
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def test_provision_sends_launch_context_and_returns_stable_runtime_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[Request] = []
+
+    def _urlopen(request: Request, *, timeout: int) -> _Response:
+        assert timeout == 15 * 60
+        requests.append(request)
+        return _Response({"runtime": {"id": "runtime_abc", "state": "running"}})
+
+    monkeypatch.setenv("OMNIGENT_REMOTE_SANDBOX_TOKEN", "runtime-secret")
+    monkeypatch.setenv("PLATFORM_GIT_BROKER_URL", "https://platform.example.com/git")
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.remote.urlopen", _urlopen)
+    launcher = RemoteSandboxLauncher(
+        url="https://platform.example.com",
+        env=["PLATFORM_GIT_BROKER_URL"],
+    )
+    launcher.set_launch_context(owner="alice@example.com", session_id="conv_alice")
+
+    assert launcher.provision("managed-abcd1234") == "runtime_abc"
+    payload = json.loads(requests[0].data or b"{}")
+    assert payload == {
+        "name": "managed-abcd1234",
+        "owner": "alice@example.com",
+        "sessionId": "conv_alice",
+        "env": {"PLATFORM_GIT_BROKER_URL": "https://platform.example.com/git"},
+    }
+    assert requests[0].headers["Authorization"] == "Bearer runtime-secret"
+    assert requests[0].headers["X-sandbox-runtime-api-version"] == "1"
+
+
+def test_run_uses_controller_command_endpoint_and_preserves_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, Any] = {}
+
+    def _urlopen(request: Request, *, timeout: int) -> _Response:
+        del timeout
+        seen["url"] = request.full_url
+        seen["payload"] = json.loads(request.data or b"{}")
+        return _Response({"result": {"exitCode": 0, "stdout": "hello\n", "stderr": ""}})
+
+    monkeypatch.setenv("OMNIGENT_REMOTE_SANDBOX_TOKEN", "runtime-secret")
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.remote.urlopen", _urlopen)
+    launcher = RemoteSandboxLauncher(url="https://platform.example.com")
+
+    result = launcher.run("runtime_abc", "printf hello")
+
+    assert seen["url"].endswith("/api/v1/sandbox-runtimes/runtime_abc/commands")
+    assert seen["payload"] == {"command": "printf hello", "timeoutSeconds": 15 * 60}
+    assert result.returncode == 0
+    assert result.stdout == "hello\n"
+
+
+def test_stopped_runtime_is_resumed_through_the_controller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[tuple[str, str]] = []
+
+    def _urlopen(request: Request, *, timeout: int) -> _Response:
+        del timeout
+        requests.append((request.method, request.full_url))
+        if request.method == "GET":
+            return _Response({"runtime": {"id": "runtime_abc", "state": "stopped"}})
+        return _Response({"runtime": {"id": "runtime_abc", "state": "running"}})
+
+    monkeypatch.setenv("OMNIGENT_REMOTE_SANDBOX_TOKEN", "runtime-secret")
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.remote.urlopen", _urlopen)
+    launcher = RemoteSandboxLauncher(url="https://platform.example.com")
+
+    assert launcher.is_running("runtime_abc") is False
+    assert launcher.exists("runtime_abc") is True
+    launcher.resume("runtime_abc")
+
+    assert requests[-1] == (
+        "POST",
+        "https://platform.example.com/api/v1/sandbox-runtimes/runtime_abc/resume",
+    )

--- a/tests/onboarding/sandboxes/test_remote.py
+++ b/tests/onboarding/sandboxes/test_remote.py
@@ -65,6 +65,8 @@ def test_run_uses_controller_command_endpoint_and_preserves_output(
         del timeout
         seen["url"] = request.full_url
         seen["payload"] = json.loads(request.data or b"{}")
+        if request.method == "GET":
+            return _Response({"runtime": {"id": "runtime_abc", "state": "running"}})
         return _Response({"result": {"exitCode": 0, "stdout": "hello\n", "stderr": ""}})
 
     monkeypatch.setenv("OMNIGENT_REMOTE_SANDBOX_TOKEN", "runtime-secret")
@@ -83,23 +85,61 @@ def test_stopped_runtime_is_resumed_through_the_controller(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     requests: list[tuple[str, str]] = []
+    get_states = iter(["stopped", "stopped", "running"])
 
     def _urlopen(request: Request, *, timeout: int) -> _Response:
         del timeout
         requests.append((request.method, request.full_url))
         if request.method == "GET":
-            return _Response({"runtime": {"id": "runtime_abc", "state": "stopped"}})
-        return _Response({"runtime": {"id": "runtime_abc", "state": "running"}})
+            return _Response({"runtime": {"id": "runtime_abc", "state": next(get_states)}})
+        return _Response({"runtime": {"id": "runtime_abc", "state": "provisioning"}})
 
     monkeypatch.setenv("OMNIGENT_REMOTE_SANDBOX_TOKEN", "runtime-secret")
     monkeypatch.setattr("omnigent.onboarding.sandboxes.remote.urlopen", _urlopen)
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.remote.time.sleep", lambda _seconds: None)
     launcher = RemoteSandboxLauncher(url="https://platform.example.com")
 
     assert launcher.is_running("runtime_abc") is False
     assert launcher.exists("runtime_abc") is True
     launcher.resume("runtime_abc")
 
-    assert requests[-1] == (
+    assert (
         "POST",
         "https://platform.example.com/api/v1/sandbox-runtimes/runtime_abc/resume",
+    ) in requests
+    assert requests[-1] == (
+        "GET",
+        "https://platform.example.com/api/v1/sandbox-runtimes/runtime_abc",
     )
+
+
+def test_first_command_polls_a_stopped_runtime_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[tuple[str, str]] = []
+    states = iter(["stopped", "provisioning", "running"])
+
+    def _urlopen(request: Request, *, timeout: int) -> _Response:
+        del timeout
+        requests.append((request.method, request.full_url))
+        if request.method == "GET":
+            return _Response({"runtime": {"id": "runtime_abc", "state": next(states)}})
+        if request.full_url.endswith("/resume"):
+            return _Response({"runtime": {"id": "runtime_abc", "state": "provisioning"}})
+        return _Response({"result": {"exitCode": 0, "stdout": "awake\n", "stderr": ""}})
+
+    monkeypatch.setenv("OMNIGENT_REMOTE_SANDBOX_TOKEN", "runtime-secret")
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.remote.urlopen", _urlopen)
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.remote.time.sleep", lambda _seconds: None)
+    launcher = RemoteSandboxLauncher(url="https://platform.example.com")
+
+    result = launcher.run("runtime_abc", "printf awake")
+
+    assert result.stdout == "awake\n"
+    assert requests == [
+        ("GET", "https://platform.example.com/api/v1/sandbox-runtimes/runtime_abc"),
+        ("POST", "https://platform.example.com/api/v1/sandbox-runtimes/runtime_abc/resume"),
+        ("GET", "https://platform.example.com/api/v1/sandbox-runtimes/runtime_abc"),
+        ("GET", "https://platform.example.com/api/v1/sandbox-runtimes/runtime_abc"),
+        ("POST", "https://platform.example.com/api/v1/sandbox-runtimes/runtime_abc/commands"),
+    ]

--- a/tests/onboarding/sandboxes/test_remote.py
+++ b/tests/onboarding/sandboxes/test_remote.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 from typing import Any
+from urllib.error import URLError
 from urllib.request import Request
 
+import click
 import pytest
 
 from omnigent.onboarding.sandboxes.remote import RemoteSandboxLauncher
@@ -21,8 +23,8 @@ class _Response:
     def __exit__(self, *_args: object) -> None:
         return None
 
-    def read(self) -> bytes:
-        return self._body
+    def read(self, amount: int = -1) -> bytes:
+        return self._body if amount < 0 else self._body[:amount]
 
 
 def test_provision_sends_launch_context_and_returns_stable_runtime_id(
@@ -175,3 +177,68 @@ def test_first_command_polls_a_stopped_runtime_before_execution(
         ("GET", "https://platform.example.com/api/v1/sandbox-runtimes/runtime_abc"),
         ("POST", "https://platform.example.com/api/v1/sandbox-runtimes/runtime_abc/commands"),
     ]
+
+
+def test_activity_signal_uses_versioned_controller_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[tuple[str, str, dict[str, object]]] = []
+
+    def _urlopen(request: Request, *, timeout: int) -> _Response:
+        assert timeout == 30
+        requests.append((request.method, request.full_url, json.loads(request.data or b"{}")))
+        return _Response({"runtime": {"id": "runtime_abc", "active": True}})
+
+    monkeypatch.setenv("OMNIGENT_REMOTE_SANDBOX_TOKEN", "runtime-secret")
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.remote.urlopen", _urlopen)
+    launcher = RemoteSandboxLauncher(url="https://platform.example.com")
+
+    launcher.set_activity("runtime_abc", active=True)
+
+    assert requests == [
+        (
+            "POST",
+            "https://platform.example.com/api/v1/sandbox-runtimes/runtime_abc/activity",
+            {"active": True},
+        )
+    ]
+
+
+def test_retryable_status_lookup_recovers_from_transient_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    def _urlopen(request: Request, *, timeout: int) -> _Response:
+        del request, timeout
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise URLError("temporary outage")
+        return _Response({"runtime": {"id": "runtime_abc", "state": "running"}})
+
+    monkeypatch.setenv("OMNIGENT_REMOTE_SANDBOX_TOKEN", "runtime-secret")
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.remote.urlopen", _urlopen)
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.remote.time.sleep", lambda _seconds: None)
+    launcher = RemoteSandboxLauncher(url="https://platform.example.com")
+
+    assert launcher.is_running("runtime_abc") is True
+    assert attempts == 2
+
+
+def test_response_body_is_bounded_before_json_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _OversizedResponse(_Response):
+        def __init__(self) -> None:
+            self._body = b"x" * (1024 * 1024 + 1)
+
+    monkeypatch.setenv("OMNIGENT_REMOTE_SANDBOX_TOKEN", "runtime-secret")
+    monkeypatch.setattr(
+        "omnigent.onboarding.sandboxes.remote.urlopen",
+        lambda _request, *, timeout: _OversizedResponse(),
+    )
+    launcher = RemoteSandboxLauncher(url="https://platform.example.com")
+
+    with pytest.raises(click.ClickException, match="response exceeded 1048576 bytes"):
+        launcher.is_running("runtime_abc")

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -33,6 +33,7 @@ from omnigent.server.managed_hosts import (
     parse_sandbox_config,
     relaunch_managed_host,
     resume_managed_host,
+    set_managed_host_activity,
     terminate_managed_host,
 )
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
@@ -1826,6 +1827,38 @@ class _IsloFakeLauncher(FakeSandboxLauncher):
     """Fake launcher carrying Islo's provider label for managed resume tests."""
 
     provider: ClassVar[str] = "islo"
+
+
+class _ActivityFakeLauncher(_IsloFakeLauncher):
+    """Capture lifecycle activity signals from the managed-host seam."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.activity: list[tuple[str, bool]] = []
+
+    def set_activity(self, sandbox_id: str, *, active: bool) -> None:
+        self.activity.append((sandbox_id, active))
+
+
+async def test_managed_host_activity_targets_its_bound_sandbox(db_uri: str) -> None:
+    """A status edge updates only the sandbox recorded on that host row."""
+    host_store = HostStore(db_uri)
+    host_id = "618f50482ee943a99eae16fcf1cc9158"
+    host_store.register_managed_host(
+        host_id=host_id,
+        name="managed-activity",
+        user_id=_OWNER,
+        token="tok-activity",
+        provider="islo",
+        sandbox_id="sb-activity",
+        token_expires_at=now_epoch() + 3600,
+    )
+    fake = _ActivityFakeLauncher()
+
+    await set_managed_host_activity(host_id, host_store, _injected_config(fake), active=True)
+    await set_managed_host_activity(host_id, host_store, _injected_config(fake), active=False)
+
+    assert fake.activity == [("sb-activity", True), ("sb-activity", False)]
 
 
 async def test_host_resume_supported_requires_resumable_matching_launcher(db_uri: str) -> None:

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -24,6 +24,7 @@ from omnigent.server.managed_hosts import (
     KUBERNETES_MANAGED_TOKEN_TTL_S,
     MODAL_MANAGED_TOKEN_TTL_S,
     OPENSHELL_MANAGED_TOKEN_TTL_S,
+    REMOTE_MANAGED_TOKEN_TTL_S,
     ManagedSandboxConfig,
     RepoWorkspace,
     host_resume_supported,
@@ -210,6 +211,28 @@ def test_parse_daytona_without_section_defaults(
     assert cfg.launcher_factory() is fake
     assert fake.image is None
     assert fake.env is None
+
+
+async def test_parse_remote_controller_config() -> None:
+    """Remote runtimes are a first-class managed provider with a bounded token."""
+    cfg = parse_sandbox_config(
+        {
+            "provider": "remote",
+            "server_url": "https://omnigent.example.com",
+            "remote": {
+                "url": "https://platform.example.com/",
+                "token_env": "PLATFORM_SANDBOX_RUNTIME_TOKEN",
+                "env": ["PLATFORM_GIT_BROKER_URL"],
+            },
+        }
+    )
+    assert cfg is not None
+    assert cfg.provider == "remote"
+    assert cfg.managed_launch_supported is True
+    assert cfg.token_ttl_s == REMOTE_MANAGED_TOKEN_TTL_S
+    launcher = cfg.launcher_factory()
+    assert launcher.provider == "remote"
+    assert launcher.can_resume is True
 
 
 def test_parse_valid_boxlite_cloud_config_builds_parameterized_factory(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a provider-neutral `remote` sandbox backend for installations that keep infrastructure lifecycle policy outside Omnigent.
- Forward session identity and active/idle status through generic launcher hooks.
- Make remote create, wake, command, stop, delete, status, and activity operations bounded and retry-safe.

### ELI5

Omnigent runs the conversation. A separate platform can run the computer behind that conversation. This PR gives the two systems a small standard plug, without teaching Omnigent about a particular cloud or sandbox account.

```text
Omnigent session
      |
      v
remote sandbox adapter  -- authenticated HTTP --> runtime service
                                                    |
                                                    v
                                             sandbox provider
```

The existing direct sandbox providers are unchanged. The remote backend is opt-in and is useful when an organisation already has a controller responsible for ownership, sleep/wake policy, credentials, reconciliation, and cleanup.

## Test Plan

- `pre-commit run --files <all files changed by this PR>`
- `python -m pytest tests/onboarding/sandboxes/test_remote.py tests/server/test_managed_hosts.py -q` — **135 passed**
- `python -m pytest tests/server/integration/test_sessions_endpoints.py -q -k external_session_status` — **7 passed**
- The equivalent adapter path has also been exercised end-to-end against a real external controller: create, model response, stop, automatic wake of the same runtime, filesystem persistence, and cleanup.

## Demo

N/A — this is a backend integration with no UI changes.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used an authenticated external runtime controller and a real sandbox provider. A session created a runtime and file, the runtime was stopped, the next message woke the same runtime, the file remained present, and final cleanup deleted the temporary session and runtime.

## Changelog

Omnigent can run managed sessions through a provider-neutral remote sandbox service, including activity-aware sleep and automatic wake.
