### PR TITLE
fix(web): filter closed sub-agents from Agents panel

### DIFF
--- a/web/src/hooks/useChildSessions.ts
+++ b/web/src/hooks/useChildSessions.ts
@@ -158,6 +158,36 @@ interface UseChildSessionsResult {
 }
 
 /**
+ * Closed-session label key and value, mirroring the backend constants
+ * in ``omnigent/session_lifecycle.py`` so the frontend can detect
+ * tombstoned sub-agents without calling ``is_session_closed`` server-side.
+ *
+ * The backend writes ``omnigent.closed=true`` when ``sys_session_close``
+ * is called.  A legacy marker ``:closed:`` may also appear in the title.
+ */
+const CLOSED_LABEL_KEY = "omnigent.closed";
+const CLOSED_LABEL_VALUE = "true";
+const CLOSED_TITLE_INFIX = ":closed:";
+
+/**
+ * Mirror of ``omnigent/session_lifecycle.is_session_closed``.
+ *
+ * @param labels - Session-scoped labels that may carry the closed marker.
+ * @param title  - Optional title for legacy closed-rows that embed
+ *   ``:closed:`` in the text.
+ * @returns ``true`` when the session was closed via ``sys_session_close``.
+ */
+export function isSessionClosed(
+  labels: Record<string, string> | undefined,
+  title: string | null | undefined,
+): boolean {
+  return (
+    labels?.[CLOSED_LABEL_KEY] === CLOSED_LABEL_VALUE ||
+    (title ?? "").includes(CLOSED_TITLE_INFIX)
+  );
+}
+
+/**
  * Fetch child sessions for a parent session.
  *
  * Exported for unit testing of the HTTP-shape contract; production
@@ -169,18 +199,20 @@ export async function fetchChildSessions(sessionId: string): Promise<ChildSessio
   );
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   const json = (await res.json()) as ChildSessionsResponse;
-  return json.data.map((row) => ({
-    id: row.id,
-    title: row.title,
-    tool: row.tool,
-    session_name: row.session_name,
-    labels: row.labels ?? {},
-    current_task_status: row.current_task_status,
-    last_task_error: parseChildSessionError(row.last_task_error),
-    busy: row.busy,
-    last_message_preview: row.last_message_preview ?? null,
-    pending_elicitations_count: row.pending_elicitations_count ?? 0,
-  }));
+  return json.data
+    .filter((row) => !isSessionClosed(row.labels, row.title))
+    .map((row) => ({
+      id: row.id,
+      title: row.title,
+      tool: row.tool,
+      session_name: row.session_name,
+      labels: row.labels ?? {},
+      current_task_status: row.current_task_status,
+      last_task_error: parseChildSessionError(row.last_task_error),
+      busy: row.busy,
+      last_message_preview: row.last_message_preview ?? null,
+      pending_elicitations_count: row.pending_elicitations_count ?? 0,
+    }));
 }
 
 /**


### PR DESCRIPTION
## Related issue

Closes #3127

## Summary

Closed sub-agents tombstoned via sys_session_close were still showing up in the Agents panel (list and graph views) with no visual indicator they were finished. Their labels carry omnigent.closed=true but the frontend never reads it.

This adds an isSessionClosed() helper that mirrors the backend check — label omnigent.closed=true or a :closed: title marker for legacy rows — and applies it as a filter in fetchChildSessions(). Since web and desktop share the same frontend bundle, a single change in useChildSessions.ts fixes both surfaces.

## Test Plan

Open a conversation with a closed sub-agent in the Agents panel. Before the fix it shows alongside active ones. After the fix it vanishes from the list. The API still returns the closed session data (the backend inspection endpoint is unchanged) — only the UI filters it out.

## Demo

N/A — this is a data filtering change. The user-facing effect is that finished agents disappear from the panel instead of lingering without a "closed" badge.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: confirmed fetchChildSessions filters rows where labels["omnigent.closed"] === "true" or title contains ":closed:". The helper isSessionClosed() is exported for unit testing but no new tests were added in this change to keep the fix minimal. The existing TanStack Query flow stays unchanged — the filter runs at the fetch boundary before data enters the React component tree.

## Changelog

Closed sub-agents now disappear from the Agents panel when the session is finished.