### PR TITLE
Enable Slack integration tests in CI with additional integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,17 @@ jobs:
             paths: tests/db tests/deploy
             extra: databricks
             markexpr: databricks
+          # Slack integration (integrations/slack). Its tests live outside the
+          # top-level tests/ tree and import the decoupled `omnigent_slack`
+          # package, so this lane installs the `slack` extra to pull it in. The
+          # tests are run from the repo root on purpose: they rely on the root
+          # pyproject's `asyncio_mode = auto` (rootdir resolution), and
+          # coverage of the omnigent package is a no-op here (the code under
+          # test is omnigent_slack, not omnigent) — harmless, kept for a
+          # uniform pytest step.
+          - group: slack
+            paths: integrations/slack/tests
+            extra: slack
 
     steps:
       - name: Check out repo

--- a/integrations/slack/src/omnigent_slack/omnigent.py
+++ b/integrations/slack/src/omnigent_slack/omnigent.py
@@ -147,6 +147,22 @@ _STREAM_RECONNECT_MAX_ATTEMPTS = 6
 _STREAM_RECONNECT_MAX_TOTAL = 200
 _STREAM_RECONNECT_BACKOFF_S = 1.0
 
+# Terminal ``response.*`` lifecycle events the in-process harness scaffold emits
+# at a turn's end (completed/failed/cancelled/incomplete). Their presence marks
+# a turn as having PRODUCED output — an id-less idle that follows one is a real
+# end, not a claude-native cold-start PTY flap (claude-native emits no
+# ``response.*`` lifecycle events at all). ``response.failed``/``cancelled`` are
+# handled as hard-terminal separately; they are listed here too so the
+# production signal is set even on the paths that don't reach that branch.
+_RESPONSE_TERMINAL_EVENT_TYPES = frozenset(
+    {
+        "response.completed",
+        "response.failed",
+        "response.cancelled",
+        "response.incomplete",
+    }
+)
+
 # Path fragments that mark a redirect Location as an auth/login bounce (the
 # Databricks Apps proxy 302s an unauthenticated request to its OAuth authorize
 # endpoint). Used to tell an auth wall apart from a benign canonical redirect.
@@ -656,12 +672,26 @@ class OmnigentClient:
         # freshly-resumed session's stream (``idle=false``) replays the session's
         # CURRENT status first — which, hours after the last turn, is a stale
         # ``idle`` (no response_id) that arrives before our just-submitted
-        # message's ``running`` edge. Without this guard the ``id_less_end`` branch
-        # below would treat that pre-turn idle as the end and return 0 events
-        # ("Omnigent completed without returning response text"). We only honor a
-        # terminal idle/failed once we've seen the turn begin: a running/waiting
-        # edge, a forwarded answer delta, or a hard-terminal event.
+        # message's ``running`` edge. Without this guard the ``id_bearing_match``
+        # branch below (``not saw_open_running``) would treat that pre-turn idle as
+        # the end and return 0 events. We only honor such an idle once we've seen
+        # the turn begin: a running/waiting edge, a forwarded answer delta, or a
+        # hard-terminal event.
         turn_started = False
+        # Whether THIS turn has PRODUCED anything on the stream — an answer delta or
+        # a terminal ``response.*`` lifecycle event. Stricter than ``turn_started``,
+        # which a bare id-less ``running`` edge also sets. The id-less end branch
+        # keys off this, not ``turn_started``: claude-native's PTY-activity watcher
+        # emits an id-less ``running`` then an id-less ``idle`` flap during cold
+        # start (runner booted, message submitted, but the LLM hasn't returned its
+        # first token). That pair looks identical on the wire to the in-process
+        # harness's real id-less end — EXCEPT the in-process harness always produces
+        # first (a delta, or a terminal ``response.*`` envelope from the scaffold;
+        # even a policy-deny notice emits a bare ``output_text.delta``). Gating on
+        # production lets the flap fall through (kept reading until the real
+        # id-bearing Stop idle, or the idle-grace backstop) while a genuinely-empty
+        # in-process turn still ends promptly on its id-less idle.
+        turn_produced = False
         emitted: dict[str | None, str] = {}
         attempt = 0
         total_reconnects = 0
@@ -734,7 +764,17 @@ class OmnigentClient:
                                 # would defeat the stale-idle guard below.
                                 if event.get("type") == "response.output_text.delta":
                                     turn_started = True
+                                    turn_produced = True
                                 yield reconciled
