### PR TITLE
fix(ios): block cross-origin redirects in the post-consent workspace probe

### DIFF
--- a/web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -29,8 +29,12 @@
 		B20000000000000000000002 /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000002 /* SettingsStoreTests.swift */; };
 		B20000000000000000000003 /* WorkspaceURLExpanderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */; };
 		B20000000000000000000004 /* DeepLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000004 /* DeepLinkTests.swift */; };
+		B20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift */; };
+		B20000000000000000000006 /* MockHTTPServer.swift in Sources (OmnigentTests) */ = {isa = PBXBuildFile; fileRef = A20000000000000000000006 /* MockHTTPServer.swift */; };
+		B40000000000000000000004 /* MockHTTPServer.swift in Sources (OmnigentUITests) */ = {isa = PBXBuildFile; fileRef = A20000000000000000000006 /* MockHTTPServer.swift */; };
 		B40000000000000000000001 /* OmnigentUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000001 /* OmnigentUITests.swift */; };
 		B40000000000000000000002 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000002 /* SnapshotHelper.swift */; };
+		B40000000000000000000003 /* RedirectConsentUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000003 /* RedirectConsentUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,9 +79,12 @@
 		A20000000000000000000002 /* SettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceURLExpanderTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000004 /* DeepLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkTests.swift; sourceTree = "<group>"; };
+		A20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceURLExpanderRedirectTests.swift; sourceTree = "<group>"; };
+		A20000000000000000000006 /* MockHTTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHTTPServer.swift; sourceTree = "<group>"; };
 		A30000000000000000000003 /* OmnigentUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OmnigentUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A40000000000000000000001 /* OmnigentUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnigentUITests.swift; sourceTree = "<group>"; };
 		A40000000000000000000002 /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
+		A40000000000000000000003 /* RedirectConsentUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectConsentUITests.swift; sourceTree = "<group>"; };
 		A30000000000000000000001 /* Omnigent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Omnigent.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A30000000000000000000002 /* OmnigentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OmnigentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -161,6 +168,8 @@
 				A20000000000000000000002 /* SettingsStoreTests.swift */,
 				A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */,
 				A20000000000000000000004 /* DeepLinkTests.swift */,
+				A20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift */,
+				A20000000000000000000006 /* MockHTTPServer.swift */,
 			);
 			path = OmnigentTests;
 			sourceTree = "<group>";
@@ -170,6 +179,7 @@
 			children = (
 				A40000000000000000000001 /* OmnigentUITests.swift */,
 				A40000000000000000000002 /* SnapshotHelper.swift */,
+				A40000000000000000000003 /* RedirectConsentUITests.swift */,
 			);
 			path = OmnigentUITests;
 			sourceTree = "<group>";
@@ -339,6 +349,8 @@
 				B20000000000000000000002 /* SettingsStoreTests.swift in Sources */,
 				B20000000000000000000003 /* WorkspaceURLExpanderTests.swift in Sources */,
 				B20000000000000000000004 /* DeepLinkTests.swift in Sources */,
