### PR TITLE
refactor(cli): replace `omni server start` with `omni server --background`

### DIFF
--- a/.claude/skills/antigravity-native-e2e-dev/SKILL.md
+++ b/.claude/skills/antigravity-native-e2e-dev/SKILL.md
@@ -86,7 +86,7 @@ Three transports, easy to confuse:
 
 ```bash
 cd /path/to/omnigent
-.venv/bin/omni server start          # detached managed server on a free loopback port
+.venv/bin/omni server --background          # detached managed server on a free loopback port
 .venv/bin/omni server status         # prints the URL, e.g. http://127.0.0.1:6767
 SERVER=http://127.0.0.1:6767         # use the printed URL below
 curl -s "$SERVER/health"             # {"status":"ok"}

--- a/.claude/skills/antigravity-sdk-e2e-dev/SKILL.md
+++ b/.claude/skills/antigravity-sdk-e2e-dev/SKILL.md
@@ -47,7 +47,7 @@ tests.
 
 ```bash
 cd /path/to/omnigent
-.venv/bin/omni server start          # spawns a detached server on a free loopback port
+.venv/bin/omni server --background          # spawns a detached server on a free loopback port
 .venv/bin/omni server status         # prints the URL, e.g. http://127.0.0.1:6767
 ```
 
@@ -134,7 +134,7 @@ streaming, harness.
 7. **Turns take ~10–60s** — always wrap in `timeout 280`.
 8. **Local-runner topology:** `omni run <bundle> --server <url>` runs the
    harness from your **current checkout**; the server only holds state. The
-   managed `omni server start` server runs from whatever venv launched it.
+   managed `omni server --background` server runs from whatever venv launched it.
 9. **Never print/echo the Gemini key** in logs or commands.
 
 ## Code & tests

--- a/.claude/skills/copilot-sdk-e2e-dev/SKILL.md
+++ b/.claude/skills/copilot-sdk-e2e-dev/SKILL.md
@@ -44,7 +44,7 @@ the unit tests.
 
 ```bash
 cd /path/to/omnigent
-.venv/bin/omni server --port 7788 --no-open    # foreground; or `omni server start` for detached
+.venv/bin/omni server --port 7788 --no-open    # foreground; or `omni server --background` for detached
 curl -s http://127.0.0.1:7788/health           # {"status":"ok"}
 ```
 

--- a/.claude/skills/cursor-sdk-e2e-dev/SKILL.md
+++ b/.claude/skills/cursor-sdk-e2e-dev/SKILL.md
@@ -35,7 +35,7 @@ Cursor as SDK `custom_tools`. This skill is the proven recipe for running it
 
 ```bash
 cd /path/to/omnigent
-.venv/bin/omni server start          # spawns a detached server on a free loopback port
+.venv/bin/omni server --background          # spawns a detached server on a free loopback port
 .venv/bin/omni server status         # prints the URL, e.g. http://127.0.0.1:6767
 ```
 
@@ -116,7 +116,7 @@ that works, the full stack is good: key, egress, bridge, harness.
 5. **Turns take 30–90s** — always wrap in `timeout 280`.
 6. **Local-runner topology:** `omni run <bundle> --server <url>` runs the
    harness from your **current checkout**; the server only holds state. The
-   managed `omni server start` server runs from whatever venv launched it.
+   managed `omni server --background` server runs from whatever venv launched it.
 7. **Never print/echo the Cursor key** in logs or commands.
 
 ## Code & tests

--- a/.claude/skills/pi-native-e2e-dev/SKILL.md
+++ b/.claude/skills/pi-native-e2e-dev/SKILL.md
@@ -76,7 +76,7 @@ Two ways a turn reaches Pi — test both:
 
 ```bash
 cd /path/to/omnigent
-.venv/bin/omni server start          # detached managed server on a free loopback port
+.venv/bin/omni server --background          # detached managed server on a free loopback port
 .venv/bin/omni server status         # prints the URL, e.g. http://127.0.0.1:6767
 SERVER=http://127.0.0.1:6767         # use the printed URL below
 curl -s "$SERVER/health"             # {"status":"ok"}

