### PR TITLE
fix(web): remove footer background from Configure agent modal

### DIFF
--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -1064,6 +1064,22 @@ describe("NewChatLandingScreen create flow", () => {
     expect(screen.queryByTestId("cost-toggle-trigger")).toBeNull();
   });
 
+  it("renders the config modal footer without its own background or top border", async () => {
+    // The Cancel/Save footer should blend into the modal body — no gray tray
+    // band and no divider line above the buttons.
+    setAgents([agent({ id: "ag_native", name: "claude-native-ui", display_name: "Claude Code" })]);
+    renderLanding();
+    await waitForWorkspaceSeed();
+    openAgentConfig("ag_native");
+
+    const footer = screen
+      .getByTestId("new-chat-landing-config-save")
+      .closest("[data-slot=dialog-footer]");
+    expect(footer).not.toBeNull();
+    expect(footer).toHaveClass("bg-transparent", "border-t-0");
+    expect(footer?.className).not.toMatch(/bg-muted/);
+  });
+
   it("omits cost_control_mode_override when Smart Routing is left unpicked", async () => {
     setAgents([agent({ id: "ag_native", name: "claude-native-ui", display_name: "Claude Code" })]);
     vi.mocked(authenticatedFetch).mockResolvedValueOnce({

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1766,7 +1766,7 @@ function HarnessConfigModal({
           )}
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="border-t-0 bg-transparent">
           <Button
             type="button"
             variant="outline"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The Configure &lt;agent&gt; modal's Cancel/Save footer used the shared `DialogFooter`'s muted tray background (`bg-muted/50`) and top divider, which rendered as a distinct gray band at the bottom of the modal.
- Override the footer with `border-t-0 bg-transparent` so it blends into the modal body, matching the cleaner look (no gray tray, no divider line).

## Test Plan

- `cd web && npm test` — full vitest suite green (added a test asserting the config-modal footer has no `bg-muted` and carries `bg-transparent border-t-0`).
- `cd web && npm run build` — passes.
- Manual: New Chat → gear/Configure on an agent → footer no longer shows the gray band or divider above Cancel/Save.

## Demo

Before: footer had a gray tray background and top border above Cancel/Save.
After: footer blends into the modal surface (no band, no divider).

<!-- Screenshots provided in the originating conversation. -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `NewChatDialog.flow.test.tsx` case asserting the config-modal footer renders without its own background or top border. Manually verified in the running app that the Configure modal footer blends into the modal body.

## Changelog

The Configure agent modal's footer no longer shows a gray background band behind Cancel/Save

This pull request and its description were written by Isaac.