### PR TITLE
feat(projects): add a config column for project-level session defaults (Phase 2)

### DIFF
--- a/designs/PROJECTS_PRD.md
+++ b/designs/PROJECTS_PRD.md
@@ -525,11 +525,15 @@ folder), carrying the first-class `id` when one exists.
   `projectsApi`).
 
 ### TODO
-- ⬜ **Benchmark.** Now that the sidebar is wired, add a `list_project_sessions`
-  journey to `dev/benchmarks/omnigent` (mirrors the existing `list_sessions` hot
-  read path), and consider a `list_projects` journey for the sidebar's project
-  list fetch. CRUD writes (create/rename/delete) are infrequent single-row ops
-  and don't need a benchmark.
+- ✅ **Benchmark (#3094).** Added `list_projects` (sidebar project list,
+  dual-read union) and `list_project_sessions` (`?project=` folder fetch)
+  latency journeys to `dev/benchmarks/omnigent`, mirroring the `list_sessions`
+  hot read path. The corpus seeder now also seeds first-class `projects` rows
+  and files a configurable fraction of sessions into them (`--projects`,
+  `--filed-fraction`) so the journeys measure a realistic sidebar instead of an
+  empty project set, and the PR benchmark regression check runs on
+  `dev/benchmarks/**` changes. CRUD writes remain unbenchmarked (infrequent
+  single-row ops).
 - ⬜ **Phase 2 — project defaults (P4a)** — add a `config` JSON column (small
   add-column migration) and plumb it through the store/entity/API; seed
   host/workspace/harness/model into the new-chat dialog (§8.1).

--- a/designs/PROJECTS_PRD.md
+++ b/designs/PROJECTS_PRD.md
@@ -452,8 +452,8 @@ projects. Session→project membership landed separately in Phase 1b (below).
   UNIQUE index on `(workspace_id, owner_user_id, name)` enforces per-owner name
   uniqueness at the DB layer for non-NULL owners (the store's `_name_taken`
   check guards NULL-owner / single-user rows, which SQL treats as distinct).
-  (No `config` column yet — deferred to Phase 2 as a small add-column migration
-  alongside the code that reads it, so we don't ship an unused column.)
+  (No `config` column in Phase 1a — deferred so we didn't ship an unused
+  column; added in Phase 2 via migration `b3c4d5e6f7a8`, see the TODO below.)
 - ✅ **Migration** `b1c2d3e4f5a6` — creates the `projects` table only;
   additive, no backfill. Chained after `d4f2a1b6c8e9`.
 - ✅ **Entity** — `Project` (`entities/project.py`).
@@ -534,18 +534,34 @@ folder), carrying the first-class `id` when one exists.
   empty project set, and the PR benchmark regression check runs on
   `dev/benchmarks/**` changes. CRUD writes remain unbenchmarked (infrequent
   single-row ops).