--- a/.claude/skills/polly-e2e-dev/SKILL.md
+++ b/.claude/skills/polly-e2e-dev/SKILL.md
@@ -118,7 +118,7 @@ right vendor, cross-reviews). That is the live recipe.
 ### Run a live turn
 
 ```bash
-.venv/bin/omni server start && .venv/bin/omni server status   # prints $SERVER, e.g. http://127.0.0.1:6767
+.venv/bin/omni server --background && .venv/bin/omni server status   # prints $SERVER, e.g. http://127.0.0.1:6767
 SERVER=http://127.0.0.1:6767
 timeout 280 .venv/bin/omni run examples/polly \
   -p "Investigate how the runner enforces tool-call policies and report file:line evidence." \

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ see step 3.)
 **Prefer the browser?** Start a server and register your machine as a host:
 
 ```bash
-omnigent server start   # start the local server and web UI in the background
+omnigent server --background   # start the local server and web UI in the background
 omnigent host           # (separate terminal) register this machine as a host
 ```
 
@@ -374,7 +374,7 @@ Omnigent supports **multi-user accounts**, controlled by one environment
 variable:
 
 ```bash
-OMNIGENT_AUTH_ENABLED=1 omnigent server start
+OMNIGENT_AUTH_ENABLED=1 omnigent server --background
 ```
 
 The **Docker deploy in [step 4](#4-deploy-a-server-and-use-it-from-your-phone)

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3216,6 +3216,19 @@ def _assert_server_port_bindable(host: str, port: int) -> None:
         "ignored with a warning if an admin already exists."
     ),
 )
+@click.option(
+    "--background",
+    "background",
+    is_flag=True,
+    default=False,
+    help=(
+        "Spawn the server as a detached background process (the managed "
+        "local server recorded in ~/.omnigent/local_server.pid) instead of "
+        "running it in the foreground. Reuses a healthy background server if "
+        "one is already up; otherwise spawns a detached one on a free "
+        "loopback port and prints its URL."
+    ),
+)
 @click.pass_context
 def server(
     ctx: click.Context,
@@ -3229,13 +3242,16 @@ def server(
     agent_dirs: tuple[str, ...],
     auto_open: bool,
     admin_password: str | None,
+    background: bool,
 ) -> None:
-    """Start the Omnigent server in the foreground, or manage the background server.
+    """Start the Omnigent server, or manage the background server.
 
     Bare ``omnigent server`` runs the server in the FOREGROUND (Ctrl-C to
-    stop) — for deploys / Docker. Subcommands manage the detached background
-    server that ``run`` / ``claude`` / ``codex`` use: ``start`` (ensure it's
-    up), ``stop`` (stop it and the local host daemon), ``status`` (is it up?).
+    stop) — for deploys / Docker. Pass ``--background`` to spawn it as a
+    detached background process instead (the managed local server that
+    ``run`` / ``claude`` / ``codex`` reuse). Subcommands manage that
+    background server: ``stop`` (stop it and the local host daemon),
+    ``status`` (is it up?).
 
     :param host: Interface to bind, e.g. ``"127.0.0.1"``.
     :param ctx: Click invocation context used to tell whether
@@ -3259,12 +3275,36 @@ def server(
         from ``--admin-password``, e.g. ``"hunter2"``. Folded into the
         ``OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD`` env var that
         bootstrap reads; ``None`` leaves the env var untouched.
+    :param background: When True, spawn the server as a detached background
+        process (the managed local server) instead of running it in the
+        foreground.
     :returns: None.
     """
     if ctx.invoked_subcommand is not None:
-        # A subcommand (start/stop/status) handles this invocation; the body
-        # below is the foreground-server path for the bare ``server`` group.
+        # A subcommand (stop/status) handles this invocation; the body
+        # below is the server path for the bare ``server`` group.
         return
+
+    if background:
+        # `omnigent server --background` replaces the removed `server start`
+        # subcommand: ensure (or reuse) the managed detached local server and
+        # return immediately instead of running uvicorn in-process.
+        startup = ensure_local_omnigent_server()
+        verb = (
+            "Started background server at"
+            if startup.spawned
+            else "Background server already running at"
+        )
+        click.echo(f"{verb} {startup.url}")
+        # Surface the exact log file so a detached server isn't a black box —
+        # `server --background` is otherwise the only signal it ever emits.
+        # Known for a spawned server and (via the log-path sidecar) for a
+        # reused one too; absent only for a foreground `omnigent server` whose
+        # logs stream to its own terminal.
+        if startup.log_path is not None:
+            click.echo(f"  log: {_display_path(startup.log_path)}")
+        return
+
     port_source = ctx.get_parameter_source("port")
     port_was_explicit = port_source is click.core.ParameterSource.COMMANDLINE
     if port_was_explicit:
@@ -3710,33 +3750,6 @@ def _stop_local_server_and_daemon(*, force: bool) -> bool:
     # running" while one was still listening on the default port).
     orphan_pid = stop_untracked_local_server()
     return was_running or orphan_pid is not None
-
-
-@server.command("start")
-def server_start() -> None:
-    """Ensure the managed background Omnigent server is running.
-
-    Reuses a healthy background server if one is already up (started here or
-    by a prior ``run`` / ``host``); otherwise spawns a detached one on a
-    free loopback port and prints its URL. The background counterpart to the
-    foreground bare ``omnigent server``.
-
-    :returns: None.
-    """
-    startup = ensure_local_omnigent_server()
-    verb = (
-        "Started background server at"
-        if startup.spawned
-        else "Background server already running at"
-    )
-    click.echo(f"{verb} {startup.url}")
-    # Surface the exact log file so a detached server isn't a black box —
-    # `server start` is otherwise the only signal it ever emits. Known for a
-    # spawned server and (via the log-path sidecar) for a reused one too;
-    # absent only for a foreground `omnigent server` whose logs stream to
-    # its own terminal.
-    if startup.log_path is not None:
-        click.echo(f"  log: {_display_path(startup.log_path)}")
 
 
 @server.command("stop")

--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -80,7 +80,7 @@ _LOCAL_SERVER_PID_PATH = _local_data_dir() / "local_server.pid"
 _LOCAL_SERVER_SIG_PATH = _local_data_dir() / "local_server.sig"
 
 # Sidecar carrying the absolute path of the background server's captured
-# stdout/stderr log file (one line). Lets `server start` / `server status`
+# stdout/stderr log file (one line). Lets `server --background` / `server status`
 # point at the exact ``logs/server/server-*.log`` even when reusing a
 # server this invocation didn't spawn. Absent for a foreground
 # ``omnigent server`` (its logs stream to the terminal, not a file).
@@ -427,7 +427,7 @@ class LocalServerStartup:
         started independently.
     :param log_path: Absolute path of the background server's captured log
         file, e.g. ``Path("/Users/alice/.omnigent/logs/server/server-ab12cd.log")``
-        — surfaced so callers (``server start``) can point the user at the
+        — surfaced so callers (``server --background``) can point the user at the
         exact log. For a spawned server this is the freshly created log; for
         a reused one it is read back from the log-path sidecar, and may be
         ``None`` when the running server is a foreground ``omnigent server``

--- a/tests/cli/test_server_lifecycle.py
+++ b/tests/cli/test_server_lifecycle.py
@@ -1,4 +1,5 @@
-"""Tests for the server-lifecycle CLI: ``server start/stop/status`` and top-level ``stop``."""
+"""Tests for the server-lifecycle CLI: ``server`` (``--background``,
+``stop``, ``status``) and top-level ``stop``."""
 
 from __future__ import annotations
 
@@ -150,11 +151,11 @@ def test_server_status_session_count_failure_is_graceful(monkeypatch: pytest.Mon
     assert "live sessions:" not in result.output  # count omitted on fetch failure
 
 
-# ── server start ───────────────────────────────────────────────────
+# ── server --background ────────────────────────────────────────────
 
 
-def test_server_start_spawns(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``server start`` reports the URL and exact log file of a spawned server."""
+def test_server_background_spawns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``server --background`` reports the URL and exact log file of a spawned server."""
     monkeypatch.setattr(
         "omnigent.cli.ensure_local_omnigent_server",
         lambda: LocalServerStartup(
@@ -164,7 +165,7 @@ def test_server_start_spawns(monkeypatch: pytest.MonkeyPatch) -> None:
         ),
     )
 
-    result = CliRunner().invoke(cli, ["server", "start"])
+    result = CliRunner().invoke(cli, ["server", "--background"])
 
     assert result.exit_code == 0, result.output
     assert "Started background server at http://127.0.0.1:8123" in result.output
@@ -173,8 +174,8 @@ def test_server_start_spawns(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "log: ~/.omnigent/logs/server/server-ab12.log" in result.output
 
 
-def test_server_start_reuses(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``server start`` reports reuse and the reused server's log file."""
+def test_server_background_reuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``server --background`` reports reuse and the reused server's log file."""
     monkeypatch.setattr(
         "omnigent.cli.ensure_local_omnigent_server",
         lambda: LocalServerStartup(
@@ -184,7 +185,7 @@ def test_server_start_reuses(monkeypatch: pytest.MonkeyPatch) -> None:
         ),
     )
 
-    result = CliRunner().invoke(cli, ["server", "start"])
+    result = CliRunner().invoke(cli, ["server", "--background"])
 
     assert result.exit_code == 0, result.output
     assert "already running at http://127.0.0.1:8123" in result.output
@@ -193,19 +194,19 @@ def test_server_start_reuses(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "log: ~/.omnigent/logs/server/server-cd34.log" in result.output
 
 
-def test_server_start_omits_log_when_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_server_background_omits_log_when_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
     """No log line when the running server has no captured-log file.
 
     A foreground ``omnigent server`` streams logs to its terminal, so a
-    reuse of it carries ``log_path=None`` and ``server start`` must not print
-    a bogus or empty ``log:`` line.
+    reuse of it carries ``log_path=None`` and ``server --background`` must not
+    print a bogus or empty ``log:`` line.
     """
     monkeypatch.setattr(
         "omnigent.cli.ensure_local_omnigent_server",
         lambda: LocalServerStartup(url="http://127.0.0.1:8123", spawned=False, log_path=None),
     )
 
-    result = CliRunner().invoke(cli, ["server", "start"])
+    result = CliRunner().invoke(cli, ["server", "--background"])
 
     assert result.exit_code == 0, result.output
     assert "log:" not in result.output

--- a/tests/host/test_local_server.py
+++ b/tests/host/test_local_server.py
@@ -602,7 +602,7 @@ def test_clear_local_server_record_leaves_other_pids_alone(
 
 
 # ---------------------------------------------------------------------------
-# Server log-path sidecar — so `server start`/`status` name the exact log
+# Server log-path sidecar — so `server --background`/`status` name the exact log
 # ---------------------------------------------------------------------------
 
 
@@ -612,7 +612,7 @@ def test_ensure_local_omnigent_server_spawn_records_and_returns_log_path(
 ) -> None:
     """A spawned server returns its captured-log path and records it for status.
 
-    ``omnigent server start`` used to be a black box — it printed only the
+    ``omnigent server --background`` used to be a black box — it printed only the
     URL. The spawn now threads the captured stdout/stderr log file out via
     ``LocalServerStartup.log_path`` AND into the log-path sidecar, so both
     the spawning call and a later ``server status`` can name the exact file.
@@ -674,7 +674,7 @@ def test_ensure_local_omnigent_server_reuse_reads_log_path_sidecar(
 
     The reuse path never sees the original spawn's ``log_path`` variable, so
     it must read the recorded path back from the sidecar — otherwise a
-    ``server start`` that reuses an existing background server could not name
+    ``server --background`` that reuses an existing background server could not name
     its log. Popen must not fire (the stub fails the test if it does).
     """
     monkeypatch.setattr(

--- a/web/electron/README.md
+++ b/web/electron/README.md
@@ -520,7 +520,7 @@ to a **remote** server never needs the CLI — only "Start locally" and hosting 
 
 ### Start locally
 
-**"Start a server on this machine"** runs `omnigent server start` (idempotent —
+**"Start a server on this machine"** runs `omnigent server --background` (idempotent —
 reuses a healthy one) and then connects this window to its
 `http://127.0.0.1:<port>` URL through the normal connect flow. It does not
 connect this machine as a runner — that stays an explicit step in the app.

