### PR TITLE
fix(kiro-native): refresh curated model picker for kiro-cli 2.14.0

### DIFF
--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -50,9 +50,21 @@ _AGENT_NAME = "kiro-native-ui"
 # global and fixed, not account-scoped. ids match what ``kiro-cli --model`` accepts
 # (and ``--list-models`` reports); ``auto`` is kiro's default and a real literal id.
 # Refresh by hand from ``kiro-cli chat --list-models --format json`` if Kiro
-# ships/renames a model.
+# ships/renames a model. Last refreshed against kiro-cli 2.14.0 (adds Claude
+# Sonnet 5, Claude Opus 4.5/4.6/4.7/4.8, and the GPT-5.6 Sol/Terra/Luna preview
+# models, none of which were surfacing in the picker despite being reachable via
+# ``kiro-cli --model`` directly).
 _KIRO_BASE_MODELS: list[dict[str, Any]] = [
     {"id": "auto", "displayName": "Auto", "isDefault": True},
+    {"id": "claude-sonnet-5", "displayName": "Claude Sonnet 5"},
+    {"id": "claude-opus-4.8", "displayName": "Claude Opus 4.8"},
+    {"id": "gpt-5.6-sol", "displayName": "GPT-5.6 Sol"},
+    {"id": "gpt-5.6-terra", "displayName": "GPT-5.6 Terra"},
+    {"id": "gpt-5.6-luna", "displayName": "GPT-5.6 Luna"},
+    {"id": "claude-opus-4.7", "displayName": "Claude Opus 4.7"},
+    {"id": "claude-opus-4.6", "displayName": "Claude Opus 4.6"},
+    {"id": "claude-sonnet-4.6", "displayName": "Claude Sonnet 4.6"},
+    {"id": "claude-opus-4.5", "displayName": "Claude Opus 4.5"},
     {"id": "claude-sonnet-4.5", "displayName": "Claude Sonnet 4.5"},
     {"id": "claude-sonnet-4", "displayName": "Claude Sonnet 4"},
     {"id": "claude-haiku-4.5", "displayName": "Claude Haiku 4.5"},

--- a/tests/test_kiro_native.py
+++ b/tests/test_kiro_native.py
@@ -551,9 +551,15 @@ def test_kiro_base_model_options_shape_and_default() -> None:
     options = kiro_base_model_options()
     ids = [o["id"] for o in options]
 
-    # Canonical ids confirmed against ``kiro-cli --list-models`` (2.10.0).
+    # Canonical ids confirmed against ``kiro-cli --list-models`` (2.14.0).
     assert ids[0] == "auto"
     assert "claude-haiku-4.5" in ids and "glm-5" in ids
+    # Regression coverage: these shipped after the picker was last refreshed and
+    # were silently missing from the Web UI picker despite being valid
+    # ``kiro-cli --model`` ids (reachable only by typing the id at the terminal).
+    assert "claude-opus-4.8" in ids
+    assert "claude-sonnet-5" in ids
+    assert "gpt-5.6-sol" in ids
     # Exactly one default, and every option carries the picker fields.
     assert [o["id"] for o in options if o["isDefault"]] == ["auto"]
     for option in options:

--- a/tests/test_kiro_native.py
+++ b/tests/test_kiro_native.py
@@ -553,13 +553,20 @@ def test_kiro_base_model_options_shape_and_default() -> None:
 
     # Canonical ids confirmed against ``kiro-cli --list-models`` (2.14.0).
     assert ids[0] == "auto"
+    assert len(ids) == len(set(ids))
+    added = {
+        "claude-sonnet-5",
+        "claude-opus-4.8",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "claude-opus-4.7",
+        "claude-opus-4.6",
+        "claude-sonnet-4.6",
+        "claude-opus-4.5",
+    }
+    assert added.issubset(set(ids))
     assert "claude-haiku-4.5" in ids and "glm-5" in ids
-    # Regression coverage: these shipped after the picker was last refreshed and
-    # were silently missing from the Web UI picker despite being valid
-    # ``kiro-cli --model`` ids (reachable only by typing the id at the terminal).
-    assert "claude-opus-4.8" in ids
-    assert "claude-sonnet-5" in ids
-    assert "gpt-5.6-sol" in ids
     # Exactly one default, and every option carries the picker fields.
     assert [o["id"] for o in options if o["isDefault"]] == ["auto"]
     for option in options:


### PR DESCRIPTION
## Summary

The Web UI model picker for the `kiro-native` harness (`omnigent.kiro_native.kiro_base_model_options`,
backing the "MODELS" dropdown users see in the Omnigent client for `omni kiro` sessions) is a
hand-maintained static snapshot, `_KIRO_BASE_MODELS`. Per its own docstring it must be "refreshed by
hand from `kiro-cli chat --list-models --format json`" whenever Kiro ships a new model — that refresh
hasn't happened since kiro-cli added several models that are now live.

## Repro

```
$ kiro-cli --version
kiro-cli 2.14.0

$ kiro-cli chat --list-models
Available models (* = default):

* auto                 1.00x credits
  claude-sonnet-5      1.30x credits      Experimental preview of Claude Sonnet 5 model with 1M context window
  claude-opus-4.8      2.20x credits      Claude Opus 4.8 model with 1M context window
  gpt-5.6-sol          2.40x credits      Experimental preview of OpenAI GPT 5.6 Sol with 272k context window
  gpt-5.6-terra        1.20x credits      Experimental preview of OpenAI GPT 5.6 Terra with 272k context window
  gpt-5.6-luna         0.60x credits      Experimental preview of OpenAI GPT 5.6 Luna with 272k context window
  claude-opus-4.7      2.20x credits      Claude Opus 4.7 model with 1M context window
  claude-opus-4.6      2.20x credits      Claude Opus 4.6 model with 1M context window
  claude-sonnet-4.6    1.30x credits      Claude Sonnet 4.6 model with 1M context window
  claude-opus-4.5      2.20x credits      Claude Opus 4.5 model
  ...
```

All nine of these (`claude-sonnet-5`, `claude-opus-4.5/4.6/4.7/4.8`, `gpt-5.6-sol/terra/luna`,
`claude-sonnet-4.6`) are valid, currently-shipping `kiro-cli --model` ids — confirmed working when
typed directly at the kiro-cli terminal — but none of them appear in Omnigent's own "MODELS" picker,
because `_KIRO_BASE_MODELS` was frozen before they existed. Confirmed this isn't an environment or
credential difference: running `kiro-cli chat --list-models` with only the exact env vars the
`kiro-native` bridge allowlists (`_CHILD_ENV_ALLOWLIST` in `kiro_native_bridge.py`) returns the
identical catalog, so the picker's staleness is the only cause.

## Fix

Refresh `_KIRO_BASE_MODELS` to match current `kiro-cli 2.14.0 --list-models` output (adds the 9
models above, in the same order kiro-cli reports them, right after `auto`). No behavior changes
elsewhere: `kiro-cli` already applies the model only at launch via `--model <id>`, so this is purely
catalog data feeding the existing picker plumbing.

## Tests

Extended `tests/test_kiro_native.py::test_kiro_base_model_options_shape_and_default` with explicit
assertions for `claude-opus-4.8`, `claude-sonnet-5`, and `gpt-5.6-sol` so a future staleness regression
like this one fails CI instead of silently hiding new models from users.

## Environment

kiro-cli 2.14.0, omnigent 0.2.0_3 (Homebrew), macOS, Kiro auth via AWS IAM Identity Center.
