### PR TITLE
feat(web): add a harness credential from the New Chat setup dialog (M3 frontend)

### DIFF
--- a/omnigent/harness_install_spec.py
+++ b/omnigent/harness_install_spec.py
@@ -35,15 +35,17 @@ class SetupStep:
     ``omnigent setup`` walks a user through — one row per requirement, in order.
 
     :param kind: Machine id for the requirement, ``"install"`` or ``"auth"``.
-    :param title: Human row label, agent-framed (e.g. ``"Install Codex"``,
-        ``"Sign in to Codex"``).
+    :param title: Human row label (e.g. ``"Install Codex"``,
+        ``"Set up authentication"``).
     :param detail: Optional one-line explanation of what the step means for
-        this harness (e.g. "Uses your ChatGPT subscription").
+        this harness (e.g. "Sign in with your subscription, an API key, or a
+        gateway").
     :param action: How the user resolves it — ``"install"`` (a one-click
-        install the server performs), ``"command"`` (a command the user runs on
-        the host, in :attr:`command`), or ``"setup"`` (run ``omnigent setup`` —
-        the M1 fallback for auth methods the UI can't yet drive, e.g. entering
-        an API key or gateway).
+        install the server performs), ``"auth"`` (the UI opens an inline
+        credential form; the harness's subscription login, if any, is one option
+        inside it via :attr:`command`), ``"command"`` (a command the user runs
+        on the host, in :attr:`command`), or ``"setup"`` (run ``omni setup`` —
+        the fallback for auth methods the UI can't drive).
     :param command: The command for ``action="command"``/``"setup"`` steps
         (e.g. ``"codex login"``); ``None`` for one-click installs.
     :param status_key: Which readiness sub-state marks this step done, or

--- a/omnigent/onboarding/harness_auth.py
+++ b/omnigent/onboarding/harness_auth.py
@@ -35,7 +35,6 @@ from omnigent.onboarding.provider_config import (
     OPENAI_FAMILY,
     load_config,
     provider_entry_settings,
-    set_default_provider,
 )
 
 _logger = logging.getLogger(__name__)
@@ -94,6 +93,49 @@ def _config_writer():  # type: ignore[no-untyped-def]
             yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=True)
 
     return _load, _save