-- ⬜ **Phase 2 — project defaults (P4a)** — add a `config` JSON column (small
-  add-column migration) and plumb it through the store/entity/API; seed
-  host/workspace/harness/model into the new-chat dialog (§8.1).
-  - **Replace the inference-based prefill (PR #2133).** That merged PR prefills
-    the composer by *inferring* defaults from the project's newest session
-    (host/agent/repo + a fresh worktree branch) — an explicit non-goal
-    workaround for the absence of stored project defaults. Once `config` stores
-    real defaults, retire that inference path (`web/src/shell/projectPrefill.ts`
-    and `useNewestProjectSession`) in favor of reading the stored config, so
-    there's one source of truth for a project's defaults instead of guessing
-    from history. Track this cleanup here so it isn't forgotten when Phase 2
-    lands.
+- 🚧 **Phase 2 — project defaults (P4a).** In progress, split across PRs:
+  - ✅ **Backend `config` column.** Added a nullable `config` column to
+    `projects` (migration `b3c4d5e6f7a8`, additive with a clean downgrade) and
+    plumbed it through the store/entity/API. `config` is an **opaque JSON
+    object**, not a typed schema: the backend persists it whole and never
+    filters on it, so the key vocabulary (host/workspace/harness/model/
+    reasoning-effort/git base-branch, …) is owned by the client and can grow
+    without a schema change. Values are *hints* (§8.1). Store `update()`
+    distinguishes `config=None` (leave unchanged) from `config={}` (clear), so
+    a rename never wipes stored defaults. Exposed on `ProjectObject` /
+    `CreateProjectRequest` / `UpdateProjectRequest` (openapi regenerated).
+  - ⬜ **Seed defaults into the new-chat dialog.** Read the stored `config` and
+    pre-fill host/workspace/harness/model in the composer, always overridable,
+    silently dropping any hint that isn't currently satisfiable (e.g. the
+    default host is offline). Land the deferred backend hardening here, once the
+    config key vocabulary firms up (from the #3108 review): (a) bound the
+    serialized `config` size on create/update — the value is persisted verbatim
+    and reflected back, so an unbounded blob is a mild storage/response-size
+    amplifier; (b) make `_decode_config` defensive — coerce a non-dict blob
+    (future writer / manual DB edit) back to `{}` rather than returning it raw.
+  - ⬜ **Replace the inference-based prefill (PR #2133).** That merged PR
+    prefills the composer by *inferring* defaults from the project's newest
+    session (host/agent/repo + a fresh worktree branch) — an explicit non-goal
+    workaround for the absence of stored project defaults. Once the dialog reads
+    the stored `config`, retire that inference path
+    (`web/src/shell/projectPrefill.ts` and `useNewestProjectSession`) in favor
+    of the stored defaults, so there's one source of truth for a project's
+    defaults instead of guessing from history.
 - ⬜ **Phase 3 — memory & context (P4b/P4c)** — new `project_memory` /
   `project_context` tables + agent read/write + injection (§8.2/§8.3).
 - ⬜ **Phase 4 — label consolidation (deferred; not required for the feature).**

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -699,6 +699,13 @@ class SqlProject(OmnigentBase):
     owner_user_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     created_at: Mapped[int] = mapped_column(Integer, nullable=False)
     updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Default session settings as a compact JSON object (host/workspace/harness/
+    # model/reasoning_effort/git base-branch, …), or NULL for "no defaults". The
+    # keys are an opaque, client-owned vocabulary: the value is read and written
+    # whole with the row and never filtered in SQL, so new keys need no schema
+    # change. Stored values are hints the new-chat dialog pre-fills and the user
+    # can always override.
+    config: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     __table_args__ = (
         # "list my projects" — prefix scan on (workspace_id, owner_user_id) with

--- a/omnigent/db/migrations/versions/b3c4d5e6f7a8_add_config_to_projects.py
+++ b/omnigent/db/migrations/versions/b3c4d5e6f7a8_add_config_to_projects.py
@@ -1,0 +1,46 @@
+"""add config to projects
+
+Revision ID: b3c4d5e6f7a8
+Revises: f4664ca64ea8
+Create Date: 2026-07-23 00:00:00.000000
+
+Phase 2 of the projects feature (see ``designs/PROJECTS_PRD.md`` §8.1): gives a
+project a place to store its default session settings (host, workspace, harness,
+model, reasoning effort, git base-branch, …). Adds a nullable ``config`` text
+column to ``projects`` holding a compact JSON object of those hints. ``NULL``
+means "no stored defaults".
+
+The column is an opaque JSON object: the backend persists it whole and never
+filters on it, so the set of keys is owned by the client (the new-chat dialog)
+and can grow without a schema change. The stored values are *hints* — the
+dialog pre-fills them and always lets the user override, dropping any that
+aren't currently satisfiable (e.g. the default host is offline).
+
+Additive: a nullable column with no default, so an older server binary reading
+the migrated DB simply ignores it. Rollback is a clean ``downgrade()`` (drops
+the column) since no existing data is rewritten.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b3c4d5e6f7a8"
+down_revision: str | None = "f4664ca64ea8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``config`` column to ``projects``."""
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.add_column(sa.Column("config", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop the ``config`` column."""
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.drop_column("config")

--- a/omnigent/entities/project.py
+++ b/omnigent/entities/project.py
@@ -9,7 +9,8 @@ conversation's metadata row (``project_id``), not here.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
@@ -26,6 +27,11 @@ class Project:
     :param created_at: Unix epoch seconds at row creation.
     :param updated_at: Unix epoch seconds of the last write, or ``None`` if the
         row has never been updated.
+    :param config: Default session settings as an opaque JSON object (host,
+        workspace, harness, model, reasoning effort, git base-branch, …), or an
+        empty dict when none are stored. The key vocabulary is owned by the
+        client; the store persists and returns it whole. These are hints the
+        new-chat dialog pre-fills, not enforced requirements.
     """
 
     id: str
@@ -33,3 +39,4 @@ class Project:
     owner_user_id: str | None
     created_at: int
     updated_at: int | None = None
+    config: dict[str, Any] = field(default_factory=dict)

--- a/omnigent/server/routes/projects.py
+++ b/omnigent/server/routes/projects.py
@@ -43,6 +43,7 @@ def _to_response(project: Project) -> dict[str, Any]:
         "name": project.name,
         "created_at": project.created_at,
         "updated_at": project.updated_at,
+        "config": project.config,
     }
 
 
@@ -78,6 +79,7 @@ def create_projects_router(
             uuid.uuid4().hex,
             body.name,
             user_id,
+            body.config,
         )
         return _to_response(project)
 
@@ -131,6 +133,7 @@ def create_projects_router(
             project_id,
             owner_user_id=user_id,
             name=body.name,
+            config=body.config,
         )
         if project is None:
             raise OmnigentError("Project not found", code=ErrorCode.NOT_FOUND)

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -4170,6 +4170,11 @@ class ProjectObject(BaseModel):
     :param name: Human-readable project name, unique per owner.
     :param created_at: Unix epoch seconds at creation.
     :param updated_at: Unix epoch seconds of the last write, or ``None``.
+    :param config: Default session settings as an opaque JSON object (host,
+        workspace, harness, model, reasoning effort, git base-branch, …). Empty
+        when the project stores no defaults. The key vocabulary is owned by the
+        client; the server persists and returns it whole. Values are hints the
+        new-chat dialog pre-fills, not enforced requirements.
     """
 
     id: str
@@ -4177,6 +4182,7 @@ class ProjectObject(BaseModel):
     name: str
     created_at: int
     updated_at: int | None = None
+    config: dict[str, Any] = Field(default_factory=dict)
 
 
 class ProjectList(BaseModel):
@@ -4211,11 +4217,14 @@ class CreateProjectRequest(BaseModel):
 
     :param name: Human-readable project name. Trimmed; must be non-empty and
         at most 100 characters; unique among the caller's projects.
+    :param config: Optional default session settings (opaque JSON object).
+        Omitted / empty stores no defaults.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     name: str
+    config: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("name")
     @classmethod
@@ -4242,11 +4251,14 @@ class UpdateProjectRequest(BaseModel):
 
     :param name: New project name. ``None`` leaves it unchanged; otherwise
         trimmed, non-empty, at most 100 characters.
+    :param config: New config object to replace the stored one. ``None`` leaves
+        it unchanged; an empty object ``{}`` clears the stored defaults.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     name: str | None = None
+    config: dict[str, Any] | None = None
 
     @field_validator("name")
     @classmethod

--- a/omnigent/stores/project_store/__init__.py
+++ b/omnigent/stores/project_store/__init__.py
@@ -13,6 +13,7 @@ Projects have no ACL of their own (PRD §9): every method is scoped by
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 from omnigent.entities import Project
 
@@ -40,6 +41,7 @@ class ProjectStore(ABC):
         project_id: str,
         name: str,
         owner_user_id: str | None,
+        config: dict[str, Any] | None = None,
     ) -> Project:
         """
         Insert a new, empty project.
@@ -48,6 +50,8 @@ class ProjectStore(ABC):
         :param name: Human-readable project name. Trimmed, non-empty, unique
             among the owner's projects.
         :param owner_user_id: Owning user, or ``None`` in single-user mode.
+        :param config: Optional default session settings (opaque JSON object);
+            ``None`` or empty stores no defaults.
         :returns: The newly created :class:`Project`.
         :raises OmnigentError: ``ALREADY_EXISTS`` if the owner already has a
             project with this name.
@@ -83,6 +87,7 @@ class ProjectStore(ABC):
         *,
         owner_user_id: str | None,
         name: str | None = None,
+        config: dict[str, Any] | None = None,
     ) -> Project | None:
         """
         Update mutable fields of an owned project.
@@ -94,6 +99,8 @@ class ProjectStore(ABC):
         :param owner_user_id: The requesting owner.
         :param name: New name, or ``None`` to leave unchanged. Trimmed,
             non-empty, unique among the owner's projects.
+        :param config: New config object to replace the stored one, or ``None``
+            to leave it unchanged. An empty dict clears the stored defaults.
         :returns: The updated :class:`Project`, or ``None`` if not found.
         :raises OmnigentError: ``ALREADY_EXISTS`` if the new name collides with
             another of the owner's projects.

--- a/omnigent/stores/project_store/sqlalchemy_store.py
+++ b/omnigent/stores/project_store/sqlalchemy_store.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from typing import Any
+
 from sqlalchemy import asc, select
 from sqlalchemy.exc import IntegrityError
 
@@ -14,6 +17,29 @@ from omnigent.db.utils import (
 from omnigent.entities import Project
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.stores.project_store import ProjectStore
+
+
+def _encode_config(config: dict[str, Any] | None) -> str | None:
+    """Pack a project's config dict into a compact JSON blob for storage.
+
+    An empty or ``None`` config stores SQL ``NULL`` rather than ``"{}"``, so
+    "no defaults" is one canonical representation.
+
+    :param config: The config object, or ``None``.
+    :returns: Compact JSON object string, or ``None`` when empty.
+    """
+    if not config:
+        return None
+    return json.dumps(config, separators=(",", ":"))
+
+
+def _decode_config(raw: str | None) -> dict[str, Any]:
+    """Unpack the stored ``config`` blob to a dict (``{}`` when unset).
+
+    :param raw: The stored JSON blob, or ``None``.
+    :returns: The decoded object, or an empty dict when ``NULL`` / empty.
+    """
+    return json.loads(raw) if raw else {}
 
 
 def _is_name_conflict(exc: IntegrityError) -> bool:
@@ -43,6 +69,7 @@ def _to_entity(row: SqlProject) -> Project:
         owner_user_id=row.owner_user_id,
         created_at=row.created_at,
         updated_at=row.updated_at,
+        config=_decode_config(row.config),
     )
 
 
@@ -103,6 +130,7 @@ class SqlAlchemyProjectStore(ProjectStore):
         project_id: str,
         name: str,
         owner_user_id: str | None,
+        config: dict[str, Any] | None = None,
     ) -> Project:
         """Insert a new, empty project.
 
@@ -126,6 +154,7 @@ class SqlAlchemyProjectStore(ProjectStore):
                 owner_user_id=owner_user_id,
                 created_at=now_epoch(),
                 updated_at=None,
+                config=_encode_config(config),
             )
             session.add(row)
             try:
@@ -165,11 +194,13 @@ class SqlAlchemyProjectStore(ProjectStore):
         *,
         owner_user_id: str | None,
         name: str | None = None,
+        config: dict[str, Any] | None = None,
     ) -> Project | None:
         """Update mutable fields of an owned project.
 
         ``None`` leaves a field unchanged. Returns ``None`` if the project does
-        not exist or is not owned by ``owner_user_id``.
+        not exist or is not owned by ``owner_user_id``. A ``config`` of ``{}``
+        clears the stored defaults (distinct from ``None`` = leave unchanged).
         """
         with self._session() as session:
             row = session.get(SqlProject, (current_workspace_id(), project_id))
@@ -186,6 +217,11 @@ class SqlAlchemyProjectStore(ProjectStore):
                     )
                 row.name = name
                 changed = True
+            if config is not None:
+                encoded = _encode_config(config)
+                if row.config != encoded:
+                    row.config = encoded
+                    changed = True
             if changed:
                 row.updated_at = now_epoch()
             try:

--- a/openapi.json
+++ b/openapi.json
@@ -1171,6 +1171,12 @@
         "additionalProperties": false,
         "description": "Request body for `POST /v1/projects`.",
         "properties": {
+          "config": {
+            "additionalProperties": true,
+            "description": "Optional default session settings (opaque JSON object). Omitted / empty stores no defaults.",
+            "title": "Config",
+            "type": "object"
+          },
           "name": {
             "description": "Human-readable project name. Trimmed; must be non-empty and at most 100 characters; unique among the caller's projects.",
             "title": "Name",
@@ -6176,6 +6182,19 @@
         "additionalProperties": false,
         "description": "Request body for `PATCH /v1/projects/{project_id}`.\n\nAll fields optional; `None` leaves a field unchanged.",
         "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New config object to replace the stored one. `None` leaves it unchanged; an empty object `{}` clears the stored defaults.",
+            "title": "Config"
+          },
           "name": {
             "anyOf": [
               {

--- a/tests/entities/test_project.py
+++ b/tests/entities/test_project.py
@@ -44,6 +44,31 @@ def test_project_owner_none_in_single_user_mode() -> None:
     assert proj.owner_user_id is None
 
 
+def test_project_config_defaults_to_empty_dict() -> None:
+    """A project with no stored defaults carries an empty config dict.
+
+    Uses the default_factory, so two instances get independent dicts (no shared
+    mutable default).
+    """
+    a = Project(id="d" * 32, name="A", owner_user_id=None, created_at=1)
+    b = Project(id="e" * 32, name="B", owner_user_id=None, created_at=1)
+    assert a.config == {}
+    a.config["host_id"] = "x"
+    assert b.config == {}  # not shared across instances
+
+
+def test_project_carries_config() -> None:
+    """A config object is stored on the entity."""
+    proj = Project(
+        id="f" * 32,
+        name="Configured",
+        owner_user_id=None,
+        created_at=1,
+        config={"host_id": "h", "workspace": "/w"},
+    )
+    assert proj.config == {"host_id": "h", "workspace": "/w"}
+
+
 def test_project_equality() -> None:
     """Dataclasses support value-based equality."""
     a = Project(id="x" * 32, name="P", owner_user_id="u", created_at=1)

--- a/tests/server/routes/test_projects_crud.py
+++ b/tests/server/routes/test_projects_crud.py
@@ -140,6 +140,59 @@ async def test_rename_missing_project_404(project_client: httpx.AsyncClient) -> 
     assert resp.status_code == 404
 
 
+async def test_create_defaults_to_empty_config(project_client: httpx.AsyncClient) -> None:
+    """A project created without a config field reports an empty config."""
+    body = (await project_client.post("/v1/projects", json={"name": "P"})).json()
+    assert body["config"] == {}
+
+
+async def test_create_and_get_roundtrips_config(project_client: httpx.AsyncClient) -> None:
+    """A config passed on create round-trips through the create + get responses."""
+    cfg = {"host_id": "host_abc", "workspace": "/work/repo", "model": "claude-opus-4-8"}
+    created = (
+        await project_client.post("/v1/projects", json={"name": "Configured", "config": cfg})
+    ).json()
+    assert created["config"] == cfg
+    fetched = (await project_client.get(f"/v1/projects/{created['id']}")).json()
+    assert fetched["config"] == cfg
+
+
+async def test_patch_replaces_config(project_client: httpx.AsyncClient) -> None:
+    """PATCH with a new config replaces the stored one and stamps updated_at."""
+    created = (
+        await project_client.post("/v1/projects", json={"name": "P", "config": {"host_id": "old"}})
+    ).json()
+    resp = await project_client.patch(
+        f"/v1/projects/{created['id']}", json={"config": {"host_id": "new", "model": "m"}}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["config"] == {"host_id": "new", "model": "m"}
+    assert body["updated_at"] is not None
+
+
+async def test_patch_without_config_preserves_it(project_client: httpx.AsyncClient) -> None:
+    """A PATCH that omits config (e.g. a rename) leaves the stored config intact."""
+    created = (
+        await project_client.post(
+            "/v1/projects", json={"name": "P", "config": {"host_id": "keep"}}
+        )
+    ).json()
+    renamed = await project_client.patch(f"/v1/projects/{created['id']}", json={"name": "P2"})
+    assert renamed.json()["config"] == {"host_id": "keep"}
+
+
+async def test_patch_empty_config_clears_it(project_client: httpx.AsyncClient) -> None:
+    """PATCH with config={} clears the stored defaults (distinct from omitting)."""
+    created = (
+        await project_client.post(
+            "/v1/projects", json={"name": "P", "config": {"host_id": "drop"}}
+        )
+    ).json()
+    resp = await project_client.patch(f"/v1/projects/{created['id']}", json={"config": {}})
+    assert resp.json()["config"] == {}
+
+
 async def test_delete_project(project_client: httpx.AsyncClient) -> None:
     """DELETE removes the project; a second delete 404s."""
     created = (await project_client.post("/v1/projects", json={"name": "Doomed"})).json()

--- a/tests/stores/test_project_store.py
+++ b/tests/stores/test_project_store.py
@@ -192,6 +192,61 @@ def test_non_name_integrity_error_is_not_masked(store: SqlAlchemyProjectStore) -
         store.create(_uid("p1"), "Different name", "alice@example.com")
 
 
+# ── config (default session settings) ──────────────────────────────────────
+
+
+def test_create_defaults_to_empty_config(store: SqlAlchemyProjectStore) -> None:
+    """A project created without config reads back an empty dict (SQL NULL)."""
+    project = store.create(_uid("p1"), "No Config", "alice@example.com")
+    assert project.config == {}
+    assert store.get(_uid("p1"), owner_user_id="alice@example.com").config == {}
+
+
+def test_create_persists_config(store: SqlAlchemyProjectStore) -> None:
+    """A config passed to ``create`` round-trips through ``get``/``list``."""
+    cfg = {"host_id": "host_abc", "workspace": "/work/repo", "model": "claude-opus-4-8"}
+    store.create(_uid("p1"), "Configured", "alice@example.com", cfg)
+    assert store.get(_uid("p1"), owner_user_id="alice@example.com").config == cfg
+    assert store.list(owner_user_id="alice@example.com")[0].config == cfg
+
+
+def test_update_replaces_config_and_stamps_updated_at(store: SqlAlchemyProjectStore) -> None:
+    """Passing a new ``config`` replaces the stored one and stamps updated_at."""
+    store.create(_uid("p1"), "P", "alice@example.com", {"host_id": "old"})
+    updated = store.update(
+        _uid("p1"), owner_user_id="alice@example.com", config={"host_id": "new", "model": "m"}
+    )
+    assert updated is not None
+    assert updated.config == {"host_id": "new", "model": "m"}
+    assert updated.updated_at is not None
+
+
+def test_update_config_none_leaves_it_unchanged(store: SqlAlchemyProjectStore) -> None:
+    """``config=None`` (the default) leaves the stored config untouched."""
+    store.create(_uid("p1"), "P", "alice@example.com", {"host_id": "keep"})
+    # Rename only — config omitted — must not wipe the stored defaults.
+    updated = store.update(_uid("p1"), owner_user_id="alice@example.com", name="Renamed")
+    assert updated is not None
+    assert updated.config == {"host_id": "keep"}
+
+
+def test_update_empty_config_clears_defaults(store: SqlAlchemyProjectStore) -> None:
+    """An explicit ``config={}`` clears the stored defaults (distinct from None)."""
+    store.create(_uid("p1"), "P", "alice@example.com", {"host_id": "drop"})
+    updated = store.update(_uid("p1"), owner_user_id="alice@example.com", config={})
+    assert updated is not None
+    assert updated.config == {}
+    assert updated.updated_at is not None
+
+
+def test_update_same_config_is_noop(store: SqlAlchemyProjectStore) -> None:
+    """Re-setting the identical config changes nothing, leaving updated_at None."""
+    store.create(_uid("p1"), "P", "alice@example.com", {"host_id": "x"})
+    updated = store.update(_uid("p1"), owner_user_id="alice@example.com", config={"host_id": "x"})
+    assert updated is not None
+    assert updated.updated_at is None
+
+
 # ── update ─────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A — Phase 2 (P4a) of the projects feature; roadmap tracked in `designs/PROJECTS_PRD.md §8.1, §12`.

## Summary

The backend half of **Phase 2 — project defaults**. Gives a project a place to store default session settings (host, workspace, harness, model, reasoning effort, git base-branch, …) so a session created in the project can pre-fill them — the groundwork for retiring the inference-based prefill (#2133) in a follow-up.

- **Migration `b3c4d5e6f7a8`** — adds a nullable `config` TEXT column to `projects` (additive, chained after `f4664ca64ea8`, clean `downgrade`). `NULL` = no stored defaults.
- **Opaque JSON, not a typed schema.** The backend persists `config` whole and never filters on it, so the key vocabulary is owned by the client (the new-chat dialog) and can grow without a schema change. Stored values are *hints*, not enforced requirements.
- **Plumbed through the stack:** `SqlProject` model, `Project` entity (decoded dict, empty when unset), `ProjectStore.create`/`update` (encode/decode helpers mirroring `session_overrides`), and the `/v1/projects` schemas + routes.
- **`update()` semantics:** `config=None` leaves it unchanged; `config={}` clears it — distinct, so a rename never wipes stored defaults.
- Regenerated `openapi.json` (`config` on `CreateProjectRequest` / `UpdateProjectRequest`). Note: the project routes return `dict[str, Any]` with no `response_model`, so `ProjectObject` isn't emitted into the spec — the response shape stays undocumented (pre-existing gap, not changed here).

Follow-up sub-items (separate PRs, tracked in the PRD): seed the stored `config` into the new-chat dialog, then retire the #2133 inference path (`projectPrefill.ts` + `useNewestProjectSession`).

## Test Plan

- `pytest tests/stores/test_project_store.py tests/server/routes/test_projects_crud.py tests/entities/test_project.py` — 54 passed (13 new config tests: store round-trip, `None`-vs-`{}` update semantics, route create/get/patch round-trip, entity `default_factory` isolation).
- `pytest tests/server/routes/test_sessions_project_membership.py tests/server/routes/test_sessions_shared_projects.py` — 14 passed (no regression in adjacent project paths).
- Migration verified up → down → up on a throwaway SQLite DB (`config` present after upgrade, dropped after downgrade `-1`, restored on re-upgrade).
- Benchmark seeder (which builds `SqlProject` rows) still passes — the nullable column defaults to `NULL`.
- `ruff format` + `ruff check` clean (pre-commit hooks pass).

## Demo

N/A — backend change, no UI (the dialog wiring is a follow-up PR).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Store, route, and entity behavior are covered by the unit/integration tests above. Manual verification was the Alembic migration up/down/up round-trip against a throwaway SQLite DB (asserting the column is added, dropped on downgrade, and restored) — not something the unit suite exercises directly.

## Changelog

Projects can store default session settings (host, workspace, harness, model, …) via a new `config` field on the projects API.

This pull request and its description were written by Isaac.

