### PR TITLE
feat(scheduled tasks): data layer, API client, hooks, schedule helpers

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -67,6 +67,7 @@
         "remark-breaks": "^4.0.0",
         "remark-emoji": "^5.0.2",
         "remark-gfm": "^4.0.1",
+        "rrule": "^2.8.1",
         "shadcn": "0.0.0-beta.9d3f70e54",
         "shiki": "^4.0.2",
         "streamdown": "^2.5.0",
@@ -14284,6 +14285,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/run-applescript": {

--- a/web/package.json
+++ b/web/package.json
@@ -78,6 +78,7 @@
     "remark-breaks": "^4.0.0",
     "remark-emoji": "^5.0.2",
     "remark-gfm": "^4.0.1",
+    "rrule": "^2.8.1",
     "shadcn": "0.0.0-beta.9d3f70e54",
     "shiki": "^4.0.2",
     "streamdown": "^2.5.0",

--- a/web/src/hooks/useScheduledTasks.test.tsx
+++ b/web/src/hooks/useScheduledTasks.test.tsx
@@ -1,0 +1,102 @@
+// Tests for the scheduled-tasks React-Query hooks: the list query shape and the
+// invalidate-on-success contract of the create / update / delete mutations.
+// The API client is mocked so we assert on hook wiring, not HTTP.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "@/lib/scheduledTasksApi";
+import {
+  SCHEDULED_TASKS_KEY,
+  useCreateScheduledTask,
+  useDeleteScheduledTask,
+  useScheduledTasks,
+  useUpdateScheduledTask,
+} from "./useScheduledTasks";
+
+vi.mock("@/lib/scheduledTasksApi", () => ({
+  listScheduledTasks: vi.fn(),
+  createScheduledTask: vi.fn(),
+  updateScheduledTask: vi.fn(),
+  deleteScheduledTask: vi.fn(),
+}));
+
+const TASK: api.ScheduledTask = {
+  id: "st_1",
+  name: "Nightly triage",
+  prompt: "Triage",
+  rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+  ownerUserId: null,
+  agentId: "ag_1",
+  timezone: "UTC",
+  createdAt: 1,
+  updatedAt: 2,
+  modelOverride: null,
+  reasoningEffort: null,
+  workspace: null,
+  hostId: null,
+  state: "active",
+  lastRunAt: null,
+  lastRunConversationId: null,
+};
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper };
+}
+
+beforeEach(() => {
+  vi.mocked(api.listScheduledTasks).mockResolvedValue([TASK]);
+  vi.mocked(api.createScheduledTask).mockResolvedValue(TASK);
+  vi.mocked(api.updateScheduledTask).mockResolvedValue({ ...TASK, state: "paused" });
+  vi.mocked(api.deleteScheduledTask).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useScheduledTasks", () => {
+  it("returns the list from the API", async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useScheduledTasks(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([TASK]);
+  });
+});
+
+describe("mutations invalidate the list", () => {
+  it("create invalidates SCHEDULED_TASKS_KEY", async () => {
+    const { queryClient, wrapper } = makeWrapper();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useCreateScheduledTask(), { wrapper });
+    await result.current.mutateAsync({
+      name: "n",
+      prompt: "p",
+      rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      agentId: "ag_1",
+    });
+    expect(spy).toHaveBeenCalledWith({ queryKey: SCHEDULED_TASKS_KEY });
+  });
+
+  it("update invalidates the list", async () => {
+    const { queryClient, wrapper } = makeWrapper();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUpdateScheduledTask(), { wrapper });
+    await result.current.mutateAsync({ id: "st_1", input: { state: "paused" } });
+    expect(spy).toHaveBeenCalledWith({ queryKey: SCHEDULED_TASKS_KEY });
+  });
+
+  it("delete invalidates the list", async () => {
+    const { queryClient, wrapper } = makeWrapper();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useDeleteScheduledTask(), { wrapper });
+    await result.current.mutateAsync("st_1");
+    expect(spy).toHaveBeenCalledWith({ queryKey: SCHEDULED_TASKS_KEY });
+  });
+});

--- a/web/src/hooks/useScheduledTasks.ts
+++ b/web/src/hooks/useScheduledTasks.ts
@@ -1,0 +1,104 @@
+// TanStack Query hooks over the `/v1/scheduled-tasks` client: a `useQuery` for
+// the list + run history, and `useMutation`s for create / update / delete. Each
+// mutation invalidates the list query on success so the Tasks page reflects the
+// change without a manual refetch. Mirrors the pattern in `useConversations.ts`
+// (invalidate-on-success), but the scheduled-tasks list reads the DB directly
+// (no async search index), so a plain invalidate can't resurrect a just-deleted
+// row — no patch-in-place gymnastics are needed here.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createScheduledTask,
+  deleteScheduledTask,
+  listScheduledTaskRuns,
+  listScheduledTasks,
+  updateScheduledTask,
+  type CreateScheduledTaskInput,
+  type ScheduledTask,
+  type ScheduledTaskRun,
+  type UpdateScheduledTaskInput,
+} from "@/lib/scheduledTasksApi";
+
+/** Query key for the caller's scheduled-tasks list. */
+export const SCHEDULED_TASKS_KEY = ["scheduled-tasks"] as const;
+
+/** Query key for one task's run history. */
+export function scheduledTaskRunsKey(id: string): readonly unknown[] {
+  return ["scheduled-task-runs", id];
+}
+
+/**
+ * The caller's scheduled tasks. There is no push stream for scheduled tasks, so
+ * a 30 s stale window keeps quick remounts cheap and a 60 s background poll
+ * catches out-of-band changes (a task created from the agent tool, or a run
+ * that just fired) without hammering the server.
+ */
+export function useScheduledTasks() {
+  return useQuery<ScheduledTask[]>({
+    queryKey: SCHEDULED_TASKS_KEY,
+    queryFn: listScheduledTasks,
+    staleTime: 30_000,
+    // POLLING CONTRACT — read before reusing this hook.
+    // The 60s interval only runs while a component that mounts this hook is
+    // mounted; TanStack Query tears the interval down on unmount. Today the sole
+    // consumer is TasksPage, which is route-scoped and lazy-loaded at /tasks — so
+    // polling happens ONLY while the user is on the Scheduled Tasks page and
+    // stops the moment they navigate away.
+    // GUARD RAIL: do NOT mount this hook in a persistent / always-rendered spot
+    // (sidebar, global layout, an app-shell badge). That would silently turn a
+    // page-scoped poll into app-wide 60s background traffic. If you need a
+    // persistent scheduled-tasks indicator, add a SEPARATE lightweight query
+    // (no short refetchInterval, or a much longer one) — don't reuse this one.
+    refetchInterval: 60_000,
+  });
+}
+
+/**
+ * One task's run history (most-recent-first). `enabled` gates the fetch so an
+ * unexpanded row costs nothing.
+ */
+export function useScheduledTaskRuns(id: string, enabled: boolean = true) {
+  return useQuery<ScheduledTaskRun[]>({
+    queryKey: scheduledTaskRunsKey(id),
+    queryFn: () => listScheduledTaskRuns(id),
+    enabled,
+    staleTime: 30_000,
+  });
+}
+
+/** Create a scheduled task, then refresh the list. */
+export function useCreateScheduledTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateScheduledTaskInput) => createScheduledTask(input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: SCHEDULED_TASKS_KEY });
+    },
+  });
+}
+
+/** Update a task (pause/reactivate/rename/reschedule), then refresh the list. */
+export function useUpdateScheduledTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: UpdateScheduledTaskInput }) =>
+      updateScheduledTask(id, input),
+    onSuccess: (updated) => {
+      void queryClient.invalidateQueries({ queryKey: SCHEDULED_TASKS_KEY });
+      // A schedule/state change can shift the run history too (e.g. a
+      // just-reactivated task), so refresh that task's runs if they're loaded.
+      void queryClient.invalidateQueries({ queryKey: scheduledTaskRunsKey(updated.id) });
+    },
+  });
+}
+
+/** Delete a task, then refresh the list. */
+export function useDeleteScheduledTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteScheduledTask(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: SCHEDULED_TASKS_KEY });
+    },
+  });
+}