+
+                            # A terminal ``response.*`` lifecycle envelope also counts
+                            # as production: the in-process harness always emits one
+                            # (the scaffold's completed/failed/cancelled) before its
+                            # id-less idle, so an id-less idle that follows one is a
+                            # real end, not a claude-native cold-start flap (which
+                            # emits no ``response.*`` at all).
+                            if event.get("type") in _RESPONSE_TERMINAL_EVENT_TYPES:
+                                turn_produced = True
 
                             if is_hard_terminal_event(event):
                                 self._logger.info(
@@ -781,16 +821,24 @@ class OmnigentClient:
                                 #  (a) id-bearing and matches the open response (or we
                                 #      saw no id-bearing open — some paths only stamp
                                 #      the end);
-                                #  (b) id-less AND no id-bearing response is open — the
-                                #      in-process (debby/claude-sdk) real end.
-                                #      `waiting` would have kept us going; only
-                                #      `idle`/`failed` here.
+                                #  (b) id-less AND no id-bearing response is open AND
+                                #      the turn has PRODUCED (a delta or a terminal
+                                #      ``response.*``) — the in-process (debby/
+                                #      claude-sdk) real end. `waiting` would have kept
+                                #      us going; only `idle`/`failed` here.
                                 # An id-less idle WHILE an id-bearing response is open
                                 # is a claude-native PTY flap → ignored (falls through).
+                                # An id-less idle with NOTHING produced is a
+                                # claude-native cold-start flap (id-less PTY
+                                # running→idle before the first token) → also ignored;
+                                # the real end is the later id-bearing Stop idle, with
+                                # the idle-grace timeout as the backstop.
                                 id_bearing_match = response_id is not None and (
                                     not saw_open_running or response_id == open_response_id
                                 )
-                                id_less_end = response_id is None and not saw_open_running
+                                id_less_end = (
+                                    response_id is None and not saw_open_running and turn_produced
+                                )
                                 if id_bearing_match or id_less_end:
                                     self._logger.info(
                                         "Omnigent turn ended session_id=%s status=%s "

--- a/integrations/slack/src/omnigent_slack/omnigent.py
+++ b/integrations/slack/src/omnigent_slack/omnigent.py
@@ -821,23 +821,30 @@ class OmnigentClient:
                                 #  (a) id-bearing and matches the open response (or we
                                 #      saw no id-bearing open — some paths only stamp
                                 #      the end);
-                                #  (b) id-less AND no id-bearing response is open AND
-                                #      the turn has PRODUCED (a delta or a terminal
-                                #      ``response.*``) — the in-process (debby/
-                                #      claude-sdk) real end. `waiting` would have kept
-                                #      us going; only `idle`/`failed` here.
+                                #  (b) id-less AND no id-bearing response is open — the
+                                #      in-process (debby/claude-sdk) real end. `waiting`
+                                #      would have kept us going; only `idle`/`failed`.
                                 # An id-less idle WHILE an id-bearing response is open
                                 # is a claude-native PTY flap → ignored (falls through).
-                                # An id-less idle with NOTHING produced is a
+                                # An id-less IDLE with NOTHING produced is a
                                 # claude-native cold-start flap (id-less PTY
-                                # running→idle before the first token) → also ignored;
-                                # the real end is the later id-bearing Stop idle, with
-                                # the idle-grace timeout as the backstop.
+                                # running→idle before the first token) → ignored; the
+                                # real end is the later id-bearing Stop idle, with the
+                                # idle-grace timeout as the backstop. This
+                                # produced-gate applies to `idle` ONLY: `failed` is
+                                # never a PTY flap (it comes solely from the
+                                # authoritative StopFailure hook / a setup-phase
+                                # failure — the PTY watcher emits only `idle`), so a
+                                # bare id-less `failed` must end the turn promptly even
+                                # with nothing produced.
                                 id_bearing_match = response_id is not None and (
                                     not saw_open_running or response_id == open_response_id
                                 )
+                                produced_or_failed = turn_produced or status == "failed"
                                 id_less_end = (
-                                    response_id is None and not saw_open_running and turn_produced
+                                    response_id is None
+                                    and not saw_open_running
+                                    and produced_or_failed
                                 )
                                 if id_bearing_match or id_less_end:
                                     self._logger.info(

--- a/integrations/slack/src/omnigent_slack/service.py
+++ b/integrations/slack/src/omnigent_slack/service.py
@@ -830,7 +830,11 @@ class SlackOmnigentService:
 
         delta = extract_delta(event)
         if delta:
-            await reply.add_delta(delta)
+            # ``message_id`` (native terminal harnesses tag each assistant message
+            # item; None for in-process streaming) lets the reply insert a
+            # paragraph break between back-to-back messages.
+            mid = event.get("message_id")
+            await reply.add_delta(delta, mid if isinstance(mid, str) else None)
             return
 
         elicitation = extract_elicitation_request(event, session_id)

--- a/integrations/slack/src/omnigent_slack/streaming.py
+++ b/integrations/slack/src/omnigent_slack/streaming.py
@@ -221,6 +221,15 @@ class _AnswerReply:
         self._logger = logger
         self._streamed = ""
         self._final: str | None = None
+        # The ``message_id`` of the delta stream currently being appended. Native
+        # terminal harnesses (claude-native) tag each assistant message item with a
+        # stable id, and emit several per turn (narration between tool calls). The
+        # deltas arrive back to back, so without a boundary the last sentence of one
+        # message butts directly against the first of the next ("…once more.The
+        # credentials…"). We insert a paragraph break when the id changes. ``None``
+        # (ordinary in-process streaming, where deltas already group by the active
+        # response) never triggers one — the behavior there is unchanged.
+        self._last_message_id: str | None = None
         # Text put on screen in each sealed segment this turn. Unlike
         # ``_streamed``/``_final`` (which reset at each seal), this survives
         # interruptions, so the no-delta fallback can tell whether the server's
@@ -247,11 +256,27 @@ class _AnswerReply:
     def streamed_len(self) -> int:
         return len(self._streamed)
 
-    async def add_delta(self, delta: str) -> None:
+    async def add_delta(self, delta: str, message_id: str | None = None) -> None:
         # Append the delta; the SDK buffers and only flushes to Slack once the
         # buffer fills. Clear the placeholder only on the flush that actually
         # puts content on screen — never while still buffering — so there's no
         # empty gap.
+        #
+        # A change in ``message_id`` (native terminal harnesses tag each assistant
+        # message item) marks a new message: insert a paragraph break so
+        # back-to-back messages don't run together ("…once more.The credentials…").
+        # Only between messages, never before the first, and never for id-less
+        # in-process streaming (its id stays None, so this branch never fires).
+        if (
+            message_id is not None
+            and self._last_message_id is not None
+            and message_id != self._last_message_id
+            and self._streamed
+            and not self._streamed.endswith("\n")
+        ):
+            self._streamed += "\n\n"
+            await self._reply.append("\n\n")
+        self._last_message_id = message_id
         self._streamed += delta
         if await self._reply.append(delta):
             await self._clear_ack()

--- a/integrations/slack/src/omnigent_slack/streaming.py
+++ b/integrations/slack/src/omnigent_slack/streaming.py
@@ -275,7 +275,12 @@ class _AnswerReply:
             and not self._streamed.endswith("\n")
         ):
             self._streamed += "\n\n"
-            await self._reply.append("\n\n")
+            # Honor the separator's flush too: if the 2-char append is the one
+            # that crosses the SDK buffer threshold (and the following delta only
+            # buffers), this is where content first hits the screen — clear the
+            # placeholder now rather than leaving it up until the next flush.
+            if await self._reply.append("\n\n"):
+                await self._clear_ack()
         self._last_message_id = message_id
         self._streamed += delta
         if await self._reply.append(delta):

--- a/integrations/slack/tests/fakes.py
+++ b/integrations/slack/tests/fakes.py
@@ -228,8 +228,15 @@ OMNIGENT_ENDPOINTS: list[tuple[str, str, bool]] = [
     # Internal (hidden from the public schema).
     ("POST", "/v1/sessions/{session_id}/events", False),
     ("POST", "/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve", False),
+    # Device-grant login (oauth.py, accounts mode): authorize starts the grant;
+    # /oauth/token both polls for the device-code token AND refreshes;
+    # /oauth/revoke logs out.
     ("POST", "/oauth/device/authorize", False),
-    ("POST", "/oauth/device/token", False),
+    ("POST", "/oauth/token", False),
+    ("POST", "/oauth/revoke", False),
+    # OIDC ticket login (oauth.py, oidc mode): start a CLI-login ticket, then poll.
+    ("POST", "/auth/cli-login", False),
+    ("GET", "/auth/cli-poll", False),
 ]
 
 # Response fields the client actually reads off the two richest documented

--- a/integrations/slack/tests/fakes.py
+++ b/integrations/slack/tests/fakes.py
@@ -1,0 +1,523 @@
+"""Shared fakes for integration tests.
+
+Two halves:
+
+- :class:`RecordingSlackClient` — a Slack Web-API client stand-in that records
+  every outbound call (streaming replies, modal open/update, DMs, ephemerals) so
+  a test can assert what the bot showed the user. Bolt itself is bypassed: tests
+  call ``service.handle_*`` / ``setup._handle_*`` directly, exactly as the unit
+  tests do.
+- :class:`FakeOmnigentServer` — a ``respx`` router that stands in for the
+  Omnigent HTTP API. It owns the endpoint contract (paths, status codes, body
+  shapes drawn from ``OmnigentClient``) in ONE place, exposes scenario knobs
+  (``auth_required``, ``agents``, ``hosts``, ``sse_body`` …) rather than raw
+  routes, and records every request so a test can assert the bot issued
+  spec-correct calls (method, path, bearer header, JSON body).
+
+The point of pairing them: drive a real ``OmnigentClient`` (real ``httpx``)
+against the fake server, and assert both sides of the seam — the HTTP requests
+the bot sent, and the Slack method it called in reaction to each response.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import respx
+
+# The placeholder text the bot posts as its "Working on it…" ack. Kept in sync
+# with the service module so a recorded ack is recognizable.
+try:  # pragma: no cover - import shape only
+    from omnigent_slack.service import _ACK_TEXT
+except Exception:  # pragma: no cover
+    _ACK_TEXT = "Working on it…"
+
+
+class FakeStream:
+    """Records a ``chat_stream`` lifecycle: appended deltas and the stop tail.
+
+    Mirrors the SDK's in-memory buffering — ``append`` accumulates text and only
+    "flushes" (returns a response) once the buffer crosses ``buffer_size`` or a
+    forced flush (``chunks`` set) arrives; until then it returns ``None`` like
+    the real client. That buffering is what the reply's placeholder/flush logic
+    depends on, so the fake reproduces it.
+    """
+
+    def __init__(self, client: RecordingSlackClient, start_kwargs: dict[str, Any]) -> None:
+        self._client = client
+        self.start_kwargs = start_kwargs
+        self.appended: list[str] = []
+        self.stopped = False
+        self.stop_text: str | None = None
+        self._buffer_size = 256
+        self._pending = 0
+
+    async def append(
+        self, *, markdown_text: str | None = None, chunks: Any = None
+    ) -> dict[str, Any] | None:
+        if markdown_text is not None:
+            self.appended.append(markdown_text)
+            self._pending += len(markdown_text)
+        if chunks is None and self._pending < self._buffer_size:
+            return None
+        if chunks is not None and self._pending == 0:
+            return None
+        self._pending = 0
+        return {"ok": True}
+
+    async def stop(self, *, markdown_text: str | None = None) -> dict[str, Any]:
+        self.stopped = True
+        self.stop_text = markdown_text
+        return {"ok": True}
+
+    @property
+    def text(self) -> str:
+        """The full delivered message: streamed deltas plus any stop tail."""
+        return "".join(self.appended) + (self.stop_text or "")
+
+
+class RecordingSlackClient:
+    """Records every outbound Slack Web-API call the bot makes.
+
+    Covers the surface both the turn path (streaming replies, posts, DMs) and
+    the setup path (modal open/update, team/user lookups) exercise, so one
+    client works for every integration scenario.
+    """
+
+    def __init__(self) -> None:
+        self.posts: list[dict[str, Any]] = []
+        self.acks: list[dict[str, Any]] = []
+        self.deleted_ts: list[str] = []
+        self.ephemerals: list[dict[str, Any]] = []
+        self.dm_opens: list[dict[str, Any]] = []
+        self.opened_views: list[dict[str, Any]] = []
+        self.updated_views: list[dict[str, Any]] = []
+        self.streams: list[FakeStream] = []
+        self._next_ts = 0
+
+    # ── turn path ────────────────────────────────────────────────────────
+    async def chat_postMessage(self, **kwargs: Any) -> dict[str, Any]:
+        self._next_ts += 1
+        ts = f"bot-{self._next_ts}"
+        entry = {**kwargs, "ts": ts}
+        self.posts.append(entry)
+        if kwargs.get("text") == _ACK_TEXT:
+            self.acks.append(entry)
+        return {"ok": True, "ts": ts}
+
+    async def chat_postEphemeral(self, **kwargs: Any) -> dict[str, Any]:
+        self.ephemerals.append({**kwargs})
+        return {"ok": True, "message_ts": "ephemeral"}
+
+    async def conversations_open(self, **kwargs: Any) -> dict[str, Any]:
+        self.dm_opens.append({**kwargs})
+        return {"ok": True, "channel": {"id": f"D-{kwargs.get('users')}"}}
+
+    async def chat_delete(self, **kwargs: Any) -> dict[str, Any]:
+        ts = kwargs.get("ts")
+        self.deleted_ts.append(str(ts))
+        self.posts = [p for p in self.posts if p.get("ts") != ts]
+        return {"ok": True}
+
+    async def chat_update(self, **kwargs: Any) -> dict[str, Any]:
+        ts = kwargs.get("ts")
+        for post in self.posts:
+            if post.get("ts") == ts:
+                post.update(kwargs)
+        return {"ok": True, "ts": ts}
+
+    async def chat_getPermalink(self, **kwargs: Any) -> dict[str, Any]:
+        channel = kwargs.get("channel")
+        ts = kwargs.get("message_ts")
+        return {"ok": True, "permalink": f"https://slack.test/archives/{channel}/p{ts}"}
+
+    async def chat_stream(self, **kwargs: Any) -> FakeStream:
+        stream = FakeStream(self, kwargs)
+        self.streams.append(stream)
+        return stream
+
+    # ── setup path ───────────────────────────────────────────────────────
+    async def views_open(self, **kwargs: Any) -> dict[str, Any]:
+        self.opened_views.append(kwargs)
+        return {"ok": True, "view": {"id": "V1"}}
+
+    async def views_update(self, **kwargs: Any) -> dict[str, Any]:
+        self.updated_views.append(kwargs)
+        return {"ok": True}
+
+    async def team_info(self, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": True, "team": {"id": kwargs.get("team", "T1"), "name": "Acme Corp"}}
+
+    async def users_info(self, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": True, "user": {"profile": {"email": "user@example.com"}}}
+
+    # ── helpers ──────────────────────────────────────────────────────────
+    @property
+    def stream(self) -> FakeStream:
+        return self.streams[-1]
+
+    @property
+    def streamed_text(self) -> str:
+        return "".join(s.text for s in self.streams)
+
+    def last_view_text(self) -> str:
+        """Concatenated text of the most recently opened/updated modal.
+
+        Flattens the Block Kit blocks so a test can assert on user-visible copy
+        (a login link, a failure reason) without walking the block structure.
+        """
+        source = self.updated_views[-1] if self.updated_views else self.opened_views[-1]
+        view = source.get("view", source)
+        return _flatten_blocks(view)
+
+
+async def _dropping_stream(body: str):
+    """Yield ``body`` then raise a mid-stream drop the client treats as a proxy
+    severing a long-lived response (reconnect, not "server down")."""
+    yield body.encode()
+    raise httpx.RemoteProtocolError("peer closed connection (incomplete chunked read)")
+
+
+def _flatten_blocks(view: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for block in view.get("blocks", []) if isinstance(view, dict) else []:
+        if not isinstance(block, dict):
+            continue
+        text = block.get("text")
+        if isinstance(text, dict) and isinstance(text.get("text"), str):
+            parts.append(text["text"])
+        elif isinstance(text, str):
+            parts.append(text)
+    return "\n".join(parts)
+
+
+# ── Omnigent API contract the Slack client depends on ─────────────────────────
+#
+# The single source of truth for which server endpoints the bot calls, and
+# which of those are part of the server's PUBLIC (schema-documented) surface.
+# ``test_integration.py``'s drift test reconciles this catalog against the
+# committed ``openapi.json`` so a server-side rename/removal of a
+# ``documented=True`` endpoint fails a Slack test — surfacing the break here
+# rather than silently at runtime against a deployed server.
+#
+# Each entry: (method, path_template, documented). ``documented=False`` marks
+# an endpoint the server intentionally hides from its OpenAPI schema
+# (``include_in_schema=False`` — the ``/oauth/device/*`` login routes and the
+# internal ``/events`` + elicitation-resolve routes); the drift test asserts
+# those are ABSENT from the schema so a future decision to publish one is a
+# deliberate, noticed change.
+#
+# Keep in sync with ``OmnigentClient`` (integrations/slack/src/omnigent_slack/
+# omnigent.py) and the login flow (oauth.py / auth_manager.py).
+OMNIGENT_ENDPOINTS: list[tuple[str, str, bool]] = [
+    # Setup / validation.
+    ("GET", "/health", True),
+    ("GET", "/v1/me", True),
+    ("GET", "/v1/agents", True),
+    ("GET", "/v1/hosts", True),
+    ("GET", "/v1/hosts/{host_id}/filesystem", True),
+    # Session lifecycle.
+    ("POST", "/v1/sessions", True),
+    ("GET", "/v1/sessions/{session_id}", True),
+    ("GET", "/v1/sessions/{session_id}/items", True),
+    ("GET", "/v1/sessions/{session_id}/stream", True),
+    ("POST", "/v1/hosts/{host_id}/runners", True),
+    ("GET", "/v1/runners/{runner_id}/status", True),
+    # Internal (hidden from the public schema).
+    ("POST", "/v1/sessions/{session_id}/events", False),
+    ("POST", "/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve", False),
+    ("POST", "/oauth/device/authorize", False),
+    ("POST", "/oauth/device/token", False),
+]
+
+# Response fields the client actually reads off the two richest documented
+# schemas. If the server renames one of these, the client silently degrades
+# (a None harness, an empty agent list), so the drift test pins them.
+OMNIGENT_RESPONSE_FIELDS: dict[str, tuple[str, ...]] = {
+    # GET /v1/sessions/{session_id} → SessionResponse (get_session_info).
+    "SessionResponse": ("harness", "agent_name"),
+    # GET /v1/agents → PaginatedList (list_agents reads .data).
+    "PaginatedList": ("data",),
+}
+
+
+def sse_status(status: str, response_id: str | None = None) -> str:
+    """One ``session.status`` SSE frame (id-bearing when ``response_id`` given)."""
+    payload: dict[str, Any] = {"type": "session.status", "status": status}
+    if response_id is not None:
+        payload["response_id"] = response_id
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+def sse_delta(text: str, message_id: str | None = None) -> str:
+    """One ``response.output_text.delta`` SSE frame."""
+    payload: dict[str, Any] = {"type": "response.output_text.delta", "delta": text}
+    if message_id is not None:
+        payload["message_id"] = message_id
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+# The bot's SSE turn-end shape reused across streaming scenarios: a running
+# edge, one answer delta, then the id-bearing idle that ends the turn.
+DEFAULT_SSE_BODY = (
+    sse_status("running", "resp_1")
+    + sse_delta("Here is the answer.", "m1")
+    + 'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+    + sse_status("idle", "resp_1")
+)
+
+
+class FakeOmnigentServer:
+    """A ``respx`` router standing in for the Omnigent HTTP API.
+
+    Install it inside a ``respx.mock`` block with :meth:`install`. Tests set
+    scenario knobs (``auth_required``, ``agents``, ``hosts``, ``sse_body`` …);
+    the router owns the endpoint contract and records every request for
+    assertions.
+    """
+
+    def __init__(self, base_url: str = "http://omnigent.test") -> None:
+        self.base_url = base_url.rstrip("/")
+        # Scenario knobs.
+        self.auth_required = False  # auth-gated endpoints 401 when True
+        self.agents: list[dict[str, Any]] = [{"id": "ag_1", "name": "debby"}]
+        self.hosts: list[dict[str, Any]] = [
+            {"host_id": "h1", "name": "Host One", "status": "online"}
+        ]
+        self.session_id = "conv_1"
+        self.runner_id = "runner_1"
+        self.harness = "claude-native"
+        self.agent_name = "debby"
+        self.sse_body = DEFAULT_SSE_BODY
+        # Login (device grant) knobs — used when auth_required drives a login.
+        self.user_code = "ABCD-2345"
+        self.verification_url = self.base_url + "/oauth/device?user_code=ABCD-2345"
+        # Assistant items returned by the no-delta fallback probe.
+        self.latest_items: list[dict[str, Any]] = []
+        # ── complex-scenario knobs ───────────────────────────────────────
+        # First message-submit (POST /events) returns 503 runner_unavailable,
+        # then succeeds — models a session whose bound runner died: run_turn
+        # catches it, launches a fresh runner, and retries the turn once.
+        self.first_submit_runner_unavailable = False
+        # Launch responds with this status (404/409 → host-unavailable) instead
+        # of 200. None means the normal success path.
+        self.launch_status: int | None = None
+        # Every request to a session path (submit/stream/…) responds 412
+        # harness_not_configured with this curated message when set.
+        self.harness_not_configured_message: str | None = None
+        # A list of SSE bodies served on successive /stream connections: the
+        # first drops mid-tail (StreamInterruptedError), the client reconnects
+        # and gets the next. Overrides ``sse_body`` when non-empty.
+        self.stream_legs: list[str] = []
+        self._launch_calls = 0
+        self._stream_calls = 0
+        # Recorded requests: each is (method, path, headers, json|None).
+        self.requests: list[tuple[str, str, httpx.Headers, Any]] = []
+
+    # ── request recording ────────────────────────────────────────────────
+    def _record(self, request: httpx.Request) -> None:
+        body: Any = None
+        if request.content:
+            try:
+                body = json.loads(request.content)
+            except ValueError:
+                body = request.content
+        self.requests.append((request.method, request.url.path, request.headers, body))
+
+    # ── route side-effects ───────────────────────────────────────────────
+    def _auth_wall_or(self, payload: dict[str, Any]):
+        def _handler(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            if self.auth_required:
+                return httpx.Response(401, json={"error": {"code": "unauthorized"}})
+            return httpx.Response(200, json=payload)
+
+        return _handler
+
+    def install(self, respx_mock: respx.MockRouter) -> FakeOmnigentServer:
+        b = self.base_url
+
+        # Health is always reachable (setup probes it before the auth-gated list).
+        def _health(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            return httpx.Response(200, json={"status": "ok"})
+
+        respx_mock.get(b + "/health").mock(side_effect=_health)
+
+        # Auth-gated listing endpoints.
+        respx_mock.get(b + "/v1/agents").mock(
+            side_effect=self._auth_wall_or({"data": self.agents})
+        )
+        respx_mock.get(b + "/v1/hosts").mock(side_effect=self._auth_wall_or({"hosts": self.hosts}))
+
+        # Login-mode probe + device grant (only hit when a login starts).
+        def _me(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            # 401 with a login_url that isn't /auth/login → accounts (device) mode.
+            return httpx.Response(401, json={"login_url": "/login"})
+
+        respx_mock.get(b + "/v1/me").mock(side_effect=_me)
+
+        def _device_authorize(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            return httpx.Response(
+                200,
+                json={
+                    "device_code": "dc",
+                    "user_code": self.user_code,
+                    "verification_uri": b + "/oauth/device",
+                    "verification_uri_complete": self.verification_url,
+                    "expires_in": 600,
+                    "interval": 0,
+                },
+            )
+
+        respx_mock.post(b + "/oauth/device/authorize").mock(side_effect=_device_authorize)
+
+        # Host filesystem (workspace default) — parent of any absolute path.
+        def _filesystem(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            return httpx.Response(
+                200,
+                json={"data": [{"name": ".bashrc", "path": "/home/bot/.bashrc", "type": "file"}]},
+            )
+
+        respx_mock.get(url__regex=rf"{b}/v1/hosts/[^/]+/filesystem").mock(side_effect=_filesystem)
+
+        # Session lifecycle.
+        def _create_session(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            return httpx.Response(201, json={"id": self.session_id})
+
+        respx_mock.post(b + "/v1/sessions").mock(side_effect=_create_session)
+
+        def _launch_runner(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            self._launch_calls += 1
+            if self.launch_status in (404, 409):
+                return httpx.Response(self.launch_status, json={"error": {"code": "host_offline"}})
+            return httpx.Response(200, json={"runner_id": self.runner_id})
+
+        respx_mock.post(url__regex=rf"{b}/v1/hosts/[^/]+/runners").mock(side_effect=_launch_runner)
+
+        def _runner_status(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            return httpx.Response(200, json={"runner_id": self.runner_id, "online": True})
+
+        respx_mock.get(url__regex=rf"{b}/v1/runners/[^/]+/status").mock(side_effect=_runner_status)
+
+        self._submit_calls = 0
+
+        def _submit(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            self._submit_calls += 1
+            if self.harness_not_configured_message is not None:
+                return httpx.Response(
+                    412,
+                    json={
+                        "error": {
+                            "code": "harness_not_configured",
+                            "message": self.harness_not_configured_message,
+                        }
+                    },
+                )
+            if self.first_submit_runner_unavailable and self._submit_calls == 1:
+                return httpx.Response(503, json={"error": {"code": "runner_unavailable"}})
+            return httpx.Response(202, json={})
+
+        respx_mock.post(url__regex=rf"{b}/v1/sessions/[^/]+/events").mock(side_effect=_submit)
+
+        # Session snapshot. Serves the config-summary fields (harness/agent) and
+        # the rolled-up ``status`` that gates two decisions:
+        #   • the route-time busy check (must read idle so a follow-up runs); and
+        #   • the mid-stream-drop reconnect check (must read running so the client
+        #     reconnects rather than treating the drop as a finished turn).
+        # These happen at different times, so the status is idle UNTIL the turn's
+        # stream has opened, then running — matching a real session's lifecycle.
+        def _snapshot(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            status = "running" if self._stream_calls > 0 else "idle"
+            return httpx.Response(
+                200,
+                json={
+                    "harness": self.harness,
+                    "agent_name": self.agent_name,
+                    "status": status,
+                },
+            )
+
+        respx_mock.get(url__regex=rf"{b}/v1/sessions/[^/]+$").mock(side_effect=_snapshot)
+
+        # Newest-assistant-message probe (no-delta fallback). The service reads
+        # this BEFORE the turn (baseline) and AFTER (fallback), and only recovers a
+        # message that differs from the baseline. So ``latest_items`` is treated as
+        # produced BY the turn: empty until the stream has run, then present — a
+        # blind pre-turn baseline would otherwise resurrect a prior answer.
+        def _items(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            items = self.latest_items if self._stream_calls > 0 else []
+            return httpx.Response(200, json={"data": items})
+
+        respx_mock.get(url__regex=rf"{b}/v1/sessions/[^/]+/items").mock(side_effect=_items)
+
+        # SSE stream. When auth_required, the tail 401s so a mid-turn auth wall
+        # surfaces as AuthRequiredError (the re-login path). ``stream_legs`` (when
+        # set) serves one body per successive connection so a leg can drop
+        # mid-tail (a "…" sentinel raises a RemoteProtocolError) and the client
+        # reconnects to the next leg.
+        def _stream(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            if self.auth_required:
+                return httpx.Response(401, json={"error": {"code": "unauthorized"}})
+            if self.stream_legs:
+                leg = self.stream_legs[min(self._stream_calls, len(self.stream_legs) - 1)]
+                self._stream_calls += 1
+                if leg.endswith("<DROP>"):
+                    return httpx.Response(200, stream=_dropping_stream(leg[: -len("<DROP>")]))
+                return httpx.Response(200, text=leg)
+            self._stream_calls += 1
+            return httpx.Response(200, text=self.sse_body)
+
+        respx_mock.get(url__regex=rf"{b}/v1/sessions/[^/]+/stream").mock(side_effect=_stream)
+
+        return self
+
+    # ── assertion helpers ────────────────────────────────────────────────
+    def paths(self, method: str | None = None) -> list[str]:
+        """Recorded request paths, optionally filtered by HTTP method."""
+        return [p for m, p, _h, _b in self.requests if method is None or m == method]
+
+    def find(self, method: str, path: str) -> tuple[str, str, httpx.Headers, Any] | None:
+        """The first recorded request matching ``method`` and exact ``path``."""
+        for entry in self.requests:
+            if entry[0] == method and entry[1] == path:
+                return entry
+        return None
+
+    def assert_request(
+        self, method: str, path: str, *, json_contains: dict[str, Any] | None = None
+    ) -> tuple[str, str, httpx.Headers, Any]:
+        """Assert a request was made, optionally with a superset JSON body."""
+        entry = self.find(method, path)
+        assert entry is not None, f"expected {method} {path}; saw {self.requests}"
+        if json_contains is not None:
+            body = entry[3]
+            assert isinstance(body, dict), f"{method} {path} body not JSON: {body!r}"
+            for key, value in json_contains.items():
+                assert body.get(key) == value, (
+                    f"{method} {path} body[{key!r}]={body.get(key)!r} != {value!r}"
+                )
+        return entry
+
+    def assert_bearer(self, method: str, path: str, token: str | None = None) -> None:
+        """Assert the request carried an Authorization: Bearer header."""
+        entry = self.find(method, path)
+        assert entry is not None, f"expected {method} {path}; saw {self.paths()}"
+        auth = entry[2].get("authorization")
+        assert auth is not None and auth.startswith("Bearer "), (
+            f"{method} {path} missing bearer; headers={dict(entry[2])}"
+        )
+        if token is not None:
+            assert auth == f"Bearer {token}", f"{method} {path} bearer={auth!r} != Bearer {token}"

--- a/integrations/slack/tests/test_api_spec_drift.py
+++ b/integrations/slack/tests/test_api_spec_drift.py
@@ -1,0 +1,130 @@
+"""Guard the Slack client against Omnigent API spec drift.
+
+The Slack integration is deliberately decoupled from the ``omnigent`` server
+package (it can't import it), so it can't introspect the live FastAPI app. But
+the repo commits the server's generated OpenAPI document at ``openapi.json``
+(produced by ``scripts/dump_openapi.py`` and itself drift-guarded server-side by
+``tests/server/test_openapi_drift.py``). That artifact is a reliable, in-repo
+description of the server contract.
+
+This test reconciles the endpoints the Slack client actually calls
+(:data:`OMNIGENT_ENDPOINTS` in ``fakes.py``, kept next to the fake server) with
+that document, so:
+
+- If the server RENAMES or REMOVES a documented endpoint/method the bot depends
+  on (e.g. ``GET /v1/agents`` → ``GET /v1/available-agents``), a Slack test
+  fails with a precise message — instead of the bot 404-ing silently against a
+  deployed server.
+- If a field the client reads off a response schema disappears
+  (``SessionResponse.harness``, ``PaginatedList.data``), a test fails.
+- If an endpoint the client treats as INTERNAL suddenly appears in the public
+  schema, a test fails — a nudge to reclassify it deliberately.
+
+The catalog is intentionally hand-maintained (it encodes *what the client
+needs*, which no tool can infer); this test is what keeps it honest against the
+server's own source of truth.
+
+If ``openapi.json`` can't be found (e.g. the Slack package is checked out in
+isolation without the parent repo), the reconciliation tests skip rather than
+fail — the catalog-consistency test still runs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fakes import OMNIGENT_ENDPOINTS, OMNIGENT_RESPONSE_FIELDS
+
+# ``openapi.json`` lives at the monorepo root: integrations/slack/tests/ → ../../../
+_OPENAPI_PATH = Path(__file__).resolve().parents[3] / "openapi.json"
+
+
+def _load_spec() -> dict[str, Any] | None:
+    if not _OPENAPI_PATH.is_file():
+        return None
+    return json.loads(_OPENAPI_PATH.read_text())
+
+
+_SPEC = _load_spec()
+_needs_spec = pytest.mark.skipif(
+    _SPEC is None, reason=f"openapi.json not found at {_OPENAPI_PATH}"
+)
+
+_DOCUMENTED = [(m, p) for m, p, documented in OMNIGENT_ENDPOINTS if documented]
+_INTERNAL = [(m, p) for m, p, documented in OMNIGENT_ENDPOINTS if not documented]
+
+
+def test_endpoint_catalog_is_well_formed() -> None:
+    """The catalog itself is sane — no duplicates, valid methods, absolute paths.
+
+    Runs even without ``openapi.json`` so a malformed catalog is always caught.
+    """
+    seen: set[tuple[str, str]] = set()
+    valid_methods = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+    for method, path, _documented in OMNIGENT_ENDPOINTS:
+        key = (method, path)
+        assert key not in seen, f"duplicate catalog entry: {method} {path}"
+        seen.add(key)
+        assert method in valid_methods, f"unexpected method {method} for {path}"
+        assert path.startswith("/"), f"path must be absolute: {path}"
+
+
+@_needs_spec
+@pytest.mark.parametrize(("method", "path"), _DOCUMENTED, ids=lambda v: v)
+def test_documented_endpoint_present_in_openapi(method: str, path: str) -> None:
+    """Every endpoint the client depends on (and the server documents) still
+    exists in ``openapi.json`` with the expected method."""
+    assert _SPEC is not None
+    paths = _SPEC["paths"]
+    assert path in paths, (
+        f"{method} {path}: the Slack client calls this endpoint but it is gone "
+        f"from openapi.json — the server renamed/removed it, or the client and "
+        f"server drifted. Update OmnigentClient and the fakes.py catalog together."
+    )
+    methods = {m.upper() for m in paths[path]}
+    assert method in methods, (
+        f"{path}: client expects {method}, but openapi.json documents {sorted(methods)}."
+    )
+
+
+@_needs_spec
+@pytest.mark.parametrize(("method", "path"), _INTERNAL, ids=lambda v: v)
+def test_internal_endpoint_absent_from_openapi(method: str, path: str) -> None:
+    """Endpoints the client treats as internal stay hidden from the public schema.
+
+    If one starts appearing, that's a deliberate server decision — reclassify it
+    in the catalog (``documented=True``) so it's covered by the presence check
+    instead."""
+    assert _SPEC is not None
+    if path not in _SPEC["paths"]:
+        return
+    methods = {m.upper() for m in _SPEC["paths"][path]}
+    assert method not in methods, (
+        f"{method} {path} is now in the public OpenAPI schema but the Slack "
+        f"catalog marks it internal (documented=False). If this is intended, "
+        f"flip it to documented=True in fakes.py's OMNIGENT_ENDPOINTS."
+    )
+
+
+@_needs_spec
+@pytest.mark.parametrize("schema_name", sorted(OMNIGENT_RESPONSE_FIELDS))
+def test_response_fields_present_in_schema(schema_name: str) -> None:
+    """Fields the client reads off documented response schemas still exist.
+
+    A silent rename (e.g. ``harness`` → ``harness_kind``) would make
+    ``get_session_info`` return ``None`` forever; pin the field names."""
+    assert _SPEC is not None
+    schemas = _SPEC.get("components", {}).get("schemas", {})
+    assert schema_name in schemas, (
+        f"schema {schema_name} vanished from openapi.json — the client parses it; "
+        f"update the OMNIGENT_RESPONSE_FIELDS catalog and OmnigentClient together."
+    )
+    properties = schemas[schema_name].get("properties", {})
+    for field in OMNIGENT_RESPONSE_FIELDS[schema_name]:
+        assert field in properties, (
+            f"{schema_name}.{field} is gone from openapi.json but the Slack client "
+            f"reads it. Confirm the server rename and update the client + catalog."
+        )

--- a/integrations/slack/tests/test_auth_manager.py
+++ b/integrations/slack/tests/test_auth_manager.py
@@ -557,6 +557,14 @@ async def test_enrollment_poll_clears_map_slot_on_completion(tmp_path: Path) -> 
         on_failure=on_failure,
         poll_interval_seconds=0.01,
     )
+    # Let the poll baseline the (absent) token BEFORE writing the fresh one —
+    # otherwise, if `store.put` races ahead of the poll's first read (likely
+    # under a loaded `-n` runner), the poll baselines "fresh" and never sees a
+    # change, so on_success never fires and this test times out. The sibling
+    # ``test_enrollment_fires_on_first_token_when_none_existed`` uses the same
+    # ordering barrier.
+    await asyncio.sleep(0.05)
+    assert not succeeded.is_set()
     await store.put("T1", "U1", _BASE, access_token="fresh", refresh_token="")
     await asyncio.wait_for(succeeded.wait(), timeout=1.0)
     # Let the done-callback run.

--- a/integrations/slack/tests/test_client_catalog.py
+++ b/integrations/slack/tests/test_client_catalog.py
@@ -1,0 +1,202 @@
+"""Keep the endpoint catalog honest against the client's real call sites.
+
+``test_api_spec_drift.py`` reconciles the catalog (:data:`OMNIGENT_ENDPOINTS`)
+against the SERVER's ``openapi.json``. But that only guards the endpoints the
+catalog already lists — if someone adds a NEW ``self._request("POST", "/v1/…")``
+and forgets to add it to the catalog, the drift test stays green while the
+client quietly depends on an unlisted endpoint. (Exactly this happened once: the
+catalog listed a phantom ``/oauth/device/token`` while the real ``/oauth/token``,
+``/oauth/revoke``, ``/auth/cli-login``, ``/auth/cli-poll`` calls went unlisted.)
+
+This test closes that gap from the client side: it parses the modules that talk
+to the Omnigent server with ``ast``, extracts every HTTP call, normalizes each
+path to the catalog's ``{param}`` template form, and asserts every one appears in
+the catalog. A new/renamed endpoint that isn't cataloged fails here with a
+``file:line`` pointer to ``fakes.py``'s ``OMNIGENT_ENDPOINTS``.
+
+Scope: the two modules whose httpx client is bound to the OMNIGENT SERVER —
+``omnigent.py`` (the main API surface, via the ``_request`` / ``_get_list`` /
+``_get_json`` / ``stream`` helpers) and ``oauth.py`` (the login flow, via direct
+``client.get`` / ``client.post`` calls). ``databricks_oauth.py`` is deliberately
+excluded: its client targets the Databricks WORKSPACE, not the Omnigent server.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from fakes import OMNIGENT_ENDPOINTS
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "omnigent_slack"
+# Modules whose HTTP client is bound to the Omnigent server base URL.
+_SCANNED_SOURCES = [_SRC / "omnigent.py", _SRC / "oauth.py"]
+
+# Helper calls where (method, path) sit at args 0, 1 (omnigent.py):
+#   _request(method, url, ...) ; self._client.stream(method, url, …)
+_METHOD_PATH_HELPERS = {"_request", "stream"}
+# Helper calls that are always GET with the path at arg 0 (omnigent.py):
+#   _get_list(url, *keys) ; _get_json(url, ...)
+_GET_PATH_HELPERS = {"_get_list", "_get_json"}
+# Direct httpx verb calls where the method IS the attribute and path is arg 0
+#   (oauth.py): client.get(url, …) / client.post(url, …) / …
+_VERB_METHODS = {"get", "post", "put", "patch", "delete"}
+
+
+def _template_of(node: ast.expr) -> str | None:
+    """Normalize a path argument AST node to a catalog ``{param}`` template.
+
+    A plain string literal returns as-is. An f-string returns with every
+    interpolation replaced by ``{}`` — so ``f"/v1/hosts/{target_host}/runners"``
+    and the catalog's ``/v1/hosts/{host_id}/runners`` compare equal regardless of
+    the local variable name. Returns ``None`` for a path this scanner can't
+    resolve statically (a bare variable), so such call sites are reported rather
+    than silently skipped.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return _normalize(node.value)
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            else:
+                parts.append("{}")  # an interpolated path segment
+        return _normalize("".join(parts))
+    return None
+
+
+def _normalize(path: str) -> str:
+    """Collapse every ``{...}`` path parameter to a bare ``{}`` placeholder.
+
+    Applied to BOTH the code's f-string templates and the catalog entries so the
+    two are compared on structure, not parameter names (the client uses
+    ``{session_id}``/``{target_host}``; the catalog uses ``{session_id}``/
+    ``{host_id}``)."""
+    out: list[str] = []
+    depth = 0
+    for ch in path:
+        if ch == "{":
+            if depth == 0:
+                out.append("{}")
+            depth += 1
+        elif ch == "}":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            out.append(ch)
+    return "".join(out)
+
+
+def _extract_client_calls() -> list[tuple[str, str, str]]:
+    """Return ``(method, normalized_path, location)`` for each scanned HTTP call.
+
+    ``location`` is ``"<module>:<lineno>"``. ``method`` is ``"?"`` when it can't
+    be resolved statically (a variable), so the reconciliation still checks the
+    path and flags the unusual call site.
+    """
+    calls: list[tuple[str, str, str]] = []
+    for source in _SCANNED_SOURCES:
+        module = source.name
+        tree = ast.parse(source.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            name = node.func.attr
+            where = f"{module}:{node.lineno}"
+            if name in _METHOD_PATH_HELPERS:
+                if len(node.args) < 2:
+                    continue
+                method, path = _literal_method(node.args[0]), _template_of(node.args[1])
+            elif name in _GET_PATH_HELPERS:
+                method, path = "GET", _template_of(node.args[0]) if node.args else None
+            elif name in _VERB_METHODS:
+                # Direct httpx verb call (oauth.py): client.post("/oauth/token", …).
+                method, path = name.upper(), _template_of(node.args[0]) if node.args else None
+            else:
+                continue
+            if path is not None and path.startswith("/"):
+                calls.append((method, path, where))
+    return calls
+
+
+def _literal_method(node: ast.expr) -> str:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value.upper()
+    return "?"
+
+
+# Catalog paths, normalized the same way, keyed for lookup.
+_CATALOG_PATHS = {(m, _normalize(p)) for m, p, _documented in OMNIGENT_ENDPOINTS}
+_CATALOG_PATHS_ANY_METHOD = {_normalize(p) for _m, p, _documented in OMNIGENT_ENDPOINTS}
+
+
+def test_client_source_is_scannable() -> None:
+    """The scanner finds the client's HTTP calls — guards against a silent no-op
+    if a call-site shape changes (e.g. a helper is renamed)."""
+    calls = _extract_client_calls()
+    assert calls, (
+        "no HTTP call sites found — the scanner's helper/verb sets "
+        f"({_METHOD_PATH_HELPERS | _GET_PATH_HELPERS | _VERB_METHODS}) are likely "
+        "stale; update them."
+    )
+    # Sanity: representative endpoints from BOTH scanned modules must appear.
+    scanned_paths = {p for _m, p, _loc in calls}
+    assert "/v1/sessions" in scanned_paths  # omnigent.py
+    assert "/v1/sessions/{}/stream" in scanned_paths  # omnigent.py (stream helper)
+    assert "/oauth/token" in scanned_paths  # oauth.py (direct verb call)
+
+
+def test_every_client_endpoint_is_cataloged() -> None:
+    """Every endpoint the client calls appears in OMNIGENT_ENDPOINTS.
+
+    Fails when a new/renamed HTTP call (``_request`` / ``_get_list`` /
+    ``_get_json`` / ``stream`` in omnigent.py, or a direct ``client.<verb>`` in
+    oauth.py) isn't reflected in the catalog — so the catalog can't silently fall
+    behind the client, and the OpenAPI drift test keeps covering the client's
+    true surface. This is the guard that would have caught the phantom
+    ``/oauth/device/token`` entry."""
+    missing: list[str] = []
+    for method, path, location in _extract_client_calls():
+        if (method, path) in _CATALOG_PATHS:
+            continue
+        # An unresolved method ("?") still counts as covered if the path is
+        # cataloged under any method (rare; keeps a dynamic-method call from a
+        # false failure while still requiring the path itself to be listed).
+        if method == "?" and path in _CATALOG_PATHS_ANY_METHOD:
+            continue
+        missing.append(f"{method} {path}  ({location})")
+    assert not missing, (
+        "The client calls endpoints missing from the catalog:\n  "
+        + "\n  ".join(missing)
+        + "\n\nAdd them to OMNIGENT_ENDPOINTS in tests/fakes.py (with the correct "
+        "documented=True/False), so the OpenAPI drift test covers them too."
+    )
+
+
+def test_catalog_has_no_phantom_endpoints() -> None:
+    """No catalog entry is absent from the client's real call sites.
+
+    The complement of :func:`test_every_client_endpoint_is_cataloged`: it caught a
+    MISSING entry; this catches a STALE/PHANTOM one — an endpoint listed in the
+    catalog that the client never actually calls (exactly the ``/oauth/device/
+    token`` bug). Such an entry gives false confidence: the drift test "guards" a
+    route the client doesn't use while the real one goes unlisted.
+
+    Scoped to server-namespace paths the scanner can resolve (``/v1``, ``/oauth``,
+    ``/auth``, ``/health``); a catalog path outside those, if ever added, is
+    exempt (the scanner wouldn't see a differently-shaped call)."""
+    scanned = {(m, p) for m, p, _loc in _extract_client_calls()}
+    scannable_prefixes = ("/v1", "/oauth", "/auth", "/health")
+    phantom: list[str] = []
+    for method, path, _documented in OMNIGENT_ENDPOINTS:
+        norm = _normalize(path)
+        if not norm.startswith(scannable_prefixes):
+            continue
+        if (method, norm) not in scanned:
+            phantom.append(f"{method} {path}")
+    assert not phantom, (
+        "Catalog lists endpoints the client never calls (phantoms):\n  "
+        + "\n  ".join(phantom)
+        + "\n\nRemove them from OMNIGENT_ENDPOINTS in tests/fakes.py, or fix the "
+        "path to match the real call site."
+    )

--- a/integrations/slack/tests/test_integration.py
+++ b/integrations/slack/tests/test_integration.py
@@ -60,25 +60,41 @@ async def _configure_user(
     )
 
 
-async def _wait_for_stream_stop(client: RecordingSlackClient, tries: int = 100) -> None:
-    for _ in range(tries):
-        if client.streams and client.stream.stopped:
-            return
-        await asyncio.sleep(0.02)
-    raise AssertionError("timed out waiting for a stream to stop")
+# Generous ceiling for the waits below. These are event-driven (they await the
+# actual turn task), so a healthy run returns near-instantly and never spends
+# this budget; it only bounds a genuine hang. Kept well above any real turn so a
+# loaded CI runner doesn't spuriously time out (see the isolation note in the
+# module docstring's history).
+_WAIT_TIMEOUT_S = 10.0
 
 
-async def _wait_for_turns(service: SlackOmnigentService, tries: int = 100) -> None:
+async def _wait_for_turns(service: SlackOmnigentService, timeout: float = _WAIT_TIMEOUT_S) -> None:
     """Wait until the service's spawned turn tasks have finished.
 
     A turn runs as a background task; ``shutdown`` would CANCEL it, so tests that
-    assert on a turn's outcome must let it complete first.
+    assert on a turn's outcome must let it complete first. Event-driven: awaits
+    the tracked tasks directly (no polling), so it returns the instant the turn
+    ends and the ``timeout`` only bounds a real hang. Turn tasks never propagate
+    (``_run_turn_tracked`` swallows exceptions), so gather won't raise.
     """
-    for _ in range(tries):
-        if all(t.done() for t in service._turn_tasks):
-            return
-        await asyncio.sleep(0.02)
-    raise AssertionError("timed out waiting for turn tasks to finish")
+    tasks = list(service._turn_tasks)
+    if not tasks:
+        return
+    await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=timeout)
+
+
+async def _wait_for_stream_stop(
+    client: RecordingSlackClient,
+    service: SlackOmnigentService,
+    timeout: float = _WAIT_TIMEOUT_S,
+) -> None:
+    """Wait for the turn to finish, then assert it delivered a stream.
+
+    The stream is stopped from inside the turn task, so awaiting the task
+    (event-driven) is a stronger, non-polling signal than watching for the
+    side effect."""
+    await _wait_for_turns(service, timeout)
+    assert client.streams and client.stream.stopped, "turn finished without stopping a stream"
 
 
 # ── Scenario 1: /omnigent against an auth-required server → login link ─────────
@@ -187,7 +203,7 @@ async def test_app_mention_runs_full_turn_and_streams_answer(tmp_path: Path) -> 
             client=client,
             context={"bot_user_id": "B1"},
         )
