### PR TITLE
feat: add Grok Build native harness (#2881)

### DIFF
--- a/omnigent/_wrapper_labels.py
+++ b/omnigent/_wrapper_labels.py
@@ -80,3 +80,7 @@ KIMI_NATIVE_WRAPPER_VALUE = "kimi-native-ui"
 # Value the ``omnigent hermes`` wrapper writes into
 # ``conversations.labels[WRAPPER_LABEL_KEY]``.
 HERMES_NATIVE_WRAPPER_VALUE = "hermes-native-ui"
+
+# Value the ``omnigent grok-build`` wrapper writes into
+# ``conversations.labels[WRAPPER_LABEL_KEY]``.
+GROK_BUILD_NATIVE_WRAPPER_VALUE = "grok-build-native-ui"

--- a/omnigent/cli_native.py
+++ b/omnigent/cli_native.py
@@ -1263,3 +1263,93 @@ def register_native_commands(cli: click.Group) -> None:
             kimi_args=_resolve_harness_startup_args(cfg, "kimi-native", kimi_args),
             auto_open_conversation=auto_open_conversation,
         )
+
+    @cli.command(
+        context_settings={
+            "ignore_unknown_options": True,
+            "allow_extra_args": True,
+        }
+    )
+    @click.option(
+        "--server",
+        default=None,
+        help=(
+            "Remote omnigent URL. Ensures the host daemon, asks the "
+            "daemon-spawned runner to launch Grok Build, and attaches this TTY. "
+            'Pass --server "" to auto-spawn a persistent local server in the '
+            "background and use that instead of a remote one."
+        ),
+    )
+    @click.option(
+        "-r",
+        "--resume",
+        "resume",
+        is_flag=False,
+        flag_value=_RESUME_PICKER_SENTINEL,
+        default=None,
+        help=(
+            "Resume a prior Omnigent conversation. With a conversation id "
+            "(e.g. ``--resume conv_abc123``) attaches directly; with no value "
+            "opens an interactive picker scoped to grok-build-native sessions."
+        ),
+    )
+    @click.option(
+        "--session",
+        "session_id",
+        metavar="SESSION_ID",
+        default=None,
+        hidden=True,
+        help="Deprecated alias for ``--resume <id>``; kept for one release.",
+    )
+    @click.argument("grok_build_args", nargs=-1, type=click.UNPROCESSED)
+    def grok_build(
+        server: str | None,
+        resume: str | None,
+        session_id: str | None,
+        grok_build_args: tuple[str, ...],
+    ) -> None:
+        """Launch the Grok Build TUI in an Omnigent terminal.
+
+        \b
+        Examples:
+          omnigent grok-build
+          omnigent grok-build --resume conv_abc123
+          omnigent grok-build --resume               # interactive picker
+          omnigent grok-build --server https://<app>.databricksapps.com
+        """
+        choice = _split_resume_value(resume)
+        if session_id is not None and (choice.picker or choice.conversation_id is not None):
+            raise click.UsageError(
+                "--session and --resume are mutually exclusive; "
+                "prefer --resume (--session is deprecated).",
+            )
+
+        from omnigent.grok_build_native import run_grok_build_native
+        from omnigent.harness_startup_config import resolve_harness_command
+
+        cfg = _load_effective_config()
+        # Thread ``--command`` / ``harness.grok-build-native.command`` config into
+        # the runner via the canonical ``OMNIGENT_GROK_BUILD_PATH`` env var.
+        _resolved = resolve_harness_command(
+            "grok-build-native", default="", explicit=None, cfg=cfg
+        )
+        if _resolved:
+            os.environ["OMNIGENT_GROK_BUILD_PATH"] = _resolved
+        if server is None:
+            server = cfg.get("server")
+        auto_open_conversation = _resolve_auto_open_conversation_from_config(cfg)
+
+        server = _ensure_backend(server)
+        resolved_session_id = (
+            choice.conversation_id if choice.conversation_id is not None else session_id
+        )
+
+        run_grok_build_native(
+            server=server,
+            session_id=resolved_session_id,
+            resume_picker=choice.picker,
+            grok_build_args=_resolve_harness_startup_args(
+                cfg, "grok-build-native", grok_build_args
+            ),
+            auto_open_conversation=auto_open_conversation,
+        )

