### PR TITLE
perf(benchmarks): add list_projects + list_project_sessions read journeys

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - "omnigent/db/migrations/**"
       - "omnigent/stores/**"
+      - "dev/benchmarks/**"
       - ".github/workflows/benchmark-pr.yml"
 
 permissions:

--- a/dev/benchmarks/omnigent/README.md
+++ b/dev/benchmarks/omnigent/README.md
@@ -207,17 +207,26 @@ API (no HTTP, no runner) into the same DB the server then boots against:
 ```bash
 # Seed 5000 sessions × 50 items into a SQLite file, then benchmark against it.
 uv run --no-sync dev/benchmarks/omnigent/seed.py \
-    --database-uri sqlite:////abs/path/bench.db --sessions 5000 --items-per-session 50
+    --database-uri sqlite:////abs/path/bench.db --sessions 5000 --items-per-session 50 \
+    --projects 20 --filed-fraction 0.5
 uv run --no-sync dev/benchmarks/omnigent/run.py \
     --database-uri sqlite:////abs/path/bench.db --output bench.json
 ```
 
-Seeding is **idempotent**: a matching corpus (same sessions/items/schema) is
-detected and reused, so re-running is a fast no-op — pass `--reseed` to force,
-or a differing config to be warned. SQLite absolute paths need four slashes
-(`sqlite:////abs/...`). The reuse marker records the DB's Alembic head read at
-seed time, so a corpus from an older schema is automatically reseeded — no
-manual revision bookkeeping. `test_seed_creates_listable_corpus` (which seeds
+The corpus also seeds **first-class projects** and files a fraction of sessions
+into them, so `list_projects` / `list_project_sessions` measure a realistic
+sidebar instead of an empty project set. `--projects N` sets the folder count
+(0 = none) and `--filed-fraction F` the fraction of sessions filed (round-robin
+across the folders); the defaults (20 projects, 0.5) put ~1/40th of the corpus
+in each folder. Projects are owned by the reserved `"local"` user the loopback
+server resolves to, so the owner-scoped project reads see them.
+
+Seeding is **idempotent**: a matching corpus (same sessions/items/projects/
+schema) is detected and reused, so re-running is a fast no-op — pass `--reseed`
+to force, or a differing config to be warned. SQLite absolute paths need four
+slashes (`sqlite:////abs/...`). The reuse marker records the DB's Alembic head
+read at seed time, so a corpus from an older schema is automatically reseeded —
+no manual revision bookkeeping. `test_seed_creates_listable_corpus` (which seeds
 through the store, running migrations to the current head) is the safety net
 that a schema change hasn't broken seeding.
 

--- a/dev/benchmarks/omnigent/README.md
+++ b/dev/benchmarks/omnigent/README.md
@@ -60,6 +60,8 @@ see *Network* below).
 | `search_sessions` | `GET /v1/sessions?search_query=` — unindexed `LIKE` | total item count |
 | `fork_session` | `POST /v1/sessions/{id}/fork` — fork (deep-copy items); forks deleted in teardown, untimed | items/session |
 | `add_comment` | `POST /v1/sessions/{id}/comments` — create a review comment | write path |