--- a/web/electron/src/omnigent_cli.js
+++ b/web/electron/src/omnigent_cli.js
@@ -1,7 +1,7 @@
 // Discovery and invocation of the local `omnigent` CLI for the desktop shell.
 //
 // The desktop manages servers by shelling out to the same `omnigent` binary a
-// user would run by hand — `server start|stop|status` and `host status` (the
+// user would run by hand — `server --background/stop/status` and `host status` (the
 // long-lived `host` connection is spawned by server_manager.js, which owns its
 // lifetime). This module locates the binary, runs the short exit-quick
 // commands, and parses their `--json` output. The CLI is the single source of
@@ -49,7 +49,7 @@ function normalizeServerUrl(value) {
 
 /**
  * True when a server URL points at the local machine — loopback host. Only
- * loopback servers expose the local-server start/stop controls. Reuses the
+ * loopback servers expose the local-server background/stop controls. Reuses the
  * shared LOCAL_HOSTS set from url.js so the desktop never disagrees on what
  * "local" means.
  *
@@ -525,13 +525,13 @@ async function getServerStatus(cliPath) {
 
 /**
  * Start (or reuse) the local background server, then re-read status for a
- * reliable URL. `server start` is idempotent on the CLI side.
+ * reliable URL. `server --background` is idempotent on the CLI side.
  *
  * @param {string} cliPath
  * @returns {Promise<{ ok: boolean, url?: string, port?: number, pid?: number, error?: string }>}
  */
 async function startLocalServer(cliPath) {
-  const res = await runCli(cliPath, ["server", "start"], { timeoutMs: 30000 });
+  const res = await runCli(cliPath, ["server", "--background"], { timeoutMs: 30000 });
   const status = await getServerStatus(cliPath);
   if (status && status.running && typeof status.url === "string") {
     return { ok: true, url: status.url, port: status.port, pid: status.pid };


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Removes the `omni server start` subcommand. `omni server` already starts
  the server (in the foreground), so `start` was a redundant way to launch it;
  the only thing it added was the detached/background mode.
- Adds a `--background` flag to `omni server` that reproduces the former
  `start` behavior: spawn (or reuse) the managed detached local server instead
  of running uvicorn in the foreground. `omni server stop` / `omni server
  status` are unchanged.
- Updates the desktop app's CLI shell-out, docs, skill files, and tests to
  the new invocation.

## Test Plan

- `omni server start` now exits `2` with "No such command 'start'" (verified
  via `CliRunner`).
- `omni server --background` routes to `ensure_local_omnigent_server()` and
  short-circuits before the foreground port-bind check; prints the URL and
  captured log path on spawn, "already running" on reuse, and omits the log
  line when `log_path` is unknown (3 renamed tests pass).
- `omni server stop` / `omni server status` behave as before (verified via
  CliRunner with stubbed registry).
- `server --help` lists `--background` and only the `stop`/`status`
  subcommands; bare `omni server` still reaches the foreground port-bind
  check.
- `node --check web/electron/src/omnigent_cli.js` passes; the spawn primitive
  in `host/local_server.py` invokes the bare `omnigent.cli server` foreground
  command, so it is unaffected by the `start` removal.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [x] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Renamed the three `test_server_start_*` tests in `tests/cli/test_server_lifecycle.py`
to `test_server_background_*` (invoking `server --background`); updated
comments in `tests/host/test_local_server.py`. Manually verified routing,
help output, and the desktop CLI arg via ad-hoc CliRunner/node checks.

## Changelog

`omni server start` is removed; use `omni server --background` to launch the
detached managed server instead.