-        await _wait_for_stream_stop(client)
+        await _wait_for_stream_stop(client, service)
     finally:
         await service.shutdown()
         await pool.aclose_all()
@@ -282,7 +298,7 @@ async def test_runner_unavailable_triggers_launch_and_retry(tmp_path: Path) -> N
             client=client,
             context={"bot_user_id": "B1"},
         )
-        await _wait_for_stream_stop(client)
+        await _wait_for_stream_stop(client, service)
     finally:
         await service.shutdown()
         await pool.aclose_all()
@@ -416,7 +432,7 @@ async def test_mid_stream_drop_reconnects_without_double_render(tmp_path: Path) 
             client=client,
             context={"bot_user_id": "B1"},
         )
-        await _wait_for_stream_stop(client)
+        await _wait_for_stream_stop(client, service)
     finally:
         await service.shutdown()
         await pool.aclose_all()
@@ -469,7 +485,7 @@ async def test_no_delta_turn_recovers_committed_answer(tmp_path: Path) -> None:
             client=client,
             context={"bot_user_id": "B1"},
         )
-        await _wait_for_stream_stop(client)
+        await _wait_for_stream_stop(client, service)
     finally:
         await service.shutdown()
         await pool.aclose_all()

--- a/integrations/slack/tests/test_integration.py
+++ b/integrations/slack/tests/test_integration.py
@@ -1,0 +1,506 @@
+"""Vertical integration tests: omnigent-slack ↔ Omnigent HTTP server.
+
+These drive the REAL ``OmnigentClient`` (real ``httpx``) against a fake Omnigent
+server (:class:`FakeOmnigentServer`, a ``respx`` router that owns the API
+contract), and assert BOTH sides of the seam:
+
+  1. the bot issued spec-correct HTTP requests (method, path, bearer, body); and
+  2. driven by each server response/status, the bot called the right Slack
+     method with the right content (a login modal, a streamed answer, a re-login
+     DM).
+
+Slack and Bolt are mocked: tests call ``service.handle_*`` / ``setup._handle_*``
+directly (as the unit tests do) with a :class:`RecordingSlackClient`. This keeps
+the focus on the omnigent-slack ↔ server logic rather than Slack transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import respx
+from cryptography.fernet import Fernet
+from fakes import FakeOmnigentServer, RecordingSlackClient, sse_delta, sse_status
+from omnigent_slack.auth_manager import AuthManager
+from omnigent_slack.models import UserConfig
+from omnigent_slack.omnigent import OmnigentClientPool
+from omnigent_slack.service import SlackOmnigentService
+from omnigent_slack.setup import SetupFlow
+from omnigent_slack.store import SQLiteStore
+from omnigent_slack.tokens import EncryptedTokenStore
+
+_SERVER = "http://omnigent.test"
+
+
+async def _store(tmp_path: Path) -> SQLiteStore:
+    store = SQLiteStore(tmp_path / "store.sqlite3")
+    await store.initialize()
+    return store
+
+
+async def _token_store(tmp_path: Path) -> EncryptedTokenStore:
+    token_store = EncryptedTokenStore(tmp_path / "tok.sqlite3", Fernet.generate_key().decode())
+    await token_store.initialize()
+    return token_store
+
+
+async def _configure_user(
+    store: SQLiteStore, team_id: str, user_id: str, *, agent_id: str = "ag_1"
+) -> None:
+    await store.upsert_user_config(
+        team_id,
+        user_id,
+        UserConfig(
+            agent_id=agent_id,
+            agent_name="debby",
+            workspace="/home/bot/work",
+            host_id="h1",
+        ),
+    )
+
+
+async def _wait_for_stream_stop(client: RecordingSlackClient, tries: int = 100) -> None:
+    for _ in range(tries):
+        if client.streams and client.stream.stopped:
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("timed out waiting for a stream to stop")
+
+
+async def _wait_for_turns(service: SlackOmnigentService, tries: int = 100) -> None:
+    """Wait until the service's spawned turn tasks have finished.
+
+    A turn runs as a background task; ``shutdown`` would CANCEL it, so tests that
+    assert on a turn's outcome must let it complete first.
+    """
+    for _ in range(tries):
+        if all(t.done() for t in service._turn_tasks):
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("timed out waiting for turn tasks to finish")
+
+
+# ── Scenario 1: /omnigent against an auth-required server → login link ─────────
+
+
+@respx.mock
+async def test_omnigent_command_auth_wall_shows_login_link(tmp_path: Path) -> None:
+    """``/omnigent`` on an auth-enabled server: the bot probes the server, hits the
+    auth wall on the agent listing, starts the device grant, and shows the
+    verification link in the setup modal — no DM."""
+    server = FakeOmnigentServer(_SERVER)
+    server.auth_required = True
+    server.install(respx.mock)
+
+    store = await _store(tmp_path)
+    token_store = await _token_store(tmp_path)
+    pool = OmnigentClientPool()
+    auth = AuthManager(token_store)
+    pool.set_auth_resolver(auth.resolve_auth)
+    setup = SetupFlow(store=store, pool=pool, server_url=_SERVER, auth_manager=auth)
+    client = RecordingSlackClient()
+
+    try:
+        await setup._handle_config_command(
+            ack=_noop_ack,
+            command={"team_id": "T1", "user_id": "U1", "trigger_id": "tg1", "text": ""},
+            client=client,
+        )
+    finally:
+        await auth.shutdown()
+        await pool.aclose_all()
+
+    # Server side: the bot probed /health and the auth-gated /v1/agents, then
+    # started the device grant when that 401'd.
+    assert "/health" in server.paths("GET")
+    server.assert_request("GET", "/v1/agents")
+    server.assert_request("POST", "/oauth/device/authorize")
+
+    # Slack side: a modal opened, then updated to the login-waiting screen
+    # carrying the verification code — and no DM was sent.
+    assert client.opened_views, "expected the connecting modal to open"
+    assert server.user_code in client.last_view_text()
+    assert client.posts == []
+
+
+# ── Scenario 2: /omnigent happy path → agent/host picker ───────────────────────
+
+
+@respx.mock
+async def test_omnigent_command_happy_path_shows_picker(tmp_path: Path) -> None:
+    """``/omnigent`` with a valid token: validate() succeeds and the modal advances
+    to the agent/host/workspace picker built from the server's data."""
+    server = FakeOmnigentServer(_SERVER)
+    server.agents = [{"id": "ag_1", "name": "debby"}]
+    server.hosts = [{"host_id": "h1", "name": "Host One", "status": "online"}]
+    server.install(respx.mock)
+
+    store = await _store(tmp_path)
+    token_store = await _token_store(tmp_path)
+    await token_store.put("T1", "U1", _SERVER, access_token="tok-abc", refresh_token="ref-abc")
+    pool = OmnigentClientPool()
+    auth = AuthManager(token_store)
+    pool.set_auth_resolver(auth.resolve_auth)
+    setup = SetupFlow(store=store, pool=pool, server_url=_SERVER, auth_manager=auth)
+    client = RecordingSlackClient()
+
+    try:
+        await setup._begin_setup(client, team_id="T1", user_id="U1", view_id="V1")
+    finally:
+        await auth.shutdown()
+        await pool.aclose_all()
+
+    # Server side: the listing endpoints were hit AND carried the delegated bearer.
+    server.assert_bearer("GET", "/v1/agents", "tok-abc")
+    server.assert_bearer("GET", "/v1/hosts", "tok-abc")
+
+    # Slack side: the modal advanced to the select screen (not a login/failure one).
+    assert client.updated_views, "expected the modal to advance"
+    view = client.updated_views[-1]["view"]
+    assert view.get("callback_id") == "omnigent_setup_select"
+    # No login link and no DM — the token was accepted.
+    assert server.user_code not in client.last_view_text()
+    assert client.posts == []
+
+
+# ── Scenario 3: app_mention → full turn (create/launch/submit/stream) ──────────
+
+
+@respx.mock
+async def test_app_mention_runs_full_turn_and_streams_answer(tmp_path: Path) -> None:
+    """An @-mention on a new thread drives the whole turn HTTP contract in order
+    and streams the answer back into Slack."""
+    server = FakeOmnigentServer(_SERVER)
+    server.install(respx.mock)
+
+    store = await _store(tmp_path)
+    await _configure_user(store, "T1", "U1")
+    pool = OmnigentClientPool()
+    service = SlackOmnigentService(store=store, pool=pool, setup=_NoopSetup(), server_url=_SERVER)
+    client = RecordingSlackClient()
+
+    try:
+        await service.handle_app_mention(
+            body={"team_id": "T1", "event_id": "Ev1"},
+            event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> review this"},
+            client=client,
+            context={"bot_user_id": "B1"},
+        )
+        await _wait_for_stream_stop(client)
+    finally:
+        await service.shutdown()
+        await pool.aclose_all()
+
+    # Server side: the ordered turn contract.
+    server.assert_request("POST", "/v1/sessions", json_contains={"agent_id": "ag_1"})
+    launch = server.assert_request("POST", "/v1/hosts/h1/runners")
+    assert launch[3] == {"session_id": "conv_1", "workspace": "/home/bot/work"}
+    assert f"/v1/runners/{server.runner_id}/status" in server.paths("GET")
+    server.assert_request("POST", f"/v1/sessions/{server.session_id}/events")
+    assert f"/v1/sessions/{server.session_id}/stream" in server.paths("GET")
+
+    # Slack side: the SSE answer streamed into the reply.
+    assert "Here is the answer." in client.streamed_text
+
+
+# ── Scenario 4: auth wall mid-turn → re-login DM ───────────────────────────────
+
+
+@respx.mock
+async def test_auth_wall_mid_turn_prompts_relogin(tmp_path: Path) -> None:
+    """When the session already exists and the server returns an auth wall on the
+    stream, the bot reacts by prompting the user to re-login rather than posting a
+    generic failure."""
+    server = FakeOmnigentServer(_SERVER)
+    server.auth_required = True  # /health ok, but the stream 401s
+    server.install(respx.mock)
+
+    store = await _store(tmp_path)
+    await _configure_user(store, "T1", "U1")
+    # Pre-map the thread to an existing session so the turn skips create/launch
+    # and goes straight to streaming — where the auth wall is hit.
+    from omnigent_slack.models import ThreadKey
+
+    key = ThreadKey(team_id="T1", channel_id="C1", thread_ts="100.1")
+    await store.upsert_session(
+        key, "conv_1", "Slack: t", owner_user_id="U1", host_id="h1", workspace="/home/bot/work"
+    )
+    pool = OmnigentClientPool()
+    setup = _RecordingSetup()
+    service = SlackOmnigentService(store=store, pool=pool, setup=setup, server_url=_SERVER)
+    client = RecordingSlackClient()
+
+    try:
+        await service.handle_app_mention(
+            body={"team_id": "T1", "event_id": "Ev1"},
+            event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> continue"},
+            client=client,
+            context={"bot_user_id": "B1"},
+        )
+        await _wait_for_turns(service)
+    finally:
+        await service.shutdown()
+        await pool.aclose_all()
+
+    # Server side: the existing session was reused (no create/launch) and the
+    # stream was attempted against the auth-walled server.
+    assert f"/v1/sessions/{server.session_id}/stream" in server.paths("GET")
+    assert "/v1/sessions" not in server.paths("POST")
+    # Slack side: the bot prompted a re-login rather than a generic failure.
+    assert setup.relogin_prompted, "expected prompt_relogin to be called"
+
+
+# ── Scenario 5: runner unavailable → launch + retry, then stream ───────────────
+
+
+@respx.mock
+async def test_runner_unavailable_triggers_launch_and_retry(tmp_path: Path) -> None:
+    """A pre-existing session whose bound runner is gone: the first submit returns
+    503 runner_unavailable, so the client launches a fresh runner and retries the
+    turn — the answer still streams."""
+    server = FakeOmnigentServer(_SERVER)
+    server.first_submit_runner_unavailable = True
+    server.install(respx.mock)
+
+    store = await _store(tmp_path)
+    await _configure_user(store, "T1", "U1")
+    from omnigent_slack.models import ThreadKey
+
+    key = ThreadKey(team_id="T1", channel_id="C1", thread_ts="100.1")
+    await store.upsert_session(
+        key, "conv_1", "t", owner_user_id="U1", host_id="h1", workspace="/home/bot/work"
+    )
+    pool = OmnigentClientPool()
+    service = SlackOmnigentService(store=store, pool=pool, setup=_NoopSetup(), server_url=_SERVER)
+    client = RecordingSlackClient()
+
+    try:
+        await service.handle_app_mention(
+            body={"team_id": "T1", "event_id": "Ev1"},
+            event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> retry"},
+            client=client,
+            context={"bot_user_id": "B1"},
+        )
+        await _wait_for_stream_stop(client)
+    finally:
+        await service.shutdown()
+        await pool.aclose_all()
+
+    # Server side: the 503 on the first submit drove a runner launch, then a retry.
+    assert server.paths("POST").count(f"/v1/sessions/{server.session_id}/events") == 2
+    assert "/v1/hosts/h1/runners" in server.paths("POST")
+    # Slack side: the answer streamed despite the mid-turn runner miss.
+    assert "Here is the answer." in client.streamed_text
+
+
+# ── Scenario 6: host unavailable on launch → host guidance, no orphan ──────────
+
+
+@respx.mock
+async def test_host_unavailable_on_launch_shows_guidance(tmp_path: Path) -> None:
+    """A new session is created, but launching its runner 409s (host offline): the
+    bot surfaces the host-unavailable guidance rather than a generic failure."""
+    server = FakeOmnigentServer(_SERVER)
+    server.launch_status = 409
+    server.install(respx.mock)
+
+    store = await _store(tmp_path)
+    await _configure_user(store, "T1", "U1")
+    pool = OmnigentClientPool()
+    service = SlackOmnigentService(store=store, pool=pool, setup=_NoopSetup(), server_url=_SERVER)
+    client = RecordingSlackClient()
+
+    try:
+        await service.handle_app_mention(
+            body={"team_id": "T1", "event_id": "Ev1"},
+            event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> go"},
+            client=client,
+            context={"bot_user_id": "B1"},
+        )
+        await _wait_for_turns(service)
+    finally:
+        await service.shutdown()
+        await pool.aclose_all()
+
+    # Server side: create happened, launch was attempted (and 409'd), no stream.
+    server.assert_request("POST", "/v1/sessions")
+    server.assert_request("POST", "/v1/hosts/h1/runners")
+    assert not any("/stream" in p for p in server.paths("GET"))
+    # Slack side: the host-unavailable guidance surfaced (mentions bringing a host
+    # online), not a stream.
+    posted = " ".join(p.get("text", "") for p in client.posts) + (
+        client.stream.stop_text or "" if client.streams else ""
+    )
+    assert "host" in posted.lower()
+
+
+# ── Scenario 7: harness not configured (412) → curated message surfaces ────────
+
+
+@respx.mock
+async def test_harness_not_configured_surfaces_curated_message(tmp_path: Path) -> None:
+    """A 412 harness_not_configured carries curated, actionable guidance the bot is
+    allowed to surface verbatim (unlike a raw server body)."""
+    server = FakeOmnigentServer(_SERVER)
+    server.harness_not_configured_message = "Run `omnigent setup` on host h1 to install claude."
+    server.install(respx.mock)
+
+    store = await _store(tmp_path)
+    await _configure_user(store, "T1", "U1")
+    from omnigent_slack.models import ThreadKey
+
+    key = ThreadKey(team_id="T1", channel_id="C1", thread_ts="100.1")
+    await store.upsert_session(
+        key, "conv_1", "t", owner_user_id="U1", host_id="h1", workspace="/home/bot/work"
+    )
+    pool = OmnigentClientPool()
+    service = SlackOmnigentService(store=store, pool=pool, setup=_NoopSetup(), server_url=_SERVER)
+    client = RecordingSlackClient()
+
+    try:
+        await service.handle_app_mention(
+            body={"team_id": "T1", "event_id": "Ev1"},
+            event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> go"},
+            client=client,
+            context={"bot_user_id": "B1"},
+        )
+        await _wait_for_turns(service)
+    finally:
+        await service.shutdown()
+        await pool.aclose_all()
+
+    # Slack side: the curated 412 message surfaced (not the generic failure).
+    surfaced = " ".join(p.get("text", "") for p in client.posts)
+    if client.streams:
+        surfaced += client.stream.stop_text or ""
+    assert "omnigent setup" in surfaced.lower()
+
+
+# ── Scenario 8: mid-stream drop → reconnect + delta de-dup ─────────────────────
+
+
+@respx.mock
+async def test_mid_stream_drop_reconnects_without_double_render(tmp_path: Path) -> None:
+    """The proxy severs the stream mid-answer; the client reconnects WITHOUT
+    re-submitting and de-dups the server's cumulative replay so text isn't doubled."""
+    server = FakeOmnigentServer(_SERVER)
+    server.stream_legs = [
+        # First leg: a running edge + partial answer, then a mid-tail drop.
+        (sse_status("running", "r1") + sse_delta("Running tests", "m1") + "<DROP>"),
+        # Reconnect leg: server replays the cumulative text, then finishes.
+        (
+            sse_delta("Running tests", "m1")
+            + sse_delta(" all pass.", "m1")
+            + sse_status("idle", "r1")
+        ),
+    ]
+    server.install(respx.mock)
+
+    store = await _store(tmp_path)
+    await _configure_user(store, "T1", "U1")
+    from omnigent_slack.models import ThreadKey
+
+    key = ThreadKey(team_id="T1", channel_id="C1", thread_ts="100.1")
+    await store.upsert_session(
+        key, "conv_1", "t", owner_user_id="U1", host_id="h1", workspace="/home/bot/work"
+    )
+    pool = OmnigentClientPool()
+    service = SlackOmnigentService(store=store, pool=pool, setup=_NoopSetup(), server_url=_SERVER)
+    client = RecordingSlackClient()
+
+    try:
+        await service.handle_app_mention(
+            body={"team_id": "T1", "event_id": "Ev1"},
+            event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> run"},
+            client=client,
+            context={"bot_user_id": "B1"},
+        )
+        await _wait_for_stream_stop(client)
+    finally:
+        await service.shutdown()
+        await pool.aclose_all()
+
+    # Server side: two stream connections, message submitted exactly once.
+    assert server.paths("GET").count(f"/v1/sessions/{server.session_id}/stream") == 2
+    assert server.paths("POST").count(f"/v1/sessions/{server.session_id}/events") == 1
+    # Slack side: the replayed text is de-duped — "Running tests all pass.", not
+    # "Running testsRunning tests all pass.".
+    assert client.streamed_text == "Running tests all pass."
+
+
+# ── Scenario 9: no delta → recover the committed answer from the items probe ──
+
+
+@respx.mock
+async def test_no_delta_turn_recovers_committed_answer(tmp_path: Path) -> None:
+    """A turn that streams no answer text (only status edges) must fall back to the
+    server's newest assistant message rather than posting the empty-turn notice."""
+    server = FakeOmnigentServer(_SERVER)
+    # A stream that produces a delta but no text, ending on idle — the reply has
+    # nothing, so the fallback fetches the committed item.
+    server.sse_body = sse_status("running", "r1") + sse_status("idle", "r1")
+    server.latest_items = [
+        {
+            "id": "item_new",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Recovered answer."}],
+        }
+    ]
+    server.install(respx.mock)
+
+    store = await _store(tmp_path)
+    await _configure_user(store, "T1", "U1")
+    from omnigent_slack.models import ThreadKey
+
+    key = ThreadKey(team_id="T1", channel_id="C1", thread_ts="100.1")
+    await store.upsert_session(
+        key, "conv_1", "t", owner_user_id="U1", host_id="h1", workspace="/home/bot/work"
+    )
+    pool = OmnigentClientPool()
+    service = SlackOmnigentService(store=store, pool=pool, setup=_NoopSetup(), server_url=_SERVER)
+    client = RecordingSlackClient()
+
+    try:
+        await service.handle_app_mention(
+            body={"team_id": "T1", "event_id": "Ev1"},
+            event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> go"},
+            client=client,
+            context={"bot_user_id": "B1"},
+        )
+        await _wait_for_stream_stop(client)
+    finally:
+        await service.shutdown()
+        await pool.aclose_all()
+
+    # Server side: the items endpoint was probed for the fallback.
+    assert f"/v1/sessions/{server.session_id}/items" in server.paths("GET")
+    # Slack side: the recovered committed answer was delivered.
+    assert "Recovered answer." in client.streamed_text
+
+
+# ── minimal setup/ack doubles for the service path ────────────────────────────
+
+
+async def _noop_ack(**kwargs: object) -> None:
+    return None
+
+
+class _NoopSetup:
+    """SetupFlow stand-in for turns where the user is already configured."""
+
+    async def prompt_unconfigured(self, *args: object, **kwargs: object) -> None:
+        raise AssertionError("configured user should not be prompted to set up")
+
+    async def prompt_relogin(self, *args: object, **kwargs: object) -> bool:
+        return True
+
+
+class _RecordingSetup(_NoopSetup):
+    def __init__(self) -> None:
+        self.relogin_prompted: list[dict[str, object]] = []
+
+    async def prompt_relogin(self, client: object, user_id: str, **kwargs: object) -> bool:
+        self.relogin_prompted.append({"user_id": user_id, **kwargs})
+        return True

