### PR TITLE
feat(cli): add `omnigent session import` (inverse of session export)

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5073,11 +5073,6 @@ def session_export(session_id: str, output: str | None, server: str | None) -> N
     click.echo(f"Exported {n_items} item(s) from {session_id} to {out_path}")
 
 
-# Item-data fields carry a serialization alias in ``to_api_dict`` output
-# (``agent`` serializes as ``model``); the reverse map de-aliases them so the
-# payload validates as ``ItemData`` again on import.
-_IMPORT_ITEM_DATA_ALIASES = {"model": "agent"}
-
 # Fields on an exported item that belong to the store/envelope, not the typed
 # ``data`` payload — dropped before rebuilding the item for re-append.
 _IMPORT_ITEM_ENVELOPE_FIELDS = frozenset(
@@ -5085,13 +5080,39 @@ _IMPORT_ITEM_ENVELOPE_FIELDS = frozenset(
 )
 
 
+def _import_agent_aliased_types() -> frozenset[str]:
+    """
+    Return the item types whose ``agent`` field serializes as ``model``.
+
+    ``to_api_dict`` renders items with ``by_alias=True``, so a data model with
+    ``agent: ... = Field(serialization_alias="model")`` exports ``agent`` as
+    ``model``. On import that must be reversed — but ONLY for those types.
+    Other types (``compaction``, ``routing_decision``) carry a genuine ``model``
+    field that must be left alone; ``routing_decision`` even has both ``model``
+    and ``agent``. Derive the set from the field definitions so it can't drift
+    if aliases are added or removed.
+
+    :returns: Item-type strings whose ``model`` export must map back to
+        ``agent`` on import, e.g. ``{"message", "function_call", ...}``.
+    """
+    from omnigent.entities.conversation import ITEM_TYPE_TO_DATA_CLS
+
+    aliased: set[str] = set()
+    for item_type, cls in ITEM_TYPE_TO_DATA_CLS.items():
+        field = cls.model_fields.get("agent")
+        if field is not None and field.serialization_alias == "model":
+            aliased.add(item_type)
+    return frozenset(aliased)
+
+
 def _import_item_payload(item: dict[str, Any]) -> dict[str, Any]:
     """
     Rebuild one exported item into a ``{"type", "data"}`` create payload.
 
-    Strips envelope fields the server reassigns, de-aliases ``model`` back to
-    ``agent``, and validates the result with :func:`parse_item_data` so a
-    malformed item fails loud client-side before the create request.
+    Strips envelope fields the server reassigns, reverses the ``agent``→
+    ``model`` serialization alias (only for the types that carry it), and
+    validates the result with :func:`parse_item_data` so a malformed item
+    fails loud client-side before the create request.
 
     :param item: One ``record_type == "item"`` object from an export JSONL.
     :returns: A ``SessionEventInput``-shaped dict for ``initial_items``.
@@ -5103,11 +5124,12 @@ def _import_item_payload(item: dict[str, Any]) -> dict[str, Any]:
     item_type = item.get("type")
     if not isinstance(item_type, str) or not item_type:
         raise click.ClickException(f"Export item is missing a 'type': {item!r}")
-    raw = {
-        _IMPORT_ITEM_DATA_ALIASES.get(key, key): value
-        for key, value in item.items()
-        if key not in _IMPORT_ITEM_ENVELOPE_FIELDS
-    }
+    raw = {key: value for key, value in item.items() if key not in _IMPORT_ITEM_ENVELOPE_FIELDS}
+    # Reverse the agent→model alias only for types that actually use it, so a
+    # genuine ``model`` field on other types (compaction, routing_decision) is
+    # preserved rather than corrupted.
+    if item_type in _import_agent_aliased_types() and "model" in raw:
+        raw["agent"] = raw.pop("model")
     try:
         parse_item_data(item_type, raw)
     except (TypeError, ValueError) as exc:
@@ -5149,7 +5171,9 @@ def session_import(input_path: str, title: str | None, server: str | None) -> No
 
     The session is created as history-only (no runner is launched); open it in
     the UI or resume it to continue. Note: per-turn ``response_id`` grouping is
-    not preserved — replayed items are seeded under a single response id.
+    not preserved — replayed items are seeded under a single response id — and
+    item authorship is re-attributed to the importing user (original
+    ``created_by`` is not carried over).
 
     \b
     Examples:
@@ -5260,7 +5284,10 @@ def session_import(input_path: str, title: str | None, server: str | None) -> No
                 f"Agent not found on server for import (tried {candidates}). "
                 "Register the agent on the target server, then retry."
             )
-        resp.raise_for_status()
+        if resp.status_code >= 400:
+            raise click.ClickException(
+                f"Failed to import session ({resp.status_code}): {resp.text[:500]}"
+            )
         created = resp.json()
 
     new_id = created.get("id") or created.get("session_id")

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5073,6 +5073,200 @@ def session_export(session_id: str, output: str | None, server: str | None) -> N
     click.echo(f"Exported {n_items} item(s) from {session_id} to {out_path}")
 
 
+# Item-data fields carry a serialization alias in ``to_api_dict`` output
+# (``agent`` serializes as ``model``); the reverse map de-aliases them so the
+# payload validates as ``ItemData`` again on import.
+_IMPORT_ITEM_DATA_ALIASES = {"model": "agent"}
+
+# Fields on an exported item that belong to the store/envelope, not the typed
+# ``data`` payload — dropped before rebuilding the item for re-append.
+_IMPORT_ITEM_ENVELOPE_FIELDS = frozenset(
+    {"record_type", "id", "type", "status", "response_id", "created_by"}
+)
+
+
+def _import_item_payload(item: dict[str, Any]) -> dict[str, Any]:
+    """
+    Rebuild one exported item into a ``{"type", "data"}`` create payload.
+
+    Strips envelope fields the server reassigns, de-aliases ``model`` back to
+    ``agent``, and validates the result with :func:`parse_item_data` so a
+    malformed item fails loud client-side before the create request.
+
+    :param item: One ``record_type == "item"`` object from an export JSONL.
+    :returns: A ``SessionEventInput``-shaped dict for ``initial_items``.
+    :raises click.ClickException: If the item has no ``type`` or its payload
+        does not validate for that type.
+    """
+    from omnigent.entities.conversation import parse_item_data
+
+    item_type = item.get("type")
+    if not isinstance(item_type, str) or not item_type:
+        raise click.ClickException(f"Export item is missing a 'type': {item!r}")
+    raw = {
+        _IMPORT_ITEM_DATA_ALIASES.get(key, key): value
+        for key, value in item.items()
+        if key not in _IMPORT_ITEM_ENVELOPE_FIELDS
+    }
+    try:
+        parse_item_data(item_type, raw)
+    except (TypeError, ValueError) as exc:
+        raise click.ClickException(
+            f"Export contains an invalid {item_type!r} item: {exc}"
+        ) from exc
+    return {"type": item_type, "data": raw}
+
+
+@session.command("import")
+@click.option(
+    "--input",
+    "-i",
+    "input_path",
+    required=True,
+    metavar="FILE",
+    help="Path to a JSONL file produced by 'omnigent session export'.",
+)
+@click.option(
+    "--title",
+    default=None,
+    help="Override the imported session title (defaults to the exported title).",
+)
+@click.option(
+    "--server",
+    default=None,
+    help=(
+        "Omnigent server URL. "
+        "Defaults to the configured server, or a local server already running."
+    ),
+)
+def session_import(input_path: str, title: str | None, server: str | None) -> None:
+    """Import a session transcript from a portable JSONL file.
+
+    The inverse of ``omnigent session export``: reads the ``session_meta`` +
+    ``item`` lines and recreates the conversation on the target server as a new
+    session (a fresh conversation id each time). Distinct from ``omnigent
+    import``, which reads native harness history rather than an export file.
+
+    The session is created as history-only (no runner is launched); open it in
+    the UI or resume it to continue. Note: per-turn ``response_id`` grouping is
+    not preserved — replayed items are seeded under a single response id.
+
+    \b
+    Examples:
+      omnigent session import -i my_session.jsonl
+      omnigent session import -i my_session.jsonl --title "Repro of ES-2065116"
+      omnigent session import -i my_session.jsonl --server https://myserver.com
+    """
+    import httpx
+
+    from omnigent.chat import _remote_headers
+    from omnigent.db.utils import builtin_agent_id
+    from omnigent.native_coding_agents import native_coding_agent_for_harness
+
+    src_path = Path(input_path)
+    if not src_path.is_file():
+        raise click.ClickException(f"Import file not found: {input_path}")
+
+    meta: dict[str, Any] | None = None
+    items: list[dict[str, Any]] = []
+    with src_path.open("r", encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except ValueError as exc:
+                raise click.ClickException(
+                    f"{input_path}:{line_no}: not valid JSON ({exc})."
+                ) from exc
+            kind = record.get("record_type")
+            if kind == "session_meta":
+                meta = record
+            elif kind == "item":
+                items.append(record)
+            # Unknown record_type lines are ignored for forward compatibility.
+
+    if meta is None:
+        raise click.ClickException(
+            f"{input_path}: no 'session_meta' line found — is this a session export?"
+        )
+    if not items:
+        raise click.ClickException(f"{input_path}: no 'item' lines to import.")
+
+    initial_items = [_import_item_payload(item) for item in items]
+
+    # Agent binding: reuse the exported agent_id when it exists on the target
+    # server; otherwise fall back to the built-in native agent for the export's
+    # harness (mirrors the /v1/imports fallback).
+    exported_agent_id = meta.get("agent_id")
+    harness = meta.get("harness") or meta.get("harness_override")
+    fallback_agent_id: str | None = None
+    native_agent = native_coding_agent_for_harness(harness)
+    if native_agent is not None:
+        fallback_agent_id = builtin_agent_id(native_agent.agent_name)
+
+    cfg = _load_effective_config()
+    base_url = _resolve_attach_server(server, cfg.get("server"))
+    if base_url is None:
+        base_url = ensure_local_omnigent_server().url
+    base_url = base_url.rstrip("/")
+
+    resolved_title = title if title is not None else meta.get("title")
+
+    def _create(agent_id: str, client: httpx.Client) -> httpx.Response:
+        body: dict[str, Any] = {
+            "agent_id": agent_id,
+            "initial_items": initial_items,
+            # Explicitly external with no host_id so the server seeds
+            # initial_items as history-only and launches no runner.
+            "host_type": "external",
+        }
+        if resolved_title:
+            body["title"] = resolved_title
+        for key in (
+            "workspace",
+            "harness_override",
+            "model_override",
+            "reasoning_effort",
+            "cost_control_mode_override",
+            "terminal_launch_args",
+        ):
+            value = meta.get(key)
+            if value is not None:
+                body[key] = value
+        return client.post("/v1/sessions", json=body)
+
+    with httpx.Client(
+        base_url=base_url, headers=_remote_headers(server_url=base_url), timeout=120.0
+    ) as client:
+        candidates = [a for a in (exported_agent_id, fallback_agent_id) if a]
+        if not candidates:
+            raise click.ClickException(
+                "Could not resolve an agent to bind: the export has no agent_id "
+                f"and harness {harness!r} has no built-in native agent. "
+                "Register the agent on the target server, then retry."
+            )
+        resp: httpx.Response | None = None
+        for idx, agent_id in enumerate(candidates):
+            resp = _create(agent_id, client)
+            if resp.status_code == 404 and idx + 1 < len(candidates):
+                # Exported agent absent on this server — try the native fallback.
+                continue
+            break
+        assert resp is not None
+        if resp.status_code == 404:
+            raise click.ClickException(
+                f"Agent not found on server for import (tried {candidates}). "
+                "Register the agent on the target server, then retry."
+            )
+        resp.raise_for_status()
+        created = resp.json()
+
+    new_id = created.get("id") or created.get("session_id")
+    click.echo(f"Imported {len(initial_items)} item(s) into {new_id}")
+
+
 # Shared option help for ``run`` and the harness commands. These are the same
 # flags the legacy argparse CLI exposed — keeping them on the unified
 # click CLI so users don't regress when a YAML declares no executor

--- a/tests/host/test_cli_session_import.py
+++ b/tests/host/test_cli_session_import.py
@@ -1,0 +1,174 @@
+"""Unit tests for ``omnigent session import``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import respx
+from click.testing import CliRunner
+
+from omnigent.cli import _import_item_payload, cli
+
+_BASE = "http://localhost:6767"
+
+
+def _patch_server(base_url: str = _BASE) -> Any:
+    """Patch the CLI so it uses *base_url* without spawning a real server."""
+    return patch("omnigent.cli._resolve_attach_server", return_value=base_url)
+
+
+def _write_export(path: Path, *, meta: dict[str, Any], items: list[dict[str, Any]]) -> None:
+    """Write a session-export JSONL: one meta line + one line per item."""
+    lines = [{"record_type": "session_meta", **meta}]
+    lines += [{"record_type": "item", **item} for item in items]
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
+
+
+def test_import_item_payload_dealiases_model_to_agent() -> None:
+    """An assistant item's ``model`` alias maps back to ``agent`` and validates."""
+    exported = {
+        "record_type": "item",
+        "id": "msg_2",
+        "type": "message",
+        "status": "completed",
+        "response_id": "resp_1",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "hi"}],
+        "model": "claude-native-ui",
+    }
+
+    payload = _import_item_payload(exported)
+
+    assert payload["type"] == "message"
+    # Envelope fields dropped; ``model`` de-aliased to ``agent``.
+    assert "id" not in payload["data"]
+    assert "status" not in payload["data"]
+    assert "model" not in payload["data"]
+    assert payload["data"]["agent"] == "claude-native-ui"
+    assert payload["data"]["role"] == "assistant"
+
+
+def test_import_item_payload_rejects_invalid_item() -> None:
+    """A payload that does not validate for its type raises a click error."""
+    import click
+
+    bad = {"record_type": "item", "type": "function_call", "id": "x"}  # missing name/call_id
+    try:
+        _import_item_payload(bad)
+    except click.ClickException as exc:
+        assert "invalid" in str(exc).lower()
+    else:
+        raise AssertionError("expected ClickException for an invalid item")
+
+
+@respx.mock
+def test_session_import_creates_session(tmp_path: Path) -> None:
+    """Import reads the JSONL and POSTs a create with de-aliased initial_items."""
+    src = tmp_path / "s.jsonl"
+    _write_export(
+        src,
+        meta={"id": "conv_old", "title": "orig", "agent_id": "ag_abc", "harness": "claude-native"},
+        items=[
+            {
+                "id": "msg_1",
+                "type": "message",
+                "status": "completed",
+                "response_id": "resp_1",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}],
+            },
+            {
+                "id": "msg_2",
+                "type": "message",
+                "status": "completed",
+                "response_id": "resp_1",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "hi"}],
+                "model": "claude-native-ui",
+            },
+        ],
+    )
+
+    route = respx.post(f"{_BASE}/v1/sessions").mock(
+        return_value=httpx.Response(200, json={"id": "conv_new", "agent_id": "ag_abc"})
+    )
+
+    runner = CliRunner()
+    with _patch_server():
+        result = runner.invoke(cli, ["session", "import", "-i", str(src)])
+
+    assert result.exit_code == 0, result.output
+    assert "conv_new" in result.output
+    assert route.called
+    body = json.loads(route.calls.last.request.content)
+    assert body["agent_id"] == "ag_abc"
+    assert body["title"] == "orig"
+    assert body["host_type"] == "external"
+    assert "host_id" not in body
+    assert len(body["initial_items"]) == 2
+    # The assistant item's model alias was de-aliased to agent before send.
+    assert body["initial_items"][1]["data"]["agent"] == "claude-native-ui"
+
+
+@respx.mock
+def test_session_import_falls_back_to_native_agent(tmp_path: Path) -> None:
+    """When the exported agent_id 404s, import retries with the native agent."""
+    from omnigent.db.utils import builtin_agent_id
+    from omnigent.native_coding_agents import native_coding_agent_for_harness
+
+    native = native_coding_agent_for_harness("claude-native")
+    assert native is not None
+    fallback_id = builtin_agent_id(native.agent_name)
+
+    src = tmp_path / "s.jsonl"
+    _write_export(
+        src,
+        meta={"id": "conv_old", "agent_id": "ag_missing", "harness": "claude-native"},
+        items=[
+            {
+                "id": "msg_1",
+                "type": "message",
+                "status": "completed",
+                "response_id": "resp_1",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hi"}],
+            }
+        ],
+    )
+
+    seen_agent_ids: list[str] = []
+
+    def _responder(request: httpx.Request) -> httpx.Response:
+        agent_id = json.loads(request.content)["agent_id"]
+        seen_agent_ids.append(agent_id)
+        if agent_id == "ag_missing":
+            return httpx.Response(404, json={"error": {"message": "Agent not found"}})
+        return httpx.Response(200, json={"id": "conv_new"})
+
+    respx.post(f"{_BASE}/v1/sessions").mock(side_effect=_responder)
+
+    runner = CliRunner()
+    with _patch_server():
+        result = runner.invoke(cli, ["session", "import", "-i", str(src)])
+
+    assert result.exit_code == 0, result.output
+    assert "conv_new" in result.output
+    # First tried the exported id, then fell back to the native agent id.
+    assert seen_agent_ids == ["ag_missing", fallback_id]
+
+
+def test_session_import_missing_meta_errors(tmp_path: Path) -> None:
+    """A file with no session_meta line is rejected with a clear message."""
+    src = tmp_path / "bad.jsonl"
+    src.write_text(json.dumps({"record_type": "item", "type": "message"}) + "\n", encoding="utf-8")
+
+    runner = CliRunner()
+    with _patch_server():
+        result = runner.invoke(cli, ["session", "import", "-i", str(src)])
+
+    assert result.exit_code != 0
+    assert "session_meta" in result.output

