### PR TITLE
fix(server): enable accounts mode for non-loopback binds

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1096,99 +1096,63 @@ def _ensure_sqlite_parent_dir(db_uri: str) -> None:
     Path(url.database).parent.mkdir(parents=True, exist_ok=True)
 
 
-def _maybe_prompt_first_admin(account_store: Any, auth_provider: Any, *, auto_open: bool) -> None:  # type: ignore[explicit-any]  # SqlAlchemyAccountStore | None, AuthProvider
-    """Interactively claim the first admin on a TTY when setup is pending.
+def _apply_bind_auth_defaults(host: str) -> None:
+    """Set auth env defaults from the server's bind interface.
 
-    The "terminal" entry point of first-run setup. It's the FALLBACK,
-    not the default: when the browser is about to auto-open the web
-    Create-admin form (the default ``--open`` on a loopback server), we
-    skip the prompt and let the browser own setup — otherwise the
-    terminal prompt would block before the lifespan ever opens the
-    browser, so the form would never appear.
+    The bind address is the discriminator for the *implicit* (env-unset)
+    auth posture. Explicit operator choices always win — an
+    ``OMNIGENT_AUTH_PROVIDER`` keeps header/oidc, and
+    ``OMNIGENT_AUTH_ENABLED`` (or its deprecated alias) pins auth on/off.
 
-    No-ops unless ALL of:
+    Decision matrix for the env-unset default:
 
-    - accounts mode is active (``account_store`` is not ``None``);
-    - no password-having account exists yet (a ``--admin-password`` /
-      ``INIT_ADMIN_PASSWORD`` would already have created one, and a
-      re-boot already has an admin);
-    - stdin AND stdout are a TTY — a headless / piped / agent run must
-      NOT block on a prompt (it falls through to the web form);
-    - the browser is NOT auto-opening a usable form, i.e. ``--no-open``
-      was passed OR the base URL isn't loopback (remote-over-SSH, where
-      opening a browser on the server box is useless but a terminal IS
-      available).
+    - **Loopback** (``127.0.0.1`` / ``localhost`` / ``::1``) + header
+      default → set ``OMNIGENT_LOCAL_SINGLE_USER=1``: the no-login
+      header-mode ``"local"`` fallback. The user's own machine, no proxy
+      to inject identity — same posture as the daemon / ``omnigent run``
+      spawn paths.
+    - **Non-loopback** (``0.0.0.0``, a network-exposed deploy) + no
+      explicit auth → set ``OMNIGENT_AUTH_ENABLED=1``: accounts (login)
+      mode. For an end user binding to a network interface there's no
+      realistic way to inject an identity header, so we opt them into
+      login. First-admin setup happens via the web Create-admin form
+      (the server boots and serves; no terminal prompt). Mirrors the
+      Docker/Cloudflare/k8s entrypoints.
 
-    On success, creates the admin and mints the loopback CLI token so a
-    subsequent ``omnigent run`` against this server is signed in.
+    Uses ``setdefault`` throughout so an operator's explicit value wins.
+    Must run before ``create_auth_provider()``, which reads these vars.
 