+				B20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift in Sources */,
+				B20000000000000000000006 /* MockHTTPServer.swift in Sources (OmnigentTests) */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -348,6 +360,8 @@
 			files = (
 				B40000000000000000000001 /* OmnigentUITests.swift in Sources */,
 				B40000000000000000000002 /* SnapshotHelper.swift in Sources */,
+				B40000000000000000000003 /* RedirectConsentUITests.swift in Sources */,
+				B40000000000000000000004 /* MockHTTPServer.swift in Sources (OmnigentUITests) */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/web/ios/Omnigent/WorkspaceURLExpander.swift
+++ b/web/ios/Omnigent/WorkspaceURLExpander.swift
@@ -9,7 +9,10 @@ enum WorkspaceURLExpander {
   /// these hosts.
   static let databricksAppsHostSuffix = "databricksapps.com"
 
-  static func expandIfNeeded(_ url: URL, session: URLSession = .shared) async -> URL {
+  static func expandIfNeeded(
+    _ url: URL,
+    session: URLSession = SameOriginRedirectHandler.session
+  ) async -> URL {
     guard url.scheme?.lowercased() == "https", isBareRoot(url), !isDatabricksAppsHost(url),
       let origin = originURL(for: url)
     else {
@@ -24,6 +27,17 @@ enum WorkspaceURLExpander {
     do {
       let (_, response) = try await session.data(for: request)
       guard let http = response as? HTTPURLResponse else { return url }
+      // Defense in depth: only trust responses that came from the approved
+      // origin. The consent alert promises the app will only talk to the host
+      // the user approved, so a response that landed on a different origin
+      // (e.g. via a cross-origin redirect) must be rejected even if the
+      // redirect delegate is bypassed (such as when a caller supplies a bare
+      // session without a redirect policy).
+      guard let responseURL = http.url, let responseOrigin = originURL(for: responseURL),
+        responseOrigin == origin
+      else {
+        return url
+      }
       guard (http.value(forHTTPHeaderField: "server") ?? "").lowercased() == "databricks" else {
         return url
       }
@@ -53,5 +67,61 @@ enum WorkspaceURLExpander {
     components.port = url.port
     components.path = "/"
     return components.url
+  }
+}
+
+/// URL session delegate that refuses to follow HTTP redirects whose
+/// destination origin differs from the original request's origin.
+///
+/// `WorkspaceURLExpander.expandIfNeeded` probes a server the user just
+/// consented to. Without a redirect policy, a malicious or misconfigured host
+/// could answer the HEAD probe with a 3xx redirect to a different origin —
+/// including a local-network service — causing the app to silently talk to a
+/// host the user never approved. This delegate allows same-origin redirects
+/// (e.g. path or trailing-slash normalization) but blocks anything that would
+/// cross origins. `expandIfNeeded` additionally verifies `response.url` so a
+/// cross-origin response is never trusted even if the caller supplies a
+/// session without this delegate.
+final class SameOriginRedirectHandler: NSObject, URLSessionTaskDelegate {
+  static let session: URLSession = {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.timeoutIntervalForRequest = 8
+    configuration.httpCookieAcceptPolicy = .never
+    configuration.httpCookieStorage = nil
+    return URLSession(
+      configuration: configuration,
+      delegate: SameOriginRedirectHandler(),
+      delegateQueue: nil
+    )
+  }()
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    willPerformHTTPRedirection response: HTTPURLResponse,
+    newRequest request: URLRequest,
+    completionHandler: @escaping @Sendable (URLRequest?) -> Void
+  ) {
+    guard
+      let original = task.originalRequest?.url,
+      let originalOrigin = Self.originKey(for: original),
+      let redirectURL = request.url,
+      let redirectOrigin = Self.originKey(for: redirectURL),
+      originalOrigin == redirectOrigin
+    else {
+      // Block the redirect; URLSession delivers the 3xx response itself as
+      // the task's final response, which `expandIfNeeded` then rejects via the
+      // `response.url` origin check.
+      completionHandler(nil)
+      return
+    }
+    completionHandler(request)
+  }
+
+  private static func originKey(for url: URL) -> String? {
+    guard let scheme = url.scheme?.lowercased(),
+      let host = url.host?.lowercased()
+    else { return nil }
+    return "\(scheme)://\(host)\(url.port.map { ":\($0)" } ?? "")"
   }
 }

--- a/web/ios/OmnigentTests/MockHTTPServer.swift
+++ b/web/ios/OmnigentTests/MockHTTPServer.swift
@@ -1,0 +1,139 @@
+import Darwin
+import Foundation
+
+/// Minimal HTTP/1.1 server on an OS-assigned port (POSIX sockets), reachable
+/// from the app via `http://localhost` on the iOS Simulator (shared loopback).
+///
+/// Shared between the integration tests (`OmnigentTests`) and the UI tests
+/// (`OmnigentUITests`) — compiled into both test targets so neither needs its
+/// own copy. Each target gets its own module, so the class is duplicated across
+/// modules (unavoidable for cross-target sharing without a framework), but the
+/// source is maintained in one place.
+final class MockHTTPServer {
+  private(set) var port: Int = 0
+  private let handler: (String, String) -> (Int, [String: String], Data)
+  private var listenFD: Int32 = -1
+  private var source: DispatchSourceRead?
+  private let queue = DispatchQueue(label: "omnigent.mock-http-server")
+
+  /// - Parameter handler: Receives `(HTTPMethod, path)` and returns
+  ///   `(statusCode, headerField -> value, body)`. Header names are lowercased
+  ///   on the way out.
+  init(handler: @escaping (String, String) -> (Int, [String: String], Data)) throws {
+    self.handler = handler
+    try start()
+  }
+
+  deinit {
+    source?.cancel()
+    if listenFD >= 0 { close(listenFD) }
+  }
+
+  private func start() throws {
+    let fd = socket(AF_INET, SOCK_STREAM, 0)
+    guard fd >= 0 else { throw URLError(.cannotConnectToHost) }
+    listenFD = fd
+
+    var opt: Int32 = 1
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout<Int32>.size))
+
+    var addr = sockaddr_in()
+    addr.sin_family = sa_family_t(AF_INET)
+    addr.sin_port = 0
+    addr.sin_addr.s_addr = 0
+    let bindResult = withUnsafePointer(to: &addr) {
+      $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+        bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+      }
+    }
+    guard bindResult == 0 else { throw URLError(.cannotFindHost) }
+
+    var actual = sockaddr_in()
+    var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+    let nameResult = withUnsafeMutablePointer(to: &actual) {
+      $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+        getsockname(fd, $0, &len)
+      }
+    }
+    guard nameResult == 0 else { throw URLError(.cannotFindHost) }
+    port = Int(UInt16(bigEndian: actual.sin_port))
+
+    guard listen(fd, 16) == 0 else { throw URLError(.cannotConnectToHost) }
+
+    let flags = fcntl(fd, F_GETFL, 0)
+    _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+
+    source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: queue)
+    source?.setEventHandler { [weak self] in self?.acceptConnections() }
+    source?.resume()
+  }
+
+  private func acceptConnections() {
+    while true {
+      let conn = accept(listenFD, nil, nil)
+      if conn < 0 { break }
+      handleConnection(conn)
+    }
+  }
+
+  private func handleConnection(_ fd: Int32) {
+    defer { close(fd) }
+
+    var buffer = Data()
+    var tmp = [UInt8](repeating: 0, count: 4096)
+    let terminator = Data([0x0D, 0x0A, 0x0D, 0x0A])
+    let deadline = Date().addingTimeInterval(5)
+    while buffer.range(of: terminator) == nil, Date() < deadline {
+      let n = read(fd, &tmp, tmp.count)
+      if n <= 0 {
+        usleep(1_000)
+        continue
+      }
+      buffer.append(tmp, count: n)
+      if buffer.count > 64 * 1024 { break }
+    }
+
+    let request = String(data: buffer, encoding: .utf8) ?? ""
+    let firstLine = request.split(separator: "\r\n", maxSplits: 1).first.map(String.init) ?? ""
+    let parts = firstLine.split(separator: " ")
+    let method = parts.first.map(String.init)?.uppercased() ?? "GET"
+    let path = parts.count > 1 ? String(parts[1]) : "/"
+
+    let (status, headers, body) = handler(method, path)
+    writeResponse(
+      fd: fd, status: status, headers: headers, body: body, includeBody: method != "HEAD")
+  }
+
+  private func writeResponse(
+    fd: Int32, status: Int, headers: [String: String], body: Data, includeBody: Bool
+  ) {
+    let reason: String
+    switch status {
+    case 200: reason = "OK"
+    case 302: reason = "Found"
+    default: reason = "OK"
+    }
+    var head = "HTTP/1.1 \(status) \(reason)\r\n"
+    var allHeaders = headers
+    if allHeaders["content-length"] == nil {
+      allHeaders["content-length"] = "\(body.count)"
+    }
+    allHeaders["connection"] = "close"
+    for (key, value) in allHeaders {
+      head += "\(key): \(value)\r\n"
+    }
+    head += "\r\n"
+
+    var out = Data(head.utf8)
+    if includeBody { out.append(body) }
+    out.withUnsafeBytes { raw in
+      var sent = 0
+      guard let ptr = raw.baseAddress else { return }
+      while sent < out.count {
+        let n = write(fd, ptr.advanced(by: sent), out.count - sent)
+        if n <= 0 { break }
+        sent += n
+      }
+    }
+  }
+}