--- a/web/src/lib/scheduleBuilder.ts
+++ b/web/src/lib/scheduleBuilder.ts
@@ -1,0 +1,176 @@
+// Build an RFC-5545 RRULE string from the manual create form's schedule model,
+// and validate it against the form's constraints before submit.
+//
+// Top-level presets (the frequency dropdown): Hourly, Daily, Weekdays, Weekly,
+// Custom. Monthly and Yearly are reachable ONLY under Custom (a sub-frequency
+// selector with an interval + specifics). The server validates the final rule
+// (`validate_rrule`), including a 1-hour-minimum-interval floor
+// (MIN_INTERVAL_SECONDS=3600); this module enforces the same floor client-side
+// (Custom Hourly INTERVAL ≥ 1) plus positive-integer intervals and non-empty
+// multi-selects, so the form never submits a rule the server would reject.
+
+/** The frequency dropdown's top-level options. */
+export type SchedulePreset = "hourly" | "daily" | "weekdays" | "weekly" | "custom";
+
+/** The frequency sub-selector shown under the "custom" preset. */
+export type CustomFreq = "hourly" | "daily" | "weekly" | "monthly" | "yearly";
+
+/** Weekday codes as used by RRULE `BYDAY` (MO..SU), in calendar order. */
+export const WEEKDAY_CODES = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"] as const;
+export type WeekdayCode = (typeof WEEKDAY_CODES)[number];
+
+/** Months 1–12 for the Custom Yearly `BYMONTH`. */
+export const MONTHS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
+
+/** The manual form's schedule inputs. Fields not relevant to the active
+ * preset/custom-frequency are simply ignored by `buildRRule`. */
+export interface ScheduleModel {
+  preset: SchedulePreset;
+  /** Hour of day 0–23 (ignored for hourly). */
+  hour: number;
+  /** Minute of hour 0–59. */
+  minute: number;
+  /** Selected weekdays for the `weekly` preset and Custom Weekly. */
+  weekdays: WeekdayCode[];
+  /** Sub-frequency when `preset === "custom"`. */
+  customFreq: CustomFreq;
+  /** Recurrence interval (every X units) for Custom; positive integer. */
+  interval: number;
+  /** Days-of-month (1–31) for Custom Monthly / Yearly (multi-select). */
+  monthDays: number[];
+  /** Month 1–12 for Custom Yearly. */
+  month: number;
+}
+
+export const DEFAULT_SCHEDULE_MODEL: ScheduleModel = {
+  preset: "daily",
+  hour: 9,
+  minute: 0,
+  weekdays: ["MO"],
+  customFreq: "daily",
+  interval: 1,
+  monthDays: [1],
+  month: 1,
+};
+
+/**
+ * Build the canonical RRULE string for a schedule model. Produces a plain
+ * `RRULE:`-less rule body (e.g. `FREQ=WEEKLY;BYDAY=MO,TU;BYHOUR=8;BYMINUTE=0`).
+ * The time-of-day is encoded via `BYHOUR`/`BYMINUTE` (no DTSTART) so the rule
+ * carries no absolute anchor and the server localizes it in the task's tz.
+ */
+export function buildRRule(model: ScheduleModel): string {
+  const { hour, minute } = model;
+  switch (model.preset) {
+    case "hourly":
+      // Every hour on the minute — meets the 1h floor exactly.
+      return "FREQ=HOURLY;BYMINUTE=0";
+    case "daily":
+      return `FREQ=DAILY;BYHOUR=${hour};BYMINUTE=${minute}`;
+    case "weekdays":
+      return `FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=${hour};BYMINUTE=${minute}`;
+    case "weekly": {
+      const byday = normalizeWeekdays(model.weekdays).join(",") || "MO";
+      return `FREQ=WEEKLY;BYDAY=${byday};BYHOUR=${hour};BYMINUTE=${minute}`;
+    }
+    case "custom":
+      return buildCustomRRule(model);
+    default:
+      return `FREQ=DAILY;BYHOUR=${hour};BYMINUTE=${minute}`;
+  }
+}
+
+function buildCustomRRule(model: ScheduleModel): string {
+  const { hour, minute } = model;
+  const interval = clampInterval(model.interval);
+  switch (model.customFreq) {
+    case "hourly":
+      // every X hours at minute Y
+      return `FREQ=HOURLY;INTERVAL=${interval};BYMINUTE=${minute}`;
+    case "daily":
+      return `FREQ=DAILY;INTERVAL=${interval};BYHOUR=${hour};BYMINUTE=${minute}`;
+    case "weekly": {
+      const byday = normalizeWeekdays(model.weekdays).join(",") || "MO";
+      return `FREQ=WEEKLY;INTERVAL=${interval};BYDAY=${byday};BYHOUR=${hour};BYMINUTE=${minute}`;
+    }
+    case "monthly": {
+      const days = normalizeMonthDays(model.monthDays).join(",") || "1";
+      return `FREQ=MONTHLY;INTERVAL=${interval};BYMONTHDAY=${days};BYHOUR=${hour};BYMINUTE=${minute}`;
+    }
+    case "yearly": {
+      const days = normalizeMonthDays(model.monthDays).join(",") || "1";
+      const month = clampMonth(model.month);
+      return `FREQ=YEARLY;INTERVAL=${interval};BYMONTH=${month};BYMONTHDAY=${days};BYHOUR=${hour};BYMINUTE=${minute}`;
+    }
+    default:
+      return `FREQ=DAILY;INTERVAL=${interval};BYHOUR=${hour};BYMINUTE=${minute}`;
+  }
+}
+
+/**
+ * Validate the schedule model against the form's constraints. Returns a
+ * human-readable error string when invalid (shown inline + gates submit), or
+ * `null` when the model is OK. Mirrors the server's rejection reasons so a bad
+ * schedule fails fast in the form rather than as a 400.
+ */
+export function validateSchedule(model: ScheduleModel): string | null {
+  // Multi-selects must have at least one selection.
+  if (model.preset === "weekly" && model.weekdays.length === 0) {
+    return "Pick at least one day of the week.";
+  }
+  if (model.preset === "custom") {
+    if (!Number.isInteger(model.interval) || model.interval < 1) {
+      return "Interval must be a whole number of at least 1.";
+    }
+    // 1-hour floor: a sub-hour cadence is only reachable via Custom Hourly with
+    // INTERVAL < 1, which the interval check above already blocks. Guard the
+    // hourly case explicitly for a clear message.
+    if (model.customFreq === "hourly" && model.interval < 1) {
+      return "Hourly tasks must run at most once per hour (interval ≥ 1).";
+    }
+    if (model.customFreq === "weekly" && model.weekdays.length === 0) {
+      return "Pick at least one day of the week.";
+    }
+    if (
+      (model.customFreq === "monthly" || model.customFreq === "yearly") &&
+      model.monthDays.length === 0
+    ) {
+      return "Pick at least one day of the month.";
+    }
+  }
+  return null;
+}
+
+/** Sort weekday codes into calendar order (MO..SU), dropping duplicates. */
+function normalizeWeekdays(codes: WeekdayCode[]): WeekdayCode[] {
+  const seen = new Set(codes);
+  return WEEKDAY_CODES.filter((c) => seen.has(c));
+}
+
+/**
+ * Sort day-of-month values ascending, drop dups, and clamp each to 1–31. We
+ * allow the full 1–31 range (not a conservative ≤28) and let the server / rrule
+ * handle short months — a `BYMONTHDAY=31` simply doesn't fire in February,
+ * which is the standard RRULE semantic and matches user expectations.
+ */
+function normalizeMonthDays(days: number[]): number[] {
+  const cleaned = days.map((d) => clampMonthDay(d)).filter((d): d is number => d != null);
+  return [...new Set(cleaned)].sort((a, b) => a - b);
+}
+
+function clampInterval(n: number): number {
+  if (!Number.isFinite(n)) return 1;
+  return Math.max(1, Math.trunc(n));
+}
+
+function clampMonthDay(day: number): number | null {
+  if (!Number.isFinite(day)) return null;
+  const d = Math.trunc(day);
+  if (d < 1 || d > 31) return null;
+  return d;
+}
+
+function clampMonth(m: number): number {
+  if (!Number.isFinite(m)) return 1;
+  return Math.min(12, Math.max(1, Math.trunc(m)));
+}

