### PR TITLE
fix(antigravity): resolve lsof independently of the daemon PATH

### DIFF
--- a/omnigent/antigravity_native_rpc.py
+++ b/omnigent/antigravity_native_rpc.py
@@ -57,6 +57,7 @@ import ipaddress
 import json
 import logging
 import os
+import shutil
 import struct
 import subprocess
 from collections.abc import AsyncIterator, Iterable
@@ -246,6 +247,29 @@ def _async_client(timeout: httpx.Timeout | float) -> httpx.AsyncClient:
     return httpx.AsyncClient(verify=False, timeout=timeout, transport=_ASYNC_HTTP_TRANSPORT)
 
 
+# Absolute fallbacks for the ``lsof`` lookup. A launchd / systemd daemon runs
+# with a minimal PATH — macOS ships lsof in ``/usr/sbin``, which is absent from
+# the omnigent host daemon's PATH, so a bare ``lsof`` argv raises
+# FileNotFoundError and agy's RPC port is never discovered (the reader then
+# never binds and mirrors nothing).
+_LSOF_FALLBACKS = ("/usr/sbin/lsof", "/usr/bin/lsof", "/bin/lsof")
+
+
+def _lsof_binary() -> str | None:
+    """
+    Resolve the ``lsof`` executable independently of the caller's ``PATH``.
+
+    :returns: An executable path, or ``None`` when lsof is unavailable.
+    """
+    found = shutil.which("lsof")
+    if found:
+        return found
+    for candidate in _LSOF_FALLBACKS:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
 def _run_lsof_listen_ports(pid: int) -> str:
     """
     Return raw ``lsof`` output listing a pid's TCP LISTEN sockets.
@@ -257,9 +281,13 @@ def _run_lsof_listen_ports(pid: int) -> str:
     :param pid: agy process id, e.g. ``72753``.
     :returns: ``lsof`` stdout, or ``""`` on any failure.
     """
+    binary = _lsof_binary()
+    if binary is None:
+        _logger.warning("lsof not found on PATH or at %s", _LSOF_FALLBACKS)
+        return ""
     try:
         completed = subprocess.run(
-            ["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", "-sTCP:LISTEN"],
+            [binary, "-nP", "-a", "-p", str(pid), "-iTCP", "-sTCP:LISTEN"],
             capture_output=True,
             text=True,
             timeout=_LSOF_TIMEOUT_S,

--- a/tests/test_antigravity_native_rpc.py
+++ b/tests/test_antigravity_native_rpc.py
@@ -2078,3 +2078,31 @@ def test_cold_start_port_no_pane_none_when_no_candidates(
     """No pane and no candidates yet → ``None`` (keep polling)."""
     monkeypatch.setattr(rpc, "_candidate_agy_rpc_ports", list)
     assert rpc.resolve_cold_start_agy_rpc_port(None, None) is None
+
+
+def test_lsof_binary_falls_back_when_not_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """lsof resolves by absolute path when ``PATH`` does not contain it.
+
+    The regression: the omnigent host daemon runs under launchd/systemd with a
+    minimal PATH. macOS ships lsof in ``/usr/sbin``, which that PATH omits, so a
+    bare ``lsof`` argv raised FileNotFoundError — agy's RPC port was never
+    discovered, the reader never bound, and the session mirrored nothing.
+    """
+    monkeypatch.setattr(rpc.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(rpc.os.path, "isfile", lambda p: p == "/usr/sbin/lsof")
+    monkeypatch.setattr(rpc.os, "access", lambda p, _mode: p == "/usr/sbin/lsof")
+
+    assert rpc._lsof_binary() == "/usr/sbin/lsof"
+
+
+def test_lsof_binary_none_when_absent_everywhere(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With lsof neither on PATH nor at a known location, resolution yields None.
+
+    ``_run_lsof_listen_ports`` then returns "" and discovery degrades to "no
+    ports" rather than raising.
+    """
+    monkeypatch.setattr(rpc.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(rpc.os.path, "isfile", lambda _p: False)
+
+    assert rpc._lsof_binary() is None
+    assert rpc._run_lsof_listen_ports(1234) == ""


### PR DESCRIPTION
## Related issue

N/A — found on a live macOS host.

## Summary

`antigravity-native` finds agy's connect-RPC port by shelling out to `lsof`
against the agy pid. The argv is a bare `"lsof"`, so it resolves through the
calling process's `PATH`.

The Omnigent host daemon runs under launchd/systemd with a **minimal `PATH`**.
macOS ships lsof in `/usr/sbin`, which that `PATH` omits, so every probe raises
`FileNotFoundError: [Errno 2] No such file or directory: 'lsof'`.

`_run_lsof_listen_ports` catches `OSError` and returns `""`, which is correct
for "the process is gone" but here means a *missing tool* is reported as
*no ports bound*. Discovery then times out with
`no agy connect-RPC port bound within 20s`, the RPC reader never binds, and the
session mirrors nothing: agy answers normally in its own TUI while the web chat
stays empty forever and a dispatched worker never returns.

Observed on a real host — the daemon's `PATH` was
`~/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin` (no `/usr/sbin`)
while lsof sat at `/usr/sbin/lsof`.

Resolve the binary independently of the inherited `PATH`: `shutil.which` first,
then a short list of absolute fallbacks. When lsof genuinely isn't installed the
behaviour is unchanged (`""`), except it now WARNs so the cause is visible in
logs instead of looking like an empty socket table. The existing `/proc/net/tcp`
fallback still covers Linux hosts where lsof can't attribute the socket.

## Test Plan

- `pytest tests/test_antigravity_native_rpc.py` — 106 passed, including new
  cases covering `PATH` resolution, the absolute-fallback hit, and the
  lsof-genuinely-absent path.
- `pre-commit run --files omnigent/antigravity_native_rpc.py tests/test_antigravity_native_rpc.py`.
- Manual, on the host that produced the failure: restarted the daemon under its
  launchd `PATH` (no `/usr/sbin`) and confirmed the port is now discovered and
  the reader binds, where the same session previously timed out at 20s.

## Demo

N/A — no visual surface. The user-visible effect is that an antigravity session
mirrors into web chat at all instead of staying permanently empty.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests stub the subprocess seam, so they pin the resolution order but cannot
prove the real launchd `PATH` case. That part was verified manually on the host
where the bug was originally observed, as described in the Test Plan.

## Changelog

Antigravity sessions on macOS hosts now mirror into web chat instead of staying empty when the daemon's PATH omits `/usr/sbin`.