--- a/web/ios/OmnigentTests/WorkspaceURLExpanderRedirectTests.swift
+++ b/web/ios/OmnigentTests/WorkspaceURLExpanderRedirectTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+@testable import Omnigent
+
+/// Integration test for the redirect-policy half of [F-CR-7], run on the
+/// simulator over a REAL local HTTP network.
+///
+/// `WorkspaceURLExpander.expandIfNeeded`'s probe is https-only, and a deep link
+/// to `localhost` infers `http` — so the probe never fires for loopback, which
+/// means a localhost UI test can't exercise the redirect. This test targets the
+/// fix mechanism directly: it starts real local HTTP servers and issues
+/// requests through a `URLSession` backed by `SameOriginRedirectHandler`,
+/// asserting that:
+///   1. a CROSS-ORIGIN redirect (distinct port ⇒ distinct origin) is NOT
+///      followed — the 3xx response is returned with `response.url` still on
+///      the approved origin; and
+///   2. a SAME-ORIGIN redirect (same host+port, different path) IS followed.
+///
+/// The `response.url` defense-in-depth check inside `expandIfNeeded` is covered
+/// separately by `WorkspaceURLExpanderTests.testRejectsResponseFromDifferentOrigin`.
+final class WorkspaceURLExpanderRedirectTests: XCTestCase {
+  func testBlocksCrossOriginRedirect() async throws {
+    // B answers the redirected probe with `server: databricks` — the payload
+    // that, if the redirect were followed, would let B impersonate a workspace.
+    let serverB = try MockHTTPServer { method, _ in
+      if method == "HEAD" {
+        return (200, ["server": "databricks", "content-length": "0"], Data())
+      }
+      return (200, ["content-type": "text/plain"], Data("LEAK".utf8))
+    }
+
+    // A 3xx-redirects the probe to B — a different origin (different port).
+    let serverA = try MockHTTPServer { method, _ in
+      if method == "HEAD" {
+        let location = "http://localhost:\(serverB.port)/"
+        return (302, ["location": location, "content-length": "0"], Data())
+      }
+      return (200, ["content-type": "text/plain"], Data("A".utf8))
+    }
+
+    let session = URLSession(
+      configuration: .ephemeral,
+      delegate: SameOriginRedirectHandler(),
+      delegateQueue: nil
+    )
+    defer { session.invalidateAndCancel() }
+
+    var request = URLRequest(url: URL(string: "http://localhost:\(serverA.port)/")!)
+    request.httpMethod = "HEAD"
+
+    let (_, response) = try await session.data(for: request)
+    let http = try XCTUnwrap(response as? HTTPURLResponse)
+
+    // The redirect must NOT have been followed: we get the 3xx from A, and the
+    // response URL is still A's origin (not B's).
+    XCTAssertEqual(http.statusCode, 302)
+    let responsePort = http.url?.port
+    XCTAssertEqual(
+      responsePort, serverA.port,
+      "Cross-origin redirect was followed to port \(String(describing: responsePort)) — consent boundary broken."
+    )
+    XCTAssertNotEqual(responsePort, serverB.port)
+  }
+
+  func testFollowsSameOriginRedirect() async throws {
+    // A same-origin redirect: /start → /elsewhere on the SAME host+port.
+    let server = try MockHTTPServer { method, path in
+      if method == "HEAD", path == "/start" {
+        return (302, ["location": "/elsewhere", "content-length": "0"], Data())
+      }
+      if method == "HEAD", path == "/elsewhere" {
+        return (200, ["server": "databricks", "content-length": "0"], Data())
+      }
+      return (404, ["content-length": "0"], Data())
+    }
+
+    let session = URLSession(
+      configuration: .ephemeral,
+      delegate: SameOriginRedirectHandler(),
+      delegateQueue: nil
+    )
+    defer { session.invalidateAndCancel() }
+
+    var request = URLRequest(url: URL(string: "http://localhost:\(server.port)/start")!)
+    request.httpMethod = "HEAD"
+
+    let (_, response) = try await session.data(for: request)
+    let http = try XCTUnwrap(response as? HTTPURLResponse)
+
+    // Same-origin redirect IS followed — we land on /elsewhere with 200.
+    XCTAssertEqual(http.statusCode, 200)
+    XCTAssertEqual(http.url?.path, "/elsewhere")
+  }
+}