--- a/tests/host/test_cli_session_import.py
+++ b/tests/host/test_cli_session_import.py
@@ -52,6 +52,48 @@ def test_import_item_payload_dealiases_model_to_agent() -> None:
     assert payload["data"]["role"] == "assistant"
 
 
+def test_import_item_payload_preserves_compaction_model() -> None:
+    """``compaction.model`` is a real field, not the agent alias — keep it."""
+    exported = {
+        "record_type": "item",
+        "id": "cmp_1",
+        "type": "compaction",
+        "status": "completed",
+        "response_id": "resp_1",
+        "summary": "did stuff",
+        "last_item_id": "msg_9",
+        "model": "openai/gpt-4o",
+        "token_count": 42,
+    }
+
+    payload = _import_item_payload(exported)
+
+    # Must NOT be renamed to agent, and must survive.
+    assert payload["data"]["model"] == "openai/gpt-4o"
+    assert "agent" not in payload["data"]
+
+
+def test_import_item_payload_preserves_routing_decision_model_and_agent() -> None:
+    """``routing_decision`` has both a required ``model`` and a real ``agent``."""
+    exported = {
+        "record_type": "item",
+        "id": "rt_1",
+        "type": "routing_decision",
+        "status": "completed",
+        "response_id": "resp_1",
+        "model": "databricks-claude-opus-4-8",
+        "applied": True,
+        "rationale": "deep reasoning",
+        "agent": "claude_code",
+    }
+
+    payload = _import_item_payload(exported)
+
+    # Both fields must survive intact — no collision, no loss.
+    assert payload["data"]["model"] == "databricks-claude-opus-4-8"
+    assert payload["data"]["agent"] == "claude_code"
+
+
 def test_import_item_payload_rejects_invalid_item() -> None:
     """A payload that does not validate for its type raises a click error."""
     import click


