### PR TITLE
docs(web): drop stale migration comments from the composer config code

### DIFF
--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -731,7 +731,7 @@ describe("Composer model/effort label", () => {
   it("falls back to the harness identity for an SDK/bundle agent with no model/effort", () => {
     // Polly (claude-sdk/pi bundle) surfaces no model or effort, so the label
     // would be empty. It falls back to the harness identity ("Polly (Pi)") so
-    // the slot isn't blank — mirroring what the pre-gear picker trigger showed.
+    // the slot isn't blank.
     useChatStore.setState({
       selectedModel: null,
       selectedEffort: null,

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -858,11 +858,10 @@ export function ChatPage() {
   const { session: activeSession, isLoading: sessionLoading } = useSession(urlConvId ?? null);
 
   // Orchestrator-only: polly's children inherit its agentName, so the gate
-  // needs the session predicate (parent linkage), not a bare name check.
-  // Same predicate the prior IntelligentModelControl used, so eligibility is
-  // unchanged — the gear modal just relocates where an eligible session's
-  // Smart Routing toggle lives (Claude folds it into the Model dropdown; other
-  // routable agents get a standalone Switch row).
+  // needs the session predicate (parent linkage), not a bare name check. An
+  // eligible session's Smart Routing toggle lives in the gear modal — Claude
+  // folds it into the Model dropdown; other routable agents get a standalone
+  // Switch row.
   const serverInfo = useServerInfo();
   const costRoutingEligible =
     serverInfo !== "loading" &&
@@ -3589,10 +3588,8 @@ export function formatModelEffortStatusLabel(
  * Identity label for the composer status tray: which harness/agent is
  * running this session. Native vendor wrappers read as the bare vendor
  * name ("Claude" / "Codex"); SDK/bundle agents read as the agent name
- * with the brain harness in parens ("Polly (Pi)"). This moved OUT of the
- * picker trigger (which now shows model/effort) — the trigger is the
- * model/effort control, so the harness identity belongs in the read-only
- * shelf below.
+ * with the brain harness in parens ("Polly (Pi)"). Lives in the status tray
+ * below the composer, separate from the read-only model/effort label.
  *
  * @param modelPickerKind - Native picker family, when the session is a
  *   claude-/codex-/cursor-native wrapper.
@@ -3898,8 +3895,8 @@ export function Composer({
   );
 
   const codexPlanMode = useChatStore((s) => s.codexPlanMode);
-  // Harness/agent identity shown in the status tray below the card. The
-  // picker trigger owns model/effort now, so the identity moves here.
+  // Harness/agent identity shown in the status tray below the card, separate
+  // from the composer's read-only model/effort label.
   const sessionHarness = useChatStore((s) => s.sessionHarness);
   const subAgentName = useChatStore((s) => s.subAgentName);
   const brainHarnessLabels = useBrainHarnessLabels();
@@ -4941,10 +4938,10 @@ export function Composer({
               }}
             />
           </div>
-          {/* Agent picker + config gear + Send — right side. Smart Routing is
-              no longer a standalone toggle here; it folds into the gear modal's
-              Model control (Claude) or a Smart Routing switch (other routable
-              agents), mirroring the new-session composer. */}
+          {/* Right side: read-only model/effort label + config gear + Send.
+              Smart Routing lives inside the gear modal — folded into the Model
+              dropdown for Claude, a standalone Switch for other routable
+              agents. */}
           <div className="flex min-w-0 items-center gap-0.5">
             {showCodexPlanMode && (
               <Tooltip>
@@ -5419,11 +5416,10 @@ function SessionConfigModal({
   // without one get a standalone Switch (matches HarnessConfigModal).
   const liveRoutingOn = costRoutingEligible && costControlModeOverride === "on";
 
-  // Resolve the row the current model maps to, matching the old picker's
-  // active-row rule: the explicit override wins, else the bound `llmModel`
-  // implicitly selects its row (so a launch-resolved model shows without an
-  // explicit pick), else the catalog default. Falls back to the "Default"
-  // sentinel when nothing resolves.
+  // Resolve the row the current model maps to: the explicit override wins,
+  // else the bound `llmModel` implicitly selects its row (so a launch-resolved
+  // model shows without an explicit pick), else the catalog default. Falls back
+  // to the "Default" sentinel when nothing resolves.
   const implicitModelId =
     pickerSelectedModel === null
       ? ((usesServerModelOptions
@@ -5935,11 +5931,10 @@ function ComposerModelEffortLabel({
   // showModels gates only the modal control, not this read-out.
   const model = showModels || modelPickerKind === null ? modelLabel : null;
   // SDK/bundle agents (e.g. Polly) that resolve no model/effort fall back to
-  // the harness identity ("Polly (Pi)") so the slot isn't empty — mirrors what
-  // the pre-gear picker trigger showed there. Scoped to SDK/bundle
-  // (modelPickerKind === null): native wrappers keep an empty label when their
-  // model is unresolved rather than resurfacing the bare vendor name, which the
-  // gear tooltip owns now.
+  // the harness identity ("Polly (Pi)") so the slot isn't empty. Scoped to
+  // SDK/bundle (modelPickerKind === null): native wrappers keep an empty label
+  // when their model is unresolved rather than surfacing the bare vendor name,
+  // which the gear tooltip already shows.
   if (!model && !effortLabel) {
     if (modelPickerKind !== null || !harnessLabel) return null;
     return (


### PR DESCRIPTION
## Related issue

N/A

## Summary

Follow-up to #3111 (in-session composer config gear). That PR left a handful of comments that narrated the change rather than describing the code, and referenced things that no longer exist:

- a dangling reference to `IntelligentModelControl` (deleted in #3111),
- "moved OUT of the picker trigger" / "the identity moves here" / "no longer a standalone toggle" / "relocates" — migration narration,
- a "picker trigger" / "Agent picker" in the composer right-side cluster that no longer exists (it's a read-only model/effort label + gear now),
- "old picker's active-row rule" / "pre-gear picker trigger" history references.

Rewrote each to describe current behavior — where the Smart Routing toggle, harness identity label, and read-only model/effort label live — per the repo's "describe the scenario, not the change history" guidance in `CLAUDE.md`.

**Comment-only; no behavior change.**

## Test Plan

- `npx tsc -b` clean, `prettier --check` clean on the touched files.
- No code lines changed (verified the diff is entirely comment text), so existing tests cover behavior unchanged.

## Demo

N/A — comment-only change, no user-visible or UI difference.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Comment-only change — no code paths altered, so existing #3111 tests cover the behavior. Verified via `git diff` that every changed line is comment text, plus tsc + prettier clean.
