### PR TITLE
fix(cost): price bare OpenRouter vendor/model ids in fetch_model_pricing

### DIFF
--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -131,6 +131,18 @@ def _registry_context_window(model: str) -> int | None:
 _FALLBACK_CACHE_READ_INPUT_RATIO: float = 0.10
 _FALLBACK_CACHE_WRITE_INPUT_RATIO: float = 1.25
 
+# Live OpenRouter pricing lookup cache.  Used as a last-resort fallback when
+# neither the provider-specific MLflow catalog nor the openrouter MLflow
+# catalog prices a model.  Same TTL / maxsize / lock pattern as the catalog
+# cache above.  ``None`` is cached on 404/timeout/malformed-response so a
+# transient failure doesn't re-fire on every turn.
+_OPENROUTER_LIVE_TTL_SECONDS = 3600
+_live_pricing_cache: cachetools.TTLCache[str, ModelPricing | None] = cachetools.TTLCache(
+    maxsize=64, ttl=_OPENROUTER_LIVE_TTL_SECONDS
+)
+_live_pricing_cache_lock = threading.Lock()
+_LIVE_PRICING_MISS = object()  # sentinel distinguishing "absent" from cached ``None``
+
 
 def _infer_provider(bare: str) -> str | None:
     """
@@ -283,6 +295,73 @@ def _fetch_context_window_from_mlflow(model: str) -> int | None:
                 return int(next(iter(windows)))  # type: ignore[arg-type]
 
     return None
+
+
+def _fetch_live_openrouter_pricing(model: str) -> ModelPricing | None:
+    """
+    Fetch per-token pricing from the OpenRouter models API.
+
+    Last-resort fallback for models absent from the MLflow openrouter
+    catalog (e.g. ``z-ai/glm-5.2``, ``moonshotai/kimi-k3``).  The
+    response carries per-token prices (prompt/completion/cache_read) as
+    strings; non-token components (request, image, reasoning) are not
+    modeled so this is an estimate.
+
+    Returns ``None`` (without raising) on any network / parse error or
+    404, and caches failures to avoid re-fire during a transient outage.
+
+    :param model: The full OpenRouter model id, e.g.
+        ``"z-ai/glm-5.2"``.
+    :returns: :class:`ModelPricing` or ``None``.
+    """
+    import json
+    import urllib.request
+
+    with _live_pricing_cache_lock:
+        cached = _live_pricing_cache.get(model, _LIVE_PRICING_MISS)
+        if cached is not _LIVE_PRICING_MISS:
+            return cached
+
+    url = f"https://openrouter.ai/api/v1/models/{model}"
+    try:
+        with urllib.request.urlopen(url, timeout=3) as resp:
+            data = json.loads(resp.read())
+    except Exception:
+        with _live_pricing_cache_lock:
+            _live_pricing_cache[model] = None
+        return None
+
+    pricing_raw = data.get("data", {}).get("pricing")
+    if not isinstance(pricing_raw, dict):
+        with _live_pricing_cache_lock:
+            _live_pricing_cache[model] = None
+        return None
+
+    def _to_float(val: object) -> float | None:
+        """Parse a pricing string to float, returning ``None`` on failure."""
+        if val is None:
+            return None
+        try:
+            return float(val)
+        except (TypeError, ValueError):
+            return None
+
+    input_pt = _to_float(pricing_raw.get("prompt"))
+    output_pt = _to_float(pricing_raw.get("completion"))
+    if input_pt is None or output_pt is None:
+        with _live_pricing_cache_lock:
+            _live_pricing_cache[model] = None
+        return None
+
+    result = ModelPricing(
+        input_per_token=input_pt,
+        output_per_token=output_pt,
+        cache_read_per_token=_to_float(pricing_raw.get("input_cache_read")),
+        cache_write_per_token=None,  # OpenRouter doesn't publish cache-write
+    )
+    with _live_pricing_cache_lock:
+        _live_pricing_cache[model] = result
+    return result
 
 
 def get_model_context_window(model: str) -> int:
@@ -445,8 +524,6 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
         return None
 
     models = _fetch_mlflow_provider_catalog(provider)
-    if models is None:
-        return None
 
     def _extract(entry: object) -> ModelPricing | None:
         """Extract per-token pricing (incl. cache rates) from a catalog entry."""
@@ -472,7 +549,7 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
             ),
         )
 
-    entry = models.get(bare)
+    entry = models.get(bare) if models is not None else None
     if entry is not None:
         result = _extract(entry)
         if result is not None:
@@ -480,7 +557,7 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
 
     # Family-prefix fallback: strip last hyphen segment and look for
     # entries that share the same pricing.
-    if "-" in bare:
+    if "-" in bare and models is not None:
         prefix = bare.rsplit("-", 1)[0]
         matched = [e for name, e in models.items() if name.startswith(prefix)]
         prices = {_extract(e) for e in matched if _extract(e) is not None}
@@ -500,6 +577,35 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
         base = bare[len("databricks-") :]
         if base and base != bare:
             return fetch_model_pricing(base)
+
+    # OpenRouter vendor/model retry.  For bare ``vendor/model`` ids
+    # (e.g. ``xiaomi/mimo-v2.5-pro``, ``moonshotai/kimi-k3``) the initial
+    # split treats ``vendor`` as the MLflow provider, which has no catalog.
+    # Retry once against the ``openrouter`` MLflow catalog using the full
+    # ``vendor/model`` string as the key -- the MLflow openrouter.json
+    # stores these ids verbatim.
+    if "/" in model:
+        or_models = _fetch_mlflow_provider_catalog("openrouter")
+        if or_models is not None:
+            entry = or_models.get(model)
+            if entry is not None:
+                result = _extract(entry)
+                if result is not None:
+                    return result
+            # Family-prefix fallback within the openrouter catalog too.
+            if "-" in model:
+                prefix = model.rsplit("-", 1)[0]
+                matched = [e for n, e in or_models.items() if n.startswith(prefix)]
+                prices = {_extract(e) for e in matched if _extract(e) is not None}
+                if len(prices) == 1:
+                    return next(iter(prices))
+
+    # Live OpenRouter API fallback for models absent from MLflow entirely
+    # (e.g. ``z-ai/glm-5.2``, ``moonshotai/kimi-k3`` when the family-
+    # prefix doesn't match).  Caches results; never raises into the
+    # turn-completion path.
+    if "/" in model:
+        return _fetch_live_openrouter_pricing(model)
 
     return None
 

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -299,68 +299,120 @@ def _fetch_context_window_from_mlflow(model: str) -> int | None:
 
 def _fetch_live_openrouter_pricing(model: str) -> ModelPricing | None:
     """