--- a/web/ios/OmnigentTests/WorkspaceURLExpanderTests.swift
+++ b/web/ios/OmnigentTests/WorkspaceURLExpanderTests.swift
@@ -65,6 +65,27 @@ final class WorkspaceURLExpanderTests: XCTestCase {
     XCTAssertNil(URLProtocolStub.handler)
   }
 
+  func testRejectsResponseFromDifferentOrigin() async {
+    // Simulates a consented host 3xx-redirecting the HEAD probe to a
+    // different origin (e.g. a local-network service). Even if the redirect
+    // were followed, the response.url origin check must reject it so the app
+    // never trusts a host the user did not approve.
+    URLProtocolStub.handler = { request in
+      let response = HTTPURLResponse(
+        url: URL(string: "http://192.168.1.5:8080")!,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: ["server": "databricks"]
+      )!
+      return (response, Data())
+    }
+
+    let original = URL(string: "https://workspace.example.com")!
+    let expanded = await WorkspaceURLExpander.expandIfNeeded(original, session: stubbedSession())
+
+    XCTAssertEqual(expanded, original)
+  }
+
   private func stubbedSession() -> URLSession {
     let configuration = URLSessionConfiguration.ephemeral
     configuration.protocolClasses = [URLProtocolStub.self]

--- a/web/ios/OmnigentUITests/RedirectConsentUITests.swift
+++ b/web/ios/OmnigentUITests/RedirectConsentUITests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+/// UI smoke test for the deep-link consent flow (the surface the [F-CR-7] fix
+/// lives behind), driven in the simulator via the DEBUG-only `--omnigent-open-url`
+/// launch seam added by F-CR-6 (#3179).
+///
+/// NOTE: this does NOT exercise the cross-origin redirect itself. A deep link
+/// to `localhost` infers `http` (`DeepLink.defaultScheme`), and
+/// `WorkspaceURLExpander.expandIfNeeded`'s workspace probe is https-only — so
+/// for a loopback link the probe never fires. The redirect-blocking policy is
+/// verified over a real local network by `WorkspaceURLExpanderRedirectTests`,
+/// and the `response.url` defense-in-depth check by
+/// `WorkspaceURLExpanderTests.testRejectsResponseFromDifferentOrigin`.
+///
+/// What this test does verify end-to-end: an `omnigent://` deep link to an
+/// unknown server presents the consent alert, approving it runs the
+/// post-consent `expandIfNeeded` path, and the WebView loads the approved
+/// server — i.e. the consent flow still works with the fix in place.
+@MainActor
+final class RedirectConsentUITests: XCTestCase {
+  func testDeepLinkConsentOpensApprovedServer() throws {
+    let marker = "OMNIGENT_DEEPLINK_CONSENT_OK"
+    let server = try MockHTTPServer { method, _ in
+      (
+        200, ["content-type": "text/html"],
+        "<html><body>\(marker)</body></html>".data(using: .utf8)!
+      )
+    }
+
+    let deepLink = "omnigent://localhost:\(server.port)/c/conv_smoke"
+
+    let app = XCUIApplication(bundleIdentifier: "ai.omnigent.ios")
+    app.launchArguments += [
+      "--omnigent-open-url", deepLink,
+      "--omnigent-reset-state",
+    ]
+    app.launch()
+
+    let alert = app.alerts["Open this Omnigent link?"]
+    XCTAssertTrue(
+      alert.waitForExistence(timeout: 15), "Expected the consent alert for \(deepLink).")
+    alert.buttons["Open"].tap()
+
+    XCTAssertTrue(
+      app.webViews.firstMatch.waitForExistence(timeout: 30), "Expected a web view after approving.")
+    XCTAssertTrue(
+      app.webViews.staticTexts[marker].waitForExistence(timeout: 30),
+      "Expected the WebView to load the approved server (marker \(marker))."
+    )
+  }
+}


### PR DESCRIPTION
fix(ios): block cross-origin redirects in the post-consent workspace probe

## Related issue

Closes #[F-CR-7]

## Summary

- After a user consents to an unknown server (deep link) or types a server URL, `WorkspaceURLExpander.expandIfNeeded` issued a HEAD probe via `URLSession.shared` with no redirect policy. The consented host could 3xx-redirect that invisible probe to a different origin — including a local-network service — so the app contacted a host the user never approved, violating the consent alert's promise ("you approved A; the app only talks to A").
- The probe now defaults to a dedicated `URLSession` backed by `SameOriginRedirectHandler`, a `URLSessionTaskDelegate` that follows only same-origin redirects (scheme + host + port match) and blocks any cross-origin redirect by returning `nil` from `willPerformHTTPRedirection`.
- As defense in depth, `expandIfNeeded` additionally verifies `response.url`'s origin matches the approved origin, so a cross-origin response is never trusted even if a caller supplies a bare session without the redirect delegate.
- Rebased onto #3179 (F-CR-6) and deduped: removed my `--omnigent-deep-link` test hook (subsumed by #3179's `--omnigent-open-url` / `--omnigent-reset-state` seam), and consolidated the two `MockHTTPServer` copies into one shared file compiled into both test targets.

## Test Plan

- **Unit** (`WorkspaceURLExpanderTests.testRejectsResponseFromDifferentOrigin`): returns a `server: databricks` 200 whose `url` is a different origin (`http://192.168.1.5:8080`) and asserts the URL is left unchanged — the `response.url` defense-in-depth check.
- **Integration** (`WorkspaceURLExpanderRedirectTests`, simulator, real local HTTP network):
  - `testBlocksCrossOriginRedirect`: server A 302-redirects the HEAD probe to server B (distinct port ⇒ distinct origin); asserts the redirect is **not** followed (response stays `302` on A's port, never reaching B). **Confirmed meaningful:** the test fails when the delegate is reverted to follow-all-redirects (the vulnerable behavior).
  - `testFollowsSameOriginRedirect`: a same-origin redirect (`/start → /elsewhere`, same host+port) **is** followed — normal path normalization still works.
- **UI** (`RedirectConsentUITests.testDeepLinkConsentOpensApprovedServer`, simulator): drives the deep-link consent flow via #3179's `--omnigent-open-url` + `--omnigent-reset-state` seam and asserts the alert appears, "Open" loads the approved server's WebView.
- **Manual simulator verification (A/B comparison):** staged two local HTTP servers (A → 302 → B) and built both a vulnerable and a fixed version (with a temporary `http` tweak so the https-only probe fires for localhost). Typing `http://localhost:8101` into the app:
  - **Vulnerable build:** Server B logged a `HEAD` request — the app contacted the unapproved host (the leak).
  - **Fixed build:** Server B logged nothing — the redirect was blocked, the app stayed on A.
- Ran on iPhone 17 simulator: all 8 expander/redirect tests + the UI smoke test + all 26 F-CR-6 deep-link tests pass; full project builds.
- Note: the UI test cannot exercise the redirect itself — a localhost deep link infers `http`, and the probe is https-only, so the probe never fires for loopback. The redirect policy is verified over a real local network by the integration test instead.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: built and ran the new unit, integration, and UI tests on the iPhone 17 simulator; confirmed all pass and that the integration test fails against the vulnerable (follow-all-redirects) baseline, proving it is a meaningful regression test. Also ran an A/B comparison with two local redirecting servers: the vulnerable build followed the redirect to the unapproved host (logged), the fixed build did not. Ran all F-CR-6 tests after the dedup to confirm no regression from #3179's shared seam.

## Changelog

The iOS app no longer follows cross-origin redirects when probing a newly approved server for the Databricks workspace mount, so a consented host can't redirect the probe to a different origin.
