### PR TITLE
feat(omnidev): add pod-wired `omnigent` passthrough subcommand

### DIFF
--- a/dev/omnidev/README.md
+++ b/dev/omnidev/README.md
@@ -1,12 +1,15 @@
 # omnidev
 
-Dev tooling for Omnigent, in one binary with two independent capabilities:
+Dev tooling for Omnigent, in one binary with three surfaces:
 
 1. A per-repo dev **pod supervisor** (bare `omnidev`) — the default.
-2. **Install management** (`omnidev install`/`update`/`check`) — install and
-   keep a git-based omnigent up to date. See
+2. **Install management** (`omnidev install`/`update`/`check`) — install
+   and keep a git-based omnigent up to date. See
    [Managing your omnigent install](#managing-your-omnigent-install). These
-   subcommands need no checkout and run anywhere.
+   need no checkout and run anywhere.
+3. **An omnigent passthrough** (`omnidev omnigent …`) — run any omnigent command
+   against the current checkout's pod, with the pod's isolated env applied.
+   See [Running omnigent commands](#running-omnigent-commands).
 
 ## Pod supervisor
 
@@ -138,6 +141,34 @@ feel familiar.
 | `c` | Clear the focused pane |
 | `q` / `Ctrl-C` | Quit and tear down all processes |
 
+## Running omnigent commands
+
+`omnidev omnigent …` runs any omnigent command against the current checkout's
+pod, via `uv run omnigent …`, with the pod's isolated env applied
+(`OMNIGENT_DATA_DIR`, `OMNIGENT_DATABASE_URI`, `OMNIGENT_CONFIG_HOME`,
+`OMNIGENT_URL`). It resolves the same repo root and pod dir the supervisor
+uses, so a command talks to the pod's database and config — and `OMNIGENT_URL`
+points at a running supervisor's server when one is up.
+
+```bash
+omnidev omnigent agent run "fix the flaky test"
+omnidev omnigent config show
+omnidev --pod-dir /tmp/x omnigent agent list   # target a specific pod
+```
+
+Everything after the subcommand is forwarded verbatim to omnigent. It runs in
+the foreground (inheriting your stdio) and exits with omnigent's status code.
+It acquires **no** lock, so it coexists with a running supervisor — the common
+case: the server is up and you issue a command against it. Use `--` to pass
+flags that look like omnidev's own:
+
+```bash
+omnidev omnigent -- --verbose agent run …
+```
+
+Supervisor-only flags (`--server-port`, `--clean`, `--no-vite`, …) don't apply
+to the passthrough; only `--pod-dir` is shared.
+
 ## Managing your omnigent install
 
 For people who *run* omnigent (installed from git via `uv tool install`) rather
@@ -145,8 +176,8 @@ than develop it. This wraps the fiddly PEP 508 install syntax and adds a daily
 update check — filling a gap, since omnigent's own update notice only works for
 PyPI-wheel installs and skips git installs.
 
-These subcommands manage the global tool and work from **any directory** (no
-checkout needed).
+These subcommands manage the global tool and work from **any directory**
+(no checkout needed).
 
 ```
 omnidev install     # uv tool install omnigent from git (databricks extra, main)
@@ -185,6 +216,6 @@ result (`${XDG_CACHE_HOME:-~/.cache}/omnidev/omnigent-check.json`) and, when
 stale (>24h), refreshes it in a detached background process — so shell startup
 never blocks on the network. When a newer commit is available it prints a notice
 and, on a terminal, prompts `Update omnigent now? [y/N]`; on yes it runs
-`omnidev update` in the foreground. Declining suppresses that same commit until a
-newer one lands. Set `OMNIGENT_NO_UPDATE_CHECK` in your environment if you want
+`omnidev update` in the foreground. Declining suppresses that same commit until
+a newer one lands. Set `OMNIGENT_NO_UPDATE_CHECK` in your environment if you want
 to silence omnigent's own separate notice.

--- a/dev/omnidev/src/main.rs
+++ b/dev/omnidev/src/main.rs
@@ -1,12 +1,15 @@
 //! omnidev — dev tooling for Omnigent.
 //!
-//! Two independent capabilities in one binary:
+//! Three surfaces in one binary:
 //! - **pod supervisor** (bare `omnidev`): manages an isolated dev instance for
 //!   the current checkout — server/host/vite, restarting the backend on Python
 //!   changes while Vite handles frontend HMR.
 //! - **install management** (`omnidev install`/`update`/`check`/…): install and
 //!   keep a git-based omnigent up to date. These need no checkout and run
 //!   anywhere.
+//! - **omnigent passthrough** (`omnidev omnigent …`): run any omnigent command
+//!   against the current checkout's pod via `uv run omnigent …`, with the pod's
+//!   isolated env applied. Requires a checkout, like the supervisor.
 
 mod install;
 mod lan;
@@ -14,6 +17,7 @@ mod lock;
 mod logs;
 mod paths;
 mod pod;
+mod omnigent_cmd;
 mod ports;
 mod process;
 mod shellhook;
@@ -44,6 +48,50 @@ struct Args {
 
     #[command(flatten)]
     run: RunArgs,
+}
+
+/// Top-level subcommands. Install management works anywhere; the `omnigent`
+/// passthrough requires a checkout (like the bare supervisor default).
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Install omnigent from git (defaults to the databricks extra, main).
+    Install {
+        /// Git ref (branch/tag/sha) to track.
+        #[arg(long, default_value = install::DEFAULT_REF)]
+        r#ref: String,
+        /// Extra to include (repeatable). Defaults to `databricks`.
+        #[arg(long = "extra")]
+        extras: Vec<String>,
+        /// Omit the default databricks extra (install with no extras).
+        #[arg(long)]
+        no_default_extra: bool,
+        /// Git repo URL.
+        #[arg(long, default_value = install::DEFAULT_REPO)]
+        repo: String,
+    },
+    /// Reinstall the latest of the tracked ref/extras.
+    Update,
+    /// Check for an omnigent update (the shell hook calls this).
+    Check {
+        /// Print nothing when already up to date.
+        #[arg(long)]
+        quiet: bool,
+    },
+    /// Refresh the update-check cache from the network (usually run detached).
+    Refresh,
+    /// Print a shell snippet to eval from .zshrc/.bashrc for daily checks.
+    ShellHook,
+    /// Run an omnigent command against this checkout's pod (`uv run omnigent …`).
+    ///
+    /// Everything after the subcommand is forwarded verbatim to omnigent. The
+    /// pod's isolated env (data dir, database, config, server URL) is applied,
+    /// so a command talks to the same pod the supervisor runs — and coexists
+    /// with a running supervisor. Use `--` to pass flags that look like
+    /// omnidev's own: `omnidev omnigent -- --verbose agent run …`.
+    Omnigent {
+        #[arg(num_args = 0.., trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 }
 
 /// Flags for the default (no-subcommand) pod-supervisor run.
@@ -84,42 +132,12 @@ struct RunArgs {
     debug: bool,
 }
 
-#[derive(Subcommand, Debug)]
-enum Command {
-    /// Install omnigent from git (defaults to the databricks extra, main).
-    Install {
-        /// Git ref (branch/tag/sha) to track.
-        #[arg(long, default_value = install::DEFAULT_REF)]
-        r#ref: String,
-        /// Extra to include (repeatable). Defaults to `databricks`.
-        #[arg(long = "extra")]
-        extras: Vec<String>,
-        /// Omit the default databricks extra (install with no extras).
-        #[arg(long)]
-        no_default_extra: bool,
-        /// Git repo URL.
-        #[arg(long, default_value = install::DEFAULT_REPO)]
-        repo: String,
-    },
-    /// Reinstall the latest of the tracked ref/extras.
-    Update,
-    /// Check for an omnigent update (the shell hook calls this).
-    Check {
-        /// Print nothing when already up to date.
-        #[arg(long)]
-        quiet: bool,
-    },
-    /// Refresh the update-check cache from the network (usually run detached).
-    Refresh,
-    /// Print a shell snippet to eval from .zshrc/.bashrc for daily checks.
-    ShellHook,
-}
-
 fn main() -> Result<()> {
     let args = Args::parse();
 
     // Install-management subcommands manage a global tool and must work from
-    // anywhere — dispatch them before any checkout discovery.
+    // anywhere — dispatch them before any checkout discovery. `omnigent …` is
+    // the pod-wired passthrough. No subcommand runs the pod supervisor.
     match args.command {
         Some(Command::Install {
             r#ref,
@@ -148,8 +166,41 @@ fn main() -> Result<()> {
             shellhook::print();
             Ok(())
         }
+        Some(Command::Omnigent { args: passthrough }) => run_omnigent(args.run, passthrough),
         None => run_supervisor(args.run),
     }
+}
+
+/// `omnidev omnigent …` — run an arbitrary omnigent command against this
+/// checkout's pod via `uv run omnigent …`, with the pod's isolated env (data
+/// dir, database URI, config home, server URL) applied on top of the inherited
+/// parent env. Resolves the repo root and pod dir (same as the supervisor),
+/// ensures the pod tree exists, then spawns in the foreground inheriting stdio.
+/// Exits with omnigent's status code. Acquires no lock — it coexists with a
+/// running supervisor (the common case: server up, you run a command).
+fn run_omnigent(args: RunArgs, passthrough: Vec<String>) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let repo_root = paths::find_repo_root(&cwd)?;
+    let pod_dir = match &args.pod_dir {
+        Some(p) => p.clone(),
+        None => paths::default_pod_dir(&repo_root)?,
+    };
+    std::fs::create_dir_all(&pod_dir)?;
+
+    // Read persisted ports so OMNIGENT_URL points at a running supervisor's
+    // server (if any). Supervisor-only flags don't apply to the passthrough, so
+    // never override — the pod stays in sync with whatever the supervisor set.
+    let ports = Ports::resolve(&pod_dir, None, None)?;
+    let pod = Pod::create(
+        repo_root,
+        pod_dir,
+        ports,
+        args.vite_host.clone(),
+        Vec::new(),
+    )?;
+
+    let cmd = omnigent_cmd::build(&pod, &passthrough);
+    omnigent_cmd::run(cmd)
 }
 
 /// Default path: the pod supervisor for the current checkout. This is the only

--- a/dev/omnidev/src/omnigent_cmd.rs
+++ b/dev/omnidev/src/omnigent_cmd.rs
@@ -1,0 +1,148 @@
+//! `omnidev omnigent …` — run an arbitrary omnigent command against this
+//! checkout's pod via `uv run omnigent …`.
+//!
+//! Unlike the supervised `process::ProcSpec`s, this runs in the foreground
+//! (inheriting the user's stdio) and does *not* inject the log-mirror env
+//! (`OMNIGENT_LOG_TTY_FD` / `OMNIGENT_LOG_FORCE_COLOR`): the user has a real
+//! TTY, so omnigent's own terminal detection should win. The pod's isolation
+//! env (`OMNIGENT_DATA_DIR`, `OMNIGENT_DATABASE_URI`, `OMNIGENT_CONFIG_HOME`,
+//! `OMNIGENT_URL`) is applied on top of the inherited parent env, so a command
+//! talks to the same pod the supervisor runs.
+
+use std::path::PathBuf;
+
+use crate::pod::Pod;
+
+/// A resolved `uv run omnigent …` invocation for the passthrough subcommand.
+pub struct OmnigentCmd {
+    pub program: String,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+    pub cwd: PathBuf,
+}
+
+/// Build the command line + env for `uv run omnigent <passthrough…>` rooted at
+/// the pod's repo, with the pod's `OMNIGENT_*` overrides applied.
+pub fn build(pod: &Pod, passthrough: &[String]) -> OmnigentCmd {
+    let mut args = vec!["run".to_string(), "omnigent".to_string()];
+    args.extend_from_slice(passthrough);
+    OmnigentCmd {
+        program: "uv".into(),
+        args,
+        env: pod.env(),
+        cwd: pod.repo_root.clone(),
+    }
+}
+
+/// Spawn the command in the foreground, inheriting stdio, and exit with its
+/// status code. A spawn failure returns an error instead of exiting.
+pub fn run(cmd: OmnigentCmd) -> anyhow::Result<()> {
+    let mut command = std::process::Command::new(&cmd.program);
+    command.args(&cmd.args).current_dir(&cmd.cwd);
+    for (k, v) in &cmd.env {
+        command.env(k, v);
+    }
+    let status = command.status()?;
+    std::process::exit(status.code().unwrap_or(1));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::Ports;
+
+    fn tempdir() -> PathBuf {
+        let unique = format!(
+            "omnidev-omnigent-cmd-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let dir = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn make_pod() -> Pod {
+        Pod::create(
+            tempdir(),
+            tempdir(),
+            Ports {
+                server: 19191,
+                vite: 19292,
+            },
+            "127.0.0.1".into(),
+            Vec::new(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn forwards_passthrough_args_after_uv_run_omnigent() {
+        let pod = make_pod();
+        let cmd = build(
+            &pod,
+            &["agent".into(), "run".into(), "fix tests".into()],
+        );
+        assert_eq!(cmd.program, "uv");
+        assert_eq!(
+            cmd.args.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["run", "omnigent", "agent", "run", "fix tests"]
+        );
+        assert_eq!(cmd.cwd, pod.repo_root);
+    }
+
+    #[test]
+    fn empty_passthrough_is_just_uv_run_omnigent() {
+        let pod = make_pod();
+        let cmd = build(&pod, &[]);
+        assert_eq!(
+            cmd.args.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["run", "omnigent"]
+        );
+    }
+
+    #[test]
+    fn applies_pod_isolation_env() {
+        let pod = make_pod();
+        let cmd = build(&pod, &["config".into(), "show".into()]);
+
+        let data_dir = cmd
+            .env
+            .iter()
+            .find(|(k, _)| k == "OMNIGENT_DATA_DIR")
+            .map(|(_, v)| v.clone());
+        assert_eq!(
+            data_dir,
+            Some(pod.dir.join("data/omnigent").display().to_string())
+        );
+
+        let url = cmd
+            .env
+            .iter()
+            .find(|(k, _)| k == "OMNIGENT_URL")
+            .map(|(_, v)| v.clone());
+        assert_eq!(url, Some(pod.server_url()));
+
+        let db = cmd
+            .env
+            .iter()
+            .find(|(k, _)| k == "OMNIGENT_DATABASE_URI")
+            .map(|(_, v)| v.clone());
+        assert_eq!(db, Some(pod.db_uri()));
+    }
+
+    #[test]
+    fn omits_log_mirror_env() {
+        let pod = make_pod();
+        let cmd = build(&pod, &["host".into()]);
+        assert!(cmd.env.iter().find(|(k, _)| k == "OMNIGENT_LOG_TTY_FD").is_none());
+        assert!(cmd
+            .env
+            .iter()
+            .find(|(k, _)| k == "OMNIGENT_LOG_FORCE_COLOR")
+            .is_none());
+    }
+}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds `omnidev omnigent <args…>`, which forwards any omnigent command to
  `uv run omnigent …` with the current checkout's pod env applied
  (`OMNIGENT_DATA_DIR`, `OMNIGENT_DATABASE_URI`, `OMNIGENT_CONFIG_HOME`,
  `OMNIGENT_URL`), so a CLI command talks to the same pod the supervisor runs
  and coexists with a running supervisor (no lock acquired).
- Resolves the repo root → pod dir (same as the supervisor), ensures the pod
  tree, and reads persisted ports so `OMNIGENT_URL` targets a live server. Runs
  in the foreground inheriting stdio and exits with omnigent's status code;
  omits the supervisor's log-mirror env so omnigent's own TTY detection wins.
- The `omnigent` subcommand is a named gate with `trailing_var_arg` +
  `allow_hyphen_values`, so the existing install subcommands
  (`install`/`update`/`check`/`refresh`/`shell-hook`) keep their top-level
  surface and clap's typo-suggestion guardrail. New `src/omnigent_cmd.rs` holds
  the pure `build` + `run` split for testability.

## Test Plan

- `cargo build` and `cargo clippy` clean (no warnings).
- `cargo test` — 60 tests pass (36 unit + 7 install-mgmt + 17 pod-setup),
  including 4 new `omnigent_cmd` unit tests: args forwarded after
  `uv run omnigent`, empty passthrough, pod-isolation env applied, and
  log-mirror env omitted.
- `omnidev --help` shows the flat subcommand surface; `omnidev omnigent …`
  outside a checkout fails at repo-root discovery (not at clap); `omnidev
  isntall` still suggests `install`.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: confirmed `--help` renders the new `omnigent` subcommand,
the passthrough routes outside a checkout (repo-root error, not a clap error),
and the typo guardrail survives (`omnidev isntall` suggests `install`).

## Changelog

`omnidev omnigent <args…>` runs an omnigent command against the current checkout's pod via `uv run omnigent`, with the pod's isolated env applied