+| `list_projects` | `GET /v1/sessions/projects` — sidebar project list (dual-read union) | project count |
+| `list_project_sessions` | `GET /v1/sessions?project=` — a project folder's sessions (dual-read filter) | sessions/project |
 
 Read journeys target a **pre-seeded** session when the DB has a corpus; against
 an empty DB they self-seed a small fallback session over HTTP (the

--- a/dev/benchmarks/omnigent/journeys.py
+++ b/dev/benchmarks/omnigent/journeys.py
@@ -15,6 +15,10 @@ v1 journeys are pure HTTP/API (server + DB, no runner, no LLM):
   ``external_conversation_item`` (see :meth:`BenchEnvironment.seed_items`).
 - ``fork_session`` — fork a session (deep-copy its items), then DELETE.
 - ``add_comment`` — create a review comment on a file (DB write).
+- ``list_projects`` — the sidebar project list (dual-read union of first-class
+  projects + legacy ``omni_project`` label-projects).
+- ``list_project_sessions`` — a project folder's session list, the
+  ``?project=`` dual-read filter behind clicking a project in the sidebar.
 
 ``read_runner_file`` needs a runner but no LLM turn: it plants a file in the
 runner environment (setup) and times the server → runner filesystem read proxy.
@@ -389,6 +393,51 @@ async def _measure_load_history(env: BenchEnvironment, ctx: JourneyContext) -> N
     resp.raise_for_status()
 
 
+# Project name for the folder-fetch journey. Self-seeded when the corpus has no
+# project so the ``?project=`` filter has a real member to resolve and return.
+_BENCH_PROJECT_NAME = "bench-project"
+
+
+async def _setup_project_name(env: BenchEnvironment) -> str:
+    """Return a project name to fetch: an existing corpus project, else seed one.
+
+    Mirrors ``_setup_target_session``: real runs read a representative project
+    from the seeded corpus, but when none exists (empty-DB smoke path) we file a
+    session under a first-class project so the ``?project=`` folder fetch
+    exercises the real dual-read filter instead of an empty match.
+    """
+    assert env.client is not None
+    listing = await env.client.get("/v1/sessions/projects")
+    listing.raise_for_status()
+    projects = listing.json()
+    if projects:
+        return str(projects[0]["name"])
+    # Empty DB: create a first-class project and file one session into it.
+    name = await env.ensure_agent()
+    agent_id = await env.agent_id(name)
+    session_id = await env.create_session(agent_id)
+    created = await env.client.post("/v1/projects", json={"name": _BENCH_PROJECT_NAME})
+    created.raise_for_status()
+    filed = await env.client.patch(
+        f"/v1/sessions/{session_id}", json={"project_id": created.json()["id"]}
+    )
+    filed.raise_for_status()
+    return _BENCH_PROJECT_NAME
+
+
+async def _measure_list_projects(env: BenchEnvironment, _ctx: JourneyContext) -> None:
+    assert env.client is not None
+    resp = await env.client.get("/v1/sessions/projects")
+    resp.raise_for_status()
+
+
+async def _measure_list_project_sessions(env: BenchEnvironment, ctx: JourneyContext) -> None:
+    assert env.client is not None
+    project = cast(str, ctx)  # _setup_project_name
+    resp = await env.client.get("/v1/sessions", params={"limit": 20, "project": project})
+    resp.raise_for_status()
+
+
 @dataclass
 class _ForkContext:
     """Fork-journey context: the session to fork + the forks to clean up.
@@ -670,6 +719,21 @@ ALL_JOURNEYS: dict[str, Journey] = {
             measure=_measure_search_sessions,
             concurrency_safe=True,
             description="GET /v1/sessions?search_query= — unindexed LIKE over titles + items.",
+        ),
+        Journey(
+            name="list_projects",
+            kind="latency",
+            measure=_measure_list_projects,
+            concurrency_safe=True,
+            description="GET /v1/sessions/projects — sidebar project list (dual-read union).",
+        ),
+        Journey(
+            name="list_project_sessions",
+            kind="latency",
+            measure=_measure_list_project_sessions,
+            setup=_setup_project_name,
+            concurrency_safe=True,
+            description="GET /v1/sessions?project= — a project folder's sessions (dual-read).",
         ),
         Journey(
             name="fork_session",

--- a/dev/benchmarks/omnigent/journeys.py
+++ b/dev/benchmarks/omnigent/journeys.py
@@ -402,9 +402,11 @@ async def _setup_project_name(env: BenchEnvironment) -> str:
     """Return a project name to fetch: an existing corpus project, else seed one.
 
     Mirrors ``_setup_target_session``: real runs read a representative project
-    from the seeded corpus, but when none exists (empty-DB smoke path) we file a
-    session under a first-class project so the ``?project=`` folder fetch
-    exercises the real dual-read filter instead of an empty match.
+    from the seeded corpus (``seed.py`` files a configurable fraction of sessions
+    into first-class projects), so the folder fetch resolves a realistically
+    populated project. When none exists (empty-DB smoke path) we file one session
+    under a fresh project so the ``?project=`` filter still exercises the real
+    dual-read path instead of an empty match.
     """
     assert env.client is not None
     listing = await env.client.get("/v1/sessions/projects")

--- a/dev/benchmarks/omnigent/seed.py
+++ b/dev/benchmarks/omnigent/seed.py
@@ -20,10 +20,16 @@ loopback server resolves every request to user ``"local"`` and
 2. ``permission_store.grant("local", sid, LEVEL_OWNER)`` — makes it listable.
 3. one batched ``append(sid, items)`` — user-role message items.
 
+Also seeds first-class projects (``projects`` rows owned by ``"local"``) and
+files a fraction of sessions into them, so the project read journeys
+(``list_projects`` / ``list_project_sessions``) measure a realistic sidebar —
+a folder count and per-folder depth — instead of an empty project set.
+
 Run standalone::
 
     uv run --no-sync dev/benchmarks/omnigent/seed.py \
-        --database-uri sqlite:///tmp/bench.db --sessions 5000 --items-per-session 50
+        --database-uri sqlite:///tmp/bench.db --sessions 5000 --items-per-session 50 \
+        --projects 20 --filed-fraction 0.5
 """
 
 from __future__ import annotations
@@ -49,6 +55,7 @@ from omnigent.db.db_models import (
     SqlConversationItem,
     SqlConversationLabel,
     SqlConversationMetadata,
+    SqlProject,
     SqlSessionPermission,
     SqlUser,
     current_workspace_id,
@@ -73,6 +80,7 @@ from omnigent.entities import MessageData, NewConversationItem
 from omnigent.server.auth import LEVEL_OWNER, RESERVED_USER_LOCAL
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
 from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
 
 # Label key stamped on the first seeded session recording the corpus config, so
 # a later run can detect an existing (and matching) seed and skip re-seeding.
@@ -84,6 +92,21 @@ _AGENT_BUNDLE = "bench/seed"  # never validated on the read path
 _DEFAULT_SESSIONS = 5000
 _DEFAULT_ITEMS = 50
 _DEFAULT_RNG_SEED = 1234
+
+# First-class projects seeded into the corpus, and the fraction of sessions
+# filed into one (round-robin). Without these the project read journeys
+# (list_projects / list_project_sessions) would measure an empty project set —
+# a 0-folder union and a 0-member folder — which tests nothing. The defaults
+# give a realistic sidebar: 20 folders, each holding ~1/20th of the filed half
+# of the corpus (e.g. 5000 sessions × 0.5 / 20 = 125 sessions/project).
+_DEFAULT_PROJECTS = 20
+_DEFAULT_FILED_FRACTION = 0.5
+
+# Owner of every seeded project. The loopback bench server is single-user, so
+# it resolves each request to the reserved ``"local"`` user; the project list
+# and the ``?project=`` filter are owner-scoped, so a project owned by anyone
+# else would be invisible to the benchmark's reads.
+_PROJECT_OWNER = RESERVED_USER_LOCAL
 
 # A pool of realistic-ish message fragments; the RNG assembles item text from
 # these so search_text has lexical variety without external data.
@@ -114,14 +137,56 @@ _FTS_INSERT_SQL = text(
 _CORE_ITEM_CHUNK = 100_000
 
 
-def _meta_value(sessions: int, items_per_session: int, rng_seed: int, head: str) -> str:
+def _meta_value(
+    sessions: int,
+    items_per_session: int,
+    rng_seed: int,
+    projects: int,
+    filed_fraction: float,
+    head: str,
+) -> str:
     """Serialize the corpus config into the seed-marker label value.
 
     Includes the Alembic *head* read at seed time, so a corpus seeded under an
     older schema auto-mismatches the current head and is reseeded — no
-    hand-maintained revision constant.
+    hand-maintained revision constant. The project knobs are part of the key so
+    a pre-existing corpus seeded without projects is reseeded once they're added.
     """
-    return f"sessions={sessions};items={items_per_session};rng={rng_seed};rev={head}"
+    return (
+        f"sessions={sessions};items={items_per_session};rng={rng_seed};"
+        f"projects={projects};filed={filed_fraction:g};rev={head}"
+    )
+
+
+def _project_id(index: int) -> str:
+    """Deterministic 32-char-hex project id for the ``index``-th seeded project.
+
+    Derived from the index (not random) so both write paths produce identical
+    project rows and a re-seed at the same config is byte-stable.
+    """
+    return hashlib.sha256(f"bench-project-{index}".encode()).hexdigest()[:32]
+
+
+def _project_plan(
+    sessions: int,
+    projects: int,
+    filed_fraction: float,
+) -> tuple[list[tuple[str, str]], dict[int, str]]:
+    """Plan the corpus's first-class projects and their session membership.
+
+    :returns: ``(project_specs, project_of_session)`` where ``project_specs`` is
+        ``[(id, name), …]`` for the ``projects`` rows to create, and
+        ``project_of_session`` maps a session index to the project id it is
+        filed under. The first ``round(sessions × filed_fraction)`` sessions are
+        filed, assigned round-robin across the projects so each folder holds a
+        realistic, even share; the rest stay unfiled.
+    """
+    if projects <= 0 or filed_fraction <= 0 or sessions <= 0:
+        return [], {}
+    specs = [(_project_id(p), f"bench project {p}") for p in range(projects)]
+    filed_count = min(sessions, round(sessions * filed_fraction))
+    project_of_session = {s: specs[s % projects][0] for s in range(filed_count)}
+    return specs, project_of_session
 
 
 def _existing_seed_meta(conv: SqlAlchemyConversationStore) -> str | None:
@@ -168,6 +233,8 @@ def seed(
     sessions: int = _DEFAULT_SESSIONS,
     items_per_session: int = _DEFAULT_ITEMS,
     rng_seed: int = _DEFAULT_RNG_SEED,
+    projects: int = _DEFAULT_PROJECTS,
+    filed_fraction: float = _DEFAULT_FILED_FRACTION,
     reseed: bool = False,
     _fast: bool | None = None,
 ) -> int:
@@ -183,6 +250,11 @@ def seed(
     :param sessions: Number of listable sessions to create.
     :param items_per_session: Conversation items appended to each session.
     :param rng_seed: Seed for the deterministic text RNG.
+    :param projects: Number of first-class ``projects`` rows to create (owned by
+        ``"local"``). ``0`` seeds no projects.
+    :param filed_fraction: Fraction of sessions filed into a project (round-robin
+        across the ``projects`` folders); the rest stay unfiled. Ignored when
+        ``projects`` is 0.
     :param reseed: Seed even when a matching corpus is already present.
     :param _fast: Override the write strategy. ``None`` (default) uses the
         bulk-insert Core fast path for SQLite and the store-API loop for every
@@ -203,7 +275,7 @@ def seed(
     # Read the current schema head at runtime (no DB contacted) and fold it into
     # the reuse marker, so a corpus from an older schema is auto-reseeded.
     head = _get_head_db_revision("sqlite:///:memory:")
-    want = _meta_value(sessions, items_per_session, rng_seed, head)
+    want = _meta_value(sessions, items_per_session, rng_seed, projects, filed_fraction, head)
     if not reseed:
         existing = _existing_seed_meta(conv)
         if existing == want:
@@ -213,6 +285,8 @@ def seed(
             print(f"seed: existing corpus differs ({existing!r} != {want!r}); pass --reseed")
             return 0
 
+    project_specs, project_of_session = _project_plan(sessions, projects, filed_fraction)
+
     if use_fast:
         n = _seed_via_core(
             db_uri,
@@ -220,6 +294,8 @@ def seed(
             items_per_session=items_per_session,
             rng_seed=rng_seed,
             want=want,
+            project_specs=project_specs,
+            project_of_session=project_of_session,
         )
     else:
         perms = SqlAlchemyPermissionStore(db_uri)
@@ -230,9 +306,14 @@ def seed(
             items_per_session=items_per_session,
             rng_seed=rng_seed,
             want=want,
+            project_specs=project_specs,
+            project_of_session=project_of_session,
         )
 
-    print(f"seed: created {n} sessions × {items_per_session} items ({want})")
+    print(
+        f"seed: created {n} sessions × {items_per_session} items, "
+        f"{len(project_specs)} projects, {len(project_of_session)} filed ({want})"
+    )
     return n
 
 
@@ -244,15 +325,23 @@ def _seed_via_store(
     items_per_session: int,
     rng_seed: int,
     want: str,
+    project_specs: list[tuple[str, str]],
+    project_of_session: dict[int, str],
 ) -> int:
     """Seed through the production store ORM API (one row/commit at a time).
 
     This is the original path and the only one used on non-SQLite dialects
     (e.g. the nightly Postgres benchmark). It is kept verbatim so behavior
-    there stays identical.
+    there stays identical, save for the added first-class projects.
     """
     perms.ensure_user(RESERVED_USER_LOCAL)
     rng = random.Random(rng_seed)
+
+    # First-class projects, owned by "local" so the owner-scoped project reads
+    # see them. Created before the sessions so membership can be set inline.
+    projects_store = SqlAlchemyProjectStore(conv.storage_location)
+    for project_id, name in project_specs:
+        projects_store.create(project_id, name, owner_user_id=_PROJECT_OWNER)
 
     last_sid = ""
     for s in range(sessions):
@@ -268,6 +357,9 @@ def _seed_via_store(
         perms.grant(RESERVED_USER_LOCAL, sid, LEVEL_OWNER)
         if items_per_session:
             conv.append(sid, _make_items(rng, items_per_session))
+        project_id = project_of_session.get(s)
+        if project_id is not None:
+            conv.set_conversation_project(sid, project_id)
         _progress(s, sessions)
 
     # Stamp the corpus config on the LAST (newest) session — that's the one
@@ -286,6 +378,8 @@ def _seed_via_core(
     items_per_session: int,
     rng_seed: int,
     want: str,
+    project_specs: list[tuple[str, str]],
+    project_of_session: dict[int, str],
 ) -> int:
     """Seed the entire corpus in one transaction via SQLAlchemy Core.
 
@@ -387,6 +481,7 @@ def _seed_via_core(
                     "runner_last_seen": None,
                     "live_status": None,
                     "pending_elicitation_count": None,
+                    "project_id": project_of_session.get(s),
                 }
             )
             perm_rows.append(
@@ -461,6 +556,27 @@ def _seed_via_core(
         conn.execute(SqlConversationMetadata.__table__.insert(), meta_rows)
         conn.execute(SqlSessionPermission.__table__.insert(), perm_rows)
 
+        # First-class projects, owned by "local" (the reserved single-user id
+        # the owner-scoped project reads resolve to). Membership already lives
+        # on each metadata row's ``project_id`` above. ``updated_at`` is NULL,
+        # matching a freshly created project (the store sets it only on rename).
+        if project_specs:
+            project_now = now_epoch()
+            conn.execute(
+                SqlProject.__table__.insert(),
+                [
+                    {
+                        "workspace_id": ws,
+                        "id": project_id,
+                        "name": name,
+                        "owner_user_id": _PROJECT_OWNER,
+                        "created_at": project_now,
+                        "updated_at": None,
+                    }
+                    for project_id, name in project_specs
+                ],
+            )
+
         # Stamp the corpus config on the LAST (newest) session, matching the
         # store path's ``set_labels`` upsert (clamped to LABEL_VALUE_MAX_LEN).
         if last_sid:
@@ -499,6 +615,22 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--items-per-session", type=int, default=_DEFAULT_ITEMS, metavar="N")
     parser.add_argument("--rng-seed", type=int, default=_DEFAULT_RNG_SEED, metavar="N")
     parser.add_argument(
+        "--projects",
+        type=int,
+        default=_DEFAULT_PROJECTS,
+        metavar="N",
+        help="First-class projects to seed (0 = none). Filed sessions are "
+        "spread round-robin across them.",
+    )
+    parser.add_argument(
+        "--filed-fraction",
+        type=float,
+        default=_DEFAULT_FILED_FRACTION,
+        metavar="F",
+        help="Fraction of sessions filed into a project (0..1); the rest stay "
+        "unfiled. Ignored when --projects is 0.",
+    )
+    parser.add_argument(
         "--reseed",
         action="store_true",
         help="Seed even if a matching corpus is already present.",
@@ -524,6 +656,8 @@ def main(argv: list[str] | None = None) -> int:
         sessions=args.sessions,
         items_per_session=args.items_per_session,
         rng_seed=args.rng_seed,
+        projects=args.projects,
+        filed_fraction=args.filed_fraction,
         reseed=args.reseed,
     )
     return 0

--- a/tests/benchmarks/test_benchmark_smoke.py
+++ b/tests/benchmarks/test_benchmark_smoke.py
@@ -566,10 +566,13 @@ def test_seed_creates_listable_corpus(tmp_path: Path) -> None:
     from omnigent.stores.conversation_store.sqlalchemy_store import (
         SqlAlchemyConversationStore,
     )
+    from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
 
     db_uri = f"sqlite:///{tmp_path / 'seed.db'}"
 
-    created = seed_mod.seed(db_uri, sessions=6, items_per_session=4)
+    created = seed_mod.seed(
+        db_uri, sessions=6, items_per_session=4, projects=2, filed_fraction=0.5
+    )
     assert created == 6
 
     conv = SqlAlchemyConversationStore(db_uri)
@@ -582,8 +585,22 @@ def test_seed_creates_listable_corpus(tmp_path: Path) -> None:
     assert len(listing.data) == 6  # all seeded sessions listable as "local"
     assert len(conv.list_items(listing.data[0].id, limit=100).data) == 4
 
+    # Projects were seeded (owner-scoped to "local") and sessions filed into them.
+    projects = SqlAlchemyProjectStore(db_uri).list(owner_user_id=RESERVED_USER_LOCAL)
+    assert len(projects) == 2
+    # 3 of 6 sessions filed (0.5), listable via the owner-scoped ?project= filter.
+    filed = conv.list_conversations(
+        limit=100,
+        accessible_by=RESERVED_USER_LOCAL,
+        owned_by=RESERVED_USER_LOCAL,
+        project=projects[0].name,
+    )
+    assert len(filed.data) >= 1  # round-robin puts ~1-2 sessions in each folder
+
     # Idempotent: a matching re-seed is a no-op.
-    assert seed_mod.seed(db_uri, sessions=6, items_per_session=4) == 0
+    assert (
+        seed_mod.seed(db_uri, sessions=6, items_per_session=4, projects=2, filed_fraction=0.5) == 0
+    )
 
     # NOTE: seed() builds the store, which runs migrations to the current head,
     # so this test always exercises the live schema — it is the safety net that

--- a/tests/benchmarks/test_benchmark_smoke.py
+++ b/tests/benchmarks/test_benchmark_smoke.py
@@ -29,6 +29,8 @@ _SMOKE_JOURNEYS = [
     "get_session",
     "load_conversation_history",
     "search_sessions",
+    "list_projects",
+    "list_project_sessions",
     "fork_session",
     "add_comment",
 ]

--- a/tests/benchmarks/test_seed_fast_path.py
+++ b/tests/benchmarks/test_seed_fast_path.py
@@ -67,6 +67,32 @@ def _item_data_ordered(engine):
     return sorted((s_by_cid[cid], pos, d) for cid, pos, d in items)
 
 
+def _projects_ordered(engine):
+    """(id, name, owner) for every project, sorted — project ids are deterministic."""
+    with engine.connect() as conn:
+        rows = conn.execute(text("SELECT id, name, owner_user_id FROM projects")).all()
+    return sorted((pid, name, owner) for pid, name, owner in rows)
+
+
+def _membership_counts(engine):
+    """(session s, project_id) for every filed session, sorted by session index.
+
+    Session ids are fresh per run, so membership is keyed by the RNG-stable
+    session index (recovered from the title) paired with the deterministic
+    project id — proving both paths file the same sessions into the same folders.
+    """
+    with engine.connect() as conn:
+        convs = conn.execute(text("SELECT id, title FROM conversations")).all()
+        s_by_cid = {cid: _s_of(t) for cid, t in convs}
+        rows = conn.execute(
+            text(
+                "SELECT id, project_id FROM omnigent_conversation_metadata "
+                "WHERE project_id IS NOT NULL"
+            )
+        ).all()
+    return sorted((s_by_cid[cid], pid) for cid, pid in rows)
+
+
 # ── fast path: row counts + read path through the store API ──
 
 
@@ -76,7 +102,9 @@ def test_seed_fast_path_row_counts_and_read_path(tmp_path: Path) -> None:
 
     db_uri = f"sqlite:///{tmp_path / 'fast.db'}"
 
-    created = seed_mod.seed(db_uri, sessions=50, items_per_session=10, _fast=True)
+    created = seed_mod.seed(
+        db_uri, sessions=50, items_per_session=10, projects=5, filed_fraction=0.6, _fast=True
+    )
     assert created == 50
 
     engine = get_or_create_engine(db_uri)
@@ -88,6 +116,27 @@ def test_seed_fast_path_row_counts_and_read_path(tmp_path: Path) -> None:
     assert _count(engine, "session_permissions") == 50
     assert _count(engine, "users") == 1
     assert _count(engine, "conversation_labels") == 1
+    assert _count(engine, "projects") == 5
+
+    with engine.connect() as conn:
+        # 30 of 50 sessions filed (0.6), spread round-robin across 5 projects,
+        # each owned by "local"; the other 20 stay unfiled (project_id IS NULL).
+        filed = conn.execute(
+            text(
+                "SELECT COUNT(*) FROM omnigent_conversation_metadata WHERE project_id IS NOT NULL"
+            )
+        ).scalar_one()
+        assert filed == 30
+        owners = conn.execute(text("SELECT DISTINCT owner_user_id FROM projects")).all()
+        assert owners == [(RESERVED_USER_LOCAL,)]
+        # Round-robin: each of the 5 projects holds 30/5 = 6 sessions.
+        per_project = conn.execute(
+            text(
+                "SELECT project_id, COUNT(*) FROM omnigent_conversation_metadata "
+                "WHERE project_id IS NOT NULL GROUP BY project_id"
+            )
+        ).all()
+        assert sorted(c for _, c in per_project) == [6, 6, 6, 6, 6]
 
     with engine.connect() as conn:
         # next_position advanced to items_per_session on every conversation.
@@ -140,14 +189,22 @@ def test_seed_fast_path_row_counts_and_read_path(tmp_path: Path) -> None:
 def test_seed_fast_path_corpus_matches_store_path(tmp_path: Path) -> None:
     """Same config + RNG seed → identical corpus shape via either write path.
 
-    The uuid4 ids are fresh per run, so we compare the RNG-determined content
-    (titles, per-session search_text in draw order, JSON ``data`` blobs) and the
-    row counts — proving the fast path draws the RNG in the same order and
-    serializes rows identically to the store ORM loop.
+    Conversation/agent ids are fresh uuid4 per run, so we compare the
+    RNG-determined content (titles, per-session search_text in draw order, JSON
+    ``data`` blobs) and the row counts — proving the fast path draws the RNG in
+    the same order and serializes rows identically to the store ORM loop. The
+    project ids ARE deterministic (derived from the index), so project rows and
+    per-project membership counts are compared directly.
     """
     from dev.benchmarks.omnigent import seed as seed_mod
 
-    cfg = {"sessions": 50, "items_per_session": 10, "rng_seed": 1234}
+    cfg = {
+        "sessions": 50,
+        "items_per_session": 10,
+        "rng_seed": 1234,
+        "projects": 5,
+        "filed_fraction": 0.6,
+    }
     fast_uri = f"sqlite:///{tmp_path / 'fast.db'}"
     slow_uri = f"sqlite:///{tmp_path / 'slow.db'}"
 
@@ -166,6 +223,7 @@ def test_seed_fast_path_corpus_matches_store_path(tmp_path: Path) -> None:
         "session_permissions",
         "users",
         "conversation_labels",
+        "projects",
     ):
         assert _count(fe, table) == _count(se, table), table
 
@@ -174,6 +232,9 @@ def test_seed_fast_path_corpus_matches_store_path(tmp_path: Path) -> None:
     assert _item_text_ordered(fe) == _item_text_ordered(se)
     # JSON serialization (default separators, exclude_none) matches byte-for-byte.
     assert _item_data_ordered(fe) == _item_data_ordered(se)
+    # Deterministic project ids/names + membership counts match byte-for-byte.
+    assert _projects_ordered(fe) == _projects_ordered(se)
+    assert _membership_counts(fe) == _membership_counts(se)
 
 
 # ── non-SQLite slow path (skipped unless a non-SQLite DB is provided) ──


### PR DESCRIPTION
## Related issue

N/A — benchmark coverage tracked in `designs/PROJECTS_PRD.md §12` (Web UI TODO).

## Summary

The web sidebar (PR #3061) wired two project read paths that had no benchmark coverage. This adds them as latency journeys in `dev/benchmarks/omnigent`, mirroring the existing `list_sessions` hot-read path:

- **`list_projects`** — `GET /v1/sessions/projects`, the sidebar project list (a dual-read union of first-class projects + legacy `omni_project` label-projects).
- **`list_project_sessions`** — `GET /v1/sessions?project=`, a project folder's sessions (the dual-read filter behind clicking a folder).

Each is a single-request read (1 HTTP/op). `list_project_sessions`' setup reads a representative project from the seeded corpus, self-seeding a first-class project + one filed session when the DB is empty (smoke path) so the `?project=` filter resolves a real member instead of an empty match. Per the PRD, CRUD writes (create/rename/delete) are infrequent single-row ops and don't need a benchmark.

## Test Plan

- Smoke ran both journeys against a throwaway SQLite DB (exercises the self-seed setup path):
  ```
  uv run --no-sync dev/benchmarks/omnigent/run.py --journeys list_projects,list_project_sessions --iterations 5 --warmup 1
  ```
  Both report 0 failures and 1 HTTP/op (confirming the timed span is exactly the one read).
- `uv run --no-sync -m pytest tests/benchmarks/test_benchmark_smoke.py` — 30 passed (the end-to-end smoke now includes both new journeys via the curated list).
- `ruff check` + `ruff format --check` clean.

## Demo

N/A — benchmark tooling, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The benchmark smoke suite (`tests/benchmarks/test_benchmark_smoke.py`) runs both new journeys end-to-end against a throwaway DB, asserting they report and don't error. Manually smoke-ran the journeys directly (command above) to confirm latency numbers and the 1-HTTP/op count. The journeys themselves are perf instrumentation, not product code.

This pull request and its description were written by Isaac.
