### PR TITLE
fix(claude-sdk): redact base64 image/document source blocks on replay

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -368,12 +368,17 @@ def _get_inline_data_uri_info(value: Any) -> tuple[str, int] | None:  # type: ig
 
 
 def _redact_inline_base64(value: Any) -> Any:  # type: ignore[explicit-any]
-    """Deep-replace any whole-string inline base64 data URI with a compact
+    """Deep-replace inline base64 attachment payloads with a compact
     ``[attachment: …]`` marker, recursing through dict/list values. The fallback
     path for values that reach ``json.dumps`` (nested dicts, non-block content)
-    so a resolver-produced base64 payload does not survive serialization. Only
-    whole-string data-URI values are redacted — not data URIs used as dict keys,
-    tuple members, or substrings embedded mid-text (the runner never emits
+    so a resolver-produced base64 payload does not survive serialization.
+
+    Two shapes are redacted: a whole-string ``data:*;base64,...`` URI (the
+    resolver form under ``image_url`` / ``file_data``), and an Anthropic content
+    block ``{"type": "image"|"document", "source": {"type": "base64", ...}}``
+    (what the ``Read`` tool returns for an image file, carried in a
+    ``function_call_output``). Neither is redacted when it appears as a dict
+    key, tuple member, or substring embedded mid-text (the runner never emits
     those)."""
     if isinstance(value, str):
         parsed = _parse_replay_data_uri(value)
@@ -383,6 +388,20 @@ def _redact_inline_base64(value: Any) -> Any:  # type: ignore[explicit-any]
     if isinstance(value, list):
         return [_redact_inline_base64(item) for item in value]
     if isinstance(value, dict):
+        source = value.get("source")
+        if (
+            value.get("type") in ("image", "document")
+            and isinstance(source, dict)
+            and source.get("type") == "base64"
+        ):
+            media_type = source.get("media_type") or "application/octet-stream"
+            data = source.get("data")
+            payload_chars = len(data) if isinstance(data, str) else 0
+            kind = "image" if value.get("type") == "image" else "attachment"
+            return {
+                "type": "text",
+                "text": f"[{kind}: {media_type}, {payload_chars} base64 chars]",
+            }
         return {key: _redact_inline_base64(item) for key, item in value.items()}
     return value
 

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -149,6 +149,33 @@ class TestPromptExtraction(unittest.TestCase):
         )
         self.assertIn("What does this document say?", prompt)
 
+    def test_historical_image_source_block_is_replaced_with_compact_placeholder(self):
+        # The ``Read`` tool returns an image file as an Anthropic content block
+        # ``{"type": "image", "source": {"type": "base64", ...}}`` — raw base64
+        # with no ``data:`` URI prefix. Redaction must catch this shape too, or a
+        # replayed image tool result flattens hundreds of KB into prompt text.
+        from omnigent.inner.claude_sdk_executor import _render_prior_content
+
+        image_payload = base64.b64encode(b"synthetic png bytes").decode("ascii")
+        content = [
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": image_payload,
+                },
+            }
+        ]
+
+        rendered = _render_prior_content(content)
+
+        self.assertNotIn(image_payload, rendered)
+        self.assertIn(
+            f"[image: image/png, {len(image_payload)} base64 chars]",
+            rendered,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests: Constructor and properties


### PR DESCRIPTION
## Related issue

n/a

## Summary

The Claude **SDK** executor already de-inlines base64 attachments on historical replay (`_redact_inline_base64` / `_render_prior_content`), but only for whole-string `data:*;base64,...` URIs — the resolver form under `image_url` / `file_data`.

Claude Code's `Read` tool returns an image file as an Anthropic content block instead:

```json
{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBOR…"}}
```

That's raw base64 with **no `data:` prefix**, so `parse_data_uri` returns `None` and redaction skipped it. If such a block reaches the `Conversation so far:` text prefix, `json.dumps` flattens the entire base64 payload into prompt text — the same class of overrun that wedges resume/compaction on the native path (fixed in #3113).

- Extend `_redact_inline_base64` to also rewrite `{"type":"image"|"document","source":{"type":"base64",...}}` blocks to a compact `[image/attachment: <media_type>, <N> base64 chars]` placeholder.

Note: in the current `_build_prompt`, `function_call_output` items don't reach the history prefix (they carry `output`, not `role`/`content`), so this is primarily defense-in-depth / consistency with the native fix — it closes the gap for any content path that does surface these blocks.

## Test Plan

- New unit test `test_historical_image_source_block_is_replaced_with_compact_placeholder`: an Anthropic image `source` block is rendered via `_render_prior_content` and asserted to contain the placeholder, not the base64.
- Verified across shapes: image source block ✅ redacted, document source block ✅ redacted, existing `data:`-URI path ✅ unchanged, plain-text ✅ passthrough.
- `pre-commit run` clean. Full `tests/inner/test_claude_sdk_executor.py` passes except one pre-existing env-specific failure (`test_resolve_sandbox_cwd_roots_relative_at_runner_workspace`), confirmed to fail identically with this change stashed.

## Demo

N/A — non-visual (history serialization).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually exercised `_render_prior_content` with image and document `source` blocks (raw base64), the existing `data:`-URI form, and plain text, confirming the new block shapes redact while established paths are unchanged.

## Changelog

Claude SDK sessions no longer inline base64 image/document tool results into replayed history, guarding against context overflow on resume
