### PR TITLE
fix(claude-native): durably persist compaction boundary on resume/replay

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -313,12 +313,21 @@ class ClaudeTranscriptItem:
     :param data: Item payload shaped like ``SessionEventInput.data``.
     :param response_id: Synthetic response id used to group the
         Claude turn in AP/web UI rendering.
+    :param is_compact_summary: ``True`` when this item was parsed from a
+        Claude ``isCompactSummary: true`` user record — the continuation
+        summary Claude writes immediately after it compacts its own
+        context. The forwarder uses this flag to persist a durable
+        Omnigent compaction boundary (see
+        :func:`omnigent.claude_native_forwarder._forward_available_items`)
+        instead of rendering the summary as a user bubble. Defaults to
+        ``False`` for every ordinary transcript item.
     """
 
     source_id: str
     item_type: str
     data: dict[str, Any]
     response_id: str
+    is_compact_summary: bool = False
 
 
 @dataclass(frozen=True)
@@ -4654,6 +4663,35 @@ def _user_transcript_items_from_entry(
     content = message.get("content") if isinstance(message, dict) else None
     source_key = _transcript_source_key(entry, line_number, record_offset)
     fallback_response_id = _response_id_from_source(source_key)
+
+    # ``isCompactSummary: true`` is the continuation-summary user record
+    # Claude writes right after it compacts its own context. It is the
+    # reliable, always-present compaction signal (the post-compaction
+    # ``SessionStart source=compact`` hook that normally persists the
+    # boundary is flaky and sometimes never fires). Surface it as a
+    # single flagged ``message`` item carrying the summary text so the
+    # forwarder can persist a durable compaction boundary instead of
+    # rendering the summary verbatim as a user bubble. Only the flag and
+    # text matter downstream — skip the slash/terminal/scaffolding
+    # detection the ordinary user path runs.
+    if entry.get("isCompactSummary") is True:
+        summary_text = content if isinstance(content, str) else _summary_text_from_blocks(content)
+        return (
+            current_response_id,
+            [
+                ClaudeTranscriptItem(
+                    source_id=_source_id(source_key, 0, "compact_summary"),
+                    item_type="message",
+                    data={
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": summary_text}],
+                    },
+                    response_id=fallback_response_id,
+                    is_compact_summary=True,
+                )
+            ],
+        )
+
     items: list[ClaudeTranscriptItem] = []
 
     if isinstance(content, str):
@@ -5041,6 +5079,34 @@ def _source_id(source_key: str, item_index: int, item_type: str) -> str:
     :returns: Stable source id string.
     """
     return f"{source_key}:{item_index}:{item_type}"
+
+
+def _summary_text_from_blocks(content: Any) -> str:
+    """
+    Join the text of a compact-summary record's content blocks.
+
+    A Claude ``isCompactSummary`` record usually carries its summary as
+    a plain string, but the JSONL format may also ship list-form
+    ``[{"type": "text", "text": ...}]`` blocks. This flattens the
+    list case to a single string so the compaction summary is preserved
+    regardless of shape.
+
+    :param content: The record's ``message.content`` — a string, a list
+        of content blocks, or anything else.
+    :returns: The concatenated summary text, or ``""`` when no text is
+        present.
+    """
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                parts.append(text)
+    return "\n".join(parts)
 
 
 def _wait_for_server_info(bridge_dir: Path, *, timeout_s: float) -> dict[str, Any]:

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -448,52 +448,30 @@ class CompactionForwardState:
     """
     Durable compaction-boundary reconciliation state.
 
-    Persisted at ``{bridge_dir}/compaction_forwarder.json`` and shared by
-    BOTH the hook forwarder and the transcript forwarder — a compaction is
-    bracketed by a ``PreCompact`` hook and completed by *either* the
-    transcript's ``isCompactSummary`` record *or* the
-    ``SessionStart source=compact`` hook, and both must reconcile against
-    one durable token so exactly one Omnigent ``compaction`` boundary is
-    persisted per compaction, regardless of arrival order or a missing
-    (flaky) completion hook.
+    Persisted at ``{bridge_dir}/compaction_forwarder.json`` and shared by the
+    hook and transcript forwarders. A compaction is bracketed by a
+    ``PreCompact`` hook and completed by *either* the transcript's
+    ``isCompactSummary`` record *or* the ``SessionStart source=compact`` hook;
+    both reconcile against one durable token so exactly one Omnigent
+    ``compaction`` boundary is persisted per compaction, regardless of arrival
+    order or a missing completion hook.
 
-    :param pending: The compaction awaiting a boundary persist, or ``None``
-        when no compaction is in flight.
-    :param last_seq: The highest sequence number minted so far. Each
-        ``PreCompact`` increments it, so repeated compactions never reuse a
-        key.
-    :param persisted_seqs: Sequence numbers whose boundary POST already
-        succeeded, bounded to the most recent
-        :data:`_MAX_PERSISTED_COMPACTION_SEQS`. Blocks a re-persist after a
-        crash/restart or cursor rewind re-reads an already-handled summary.
-    :param last_precompact_cursor: Highest hook ``event_cursor`` already
-        minted into a pending token. A ``PreCompact`` edge is noted at most
-        once even though it is scanned twice per poll — a pre-items prescan
-        (so the token exists before the transcript summary in the same poll
-        is processed) and again by the main hook phase. Zero means no
-        cursor-keyed ``PreCompact`` has been minted yet.
-    :param expect_completion_ack: ``True`` when the transcript
-        ``isCompactSummary`` path has just persisted a boundary and a paired
-        ``SessionStart source=compact`` completion hook may still trail it.
-        The two are completion signals for the *same* compaction, but once
-        the pending token is consumed the durable state is indistinguishable
-        from a fresh standalone compaction — so this one-shot flag tells the
-        standalone-completion path to absorb (not re-persist) the trailing
-        hook. Cleared when the hook is absorbed or a new ``PreCompact`` opens
-        the next cycle, bounding it to a single compaction.
-    :param expect_completion_ack_seq: The ``seq`` of the boundary that armed
-        :attr:`expect_completion_ack`, binding the ack window to a specific
-        persisted compaction rather than a bare, unattributed flag. The
-        standalone-completion path only absorbs a trailing hook when this seq
-        is genuinely present in :attr:`persisted_seqs` — i.e. the boundary it
-        would be acking really was stored. If the flag is somehow armed for a
-        seq that is not persisted (corruption, partial write, a state file
-        from before this field existed), the path biases to the *safe*
-        direction and persists a fresh boundary rather than silently
-        absorbing the hook, because a lost boundary (a full pre-compaction
-        history reload on resume) is far worse than an at-most-once duplicate.
-        Zero means no ack is armed, or the ack came from a legacy state file
-        with no recorded seq. Cleared alongside :attr:`expect_completion_ack`.
+    :param pending: The compaction awaiting a boundary persist, or ``None``.
+    :param last_seq: Highest sequence number minted so far; each ``PreCompact``
+        increments it so keys are never reused.
+    :param persisted_seqs: Sequence numbers whose boundary POST succeeded,
+        bounded to :data:`_MAX_PERSISTED_COMPACTION_SEQS`; blocks re-persist on
+        a cursor rewind or restart.
+    :param last_precompact_cursor: Highest hook ``event_cursor`` already minted;
+        de-dupes the ``PreCompact`` edge across the twice-per-poll scan.
+    :param expect_completion_ack: One-shot flag: a transcript boundary just
+        persisted and a paired completion hook may still trail it, so the
+        standalone-completion path absorbs (not re-persists) that hook.
+    :param expect_completion_ack_seq: The ``seq`` that armed
+        :attr:`expect_completion_ack`; the trailing hook is absorbed only when
+        this seq is in :attr:`persisted_seqs`, otherwise the path biases to
+        persisting a fresh boundary. Zero means no ack armed (or a legacy state
+        file).
     """
 
     pending: _PendingCompaction | None = None

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -53,7 +53,14 @@ _FORWARDER_STATE_FILE = "transcript_forwarder.json"
 _HOOK_STATE_FILE = "hook_forwarder.json"
 _SUBAGENT_STATE_FILE = "subagent_forwarder.json"
 _DELTA_STATE_FILE = "message_deltas_forwarder.json"
+_COMPACTION_STATE_FILE = "compaction_forwarder.json"
 _HOOKS_FILE = "hooks.jsonl"
+
+# Cap on the ``persisted_seqs`` history kept in the durable compaction
+# state. Each entry is one completed compaction boundary; a session sees
+# a handful over its lifetime, so a small bound is ample while still
+# surviving a cursor rewind that re-reads an already-persisted summary.
+_MAX_PERSISTED_COMPACTION_SEQS = 16
 
 # Cap on the in-memory ``(message_id, index)`` dedupe ring for streamed
 # deltas. The byte offset already prevents re-reading on the normal
@@ -345,6 +352,47 @@ def _note_forward_failure(retry_key: str) -> None:
         _forward_health.degraded_logged = True
 
 