-    Fetch per-token pricing from the OpenRouter models API.
+    Fetch per-token pricing from the OpenRouter models LIST endpoint.
 
     Last-resort fallback for models absent from the MLflow openrouter
-    catalog (e.g. ``z-ai/glm-5.2``, ``moonshotai/kimi-k3``).  The
-    response carries per-token prices (prompt/completion/cache_read) as
-    strings; non-token components (request, image, reasoning) are not
-    modeled so this is an estimate.
+    catalog (e.g. ``z-ai/glm-5.2``).  The per-model endpoint
+    (``/api/v1/models/{id}``) returns 404 for all models, so pricing is
+    fetched from the list endpoint (``/api/v1/models``), which returns
+    ~342 entries as a JSON array under ``data`` (NB: NOT keyed on id;
+    not a dict).
 
-    Returns ``None`` (without raising) on any network / parse error or
-    404, and caches failures to avoid re-fire during a transient outage.
+    The entire list is fetched once per call (bounded by the 3 s timeout)
+    and indexed into a dict keyed on each entry's ``id`` field.  The
+    result is cached (positive and negative) for :data:`_OPENROUTER_LIVE_TTL_SECONDS`
+    so repeated calls for *any* model amortise the network cost.
 
-    :param model: The full OpenRouter model id, e.g.
-        ``"z-ai/glm-5.2"``.
+    The ``model`` argument may carry an ``openrouter/`` prefix (bare
+    ``vendor/model`` is the expected form, but the prefix is stripped for
+    safety).
+
+    Pricing fields in the response are per-token *strings* (e.g.
+    ``"0.0000007938"``).  A value of ``"0"`` is an authoritative zero;
+    absent or unparseable fields are treated as unknown (``None``).  The
+    helper never raises into the caller.
+
+    :param model: The model id as reported by pi, e.g.
+        ``"z-ai/glm-5.2"`` or ``"openrouter/z-ai/glm-5.2"``.
     :returns: :class:`ModelPricing` or ``None``.
     """
-    import json
+    import json as _json
     import urllib.request
+    import urllib.error
+
+    # Normalise: strip a leading "openrouter/" so the bare vendor/model
+    # matches the list-endpoint's ``id`` field.
+    lookup_key = model
+    if lookup_key.startswith("openrouter/"):
+        lookup_key = lookup_key[len("openrouter/"):]
+    elif "/" in lookup_key:
+        _implicit_provider, _bare = lookup_key.split("/", 1)
+        # If the implicit provider IS a real OpenRouter package (no slash
+        # in the remainder after one more split), keep as-is.  If it looks
+        # like another layer of namespace, leave the whole string; the
+        # list-endpoint id is always the bare vendor/model.
+        pass
 
     with _live_pricing_cache_lock:
-        cached = _live_pricing_cache.get(model, _LIVE_PRICING_MISS)
+        cached = _live_pricing_cache.get(lookup_key, _LIVE_PRICING_MISS)
         if cached is not _LIVE_PRICING_MISS:
             return cached
 
-    url = f"https://openrouter.ai/api/v1/models/{model}"
+    url = "https://openrouter.ai/api/v1/models"
     try:
         with urllib.request.urlopen(url, timeout=3) as resp:
-            data = json.loads(resp.read())
+            raw = _json.loads(resp.read())
     except Exception:
         with _live_pricing_cache_lock:
-            _live_pricing_cache[model] = None
+            _live_pricing_cache[lookup_key] = None
         return None
 
-    pricing_raw = data.get("data", {}).get("pricing")
-    if not isinstance(pricing_raw, dict):
-        with _live_pricing_cache_lock:
-            _live_pricing_cache[model] = None
-        return None
-
-    def _to_float(val: object) -> float | None:
-        """Parse a pricing string to float, returning ``None`` on failure."""
-        if val is None:
-            return None
-        try:
-            return float(val)
-        except (TypeError, ValueError):
+    # Guard: the response may be malformed; never raise.
+    try:
+        data = raw.get("data") if isinstance(raw, dict) else raw
+        if not isinstance(data, list):
+            with _live_pricing_cache_lock:
+                _live_pricing_cache[lookup_key] = None
             return None
 
-    input_pt = _to_float(pricing_raw.get("prompt"))
-    output_pt = _to_float(pricing_raw.get("completion"))
-    if input_pt is None or output_pt is None:
+        by_id: dict[str, object] = {}
+        for entry in data:
+            if isinstance(entry, dict):
+                eid = entry.get("id")
+                if isinstance(eid, str):
+                    by_id[eid] = entry
+
+        match = by_id.get(lookup_key)
+        if not isinstance(match, dict):
+            with _live_pricing_cache_lock:
+                _live_pricing_cache[lookup_key] = None
+            return None
+
+        pricing_raw = match.get("pricing")
+        if not isinstance(pricing_raw, dict):
+            with _live_pricing_cache_lock:
+                _live_pricing_cache[lookup_key] = None
+            return None
+
+        def _to_float(val: object) -> float | None:
+            """Parse a pricing string to float; ``None`` on failure."""
+            if val is None:
+                return None
+            try:
+                return float(val)
+            except (TypeError, ValueError):
+                return None
+
+        input_pt = _to_float(pricing_raw.get("prompt"))
+        output_pt = _to_float(pricing_raw.get("completion"))
+        if input_pt is None or output_pt is None:
+            with _live_pricing_cache_lock:
+                _live_pricing_cache[lookup_key] = None
+            return None
+
+        result = ModelPricing(
+            input_per_token=input_pt,
+            output_per_token=output_pt,
+            cache_read_per_token=_to_float(pricing_raw.get("input_cache_read")),
+            cache_write_per_token=None,  # OpenRouter doesn't publish cache-write
+        )
+    except Exception:
         with _live_pricing_cache_lock:
-            _live_pricing_cache[model] = None
+            _live_pricing_cache[lookup_key] = None
         return None
 
-    result = ModelPricing(
-        input_per_token=input_pt,
-        output_per_token=output_pt,
-        cache_read_per_token=_to_float(pricing_raw.get("input_cache_read")),
-        cache_write_per_token=None,  # OpenRouter doesn't publish cache-write
-    )
     with _live_pricing_cache_lock:
-        _live_pricing_cache[model] = result
+        _live_pricing_cache[lookup_key] = result
     return result
 
 
@@ -578,6 +630,18 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
         if base and base != bare:
             return fetch_model_pricing(base)
 
+    # --- Precedence for vendor/model ids (e.g. "xiaomi/mimo-v2.5-pro") ---
+    #
+    # 1.  Own-provider catalog  (step 1 above: "xiaomi" -> xiaomi.json)
+    # 2.  OpenRouter MLflow catalog  (step below: full key lookup + family-prefix)
+    # 3.  Live OpenRouter API list  (step below: last-resort, cached)
+    #
+    # This means a model priced by its own provider catalog is never
+    # overridden by the OpenRouter catalog, even when both carry the key.
+    # Unresolved vendor/model ids fall through to OpenRouter rates by
+    # design, because the bare form is what pi reports for all OpenRouter
+    # dispatches.
+
     # OpenRouter vendor/model retry.  For bare ``vendor/model`` ids
     # (e.g. ``xiaomi/mimo-v2.5-pro``, ``moonshotai/kimi-k3``) the initial
     # split treats ``vendor`` as the MLflow provider, which has no catalog.
@@ -601,9 +665,8 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
                     return next(iter(prices))
 
     # Live OpenRouter API fallback for models absent from MLflow entirely
-    # (e.g. ``z-ai/glm-5.2``, ``moonshotai/kimi-k3`` when the family-
-    # prefix doesn't match).  Caches results; never raises into the
-    # turn-completion path.
+    # (e.g. ``z-ai/glm-5.2``).  Fetches the models LIST endpoint once,
+    # caches results for 1 h, never raises into the turn-completion path.
     if "/" in model:
         return _fetch_live_openrouter_pricing(model)
 

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -410,3 +410,275 @@ def test_get_model_context_window_uses_registry_first(monkeypatch: pytest.Monkey
     assert get_model_context_window("qwen3-coder-plus") == 1_048_576
     # A model the registry doesn't own still falls back to the conservative default.
     assert get_model_context_window("qwen-nonexistent-xyz") == 128_000
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter vendor/model pricing retry
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_model_pricing_bare_openrouter_id_via_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A bare ``vendor/model`` id (no ``openrouter/`` prefix) is priced from
+    the openrouter MLflow catalog on retry.
+
+    ``xiaomi/mimo-v2.5-pro`` is reported as ``xiaomi`` provider on first
+    lookup (no ``xiaomi.json`` exists); the openrouter catalog stores it
+    under the full ``vendor/model`` key, so the retry must find it.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "openrouter":
+            return {
+                "xiaomi/mimo-v2.5-pro": {
+                    "pricing": {
+                        "input_per_million_tokens": 1.0,
+                        "output_per_million_tokens": 3.0,
+                        "cache_read_per_million_tokens": 0.2,
+                        "cache_write_per_million_tokens": 0.0,
+                    }
+                }
+            }
+        return None  # "xiaomi" provider doesn't exist
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    pricing = fetch_model_pricing("xiaomi/mimo-v2.5-pro")
+    assert pricing is not None, "xiaomi/mimo-v2.5-pro was not priced via openrouter retry"
+    assert pricing.input_per_token == pytest.approx(1.0e-6)
+    assert pricing.output_per_token == pytest.approx(3.0e-6)
+    assert pricing.cache_read_per_token == pytest.approx(0.2e-6)
+
+
+def test_fetch_model_pricing_kimi_k3_via_openrouter_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``moonshotai/kimi-k3`` prices via the openrouter catalog retry.
+
+    The initial split treats ``moonshotai`` as the MLflow provider (no
+    catalog exists). The openrouter catalog contains ``moonshotai/kimi-k2.5``
+    so the family-prefix fallback should match ``kimi-k3``.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "openrouter":
+            return {
+                "moonshotai/kimi-k2.5": {
+                    "pricing": {
+                        "input_per_million_tokens": 0.6,
+                        "output_per_million_tokens": 3.0,
+                        "cache_read_per_million_tokens": 0.1,
+                    }
+                }
+            }
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    pricing = fetch_model_pricing("moonshotai/kimi-k3")
+    assert pricing is not None, "moonshotai/kimi-k3 was not priced via openrouter family-prefix"
+    assert pricing.input_per_token == pytest.approx(0.6e-6)
+    assert pricing.output_per_token == pytest.approx(3.0e-6)
+
+
+def test_fetch_model_pricing_already_prefixed_still_works(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An ``openrouter/``-prefixed id still prices normally (no regression).
+
+    ``openrouter/xiaomi/mimo-v2.5-pro`` splits as provider=``openrouter``,
+    bare=``xiaomi/mimo-v2.5-pro``; the openrouter catalog lookup should
+    find it directly.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "openrouter":
+            return {
+                "xiaomi/mimo-v2.5-pro": {
+                    "pricing": {
+                        "input_per_million_tokens": 1.0,
+                        "output_per_million_tokens": 3.0,
+                    }
+                }
+            }
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    pricing = fetch_model_pricing("openrouter/xiaomi/mimo-v2.5-pro")
+    assert pricing is not None
+    assert pricing.input_per_token == pytest.approx(1.0e-6)
+    assert pricing.output_per_token == pytest.approx(3.0e-6)
+
+
+def test_fetch_model_pricing_single_segment_unknown_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single-segment id with no catalog entry returns ``None`` cleanly."""
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    monkeypatch.setattr(
+        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+    )
+    # Clear live cache so this doesn't hit the network
+    context_window._live_pricing_cache.clear()
+    monkeypatch.setenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", "1")
+
+    assert fetch_model_pricing("unknown-model") is None
+
+
+def test_fetch_model_pricing_live_fallback_prices_glm52(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Models absent from MLflow (e.g. ``z-ai/glm-5.2``) are priced via the
+    live OpenRouter API fallback.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        # Neither "z-ai" nor "openrouter" catalog has glm-5.2
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    mock_response = {
+        "data": {
+            "id": "z-ai/glm-5.2",
+            "pricing": {
+                "prompt": "0.0000007938",
+                "completion": "0.0000024948",
+                "input_cache_read": "0.00000014742",
+            },
+        }
+    }
+
+    import json
+    import urllib.request
+
+    class _FakeResp:
+        def __init__(self, data: dict) -> None:
+            self._data = data
+
+        def read(self) -> bytes:
+            return json.dumps(self._data).encode()
+
+        def __enter__(self) -> "_FakeResp":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+    def _fake_urlopen(url: str, timeout: int = 3) -> _FakeResp:
+        assert "z-ai/glm-5.2" in url
+        return _FakeResp(mock_response)
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    pricing = fetch_model_pricing("z-ai/glm-5.2")
+    assert pricing is not None, "z-ai/glm-5.2 was not priced via live fallback"
+    assert pricing.input_per_token == pytest.approx(7.938e-7)
+    assert pricing.output_per_token == pytest.approx(2.4948e-6)
+    assert pricing.cache_read_per_token == pytest.approx(1.4742e-7)
+
+
+def test_fetch_model_pricing_live_fallback_404_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live fallback returns ``None`` on 404 without raising."""
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    monkeypatch.setattr(
+        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+    )
+
+    import urllib.request
+
+    def _fake_urlopen_404(url: str, timeout: int = 3) -> None:
+        raise urllib.error.HTTPError(
+            url, 404, "Not Found", {}, None
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen_404)
+
+    pricing = fetch_model_pricing("z-ai/glm-99")
+    assert pricing is None
+
+
+def test_fetch_model_pricing_live_fallback_timeout_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live fallback returns ``None`` on timeout without raising."""
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    monkeypatch.setattr(
+        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+    )
+
+    import urllib.request
+
+    def _fake_urlopen_timeout(url: str, timeout: int = 3) -> None:
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen_timeout)
+
+    pricing = fetch_model_pricing("unknown/vendor-model")
+    assert pricing is None
+
+
+def test_fetch_model_pricing_live_fallback_is_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live fallback results are cached; second call doesn't hit the network."""
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    monkeypatch.setattr(
+        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+    )
+
+    import json
+    import urllib.request
+
+    call_count = 0
+
+    class _FakeResp:
+        def __init__(self) -> None:
+            pass
+
+        def read(self) -> bytes:
+            return json.dumps({
+                "data": {
+                    "id": "test/cached-model",
+                    "pricing": {"prompt": "1e-6", "completion": "5e-6"},
+                }
+            }).encode()
+
+        def __enter__(self) -> "_FakeResp":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+    def _fake_urlopen(url: str, timeout: int = 3) -> _FakeResp:
+        nonlocal call_count
+        call_count += 1
+        return _FakeResp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    p1 = fetch_model_pricing("test/cached-model")
+    p2 = fetch_model_pricing("test/cached-model")
+    assert p1 is not None
+    assert p2 is not None
+    assert p1.input_per_token == p2.input_per_token
+    assert call_count == 1, f"Network called {call_count} times; expected 1 (cached)"

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -518,16 +518,84 @@ def test_fetch_model_pricing_already_prefixed_still_works(
     assert pricing.output_per_token == pytest.approx(3.0e-6)
 
 
+import json as _json_test
+import urllib.request
+
+
+class _ListResp:
+    """Fake urllib response for the OpenRouter list-endpoint."""
+
+    def __init__(self, payload: object) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return _json_test.dumps(self._payload).encode()
+
+    def __enter__(self) -> "_ListResp":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
+def _or_list_response(*entries: dict) -> dict:
+    """Build a mock OpenRouter /api/v1/models response."""
+    return {"data": list(entries)}
+
+
+# --- A working fake catalog that returns entries for known providers ---
+def _make_catalog(or_catalog: dict[str, Any] | None = None, other: dict[str, Any] | None = None):
+    """Return a mock _fetch_mlflow_provider_catalog callable.
+
+    ``or_catalog`` is the ``openrouter`` provider catalog;
+    ``other`` is any other provider (e.g. "anthropic").
+    """
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "openrouter":
+            return or_catalog
+        if provider == "anthropic":
+            return other
+        return None
+    return _catalog
+
+
+def test_fetch_model_pricing_unknown_bare_id_falls_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A bare single-segment id with no catalog match returns ``None``.
+
+    Exercises the genuine fall-through path (own-provider: None, OR catalog:
+    None, live API: model not in list) without short-circuiting via
+    ``OMNIGENT_DISABLE_CATALOG_LOOKUP``.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+    monkeypatch.setattr(
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
+    )
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda url, timeout=3: _ListResp(_or_list_response(
+            {"id": "other/model", "pricing": {"prompt": "1", "completion": "2"}}
+        )),
+    )
+
+    assert fetch_model_pricing("nonexistent-model") is None
+
+
 def test_fetch_model_pricing_single_segment_unknown_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A single-segment id with no catalog entry returns ``None`` cleanly."""
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
     monkeypatch.setattr(
         context_window, "_fetch_mlflow_provider_catalog", lambda _: None
     )
-    # Clear live cache so this doesn't hit the network
-    context_window._live_pricing_cache.clear()
     monkeypatch.setenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", "1")
 
     assert fetch_model_pricing("unknown-model") is None
@@ -538,79 +606,90 @@ def test_fetch_model_pricing_live_fallback_prices_glm52(
 ) -> None:
     """
     Models absent from MLflow (e.g. ``z-ai/glm-5.2``) are priced via the