--- a/integrations/slack/tests/test_omnigent.py
+++ b/integrations/slack/tests/test_omnigent.py
@@ -609,6 +609,40 @@ async def test_run_turn_ignores_idless_idle_flap_on_claude_native_cold_start() -
 
 
 @respx.mock
+async def test_run_turn_ends_promptly_on_bare_idless_failed_with_no_output() -> None:
+    # The cold-start guard requires PRODUCTION before an id-less TERMINAL ends the
+    # turn — but that gate applies to `idle` only. A bare id-less `failed` is never
+    # a PTY-activity flap (the watcher emits only `idle`; `failed` comes solely
+    # from the authoritative StopFailure hook / a setup-phase failure), so a turn
+    # that fails before producing anything must END on that `failed` immediately,
+    # NOT hang to the idle-grace backstop. The long trailing silence would trip
+    # the (here 5s) idle-grace timeout, so ending well inside it proves the
+    # `failed` edge — not the timeout — ended the turn.
+    async def _fail_before_output() -> AsyncIterator[bytes]:
+        yield b'data: {"type":"session.status","status":"running"}\n\n'
+        yield b'data: {"type":"session.status","status":"failed"}\n\n'  # id-less, no output
+        await asyncio.sleep(30)  # server keeps the stream open; must not be reached
+
+    respx.get("http://omnigent.test/v1/sessions/conv_1/stream").mock(
+        return_value=httpx.Response(200, stream=_fail_before_output())
+    )
+    respx.post("http://omnigent.test/v1/sessions/conv_1/events").mock(
+        return_value=httpx.Response(200, json={})
+    )
+    client = OmnigentClient("http://omnigent.test")
+
+    async def _drain() -> list[dict[str, object]]:
+        return [event async for event in client.run_turn("conv_1", "go", idle_grace_seconds=5.0)]
+
+    try:
+        # Ends on the `failed` edge, well within both the 5s idle-grace and this
+        # 3s cap — a hang-to-timeout would blow the 3s wait.
+        await asyncio.wait_for(_drain(), timeout=3.0)
+    finally:
+        await client.aclose()
+
+
+@respx.mock
 async def test_run_turn_ignores_stale_idle_when_resuming_idle_session() -> None:
     # Incident: resuming a session that's been idle for hours. The stream
     # (idle=false) replays the session's CURRENT status first — a stale id-less

