### PR TITLE
fix(cost): price bare OpenRouter vendor/model ids in fetch_model_pricing

### DIFF
--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -54,6 +54,13 @@ _MODEL_PREFIX_TO_PROVIDER: dict[str, str] = {
     "mistral-": "mistral",
 }
 
+# Providers Omnigent routes directly for explicit ``vendor/model`` ids.
+# :func:`fetch_model_pricing` gates its OpenRouter fallbacks on this set so a
+# transient catalog-fetch failure for one of these providers (``models is
+# None``) can't be mistaken for "unrecognized provider" and mis-price e.g.
+# ``openai/gpt-4o`` at OpenRouter's public rate.
+_KNOWN_DIRECT_PROVIDERS: frozenset[str] = frozenset(_MODEL_PREFIX_TO_PROVIDER.values())
+
 _DEFAULT_CONTEXT_WINDOW: int = 128_000
 
 # Omnigent's authoritative context-window registry, consulted BEFORE litellm
@@ -697,20 +704,14 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
     # design, because the bare form is what pi reports for all OpenRouter
     # dispatches.
     #
-    # (#3) GATE: the OpenRouter fallbacks apply when EITHER:
-    #   (a) an explicit ``openrouter/`` prefix was present (or_model != model), OR
-    #   (b) the head segment is NOT a recognized direct MLflow provider
-    #       (models is None -- the provider catalog does not exist).
-    # BLOCK: when the head IS a recognized provider whose own catalog was
-    # consulted (models is not None), the OpenRouter fallbacks are skipped
-    # so ``openai/gpt-4o`` never silently gets OpenRouter public rates.
-    #
-    # The signal: ``models`` is ``None`` when the provider catalog does not
-    # exist (unknown provider or network error).  It is a (possibly empty)
-    # dict when the provider IS recognized.  A recognized provider with a
-    # missing model returns ``None`` from this function (the caller skips
-    # pricing); an unrecognized provider (e.g. "xiaomi", "z-ai") falls
-    # through to the OpenRouter catalogs below.
+    # (#3) GATE: OpenRouter fallbacks apply only for an explicit
+    # ``openrouter/`` prefix (or_model != model) or a provider outside
+    # _KNOWN_DIRECT_PROVIDERS. Gating on the provider name rather than on
+    # ``models is None`` matters because that signal is ambiguous: it's
+    # ``None`` both for an unrecognized provider (safe to fall through) and
+    # for a known provider's catalog fetch failing transiently (must NOT
+    # fall through, or a one-off timeout mis-prices e.g. ``openai/gpt-4o``
+    # at OpenRouter's rate for up to an hour).
 
     # OpenRouter vendor/model retry.  For bare ``vendor/model`` ids from
     # unrecognized providers (e.g. ``xiaomi/mimo-v2.5-pro``,
@@ -721,9 +722,9 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
     # so ``openrouter/vendor/model`` matches the catalog key
     # ``vendor/model``.
     #
-    # The condition: explicit ``openrouter/`` prefix OR no own-provider
-    # catalog (unrecognized provider).
-    if or_model != model or models is None:
+    # The condition: explicit ``openrouter/`` prefix OR provider is not one
+    # Omnigent routes directly.
+    if or_model != model or provider not in _KNOWN_DIRECT_PROVIDERS:
         or_models = _fetch_mlflow_provider_catalog("openrouter")
         if or_models is not None:
             entry = or_models.get(or_model)

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -327,21 +327,20 @@ def _fetch_live_openrouter_pricing(model: str) -> ModelPricing | None:
     :returns: :class:`ModelPricing` or ``None``.
     """
     import json as _json
-    import urllib.request
     import urllib.error
+    import urllib.request
 
     # Normalise: strip a leading "openrouter/" so the bare vendor/model
     # matches the list-endpoint's ``id`` field.
     lookup_key = model
     if lookup_key.startswith("openrouter/"):
-        lookup_key = lookup_key[len("openrouter/"):]
+        lookup_key = lookup_key[len("openrouter/") :]
     elif "/" in lookup_key:
         _implicit_provider, _bare = lookup_key.split("/", 1)
         # If the implicit provider IS a real OpenRouter package (no slash
         # in the remainder after one more split), keep as-is.  If it looks
         # like another layer of namespace, leave the whole string; the
         # list-endpoint id is always the bare vendor/model.
-        pass
 
     with _live_pricing_cache_lock:
         cached = _live_pricing_cache.get(lookup_key, _LIVE_PRICING_MISS)

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -9,8 +9,10 @@ fallback.
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -88,6 +90,8 @@ _CONTEXT_WINDOW_REGISTRY: dict[str, int] = {
 _ANTHROPIC_1M_BETA_SUFFIX = "[1m]"
 _ANTHROPIC_1M_BETA_WINDOW = 1_000_000
 
+_logger = logging.getLogger(__name__)
+
 
 def _registry_context_window(model: str) -> int | None:
     """Resolve a model's context window from Omnigent's authoritative registry.
@@ -131,17 +135,28 @@ def _registry_context_window(model: str) -> int | None:
 _FALLBACK_CACHE_READ_INPUT_RATIO: float = 0.10
 _FALLBACK_CACHE_WRITE_INPUT_RATIO: float = 1.25
 
-# Live OpenRouter pricing lookup cache.  Used as a last-resort fallback when
-# neither the provider-specific MLflow catalog nor the openrouter MLflow
-# catalog prices a model.  Same TTL / maxsize / lock pattern as the catalog
-# cache above.  ``None`` is cached on 404/timeout/malformed-response so a
-# transient failure doesn't re-fire on every turn.
+# Live OpenRouter pricing lookup cache.  The entire /api/v1/models list
+# (~342 entries) is fetched once and cached under the singleton key
+# _LIVE_PRICING_LIST_KEY as a dict[str, ModelPricing | None].  Per-model
+# lookups are plain dict.get() against this cached map, so a single network
+# call amortises across ALL models (the "one network call" property).
+# Negative results (model not in list) are implicitly cached as missing keys.
+# Transient failures (timeout/DNS/5xx) are cached separately at a short TTL
+# so the model can recover quickly, while "not found" stays cached for the
+# full list TTL.
 _OPENROUTER_LIVE_TTL_SECONDS = 3600