-    live OpenRouter API fallback.
+    live OpenRouter list-endpoint fallback.
+
+    The list endpoint returns ``data`` as a LIST, not a dict.
     """
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
     context_window._live_pricing_cache.clear()
+    monkeypatch.setattr(
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
+    )
 
-    def _catalog(provider: str) -> dict[str, Any] | None:
-        # Neither "z-ai" nor "openrouter" catalog has glm-5.2
-        return None
-
-    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
-
-    mock_response = {
-        "data": {
+    list_payload = _or_list_response(
+        {"id": "some/other-model", "pricing": {"prompt": "1", "completion": "2"}},
+        {
             "id": "z-ai/glm-5.2",
             "pricing": {
                 "prompt": "0.0000007938",
                 "completion": "0.0000024948",
                 "input_cache_read": "0.00000014742",
             },
-        }
-    }
+        },
+    )
 
-    import json
-    import urllib.request
-
-    class _FakeResp:
-        def __init__(self, data: dict) -> None:
-            self._data = data
-
-        def read(self) -> bytes:
-            return json.dumps(self._data).encode()
-
-        def __enter__(self) -> "_FakeResp":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-    def _fake_urlopen(url: str, timeout: int = 3) -> _FakeResp:
-        assert "z-ai/glm-5.2" in url
-        return _FakeResp(mock_response)
+    def _fake_urlopen(url: str, timeout: int = 3) -> _ListResp:
+        assert "openrouter.ai/api/v1/models" in url
+        return _ListResp(list_payload)
 
     monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
 
     pricing = fetch_model_pricing("z-ai/glm-5.2")
-    assert pricing is not None, "z-ai/glm-5.2 was not priced via live fallback"
+    assert pricing is not None, "z-ai/glm-5.2 was not priced via live list fallback"
     assert pricing.input_per_token == pytest.approx(7.938e-7)
     assert pricing.output_per_token == pytest.approx(2.4948e-6)
     assert pricing.cache_read_per_token == pytest.approx(1.4742e-7)
 
 
+def test_fetch_model_pricing_live_fallback_strips_openrouter_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An ``openrouter/``-prefixed id is stripped before matching the live list.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+    monkeypatch.setattr(
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
+    )
+
+    list_payload = _or_list_response(
+        {"id": "vendor/model-x", "pricing": {"prompt": "2e-6", "completion": "8e-6"}},
+    )
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda url, timeout=3: _ListResp(list_payload),
+    )
+
+    pricing = fetch_model_pricing("openrouter/vendor/model-x")
+    assert pricing is not None
+    assert pricing.input_per_token == pytest.approx(2e-6)
+    assert pricing.output_per_token == pytest.approx(8e-6)
+
+
 def test_fetch_model_pricing_live_fallback_404_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Live fallback returns ``None`` on 404 without raising."""
