### PR TITLE
[Bug] Cursor sessions launched from Omnigent Web lose user-defined MCP servers

### DIFF
--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -303,6 +303,24 @@ def write_mcp_config(
     cursor_dir.mkdir(parents=True, exist_ok=True)
     path = cursor_dir / _MCP_CONFIG_FILE
     payload = build_mcp_config(bridge_dir, python_executable=python_executable)
+
+    # Preserve user-defined MCP servers — Cursor's mcp.json can hold
+    # multiple MCP servers alongside the Omnigent relay, and overwriting
+    # the file on every session launch would discard custom entries the
+    # user configured outside Omnigent.
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+            user_servers = {
+                k: v
+                for k, v in existing.get("mcpServers", {}).items()
+                if k != _MCP_SERVER_NAME
+            }
+            if user_servers:
+                payload["mcpServers"].update(user_servers)
+        except (json.JSONDecodeError, OSError):
+            pass  # Invalid or unreadable — start fresh
+
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     os.replace(tmp, path)


### PR DESCRIPTION
## Summary

When launching a Cursor session from Omnigent Web, any MCP servers the user configured in `.cursor/mcp.json` outside Omnigent (e.g. custom tools, third-party MCPs like Atlassian) are silently discarded. The `write_mcp_config` function atomically replaces the file with a config containing only the Omnigent relay server.

This does not affect CLI-launched sessions (`omnigent cursor`), which use a separate MCP configuration path — consistent with the issue report.

## Changes

In `write_mcp_config`: before writing, read the existing `.cursor/mcp.json` if it exists and merge back any user-defined `mcpServers` entries (everything except `"omnigent"`) into the fresh Omnigent config. Handles missing, malformed, or unreadable files gracefully by falling back to the current overwrite behavior.

## Test Plan

1. Manual logic verification: the merge preserves existing servers, the Omnigent entry always wins for name conflicts, and corrupted/missing files are handled without crashing.
2. Existing test suite — this is a non-refactor change to a single function with no new dependencies.

## Demo

Before this fix: A user who configured custom MCP servers (e.g., Atlassian, custom tools) in their `.cursor/mcp.json` outside of Omnigent would find those servers silently deleted the first time they launched a Cursor session from the Omnigent web UI. The `write_mcp_config` function would atomically replace the file with only the Omnigent relay server entry.

After this fix: The same user's custom MCP servers are preserved. Cursor sessions launched from the web UI now merge the Omnigent relay server alongside any pre-existing user-defined servers instead of overwriting them entirely.

This is a backend-only change — the effect is visible in the `.cursor/mcp.json` file contents rather than in any UI surface. The behaviour can be verified by inspecting the config file before and after launching a web UI session.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] UI / frontend change
- [ ] Refactor

## Test coverage

- [ ] Unit tests added
- [ ] Integration tests added
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

The function has no existing unit tests; the change is scoped to one merge operation with defensive error handling.