--- a/omnigent/grok_build_native.py
+++ b/omnigent/grok_build_native.py
@@ -1,0 +1,625 @@
+"""Native Grok Build TUI wrapper for the Omnigent CLI.
+
+``omnigent grok-build`` launches xAI's Grok Build CLI interactive TUI (the bare
+``grok`` command) inside an Omnigent-runner-owned tmux terminal and attaches the
+local TTY — the Grok Build analog of ``omnigent goose`` / ``omnigent cursor``.
+The runner spawns the process (see
+:func:`omnigent.runner.app._auto_create_grok_build_terminal`); this module owns the
+CLI-side orchestration: session create/resume, daemon runner bind, terminal-ready
+poll, and the direct tmux attach.
+
+Auth is Grok Build's own configuration (``grok`` opens a browser on first launch
+for OAuth); no Omnigent-managed key is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import click
+import httpx
+import yaml
+
+from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
+from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
+from omnigent._wrapper_labels import GROK_BUILD_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE
+from omnigent._wrapper_labels import WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY
+from omnigent.conversation_browser import conversation_url, open_conversation_link_if_enabled
+from omnigent.entities.session_resources import terminal_resource_id
+from omnigent.host.daemon_launch import (
+    error_text,
+    launch_or_reuse_daemon_runner,
+    wait_for_host_online,
+    wait_for_runner_online,
+)
+from omnigent.native_coding_agents import native_shell_terminal_spec
+from omnigent.native_terminal import (
+    DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
+)
+from omnigent.native_terminal import (
+    DAEMON_RUNNER_ONLINE_TIMEOUT_S as _DAEMON_RUNNER_ONLINE_TIMEOUT_S,
+)
+from omnigent.native_terminal import (
+    DAEMON_TERMINAL_READY_TIMEOUT_S as _DAEMON_TERMINAL_READY_TIMEOUT_S,
+)
+from omnigent.native_terminal import bind_session_runner as _bind_session_runner
+from omnigent.native_terminal import url_component
+
+_DEFAULT_GROK_BUILD_COMMAND = "grok"
+_GROK_BUILD_PATH_ENV = "OMNIGENT_GROK_BUILD_PATH"
+_AGENT_NAME = "grok-build-native-ui"
+_TERMINAL_NAME = "grok-build"
+_TERMINAL_SESSION_KEY = "main"
+_SESSION_LABELS = {
+    "omnigent.ui": "terminal",
+    _WRAPPER_LABEL_KEY: _WRAPPER_LABEL_VALUE,
+}
+
+
+@dataclass(frozen=True)
+class NativeGrokBuildLaunch:
+    """Resolved native Grok Build process launch."""
+
+    executable: str
+    argv: list[str]
+
+
+@dataclass(frozen=True)
+class LaunchedGrokBuildTerminal:
+    """Terminal resource returned by the Omnigent runner launch path."""
+
+    terminal_id: str
+    tmux_socket: Path | None
+    tmux_target: str | None
+
+
+@dataclass(frozen=True)
+class PreparedGrokBuildTerminal:
+    """Prepared native Grok Build terminal attachment details.
+
+    :param reattached: ``True`` when an existing, still-running session terminal
+        was reused (the live-reattach path: prior session intact).
+    :param cold_resumed: ``True`` when resuming an existing Omnigent session whose
+        terminal had already exited, so a *fresh* ``grok`` TUI was launched.
+    """
+
+    session_id: str
+    terminal_id: str
+    tmux_socket: Path | None
+    tmux_target: str | None
+    reattached: bool
+    cold_resumed: bool = False
+
+
+def _configured_grok_build_command(env: Mapping[str, str]) -> str:
+    """Return the configured grok executable name/path from *env*."""
+    value = env.get(_GROK_BUILD_PATH_ENV, "").strip()
+    return value or _DEFAULT_GROK_BUILD_COMMAND
+
+
+def resolve_grok_build_executable(
+    *,
+    env: Mapping[str, str] | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> str:
+    """
+    Resolve the native Grok Build (``grok``) executable.
+
+    :param env: Environment mapping to inspect. Defaults to ``os.environ``.
+    :param which: Resolver hook for tests; defaults to ``shutil.which``.
+    :returns: Absolute executable path.
+    :raises click.ClickException: If no grok CLI is available.
+    """
+    env = os.environ if env is None else env
+    which = shutil.which if which is None else which
+    command = _configured_grok_build_command(env)
+    resolved = which(command)
+    if resolved is None:
+        install_url = "https://x.ai/cli/install.sh"
+        raise click.ClickException(
+            "Native Grok Build requires the 'grok' CLI on PATH. Install it with: "
+            f"curl -fsSL {install_url} | bash, "
+            "or download from https://github.com/xai-org/grok-build. "
+            f"You can also set {_GROK_BUILD_PATH_ENV}=/path/to/grok."
+        )
+    return resolved
+
+
+def build_grok_build_launch(
+    grok_build_args: Sequence[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> NativeGrokBuildLaunch:
+    """Build the argv for a native Grok Build process."""
+    executable = resolve_grok_build_executable(env=env, which=which)
+    return NativeGrokBuildLaunch(executable=executable, argv=[executable, *grok_build_args])
+
+
+def run_grok_build_native(
+    *,
+    server: str | None,
+    session_id: str | None,
+    grok_build_args: tuple[str, ...],
+    resume_picker: bool = False,
+    auto_open_conversation: bool = False,
+) -> None:
+    """
+    Launch the Grok Build TUI in an Omnigent terminal.
+
+    :param server: Resolved Omnigent server URL.
+    :param session_id: Optional existing Omnigent conversation id.
+    :param grok_build_args: Raw grok CLI args to persist for the runner-owned TUI.
+    :param resume_picker: ``True`` runs the grok-build-native picker.
+    :param auto_open_conversation: When ``True``, open the browser conversation
+        URL after launch.
+    :returns: None after the terminal attach session ends.
+    """
+    _preflight_local_tools()
+    if server is None:
+        raise click.ClickException(
+            "Grok Build requires a resolved Omnigent server URL. The CLI should call "
+            "_ensure_backend before run_grok_build_native."
+        )
+    with TemporaryDirectory(prefix="omnigent-grok-build-native-") as tmpdir:
+        spec_path = _materialize_grok_build_agent_spec(Path(tmpdir))
+        _run_with_remote_server(
+            server.rstrip("/"),
+            spec_path,
+            session_id=session_id,
+            resume_picker=resume_picker,
+            grok_build_args=grok_build_args,
+            auto_open_conversation=auto_open_conversation,
+        )
+
+
+def _materialize_grok_build_agent_spec(tmpdir: Path) -> Path:
+    """
+    Write the terminal-first agent spec used by ``omnigent grok-build``.
+
+    :param tmpdir: Temporary directory for the generated YAML file.
+    :returns: Path to the generated YAML spec.
+    """
+    yaml_path = tmpdir / "grok-build-native-ui.yaml"
+    raw: dict[str, Any] = {
+        "name": _AGENT_NAME,
+        "prompt": (
+            "Grok Build is running in the session terminal. The user drives the "
+            "grok TUI directly."
+        ),
+        "executor": {"harness": "grok-build-native"},
+        "spawn": True,
+        "os_env": {
+            "type": "caller_process",
+            "cwd": ".",
+            "sandbox": {"type": "none"},
+        },
+        "terminals": native_shell_terminal_spec(),
+    }
+    yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    return yaml_path
+
+
+def _run_with_remote_server(
+    base_url: str,
+    spec_path: Path,
+    *,
+    session_id: str | None,
+    resume_picker: bool,
+    grok_build_args: tuple[str, ...],
+    auto_open_conversation: bool = False,
+) -> None:
+    """
+    Launch Grok Build on an Omnigent server via a daemon-spawned runner.
+
+    :param base_url: Omnigent server base URL.
+    :param spec_path: Generated Grok Build wrapper agent spec.
+    :param session_id: Optional existing Omnigent session id.
+    :param resume_picker: When ``True``, run the grok-build-native picker.
+    :param grok_build_args: Raw grok CLI args.
+    :param auto_open_conversation: Whether to open the web conversation URL.
+    """
+    from omnigent.chat import _bundle_agent, _remote_headers
+    from omnigent.cli import _ensure_host_daemon
+    from omnigent.host.identity import load_or_create_host_identity
+
+    headers = _remote_headers(server_url=base_url)
+    try:
+        resolved_session_id = _resolve_session_id_for_resume(
+            base_url=base_url,
+            headers=headers,
+            session_id=session_id,
+            resume_picker=resume_picker,
+        )
+        if resolved_session_id is None and resume_picker and session_id is None:
+            return
+
+        async def _drive() -> None:
+            with runner_startup_progress(initial_message="Preparing Grok Build...") as progress:
+                _update_startup_progress(progress, "Connecting to local daemon...")
+                _ensure_host_daemon(base_url)
+                host_id = load_or_create_host_identity().host_id
+                bundle = None if resolved_session_id is not None else _bundle_agent(spec_path)
+                prepared = await _prepare_grok_build_terminal_via_daemon(
+                    base_url=base_url,
+                    headers=headers,
+                    session_id=resolved_session_id,
+                    session_bundle=bundle,
+                    grok_build_args=grok_build_args,
+                    host_id=host_id,
+                    workspace=str(Path.cwd().resolve()),
+                    startup_progress=progress,
+                )
+            click.echo(f"Web UI: {conversation_url(base_url, prepared.session_id)}", err=True)
+            open_conversation_link_if_enabled(
+                base_url=base_url,
+                conversation_id=prepared.session_id,
+                enabled=auto_open_conversation,
+                warn=lambda message: click.echo(message, err=True),
+            )
+            if prepared.cold_resumed:
+                echo_native_cold_resume_hint(agent_label="Grok Build")
+            await _attach_terminal_resource(prepared)
+            if resolved_session_id is None:
+                echo_native_resume_hint(
+                    native_command="grok-build",
+                    session_id=prepared.session_id,
+                    server=base_url,
+                )
+
+        asyncio.run(_drive())
+    except httpx.ConnectError as exc:
+        raise click.ClickException(
+            f"Could not reach the omnigent server at {base_url}. "
+            "Confirm the server is running and reachable from here "
+            f"(e.g. `curl {base_url}/health`), and that --server is correct."
+        ) from exc
+
+
+async def _prepare_grok_build_terminal_via_daemon(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str | None,
+    session_bundle: bytes | None,
+    grok_build_args: tuple[str, ...],
+    host_id: str,
+    workspace: str,
+    startup_progress: RunnerStartupProgress | None = None,
+) -> PreparedGrokBuildTerminal:
+    """
+    Create or resume a grok-build-native session through a daemon runner.
+
+    :returns: Prepared terminal details for attaching.
+    """
+    persist_args = list(grok_build_args)
+    timeout = httpx.Timeout(30.0, read=120.0)
+    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+        reattached = False
+        cold_resumed = False
+        if session_id is None:
+            if session_bundle is None:
+                raise click.ClickException(
+                    "Creating a Grok Build session requires a session bundle."
+                )
+            _update_startup_progress(startup_progress, "Creating Grok Build session...")
+            session_id = await _create_grok_build_session(
+                client,
+                session_bundle,
+                terminal_launch_args=persist_args or None,
+            )
+        else:
+            _update_startup_progress(startup_progress, "Loading Grok Build session...")
+            payload = await _fetch_grok_build_session(client, session_id)
+            labels = payload.get("labels") if isinstance(payload, dict) else None
+            if (
+                not isinstance(labels, dict)
+                or labels.get(_WRAPPER_LABEL_KEY) != _WRAPPER_LABEL_VALUE
+            ):
+                raise click.ClickException(
+                    f"Conversation {session_id!r} is not a grok-build-native session."
+                )
+            existing_terminal = await _find_running_grok_build_terminal(client, session_id)
+            if existing_terminal is not None:
+                if persist_args:
+                    click.echo(
+                        "Ignoring Grok Build launch args for an already-running terminal; "
+                        "restart the session terminal to apply them.",
+                        err=True,
+                    )
+                _update_startup_progress(startup_progress, "Grok Build terminal ready.")
+                return PreparedGrokBuildTerminal(
+                    session_id=session_id,
+                    terminal_id=existing_terminal.terminal_id,
+                    tmux_socket=existing_terminal.tmux_socket,
+                    tmux_target=existing_terminal.tmux_target,
+                    reattached=True,
+                )
+            # Session exists but its terminal exited: relaunch a fresh TUI.
+            cold_resumed = True
+            if persist_args:
+                _update_startup_progress(startup_progress, "Updating Grok Build session...")
+                resp = await client.patch(
+                    f"/v1/sessions/{url_component(session_id)}",
+                    json={"terminal_launch_args": persist_args},
+                )
+                if resp.status_code >= 400:
+                    raise click.ClickException(
+                        f"Grok Build session launch config update failed "
+                        f"({resp.status_code}): {error_text(resp)}"
+                    )
+
+        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        _update_startup_progress(startup_progress, "Starting runner...")
+        runner_id = await launch_or_reuse_daemon_runner(
+            client,
+            host_id=host_id,
+            session_id=session_id,
+            workspace=workspace,
+        )
+        _update_startup_progress(startup_progress, "Waiting for runner...")
+        await wait_for_runner_online(
+            client, runner_id, timeout_s=_DAEMON_RUNNER_ONLINE_TIMEOUT_S
+        )
+        await _bind_session_runner(client, session_id, runner_id)
+        _update_startup_progress(startup_progress, "Starting Grok Build terminal...")
+        await _ensure_grok_build_terminal_on_runner(client, session_id)
+        terminal = await _wait_for_grok_build_terminal_ready(
+            client,
+            session_id,
+            timeout_s=_DAEMON_TERMINAL_READY_TIMEOUT_S,
+        )
+        _update_startup_progress(startup_progress, "Grok Build terminal ready.")
+    return PreparedGrokBuildTerminal(
+        session_id=session_id,
+        terminal_id=terminal.terminal_id,
+        tmux_socket=terminal.tmux_socket,
+        tmux_target=terminal.tmux_target,
+        reattached=reattached,
+        cold_resumed=cold_resumed,
+    )
+
+
+async def _create_grok_build_session(
+    client: httpx.AsyncClient,
+    bundle: bytes,
+    *,
+    terminal_launch_args: list[str] | None = None,
+) -> str:
+    """Create a bundled terminal-first grok-build-native session."""
+    metadata: dict[str, Any] = {"labels": dict(_SESSION_LABELS)}
+    if terminal_launch_args:
+        metadata["terminal_launch_args"] = terminal_launch_args
+    resp = await client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps(metadata)},
+        files={"bundle": ("grok-build-native-ui.tar.gz", bundle, "application/gzip")},
+        timeout=120.0,
+    )
+    if resp.status_code >= 400:
+        raise click.ClickException(
+            f"Grok Build session creation failed ({resp.status_code}): {error_text(resp)}"
+        )
+    body = resp.json()
+    new_session_id = body.get("session_id")
+    if not isinstance(new_session_id, str) or not new_session_id:
+        raise click.ClickException(
+            "Grok Build session creation response did not include session_id."
+        )
+    return new_session_id
+
+
+async def _fetch_grok_build_session(
+    client: httpx.AsyncClient, session_id: str
+) -> dict[str, Any]:
+    """Fetch an existing Omnigent session."""
+    resp = await client.get(f"/v1/sessions/{url_component(session_id)}")
+    if resp.status_code == 404:
+        raise click.ClickException(f"Conversation {session_id!r} not found on the server.")
+    if resp.status_code >= 400:
+        raise click.ClickException(
+            f"Failed to fetch conversation {session_id!r} ({resp.status_code}): "
+            f"{error_text(resp)}"
+        )
+    payload = resp.json()
+    if not isinstance(payload, dict):
+        raise click.ClickException("Conversation fetch returned non-object JSON.")
+    return payload
+
+
+async def _ensure_grok_build_terminal_on_runner(
+    client: httpx.AsyncClient, session_id: str
+) -> None:
+    """Ask the bound runner to ensure the Grok Build terminal exists."""
+    resp = await client.post(
+        f"/v1/sessions/{url_component(session_id)}/resources/terminals",
+        json={
+            "terminal": _TERMINAL_NAME,
+            "session_key": _TERMINAL_SESSION_KEY,
+            "ensure_native_terminal": True,
+        },
+        timeout=60.0,
+    )
+    if resp.status_code >= 400:
+        raise click.ClickException(
+            f"Grok Build terminal ensure failed ({resp.status_code}): {error_text(resp)}"
+        )
+
+
+async def _wait_for_grok_build_terminal_ready(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    timeout_s: float,
+) -> LaunchedGrokBuildTerminal:
+    """Wait until the runner exposes the Grok Build terminal resource."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        terminal = await _find_running_grok_build_terminal(client, session_id)
+        if terminal is not None:
+            return terminal
+        await asyncio.sleep(0.2)
+    raise click.ClickException(
+        f"The runner did not create the Grok Build terminal for {session_id!r} "
+        f"within {timeout_s:.0f}s."
+    )
+
+
+async def _find_running_grok_build_terminal(
+    client: httpx.AsyncClient,
+    session_id: str,
+) -> LaunchedGrokBuildTerminal | None:
+    """Return the existing running Grok Build terminal id if present."""
+    terminal_id = grok_build_terminal_resource_id()
+    resp = await client.get(
+        f"/v1/sessions/{url_component(session_id)}"
+        f"/resources/terminals/{url_component(terminal_id)}"
+    )
+    if resp.status_code == 404:
+        return None
+    if resp.status_code >= 400:
+        text = error_text(resp)
+        if resp.status_code in {409, 503} and (
+            "not bound to a runner" in text or "offline" in text
+        ):
+            return None
+        raise click.ClickException(
+            f"Failed to fetch Grok Build terminal ({resp.status_code}): {text}"
+        )
+    payload = resp.json()
+    metadata = payload.get("metadata") if isinstance(payload, dict) else None
+    if isinstance(metadata, dict) and metadata.get("running") is False:
+        return None
+    return _launched_grok_build_terminal_from_payload(payload)
+
+
+def _launched_grok_build_terminal_from_payload(payload: object) -> LaunchedGrokBuildTerminal:
+    """Decode terminal launch metadata returned by the runner."""
+    if not isinstance(payload, dict):
+        raise click.ClickException("Grok Build terminal launch returned non-object JSON.")
+    terminal_id = payload.get("id")
+    if not isinstance(terminal_id, str) or not terminal_id:
+        raise click.ClickException(
+            "Grok Build terminal launch response did not include terminal id."
+        )
+    metadata = payload.get("metadata")
+    tmux_socket: Path | None = None
+    tmux_target: str | None = None
+    if isinstance(metadata, dict):
+        raw_socket = metadata.get("tmux_socket")
+        raw_target = metadata.get("tmux_target")
+        if isinstance(raw_socket, str) and raw_socket:
+            tmux_socket = Path(raw_socket)
+        if isinstance(raw_target, str) and raw_target:
+            tmux_target = raw_target
+    return LaunchedGrokBuildTerminal(
+        terminal_id=terminal_id,
+        tmux_socket=tmux_socket,
+        tmux_target=tmux_target,
+    )
+
+
+async def _attach_terminal_resource(prepared: PreparedGrokBuildTerminal) -> None:
+    """Attach the current terminal to the prepared Grok Build terminal resource."""
+    direct_tmux_error = _direct_tmux_unavailable_reason(prepared)
+    if direct_tmux_error is not None:
+        raise click.ClickException(
+            f"Runner-owned Grok Build terminal requires direct tmux attach, but "
+            f"{direct_tmux_error}"
+        )
+    if prepared.tmux_socket is None or prepared.tmux_target is None:
+        raise click.ClickException("Grok Build tmux attach metadata was incomplete.")
+    await _attach_direct_tmux(prepared.tmux_socket, prepared.tmux_target)
+
+
+async def _attach_direct_tmux(socket_path: Path, tmux_target: str) -> None:
+    """Attach the current terminal directly to the runner-owned tmux pane."""
+    env = os.environ.copy()
+    env.pop("TMUX", None)
+    process = await asyncio.create_subprocess_exec(
+        "tmux",
+        "-S",
+        str(socket_path),
+        "-f",
+        os.devnull,
+        "attach",
+        "-t",
+        tmux_target,
+        env=env,
+    )
+    await process.wait()
+
+
+def _direct_tmux_unavailable_reason(prepared: PreparedGrokBuildTerminal) -> str | None:
+    """Explain why direct tmux attach is unavailable."""
+    if prepared.tmux_socket is None:
+        return "the terminal resource did not include a tmux socket path."
+    if prepared.tmux_target is None:
+        return "the terminal resource did not include a tmux target."
+    if not prepared.tmux_socket.exists():
+        return f"tmux socket {prepared.tmux_socket} is not reachable from this CLI process."
+    if shutil.which("tmux") is None:
+        return "tmux is not available on PATH."
+    return None
+
+
+def _resolve_session_id_for_resume(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str | None,
+    resume_picker: bool,
+) -> str | None:
+    """Translate resume inputs into a concrete grok-build-native session id."""
+    if session_id is not None:
+        return session_id
+    if not resume_picker:
+        return None
+    from omnigent_client import OmnigentClient
+
+    from omnigent.repl._resume_picker import pick_conversation_by_wrapper_label_from_sdk
+
+    async def _drive() -> str | None:
+        async with OmnigentClient(
+            base_url=base_url,
+            headers=headers if headers else None,
+        ) as client:
+            return await pick_conversation_by_wrapper_label_from_sdk(
+                client,
+                wrapper_value=_WRAPPER_LABEL_VALUE,
+                agent_name=_AGENT_NAME,
+            )
+
+    return asyncio.run(_drive())
+
+
+def _update_startup_progress(
+    startup_progress: RunnerStartupProgress | None,
+    message: str,
+) -> None:
+    """Show one concise Grok Build startup milestone when a renderer is active."""
+    if startup_progress is not None:
+        startup_progress.update(message)
+
+
+def _preflight_local_tools() -> None:
+    """Verify local executables required by the native Grok Build wrapper."""
+    if shutil.which("tmux") is None:
+        raise click.ClickException(
+            "tmux was not found on local PATH. The native Grok Build wrapper "
+            "attaches to the runner-owned Grok Build tmux terminal."
+        )
+
+
+def grok_build_terminal_resource_id() -> str:
+    """Return the deterministic terminal resource id for Grok Build."""
+    return terminal_resource_id(_TERMINAL_NAME, _TERMINAL_SESSION_KEY)

