### PR TITLE
feat(projects): polish project-folder header actions

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_projects.py
+++ b/tests/e2e_ui/sessions/test_sidebar_projects.py
@@ -145,3 +145,54 @@ def test_remove_session_from_project(
     expect(_section(page, "Sessions").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
     expect(page.get_by_role("button", name=project, exact=True)).to_have_count(1)
     expect(_section(page, project).locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+
+
+# A phone-width viewport: below the 768px `md` breakpoint, so the sidebar is the
+# mobile overlay and the folder header's new-session pencil (`max-md:hidden`)
+# collapses into the kebab.
+_MOBILE_VIEWPORT = {"width": 390, "height": 780}
+
+
+def test_project_new_session_folds_into_kebab_on_mobile(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """On mobile the folder pencil hides and its action lives in the kebab.
+
+    On desktop the project-folder header shows a hover-revealed pencil that
+    starts a new session pre-filed under the project. Below the ``md``
+    breakpoint the pencil is hidden (``max-md:hidden``) and the same action is
+    offered as a ``md:hidden`` "New session" item inside the folder kebab,
+    linking to the pre-filed composer (``/?project=<name>``). Drives the real
+    responsive chain the ``Sidebar`` unit test asserts via class names.
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-proj-mobile-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_id, title)
+    project = f"Project {uuid.uuid4().hex[:6]}"
+
+    # File the session into a fresh project on desktop first (the mobile overlay
+    # hides the row kebab's hover affordances), then shrink to phone width.
+    page.goto(f"{base_url}/c/{session_id}")
+    _move_to_new_project(page, _row(page, session_id), project)
+    expect(page.get_by_role("button", name=project, exact=True)).to_be_visible()
+
+    # Shrink to phone width; the mobile sidebar starts closed, so reopen it via
+    # the one-shot ``?sidebar=open`` param (the notification-tap destination).
+    page.set_viewport_size(_MOBILE_VIEWPORT)
+    page.goto(f"{base_url}/c/{session_id}?sidebar=open")
+
+    header = page.get_by_role("button", name=project, exact=True)
+    expect(header).to_be_visible()
+
+    # The pencil is in the DOM but hidden at this width (max-md:hidden).
+    expect(page.get_by_test_id("project-new-session")).to_be_hidden()
+
+    # Open the folder kebab → the mobile-only "New session" item, pre-filed
+    # under this project via the ?project= composer link.
+    header.hover()
+    page.get_by_test_id("project-actions").click()
+    # asChild renders the item as the <a> itself, so the link href lives on it.
+    menu_item = page.get_by_test_id("project-new-session-menu")
+    expect(menu_item).to_be_visible()
+    expect(menu_item).to_have_attribute("href", f"/?project={project.replace(' ', '%20')}")

--- a/tests/e2e_ui/sessions/test_sidebar_projects.py
+++ b/tests/e2e_ui/sessions/test_sidebar_projects.py
@@ -185,13 +185,19 @@ def test_project_new_session_folds_into_kebab_on_mobile(
     header = page.get_by_role("button", name=project, exact=True)
     expect(header).to_be_visible()
 
+    # Scope to THIS project's controls by their per-project accessible names —
+    # the shared server carries other tests' folders, so the bare test-ids match
+    # multiple pencils/kebabs (strict-mode violation).
+    pencil = page.get_by_role("link", name=f"New session in {project}")
+    kebab = page.get_by_role("button", name=f"Project actions for {project}")
+
     # The pencil is in the DOM but hidden at this width (max-md:hidden).
-    expect(page.get_by_test_id("project-new-session")).to_be_hidden()
+    expect(pencil).to_be_hidden()
 
     # Open the folder kebab → the mobile-only "New session" item, pre-filed
     # under this project via the ?project= composer link.
     header.hover()
-    page.get_by_test_id("project-actions").click()
+    kebab.click()
     # asChild renders the item as the <a> itself, so the link href lives on it.
     menu_item = page.get_by_test_id("project-new-session-menu")
     expect(menu_item).to_be_visible()

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -937,6 +937,30 @@ describe("Sidebar project sections", () => {
       expect.anything(),
     );
   });
+
+  it("folds the new-session pencil into the kebab on mobile", async () => {
+    // The pencil is desktop-only (max-md:hidden); on mobile the same action is
+    // offered as a md:hidden "New session" kebab item pre-filed under the
+    // project (same ?project= link as the pencil).
+    projectsMock.push("Customer X");
+    mockConversations([
+      conv("conv_filed", "Claude Code", { labels: { omni_project: "Customer X" } }),
+    ]);
+    renderSidebar();
+
+    // Pencil stays in the tree but is hidden below the md breakpoint.
+    expect(screen.getByTestId("project-new-session")).toHaveClass("max-md:hidden");
+
+    // Open the kebab → a mobile-only "New session" item linking to the same
+    // pre-filed composer.
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Project actions for Customer X" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    const menuItem = await screen.findByTestId("project-new-session-menu");
+    expect(menuItem).toHaveClass("md:hidden");
+    expect(menuItem.closest("a")).toHaveAttribute("href", "/?project=Customer%20X");
+  });
 });
 
 // A collapsed project bubbles up its hidden rows' marker, using the same

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -2824,7 +2824,7 @@ function ConversationRow({
           aria-label={isPinned ? "Unpin conversation" : "Pin conversation"}
           data-testid="quick-pin-conversation"
           className={cn(
-            "-translate-y-1/2 absolute top-1/2 right-9 transition-opacity",
+            "-translate-y-1/2 absolute top-1/2 right-8 transition-opacity",
             // Desktop-only quick affordance: hidden on mobile (the kebab's
             // Pin item below covers that), hover/focus-revealed from `md` up.
             // Pinned rows no longer keep a persistent pin marker, since the
@@ -3153,27 +3153,35 @@ function ProjectFolderActions({
 }) {
   return (
     <div className="flex items-center">
-      <ProjectFolderMenu projectName={projectName} projectId={projectId} />
-      <Button
-        asChild
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        aria-label={`New session in ${projectName}`}
-        data-testid="project-new-session"
-      >
-        <Link
-          to={`/?project=${encodeURIComponent(projectName)}`}
-          onClick={(e) => {
-            // Keep the click off the folder's collapse toggle, then run the
-            // shared nav handler (closes the sidebar overlay on mobile).
-            e.stopPropagation();
-            onNavigate(e);
-          }}
-        >
-          <SquarePenIcon className="size-3.5" />
-        </Link>
-      </Button>
+      {/* Desktop-only quick affordance; on mobile it folds into the kebab's
+          "New session" item below. */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            asChild
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`New session in ${projectName}`}
+            data-testid="project-new-session"
+            className="max-md:hidden"
+          >
+            <Link
+              to={`/?project=${encodeURIComponent(projectName)}`}
+              onClick={(e) => {
+                // Keep the click off the folder's collapse toggle, then run the
+                // shared nav handler (closes the sidebar overlay on mobile).
+                e.stopPropagation();
+                onNavigate(e);
+              }}
+            >
+              <SquarePenIcon className="size-3.5" />
+            </Link>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">New session in project</TooltipContent>
+      </Tooltip>
+      <ProjectFolderMenu projectName={projectName} projectId={projectId} onNavigate={onNavigate} />
     </div>
   );
 }
@@ -3189,9 +3197,13 @@ function ProjectFolderActions({
 function ProjectFolderMenu({
   projectName,
   projectId,
+  onNavigate,
 }: {
   projectName: string;
   projectId: string | null;
+  /** Nav handler for the mobile-only "New session" item (desktop uses the
+      hover-revealed pencil). Closes the sidebar overlay on mobile. */
+  onNavigate: (e: MouseEvent<HTMLAnchorElement>) => void;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -3217,6 +3229,20 @@ function ProjectFolderMenu({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="min-w-40 [&_[role=menuitem]]:text-xs">
+          {/* New session — mobile-only (md:hidden); desktop uses the
+              hover-revealed pencil on the folder header. */}
+          <DropdownMenuItem asChild className="md:hidden" data-testid="project-new-session-menu">
+            <Link
+              to={`/?project=${encodeURIComponent(projectName)}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onNavigate(e);
+              }}
+            >
+              <SquarePenIcon className="size-3.5" />
+              New session
+            </Link>
+          </DropdownMenuItem>
           <DropdownMenuItem
             data-testid="rename-project"
             onSelect={() => {


### PR DESCRIPTION
## Related issue

N/A

## Summary

Small UX polish on the project-folder header actions in the web sidebar
(follow-up to #3061):

- **Swap order** so the new-session (pencil) sits left of the `...` kebab.
- **Align** a session row's quick-pin with the kebab (`right-8`) so the
  pin/kebab pair lines up with the project row's pencil/kebab pair.
- **Tooltip** "New session in project" on the pencil.
- **Mobile:** hide the pencil (`max-md:hidden`) and fold the action into the
  kebab as a `md:hidden` "New session" item linking to the same pre-filed
  composer.

## Test Plan

- `cd web && npm test` — Sidebar unit tests pass, including a new test
  asserting the pencil is `max-md:hidden` and the kebab exposes a `md:hidden`
  "New session" item pointing at `/?project=<name>`.
- `cd web && npm run build` — clean.
- `pytest tests/e2e_ui/sessions/test_sidebar_projects.py::test_project_new_session_folds_into_kebab_on_mobile`
  — new Playwright e2e drives the responsive fold: at phone width the pencil is
  hidden and the folder kebab exposes the "New session" item linking to the
  pre-filed composer. Passes locally.
- Manual: expanded a project folder, confirmed pencil-left/kebab-right order,
  tooltip on hover, and pin/kebab alignment against the project row.

## Demo

N/A (hover/breakpoint-gated header controls; covered by unit + e2e tests)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a Sidebar unit test and an e2e_ui Playwright test for the mobile fold.
Manually verified the desktop ordering, alignment, and tooltip in the running
web app since those are hover-gated and not observable in jsdom.

## Changelog

Reordered the project-folder header buttons (new-session before the menu),
aligned session pin/kebab with them, added a new-session tooltip, and folded
the new-session action into the kebab on mobile

This pull request and its description were written by Isaac.