### PR TITLE
test(runner-init): guard fork-history directives survive the reconnect envelope

### DIFF
--- a/tests/server/test_runner_session_init.py
+++ b/tests/server/test_runner_session_init.py
@@ -150,25 +150,12 @@ async def test_session_init_readiness_is_explicit_and_backward_compatible(
 
 
 def test_reconnect_init_envelope_carries_fork_history_directives(db_uri: str) -> None:
-    """A forked native session's fork directives survive to the runner envelope.
+"""Regression guard: fork directives survive runner reconnect init.
 
-    End-to-end regression guard for the exact seam that dropped a forked
-    claude-native session's history: the runner reconnect path
-    (``_on_runner_connect``) sources its conversations from
-    ``list_conversations_by_runner_id`` and hands each straight to
-    ``build_runner_session_init_payload``, which projects
-    ``conversation.labels`` into the init envelope the runner reads to decide
-    whether to clone/rebuild the vendor transcript. When that store lookup
-    returned label-less conversations, the envelope shipped no ``omnigent.fork.*``
-    directives, so the runner skipped its clone/rebuild branch and launched the
-    TUI fresh — history lost — even though the fork copied the history into the
-    store.
-
-    This drives the real store (fork included), not a hand-built envelope, so it
-    fails if any layer between the by-runner-id lookup and the envelope stops
-    carrying labels. The label→launch-metadata projection is covered separately
-    by ``test_claude_launch_metadata_envelope_never_calls_server``.
-    """
+Exercises store-backed fork → list_conversations_by_runner_id → build_runner_session_init_payload →
+parse_runner_session_init_envelope, and asserts the fork labels are present and parsed into
+Claude launch metadata.
+"""
     agent_store = SqlAlchemyAgentStore(db_uri)
     conversation_store = SqlAlchemyConversationStore(db_uri)
 

--- a/tests/server/test_runner_session_init.py
+++ b/tests/server/test_runner_session_init.py
@@ -150,17 +150,30 @@ async def test_session_init_readiness_is_explicit_and_backward_compatible(
 
 
 def test_reconnect_init_envelope_carries_fork_history_directives(db_uri: str) -> None:
-"""Regression guard: fork directives survive runner reconnect init.
+    """A forked native session's fork directives survive to the runner envelope.
 
-Exercises store-backed fork → list_conversations_by_runner_id → build_runner_session_init_payload →
-parse_runner_session_init_envelope, and asserts the fork labels are present and parsed into
-Claude launch metadata.
-"""
+    End-to-end regression guard for the exact seam that dropped a forked
+    claude-native session's history: the runner reconnect path
+    (``_on_runner_connect``) sources its conversations from
+    ``list_conversations_by_runner_id`` and hands each straight to
+    ``build_runner_session_init_payload``, which projects
+    ``conversation.labels`` into the init envelope the runner reads to decide
+    whether to clone/rebuild the vendor transcript. When that store lookup
+    returned label-less conversations, the envelope shipped no ``omnigent.fork.*``
+    directives, so the runner skipped its clone/rebuild branch and launched the
+    TUI fresh -- history lost -- even though the fork copied the history into the
+    store.
+
+    This drives the real store (fork included), not a hand-built envelope, so it
+    fails if any layer between the by-runner-id lookup and the envelope stops
+    carrying labels. The label-to-launch-metadata projection is covered
+    separately by ``test_claude_launch_metadata_envelope_never_calls_server``.
+    """
     agent_store = SqlAlchemyAgentStore(db_uri)
     conversation_store = SqlAlchemyConversationStore(db_uri)
 
     # A claude-native SOURCE with a captured native session id and a bound
-    # workspace — the two preconditions fork_conversation needs to stamp the
+    # workspace -- the two preconditions fork_conversation needs to stamp the
     # source-transcript directive.
     agent = agent_store.create(generate_agent_id(), "claude-native-ui", "bundle/loc")
     source = conversation_store.create_conversation(agent_id=agent.id, workspace="/tmp/ws")
@@ -176,7 +189,7 @@ Claude launch metadata.
     # Bind the fork to a runner so the reconnect lookup returns it.
     assert conversation_store.set_runner_id(fork.id, "runner_fork")
 
-    # The reconnect path: by-runner-id lookup → init payload.
+    # The reconnect path: by-runner-id lookup -> init payload.
     bound = conversation_store.list_conversations_by_runner_id("runner_fork")
     assert [c.id for c in bound] == [fork.id]
 
@@ -191,7 +204,7 @@ Claude launch metadata.
     assert labels.get(FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY) == "src-claude-sid"
     assert labels.get(FORK_SOURCE_LABEL_KEY) == source.id
 
-    # And the runner's own projection reads them as launch directives — the
+    # And the runner's own projection reads them as launch directives -- the
     # boolean the clone/rebuild branch gates on.
     from omnigent.runner.app import _claude_launch_metadata_from_envelope
 

--- a/tests/server/test_runner_session_init.py
+++ b/tests/server/test_runner_session_init.py
@@ -8,8 +8,20 @@ from typing import Any
 import httpx
 import pytest
 
+from omnigent.db.utils import generate_agent_id
 from omnigent.entities import Conversation
+from omnigent.runner.session_init_protocol import (
+    build_runner_session_init_payload,
+    parse_runner_session_init_envelope,
+)
 from omnigent.server.runner_session_init import RunnerSessionInitializer
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.conversation_store import (
+    FORK_CARRY_HISTORY_LABEL_KEY,
+    FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY,
+    FORK_SOURCE_LABEL_KEY,
+)
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
 
 
 class _Registry:
@@ -135,3 +147,67 @@ async def test_session_init_readiness_is_explicit_and_backward_compatible(
     )
 
     assert ready is expected_ready
+
+
+def test_reconnect_init_envelope_carries_fork_history_directives(db_uri: str) -> None:
+    """A forked native session's fork directives survive to the runner envelope.
+
+    End-to-end regression guard for the exact seam that dropped a forked
+    claude-native session's history: the runner reconnect path
+    (``_on_runner_connect``) sources its conversations from
+    ``list_conversations_by_runner_id`` and hands each straight to
+    ``build_runner_session_init_payload``, which projects
+    ``conversation.labels`` into the init envelope the runner reads to decide
+    whether to clone/rebuild the vendor transcript. When that store lookup
+    returned label-less conversations, the envelope shipped no ``omnigent.fork.*``
+    directives, so the runner skipped its clone/rebuild branch and launched the
+    TUI fresh — history lost — even though the fork copied the history into the
+    store.
+
+    This drives the real store (fork included), not a hand-built envelope, so it
+    fails if any layer between the by-runner-id lookup and the envelope stops
+    carrying labels. The label→launch-metadata projection is covered separately
+    by ``test_claude_launch_metadata_envelope_never_calls_server``.
+    """
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    conversation_store = SqlAlchemyConversationStore(db_uri)
+
+    # A claude-native SOURCE with a captured native session id and a bound
+    # workspace — the two preconditions fork_conversation needs to stamp the
+    # source-transcript directive.
+    agent = agent_store.create(generate_agent_id(), "claude-native-ui", "bundle/loc")
+    source = conversation_store.create_conversation(agent_id=agent.id, workspace="/tmp/ws")
+    conversation_store.set_external_session_id(source.id, "src-claude-sid")
+
+    # Fork it the way the route does for a same-family native target: carry
+    # history and resume the source's native transcript.
+    fork = conversation_store.fork_conversation(
+        source.id,
+        carry_history_into_native=True,
+        resume_source_native_session=True,
+    )
+    # Bind the fork to a runner so the reconnect lookup returns it.
+    assert conversation_store.set_runner_id(fork.id, "runner_fork")
+
+    # The reconnect path: by-runner-id lookup → init payload.
+    bound = conversation_store.list_conversations_by_runner_id("runner_fork")
+    assert [c.id for c in bound] == [fork.id]
+
+    payload = build_runner_session_init_payload(bound[0], server_version="0.6.0.dev0")
+    envelope = parse_runner_session_init_envelope(payload)
+    assert envelope is not None
+
+    # The directives that select the runner's clone/rebuild branch must be
+    # present in the envelope the runner actually reads.
+    labels = envelope.snapshot.labels
+    assert labels.get(FORK_CARRY_HISTORY_LABEL_KEY) == "1"
+    assert labels.get(FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY) == "src-claude-sid"
+    assert labels.get(FORK_SOURCE_LABEL_KEY) == source.id
+
+    # And the runner's own projection reads them as launch directives — the
+    # boolean the clone/rebuild branch gates on.
+    from omnigent.runner.app import _claude_launch_metadata_from_envelope
+
+    metadata = _claude_launch_metadata_from_envelope(envelope)
+    assert metadata.fork_carry_history is True
+    assert metadata.fork_source_external_id == "src-claude-sid"


### PR DESCRIPTION
## Related issue

N/A — follow-up test hardening for #3116.

## Summary

Adds a CI-runnable regression test for the seam that broke forked native
history in #2793 and was fixed in #3116.

The bug: `list_conversations_by_runner_id` returned label-less conversations,
so the runner reconnect path (`_on_runner_connect`) built a session-init
envelope with no `omnigent.fork.*` directives — the runner then skipped its
clone/rebuild branch and launched the vendor TUI fresh, losing history.

Coverage gap it fills: the existing envelope tests hand-build an envelope with
the fork label already present (they test the *projection*, downstream of where
the label was dropped), and the opt-in
`tests/e2e/test_host_claude_native_fork_e2e.py` — the only test that exercised
the real reconnect path — needs an interactive Claude login and so never gates
CI. That's exactly why the regression slipped through.

This test drives the **real store, end to end**: create a claude-native source
with a captured `external_session_id` + workspace, fork it with
`carry_history_into_native`, bind it to a runner, then run
`list_conversations_by_runner_id` → `build_runner_session_init_payload` →
`parse_runner_session_init_envelope` → `_claude_launch_metadata_from_envelope`
and assert the fork directives survive as launch metadata. No vendor CLI, so it
runs in CI.

## Test Plan

```
pytest tests/server/test_runner_session_init.py
```

- New `test_reconnect_init_envelope_carries_fork_history_directives` passes (5/5
  in the file).
- **Verified it actually catches the regression:** temporarily reverting #3116's
  label hydration in `list_conversations_by_runner_id` makes the new test fail
  with an empty label set (`{}.get(...)` → `None`); restoring the fix makes it
  pass. A test that couldn't fail would be worthless, so this was confirmed both
  ways.
- Related store-layer tests still green:
  `pytest tests/stores/test_conversation_store.py -k by_runner_id`.

## Demo

N/A — test-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — this PR *is* the added coverage. Guards the store→envelope→launch-metadata
reconnect seam that #3116 fixed, at a layer that runs in CI (the full
fork→runner→TUI E2E remains opt-in in `test_host_claude_native_fork_e2e.py`).

This pull request and its description were written by Isaac.
