### PR TITLE
fix(llms): flatten list-shaped content in non-streaming converter

### DIFF
--- a/omnigent/llms/_responses_to_chat.py
+++ b/omnigent/llms/_responses_to_chat.py
@@ -216,9 +216,14 @@ def chat_response_to_response(
     choice = chat_dict["choices"][0]
     message = choice["message"]
 
-    # Text content
-    if content := message.get("content"):
-        output.append(MessageOutput(content=[OutputText(text=content)]))
+    # Text content — content may be a plain string or a list of typed
+    # blocks (Claude via Databricks, Kimi, etc.). Flatten via the shared
+    # helper so list-shaped content is joined into a string rather than
+    # stored raw.
+    if raw_content := message.get("content"):
+        text, _reasoning = _extract_delta_content(raw_content)
+        if text:
+            output.append(MessageOutput(content=[OutputText(text=text)]))
 
     # Tool calls
     for tc in message.get("tool_calls") or []:

--- a/tests/llms/test_responses_to_chat.py
+++ b/tests/llms/test_responses_to_chat.py
@@ -352,6 +352,63 @@ def test_chat_text_response_to_response() -> None:
     assert resp.usage == Usage(input_tokens=10, output_tokens=5, total_tokens=15)
 
 
+def test_chat_list_content_flattened_to_string() -> None:
+    # Claude via Databricks (and Kimi, etc.) return non-streaming
+    # message.content as a list of typed blocks rather than a plain
+    # string. It must be flattened so downstream consumers get a str.
+    chat_dict = {
+        "id": "chatcmpl-list",
+        "model": "databricks-claude-sonnet-4",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": '{"action":"allow"}'}],
+                    "tool_calls": None,
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": None,
+    }
+    resp = chat_response_to_response(chat_dict)
+    assert len(resp.output) == 1
+    assert isinstance(resp.output[0], MessageOutput)
+    assert resp.output[0].content[0].text == '{"action":"allow"}'
+
+
+def test_chat_list_content_reasoning_and_text_flattened() -> None:
+    # A mixed reasoning + text block list flattens to just the visible
+    # text; reasoning blocks are not folded into the message text.
+    chat_dict = {
+        "id": "chatcmpl-mixed",
+        "model": "databricks-claude-sonnet-4",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "reasoning",
+                            "summary": [{"type": "summary_text", "text": "thinking..."}],
+                        },
+                        {"type": "text", "text": '{"action":"deny"}'},
+                    ],
+                    "tool_calls": None,
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": None,
+    }
+    resp = chat_response_to_response(chat_dict)
+    assert len(resp.output) == 1
+    assert isinstance(resp.output[0], MessageOutput)
+    assert resp.output[0].content[0].text == '{"action":"deny"}'
+
+
 def test_chat_tool_calls_to_response() -> None:
     chat_dict = {
         "id": "chatcmpl-456",


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Non-streaming `chat_response_to_response` stored `message.content` raw. For Claude served via Databricks (and Kimi, etc.) — which return `content` as a list of typed blocks (`[{"type":"text","text":"…"}, {"type":"reasoning",…}]`) rather than a plain string — `OutputText.text` became a **list** instead of a `str`.
- This broke every non-streaming consumer of `databricks-claude-*` models. Most visibly, `prompt_policy` failed closed (returned `DENY`, "Policy classifier error (fail-closed)") when `_strip_code_fences` called `.strip()` on a list. `smart_routing` was also fed a list.
- The streaming path already flattens list-of-blocks content via `_extract_delta_content`; only the non-streaming converter was missed. This reuses that same helper, which returns the plain string unchanged for existing providers.

## Test Plan

- Added two unit tests to `tests/llms/test_responses_to_chat.py`:
  - `test_chat_list_content_flattened_to_string` — list `content` with a single text block flattens to the joined string.
  - `test_chat_list_content_reasoning_and_text_flattened` — a mixed reasoning+text block list flattens to just the visible text.
- `uv run --extra dev pytest tests/llms/test_responses_to_chat.py -q` → 44 passed.
- `pre-commit` (ruff format + check) clean on both files.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by new unit tests.

## Changelog

Databricks-served Claude models no longer break non-streaming responses (prompt-policy and smart routing) when returning typed content blocks