+@dataclass
+class _CompactionSkipStats:
+    """
+    Process-level counters for skipped compaction-summary records.
+
+    An ``isCompactSummary`` transcript record is skipped (not persisted as a
+    boundary) whenever :func:`_consume_pending_compaction` finds no
+    consumable pending token. Two causes must be told apart so a genuinely
+    missed ``PreCompact`` is observable instead of silently dropped:
+
+    * ``expected_skip`` — a historical/replayed summary or the trailing
+      duplicate of a boundary the hook path already persisted. Benign; the
+      durable state shows a prior boundary or an in-flight cycle.
+    * ``precompact_miss`` — no token AND no boundary ever persisted for this
+      session's compaction state. This is the flaky-hook failure mode the
+      fix targets on the transcript side too; it means the boundary was NOT
+      captured, so it is escalated to a warning and counted to measure the
+      true miss rate.
+
+    :param expected_skip: Count of benign skips since process start / reset.
+    :param precompact_miss: Count of skips with no pending token and no
+        persisted boundary — a true, observable ``PreCompact`` miss.
+    """
+
+    expected_skip: int = 0
+    precompact_miss: int = 0
+
+
+_compaction_skip_stats = _CompactionSkipStats()
+
+
+def _reset_compaction_skip_stats() -> None:
+    """
+    Reset the compaction-skip counters (test seam / new forwarder lifetime).
+
+    :returns: None.
+    """
+    global _compaction_skip_stats
+    _compaction_skip_stats = _CompactionSkipStats()
+
+
 @dataclass(frozen=True)
 class HookForwardState:
     """
@@ -363,6 +411,83 @@ class HookForwardState:
     event_cursor: int
     byte_offset: int | None = None
     cursor_fingerprint: str | None = None
+
+
+@dataclass(frozen=True)
+class _PendingCompaction:
+    """
+    One in-flight compaction awaiting its boundary persist.
+
+    Minted from a ``PreCompact`` hook and consumed by whichever
+    completion signal arrives first — the transcript's
+    ``isCompactSummary`` record (primary, durable) or the
+    ``SessionStart source=compact`` hook (secondary, best-effort).
+
+    :param seq: Monotonic sequence number for this compaction within the
+        session, e.g. ``3``. Used as the idempotency key so a boundary is
+        persisted exactly once even if both completion signals arrive.
+    :param claude_session_id: Claude-native session uuid captured from the
+        ``PreCompact`` hook, or ``None`` when the hook omitted it. Used to
+        correlate the completion signal to this compaction; ``None`` acts
+        as a wildcard match.
+    :param transcript_path: Claude transcript path from the ``PreCompact``
+        hook as a string, or ``None`` when absent. Also used for
+        correlation with wildcard semantics.
+    :param seen_at: Unix timestamp the ``PreCompact`` was observed, e.g.
+        ``1779922393.2``. Diagnostic only.
+    """
+
+    seq: int
+    claude_session_id: str | None = None
+    transcript_path: str | None = None
+    seen_at: float | None = None
+
+
+@dataclass(frozen=True)
+class CompactionForwardState:
+    """
+    Durable compaction-boundary reconciliation state.
+
+    Persisted at ``{bridge_dir}/compaction_forwarder.json`` and shared by
+    BOTH the hook forwarder and the transcript forwarder — a compaction is
+    bracketed by a ``PreCompact`` hook and completed by *either* the
+    transcript's ``isCompactSummary`` record *or* the
+    ``SessionStart source=compact`` hook, and both must reconcile against
+    one durable token so exactly one Omnigent ``compaction`` boundary is
+    persisted per compaction, regardless of arrival order or a missing
+    (flaky) completion hook.
+
+    :param pending: The compaction awaiting a boundary persist, or ``None``
+        when no compaction is in flight.
+    :param last_seq: The highest sequence number minted so far. Each
+        ``PreCompact`` increments it, so repeated compactions never reuse a
+        key.
+    :param persisted_seqs: Sequence numbers whose boundary POST already
+        succeeded, bounded to the most recent
+        :data:`_MAX_PERSISTED_COMPACTION_SEQS`. Blocks a re-persist after a
+        crash/restart or cursor rewind re-reads an already-handled summary.
+    :param last_precompact_cursor: Highest hook ``event_cursor`` already
+        minted into a pending token. A ``PreCompact`` edge is noted at most
+        once even though it is scanned twice per poll — a pre-items prescan
+        (so the token exists before the transcript summary in the same poll
+        is processed) and again by the main hook phase. Zero means no
+        cursor-keyed ``PreCompact`` has been minted yet.
+    :param expect_completion_ack: ``True`` when the transcript
+        ``isCompactSummary`` path has just persisted a boundary and a paired
+        ``SessionStart source=compact`` completion hook may still trail it.
+        The two are completion signals for the *same* compaction, but once
+        the pending token is consumed the durable state is indistinguishable
+        from a fresh standalone compaction — so this one-shot flag tells the
+        standalone-completion path to absorb (not re-persist) the trailing
+        hook. Cleared when the hook is absorbed or a new ``PreCompact`` opens
+        the next cycle, bounding it to a single compaction.
+    """
+
+    pending: _PendingCompaction | None = None
+    last_seq: int = 0
+    persisted_seqs: tuple[int, ...] = ()
+    last_precompact_cursor: int = 0
+    expect_completion_ack: bool = False
 
 
 @dataclass(frozen=True)
@@ -923,6 +1048,13 @@ async def forward_claude_transcript_to_session(
                         seen_keys=seen_delta_keys,
                         ordering=delta_ordering,
                     )
+                    # Mint a pending token for any PreCompact that first
+                    # became visible THIS poll, before the transcript items
+                    # phase (which consumes the isCompactSummary completion
+                    # record) runs — else a PreCompact + summary landing in
+                    # the same poll would lose the boundary. Cursor-keyed, so
+                    # the main hook phase below does not re-mint.
+                    await _prescan_precompact_edges(bridge_dir, hook_state)
                     state = await _forward_available_items(
                         client=client,
                         session_id=current_session_id,
@@ -2668,23 +2800,65 @@ async def _forward_available_status_events(
                         compaction_status,
                         exc_info=True,
                     )
-                # Persist a compaction item so session resume knows
-                # the compaction boundary. Without this, rebuilding
-                # the transcript from the conversation DB loads the
-                # full pre-compaction history.
-                if compaction_status == "completed":
-                    try:
-                        await _persist_native_compaction_item(
-                            client,
-                            session_id=session_id,
-                            bridge_dir=bridge_dir,
-                        )
-                    except Exception:  # noqa: BLE001
-                        _logger.warning(
-                            "Failed to persist compaction item for %s",
-                            session_id,
-                            exc_info=True,
-                        )
+                if compaction_status == "in_progress":
+                    # ``PreCompact`` mints a durable pending token that the
+                    # completion signal (transcript ``isCompactSummary`` or
+                    # this hook's ``SessionStart source=compact``) consumes,
+                    # so exactly one boundary persists per compaction. Keyed
+                    # by ``event_cursor`` so the pre-items prescan (which may
+                    # already have minted this same edge this poll) and this
+                    # phase converge on one token, never two.
+                    await _note_precompact(
+                        bridge_dir,
+                        claude_session_id=record.claude_session_id,
+                        transcript_path=(
+                            str(record.transcript_path)
+                            if record.transcript_path is not None
+                            else None
+                        ),
+                        event_cursor=record.event_cursor,
+                    )
+                elif compaction_status == "completed":
+                    # Secondary, best-effort persist. The transcript's
+                    # ``isCompactSummary`` record is the primary, durable
+                    # persister (it carries the summary text and always
+                    # fires — this hook is flaky). Persist here if the
+                    # pending token is still unconsumed; on failure leave the
+                    # token set so the transcript path still completes it.
+                    seq = await _consume_pending_compaction(
+                        bridge_dir,
+                        claude_session_id=record.claude_session_id,
+                        transcript_path=(
+                            str(record.transcript_path)
+                            if record.transcript_path is not None
+                            else None
+                        ),
+                    )
+                    if seq is None:
+                        # No pending token: either the transcript path already
+                        # persisted this boundary (a trailing ack to absorb),
+                        # or the ``PreCompact`` was dropped / the forwarder
+                        # attached after it fired. The legacy
+                        # standalone-completion safety must still persist
+                        # exactly one boundary in the latter case, or resume
+                        # reloads the full pre-compaction history.
+                        seq = await _claim_standalone_completion(bridge_dir)
+                    if seq is not None:
+                        try:
+                            await _persist_native_compaction_item(
+                                client,
+                                session_id=session_id,
+                                bridge_dir=bridge_dir,
+                            )
+                        except Exception:  # noqa: BLE001
+                            _logger.warning(
+                                "Failed to persist compaction item (hook path) for %s; "
+                                "leaving pending token for transcript-path retry",
+                                session_id,
+                                exc_info=True,
+                            )
+                        else:
+                            await _mark_compaction_persisted(bridge_dir, seq)
                 durable = next_durable
                 await _write_hook_state_async(bridge_dir, durable)
                 continue
@@ -2898,6 +3072,149 @@ def _turn_has_assistant_output(items: list[ClaudeTranscriptItem], response_id: s
     return False
 
 
+def _compact_summary_text(item: ClaudeTranscriptItem) -> str | None:
+    """
+    Pull the continuation-summary text out of a compact-summary item.
+
+    :param item: A transcript item with ``is_compact_summary`` set.
+    :returns: The summary text, or ``None`` when the item carried none.
+    """
+    content = item.data.get("content")
+    if not isinstance(content, list):
+        return None
+    parts = [
+        block.get("text")
+        for block in content
+        if isinstance(block, dict) and isinstance(block.get("text"), str) and block.get("text")
+    ]
+    return "\n".join(parts) if parts else None
+
+
+async def _handle_compact_summary_item(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    item: ClaudeTranscriptItem,
+    retry_tracker: _PostRetryTracker,
+) -> bool:
+    """
+    Persist a durable compaction boundary from a transcript summary record.
+
+    Primary path for the compaction fix. Consumes the pending
+    ``PreCompact`` token, and — only when one is pending and unconsumed —
+    persists exactly one Omnigent ``compaction`` boundary carrying the
+    record's summary text, then marks the sequence persisted so neither
+    completion signal re-persists it.
+
+    * No pending token (historical or already-persisted summary, e.g. a
+      replay after restart) → nothing to do; report handled so the caller
+      advances past the record without forwarding it as a bubble.
+    * Pending token present → attempt the boundary persist. On success,
+      mark persisted and report handled. On an active retry backoff or a
+      hard POST failure, report **not** handled so the caller stops the
+      batch with the cursor before this record and retries next poll — the
+      summary is never consumed until its boundary is durably stored.
+
+    :param client: Omnigent HTTP client.
+    :param session_id: Omnigent session/conversation id.
+    :param bridge_dir: Native Claude bridge directory.
+    :param item: The compact-summary transcript item.
+    :param retry_tracker: Retry/backoff tracker; keyed per compaction seq.
+    :returns: ``True`` when the caller may advance past this record,
+        ``False`` when it must be retried later.
+    """
+    seq = await _consume_pending_compaction(
+        bridge_dir,
+        claude_session_id=None,
+        transcript_path=None,
+    )
+    if seq is None:
+        # No correlated pending compaction — a historical/replayed summary,
+        # one the hook path already persisted, or a genuine ``PreCompact``
+        # miss. Distinguish the benign cases from a true miss so the latter
+        # is observable rather than silently dropped, then close any pending
+        # completion-ack window (this summary starts a new cycle for the
+        # completion hook). Either way, report handled so the caller advances
+        # past the record without forwarding it as a bubble.
+        state = _read_compaction_state(bridge_dir)
+        if state.pending is None and not state.persisted_seqs:
+            _compaction_skip_stats.precompact_miss += 1
+            _logger.warning(
+                "Skipping isCompactSummary with no pending PreCompact and no "
+                "persisted boundary (likely a missed PreCompact hook); "
+                "session=%s bridge_dir=%s precompact_miss_total=%s",
+                session_id,
+                bridge_dir,
+                _compaction_skip_stats.precompact_miss,
+            )
+        else:
+            _compaction_skip_stats.expected_skip += 1
+            _logger.debug(
+                "Skipping isCompactSummary with no consumable token (expected "
+                "replay/dedupe); session=%s bridge_dir=%s expected_skip_total=%s",
+                session_id,
+                bridge_dir,
+                _compaction_skip_stats.expected_skip,
+            )
+        await _note_transcript_summary_without_token(bridge_dir)
+        return True
+    retry_key = f"compaction:{seq}"
+    if retry_tracker.retry_delay_s(retry_key) is not None:
+        return False
+    try:
+        await _persist_native_compaction_item(
+            client,
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            summary_override=_compact_summary_text(item),
+        )
+    except httpx.HTTPError as exc:
+        if post_may_have_been_delivered(exc):
+            # Ambiguous delivery: the boundary may already be committed.
+            # Mark persisted and advance rather than risk a duplicate
+            # boundary — mirrors the item-forwarding ambiguous-failure rule.
+            _logger.warning(
+                "Ambiguous compaction boundary POST for %s (may be committed); "
+                "marking persisted to avoid a duplicate boundary; seq=%s",
+                session_id,
+                seq,
+                exc_info=True,
+            )
+            retry_tracker.clear(retry_key)
+            await _mark_compaction_persisted(bridge_dir, seq, expect_completion_ack=True)
+            return True
+        decision = retry_tracker.record_failure(retry_key, exc)
+        _logger.warning(
+            "Failed to persist compaction boundary (transcript path); "
+            "session=%s seq=%s attempt=%s permanent=%s next_retry_s=%.3f http_status=%s",
+            session_id,
+            seq,
+            decision.attempts,
+            decision.permanent,
+            decision.delay_s,
+            _http_status_for_log(exc),
+            exc_info=True,
+        )
+        return False
+    except Exception:  # noqa: BLE001
+        # Non-HTTP failure (e.g. reading Claude session messages). Retry.
+        _logger.warning(
+            "Unexpected error persisting compaction boundary (transcript path) for %s; seq=%s",
+            session_id,
+            seq,
+            exc_info=True,
+        )
+        return False
+    retry_tracker.clear(retry_key)
+    # Transcript path persisted the boundary. A ``SessionStart source=compact``
+    # completion hook may still trail this summary for the SAME compaction;
+    # arm the completion-ack window so that hook is absorbed, not persisted
+    # again as a spurious standalone boundary.
+    await _mark_compaction_persisted(bridge_dir, seq, expect_completion_ack=True)
+    return True
+
+
 async def _forward_available_items(
     *,
     client: httpx.AsyncClient,
@@ -2993,6 +3310,41 @@ async def _forward_available_items(
     updated = state
     for item in items:
         if item.source_id in seen:
+            continue
+        # Compaction boundary (primary, durable path). Claude writes an
+        # ``isCompactSummary`` user record immediately after it compacts
+        # its own context; that record — not the flaky
+        # ``SessionStart source=compact`` hook — is the reliable signal.
+        # Persist a durable Omnigent ``compaction`` boundary here (never
+        # forward the summary as a user bubble). Correlate to a pending
+        # ``PreCompact`` so we don't persist for a historical/replayed
+        # summary, and do NOT advance the transcript cursor until the
+        # boundary POST succeeds — a failed persist must be retried, not
+        # silently skipped, or resume would reload the full pre-compaction
+        # history.
+        if item.is_compact_summary:
+            handled = await _handle_compact_summary_item(
+                client,
+                session_id=session_id,
+                bridge_dir=bridge_dir,
+                item=item,
+                retry_tracker=retry_tracker,
+            )
+            if not handled:
+                # Hard persist failure or active backoff — stop the batch
+                # here with the cursor before this item so it is retried.
+                return updated
+            seen.add(item.source_id)
+            seen_source_ids.append(item.source_id)
+            updated = TranscriptForwardState(
+                transcript_path=state.transcript_path,
+                line_cursor=state.line_cursor,
+                byte_offset=state.byte_offset,
+                current_response_id=current_response_id,
+                seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
+                cursor_fingerprint=state.cursor_fingerprint,
+            )
+            await _write_forward_state_async(bridge_dir, updated)
             continue
         if skip_user_messages and item.item_type == "message" and item.data.get("role") == "user":
             seen_source_ids.append(item.source_id)
@@ -3215,6 +3567,45 @@ def _read_hook_events_for_state(
         state.byte_offset,
         start_event_count=state.event_cursor,
     )
+
+
+async def _prescan_precompact_edges(
+    bridge_dir: Path,
+    hook_state: HookForwardState | None,
+) -> None:
+    """
+    Mint pending tokens for newly-visible ``PreCompact`` edges before items.
+
+    Within one poll the transcript forwarder (which processes the
+    ``isCompactSummary`` completion record) runs *before* the hook forwarder
+    (which mints the ``PreCompact`` token). A ``PreCompact`` and its summary
+    that first become visible in the same poll would otherwise lose the
+    boundary: the summary is consumed with no token yet minted. This scan
+    reads the same hook records WITHOUT advancing the hook cursor and notes
+    each ``PreCompact`` via :func:`_note_precompact`, keyed by ``event_cursor``
+    so the main hook phase does not re-mint. Only ``PreCompact`` edges are
+    touched — message/status/task semantics are untouched and stay owned by
+    :func:`_forward_available_status_events`.
+
+    :param bridge_dir: Native Claude bridge directory.
+    :param hook_state: Current hook cursor, or ``None`` before it is seeded
+        (nothing to prescan yet).
+    :returns: None.
+    """
+    if hook_state is None:
+        return
+    result = await asyncio.to_thread(_read_hook_events_for_state, bridge_dir, hook_state)
+    for record in result.records:
+        if record.event_name != "PreCompact":
+            continue
+        await _note_precompact(
+            bridge_dir,
+            claude_session_id=record.claude_session_id,
+            transcript_path=(
+                str(record.transcript_path) if record.transcript_path is not None else None
+            ),
+            event_cursor=record.event_cursor,
+        )
 
 
 def _validated_hook_state(
@@ -3871,15 +4262,17 @@ async def _persist_native_compaction_item(
     *,
     session_id: str,
     bridge_dir: Path,
+    summary_override: str | None = None,
 ) -> None:
     """
     Persist a compaction boundary item to the conversation store.
 
