### PR TITLE
fix(antigravity): mirror steps committed before bind, and bound the idle stream read

### DIFF
--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -1024,6 +1024,33 @@ async def supervise_reader(
         return should_stop() or bool(rotation_holder)
 
     async def _run_body() -> None:
+        # Backfill BEFORE streaming: the connect-stream only carries frames minted
+        # after it opens, so a bind landing on a cascade whose steps are already
+        # committed — exactly what the adopt-in-place rebind onto a TUI-minted
+        # cascade does — would mirror nothing and leave the turn open forever.
+        # ``state``'s seen-set keeps this idempotent against the stream's own
+        # delivery; a failure is swallowed so the stream/poll paths still run.
+        try:
+            initial_steps = await asyncio.to_thread(get_trajectory_steps, port, cascade_id)
+        except (httpx.HTTPError, ValueError) as exc:
+            _logger.warning(
+                "agy RPC reader backfill failed; relying on stream/poll: "
+                "cascade=%s port=%s error=%r",
+                cascade_id,
+                port,
+                exc,
+            )
+        else:
+            for step in initial_steps:
+                await _process_committed_step(
+                    step,
+                    client=client,
+                    session_id=session_id,
+                    cascade_id=cascade_id,
+                    state=state,
+                    on_pending_interaction=on_pending_interaction,
+                )
+
         # STREAM-primary (Task T-D): consume the connect server-stream for live
         # ``output_text_delta`` typing parity. On a stream error (transport
         # ``httpx.HTTPError`` or a connect-trailer ``AntigravityRpcError``) fall

--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -122,6 +122,11 @@ _DEFAULT_ROTATION_INTERVAL_S = 3.0
 # stream at zero delay and pin a CPU — the poll fallback only triggers on an
 # exception, never a clean immediate return.
 _STREAM_REENTRY_BACKOFF_S = 0.5
+# Idle read deadline for ONE stream entry. While agy is parked it emits neither a
+# frame nor a trailer, so an unbounded read wedges the body: the ``stop``
+# checkpoint is unreachable and the exception-gated poll fallback never fires.
+# Bounding each entry makes the loop periodically re-checkable without churn.
+_STREAM_IDLE_READ_TIMEOUT_S = 30.0
 
 # Teardown drain passes for the interaction bridge + chained re-scan tasks. Cancelling
 # a bridge stops it scheduling a re-scan and vice versa, so the chain collapses fast;
@@ -1369,7 +1374,25 @@ async def _stream_loop(
         falls back).
     """
     while not stop():
-        async for frame in stream_agent_state_updates(port, cascade_id):
+        frames = stream_agent_state_updates(port, cascade_id).__aiter__()
+        while True:
+            try:
+                frame = await asyncio.wait_for(
+                    frames.__anext__(), timeout=_STREAM_IDLE_READ_TIMEOUT_S
+                )
+            except StopAsyncIteration:
+                break
+            except TimeoutError:
+                # Idle deadline. agy parked with no frame and no trailer, so a
+                # deadline-less read would block here forever: the loop's ``stop``
+                # checkpoint is never reached and the poll fallback (gated on an
+                # exception) never runs. End this entry so the outer loop re-checks
+                # ``stop`` and re-opens; close the generator to free the response.
+                aclose = getattr(frames, "aclose", None)
+                if aclose is not None:
+                    with contextlib.suppress(Exception):
+                        await aclose()
+                break
             # NOTE on /clear rotation: this stream is bound to ONE cascade and only
             # ever reports THAT cascade's id, so it can NEVER observe a sibling
             # conversation — a per-frame "did the conversation change?" guard here

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -1445,8 +1445,9 @@ async def test_http_error_does_not_crash_loop(
         iterations=3,
     )
 
-    # First poll raised; second poll delivered the message — loop survived.
-    assert steps.calls == 2
+    # Backfill consumed the raise, then the poll loop delivered the message —
+    # loop survived. 3 = one bind-time backfill + two poll iterations.
+    assert steps.calls == 3
     assert sink.item_types() == ["message"]
 
 
@@ -1473,7 +1474,8 @@ async def test_value_error_does_not_crash_loop(
         iterations=3,
     )
 
-    assert steps.calls == 2
+    # 3 = one bind-time backfill + two poll iterations (raise, then recover).
+    assert steps.calls == 3
     assert sink.item_types() == ["message"]
 
 
@@ -3694,8 +3696,9 @@ async def test_supervise_reader_actuates_rotation_when_stream_is_wedged(
 
     Before the fix this would hang (the body ``await``-ed the wedged stream
     directly); the tight :func:`asyncio.wait_for` budget makes a regression fail
-    loudly as a timeout rather than wedging the suite. The poll fallback is never
-    reached (the stream never raises), so its step source is asserted untouched.
+    loudly as a timeout rather than wedging the suite. The poll LOOP is never
+    reached (the stream never raises), so its step source is touched exactly once
+    — by the bind-time backfill, not by any poll iteration.
     """
     new_cascade = "deadlock-1111-2222-3333-444444444444"
     blocking = _BlockingStream()
@@ -3732,9 +3735,10 @@ async def test_supervise_reader_actuates_rotation_when_stream_is_wedged(
 
     assert result == new_cascade
     # The wedged stream was interrupted by cancellation (the actuation path), and
-    # the poll fallback was never reached (the stream never errored).
+    # the poll fallback was never reached (the stream never errored); the single
+    # call is the bind-time backfill, which runs before the stream opens.
     assert blocking.cancelled is True
-    assert poll.calls == 0
+    assert poll.calls == 1
 
 
 @pytest.mark.asyncio
@@ -3782,6 +3786,7 @@ async def test_supervise_reader_external_cancel_propagates_not_rotation(
         await asyncio.wait_for(task, timeout=5)
 
 
+<<<<<<< HEAD
 # ---------------------------------------------------------------------------
 # Quiescence backstop (agy's own CASCADE_RUN_STATUS)
 # ---------------------------------------------------------------------------
@@ -3855,3 +3860,73 @@ async def test_watch_for_rotation_signals_quiescence_only_after_consecutive_idle
         )
 
     assert calls == [1], "expected exactly one quiescence signal, after two idle ticks"
+
+
+class _EmptyStream:
+    """A ``stream_agent_state_updates`` that yields no frame and ends cleanly.
+
+    Models the real failure: the reader binds to a cascade whose steps are
+    ALREADY committed, so the connect-stream (which only carries frames minted
+    after it opens) delivers nothing and never errors — meaning the poll
+    fallback, gated on an exception, never runs.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, port: int, conversation_id: str) -> AsyncIterator[dict[str, object]]:
+        self.calls += 1
+
+        async def _gen() -> AsyncIterator[dict[str, object]]:
+            return
+            yield {}  # pragma: no cover  (unreachable; marks this an async gen)
+
+        return _gen()
+
+
+@pytest.mark.asyncio
+async def test_backfill_mirrors_steps_already_committed_at_bind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_discovery: None,
+) -> None:
+    """Steps that predate the bind are mirrored, even when the stream is silent.
+
+    The regression: an adopt-in-place rebind onto a TUI-minted cascade lands
+    AFTER its steps are committed. The stream carries only post-open frames and
+    never errors, so the poll fallback never fires — leaving the assistant's
+    reply unmirrored and the turn open forever in the web UI. The bind-time
+    backfill must deliver those steps on its own.
+    """
+    text = _load("planner_response_text")
+    steps = _StepScript([[text]])
+    stream = _EmptyStream()
+    sink = _PostSink()
+
+    monkeypatch.setattr(reader, "stream_agent_state_updates", stream)
+    monkeypatch.setattr(reader, "get_trajectory_steps", steps)
+    monkeypatch.setattr(reader, "post_session_event_with_retry", sink)
+
+    async def _noop_sleep(_seconds: float) -> None:
+        await asyncio.sleep(0)
+
+    async def _noop_pending(_cid: str, _port: int, _pending: PendingInteraction) -> None:
+        return None
+
+    monkeypatch.setattr(reader, "_sleep", _noop_sleep)
+
+    await reader.supervise_reader(
+        _bridge_dir(tmp_path),
+        _SESSION_ID,
+        client=cast(httpx.AsyncClient, object()),
+        on_pending_interaction=cast(Any, _noop_pending),
+        poll_interval_s=0.0,
+        stop=_stop_after(1),
+    )
+
+    # The silent stream opened and returned without error, so the poll loop was
+    # never entered — the single step read is the backfill, and it is what put
+    # the assistant message on the wire.
+    assert stream.calls == 1
+    assert steps.calls == 1
+    assert sink.item_types() == ["message"]

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -3786,7 +3786,6 @@ async def test_supervise_reader_external_cancel_propagates_not_rotation(
         await asyncio.wait_for(task, timeout=5)
 
 
-<<<<<<< HEAD
 # ---------------------------------------------------------------------------
 # Quiescence backstop (agy's own CASCADE_RUN_STATUS)
 # ---------------------------------------------------------------------------
@@ -3930,3 +3929,59 @@ async def test_backfill_mirrors_steps_already_committed_at_bind(
     assert stream.calls == 1
     assert steps.calls == 1
     assert sink.item_types() == ["message"]
+
+
+@pytest.mark.asyncio
+async def test_stream_idle_deadline_ends_entry_instead_of_wedging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stream that never yields ends on the idle deadline rather than blocking.
+
+    The regression: while agy is parked it emits neither frame nor trailer, so an
+    unbounded read wedged ``_stream_loop`` forever — the ``stop`` checkpoint was
+    unreachable and the exception-gated poll fallback never fired. The bounded
+    entry must return so the loop can re-check ``stop``.
+    """
+    opened = 0
+
+    def _never_yields(port: int, conversation_id: str) -> AsyncIterator[dict[str, object]]:
+        nonlocal opened
+        opened += 1
+
+        async def _gen() -> AsyncIterator[dict[str, object]]:
+            await asyncio.sleep(3600)  # park like an idle agy
+            yield {}  # pragma: no cover
+
+        return _gen()
+
+    monkeypatch.setattr(reader, "stream_agent_state_updates", _never_yields)
+    monkeypatch.setattr(reader, "_STREAM_IDLE_READ_TIMEOUT_S", 0.05)
+
+    async def _noop_sleep(_seconds: float) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(reader, "_sleep", _noop_sleep)
+
+    # stop() is False for the first entry, then True — so a working deadline lets
+    # the loop reach its checkpoint and exit. A wedge would hang until the timeout.
+    ticks = iter([False, True, True])
+
+    await asyncio.wait_for(
+        reader._stream_loop(
+            port=1234,
+            cascade_id=_CASCADE_ID,
+            client=cast(httpx.AsyncClient, object()),
+            session_id=_SESSION_ID,
+            on_pending_interaction=cast(Any, None),
+            state=reader._ReaderState(
+                allocator=reader._ToolCallIdAllocator(conversation_id=_CASCADE_ID),
+                seen=set(),
+                interacted=set(),
+                port=_PORT,
+            ),
+            stop=lambda: next(ticks, True),
+        ),
+        timeout=5,
+    )
+
+    assert opened >= 1


### PR DESCRIPTION
## Related issue

N/A — found on a live antigravity session.

## Summary

Two related defects in the `antigravity-native` RPC read driver. Either one
leaves a session's reply stranded in the agy TUI while the web chat stays empty
and a dispatched worker never returns.

**1. No backfill at bind.** The reader is stream-primary, and
`StreamAgentStateUpdates` only carries frames minted *after* the stream opens.
When it binds to a cascade whose steps are already committed — exactly what the
adopt-in-place rebind onto a TUI-minted cascade does after a `/clear` — it
mirrors nothing.

`_poll_loop` is the only caller of `GetCascadeTrajectorySteps`, and it runs only
in the `except` arm of the stream call. A *silent* stream is not a *failed*
stream: it never raises, so that fallback never fires. Observed live on one
session: **1446** `GetAllCascadeTrajectories` polls, **0** step fetches, **0**
events posted, and not one error logged.

Fix: read the committed snapshot once at bind, before streaming. `state`'s
seen-set already de-duplicates against the stream's own delivery, so this is
idempotent. A failed backfill is logged and swallowed, leaving the stream and
poll paths exactly as they were.

**2. Unbounded idle stream read.** While agy is parked it emits neither a frame
nor a trailer. An unbounded `__anext__` therefore wedges the reader body: the
loop's `stop()` checkpoint is unreachable, and the poll fallback — gated on an
exception — never fires either. The reader is alive but permanently
uninterruptible.

Fix: bound each stream entry with an idle deadline. On expiry the generator is
closed and the outer loop re-checks `stop()` and re-opens. The existing
`_STREAM_REENTRY_BACKOFF_S` keeps re-entry from spinning.

## Test Plan

- `pytest tests/test_antigravity_native_reader.py` — 87 passed. New cases:
  `test_backfill_mirrors_steps_already_committed_at_bind` drives
  `supervise_reader` with a stream that yields nothing and ends cleanly, and
  asserts the single step read is the backfill and that it is what puts the
  assistant message on the wire; further cases cover the idle-deadline re-entry
  and that a failing backfill still leaves the stream/poll paths running.
- `pre-commit run --files omnigent/antigravity_native_reader.py tests/test_antigravity_native_reader.py`.
- Rebased onto current `main` (over #3499, which reworked this reader) — the
  quiescence-backstop tests added there still pass alongside the new ones.

## Demo

N/A — no visual surface of its own. The user-visible effect is that the reply
appears in web chat at all, rather than only in the agy TUI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit tests stub the stream and step-fetch seams, which pins the control flow
precisely but cannot reproduce a real agy parked mid-turn. The
1446-polls-0-fetches trace quoted above came from a live session, and the
adopt-in-place rebind after `/clear` was re-run against a real agy to confirm
the reply now mirrors.

## Changelog

Antigravity sessions now mirror a reply that was already in progress when the reader attached, instead of leaving the turn open forever.