-_live_pricing_cache: cachetools.TTLCache[str, ModelPricing | None] = cachetools.TTLCache(
-    maxsize=64, ttl=_OPENROUTER_LIVE_TTL_SECONDS
+_LIVE_PRICING_FAILURE_TTL_SECONDS = 60  # short TTL for transient failures
+_live_pricing_cache: cachetools.TTLCache[str, dict[str, ModelPricing] | None] = (
+    cachetools.TTLCache(maxsize=8, ttl=_OPENROUTER_LIVE_TTL_SECONDS)
 )
 _live_pricing_cache_lock = threading.Lock()
-_LIVE_PRICING_MISS = object()  # sentinel distinguishing "absent" from cached ``None``
+_LIVE_PRICING_LIST_KEY = "__openrouter_list__"
+_LIVE_PRICING_MISS = object()  # sentinel distinguishing "absent" from cached None
+# Per-key failure cache: maps lookup_key -> (reason, timestamp).
+# Checked AFTER the main cache miss; entries expire after
+# _LIVE_PRICING_FAILURE_TTL_SECONDS so transient failures recover quickly.
+_live_pricing_failure_cache: dict[str, tuple[str, float]] = {}
+_live_pricing_failure_lock = threading.Lock()
 
 
 def _infer_provider(bare: str) -> str | None:
@@ -283,7 +298,7 @@ def _fetch_context_window_from_mlflow(model: str) -> int | None:
         matched = {
             name: e
             for name, e in models.items()
-            if name.startswith(prefix) and isinstance(e, dict)
+            if name.startswith(prefix + "-") and isinstance(e, dict)
         }
         if matched:
             windows = {
@@ -310,8 +325,11 @@ def _fetch_live_openrouter_pricing(model: str) -> ModelPricing | None:
 
     The entire list is fetched once per call (bounded by the 3 s timeout)
     and indexed into a dict keyed on each entry's ``id`` field.  The
-    result is cached (positive and negative) for :data:`_OPENROUTER_LIVE_TTL_SECONDS`
-    so repeated calls for *any* model amortise the network cost.
+    *entire* ``by_id`` map is then cached under a single singleton key
+    (:data:`_LIVE_PRICING_LIST_KEY`) so a single network call amortises
+    across ALL models -- the "one network call" property holds across
+    different models.  Per-model lookups are plain ``dict.get()`` against
+    this cached map.
 
     The ``model`` argument may carry an ``openrouter/`` prefix (bare
     ``vendor/model`` is the expected form, but the prefix is stripped for
@@ -321,6 +339,11 @@ def _fetch_live_openrouter_pricing(model: str) -> ModelPricing | None:
     ``"0.0000007938"``).  A value of ``"0"`` is an authoritative zero;
     absent or unparseable fields are treated as unknown (``None``).  The
     helper never raises into the caller.
+
+    Transient failures (timeout/DNS/5xx) are cached for a short TTL
+    (:data:`_LIVE_PRICING_FAILURE_TTL_SECONDS`) so the model can recover
+    quickly.  "Not found" results are cached for the full list TTL
+    (:data:`_OPENROUTER_LIVE_TTL_SECONDS`).
 
     :param model: The model id as reported by pi, e.g.
         ``"z-ai/glm-5.2"`` or ``"openrouter/z-ai/glm-5.2"``.
@@ -332,55 +355,56 @@ def _fetch_live_openrouter_pricing(model: str) -> ModelPricing | None:
 
     # Normalise: strip a leading "openrouter/" so the bare vendor/model
     # matches the list-endpoint's ``id`` field.
-    lookup_key = model
-    if lookup_key.startswith("openrouter/"):
-        lookup_key = lookup_key[len("openrouter/") :]
-    elif "/" in lookup_key:
-        _implicit_provider, _bare = lookup_key.split("/", 1)
-        # If the implicit provider IS a real OpenRouter package (no slash
-        # in the remainder after one more split), keep as-is.  If it looks
-        # like another layer of namespace, leave the whole string; the
-        # list-endpoint id is always the bare vendor/model.
+    lookup_key = model.removeprefix("openrouter/")
 
+    # --- Check the main list cache first (singleton key) ---
     with _live_pricing_cache_lock:
-        cached = _live_pricing_cache.get(lookup_key, _LIVE_PRICING_MISS)
-        if cached is not _LIVE_PRICING_MISS:
-            return cached
+        cached_list = _live_pricing_cache.get(_LIVE_PRICING_LIST_KEY, _LIVE_PRICING_MISS)
+        if cached_list is not _LIVE_PRICING_MISS:
+            if cached_list is None:
+                return None
+            return cached_list.get(lookup_key)
 
+    # --- Check the short-TTL failure cache ---
+    with _live_pricing_failure_lock:
+        failure_entry = _live_pricing_failure_cache.get(lookup_key)
+        if failure_entry is not None:
+            reason, failure_ts = failure_entry
+            elapsed = time.monotonic() - failure_ts
+            if elapsed < _LIVE_PRICING_FAILURE_TTL_SECONDS:
+                _logger.debug(
+                    "openrouter pricing failure (cached %.0fs ago): %s: %s",
+                    elapsed,
+                    lookup_key,
+                    reason,
+                )
+                return None
+
+    # --- Fetch the full list (one network call) ---
     url = "https://openrouter.ai/api/v1/models"
     try:
         with urllib.request.urlopen(url, timeout=3) as resp:
             raw = _json.loads(resp.read())
-    except Exception:
-        with _live_pricing_cache_lock:
-            _live_pricing_cache[lookup_key] = None
+    except Exception as exc:
+        _logger.debug("openrouter pricing fetch failed for %s: %s", lookup_key, exc)
+        with _live_pricing_failure_lock:
+            _live_pricing_failure_cache[lookup_key] = (str(exc), time.monotonic())
         return None
 
-    # Guard: the response may be malformed; never raise.
+    # Parse the list into a by_id map.  On parse failure, cache a
+    # short-TTL failure so the next call retries quickly.
     try:
         data = raw.get("data") if isinstance(raw, dict) else raw
         if not isinstance(data, list):
-            with _live_pricing_cache_lock:
-                _live_pricing_cache[lookup_key] = None
-            return None
-
-        by_id: dict[str, object] = {}
-        for entry in data:
-            if isinstance(entry, dict):
-                eid = entry.get("id")
-                if isinstance(eid, str):
-                    by_id[eid] = entry
-
-        match = by_id.get(lookup_key)
-        if not isinstance(match, dict):
-            with _live_pricing_cache_lock:
-                _live_pricing_cache[lookup_key] = None
-            return None
-
-        pricing_raw = match.get("pricing")
-        if not isinstance(pricing_raw, dict):
-            with _live_pricing_cache_lock:
-                _live_pricing_cache[lookup_key] = None
+            _logger.debug(
+                "openrouter pricing: malformed response (data is %s)",
+                type(data).__name__,
+            )
+            with _live_pricing_failure_lock:
+                _live_pricing_failure_cache[lookup_key] = (
+                    f"malformed response: data is {type(data).__name__}",
+                    time.monotonic(),
+                )
             return None
 
         def _to_float(val: object) -> float | None:
@@ -392,27 +416,38 @@ def _fetch_live_openrouter_pricing(model: str) -> ModelPricing | None:
             except (TypeError, ValueError):
                 return None
 
-        input_pt = _to_float(pricing_raw.get("prompt"))
-        output_pt = _to_float(pricing_raw.get("completion"))
-        if input_pt is None or output_pt is None:
-            with _live_pricing_cache_lock:
-                _live_pricing_cache[lookup_key] = None
-            return None
+        by_id: dict[str, ModelPricing] = {}
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            eid = entry.get("id")
+            if not isinstance(eid, str):
+                continue
+            pricing_raw = entry.get("pricing")
+            if not isinstance(pricing_raw, dict):
+                continue
+            input_pt = _to_float(pricing_raw.get("prompt"))
+            output_pt = _to_float(pricing_raw.get("completion"))
+            if input_pt is None or output_pt is None:
+                continue
+            by_id[eid] = ModelPricing(
+                input_per_token=input_pt,
+                output_per_token=output_pt,
+                cache_read_per_token=_to_float(pricing_raw.get("input_cache_read")),
+                cache_write_per_token=None,  # OpenRouter doesn't publish cache-write
+            )
 
-        result = ModelPricing(
-            input_per_token=input_pt,
-            output_per_token=output_pt,
-            cache_read_per_token=_to_float(pricing_raw.get("input_cache_read")),
-            cache_write_per_token=None,  # OpenRouter doesn't publish cache-write
-        )
-    except Exception:
+        # Cache the entire list under the singleton key.  If the target
+        # model is absent, by_id.get(lookup_key) returns None (implicit
+        # negative cache for the full list TTL).
         with _live_pricing_cache_lock:
-            _live_pricing_cache[lookup_key] = None
+            _live_pricing_cache[_LIVE_PRICING_LIST_KEY] = by_id
+        return by_id.get(lookup_key)
+    except Exception as exc:
+        _logger.debug("openrouter pricing parse failed for %s: %s", lookup_key, exc)
+        with _live_pricing_failure_lock:
+            _live_pricing_failure_cache[lookup_key] = (str(exc), time.monotonic())
         return None
-
-    with _live_pricing_cache_lock:
-        _live_pricing_cache[lookup_key] = result
-    return result
 
 
 def get_model_context_window(model: str) -> int:
@@ -564,6 +599,13 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
     if os.environ.get("OMNIGENT_DISABLE_CATALOG_LOOKUP") == "1":
         return None
 
+    # Strip explicit openrouter/ prefix early so the lookup key is the
+    # bare vendor/model form used by both the OpenRouter MLflow catalog
+    # and the live API.  This MUST happen before the catalog retry and
+    # family-prefix block so an ``openrouter/vendor/model`` id hits the
+    # catalog retry (and doesn't fall through to the network path).
+    or_model = model.removeprefix("openrouter/")
+
     if "/" in model:
         _explicit_provider, bare = model.split("/", 1)
         provider = _explicit_provider
@@ -608,12 +650,26 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
 
     # Family-prefix fallback: strip last hyphen segment and look for
     # entries that share the same pricing.
+    # (#7) Use startswith(prefix + "-") to avoid over-matching
+    # ("kimi" matching "kimi-k30").
     if "-" in bare and models is not None:
         prefix = bare.rsplit("-", 1)[0]
-        matched = [e for name, e in models.items() if name.startswith(prefix)]
-        prices = {_extract(e) for e in matched if _extract(e) is not None}
+        matched = [e for name, e in models.items() if name.startswith(prefix + "-")]
+        # (#1) Compute _extract once per element, dedupe on a tuple key
+        # to avoid requiring ModelPricing to be hashable.
+        prices: dict[tuple, ModelPricing] = {}
+        for e in matched:
+            p = _extract(e)
+            if p is not None:
+                k = (
+                    p.input_per_token,
+                    p.output_per_token,
+                    p.cache_read_per_token,
+                    p.cache_write_per_token,
+                )
+                prices[k] = p
         if len(prices) == 1:
-            return next(iter(prices))
+            return next(iter(prices.values()))
 
     # Databricks-gateway alias fallback. A model served through the
     # Databricks gateway is reported as ``databricks-<base>`` (e.g.
@@ -640,34 +696,65 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
     # Unresolved vendor/model ids fall through to OpenRouter rates by
     # design, because the bare form is what pi reports for all OpenRouter
     # dispatches.
+    #
+    # (#3) GATE: the OpenRouter fallbacks apply when EITHER:
+    #   (a) an explicit ``openrouter/`` prefix was present (or_model != model), OR
+    #   (b) the head segment is NOT a recognized direct MLflow provider
+    #       (models is None -- the provider catalog does not exist).
+    # BLOCK: when the head IS a recognized provider whose own catalog was
+    # consulted (models is not None), the OpenRouter fallbacks are skipped
+    # so ``openai/gpt-4o`` never silently gets OpenRouter public rates.
+    #
+    # The signal: ``models`` is ``None`` when the provider catalog does not
+    # exist (unknown provider or network error).  It is a (possibly empty)
+    # dict when the provider IS recognized.  A recognized provider with a
+    # missing model returns ``None`` from this function (the caller skips
+    # pricing); an unrecognized provider (e.g. "xiaomi", "z-ai") falls
+    # through to the OpenRouter catalogs below.
 
-    # OpenRouter vendor/model retry.  For bare ``vendor/model`` ids
-    # (e.g. ``xiaomi/mimo-v2.5-pro``, ``moonshotai/kimi-k3``) the initial
-    # split treats ``vendor`` as the MLflow provider, which has no catalog.
-    # Retry once against the ``openrouter`` MLflow catalog using the full
-    # ``vendor/model`` string as the key -- the MLflow openrouter.json
-    # stores these ids verbatim.
-    if "/" in model:
+    # OpenRouter vendor/model retry.  For bare ``vendor/model`` ids from
+    # unrecognized providers (e.g. ``xiaomi/mimo-v2.5-pro``,
+    # ``moonshotai/kimi-k3``) or explicitly ``openrouter/``-prefixed ids,
+    # retry against the ``openrouter`` MLflow catalog.  The MLflow
+    # openrouter.json stores these ids verbatim.
+    # (#2) Uses the prefix-stripped ``or_model`` (not the raw ``model``)
+    # so ``openrouter/vendor/model`` matches the catalog key
+    # ``vendor/model``.
+    #
+    # The condition: explicit ``openrouter/`` prefix OR no own-provider
+    # catalog (unrecognized provider).
+    if or_model != model or models is None:
         or_models = _fetch_mlflow_provider_catalog("openrouter")
         if or_models is not None:
-            entry = or_models.get(model)
+            entry = or_models.get(or_model)
             if entry is not None:
                 result = _extract(entry)
                 if result is not None:
                     return result
             # Family-prefix fallback within the openrouter catalog too.
-            if "-" in model:
-                prefix = model.rsplit("-", 1)[0]
-                matched = [e for n, e in or_models.items() if n.startswith(prefix)]
-                prices = {_extract(e) for e in matched if _extract(e) is not None}
+            # (#7) Use startswith(prefix + "-") to avoid over-matching.
+            if "-" in or_model:
+                prefix = or_model.rsplit("-", 1)[0]
+                matched = [e for n, e in or_models.items() if n.startswith(prefix + "-")]
+                # (#1) Dedupe on a tuple key; compute _extract once.
+                prices = {}
+                for e in matched:
+                    p = _extract(e)
+                    if p is not None:
+                        k = (
+                            p.input_per_token,
+                            p.output_per_token,
+                            p.cache_read_per_token,
+                            p.cache_write_per_token,
+                        )
+                        prices[k] = p
                 if len(prices) == 1:
-                    return next(iter(prices))
+                    return next(iter(prices.values()))
 
-    # Live OpenRouter API fallback for models absent from MLflow entirely
-    # (e.g. ``z-ai/glm-5.2``).  Fetches the models LIST endpoint once,
-    # caches results for 1 h, never raises into the turn-completion path.
-    if "/" in model:
-        return _fetch_live_openrouter_pricing(model)
+        # Live OpenRouter API fallback for models absent from MLflow entirely
+        # (e.g. ``z-ai/glm-5.2``).  Fetches the models LIST endpoint once,
+        # caches results for 1 h, never raises into the turn-completion path.
+        return _fetch_live_openrouter_pricing(or_model)
 
     return None
 

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -131,6 +131,18 @@ def _registry_context_window(model: str) -> int | None:
 _FALLBACK_CACHE_READ_INPUT_RATIO: float = 0.10
 _FALLBACK_CACHE_WRITE_INPUT_RATIO: float = 1.25
 
+# Live OpenRouter pricing lookup cache.  Used as a last-resort fallback when
+# neither the provider-specific MLflow catalog nor the openrouter MLflow
+# catalog prices a model.  Same TTL / maxsize / lock pattern as the catalog
+# cache above.  ``None`` is cached on 404/timeout/malformed-response so a
+# transient failure doesn't re-fire on every turn.
+_OPENROUTER_LIVE_TTL_SECONDS = 3600
+_live_pricing_cache: cachetools.TTLCache[str, ModelPricing | None] = cachetools.TTLCache(
+    maxsize=64, ttl=_OPENROUTER_LIVE_TTL_SECONDS
+)
+_live_pricing_cache_lock = threading.Lock()
+_LIVE_PRICING_MISS = object()  # sentinel distinguishing "absent" from cached ``None``
+
 
 def _infer_provider(bare: str) -> str | None:
     """
@@ -283,6 +295,73 @@ def _fetch_context_window_from_mlflow(model: str) -> int | None:
                 return int(next(iter(windows)))  # type: ignore[arg-type]
 
     return None
+
+
+def _fetch_live_openrouter_pricing(model: str) -> ModelPricing | None:
+    """
+    Fetch per-token pricing from the OpenRouter models API.
+
+    Last-resort fallback for models absent from the MLflow openrouter
+    catalog (e.g. ``z-ai/glm-5.2``, ``moonshotai/kimi-k3``).  The
+    response carries per-token prices (prompt/completion/cache_read) as
+    strings; non-token components (request, image, reasoning) are not
+    modeled so this is an estimate.
+
+    Returns ``None`` (without raising) on any network / parse error or
+    404, and caches failures to avoid re-fire during a transient outage.
+
+    :param model: The full OpenRouter model id, e.g.
+        ``"z-ai/glm-5.2"``.
+    :returns: :class:`ModelPricing` or ``None``.
+    """
+    import json
+    import urllib.request
+
+    with _live_pricing_cache_lock:
+        cached = _live_pricing_cache.get(model, _LIVE_PRICING_MISS)
+        if cached is not _LIVE_PRICING_MISS:
+            return cached
+
+    url = f"https://openrouter.ai/api/v1/models/{model}"
+    try:
+        with urllib.request.urlopen(url, timeout=3) as resp:
+            data = json.loads(resp.read())
+    except Exception:
+        with _live_pricing_cache_lock:
+            _live_pricing_cache[model] = None
+        return None
+
+    pricing_raw = data.get("data", {}).get("pricing")
+    if not isinstance(pricing_raw, dict):
+        with _live_pricing_cache_lock:
+            _live_pricing_cache[model] = None
+        return None
+
+    def _to_float(val: object) -> float | None:
+        """Parse a pricing string to float, returning ``None`` on failure."""
+        if val is None:
+            return None
+        try:
+            return float(val)
+        except (TypeError, ValueError):
+            return None
+
+    input_pt = _to_float(pricing_raw.get("prompt"))
+    output_pt = _to_float(pricing_raw.get("completion"))
+    if input_pt is None or output_pt is None:
+        with _live_pricing_cache_lock:
+            _live_pricing_cache[model] = None
+        return None
+
+    result = ModelPricing(
+        input_per_token=input_pt,
+        output_per_token=output_pt,
+        cache_read_per_token=_to_float(pricing_raw.get("input_cache_read")),
+        cache_write_per_token=None,  # OpenRouter doesn't publish cache-write
+    )
+    with _live_pricing_cache_lock:
+        _live_pricing_cache[model] = result
+    return result
 
 
 def get_model_context_window(model: str) -> int:
@@ -445,8 +524,6 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
         return None
 
     models = _fetch_mlflow_provider_catalog(provider)
-    if models is None:
-        return None
 
     def _extract(entry: object) -> ModelPricing | None:
         """Extract per-token pricing (incl. cache rates) from a catalog entry."""
@@ -472,7 +549,7 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
             ),
         )
 
-    entry = models.get(bare)
+    entry = models.get(bare) if models is not None else None
     if entry is not None:
         result = _extract(entry)
         if result is not None:
@@ -480,7 +557,7 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
 
     # Family-prefix fallback: strip last hyphen segment and look for
     # entries that share the same pricing.
-    if "-" in bare:
+    if "-" in bare and models is not None:
         prefix = bare.rsplit("-", 1)[0]
         matched = [e for name, e in models.items() if name.startswith(prefix)]
         prices = {_extract(e) for e in matched if _extract(e) is not None}
@@ -500,6 +577,35 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
         base = bare[len("databricks-") :]
         if base and base != bare:
             return fetch_model_pricing(base)
+
+    # OpenRouter vendor/model retry.  For bare ``vendor/model`` ids
+    # (e.g. ``xiaomi/mimo-v2.5-pro``, ``moonshotai/kimi-k3``) the initial
+    # split treats ``vendor`` as the MLflow provider, which has no catalog.
+    # Retry once against the ``openrouter`` MLflow catalog using the full
+    # ``vendor/model`` string as the key -- the MLflow openrouter.json
+    # stores these ids verbatim.
+    if "/" in model:
+        or_models = _fetch_mlflow_provider_catalog("openrouter")
+        if or_models is not None:
+            entry = or_models.get(model)
+            if entry is not None:
+                result = _extract(entry)
+                if result is not None:
+                    return result
+            # Family-prefix fallback within the openrouter catalog too.
+            if "-" in model:
+                prefix = model.rsplit("-", 1)[0]
+                matched = [e for n, e in or_models.items() if n.startswith(prefix)]
+                prices = {_extract(e) for e in matched if _extract(e) is not None}
+                if len(prices) == 1:
+                    return next(iter(prices))
+
+    # Live OpenRouter API fallback for models absent from MLflow entirely
+    # (e.g. ``z-ai/glm-5.2``, ``moonshotai/kimi-k3`` when the family-
+    # prefix doesn't match).  Caches results; never raises into the
+    # turn-completion path.
+    if "/" in model:
+        return _fetch_live_openrouter_pricing(model)
 
     return None
 

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -299,68 +299,120 @@ def _fetch_context_window_from_mlflow(model: str) -> int | None:
 
 def _fetch_live_openrouter_pricing(model: str) -> ModelPricing | None:
     """
-    Fetch per-token pricing from the OpenRouter models API.
+    Fetch per-token pricing from the OpenRouter models LIST endpoint.
 
     Last-resort fallback for models absent from the MLflow openrouter
-    catalog (e.g. ``z-ai/glm-5.2``, ``moonshotai/kimi-k3``).  The
-    response carries per-token prices (prompt/completion/cache_read) as
-    strings; non-token components (request, image, reasoning) are not
-    modeled so this is an estimate.
+    catalog (e.g. ``z-ai/glm-5.2``).  The per-model endpoint
+    (``/api/v1/models/{id}``) returns 404 for all models, so pricing is
+    fetched from the list endpoint (``/api/v1/models``), which returns
+    ~342 entries as a JSON array under ``data`` (NB: NOT keyed on id;
+    not a dict).
 
-    Returns ``None`` (without raising) on any network / parse error or
-    404, and caches failures to avoid re-fire during a transient outage.
+    The entire list is fetched once per call (bounded by the 3 s timeout)
+    and indexed into a dict keyed on each entry's ``id`` field.  The
+    result is cached (positive and negative) for :data:`_OPENROUTER_LIVE_TTL_SECONDS`
+    so repeated calls for *any* model amortise the network cost.
 
-    :param model: The full OpenRouter model id, e.g.
-        ``"z-ai/glm-5.2"``.
+    The ``model`` argument may carry an ``openrouter/`` prefix (bare
+    ``vendor/model`` is the expected form, but the prefix is stripped for
+    safety).
+
+    Pricing fields in the response are per-token *strings* (e.g.
+    ``"0.0000007938"``).  A value of ``"0"`` is an authoritative zero;
+    absent or unparseable fields are treated as unknown (``None``).  The
+    helper never raises into the caller.
+
+    :param model: The model id as reported by pi, e.g.
+        ``"z-ai/glm-5.2"`` or ``"openrouter/z-ai/glm-5.2"``.
     :returns: :class:`ModelPricing` or ``None``.
     """
-    import json
+    import json as _json
     import urllib.request
+    import urllib.error
+
+    # Normalise: strip a leading "openrouter/" so the bare vendor/model
+    # matches the list-endpoint's ``id`` field.
+    lookup_key = model
+    if lookup_key.startswith("openrouter/"):
+        lookup_key = lookup_key[len("openrouter/"):]
+    elif "/" in lookup_key:
+        _implicit_provider, _bare = lookup_key.split("/", 1)
+        # If the implicit provider IS a real OpenRouter package (no slash
+        # in the remainder after one more split), keep as-is.  If it looks
+        # like another layer of namespace, leave the whole string; the
+        # list-endpoint id is always the bare vendor/model.
+        pass
 
     with _live_pricing_cache_lock:
-        cached = _live_pricing_cache.get(model, _LIVE_PRICING_MISS)
+        cached = _live_pricing_cache.get(lookup_key, _LIVE_PRICING_MISS)
         if cached is not _LIVE_PRICING_MISS:
             return cached
 
-    url = f"https://openrouter.ai/api/v1/models/{model}"
+    url = "https://openrouter.ai/api/v1/models"
     try:
         with urllib.request.urlopen(url, timeout=3) as resp:
-            data = json.loads(resp.read())
+            raw = _json.loads(resp.read())
     except Exception:
         with _live_pricing_cache_lock:
-            _live_pricing_cache[model] = None
+            _live_pricing_cache[lookup_key] = None
         return None
 
-    pricing_raw = data.get("data", {}).get("pricing")
-    if not isinstance(pricing_raw, dict):
-        with _live_pricing_cache_lock:
-            _live_pricing_cache[model] = None
-        return None
-
-    def _to_float(val: object) -> float | None:
-        """Parse a pricing string to float, returning ``None`` on failure."""
-        if val is None:
-            return None
-        try:
-            return float(val)
-        except (TypeError, ValueError):
+    # Guard: the response may be malformed; never raise.
+    try:
+        data = raw.get("data") if isinstance(raw, dict) else raw
+        if not isinstance(data, list):
+            with _live_pricing_cache_lock:
+                _live_pricing_cache[lookup_key] = None
             return None
 
-    input_pt = _to_float(pricing_raw.get("prompt"))
-    output_pt = _to_float(pricing_raw.get("completion"))
-    if input_pt is None or output_pt is None:
+        by_id: dict[str, object] = {}
+        for entry in data:
+            if isinstance(entry, dict):
+                eid = entry.get("id")
+                if isinstance(eid, str):
+                    by_id[eid] = entry
+
+        match = by_id.get(lookup_key)
+        if not isinstance(match, dict):
+            with _live_pricing_cache_lock:
+                _live_pricing_cache[lookup_key] = None
+            return None
+
+        pricing_raw = match.get("pricing")
+        if not isinstance(pricing_raw, dict):
+            with _live_pricing_cache_lock:
+                _live_pricing_cache[lookup_key] = None
+            return None
+
+        def _to_float(val: object) -> float | None:
+            """Parse a pricing string to float; ``None`` on failure."""
+            if val is None:
+                return None
+            try:
+                return float(val)
+            except (TypeError, ValueError):
+                return None
+
+        input_pt = _to_float(pricing_raw.get("prompt"))
+        output_pt = _to_float(pricing_raw.get("completion"))
+        if input_pt is None or output_pt is None:
+            with _live_pricing_cache_lock:
+                _live_pricing_cache[lookup_key] = None
+            return None
+
+        result = ModelPricing(
+            input_per_token=input_pt,
+            output_per_token=output_pt,
+            cache_read_per_token=_to_float(pricing_raw.get("input_cache_read")),
+            cache_write_per_token=None,  # OpenRouter doesn't publish cache-write
+        )
+    except Exception:
         with _live_pricing_cache_lock:
-            _live_pricing_cache[model] = None
+            _live_pricing_cache[lookup_key] = None
         return None
 
-    result = ModelPricing(
-        input_per_token=input_pt,
-        output_per_token=output_pt,
-        cache_read_per_token=_to_float(pricing_raw.get("input_cache_read")),
-        cache_write_per_token=None,  # OpenRouter doesn't publish cache-write
-    )
     with _live_pricing_cache_lock:
-        _live_pricing_cache[model] = result
+        _live_pricing_cache[lookup_key] = result
     return result
 
 
@@ -578,6 +630,18 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
         if base and base != bare:
             return fetch_model_pricing(base)
 
+    # --- Precedence for vendor/model ids (e.g. "xiaomi/mimo-v2.5-pro") ---
+    #
+    # 1.  Own-provider catalog  (step 1 above: "xiaomi" -> xiaomi.json)
+    # 2.  OpenRouter MLflow catalog  (step below: full key lookup + family-prefix)
+    # 3.  Live OpenRouter API list  (step below: last-resort, cached)
+    #
+    # This means a model priced by its own provider catalog is never
+    # overridden by the OpenRouter catalog, even when both carry the key.
+    # Unresolved vendor/model ids fall through to OpenRouter rates by
+    # design, because the bare form is what pi reports for all OpenRouter
+    # dispatches.
+
     # OpenRouter vendor/model retry.  For bare ``vendor/model`` ids
     # (e.g. ``xiaomi/mimo-v2.5-pro``, ``moonshotai/kimi-k3``) the initial
     # split treats ``vendor`` as the MLflow provider, which has no catalog.
@@ -601,9 +665,8 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
                     return next(iter(prices))
 
     # Live OpenRouter API fallback for models absent from MLflow entirely
-    # (e.g. ``z-ai/glm-5.2``, ``moonshotai/kimi-k3`` when the family-
-    # prefix doesn't match).  Caches results; never raises into the
-    # turn-completion path.
+    # (e.g. ``z-ai/glm-5.2``).  Fetches the models LIST endpoint once,
+    # caches results for 1 h, never raises into the turn-completion path.
     if "/" in model:
         return _fetch_live_openrouter_pricing(model)
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -4315,7 +4315,11 @@ async def _relay_runner_stream(
                         # policy callables can read
                         # event["context"]["usage"]["total_cost_usd"] and the
                         # subtree roll-up below sees the new totals.
-                        _accumulate_session_usage(
+                        # Threaded: a cold pricing-catalog miss can block on a
+                        # network fetch up to the socket timeout, which must
+                        # not stall the relay loop.
+                        await asyncio.to_thread(
+                            _accumulate_session_usage,
                             event.get("response", {}),
                             session_id,
                             conversation_store,

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -8,6 +8,8 @@ cache-write rates from a catalog entry.
 
 from __future__ import annotations
 
+import json as _json_test
+import urllib.request
 from typing import Any
 
 import pytest
@@ -518,10 +520,6 @@ def test_fetch_model_pricing_already_prefixed_still_works(
     assert pricing.output_per_token == pytest.approx(3.0e-6)
 
 
-import json as _json_test
-import urllib.request
-
-
 class _ListResp:
     """Fake urllib response for the OpenRouter list-endpoint."""
 
@@ -531,7 +529,7 @@ class _ListResp:
     def read(self) -> bytes:
         return _json_test.dumps(self._payload).encode()
 
-    def __enter__(self) -> "_ListResp":
+    def __enter__(self) -> _ListResp:
         return self
 
     def __exit__(self, *args: object) -> None:
@@ -550,12 +548,14 @@ def _make_catalog(or_catalog: dict[str, Any] | None = None, other: dict[str, Any
     ``or_catalog`` is the ``openrouter`` provider catalog;
     ``other`` is any other provider (e.g. "anthropic").
     """
+
     def _catalog(provider: str) -> dict[str, Any] | None:
         if provider == "openrouter":
             return or_catalog
         if provider == "anthropic":
             return other
         return None
+
     return _catalog
 
 
@@ -579,9 +579,9 @@ def test_fetch_model_pricing_unknown_bare_id_falls_through(
     monkeypatch.setattr(
         urllib.request,
         "urlopen",
-        lambda url, timeout=3: _ListResp(_or_list_response(
-            {"id": "other/model", "pricing": {"prompt": "1", "completion": "2"}}
-        )),
+        lambda url, timeout=3: _ListResp(
+            _or_list_response({"id": "other/model", "pricing": {"prompt": "1", "completion": "2"}})
+        ),
     )
 
     assert fetch_model_pricing("nonexistent-model") is None
@@ -593,9 +593,7 @@ def test_fetch_model_pricing_single_segment_unknown_returns_none(
     """A single-segment id with no catalog entry returns ``None`` cleanly."""
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
     context_window._live_pricing_cache.clear()
-    monkeypatch.setattr(
-        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
-    )
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", lambda _: None)
     monkeypatch.setenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", "1")
 
     assert fetch_model_pricing("unknown-model") is None
@@ -744,8 +742,7 @@ def test_fetch_model_pricing_live_fallback_malformed_list_returns_none(
         )
         result = fetch_model_pricing("test/model-v1")
         assert result is None, (
-            f"Malformed payload returned non-None: {result!r}"
-            f"  payload={malformed_payload!r}"
+            f"Malformed payload returned non-None: {result!r}  payload={malformed_payload!r}"
         )
 
 

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -410,3 +410,275 @@ def test_get_model_context_window_uses_registry_first(monkeypatch: pytest.Monkey
     assert get_model_context_window("qwen3-coder-plus") == 1_048_576
     # A model the registry doesn't own still falls back to the conservative default.
     assert get_model_context_window("qwen-nonexistent-xyz") == 128_000
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter vendor/model pricing retry
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_model_pricing_bare_openrouter_id_via_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A bare ``vendor/model`` id (no ``openrouter/`` prefix) is priced from
+    the openrouter MLflow catalog on retry.
+
+    ``xiaomi/mimo-v2.5-pro`` is reported as ``xiaomi`` provider on first
+    lookup (no ``xiaomi.json`` exists); the openrouter catalog stores it
+    under the full ``vendor/model`` key, so the retry must find it.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "openrouter":
+            return {
+                "xiaomi/mimo-v2.5-pro": {
+                    "pricing": {
+                        "input_per_million_tokens": 1.0,
+                        "output_per_million_tokens": 3.0,
+                        "cache_read_per_million_tokens": 0.2,
+                        "cache_write_per_million_tokens": 0.0,
+                    }
+                }
+            }
+        return None  # "xiaomi" provider doesn't exist
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    pricing = fetch_model_pricing("xiaomi/mimo-v2.5-pro")
+    assert pricing is not None, "xiaomi/mimo-v2.5-pro was not priced via openrouter retry"
+    assert pricing.input_per_token == pytest.approx(1.0e-6)
+    assert pricing.output_per_token == pytest.approx(3.0e-6)
+    assert pricing.cache_read_per_token == pytest.approx(0.2e-6)
+
+
+def test_fetch_model_pricing_kimi_k3_via_openrouter_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``moonshotai/kimi-k3`` prices via the openrouter catalog retry.
+
+    The initial split treats ``moonshotai`` as the MLflow provider (no
+    catalog exists). The openrouter catalog contains ``moonshotai/kimi-k2.5``
+    so the family-prefix fallback should match ``kimi-k3``.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "openrouter":
+            return {
+                "moonshotai/kimi-k2.5": {
+                    "pricing": {
+                        "input_per_million_tokens": 0.6,
+                        "output_per_million_tokens": 3.0,
+                        "cache_read_per_million_tokens": 0.1,
+                    }
+                }
+            }
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    pricing = fetch_model_pricing("moonshotai/kimi-k3")
+    assert pricing is not None, "moonshotai/kimi-k3 was not priced via openrouter family-prefix"
+    assert pricing.input_per_token == pytest.approx(0.6e-6)
+    assert pricing.output_per_token == pytest.approx(3.0e-6)
+
+
+def test_fetch_model_pricing_already_prefixed_still_works(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An ``openrouter/``-prefixed id still prices normally (no regression).
+
+    ``openrouter/xiaomi/mimo-v2.5-pro`` splits as provider=``openrouter``,
+    bare=``xiaomi/mimo-v2.5-pro``; the openrouter catalog lookup should
+    find it directly.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "openrouter":
+            return {
+                "xiaomi/mimo-v2.5-pro": {
+                    "pricing": {
+                        "input_per_million_tokens": 1.0,
+                        "output_per_million_tokens": 3.0,
+                    }
+                }
+            }
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    pricing = fetch_model_pricing("openrouter/xiaomi/mimo-v2.5-pro")
+    assert pricing is not None
+    assert pricing.input_per_token == pytest.approx(1.0e-6)
+    assert pricing.output_per_token == pytest.approx(3.0e-6)
+
+
+def test_fetch_model_pricing_single_segment_unknown_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single-segment id with no catalog entry returns ``None`` cleanly."""
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    monkeypatch.setattr(
+        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+    )
+    # Clear live cache so this doesn't hit the network
+    context_window._live_pricing_cache.clear()
+    monkeypatch.setenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", "1")
+
+    assert fetch_model_pricing("unknown-model") is None
+
+
+def test_fetch_model_pricing_live_fallback_prices_glm52(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Models absent from MLflow (e.g. ``z-ai/glm-5.2``) are priced via the
+    live OpenRouter API fallback.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        # Neither "z-ai" nor "openrouter" catalog has glm-5.2
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    mock_response = {
+        "data": {
+            "id": "z-ai/glm-5.2",
+            "pricing": {
+                "prompt": "0.0000007938",
+                "completion": "0.0000024948",
+                "input_cache_read": "0.00000014742",
+            },
+        }
+    }
+
+    import json
+    import urllib.request
+
+    class _FakeResp:
+        def __init__(self, data: dict) -> None:
+            self._data = data
+
+        def read(self) -> bytes:
+            return json.dumps(self._data).encode()
+
+        def __enter__(self) -> "_FakeResp":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+    def _fake_urlopen(url: str, timeout: int = 3) -> _FakeResp:
+        assert "z-ai/glm-5.2" in url
+        return _FakeResp(mock_response)
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    pricing = fetch_model_pricing("z-ai/glm-5.2")
+    assert pricing is not None, "z-ai/glm-5.2 was not priced via live fallback"
+    assert pricing.input_per_token == pytest.approx(7.938e-7)
+    assert pricing.output_per_token == pytest.approx(2.4948e-6)
+    assert pricing.cache_read_per_token == pytest.approx(1.4742e-7)
+
+
+def test_fetch_model_pricing_live_fallback_404_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live fallback returns ``None`` on 404 without raising."""
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    monkeypatch.setattr(
+        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+    )
+
+    import urllib.request
+
+    def _fake_urlopen_404(url: str, timeout: int = 3) -> None:
+        raise urllib.error.HTTPError(
+            url, 404, "Not Found", {}, None
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen_404)
+
+    pricing = fetch_model_pricing("z-ai/glm-99")
+    assert pricing is None
+
+
+def test_fetch_model_pricing_live_fallback_timeout_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live fallback returns ``None`` on timeout without raising."""
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    monkeypatch.setattr(
+        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+    )
+
+    import urllib.request
+
+    def _fake_urlopen_timeout(url: str, timeout: int = 3) -> None:
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen_timeout)
+
+    pricing = fetch_model_pricing("unknown/vendor-model")
+    assert pricing is None
+
+
+def test_fetch_model_pricing_live_fallback_is_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live fallback results are cached; second call doesn't hit the network."""
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    monkeypatch.setattr(
+        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+    )
+
+    import json
+    import urllib.request
+
+    call_count = 0
+
+    class _FakeResp:
+        def __init__(self) -> None:
+            pass
+
+        def read(self) -> bytes:
+            return json.dumps({
+                "data": {
+                    "id": "test/cached-model",
+                    "pricing": {"prompt": "1e-6", "completion": "5e-6"},
+                }
+            }).encode()
+
+        def __enter__(self) -> "_FakeResp":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+    def _fake_urlopen(url: str, timeout: int = 3) -> _FakeResp:
+        nonlocal call_count
+        call_count += 1
+        return _FakeResp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    p1 = fetch_model_pricing("test/cached-model")
+    p2 = fetch_model_pricing("test/cached-model")
+    assert p1 is not None
+    assert p2 is not None
+    assert p1.input_per_token == p2.input_per_token
+    assert call_count == 1, f"Network called {call_count} times; expected 1 (cached)"

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -518,16 +518,84 @@ def test_fetch_model_pricing_already_prefixed_still_works(
     assert pricing.output_per_token == pytest.approx(3.0e-6)
 
 
+import json as _json_test
+import urllib.request
+
+
+class _ListResp:
+    """Fake urllib response for the OpenRouter list-endpoint."""
+
+    def __init__(self, payload: object) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return _json_test.dumps(self._payload).encode()
+
+    def __enter__(self) -> "_ListResp":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
+def _or_list_response(*entries: dict) -> dict:
+    """Build a mock OpenRouter /api/v1/models response."""
+    return {"data": list(entries)}
+
+
+# --- A working fake catalog that returns entries for known providers ---
+def _make_catalog(or_catalog: dict[str, Any] | None = None, other: dict[str, Any] | None = None):
+    """Return a mock _fetch_mlflow_provider_catalog callable.
+
+    ``or_catalog`` is the ``openrouter`` provider catalog;
+    ``other`` is any other provider (e.g. "anthropic").
+    """
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "openrouter":
+            return or_catalog
+        if provider == "anthropic":
+            return other
+        return None
+    return _catalog
+
+
+def test_fetch_model_pricing_unknown_bare_id_falls_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A bare single-segment id with no catalog match returns ``None``.
+
+    Exercises the genuine fall-through path (own-provider: None, OR catalog:
+    None, live API: model not in list) without short-circuiting via
+    ``OMNIGENT_DISABLE_CATALOG_LOOKUP``.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+    monkeypatch.setattr(
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
+    )
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda url, timeout=3: _ListResp(_or_list_response(
+            {"id": "other/model", "pricing": {"prompt": "1", "completion": "2"}}
+        )),
+    )
+
+    assert fetch_model_pricing("nonexistent-model") is None
+
+
 def test_fetch_model_pricing_single_segment_unknown_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A single-segment id with no catalog entry returns ``None`` cleanly."""
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
     monkeypatch.setattr(
         context_window, "_fetch_mlflow_provider_catalog", lambda _: None
     )
-    # Clear live cache so this doesn't hit the network
-    context_window._live_pricing_cache.clear()
     monkeypatch.setenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", "1")
 
     assert fetch_model_pricing("unknown-model") is None
@@ -538,79 +606,90 @@ def test_fetch_model_pricing_live_fallback_prices_glm52(
 ) -> None:
     """
     Models absent from MLflow (e.g. ``z-ai/glm-5.2``) are priced via the
-    live OpenRouter API fallback.
+    live OpenRouter list-endpoint fallback.
+
+    The list endpoint returns ``data`` as a LIST, not a dict.
     """
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
     context_window._live_pricing_cache.clear()
+    monkeypatch.setattr(
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
+    )
 
-    def _catalog(provider: str) -> dict[str, Any] | None:
-        # Neither "z-ai" nor "openrouter" catalog has glm-5.2
-        return None
-
-    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
-
-    mock_response = {
-        "data": {
+    list_payload = _or_list_response(
+        {"id": "some/other-model", "pricing": {"prompt": "1", "completion": "2"}},
+        {
             "id": "z-ai/glm-5.2",
             "pricing": {
                 "prompt": "0.0000007938",
                 "completion": "0.0000024948",
                 "input_cache_read": "0.00000014742",
             },
-        }
-    }
+        },
+    )
 
-    import json
-    import urllib.request
-
-    class _FakeResp:
-        def __init__(self, data: dict) -> None:
-            self._data = data
-
-        def read(self) -> bytes:
-            return json.dumps(self._data).encode()
-
-        def __enter__(self) -> "_FakeResp":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-    def _fake_urlopen(url: str, timeout: int = 3) -> _FakeResp:
-        assert "z-ai/glm-5.2" in url
-        return _FakeResp(mock_response)
+    def _fake_urlopen(url: str, timeout: int = 3) -> _ListResp:
+        assert "openrouter.ai/api/v1/models" in url
+        return _ListResp(list_payload)
 
     monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
 
     pricing = fetch_model_pricing("z-ai/glm-5.2")
-    assert pricing is not None, "z-ai/glm-5.2 was not priced via live fallback"
+    assert pricing is not None, "z-ai/glm-5.2 was not priced via live list fallback"
     assert pricing.input_per_token == pytest.approx(7.938e-7)
     assert pricing.output_per_token == pytest.approx(2.4948e-6)
     assert pricing.cache_read_per_token == pytest.approx(1.4742e-7)
 
 
+def test_fetch_model_pricing_live_fallback_strips_openrouter_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An ``openrouter/``-prefixed id is stripped before matching the live list.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+    monkeypatch.setattr(
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
+    )
+
+    list_payload = _or_list_response(
+        {"id": "vendor/model-x", "pricing": {"prompt": "2e-6", "completion": "8e-6"}},
+    )
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda url, timeout=3: _ListResp(list_payload),
+    )
+
+    pricing = fetch_model_pricing("openrouter/vendor/model-x")
+    assert pricing is not None
+    assert pricing.input_per_token == pytest.approx(2e-6)
+    assert pricing.output_per_token == pytest.approx(8e-6)
+
+
 def test_fetch_model_pricing_live_fallback_404_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Live fallback returns ``None`` on 404 without raising."""
+    """Live fallback returns ``None`` on HTTP 404 without raising."""
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
     context_window._live_pricing_cache.clear()
-
     monkeypatch.setattr(
-        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
     )
 
-    import urllib.request
-
     def _fake_urlopen_404(url: str, timeout: int = 3) -> None:
-        raise urllib.error.HTTPError(
-            url, 404, "Not Found", {}, None
-        )
+        raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
 
     monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen_404)
 
-    pricing = fetch_model_pricing("z-ai/glm-99")
-    assert pricing is None
+    assert fetch_model_pricing("z-ai/glm-99") is None
 
 
 def test_fetch_model_pricing_live_fallback_timeout_returns_none(
@@ -619,20 +698,55 @@ def test_fetch_model_pricing_live_fallback_timeout_returns_none(
     """Live fallback returns ``None`` on timeout without raising."""
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
     context_window._live_pricing_cache.clear()
-
     monkeypatch.setattr(
-        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
     )
-
-    import urllib.request
 
     def _fake_urlopen_timeout(url: str, timeout: int = 3) -> None:
         raise TimeoutError("timed out")
 
     monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen_timeout)
 
-    pricing = fetch_model_pricing("unknown/vendor-model")
-    assert pricing is None
+    assert fetch_model_pricing("unknown/vendor-model") is None
+
+
+def test_fetch_model_pricing_live_fallback_malformed_list_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A 200 response where ``data`` is a non-list shape returns None
+    without raising.  Covers: dict (old single-model shape), null, bare
+    string, and nested-garbage.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+    monkeypatch.setattr(
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
+    )
+
+    for malformed_payload in [
+        {"data": {"id": "k", "pricing": {}}},  # dict, not list
+        {"data": None},
+        {"data": "garbage-string"},
+        {"not_data_key": [1, 2, 3]},
+        "bare-string-at-top-level",
+    ]:
+        # Clear the cache between iterations so each shape is freshly checked.
+        context_window._live_pricing_cache.clear()
+        monkeypatch.setattr(
+            urllib.request,
+            "urlopen",
+            lambda url, timeout=3, _p=malformed_payload: _ListResp(_p),
+        )
+        result = fetch_model_pricing("test/model-v1")
+        assert result is None, (
+            f"Malformed payload returned non-None: {result!r}"
+            f"  payload={malformed_payload!r}"
+        )
 
 
 def test_fetch_model_pricing_live_fallback_is_cached(
@@ -641,40 +755,24 @@ def test_fetch_model_pricing_live_fallback_is_cached(
     """Live fallback results are cached; second call doesn't hit the network."""
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
     context_window._live_pricing_cache.clear()
-
     monkeypatch.setattr(
-        context_window, "_fetch_mlflow_provider_catalog", lambda _: None
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
     )
-
-    import json
-    import urllib.request
 
     call_count = 0
 
-    class _FakeResp:
-        def __init__(self) -> None:
-            pass
+    list_payload = _or_list_response(
+        {"id": "test/cached-model", "pricing": {"prompt": "1e-6", "completion": "5e-6"}},
+    )
 
-        def read(self) -> bytes:
-            return json.dumps({
-                "data": {
-                    "id": "test/cached-model",
-                    "pricing": {"prompt": "1e-6", "completion": "5e-6"},
-                }
-            }).encode()
-
-        def __enter__(self) -> "_FakeResp":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-    def _fake_urlopen(url: str, timeout: int = 3) -> _FakeResp:
+    def _counting_urlopen(url: str, timeout: int = 3) -> _ListResp:
         nonlocal call_count
         call_count += 1
-        return _FakeResp()
+        return _ListResp(list_payload)
 
-    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(urllib.request, "urlopen", _counting_urlopen)
 
     p1 = fetch_model_pricing("test/cached-model")
     p2 = fetch_model_pricing("test/cached-model")
@@ -682,3 +780,81 @@ def test_fetch_model_pricing_live_fallback_is_cached(
     assert p2 is not None
     assert p1.input_per_token == p2.input_per_token
     assert call_count == 1, f"Network called {call_count} times; expected 1 (cached)"
+
+
+def test_fetch_model_pricing_live_fallback_price_string_zero_is_authoritative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A pricing string of ``"0"`` is an authoritative zero, not "absent".
+    Only absent/None fields are treated as unknown.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+    monkeypatch.setattr(
+        context_window,
+        "_fetch_mlflow_provider_catalog",
+        _make_catalog(or_catalog=None),
+    )
+
+    list_payload = _or_list_response(
+        {"id": "free/model", "pricing": {"prompt": "0", "completion": "0"}},
+    )
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda url, timeout=3: _ListResp(list_payload),
+    )
+
+    pricing = fetch_model_pricing("free/model")
+    assert pricing is not None, "Price string '0' should be parsed as 0.0"
+    assert pricing.input_per_token == 0.0
+    assert pricing.output_per_token == 0.0
+
+
+def test_fetch_model_pricing_own_catalog_precedence_over_openrouter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A vendor/model id priced by its OWN provider catalog returns the
+    own-catalog price, even when the openrouter catalog holds the same
+    key at a DIFFERENT price.  This locks in precedence.
+
+    Example: "anthropic/claude-sonnet-4-6" -- if "anthropic" catalog has
+    it at $3/M input and openrouter catalog has it at $99/M input, the
+    own-catalog price wins.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    OWN_PRICE = 3.0  # $/M tokens -- own catalog
+    OR_PRICE = 99.0  # $/M tokens -- openrouter catalog (different!)
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "anthropic":
+            return {
+                "claude-sonnet-4-6": {
+                    "pricing": {
+                        "input_per_million_tokens": OWN_PRICE,
+                        "output_per_million_tokens": 15.0,
+                    }
+                }
+            }
+        if provider == "openrouter":
+            return {
+                "anthropic/claude-sonnet-4-6": {
+                    "pricing": {
+                        "input_per_million_tokens": OR_PRICE,
+                        "output_per_million_tokens": 450.0,
+                    }
+                }
+            }
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    pricing = fetch_model_pricing("anthropic/claude-sonnet-4-6")
+    assert pricing is not None
+    assert pricing.input_per_token == pytest.approx(OWN_PRICE / 1_000_000), (
+        "Own-provider catalog price must take precedence over openrouter"
+    )

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -423,12 +423,10 @@ def test_fetch_model_pricing_bare_openrouter_id_via_catalog(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    A bare ``vendor/model`` id (no ``openrouter/`` prefix) is priced from
-    the openrouter MLflow catalog on retry.
-
-    ``xiaomi/mimo-v2.5-pro`` is reported as ``xiaomi`` provider on first
-    lookup (no ``xiaomi.json`` exists); the openrouter catalog stores it
-    under the full ``vendor/model`` key, so the retry must find it.
+    A bare ``vendor/model`` id (no ``openrouter/`` prefix) from an
+    unrecognized provider is priced from the openrouter MLflow catalog
+    on retry.  ``xiaomi`` has no own-provider catalog, so the fallback
+    fires correctly.
     """
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
 
@@ -461,9 +459,9 @@ def test_fetch_model_pricing_kimi_k3_via_openrouter_catalog(
     """
     ``moonshotai/kimi-k3`` prices via the openrouter catalog retry.
 
-    The initial split treats ``moonshotai`` as the MLflow provider (no
-    catalog exists). The openrouter catalog contains ``moonshotai/kimi-k2.5``
-    so the family-prefix fallback should match ``kimi-k3``.
+    ``moonshotai`` has no own-provider catalog, so the fallback fires.
+    The openrouter catalog contains ``moonshotai/kimi-k2.5`` so the
+    family-prefix fallback should match ``kimi-k3``.
     """
     monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
 
@@ -855,3 +853,374 @@ def test_fetch_model_pricing_own_catalog_precedence_over_openrouter(
     assert pricing.input_per_token == pytest.approx(OWN_PRICE / 1_000_000), (
         "Own-provider catalog price must take precedence over openrouter"
     )
+
+
+# ---------------------------------------------------------------------------
+# New tests for review items
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_model_pricing_multi_match_distinct_prices_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    (#1) Family-prefix fallback with >1 distinct price returns None.
+
+    When multiple entries share a family prefix but have DIFFERENT pricing,
+    the fallback cannot disambiguate. The old code built a set of
+    ModelPricing objects which would TypeError on a non-frozen dataclass;
+    the fix dedupes on a tuple key. This test exercises that path.
+
+    Uses entries like "vendor/model-v1" and "vendor/model-v2" so
+    rsplit("-", 1)[0] yields "vendor/model" and startswith("vendor/model-")
+    matches both entries.  A query for "vendor/model-v99" (absent) should
+    match the family prefix but return None because prices differ.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "openrouter":
+            return {
+                "vendor/model-v1": {
+                    "pricing": {
+                        "input_per_million_tokens": 1.0,
+                        "output_per_million_tokens": 3.0,
+                    }
+                },
+                "vendor/model-v2": {
+                    "pricing": {
+                        # DIFFERENT price from model-v1
+                        "input_per_million_tokens": 2.0,
+                        "output_per_million_tokens": 6.0,
+                    }
+                },
+            }
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    # vendor/model-v99 shares the family prefix "vendor/model" with both
+    # model-v1 and model-v2 (via startswith("vendor/model-")), but they
+    # have different prices.
+    pricing = fetch_model_pricing("vendor/model-v99")
+    assert pricing is None, (
+        f"Multi-match with >1 distinct price should return None, got {pricing!r}"
+    )
+
+
+def test_fetch_model_pricing_openrouter_prefixed_id_via_catalog_no_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    (#2) An ``openrouter/vendor/model`` id resolves via catalog without
+    hitting the network.
+
+    The ``openrouter/`` prefix is stripped before the catalog retry lookup,
+    so ``openrouter/vendor/model`` matches the openrouter catalog key
+    ``vendor/model``. No network (live API) call should be made.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    network_called = False
+
+    def _boom(url: str, timeout: int = 3):
+        nonlocal network_called
+        network_called = True
+        raise AssertionError("Network should not be called for catalog-resolved id")
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "openrouter":
+            return {
+                "vendor/model-x": {
+                    "pricing": {
+                        "input_per_million_tokens": 1.0,
+                        "output_per_million_tokens": 3.0,
+                    }
+                }
+            }
+        return None
+
+    # vendor has no own-provider catalog (returns None), so the fallback fires
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+    monkeypatch.setattr(urllib.request, "urlopen", _boom)
+
+    pricing = fetch_model_pricing("openrouter/vendor/model-x")
+    assert pricing is not None, "openrouter/vendor/model-x was not priced via catalog"
+    assert pricing.input_per_token == pytest.approx(1.0e-6)
+    assert not network_called, "Network was called despite catalog match"
+
+
+def test_fetch_model_pricing_directly_routed_id_no_openrouter_pricing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    (#3) A directly-routed ``openai/gpt-4o``-style id does NOT get OpenRouter
+    pricing via the fallback path.
+
+    When the own-provider catalog has no entry for a directly-routed id,
+    the function returns None -- it must NOT fall through to OpenRouter's
+    public rates (which may differ from the provider's contract rates).
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    or_api_called = False
+
+    def _boom(url: str, timeout: int = 3):
+        nonlocal or_api_called
+        or_api_called = True
+        raise AssertionError("OpenRouter API should not be called for directly-routed provider id")
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        # openai catalog EXISTS and is recognized, but lacks gpt-4o
+        if provider == "openai":
+            return {
+                "gpt-5": {
+                    "pricing": {
+                        "input_per_million_tokens": 5.0,
+                        "output_per_million_tokens": 15.0,
+                    }
+                }
+            }
+        # openrouter catalog has gpt-4o at a different price (should NOT be reached)
+        if provider == "openrouter":
+            return {
+                "openai/gpt-4o": {
+                    "pricing": {
+                        "input_per_million_tokens": 99.0,
+                        "output_per_million_tokens": 99.0,
+                    }
+                }
+            }
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+    monkeypatch.setattr(urllib.request, "urlopen", _boom)
+
+    pricing = fetch_model_pricing("openai/gpt-4o")
+    # The own-provider catalog has gpt-5 which matches gpt-4o's family prefix
+    # "gpt-" (via startswith("gpt-")).  This is correct own-provider pricing.
+    # The key assertion: it must NOT get OpenRouter's $99/M rate.
+    assert pricing is not None, (
+        "openai/gpt-4o should be priced via own-provider family-prefix "
+        "(gpt-5 matches gpt-), but got None"
+    )
+    assert pricing.input_per_token == pytest.approx(5e-6), (
+        f"openai/gpt-4o should get own-provider rate (5e-6), "
+        f"not OpenRouter rate (99e-6). Got {pricing.input_per_token}"
+    )
+    assert not or_api_called, "OpenRouter API was called for a directly-routed provider id"
+
+
+def test_fetch_model_pricing_two_cold_models_single_download(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    (#4) Two different cold models trigger only one network download.
+
+    The live OpenRouter list endpoint (~342 entries) is fetched once and
+    cached under a singleton key. Per-model lookups are plain dict.get()
+    against this cached map, so the "one network call" property holds
+    across different models.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+    context_window._live_pricing_failure_cache.clear()
+
+    download_count = 0
+
+    list_payload = _or_list_response(
+        {"id": "vendor/model-a", "pricing": {"prompt": "1e-6", "completion": "5e-6"}},
+        {"id": "vendor/model-b", "pricing": {"prompt": "2e-6", "completion": "8e-6"}},
+    )
+
+    def _counting_urlopen(url: str, timeout: int = 3) -> _ListResp:
+        nonlocal download_count
+        download_count += 1
+        return _ListResp(list_payload)
+
+    monkeypatch.setattr(
+        context_window, "_fetch_mlflow_provider_catalog", _make_catalog(or_catalog=None)
+    )
+    monkeypatch.setattr(urllib.request, "urlopen", _counting_urlopen)
+
+    p1 = fetch_model_pricing("vendor/model-a")
+    p2 = fetch_model_pricing("vendor/model-b")
+
+    assert p1 is not None, "vendor/model-a was not priced"
+    assert p2 is not None, "vendor/model-b was not priced"
+    assert p1.input_per_token == pytest.approx(1e-6)
+    assert p2.input_per_token == pytest.approx(2e-6)
+    assert download_count == 1, (
+        f"Expected 1 network download, got {download_count}. "
+        "The full list should be cached under a singleton key."
+    )
+
+
+def test_fetch_model_pricing_transient_failure_short_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    (#5) Transient failures (timeout/DNS/5xx) are cached for a short TTL,
+    not the full 1-hour "not found" TTL.
+
+    After the short TTL expires, the next call should retry the network.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+    context_window._live_pricing_failure_cache.clear()
+
+    attempt_count = 0
+
+    def _timeout_then_succeed(url: str, timeout: int = 3):
+        nonlocal attempt_count
+        attempt_count += 1
+        if attempt_count == 1:
+            raise TimeoutError("simulated timeout")
+        return _ListResp(
+            _or_list_response(
+                {"id": "vendor/model", "pricing": {"prompt": "1e-6", "completion": "5e-6"}},
+            )
+        )
+
+    monkeypatch.setattr(
+        context_window, "_fetch_mlflow_provider_catalog", _make_catalog(or_catalog=None)
+    )
+    monkeypatch.setattr(urllib.request, "urlopen", _timeout_then_succeed)
+
+    # First call: timeout -> cached as failure
+    p1 = fetch_model_pricing("vendor/model")
+    assert p1 is None
+    assert attempt_count == 1
+
+    # Simulate TTL expiry by clearing the failure cache
+    context_window._live_pricing_failure_cache.clear()
+
+    # Second call: should retry and succeed
+    p2 = fetch_model_pricing("vendor/model")
+    assert p2 is not None, "Should succeed after failure cache expires"
+    assert p2.input_per_token == pytest.approx(1e-6)
+    assert attempt_count == 2, f"Expected 2 attempts (failure + retry), got {attempt_count}"
+
+
+def test_fetch_model_pricing_pinned_bare_id_xiaomi_prices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The pinned bare id ``xiaomi/mimo-v2.5-pro`` (no ``openrouter/`` prefix)
+    resolves to OpenRouter pricing via the catalog retry.
+
+    ``xiaomi`` is not a recognized MLflow provider (catalog is None), so the
+    OpenRouter fallback fires and the openrouter catalog stores the id
+    verbatim.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "openrouter":
+            return {
+                "xiaomi/mimo-v2.5-pro": {
+                    "pricing": {
+                        "input_per_million_tokens": 1.0,
+                        "output_per_million_tokens": 3.0,
+                        "cache_read_per_million_tokens": 0.2,
+                        "cache_write_per_million_tokens": 0.0,
+                    }
+                }
+            }
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    pricing = fetch_model_pricing("xiaomi/mimo-v2.5-pro")
+    assert pricing is not None, (
+        "Pinned bare id xiaomi/mimo-v2.5-pro must be priced (via openrouter catalog retry)"
+    )
+    assert pricing.input_per_token == pytest.approx(1.0e-6)
+    assert pricing.output_per_token == pytest.approx(3.0e-6)
+    assert pricing.cache_read_per_token == pytest.approx(0.2e-6)
+
+
+def test_fetch_model_pricing_pinned_bare_id_kimi_k3_prices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The pinned bare id ``moonshotai/kimi-k3`` (no ``openrouter/`` prefix)
+    resolves to OpenRouter pricing via catalog family-prefix fallback.
+
+    ``moonshotai`` is not a recognized MLflow provider. The openrouter
+    catalog contains ``moonshotai/kimi-k2.5`` so the family-prefix fallback
+    matches.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        if provider == "openrouter":
+            return {
+                "moonshotai/kimi-k2.5": {
+                    "pricing": {
+                        "input_per_million_tokens": 0.6,
+                        "output_per_million_tokens": 3.0,
+                        "cache_read_per_million_tokens": 0.1,
+                    }
+                }
+            }
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+
+    pricing = fetch_model_pricing("moonshotai/kimi-k3")
+    assert pricing is not None, (
+        "Pinned bare id moonshotai/kimi-k3 must be priced (via openrouter family-prefix)"
+    )
+    assert pricing.input_per_token == pytest.approx(0.6e-6)
+    assert pricing.output_per_token == pytest.approx(3.0e-6)
+
+
+def test_fetch_model_pricing_pinned_bare_id_glm52_prices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The pinned bare id ``z-ai/glm-5.2`` (no ``openrouter/`` prefix)
+    resolves to OpenRouter pricing via the live API fallback.
+
+    ``z-ai`` is not a recognized MLflow provider and is absent from the
+    openrouter MLflow catalog, so the live list-endpoint fallback fires.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+    context_window._live_pricing_failure_cache.clear()
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        return None
+
+    list_payload = _or_list_response(
+        {"id": "some/other", "pricing": {"prompt": "1", "completion": "2"}},
+        {
+            "id": "z-ai/glm-5.2",
+            "pricing": {
+                "prompt": "0.0000007938",
+                "completion": "0.0000024948",
+                "input_cache_read": "0.00000014742",
+            },
+        },
+    )
+
+    def _fake_urlopen(url: str, timeout: int = 3) -> _ListResp:
+        assert "openrouter.ai/api/v1/models" in url
+        return _ListResp(list_payload)
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    pricing = fetch_model_pricing("z-ai/glm-5.2")
+    assert pricing is not None, (
+        "Pinned bare id z-ai/glm-5.2 must be priced (via live OpenRouter API)"
+    )
+    assert pricing.input_per_token == pytest.approx(7.938e-7)
+    assert pricing.output_per_token == pytest.approx(2.4948e-6)
+    assert pricing.cache_read_per_token == pytest.approx(1.4742e-7)

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -1014,6 +1014,59 @@ def test_fetch_model_pricing_directly_routed_id_no_openrouter_pricing(
     assert not or_api_called, "OpenRouter API was called for a directly-routed provider id"
 
 
+def test_fetch_model_pricing_known_provider_transient_catalog_failure_no_openrouter_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    (#3) A known direct provider's OWN catalog fetch failing transiently
+    (network error -> ``models is None``) must NOT fall through to
+    OpenRouter pricing.
+
+    ``models is None`` is ambiguous between "unrecognized provider" (safe to
+    fall through) and "recognized provider whose catalog fetch just failed"
+    (must not fall through). Gating on ``models is None`` alone -- rather
+    than on whether the provider is one Omnigent routes directly -- would
+    let a one-off timeout fetching openai.json mis-price
+    ``openai/gpt-4o`` at OpenRouter's public rate for up to an hour.
+    """
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    context_window._live_pricing_cache.clear()
+
+    or_api_called = False
+
+    def _boom(url: str, timeout: int = 3):
+        nonlocal or_api_called
+        or_api_called = True
+        raise AssertionError("OpenRouter API should not be called for a known direct provider")
+
+    def _catalog(provider: str) -> dict[str, Any] | None:
+        # Simulate a transient failure fetching the openai catalog (e.g. a
+        # timeout) -- returns None just like an unrecognized provider would,
+        # but "openai" IS a provider Omnigent routes directly.
+        if provider == "openai":
+            return None
+        if provider == "openrouter":
+            return {
+                "openai/gpt-4o": {
+                    "pricing": {
+                        "input_per_million_tokens": 99.0,
+                        "output_per_million_tokens": 99.0,
+                    }
+                }
+            }
+        return None
+
+    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+    monkeypatch.setattr(urllib.request, "urlopen", _boom)
+
+    pricing = fetch_model_pricing("openai/gpt-4o")
+    assert pricing is None, (
+        "A known direct provider's transient catalog failure must return None, "
+        f"not fall through to OpenRouter pricing. Got {pricing!r}"
+    )
+    assert not or_api_called, "OpenRouter API was called despite a known direct provider"
+
+
 def test_fetch_model_pricing_two_cold_models_single_download(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -4474,6 +4474,61 @@ async def test_relay_flushes_final_text_on_fenced_response_completed(
 
 
 @pytest.mark.asyncio
+async def test_relay_accumulates_usage_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Usage accumulation is dispatched off the event loop.
+
+    ``_accumulate_session_usage`` runs a synchronous pricing lookup whose
+    live fallback can block on a network fetch up to the socket timeout on
+    a cold cache miss. Running it on the loop thread stalls turn relay for
+    every session on that loop, so the relay must offload it
+    (``asyncio.to_thread``). Without the offload this test fails: the spy
+    records the loop's own thread id.
+    """
+    import threading
+
+    import omnigent.server.routes._sessions.orchestration as orchestration_module
+    from omnigent.server.routes.sessions import _relay_runner_stream
+
+    loop_thread = threading.get_ident()
+    calls: list[tuple[int, tuple[Any, ...]]] = []
+
+    def _spy(*args: Any) -> None:
+        calls.append((threading.get_ident(), args))
+
+    monkeypatch.setattr(orchestration_module, "_accumulate_session_usage", _spy)
+
+    sid = "79b22ebd2309e48fdeb450c65611d51b"
+    usage = {"input_tokens": 3, "output_tokens": 4, "total_tokens": 7}
+    store = _ConversationStore()
+    client = _FakeStreamingRunnerClient(
+        [
+            _sse_frame(
+                {
+                    "type": "response.completed",
+                    "response": {"id": "resp_usage", "model": "m", "usage": usage},
+                }
+            ),
+            "data: [DONE]\n\n",
+        ]
+    )
+
+    await _relay_runner_stream(sid, client, store)  # type: ignore[arg-type]
+
+    assert len(calls) == 1, f"expected one accumulation call, got {calls}"
+    worker_thread, args = calls[0]
+    assert worker_thread != loop_thread, (
+        "_accumulate_session_usage ran on the event-loop thread; a cold pricing "
+        "fetch would stall turn relay for every session on the loop"
+    )
+    # Same call shape as before the offload: response dict, session id, store.
+    assert args[0]["usage"] == usage
+    assert args[1] == sid
+    assert args[2] is store
+
+
+@pytest.mark.asyncio
 async def test_relay_persists_pre_stop_narration_on_fenced_incomplete(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Problem

Pi-harness turns using OpenRouter models are recorded UNPRICED - tokens captured, cost absent - because `fetch_model_pricing` (`omnigent/llms/context_window.py`) splits a model id on the first `/` and treats the head as the MLflow catalog provider.

**Bare `vendor/model` ids** (e.g. `xiaomi/mimo-v2.5-pro`, `moonshotai/kimi-k3`, `z-ai/glm-5.2`) - which is what pi reports and what omnigent pins as its OpenRouter default - 404 the catalog and return `None`.

(`openrouter/`-prefixed ids already price because the split leaves `vendor/model` as the key.)

## Fix (this PR)

Three fallbacks in `fetch_model_pricing`, applied in precedence order after the existing databricks-alias path:

1. **OpenRouter MLflow retry** - when the initial provider catalog lookup yields `None` and the id contains `/`, retry with `_fetch_mlflow_provider_catalog("openrouter")` using the full `vendor/model` string as key (with family-prefix fallback). Covers e.g. `xiaomi/mimo-v2.5-pro`.

2. **Live OpenRouter list-endpoint fallback** - for models absent from the MLflow openrouter catalog (e.g. `z-ai/glm-5.2`). Fetches `GET https://openrouter.ai/api/v1/models` and indexes the list by id. Bounded (3s timeout), cached (1h TTL, entire parsed list). Fails safe to `None` on any error; never blocks turn completion.

3. **Precedence guard** - a brief code comment documenting the intended precedence: own-provider catalog first (step 1: e.g. `anthropic` -> `anthropic.json`), then OpenRouter MLflow catalog (step 2: full key + family-prefix), then live OpenRouter list (step 3). This means a model priced by its own provider catalog is never overridden by the OpenRouter catalog, even when both carry the key.

Priority: `0` pricing strings are treated as authoritative zero; only absent/None pricing is treated as unpriced.

Reuses the existing `usage.cost_usd` contract. No new fields. No `pi_executor` or `policies/builder` changes.

## Out of scope (external dependency)

Authoritative per-request OpenRouter `usage.cost` requires an upstream pi change (pi normalizes usage and discards the scalar cost; `usage.cost` is opt-in). This is a follow-up.

## Testing

```
python -m pytest tests/llms/test_context_window.py -q -p no:cacheprovider -o addopts=""
```
29 passed (13 new tests):
- `test_fetch_model_pricing_bare_openrouter_id_via_catalog` - bare vendor/model prices via MLflow openrouter retry
- `test_fetch_model_pricing_kimi_k3_via_openrouter_catalog` - openrouter family-prefix fallback
- `test_fetch_model_pricing_already_prefixed_still_works` - `openrouter/`-prefixed regex
- `test_fetch_model_pricing_unknown_bare_id_falls_through` - genuine fall-through (own-provider None + OR None + live None -> None, no env short-circuit)
- `test_fetch_model_pricing_single_segment_unknown_returns_none` - single-segment clean None
- `test_fetch_model_pricing_live_fallback_prices_glm52` - live list-endpoint returns prices for absent models
- `test_fetch_model_pricing_live_fallback_strips_openrouter_prefix` - prefix handling in live fallback
- `test_fetch_model_pricing_live_fallback_404_returns_none` - HTTP error handling
- `test_fetch_model_pricing_live_fallback_timeout_returns_none` - timeout handling
- `test_fetch_model_pricing_live_fallback_malformed_list_returns_none` - malformed 200 (dict/null/garbage)
- `test_fetch_model_pricing_live_fallback_is_cached` - cache dedup (single network call)
- `test_fetch_model_pricing_live_fallback_price_string_zero_is_authoritative` - `0` -> 0.0, not unpriced
- `test_fetch_model_pricing_own_catalog_precedence_over_openrouter` - own-catalog price wins over OR catalog

No live network calls in tests. All mocked.

## Related PRs

- **#2787** - downstream reporting consumer (`omni usage`); depends on this fix for OpenRouter lines.
- **#2495** - assigns models/budgets but does not measure spend; non-duplicative.
- **#3026** - substantive subscription work (body is an unfilled template, NOT empty); non-duplicative. Coordinate on the shared "present $0 is priced, absent cost is unpriced" invariant.

---
*Reopened as this PR due to DCO fix requiring branch force-push. Previous: #3139.*

## Known limitations / follow-ups

Non-blocking follow-ups identified during review; none of these gate this PR.

1. The direct-provider namespace gate is a string-based approximation: `openai`, `anthropic`, and `google` are simultaneously valid direct-provider prefixes AND real OpenRouter vendor namespaces, and LLMConfig documents direct configs in the byte-identical `provider/model` form, so no string discriminator can separate them. Proper fix is to plumb routed-via context (which client actually issued the request) into the pricing lookup. Today's effect is limited to a transient own-catalog fetch failure for those three namespaces returning unpriced, which matches main's current behavior.
2. `_live_pricing_failure_cache` has no eviction and is keyed per-model although fetch failures are list-wide, so a prolonged provider outage across N distinct models causes N fetches per TTL window plus unbounded slow growth.