### PR DESCRIPTION
## Related issue

N/A (developer/debug tooling — complements `session export`)

## Summary

`omnigent session export` writes a portable JSONL but there was **no way to load it back**. Inspecting a shared/exported session (e.g. reproducing a resume/overflow bug like ES-2065116) meant hand-writing items into `chat.db` via the store API — fiddly, and it hits real gotchas (agent binding, the `model`↔`agent` serialization alias).

Add `omnigent session import` to close the round-trip:
- Reads the `session_meta` + `item` lines and recreates the conversation on the target server as a **new session** (fresh id each time) via `POST /v1/sessions`, passing history as `initial_items`.
- **De-aliases** the `model` serialization alias back to `agent` per item and validates each with `parse_item_data()` client-side before the request (fails loud on malformed input).
- **Agent binding:** reuse the exported `agent_id` when it exists on the target server; else fall back to the built-in native agent for the export's harness (mirrors `/v1/imports`); else fail with a clear message.
- Creates **history-only** (`host_type=external`, no `host_id`) so no runner launches. Carries over `title` / `workspace` / `harness_override` / `model_override` / `reasoning_effort` / `cost_control_mode_override` / `terminal_launch_args` from the meta.

Client-only — reuses existing endpoints, no new server route.

### Known limitation (documented in `--help`)

`POST /v1/sessions` seeds `initial_items` under a single synthetic `response_id`, so exact per-turn `response_id` grouping is **not** preserved. Fine for viewing/debugging a session; a follow-up server route could preserve it if that ever matters.

## Test Plan

- New unit tests (`tests/host/test_cli_session_import.py`, respx-mocked, 5 tests): de-alias `model`→`agent`, reject invalid item, full create with correct body (`host_type=external`, no `host_id`, de-aliased items), native-agent fallback on 404, and missing-`session_meta` error.
- Existing `tests/host/test_cli_session_export.py` still passes (5).
- **End-to-end against a live local server** with the real 260-item export:
  - `omnigent session import -i 3440987444542977.jsonl` → `Imported 260 item(s) into <conv>`
  - re-exported and diffed: **identical item counts and types** across all 5 types, agent bound (`claude-native-ui`), and the `model`↔`agent` alias round-trips.
- `pre-commit run` clean.

## Demo

N/A — CLI, non-visual.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Beyond the unit tests, manually round-tripped the real 260-item shared export through import → re-export against a live local server and diffed item counts/types and the agent binding to confirm fidelity.

## Changelog

`omnigent session import` loads a `session export` JSONL back into a server as a new session
