### PR TITLE
fix(runtime): strip base64 image data from stored history on replay

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -3881,6 +3881,15 @@ def _claude_transcript_record_from_session_item(
         output = item.get("output")
         if not isinstance(output, str):
             output = "" if output is None else json.dumps(output, separators=(",", ":"))
+        # An intact base64 image rehydrates into a real image block below (cheap
+        # for the model, so it is kept as-is). But a payload clipped at the
+        # conversation-store byte cap holds corrupt/partial base64 that no
+        # longer parses — rehydration fails and the raw ~250K-char string would
+        # be sent as text on ``--resume``, re-overflowing the context and
+        # wedging compaction. Collapse only that truncated case to a
+        # placeholder, so both the tool_result content and the toolUseResult
+        # metadata stay small while intact images still resume as images.
+        output = _strip_unparseable_image_output(output)
         record_type = "user"
         # Image (and other structured) tool results are persisted as a
         # stringified content-block array. Rehydrate them into real blocks
@@ -4047,6 +4056,32 @@ def _json_safe_tool_use_result(output: str) -> str:
         json.loads(output)
     except (json.JSONDecodeError, ValueError):
         return json.dumps(output)
+    return output
+
+
+def _strip_unparseable_image_output(output: str) -> str:
+    """Collapse a truncated/corrupt base64 image tool result to a placeholder.
+
+    Intact image outputs (valid JSON) are returned unchanged so the caller can
+    rehydrate them into real image blocks for ``--resume``. Only a payload that
+    *looks* like an image but no longer parses as JSON — the shape produced when
+    the conversation store clipped it at its byte cap — is replaced with a short
+    placeholder, so the corrupt ~250K-char base64 is never sent as prompt text.
+
+    :param output: The persisted tool-result string.
+    :returns: The original string, or a placeholder JSON array when the output
+        is an unparseable image payload.
+    """
+    stripped = output.lstrip()
+    if stripped[:1] not in ("[", "{") or '"image"' not in output or '"base64"' not in output:
+        return output
+    try:
+        json.loads(output)
+    except (json.JSONDecodeError, ValueError):
+        from omnigent.runtime.prompt import _image_omitted_placeholder
+
+        placeholder = {"type": "text", "text": _image_omitted_placeholder(None)}
+        return json.dumps([placeholder], separators=(",", ":"))
     return output
 
 

--- a/omnigent/runtime/prompt.py
+++ b/omnigent/runtime/prompt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Sequence
 from typing import Any
 
@@ -119,6 +120,69 @@ def _strip_output_annotations(
     return result
 
 
+def _strip_output_image_data(value: Any) -> Any:
+    """Rewrite inline base64 image blocks to a text placeholder.
+
+    Walks a tool result's decoded content and replaces any Anthropic
+    ``{"type": "image", "source": {"type": "base64", ...}}`` block with a
+    short text block, dropping the base64 ``data``. Non-image content is
+    returned unchanged.
+
+    :param value: Decoded ``function_call_output`` content (list, dict, or
+        scalar).
+    :returns: The same structure with image base64 payloads removed.
+    """
+    if isinstance(value, list):
+        return [_strip_output_image_data(item) for item in value]
+    if isinstance(value, dict):
+        source = value.get("source")
+        if value.get("type") == "image" and isinstance(source, dict):
+            media_type = source.get("media_type")
+            label = (
+                f"{media_type} image" if isinstance(media_type, str) and media_type else "image"
+            )
+            return {
+                "type": "text",
+                "text": (
+                    f"[{label} omitted from history to save context — "
+                    "re-run the tool call above (e.g. Read the same path) "
+                    "to view it again]"
+                ),
+            }
+        return {key: _strip_output_image_data(val) for key, val in value.items()}
+    return value
+
+
+def _dedupe_tool_output_images(output: str) -> str:
+    """Strip inline base64 image data from a persisted tool-result string.
+
+    Older stored ``function_call_output`` items (and any harness ingest that
+    predates the strip-on-write path) can carry a full base64 image — a single
+    ``Read`` of an image inlines hundreds of KB, which is replayed as prompt
+    text on every resume and overflows the context window, wedging compaction.
+    Strip it here at the replay boundary so already-stored large-image sessions
+    resume cleanly without a store migration. Plain-text outputs (the common
+    case) are returned unchanged.
+
+    :param output: The persisted ``function_call_output.output`` string.
+    :returns: The output with any inline base64 image data replaced by a
+        placeholder, or the original string when it holds no image JSON.
+    """
+    # Fast path: only JSON arrays/objects can carry an image block, and every
+    # such payload contains the ``"image"`` type tag. Skip the parse otherwise.
+    stripped = output.lstrip()
+    if stripped[:1] not in ("[", "{") or '"image"' not in output:
+        return output
+    try:
+        decoded = json.loads(output)
+    except (ValueError, TypeError):
+        return output
+    sanitized = _strip_output_image_data(decoded)
+    if sanitized == decoded:
+        return output
+    return json.dumps(sanitized, separators=(",", ":"))
+
+
 def history_to_input_items(
     items: list[ConversationItem],
 ) -> list[dict[str, Any]]:
@@ -170,7 +234,10 @@ def history_to_input_items(
                 {
                     "type": "function_call_output",
                     "call_id": item.data.call_id,
-                    "output": item.data.output,
+                    # Strip inline base64 image data on the way into the
+                    # prompt so already-stored large-image sessions resume
+                    # without overflowing the context window.
+                    "output": _dedupe_tool_output_images(item.data.output),
                 }
             )
 

--- a/omnigent/runtime/prompt.py
+++ b/omnigent/runtime/prompt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Sequence
 from typing import Any
 
@@ -120,6 +121,19 @@ def _strip_output_annotations(
     return result
 
 
+def _image_omitted_placeholder(media_type: str | None) -> str:
+    """Return the placeholder text for a stripped inline image.
+
+    :param media_type: Image MIME type when known, e.g. ``"image/png"``.
+    :returns: Human/agent-readable placeholder naming how to recover it.
+    """
+    label = f"{media_type} image" if isinstance(media_type, str) and media_type else "image"
+    return (
+        f"[{label} omitted from history to save context — "
+        "re-run the tool call above (e.g. Read the same path) to view it again]"
+    )
+
+
 def _strip_output_image_data(value: Any) -> Any:
     """Rewrite inline base64 image blocks to a text placeholder.
 
@@ -137,20 +151,28 @@ def _strip_output_image_data(value: Any) -> Any:
     if isinstance(value, dict):
         source = value.get("source")
         if value.get("type") == "image" and isinstance(source, dict):
-            media_type = source.get("media_type")
-            label = (
-                f"{media_type} image" if isinstance(media_type, str) and media_type else "image"
-            )
             return {
                 "type": "text",
-                "text": (
-                    f"[{label} omitted from history to save context — "
-                    "re-run the tool call above (e.g. Read the same path) "
-                    "to view it again]"
-                ),
+                "text": _image_omitted_placeholder(source.get("media_type")),
             }
         return {key: _strip_output_image_data(val) for key, val in value.items()}
     return value
+
+
+# Matches one Anthropic image ``source`` object inside a tool-result JSON
+# string. The ``source`` only ever holds ``type``/``media_type``/``data``, so
+# each key is a fixed, optional group and the base64 value ranges over an
+# alphabet disjoint from the ``"`` terminator — no nested quantifiers, so the
+# match stays linear even against a multi-hundred-KB payload. The trailing
+# ``"?`` and optional closing braces tolerate a block clipped mid-``data`` when
+# the output was truncated at the conversation-store byte cap.
+_IMAGE_SOURCE_RE = re.compile(
+    r'\{"type":"image","source":\{'
+    r'(?:"type":"base64",?)?'
+    r'(?:"media_type":"(?P<media>[^"]*)",?)?'
+    r'"data":"[A-Za-z0-9+/=]*"?'
+    r"\}?\}?"
+)
 
 
 def _dedupe_tool_output_images(output: str) -> str:
@@ -164,19 +186,30 @@ def _dedupe_tool_output_images(output: str) -> str:
     resume cleanly without a store migration. Plain-text outputs (the common
     case) are returned unchanged.
 
+    Two forms are handled: well-formed JSON (parsed, walked, reserialized) and
+    JSON that was truncated at the conversation-store byte cap — the exact shape
+    that wedges resume — which no longer parses, so a regex fallback rewrites the
+    ``{"type":"image","source":{...base64...}}`` block in place.
+
     :param output: The persisted ``function_call_output.output`` string.
     :returns: The output with any inline base64 image data replaced by a
-        placeholder, or the original string when it holds no image JSON.
+        placeholder, or the original string when it holds no image data.
     """
     # Fast path: only JSON arrays/objects can carry an image block, and every
-    # such payload contains the ``"image"`` type tag. Skip the parse otherwise.
+    # such payload contains the ``"image"`` type tag. Skip otherwise.
     stripped = output.lstrip()
     if stripped[:1] not in ("[", "{") or '"image"' not in output:
         return output
     try:
         decoded = json.loads(output)
     except (ValueError, TypeError):
-        return output
+        # Truncated/invalid JSON (e.g. clipped at the store byte cap): fall back
+        # to an in-place regex rewrite of any image source block.
+        def _replace(match: re.Match[str]) -> str:
+            placeholder = _image_omitted_placeholder(match.group("media"))
+            return json.dumps({"type": "text", "text": placeholder}, separators=(",", ":"))
+
+        return _IMAGE_SOURCE_RE.sub(_replace, output)
     sanitized = _strip_output_image_data(decoded)
     if sanitized == decoded:
         return output

--- a/tests/runtime/test_prompt.py
+++ b/tests/runtime/test_prompt.py
@@ -4,6 +4,8 @@ import json
 from types import SimpleNamespace
 from typing import cast
 
+import pytest
+
 from omnigent.entities import ConversationItem, FunctionCallOutputData
 from omnigent.runtime.prompt import (
     append_framework_instructions,
@@ -50,6 +52,33 @@ def test_history_replay_strips_inline_base64_image() -> None:
     assert huge_b64 not in output, "base64 image data must not be replayed as text"
     assert "image/png image omitted from history" in output
     assert "re-run the tool call" in output
+    assert len(output) < 300
+
+
+def test_history_replay_strips_truncated_image_block() -> None:
+    """Base64 clipped at the store byte cap (invalid JSON) is still stripped.
+
+    Real wedged sessions stored the image output truncated at the
+    conversation-store byte cap, leaving the base64 string unterminated — so it
+    no longer parses as JSON. The strip must fall back to an in-place rewrite,
+    or the exact payloads that wedge resume would slip through unchanged.
+    """
+    huge_b64 = "iVBORw0KGgo" + "A" * 100_000
+    # Mimic the store cap: a valid prefix cut mid-base64, no closing quote/braces.
+    truncated = (
+        '[{"type":"image","source":{"type":"base64","data":"'
+        + huge_b64
+        + "…[truncated by conversation-store: item exceeded 245760B cap]"
+    )
+    # Precondition: this is genuinely not parseable JSON.
+    with pytest.raises(ValueError):
+        json.loads(truncated)
+
+    result = history_to_input_items([_output_item(truncated)])
+
+    output = result[0]["output"]
+    assert huge_b64 not in output, "truncated base64 must not survive replay"
+    assert "image omitted from history" in output
     assert len(output) < 300
 
 

--- a/tests/runtime/test_prompt.py
+++ b/tests/runtime/test_prompt.py
@@ -1,10 +1,69 @@
 """Tests for canonical system-instruction composition."""
 
+import json
 from types import SimpleNamespace
 from typing import cast
 
-from omnigent.runtime.prompt import append_framework_instructions, build_instructions
+from omnigent.entities import ConversationItem, FunctionCallOutputData
+from omnigent.runtime.prompt import (
+    append_framework_instructions,
+    build_instructions,
+    history_to_input_items,
+)
 from omnigent.spec import AgentSpec
+
+
+def _output_item(output: str) -> ConversationItem:
+    """Build a persisted ``function_call_output`` item for replay tests."""
+    return ConversationItem(
+        id="i1",
+        status="completed",
+        response_id="r1",
+        created_at=1,
+        type="function_call_output",
+        data=FunctionCallOutputData(call_id="c1", output=output),
+    )
+
+
+def test_history_replay_strips_inline_base64_image() -> None:
+    """A stored image tool result must not replay its base64 as prompt text.
+
+    Older sessions persisted a ``Read`` of an image as a JSON list of
+    ``{"type":"image","source":{"type":"base64",...}}`` blocks. Replaying that
+    verbatim on resume overflows the context window and wedges compaction, so
+    ``history_to_input_items`` strips the base64 to a placeholder.
+    """
+    huge_b64 = "iVBORw0KGgo" + "A" * 100_000
+    stored = json.dumps(
+        [
+            {
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/png", "data": huge_b64},
+            }
+        ],
+        separators=(",", ":"),
+    )
+
+    result = history_to_input_items([_output_item(stored)])
+
+    output = result[0]["output"]
+    assert huge_b64 not in output, "base64 image data must not be replayed as text"
+    assert "image/png image omitted from history" in output
+    assert "re-run the tool call" in output
+    assert len(output) < 300
+
+
+def test_history_replay_leaves_plain_text_output_unchanged() -> None:
+    """Plain-text tool outputs (the common case) pass through untouched."""
+    result = history_to_input_items([_output_item("TODO contents")])
+    assert result[0]["output"] == "TODO contents"
+
+
+def test_history_replay_leaves_non_image_json_output_unchanged() -> None:
+    """A JSON tool output with no image block is returned byte-for-byte."""
+    stored = json.dumps([{"type": "text", "text": "hello"}], separators=(",", ":"))
+    result = history_to_input_items([_output_item(stored)])
+    assert result[0]["output"] == stored
 
 
 def test_framework_instructions_append_after_custom_prompts() -> None:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -6693,6 +6693,46 @@ def test_claude_transcript_image_result_sent_as_blocks_not_text() -> None:
     assert block["content"][0]["source"]["data"] == big_b64
 
 
+def test_claude_transcript_truncated_image_result_stripped_not_leaked() -> None:
+    """
+    A base64 image clipped at the store byte cap must not leak on resume.
+
+    Real wedged sessions stored image tool results truncated at the
+    conversation-store byte cap, leaving the base64 unterminated (invalid
+    JSON). Rehydration fails on that, so the old path fell back to sending the
+    raw ~250K-char base64 as ``tool_result`` text AND stashed it in
+    ``toolUseResult`` — re-overflowing the resumed context. The synthesizer
+    must collapse such a payload to a placeholder in both places.
+    """
+    big_b64 = "iVBORw0KGgo" + "A" * 100_000
+    truncated = (
+        '[{"type":"image","source":{"type":"base64","data":"'
+        + big_b64
+        + "…[truncated by conversation-store: item exceeded 245760B cap]"
+    )
+    items: list[dict[str, Any]] = [
+        {
+            "id": "fco_1",
+            "response_id": "resp_1",
+            "type": "function_call_output",
+            "call_id": "toolu_1",
+            "output": truncated,
+        }
+    ]
+    records = claude_native._claude_transcript_records_from_session_items(
+        items,
+        session_id="conv_test",
+        external_session_id="02857840-6362-408f-b41f-309e396ed7c6",
+        cwd=Path("/tmp/test"),
+    )
+    assert len(records) == 1
+    # No base64 anywhere in the record — not in tool_result content, not in
+    # toolUseResult metadata.
+    blob = json.dumps(records[0])
+    assert big_b64 not in blob, "truncated base64 must not survive into the transcript"
+    assert "omitted from history" in blob
+
+
 def test_tool_use_result_regression_old_flatten_would_crash_resume() -> None:
     """
     Pin the resume crash to the old ``toolUseResult = output`` flatten.


### PR DESCRIPTION
## Related issue

Related to ES-2065116 (resume-side follow-up to the merged native-ingest strip)

## Summary

The merged fix strips base64 images at **ingest**, so it only helps images read *after* it landed. Many sessions already in the store still hold full base64 images in their `function_call_output` items — and on the real wedged export those are **truncated at the conversation-store 245760B cap**, i.e. invalid JSON. This PR strips them on **resume**, covering both resume paths:

**1. SDK / store-replay path** — `history_to_input_items` (`omnigent/runtime/prompt.py`)
- Strips inline base64 image blocks when converting stored items to Responses-API input.
- Handles well-formed JSON (parse → walk → reserialize) **and** the truncated/invalid-JSON shape via a linear regex fallback (an earlier lazy-quantifier attempt hung on 245KB of base64 — the final pattern is backtracking-free).

**2. Native Claude Code path** — `_claude_transcript_records_from_session_items` (`omnigent/claude_native.py`)
- Native resumes from Claude's **own** local transcript, which the wrapper rebuilds from Omnigent items before `claude --resume`. Intact images are intentionally rehydrated into real image blocks (~1.5K tokens). But a **truncated** image can't be rehydrated, so the old path dumped the raw ~250K-char base64 into both the `tool_result` content and the `toolUseResult` metadata — re-overflowing the resumed context.
- New `_strip_unparseable_image_output` collapses **only** the truncated/unparseable-image case to a recoverable placeholder; intact images still resume as images.

Placeholder text points the agent back at the originating tool call, so the image stays recoverable on demand.

## Test Plan

- New unit tests:
  - `tests/runtime/test_prompt.py`: strips well-formed image, strips **truncated** image (invalid JSON), leaves plain text + non-image JSON unchanged.
  - `tests/test_claude_native.py::test_claude_transcript_truncated_image_result_stripped_not_leaked`: full native transcript rebuild has no base64 in `tool_result` content or `toolUseResult`.
- Verified against the **real wedged session** (`3440987444542977.jsonl`) through the actual code paths:
  - SDK replay: 4 truncated image items, 982,448 → 832 chars (99.92%), base64 gone, sub-ms.
  - Native rebuild: full transcript 1,549,700 → 563,994 chars, **zero base64 leak**, while a valid image still rehydrates to an image block.
- `tests/test_claude_native.py` + `tests/runtime/test_prompt.py`: 154 + 7 pass (clean env). `pre-commit` clean.

## Demo

N/A — non-visual (history serialization).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Ran the real wedged session's stored items through both `history_to_input_items` (SDK replay) and `_claude_transcript_records_from_session_items` (native cold resume), confirming truncated base64 images collapse to a placeholder with zero leak in either path while intact images still resume as real image blocks.

## Changelog

Resuming a session with large images stored in history no longer overflows the context window or breaks compaction, on both the SDK and native Claude Code paths