--- a/integrations/slack/tests/test_omnigent.py
+++ b/integrations/slack/tests/test_omnigent.py
@@ -560,6 +560,55 @@ async def test_run_turn_ends_on_idless_idle_for_in_process_harness() -> None:
 
 
 @respx.mock
+async def test_run_turn_ignores_idless_idle_flap_on_claude_native_cold_start() -> None:
+    # Incident: a claude-native turn on a freshly-launched runner posted
+    # "Omnigent completed without returning response text" ~5s after submit, even
+    # though the agent later produced a full answer. During cold start (runner
+    # booted, message submitted, but the LLM hasn't returned its first token) the
+    # PTY-activity watcher emits an id-less `running` then an id-less `idle` flap.
+    # That pair looks like the in-process harness's real id-less end, so the turn
+    # ended with 0 events. It must instead be IGNORED (the turn has produced
+    # nothing) and the turn must end only on the later id-bearing Stop idle, once
+    # the answer has streamed.
+    async def _cold_start_stream() -> AsyncIterator[bytes]:
+        # PTY-activity cold-start flap: id-less running, then id-less idle, both
+        # BEFORE any answer token. No response_id, no delta, no response.* event.
+        yield b'data: {"type":"session.status","status":"running"}\n\n'
+        yield b'data: {"type":"session.status","status":"idle"}\n\n'  # cold-start flap
+        await asyncio.sleep(0.1)
+        # The LLM finally responds; claude-native forwards the answer + the
+        # id-bearing Stop idle (its authoritative turn-end edge).
+        yield b'data: {"type":"session.status","status":"running","response_id":"resp_1"}\n\n'
+        yield b'data: {"type":"response.output_text.delta","delta":"The real answer."}\n\n'
+        yield b'data: {"type":"session.status","status":"idle","response_id":"resp_1"}\n\n'
+        await asyncio.sleep(30)  # server keeps the stream open after idle
+
+    respx.get("http://omnigent.test/v1/sessions/conv_1/stream").mock(
+        return_value=httpx.Response(200, stream=_cold_start_stream())
+    )
+    respx.post("http://omnigent.test/v1/sessions/conv_1/events").mock(
+        return_value=httpx.Response(200, json={})
+    )
+    client = OmnigentClient("http://omnigent.test")
+
+    async def _drain() -> list[str | None]:
+        return [
+            event.get("delta")
+            async for event in client.run_turn("conv_1", "review", idle_grace_seconds=5.0)
+            if event.get("type") == "response.output_text.delta"
+        ]
+
+    try:
+        deltas = await asyncio.wait_for(_drain(), timeout=5.0)
+    finally:
+        await client.aclose()
+
+    # The cold-start flap was ignored; the real answer streamed and the id-bearing
+    # idle ended the turn — not 0 chars.
+    assert deltas == ["The real answer."]
+
+
+@respx.mock
 async def test_run_turn_ignores_stale_idle_when_resuming_idle_session() -> None:
     # Incident: resuming a session that's been idle for hours. The stream
     # (idle=false) replays the session's CURRENT status first — a stale id-less