--- a/omnigent/grok_build_native_bridge.py
+++ b/omnigent/grok_build_native_bridge.py
@@ -1,0 +1,342 @@
+"""Filesystem bridge + tmux injection for the grok-build-native terminal harness.
+
+The runner launches the ``grok`` TUI in a private tmux pane and records that
+pane's socket + target here via :func:`write_tmux_target`. The harness executor
+then delivers Omnigent web-UI messages into the *same* pane via
+:func:`inject_user_message` (tmux bracketed paste + a single Enter).
+
+Unlike cursor-native, this bridge does NOT write any vendor MCP config: Grok
+Build's MCP configuration lives in the user's own config (``grok configure``),
+and Omnigent does not mutate user config in v1.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from omnigent._platform import stable_user_id
+
+#: Env var carrying the bridge dir into the harness executor process.
+BRIDGE_DIR_ENV_VAR = "HARNESS_GROK_BUILD_NATIVE_BRIDGE_DIR"
+
+_BRIDGE_ROOT = Path(tempfile.gettempdir()) / f"omnigent-{stable_user_id()}" / "grok-build-native"
+_TMUX_FILE = "tmux.json"
+_TMUX_READY_TIMEOUT_S = 30.0
+_TMUX_SEND_TIMEOUT_S = 10.0
+_POLL_INTERVAL_S = 0.2
+_PASTE_SETTLE_S = 0.3
+_PASTE_BUFFER = "omnigent-grok-build-paste"
+# How long to wait for the pasted text to become visible in the pane before
+# sending Enter — submitting before the TUI commits the paste folds the Enter
+# into the paste as a newline and the message sits unsent.
+_PASTE_COMMIT_TIMEOUT_S = 5.0
+# Grok Build emits no fixed ready-prompt sentinel; readiness is detected by the
+# pane settling (no byte changes across consecutive captures). This many stable
+# polls in a row marks the input box ready.
+_SETTLE_STABLE_POLLS = 3
+
+
+def bridge_dir_for_session_id(session_id: str) -> Path:
+    """Return the per-session bridge dir, e.g. ``/tmp/omnigent-<uid>/grok-build-native/<hash>``."""
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:32]
+    return _BRIDGE_ROOT / digest
+
+
+def bridge_root() -> Path:
+    """Return the configured grok-build-native bridge root."""
+    return _BRIDGE_ROOT
+
+
+def _ensure_dir(path: Path) -> None:
+    """Create *path* (and parents) with owner-only permissions."""
+    path.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError):
+        os.chmod(path, 0o700)
+
+
+def build_grok_build_native_spawn_env(
+    session_id: str,
+) -> dict[str, str]:
+    """Build the ``HARNESS_GROK_BUILD_NATIVE_*`` env the terminal reads.
+
+    Sets the bridge dir (for the harness executor). Auth is Grok Build's own
+    (``grok`` opens a browser on first launch); no Omnigent-managed credential
+    is required.
+
+    :param session_id: The Omnigent session id (keys the bridge dir).
+    :returns: Env-var overrides for the terminal spawn.
+    """
+    bridge_dir = bridge_dir_for_session_id(session_id)
+    _ensure_dir(bridge_dir)
+    env: dict[str, str] = {
+        BRIDGE_DIR_ENV_VAR: str(bridge_dir),
+        # Force color off so the pane is cheaper to scrape (parity with
+        # goose-native's GOOSE_CLI_THEME=ansi and hermes-native's NO_COLOR).
+        "NO_COLOR": "1",
+    }
+    return env
+
+
+def write_tmux_target(
+    bridge_dir: Path,
+    *,
+    socket_path: Path,
+    tmux_target: str,
+    pid: int | None = None,
+) -> None:
+    """Advertise the tmux socket + target for the running Grok Build terminal."""
+    _ensure_dir(bridge_dir)
+    payload: dict[str, Any] = {
+        "socket_path": str(socket_path),
+        "tmux_target": tmux_target,
+        "updated_at": time.time(),
+    }
+    if pid is not None:
+        payload["pid"] = pid
+    tmp = bridge_dir / (_TMUX_FILE + ".tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    os.replace(tmp, bridge_dir / _TMUX_FILE)
+
+
+def read_tmux_info(bridge_dir: Path) -> dict[str, str] | None:
+    """Return ``{socket_path, tmux_target}`` from ``tmux.json``, or ``None``."""
+    try:
+        raw = (bridge_dir / _TMUX_FILE).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    socket_path = data.get("socket_path")
+    tmux_target = data.get("tmux_target")
+    if (
+        isinstance(socket_path, str)
+        and socket_path
+        and isinstance(tmux_target, str)
+        and tmux_target
+    ):
+        return {"socket_path": socket_path, "tmux_target": tmux_target}
+    return None
+
+
+def _wait_for_tmux_info(bridge_dir: Path, *, timeout_s: float) -> dict[str, str]:
+    """Block until ``tmux.json`` is advertised, or raise on timeout."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        info = read_tmux_info(bridge_dir)
+        if info is not None:
+            return info
+        time.sleep(_POLL_INTERVAL_S)
+    raise RuntimeError(
+        f"grok-build-native tmux target was not advertised within {timeout_s:.0f}s"
+    )
+
+
+def _run_tmux(socket_path: str, *args: str) -> None:
+    """Invoke ``tmux -S <socket> <args...>`` and raise on failure."""
+    try:
+        proc = subprocess.run(
+            ["tmux", "-S", socket_path, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_SEND_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"tmux command timed out after {_TMUX_SEND_TIMEOUT_S}s"
+        ) from exc
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "<no output>"
+        raise RuntimeError(f"tmux command failed (rc={proc.returncode}): {detail}")
+
+
+def _capture_pane(socket_path: str, tmux_target: str) -> str:
+    """Capture the visible pane contents; ``""`` on any failure (treat as not-ready)."""
+    try:
+        proc = subprocess.run(
+            ["tmux", "-S", socket_path, "capture-pane", "-p", "-t", tmux_target],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_SEND_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    return proc.stdout if proc.returncode == 0 else ""
+
+
+def _paste_payload_bytes(text: str) -> bytes:
+    r"""Encode text for ``tmux load-buffer``: line breaks → CR, tabs kept, other
+    control bytes dropped (a stray ESC would close the bracketed-paste early)."""
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    body = bytearray()
+    for ch in normalized:
+        if ch == "\n":
+            body.append(0x0D)
+            continue
+        if ch == "\t":
+            body.append(0x09)
+            continue
+        if ord(ch) < 0x20:
+            continue
+        body.extend(ch.encode("utf-8"))
+    return bytes(body)
+
+
+def _session_alive(socket_path: str, tmux_target: str) -> bool:
+    """Return whether the tmux session/pane still exists (the TUI is running)."""
+    try:
+        proc = subprocess.run(
+            ["tmux", "-S", socket_path, "has-session", "-t", tmux_target],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_SEND_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return proc.returncode == 0
+
+
+def _submit_needle(content: str) -> str:
+    """A stable single-line substring used to confirm the paste rendered in the pane."""
+    for line in reversed(content.splitlines()):
+        stripped = line.strip()
+        if len(stripped) >= 4:
+            return stripped[:24]
+    stripped = content.strip()
+    return stripped[:24] if len(stripped) >= 4 else ""
+
+
+def _settle_pane(socket_path: str, tmux_target: str, *, timeout_s: float) -> None:
+    """Best-effort wait until the Grok Build input box is ready to receive a paste.
+
+    Grok Build emits no fixed idle marker, so readiness is detected by the pane
+    settling: the captured contents stop changing for :data:`_SETTLE_STABLE_POLLS`
+    consecutive polls. Falls through after the timeout rather than raising.
+    """
+    deadline = time.monotonic() + timeout_s
+    previous = _capture_pane(socket_path, tmux_target)
+    stable = 0
+    while time.monotonic() < deadline:
+        time.sleep(_POLL_INTERVAL_S)
+        current = _capture_pane(socket_path, tmux_target)
+        if current and current == previous:
+            stable += 1
+            if stable >= _SETTLE_STABLE_POLLS:
+                return
+        else:
+            stable = 0
+        previous = current
+
+
+def inject_user_message(
+    bridge_dir: Path,
+    *,
+    content: str,
+    timeout_s: float = _TMUX_READY_TIMEOUT_S,
+) -> None:
+    """Deliver a web-UI user message into the Grok Build TUI via a tmux bracketed paste.
+
+    Clears any leftover draft, pastes *content* (multi-line safe via
+    ``load-buffer``/``paste-buffer -p`` so interior newlines stay data, not
+    submits), settles, then submits with a *single* Enter.
+
+    :param bridge_dir: The grok-build-native bridge dir holding ``tmux.json``.
+    :param content: User text (non-empty).
+    :param timeout_s: Per-readiness-gate timeout.
+    :raises RuntimeError: If the tmux target is never advertised or a tmux
+        command fails.
+    """
+    if not content:
+        raise RuntimeError("grok-build-native injection requires non-empty content")
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    socket_path = info["socket_path"]
+    tmux_target = info["tmux_target"]
+    # Fast-fail if the TUI already exited.
+    if not _session_alive(socket_path, tmux_target):
+        raise RuntimeError(
+            "grok build terminal is no longer running (the TUI exited); restart the session"
+        )
+    _settle_pane(socket_path, tmux_target, timeout_s=timeout_s)
+    # Clear any leftover draft: Home (C-a) + kill-to-end (C-k).
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-a")
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-k")
+    with tempfile.NamedTemporaryFile(
+        dir=bridge_dir, prefix="paste_", suffix=".bin", delete=False
+    ) as paste_file:
+        # Trailing newline absorbs any trailing backslash so it can't escape Enter.
+        paste_file.write(_paste_payload_bytes(content + "\n"))
+        paste_path = paste_file.name
+    try:
+        _run_tmux(socket_path, "load-buffer", "-b", _PASTE_BUFFER, paste_path)
+        _run_tmux(
+            socket_path,
+            "paste-buffer",
+            "-p",  # bracketed-paste markers — the TUI keeps newlines as data
+            "-d",  # drop the buffer after pasting
+            "-b",
+            _PASTE_BUFFER,
+            "-t",
+            tmux_target,
+        )
+    finally:
+        with contextlib.suppress(OSError):
+            os.unlink(paste_path)
+    # Wait until the paste is visibly committed before Enter.
+    needle = _submit_needle(content)
+    if needle:
+        deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if needle in _capture_pane(socket_path, tmux_target):
+                break
+            time.sleep(_POLL_INTERVAL_S)
+    time.sleep(_PASTE_SETTLE_S)
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
+
+
+def inject_interrupt(
+    bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S
+) -> None:
+    """Cancel the in-flight Grok Build turn by sending ``Escape`` to the pane.
+
+    :raises RuntimeError: If the tmux target is not advertised or send-keys fails.
+    """
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Escape")
+
+
+def kill_session(
+    bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S
+) -> None:
+    """Hard-stop the Grok Build session by killing its tmux session.
+
+    :raises RuntimeError: If the tmux target is not advertised or kill-session fails.
+    """
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    _run_tmux(info["socket_path"], "kill-session", "-t", info["tmux_target"])
+
+
+def capture_grok_build_pane(bridge_dir: Path) -> str | None:
+    """Return the visible Grok Build pane text, or ``None`` if the TUI is not running.
+
+    :param bridge_dir: The grok-build-native bridge dir holding ``tmux.json``.
+    :returns: The captured pane text, or ``None`` when no live pane exists.
+    """
+    info = read_tmux_info(bridge_dir)
+    if info is None:
+        return None
+    socket_path, tmux_target = info["socket_path"], info["tmux_target"]
+    if not _session_alive(socket_path, tmux_target):
+        return None
+    return _capture_pane(socket_path, tmux_target)

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -19,6 +19,7 @@ from omnigent._wrapper_labels import (
     CODEX_NATIVE_WRAPPER_VALUE,
     CURSOR_NATIVE_WRAPPER_VALUE,
     GOOSE_NATIVE_WRAPPER_VALUE,
+    GROK_BUILD_NATIVE_WRAPPER_VALUE,
     HERMES_NATIVE_WRAPPER_VALUE,
     KIMI_NATIVE_WRAPPER_VALUE,
     KIRO_NATIVE_WRAPPER_VALUE,
@@ -198,6 +199,15 @@ HERMES_NATIVE_CODING_AGENT = NativeCodingAgent(
     terminal_name="hermes",
 )
 
+GROK_BUILD_NATIVE_CODING_AGENT = NativeCodingAgent(
+    key="grok-build",
+    display_name="Grok Build",
+    agent_name="grok-build-native-ui",
+    harness="grok-build-native",
+    wrapper_label=GROK_BUILD_NATIVE_WRAPPER_VALUE,
+    terminal_name="grok-build",
+)
+
 
 # Declared capabilities for the built-in harnesses. Each value is backed by the
 # module that implements it; the derivable axes (model_family, subagents) are
@@ -341,6 +351,17 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
     "hermes-native": _C(
         _IM.NATIVE_TUI,
         _EL.APPROVAL_MIRROR,
+        _RS.WARM_REATTACH,
+        _EF.NONE,
+        _MF.MULTI,
+        _AU.OWN_AUTH,
+        subagents=False,
+        interrupt=True,
+        streaming=True,
+    ),
+    "grok-build-native": _C(
+        _IM.NATIVE_TUI,
+        _EL.NONE,
         _RS.WARM_REATTACH,
         _EF.NONE,
         _MF.MULTI,
@@ -521,6 +542,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
             "cursor-native",
             "goose",
             "goose-native",
+            "grok-build-native",
             "hermes",
             "hermes-native",
             "kimi",
@@ -548,6 +570,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "cursor-native": "omnigent.inner.cursor_native_harness",
         "goose": "omnigent.inner.goose_harness",
         "goose-native": "omnigent.inner.goose_native_harness",
+        "grok-build-native": "omnigent.inner.grok_build_native_harness",
         "hermes": "omnigent.inner.hermes_harness",
         "hermes-native": "omnigent.inner.hermes_native_harness",
         "kimi": "omnigent.inner.kimi_harness",
@@ -568,6 +591,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "kimi-code": "kimi",
         "native-antigravity": "antigravity-native",
         "native-goose": "goose-native",
+        "native-grok-build": "grok-build-native",
         "native-hermes": "hermes-native",
         "native-kimi": "kimi-native",
         "native-kiro": "kiro-native",
@@ -585,6 +609,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
             "codex-native",
             "cursor-native",
             "goose-native",
+            "grok-build-native",
             "hermes-native",
             "kimi-native",
             "kiro-native",
@@ -593,6 +618,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
             "native-codex",
             "native-cursor",
             "native-goose",
+            "native-grok-build",
             "native-hermes",
             "native-kimi",
             "native-kiro",
@@ -616,6 +642,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         QWEN_NATIVE_CODING_AGENT,
         KIMI_NATIVE_CODING_AGENT,
         HERMES_NATIVE_CODING_AGENT,
+        GROK_BUILD_NATIVE_CODING_AGENT,
     ),
     model_env_keys={
         "acp": "HARNESS_ACP_MODEL",

--- a/omnigent/inner/grok_build_native_executor.py
+++ b/omnigent/inner/grok_build_native_executor.py
@@ -1,0 +1,148 @@
+"""Executor that bridges Omnigent web-chat turns into the native Grok Build TUI.
+
+It does not launch ``grok`` — the ``omnigent grok-build`` wrapper already launched
+the interactive ``grok`` TUI in the session terminal. Each web-UI turn injects
+the latest user message into that same tmux pane (bracketed paste + Enter), so the
+message appears in the running Grok Build TUI (and, since the web UI embeds the
+pane, in both surfaces). Output is terminal-originated; the embedded terminal
+renders it live. Mirrors
+:class:`omnigent.inner.goose_native_executor.GooseNativeExecutor`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+from omnigent.grok_build_native_bridge import (
+    BRIDGE_DIR_ENV_VAR,
+    inject_interrupt,
+    inject_user_message,
+)
+from omnigent.inner.executor import (
+    Executor,
+    ExecutorConfig,
+    ExecutorError,
+    ExecutorEvent,
+    Message,
+    ToolSpec,
+    TurnComplete,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GrokBuildNativeExecutor(Executor):
+    """Harness-side executor for ``omnigent grok-build`` web-UI turns.
+
+    Injects each web-UI message into the running Grok Build TUI's tmux pane. Does
+    not stream output (the embedded terminal shows it); accepts mid-turn steering.
+
+    :param bridge_dir: Optional bridge dir override; ``None`` reads
+        :data:`BRIDGE_DIR_ENV_VAR` from the harness spawn env.
+    """
+
+    def __init__(self, bridge_dir: Path | None = None) -> None:
+        self._bridge_dir = bridge_dir or _bridge_dir_from_env()
+        self._inject_lock = asyncio.Lock()
+
+    def supports_streaming(self) -> bool:
+        """:returns: ``False`` — output is shown by the embedded terminal, not this executor."""
+        return False
+
+    def supports_live_message_queue(self) -> bool:
+        """:returns: ``True`` — messages can be injected mid-turn (steering)."""
+        return True
+
+    async def enqueue_session_message(self, session_key: str, content: Any) -> bool:
+        """Inject a live steering message into the Grok Build terminal."""
+        del session_key
+        text = _content_to_text(content, self._bridge_dir)
+        if not text:
+            return False
+        try:
+            async with self._inject_lock:
+                await asyncio.to_thread(inject_user_message, self._bridge_dir, content=text)
+        except RuntimeError:
+            return False
+        return True
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],
+        system_prompt: str,
+        config: ExecutorConfig | None = None,
+    ) -> AsyncIterator[ExecutorEvent]:
+        """Inject the latest web-UI user message into the Grok Build TUI pane."""
+        del tools, system_prompt, config
+        text = _latest_user_text(messages, self._bridge_dir)
+        if not text:
+            yield ExecutorError(message="grok build native turn had no user text to send")
+            return
+        try:
+            async with self._inject_lock:
+                await asyncio.to_thread(inject_user_message, self._bridge_dir, content=text)
+        except RuntimeError as exc:
+            yield ExecutorError(message=str(exc))
+            return
+        yield TurnComplete(response=None)
+
+    async def interrupt_session(self, session_key: str) -> bool:
+        """Cancel the in-flight Grok Build turn by sending Escape to the TUI pane."""
+        del session_key
+        try:
+            await asyncio.to_thread(inject_interrupt, self._bridge_dir)
+        except RuntimeError:
+            return False
+        return True
+
+
+def _bridge_dir_from_env() -> Path:
+    """Resolve the grok-build-native bridge dir from the harness spawn env."""
+    raw = os.environ.get(BRIDGE_DIR_ENV_VAR, "").strip()
+    if not raw:
+        raise RuntimeError(f"{BRIDGE_DIR_ENV_VAR} is required for the grok-build-native harness")
+    return Path(raw)
+
+
+def _latest_user_text(messages: list[Message], bridge_dir: Path) -> str:
+    """Return the latest user message's text (attachments materialized to disk)."""
+    for message in reversed(messages):
+        if message.get("role") == "user":
+            return _content_to_text(message.get("content"), bridge_dir)
+    return ""
+
+
+def _content_to_text(content: Any, bridge_dir: Path) -> str:
+    """Normalize executor content into text the Grok Build TUI receives.
+
+    Text blocks are extracted directly. Image/file blocks carrying a base64 data
+    URI are materialized to the bridge dir and referenced by absolute path
+    (``[Attached: <path>]``) so Grok Build can open them with its tools.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        from omnigent.inner.native_attachments import materialize_attachment
+
+        attachment_lines: list[str] = []
+        text_parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type", "")
+            if block_type in ("input_text", "text"):
+                text = block.get("text")
+                if isinstance(text, str):
+                    text_parts.append(text)
+            elif block_type in ("input_image", "input_file"):
+                path = materialize_attachment(block, bridge_dir)
+                if path is not None:
+                    attachment_lines.append(f"[Attached: {path}]")
+        return "\n\n".join(attachment_lines + text_parts)
+    return ""

--- a/omnigent/inner/grok_build_native_harness.py
+++ b/omnigent/inner/grok_build_native_harness.py
@@ -1,0 +1,35 @@
+"""``harness: grok-build-native`` wrap (the native Grok Build TUI).
+
+Thin module exposing :func:`create_app` — the entry point the shared
+:mod:`omnigent.runtime.harnesses._runner` invokes after the parent process
+resolves ``"grok-build-native"`` to this module via
+:data:`omnigent.runtime.harnesses._HARNESS_MODULES`.
+
+Wraps a :class:`omnigent.inner.grok_build_native_executor.GrokBuildNativeExecutor`,
+which injects web-UI messages into the running ``grok`` TUI (launched by
+``omnigent grok-build`` in the session terminal) via tmux. The bridge dir is read
+from :data:`~omnigent.grok_build_native_bridge.BRIDGE_DIR_ENV_VAR` in the spawn env.
+
+Tool policies: Grok Build runs its tools inside its own TUI and gates them with
+its own approval mode, which Omnigent does not intercept. Treat the Grok Build
+TUI's own approval as the sole tool gate.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from omnigent.inner.executor import Executor
+from omnigent.inner.grok_build_native_executor import GrokBuildNativeExecutor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+
+def _build_grok_build_native_executor() -> Executor:
+    """Construct a :class:`GrokBuildNativeExecutor` (reads the bridge dir from env)."""
+    return GrokBuildNativeExecutor()
+
+
+def create_app() -> FastAPI:
+    """Build the grok-build-native harness's FastAPI app (required entry point)."""
+    adapter = ExecutorAdapter(executor_factory=_build_grok_build_native_executor)
+    return adapter.build()

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -92,6 +92,9 @@ COPILOT_KEY = "copilot"
 # Omnigent-managed credentials). The ``hermes`` binary must be on PATH.
 HERMES_KEY = "hermes"
 
+_GROK_BUILD_INSTALL_HINT = "curl -fsSL https://x.ai/cli/install.sh | bash"
+GROK_BUILD_KEY = "grok-build"
+
 _HERMES_INSTALL_HINT = "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash"
 
 
@@ -202,6 +205,13 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         install_hint=_HERMES_INSTALL_HINT,
         install_command=("bash", "-c", _HERMES_INSTALL_HINT),
     ),
+    GROK_BUILD_KEY: HarnessInstallSpec(
+        "Grok Build",
+        "grok",
+        package=None,
+        install_hint=_GROK_BUILD_INSTALL_HINT,
+        install_command=("bash", "-c", _GROK_BUILD_INSTALL_HINT),
+    ),
 }
 
 
@@ -266,6 +276,10 @@ _HARNESS_NAME_TO_KEY: dict[str, str] = {
     # gates on the same binary.
     "hermes-native": HERMES_KEY,
     "native-hermes": HERMES_KEY,
+    # Grok Build TUI (``grok-build-native``) wraps the ``grok`` CLI;
+    # ``native-grok-build`` reversed spelling gates on the same binary.
+    "grok-build-native": GROK_BUILD_KEY,
+    "native-grok-build": GROK_BUILD_KEY,
 }
 
 

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -39,6 +39,7 @@ from omnigent.onboarding.harness_install import (
     COPILOT_KEY,
     CURSOR_KEY,
     GOOSE_KEY,
+    GROK_BUILD_KEY,
     HERMES_KEY,
     KIMI_KEY,
     KIRO_KEY,
@@ -126,6 +127,11 @@ _KIMI_NATIVE_HARNESSES: frozenset[str] = frozenset({"kimi-native", "native-kimi"
 # native CLI harnesses. Hermes owns its own auth (``hermes setup`` /
 # ``hermes model``); the headless ``hermes`` harness gates on the same binary.
 _HERMES_NATIVE_HARNESSES: frozenset[str] = frozenset({"hermes-native", "native-hermes"})
+
+# Native Grok Build TUI harnesses (``omnigent grok-build``). Boot the ``grok``
+# TUI and can't launch without the ``grok`` binary on ``PATH`` — gate on it.
+# Grok Build owns its own auth (browser OAuth on first launch).
+_GROK_BUILD_NATIVE_HARNESSES: frozenset[str] = frozenset({"grok-build-native", "native-grok-build"})
 
 # CLI-wrapping qwen harnesses. ``qwen`` / ``qwen-code`` (the ACP harness) and
 # ``qwen-native`` / ``native-qwen`` (the native TUI via ``omni qwen``) all resolve
@@ -228,6 +234,12 @@ def harness_is_configured(harness: str) -> bool:
         # Research). Auth/provider config surfaces at run time via Hermes' own
         # ``hermes model`` flow; gate only on binary presence.
         return harness_cli_installed(HERMES_KEY)
+    if canonical in _GROK_BUILD_NATIVE_HARNESSES or canonical == GROK_BUILD_KEY:
+        # Grok Build — the native TUI (``grok-build-native`` /
+        # ``native-grok-build``, via ``omni grok-build``) — wraps the ``grok``
+        # CLI (installed via a curl script from xAI). Auth surfaces at run time
+        # via Grok Build's own browser OAuth; gate only on binary presence.
+        return harness_cli_installed(GROK_BUILD_KEY)
     if canonical == CURSOR_KEY:
         # Cursor runs in-process via ``cursor-sdk`` and authenticates with a
         # ``CURSOR_API_KEY`` (a ``cursor-agent login`` does not apply). So,
@@ -368,6 +380,7 @@ def configured_harness_map() -> dict[str, HarnessAvailability]:
     spellings.update(_GOOSE_NATIVE_HARNESSES)
     spellings.update(_KIMI_NATIVE_HARNESSES)
     spellings.update(_HERMES_NATIVE_HARNESSES)
+    spellings.update(_GROK_BUILD_NATIVE_HARNESSES)
     spellings.update(_QWEN_HARNESSES)
     spellings.add(CURSOR_KEY)
     spellings.add(KIMI_SURFACE)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -68,6 +68,7 @@ from omnigent.runner.resource_registry import (
     CODEX_NATIVE_TERMINAL_ROLE,
     CURSOR_NATIVE_TERMINAL_ROLE,
     GOOSE_NATIVE_TERMINAL_ROLE,
+    GROK_BUILD_NATIVE_TERMINAL_ROLE,
     HERMES_NATIVE_TERMINAL_ROLE,
     KIMI_NATIVE_TERMINAL_ROLE,
     KIRO_NATIVE_TERMINAL_ROLE,
@@ -2872,6 +2873,87 @@ async def _auto_create_hermes_terminal(
         "Auto-created hermes terminal + forwarder/approval-mirror for session %s; task=%s",
         session_id,
         _forwarder_task.get_name(),
+    )
+    return terminal_view
+
+
+async def _auto_create_grok_build_terminal(
+    session_id: str,
+    resource_registry: SessionResourceRegistry,
+    publish_event: Callable[[str, dict[str, Any]], None],
+    *,
+    server_client: httpx.AsyncClient | None,
+    ensure_comment_relay: Callable[..., Awaitable[None]] | None = None,
+) -> SessionResourceView:
+    """
+    Auto-create the Grok Build TUI terminal for a grok-build-native session.
+
+    Launches ``grok`` in a runner-owned tmux pane. Auth is Grok Build's own
+    (``grok`` opens a browser on first launch for OAuth), so no Omnigent-managed
+    key is required.
+    """
+    from omnigent.grok_build_native import resolve_grok_build_executable
+    from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
+
+    await _cancel_auto_forwarder_task(session_id)
+    from omnigent.grok_build_native_bridge import (
+        bridge_dir_for_session_id,
+        write_tmux_target,
+    )
+
+    bridge_dir = bridge_dir_for_session_id(session_id)
+    # No forwarder for grok-build-native in v1: the embedded terminal is the sole
+    # output surface. grok-build-native has no SQLite session store to mirror from
+    # (parity with the minimal goose-native setup without a transcript DB).
+
+    launch_config = await _pi_native_launch_config(
+        session_id=session_id,
+        server_client=server_client,
+    )
+    workspace = os.path.realpath(str(launch_config.workspace))
+    grok_build_command = resolve_grok_build_executable()
+    grok_build_env: dict[str, str] = {
+        "NO_COLOR": "1",
+    }
+    launch_epoch_s = time.time()
+    grok_build_launch_args = launch_config.terminal_launch_args or []
+    terminal_spec = TerminalEnvSpec(
+        command=grok_build_command,
+        args=grok_build_launch_args,
+        env=grok_build_env,
+        scrollback=100_000,
+        tmux_allow_passthrough=True,
+        tmux_start_on_attach=False,
+    )
+    grok_build_resource_role = GROK_BUILD_NATIVE_TERMINAL_ROLE
+    terminal_view = await resource_registry.ensure_terminal(
+        session_id=session_id,
+        terminal_name="grok-build",
+        session_key="main",
+        spec=terminal_spec,
+        cwd=workspace,
+        resource_role=grok_build_resource_role,
+        os_env=OSEnvSpec(type="caller_process", cwd=workspace, fork=False).as_dict(),
+    )
+    terminal_registry = resource_registry.terminal_registry
+    if terminal_registry is not None:
+        instance = terminal_registry.get(session_id, "grok-build", "main")
+        if instance is not None and instance.running:
+            write_tmux_target(
+                bridge_dir,
+                socket_path=instance.socket_path,
+                tmux_target=instance.tmux_target,
+            )
+    publish_event(
+        session_id,
+        {
+            "type": "session.resource.created",
+            "resource": session_resource_view_to_dict(terminal_view),
+        },
+    )
+    _logger.info(
+        "Auto-created grok-build terminal for session %s",
+        session_id,
     )
     return terminal_view
 
@@ -8311,6 +8393,7 @@ def create_runner_app(
     _qwen_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     _kimi_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     _hermes_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
+    _grok_build_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     # Per-session lock guarding the claude-native terminal auto-create in
     # ``create_session``. Two ``POST /v1/sessions`` calls can land
     # concurrently on a host-launched runner — ``_on_runner_connect``
@@ -10252,6 +10335,40 @@ def create_runner_app(
                     finally:
                         _publish_terminal_pending(_publish_event, session_id, False)
 
+        if harness_name == "grok-build-native":
+            _grok_build_ensure_lock = _grok_build_terminal_ensure_locks.setdefault(
+                session_id, asyncio.Lock()
+            )
+            async with _grok_build_ensure_lock:
+                _tr = resource_registry.terminal_registry
+                _has_grok_build_terminal = (
+                    _tr is not None
+                    and _tr.get(session_id, "grok-build", "main") is not None
+                )
+                if not _has_grok_build_terminal:
+                    _publish_terminal_pending(_publish_event, session_id, True)
+                    try:
+                        await _auto_create_grok_build_terminal(
+                            session_id,
+                            resource_registry,
+                            _publish_event,
+                            server_client=server_client,
+                            ensure_comment_relay=_ensure_comment_relay_started,
+                        )
+                    except Exception as exc:
+                        _logger.exception(
+                            "Failed to auto-create grok-build terminal for %s",
+                            session_id,
+                        )
+                        _publish_native_terminal_start_error(
+                            _publish_event,
+                            session_id,
+                            "Grok Build",
+                            exc,
+                        )
+                    finally:
+                        _publish_terminal_pending(_publish_event, session_id, False)
+
         # Auto-bootstrap the Omnigent REPL terminal for non-native
         # (SDK-harness) top-level sessions: host the framework's own TUI
         # (``omnigent attach``) in a tmux pane so the web UI can embed it
@@ -10576,6 +10693,7 @@ def create_runner_app(
         _qwen_terminal_ensure_locks.pop(session_id, None)
         _kimi_terminal_ensure_locks.pop(session_id, None)
         _hermes_terminal_ensure_locks.pop(session_id, None)
+        _grok_build_terminal_ensure_locks.pop(session_id, None)
         _repl_terminal_ensure_locks.pop(session_id, None)
         _interrupted_sessions.discard(session_id)
         # Stop any TUI→web transcript forwarder (cursor-/goose-native) for this
@@ -11265,6 +11383,7 @@ def create_runner_app(
             "cursor-native",
             "kiro-native",
             "goose-native",
+            "grok-build-native",
             "qwen-native",
             "kimi-native",
             "hermes-native",
@@ -17044,6 +17163,43 @@ def create_runner_app(
                 content=session_resource_view_to_dict(terminal_view),
             )
 
+        if (
+            body.get("ensure_native_terminal")
+            and terminal_name == "grok-build"
+            and session_key == "main"
+        ):
+            grok_build_terminal_id = terminal_resource_id("grok-build", "main")
+            ensure_lock = _grok_build_terminal_ensure_locks.setdefault(
+                session_id, asyncio.Lock()
+            )
+            async with ensure_lock:
+                existing = await resource_registry.get_terminal_resource(
+                    session_id, grok_build_terminal_id
+                )
+                if existing is not None:
+                    return JSONResponse(
+                        status_code=200,
+                        content=session_resource_view_to_dict(existing),
+                    )
+                try:
+                    terminal_view = await _auto_create_grok_build_terminal(
+                        session_id,
+                        resource_registry,
+                        _publish_event,
+                        server_client=server_client,
+                        ensure_comment_relay=_ensure_comment_relay_started,
+                    )
+                except Exception as exc:
+                    _logger.exception(
+                        "grok-build terminal ensure failed for session=%s",
+                        session_id,
+                    )
+                    return _native_terminal_start_error_response(exc, "Grok Build")
+            return JSONResponse(
+                status_code=200,
+                content=session_resource_view_to_dict(terminal_view),
+            )
+
         from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
 
         cwd_override = body.get("cwd")
@@ -18812,6 +18968,7 @@ def create_runner_app(
         _qwen_terminal_ensure_locks.pop(session_id, None)
         _kimi_terminal_ensure_locks.pop(session_id, None)
         _hermes_terminal_ensure_locks.pop(session_id, None)
+        _grok_build_terminal_ensure_locks.pop(session_id, None)
         _repl_terminal_ensure_locks.pop(session_id, None)
         await resource_registry.cleanup_session(session_id)
         # This is the runner endpoint the SERVER's session-delete actually
@@ -18882,6 +19039,7 @@ def create_runner_app(
         _qwen_terminal_ensure_locks.pop(session_id, None)
         _kimi_terminal_ensure_locks.pop(session_id, None)
         _hermes_terminal_ensure_locks.pop(session_id, None)
+        _grok_build_terminal_ensure_locks.pop(session_id, None)
         _repl_terminal_ensure_locks.pop(session_id, None)
         # Close terminals with ``session.resource.deleted`` events BEFORE
         # cleanup_session — cleanup_conversation would silently pop them

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -62,6 +62,7 @@ ANTIGRAVITY_NATIVE_TERMINAL_ROLE = "antigravity-native"
 QWEN_NATIVE_TERMINAL_ROLE = "qwen-native"
 KIMI_NATIVE_TERMINAL_ROLE = "kimi-native"
 HERMES_NATIVE_TERMINAL_ROLE = "hermes-native"
+GROK_BUILD_NATIVE_TERMINAL_ROLE = "grok-build-native"
 # Role marker for the embedded Omnigent REPL terminal auto-created for
 # runner-hosted SDK sessions (``omnigent attach`` in a tmux pane — the
 # SDK mirror of the native terminals above). The attach WebSocket uses
@@ -1022,6 +1023,7 @@ class SessionResourceRegistry:
             # SQLite transcript, not status), so the PTY watcher is its status
             # source too.
             HERMES_NATIVE_TERMINAL_ROLE,
+            GROK_BUILD_NATIVE_TERMINAL_ROLE,
         }
         if activity_publisher is None and not emit_status and exit_publisher is None:
             return

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -33,6 +33,7 @@ from omnigent.harness_plugins import (
     CODEX_NATIVE_CODING_AGENT,
     CURSOR_NATIVE_CODING_AGENT,
     GOOSE_NATIVE_CODING_AGENT,
+    GROK_BUILD_NATIVE_CODING_AGENT,
     HERMES_NATIVE_CODING_AGENT,
     KIMI_NATIVE_CODING_AGENT,
     KIRO_NATIVE_CODING_AGENT,
@@ -172,6 +173,7 @@ _CURSOR_NATIVE_AGENT_NAME = CURSOR_NATIVE_CODING_AGENT.agent_name
 _KIRO_NATIVE_AGENT_NAME = KIRO_NATIVE_CODING_AGENT.agent_name
 _GOOSE_NATIVE_AGENT_NAME = GOOSE_NATIVE_CODING_AGENT.agent_name
 _HERMES_NATIVE_AGENT_NAME = HERMES_NATIVE_CODING_AGENT.agent_name
+_GROK_BUILD_NATIVE_AGENT_NAME = GROK_BUILD_NATIVE_CODING_AGENT.agent_name
 _ANTIGRAVITY_NATIVE_AGENT_NAME = ANTIGRAVITY_NATIVE_CODING_AGENT.agent_name
 _QWEN_NATIVE_AGENT_NAME = QWEN_NATIVE_CODING_AGENT.agent_name
 _KIMI_NATIVE_AGENT_NAME = KIMI_NATIVE_CODING_AGENT.agent_name
@@ -496,6 +498,7 @@ def _ensure_default_agents(
     _ensure_default_kiro_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_goose_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_hermes_agent(agent_store, artifact_store, agent_cache)
+    _ensure_default_grok_build_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_antigravity_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_qwen_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_kimi_native_agent(agent_store, artifact_store, agent_cache)
@@ -870,6 +873,34 @@ def _ensure_default_hermes_agent(
         agent_cache,
         name=_HERMES_NATIVE_AGENT_NAME,
         bundle_bytes=_build_hermes_native_bundle(),
+    )
+
+
+def _build_grok_build_native_bundle() -> bytes:
+    """Build a gzipped tarball of the grok-build-native-ui agent spec."""
+    import tempfile
+
+    from omnigent.grok_build_native import _materialize_grok_build_agent_spec
+    from omnigent.spec import materialize_bundle
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        spec_path = _materialize_grok_build_agent_spec(Path(tmpdir))
+        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
+        return _tar_gz_dir(bundle_dir)
+
+
+def _ensure_default_grok_build_agent(
+    agent_store: AgentStore,
+    artifact_store: ArtifactStore,
+    agent_cache: Any,
+) -> None:
+    """Register or refresh the grok-build-native-ui agent."""
+    _ensure_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_cache,
+        name=_GROK_BUILD_NATIVE_AGENT_NAME,
+        bundle_bytes=_build_grok_build_native_bundle(),
     )
 
 

--- a/omnigent/terminals/pane_reaper.py
+++ b/omnigent/terminals/pane_reaper.py
@@ -54,6 +54,7 @@ NATIVE_PANE_TERMINAL_NAMES: frozenset[str] = frozenset(
         "codex",
         "cursor",
         "goose",
+        "grok-build",
         "hermes",
         "kiro",
         "qwen",


### PR DESCRIPTION
## Summary

Add grok-build-native harness as a first-class native TUI wrap for xAI Grok Build CLI. 13 files, 1490 insertions. Mirrors goose-native/hermes-native pattern.

Closes #2881