+
+
+def _pin_defaults_after_write(name: str, family: str, load, save) -> None:  # type: ignore[no-untyped-def]
+    """Point the right defaults at a just-written provider entry *name*.
+
+    Two pins, each only when nothing already claims the slot (so we never
+    silently re-route something the user configured):
+
+    1. The family default, when the family has none yet — the entry becomes
+       what claude/codex/pi resolve for that family.
+    2. Pi's own default, when Pi still can't resolve a provider. Pi consumes the
+       anthropic/openai families but has no CLI login, so it depends entirely on
+       an omnigent-managed provider. When the family default is a kind Pi can't
+       use — a subscription CLI login or bedrock — Pi's resolver skips it and
+       (unlike codex, which has a runtime route-around) finds nothing, leaving
+       Pi stuck at "needs-auth" even though the user just added a usable key. A
+       ``PI_SURFACE``-scoped default fixes that without touching the family's own
+       default (claude keeps its subscription). Applies to any pi-capable family
+       write; the guard makes it a no-op when the family default already serves
+       pi (the clean-config case).
+
+    ``set_default_provider`` rewrites the whole providers block (it clears
+    sibling default flags a deep-merge can't reach), so each pin re-reads first.
+    """
+    from omnigent.onboarding.provider_config import (
+        PI_SURFACE,
+        default_provider_for_harness,
+        get_default_provider,
+        set_default_provider,
+    )
+
+    def _pin(scope: str, resolved) -> None:  # type: ignore[no-untyped-def]
+        if resolved is not None:
+            return
+        block = load().get("providers")
+        if isinstance(block, dict):
+            save(
+                {"providers": set_default_provider(block, name, scope)},
+                deep_merge_providers=False,
+            )
+
+    _pin(family, get_default_provider(load(), family))
+    _pin(PI_SURFACE, default_provider_for_harness(load(), PI_SURFACE))
 
 
 def store_harness_credential(
@@ -173,22 +215,10 @@ def store_harness_credential(
 
     _load, _save = _config_writer()
     try:
-        # Add/update the one provider entry (deep-merge keeps siblings).
+        # Add/update the one provider entry (deep-merge keeps siblings), then
+        # point the family default (and, when needed, Pi's own default) at it.
         _save(provider_entry_settings(name, entry, make_default=False), deep_merge_providers=True)
-        # Make it the family default only when nothing else claims it yet, so we
-        # don't silently re-route a family the user already configured. When we
-        # do set it, rewrite the whole providers block (set_default_provider
-        # clears sibling default flags a deep-merge can't reach).
-        from omnigent.onboarding.provider_config import get_default_provider
-
-        cfg = _load()
-        if get_default_provider(cfg, family) is None:
-            block = cfg.get("providers")
-            if isinstance(block, dict):
-                _save(
-                    {"providers": set_default_provider(block, name, family)},
-                    deep_merge_providers=False,
-                )
+        _pin_defaults_after_write(name, family, _load, _save)
     except Exception as exc:  # pragma: no cover - config write failure
         _logger.debug("store_harness_credential: config write failed", exc_info=True)
         return StoreCredentialResult(False, None, f"could not write provider config: {exc}")
@@ -294,16 +324,7 @@ def adopt_env_credential(*, family: str, env_var: str) -> StoreCredentialResult:
     _load, _save = _config_writer()
     try:
         _save(provider_entry_settings(name, entry, make_default=False), deep_merge_providers=True)
-        from omnigent.onboarding.provider_config import get_default_provider
-
-        cfg = _load()
-        if get_default_provider(cfg, family) is None:
-            block = cfg.get("providers")
-            if isinstance(block, dict):
-                _save(
-                    {"providers": set_default_provider(block, name, family)},
-                    deep_merge_providers=False,
-                )
+        _pin_defaults_after_write(name, family, _load, _save)
     except Exception as exc:  # pragma: no cover - config write failure
         _logger.debug("adopt_env_credential: config write failed", exc_info=True)
         return StoreCredentialResult(False, None, f"could not write provider config: {exc}")

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -382,17 +382,22 @@ def ui_credential_configurable_harnesses() -> frozenset[str]:
 _UI_AUTH_STEP_BY_KEY: dict[str, SetupStep] = {
     ANTHROPIC_FAMILY: SetupStep(
         kind="auth",
-        title="Sign in to Claude",
-        detail="Uses your Claude subscription — sign in on the host.",
-        action="command",
+        # UI-authable: the dialog opens a form listing every way to authenticate
+        # (subscription login, API key, gateway, or adopting a detected key), so
+        # the row is a neutral "set up auth" rather than naming just one path —
+        # the subscription ``command`` below is one option inside that form, not
+        # the whole step.
+        title="Set up authentication",
+        detail="Sign in with your Claude subscription, an API key, or a gateway.",
+        action="auth",
         command="claude auth login --claudeai",
         status_key="authed",
     ),
     OPENAI_FAMILY: SetupStep(
         kind="auth",
-        title="Sign in to Codex",
-        detail="Uses your ChatGPT subscription — sign in on the host.",
-        action="command",
+        title="Set up authentication",
+        detail="Sign in with your ChatGPT subscription, an API key, or a gateway.",
+        action="auth",
         command="codex login",
         status_key="authed",
     ),
@@ -406,13 +411,14 @@ _UI_AUTH_STEP_BY_KEY: dict[str, SetupStep] = {
     ),
     PI_KEY: SetupStep(
         kind="auth",
-        title="Add a Pi credential",
-        # Pi is UI-authable: the setup dialog renders an inline credential form
-        # (API key / gateway / adopt) for it, keyed on kind == "auth". No
-        # ``command`` — Pi has no subscription CLI login, so no copy-signpost.
-        # ``status_key="authed"`` makes the step trackable so it isn't dropped
-        # as "unknown" (which would make the dialog wrongly read "ready").
-        detail="Add an API key or gateway so Pi can run.",
+        # Same neutral "set up auth" framing as claude/codex — the dialog opens a
+        # form listing the ways to authenticate. Pi has NO subscription CLI login
+        # (``command=None``, so the form omits that option), so the detail names
+        # only the applicable paths. ``status_key="authed"`` keeps the step
+        # trackable so it isn't dropped as "unknown" (which would wrongly read
+        # "ready").
+        title="Set up authentication",
+        detail="Add an API key or a gateway so Pi can run.",
         action="auth",
         command=None,
         status_key="authed",

--- a/tests/e2e_ui/start_session/test_harness_credential.py
+++ b/tests/e2e_ui/start_session/test_harness_credential.py
@@ -1,13 +1,14 @@
-"""E2E: one-click harness install from the new-session landing page.
+"""E2E: add a harness credential from the new-session setup dialog.
 
-Covers the user journey where the selected agent's harness isn't set up on the
-chosen host: the composer shows an "Install" button (instead of the "run
-omni setup" hint), clicking it installs the harness, and the readiness
-warning clears once the host reports the harness ready.
+Covers the M3 journey where the selected agent's harness is installed but not
+configured (``needs-auth``): the setup dialog offers "Set up auth", which expands an
+inline credential form; pasting an API key POSTs the credential and the
+readiness warning clears once the host reports the harness ready.
 
-Uses the same route-stubbing approach as ``test_create_custom_agent.py``:
-``/v1/info``, ``/v1/hosts``, ``/v1/agents`` and the install ``POST`` are faked
-so the test drives the real UI without a live host or a real npm install.
+Uses the same route-stubbing approach as ``test_harness_install.py``:
+``/v1/info``, ``/v1/hosts``, ``/v1/agents``, ``/v1/harnesses``, the credential
+``POST`` and the adopt-detect ``GET`` are faked so the test drives the real UI
+without a live host or a real credential write.
 """
 
 from __future__ import annotations
@@ -22,10 +23,8 @@ from typing import Any
 from playwright.async_api import Route, async_playwright, expect
 
 _HOST_ID = "host_e2e"
-# The stub host reports Claude ready and Codex missing. Claude remains the
-# selected inline default, so Codex exercises the picker's More submenu before
-# the install POST flips it to ready.
-_READY_HARNESS = "claude-native"
+# The stub host reports codex installed-but-not-configured; the credential POST
+# flips it to ready so the warning clears.
 _HARNESS = "codex-native"
 
 
@@ -47,18 +46,9 @@ def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
 
 
 def _agents_body() -> str:
-    """A ready default agent plus the missing Codex harness under test."""
     return json.dumps(
         {
             "data": [
-                {
-                    "id": "ag_claude_e2e",
-                    "name": "claude-native-ui",
-                    "display_name": "Claude Code",
-                    "description": "Anthropic's coding agent",
-                    "harness": _READY_HARNESS,
-                    "skills": [],
-                },
                 {
                     "id": "ag_codex_e2e",
                     "name": "codex-native-ui",
@@ -66,14 +56,14 @@ def _agents_body() -> str:
                     "description": "OpenAI's coding agent",
                     "harness": _HARNESS,
                     "skills": [],
-                },
+                }
             ]
         }
     )
 
 
 def _hosts_body(*, ready: bool) -> str:
-    """One online host; ``ready`` toggles the harness's readiness."""
+    """One online host; ``ready`` toggles codex between needs-auth and ready."""
     return json.dumps(
         {
             "hosts": [
@@ -82,10 +72,7 @@ def _hosts_body(*, ready: bool) -> str:
                     "name": "e2e-host",
                     "owner": "e2e",
                     "status": "online",
-                    "configured_harnesses": {
-                        _READY_HARNESS: True,
-                        _HARNESS: ready,
-                    },
+                    "configured_harnesses": {_HARNESS: True if ready else "needs-auth"},
                 }
             ]
         }
@@ -93,7 +80,6 @@ def _hosts_body(*, ready: bool) -> str:
 
 
 def _info_body() -> str:
-    """``/v1/info`` with the install feature on and codex accepted."""
     return json.dumps(
         {
             "accounts_enabled": False,
@@ -114,8 +100,6 @@ def _info_body() -> str:
 
 
 def _harnesses_body() -> str:
-    """``/v1/harnesses`` with a setup_steps map keyed by the native spelling —
-    the shape the setup dialog reads to render its checklist."""
     return json.dumps(
         {
             "data": [{"id": "codex", "label": "Codex"}],
@@ -145,11 +129,13 @@ def _harnesses_body() -> str:
     )
 
 
-async def _register_routes(page, *, install_requests: list[str]) -> None:
-    """Stub info, hosts, agents, harnesses, and the harness-install POST.
+async def _register_routes(page, *, credential_requests: list[dict[str, Any]]) -> None:
+    """Stub info/hosts/agents/harnesses, the credential POST, and adopt-detect.
 
-    The install POST records the call and returns a readiness map with the
-    harness now ready, mirroring the real endpoint's response.
+    The credential POST records its JSON body and returns a readiness map with
+    the harness now ready, mirroring the real endpoint. Detect returns nothing
+    (the test exercises the paste-key path, not adopt). ``/v1/hosts`` flips to
+    ready once a credential has been written, so the warning clears.
     """
 
     async def handle_info(route: Route) -> None:
@@ -157,7 +143,9 @@ async def _register_routes(page, *, install_requests: list[str]) -> None:
 
     async def handle_hosts(route: Route) -> None:
         await route.fulfill(
-            status=200, content_type="application/json", body=_hosts_body(ready=False)
+            status=200,
+            content_type="application/json",
+            body=_hosts_body(ready=bool(credential_requests)),
         )
 
     async def handle_agents(route: Route) -> None:
@@ -166,29 +154,35 @@ async def _register_routes(page, *, install_requests: list[str]) -> None:
     async def handle_harnesses(route: Route) -> None:
         await route.fulfill(status=200, content_type="application/json", body=_harnesses_body())
 
-    async def handle_agent_scan(route: Route) -> None:
-        # The picker ALSO scans GET /v1/sessions?kind=any for registered agents.
-        # The seeded_session fixture creates real sessions in the DB, so without
-        # this stub those leak in as agents and the picker auto-selects the
-        # built-in Claude Code (ready) instead of our unconfigured Codex —
-        # leaving no "Set up Codex" notice (the CI-only failure). Return none so
-        # only the stubbed /v1/agents Codex populates the picker.
+    async def handle_detect(route: Route) -> None:
         await route.fulfill(
-            status=200, content_type="application/json", body=json.dumps({"data": []})
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"object": "detected_credentials", "credentials": []}),
         )
 
-    async def handle_install(route: Route) -> None:
-        install_requests.append(route.request.url)
+    async def handle_credential(route: Route) -> None:
+        credential_requests.append(json.loads(route.request.post_data or "{}"))
         await route.fulfill(
             status=200,
             content_type="application/json",
             body=json.dumps(
                 {
-                    "object": "harness_install",
+                    "object": "harness_credential",
                     "harness": _HARNESS,
                     "configured_harnesses": {_HARNESS: True},
                 }
             ),
+        )
+
+    async def handle_agent_scan(route: Route) -> None:
+        # The picker also scans GET /v1/sessions?kind=any for registered agents.
+        # The seeded_session fixture creates real sessions in the DB, so without
+        # this stub those leak in and the picker auto-selects the built-in Claude
+        # Code (ready) instead of our unconfigured Codex — no "Set up" notice
+        # (a CI-only failure). Return none so only the stubbed Codex populates it.
+        await route.fulfill(
+            status=200, content_type="application/json", body=json.dumps({"data": []})
         )
 
     await page.route("**/v1/info", handle_info)
@@ -196,11 +190,11 @@ async def _register_routes(page, *, install_requests: list[str]) -> None:
     await page.route("**/v1/agents", handle_agents)
     await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
     await page.route("**/v1/harnesses", handle_harnesses)
-    await page.route(f"**/v1/hosts/*/harnesses/{_HARNESS}/install", handle_install)
+    await page.route("**/v1/hosts/*/credentials/detected", handle_detect)
+    await page.route(f"**/v1/hosts/*/harnesses/{_HARNESS}/credential", handle_credential)
 
 
 async def _seed_workspace(page) -> None:
-    """Seed a recent workspace so the composer settles on the stub host."""
     await page.add_init_script(
         f"""window.localStorage.setItem(
             "omnigent:recent-workspaces",
@@ -212,54 +206,57 @@ async def _seed_workspace(page) -> None:
 # ── Tests ──────────────────────────────────────────────────────────
 
 
-def test_install_button_installs_missing_harness(
+def test_add_key_configures_needs_auth_harness(
     seeded_session: tuple[str, str],
 ) -> None:
-    """The composer offers Install for a missing harness; clicking it installs
-    and clears the readiness warning."""
+    """The setup dialog offers an inline credential form for a needs-auth
+    harness; pasting a key writes it and clears the readiness warning."""
     base_url, _session_id = seeded_session
-    _run_in_fresh_loop(_drive_install(base_url))
+    _run_in_fresh_loop(_drive_add_key(base_url))
 
 
-async def _drive_install(base_url: str) -> None:
+async def _drive_add_key(base_url: str) -> None:
     async with async_playwright() as pw:
         browser = await pw.chromium.launch()
         page = await browser.new_page()
         try:
-            install_requests: list[str] = []
-            await _register_routes(page, install_requests=install_requests)
+            credential_requests: list[dict[str, Any]] = []
+            await _register_routes(page, credential_requests=credential_requests)
             await _seed_workspace(page)
 
             await page.goto(f"{base_url}/")
             await page.get_by_test_id("new-chat-landing-input").wait_for(
                 state="visible", timeout=30_000
             )
-            # The composer auto-selects the built-in Claude Code (ranked first),
-            # NOT our stubbed Codex agent — and Claude Code is ready on the host,
-            # so no "Set up" notice appears. Explicitly select Codex in the
-            # picker: open it, wait for the Codex row to render (it mounts only
-            # after the /v1/agents fetch resolves — can lag under CI load), then
-            # click it. Only then does the composer show the "Set up Codex"
-            # notice for its unconfigured harness.
+
+            # Commit the Codex agent (installed but needs-auth on the host). The
+            # composer auto-selects the built-in Claude Code, not our stubbed
+            # Codex, so select Codex explicitly — waiting for its row to render
+            # (it mounts only after the /v1/agents fetch resolves; can lag on CI).
             await page.get_by_test_id("new-chat-landing-agent-select").click()
-            await page.get_by_test_id("new-chat-landing-harness-more").click()
             codex_option = page.get_by_test_id("new-chat-landing-agent-ag_codex_e2e")
             await expect(codex_option).to_be_visible(timeout=60_000)
             await codex_option.click()
 
+            # "Set up →" opens the dialog; there's no Install (already installed).
             setup = page.get_by_test_id("new-chat-landing-harness-setup")
             await expect(setup).to_be_visible(timeout=60_000)
             await setup.click()
+            await expect(page.get_by_test_id("harness-setup-install")).to_have_count(0)
 
-            # The dialog's checklist offers a one-click Install for this harness.
-            install_button = page.get_by_test_id("harness-setup-install")
-            await expect(install_button).to_be_visible(timeout=5_000)
+            # The auth step offers "Set up auth" → expands the inline credential form.
+            await page.get_by_test_id("harness-setup-add-credential").click()
+            await expect(page.get_by_test_id("harness-credential-form")).to_be_visible(
+                timeout=5_000
+            )
 
-            # Install → the endpoint is hit and the warning clears once the host
-            # reports the harness ready (the response's readiness map is applied
-            # to the cache, so no reconnect is needed).
-            await install_button.click()
-            await _wait_until(lambda: len(install_requests) == 1)
+            # Paste a key and save → the credential POST is hit and the warning
+            # clears once the host reports the harness ready.
+            await page.get_by_test_id("harness-credential-key").fill("sk-ant-e2e-test")
+            await page.get_by_test_id("harness-credential-save").click()
+            await _wait_until(lambda: len(credential_requests) == 1)
+            assert credential_requests[0]["kind"] == "key"
+            assert credential_requests[0]["secret"] == "sk-ant-e2e-test"
             await expect(page.get_by_test_id("new-chat-landing-harness-warning")).to_be_hidden(
                 timeout=10_000
             )

--- a/tests/onboarding/test_harness_auth.py
+++ b/tests/onboarding/test_harness_auth.py
@@ -137,6 +137,57 @@ def test_store_flips_readiness_to_configured(monkeypatch: pytest.MonkeyPatch) ->
     assert default_provider_for_harness(load_config(), "claude-native") is not None
 
 
+def _seed_subscription_defaults(tmp_path: Path) -> None:
+    """Write a config whose anthropic + openai family defaults are subscription
+    CLI logins — the shape a user who ran `claude auth login` / `codex login`
+    ends up with, and the case that stranded Pi."""
+    (Path(tmp_path) / "config.yaml").write_text(
+        "providers:\n"
+        "  claude: {cli: claude, default: true, kind: subscription}\n"
+        "  codex: {cli: codex, default: true, kind: subscription}\n"
+    )
+
+
+def test_store_key_makes_pi_ready_despite_subscription_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A pi credential must make Pi resolvable even when the anthropic family
+    default is a subscription login Pi can't use.
+
+    Regression: Pi consumes the anthropic family but has no CLI login, so it
+    depends on an omnigent-managed provider. With a pre-existing subscription
+    default, the new key was written as a non-default sibling and Pi's resolver
+    (which skips subscription) fell through to nothing — Pi stayed "needs-auth"
+    after a successful write. The write now also pins the key as Pi's own
+    default (pi-scoped), without disturbing Claude's subscription.
+    """
+    _seed_subscription_defaults(tmp_path)
+    assert default_provider_for_harness(load_config(), "pi") is None
+
+    result = ha.store_harness_credential(family="anthropic", kind="key", secret="sk-ant-pi")
+    assert result.stored is True
+
+    cfg = load_config()
+    # Pi now resolves a usable (non-subscription) provider…
+    pi_provider = default_provider_for_harness(cfg, "pi")
+    assert pi_provider is not None and pi_provider.kind != "subscription"
+    # …while Claude's own subscription default is left intact.
+    claude_provider = default_provider_for_harness(cfg, "claude-native")
+    assert claude_provider is not None and claude_provider.kind == "subscription"
+
+
+def test_adopt_makes_pi_ready_despite_subscription_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same pi-scope pin applies to the adopt path (env-var credential)."""
+    _seed_subscription_defaults(tmp_path)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-present")
+    result = ha.adopt_env_credential(family="anthropic", env_var="ANTHROPIC_API_KEY")
+    assert result.stored is True
+    pi_provider = default_provider_for_harness(load_config(), "pi")
+    assert pi_provider is not None and pi_provider.kind != "subscription"
+
+
 def test_adopt_env_credential_writes_env_reference(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -973,15 +973,18 @@ def test_ui_installable_harnesses_includes_native_spellings() -> None:
     assert "claude-sdk" not in installable
 
 
-def test_ui_setup_steps_install_then_command_auth_for_codex() -> None:
-    """Codex: one-click install, then a status-tracked login command."""
+def test_ui_setup_steps_install_then_ui_auth_for_codex() -> None:
+    """Codex: one-click install, then a UI-authable auth step. The step opens
+    the credential form (action ``"auth"``) whose options include the ``codex
+    login`` subscription; it stays status-tracked (``"authed"``)."""
     steps = hi.ui_setup_steps("codex")
     assert [s.kind for s in steps] == ["install", "auth"]
     install, auth = steps
     assert install.action == "install"
     assert install.status_key == "installed"
     assert install.command is None
-    assert auth.action == "command"
+    assert auth.action == "auth"
+    assert auth.title == "Set up authentication"
     assert auth.command == "codex login"
     assert auth.status_key == "authed"
 

--- a/tests/test_harness_capabilities.py
+++ b/tests/test_harness_capabilities.py
@@ -180,9 +180,11 @@ def test_catalog_rows_carry_setup_steps() -> None:
             # JSON-serializable primitives only.
             for value in step.values():
                 assert value is None or isinstance(value, str)
-    # Codex is a first-class harness: install (one-click) then a login command.
+    # Codex is a first-class harness: install (one-click) then a UI-authable
+    # auth step. The step opens the credential form (action "auth"); its
+    # subscription option still carries the `codex login` command.
     codex = rows["codex"]["setup_steps"]
-    assert [s["action"] for s in codex] == ["install", "command"]
+    assert [s["action"] for s in codex] == ["install", "auth"]
     assert codex[1]["command"] == "codex login"
 
 

--- a/web/src/hooks/useHosts.test.tsx
+++ b/web/src/hooks/useHosts.test.tsx
@@ -200,9 +200,10 @@ describe("useHosts", () => {
     // terminal to run the command, then tab back. If the hosts_changed WS push
     // is missed (reconnect gap, or the interval poll paused while the tab was
     // hidden), the badge would sit on a stale "needs setup" until a manual
-    // reload. useHosts overrides the app-wide `refetchOnWindowFocus: false` so
-    // returning to the tab refetches and the badge clears. The wrapper mirrors
-    // that global default to prove the per-query override is what refires.
+    // reload. With `refetchOnFocus: true` (the setup flow's opt-in) useHosts
+    // overrides the app-wide `refetchOnWindowFocus: false` so returning to the
+    // tab refetches and the badge clears. The wrapper mirrors that global
+    // default to prove the per-query override is what refires.
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
     });
@@ -222,7 +223,9 @@ describe("useHosts", () => {
     };
     fetchMock.mockResolvedValue(mockResponse(hostsBody));
 
-    const { result } = renderHook(() => useHosts(), { wrapper: focusWrapper });
+    const { result } = renderHook(() => useHosts({ refetchOnFocus: true }), {
+      wrapper: focusWrapper,
+    });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -233,6 +236,30 @@ describe("useHosts", () => {
     focusManager.setFocused(false);
     focusManager.setFocused(true);
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    focusManager.setFocused(undefined);
+  });
+
+  it("does NOT refetch on focus by default so non-setup consumers aren't taxed", async () => {
+    // The aggressive refocus refetch is opt-in (refetchOnFocus). The ~8 other
+    // useHosts consumers (Sidebar, HostBadge, …) keep the 30 s stale window, so
+    // a tab refocus must not refire their /v1/hosts query.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    function focusWrapper({ children }: { children: ReactNode }) {
+      return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    }
+    fetchMock.mockResolvedValue(mockResponse({ hosts: [] }));
+
+    const { result } = renderHook(() => useHosts(), { wrapper: focusWrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    focusManager.setFocused(false);
+    focusManager.setFocused(true);
+    // Give any (unwanted) refetch a chance to fire, then assert it didn't.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     focusManager.setFocused(undefined);
   });
 

--- a/web/src/hooks/useHosts.test.tsx
+++ b/web/src/hooks/useHosts.test.tsx
@@ -1,9 +1,14 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { focusManager, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useHostModelOptions, useHosts } from "./useHosts";
+import {
+  useHostModelOptions,
+  useHosts,
+  useInstallHarness,
+  useInstallingHarnesses,
+} from "./useHosts";
 
 const fetchMock = vi.fn();
 
@@ -190,6 +195,47 @@ describe("useHosts", () => {
     expect(result.current.all.data?.map((h) => h.host_id)).toEqual(["host_sandbox", "host_laptop"]);
   });
 
+  it("refetches on window focus so a missed readiness push recovers on tab return", async () => {
+    // The common `omni setup` flow is: open the setup dialog, alt-tab to a
+    // terminal to run the command, then tab back. If the hosts_changed WS push
+    // is missed (reconnect gap, or the interval poll paused while the tab was
+    // hidden), the badge would sit on a stale "needs setup" until a manual
+    // reload. useHosts overrides the app-wide `refetchOnWindowFocus: false` so
+    // returning to the tab refetches and the badge clears. The wrapper mirrors
+    // that global default to prove the per-query override is what refires.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    function focusWrapper({ children }: { children: ReactNode }) {
+      return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    }
+    const hostsBody = {
+      hosts: [
+        {
+          host_id: "host_1",
+          name: "Laptop",
+          owner: "alice",
+          status: "online",
+          sandbox_provider: null,
+        },
+      ],
+    };
+    fetchMock.mockResolvedValue(mockResponse(hostsBody));
+
+    const { result } = renderHook(() => useHosts(), { wrapper: focusWrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Drive React Query's focusManager directly — the same signal the browser
+    // visibilitychange/focus listener feeds it on a real tab return (jsdom's
+    // visibilityState is fixed, so we can't rely on dispatching the DOM event).
+    // staleTime 0 means it refires rather than serving cache.
+    focusManager.setFocused(false);
+    focusManager.setFocused(true);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    focusManager.setFocused(undefined);
+  });
+
   it("surfaces an error when the request fails", async () => {
     fetchMock.mockResolvedValueOnce(mockResponse({ detail: "nope" }, 503));
 
@@ -198,6 +244,91 @@ describe("useHosts", () => {
 
     expect(result.current.error).toBeInstanceOf(Error);
     expect((result.current.error as Error).message).toContain("503");
+  });
+});
+
+describe("useInstallHarness + useInstallingHarnesses (concurrent installs)", () => {
+  // Reproduces the "switch harness mid-install" bug: the setup dialog is one
+  // persistent instance sharing a single install mutation observer. That
+  // observer only remembers the LATEST mutate() call's per-call callbacks, so
+  // when a user installs Codex, switches to Pi, and installs Pi before Codex
+  // finishes, Codex's per-call onSettled/onSuccess are overwritten — leaving
+  // Codex stuck on "Installing…" with an unpatched badge. The in-flight set and
+  // the cache patch must therefore NOT ride on per-call callbacks.
+  function deferred<T>() {
+    let resolve!: (v: T) => void;
+    const promise = new Promise<T>((r) => (resolve = r));
+    return { promise, resolve };
+  }
+
+  const HOST = "host_1";
+  const installResult = (harness: string, readiness: Record<string, boolean | string>) =>
+    mockResponse({ object: "harness_install", harness, configured_harnesses: readiness });
+
+  it("keeps the first install's in-flight state and cache patch when a second starts", async () => {
+    // Both hooks share ONE QueryClient — exactly the dialog's single instance.
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    function sharedWrapper({ children }: { children: ReactNode }) {
+      return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    }
+    // Seed the hosts cache so the readiness patch has something to write into.
+    client.setQueryData(
+      ["hosts", { includeSandbox: false }],
+      [{ host_id: HOST, name: "Laptop", owner: "alice", status: "online" }],
+    );
+
+    const { result } = renderHook(
+      () => ({
+        install: useInstallHarness(HOST),
+        installing: useInstallingHarnesses(HOST),
+      }),
+      { wrapper: sharedWrapper },
+    );
+
+    // Fire Codex's install and hold it in flight.
+    const codex = deferred<Response>();
+    fetchMock.mockReturnValueOnce(codex.promise);
+    result.current.install.mutate("codex-native");
+    await waitFor(() => expect(result.current.installing.has("codex-native")).toBe(true));
+
+    // Now fire Pi's install (same observer) BEFORE Codex resolves.
+    const pi = deferred<Response>();
+    fetchMock.mockReturnValueOnce(pi.promise);
+    result.current.install.mutate("pi-native");
+    await waitFor(() => expect(result.current.installing.has("pi-native")).toBe(true));
+    // The bug: starting Pi must NOT drop Codex from the in-flight set.
+    expect(result.current.installing.has("codex-native")).toBe(true);
+
+    // Resolve Codex: its config-level onSuccess must still patch the badge, and
+    // it must leave the in-flight set even though Pi's mutate() fired last.
+    // The server returns the FULL refreshed readiness map on every install (see
+    // the /install route), so Codex's response already reflects Pi still
+    // installing (binary-missing).
+    codex.resolve(
+      installResult("codex-native", {
+        "codex-native": "needs-auth",
+        "pi-native": "binary-missing",
+      }),
+    );
+    await waitFor(() => expect(result.current.installing.has("codex-native")).toBe(false));
+    expect(result.current.installing.has("pi-native")).toBe(true); // Pi still going
+    const hosts = client.getQueryData<Array<{ configured_harnesses?: Record<string, unknown> }>>([
+      "hosts",
+      { includeSandbox: false },
+    ]);
+    expect(hosts?.[0].configured_harnesses?.["codex-native"]).toBe("needs-auth");
+
+    // Resolve Pi: it clears too and its response (again the full map) reflects
+    // both harnesses' final readiness.
+    pi.resolve(installResult("pi-native", { "codex-native": "needs-auth", "pi-native": true }));
+    await waitFor(() => expect(result.current.installing.has("pi-native")).toBe(false));
+    const hosts2 = client.getQueryData<Array<{ configured_harnesses?: Record<string, unknown> }>>([
+      "hosts",
+      { includeSandbox: false },
+    ]);
+    expect(hosts2?.[0].configured_harnesses?.["pi-native"]).toBe(true);
+    // Codex's readiness is still present (the server's full map carries it).
+    expect(hosts2?.[0].configured_harnesses?.["codex-native"]).toBe("needs-auth");
   });
 });
 

--- a/web/src/hooks/useHosts.test.tsx
+++ b/web/src/hooks/useHosts.test.tsx
@@ -4,10 +4,12 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  useDetectedCredentials,
   useHostModelOptions,
   useHosts,
   useInstallHarness,
   useInstallingHarnesses,
+  useStoreCredential,
 } from "./useHosts";
 
 const fetchMock = vi.fn();
@@ -388,5 +390,112 @@ describe("useHostModelOptions", () => {
     renderHook(() => useHostModelOptions(null, "claude-native"), { wrapper });
     await Promise.resolve();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("useStoreCredential", () => {
+  const credResult = (harness: string, readiness: Record<string, boolean | string>) =>
+    mockResponse({ object: "harness_credential", harness, configured_harnesses: readiness });
+
+  it("POSTs the harness in the path and the rest of the input as the body (no secret in the URL)", async () => {
+    fetchMock.mockResolvedValueOnce(credResult("codex-native", { "codex-native": true }));
+    const { result } = renderHook(() => useStoreCredential("host_1"), { wrapper });
+
+    result.current.mutate({ harness: "codex-native", kind: "key", secret: "sk-secret" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/v1/hosts/host_1/harnesses/codex-native/credential");
+    expect(init.method).toBe("POST");
+    // The secret rides in the body, never the URL, and `harness` is stripped
+    // from the body (it's already in the path).
+    expect(url).not.toContain("sk-secret");
+    expect(JSON.parse(init.body)).toEqual({ kind: "key", secret: "sk-secret" });
+  });
+
+  it("surfaces the server's JSON `detail` on a failed write", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ detail: "a gateway base_url must start with http:// or https://" }, 400),
+    );
+    const { result } = renderHook(() => useStoreCredential("host_1"), { wrapper });
+
+    result.current.mutate({ harness: "codex-native", kind: "gateway", base_url: "ftp://nope" });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe(
+      "a gateway base_url must start with http:// or https://",
+    );
+  });
+
+  it("falls back to the status line when the error body isn't JSON", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      json: async () => {
+        throw new Error("not json");
+      },
+    } as unknown as Response);
+    const { result } = renderHook(() => useStoreCredential("host_1"), { wrapper });
+
+    result.current.mutate({ harness: "codex-native", kind: "key", secret: "sk" });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe("502 Bad Gateway");
+  });
+
+  it("patches the hosts cache and invalidates the detect query on success", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    function sharedWrapper({ children }: { children: ReactNode }) {
+      return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    }
+    client.setQueryData(
+      ["hosts", { includeSandbox: false }],
+      [{ host_id: "host_1", name: "Laptop", owner: "alice", status: "online" }],
+    );
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useStoreCredential("host_1"), { wrapper: sharedWrapper });
+    fetchMock.mockResolvedValueOnce(credResult("codex-native", { "codex-native": true }));
+    result.current.mutate({ harness: "codex-native", kind: "key", secret: "sk" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const hosts = client.getQueryData<Array<{ configured_harnesses?: Record<string, unknown> }>>([
+      "hosts",
+      { includeSandbox: false },
+    ]);
+    expect(hosts?.[0].configured_harnesses?.["codex-native"]).toBe(true);
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["detected-credentials", "host_1"] });
+  });
+});
+
+describe("useDetectedCredentials", () => {
+  it("GETs the detect endpoint and returns the credentials array", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        credentials: [{ family: "openai", source: "$OPENAI_API_KEY", env_var: "OPENAI_API_KEY" }],
+      }),
+    );
+    const { result } = renderHook(() => useDetectedCredentials("host_1", true), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/hosts/host_1/credentials/detected");
+    expect(result.current.data).toEqual([
+      { family: "openai", source: "$OPENAI_API_KEY", env_var: "OPENAI_API_KEY" },
+    ]);
+  });
+
+  it("degrades to an empty list when the body omits `credentials`", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    const { result } = renderHook(() => useDetectedCredentials("host_1", true), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("does not fetch when disabled or without a host id", async () => {
+    const disabled = renderHook(() => useDetectedCredentials("host_1", false), { wrapper });
+    const noHost = renderHook(() => useDetectedCredentials(null, true), { wrapper });
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+    disabled.unmount();
+    noHost.unmount();
   });
 });

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -43,11 +43,17 @@ async function fetchHosts(includeSandbox: boolean): Promise<Host[]> {
 interface UseHostsOptions {
   enabled?: boolean;
   includeSandbox?: boolean;
+  /** Refetch on every window refocus (paired with `staleTime: 0`) so returning
+   *  to the tab is a guaranteed readiness recovery. Only the setup flow needs
+   *  this; other consumers keep the 30 s stale window to avoid an app-wide bump
+   *  in `/v1/hosts` volume on refocus. */
+  refetchOnFocus?: boolean;
 }
 
 export function useHosts(options: UseHostsOptions = {}) {
   const enabled = options.enabled ?? true;
   const includeSandbox = options.includeSandbox ?? false;
+  const refetchOnFocus = options.refetchOnFocus ?? false;
   return useQuery({
     // Distinct cache key per filtering mode so the picker's filtered
     // list and the header's unfiltered list don't overwrite each other.
@@ -57,15 +63,16 @@ export function useHosts(options: UseHostsOptions = {}) {
     enabled,
     // Readiness is pushed live via WS (hosts_changed → invalidate in
     // SessionUpdatesProvider), so the badge normally clears within seconds of
-    // `omni setup` finishing. These two settle the case that push misses: a
-    // user typically runs setup in a terminal with the tab backgrounded, which
-    // pauses the interval poll AND is when a reconnect gap can drop the frame.
-    // Refetching on refocus makes returning to the tab a guaranteed recovery —
-    // paired with staleTime 0 so that refocus always refires rather than
-    // serving a stale "needs setup" from cache. The 60 s interval remains the
-    // in-tab fallback.
-    staleTime: 0,
-    refetchOnWindowFocus: true,
+    // `omni setup` finishing. The refocus recovery settles the case that push
+    // misses: a user typically runs setup in a terminal with the tab
+    // backgrounded, which pauses the interval poll AND is when a reconnect gap
+    // can drop the frame. Refetching on refocus makes returning to the tab a
+    // guaranteed recovery — paired with staleTime 0 so refocus always refires
+    // rather than serving a stale "needs setup" from cache. Scoped to the setup
+    // flow via `refetchOnFocus` so the other ~8 consumers don't pay it. The 60 s
+    // interval remains the in-tab fallback.
+    staleTime: refetchOnFocus ? 0 : 30_000,
+    refetchOnWindowFocus: refetchOnFocus,
     refetchInterval: enabled ? 60_000 : false,
   });
 }

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useMutationState, useQuery, useQueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
 import type { NativeModelOption } from "@/lib/types";
 
@@ -55,9 +55,17 @@ export function useHosts(options: UseHostsOptions = {}) {
     queryKey: ["hosts", { includeSandbox }],
     queryFn: () => fetchHosts(includeSandbox),
     enabled,
-    staleTime: 30_000,
-    // Host status is pushed via WS (hosts_changed frame in SessionUpdatesProvider).
-    // 60 s fallback poll catches any missed events (tab backgrounded, reconnect gap).
+    // Readiness is pushed live via WS (hosts_changed → invalidate in
+    // SessionUpdatesProvider), so the badge normally clears within seconds of
+    // `omni setup` finishing. These two settle the case that push misses: a
+    // user typically runs setup in a terminal with the tab backgrounded, which
+    // pauses the interval poll AND is when a reconnect gap can drop the frame.
+    // Refetching on refocus makes returning to the tab a guaranteed recovery —
+    // paired with staleTime 0 so that refocus always refires rather than
+    // serving a stale "needs setup" from cache. The 60 s interval remains the
+    // in-tab fallback.
+    staleTime: 0,
+    refetchOnWindowFocus: true,
     refetchInterval: enabled ? 60_000 : false,
   });
 }
@@ -95,7 +103,7 @@ interface InstallHarnessResult {
  * Install a missing harness onto a connected host from the UI.
  *
  * POSTs to the flag-gated install endpoint; the server drives the same
- * installer `omnigent setup` uses and returns the host's refreshed readiness.
+ * installer `omni setup` uses and returns the host's refreshed readiness.
  * On success we write that map straight into every cached host list so the
  * "needs setup" badge flips to ready without waiting for the 60 s poll or a
  * reconnect. The caller passes the harness id (e.g. `"codex"`); only ids in the
@@ -107,9 +115,18 @@ interface InstallHarnessResult {
  * the call's own `onSettled` (see `HarnessSetupDialog`) rather than the shared
  * observer's `isPending`, which only reflects the latest call.
  */
+/** Stable mutation key for harness-install mutations on a host. Lets the setup
+ *  dialog read per-harness in-flight state via {@link useInstallingHarnesses}
+ *  regardless of which install fired last (a shared observer only remembers the
+ *  latest call's callbacks — see the comment in {@link useInstallHarness}). */
+export function installHarnessMutationKey(hostId: string): readonly unknown[] {
+  return ["install-harness", hostId];
+}
+
 export function useInstallHarness(hostId: string) {
   const queryClient = useQueryClient();
   return useMutation({
+    mutationKey: installHarnessMutationKey(hostId),
     mutationFn: async (harness: string): Promise<InstallHarnessResult> => {
       const res = await authenticatedFetch(
         `/v1/hosts/${encodeURIComponent(hostId)}/harnesses/${encodeURIComponent(harness)}/install`,
@@ -129,12 +146,143 @@ export function useInstallHarness(hostId: string) {
     },
     onSuccess: (result) => {
       // Patch the refreshed readiness into every ["hosts", …] cache entry
-      // (filtered + unfiltered) so the badge updates immediately.
+      // (filtered + unfiltered) so the badge updates immediately. This lives at
+      // config level (not the per-call mutate() options) on purpose: config
+      // callbacks fire per-mutation from the Mutation object, so a concurrent
+      // second install can't orphan the first one's cache patch — unlike the
+      // observer's per-call callbacks, which the later mutate() overwrites.
       queryClient.setQueriesData<Host[]>({ queryKey: ["hosts"] }, (hosts) =>
         hosts?.map((h) =>
           h.host_id === hostId ? { ...h, configured_harnesses: result.configured_harnesses } : h,
         ),
       );
     },
+  });
+}
+
+/**
+ * The set of harness ids with an install currently in flight on *hostId*.
+ *
+ * Reads React Query's global mutation state (filtered to this host's install
+ * mutations), so it reflects EVERY pending install regardless of which one
+ * fired last. The setup dialog is a single persistent instance sharing one
+ * install mutation observer; that observer only remembers the latest call's
+ * per-call callbacks, so tracking in-flight installs via a local set fed by
+ * mutate()'s onSettled loses any earlier install when a second one starts —
+ * leaving the first harness stuck showing "Installing…" forever. Deriving the
+ * set from mutation state instead is observer-independent and self-heals.
+ */
+export function useInstallingHarnesses(hostId: string): ReadonlySet<string> {
+  const pending = useMutationState({
+    filters: { mutationKey: installHarnessMutationKey(hostId), status: "pending" },
+    select: (mutation) => mutation.state.variables as string | undefined,
+  });
+  return new Set(pending.filter((h): h is string => typeof h === "string"));
+}
+
+/** Payload for {@link useStoreCredential}: an API key, a gateway, or adopt. */
+export interface StoreCredentialInput {
+  harness: string;
+  kind: "key" | "gateway" | "adopt";
+  /** The API key / gateway token for `key` / `gateway`; omitted for `adopt`. */
+  secret?: string;
+  /** Gateway base URL (required for `kind: "gateway"`). */
+  base_url?: string;
+  /** Family default model id to pin. Accepted by the backend but not yet
+   *  surfaced by the v1 form — reserved for a follow-up. */
+  default_model?: string;
+  /** OpenAI wire protocol (`"chat"` / `"responses"`), gateway/key openai only.
+   *  Reserved for a follow-up like {@link default_model}. */
+  wire_api?: string;
+  /** For `kind: "adopt"`, the host env var to reference. */
+  env_var?: string;
+}
+
+interface StoreCredentialResult {
+  object: "harness_credential";
+  harness: string;
+  configured_harnesses: Record<string, boolean | string>;
+}
+
+/**
+ * Write a harness provider credential onto a connected host from the UI.
+ *
+ * POSTs to the flag-gated credential endpoint; the server forwards the secret
+ * to the host daemon, which writes it (keychain + a `providers:` reference) and
+ * returns the host's refreshed readiness. On success we patch that map into
+ * every cached host list so the harness badge flips (yellow → green) without a
+ * reconnect. The secret rides in the request body and is never held server-side.
+ */
+export function useStoreCredential(hostId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: StoreCredentialInput): Promise<StoreCredentialResult> => {
+      const { harness, ...body } = input;
+      const res = await authenticatedFetch(
+        `/v1/hosts/${encodeURIComponent(hostId)}/harnesses/${encodeURIComponent(harness)}/credential`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+      if (!res.ok) {
+        let detail = `${res.status} ${res.statusText}`;
+        try {
+          const err = (await res.json()) as { detail?: string };
+          if (typeof err.detail === "string" && err.detail) detail = err.detail;
+        } catch {
+          // Non-JSON error body — keep the status-line detail.
+        }
+        throw new Error(detail);
+      }
+      return (await res.json()) as StoreCredentialResult;
+    },
+    // This mutation-level onSuccess patches the ["hosts"] cache (badge flip) and
+    // invalidates the detect query so a just-adopted credential stops showing.
+    // Callers may ALSO pass a call-level onSuccess (toast + close the form);
+    // react-query fires both — don't consolidate them, or the cache patch here
+    // is lost.
+    onSuccess: (result) => {
+      queryClient.setQueriesData<Host[]>({ queryKey: ["hosts"] }, (hosts) =>
+        hosts?.map((h) =>
+          h.host_id === hostId ? { ...h, configured_harnesses: result.configured_harnesses } : h,
+        ),
+      );
+      // A written/adopted credential changes what's adoptable — refetch it.
+      void queryClient.invalidateQueries({ queryKey: ["detected-credentials", hostId] });
+    },
+  });
+}
+
+/** A credential already on the host, offered for one-click adopt (non-secret). */
+export interface DetectedCredential {
+  family: string;
+  source: string;
+  env_var: string | null;
+}
+
+/**
+ * Fetch the credentials already present on a host, for the adopt affordance.
+ *
+ * Hits the flag-gated detect endpoint; the server asks the host daemon for
+ * NON-secret descriptors (family + source label + env var name) of adoptable
+ * credentials. Enabled only when a host id is given and `enabled` is set (the
+ * dialog turns it on only for a harness whose credential the UI can write), so
+ * we don't probe hosts for closed dialogs.
+ */
+export function useDetectedCredentials(hostId: string | null | undefined, enabled: boolean) {
+  return useQuery({
+    queryKey: ["detected-credentials", hostId],
+    queryFn: async (): Promise<DetectedCredential[]> => {
+      const res = await authenticatedFetch(
+        `/v1/hosts/${encodeURIComponent(hostId ?? "")}/credentials/detected`,
+      );
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      const body = (await res.json()) as { credentials?: DetectedCredential[] };
+      return Array.isArray(body.credentials) ? body.credentials : [];
+    },
+    enabled: enabled && !!hostId,
+    staleTime: 30_000,
   });
 }

--- a/web/src/lib/harnessSetup.test.ts
+++ b/web/src/lib/harnessSetup.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  harnessAuthableOnHost,
+  harnessCredentialFamily,
   harnessInstallableOnHost,
   harnessUnavailableReasonOnHost,
   harnessUnconfiguredOnHost,
   resolveSetupSteps,
-  setupProgress,
 } from "./harnessSetup";
 import type { SetupStepWire } from "@/lib/agentLabels";
 import type { Host } from "@/hooks/useHosts";
@@ -27,7 +28,9 @@ const info = (overrides: Partial<ServerInfo> = {}): ServerInfo =>
     ...overrides,
   }) as ServerInfo;
 
-// A codex-shaped server descriptor: one-click install, then a login command.
+// A codex-shaped server descriptor: one-click install, then a UI-authable auth
+// step (the form lists subscription / API key / gateway; `command` is the
+// subscription option carried into it).
 const CODEX_STEPS: SetupStepWire[] = [
   {
     kind: "install",
@@ -39,15 +42,16 @@ const CODEX_STEPS: SetupStepWire[] = [
   },
   {
     kind: "auth",
-    title: "Sign in to Codex",
-    detail: "Uses your ChatGPT subscription — sign in on the host.",
-    action: "command",
+    title: "Set up authentication",
+    detail: "Sign in with your ChatGPT subscription, an API key, or a gateway.",
+    action: "auth",
     command: "codex login",
     status_key: "authed",
   },
 ];
 
-// A pi-shaped descriptor: install, then an untracked "omnigent setup" credential step.
+// A pi-shaped descriptor: install, then a UI-authable credential step
+// (action "auth", tracked via status_key "authed", no CLI login command).
 const PI_STEPS: SetupStepWire[] = [
   {
     kind: "install",
@@ -59,10 +63,32 @@ const PI_STEPS: SetupStepWire[] = [
   },
   {
     kind: "auth",
-    title: "Add a Pi credential",
-    detail: "Pi needs an API key or gateway. Set it up on the host for now.",
+    title: "Set up authentication",
+    detail: "Add an API key or a gateway so Pi can run.",
+    action: "auth",
+    command: null,
+    status_key: "authed",
+  },
+];
+
+// A qwen-shaped descriptor: install, then an UNTRACKED "omni setup"
+// signpost (env-auth, not UI-authable) — the case that should get dropped when
+// a trackable step anchors the list.
+const QWEN_STEPS: SetupStepWire[] = [
+  {
+    kind: "install",
+    title: "Install Qwen",
+    detail: "We'll install Qwen on the host for you.",
+    action: "install",
+    command: null,
+    status_key: "installed",
+  },
+  {
+    kind: "auth",
+    title: "Add a Qwen credential",
+    detail: "Qwen needs an API key or gateway. Set it up on the host for now.",
     action: "setup",
-    command: "omnigent setup",
+    command: "omni setup",
     status_key: null,
   },
 ];
@@ -119,6 +145,50 @@ describe("harnessInstallableOnHost", () => {
   });
 });
 
+describe("harnessCredentialFamily", () => {
+  it("maps Claude/Codex/Pi spellings to their provider family", () => {
+    expect(harnessCredentialFamily("claude-native")).toBe("anthropic");
+    expect(harnessCredentialFamily("native-claude")).toBe("anthropic");
+    expect(harnessCredentialFamily("codex")).toBe("openai");
+    expect(harnessCredentialFamily("codex-native")).toBe("openai");
+    // Pi resolves to its preferred anthropic fallback family.
+    expect(harnessCredentialFamily("pi")).toBe("anthropic");
+    expect(harnessCredentialFamily("pi-native")).toBe("anthropic");
+  });
+
+  it("returns null for harnesses the UI can't authenticate", () => {
+    expect(harnessCredentialFamily("opencode-native")).toBe(null);
+    expect(harnessCredentialFamily("qwen")).toBe(null);
+    expect(harnessCredentialFamily("cursor-native")).toBe(null);
+    expect(harnessCredentialFamily(null)).toBe(null);
+    expect(harnessCredentialFamily(undefined)).toBe(null);
+  });
+});
+
+describe("harnessAuthableOnHost", () => {
+  const online = hostWith({ codex: "needs-auth" });
+
+  it("true for Claude/Codex/Pi families when feature on and host online", () => {
+    expect(harnessAuthableOnHost(info(), "codex-native", online)).toBe(true);
+    expect(harnessAuthableOnHost(info(), "claude-native", online)).toBe(true);
+    expect(harnessAuthableOnHost(info(), "pi", online)).toBe(true);
+  });
+
+  it("false for env-auth / own-login harnesses, flag off, offline, or loading", () => {
+    // OpenCode/Qwen (env-auth) and Cursor (own-login) are NOT UI-authable.
+    expect(harnessAuthableOnHost(info(), "opencode-native", online)).toBe(false);
+    expect(harnessAuthableOnHost(info(), "qwen", online)).toBe(false);
+    expect(harnessAuthableOnHost(info(), "cursor-native", online)).toBe(false);
+    expect(harnessAuthableOnHost(info({ harness_install_enabled: false }), "codex", online)).toBe(
+      false,
+    );
+    expect(harnessAuthableOnHost(info(), "codex", { ...online, status: "offline" } as Host)).toBe(
+      false,
+    );
+    expect(harnessAuthableOnHost("loading", "codex", online)).toBe(false);
+  });
+});
+
 describe("resolveSetupSteps", () => {
   it("marks install todo + auth todo when the binary is missing", () => {
     const steps = resolveSetupSteps(CODEX_STEPS, "codex", hostWith({ codex: "binary-missing" }));
@@ -141,45 +211,46 @@ describe("resolveSetupSteps", () => {
   });
 
   it("drops an untrackable step when a trackable step anchors the list", () => {
-    // Pi's credential step (status_key: null) can't be tracked; showing it
+    // Qwen's credential step (status_key: null) can't be tracked; showing it
     // pre-install then vanishing post-install is confusing, so it's dropped —
     // leaving just the trackable install step.
-    const steps = resolveSetupSteps(PI_STEPS, "pi", hostWith({ pi: false }));
+    const steps = resolveSetupSteps(QWEN_STEPS, "qwen", hostWith({ qwen: false }));
     expect(steps).toHaveLength(1);
     expect(steps[0].kind).toBe("install");
   });
 
+  it("keeps Pi's tracked auth step (needs-auth → todo, not dropped)", () => {
+    // Regression: Pi's auth step is now status-tracked ("authed"), so an
+    // installed-but-no-credential Pi must show BOTH steps — install ✓ and the
+    // auth step to-do — not collapse to a "ready" one-step list.
+    const steps = resolveSetupSteps(PI_STEPS, "pi", hostWith({ pi: "needs-auth" }));
+    expect(steps.map((s) => [s.kind, s.status])).toEqual([
+      ["install", "done"],
+      ["auth", "todo"],
+    ]);
+    expect(steps[1].action).toBe("auth");
+  });
+
   it("keeps a sole untrackable step (non-installable harness fallback)", () => {
-    // A generic "run omnigent setup" step is untrackable but must still show —
+    // A generic "run omni setup" step is untrackable but must still show —
     // it's the only guidance for a harness the UI can't install.
     const generic: SetupStepWire[] = [
       {
         kind: "install",
         title: "Set up on the host",
-        detail: "Run omnigent setup on the host.",
+        detail: "Run omni setup on the host.",
         action: "setup",
-        command: "omnigent setup",
+        command: "omni setup",
         status_key: null,
       },
     ];
     const steps = resolveSetupSteps(generic, "cursor-native", hostWith({ "cursor-native": false }));
     expect(steps).toHaveLength(1);
-    expect(steps[0].command).toBe("omnigent setup");
+    expect(steps[0].command).toBe("omni setup");
   });
 
   it("returns [] with no descriptor or no harness", () => {
     expect(resolveSetupSteps(undefined, "codex", hostWith({ codex: false }))).toEqual([]);
     expect(resolveSetupSteps(CODEX_STEPS, null, hostWith({ codex: false }))).toEqual([]);
-  });
-});
-
-describe("setupProgress", () => {
-  it("counts tracked steps for the progress header", () => {
-    // Codex needs-auth: install done, auth todo → 1 of 2.
-    const codex = resolveSetupSteps(CODEX_STEPS, "codex", hostWith({ codex: "needs-auth" }));
-    expect(setupProgress(codex)).toEqual({ done: 1, total: 2 });
-    // Pi (install-only after dropping the untrackable step): 0 of 1 when missing.
-    const pi = resolveSetupSteps(PI_STEPS, "pi", hostWith({ pi: false }));
-    expect(setupProgress(pi)).toEqual({ done: 0, total: 1 });
   });
 });

--- a/web/src/lib/harnessSetup.test.ts
+++ b/web/src/lib/harnessSetup.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   harnessAuthableOnHost,
+  harnessCredentialAdoptFamilies,
   harnessCredentialFamily,
   harnessInstallableOnHost,
   harnessUnavailableReasonOnHost,
@@ -162,6 +163,25 @@ describe("harnessCredentialFamily", () => {
     expect(harnessCredentialFamily("cursor-native")).toBe(null);
     expect(harnessCredentialFamily(null)).toBe(null);
     expect(harnessCredentialFamily(undefined)).toBe(null);
+  });
+});
+
+describe("harnessCredentialAdoptFamilies", () => {
+  it("returns the single own family for Claude/Codex", () => {
+    expect(harnessCredentialAdoptFamilies("claude-native")).toEqual(["anthropic"]);
+    expect(harnessCredentialAdoptFamilies("codex")).toEqual(["openai"]);
+    expect(harnessCredentialAdoptFamilies("codex-native")).toEqual(["openai"]);
+  });
+
+  it("returns BOTH families for Pi (it consumes anthropic + openai)", () => {
+    expect(harnessCredentialAdoptFamilies("pi")).toEqual(["anthropic", "openai"]);
+    expect(harnessCredentialAdoptFamilies("pi-native")).toEqual(["anthropic", "openai"]);
+  });
+
+  it("returns an empty list for harnesses the UI can't authenticate", () => {
+    expect(harnessCredentialAdoptFamilies("opencode-native")).toEqual([]);
+    expect(harnessCredentialAdoptFamilies(null)).toEqual([]);
+    expect(harnessCredentialAdoptFamilies(undefined)).toEqual([]);
   });
 });
 

--- a/web/src/lib/harnessSetup.ts
+++ b/web/src/lib/harnessSetup.ts
@@ -28,7 +28,7 @@ export interface ResolvedSetupStep {
   kind: string;
   title: string;
   detail: string;
-  /** ``"install"`` (one-click), ``"command"`` (run on host), ``"setup"`` (omnigent setup). */
+  /** ``"install"`` (one-click), ``"command"`` (run on host), ``"setup"`` (omni setup). */
   action: string;
   command: string | null;
   status: SetupStepStatus;
@@ -124,6 +124,44 @@ export function harnessInstallableOnHost(
 }
 
 /**
+ * The provider family a UI-authable *harness* configures, or ``null`` when the
+ * harness isn't one the UI authenticates. Mirrors the backend's harness→family
+ * resolution: Claude → anthropic, Codex → openai, Pi → anthropic (its preferred
+ * fallback family). The single source of truth for "which harnesses the UI can
+ * authenticate" — {@link harnessAuthableOnHost} keys off a non-null result, and
+ * the credential form scopes host-wide detected credentials to this family so
+ * the adopt affordance can't offer (and persist) a cross-family key — e.g. an
+ * Anthropic key for Codex.
+ */
+export function harnessCredentialFamily(harness: string | null | undefined): string | null {
+  if (!harness) return null;
+  if (["claude", "claude-native", "native-claude"].includes(harness)) return "anthropic";
+  if (["codex", "codex-native", "native-codex"].includes(harness)) return "openai";
+  if (["pi", "pi-native", "native-pi"].includes(harness)) return "anthropic";
+  return null;
+}
+
+/**
+ * Whether the UI can write a credential for *harness* on *host* (the M3 auth
+ * form vs. a copy-command signpost). True only when the feature is on, the host
+ * is online, and the harness is one whose credential omnigent owns (Claude /
+ * Codex / Pi). Mirrors the server's UI-auth allowlist so the form never posts a
+ * credential the route would reject.
+ */
+export function harnessAuthableOnHost(
+  info: ServerInfo | "loading",
+  harness: string | null | undefined,
+  host: Host | undefined | null,
+): boolean {
+  return (
+    info !== "loading" &&
+    info.harness_install_enabled &&
+    harnessCredentialFamily(harness) !== null &&
+    host?.status === "online"
+  );
+}
+
+/**
  * Resolve a server step's done/todo status from the host's readiness value.
  *
  * The host reports one availability per harness — ``true`` (ready),
@@ -174,13 +212,7 @@ export function resolveSetupSteps(
   // Showing an untrackable step pre-install and then having it vanish once the
   // binary lands (the harness reports "ready") is more confusing than never
   // showing it. But never drop the *only* step — a non-installable harness's
-  // sole "run omnigent setup" step must still render.
+  // sole "run omni setup" step must still render.
   const trackable = resolved.filter((s) => s.status !== "unknown");
   return trackable.length > 0 ? trackable : resolved;
-}
-
-/** How many tracked (non-``unknown``) steps are done, for the progress header. */
-export function setupProgress(steps: ResolvedSetupStep[]): { done: number; total: number } {
-  const tracked = steps.filter((s) => s.status !== "unknown");
-  return { done: tracked.filter((s) => s.status === "done").length, total: tracked.length };
 }

--- a/web/src/lib/harnessSetup.ts
+++ b/web/src/lib/harnessSetup.ts
@@ -142,6 +142,25 @@ export function harnessCredentialFamily(harness: string | null | undefined): str
 }
 
 /**
+ * The provider families whose detected credentials a harness can *adopt*.
+ *
+ * Usually the harness's own family (Claude → anthropic, Codex → openai). Pi is
+ * the exception: it consumes BOTH anthropic and openai (it has no CLI login and
+ * routes through either), and the daemon adopts a detected credential under its
+ * OWN detected family — so a host with only ``$OPENAI_API_KEY`` can still back
+ * Pi. Scoping the adopt filter to this set (not the single write-default family)
+ * surfaces that affordance while still keeping a cross-family key off a harness
+ * that can't use it (e.g. an Anthropic key for Codex). Empty when the harness
+ * isn't UI-authable.
+ */
+export function harnessCredentialAdoptFamilies(harness: string | null | undefined): string[] {
+  const family = harnessCredentialFamily(harness);
+  if (family === null) return [];
+  if (["pi", "pi-native", "native-pi"].includes(harness as string)) return ["anthropic", "openai"];
+  return [family];
+}
+
+/**
  * Whether the UI can write a credential for *harness* on *host* (the M3 auth
  * form vs. a copy-command signpost). True only when the feature is on, the host
  * is online, and the harness is one whose credential omnigent owns (Claude /

--- a/web/src/shell/HarnessCredentialForm.test.tsx
+++ b/web/src/shell/HarnessCredentialForm.test.tsx
@@ -113,6 +113,21 @@ describe("HarnessCredentialForm", () => {
     );
   });
 
+  it("offers Pi an openai-family credential too (Pi consumes both families)", () => {
+    // Pi has no CLI login and routes through anthropic OR openai; the daemon
+    // adopts under the detected family, so a host with only $OPENAI_API_KEY can
+    // still back Pi. The adopt filter must not narrow Pi to anthropic-only.
+    detected = [{ family: "openai", source: "$OPENAI_API_KEY", env_var: "OPENAI_API_KEY" }];
+    render(<HarnessCredentialForm harness="pi" host={HOST} command={null} onDone={vi.fn()} />);
+    const adopt = screen.getByTestId("harness-credential-adopt");
+    expect(adopt.textContent).toContain("$OPENAI_API_KEY");
+    fireEvent.click(adopt.querySelector("button")!);
+    expect(mutateMock).toHaveBeenCalledWith(
+      { harness: "pi", kind: "adopt", env_var: "OPENAI_API_KEY" },
+      expect.anything(),
+    );
+  });
+
   it("shows no adopt row when nothing is detected", () => {
     detected = [];
     render(<HarnessCredentialForm harness="codex" host={HOST} command={null} onDone={vi.fn()} />);

--- a/web/src/shell/HarnessCredentialForm.test.tsx
+++ b/web/src/shell/HarnessCredentialForm.test.tsx
@@ -20,8 +20,9 @@ vi.mock("@/lib/clipboard", () => ({ copyText: copyTextMock }));
 vi.mock("@/components/ui/toast", () => ({ showToast: showToastMock }));
 
 let detected: { family: string; source: string; env_var: string | null }[] = [];
+let storePending = false;
 vi.mock("@/hooks/useHosts", () => ({
-  useStoreCredential: () => ({ mutate: mutateMock, isPending: false }),
+  useStoreCredential: () => ({ mutate: mutateMock, isPending: storePending }),
   useDetectedCredentials: () => ({ data: detected }),
 }));
 
@@ -33,6 +34,7 @@ afterEach(() => {
   copyTextMock.mockClear();
   showToastMock.mockReset();
   detected = [];
+  storePending = false;
 });
 
 describe("HarnessCredentialForm", () => {
@@ -240,6 +242,20 @@ describe("HarnessCredentialForm", () => {
     );
     expect(showToastMock).not.toHaveBeenCalledWith(expect.stringContaining("is ready on"));
     expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("does not re-submit on Enter while a write is in flight", () => {
+    // The Save button is disabled during a write, but the input isn't — pressing
+    // Enter in the field (paste-then-hammer-Enter) would re-fire the POST and
+    // send the secret twice. The onSubmit is gated on !busy, so a submit while
+    // pending is a no-op.
+    storePending = true;
+    render(<HarnessCredentialForm harness="codex" host={HOST} command={null} onDone={vi.fn()} />);
+    const keyInput = screen.getByTestId("harness-credential-key");
+    fireEvent.change(keyInput, { target: { value: "sk-x" } });
+    fireEvent.submit(keyInput.closest("form")!);
+    fireEvent.submit(keyInput.closest("form")!);
+    expect(mutateMock).not.toHaveBeenCalled();
   });
 
   it("uses the friendly label (not the raw harness id) in the ready toast", () => {

--- a/web/src/shell/HarnessCredentialForm.test.tsx
+++ b/web/src/shell/HarnessCredentialForm.test.tsx
@@ -1,0 +1,293 @@
+// Tests for HarnessCredentialForm — the inline "Add a credential" form for the
+// harness setup dialog. Covers the equally-weighted options (adopt a detected
+// key, sign in with a subscription, paste an API key, connect a gateway) and
+// that they're presented as alternatives ("or" dividers), not one primary field
+// with the rest demoted. The hooks are mocked so the form is exercised without a
+// live host.
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Host } from "@/hooks/useHosts";
+import { HarnessCredentialForm } from "./HarnessCredentialForm";
+
+const mutateMock = vi.fn();
+const { copyTextMock, showToastMock } = vi.hoisted(() => ({
+  copyTextMock: vi.fn(() => Promise.resolve()),
+  showToastMock: vi.fn(),
+}));
+vi.mock("@/lib/clipboard", () => ({ copyText: copyTextMock }));
+vi.mock("@/components/ui/toast", () => ({ showToast: showToastMock }));
+
+let detected: { family: string; source: string; env_var: string | null }[] = [];
+vi.mock("@/hooks/useHosts", () => ({
+  useStoreCredential: () => ({ mutate: mutateMock, isPending: false }),
+  useDetectedCredentials: () => ({ data: detected }),
+}));
+
+const HOST = { host_id: "host_1", name: "corey-laptop", status: "online" } as Host;
+
+afterEach(() => {
+  cleanup();
+  mutateMock.mockReset();
+  copyTextMock.mockClear();
+  showToastMock.mockReset();
+  detected = [];
+});
+
+describe("HarnessCredentialForm", () => {
+  it("saves a pasted API key", () => {
+    render(
+      <HarnessCredentialForm harness="codex" host={HOST} command="codex login" onDone={vi.fn()} />,
+    );
+    fireEvent.change(screen.getByTestId("harness-credential-key"), {
+      target: { value: "sk-ant-XYZ" },
+    });
+    fireEvent.click(screen.getByTestId("harness-credential-save"));
+    expect(mutateMock).toHaveBeenCalledWith(
+      { harness: "codex", kind: "key", secret: "sk-ant-XYZ" },
+      expect.anything(),
+    );
+  });
+
+  it("does not submit an empty key (Save disabled)", () => {
+    render(<HarnessCredentialForm harness="codex" host={HOST} command={null} onDone={vi.fn()} />);
+    expect((screen.getByTestId("harness-credential-save") as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("submits a gateway", () => {
+    render(<HarnessCredentialForm harness="codex" host={HOST} command={null} onDone={vi.fn()} />);
+    // Gateway is an equally-weighted option, always shown (no toggle).
+    const gateway = screen.getByTestId("harness-credential-gateway");
+    const [urlInput, keyInput] = gateway.querySelectorAll("input");
+    fireEvent.change(urlInput, { target: { value: "https://openrouter.ai/api/v1" } });
+    fireEvent.change(keyInput, { target: { value: "or-KEY" } });
+    fireEvent.submit(gateway);
+    expect(mutateMock).toHaveBeenCalledWith(
+      {
+        harness: "codex",
+        kind: "gateway",
+        base_url: "https://openrouter.ai/api/v1",
+        secret: "or-KEY",
+      },
+      expect.anything(),
+    );
+  });
+
+  it("offers a detected credential for one-click adopt", () => {
+    detected = [{ family: "openai", source: "$OPENAI_API_KEY", env_var: "OPENAI_API_KEY" }];
+    render(<HarnessCredentialForm harness="codex" host={HOST} command={null} onDone={vi.fn()} />);
+    const adopt = screen.getByTestId("harness-credential-adopt");
+    expect(adopt.textContent).toContain("$OPENAI_API_KEY");
+    fireEvent.click(adopt.querySelector("button")!);
+    expect(mutateMock).toHaveBeenCalledWith(
+      { harness: "codex", kind: "adopt", env_var: "OPENAI_API_KEY" },
+      expect.anything(),
+    );
+  });
+
+  it("does not offer a cross-family credential for adopt", () => {
+    // The detect endpoint is host-wide: an Anthropic key is present but the
+    // harness is Codex (openai family). The adopt row must NOT appear — offering
+    // "Use $ANTHROPIC_API_KEY" for Codex would persist an openai provider that
+    // points at an Anthropic key.
+    detected = [
+      { family: "anthropic", source: "$ANTHROPIC_API_KEY", env_var: "ANTHROPIC_API_KEY" },
+    ];
+    render(<HarnessCredentialForm harness="codex" host={HOST} command={null} onDone={vi.fn()} />);
+    expect(screen.queryByTestId("harness-credential-adopt")).toBeNull();
+  });
+
+  it("offers a Pi (anthropic-family) credential to adopt", () => {
+    // Pi resolves to the anthropic family, so an ANTHROPIC_API_KEY is adoptable.
+    detected = [
+      { family: "anthropic", source: "$ANTHROPIC_API_KEY", env_var: "ANTHROPIC_API_KEY" },
+    ];
+    render(<HarnessCredentialForm harness="pi" host={HOST} command={null} onDone={vi.fn()} />);
+    expect(screen.getByTestId("harness-credential-adopt").textContent).toContain(
+      "$ANTHROPIC_API_KEY",
+    );
+  });
+
+  it("shows no adopt row when nothing is detected", () => {
+    detected = [];
+    render(<HarnessCredentialForm harness="codex" host={HOST} command={null} onDone={vi.fn()} />);
+    expect(screen.queryByTestId("harness-credential-adopt")).toBeNull();
+  });
+
+  it("copies the subscription login command (never a form field)", async () => {
+    render(
+      <HarnessCredentialForm
+        harness="claude"
+        host={HOST}
+        command="claude auth login"
+        onDone={vi.fn()}
+      />,
+    );
+    const loginCopy = screen.getByTestId("harness-credential-login-copy");
+    expect(loginCopy.textContent).toContain("claude auth login");
+    fireEvent.click(loginCopy);
+    await waitFor(() => expect(copyTextMock).toHaveBeenCalledWith("claude auth login"));
+  });
+
+  it("omits the subscription signpost when there is no login command (Pi)", () => {
+    render(<HarnessCredentialForm harness="pi" host={HOST} command={null} onDone={vi.fn()} />);
+    expect(screen.queryByTestId("harness-credential-login-copy")).toBeNull();
+  });
+
+  it("presents the paths as equal alternatives joined by 'or'", () => {
+    // Codex with a detected key: adopt + subscription + API key + gateway = four
+    // options, so three "or" dividers separate them. Each is a labeled block
+    // (no field is the primary with the rest demoted).
+    detected = [{ family: "openai", source: "$OPENAI_API_KEY", env_var: "OPENAI_API_KEY" }];
+    const { container } = render(
+      <HarnessCredentialForm harness="codex" host={HOST} command="codex login" onDone={vi.fn()} />,
+    );
+    // Each path carries its own equal-weight label.
+    for (const label of [
+      "Use a credential found on this host",
+      "Sign in with your subscription",
+      "Use an API key",
+      "Connect a gateway",
+    ]) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+    // Four options → three "or" separators between them.
+    expect(countOrDividers(container)).toBe(3);
+  });
+
+  it("drops the subscription option for Pi, leaving key + gateway (one 'or')", () => {
+    // Pi has no CLI login and nothing detected → just API key and gateway, so a
+    // single "or" divides them; the subscription block is absent.
+    const { container } = render(
+      <HarnessCredentialForm harness="pi" host={HOST} command={null} onDone={vi.fn()} />,
+    );
+    expect(screen.getByText("Use an API key")).toBeTruthy();
+    expect(screen.getByText("Connect a gateway")).toBeTruthy();
+    expect(screen.queryByText("Sign in with your subscription")).toBeNull();
+    expect(countOrDividers(container)).toBe(1);
+  });
+
+  it("confirms ready and closes only when the write turns the harness ready", () => {
+    // The write succeeded AND readiness flipped to true → toast says ready and
+    // the form closes (onDone).
+    mutateMock.mockImplementation((_input, opts?: { onSuccess?: (r: unknown) => void }) =>
+      opts?.onSuccess?.({
+        object: "harness_credential",
+        harness: "pi",
+        configured_harnesses: { pi: true },
+      }),
+    );
+    const onDone = vi.fn();
+    render(<HarnessCredentialForm harness="pi" host={HOST} command={null} onDone={onDone} />);
+    fireEvent.change(screen.getByTestId("harness-credential-key"), { target: { value: "sk-x" } });
+    fireEvent.click(screen.getByTestId("harness-credential-save"));
+    expect(showToastMock).toHaveBeenCalledWith(expect.stringContaining("is ready on"));
+    expect(onDone).toHaveBeenCalled();
+  });
+
+  it("does NOT claim ready when the write leaves the harness not-ready", () => {
+    // Regression: the toast used to say "ready" unconditionally, contradicting a
+    // still-yellow dot. When readiness stays not-true, say so and keep the form
+    // open (don't call onDone) so the user can try another option.
+    mutateMock.mockImplementation((_input, opts?: { onSuccess?: (r: unknown) => void }) =>
+      opts?.onSuccess?.({
+        object: "harness_credential",
+        harness: "pi",
+        configured_harnesses: { pi: "needs-auth" },
+      }),
+    );
+    const onDone = vi.fn();
+    render(<HarnessCredentialForm harness="pi" host={HOST} command={null} onDone={onDone} />);
+    const keyInput = screen.getByTestId("harness-credential-key") as HTMLInputElement;
+    fireEvent.change(keyInput, { target: { value: "sk-x" } });
+    fireEvent.click(screen.getByTestId("harness-credential-save"));
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.stringContaining("still needs setup"),
+      expect.anything(),
+    );
+    expect(showToastMock).not.toHaveBeenCalledWith(expect.stringContaining("is ready on"));
+    expect(onDone).not.toHaveBeenCalled();
+    // The form stays open on a not-ready result; the entered key must not linger
+    // in the field while the user tries another option.
+    expect(keyInput.value).toBe("");
+  });
+
+  it("surfaces a sticky error toast when the write is rejected", () => {
+    // A backend-rejected write (e.g. a malformed gateway base_url the host
+    // bounces as a 502) rejects the mutation. The form must report the failure
+    // via the onError toast — kept sticky (duration 0) so it isn't missed — and
+    // must NOT claim ready or close.
+    mutateMock.mockImplementation((_input, opts?: { onError?: (e: Error) => void }) =>
+      opts?.onError?.(
+        new Error(
+          "host credential write failed: a gateway base_url must start with http:// or https://",
+        ),
+      ),
+    );
+    const onDone = vi.fn();
+    render(<HarnessCredentialForm harness="codex" host={HOST} command={null} onDone={onDone} />);
+    const gateway = screen.getByTestId("harness-credential-gateway");
+    const [urlInput, keyInput] = gateway.querySelectorAll("input");
+    fireEvent.change(urlInput, { target: { value: "ftp://nope" } });
+    fireEvent.change(keyInput, { target: { value: "tok" } });
+    fireEvent.submit(gateway);
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.stringContaining("Couldn't save the credential"),
+      expect.objectContaining({ duration: 0 }),
+    );
+    expect(showToastMock).not.toHaveBeenCalledWith(expect.stringContaining("is ready on"));
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("uses the friendly label (not the raw harness id) in the ready toast", () => {
+    // The dialog passes a display name ("Codex") while the harness id is the
+    // canonical "codex-native" (what readiness is keyed on). The toast must read
+    // "Codex is ready", never "codex-native is ready" — the id is plumbing.
+    mutateMock.mockImplementation((_input, opts?: { onSuccess?: (r: unknown) => void }) =>
+      opts?.onSuccess?.({
+        object: "harness_credential",
+        harness: "codex-native",
+        configured_harnesses: { "codex-native": true },
+      }),
+    );
+    render(
+      <HarnessCredentialForm
+        harness="codex-native"
+        label="Codex"
+        host={HOST}
+        command={null}
+        onDone={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("harness-credential-key"), { target: { value: "sk-x" } });
+    fireEvent.click(screen.getByTestId("harness-credential-save"));
+    expect(showToastMock).toHaveBeenCalledWith("Codex is ready on corey-laptop.");
+    expect(showToastMock).not.toHaveBeenCalledWith(expect.stringContaining("codex-native"));
+  });
+
+  it("keeps a light, non-error disabled Save until input is entered", () => {
+    // A disabled Save must read as "waiting for input" (outline), not a heavy
+    // dark fill that looks like an error/unavailable state. Typing a key flips
+    // it to the solid primary.
+    render(<HarnessCredentialForm harness="pi" host={HOST} command={null} onDone={vi.fn()} />);
+    const save = screen.getByTestId("harness-credential-save") as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+    expect(save.getAttribute("data-variant")).toBe("outline");
+    fireEvent.change(screen.getByTestId("harness-credential-key"), { target: { value: "sk-x" } });
+    expect((screen.getByTestId("harness-credential-save") as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+    expect(screen.getByTestId("harness-credential-save").getAttribute("data-variant")).toBe(
+      "default",
+    );
+  });
+});
+
+/** Count the "or" divider blocks (a div whose visible text is exactly "or",
+ *  its two flanking rules being empty spans). */
+function countOrDividers(container: HTMLElement): number {
+  return Array.from(container.querySelectorAll("div")).filter((d) => d.textContent === "or").length;
+}

--- a/web/src/shell/HarnessCredentialForm.tsx
+++ b/web/src/shell/HarnessCredentialForm.tsx
@@ -1,0 +1,316 @@
+/**
+ * Inline "Add a credential" form for the harness setup dialog (Claude/Codex/Pi).
+ *
+ * Presents every applicable auth path as an equally-weighted, labeled option
+ * separated by "or", so it reads as a set of alternatives rather than one
+ * primary field with the rest demoted:
+ *   - adopt a credential omnigent detected on the host (only when one is found),
+ *   - sign in with the harness's subscription (a copy-command — the UI can't
+ *     drive browser OAuth; omitted for Pi, which has no CLI login),
+ *   - use an API key,
+ *   - connect a gateway (base URL + key).
+ * Writing goes through {@link useStoreCredential}; on success the host's
+ * readiness flips and the dialog's row turns green.
+ */
+
+import { Fragment, useState } from "react";
+import { KeyRound, UserRound, Waypoints } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { showToast } from "@/components/ui/toast";
+import { copyText } from "@/lib/clipboard";
+import {
+  useDetectedCredentials,
+  useStoreCredential,
+  type DetectedCredential,
+  type Host,
+  type StoreCredentialInput,
+} from "@/hooks/useHosts";
+import { harnessCredentialFamily } from "@/lib/harnessSetup";
+
+export function HarnessCredentialForm({
+  harness,
+  label,
+  host,
+  command,
+  onDone,
+}: {
+  harness: string;
+  /** Friendly display name for user-facing toasts (e.g. "Codex"); the raw
+   *  `harness` id (e.g. "codex-native") is still used for the readiness lookup
+   *  and the API call. Falls back to `harness` when not supplied. */
+  label?: string;
+  host: Host | undefined | null;
+  /** The server's subscription-login command (e.g. `codex login`), shown as a
+   *  copy signpost — the UI can't drive browser OAuth. `null` for Pi. */
+  command: string | null;
+  onDone: () => void;
+}) {
+  // What the user sees in toasts — the friendly name, not the canonical id.
+  const display = label ?? harness;
+  const store = useStoreCredential(host?.host_id ?? "");
+  // Detection is only meaningful for a live host and this open form.
+  const { data: detected } = useDetectedCredentials(host?.host_id, !!host);
+  // The detect endpoint is host-wide (both families), so scope the adopt
+  // affordance to THIS harness's family — otherwise we could offer (and
+  // persist) a cross-family key, e.g. an Anthropic key for Codex.
+  const family = harnessCredentialFamily(harness);
+  const adoptable = (detected ?? []).find((d) => d.env_var && d.family === family);
+
+  const [apiKey, setApiKey] = useState("");
+  const [gatewayUrl, setGatewayUrl] = useState("");
+  const [gatewayKey, setGatewayKey] = useState("");
+
+  const busy = store.isPending;
+
+  const submit = (input: StoreCredentialInput) => {
+    // The form only mounts for an online host (gated by harnessAuthableOnHost),
+    // so a host id is always present — but guard explicitly rather than POST to
+    // a malformed `/v1/hosts//…` URL if that invariant ever changes.
+    if (!host?.host_id) return;
+    store.mutate(input, {
+      onSuccess: (result) => {
+        // Key the toast on the harness's REFRESHED readiness, not the mere fact
+        // that the write succeeded: a credential can be stored yet leave the
+        // harness not-ready (e.g. the daemon couldn't route it), and claiming
+        // "ready" then would contradict the still-yellow dot. Only close the
+        // form when the harness actually turned ready, so a not-ready result
+        // keeps the options visible to try another.
+        const ready = result.configured_harnesses[harness] === true;
+        // Clear the secret fields so a saved value doesn't linger in the input
+        // (the form stays open on a not-ready result to try another option).
+        setApiKey("");
+        setGatewayUrl("");
+        setGatewayKey("");
+        if (ready) {
+          showToast(`${display} is ready on ${host.name}.`);
+          onDone();
+        } else {
+          showToast(
+            `Saved, but ${display} still needs setup on ${host.name}. Try another option.`,
+            { duration: 0 },
+          );
+        }
+      },
+      onError: (err) => showToast(`Couldn't save the credential: ${err.message}`, { duration: 0 }),
+    });
+  };
+
+  // Build the applicable options in a fixed order; each renders as an
+  // equally-weighted labeled block, joined by "or" dividers below. Adopt and
+  // subscription are conditional; API key and gateway always apply. Each carries
+  // a stable id key: the async adopt row prepends once detection resolves, so an
+  // array-index key would shift and remount the rows below it.
+  const options: { id: string; node: React.ReactNode }[] = [];
+  if (adoptable) {
+    options.push({
+      id: "adopt",
+      node: (
+        <CredentialOption icon={<KeyRound />} label="Use a credential found on this host">
+          <AdoptRow
+            detected={adoptable}
+            busy={busy}
+            onUse={() =>
+              submit({ harness, kind: "adopt", env_var: adoptable.env_var ?? undefined })
+            }
+          />
+        </CredentialOption>
+      ),
+    });
+  }
+  if (command) {
+    options.push({
+      id: "subscription",
+      node: (
+        <CredentialOption icon={<UserRound />} label="Sign in with your subscription">
+          <p className="text-xs text-muted-foreground">
+            Use your existing plan — run{" "}
+            <button
+              type="button"
+              className="rounded bg-muted px-1 py-0.5 font-mono hover:text-foreground"
+              data-testid="harness-credential-login-copy"
+              onClick={() => {
+                void copyText(command)
+                  .then(() => showToast("Copied to clipboard."))
+                  .catch(() =>
+                    showToast("Couldn't copy — select and copy manually.", { duration: 0 }),
+                  );
+              }}
+            >
+              {command}
+            </button>{" "}
+            on {host?.name}.
+          </p>
+        </CredentialOption>
+      ),
+    });
+  }
+  options.push({
+    id: "key",
+    node: (
+      <CredentialOption icon={<KeyRound />} label="Use an API key">
+        <form
+          className="flex items-center gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (apiKey.trim()) submit({ harness, kind: "key", secret: apiKey.trim() });
+          }}
+        >
+          <Input
+            type="password"
+            autoComplete="off"
+            placeholder="Paste an API key"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            data-testid="harness-credential-key"
+            className="h-8 font-mono text-xs"
+          />
+          <SaveButton busy={busy} disabled={!apiKey.trim()} testId="harness-credential-save" />
+        </form>
+      </CredentialOption>
+    ),
+  });
+  options.push({
+    id: "gateway",
+    node: (
+      <CredentialOption icon={<Waypoints />} label="Connect a gateway">
+        <p className="text-xs text-muted-foreground">
+          Route through an OpenAI-compatible proxy (e.g. OpenRouter).
+        </p>
+        <form
+          className="flex flex-col gap-2"
+          data-testid="harness-credential-gateway"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (gatewayUrl.trim() && gatewayKey.trim()) {
+              submit({
+                harness,
+                kind: "gateway",
+                base_url: gatewayUrl.trim(),
+                secret: gatewayKey.trim(),
+              });
+            }
+          }}
+        >
+          <Input
+            type="text"
+            placeholder="Gateway base URL (e.g. https://openrouter.ai/api/v1)"
+            value={gatewayUrl}
+            onChange={(e) => setGatewayUrl(e.target.value)}
+            className="h-8 text-xs"
+          />
+          <div className="flex items-center gap-2">
+            <Input
+              type="password"
+              autoComplete="off"
+              placeholder="Gateway API key"
+              value={gatewayKey}
+              onChange={(e) => setGatewayKey(e.target.value)}
+              className="h-8 font-mono text-xs"
+            />
+            <SaveButton busy={busy} disabled={!gatewayUrl.trim() || !gatewayKey.trim()} />
+          </div>
+        </form>
+      </CredentialOption>
+    ),
+  });
+
+  return (
+    <div className="flex flex-col gap-3 py-1" data-testid="harness-credential-form">
+      {options.map((option, i) => (
+        <Fragment key={option.id}>
+          {i > 0 && <OrDivider />}
+          {option.node}
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+/** A labeled, equally-weighted auth choice block, with a leading glyph so the
+ *  paths are scannable at a glance. */
+function CredentialOption({
+  icon,
+  label,
+  children,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="flex items-center gap-1.5 text-xs font-medium">
+        <span className="text-muted-foreground [&_svg]:size-3.5">{icon}</span>
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+/** Save button whose disabled state stays a light, clearly-inert outline
+ *  (rather than a heavy dark fill that reads as an error). */
+function SaveButton({
+  busy,
+  disabled,
+  testId,
+}: {
+  busy: boolean;
+  disabled: boolean;
+  testId?: string;
+}) {
+  return (
+    <Button
+      type="submit"
+      size="sm"
+      loading={busy}
+      disabled={disabled}
+      variant={disabled ? "outline" : "default"}
+      data-testid={testId}
+      className="shrink-0"
+    >
+      Save
+    </Button>
+  );
+}
+
+/** Short, centered "or" separator between two equally-weighted options — a
+ *  quiet divider, not a section header. */
+function OrDivider() {
+  return (
+    <div
+      className="flex items-center justify-center gap-2 text-[10px] uppercase tracking-wide text-muted-foreground"
+      aria-hidden
+    >
+      <span className="h-px w-6 bg-border" />
+      or
+      <span className="h-px w-6 bg-border" />
+    </div>
+  );
+}
+
+function AdoptRow({
+  detected,
+  busy,
+  onUse,
+}: {
+  detected: DetectedCredential;
+  busy: boolean;
+  onUse: () => void;
+}) {
+  return (
+    <div
+      className="flex items-center gap-2 rounded bg-emerald-50 px-2 py-1.5 dark:bg-emerald-500/10"
+      data-testid="harness-credential-adopt"
+    >
+      <span className="flex-1 text-xs">
+        Found <code className="font-mono">{detected.source}</code> on this host.
+      </span>
+      <Button type="button" size="sm" loading={busy} onClick={onUse}>
+        Use it
+      </Button>
+    </div>
+  );
+}

--- a/web/src/shell/HarnessCredentialForm.tsx
+++ b/web/src/shell/HarnessCredentialForm.tsx
@@ -154,7 +154,9 @@ export function HarnessCredentialForm({
           className="flex items-center gap-2"
           onSubmit={(e) => {
             e.preventDefault();
-            if (apiKey.trim()) submit({ harness, kind: "key", secret: apiKey.trim() });
+            // Guard on !busy too: the Save button is disabled while a write is
+            // in flight, but Enter in the field would otherwise re-fire the POST.
+            if (!busy && apiKey.trim()) submit({ harness, kind: "key", secret: apiKey.trim() });
           }}
         >
           <Input
@@ -183,7 +185,8 @@ export function HarnessCredentialForm({
           data-testid="harness-credential-gateway"
           onSubmit={(e) => {
             e.preventDefault();
-            if (gatewayUrl.trim() && gatewayKey.trim()) {
+            // See the API-key form: gate on !busy so Enter can't re-POST mid-save.
+            if (!busy && gatewayUrl.trim() && gatewayKey.trim()) {
               submit({
                 harness,
                 kind: "gateway",

--- a/web/src/shell/HarnessCredentialForm.tsx
+++ b/web/src/shell/HarnessCredentialForm.tsx
@@ -27,7 +27,7 @@ import {
   type Host,
   type StoreCredentialInput,
 } from "@/hooks/useHosts";
-import { harnessCredentialFamily } from "@/lib/harnessSetup";
+import { harnessCredentialAdoptFamilies } from "@/lib/harnessSetup";
 
 export function HarnessCredentialForm({
   harness,
@@ -53,10 +53,11 @@ export function HarnessCredentialForm({
   // Detection is only meaningful for a live host and this open form.
   const { data: detected } = useDetectedCredentials(host?.host_id, !!host);
   // The detect endpoint is host-wide (both families), so scope the adopt
-  // affordance to THIS harness's family — otherwise we could offer (and
-  // persist) a cross-family key, e.g. an Anthropic key for Codex.
-  const family = harnessCredentialFamily(harness);
-  const adoptable = (detected ?? []).find((d) => d.env_var && d.family === family);
+  // affordance to the families THIS harness can adopt — otherwise we could offer
+  // (and persist) a cross-family key, e.g. an Anthropic key for Codex. Pi
+  // consumes both families, so it can adopt an openai OR an anthropic key.
+  const adoptFamilies = harnessCredentialAdoptFamilies(harness);
+  const adoptable = (detected ?? []).find((d) => d.env_var && adoptFamilies.includes(d.family));
 
   const [apiKey, setApiKey] = useState("");
   const [gatewayUrl, setGatewayUrl] = useState("");

--- a/web/src/shell/HarnessSetupDialog.tsx
+++ b/web/src/shell/HarnessSetupDialog.tsx
@@ -60,7 +60,7 @@ export function HarnessSetupDialog({
   // patches the ["hosts"] cache, and the dialog must reflect that (flip ✓)
   // without being closed and reopened. Falls back to the snapshot while the
   // query is loading.
-  const { data: hosts } = useHosts();
+  const { data: hosts } = useHosts({ refetchOnFocus: true });
   const host = hosts?.find((h) => h.host_id === hostProp?.host_id) ?? hostProp;
   const install = useInstallHarness(host?.host_id ?? "");
   const steps = resolveSetupSteps(

--- a/web/src/shell/HarnessSetupDialog.tsx
+++ b/web/src/shell/HarnessSetupDialog.tsx
@@ -1,12 +1,18 @@
 /**
  * "Set up <agent> on <host>" dialog for the New Chat landing screen.
  *
- * Renders the harness's setup requirements as an always-visible checklist with
- * a "N of M done" progress header, mirroring what ``omnigent setup`` walks a
- * user through. The steps are authored by the server (``/v1/harnesses`` →
- * ``setup_steps``); this component marks each done/todo from the host's
- * readiness and offers the right control per step: a one-click Install for
- * server-performed steps, or a click-to-copy command the user runs on the host.
+ * Renders the harness's setup requirements as a checklist, mirroring what
+ * ``omni setup`` walks a user through. The step descriptors are authored by
+ * the server (``/v1/harnesses`` → ``setup_steps``); this component marks each
+ * done/todo from the host's readiness and offers the right control per step:
+ *   - a one-click Install for a server-installable harness,
+ *   - an inline "Add a credential" form (adopt an existing key / paste an API
+ *     key / configure a gateway) for the Claude / Codex / Pi families the UI can
+ *     authenticate,
+ *   - a click-to-copy command for a step the UI can't do yet.
+ * When no step is UI-actionable the dialog collapses to a single "run omnigent
+ * setup" signpost. There is no progress counter — the per-row dots already show
+ * each step's state.
  */
 
 import { useState } from "react";
@@ -25,13 +31,14 @@ import { showToast } from "@/components/ui/toast";
 import { copyText } from "@/lib/clipboard";
 import { useHarnessSetupSteps } from "@/lib/agentLabels";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
-import { useHosts, useInstallHarness, type Host } from "@/hooks/useHosts";
+import { useHosts, useInstallHarness, useInstallingHarnesses, type Host } from "@/hooks/useHosts";
 import {
+  harnessAuthableOnHost,
   harnessInstallableOnHost,
   resolveSetupSteps,
-  setupProgress,
   type ResolvedSetupStep,
 } from "@/lib/harnessSetup";
+import { HarnessCredentialForm } from "@/shell/HarnessCredentialForm";
 
 export function HarnessSetupDialog({
   open,
@@ -49,8 +56,8 @@ export function HarnessSetupDialog({
   const setupStepsByHarness = useHarnessSetupSteps();
   const info = useServerInfo();
   // Re-resolve the host LIVE from the hosts query rather than trusting the
-  // snapshot passed at open time: a successful install patches the ["hosts"]
-  // cache, and the dialog must reflect that (flip ✓, recompute progress)
+  // snapshot passed at open time: a successful install / credential write
+  // patches the ["hosts"] cache, and the dialog must reflect that (flip ✓)
   // without being closed and reopened. Falls back to the snapshot while the
   // query is loading.
   const { data: hosts } = useHosts();
@@ -62,33 +69,54 @@ export function HarnessSetupDialog({
     host,
   );
   // Defence in depth: only render the one-click Install when the server's
-  // allowlist actually accepts this harness on this host. A server step with
-  // action "install" is the primary signal, but gating on the allowlist too
-  // means the UI can never offer an install the route would reject (409/400)
-  // if the two ever drift.
+  // allowlist accepts this harness (guards against step-catalog/allowlist
+  // drift). Likewise the inline credential form only for a harness whose
+  // credential the UI can actually write.
   const installable = harnessInstallableOnHost(info, harness, host);
-  const { done, total } = setupProgress(steps);
+  const authable = harnessAuthableOnHost(info, harness, host);
   const name = agentName ?? harness ?? "this agent";
-  const allDone = total > 0 && done === total;
-  // Track which harness ids have an install in flight. The dialog is one
-  // persistent instance sharing a single install mutation, so its isPending
-  // only reflects the latest call — useless when installs run concurrently or
-  // the dialog switches harnesses mid-install. Each mutate() call adds its
-  // harness on start and removes it on settle (per-call callbacks fire
-  // independently), so every row reflects its OWN harness's real state.
-  const [installing, setInstalling] = useState<ReadonlySet<string>>(new Set());
+
+  // Auth is a SECOND step: gate the credential form until the binary is
+  // present, so the checklist runs Install → Set up auth in order. Without this,
+  // a not-yet-installed harness shows both buttons and an auth-first write
+  // would succeed yet leave the dot red (readiness is binary-missing until the
+  // CLI lands) — a contradictory "saved but not ready" state. "Installed" =
+  // no install step is still to-do.
+  const installComplete = steps.every((s) => s.kind !== "install" || s.status === "done");
+
+  // A step is UI-actionable when we can perform it here: an install we're
+  // allowed to run, or an auth step for a harness we can authenticate. When NO
+  // step is actionable (a curl/own-login harness), collapse to one signpost.
+  const anyActionable = steps.some(
+    (s) =>
+      (s.action === "install" && installable) ||
+      (s.kind === "auth" && authable) ||
+      s.command != null,
+  );
+  const allDone = steps.length > 0 && steps.every((s) => s.status === "done");
+
+  // Which harness ids have an install in flight, read from React Query's
+  // mutation state (not a local set). The dialog is one persistent instance
+  // sharing a single install mutation observer, and that observer only
+  // remembers the LATEST mutate() call's per-call callbacks. Tracking in-flight
+  // installs via mutate()'s onSettled therefore lost an earlier harness the
+  // moment a second install started — leaving the first stuck on "Installing…".
+  // useInstallingHarnesses derives the set from mutation state, so every row
+  // reflects its OWN harness's state regardless of firing order.
+  const installing = useInstallingHarnesses(host?.host_id ?? "");
   const installingThisHarness = !!harness && installing.has(harness);
 
   const startInstall = (h: string) => {
-    setInstalling((prev) => new Set(prev).add(h));
+    // Only the toast rides on the per-call callbacks; the in-flight indicator
+    // (mutation state) and the readiness cache patch (config-level onSuccess in
+    // useInstallHarness) are both observer-independent, so a concurrent second
+    // install can't strand this one. A lost toast is cosmetic; a stuck spinner
+    // or an unpatched badge is the bug we're avoiding.
     install.mutate(h, {
       onSuccess: (result) => {
         // The install succeeded, but the harness may still need a credential
-        // (e.g. Codex → "needs-auth"): the checklist shows the remaining
-        // sign-in row, so a flat "is ready" toast would contradict it. Key the
-        // toast on the refreshed readiness the install returned — "ready" only
-        // when the harness is actually launchable, otherwise "installed" with a
-        // nudge to the remaining step.
+        // (e.g. Codex → "needs-auth"): key the toast on the refreshed readiness
+        // so it doesn't claim "ready" while a sign-in row is still showing.
         const ready = result.configured_harnesses[h] === true;
         showToast(
           ready
@@ -97,67 +125,57 @@ export function HarnessSetupDialog({
         );
       },
       onError: (err) => showToast(`Couldn't install ${name}: ${err.message}`, { duration: 0 }),
-      onSettled: () =>
-        setInstalling((prev) => {
-          const next = new Set(prev);
-          next.delete(h);
-          return next;
-        }),
     });
   };
+
+  const hasSteps = steps.length > 0;
+  const collapsed = !hasSteps || !anyActionable;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg" data-testid="harness-setup-dialog">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <span>
-              Set up {name} on {host?.name}
-            </span>
-            {total > 0 && (
-              <span
-                className="rounded-full bg-muted px-2 py-0.5 text-xs font-normal text-muted-foreground"
-                data-testid="harness-setup-progress"
-              >
-                {done} of {total} done
-              </span>
-            )}
+          <DialogTitle>
+            Set up {name} on {host?.name}
           </DialogTitle>
-          <DialogDescription>
-            {allDone
-              ? `${name} is ready on ${host?.name}.`
-              : steps.length > 0
-                ? `Complete these steps on ${host?.name} to use ${name}.`
-                : `${name} needs a bit more setup on ${host?.name}.`}
-          </DialogDescription>
+          {/* Only show a description when it adds something the title doesn't:
+              the done / needs-more-setup states. The generic "complete these
+              steps…" just echoes the title, so it's omitted for the common
+              checklist case. */}
+          {allDone ? (
+            <DialogDescription>{`${name} is ready on ${host?.name}.`}</DialogDescription>
+          ) : collapsed ? (
+            <DialogDescription>{`${name} needs a bit more setup on ${host?.name}.`}</DialogDescription>
+          ) : null}
         </DialogHeader>
 
-        {steps.length > 0 ? (
+        {collapsed && !allDone ? (
+          // No step the UI can perform (curl-install / own-login harness, or no
+          // published steps) and not yet done. One clear signpost — never a
+          // dead-end. When everything IS done we fall through to the checklist
+          // (all green ticks) rather than showing a "run omni setup"
+          // signpost that would contradict the "is ready" description.
+          <p className="py-1 text-sm text-muted-foreground" data-testid="harness-setup-empty">
+            Run <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">omni setup</code>{" "}
+            on {host?.name} to finish setting up {name}.
+          </p>
+        ) : hasSteps ? (
           <ul className="flex flex-col gap-3 py-1">
             {steps.map((step) => (
               <SetupStepRow
                 key={step.kind}
                 step={step}
+                label={name}
                 installable={installable}
+                authable={authable}
+                installComplete={installComplete}
                 installing={installingThisHarness}
+                host={host}
                 onInstall={startInstall}
               />
             ))}
           </ul>
-        ) : (
-          // The server published no steps for this spelling (a harness the UI
-          // can't yet guide). Don't leave an empty dialog — point at the CLI.
-          <p className="py-1 text-sm text-muted-foreground" data-testid="harness-setup-empty">
-            Run{" "}
-            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">omnigent setup</code>{" "}
-            on {host?.name} to finish setting up {name}.
-          </p>
-        )}
-        {installingThisHarness && (
-          <p className="text-xs text-muted-foreground" data-testid="harness-setup-installing">
-            Installing on {host?.name} — this can take a few minutes for larger agents.
-          </p>
-        )}
+        ) : null}
 
         <DialogFooter>
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
@@ -189,46 +207,111 @@ function StepIcon({ status }: { status: ResolvedSetupStep["status"] }) {
 
 function SetupStepRow({
   step,
+  label,
   installable,
+  authable,
+  installComplete,
   installing,
+  host,
   onInstall,
 }: {
   step: ResolvedSetupStep;
+  /** Friendly agent/harness name for the credential form's toasts. */
+  label: string;
   installable: boolean;
+  authable: boolean;
+  installComplete: boolean;
   installing: boolean;
+  host: Host | undefined | null;
   onInstall: (harness: string) => void;
 }) {
+  // An auth step for a harness the UI can authenticate expands an inline
+  // credential form — but only once the binary is installed, so the checklist
+  // runs Install → Set up auth in order (readiness can't be "has key, no
+  // binary", so an auth-first write would leave the dot red).
+  const isAuthStep = step.kind === "auth" && authable && step.status !== "done";
+  const isAuthForm = isAuthStep && installComplete;
+  // Auth is unlocked but blocked on install: show a disabled "Set up auth" so the
+  // step reads as a real next action rather than vanishing.
+  const authPending = isAuthStep && !installComplete;
+  const [formOpen, setFormOpen] = useState(false);
+
   const done = step.status === "done";
   // The server's detail is future-tense ("We'll install …") — right for a
   // pending step, wrong under a green check. Show a past-tense confirmation
   // once done instead of the stale promise.
   const detail = done ? doneDetail(step.kind) : step.detail;
+
   return (
-    <li className="flex items-start gap-2.5" data-testid={`harness-setup-step-${step.kind}`}>
-      <span className="mt-0.5">
-        <StepIcon status={step.status} />
-      </span>
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <span className="text-sm font-medium">{step.title}</span>
-        {detail && <span className="text-xs text-muted-foreground">{detail}</span>}
+    <li className="flex flex-col gap-2" data-testid={`harness-setup-step-${step.kind}`}>
+      <div className="flex items-start gap-2.5">
+        <span className="mt-0.5">
+          <StepIcon status={step.status} />
+        </span>
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <span className="text-sm font-medium">{step.title}</span>
+          {/* While this harness's install is in flight, the detail line becomes
+              the progress caption — kept next to the install step it describes
+              rather than stranded at the bottom of the dialog. */}
+          {step.kind === "install" && installing ? (
+            <span className="text-xs text-muted-foreground" data-testid="harness-setup-installing">
+              Installing on {host?.name} — this can take a few minutes for larger agents.
+            </span>
+          ) : (
+            detail && <span className="text-xs text-muted-foreground">{detail}</span>
+          )}
+        </div>
+        {/* Control: one-click Install (when the allowlist accepts it), an
+            "Add credential" toggle (auth step the UI can do), else the command
+            to copy. */}
+        {done ? null : step.action === "install" && installable ? (
+          <Button
+            type="button"
+            size="sm"
+            loading={installing}
+            data-testid="harness-setup-install"
+            onClick={() => onInstall(step.harness)}
+          >
+            Install
+          </Button>
+        ) : isAuthForm ? (
+          <Button
+            type="button"
+            size="sm"
+            variant={formOpen ? "outline" : "default"}
+            data-testid="harness-setup-add-credential"
+            aria-expanded={formOpen}
+            onClick={() => setFormOpen((v) => !v)}
+          >
+            {formOpen ? "Cancel" : "Set up auth"}
+          </Button>
+        ) : authPending ? (
+          // Installed first: the credential form unlocks once the binary lands.
+          <Button
+            type="button"
+            size="sm"
+            disabled
+            data-testid="harness-setup-add-credential"
+            title="Install first, then set up authentication"
+          >
+            Set up auth
+          </Button>
+        ) : step.command ? (
+          <CopyCommand command={step.command} />
+        ) : null}
       </div>
-      {/* No control once the step is done. Otherwise: a one-click Install for a
-          server-performed step the allowlist still accepts (`installable`
-          guards against drift between the step catalog and the install route),
-          else the command to run on the host. */}
-      {done ? null : step.action === "install" && installable ? (
-        <Button
-          type="button"
-          size="sm"
-          loading={installing}
-          data-testid="harness-setup-install"
-          onClick={() => onInstall(step.harness)}
-        >
-          Install
-        </Button>
-      ) : step.command ? (
-        <CopyCommand command={step.command} />
-      ) : null}
+
+      {isAuthForm && formOpen && (
+        <div className="ml-7">
+          <HarnessCredentialForm
+            harness={step.harness}
+            label={label}
+            host={host}
+            command={step.command}
+            onDone={() => setFormOpen(false)}
+          />
+        </div>
+      )}
     </li>
   );
 }

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -59,6 +59,7 @@ vi.mock("@/hooks/useHosts", () => ({
     ],
   })),
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useInstallingHarnesses: vi.fn(() => new Set<string>()),
 }));
 vi.mock("@/hooks/useAvailableAgents", () => ({
   useAvailableAgents: vi.fn(),

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -41,6 +41,7 @@ vi.mock("@/hooks/useHosts", () => ({
   useHosts: vi.fn(),
   useHostModelOptions: vi.fn(() => ({ data: [] })),
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useInstallingHarnesses: vi.fn(() => new Set<string>()),
 }));
 vi.mock("@/hooks/useAvailableAgents", () => ({ useAvailableAgents: vi.fn() }));
 vi.mock("@/hooks/useHostFilesystem", () => ({

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -22,7 +22,13 @@ import {
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
 import type { ServerInfo } from "@/lib/capabilities";
 import { authenticatedFetch } from "@/lib/identity";
-import { useHostModelOptions, useHosts, useInstallHarness, type Host } from "@/hooks/useHosts";
+import {
+  useHostModelOptions,
+  useHosts,
+  useInstallHarness,
+  useInstallingHarnesses,
+  type Host,
+} from "@/hooks/useHosts";
 import { useAvailableAgents, type AvailableAgent } from "@/hooks/useAvailableAgents";
 import { useHostFilesystem, type HostFilesystemEntry } from "@/hooks/useHostFilesystem";
 import { useHostWorktrees } from "@/hooks/useHostWorktrees";
@@ -43,9 +49,12 @@ vi.mock("@/lib/identity", async (importOriginal) => ({
 vi.mock("@/hooks/useHosts", () => ({
   useHosts: vi.fn(),
   useHostModelOptions: vi.fn(),
-  // The setup dialog mounts these; default to an inert mutation + not-installing
-  // so tests that don't exercise install don't need to wire them up.
+  // The setup dialog mounts these; default to inert so tests that don't
+  // exercise install / credential-write don't need to wire them up.
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useInstallingHarnesses: vi.fn(() => new Set<string>()),
+  useStoreCredential: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useDetectedCredentials: vi.fn(() => ({ data: [] })),
 }));
 // The setup dialog's copyable command rows call copyText; stub it so a click
 // can be asserted without touching the real clipboard.
@@ -109,9 +118,9 @@ vi.mock("@/lib/agentLabels", async (importOriginal) => ({
       },
       {
         kind: "auth",
-        title: "Sign in to Codex",
-        detail: "Uses your ChatGPT subscription — sign in on the host.",
-        action: "command",
+        title: "Set up authentication",
+        detail: "Sign in with your ChatGPT subscription, an API key, or a gateway.",
+        action: "auth",
         command: "codex login",
         status_key: "authed",
       },
@@ -604,6 +613,15 @@ function setupLandingMocks() {
   useHostWorktreesMock.mockReset();
   useDirectorySessionsMock.mockReset();
   useRunnerHealthMock.mockReset();
+  // Reset the install hooks to their inert defaults: per-test overrides
+  // (a pending install set, a callback-firing mutate) must not leak into the
+  // next test — a stale pending set would disable the Install button and make
+  // a later click a silent no-op.
+  vi.mocked(useInstallHarness).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useInstallHarness>);
+  vi.mocked(useInstallingHarnesses).mockReturnValue(new Set<string>());
   setOmnigentHostConfig({});
   resetLandingDraft();
   localStorage.clear();
@@ -1177,15 +1195,54 @@ describe("NewChatLandingScreen", () => {
     expect(installMutate).toHaveBeenCalledWith("codex-native", expect.anything());
   });
 
+  it("gates Set up auth until the harness is installed (no auth-before-install)", () => {
+    // codex-native not installed: the credential form must NOT be available
+    // yet — the auth row shows a DISABLED "Set up auth" (install first).
+    // Clicking it does nothing / the form doesn't expand, so an auth-first write
+    // (which would leave the dot red) can't happen.
+    mockHosts([{ ...host("online"), configured_harnesses: { "codex-native": false } } as Host]);
+    renderLanding({
+      harness_install_enabled: true,
+      installable_harnesses: ["codex", "codex-native"],
+    });
+    selectUnconfiguredAgent("a2");
+    fireEvent.click(screen.getByTestId("new-chat-landing-harness-setup"));
+
+    // Install is offered; the auth row's control is present but disabled.
+    expect(screen.getByTestId("harness-setup-install")).toBeTruthy();
+    const setUpAuth = screen.getByTestId("harness-setup-add-credential") as HTMLButtonElement;
+    expect(setUpAuth.textContent).toBe("Set up auth");
+    expect(setUpAuth.disabled).toBe(true);
+    fireEvent.click(setUpAuth);
+    expect(screen.queryByTestId("harness-credential-form")).toBeNull();
+  });
+
+  it("enables Set up auth once the harness is installed (needs-auth)", () => {
+    // Installed but no credential → the auth row's "Set up auth" is enabled and
+    // expands the credential form.
+    mockHosts([
+      { ...host("online"), configured_harnesses: { "codex-native": "needs-auth" } } as Host,
+    ]);
+    renderLanding({
+      harness_install_enabled: true,
+      installable_harnesses: ["codex", "codex-native"],
+    });
+    selectUnconfiguredAgent("a2");
+    fireEvent.click(screen.getByTestId("new-chat-landing-harness-setup"));
+
+    const setUpAuth = screen.getByTestId("harness-setup-add-credential") as HTMLButtonElement;
+    expect(setUpAuth.textContent).toBe("Set up auth");
+    expect(setUpAuth.disabled).toBe(false);
+    fireEvent.click(setUpAuth);
+    expect(screen.getByTestId("harness-credential-form")).toBeTruthy();
+  });
+
   it("marks its Install button loading while THIS harness's install is pending", () => {
-    // The dialog tracks in-flight installs in a local set driven by mutate()'s
-    // onSettled. Hold the mutation pending (never settle) → clicking Install
-    // flips this harness's button to the loading/disabled state.
-    vi.mocked(useInstallHarness).mockReturnValue({
-      // mutate never invokes its options callbacks → install stays in flight.
-      mutate: vi.fn(),
-      isPending: false,
-    } as unknown as ReturnType<typeof useInstallHarness>);
+    // The dialog derives the in-flight indicator from React Query's mutation
+    // state via useInstallingHarnesses (observer-independent, so a concurrent
+    // install can't strand it). When that reports codex-native pending, the
+    // button shows the loading/disabled state.
+    vi.mocked(useInstallingHarnesses).mockReturnValue(new Set(["codex-native"]));
     mockHosts([{ ...host("online"), configured_harnesses: { "codex-native": false } } as Host]);
     renderLanding({
       harness_install_enabled: true,
@@ -1194,18 +1251,19 @@ describe("NewChatLandingScreen", () => {
     selectUnconfiguredAgent("a2");
 
     fireEvent.click(screen.getByTestId("new-chat-landing-harness-setup"));
-    const button = screen.getByTestId("harness-setup-install") as HTMLButtonElement;
-    expect(button.disabled).toBe(false);
-    // Clicking starts the install; the button shows the pending state (disabled)
-    // because codex-native was added to the dialog's installing set.
-    fireEvent.click(button);
     expect((screen.getByTestId("harness-setup-install") as HTMLButtonElement).disabled).toBe(true);
+    // The "Installing…" caption sits INSIDE the install step row (next to what
+    // it describes), not stranded at the dialog footer.
+    const installStep = screen.getByTestId("harness-setup-step-install");
+    const installingCaption = screen.getByTestId("harness-setup-installing");
+    expect(installStep.contains(installingCaption)).toBe(true);
   });
 
-  it("copies the login command (no Install) for a codex needs-auth state", async () => {
-    // Binary present, just not logged in → dialog shows the `codex login`
-    // instruction as a click-to-copy command, never an Install button (a
-    // reinstall wouldn't add the login).
+  it("offers the inline credential form (not an install) for codex needs-auth", async () => {
+    // Binary present, just not authed → the auth step offers "Set up auth",
+    // which expands the inline credential form. Never an Install button (a
+    // reinstall wouldn't add the credential). The subscription `codex login` is
+    // one option inside the form (the UI can't drive browser OAuth).
     copyTextMock.mockClear();
     mockHosts([
       { ...host("online"), configured_harnesses: { "codex-native": "needs-auth" } } as Host,
@@ -1217,11 +1275,15 @@ describe("NewChatLandingScreen", () => {
     selectUnconfiguredAgent("a2");
 
     fireEvent.click(screen.getByTestId("new-chat-landing-harness-setup"));
-    const command = screen.getByTestId("harness-setup-command");
-    expect(command.textContent).toContain("codex login");
     expect(screen.queryByTestId("harness-setup-install")).toBeNull();
-
-    fireEvent.click(command);
+    // Open the inline form.
+    fireEvent.click(screen.getByTestId("harness-setup-add-credential"));
+    expect(screen.getByTestId("harness-credential-form")).toBeTruthy();
+    expect(screen.getByTestId("harness-credential-key")).toBeTruthy();
+    // The subscription login is a copy signpost inside the form.
+    const loginCopy = screen.getByTestId("harness-credential-login-copy");
+    expect(loginCopy.textContent).toContain("codex login");
+    fireEvent.click(loginCopy);
     await waitFor(() => expect(copyTextMock).toHaveBeenCalledWith("codex login"));
   });
 
@@ -1306,13 +1368,13 @@ describe("NewChatLandingScreen", () => {
     selectAgent("a1");
 
     fireEvent.click(screen.getByTestId("new-chat-landing-harness-setup"));
-    expect(screen.getByTestId("harness-setup-empty").textContent).toContain("omnigent setup");
+    expect(screen.getByTestId("harness-setup-empty").textContent).toContain("omni setup");
     expect(screen.queryByTestId("harness-setup-install")).toBeNull();
   });
 
   it("falls back to the original setup guidance when the feature is off", () => {
     // Flag OFF (renderLanding default) → the pre-feature UI: the warning shows
-    // the descriptive "run omnigent setup" message, NOT the "Set up" action or
+    // the descriptive "run omni setup" message, NOT the "Set up" action or
     // dialog. This is the no-op-when-disabled contract.
     mockHosts([
       { ...host("online"), configured_harnesses: { "codex-native": "needs-auth" } } as Host,

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1622,7 +1622,9 @@ export function NewChatLandingScreen() {
   const queryClient = useQueryClient();
   const serverUrl = getCliServerUrl();
   const { data: agents } = useAvailableAgents();
-  const { data: hosts, isLoading: hostsLoading } = useHosts();
+  // refetchOnFocus: returning from a terminal `omni setup` must clear the
+  // readiness badge even if the live push was missed while the tab was hidden.
+  const { data: hosts, isLoading: hostsLoading } = useHosts({ refetchOnFocus: true });
 
   const agentList = useMemo(
     () =>

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -533,13 +533,13 @@ export async function describeCreateError(res: Response): Promise<string> {
 }
 
 /**
- * The pre-feature "run omnigent setup" guidance (ReactNode), shown under the
+ * The pre-feature "run omni setup" guidance (ReactNode), shown under the
  * composer when the UI-driven setup feature is OFF.
  *
  * The ``needs-auth`` / ``binary-missing`` copy is Codex-specific ("run codex
  * login" / "set OMNIGENT_CODEX_PATH"), so it's gated on {@link isCodexHarness}.
  * Other harnesses that report those structured reasons (claude-native /
- * opencode-native now do) fall through to the generic "run omnigent setup"
+ * opencode-native now do) fall through to the generic "run omni setup"
  * message — matching the pre-feature behavior, where only Codex ever produced
  * these reasons and everything else showed the generic text.
  */
@@ -572,14 +572,13 @@ function harnessWarningMessage(
       <>
         {agentName} can&apos;t find the Codex binary on {hostName} — if codex is installed, restart
         the host with <code>omnigent host</code> so it picks up your PATH, or set{" "}
-        <code>OMNIGENT_CODEX_PATH</code>. Otherwise run <code>omnigent setup</code>.
+        <code>OMNIGENT_CODEX_PATH</code>. Otherwise run <code>omni setup</code>.
       </>
     );
   }
   return (
     <>
-      {agentName} isn&apos;t configured on {hostName} — run <code>omnigent setup</code> on that
-      machine.
+      {agentName} isn&apos;t configured on {hostName} — run <code>omni setup</code> on that machine.
     </>
   );
 }
@@ -1717,7 +1716,7 @@ export function NewChatLandingScreen() {
   const smartRoutingEnabled = info !== "loading" && info.smart_routing_enabled;
   // Gates the whole UI-driven setup experience (Set up affordance + dialog +
   // collapsed badge). OFF → the composer/picker fall back to the original
-  // "run omnigent setup" guidance, so a disabled flag is a no-op on the UI.
+  // "run omni setup" guidance, so a disabled flag is a no-op on the UI.
   const harnessInstallEnabled = info !== "loading" && info.harness_install_enabled;
   const brainHarnessLabels = useBrainHarnessLabels(smartRoutingEnabled);
   // Provider-named label for the sandbox option (e.g. "Modal Sandbox"),


### PR DESCRIPTION
> **Stacked on #3088** (the `host.store_secret` backend). Until #3088 merges, this PR's diff includes B's backend commits — **review only the `web/` changes here**; the backend is reviewed in #3088 (and #3072 for readiness, now merged). Merge order: #3072 → #3088 → this. GitHub can't base a PR on a fork branch, so it targets `main`; the extra commits drop out once #3088 lands.

## Summary

Frontend for **Setup From the Web UI** — lets a user turn a yellow *"needs setup"* harness **green from the browser** for **Claude / Codex / Pi**, and applies the locked UX cleanups to the setup dialog.

### Inline "Set up authentication" form (`HarnessCredentialForm`)
Expands in place under the auth step (no drill-in, no stacked modal). The paths are presented as **equally-weighted, labeled alternatives** joined by "or" — not one primary field with the rest demoted:

- **Use a credential found on this host** — one-click adopt of a detected env var (writes an `env:<VAR>` reference; the value is never read). Shown only when one is detected for the harness's family.
- **Sign in with your subscription** — a `codex login` / `claude auth login` **copy signpost** (the UI can't drive browser OAuth). Omitted for Pi (no CLI login).
- **Use an API key** — paste a key → `Save`.
- **Connect a gateway** — base URL + key → `Save`.

Wired to new `useStoreCredential` / `useDetectedCredentials` hooks (POST `…/credential`, GET `…/credentials/detected`).

### Dialog & step cleanups (locked UX decisions)
- The auth step reads **"Set up authentication"** (neutral) and expands the form for a **UI-authable** harness (`harnessAuthableOnHost` — Claude/Codex/Pi); env-auth (OpenCode/Qwen) and own-login (Cursor/…) keep the copy-command signpost.
- When **no step is UI-actionable**, the dialog collapses to a single *"run omni setup"* signpost — no dead ends.
- Removed the "N of M done" progress counter (redundant with the per-row dots).
- Auth step gated until install completes; the "Installing…" caption sits in the install row; the equal-weight form uses a light (non-error) disabled Save.
- Refetch the hosts query on tab focus so a missed readiness push still clears the badge when the user returns from their terminal.

Gated behind the existing `harness_install_enabled` capability — flag off → the dialog is unchanged.

## Test Plan

https://github.com/user-attachments/assets/6e87cb52-5afb-4ce6-a643-7d00fea534b4



**Automated** (changed-file suites): `HarnessCredentialForm` (adopt / api-key / gateway / subscription-signpost / equal-weight layout / ready-vs-not-ready toast), `useHosts` (focus-refetch, concurrent-install tracking), `harnessSetup` (`harnessCredentialFamily`, authable/installable), `NewChatDialog` (install flow, gated auth). Changed-file tests pass locally (192); `type-check` clean. Backend adopt-family + readiness tests pass. E2E: `test_install_button_installs_missing_harness` green on CI.

**Manual — verified end-to-end in a real browser** (live server + connected host; watched the badge/dialog flip, no reload):

| Path | Harness | Result |
|------|---------|--------|
| Paste an API key | **Pi** | ✅ dialog → "Pi is ready", step → "Signed in on the host", picker badge cleared |
| Sign in on host (`opencode auth login`) | **OpenCode** | ✅ step → "Signed in on the host", badge cleared live (no reload) |
| One-click Install | **Goose** (signpost harness) | ✅ installed → graduated out of "More", badge cleared |
| `omni setup` on host → readiness flip | cursor / kimi / kiro / antigravity / goose / hermes / copilot | ✅ each flips to ready on the daemon's readiness refresh; badge clears (no server restart) |

**Verified at the API layer** (server → daemon → readiness map; not yet a browser click-through — tracked as follow-up): Codex + API key, Pi/Codex + gateway, Pi/Codex adopt. Each returns the harness `True`.

## Demo

See the table above; screen captures of the inline form (equal-weight options) and the Pi/OpenCode green-flip are attached below.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] UI / frontend change

## Test coverage

- [x] Automated tests added/updated
- [x] Manual verification completed

## Coverage notes

Manual browser verification covers the API-key and sign-in-on-host paths and the readiness-flip for signpost harnesses (table above). Gateway / adopt / Codex-via-form are verified at the API layer; a browser click-through for those is a tracked follow-up.