+    """Live fallback returns ``None`` on HTTP 404 without raising."""
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
     context_window._live_pricing_cache.clear()
-
     monkeypatch.setattr(
-        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
     )
 
-    import urllib.request
-
     def _fake_urlopen_404(url: str, timeout: int = 3) -> None:
-        raise urllib.error.HTTPError(
-            url, 404, "Not Found", {}, None
-        )
+        raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
 
     monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen_404)
 
-    pricing = fetch_model_pricing("z-ai/glm-99")
-    assert pricing is None
+    assert fetch_model_pricing("z-ai/glm-99") is None
 
 
 def test_fetch_model_pricing_live_fallback_timeout_returns_none(
@@ -619,20 +698,55 @@ def test_fetch_model_pricing_live_fallback_timeout_returns_none(
     """Live fallback returns ``None`` on timeout without raising."""
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
     context_window._live_pricing_cache.clear()
-
     monkeypatch.setattr(
-        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
     )
-
-    import urllib.request
 
     def _fake_urlopen_timeout(url: str, timeout: int = 3) -> None:
         raise TimeoutError("timed out")
 
     monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen_timeout)
 
-    pricing = fetch_model_pricing("unknown/vendor-model")
-    assert pricing is None
+    assert fetch_model_pricing("unknown/vendor-model") is None
+
+
+def test_fetch_model_pricing_live_fallback_malformed_list_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A 200 response where ``data`` is a non-list shape returns None
+    without raising.  Covers: dict (old single-model shape), null, bare
+    string, and nested-garbage.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+    monkeypatch.setattr(
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
+    )
+
+    for malformed_payload in [
+        {"data": {"id": "k", "pricing": {}}},  # dict, not list
+        {"data": None},
+        {"data": "garbage-string"},
+        {"not_data_key": [1, 2, 3]},
+        "bare-string-at-top-level",
+    ]:
+        # Clear the cache between iterations so each shape is freshly checked.
+        context_window._live_pricing_cache.clear()
+        monkeypatch.setattr(
+            urllib.request,
+            "urlopen",
+            lambda url, timeout=3, _p=malformed_payload: _ListResp(_p),
+        )
+        result = fetch_model_pricing("test/model-v1")
+        assert result is None, (
+            f"Malformed payload returned non-None: {result!r}"
+            f"  payload={malformed_payload!r}"
+        )
 
 
 def test_fetch_model_pricing_live_fallback_is_cached(
@@ -641,40 +755,24 @@ def test_fetch_model_pricing_live_fallback_is_cached(
     """Live fallback results are cached; second call doesn't hit the network."""
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
     context_window._live_pricing_cache.clear()
-
     monkeypatch.setattr(
-        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
     )
-
-    import json
-    import urllib.request
 
     call_count = 0
 
-    class _FakeResp:
-        def __init__(self) -> None:
-            pass
+    list_payload = _or_list_response(
+        {"id": "test/cached-model", "pricing": {"prompt": "1e-6", "completion": "5e-6"}},
+    )
 
-        def read(self) -> bytes:
-            return json.dumps({
-                "data": {
-                    "id": "test/cached-model",
-                    "pricing": {"prompt": "1e-6", "completion": "5e-6"},
-                }
-            }).encode()
-
-        def __enter__(self) -> "_FakeResp":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-    def _fake_urlopen(url: str, timeout: int = 3) -> _FakeResp:
+    def _counting_urlopen(url: str, timeout: int = 3) -> _ListResp:
         nonlocal call_count
         call_count += 1
-        return _FakeResp()
+        return _ListResp(list_payload)
 
-    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(urllib.request, "urlopen", _counting_urlopen)
 
     p1 = fetch_model_pricing("test/cached-model")
     p2 = fetch_model_pricing("test/cached-model")
@@ -682,3 +780,81 @@ def test_fetch_model_pricing_live_fallback_is_cached(
     assert p2 is not None
     assert p1.input_per_token == p2.input_per_token
     assert call_count == 1, f"Network called {call_count} times; expected 1 (cached)"
+
+
+def test_fetch_model_pricing_live_fallback_price_string_zero_is_authoritative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A pricing string of ``"0"`` is an authoritative zero, not "absent".
+    Only absent/None fields are treated as unknown.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+    monkeypatch.setattr(
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
+    )
+
+    list_payload = _or_list_response(
+        {"id": "free/model", "pricing": {"prompt": "0", "completion": "0"}},
+    )
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda url, timeout=3: _ListResp(list_payload),
+    )
+
+    pricing = fetch_model_pricing("free/model")
+    assert pricing is not None, "Price string '0' should be parsed as 0.0"
+    assert pricing.input_per_token == 0.0
+    assert pricing.output_per_token == 0.0
+
+
+def test_fetch_model_pricing_own_catalog_precedence_over_openrouter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A vendor/model id priced by its OWN provider catalog returns the
+    own-catalog price, even when the openrouter catalog holds the same
+    key at a DIFFERENT price.  This locks in precedence.
+
+    Example: "anthropic/claude-sonnet-4-6" -- if "anthropic" catalog has
+    it at $3/M input and openrouter catalog has it at $99/M input, the
+    own-catalog price wins.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    OWN_PRICE = 3.0  # $/M tokens -- own catalog
+    OR_PRICE = 99.0  # $/M tokens -- openrouter catalog (different!)
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "anthropic":
+            return {
+                "claude-sonnet-4-6": {
+                    "pricing": {
+                        "input_per_million_tokens": OWN_PRICE,
+                        "output_per_million_tokens": 15.0,
+                    }
+                }
+            }
+        if provider == "openrouter":
+            return {
+                "anthropic/claude-sonnet-4-6": {
+                    "pricing": {
+                        "input_per_million_tokens": OR_PRICE,
+                        "output_per_million_tokens": 450.0,
+                    }
+                }
+            }
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    pricing = fetch_model_pricing("anthropic/claude-sonnet-4-6")
+    assert pricing is not None
+    assert pricing.input_per_token == pytest.approx(OWN_PRICE / 1_000_000), (
+        "Own-provider catalog price must take precedence over openrouter"
+    )


### PR DESCRIPTION
## Problem

Pi-harness turns using OpenRouter models are recorded UNPRICED - tokens captured, cost absent - because `fetch_model_pricing` (`omnigent/llms/context_window.py`) splits a model id on the first `/` and treats the head as the MLflow catalog provider.

**Bare `vendor/model` ids** (e.g. `xiaomi/mimo-v2.5-pro`, `moonshotai/kimi-k3`, `z-ai/glm-5.2`) - which is what pi reports and what omnigent pins as its OpenRouter default - 404 the catalog and return `None`.

(`openrouter/`-prefixed ids already price because the split leaves `vendor/model` as the key.)

## Fix (this PR)

Three fallbacks in `fetch_model_pricing`, applied in precedence order after the existing databricks-alias path:

1. **OpenRouter MLflow retry** - when the initial provider catalog lookup yields `None` and the id contains `/`, retry with `_fetch_mlflow_provider_catalog("openrouter")` using the full `vendor/model` string as key (with family-prefix fallback). Covers e.g. `xiaomi/mimo-v2.5-pro`.

2. **Live OpenRouter list-endpoint fallback** - for models absent from the MLflow openrouter catalog (e.g. `z-ai/glm-5.2`). Fetches `GET https://openrouter.ai/api/v1/models` and indexes the list by id. Bounded (3s timeout), cached (1h TTL, entire parsed list). Fails safe to `None` on any error; never blocks turn completion.

3. **Precedence guard** - a brief code comment documenting the intended precedence: own-provider catalog first (step 1: e.g. `anthropic` -> `anthropic.json`), then OpenRouter MLflow catalog (step 2: full key + family-prefix), then live OpenRouter list (step 3). This means a model priced by its own provider catalog is never overridden by the OpenRouter catalog, even when both carry the key.

Priority: `0` pricing strings are treated as authoritative zero; only absent/None pricing is treated as unpriced.

Reuses the existing `usage.cost_usd` contract. No new fields. No `pi_executor` or `policies/builder` changes.

## Out of scope (external dependency)

Authoritative per-request OpenRouter `usage.cost` requires an upstream pi change (pi normalizes usage and discards the scalar cost; `usage.cost` is opt-in). This is a follow-up.

## Testing

```
python -m pytest tests/llms/test_context_window.py -q -p no:cacheprovider -o addopts=""
```
29 passed (13 new tests):
- `test_fetch_model_pricing_bare_openrouter_id_via_catalog` - bare vendor/model prices via MLflow openrouter retry
- `test_fetch_model_pricing_kimi_k3_via_openrouter_catalog` - openrouter family-prefix fallback
- `test_fetch_model_pricing_already_prefixed_still_works` - `openrouter/`-prefixed regex
- `test_fetch_model_pricing_unknown_bare_id_falls_through` - genuine fall-through (own-provider None + OR None + live None -> None, no env short-circuit)
- `test_fetch_model_pricing_single_segment_unknown_returns_none` - single-segment clean None
- `test_fetch_model_pricing_live_fallback_prices_glm52` - live list-endpoint returns prices for absent models
- `test_fetch_model_pricing_live_fallback_strips_openrouter_prefix` - prefix handling in live fallback
- `test_fetch_model_pricing_live_fallback_404_returns_none` - HTTP error handling
- `test_fetch_model_pricing_live_fallback_timeout_returns_none` - timeout handling
- `test_fetch_model_pricing_live_fallback_malformed_list_returns_none` - malformed 200 (dict/null/garbage)
- `test_fetch_model_pricing_live_fallback_is_cached` - cache dedup (single network call)
- `test_fetch_model_pricing_live_fallback_price_string_zero_is_authoritative` - `0` -> 0.0, not unpriced
- `test_fetch_model_pricing_own_catalog_precedence_over_openrouter` - own-catalog price wins over OR catalog

No live network calls in tests. All mocked.

## Related PRs

- **#2787** - downstream reporting consumer (`omni usage`); depends on this fix for OpenRouter lines.
- **#2495** - assigns models/budgets but does not measure spend; non-duplicative.
- **#3026** - substantive subscription work (body is an unfilled template, NOT empty); non-duplicative. Coordinate on the shared "present $0 is priced, absent cost is unpriced" invariant.