-    :param account_store: The accounts store, or ``None`` in
-        header/OIDC mode (then this is a no-op).
-    :param auth_provider: The active auth provider; its accounts config
-        supplies the cookie secret / base URL / session TTL.
-    :param auto_open: The resolved ``--open/--no-open`` flag. When True
-        and the base URL is loopback, the lifespan opens the browser to
-        the form, so we defer to it and skip the prompt.
+    :param host: The resolved bind host, e.g. ``"127.0.0.1"`` or
+        ``"0.0.0.0"``.
     :returns: None.
     """
-    if account_store is None:
-        return
-    if not (sys.stdin.isatty() and sys.stdout.isatty()):
-        return
-    if any(u.has_password for u in account_store.list_users()):
-        return
+    from omnigent.server.auth import resolve_auth_source as _resolve_auth_source
 
-    from omnigent.server.accounts_bootstrap import (
-        _is_loopback_base_url,
-        _mint_loopback_cli_token,
-        resolve_admin_username,
+    _is_loopback_bind = host in ("127.0.0.1", "localhost", "::1")
+    # Compose-style deploys pass OMNIGENT_AUTH_PROVIDER as an empty
+    # string when unset ("${VAR:-}"), so empty and missing both mean
+    # "not explicitly pinned".
+    _raw_auth_provider = os.environ.get("OMNIGENT_AUTH_PROVIDER")
+    _auth_provider_explicit = bool(_raw_auth_provider and _raw_auth_provider.strip())
+
+    # Loopback + header default → single-user marker (no login).
+    if _is_loopback_bind and not _auth_provider_explicit and _resolve_auth_source() == "header":
+        os.environ.setdefault("OMNIGENT_LOCAL_SINGLE_USER", "1")
+
+    # Non-loopback + no explicit auth → accounts (login) mode.
+    _raw_auth_enabled = os.environ.get("OMNIGENT_AUTH_ENABLED", "").strip()
+    _auth_enabled_explicit = bool(
+        _raw_auth_enabled or os.environ.get("OMNIGENT_ACCOUNTS_ENABLED", "").strip()
     )
-    from omnigent.server.auth import UnifiedAuthProvider
-    from omnigent.server.passwords import hash_password
-    from omnigent.server.routes.accounts_auth import _MIN_PASSWORD_LENGTH
-
-    # Read the accounts config off the concrete provider (same direct
-    # access app.py uses). isinstance-narrowed so mypy sees the attribute
-    # rather than reaching through getattr(..., "<literal>").
-    base_url: str | None = None
-    if isinstance(auth_provider, UnifiedAuthProvider):
-        cfg = auth_provider._accounts_config
-        base_url = cfg.base_url if cfg is not None else None
-    # Defer to the browser form when it's going to open (default --open
-    # on a loopback server). Only prompt when no browser form will appear.
-    if auto_open and base_url is not None and _is_loopback_base_url(base_url):
-        return
-
-    click.echo("\n  First-run setup — create the admin account for this server.")
-    username = click.prompt("  Username", default=resolve_admin_username()).strip().lower()
-    while True:
-        password = click.prompt("  Password", hide_input=True, confirmation_prompt=True)
-        if len(password) >= _MIN_PASSWORD_LENGTH:
-            break
-        click.echo(f"  Password must be at least {_MIN_PASSWORD_LENGTH} characters.", err=True)
-
-    try:
-        account_store.create_user_with_password(username, hash_password(password), is_admin=True)
-    except ValueError:
-        # Raced another claimer (e.g. someone hit the web form first).
-        click.echo("  An admin was just created elsewhere — skipping.", err=True)
-        return
-
-    # Mint the loopback CLI token so `omnigent run` is signed in.
-    # (Reuses cfg/base_url resolved above.)
-    if (
-        cfg is not None
-        and base_url is not None
-        and cfg.cookie_secret is not None
-        and _is_loopback_base_url(base_url)
-    ):
-        _mint_loopback_cli_token(
-            username,
-            base_url=base_url,
-            cookie_secret=cfg.cookie_secret,
-            session_ttl_hours=cfg.session_ttl_hours,
+    if not _is_loopback_bind and not _auth_provider_explicit and not _auth_enabled_explicit:
+        os.environ.setdefault("OMNIGENT_AUTH_ENABLED", "1")
+        click.echo(
+            f"  ⚠ Binding to non-local interface {host}: enabling accounts "
+            "(login) mode to prevent unauthorized access.\n"
+            "    Open the server URL in a browser to create the first admin "
+            "account.",
+            err=True,
         )
-    click.echo(f"  ✓ Admin '{username}' created. Sign in at the server URL.\n")
 
 
 def _create_artifact_store(location: str) -> Any:  # type: ignore[explicit-any]  # returns ArtifactStore protocol (optional deps)
@@ -3311,31 +3275,10 @@ def server(
         and not port_was_explicit
     )
 
-    # Single-user marker: ANY loopback-bound `omnigent server` running
-    # the env-unset header default IS a local single-user runtime — the
-    # user's own machine, no proxy to inject identity — so it keeps the
-    # no-login header-mode "local" fallback (same posture as the daemon
-    # / `omnigent run` spawn paths, which set this var themselves). The
-    # bind address is the discriminator, NOT the port/db-uri: a
-    # dedicated `omnigent server --port 9001 --database-uri …` on
-    # loopback (manual local runs, the e2e harness) is still single
-    # user, so it must not 401 its own headerless traffic. What stays
-    # fail-closed: a non-loopback bind (`--host 0.0.0.0`,
-    # a network-exposed deploy — those MUST front a proxy or use
-    # accounts/oidc) and an explicit OMNIGENT_AUTH_PROVIDER=header
-    # deploy behind an identity-injecting proxy. setdefault so an
-    # operator's explicit OMNIGENT_LOCAL_SINGLE_USER=0 wins. Must run
-    # before create_auth_provider() below, which reads the var.
-    from omnigent.server.auth import resolve_auth_source as _resolve_auth_source
-
-    _is_loopback_bind = host in ("127.0.0.1", "localhost", "::1")
-    # Compose-style deploys pass OMNIGENT_AUTH_PROVIDER as an empty
-    # string when unset ("${VAR:-}"), so empty and missing both mean
-    # "not explicitly pinned".
-    _raw_auth_provider = os.environ.get("OMNIGENT_AUTH_PROVIDER")
-    _auth_provider_explicit = bool(_raw_auth_provider and _raw_auth_provider.strip())
-    if _is_loopback_bind and not _auth_provider_explicit and _resolve_auth_source() == "header":
-        os.environ.setdefault("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    # Resolve auth defaults from the bind interface. MUST run before
+    # create_auth_provider() below, which reads the vars this sets.
+    # See _apply_bind_auth_defaults for the full decision matrix.
+    _apply_bind_auth_defaults(host)
 
     if _is_canonical_local_server:
         from omnigent.host.local_server import (
@@ -3577,14 +3520,6 @@ def server(
     click.echo(f"  database:  {db_uri}")
     click.echo(f"  artifacts: {art_loc}")
     click.echo(f"  log:       {_display_path(server_log_path)}")
-
-    # First-run terminal setup: the FALLBACK entry point. Fires only on
-    # an interactive TTY when no admin exists AND the browser isn't about
-    # to open the web Create-admin form (i.e. --no-open, or a non-loopback
-    # base URL). The default `omnigent server` on loopback opens the
-    # browser to the form instead, so this no-ops there. (The other entry
-    # points are --admin-password and the web form.)
-    _maybe_prompt_first_admin(account_store, auth_provider, auto_open=auto_open)
 
     # Warn loudly when the SPA bundle is absent: the server still boots
     # but serves an API-only JSON landing at "/", so the operator hits

--- a/tests/cli/test_bind_auth_defaults.py
+++ b/tests/cli/test_bind_auth_defaults.py
@@ -1,0 +1,191 @@
+"""Unit tests for ``_apply_bind_auth_defaults`` — the bind-interface → auth-mode decision.
+
+Covers the four corners of the matrix:
+
+- loopback + env-unset → single-user marker (no login);
+- non-loopback + env-unset → accounts mode (login required) + warning;
+- explicit ``OMNIGENT_AUTH_PROVIDER`` → no implicit change;
+- explicit ``OMNIGENT_AUTH_ENABLED=0`` → no implicit re-enable.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from omnigent.cli import _apply_bind_auth_defaults
+
+# The env vars the helper reads / writes. Cleared per-test so no
+# cross-test leakage.
+_AUTH_ENVS = (
+    "OMNIGENT_AUTH_PROVIDER",
+    "OMNIGENT_AUTH_ENABLED",
+    "OMNIGENT_ACCOUNTS_ENABLED",
+    "OMNIGENT_LOCAL_SINGLE_USER",
+    "OMNIGENT_OIDC_ISSUER",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear all auth-related env vars before each test."""
+    for _var in _AUTH_ENVS:
+        monkeypatch.delenv(_var, raising=False)
+
+
+def _stderr(capsys: pytest.CaptureFixture[str]) -> str:
+    """Stderr captured from the last helper call."""
+    return capsys.readouterr().err
+
+
+# ── loopback ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_loopback_enables_single_user(host: str, capsys: pytest.CaptureFixture[str]) -> None:
+    """A loopback bind with no explicit auth gets the single-user marker.
+
+    The default ``omnigent server`` on loopback is a local single-user
+    runtime — no proxy to inject identity — so it keeps the no-login
+    ``"local"`` header-mode fallback.
+    """
+    _apply_bind_auth_defaults(host)
+    assert os.environ.get("OMNIGENT_LOCAL_SINGLE_USER") == "1"
+    # Accounts mode must NOT be auto-enabled on loopback.
+    assert os.environ.get("OMNIGENT_AUTH_ENABLED") is None
+    # No warning on the loopback path.
+    assert _stderr(capsys) == ""
+
+
+def test_loopback_respects_explicit_single_user_off(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An explicit OMNIGENT_LOCAL_SINGLE_USER=0 wins on loopback.
+
+    setdefault must not clobber an operator's explicit "off".
+    """
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "0")
+    _apply_bind_auth_defaults("127.0.0.1")
+    assert os.environ.get("OMNIGENT_LOCAL_SINGLE_USER") == "0"
+    assert _stderr(capsys) == ""
+
+
+# ── non-loopback ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "192.168.1.10", "10.0.0.5"])
+def test_non_loopback_enables_accounts(host: str, capsys: pytest.CaptureFixture[str]) -> None:
+    """A non-loopback bind with no explicit auth enables accounts mode.
+
+    An end user binding to a network interface has no realistic way to
+    inject an identity header, so we opt them into login. A warning is
+    echoed to stderr so the operator knows accounts mode was
+    auto-enabled and how to create the first admin.
+    """
+    _apply_bind_auth_defaults(host)
+
+    assert os.environ.get("OMNIGENT_AUTH_ENABLED") == "1"
+    # The single-user marker must NOT be set on a non-loopback bind.
+    assert os.environ.get("OMNIGENT_LOCAL_SINGLE_USER") is None
+
+    # The warning names the host and mentions accounts mode + admin setup.
+    _msg = _stderr(capsys)
+    assert host in _msg
+    assert "accounts" in _msg.lower()
+    assert "admin" in _msg.lower()
+
+
+def test_non_loopback_respects_explicit_auth_provider(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An explicit OMNIGENT_AUTH_PROVIDER prevents the auto-enable.
+
+    An operator who declared ``header`` (behind an identity-injecting
+    proxy) or ``oidc`` chose their auth deliberately — don't override it.
+    """
+    monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", "header")
+    _apply_bind_auth_defaults("0.0.0.0")
+
+    assert os.environ.get("OMNIGENT_AUTH_ENABLED") is None
+    # No auto-enable warning — the operator was explicit.
+    assert _stderr(capsys) == ""
+
+
+def test_non_loopback_respects_explicit_auth_enabled_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An explicit OMNIGENT_AUTH_ENABLED=0 disables auth — no re-enable.
+
+    The operator explicitly turned auth off; we must not flip it back on.
+    """
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "0")
+    _apply_bind_auth_defaults("0.0.0.0")
+
+    # Stays "0", not overwritten by setdefault.
+    assert os.environ.get("OMNIGENT_AUTH_ENABLED") == "0"
+    assert _stderr(capsys) == ""
+
+
+def test_non_loopback_respects_deprecated_accounts_enabled(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The deprecated OMNIGENT_ACCOUNTS_ENABLED alias also counts as explicit.
+
+    An operator who set the old var name should not be auto-overridden.
+    """
+    monkeypatch.setenv("OMNIGENT_ACCOUNTS_ENABLED", "0")
+    _apply_bind_auth_defaults("0.0.0.0")
+
+    assert os.environ.get("OMNIGENT_AUTH_ENABLED") is None
+    assert _stderr(capsys) == ""
+
+
+def test_non_loopback_with_existing_auth_enabled_no_double_warning(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """OMNIGENT_AUTH_ENABLED=1 already set → no warning (it's not auto-enabled).
+
+    The operator already opted in; the "we enabled accounts for you"
+    warning would be noise.
+    """
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "1")
+    _apply_bind_auth_defaults("0.0.0.0")
+
+    assert os.environ.get("OMNIGENT_AUTH_ENABLED") == "1"
+    assert _stderr(capsys) == ""
+
+
+def test_non_loopback_empty_auth_provider_string_is_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty OMNIGENT_AUTH_PROVIDER ('') is treated as unset.
+
+    Compose-style deploys pass ``${VAR:-}`` which expands to an empty
+    string — empty and missing both mean "not explicitly pinned", so the
+    non-loopback auto-enable should still fire.
+    """
+    monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", "")
+    _apply_bind_auth_defaults("0.0.0.0")
+
+    assert os.environ.get("OMNIGENT_AUTH_ENABLED") == "1"
+
+
+# ── OIDC ───────────────────────────────────────────────────────────
+
+
+def test_non_loopback_with_oidc_resolves_to_oidc(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-loopback + AUTH_ENABLED=1 + OIDC issuer → resolve_auth_source returns oidc.
+
+    The helper only sets AUTH_ENABLED; the downstream accounts-ergonomics
+    block gates on resolve_auth_source(), which returns ``oidc`` (not
+    ``accounts``) when an OIDC issuer is present — so no accounts secrets
+    are minted. This test documents that the helper's single env-var
+    flip is enough: OIDC config is respected downstream.
+    """
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "1")
+    monkeypatch.setenv("OMNIGENT_OIDC_ISSUER", "https://idp.example.com")
+
+    _apply_bind_auth_defaults("0.0.0.0")
+
+    from omnigent.server.auth import resolve_auth_source
+
+    assert resolve_auth_source() == "oidc"

--- a/tests/e2e/test_managed_runner_http_auth.py
+++ b/tests/e2e/test_managed_runner_http_auth.py
@@ -97,8 +97,8 @@ def accounts_server(tmp_path: Path) -> Iterator[tuple[str, str]]:
     Accounts mode is selected by ``OMNIGENT_AUTH_PROVIDER=accounts`` plus a
     shared cookie secret; the subprocess handles the full runtime lifecycle
     (migrations, DBOS, auth provider, permission store) exactly as a deployed
-    server does. ``_maybe_prompt_first_admin`` no-ops without a TTY, so the
-    boot is non-interactive.
+    server does. The server boots without prompting; first-admin setup is
+    via the web form or ``--admin-password``.
 
     Deliberately independent of the session-scoped ``live_server`` fixture
     (which spawns a server + runner pair for the harness matrix): this test


### PR DESCRIPTION
## Related issue
N/A

## Summary
- A bare `omnigent server --host 0.0.0.0` used to stay in header mode and fail-close (401 on every request) with no warning and no path forward, because an end user has no realistic way to inject an identity header. The existing first-admin terminal prompt also never fired, since it no-ops when `account_store is None` (header mode).
- Now a non-loopback bind with no explicit auth config auto-enables accounts (login) mode, mirroring the Docker/Cloudflare/k8s entrypoints. The server boots and serves; first-admin setup happens via the web Create-admin form. A stderr warning is emitted at startup naming the host and the mode change.
- Removed the `_maybe_prompt_first_admin` TUI prompt path entirely — the server should just be a server, and the web Create-admin form (which is fully self-sufficient) is now the only interactive setup route. Explicit operator choices (`OMNIGENT_AUTH_PROVIDER`, `OMNIGENT_AUTH_ENABLED`, deprecated `OMNIGENT_ACCOUNTS_ENABLED`) always win; the loopback default is unchanged.

## Test Plan
- `uv run python -m pytest tests/cli/test_bind_auth_defaults.py -v` — 13 new unit tests covering the loopback/non-loopback/explicit-override matrix (accounts auto-enabled + warning on non-loopback; explicit provider/auth-enabled respected; empty `AUTH_PROVIDER` treated as unset; OIDC resolves downstream).
- `uv run python -m pytest tests/cli/test_server_lifecycle.py tests/cli/test_cli_auth.py tests/server/test_accounts.py -q` — existing tests still pass (131 total).

## Demo
N/A

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage
- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes
The new `_apply_bind_auth_defaults` helper is unit-tested directly across all matrix corners; existing server-lifecycle / accounts / CLI-auth suites confirm no regressions.

## Changelog
`omnigent server --host 0.0.0.0` now enables accounts (login) mode automatically instead of silently 401-ing every request