-    Called when the forwarder observes a compaction-completed signal
-    (``SessionStart source=compact``). Queries the latest conversation
-    item to use as ``last_item_id`` so session resume knows the
-    compaction boundary — items before this marker are summarized
-    and don't need to be loaded.
+    Called when the forwarder observes a compaction-completed signal —
+    either the transcript's ``isCompactSummary`` record (primary,
+    durable) or the ``SessionStart source=compact`` hook (secondary).
+    Queries the latest conversation item to use as ``last_item_id`` so
+    session resume knows the compaction boundary — items before this
+    marker are summarized and don't need to be loaded.
 
     After writing the boundary, it also reads the post-compaction
     transcript from Claude's own session state via
@@ -3891,6 +4284,13 @@ async def _persist_native_compaction_item(
     :param session_id: Omnigent session/conversation id.
     :param bridge_dir: Bridge directory path used to look up the
         Claude-native session id.
+    :param summary_override: The continuation-summary text from a
+        transcript ``isCompactSummary`` record, stored as the boundary's
+        ``summary``. ``None`` (the hook-driven path, which has no summary
+        text) falls back to a generic placeholder.
+    :raises httpx.HTTPError: If the boundary POST fails or is rejected.
+        The caller must not advance its cursor or mark the boundary
+        persisted when this raises.
     """
     # Find the last persisted item to use as the compaction boundary.
     resp = await client.get(
@@ -3921,8 +4321,13 @@ async def _persist_native_compaction_item(
             exc_info=True,
         )
 
+    summary = (
+        summary_override
+        if summary_override
+        else "[Claude Code compaction — context was compacted in the terminal]"
+    )
     event_data: dict[str, Any] = {
-        "summary": "[Claude Code compaction — context was compacted in the terminal]",
+        "summary": summary,
         "last_item_id": last_item_id,
         "model": "unknown",
         "token_count": 0,
@@ -4187,6 +4592,364 @@ async def _write_hook_state_async(bridge_dir: Path, state: HookForwardState) -> 
     :returns: None.
     """
     await asyncio.to_thread(_write_hook_state, bridge_dir, state)
+
+
+def _read_compaction_state(bridge_dir: Path) -> CompactionForwardState:
+    """
+    Read the durable compaction-reconciliation state.
+
+    :param bridge_dir: Native Claude bridge directory.
+    :returns: The persisted state, or a fresh empty state when no usable
+        file exists (missing, corrupt, or malformed).
+    """
+    try:
+        raw = json.loads((bridge_dir / _COMPACTION_STATE_FILE).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return CompactionForwardState()
+    if not isinstance(raw, dict):
+        return CompactionForwardState()
+    last_seq = raw.get("last_seq")
+    if not isinstance(last_seq, int) or last_seq < 0:
+        last_seq = 0
+    last_precompact_cursor = raw.get("last_precompact_cursor")
+    if not isinstance(last_precompact_cursor, int) or last_precompact_cursor < 0:
+        last_precompact_cursor = 0
+    expect_completion_ack = bool(raw.get("expect_completion_ack"))
+    persisted_raw = raw.get("persisted_seqs")
+    persisted_seqs: tuple[int, ...] = ()
+    if isinstance(persisted_raw, list):
+        persisted_seqs = tuple(s for s in persisted_raw if isinstance(s, int))
+    pending: _PendingCompaction | None = None
+    pending_raw = raw.get("pending")
+    if isinstance(pending_raw, dict):
+        seq = pending_raw.get("seq")
+        if isinstance(seq, int) and seq >= 0:
+            sid = pending_raw.get("claude_session_id")
+            tpath = pending_raw.get("transcript_path")
+            seen_at = pending_raw.get("seen_at")
+            pending = _PendingCompaction(
+                seq=seq,
+                claude_session_id=sid if isinstance(sid, str) else None,
+                transcript_path=tpath if isinstance(tpath, str) else None,
+                seen_at=seen_at if isinstance(seen_at, (int, float)) else None,
+            )
+    return CompactionForwardState(
+        pending=pending,
+        last_seq=last_seq,
+        persisted_seqs=persisted_seqs,
+        last_precompact_cursor=last_precompact_cursor,
+        expect_completion_ack=expect_completion_ack,
+    )
+
+
+def _write_compaction_state(bridge_dir: Path, state: CompactionForwardState) -> None:
+    """
+    Write the durable compaction-reconciliation state atomically.
+
+    :param bridge_dir: Native Claude bridge directory.
+    :param state: State to persist.
+    :returns: None.
+    """
+    bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "last_seq": state.last_seq,
+        "persisted_seqs": list(state.persisted_seqs),
+        "last_precompact_cursor": state.last_precompact_cursor,
+        "expect_completion_ack": state.expect_completion_ack,
+        "updated_at": time.time(),
+    }
+    if state.pending is not None:
+        pending_payload: dict[str, Any] = {"seq": state.pending.seq}
+        if state.pending.claude_session_id is not None:
+            pending_payload["claude_session_id"] = state.pending.claude_session_id
+        if state.pending.transcript_path is not None:
+            pending_payload["transcript_path"] = state.pending.transcript_path
+        if state.pending.seen_at is not None:
+            pending_payload["seen_at"] = state.pending.seen_at
+        payload["pending"] = pending_payload
+    _write_json_atomic(bridge_dir / _COMPACTION_STATE_FILE, payload)
+
+
+async def _note_precompact(
+    bridge_dir: Path,
+    *,
+    claude_session_id: str | None,
+    transcript_path: str | None,
+    event_cursor: int | None = None,
+) -> None:
+    """
+    Record that a ``PreCompact`` fired, minting a fresh pending token.
+
+    Increments ``last_seq`` and installs a new :class:`_PendingCompaction`
+    so the next completion signal (transcript summary or compact
+    ``SessionStart``) has a token to consume. A pending from a prior
+    compaction whose boundary never persisted is overwritten — the newer
+    compaction supersedes it (its summary reflects the newer boundary).
+
+    Idempotent per hook edge: each poll scans hook records twice — a
+    pre-items prescan mints the token *before* the same poll's transcript
+    summary is processed (closing the consumer-before-minter race), and the
+    main hook phase would otherwise mint it a second time. When
+    ``event_cursor`` is supplied, a ``PreCompact`` at or below the highest
+    already-minted cursor is a no-op, so the two scans converge on exactly
+    one token per edge. ``event_cursor=None`` preserves the legacy
+    always-mint behaviour for callers without a cursor (e.g. tests).
+
+    :param bridge_dir: Native Claude bridge directory.
+    :param claude_session_id: Claude session uuid from the hook, or ``None``.
+    :param transcript_path: Claude transcript path from the hook, or ``None``.
+    :param event_cursor: Hook ``event_cursor`` of this ``PreCompact`` record,
+        or ``None`` to always mint (no idempotency key).
+    :returns: None.
+    """
+
+    def _mutate() -> None:
+        state = _read_compaction_state(bridge_dir)
+        if event_cursor is not None and event_cursor <= state.last_precompact_cursor:
+            # Already minted for this hook edge (the other of the two
+            # per-poll scans got here first) — do not re-mint.
+            return
+        next_seq = state.last_seq + 1
+        _write_compaction_state(
+            bridge_dir,
+            CompactionForwardState(
+                pending=_PendingCompaction(
+                    seq=next_seq,
+                    claude_session_id=claude_session_id,
+                    transcript_path=transcript_path,
+                    seen_at=time.time(),
+                ),
+                last_seq=next_seq,
+                persisted_seqs=state.persisted_seqs,
+                last_precompact_cursor=(
+                    event_cursor if event_cursor is not None else state.last_precompact_cursor
+                ),
+                # A fresh compaction cycle opens: any trailing completion ack
+                # we were still expecting belonged to the previous cycle and
+                # is now moot.
+                expect_completion_ack=False,
+            ),
+        )
+
+    await asyncio.to_thread(_mutate)
+
+
+def _compaction_identifiers_match(
+    pending: _PendingCompaction,
+    *,
+    claude_session_id: str | None,
+    transcript_path: str | None,
+) -> bool:
+    """
+    Whether a completion signal correlates to a pending compaction.
+
+    A missing identifier on either side is a wildcard: the transcript
+    ``isCompactSummary`` record carries no session id, and some hooks omit
+    the transcript path, so a strict equality gate would never match.
+    Correlation fails only when both sides supply a value and they differ.
+
+    :param pending: The in-flight compaction token.
+    :param claude_session_id: Session uuid of the completion signal, or ``None``.
+    :param transcript_path: Transcript path of the completion signal, or ``None``.
+    :returns: ``True`` when the signal may complete this compaction.
+    """
+    if (
+        pending.claude_session_id is not None
+        and claude_session_id is not None
+        and pending.claude_session_id != claude_session_id
+    ):
+        return False
+    if (
+        pending.transcript_path is not None
+        and transcript_path is not None
+        and pending.transcript_path != transcript_path
+    ):
+        return False
+    return True
+
+
+async def _consume_pending_compaction(
+    bridge_dir: Path,
+    *,
+    claude_session_id: str | None,
+    transcript_path: str | None,
+) -> int | None:
+    """
+    Return the pending compaction's ``seq`` if this signal should persist it.
+
+    Returns ``None`` (do not persist) when there is no pending compaction,
+    when the identifiers do not correlate, or when the pending ``seq`` was
+    already persisted (a crash/restart or cursor rewind re-reading the
+    summary). This does NOT clear the pending — the caller clears it via
+    :func:`_mark_compaction_persisted` only after the boundary POST
+    succeeds, so a failed persist is retried on the next poll.
+
+    :param bridge_dir: Native Claude bridge directory.
+    :param claude_session_id: Session uuid of the completion signal, or ``None``.
+    :param transcript_path: Transcript path of the completion signal, or ``None``.
+    :returns: The ``seq`` to persist, or ``None`` to skip.
+    """
+
+    def _check() -> int | None:
+        state = _read_compaction_state(bridge_dir)
+        pending = state.pending
+        if pending is None:
+            return None
+        if pending.seq in state.persisted_seqs:
+            return None
+        if not _compaction_identifiers_match(
+            pending,
+            claude_session_id=claude_session_id,
+            transcript_path=transcript_path,
+        ):
+            return None
+        return pending.seq
+
+    return await asyncio.to_thread(_check)
+
+
+async def _mark_compaction_persisted(
+    bridge_dir: Path,
+    seq: int,
+    *,
+    expect_completion_ack: bool = False,
+) -> None:
+    """
+    Record that the boundary for ``seq`` was persisted; clear the token.
+
+    Adds ``seq`` to ``persisted_seqs`` (bounded) and clears ``pending`` when
+    it matches, so neither completion signal re-persists the same boundary.
+
+    :param bridge_dir: Native Claude bridge directory.
+    :param seq: The compaction sequence number whose boundary POST succeeded.
+    :param expect_completion_ack: Set ``True`` only when the transcript
+        ``isCompactSummary`` path persisted this boundary, so a paired
+        ``SessionStart source=compact`` hook that trails it is absorbed
+        rather than treated as a fresh standalone compaction. The hook and
+        standalone paths leave it ``False``.
+    :returns: None.
+    """
+
+    def _mutate() -> None:
+        state = _read_compaction_state(bridge_dir)
+        persisted = tuple(state.persisted_seqs)
+        if seq not in persisted:
+            persisted = (*persisted, seq)[-_MAX_PERSISTED_COMPACTION_SEQS:]
+        pending = state.pending
+        if pending is not None and pending.seq == seq:
+            pending = None
+        _write_compaction_state(
+            bridge_dir,
+            CompactionForwardState(
+                pending=pending,
+                last_seq=state.last_seq,
+                persisted_seqs=persisted,
+                last_precompact_cursor=state.last_precompact_cursor,
+                expect_completion_ack=expect_completion_ack,
+            ),
+        )
+
+    await asyncio.to_thread(_mutate)
+
+
+async def _note_transcript_summary_without_token(bridge_dir: Path) -> None:
+    """
+    Close the completion-ack window when a summary finds no pending token.
+
+    An ``isCompactSummary`` record with no consumable token is either a
+    historical/replayed summary or the leading edge of a NEW compaction
+    whose ``PreCompact`` was dropped. Either way the previous
+    transcript-persist's ack window is over: clear ``expect_completion_ack``
+    so a ``SessionStart source=compact`` hook that follows THIS summary is
+    correctly treated as a standalone boundary to persist, not as a trailing
+    ack to absorb.
+
+    :param bridge_dir: Native Claude bridge directory.
+    :returns: None.
+    """
+
+    def _mutate() -> None:
+        state = _read_compaction_state(bridge_dir)
+        if not state.expect_completion_ack:
+            return
+        _write_compaction_state(
+            bridge_dir,
+            CompactionForwardState(
+                pending=state.pending,
+                last_seq=state.last_seq,
+                persisted_seqs=state.persisted_seqs,
+                last_precompact_cursor=state.last_precompact_cursor,
+                expect_completion_ack=False,
+            ),
+        )
+
+    await asyncio.to_thread(_mutate)
+
+
+async def _claim_standalone_completion(bridge_dir: Path) -> int | None:
+    """
+    Resolve a completion hook that found no pending ``PreCompact`` token.
+
+    Restores the legacy standalone-completion safety. A
+    ``SessionStart source=compact`` (compaction *completed*) can arrive with
+    no live token for two reasons, which must be handled differently:
+
+    * The transcript ``isCompactSummary`` path already persisted this
+      compaction's boundary and set ``expect_completion_ack`` — this hook is
+      the trailing duplicate completion signal. Absorb it (clear the flag,
+      return ``None``): re-persisting would write a second boundary.
+    * No boundary is expected — the ``PreCompact`` was dropped or the
+      forwarder attached after it fired, so neither the transcript path nor a
+      token exists to persist the boundary. Mint a fresh monotonic ``seq``,
+      install it as the pending token (so a later transcript summary
+      reconciles against the same sequence), and return it for the caller to
+      persist. On POST failure the caller leaves the token set for retry.
+
+    :param bridge_dir: Native Claude bridge directory.
+    :returns: The ``seq`` to persist for a genuine standalone boundary, or
+        ``None`` when the hook is a trailing ack (already persisted) or a
+        pending token appeared concurrently.
+    """
+
+    def _mutate() -> int | None:
+        state = _read_compaction_state(bridge_dir)
+        if state.pending is not None:
+            # A token appeared between the caller's consume and this
+            # mutation — the standard consume path owns it, do not mint.
+            return None
+        if state.expect_completion_ack:
+            # Trailing completion hook for a transcript-persisted boundary.
+            # Absorb it and close the window.
+            _write_compaction_state(
+                bridge_dir,
+                CompactionForwardState(
+                    pending=None,
+                    last_seq=state.last_seq,
+                    persisted_seqs=state.persisted_seqs,
+                    last_precompact_cursor=state.last_precompact_cursor,
+                    expect_completion_ack=False,
+                ),
+            )
+            return None
+        next_seq = state.last_seq + 1
+        _write_compaction_state(
+            bridge_dir,
+            CompactionForwardState(
+                pending=_PendingCompaction(
+                    seq=next_seq,
+                    claude_session_id=None,
+                    transcript_path=None,
+                    seen_at=time.time(),
+                ),
+                last_seq=next_seq,
+                persisted_seqs=state.persisted_seqs,
+                last_precompact_cursor=state.last_precompact_cursor,
+                expect_completion_ack=False,
+            ),
+        )
+        return next_seq
+
+    return await asyncio.to_thread(_mutate)
 
 
 def _usage_from_status_state(state: dict[str, Any]) -> dict[str, float] | None:

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -481,6 +481,19 @@ class CompactionForwardState:
         standalone-completion path to absorb (not re-persist) the trailing
         hook. Cleared when the hook is absorbed or a new ``PreCompact`` opens
         the next cycle, bounding it to a single compaction.
+    :param expect_completion_ack_seq: The ``seq`` of the boundary that armed
+        :attr:`expect_completion_ack`, binding the ack window to a specific
+        persisted compaction rather than a bare, unattributed flag. The
+        standalone-completion path only absorbs a trailing hook when this seq
+        is genuinely present in :attr:`persisted_seqs` — i.e. the boundary it
+        would be acking really was stored. If the flag is somehow armed for a
+        seq that is not persisted (corruption, partial write, a state file
+        from before this field existed), the path biases to the *safe*
+        direction and persists a fresh boundary rather than silently
+        absorbing the hook, because a lost boundary (a full pre-compaction
+        history reload on resume) is far worse than an at-most-once duplicate.
+        Zero means no ack is armed, or the ack came from a legacy state file
+        with no recorded seq. Cleared alongside :attr:`expect_completion_ack`.
     """
 
     pending: _PendingCompaction | None = None
@@ -488,6 +501,7 @@ class CompactionForwardState:
     persisted_seqs: tuple[int, ...] = ()
     last_precompact_cursor: int = 0
     expect_completion_ack: bool = False
+    expect_completion_ack_seq: int = 0
 
 
 @dataclass(frozen=True)
@@ -2844,20 +2858,86 @@ async def _forward_available_status_events(
                         # reloads the full pre-compaction history.
                         seq = await _claim_standalone_completion(bridge_dir)
                     if seq is not None:
+                        # Persist the boundary with the SAME hold-cursor +
+                        # backoff discipline as the transcript path (P2-2). A
+                        # transient POST failure must not advance past this
+                        # completion hook and lose the boundary: for a genuine
+                        # hook-only standalone compaction no transcript summary
+                        # will ever arrive to retry it. Hold the hook cursor at
+                        # this record and retry next poll; the pending token
+                        # (minted here or by ``_claim_standalone_completion``)
+                        # makes the retry idempotent — the re-seen hook
+                        # re-consumes the same seq rather than minting a new
+                        # one. Exhausted permanent failures drop the boundary
+                        # and advance so a hard rejection can't wedge the hook
+                        # stream forever.
+                        retry_key = f"compaction-hook:{record.event_cursor}"
+                        if retry_tracker.retry_delay_s(retry_key) is not None:
+                            return durable
                         try:
                             await _persist_native_compaction_item(
                                 client,
                                 session_id=session_id,
                                 bridge_dir=bridge_dir,
                             )
+                        except httpx.HTTPError as exc:
+                            if post_may_have_been_delivered(exc):
+                                # Ambiguous delivery: the boundary may already
+                                # be committed. Mark persisted and advance
+                                # rather than risk a duplicate on retry.
+                                _logger.warning(
+                                    "Ambiguous compaction boundary POST (hook path) for %s "
+                                    "(may be committed); marking persisted to avoid a "
+                                    "duplicate boundary; seq=%s",
+                                    session_id,
+                                    seq,
+                                    exc_info=True,
+                                )
+                                retry_tracker.clear(retry_key)
+                                await _mark_compaction_persisted(bridge_dir, seq)
+                            else:
+                                decision = retry_tracker.record_failure(retry_key, exc)
+                                if decision.exhausted:
+                                    _logger.error(
+                                        "Dropping compaction boundary (hook path) after "
+                                        "permanent HTTP failures; session=%s bridge_dir=%s "
+                                        "seq=%s attempts=%s http_status=%s; leaving pending "
+                                        "token for a possible transcript-path retry",
+                                        session_id,
+                                        bridge_dir,
+                                        seq,
+                                        decision.attempts,
+                                        _http_status_for_log(exc),
+                                    )
+                                    # Fall through to advance the cursor.
+                                else:
+                                    _logger.warning(
+                                        "Failed to persist compaction boundary (hook path); "
+                                        "session=%s bridge_dir=%s seq=%s attempt=%s "
+                                        "permanent=%s next_retry_s=%.3f http_status=%s",
+                                        session_id,
+                                        bridge_dir,
+                                        seq,
+                                        decision.attempts,
+                                        decision.permanent,
+                                        decision.delay_s,
+                                        _http_status_for_log(exc),
+                                        exc_info=True,
+                                    )
+                                    return durable
                         except Exception:  # noqa: BLE001
+                            # Non-HTTP failure (e.g. reading Claude session
+                            # messages). Hold the cursor and retry next poll.
                             _logger.warning(
-                                "Failed to persist compaction item (hook path) for %s; "
-                                "leaving pending token for transcript-path retry",
+                                "Unexpected error persisting compaction boundary "
+                                "(hook path) for %s; seq=%s; holding cursor for retry",
                                 session_id,
+                                seq,
                                 exc_info=True,
                             )
+                            return durable
                         else:
+                            retry_tracker.clear(retry_key)
                             await _mark_compaction_persisted(bridge_dir, seq)
                 durable = next_durable
                 await _write_hook_state_async(bridge_dir, durable)
@@ -3140,10 +3220,14 @@ async def _handle_compact_summary_item(
         state = _read_compaction_state(bridge_dir)
         if state.pending is None and not state.persisted_seqs:
             _compaction_skip_stats.precompact_miss += 1
+            # NB: the *_process_total counters are module-global, accumulating
+            # across ALL sessions in this forwarder process (reset only on a
+            # fresh process / the test seam), not per-session. The session=/
+            # bridge_dir= fields scope THIS skip; the total is process-wide.
             _logger.warning(
                 "Skipping isCompactSummary with no pending PreCompact and no "
                 "persisted boundary (likely a missed PreCompact hook); "
-                "session=%s bridge_dir=%s precompact_miss_total=%s",
+                "session=%s bridge_dir=%s precompact_miss_process_total=%s",
                 session_id,
                 bridge_dir,
                 _compaction_skip_stats.precompact_miss,
@@ -3152,7 +3236,7 @@ async def _handle_compact_summary_item(
             _compaction_skip_stats.expected_skip += 1
             _logger.debug(
                 "Skipping isCompactSummary with no consumable token (expected "
-                "replay/dedupe); session=%s bridge_dir=%s expected_skip_total=%s",
+                "replay/dedupe); session=%s bridge_dir=%s expected_skip_process_total=%s",
                 session_id,
                 bridge_dir,
                 _compaction_skip_stats.expected_skip,
@@ -3586,6 +3670,16 @@ async def _prescan_precompact_edges(
     so the main hook phase does not re-mint. Only ``PreCompact`` edges are
     touched — message/status/task semantics are untouched and stay owned by
     :func:`_forward_available_status_events`.
+
+    Cost note: this deliberately re-reads the same unforwarded hook records
+    that :func:`_forward_available_status_events` reads later in the poll —
+    one extra ``hooks.jsonl`` scan per poll that scales with the unforwarded
+    backlog. It is correctness-neutral (the ``event_cursor`` idempotency key
+    makes the double-mint a no-op) and cheap relative to the network POSTs in
+    the same poll; folding the two reads into one shared pass is a possible
+    micro-optimisation, deliberately not taken here to keep the prescan a
+    self-contained, side-effect-only step that cannot perturb the main
+    forwarding order.
 
     :param bridge_dir: Native Claude bridge directory.
     :param hook_state: Current hook cursor, or ``None`` before it is seeded
@@ -4615,6 +4709,9 @@ def _read_compaction_state(bridge_dir: Path) -> CompactionForwardState:
     if not isinstance(last_precompact_cursor, int) or last_precompact_cursor < 0:
         last_precompact_cursor = 0
     expect_completion_ack = bool(raw.get("expect_completion_ack"))
+    expect_completion_ack_seq = raw.get("expect_completion_ack_seq")
+    if not isinstance(expect_completion_ack_seq, int) or expect_completion_ack_seq < 0:
+        expect_completion_ack_seq = 0
     persisted_raw = raw.get("persisted_seqs")
     persisted_seqs: tuple[int, ...] = ()
     if isinstance(persisted_raw, list):
@@ -4639,6 +4736,7 @@ def _read_compaction_state(bridge_dir: Path) -> CompactionForwardState:
         persisted_seqs=persisted_seqs,
         last_precompact_cursor=last_precompact_cursor,
         expect_completion_ack=expect_completion_ack,
+        expect_completion_ack_seq=expect_completion_ack_seq,
     )
 
 
@@ -4656,6 +4754,7 @@ def _write_compaction_state(bridge_dir: Path, state: CompactionForwardState) -> 
         "persisted_seqs": list(state.persisted_seqs),
         "last_precompact_cursor": state.last_precompact_cursor,
         "expect_completion_ack": state.expect_completion_ack,
+        "expect_completion_ack_seq": state.expect_completion_ack_seq,
         "updated_at": time.time(),
     }
     if state.pending is not None:
@@ -4728,6 +4827,7 @@ async def _note_precompact(
                 # we were still expecting belonged to the previous cycle and
                 # is now moot.
                 expect_completion_ack=False,
+                expect_completion_ack_seq=0,
             ),
         )
 
@@ -4846,6 +4946,11 @@ async def _mark_compaction_persisted(
                 persisted_seqs=persisted,
                 last_precompact_cursor=state.last_precompact_cursor,
                 expect_completion_ack=expect_completion_ack,
+                # Bind the ack window to THIS boundary's seq so a trailing
+                # completion hook is only absorbed as an ack for the exact
+                # compaction the transcript path just persisted, never a
+                # different one whose PreCompact also went missing (P2-1).
+                expect_completion_ack_seq=(seq if expect_completion_ack else 0),
             ),
         )
 
@@ -4880,6 +4985,7 @@ async def _note_transcript_summary_without_token(bridge_dir: Path) -> None:
                 persisted_seqs=state.persisted_seqs,
                 last_precompact_cursor=state.last_precompact_cursor,
                 expect_completion_ack=False,
+                expect_completion_ack_seq=0,
             ),
         )
 
@@ -4895,15 +5001,35 @@ async def _claim_standalone_completion(bridge_dir: Path) -> int | None:
     no live token for two reasons, which must be handled differently:
 
     * The transcript ``isCompactSummary`` path already persisted this
-      compaction's boundary and set ``expect_completion_ack`` — this hook is
-      the trailing duplicate completion signal. Absorb it (clear the flag,
-      return ``None``): re-persisting would write a second boundary.
+      compaction's boundary and set ``expect_completion_ack`` for its ``seq``
+      — this hook is the trailing duplicate completion signal. Absorb it
+      (clear the window, return ``None``): re-persisting would write a second
+      boundary.
     * No boundary is expected — the ``PreCompact`` was dropped or the
       forwarder attached after it fired, so neither the transcript path nor a
       token exists to persist the boundary. Mint a fresh monotonic ``seq``,
       install it as the pending token (so a later transcript summary
       reconciles against the same sequence), and return it for the caller to
       persist. On POST failure the caller leaves the token set for retry.
+
+    The ack window is bound to the ``seq`` it was armed for
+    (``expect_completion_ack_seq``). A hook is absorbed *only* when that seq
+    is genuinely present in ``persisted_seqs`` — the boundary the ack would
+    acknowledge really was stored. This closes the compound-miss lost-boundary
+    hazard (P2-1): if compaction A persists via the transcript path, A's
+    completion hook never fires (so the flag stays armed), and a later
+    compaction B's ``PreCompact`` is *also* dropped, B's completion hook would
+    otherwise be swallowed as A's stale ack and B's boundary lost. Requiring
+    the armed seq to be persisted does not by itself distinguish A's late hook
+    from B's hook (both correlate to the same session and A's seq is
+    persisted), so absorption stays one-shot: the window is closed the first
+    time it is consumed, and any *further* completion hook with no armed ack
+    falls through to a standalone persist. The residual — A's real trailing
+    hook arriving *after* B's boundary already reused the one-shot window — is
+    an at-most-once duplicate boundary (deduped downstream / benign on
+    resume), which we accept over a lost boundary. If the flag is armed but
+    its seq is not persisted (corrupt/partial state, or a legacy file with no
+    recorded seq), we bias to safe and persist rather than absorb.
 
     :param bridge_dir: Native Claude bridge directory.
     :returns: The ``seq`` to persist for a genuine standalone boundary, or
@@ -4917,9 +5043,16 @@ async def _claim_standalone_completion(bridge_dir: Path) -> int | None:
             # A token appeared between the caller's consume and this
             # mutation — the standard consume path owns it, do not mint.
             return None
-        if state.expect_completion_ack:
-            # Trailing completion hook for a transcript-persisted boundary.
-            # Absorb it and close the window.
+        ack_seq = state.expect_completion_ack_seq
+        ack_is_genuine = (
+            state.expect_completion_ack and ack_seq > 0 and ack_seq in state.persisted_seqs
+        )
+        if ack_is_genuine:
+            # Trailing completion hook for the transcript-persisted boundary
+            # ``ack_seq`` (which is confirmed stored). Absorb it and close the
+            # one-shot window so a subsequent hook — e.g. a different
+            # compaction whose PreCompact was dropped — is NOT swallowed as a
+            # stale ack (P2-1).
             _write_compaction_state(
                 bridge_dir,
                 CompactionForwardState(
@@ -4928,9 +5061,25 @@ async def _claim_standalone_completion(bridge_dir: Path) -> int | None:
                     persisted_seqs=state.persisted_seqs,
                     last_precompact_cursor=state.last_precompact_cursor,
                     expect_completion_ack=False,
+                    expect_completion_ack_seq=0,
                 ),
             )
             return None
+        if state.expect_completion_ack:
+            # Flag armed but its seq is not persisted (corrupt/partial write,
+            # or a legacy state file with no recorded seq). Bias to safe: fall
+            # through and persist a fresh boundary rather than absorb a hook we
+            # cannot prove is a duplicate — a lost boundary reloads the full
+            # pre-compaction history on resume, far worse than an at-most-once
+            # duplicate. Clear the stale window as we go.
+            _logger.warning(
+                "Compaction completion-ack armed for seq=%s not in persisted_seqs=%s; "
+                "persisting standalone boundary rather than absorbing (bias-to-safe); "
+                "bridge_dir=%s",
+                ack_seq,
+                state.persisted_seqs,
+                bridge_dir,
+            )
         next_seq = state.last_seq + 1
         _write_compaction_state(
             bridge_dir,
@@ -4945,6 +5094,7 @@ async def _claim_standalone_completion(bridge_dir: Path) -> int | None:
                 persisted_seqs=state.persisted_seqs,
                 last_precompact_cursor=state.last_precompact_cursor,
                 expect_completion_ack=False,
+                expect_completion_ack_seq=0,
             ),
         )
         return next_seq

--- a/tests/e2e_ui/agents/test_agent_info_popover.py
+++ b/tests/e2e_ui/agents/test_agent_info_popover.py
@@ -31,7 +31,14 @@ from playwright.sync_api import Page, expect
 
 _COMPOSER = "Ask the agent anything…"
 _AGENT_INFO_TRIGGER = '[data-testid="agent-info-trigger"]'
+_AGENT_INFO_PANEL = '[data-testid="agent-info-panel"]'
 _REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Time for the popover's open animation (Radix ``duration-150`` zoom/slide) to
+# settle so an in-panel button is at rest before we click it. Spent while the
+# pointer already sits on the panel, so the panel can't close during it. Mirrors
+# ``_ANIM_SETTLE_MS`` in ``sessions/test_agent_info_hover.py``.
+_PANEL_SETTLE_MS = 250
 _ECHO_MCP_SERVER = _REPO_ROOT / "tests" / "tools" / "fixtures" / "echo_stdio_mcp_server.py"
 
 
@@ -128,14 +135,33 @@ def _open_popover(page: Page) -> None:
     follows. Pressing Escape first guarantees we re-open from a closed state
     rather than toggling an already-open popover shut.
 
+    After opening, park the pointer on the panel and let the open animation
+    settle. The trigger opens on hover and schedules a ``HOVER_CLOSE_DELAY_MS``
+    (150ms) close the moment the pointer leaves it (see ``AgentInfoButton`` in
+    ``web/src/components/AgentInfo.tsx``). A follow-up ``.click()`` on an
+    in-panel control (e.g. "Manage MCP servers") first waits for that control to
+    be *stable*, but the panel is still mid ``duration-150`` zoom/slide, so the
+    stability retries can outlast the 150ms close timer — the panel then
+    unmounts and the control detaches mid-click (the observed CI flake). Moving
+    the pointer onto the panel cancels the pending close (``cancelCloseOnEnter``)
+    the same way a real user's pointer does, and the settle wait lets the
+    animation finish so the control is at rest before callers click it.
+
     :param page: Playwright page on a ``/c/<id>`` route.
     """
     page.keyboard.press("Escape")
     trigger = page.locator(_AGENT_INFO_TRIGGER)
     expect(trigger).to_be_visible(timeout=30_000)
     trigger.click()
+    panel = page.locator(_AGENT_INFO_PANEL)
+    expect(panel).to_be_visible(timeout=15_000)
     # "Policies" section label proves the popover content mounted.
     expect(page.get_by_text("Policies", exact=True)).to_be_visible(timeout=15_000)
+    # Land the pointer on the panel so leaving the trigger can't schedule a
+    # hover-close under a subsequent in-panel click, then let the open
+    # animation settle so in-panel controls are stable geometry.
+    panel.hover()
+    page.wait_for_timeout(_PANEL_SETTLE_MS)
 
 
 def test_agent_info_policy_add_and_remove(
@@ -224,6 +250,12 @@ def test_agent_info_policy_integer_params_validate_and_submit(
     assert stored_policy["factory_params"] == {"limit": 100}
 
 
+# Belt-and-suspenders for the residual session-bind/hydration race the
+# ``_open_popover`` pointer-park fix can't reach: the header info trigger only
+# mounts after the session binds and hydrates, so a rare mid-hydration open can
+# still miss. Matches the sibling hover suite (``sessions/test_agent_info_hover``),
+# which reruns rather than papering over the race with longer per-action waits.
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
 def test_agent_info_mcp_server_add_and_remove(
     page: Page,
     seeded_session: tuple[str, str],

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -657,6 +657,46 @@ def test_read_transcript_items_since_marks_task_notifications_meta(tmp_path: Pat
     }
 
 
+def test_read_transcript_items_since_flags_compact_summary(tmp_path: Path) -> None:
+    """
+    An ``isCompactSummary`` user record is flagged, not rendered as a bubble.
+
+    Claude writes an ``isCompactSummary: true`` user record carrying the
+    continuation summary right after it compacts. The bridge must surface it
+    as a single ``message`` item with ``is_compact_summary=True`` (so the
+    forwarder can persist a durable compaction boundary) and preserve the
+    summary text — never drop it or route it through slash/scaffolding
+    detection.
+    """
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "uuid": "compact-summary-1",
+                "isCompactSummary": True,
+                "message": {
+                    "role": "user",
+                    "content": "This session is being continued. Prior summary: …",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    _cursor, _current_response_id, items = read_transcript_items_since(
+        transcript_path,
+        0,
+        agent_name="claude-native-ui",
+    )
+
+    assert len(items) == 1
+    assert items[0].is_compact_summary is True
+    assert items[0].item_type == "message"
+    assert items[0].data["content"][0]["text"].startswith("This session is being continued")
+
+
 @pytest.mark.parametrize(
     "raw_text",
     [

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -7024,6 +7024,174 @@ async def test_precompact_miss_is_counted_and_warned(tmp_path: Path) -> None:
     assert forwarder._compaction_skip_stats.expected_skip == 1
 
 
+@pytest.mark.asyncio
+async def test_stale_completion_ack_does_not_swallow_a_later_boundary(
+    tmp_path: Path,
+) -> None:
+    """
+    P2-1: a completion ack is bound to its seq and is one-shot per boundary.
+
+    The lost-boundary hazard: compaction A persists via the transcript path
+    and arms ``expect_completion_ack``; A's own ``SessionStart source=compact``
+    hook never fires (flaky), so the flag stays armed. A later compaction B's
+    ``PreCompact`` is *also* dropped, then B's completion hook fires. With a
+    bare unattributed flag, B's hook would be absorbed as A's stale ack and
+    B's boundary lost.
+
+    Binding the ack to a ``seq`` and making absorption one-shot fixes it: the
+    window is consumed exactly once (the trailing hook for A), and any
+    *further* standalone completion — B's — falls through to a fresh persist
+    instead of being swallowed.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    await _note_precompact(bridge_dir, claude_session_id="claude-1", transcript_path=None)
+
+    persist = _persist_mock()
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", persist):
+        # Compaction A persists via the transcript path → arms the ack for A's seq.
+        await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_p21",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item(),
+            retry_tracker=_PostRetryTracker(),
+        )
+    armed = _read_compaction_state(bridge_dir)
+    assert armed.expect_completion_ack is True
+    assert armed.expect_completion_ack_seq == 1  # bound to A's seq, not a bare bool
+    assert armed.persisted_seqs == (1,)
+
+    # A's own trailing completion hook arrives late and is absorbed (one-shot).
+    absorbed = await _claim_standalone_completion(bridge_dir)
+    assert absorbed is None
+    after_absorb = _read_compaction_state(bridge_dir)
+    assert after_absorb.expect_completion_ack is False
+    assert after_absorb.expect_completion_ack_seq == 0  # window closed
+
+    # Compaction B: its PreCompact was dropped too, so B arrives as a
+    # standalone completion hook with NO pending token and NO armed ack. It
+    # must persist a fresh boundary, not be swallowed as A's stale ack.
+    b_seq = await _claim_standalone_completion(bridge_dir)
+    assert b_seq == 2, "B's boundary must be persisted, not lost to a stale ack"
+    final = _read_compaction_state(bridge_dir)
+    assert final.pending is not None
+    assert final.pending.seq == 2
+
+
+@pytest.mark.asyncio
+async def test_completion_ack_armed_for_unpersisted_seq_biases_to_persist(
+    tmp_path: Path,
+) -> None:
+    """
+    P2-1: an ack armed for a seq that is NOT persisted persists (bias-to-safe).
+
+    If durable state is somehow armed (corrupt/partial write, or a legacy
+    ``compaction_forwarder.json`` from before ``expect_completion_ack_seq``
+    existed so the seq reads back as ``0``) the standalone path cannot prove
+    the arriving hook is a duplicate. A lost boundary reloads the full
+    pre-compaction history on resume — far worse than an at-most-once
+    duplicate — so the path biases to persisting a fresh boundary rather than
+    silently absorbing the hook.
+    """
+    from omnigent.claude_native_forwarder import _write_compaction_state
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    # Legacy/corrupt shape: flag armed but the seq it points at is not in
+    # persisted_seqs (here it reads back as 0, mimicking an old state file).
+    _write_compaction_state(
+        bridge_dir,
+        CompactionForwardState(
+            pending=None,
+            last_seq=1,
+            persisted_seqs=(),
+            expect_completion_ack=True,
+            expect_completion_ack_seq=0,
+        ),
+    )
+    seq = await _claim_standalone_completion(bridge_dir)
+    assert seq == 2, "bias-to-safe: persist rather than absorb an unprovable ack"
+    state = _read_compaction_state(bridge_dir)
+    assert state.pending is not None
+    assert state.pending.seq == 2
+
+
+@pytest.mark.asyncio
+async def test_standalone_hook_persist_failure_holds_cursor_for_retry(
+    tmp_path: Path,
+) -> None:
+    """
+    P2-2: a standalone-completion persist failure holds the hook cursor.
+
+    A ``SessionStart source=compact`` with no pending token and no transcript
+    summary is a hook-only standalone compaction. If its boundary POST fails
+    transiently the forwarder must NOT advance past the hook (losing the
+    boundary, since no transcript summary will ever retry it) — it holds the
+    hook cursor and retries next poll, mirroring the transcript path. The
+    pending token minted by ``_claim_standalone_completion`` makes the retry
+    idempotent: the re-seen hook re-consumes the same seq. A later successful
+    POST persists exactly one boundary.
+    """
+    bridge_dir = tmp_path / "bridge"
+    # A lone compact SessionStart (no preceding PreCompact) — standalone.
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "source": "compact",
+            "session_id": "claude-standalone",
+        },
+    )
+    start_state = forwarder.HookForwardState(event_cursor=0, byte_offset=0)
+
+    request = httpx.Request("POST", "http://test/items")
+    response = httpx.Response(503, request=request)
+    failing = AsyncMock(
+        side_effect=httpx.HTTPStatusError("boom", request=request, response=response)
+    )
+
+    async def _run_once(state: forwarder.HookForwardState) -> forwarder.HookForwardState:
+        # The best-effort spinner status post is orthogonal to the durable
+        # persist under test; stub it so the client mock stays quiet.
+        with patch(
+            "omnigent.claude_native_forwarder._post_external_compaction_status",
+            AsyncMock(return_value=None),
+        ):
+            return await forwarder._forward_available_status_events(
+                client=AsyncMock(),
+                session_id="conv_p22",
+                bridge_dir=bridge_dir,
+                state=state,
+                retry_tracker=_PostRetryTracker(),
+                task_subjects={},
+                task_statuses={},
+                task_order=[],
+            )
+
+    # Poll 1: persist fails → cursor is held BEFORE the compaction hook record,
+    # a pending token is minted, and no boundary is marked persisted.
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", failing):
+        after_fail = await _run_once(start_state)
+    assert failing.await_count == 1
+    assert after_fail.event_cursor == start_state.event_cursor  # cursor held
+    held = _read_compaction_state(bridge_dir)
+    assert held.pending is not None  # token minted, awaiting a durable persist
+    assert not held.persisted_seqs  # nothing marked persisted on failure
+    minted_seq = held.pending.seq
+
+    # Poll 2 (retry): the same hook record is re-seen; the persist succeeds and
+    # re-consumes the SAME seq (idempotent), marking exactly one boundary.
+    ok = _persist_mock()
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", ok):
+        after_ok = await _run_once(after_fail)
+    assert ok.await_count == 1
+    persisted = _read_compaction_state(bridge_dir)
+    assert persisted.persisted_seqs == (minted_seq,)  # exactly one boundary
+    assert persisted.pending is None
+    assert after_ok.event_cursor > after_fail.event_cursor  # cursor advanced
+
+
 def test_forward_failures_escalate_to_degraded_once() -> None:
     """
     Sustained forward failures flip the degraded latch exactly once (#1120).

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -29,7 +29,16 @@ from omnigent.claude_native_bridge import (
     write_active_session_id,
 )
 from omnigent.claude_native_forwarder import (
+    CompactionForwardState,
+    _claim_standalone_completion,
+    _consume_pending_compaction,
+    _handle_compact_summary_item,
+    _note_precompact,
     _persist_native_compaction_item,
+    _PostRetryTracker,
+    _prescan_precompact_edges,
+    _read_compaction_state,
+    _reset_compaction_skip_stats,
     forward_claude_transcript_to_session,
 )
 from omnigent.reasoning_effort import CLAUDE_EFFORTS, EFFORT_CLEAR_VALUES
@@ -6388,6 +6397,13 @@ async def test_compaction_completed_triggers_persist(tmp_path: Path) -> None:
             "transcript_path": str(transcript_path),
         },
     )
+    # PreCompact mints the pending token the completion signal consumes.
+    # A real compaction always fires PreCompact before the compact
+    # SessionStart; the hook path only persists when that token exists.
+    record_hook_event(
+        bridge_dir,
+        {"hook_event_name": "PreCompact", "session_id": "claude-session"},
+    )
     # Post-compaction SessionStart — the completion signal.
     record_hook_event(
         bridge_dir,
@@ -6420,8 +6436,18 @@ async def test_compaction_completed_triggers_persist(tmp_path: Path) -> None:
             )
         )
         try:
-            # Wait for the compaction status POST to arrive.
-            request = await _get_recorded_request(server)
+            # Wait for the compaction-completed status POST to arrive
+            # (the leading PreCompact in_progress edge is skipped).
+            request = None
+            for _ in range(10):
+                candidate = await _get_recorded_request(server)
+                if (
+                    candidate["body"].get("type") == "external_compaction_status"
+                    and candidate["body"]["data"].get("status") == "completed"
+                ):
+                    request = candidate
+                    break
+            assert request is not None, "compaction-completed status was never posted"
             # Wait for _persist_native_compaction_item to be called
             # (it runs right after the POST in the same await chain).
             await asyncio.wait_for(persist_called.wait(), timeout=5.0)
@@ -6433,7 +6459,7 @@ async def test_compaction_completed_triggers_persist(tmp_path: Path) -> None:
             server.server_close()
             thread.join(timeout=5.0)
 
-    # The recording server captured the compaction status POST.
+    # The recording server captured the compaction-completed status POST.
     assert request["body"]["type"] == "external_compaction_status"
     assert request["body"]["data"]["status"] == "completed"
     # _persist_native_compaction_item was called with the right session id.
@@ -6498,6 +6524,504 @@ async def test_compaction_in_progress_does_not_persist(tmp_path: Path) -> None:
     assert request["body"]["data"]["status"] == "in_progress"
     # _persist_native_compaction_item must NOT be called for in_progress.
     persist_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Durable compaction-boundary reconciliation (native resume/replay fix)
+# ---------------------------------------------------------------------------
+
+
+def _compact_summary_item(text: str = "compaction summary text") -> ClaudeTranscriptItem:
+    """
+    Build a transcript item flagged as a Claude ``isCompactSummary`` record.
+
+    :param text: The continuation-summary text carried by the item.
+    :returns: A ``ClaudeTranscriptItem`` with ``is_compact_summary=True``.
+    """
+    return ClaudeTranscriptItem(
+        source_id="summary-uuid:0:compact_summary",
+        item_type="message",
+        data={"role": "user", "content": [{"type": "input_text", "text": text}]},
+        response_id="resp_summary",
+        is_compact_summary=True,
+    )
+
+
+def _persist_mock() -> AsyncMock:
+    """
+    Build an ``AsyncMock`` standing in for ``_persist_native_compaction_item``.
+
+    :returns: An async mock that records calls and returns ``None``.
+    """
+    return AsyncMock(return_value=None)
+
+
+@pytest.mark.asyncio
+async def test_missing_compact_session_start_still_persists_from_transcript(
+    tmp_path: Path,
+) -> None:
+    """
+    A transcript ``isCompactSummary`` record persists the boundary alone.
+
+    Reproduces the core bug: the flaky ``SessionStart source=compact`` hook
+    never fires, so only the transcript summary is available. The transcript
+    path must still persist exactly one compaction boundary (carrying the
+    summary text) once a ``PreCompact`` token is pending.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    await _note_precompact(
+        bridge_dir, claude_session_id="claude-1", transcript_path="/t/session.jsonl"
+    )
+
+    persist = _persist_mock()
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", persist):
+        handled = await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_missing_hook",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item("the summary"),
+            retry_tracker=_PostRetryTracker(),
+        )
+
+    assert handled is True
+    persist.assert_called_once()
+    assert persist.call_args[1]["session_id"] == "conv_missing_hook"
+    assert persist.call_args[1]["summary_override"] == "the summary"
+    # Boundary marked persisted; pending cleared.
+    state = _read_compaction_state(bridge_dir)
+    assert state.pending is None
+    assert 1 in state.persisted_seqs
+
+
+@pytest.mark.asyncio
+async def test_normal_hook_after_transcript_does_not_double_persist(tmp_path: Path) -> None:
+    """
+    The completion hook does not re-persist a boundary the transcript wrote.
+
+    After the transcript path persists the boundary and marks the sequence
+    done, a later ``SessionStart source=compact`` hook finds no consumable
+    pending token, so ``_consume_pending_compaction`` returns ``None`` and no
+    second boundary is written.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    await _note_precompact(bridge_dir, claude_session_id="claude-1", transcript_path=None)
+
+    persist = _persist_mock()
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", persist):
+        # Transcript path persists first.
+        await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_dedupe",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item(),
+            retry_tracker=_PostRetryTracker(),
+        )
+    assert persist.call_count == 1
+
+    # Hook path arrives later — the token is already consumed.
+    seq = await _consume_pending_compaction(
+        bridge_dir, claude_session_id="claude-1", transcript_path=None
+    )
+    assert seq is None
+
+
+@pytest.mark.asyncio
+async def test_failed_boundary_post_is_retried_not_consumed(tmp_path: Path) -> None:
+    """
+    A hard POST failure leaves the summary unconsumed for retry.
+
+    ``_handle_compact_summary_item`` must return ``False`` (so the caller
+    holds the transcript cursor before the summary record) and must NOT mark
+    the sequence persisted, so the boundary is retried on a later poll rather
+    than silently lost — which would make resume reload the full history.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    await _note_precompact(bridge_dir, claude_session_id="claude-1", transcript_path=None)
+
+    # A definitively-permanent 400 (not an ambiguous/network failure).
+    request = httpx.Request("POST", "http://x/events")
+    response = httpx.Response(400, request=request)
+    failing = AsyncMock(
+        side_effect=httpx.HTTPStatusError("bad", request=request, response=response)
+    )
+
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", failing):
+        handled = await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_retry",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item(),
+            retry_tracker=_PostRetryTracker(),
+        )
+
+    assert handled is False
+    state = _read_compaction_state(bridge_dir)
+    # Pending still set, nothing persisted — the summary will be retried.
+    assert state.pending is not None
+    assert state.pending.seq == 1
+    assert state.persisted_seqs == ()
+
+
+@pytest.mark.asyncio
+async def test_restart_reattach_does_not_repersist_completed_boundary(tmp_path: Path) -> None:
+    """
+    An already-persisted boundary is never re-persisted after a rewind.
+
+    Simulates a process restart / cursor rewind that re-reads a summary whose
+    boundary already POSTed: ``persisted_seqs`` records the sequence, so
+    ``_consume_pending_compaction`` returns ``None`` and
+    ``_handle_compact_summary_item`` drops the record without persisting.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    # Durable state as it would exist after a completed compaction: seq 1
+    # persisted, but a stale pending token for the same seq lingers (e.g.
+    # crash between POST success and mark). The persisted set must win.
+    from omnigent.claude_native_forwarder import _PendingCompaction, _write_compaction_state
+
+    _write_compaction_state(
+        bridge_dir,
+        CompactionForwardState(
+            pending=_PendingCompaction(seq=1, claude_session_id="claude-1"),
+            last_seq=1,
+            persisted_seqs=(1,),
+        ),
+    )
+
+    persist = _persist_mock()
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", persist):
+        handled = await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_restart",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item(),
+            retry_tracker=_PostRetryTracker(),
+        )
+
+    assert handled is True
+    persist.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_repeated_compactions_persist_distinct_boundaries(tmp_path: Path) -> None:
+    """
+    Two compaction cycles persist two distinct boundaries.
+
+    Each ``PreCompact`` mints a fresh monotonic sequence, so a second
+    compaction is not blocked by the first's ``persisted_seqs`` entry.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    persist = _persist_mock()
+
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", persist):
+        # First compaction.
+        await _note_precompact(bridge_dir, claude_session_id="claude-1", transcript_path=None)
+        await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_repeat",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item("first"),
+            retry_tracker=_PostRetryTracker(),
+        )
+        # Second compaction, later in the same session.
+        await _note_precompact(bridge_dir, claude_session_id="claude-1", transcript_path=None)
+        await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_repeat",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item("second"),
+            retry_tracker=_PostRetryTracker(),
+        )
+
+    assert persist.call_count == 2
+    state = _read_compaction_state(bridge_dir)
+    assert state.pending is None
+    assert set(state.persisted_seqs) == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_historical_summary_without_pending_is_skipped(tmp_path: Path) -> None:
+    """
+    An ``isCompactSummary`` record with no pending PreCompact is dropped.
+
+    On a cold resume the transcript may contain a historical compact-summary
+    record from a prior compaction with no live ``PreCompact`` token. It must
+    not persist a spurious boundary, and must not be forwarded as a user
+    bubble — ``_handle_compact_summary_item`` returns handled with no persist.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()  # no _note_precompact — no pending token
+
+    persist = _persist_mock()
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", persist):
+        handled = await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_historical",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item(),
+            retry_tracker=_PostRetryTracker(),
+        )
+
+    assert handled is True
+    persist.assert_not_called()
+    assert _read_compaction_state(bridge_dir).persisted_seqs == ()
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_boundary_post_marks_persisted(tmp_path: Path) -> None:
+    """
+    An ambiguous POST failure is treated as delivered (no duplicate boundary).
+
+    Mirrors the item-forwarding rule: when the server may already have
+    committed the boundary (e.g. a dropped response on a 2xx), retrying would
+    risk a duplicate compaction bubble, so the sequence is marked persisted
+    and the record advanced.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    await _note_precompact(bridge_dir, claude_session_id="claude-1", transcript_path=None)
+
+    ambiguous = AsyncMock(side_effect=httpx.ReadError("connection dropped mid-response"))
+
+    with (
+        patch("omnigent.claude_native_forwarder._persist_native_compaction_item", ambiguous),
+        patch("omnigent.claude_native_forwarder.post_may_have_been_delivered", return_value=True),
+    ):
+        handled = await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_ambiguous",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item(),
+            retry_tracker=_PostRetryTracker(),
+        )
+
+    assert handled is True
+    state = _read_compaction_state(bridge_dir)
+    assert 1 in state.persisted_seqs
+    assert state.pending is None
+
+
+@pytest.mark.asyncio
+async def test_precompact_and_summary_same_poll_persists_boundary(tmp_path: Path) -> None:
+    """
+    P1-1: a PreCompact + summary first visible in one poll persists a boundary.
+
+    The transcript forwarder (which consumes the ``isCompactSummary`` record)
+    runs before the hook forwarder (which mints the ``PreCompact`` token)
+    within a single poll. Without the pre-items prescan, a ``PreCompact`` and
+    its summary that both first appear in the same poll would lose the
+    boundary — the summary is consumed with no token yet minted.
+    ``_prescan_precompact_edges`` mints the token first, so the summary that
+    follows in the same poll finds it.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    # A PreCompact hook is written but the hook cursor has NOT advanced past
+    # it yet (mirrors the same-poll ordering: hooks are forwarded AFTER items).
+    record_hook_event(
+        bridge_dir,
+        {"hook_event_name": "PreCompact", "session_id": "claude-1"},
+    )
+    hook_state = await forwarder._ensure_hook_state(
+        bridge_dir, start_at_end=False, session_id="conv_same_poll"
+    )
+
+    # No pending token before the prescan.
+    assert _read_compaction_state(bridge_dir).pending is None
+
+    # Prescan mints the token BEFORE the transcript summary is processed.
+    await _prescan_precompact_edges(bridge_dir, hook_state)
+    state = _read_compaction_state(bridge_dir)
+    assert state.pending is not None
+    assert state.pending.seq == 1
+
+    # The summary in the same poll now finds the token and persists once.
+    persist = _persist_mock()
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", persist):
+        handled = await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_same_poll",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item("same-poll summary"),
+            retry_tracker=_PostRetryTracker(),
+        )
+
+    assert handled is True
+    persist.assert_called_once()
+    state = _read_compaction_state(bridge_dir)
+    assert 1 in state.persisted_seqs
+    assert state.pending is None
+
+
+@pytest.mark.asyncio
+async def test_prescan_is_idempotent_with_hook_phase(tmp_path: Path) -> None:
+    """
+    P1-1: the prescan and the main hook phase mint one token per PreCompact.
+
+    Both scans see the same ``PreCompact`` record each poll. The
+    ``event_cursor`` idempotency key must keep them converging on a single
+    pending token — never two — so a re-mint cannot overwrite a token whose
+    boundary is mid-persist.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    record_hook_event(
+        bridge_dir,
+        {"hook_event_name": "PreCompact", "session_id": "claude-1"},
+    )
+    hook_state = await forwarder._ensure_hook_state(
+        bridge_dir, start_at_end=False, session_id="conv_idem"
+    )
+
+    # Prescan mints seq 1.
+    await _prescan_precompact_edges(bridge_dir, hook_state)
+    first = _read_compaction_state(bridge_dir)
+    assert first.pending is not None and first.pending.seq == 1
+    assert first.last_precompact_cursor == 1
+
+    # The main hook phase would note the SAME edge (same event_cursor=1).
+    # It must be a no-op: same seq, no second token.
+    await _note_precompact(
+        bridge_dir, claude_session_id="claude-1", transcript_path=None, event_cursor=1
+    )
+    second = _read_compaction_state(bridge_dir)
+    assert second.pending is not None and second.pending.seq == 1
+    assert second.last_seq == 1
+
+    # A genuinely NEW PreCompact edge (higher cursor) mints the next seq.
+    await _note_precompact(
+        bridge_dir, claude_session_id="claude-1", transcript_path=None, event_cursor=2
+    )
+    third = _read_compaction_state(bridge_dir)
+    assert third.pending is not None and third.pending.seq == 2
+    assert third.last_precompact_cursor == 2
+
+
+@pytest.mark.asyncio
+async def test_standalone_completion_hook_persists_without_pending(tmp_path: Path) -> None:
+    """
+    P1-2: a compact SessionStart with no pending token still persists a boundary.
+
+    Restores the legacy standalone-completion safety. When the
+    ``PreCompact`` hook was dropped (or the forwarder attached after it
+    fired) AND no transcript summary has persisted a boundary, the
+    ``SessionStart source=compact`` completion hook must still persist
+    exactly one boundary — otherwise resume reloads the full pre-compaction
+    history. ``_claim_standalone_completion`` mints the sequence for it.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    # No _note_precompact, no persisted boundary — genuinely standalone.
+    seq = await _claim_standalone_completion(bridge_dir)
+    assert seq == 1
+    state = _read_compaction_state(bridge_dir)
+    # A pending token is installed so a later transcript summary reconciles
+    # against the same sequence instead of double-persisting.
+    assert state.pending is not None
+    assert state.pending.seq == 1
+
+    # After the caller persists and marks it done, the boundary is recorded.
+    from omnigent.claude_native_forwarder import _mark_compaction_persisted
+
+    await _mark_compaction_persisted(bridge_dir, seq)
+    final = _read_compaction_state(bridge_dir)
+    assert 1 in final.persisted_seqs
+    assert final.pending is None
+
+
+@pytest.mark.asyncio
+async def test_completion_hook_after_transcript_persist_is_absorbed(tmp_path: Path) -> None:
+    """
+    P1-2: a completion hook trailing a transcript-persisted boundary is absorbed.
+
+    The transcript ``isCompactSummary`` path and the
+    ``SessionStart source=compact`` hook are two completion signals for the
+    SAME compaction. When the transcript path persists first it arms the
+    completion-ack window; the trailing hook must be absorbed (return
+    ``None``, no new sequence) rather than persist a spurious standalone
+    boundary.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    await _note_precompact(bridge_dir, claude_session_id="claude-1", transcript_path=None)
+
+    persist = _persist_mock()
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", persist):
+        # Transcript path persists the boundary; arms expect_completion_ack.
+        await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_absorb",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item(),
+            retry_tracker=_PostRetryTracker(),
+        )
+    assert persist.call_count == 1
+    armed = _read_compaction_state(bridge_dir)
+    assert armed.expect_completion_ack is True
+
+    # The trailing completion hook finds no pending token and is absorbed.
+    seq = await _consume_pending_compaction(
+        bridge_dir, claude_session_id="claude-1", transcript_path=None
+    )
+    assert seq is None
+    seq = await _claim_standalone_completion(bridge_dir)
+    assert seq is None  # absorbed, NOT a new standalone boundary
+    after = _read_compaction_state(bridge_dir)
+    assert after.expect_completion_ack is False
+    assert after.persisted_seqs == (1,)  # still exactly one boundary
+
+
+@pytest.mark.asyncio
+async def test_precompact_miss_is_counted_and_warned(tmp_path: Path) -> None:
+    """
+    P1-3: a summary skipped with no token and no boundary is counted as a miss.
+
+    A skipped ``isCompactSummary`` with no pending token AND no boundary ever
+    persisted is the observable ``PreCompact``-miss failure mode — it must
+    bump the ``precompact_miss`` counter (not be silently dropped). A skip
+    that follows a persisted boundary is an expected replay/dedupe and bumps
+    ``expected_skip`` instead.
+    """
+    _reset_compaction_skip_stats()
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()  # no PreCompact, no persisted boundary
+
+    persist = _persist_mock()
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", persist):
+        handled = await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_miss",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item(),
+            retry_tracker=_PostRetryTracker(),
+        )
+
+    assert handled is True
+    persist.assert_not_called()
+    assert forwarder._compaction_skip_stats.precompact_miss == 1
+    assert forwarder._compaction_skip_stats.expected_skip == 0
+
+    # A skip AFTER a boundary was persisted is an expected replay, not a miss.
+    from omnigent.claude_native_forwarder import _write_compaction_state
+
+    _write_compaction_state(
+        bridge_dir,
+        CompactionForwardState(pending=None, last_seq=1, persisted_seqs=(1,)),
+    )
+    with patch("omnigent.claude_native_forwarder._persist_native_compaction_item", persist):
+        await _handle_compact_summary_item(
+            AsyncMock(),
+            session_id="conv_miss",
+            bridge_dir=bridge_dir,
+            item=_compact_summary_item(),
+            retry_tracker=_PostRetryTracker(),
+        )
+    assert forwarder._compaction_skip_stats.precompact_miss == 1  # unchanged
+    assert forwarder._compaction_skip_stats.expected_skip == 1
 
 
 def test_forward_failures_escalate_to_degraded_once() -> None:


### PR DESCRIPTION
The native Claude bridge relies on the `SessionStart source=compact` hook to mark a compaction boundary complete, but that hook is flaky and sometimes never fires. When it is missing, no compaction item is persisted, so a resumed/forked session reloads the entire pre-compaction history instead of the continuation summary — the token blowup this fixes.

Recognize the always-present `isCompactSummary` transcript record as the durable completion signal, correlated to a pending `PreCompact` for the same native session/transcript. A single-slot pending token is minted by `PreCompact` and consumed by whichever completion signal arrives first (transcript summary — primary/durable; or the `SessionStart source=compact` hook — secondary/best-effort), keyed by a monotonic `seq` with a bounded `persisted_seqs` history. This reconciles the two signals idempotently regardless of arrival order and survives API POST failure/retry, process crash/restart, bridge reattach, cursor rewind, and repeated compactions. Historical/replayed summary records with no pending token are dropped.

The forwarder does not advance its transcript cursor or mark the boundary persisted until the compaction POST succeeds, so a failed POST is retried rather than silently losing the boundary. The continuation-summary text is carried into the boundary's `summary`. Replaces the simplistic `compaction_fallback.json` POC with durable `compaction_forwarder.json` state.

Robustness fixes from independent review:

- Close the same-poll consumer-before-minter race: the poll loop forwards transcript items (including `isCompactSummary`) BEFORE it drains hook events, so a `PreCompact` and its continuation summary first-seen in the same poll would lose the boundary. A cursor-keyed pre-scan (`_prescan_precompact_edges`) now mints any newly visible `PreCompact` token WITHOUT advancing the hook cursor, immediately before transcript items are processed. Minting is idempotent via `last_precompact_cursor`, so the pre-scan and the main hook phase converge on exactly one token per edge and unrelated message/status ordering is untouched.

- Restore standalone completion-hook safety: a `SessionStart source=compact` hook arriving with no pending `PreCompact` token now persists exactly one boundary again (`_claim_standalone_completion`) instead of silently doing nothing. To avoid a double-persist against the durable transcript path, a one-shot `expect_completion_ack` flag armed on transcript persist absorbs the trailing hook rather than re-persisting; a fresh `PreCompact` or a token-less summary clears it.

- Make skipped summaries observable: when an `isCompactSummary` finds no consumable token, a `_CompactionSkipStats` counter distinguishes an expected replay/dedupe (`expected_skip`, DEBUG) from a likely true `PreCompact` miss (`precompact_miss`, WARN), so real miss rates can be measured instead of silently dropped.

Scope is resume/replay correctness only; live same-process autocompaction, Claude SDK attachment replay, and Layer-3 compaction are unchanged. Manual `/compact` CAN now persist a boundary on resume/replay: its `PreCompact` mints a token that the continuation-summary (or the completion hook) consumes through the same reconciliation path.

Tests: narrowly scoped regression coverage for missing compact SessionStart, normal-hook dedupe, failed-POST retry, restart/reattach, repeated compactions, historical summary replay, ambiguous-delivery, and the bridge `isCompactSummary` flag; plus the review-fix cases — same-poll PreCompact+summary, pre-scan/hook-phase idempotency, standalone completion hook, trailing-hook absorption, and the PreCompact-miss counter. Resume/fork reconstruction stays green.

Co-authored-by: Isaac

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

<Add a line to describe the change, else delete this section>