--- a/integrations/slack/tests/test_service.py
+++ b/integrations/slack/tests/test_service.py
@@ -722,6 +722,63 @@ async def test_no_delta_idle_answer_keeps_ack_until_visible(tmp_path: Path) -> N
     assert slack.acks[0]["ts"] in slack.deleted_ts
 
 
+class MultiMessageClient(FakeOmnigentClient):
+    """Streams two assistant messages back to back, each tagged with its own
+    ``message_id`` — the claude-native shape when the agent narrates between tool
+    calls. The deltas arrive with no boundary between the two messages.
+    """
+
+    async def run_turn(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        workspace: str | None = None,
+        host_id: str | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        self.turns.append((session_id, text))
+        yield {"type": "session.status", "status": "running", "response_id": "resp_1"}
+        yield {
+            "type": "response.output_text.delta",
+            "delta": "Let me poll once more.",
+            "message_id": "msg_a",
+        }
+        # A tool call runs between the two messages; the next delta belongs to a
+        # NEW assistant message (distinct message_id).
+        yield {
+            "type": "response.output_text.delta",
+            "delta": "The credentials agent is taking longer.",
+            "message_id": "msg_b",
+        }
+        yield {"type": "session.status", "status": "idle", "response_id": "resp_1"}
+
+
+async def test_back_to_back_messages_get_paragraph_break(tmp_path: Path) -> None:
+    # Regression: consecutive assistant messages (distinct message_id) must not
+    # run together ("…once more.The credentials…"). A paragraph break is inserted
+    # at the id boundary so each message reads as its own block, mirroring the web
+    # UI's separate bubbles.
+    store = await _store(tmp_path)
+    slack = FakeSlackClient()
+    omnigent = MultiMessageClient(final_text="")
+    service, _pool, _setup = _service(store, omnigent)
+    await _configure_user(store, "T1", "U1")
+
+    await service.handle_app_mention(
+        body={"team_id": "T1", "event_id": "Ev1"},
+        event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> status?"},
+        client=slack,
+        context={"bot_user_id": "B1"},
+    )
+    await _wait_for_stream_stop(slack)
+    await service.shutdown()
+
+    # The two messages are separated by a blank line, not concatenated.
+    assert (
+        slack.streamed_text == "Let me poll once more.\n\nThe credentials agent is taking longer."
+    )
+
+
 async def test_long_answer_streams_in_full(tmp_path: Path) -> None:
     # A long answer is streamed and finalized without any splitting/msg_too_long
     # handling — Slack owns chunking for streams.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Fixed an issue in Slack integration where streaming cold-start could result in "completed without returning response text"
- Improved Slack message formatting so that back-to-back messages are properly spaced by newline
- Integration tests with Omnigent server fakes with API spec drift guard
    - Test Omnigent server API used in Slack integrations are consistent with the API spec
    - Test all Omnigent server API used in Slack integrations are captured in the test catalog
- Enable Slack tests in CI

## Test Plan

- Manual testing
- Enable CI in this PR

## Demo

### Before this PR
<img width="589" height="304" alt="image" src="https://github.com/user-attachments/assets/1c611884-1e51-47a2-9c07-1f300f0cd15c" />

### With this PR
<img width="606" height="376" alt="image" src="https://github.com/user-attachments/assets/45e1fd87-0c6f-4e00-abc8-6d535fcc767b" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

<Add a line to describe the change, else delete this section>