--- a/web/src/lib/scheduleText.test.ts
+++ b/web/src/lib/scheduleText.test.ts
@@ -1,0 +1,322 @@
+// Tests for the client-side schedule text + next-run derivation, and the RRULE
+// builder + validation that feed them. Covers every shape the create form can
+// produce: the simple presets (Hourly/Daily/Weekdays/Weekly) and all five
+// Custom frequencies (with INTERVAL, multi weekday/month-day selects, and
+// yearly BYMONTH), plus the 1-hour-floor validation.
+
+import { describe, expect, it } from "vitest";
+import { describeSchedule, formatClockTime, nextRunAtMs } from "./scheduleText";
+import {
+  buildRRule,
+  DEFAULT_SCHEDULE_MODEL,
+  validateSchedule,
+  type ScheduleModel,
+} from "./scheduleBuilder";
+
+/** Convenience: a model with overrides on top of the default. */
+function model(overrides: Partial<ScheduleModel>): ScheduleModel {
+  return { ...DEFAULT_SCHEDULE_MODEL, ...overrides };
+}
+
+describe("formatClockTime", () => {
+  it("formats 12-hour times with AM/PM", () => {
+    expect(formatClockTime(8, 0)).toBe("8:00 AM");
+    expect(formatClockTime(0, 0)).toBe("12:00 AM");
+    expect(formatClockTime(12, 30)).toBe("12:30 PM");
+    expect(formatClockTime(13, 5)).toBe("1:05 PM");
+    expect(formatClockTime(23, 59)).toBe("11:59 PM");
+  });
+});
+
+describe("buildRRule — simple presets", () => {
+  it("hourly (no inputs)", () => {
+    expect(buildRRule(model({ preset: "hourly" }))).toBe("FREQ=HOURLY;BYMINUTE=0");
+  });
+
+  it("daily (time only)", () => {
+    expect(buildRRule(model({ preset: "daily", hour: 9, minute: 0 }))).toBe(
+      "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+    );
+  });
+
+  it("weekdays (Mon–Fri + time)", () => {
+    expect(buildRRule(model({ preset: "weekdays", hour: 8, minute: 0 }))).toBe(
+      "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=8;BYMINUTE=0",
+    );
+  });
+
+  it("weekly (multi weekday, sorted to calendar order)", () => {
+    expect(
+      buildRRule(model({ preset: "weekly", weekdays: ["FR", "MO"], hour: 8, minute: 0 })),
+    ).toBe("FREQ=WEEKLY;BYDAY=MO,FR;BYHOUR=8;BYMINUTE=0");
+  });
+
+  it("weekly falls back to MO when the (invalid) empty set is built", () => {
+    // validateSchedule blocks submit, but buildRRule must still emit a legal rule.
+    expect(buildRRule(model({ preset: "weekly", weekdays: [], hour: 8, minute: 0 }))).toBe(
+      "FREQ=WEEKLY;BYDAY=MO;BYHOUR=8;BYMINUTE=0",
+    );
+  });
+});
+
+describe("buildRRule — custom frequencies with INTERVAL", () => {
+  it("custom hourly: every X hours at minute Y", () => {
+    expect(
+      buildRRule(model({ preset: "custom", customFreq: "hourly", interval: 2, minute: 15 })),
+    ).toBe("FREQ=HOURLY;INTERVAL=2;BYMINUTE=15");
+  });
+
+  it("custom daily: every X days at h:m", () => {
+    expect(
+      buildRRule(
+        model({ preset: "custom", customFreq: "daily", interval: 3, hour: 9, minute: 30 }),
+      ),
+    ).toBe("FREQ=DAILY;INTERVAL=3;BYHOUR=9;BYMINUTE=30");
+  });
+
+  it("custom weekly: every X weeks on <days> at h:m", () => {
+    expect(
+      buildRRule(
+        model({
+          preset: "custom",
+          customFreq: "weekly",
+          interval: 2,
+          weekdays: ["MO", "WE", "FR"],
+          hour: 8,
+          minute: 0,
+        }),
+      ),
+    ).toBe("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR;BYHOUR=8;BYMINUTE=0");
+  });
+
+  it("custom monthly: every X months on <multi days> at h:m", () => {
+    expect(
+      buildRRule(
+        model({
+          preset: "custom",
+          customFreq: "monthly",
+          interval: 3,
+          monthDays: [15, 1],
+          hour: 6,
+          minute: 0,
+        }),
+      ),
+    ).toBe("FREQ=MONTHLY;INTERVAL=3;BYMONTHDAY=1,15;BYHOUR=6;BYMINUTE=0");
+  });
+
+  it("custom yearly: every X years in month Y on <multi days> at h:m", () => {
+    expect(
+      buildRRule(
+        model({
+          preset: "custom",
+          customFreq: "yearly",
+          interval: 2,
+          month: 3,
+          monthDays: [1],
+          hour: 9,
+          minute: 0,
+        }),
+      ),
+    ).toBe("FREQ=YEARLY;INTERVAL=2;BYMONTH=3;BYMONTHDAY=1;BYHOUR=9;BYMINUTE=0");
+  });
+
+  it("clamps a bad interval up to 1 in the built rule", () => {
+    expect(buildRRule(model({ preset: "custom", customFreq: "daily", interval: 0 }))).toContain(
+      "INTERVAL=1",
+    );
+  });
+
+  it("allows day-of-month up to 31 (short months handled by rrule)", () => {
+    expect(
+      buildRRule(model({ preset: "custom", customFreq: "monthly", interval: 1, monthDays: [31] })),
+    ).toContain("BYMONTHDAY=31");
+  });
+});
+
+describe("validateSchedule — 1-hour floor + required selections", () => {
+  it("accepts every simple preset", () => {
+    expect(validateSchedule(model({ preset: "hourly" }))).toBeNull();
+    expect(validateSchedule(model({ preset: "daily" }))).toBeNull();
+    expect(validateSchedule(model({ preset: "weekdays" }))).toBeNull();
+    expect(validateSchedule(model({ preset: "weekly", weekdays: ["MO"] }))).toBeNull();
+  });
+
+  it("rejects an empty weekly weekday set", () => {
+    expect(validateSchedule(model({ preset: "weekly", weekdays: [] }))).toMatch(
+      /at least one day/i,
+    );
+  });
+
+  it("rejects a sub-1 interval (the 1h floor) on custom hourly", () => {
+    expect(
+      validateSchedule(model({ preset: "custom", customFreq: "hourly", interval: 0 })),
+    ).toMatch(/at least 1/i);
+  });
+
+  it("rejects a non-integer / <1 interval for any custom frequency", () => {
+    expect(validateSchedule(model({ preset: "custom", customFreq: "daily", interval: 0 }))).toMatch(
+      /at least 1/i,
+    );
+    expect(
+      validateSchedule(model({ preset: "custom", customFreq: "daily", interval: 1.5 })),
+    ).toMatch(/whole number/i);
+  });
+
+  it("accepts a valid custom hourly interval (>=1 → within the floor)", () => {
+    expect(
+      validateSchedule(model({ preset: "custom", customFreq: "hourly", interval: 1 })),
+    ).toBeNull();
+    expect(
+      validateSchedule(model({ preset: "custom", customFreq: "hourly", interval: 6 })),
+    ).toBeNull();
+  });
+
+  it("requires at least one custom weekly weekday and monthly/yearly day", () => {
+    expect(
+      validateSchedule(
+        model({ preset: "custom", customFreq: "weekly", interval: 1, weekdays: [] }),
+      ),
+    ).toMatch(/at least one day/i);
+    expect(
+      validateSchedule(
+        model({ preset: "custom", customFreq: "monthly", interval: 1, monthDays: [] }),
+      ),
+    ).toMatch(/at least one day of the month/i);
+    expect(
+      validateSchedule(
+        model({ preset: "custom", customFreq: "yearly", interval: 1, monthDays: [] }),
+      ),
+    ).toMatch(/at least one day of the month/i);
+  });
+});
+
+describe("describeSchedule", () => {
+  it("collapses the Mon–Fri set to Weekdays", () => {
+    expect(describeSchedule("FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=8;BYMINUTE=0")).toBe(
+      "Weekdays at 8:00 AM",
+    );
+  });
+
+  it("renders a daily rule", () => {
+    expect(describeSchedule("FREQ=DAILY;BYHOUR=9;BYMINUTE=0")).toBe("Every day at 9:00 AM");
+  });
+
+  it("renders a specific weekly day and a multi-day set", () => {
+    expect(describeSchedule("FREQ=WEEKLY;BYDAY=MO;BYHOUR=14;BYMINUTE=30")).toBe(
+      "Weekly on Monday at 2:30 PM",
+    );
+    expect(describeSchedule("FREQ=WEEKLY;BYDAY=MO,FR;BYHOUR=8;BYMINUTE=0")).toBe(
+      "Weekly on Monday and Friday at 8:00 AM",
+    );
+  });
+
+  it("renders weekends", () => {
+    expect(describeSchedule("FREQ=WEEKLY;BYDAY=SA,SU;BYHOUR=10;BYMINUTE=0")).toBe(
+      "Weekends at 10:00 AM",
+    );
+  });
+
+  it("renders plain hourly and interval-hourly", () => {
+    expect(describeSchedule("FREQ=HOURLY;BYMINUTE=0")).toBe("Hourly");
+    // interval-1 hourly with a non-zero BYMINUTE shows the minute (not bare "Hourly").
+    expect(describeSchedule("FREQ=HOURLY;BYMINUTE=30")).toBe("Hourly at :30");
+    expect(describeSchedule("FREQ=HOURLY;INTERVAL=2;BYMINUTE=15")).toBe("Every 2 hours at :15");
+  });
+
+  it("renders interval daily / weekly", () => {
+    expect(describeSchedule("FREQ=DAILY;INTERVAL=3;BYHOUR=9;BYMINUTE=30")).toBe(
+      "Every 3 days at 9:30 AM",
+    );
+    expect(describeSchedule("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE;BYHOUR=8;BYMINUTE=0")).toBe(
+      "Every 2 weeks on Monday and Wednesday at 8:00 AM",
+    );
+  });
+
+  it("renders monthly with single + multi day, plain + interval", () => {
+    expect(describeSchedule("FREQ=MONTHLY;BYMONTHDAY=1;BYHOUR=6;BYMINUTE=0")).toBe(
+      "Monthly on the 1st at 6:00 AM",
+    );
+    expect(describeSchedule("FREQ=MONTHLY;INTERVAL=3;BYMONTHDAY=1,15;BYHOUR=6;BYMINUTE=0")).toBe(
+      "Every 3 months on the 1st and 15th at 6:00 AM",
+    );
+  });
+
+  it("renders yearly with month + day, plain + interval", () => {
+    expect(describeSchedule("FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=1;BYHOUR=9;BYMINUTE=0")).toBe(
+      "Yearly in March on the 1st at 9:00 AM",
+    );
+    expect(
+      describeSchedule("FREQ=YEARLY;INTERVAL=2;BYMONTH=12;BYMONTHDAY=25;BYHOUR=9;BYMINUTE=0"),
+    ).toBe("Every 2 years in December on the 25th at 9:00 AM");
+  });
+
+  it("falls back to the raw rule for an unparseable string", () => {
+    expect(describeSchedule("not a rule")).toBe("not a rule");
+  });
+
+  it("round-trips every builder output to non-empty readable text", () => {
+    const cases: ScheduleModel[] = [
+      model({ preset: "hourly" }),
+      model({ preset: "daily" }),
+      model({ preset: "weekdays" }),
+      model({ preset: "weekly", weekdays: ["TU", "TH"] }),
+      model({ preset: "custom", customFreq: "hourly", interval: 4, minute: 0 }),
+      model({ preset: "custom", customFreq: "daily", interval: 2 }),
+      model({ preset: "custom", customFreq: "weekly", interval: 2, weekdays: ["MO"] }),
+      model({ preset: "custom", customFreq: "monthly", interval: 1, monthDays: [1, 15] }),
+      model({ preset: "custom", customFreq: "yearly", interval: 1, month: 6, monthDays: [1] }),
+    ];
+    for (const m of cases) {
+      const text = describeSchedule(buildRRule(m));
+      expect(text.length).toBeGreaterThan(0);
+      // Never leaks the raw FREQ= rule as the "readable" text.
+      expect(text.startsWith("FREQ=")).toBe(false);
+    }
+  });
+});
+
+describe("nextRunAtMs", () => {
+  it("computes the next daily occurrence after now", () => {
+    // 2026-01-01 06:00 UTC; a 9:00 UTC daily rule fires later the same day.
+    const now = new Date("2026-01-01T06:00:00Z");
+    const next = nextRunAtMs("FREQ=DAILY;BYHOUR=9;BYMINUTE=0", "UTC", now);
+    expect(next).not.toBeNull();
+    const d = new Date(next!);
+    expect(d.getUTCHours()).toBe(9);
+    expect(d.getUTCDate()).toBe(1);
+  });
+
+  it("rolls to the next day when today's time has passed", () => {
+    const now = new Date("2026-01-01T12:00:00Z");
+    const next = nextRunAtMs("FREQ=DAILY;BYHOUR=9;BYMINUTE=0", "UTC", now);
+    expect(new Date(next!).getUTCDate()).toBe(2);
+  });
+
+  it("handles interval-daily (every 3 days)", () => {
+    const now = new Date("2026-01-01T00:00:00Z");
+    const next = nextRunAtMs("FREQ=DAILY;INTERVAL=3;BYHOUR=9;BYMINUTE=0", "UTC", now);
+    expect(next).not.toBeNull();
+    expect(new Date(next!).getUTCHours()).toBe(9);
+  });
+
+  it("handles yearly with BYMONTH + BYMONTHDAY", () => {
+    const now = new Date("2026-01-01T00:00:00Z");
+    const next = nextRunAtMs("FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=1;BYHOUR=9;BYMINUTE=0", "UTC", now);
+    expect(next).not.toBeNull();
+    const d = new Date(next!);
+    expect(d.getUTCMonth()).toBe(2); // March (0-indexed)
+    expect(d.getUTCDate()).toBe(1);
+  });
+
+  it("handles multi-day monthly (picks the nearest upcoming day)", () => {
+    const now = new Date("2026-01-10T00:00:00Z");
+    const next = nextRunAtMs("FREQ=MONTHLY;BYMONTHDAY=1,15;BYHOUR=9;BYMINUTE=0", "UTC", now);
+    expect(next).not.toBeNull();
+    // Next after the 10th is the 15th of the same month.
+    expect(new Date(next!).getUTCDate()).toBe(15);
+  });
+
+  it("returns null for an unparseable rule", () => {
+    expect(nextRunAtMs("garbage", "UTC")).toBeNull();
+  });
+});

--- a/web/src/lib/scheduleText.ts
+++ b/web/src/lib/scheduleText.ts
@@ -1,0 +1,349 @@
+// Client-side derivation of the human-readable schedule summary the Tasks list
+// shows for each task ("Weekdays at 8:00 AM"), computed from the stored
+// RFC-5545 RRULE. `describeSchedule` is always correct because it only restates
+// the rule.
+//
+// `nextRunAtMs` also computes the next-occurrence instant from the RRULE + IANA
+// timezone, but it is NOT rendered as a user-facing countdown (see below) — we
+// don't display a "Next run in Xh" number because there is no stable server
+// anchor to match for INTERVAL>1 rules (the server anchors to the query day;
+// this uses a fixed dtstart), so a shown countdown could be off by a period.
+// It survives ONLY as the sort key for ordering active tasks by soonest run in
+// TasksPage, where an approximate relative ordering is acceptable.
+//
+// We use the `rrule` library only for the next-occurrence math (parsing the
+// rule and stepping to the next firing). The summary text is hand-formatted:
+// rrule's own `.toText()` produces "every week on Monday, Tuesday, …" which is
+// verbose and doesn't collapse the weekday set to "Weekdays" the way the design
+// calls for.
+
+import { RRule, rrulestr } from "rrule";
+
+// A fixed, far-past UTC anchor for occurrence generation. The scheduled-task
+// RRULEs carry no DTSTART (the time-of-day lives in BYHOUR/BYMINUTE), and
+// without an explicit dtstart rrule.js defaults the anchor to the module's
+// import-time `new Date()`, which would make `.after` generate occurrences from
+// today rather than honoring the caller's `now`. Anchoring to a stable past
+// date makes BY* rules fully determine the schedule. Matches the server's
+// fixed-deterministic-anchor approach.
+const OCCURRENCE_ANCHOR = new Date(Date.UTC(2000, 0, 1, 0, 0, 0));
+
+/** Days-of-week bit set helpers. RRule weekday order is MO..SU (0..6). */
+const WEEKDAYS = [RRule.MO, RRule.TU, RRule.WE, RRule.TH, RRule.FR].map((d) => d.weekday);
+const ALL_DAYS = [RRule.MO, RRule.TU, RRule.WE, RRule.TH, RRule.FR, RRule.SA, RRule.SU].map(
+  (d) => d.weekday,
+);
+
+const DAY_LABELS: Record<number, string> = {
+  [RRule.MO.weekday]: "Monday",
+  [RRule.TU.weekday]: "Tuesday",
+  [RRule.WE.weekday]: "Wednesday",
+  [RRule.TH.weekday]: "Thursday",
+  [RRule.FR.weekday]: "Friday",
+  [RRule.SA.weekday]: "Saturday",
+  [RRule.SU.weekday]: "Sunday",
+};
+
+/**
+ * Format an hour/minute pair as a 12-hour clock time, e.g. `8:00 AM`,
+ * `12:30 PM`. Falls back to `midnight` semantics via the standard 12-hour
+ * convention (0 → 12 AM).
+ */
+export function formatClockTime(hour: number, minute: number): string {
+  const period = hour < 12 ? "AM" : "PM";
+  const h12 = hour % 12 === 0 ? 12 : hour % 12;
+  const mm = minute.toString().padStart(2, "0");
+  return `${h12}:${mm} ${period}`;
+}
+
+/** Parse an RRULE string into an `RRule`, or `null` if it can't be parsed. */
+function tryParse(rrule: string): RRule | null {
+  try {
+    const parsed = rrulestr(rrule);
+    // rrulestr can return an RRuleSet for multi-rule strings; the scheduled-task
+    // backend stores a single RRULE, so we only handle the RRule case for text.
+    return parsed instanceof RRule ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+/**
+ * Human-readable summary of an RRULE's recurrence. Handles every shape the
+ * create form can produce — the simple presets and all five Custom
+ * frequencies, including INTERVAL (>1), multi-day BYMONTHDAY, and yearly
+ * BYMONTH — e.g.:
+ *   - "Weekdays at 8:00 AM"
+ *   - "Every day at 9:00 AM"
+ *   - "Weekly on Monday and Friday at 2:30 PM"
+ *   - "Every 2 hours at :15"
+ *   - "Every 3 months on the 1st and 15th at 6:00 AM"
+ *   - "Every 2 years in March on the 1st at 9:00 AM"
+ *
+ * Falls back to the library's `.toText()` (then the raw rule) for anything this
+ * formatter doesn't special-case, so a valid-but-unusual rule still renders
+ * something readable rather than blank.
+ */
+export function describeSchedule(rrule: string): string {
+  const rule = tryParse(rrule);
+  if (!rule) return rrule;
+  const o = rule.origOptions;
+  // BYHOUR/BYMINUTE come back as number | number[] | null | undefined.
+  const hour = firstOf(o.byhour) ?? 0;
+  const minute = firstOf(o.byminute) ?? 0;
+  const timeSuffix = ` at ${formatClockTime(hour, minute)}`;
+  const days = normalizeWeekdays(o.byweekday);
+  const interval = typeof o.interval === "number" && o.interval > 1 ? o.interval : 1;
+
+  if (o.freq === RRule.HOURLY) {
+    // Time-of-day is meaningless hourly; show the minute offset instead.
+    const min = `:${minute.toString().padStart(2, "0")}`;
+    if (interval > 1) return `Every ${interval} hours at ${min}`;
+    // interval 1: bare "Hourly" only when it fires on the hour; otherwise show
+    // the non-zero BYMINUTE so ":30" isn't silently dropped.
+    return minute === 0 ? "Hourly" : `Hourly at ${min}`;
+  }
+
+  if (o.freq === RRule.DAILY) {
+    if (interval > 1) return `Every ${interval} days${timeSuffix}`;
+    return `Every day${timeSuffix}`;
+  }
+
+  if (o.freq === RRule.WEEKLY) {
+    const dayText = weekdayText(days);
+    if (interval > 1) {
+      // "Every 2 weeks on Monday…" — a named weekday set reads better than the
+      // Weekdays/Weekends shorthands once an interval is involved.
+      const on = days.length > 0 ? ` on ${dayLabelList(days)}` : "";
+      return `Every ${interval} weeks${on}${timeSuffix}`;
+    }
+    if (days.length === 0) return `Weekly${timeSuffix}`;
+    return `${dayText}${timeSuffix}`;
+  }
+
+  if (o.freq === RRule.MONTHLY) {
+    const monthDays = normalizeNums(o.bymonthday);
+    const on = monthDays.length > 0 ? ` on the ${ordinalList(monthDays)}` : "";
+    if (interval > 1) return `Every ${interval} months${on}${timeSuffix}`;
+    return `Monthly${on}${timeSuffix}`;
+  }
+
+  if (o.freq === RRule.YEARLY) {
+    const monthNums = normalizeNums(o.bymonth);
+    const monthDays = normalizeNums(o.bymonthday);
+    const inMonth =
+      monthNums.length > 0
+        ? ` in ${monthNums
+            .map((m) => MONTH_NAMES[m - 1])
+            .filter(Boolean)
+            .join(", ")}`
+        : "";
+    const on = monthDays.length > 0 ? ` on the ${ordinalList(monthDays)}` : "";
+    if (interval > 1) return `Every ${interval} years${inMonth}${on}${timeSuffix}`;
+    return `Yearly${inMonth}${on}${timeSuffix}`;
+  }
+
+  // Anything else: defer to the library's text, then the raw rule.
+  try {
+    return capitalize(rule.toText());
+  } catch {
+    return rrule;
+  }
+}
+
+/** Weekday-set phrasing for the interval-1 weekly case (with shorthands). */
+function weekdayText(days: number[]): string {
+  if (sameSet(days, WEEKDAYS)) return "Weekdays";
+  if (sameSet(days, ALL_DAYS)) return "Every day";
+  if (sameSet(days, [RRule.SA.weekday, RRule.SU.weekday])) return "Weekends";
+  return `Weekly on ${dayLabelList(days)}`;
+}
+
+function dayLabelList(days: number[]): string {
+  return joinList(days.map((d) => DAY_LABELS[d]).filter(Boolean));
+}
+
+/**
+ * The next firing of `rrule` after `now`, as an epoch-ms timestamp, or `null`
+ * when the rule has no future occurrence (or can't be parsed).
+ *
+ * Timezone handling: the backend evaluates the rule in the task's IANA
+ * `timezone`, but the `rrule` lib computes in "floating" wall-clock time with no
+ * zone. We compute the next occurrence in the rule's own frame, then shift it by
+ * the offset between the task timezone and the viewer's local zone at that
+ * instant, so "8:00 AM America/New_York" resolves to the correct absolute
+ * moment regardless of where the viewer sits. This mirrors how the server's
+ * `python-dateutil` evaluation localizes the rule.
+ */
+export function nextRunAtMs(
+  rrule: string,
+  timezone: string,
+  now: Date = new Date(),
+): number | null {
+  const base = tryParse(rrule);
+  if (!base) return null;
+  // Rebuild with a fixed dtstart so occurrence generation is anchored
+  // deterministically (see OCCURRENCE_ANCHOR) rather than to import-time now.
+  let rule: RRule;
+  try {
+    rule = new RRule({ ...base.origOptions, dtstart: OCCURRENCE_ANCHOR });
+  } catch {
+    return null;
+  }
+  // rrule's `.after` treats the DTSTART/occurrences as UTC-naive wall times.
+  // Query against a "now" that is itself the current wall time in the task's
+  // timezone, so the comparison happens in the rule's frame.
+  const nowInTz = shiftWallClock(now, timezone);
+  let occurrence: Date | null;
+  try {
+    occurrence = rule.after(nowInTz, false);
+  } catch {
+    return null;
+  }
+  if (!occurrence) return null;
+  // `occurrence` is a wall-clock time in the task timezone, expressed as a naive
+  // Date (its UTC fields hold the tz-local Y/M/D H:M). Convert back to a real
+  // absolute instant by subtracting the tz offset at that wall time.
+  return wallClockToInstantMs(occurrence, timezone);
+}
+
+// ── internals ────────────────────────────────────────────────────────────────
+
+function firstOf(v: number | number[] | null | undefined): number | null {
+  if (v == null) return null;
+  return Array.isArray(v) ? (v.length > 0 ? v[0]! : null) : v;
+}
+
+/** Normalize a scalar-or-array RRULE option (e.g. bymonthday, bymonth) to a
+ * sorted, de-duped number[]. */
+function normalizeNums(v: number | number[] | null | undefined): number[] {
+  if (v == null) return [];
+  const arr = Array.isArray(v) ? v : [v];
+  const nums = arr.filter((n): n is number => typeof n === "number");
+  return [...new Set(nums)].sort((a, b) => a - b);
+}
+
+/** English ordinal for a day-of-month, e.g. 1 → "1st", 22 → "22nd". */
+function ordinal(n: number): string {
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
+  switch (n % 10) {
+    case 1:
+      return `${n}st`;
+    case 2:
+      return `${n}nd`;
+    case 3:
+      return `${n}rd`;
+    default:
+      return `${n}th`;
+  }
+}
+
+/** "1st", "1st and 15th", "1st, 15th, and 28th". */
+function ordinalList(days: number[]): string {
+  return joinList(days.map(ordinal));
+}
+
+/**
+ * Normalize rrule's `byweekday` (which can be a Weekday, number, or arrays of
+ * either, in any order) into a sorted array of weekday indices (0=MO..6=SU).
+ */
+function normalizeWeekdays(byweekday: RRule["origOptions"]["byweekday"]): number[] {
+  if (byweekday == null) return [];
+  const arr = Array.isArray(byweekday) ? byweekday : [byweekday];
+  const nums = arr
+    .map((d) => (typeof d === "number" ? d : (d as { weekday: number }).weekday))
+    .filter((n): n is number => typeof n === "number");
+  return [...new Set(nums)].sort((a, b) => a - b);
+}
+
+function sameSet(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false;
+  const sb = [...b].sort((x, y) => x - y);
+  const sa = [...a].sort((x, y) => x - y);
+  return sa.every((v, i) => v === sb[i]);
+}
+
+function joinList(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1);
+}
+
+/**
+ * The offset in minutes between UTC and `timezone` at instant `date`
+ * (positive when the zone is behind UTC, matching `Date.getTimezoneOffset`).
+ * Uses `Intl` so it's DST-correct for the given instant.
+ */
+function tzOffsetMinutes(date: Date, timezone: string): number {
+  try {
+    const dtf = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      hour12: false,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    const parts = dtf.formatToParts(date);
+    const map: Record<string, number> = {};
+    for (const p of parts) {
+      if (p.type !== "literal") map[p.type] = Number(p.value);
+    }
+    // Wall-clock time in the target zone, as if it were UTC.
+    const asUtc = Date.UTC(
+      map.year!,
+      map.month! - 1,
+      map.day!,
+      map.hour === 24 ? 0 : map.hour!,
+      map.minute!,
+      map.second!,
+    );
+    return (date.getTime() - asUtc) / 60_000;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Represent `date` as the naive wall-clock time in `timezone` (a Date whose UTC
+ * fields hold the zone-local Y/M/D H:M:S), so it can be fed to rrule's
+ * zone-naive `.after`.
+ */
+function shiftWallClock(date: Date, timezone: string): Date {
+  const offset = tzOffsetMinutes(date, timezone);
+  return new Date(date.getTime() - offset * 60_000);
+}
+
+/**
+ * Inverse of {@link shiftWallClock}: given a naive wall-clock Date in
+ * `timezone`, return the real absolute instant (epoch ms).
+ */
+function wallClockToInstantMs(wallDate: Date, timezone: string): number {
+  // The offset at the wall instant is a close approximation of the offset at the
+  // real instant; a single correction pass handles the common case. (DST-edge
+  // firings are within an hour, well inside the "Xh" rounding the label uses.)
+  const offset = tzOffsetMinutes(wallDate, timezone);
+  return wallDate.getTime() + offset * 60_000;
+}

--- a/web/src/lib/scheduledTasksApi.test.ts
+++ b/web/src/lib/scheduledTasksApi.test.ts
@@ -1,0 +1,213 @@
+// Unit tests for `scheduledTasksApi.ts` — happy-path requests with a mocked
+// `fetch`, snake↔camel conversion at the boundary, the optional-field omission
+// rules on create/update, and the typed error path.
+//
+// Mirrors the `sessionsApi.test.ts` pattern: one fetchMock per test,
+// vi.stubGlobal/unstubAllGlobals around it.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ScheduledTaskApiError,
+  createScheduledTask,
+  deleteScheduledTask,
+  getScheduledTask,
+  listScheduledTaskRuns,
+  listScheduledTasks,
+  updateScheduledTask,
+} from "./scheduledTasksApi";
+
+function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: "OK",
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const TASK_WIRE = {
+  id: "st_1",
+  name: "Nightly triage",
+  prompt: "Triage new issues",
+  rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+  owner_user_id: "alice",
+  agent_id: "ag_1",
+  timezone: "America/New_York",
+  created_at: 1_700_000_000,
+  updated_at: 1_700_000_100,
+  model_override: null,
+  reasoning_effort: null,
+  workspace: null,
+  host_id: null,
+  state: "active",
+  last_run_at: null,
+  last_run_conversation_id: null,
+};
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("listScheduledTasks", () => {
+  it("GETs /v1/scheduled-tasks and camelCases the rows", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ scheduled_tasks: [TASK_WIRE] }));
+    const tasks = await listScheduledTasks();
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/scheduled-tasks");
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      id: "st_1",
+      name: "Nightly triage",
+      ownerUserId: "alice",
+      agentId: "ag_1",
+      timezone: "America/New_York",
+      state: "active",
+      hostId: null,
+      workspace: null,
+    });
+  });
+
+  it("returns [] when the server omits the key", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    await expect(listScheduledTasks()).resolves.toEqual([]);
+  });
+});
+
+describe("getScheduledTask", () => {
+  it("GETs /v1/scheduled-tasks/{id} and encodes the id", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(TASK_WIRE));
+    const task = await getScheduledTask("st 1");
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/scheduled-tasks/st%201");
+    expect(task.id).toBe("st_1");
+  });
+});
+
+describe("listScheduledTaskRuns", () => {
+  it("GETs the runs subpath and camelCases run rows", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        runs: [
+          {
+            id: "run_1",
+            scheduled_task_id: "st_1",
+            status: "succeeded",
+            scheduled_at: 1_700_000_000,
+            conversation_id: "conv_1",
+            fired_at: 1_700_000_005,
+            finished_at: 1_700_000_050,
+            error_code: null,
+          },
+        ],
+      }),
+    );
+    const runs = await listScheduledTaskRuns("st_1");
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/scheduled-tasks/st_1/runs");
+    expect(runs[0]).toMatchObject({
+      id: "run_1",
+      scheduledTaskId: "st_1",
+      status: "succeeded",
+      conversationId: "conv_1",
+      firedAt: 1_700_000_005,
+      finishedAt: 1_700_000_050,
+      errorCode: null,
+    });
+  });
+});
+
+describe("createScheduledTask", () => {
+  it("POSTs required fields and omits unset optionals", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(TASK_WIRE));
+    await createScheduledTask({
+      name: "Nightly triage",
+      prompt: "Triage new issues",
+      rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      agentId: "ag_1",
+    });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/v1/scheduled-tasks");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({
+      name: "Nightly triage",
+      prompt: "Triage new issues",
+      rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      agent_id: "ag_1",
+    });
+    // Optional keys must be absent, not null.
+    expect(body).not.toHaveProperty("host_id");
+    expect(body).not.toHaveProperty("workspace");
+    expect(body).not.toHaveProperty("timezone");
+  });
+
+  it("includes the host/workspace pair and timezone when provided", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(TASK_WIRE));
+    await createScheduledTask({
+      name: "n",
+      prompt: "p",
+      rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      agentId: "ag_1",
+      timezone: "UTC",
+      hostId: "host_1",
+      workspace: "/home/me/repo",
+    });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.timezone).toBe("UTC");
+    expect(body.host_id).toBe("host_1");
+    expect(body.workspace).toBe("/home/me/repo");
+  });
+});
+
+describe("updateScheduledTask", () => {
+  it("PATCHes only the fields present in the input", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ ...TASK_WIRE, state: "paused" }));
+    const updated = await updateScheduledTask("st_1", { state: "paused" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/v1/scheduled-tasks/st_1");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body)).toEqual({ state: "paused" });
+    expect(updated.state).toBe("paused");
+  });
+});
+
+describe("deleteScheduledTask", () => {
+  it("DELETEs /v1/scheduled-tasks/{id}", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ deleted: true, id: "st_1" }));
+    await deleteScheduledTask("st_1");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/v1/scheduled-tasks/st_1");
+    expect(init.method).toBe("DELETE");
+  });
+});
+
+describe("error path", () => {
+  it("throws a ScheduledTaskApiError carrying the server code + message", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse(
+        { error: { code: "invalid_input", message: "invalid rrule: fires only once" } },
+        { ok: false, status: 400 },
+      ),
+    );
+    await expect(
+      createScheduledTask({ name: "n", prompt: "p", rrule: "bad", agentId: "ag_1" }),
+    ).rejects.toMatchObject({
+      name: "ScheduledTaskApiError",
+      status: 400,
+      code: "invalid_input",
+      message: "invalid rrule: fires only once",
+    });
+  });
+
+  it("falls back to the status line on a non-error-shaped body", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse("nope", { ok: false, status: 500 }));
+    const err = await listScheduledTasks().catch((e) => e);
+    expect(err).toBeInstanceOf(ScheduledTaskApiError);
+    expect(err.status).toBe(500);
+    expect(err.code).toBeNull();
+  });
+});

