### PR TITLE
fix(store): hydrate labels in list_conversations_by_runner_id so forked native sessions resume history

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2876,7 +2876,17 @@ class SqlAlchemyConversationStore(ConversationStore):
                 .scalars()
                 .all()
             )
-        return [_to_conversation(r, meta_by_id.get(r.id)) for r in ap_rows]
+            # Hydrate labels (one batched query, no N+1): the runner
+            # session-init envelope is built from ``conversation.labels``, and
+            # the reconnect path (``_on_runner_connect``) sources its
+            # conversations here. Without this the envelope ships empty labels,
+            # so fork directives (carry-history / source transcript) never reach
+            # the runner and a forked native session launches without history.
+            labels_by_conv = _fetch_labels_bulk(ap_sess, conv_ids)
+        return [
+            _to_conversation(r, meta_by_id.get(r.id), labels_by_conv.get(r.id, {}))
+            for r in ap_rows
+        ]
 
     def set_host_id(
         self,

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -2393,6 +2393,36 @@ def test_list_conversations_by_runner_id_filters(
     assert result[0].runner_id == "runner_token_a"
 
 
+def test_list_conversations_by_runner_id_hydrates_labels(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Conversations from the reconnect lookup carry their labels.
+
+    ``_on_runner_connect`` sources conversations here and feeds them to
+    the runner session-init envelope, which is built from
+    ``conversation.labels``. If this path returns label-less entities the
+    envelope ships empty labels, so a forked native session's fork
+    directives (carry-history / source transcript id) never reach the
+    runner and it launches without history. Guards that regression.
+    """
+    bound = conversation_store.create_conversation(runner_id="runner_token_a")
+    conversation_store.set_labels(
+        bound.id,
+        {
+            "omnigent.fork.carry_history": "1",
+            "omnigent.fork.source_external_session_id": "src-claude-sid",
+        },
+    )
+
+    result = conversation_store.list_conversations_by_runner_id("runner_token_a")
+
+    assert [c.id for c in result] == [bound.id]
+    assert result[0].labels == {
+        "omnigent.fork.carry_history": "1",
+        "omnigent.fork.source_external_session_id": "src-claude-sid",
+    }
+
+
 # ── Host id ─────────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Forked **claude-native** sessions launched the vendor TUI with **no prior
conversation history**, even though the fork copied the history into the store
(the web UI showed it). The runner never received the fork directives that seed
the resumable transcript, so it launched Claude fresh.

Root cause is a **label-hydration gap** in `list_conversations_by_runner_id`,
not in the fork/transcript-seeding logic:

- The runner reconnect path (`_on_runner_connect`) sources its conversations
  from `list_conversations_by_runner_id` and feeds each into the session-init
  envelope, which is built from `conversation.labels`.
- That store method built its `Conversation` entities **without fetching
  labels** (`labels={}`), so the fork directives
  (`omnigent.fork.carry_history`, `omnigent.fork.source_external_session_id`)
  were dropped in transit. The runner saw no fork labels, skipped its
  clone/rebuild branches, and launched fresh.
- The `RunnerSessionInitializer` then **caches and shares** that label-less
  envelope with the first-turn path, so even the label-hydrated
  `get_conversation` result on that path was never used for the envelope.

Fix: hydrate labels via the existing batched `_fetch_labels_bulk` inside the
same `_conv_session`, and thread them into `_to_conversation`. One extra query,
no N+1, correct under the split-DB topology (labels live in the conversation DB).

**Regression window:** introduced by #2793 ("Coalesce session initialization",
`6441f3b3`, 2026-07-21). Before that, neither init POST carried labels — the
runner fetched them itself via `GET /v1/sessions/{id}` (which hydrates labels
through `get_conversation`). #2793 moved the label source to the server-pushed
envelope built from `list_conversations_by_runner_id`, exposing the missing
hydration.

**Other affected harnesses:** the empty-labels result fed *every* consumer of
the reconnect path, so any label-driven behavior on reconnect was equally
broken and is fixed by the same one-line hydration — codex-native / pi-native /
qwen-native fork history (all read `omnigent.fork.*` labels), cursor-native /
opencode-native fork-history preamble (`omnigent.fork.carry_history`), and the
presentation labels (`omnigent.ui` / `omnigent.wrapper`) that set a session's
Web UI mode on reconnect.

## Test Plan

- New unit test `test_list_conversations_by_runner_id_hydrates_labels` asserts
  fork labels survive the reconnect lookup. Passing, along with the existing
  `..._filters` test and the split-DB variants (labels-in-conv-DB topology):
  ```
  pytest tests/stores/test_conversation_store.py -k by_runner_id
  pytest tests/stores/test_conversation_store_split_db.py -k "by_runner_id or label"
  ```
- **Manual E2E:** with a local server built from this branch, forked a
  claude-native session and sent it a message. Before the fix the runner log
  showed the init envelope carrying only `omnigent.claude_native.bridge_id`
  (`fork_source_set=False`, `resume_enabled=False`, no `--resume`); after the
  fix the fork's TUI resumes with the source conversation's history. Verified
  the fork's stored labels (`omnigent.fork.carry_history=1`,
  `omnigent.fork.source_external_session_id=...`) now reach the runner.

## Demo

N/A — non-visual (store/runtime data-flow fix; the "demo" is the forked TUI
recalling prior history, covered in the Test Plan).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage guards the store method directly (both single-DB and split-DB).
The full fork→runner→TUI path is covered by the opt-in
`tests/e2e/test_host_claude_native_fork_e2e.py` (requires a real interactive
Claude login, so not in CI); I exercised it manually against a live local
server as described in the Test Plan.

## Changelog

Forked native sessions (Claude Code, Codex, Pi, Qwen) again resume with their prior conversation history.

This pull request and its description were written by Isaac.
