### PR TITLE
feat(server): support native TLS termination

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -155,7 +155,7 @@ OMNIGENT_OIDC_COOKIE_SECRET=<64-hex-chars>
 
 Most IdPs require HTTPS for non-localhost redirect URIs, and the
 session cookie uses the `__Host-` prefix which browsers only
-accept over HTTPS. Three options:
+accept over HTTPS. A few options, in order of preference:
 
 1. **Use the bundled Caddy overlay** (easiest — any VPS / EC2 / home
    server with a public domain):
@@ -178,6 +178,22 @@ accept over HTTPS. Three options:
    `omnigent:8000` over the docker network (or `127.0.0.1:8000`
    from the host). Examples: AWS ALB with ACM cert, Cloudflare in
    "Full" SSL mode, Fly.io / Cloud Run / Render platform certs.
+
+3. **Native TLS in the container** — for a standalone box with no
+   proxy in front and a cert you manage yourself (e.g. an existing
+   Let's Encrypt cert renewed by a host-level `certbot` timer). Mount
+   the cert/key into the container and point the server at them:
+
+   ```bash
+   # In .env, or as container env vars:
+   SSL_CERTFILE=/certs/fullchain.pem
+   SSL_KEYFILE=/certs/privkey.pem
+   ```
+
+   The server terminates HTTPS itself on `PORT` (still 8000 by
+   default) — publish that port directly instead of routing through
+   Caddy or another proxy. `OMNIGENT_ACCOUNTS_BASE_URL` defaults to
+   `https://` automatically once `SSL_CERTFILE` is set.
 
 ## Header-proxy mode (for deploys behind an existing SSO proxy)
 

--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -29,6 +29,16 @@ Configuration is via environment variables:
                         Defaults to ``/data/artifacts`` (the volume
                         mount point used by docker-compose).
   HOST, PORT            Bind address. Default ``0.0.0.0:8000``.
+  SSL_CERTFILE          Optional path to a TLS certificate (PEM) for
+                        native HTTPS termination. Most deploys should
+                        instead terminate TLS at a reverse proxy or
+                        PaaS edge (see deploy/docker/README.md); this
+                        is for standalone containers with no proxy in
+                        front. Requires SSL_KEYFILE unless the file
+                        also bundles the private key.
+  SSL_KEYFILE           Path to the TLS private key (PEM) matching
+                        SSL_CERTFILE.
+  SSL_KEYFILE_PASSWORD  Password for an encrypted SSL_KEYFILE, if any.
 """
 
 from __future__ import annotations
@@ -74,6 +84,9 @@ class _ResolvedConfig:
     artifact_store_uri: str | None
     host: str
     port: int
+    ssl_certfile: str | None = None
+    ssl_keyfile: str | None = None
+    ssl_keyfile_password: str | None = None
 
 
 @dataclass(frozen=True)
@@ -152,6 +165,20 @@ def _resolve_config() -> _ResolvedConfig:
     port = int(cfg.get("port") or os.environ.get("PORT") or _DEFAULT_PORT)
     artifact_dir.mkdir(parents=True, exist_ok=True)
 
+    # Native TLS termination is opt-in and rare in this deploy path — most
+    # containers sit behind a reverse proxy or PaaS edge that already
+    # terminates HTTPS (see deploy/docker/README.md). ``or None`` also turns
+    # compose's empty-string-when-unset ("${VAR:-}") into a real absence.
+    ssl_certfile = cfg.get("ssl_certfile") or os.environ.get("SSL_CERTFILE") or None
+    ssl_keyfile = cfg.get("ssl_keyfile") or os.environ.get("SSL_KEYFILE") or None
+    ssl_keyfile_password = (
+        cfg.get("ssl_keyfile_password") or os.environ.get("SSL_KEYFILE_PASSWORD") or None
+    )
+    if ssl_keyfile and not ssl_certfile:
+        raise RuntimeError(
+            "SSL_KEYFILE (or `ssl_keyfile:` in config) requires SSL_CERTFILE (or `ssl_certfile:`)."
+        )
+
     # Optional remote artifact store (S3 / Cloudflare R2 / MinIO / …). When set,
     # the artifact STORE is remote and durable; artifact_dir stays local for the
     # cookie secret and on-disk cache. Mirrors how DATABASE_URL selects the DB.
@@ -218,7 +245,7 @@ def _resolve_config() -> _ResolvedConfig:
             # Fly / HF Spaces) so a 1-click deploy needs zero manual config;
             # falls back to the bind address for local / Docker / EC2.
             os.environ["OMNIGENT_ACCOUNTS_BASE_URL"] = detect_base_url(
-                os.environ, host=host, port=port
+                os.environ, host=host, port=port, ssl_enabled=bool(ssl_certfile)
             )
 
     return _ResolvedConfig(
@@ -228,6 +255,9 @@ def _resolve_config() -> _ResolvedConfig:
         artifact_store_uri=artifact_store_uri,
         host=host,
         port=port,
+        ssl_certfile=ssl_certfile,
+        ssl_keyfile=ssl_keyfile,
+        ssl_keyfile_password=ssl_keyfile_password,
     )
 
 
@@ -396,6 +426,9 @@ def main() -> None:
             host=resolved.host,
             port=resolved.port,
             ws_max_size=RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
+            ssl_certfile=resolved_config.ssl_certfile,
+            ssl_keyfile=resolved_config.ssl_keyfile,
+            ssl_keyfile_password=resolved_config.ssl_keyfile_password,
         )
     except Exception:  # noqa: BLE001 — startup catch-all so failures land in logs
         logger.error("FATAL: omnigent server failed to start:\n%s", traceback.format_exc())

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3155,6 +3155,27 @@ def _assert_server_port_bindable(host: str, port: int) -> None:
     help="Port to listen on.",
 )
 @click.option(
+    "--ssl-certfile",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to a TLS certificate (PEM) for native HTTPS termination. "
+    "Most deploys should terminate TLS at a reverse proxy or PaaS edge "
+    "instead (see deploy/docker/README.md); use this for standalone "
+    "servers with no proxy in front. Requires --ssl-keyfile unless the "
+    "file also bundles the private key.",
+)
+@click.option(
+    "--ssl-keyfile",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the TLS private key (PEM) matching --ssl-certfile.",
+)
+@click.option(
+    "--ssl-keyfile-password",
+    default=None,
+    help="Password for an encrypted --ssl-keyfile, if any.",
+)
+@click.option(
     "--database-uri",
     default=None,
     help="Database URI for stores.  [default: sqlite at <data-dir>/chat.db, "
@@ -3221,6 +3242,9 @@ def server(
     ctx: click.Context,
     host: str,
     port: int,
+    ssl_certfile: str | None,
+    ssl_keyfile: str | None,
+    ssl_keyfile_password: str | None,
     database_uri: str | None,
     conversation_database_uri: str | None,
     artifact_location: str | None,
@@ -3241,6 +3265,13 @@ def server(
     :param ctx: Click invocation context used to tell whether
         ``--port`` came from the command line or from the default.
     :param port: TCP port to listen on, e.g. ``6767``.
+    :param ssl_certfile: Optional path to a TLS certificate (PEM) for
+        native HTTPS termination, e.g. ``"/etc/omnigent/cert.pem"``.
+        ``None`` binds plain HTTP.
+    :param ssl_keyfile: Optional path to the TLS private key (PEM)
+        matching ``ssl_certfile``.
+    :param ssl_keyfile_password: Optional password for an encrypted
+        ``ssl_keyfile``.
     :param database_uri: Optional database URI, e.g.
         ``"sqlite:///omnigent.db"``.
     :param artifact_location: Optional artifact location, e.g.
@@ -3269,6 +3300,11 @@ def server(
     port_was_explicit = port_source is click.core.ParameterSource.COMMANDLINE
     if port_was_explicit:
         _assert_server_port_bindable(host, port)
+
+    if ssl_keyfile and not ssl_certfile:
+        raise click.ClickException("--ssl-keyfile requires --ssl-certfile.")
+    if ssl_keyfile_password and not ssl_keyfile:
+        raise click.ClickException("--ssl-keyfile-password requires --ssl-keyfile.")
 
     # --admin-password is sugar for the INIT_ADMIN_PASSWORD env var that
     # bootstrap_admin already consumes — fold it in here so the rest of
@@ -3303,12 +3339,16 @@ def server(
     # port and must NOT consult or register in the shared pidfile, or it would
     # reuse/hijack the canonical server and exit without ever binding its port.
     # Likewise a non-loopback bind (`--host 0.0.0.0`, a real deploy) is exempt
-    # and binds the exact port.
+    # and binds the exact port. --ssl-certfile is exempt too: the canonical
+    # server's URL is recorded (and dialed by other tooling) as plain
+    # http://127.0.0.1:{port} — reusing that record for a TLS-terminating
+    # invocation would make callers speak http to an https-only socket.
     _is_canonical_local_server = (
         host in ("127.0.0.1", "localhost")
         and database_uri is None
         and artifact_location is None
         and not port_was_explicit
+        and ssl_certfile is None
     )
 
     # Single-user marker: ANY loopback-bound `omnigent server` running
@@ -3527,7 +3567,8 @@ def server(
             "OMNIGENT_ACCOUNTS_COOKIE_SECRET",
             load_or_generate_cookie_secret(art_loc),
         )
-        os.environ.setdefault("OMNIGENT_ACCOUNTS_BASE_URL", f"http://{host}:{port}")
+        _default_scheme = "https" if ssl_certfile else "http"
+        os.environ.setdefault("OMNIGENT_ACCOUNTS_BASE_URL", f"{_default_scheme}://{host}:{port}")
 
     auth_provider = create_auth_provider()
 
@@ -3672,6 +3713,9 @@ def server(
         ws_ping_interval=TUNNEL_KEEPALIVE_PING_INTERVAL_S,
         ws_ping_timeout=TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
         timeout_graceful_shutdown=_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_S,
+        ssl_certfile=ssl_certfile,
+        ssl_keyfile=ssl_keyfile,
+        ssl_keyfile_password=ssl_keyfile_password,
     )
     try:
         _ShutdownSignalingServer(_config).run()

--- a/omnigent/server/paas_env.py
+++ b/omnigent/server/paas_env.py
@@ -67,6 +67,7 @@ def detect_base_url(
     *,
     host: str,
     port: int,
+    ssl_enabled: bool = False,
 ) -> str:
     """
     Derive the server's public base URL from the PaaS environment.
@@ -86,6 +87,10 @@ def detect_base_url(
         e.g. ``"0.0.0.0"``.
     :param port: The bind port, used only for the local fallback,
         e.g. ``8000``.
+    :param ssl_enabled: Whether the process terminates TLS itself (e.g.
+        ``SSL_CERTFILE`` set). Only affects the local fallback's scheme —
+        every PaaS branch above already fronts the app with ``https://``
+        regardless of how the app itself is bound.
     :returns: The public base URL, e.g. ``"https://myapp.onrender.com"`` or
         ``"http://0.0.0.0:8000"``.
     """
@@ -101,4 +106,5 @@ def detect_base_url(
     hf_host = environ.get("SPACE_HOST")
     if hf_host:
         return f"https://{hf_host}"
-    return f"http://{host}:{port}"
+    scheme = "https" if ssl_enabled else "http"
+    return f"{scheme}://{host}:{port}"

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1948,6 +1948,114 @@ def test_server_with_explicit_port_does_not_check_canonical_server(
     assert "Starting omnigent server on 127.0.0.1:44770" in result.output
 
 
+def test_server_command_rejects_ssl_keyfile_without_certfile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """--ssl-keyfile without --ssl-certfile fails fast with a clear error.
+
+    uvicorn accepts a certfile-only bundle (cert + key in one PEM) but
+    never a keyfile-only config, so this is validated up front instead
+    of surfacing as a confusing failure deep inside uvicorn's TLS setup.
+    """
+    keyfile = tmp_path / "key.pem"
+    keyfile.write_text("fake-key")
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+
+    result = CliRunner().invoke(
+        cli,
+        ["server", "--ssl-keyfile", str(keyfile), "--no-open"],
+    )
+
+    assert result.exit_code != 0
+    assert "--ssl-certfile" in result.output
+
+
+def test_server_command_passes_ssl_options_to_uvicorn_and_exempts_canonical_reuse(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """--ssl-certfile reaches uvicorn.Config and opts out of canonical-server reuse.
+
+    The canonical local-server record (``~/.omnigent/local_server.pid``) is
+    always dialed as plain ``http://127.0.0.1:<port>`` (local_server.py), so
+    a TLS-terminating bare ``omnigent server`` must never consult or
+    register in that shared record — otherwise other tooling would try to
+    speak http to an https-only socket. Regression target:
+    ``_is_canonical_local_server`` in cli.py dropping its ``ssl_certfile is
+    None`` condition.
+    """
+    import uvicorn
+    import uvicorn.server
+
+    captured: dict[str, Any] = {}
+
+    def _fake_server_run(self: Any) -> None:
+        """Skip the blocking server loop; capture the TLS config uvicorn got.
+
+        :param self: The uvicorn Server instance whose config holds all options.
+        :returns: None.
+        """
+        captured["uvicorn_kwargs"] = {
+            "ssl_certfile": self.config.ssl_certfile,
+            "ssl_keyfile": self.config.ssl_keyfile,
+            "ssl_keyfile_password": self.config.ssl_keyfile_password,
+        }
+
+    def _must_not_check_existing() -> str | None:
+        """Fail if --ssl-certfile still consults the canonical server record.
+
+        :returns: Never returns in this test.
+        """
+        raise AssertionError("--ssl-certfile must not check the canonical local server")
+
+    def _must_not_touch_pidfile(_port: int | None = None) -> None:
+        """Fail if --ssl-certfile still mutates the canonical server record.
+
+        :param _port: Optional port argument accepted for register calls.
+        :returns: Never returns in this test.
+        """
+        raise AssertionError("--ssl-certfile must not touch the shared pidfile")
+
+    from omnigent.host import local_server as _local_server_mod
+
+    monkeypatch.setattr(uvicorn.server.Server, "run", _fake_server_run)
+    monkeypatch.setattr(_local_server_mod, "local_server_url_if_healthy", _must_not_check_existing)
+    monkeypatch.setattr(_local_server_mod, "register_local_server", _must_not_touch_pidfile)
+    monkeypatch.setattr(_local_server_mod, "clear_local_server_record", _must_not_touch_pidfile)
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "0")
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+
+    certfile = tmp_path / "cert.pem"
+    keyfile = tmp_path / "key.pem"
+    certfile.write_text("fake-cert")
+    keyfile.write_text("fake-key")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "server",
+            "--host",
+            "127.0.0.1",
+            "--ssl-certfile",
+            str(certfile),
+            "--ssl-keyfile",
+            str(keyfile),
+            "--ssl-keyfile-password",
+            "hunter2",
+            "--no-open",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "already running" not in result.output
+    assert captured["uvicorn_kwargs"] == {
+        "ssl_certfile": str(certfile),
+        "ssl_keyfile": str(keyfile),
+        "ssl_keyfile_password": "hunter2",
+    }
+
+
 def test_server_command_explicit_occupied_port_fails() -> None:
     """
     An explicit ``--port`` must fail instead of choosing a replacement.

--- a/tests/deploy/test_docker_entrypoint_import.py
+++ b/tests/deploy/test_docker_entrypoint_import.py
@@ -132,6 +132,42 @@ def test_resolve_config_rejects_non_s3_artifact_uri(
         _resolve_config()
 
 
+def test_resolve_config_defaults_ssl_unset(_entrypoint_env: None) -> None:
+    from deploy.docker.entrypoint import _resolve_config
+
+    resolved = _resolve_config()
+    assert resolved.ssl_certfile is None
+    assert resolved.ssl_keyfile is None
+    assert resolved.ssl_keyfile_password is None
+
+
+def test_resolve_config_captures_ssl_certfile_and_keyfile(
+    _entrypoint_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from deploy.docker.entrypoint import _resolve_config
+
+    certfile = tmp_path / "cert.pem"
+    keyfile = tmp_path / "key.pem"
+    monkeypatch.setenv("SSL_CERTFILE", str(certfile))
+    monkeypatch.setenv("SSL_KEYFILE", str(keyfile))
+    monkeypatch.setenv("SSL_KEYFILE_PASSWORD", "hunter2")
+
+    resolved = _resolve_config()
+    assert resolved.ssl_certfile == str(certfile)
+    assert resolved.ssl_keyfile == str(keyfile)
+    assert resolved.ssl_keyfile_password == "hunter2"
+
+
+def test_resolve_config_rejects_ssl_keyfile_without_certfile(
+    _entrypoint_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from deploy.docker.entrypoint import _resolve_config
+
+    monkeypatch.setenv("SSL_KEYFILE", str(tmp_path / "key.pem"))
+    with pytest.raises(RuntimeError, match="SSL_CERTFILE"):
+        _resolve_config()
+
+
 @pytest.mark.parametrize(
     ("artifact_store_uri", "expected_type"),
     [

--- a/tests/server/test_paas_env.py
+++ b/tests/server/test_paas_env.py
@@ -82,3 +82,27 @@ def test_detect_base_url(environ: dict[str, str], expected: str):
     wrong ``OMNIGENT_ACCOUNTS_BASE_URL`` and break magic-link / cookie flows.
     """
     assert detect_base_url(environ, host="0.0.0.0", port=8000) == expected
+
+
+def test_detect_base_url_ssl_enabled_local_fallback():
+    """ssl_enabled only affects the local fallback scheme, never a PaaS branch.
+
+    A failure here means a native-TLS container would advertise an
+    ``http://`` base URL (breaking secure-cookie defaults) or, worse, an
+    ``https://`` base URL when the operator never configured TLS.
+    """
+    assert (
+        detect_base_url({}, host="0.0.0.0", port=8000, ssl_enabled=True) == "https://0.0.0.0:8000"
+    )
+    assert (
+        detect_base_url({}, host="0.0.0.0", port=8000, ssl_enabled=False) == "http://0.0.0.0:8000"
+    )
+    assert (
+        detect_base_url(
+            {"RENDER_EXTERNAL_URL": "https://svc.onrender.com"},
+            host="0.0.0.0",
+            port=8000,
+            ssl_enabled=False,
+        )
+        == "https://svc.onrender.com"
+    )


### PR DESCRIPTION
## Related issue

Closes #3099

## Summary

- `omnigent server` (FastAPI/uvicorn) has no way to terminate TLS itself — every documented deploy path (Caddy overlay, k8s Ingress, Render/Railway/Fly/HF Spaces) works around this by terminating TLS *outside* the app. That's the right default for most deploys, but leaves a gap for standalone/bare-metal setups with no proxy in front and a cert the operator already manages (e.g. a host-level `certbot` renewal).
- Adds opt-in native TLS: `--ssl-certfile`/`--ssl-keyfile`/`--ssl-keyfile-password` on `omnigent server`, passed straight through to `uvicorn.Config`, plus matching `SSL_CERTFILE`/`SSL_KEYFILE`/`SSL_KEYFILE_PASSWORD` env vars for the Docker entrypoint.
- Two related correctness fixes so the rest of the stack doesn't assume plain HTTP once TLS is configured:
  - The canonical local-server reuse path (`~/.omnigent/local_server.pid`, always dialed as `http://127.0.0.1:<port>`) now excludes TLS-terminating invocations, so other tooling never tries to speak http to an https-only socket.
  - `OMNIGENT_ACCOUNTS_BASE_URL`'s auto-derived default (both the CLI and `paas_env.detect_base_url` used by the Docker entrypoint) switches to `https://` when a cert is configured, so secure-cookie behavior works out of the box.
- Docs: `deploy/docker/README.md`'s "HTTPS for the callback URL" section gets a third option alongside the bundled Caddy overlay and "behind an existing proxy."

## Test Plan

- `uv run pytest tests/cli/test_cli.py tests/server/test_paas_env.py tests/deploy/test_docker_entrypoint_import.py` — 271 passed (5 new: CLI validation + kwarg passthrough + canonical-reuse exemption, `detect_base_url` scheme flip, Docker entrypoint env-var resolution + validation).
- Manual end-to-end smoke test: generated a self-signed cert with `openssl req -x509 -newkey rsa:2048 ...`, started `omnigent server --ssl-certfile ... --ssl-keyfile ...`, confirmed a plain-HTTP `curl` to the port gets an empty reply (TLS-only socket), and `curl --cacert cert.pem https://localhost:<port>/` returns `200` with full certificate-chain verification.
- `pre-commit run --all-files` (ruff format/check) passes.

## Demo

N/A (CLI/server flag, no UI change)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the actual TLS handshake end-to-end (self-signed cert, real `uvicorn` bind, `curl` over https with certificate verification) since spinning up a real TLS socket in the unit-test CLI runner isn't practical — those tests instead stub `uvicorn.server.Server.run` and assert the `ssl_certfile`/`ssl_keyfile`/`ssl_keyfile_password` config values reach `uvicorn.Config` correctly, plus the validation and canonical-server-exemption logic around them.

## Changelog

`omnigent server` and the Docker entrypoint can now terminate HTTPS natively via `--ssl-certfile`/`--ssl-keyfile` (or `SSL_CERTFILE`/`SSL_KEYFILE`), for standalone deploys with no reverse proxy in front