--- a/web/src/lib/scheduledTasksApi.ts
+++ b/web/src/lib/scheduledTasksApi.ts
@@ -1,0 +1,286 @@
+// Hand-written client for the six `/v1/scheduled-tasks` endpoints, mirroring
+// `omnigent/server/routes/scheduled_tasks.py`. Follows the same conventions as
+// the sibling `sessionsApi.ts`: requests go through the Vite `/v1` proxy, the
+// wire is snake_case while the TS surface is camelCase, and non-OK responses
+// throw a typed error carrying the server's machine-readable `code`.
+//
+// A scheduled task is a saved prompt that fires an agent session on a recurring
+// RFC-5545 RRULE schedule. `host_id` / `workspace` are optional (post-FU-3):
+// omit both and the server resolves the owner's connected host + its home dir
+// at fire time; supply them only as a validated pair.
+
+import { authenticatedFetch } from "./identity";
+
+/** Lifecycle state of a scheduled task. `paused` tasks don't fire. */
+export type ScheduledTaskState = "active" | "paused";
+
+/** Terminal + in-flight statuses a single run can hold. */
+export type ScheduledTaskRunStatus =
+  | "scheduled"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "skipped"
+  | "incomplete";
+
+/**
+ * A scheduled task, camelCased from the server's `_to_response` shape. The
+ * server preserves the JSON key `owner_user_id` for the owning user even though
+ * the DB column is `user_id`; it's surfaced here as `ownerUserId`.
+ */
+export interface ScheduledTask {
+  id: string;
+  name: string;
+  prompt: string;
+  /** RFC-5545 recurrence rule, e.g. `FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=8;BYMINUTE=0`. */
+  rrule: string;
+  /** Owning user, or `null` in single-user / auth-disabled deployments. */
+  ownerUserId: string | null;
+  agentId: string;
+  /** IANA timezone the RRULE is evaluated in, e.g. `America/Los_Angeles`. */
+  timezone: string;
+  createdAt: number;
+  updatedAt: number;
+  modelOverride: string | null;
+  reasoningEffort: string | null;
+  /** Pinned absolute workspace, or `null` (server defaults to the host home). */
+  workspace: string | null;
+  /** Pinned host, or `null` (server resolves the connected host at fire time). */
+  hostId: string | null;
+  state: ScheduledTaskState;
+  /** Epoch seconds of the last fire, or `null` if it has never fired. */
+  lastRunAt: number | null;
+  lastRunConversationId: string | null;
+}
+
+/** One run of a scheduled task, camelCased from `_run_to_response`. */
+export interface ScheduledTaskRun {
+  id: string;
+  scheduledTaskId: string;
+  status: ScheduledTaskRunStatus;
+  scheduledAt: number;
+  conversationId: string | null;
+  firedAt: number | null;
+  finishedAt: number | null;
+  /** Queryable failure classification, e.g. `no_online_host`; `null` on success. */
+  errorCode: string | null;
+}
+
+/** Body for `POST /v1/scheduled-tasks`. */
+export interface CreateScheduledTaskInput {
+  name: string;
+  prompt: string;
+  rrule: string;
+  agentId: string;
+  timezone?: string;
+  modelOverride?: string | null;
+  reasoningEffort?: string | null;
+  /** Optional pinned workspace; only valid together with `hostId`. */
+  workspace?: string | null;
+  /** Optional pinned host. */
+  hostId?: string | null;
+}
+
+/**
+ * Body for `PATCH /v1/scheduled-tasks/{id}`. Every field is optional; only the
+ * fields present are changed. The server rejects nulling an already-set
+ * `workspace` / `hostId` — send a new value or leave the field unset.
+ */
+export interface UpdateScheduledTaskInput {
+  name?: string;
+  prompt?: string;
+  rrule?: string;
+  timezone?: string;
+  modelOverride?: string | null;
+  reasoningEffort?: string | null;
+  workspace?: string;
+  hostId?: string;
+  state?: ScheduledTaskState;
+}
+
+/** Wire shape of a task row (snake_case), matching `_to_response`. */
+interface ScheduledTaskWire {
+  id: string;
+  name: string;
+  prompt: string;
+  rrule: string;
+  owner_user_id: string | null;
+  agent_id: string;
+  timezone: string;
+  created_at: number;
+  updated_at: number;
+  model_override: string | null;
+  reasoning_effort: string | null;
+  workspace: string | null;
+  host_id: string | null;
+  state: ScheduledTaskState;
+  last_run_at: number | null;
+  last_run_conversation_id: string | null;
+}
+
+/** Wire shape of a run row (snake_case), matching `_run_to_response`. */
+interface ScheduledTaskRunWire {
+  id: string;
+  scheduled_task_id: string;
+  status: ScheduledTaskRunStatus;
+  scheduled_at: number;
+  conversation_id: string | null;
+  fired_at: number | null;
+  finished_at: number | null;
+  error_code: string | null;
+}
+
+/**
+ * A typed HTTP error carrying the server's machine-readable `code`, so callers
+ * can branch on the failure kind (e.g. `invalid_input` for a bad RRULE) rather
+ * than string-matching the message. Mirrors `ApiError` in `sessionsApi.ts`;
+ * kept local so this module has no cross-import on the sessions client.
+ */
+export class ScheduledTaskApiError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+  constructor(message: string, status: number, code: string | null) {
+    super(message);
+    this.name = "ScheduledTaskApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+/**
+ * Build a {@link ScheduledTaskApiError} from a non-OK response, preferring the
+ * server's `error.message` / `error.code` (the `OmnigentError` shape) over the
+ * bare status line.
+ */
+async function errorFromResponse(res: Response): Promise<ScheduledTaskApiError> {
+  let message = `${res.status} ${res.statusText}`;
+  let code: string | null = null;
+  try {
+    const body = (await res.json()) as { error?: { code?: string; message?: string } };
+    if (body.error?.message) message = body.error.message;
+    if (body.error?.code) code = body.error.code;
+  } catch {
+    // Non-JSON / empty body — keep the status-line fallback.
+  }
+  return new ScheduledTaskApiError(message, res.status, code);
+}
+
+async function readJsonOrThrow<T>(res: Response): Promise<T> {
+  if (!res.ok) throw await errorFromResponse(res);
+  return (await res.json()) as T;
+}
+
+function taskFromWire(wire: ScheduledTaskWire): ScheduledTask {
+  return {
+    id: wire.id,
+    name: wire.name,
+    prompt: wire.prompt,
+    rrule: wire.rrule,
+    ownerUserId: wire.owner_user_id,
+    agentId: wire.agent_id,
+    timezone: wire.timezone,
+    createdAt: wire.created_at,
+    updatedAt: wire.updated_at,
+    modelOverride: wire.model_override,
+    reasoningEffort: wire.reasoning_effort,
+    workspace: wire.workspace,
+    hostId: wire.host_id,
+    state: wire.state,
+    lastRunAt: wire.last_run_at,
+    lastRunConversationId: wire.last_run_conversation_id,
+  };
+}
+
+function runFromWire(wire: ScheduledTaskRunWire): ScheduledTaskRun {
+  return {
+    id: wire.id,
+    scheduledTaskId: wire.scheduled_task_id,
+    status: wire.status,
+    scheduledAt: wire.scheduled_at,
+    conversationId: wire.conversation_id,
+    firedAt: wire.fired_at,
+    finishedAt: wire.finished_at,
+    errorCode: wire.error_code,
+  };
+}
+
+/** List the caller's scheduled tasks (owner-scoped server-side). */
+export async function listScheduledTasks(): Promise<ScheduledTask[]> {
+  const res = await authenticatedFetch("/v1/scheduled-tasks");
+  const body = await readJsonOrThrow<{ scheduled_tasks: ScheduledTaskWire[] }>(res);
+  return (body.scheduled_tasks ?? []).map(taskFromWire);
+}
+
+/** Fetch one of the caller's scheduled tasks (404 if not owned). */
+export async function getScheduledTask(id: string): Promise<ScheduledTask> {
+  const res = await authenticatedFetch(`/v1/scheduled-tasks/${encodeURIComponent(id)}`);
+  return taskFromWire(await readJsonOrThrow<ScheduledTaskWire>(res));
+}
+
+/** List a task's run history, most-recent-first (404 if not owned). */
+export async function listScheduledTaskRuns(id: string): Promise<ScheduledTaskRun[]> {
+  const res = await authenticatedFetch(`/v1/scheduled-tasks/${encodeURIComponent(id)}/runs`);
+  const body = await readJsonOrThrow<{ runs: ScheduledTaskRunWire[] }>(res);
+  return (body.runs ?? []).map(runFromWire);
+}
+
+/**
+ * Create a scheduled task. Only the fields the user actually set are sent, so
+ * the server applies its own defaults (`timezone` → UTC) and the optional
+ * host/workspace pair is omitted entirely when unset (server resolves the
+ * connected host at fire time).
+ */
+export async function createScheduledTask(input: CreateScheduledTaskInput): Promise<ScheduledTask> {
+  const body: Record<string, unknown> = {
+    name: input.name,
+    prompt: input.prompt,
+    rrule: input.rrule,
+    agent_id: input.agentId,
+  };
+  if (input.timezone !== undefined) body.timezone = input.timezone;
+  if (input.modelOverride != null) body.model_override = input.modelOverride;
+  if (input.reasoningEffort != null) body.reasoning_effort = input.reasoningEffort;
+  if (input.workspace != null) body.workspace = input.workspace;
+  if (input.hostId != null) body.host_id = input.hostId;
+  const res = await authenticatedFetch("/v1/scheduled-tasks", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return taskFromWire(await readJsonOrThrow<ScheduledTaskWire>(res));
+}
+
+/**
+ * Update mutable fields of a task (pause/reactivate/rename/reschedule). Only
+ * the keys present in `input` are sent, matching the server's
+ * `exclude_unset` semantics.
+ */
+export async function updateScheduledTask(
+  id: string,
+  input: UpdateScheduledTaskInput,
+): Promise<ScheduledTask> {
+  const body: Record<string, unknown> = {};
+  if (input.name !== undefined) body.name = input.name;
+  if (input.prompt !== undefined) body.prompt = input.prompt;
+  if (input.rrule !== undefined) body.rrule = input.rrule;
+  if (input.timezone !== undefined) body.timezone = input.timezone;
+  if (input.modelOverride !== undefined) body.model_override = input.modelOverride;
+  if (input.reasoningEffort !== undefined) body.reasoning_effort = input.reasoningEffort;
+  if (input.workspace !== undefined) body.workspace = input.workspace;
+  if (input.hostId !== undefined) body.host_id = input.hostId;
+  if (input.state !== undefined) body.state = input.state;
+  const res = await authenticatedFetch(`/v1/scheduled-tasks/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return taskFromWire(await readJsonOrThrow<ScheduledTaskWire>(res));
+}
+
+/** Delete a task so it no longer fires. */
+export async function deleteScheduledTask(id: string): Promise<void> {
+  const res = await authenticatedFetch(`/v1/scheduled-tasks/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) throw await errorFromResponse(res);
+}

--- a/web/src/lib/timezones.ts
+++ b/web/src/lib/timezones.ts
@@ -1,0 +1,63 @@
+// Timezone options for the scheduled-task create form. Uses the platform's IANA
+// zone list when available (`Intl.supportedValuesOf`), falling back to a small
+// curated list on older engines that lack it. The server validates the chosen
+// value against the full IANA database, so this list only needs to be usable,
+// not exhaustive.
+
+/** The viewer's local IANA timezone, or `UTC` if it can't be resolved. */
+export function localTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+const FALLBACK_ZONES = [
+  "UTC",
+  "America/Los_Angeles",
+  "America/Denver",
+  "America/Chicago",
+  "America/New_York",
+  "America/Sao_Paulo",
+  "Europe/London",
+  "Europe/Berlin",
+  "Europe/Paris",
+  "Europe/Moscow",
+  "Asia/Kolkata",
+  "Asia/Singapore",
+  "Asia/Shanghai",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+];
+
+/**
+ * The timezone options to offer, always including `UTC` and `ensure` (the
+ * currently-selected value) so a preselected local/uncommon zone is never
+ * missing from the list.
+ *
+ * NOTE: not currently called — v1 infers the timezone from the browser
+ * (`localTimezone`) with no visible picker. Retained for the future
+ * cross-timezone picker (see the comment in CreateScheduledTaskDialog).
+ */
+export function commonTimezones(ensure?: string): string[] {
+  let zones: string[];
+  try {
+    // `supportedValuesOf` is ES2023; guard for older runtimes/tests.
+    const supported = (
+      Intl as unknown as { supportedValuesOf?: (key: string) => string[] }
+    ).supportedValuesOf?.("timeZone");
+    zones = supported && supported.length > 0 ? [...supported] : [...FALLBACK_ZONES];
+  } catch {
+    zones = [...FALLBACK_ZONES];
+  }
+  const set = new Set(zones);
+  set.add("UTC");
+  if (ensure) set.add(ensure);
+  return [...set].sort((a, b) => {
+    // UTC first, then alphabetical.
+    if (a === "UTC") return -1;
+    if (b === "UTC") return 1;
+    return a.localeCompare(b);
+  });
+}


### PR DESCRIPTION
## Related issue

<!-- Tracked in Linear (OMNI-1193). No GitHub issue to auto-close. -->
N/A — tracked in Linear ([OMNI-1193](https://linear.app/omnigent/issue/OMNI-1193)). PR 1 of 3 in the Scheduled Tasks UI (UI-1) stack: **data layer** → create dialog → list page.

## Summary

First layer of the Scheduled Tasks frontend: the **data + schedule-logic foundation** that the create dialog (PR 2) and list page (PR 3) build on. No UI is rendered in this PR — these modules are imported by later layers.

- **API client** (`scheduledTasksApi.ts`) — hand-written fetch wrappers over the existing `/v1/scheduled-tasks` REST surface (list / get / create / update / delete), mirroring the `sessionsApi.ts` convention. The client is deliberately hand-written, not codegen'd from `openapi.json`.
- **Query hooks** (`useScheduledTasks.ts`) — TanStack-Query `useScheduledTasks` (list) + `useCreateScheduledTask` / update / delete mutations that invalidate the list. The list query carries a 60s `refetchInterval` with a **guard-rail comment**: it polls only while a consumer is mounted, so it must not be mounted in a persistent/global location or it becomes app-wide polling.
- **Schedule logic** (`scheduleText.ts`, `scheduleBuilder.ts`, `timezones.ts`) — RRULE helpers: `nextRunAtMs` computes the next firing from an RRULE + timezone, `nextRunLabel` renders the relative "Next run in Xh" string, `describeSchedule` renders the human schedule text; `scheduleBuilder` assembles an RRULE from form inputs; `timezones` is the tz list. The next-run label is derived client-side from the RRULE (not read back from the server).
- **Dependency** — adds `rrule@^2.8.1` (accounts for the large `package-lock.json` diff).

**ELI5:** This PR adds the "plumbing" for the scheduled-tasks screen — the code that talks to the server, caches the list, and works out when each task runs next — but doesn't draw anything on screen yet. The visible page comes in the next two PRs.

## Test Plan

Automated — typecheck clean, **51 tests pass** for this layer:

```bash
cd web
npm run type-check   # 0 errors
npm run test -- src/lib/scheduleText.test.ts \
                 src/lib/scheduledTasksApi.test.ts \
                 src/hooks/useScheduledTasks.test.tsx
```

- **scheduleText**: `nextRunAtMs` / `nextRunLabel` / `describeSchedule` across daily/weekly/weekday RRULEs, timezones, and the "no upcoming runs" / "due now" edges.
- **scheduledTasksApi**: each verb hits the right method/path and parses the response.
- **useScheduledTasks**: list query shape; create/update/delete mutations invalidate the list.

No manual/UI verification — nothing renders in this PR.

## Demo

N/A — no user-visible UI in this layer (data + hooks only).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage (Vitest + RTL) is described in the Test Plan — 51 tests over the API client, query/mutation hooks, and the RRULE schedule helpers. No manual or E2E verification applies because this layer renders no UI; the end-to-end create/pause/delete flow is exercised in PR 3 where the page mounts these modules.

## Changelog

<!-- No user-facing change in this PR alone — the feature becomes visible in PR 3. Deleting per the template guidance for non-noteworthy foundation layers. -->