### PR TITLE
perf(native): cut idle poll CPU in the terminal watcher and transcript forwarder

### DIFF
--- a/designs/native-poll-cpu.md
+++ b/designs/native-poll-cpu.md
@@ -1,0 +1,1247 @@
+# Native-harness idle poll CPU
+
+Design for the two load-proportional poll loops that dominate runner CPU on a
+host running many concurrent native sessions:
+
+- **#2702** — `TerminalInstance._idle_watch_loop_threaded`: one daemon thread
+  per live terminal, fork+exec'ing tmux twice per tick.
+- **#3000** — `forward_claude_transcript_to_session`: one asyncio task per live
+  session, re-reading the whole bridge state on every tick.
+
+Acceptance bar: **an idle session must cost near zero.** Both costs scale with
+live terminals / live sessions, so they multiply exactly under sub-agent
+fan-out.
+
+Out of scope, deliberately: #2703 (YAML re-parse), #1349 (idle native session
+reaping), #2421 (ownerless tree leak). See "Interaction with adjacent issues".
+
+## 1. Pre-change mechanisms
+
+### 1.1 Terminal idle watcher (#2702)
+
+`TerminalInstance.start_idle_watcher_thread` spawns one daemon thread named
+`terminal-idle-<name>-<key>`. Each tick in
+`TerminalInstance._idle_watch_loop_threaded`:
+
+1. `stop_event.wait(interval)` — the poll sleep.
+2. `_capture_pane_for_idle_or_none()` → `subprocess.run(tmux … capture-pane)`.
+3. `_pane_is_dead()` → `subprocess.run(tmux … list-panes -F '#{pane_dead} #{pane_dead_status}')`, then records the exit status with `_remember_exit_status`.
+4. `_IdleDetector.tick(snapshot)` — pure diff/marker state machine.
+5. Fires `on_activity` / `on_idle` / `on_exit`.
+
+Two `subprocess.run` calls per tick. `_tmux_base_cmd()` uses the bare string
+`"tmux"`, so `execvp` walks `PATH` — the issue's `strace` shows **4 `execve`
+per invocation, 3 of them `ENOENT`**.
+
+The base watcher already records `pane_dead_status`; the folded probe must
+preserve that contract rather than adding it as new behaviour.
+
+Two watcher configurations are wired by
+`SessionResourceRegistry._start_terminal_activity_watcher`:
+
+| watcher | interval | idle threshold | callbacks |
+|---|---|---|---|
+| generic terminal (no PTY-status-owning role) | 1.0 s | 10.0 s | `on_activity`, `on_exit` |
+| the 7 PTY-only native agent terminals | 0.2 s | 1.0 s | `on_activity`, `on_idle`, `on_exit` |
+| claude-native agent terminal | 0.2 s | 1.0 s | `on_activity`, `on_idle`, `on_exit`, `on_tick` (status-file poller) |
+
+The asyncio sibling `_idle_watch_loop` has **no production caller** (only
+`close()` stops it). It is left alone apart from inheriting the resolved tmux
+path.
+
+#### Latency consumers
+
+| consumer | source | budget |
+|---|---|---|
+| `session.terminal.activity` pulse (web activity badge) | `_on_activity` → `activity_publisher` | web keeps the badge lit for 1.5 s (`ACTIVE_OUTPUT_WINDOW_MS`); already throttled to 1 emit/s by `_TERMINAL_ACTIVITY_EMIT_MIN_INTERVAL_SECONDS` |
+| session `running` status (Agents panel) | active status-file poller for claude-native; otherwise `_on_activity` → `status_publisher` | human-visible; sub-second desirable at turn start |
+| session `idle` status | active status-file poller for claude-native; otherwise `_on_idle` → `status_publisher` | also memoised for exit classification (`_set_session_status_memo`) |
+| terminal exit lifecycle | `_on_exit` → `_handle_terminal_exit` | seconds-scale is fine; it publishes a lifecycle event and cleans up |
+
+The critical observation: **the `running` edge that users actually notice is
+turn start, and turn start is initiated by the runner itself.** Native
+harnesses inject from their harness process rather than through `send()`, but
+the runner still knows when dispatch begins and can wake a backed-off watcher.
+
+### 1.2 Claude transcript forwarder (#3000)
+
+`forward_claude_transcript_to_session`
+polls every `_DEFAULT_POLL_INTERVAL_S = 0.25` and, per tick, re-reads the bridge
+state from scratch and runs ~10 independent scans. Measured locally with
+cProfile on 4 idle sessions at fan-out 6: **~20 `open()` and ~17
+`asyncio.to_thread` dispatches per session per tick**. The thread-pool
+dispatches (future creation, context copy, lock traffic) are as expensive as
+the I/O.
+
+Everything the loop consumes is a file:
+
+| file | writer | shape |
+|---|---|---|
+| `bridge.json` | bridge setup | atomic replace |
+| `state.json` | hooks (`record_hook_event`) | atomic replace |
+| `hooks.jsonl` | hooks | append-only |
+| `context.json` | statusLine wrapper | atomic replace |
+| `message_deltas.jsonl` | message-display hook | append-only |
+| `<transcript>.jsonl` | Claude Code | append-only |
+| `<session>/subagents/agent-*.jsonl` + `.meta.json` | Claude Code | append/create |
+
+Plus the forwarder's own cursors (`*_forwarder.json`), which only change when
+the forwarder did work.
+
+#### Latency consumers
+
+| consumer | budget |
+|---|---|
+| assistant-text deltas → live streaming in the web transcript | **tightest**: this is what makes streaming feel live. Must stay at the current 0.25 s. |
+| transcript items, tool calls/results | same tick as deltas |
+| turn-start `running` / turn-end `idle` status edges | sub-second |
+| session cost + model mirror (feeds cost-budget policy gating) | sub-second within a turn |
+| sub-agent status | 5 s quiescence heuristic already |
+
+Because streaming latency is non-negotiable, **the poll interval cannot back
+off.** The tick body has to get cheap instead.
+
+## 2. Strategies considered
+
+### #2702
+
+| strategy | verdict |
+|---|---|
+| **A. tmux control mode (`tmux -CC`) `%output` notifications** | Rejected. Each terminal has its *own* tmux server, so this is one persistent control client process **per terminal** plus a reader thread. On the reported host that is ~42 new processes — the tax moved, not removed. Also gives raw output bytes, not rendered pane content, so the marker track (`_IDLE_MARKER_SUBSTRINGS`) would need a separate renderer. |
+| **B. `pipe-pane -o 'cat >> file'`** | Rejected for the same reason: tmux spawns a shell per pane. Also raw bytes, not rendered cells. |
+| **C. `/proc/<pane_pid>/stat` CPU-time pre-filter** | Rejected. Linux-only (the repo runs on macOS too), needs the pane's process *tree* (the agent is a grandchild of `pane_pid`), and walking `/proc` per tick is its own cost. |
+| **D. Cheaper ticks + adaptive backoff** | **Chosen.** Three independent, composable reductions, all portable: resolve the tmux binary once (4 `execve` → 1); merge the two tmux invocations into one command sequence (2 fork+exec → 1); back the interval off after sustained quiescence, with an explicit wake. |
+
+Strategy D's three parts multiply when backoff is allowed:
+`8 execve/tick → 1 execve/tick`, then `5 ticks/s → 0.5 ticks/s` for a watcher
+using the 0.2 s base. An active claude-native status-file poller deliberately
+disables the interval reduction, because it needs every watcher tick.
+
+### #3000
+
+| strategy | verdict |
+|---|---|
+| **A. Interval backoff (0.25 → 1 → 5 s)** | Rejected as the primary fix. It buys idle CPU by directly spending streaming latency — the one budget that cannot move. |
+| **B. Tear the forwarder down on `Stop`** | Rejected. `Stop` is not terminal: the user resumes the same session in the same pane, and the tail must be live when they do. This is the issue's own open question; the chosen fix makes it moot (a stopped harness writes nothing, so it costs nothing) without gambling on lifecycle semantics. It also stays clear of #1349's reaping decision. |
+| **C. Memoise the individual file reads** | Partial. Kills the `_read_json_file` / `pathlib` share but leaves the ~17 `to_thread` dispatches and the ~10 scans. |
+| **D. Gate the whole tick body behind a cheap change-detector** | **Chosen.** Keep ticking at 0.25 s — *zero* added latency — but make a no-change tick cost a handful of `stat`s instead of the full body. |
+
+## 3. Chosen design
+
+### 3.1 One mechanism or two?
+
+**Two.** They share a diagnosis (unconditional per-unit polling) but not a
+remedy, because their per-tick work has opposite shapes:
+
+- The forwarder's inputs are **files**, so "did anything change?" is answerable
+  for ~1% of the cost of the tick itself. Gate the work, keep the rate.
+- The terminal watcher's input is **rendered tmux pane state**, which has no
+  cheap out-of-band change signal short of spawning a per-pane process. There
+  is nothing to gate on, so the rate has to move.
+
+Forcing one abstraction over both would mean either paying a process per pane
+(to give the terminal a file-like signal) or spending streaming latency (to give
+the forwarder a backoff). Both are worse than two small, local fixes.
+
+### 3.2 #2702 — cheaper ticks + post-idle backoff
+
+**(a) Resolve the tmux binary once.** Module-level `functools.lru_cache` over
+`shutil.which("tmux")`, falling back to the bare name so the failure message is
+unchanged when tmux is absent. Cuts `execve` 4 → 1 per invocation. No behaviour
+change.
+
+**(b) Merge the pane-dead probe into the capture.** One tmux command sequence:
+
+```
+tmux -S <sock> -f /dev/null list-panes -t main -F '#{pane_dead} #{pane_dead_status}' \; capture-pane -t main -p -e
+```
+
+The first line carries liveness and the dead pane's exit status; the remaining
+output is the pane capture. `list-panes` is intentional: unlike
+`display-message`, it errors for an unknown target instead of silently falling
+back to another pane. The folded method records `pane_dead_status` for
+`TerminalExitEvent.exit_status`. It halves fork+exec per tick and removes the
+race where the pane died between separate capture and probe calls.
+
+**(c) Post-idle interval backoff.** Per tick:
+
+```
+changed        → interval = base                     (activity: full rate)
+quiescent ≥ idle_threshold → interval = min(interval × 2, max_interval)
+otherwise      → interval unchanged
+```
+
+`max_interval = min(base × 10, 5.0)` → 2.0 s for the claude-native watcher
+(base 0.2), 5.0 s for generic terminals (base 1.0).
+
+The runner supplies a dynamic backoff predicate. While claude-native's
+`SessionStatusPoller` is active, the predicate is false and the watcher stays
+at its 0.2 s base interval: that file is the sole status publisher, and its
+`waiting` transitions and reconnect resyncs must not wait up to 2 s. Before
+the file is found, or after the poller retires, the pane fallback may back off.
+Other terminal roles have no status-file poller and retain adaptive backoff.
+
+**The false-idle invariant.** Backoff only grows once `_IdleDetector` reports
+`idle_notified` — i.e. strictly *after* the edge has fired. It is read off the
+detector rather than re-timed in the loop on purpose: the loop's clock starts
+when the watcher starts and the detector's when it takes its first snapshot, so
+a loop-side quiescence timer runs one tick ahead and lets the interval grow
+*before* the edge it is supposed to trail, delaying that edge. Consequences:
+
+- Backoff can never make the idle edge fire **early**: `_IdleDetector` compares
+  wall-clock (`time.monotonic()`) against the threshold, not tick counts, so
+  sampling less often can only delay a decision, never advance it.
+- Backoff can never make idle fire **when it shouldn't**: a session that is
+  working repaints its pane, every tick sees a change, the interval stays at
+  base, and the growth branch is never reached.
+- What backoff *can* cost is a late `running` edge — the idle→running
+  transition, bounded by `max_interval`.
+
+**The wake path** collapses that cost for every case a user actually notices.
+A per-watcher `_WakeSignal` is raised by:
+
+- `_publish_turn_status(conv, "running")` in the runner, via
+  `SessionResourceRegistry.wake_session_terminal_watchers` — **the turn-start
+  hook that matters.** Native harnesses do *not* reach the pane through
+  `TerminalInstance.send`: the executor calls `inject_user_message` from the
+  harness process, which drives tmux over the socket directly, so the runner's
+  watcher sees nothing in-process. `_publish_turn_status` is the one point
+  every dispatch path passes through — background turns, continuation turns,
+  the recovery path, and the streaming branch that never reaches
+  `_run_turn_bg`. The wake runs *before* that function's native-harness
+  suppression, because the harnesses whose status edge is terminal-driven are
+  exactly the ones that need it.
+- `TerminalInstance.send()` — the runner typing into a pane directly (tool-
+  driven terminals).
+- `TerminalInstance.note_client_interaction()` — attach/detach, focus, mouse,
+  keystroke, resize from the web terminal.
+- `_stop_idle_watcher_thread()` — so teardown does not wait out a backed-off
+  sleep.
+
+**Scope.** The turn-start wake fires only for
+`PTY_STATUS_OWNING_TERMINAL_ROLES` — the eight harnesses whose pane watcher
+keeps session status current. For claude-native an active status-file poller
+riding that tick is the sole publisher; the pane is its fallback. A generic
+shell or auxiliary pane drives only the
+activity badge, and a session turn implies nothing about whether it will
+produce output; waking it would put it on high-rate polling for an unrelated
+turn, which is the cost this change exists to remove. The same frozenset gates
+the watcher's own status emission, so the two cannot drift.
+
+The wake and its reason live in one `_WakeSignal`, taken together under a
+single lock by `consume()`. They began as a `threading.Event` beside a `bool`,
+which meant a wake's two halves could be observed and cleared independently —
+whether that was safe took an interleaving-by-interleaving argument, which is
+the tell that the state wanted to be one object. Two properties are now
+structural rather than argued: a wake can never be split across ticks, and one
+raised after `consume()` returns stays pending for the next call instead of
+being dropped.
+
+**Grace.** A turn-start wake says output is *coming*, not that it has arrived,
+and turn setup can outlast the idle threshold — so it also pins the base
+interval for `_IDLE_POLL_WAKE_GRACE_SECONDS`. Two bounds keep that cheap:
+
+- Only wakes that pass `expect_output=True` arm it. Client interactions do
+  not: they are one-off repaints arriving per keystroke and mouse event, and
+  arming a full window on each would hold the pane at base rate far longer
+  than the repaint warrants.
+- It is released the moment the pane actually changes. A normal turn therefore
+  pays a handful of extra captures, not the whole window; the full window is
+  spent only when the expected output never comes, which is exactly the case
+  it exists for.
+
+The grace remains necessary for the seven PTY-only status roles and for
+claude-native before its status file resolves or after its poller retires. An
+active claude-native poller already pins base cadence, so the grace is inert in
+that state rather than being the source of responsiveness.
+
+The sleep is split so a wake storm cannot become a fork storm:
+
+```
+phase 1: stop_event.wait(base_interval)          # mandatory, un-wakeable floor
+phase 2: wake_signal.consume(interval - base)    # only extra backoff is skippable
+```
+
+Poll rate is therefore capped at `1/base` no matter how many wakes arrive — a
+user dragging the mouse over an attached terminal cannot drive tmux faster than
+today's rate. Phase 1 keeps the `close()` join window bounded by `base` exactly
+as it is today. Teardown sets `stop_event` and separately raises `_WakeSignal`,
+so phase 2 returns promptly while the stop condition remains independently
+observable.
+
+Residual (accepted, called out below): a pane parked on a permission prompt with
+a blinking spinner changes every tick, so it never backs off. That session is
+"idle" to a human but not to the pane, and treating it as backoff-eligible would
+just oscillate (each backed-off sample sees a different spinner frame → reset).
+
+### 3.3 #3000 — change-detector gate, unchanged interval
+
+Per tick, before the body:
+
+```
+fingerprint = stat(each _WATCHED_BRIDGE_FILES) + stat(transcript)
+            + stat(subagents_dir) + stat(each cached agent-*.jsonl)
+              → {name: (st_mtime_ns, st_size, st_ino)}
+```
+
+Targets are pre-resolved once per session and the sub-agent listing is cached;
+see §3.3.1 for why, and for what the first version got wrong.
+
+`st_ino` is what makes this airtight: `_write_json_file` writes a temp file and
+`os.replace`s it, so every state write lands a **new inode**. Append-only files
+(`hooks.jsonl`, `message_deltas.jsonl`, transcripts) always grow `st_size`. A
+same-size, same-nanosecond, same-inode rewrite is the only blind spot, and no
+writer here can produce one.
+
+Run the full body when **any** of:
+
+1. the fingerprint changed (or this is the first tick — no baseline yet), **or**
+2. fewer than `_IDLE_SETTLE_SECONDS = 8.0` have passed since the last change —
+   the settle window that lets purely time-based transitions complete, **or**
+3. a retry tracker or the cost-retry backoff has a post due, **or**
+4. `_IDLE_RESYNC_SECONDS = 10.0` have passed since the last full body — a
+   belt-and-braces resync that bounds the damage of any blind spot.
+
+The settle window is sized against the in-process deadlines that fire with no
+file change:
+
+| deadline | value | covered by |
+|---|---|---|
+| sub-agent idle quiescence | 5.0 s | settle window |
+| HTTP post retry | 1–30 s | explicit tracker check (3) |
+| cost post retry | backoff | explicit `cost_retry_not_before` check (3) |
+
+**Latency impact: none.** The poll interval is untouched, and any change to a
+currently watched input file is seen on the very next 0.25 s tick. An input
+that is not watched falls back to the resync — see §3.3.1 and the
+"classification contract is not fail-closed" residual risk.
+
+### 3.3.1 The detector must not watch its own outputs
+
+The first version fingerprinted the bridge directory with `os.scandir` plus a
+`DirEntry.stat` per entry, which is self-maintaining — a bridge file added
+later is covered without anyone remembering. It also swept in the forwarder's
+own cursor files, and that turned out to matter: writing a cursor moves the
+fingerprint, which runs the next tick's body, which can write the cursor
+again. On an idle session with a `message_deltas.jsonl` present the gate
+engaged only **54 %** of ticks instead of settling.
+
+So inputs are stat'ed by name from `_WATCHED_BRIDGE_FILES`. Two unwatched
+buckets make the exclusion explicit: `_FORWARDER_OWNED_BRIDGE_FILES` contains
+the loop's own cursors plus the shared dead-letter sink, while
+`_OTHER_PRODUCER_BRIDGE_FILES` contains five adjacent-router outputs the loop
+does not consume (`turn_router.json`, `turn_routing_done`,
+`turn_replay_pending.json`, `turn_routing.log`, and `subagent_router.json`).
+
+That trades the scan's self-maintaining property for an explicit contract,
+guarded by four tests that fail for different mistakes:
+
+- `test_fingerprint_classifies_every_declared_bridge_file` sweeps the `*_FILE`
+  constants of the seven modules that write into a bridge dir — the bridge,
+  forwarder, statusLine wrapper, message-display hook, shared post-delivery
+  module, turn router, and sub-agent router. Blind to a producer nobody listed.
+- `test_fingerprint_classifies_every_file_a_live_session_writes` drives those
+  producers and requires every file left in the directory to be classified.
+  Blind to a producer or branch the scenario does not reach.
+- `test_bridge_file_disposition_controls_fingerprint` replaces each known
+  producer file and pins whether the observed fingerprint must move. Its
+  semantic table is independent of the production tuples, so moving a watched
+  input into an unwatched bucket fails on behaviour rather than spelling.
+- `test_other_producer_bridge_files_are_not_opened_through_path_open` seeds all five
+  adjacent-router outputs and observes real full ticks, requiring that none is
+  opened through `Path.open`.
+
+**None is fail-closed, and together they are not either** — they are four
+partial nets over the same contract, and the residual is stated in §8. A
+genuinely closed version would need every producer to take its filenames from
+one registry, but nothing forces a producer to use a registry rather than a
+literal, so that buys discoverability rather than a guarantee — at the cost of
+threading a new dependency through seven modules. Worth revisiting if the
+producer set grows; not worth it for the current seven.
+
+A miss costs bounded staleness rather than permanent loss: an unwatched
+input's changes surface on the `_IDLE_RESYNC_SECONDS` sweep instead of the
+next tick. That is eventual observation, not correctness during the gap — see the
+"classification contract is not fail-closed" residual risk.
+
+Paths are pre-resolved once per session into `_BridgeInputPaths` and held as
+plain strings. This is not incidental: a by-name version that built
+`bridge_dir / name` per tick measured *slower* than the directory scan it
+replaced, because `pathlib` construction costs more than the `os.stat` it
+feeds.
+
+Sub-agent membership is cached and re-listed when the `subagents/` directory's
+own mtime moves, **or while that mtime is too recent to trust**. Appends to an
+existing transcript move neither the directory mtime nor the member list,
+which is why the cached transcripts are still stat'ed individually every tick.
+
+The second condition is not belt-and-braces. `st_mtime_ns` reports nanoseconds
+but filesystems do not store them: Linux stamps directory mtimes from the jiffy
+clock — 4 ms at the common `CONFIG_HZ=250` — and older filesystems round to
+1-2 s. An entry created inside the tick already recorded leaves the mtime
+unchanged, and nothing moves it afterwards either, so comparing mtimes alone
+loses that sub-agent until the resync. Measured on a `CONFIG_HZ=250` box:
+adding an entry left the directory mtime unchanged **194 times out of 200**.
+APFS stamps at ~50 µs and misses 0/200, which is why this survived review and
+only surfaced on an integration build.
+
+`_DIR_MTIME_RACY_WINDOW_NS` (2 s, comfortably past the 1-2 s filesystems)
+therefore forces a re-list while the mtime sits within that window of now —
+the same "racily clean" problem git solves for its index.
+
+The window alone is not enough, because **a coarse mtime records the start of
+its bucket, not the moment of the change**. An entry landing late in a 2 s
+bucket can already read as older than the window by the time the next tick
+runs; with the directory key unchanged and the mtime no longer recent, nothing
+would re-list — and nothing ever moves that key again. So a listing taken while
+the mtime was racy is marked *provisional*, and that uncertainty is latched
+until one further listing is taken with the mtime settled.
+
+The age check is one-sided rather than a distance. A stamp from the future is
+untrustworthy however far ahead it is, and `abs()` would call one 5 s ahead
+"settled" simply because it is far from now — exactly inverting the intent for
+a clock-skewed network filesystem.
+
+Cost: extra listings only just after a change, plus one when the window
+expires, and nothing once the directory is quiet — so the steady state this
+gate exists to make cheap is unaffected, measured unchanged at fan-out 6
+and 100.
+
+### 3.4 Blast radius, kill switches, observability
+
+| knob | default | effect when disabled |
+|---|---|---|
+| `OMNIGENT_TERMINAL_IDLE_POLL_BACKOFF=0` | enabled | watcher polls at the fixed base interval, exactly as today |
+| `OMNIGENT_CLAUDE_FORWARDER_IDLE_GATE=0` | enabled | forwarder runs the full body every tick, exactly as today |
+
+Both are read once per loop start, so a restart picks up a change. Neither
+switch touches the tmux-path resolution or the merged probe — those are pure
+cost reductions with no behavioural surface, so they carry no switch.
+
+Field diagnosability, at `DEBUG`, one line per transition rather than per tick:
+
+| where | logged when |
+|---|---|
+| `_idle_watch_loop_threaded` | the interval grows a step (`pane quiescent; poll a -> b`) |
+| `_idle_watch_loop_threaded` | a pane change collapses it back to base (`pane changed`) |
+| `_idle_watch_loop_threaded` | a wake collapses it back to base (`idle watcher woken`) |
+| `forward_claude_transcript_to_session` | the gate first starts skipping (`idle; skipping unchanged polls`) |
+| `forward_claude_transcript_to_session` | the gate re-opens (`resumed`) |
+
+A regression therefore shows up as either "never engages" (no CPU win) or
+"engaged while a turn was live" (a bug), both visible in the runner log without
+a rebuild.
+
+### 3.5 Platform reach
+
+Everything used is portable: `shutil.which`, `subprocess.run`,
+`threading.Event` / `threading.Condition`, `os.scandir`, `os.stat`. No
+`inotify`, no `kqueue`, no `/proc`. There is no degraded path to fall back to
+because there is no platform-specific path.
+
+`st_ino` and `st_mtime_ns` are meaningful on both APFS and ext4, but their
+*resolution* is not portable and must not be assumed — see the granularity
+discussion in §3.3.1. Timestamp-derived logic is written against a window, not
+against equality, precisely because a nanosecond field can carry a 4 ms (or
+1 s) value.
+
+## 4. Measurement
+
+`dev/benchmarks/native_poll_cpu.py`, two scenarios, both holding everything
+genuinely idle (no turns, no pane output, no transcript growth):
+
+Below is the schedule each Set 1 row was actually produced by. Run from the
+candidate root. **Three separate campaigns** produced the rows, each with its
+own base worktree materialised **before** its measurements, and each is given
+here as its own block because their round structures differ. One scenario per
+invocation throughout.
+
+Read the loop bodies as the definition of what "paired" means in Set 1: two
+readings are a **matched pair** for a round if, and only if, **both** hold —
+
+1. they were produced by invocations in the **same iteration of the same loop**
+   below (the same round, on the same host, with no other round intervening);
+   and
+2. one of them is that iteration's **base** (`d720d2762`) reading and the other
+   is the **branch** reading being compared against it.
+
+Clause 2 is what keeps the pairing base-versus-branch, which is the only
+comparison Set 1 models: two branch readings from one iteration are never a
+pair, however close together they ran.
+
+Adjacency inside the iteration is *not* required, and one iteration can yield
+more than one pair: the `rev` loop runs base, backoff and pinned in a single
+iteration, so that round supplies a base/backoff pair **and** a base/pinned
+pair — even though backoff sits between the latter two — while its
+backoff/pinned combination is **not** a pair, because neither member is the
+base reading. The other exclusion is the c1 pinned runs: they occupy a loop of
+their own whose iterations contain no base invocation, so clause 2 can never be
+satisfied there and they pair with nothing. That is exactly why Set 1 never
+treats them as matched.
+
+```bash
+# Shared preamble. The conditional kwarg splat keeps the script compatible with
+# the base watcher's older signature; the base watcher has no backoff predicate
+# at all, so one base terminal row is the before-side for BOTH branch predicate
+# states.
+benchmark_source="$PWD/dev/benchmarks/native_poll_cpu.py"
+bench="uv run python -m dev.benchmarks.native_poll_cpu"
+
+materialise_base() {  # $1 = target dir
+  git worktree add --detach "$1" d720d2762
+  cp "$benchmark_source" "$1/dev/benchmarks/native_poll_cpu.py"
+}
+
+# ---------------------------------------------------------------------------
+# CAMPAIGN c1 (author) — terminal rounds c1 r1-r3, the author pinned block,
+# and ALL forwarder rows.
+# ---------------------------------------------------------------------------
+c1_base="$(mktemp -d /tmp/omnigent-native-poll-base.XXXXXX)"
+materialise_base "$c1_base"
+
+# c1 step 1 — terminal base/backoff MATCHED PAIRS: both in one iteration.
+for run in 1 2 3; do
+  (cd "$c1_base" && $bench terminal --terminals 8 --seconds 30 --warmup 6)
+  $bench terminal --terminals 8 --seconds 30 --warmup 6
+done
+
+# c1 step 2 — the author's --pin-base runs were NOT interleaved with base.
+#   They ran as this separate block afterwards, reusing step 1's base rows as
+#   their before-side. These three pinned rows are therefore NOT matched pairs
+#   and Set 1 never treats them as such.
+for run in 1 2 3; do
+  $bench terminal --terminals 8 --seconds 30 --warmup 6 --pin-base
+done
+
+# c1 step 3 — forwarder MATCHED PAIRS, base then current in one iteration.
+for run in 1 2 3; do
+  (cd "$c1_base" && $bench forwarder --sessions 8 --seconds 30 --warmup 15 --fanout 0)
+  $bench forwarder --sessions 8 --seconds 30 --warmup 15 --fanout 0
+done
+for run in 1 2 3; do
+  (cd "$c1_base" && $bench forwarder --sessions 8 --seconds 30 --warmup 15 --fanout 6)
+  $bench forwarder --sessions 8 --seconds 30 --warmup 15 --fanout 6
+done
+for run in 1 2 3; do
+  (cd "$c1_base" && $bench forwarder --sessions 4 --seconds 30 --warmup 15 --fanout 100)
+  $bench forwarder --sessions 4 --seconds 30 --warmup 15 --fanout 100
+done
+
+git worktree remove --force "$c1_base"
+
+# ---------------------------------------------------------------------------
+# CAMPAIGN c2 (author) — terminal rounds c2 r4-r8. Base worktree
+# re-materialised from the same commit. No pinned runs in this campaign, which
+# is why five base rows here have no pinned counterpart.
+# ---------------------------------------------------------------------------
+c2_base="$(mktemp -d /tmp/omnigent-native-poll-base.XXXXXX)"
+materialise_base "$c2_base"
+
+# c2 — terminal base/backoff MATCHED PAIRS.
+for run in 4 5 6 7 8; do
+  (cd "$c2_base" && $bench terminal --terminals 8 --seconds 30 --warmup 6)
+  $bench terminal --terminals 8 --seconds 30 --warmup 6
+done
+
+git worktree remove --force "$c2_base"
+
+# ---------------------------------------------------------------------------
+# CAMPAIGN rev (independent reviewer) — terminal rounds rev r1-r3, from an
+# independently materialised base worktree. This campaign ran all THREE shapes
+# inside each round, which is what makes its pinned rows matched pairs. It is
+# NOT the c1 step-1/step-2 pattern.
+# ---------------------------------------------------------------------------
+rev_base="$(mktemp -d /tmp/omnigent-native-poll-base.XXXXXX)"
+materialise_base "$rev_base"
+
+# rev — all three shapes run inside ONE iteration, so this round yields exactly
+#   TWO MATCHED PAIRS, both against its base reading: base/backoff and
+#   base/pinned. Pinned need not sit next to base to be matched, only in the
+#   same iteration. backoff/pinned is NOT a pair — neither member is base.
+#   The three true pinned pairs Set 1 relies on come from here and nowhere else.
+for run in 1 2 3; do
+  (cd "$rev_base" && $bench terminal --terminals 8 --seconds 30 --warmup 6)
+  $bench terminal --terminals 8 --seconds 30 --warmup 6
+  $bench terminal --terminals 8 --seconds 30 --warmup 6 --pin-base
+done
+
+git worktree remove --force "$rev_base"
+```
+
+The terminal scenario launches real tmux terminals and reports `RUSAGE_CHILDREN`
+(the tmux processes) as well as `RUSAGE_SELF`, plus a tmux-invocation count. The
+forwarder scenario runs real forwarder tasks against a local sink server and
+reports `RUSAGE_SELF`.
+
+Both scenarios take a `--warmup` that runs before the measurement window opens,
+defaulting past each loop's settle period. Without it the window captures the
+tail of the last activity burst instead of steady-state idle, which understates
+the win by roughly 3x.
+
+The forwarder scenario builds the full bridge directory a live session
+accumulates (~9 files including `message_deltas.jsonl`). An earlier version
+created only 4, which made every per-file cost look smaller than production
+and hid the self-triggering gate in §3.3.1 entirely — the deltas path never
+ran, so the cursor it churns was never written.
+
+### Results
+
+Three measurement sets follow, each with a different before-side. Read the
+scope line before quoting any factor: only the first set compares the current
+tree against base `d720d2762`.
+
+#### What the terminal scenario actually configures
+
+The terminal benchmark constructs a bare `TerminalInstance` and calls
+`start_idle_watcher_thread` directly. There is **no** `SessionResourceRegistry`,
+**no** `resource_role`, **no** session-status publisher, **no**
+`SessionStatusPoller` and **no** `on_tick` on either side of any comparison
+below. It passes `idle_threshold_s=1.0` and `poll_interval_s=0.2` — the cadence
+`resource_registry.py` gives the eight `PTY_STATUS_OWNING_TERMINAL_ROLES`
+terminals (`_CLAUDE_NATIVE_STATUS_IDLE_THRESHOLD_SECONDS` /
+`_CLAUDE_NATIVE_STATUS_POLL_INTERVAL_SECONDS`).
+
+A **generic** pane is a different shape and is *not* measured anywhere in this
+section. For a generic pane `emit_status` is false, so the registry starts the
+watcher with no interval arguments at all and it falls back to
+`_IDLE_POLL_INTERVAL_SECONDS = 1.0` / `_IDLE_THRESHOLD_SECONDS = 10.0` — a 5x
+slower base cadence, so a generic pane's *before* side is roughly 5x cheaper
+than every "before" number here, and its factor cannot be read off these tables.
+
+The two branch-side predicate states map to roles as follows:
+
+- **backoff allowed** (no `--pin-base`) — the seven PTY-status-owning roles
+  other than claude-native. They get `status_poller is None`, hence
+  `idle_poll_backoff_allowed=None`, hence backoff always permitted. The
+  benchmark reproduces that shape exactly.
+- **base pinned** (`--pin-base`) — injects *only*
+  `idle_poll_backoff_allowed=lambda: False`, i.e. claude-native while its status
+  file owns the session. This reproduces the active poller's effect on
+  **cadence**, not its per-tick cost: no `on_tick` runs on either side, so the
+  `SessionStatusPoller.tick()` `stat` that claude-native performs every tick is
+  absent from the "after" column. Read this row as the cadence floor for
+  claude-native, not as a complete model of it.
+
+#### Set 1 — current tree vs base `d720d2762`, one Linux host
+
+Linux (24-core shared dev host, load ~1.3 at start of the first campaign),
+Python 3.12.13, 30 s windows, `--warmup 6` (terminal) / `--warmup 15`
+(forwarder), base materialised via `git worktree add --detach` per the repro
+block above. "Campaign" below means one of the three labelled campaign blocks in
+that repro block — its own base worktree, its own back-to-back rounds; it is not
+a session count. **Three campaigns** contribute terminal rows (author c1, author
+c2, reviewer rev); the forwarder rows come from campaign c1 only. Unit
+counts are whatever each table's row says: the terminal rows are **8 bare
+`TerminalInstance`s** with no application session at all, and the forwarder rows
+are **8 synthetic forwarder sessions** (4 at fan-out 100). Every raw reading is
+listed; no outlier was dropped.
+
+**Scheduling, precisely.** Base and branch alternate inside each round for the
+terminal backoff-allowed rows and for all three forwarder shapes, so drift hits
+both sides of a pair and each such row yields a genuine paired ratio. The
+**`--pin-base` rows are the exception**: the author's three ran as their own
+block after the c1 base rows, not drift-paired against them, so only the
+reviewer's three pinned runs — which ran base, backoff and pinned inside one
+round — are matched pairs. Every pinned aggregate that spans all six pinned runs
+is therefore a **marginal** statistic and is labelled as one; the only
+matched-pair pinned figure is the n=3 reviewer row. Either way the invocation
+count carries the claim.
+
+The base tree has no backoff predicate and no backoff mechanism at all, so the
+single set of base rows is the correct before-side for **both** branch predicate
+states.
+
+##### Terminal — every reading, presented once
+
+All terminal readings live in this one place; there is no second, superseded
+terminal table anywhere in §4. Three campaigns, same host, same invocation
+(`--terminals 8 --seconds 30 --warmup 6`): the author's original three rounds
+(**c1**), five further author rounds with the base worktree re-materialised from
+the same commit (**c2**), and three independent rounds by a reviewer who
+materialised their own base worktree (**rev**). Rounds `c1 r1`–`c1 r3` are the
+original three that earlier revisions of this note reported on their own.
+
+Base and backoff-allowed alternate within every round in all three campaigns, so
+each row below is a genuine **matched pair** and its ratio is meaningful:
+
+| round | base CPU % | backoff CPU % | paired CPU ratio | base inv/s | backoff inv/s | paired inv ratio |
+|---|---:|---:|---:|---:|---:|---:|
+| c1 r1 | 14.6892 | 0.9690 | 15.1591x | 8.46 | 0.50 | 16.92x |
+| c1 r2 | 15.9013 | 0.9639 | 16.4968x | 8.35 | 0.50 | 16.70x |
+| c1 r3 | 15.3303 | 0.9912 | 15.4664x | 8.35 | 0.50 | 16.70x |
+| c2 r4 | 16.2989 | 0.8048 | 20.2521x | 8.28 | 0.50 | 16.56x |
+| c2 r5 | 15.2219 | 0.9294 | 16.3782x | 8.37 | 0.50 | 16.74x |
+| c2 r6 | 15.0571 | 0.9737 | 15.4638x | 8.41 | 0.50 | 16.82x |
+| c2 r7 | 14.7716 | 1.0413 | 14.1857x | 8.47 | 0.50 | 16.94x |
+| c2 r8 | 15.3576 | 0.8929 | 17.1997x | 8.40 | 0.50 | 16.80x |
+| rev r1 | 16.6338 | **1.5786** | **10.5371x** | 8.25 | 0.50 | 16.50x |
+| rev r2 | 14.7607 | 0.9427 | 15.6579x | 8.47 | 0.50 | 16.94x |
+| rev r3 | 16.2601 | 0.9266 | 17.5481x | 8.25 | 0.50 | 16.50x |
+
+The `--pin-base` runs are **not** all matched pairs and are kept separate for
+that reason. The author's three ran as their own block after the c1 base rows
+(see the scheduling note above); only the reviewer's three were interleaved with
+a base run in the same round:
+
+| run | pinned CPU % | pinned inv/s | schedule | round-mate base row | paired CPU ratio | paired inv ratio |
+|---|---:|---:|---|---|---:|---:|
+| c1 block 1 | 8.8927 | 4.53 | own block, after c1 base | none | — | — |
+| c1 block 2 | 7.5721 | 4.60 | own block, after c1 base | none | — | — |
+| c1 block 3 | 8.0698 | 4.58 | own block, after c1 base | none | — | — |
+| rev r1 | 8.1762 | 4.56 | interleaved | 16.6338 % / 8.25 | 2.0344x | 1.8092x |
+| rev r2 | 8.8012 | 4.50 | interleaved | 14.7607 % / 8.47 | 1.6771x | 1.8822x |
+| rev r3 | 8.9868 | 4.51 | interleaved | 16.2601 % / 8.25 | 1.8093x | 1.8293x |
+
+**Backoff-allowed — the paired result.** The 11 matched pairs are the statistic
+this sampling design actually supports:
+
+| paired statistic (n = 11) | min | median | max |
+|---|---:|---:|---:|
+| terminal CPU, base → backoff allowed | **10.54x** | **15.66x** | 20.25x |
+| terminal tmux invocations, base → backoff allowed | **16.50x** | **16.74x** | 16.94x |
+
+A deliberately conservative **unmatched-extrema** bound — the lowest base
+reading over the highest backoff reading, `14.6892 / 1.5786 = 9.31x` — is also
+quotable, but those two readings come from different campaigns and were never
+taken together. It is a floor construction, **not an observed pairing**. The
+observed paired minimum is 10.54x.
+
+Marginal (unpaired) distributions, for completeness:
+
+| pooled shape | n | min | median | max |
+|---|---:|---:|---:|---:|
+| base CPU | 11 | 14.6892 % | 15.3303 % | 16.6338 % |
+| backoff-allowed CPU | 11 | 0.8048 % | 0.9639 % | **1.5786 %** |
+| base tmux invocations | 11 | 8.25 /s | 8.37 /s | 8.47 /s |
+| backoff-allowed tmux invocations | 11 | 0.50 /s | 0.50 /s | 0.50 /s |
+
+**`--pin-base` — a marginal estimate, and labelled as one.** Only three of the
+six pinned runs are round-paired with a base run, so no 6-pair statistic exists.
+The first two figures below are **marginal**: they divide a base median by a
+pinned median drawn from a *different* and partly *differently scheduled* set of
+runs. **Three** variants, all shown because they differ; only the third is a
+matched-pair statistic:
+
+| pinned derivation | base rows used | n (base vs pinned) | CPU factor | invocation factor |
+|---|---|---|---:|---:|
+| **corresponding-campaign** (preferred) | c1 + rev only — the campaigns that actually contain the pinned runs | 6 vs 6 | 15.6158 / 8.4887 = **1.84x** | 8.35 / 4.545 = **1.84x** |
+| all-base marginal | all 11, incl. 5 c2 rows with no pinned counterpart | 11 vs 6 | 15.3303 / 8.4887 = 1.81x | 8.37 / 4.545 = 1.84x |
+| reviewer's 3 true pairs (the only matched pinned data) | rev only, matched | 3 pairs | median **1.81x** (1.68–2.03x) | median **1.83x** (1.81–1.88x) |
+
+Use **1.84x**. The all-base variant mixes an 11-row base median against a 6-row
+pinned median across two schedules and is shown only so the difference is
+visible rather than inferred. Cross-extrema bounds are identical under both base
+sets (CPU 1.63x–2.20x, invocations 1.79x–1.88x) because the 6-row subset
+contains both the overall base minimum and maximum; only the median moves.
+
+**Which figure is robust.** The **invocation rate is the robust one** and is the
+figure to quote: 0.50 /s/terminal in **all 11** backoff-allowed runs across three
+campaigns and two independent samplers, giving a paired range of 16.50–16.94x
+that holds on every reading taken. Pinned invocations are equally tight,
+4.50–4.60 /s, giving 1.79x–1.88x however the rows are grouped.
+
+The **CPU factor is not robust enough for a point headline**. One reviewer
+backoff-allowed sample landed at 1.5786 %, ~59 % above the highest of the
+author's eight and the only reading above 1.05 % in eleven; that round's own
+pair is 10.54x against a paired median of 15.66x. The direction is unaffected —
+every one of the 11 pairs is a large win — but the honest CPU statement is
+**"roughly 10–20x, observed paired minimum 10.5x"**, not a single multiplier.
+The pinned CPU claim is likewise carried by invocations, not CPU.
+
+No attempt was made to reconcile the 1.5786 % outlier away. This is a shared
+host with other live agent sessions; the tail is real and a maintainer
+re-running the block may land in it.
+
+Halving processes per tick does not give exactly 2x fewer invocations because
+the 0.2 s sleep is followed by blocking tmux work; removing one process shortens
+that work and lets the folded watcher tick more often.
+
+##### Forwarder
+
+Same campaign as terminal rounds c1, base and branch alternating inside each
+round:
+
+| shape | run | base `d720d2762` | this branch |
+|---|---:|---:|---:|
+| fan-out 0, 8 sessions | 1 | 4.3343 % | 0.3640 % |
+| fan-out 0, 8 sessions | 2 | 5.2218 % | 0.3829 % |
+| fan-out 0, 8 sessions | 3 | 4.2855 % | 0.3247 % |
+| fan-out 6, 8 sessions | 1 | 7.4383 % | 0.5780 % |
+| fan-out 6, 8 sessions | 2 | 7.8422 % | 0.5569 % |
+| fan-out 6, 8 sessions | 3 | 7.0324 % | 0.4652 % |
+| fan-out 100, 4 sessions | 1 | 24.9971 % | 2.4478 % |
+| fan-out 100, 4 sessions | 2 | 26.2428 % | 2.4293 % |
+| fan-out 100, 4 sessions | 3 | 27.2336 % | 2.3091 % |
+
+| comparison | before (median, range) | after (median, range) | median factor | worst-case bound |
+|---|---|---|---:|---:|
+| forwarder, fan-out 0 (8 sessions) | 4.3343 % (4.2855–5.2218) | 0.3640 % (0.3247–0.3829) | **11.9x** | **11.2x** |
+| forwarder, fan-out 6 (8 sessions) | 7.4383 % (7.0324–7.8422) | 0.5569 % (0.4652–0.5780) | **13.4x** | **12.2x** |
+| forwarder, fan-out 100 (4 sessions) | 26.2428 % (24.9971–27.2336) | 2.4293 % (2.3091–2.4478) | **≥10.8x** | **≥10.2x** |
+
+The fan-out-100 base rows are a **lower bound**, not a measurement of demand.
+All four forwarders share one event loop thread, and total process CPU
+(`RUSAGE_SELF`, which also covers the sink server's threads) was 99.99 / 104.97
+/ 108.93 % of a core across the three base runs. The loop was therefore at or
+near saturation, so base per-session cost is at least what is shown and the
+factor is at least what is shown. The branch rows are nowhere near that ceiling
+(9.24–9.79 % of a core total), so they are unclipped.
+
+These forwarder factors are much larger than the macOS set below because the
+macOS "before" column was measured on the sparse 4-file bridge fixture, which
+understates the per-file cost that dominates the base detector. Set 1 uses the
+current ~9-file fixture on both sides.
+
+#### Set 2 — earlier macOS run (historical; sparse fixture on the forwarder rows)
+
+Pre-change source vs an **earlier build of this branch**, macOS 27 / M-series,
+Python 3.12.13, 30 s window, everything idle. The branch-side vintage predates
+the §3.3.1 detector fix; the build's `_scan_into_fingerprint` and
+`_bridge_input_fingerprint` symbols are no longer present in the tree (§7.3.1).
+This set is retained for the `execve`-per-invocation accounting (4 → 1), which
+is a structural property of the change rather than a host measurement. It is
+**not** a current-tree-vs-base comparison.
+
+| scenario | before | after | factor |
+|---|---|---|---|
+| terminal, base tree (no predicate for any role) → backoff allowed (7 PTY-only native roles; **not** generic panes), 8 terminals | **6.17 %** of a core / terminal | **0.42 %** | **15x** |
+| terminal, same base → backoff-allowed predicate states, tmux invocations | 8.57 /s / terminal | 0.50 /s | **17x** |
+| terminal, same base → backoff-allowed predicate states, `execve` (4 per invocation → 1) | ~34 /s / terminal | 0.50 /s | **69x** |
+| forwarder, no fan-out (8 sessions), **sparse 4-file fixture, earlier branch build** | **0.71 %** of a core / session | **0.12 %** | 6.1x |
+| forwarder, fan-out 6 (8 sessions), **sparse 4-file fixture, earlier branch build** | **1.47 %** of a core / session | **0.15 %** | 9.9x |
+| forwarder, fan-out 100 (4 sessions), **sparse 4-file fixture, earlier branch build** | **7.05 %** of a core / session | **0.65 %** | 10.9x |
+
+**Precision caveat — these factors are not auditable from this table.** The
+raw per-run readings behind Set 2 were not retained; only the two-decimal
+aggregates above survive, and the factors were computed from the unrounded
+readings. Every factor in the table was re-checked against its own displayed
+operands. Three do not recompute from them:
+
+| row | displayed operands | quotient at displayed precision | printed factor |
+|---|---|---:|---:|
+| forwarder, no fan-out | 0.71 / 0.12 | 5.9x | 6.1x |
+| forwarder, fan-out 6 | 1.47 / 0.15 | 9.8x | 9.9x |
+| forwarder, fan-out 100 | 7.05 / 0.65 | 10.8x | 10.9x |
+
+All three are reachable from operands that round to the values shown (the
+displayed pairs admit up to 6.22x, 10.17x and 10.94x respectively), so this is
+missing precision rather than a demonstrated arithmetic error — but it cannot be
+confirmed from what is retained. **Treat all three as approximate.** The other
+three rows do recompute at their displayed precision: 6.17 / 0.42 = 14.7 → 15x,
+8.57 / 0.50 = 17.1 → 17x, and 4 × 8.57 / 0.50 = 68.6 → 69x (the `execve` before
+column is printed rounded as "~34").
+
+The three forwarder factors here are also optimistic on both columns and are
+superseded by Set 1, whose raw rows are all retained. The absolute CPU
+percentages must not be compared across the Linux and macOS tables in either
+direction: per-invocation tmux cost and per-`stat` cost differ materially
+between the hosts.
+
+An earlier Linux terminal measurement, taken on the same host under heavier
+load, recorded base `d720d2762` at 19.3378 / 18.7224 / 23.2788 % and 7.97 /
+8.00 / 7.44 invocations/s/terminal, against `--pin-base` at 14.8720 / 10.3462 /
+10.1234 % and 4.11 / 4.44 / 4.48 /s. Those rows were superseded by the Set 1
+re-run rather than averaged with it — the host was materially busier, which
+raised CPU and *lowered* tick rate on both sides. The invocation-count factor
+agreed: 7.97 / 4.44 = 1.8x then, 8.35 / 4.58 = 1.82x now.
+
+Thus claude-native, whose active status poller keeps the predicate false, gets
+the robust **~1.8x tmux-invocation** reduction from folding the probe and
+caching the tmux path, but no adaptive-backoff reduction.
+
+Extrapolating to the reported host (~20 sessions with fan-out), the forwarder
+alone goes from ~29 % of a core to ~3 % — that is 20 × the Set 2 fan-out-6 row
+(20 × 1.47 = 29.4, 20 × 0.15 = 3.0), so it inherits Set 2's sparse-fixture
+caveat and its macOS per-`stat` cost. Terminal savings depend on role: an
+active claude-native status poller keeps the 0.2 s cadence and receives only the
+one-process/one-`execve` reductions, while the seven other PTY-status-owning
+native roles also receive the measured interval reduction. Generic panes receive
+the same structural reductions from a 5x cheaper starting cadence, and are not
+measured here.
+
+#### Set 3 — detector fix (§3.3.1), branch-vs-branch on the realistic fixture
+
+**Deployed** code (an intermediate build of this branch, not base
+`d720d2762`) vs this branch, 60 s window, 8 sessions (4 at fan-out 100),
+everything idle. This set isolates the §3.3.1 detector change alone; for the
+current-tree-vs-base forwarder numbers see Set 1.
+
+| scenario | deployed | after | factor |
+|---|---|---|---|
+| forwarder, no fan-out | **0.47 %** of a core / session | **0.13 %** | 3.7x |
+| forwarder, fan-out 6 | **0.79 %** of a core / session | **0.17 %** | **4.6x** |
+| forwarder, fan-out 100 | **2.85 %** of a core / session | **0.65 %** | **4.4x** |
+| gate engagement, no fan-out | 54 % of ticks | **97.5 %** | — |
+
+**Precision caveat.** As with Set 2, the raw per-run readings were not retained
+and the factors were computed from unrounded values. Every factor in this set
+was re-checked against its displayed operands. One does not recompute:
+0.47 / 0.13 = **3.6x** at displayed precision against a printed **3.7x**. It is
+reachable from operands that round to those values (up to 3.80x), so treat it as
+approximate. The other two do recompute: 0.79 / 0.17 = 4.65 → 4.6x and
+2.85 / 0.65 = 4.38 → 4.4x. The gate-engagement row states no factor. For a
+current-tree-vs-base forwarder number with raw rows retained, use Set 1.
+
+Most of that is the gate finally settling rather than the detector being
+cheaper; the fingerprint itself is ~2x cheaper at fan-out 0 (28.7 → 14.1 µs,
+2.04x) and ~1.7x at fan-out 100 (252 → 149 µs, 1.69x — the "~2x" shorthand is
+loose at that end). The remaining 2.5 % of ungated ticks is the 10 s resync, as
+designed.
+
+### High-fan-out budget
+
+Forwarder CPU stays **proportional to accumulated fan-out**: every sub-agent
+transcript a session has ever produced stays on disk and is stat'ed on every
+tick. The sibling `agent-*.meta.json` files are exempt — read once at
+discovery, never re-read — and the directory is re-listed only when its own
+mtime moves, so the per-tick cost is one stat per transcript plus one for the
+directory. That directory stat is in the fingerprint, which is what keeps a
+new sub-agent's arrival visible even when its meta file lands first.
+
+The remaining proportionality is inherent to a change-detector that must
+notice growth in any of those files, and the shape is unchanged from before —
+the constant is ~11x smaller. Budget to plan against: **~0.65 % of a core per
+idle session at fan-out 100** on the macOS host of Set 2, and **~2.4 %** on the
+Linux host of Set 1 — the ratio to fan-out 6 holds on both, but the absolute
+figure is per-`stat` cost and does not port between hosts. Either way, a session
+with 100 accumulated sub-agents costs four to five fan-out-6 sessions on the
+same host (7.05 / 1.47 = 4.8 on macOS, 2.4293 / 0.5569 = 4.4 on Linux).
+Removing that would require
+knowing which sub-agents can no longer produce output, and the 5 s quiescence
+heuristic that marks them idle is not that — a sub-agent inside a long tool
+call reads idle and then resumes, so skipping it would strand its output.
+
+The forwarder's residual at low fan-out is dominated by the fingerprint itself
+(~59 µs/tick, ~66 % of what is left) plus the bare asyncio wake at 4 Hz. Both
+are the irreducible cost of *not* backing the interval off, which is what keeps
+streaming latency unchanged.
+
+## 5. Interaction with adjacent issues
+
+- **#2703** (YAML re-parse during fan-out) — disjoint code path
+  (agent-bundle loading, not the poll loops). No overlap.
+- **#1349** (idle native sessions never reaped) — **closed**. This change
+  deliberately does *not* reap anything. It makes an un-reaped idle session
+  cheap, which lowers the urgency of reaping but does not substitute for it: the
+  memory a reaper reclaims is untouched here.
+- **#2421** (ownerless tree leak) — no new processes or threads are created, so
+  nothing new can be orphaned. The one adjacency is teardown: a backed-off
+  watcher must not linger past `close()`, which is why teardown both sets the
+  stop event and raises `_WakeSignal` (§3.2). Reviewed explicitly in Phase 3.
+- **#2702's own "amplifier" note** — terminals kept alive via
+  `keep_alive_after_exit` inflate the watcher count. Unaddressed here (it is the
+  #2421/#1349 teardown gap), but each such watcher now costs ~1 % of what it did.
+
+## 6. Explicitly not covered
+
+- Reaping or capping live terminals / sessions (#1349, #2421).
+- The codex / cursor / other native forwarders. They have the same shape and
+  the same fix would apply, but each has its own state files and cursor
+  semantics; landing one at a time keeps the blast radius reviewable.
+- The permission-prompt spinner case (§3.2), which keeps a watcher at full rate.
+- `_idle_watch_loop` (asyncio) backoff — no production caller.
+- Replacing polling with true eventing. Every eventing option costs a process or
+  a thread per unit, which is the thing being removed.
+
+## 7. What the adversarial review caught
+
+Reviewed as a hostile reader after the code landed; four findings changed the
+implementation.
+
+1. **A failing endpoint would have disabled the gate entirely.** The first cut
+   held the gate open whenever any retry was *scheduled* (`has_pending()`) or
+   `cost_retry_not_before` was non-zero. Those are set on failure and cleared
+   only on success, so a permanently rejecting cost or events endpoint would
+   have pinned every session at full-rate polling — the exact regression the
+   change exists to prevent, triggered by an outage. Now the check is
+   *due*, not *scheduled*: `has_due_retry(now)` and
+   `0 < cost_retry_not_before <= now`.
+2. **A client-interaction wake would not have reset the backoff.** Pane changes
+   inside the client-interaction window are deliberately suppressed
+   (`suppress_activity`), so the change path could not reset the interval for
+   exactly the case the wake exists to serve. `_wait_next_idle_tick` now
+   reports whether it was woken and the loop resets the interval on that.
+3. **A wake storm could have become a fork storm.** `note_client_interaction`
+   fires on every keystroke and mouse event. A single interruptible sleep would
+   have let a user dragging the mouse drive tmux at input frequency. The sleep
+   is now split: an un-interruptible `base_interval` floor, then the
+   skippable backoff remainder. Poll rate is capped at the base rate by
+   construction.
+4. **A backed-off watcher could have lingered past teardown** — the
+   ownerless-thread shape #2421 describes. `_stop_idle_watcher_thread` now sets
+   the wake event alongside the stop event, and
+   `test_threaded_idle_watcher_backoff_stops_promptly` asserts the thread is
+   dead when the stop call returns.
+
+Also fixed in review: `_tmux_executable` was cached for the process lifetime,
+which would have returned a stale binary if `PATH` changed; it is now keyed on
+`PATH`. `_capture_pane_for_idle_or_none` was renamed to
+`_capture_pane_state_or_none` to match its new `(pane_dead, pane)` return, and a
+docstring reference to the deleted `_pane_is_dead` was repointed.
+
+Both test suites were mutation-checked: a fingerprint blinded to transcript
+growth fails the two gate tests, and a backoff that grows without waiting for
+post-idle quiescence fails
+`test_threaded_idle_watcher_slow_output_never_reads_idle`.
+
+### 7.1 Second round — cross-vendor review
+
+1. **The turn-start wake never fired for native turns (blocking).** It was hung
+   off `TerminalInstance.send`, but native harnesses inject through the bridge
+   from the *harness process* (`claude_native_executor` →
+   `inject_user_message`), which drives tmux over the socket and never touches
+   the runner's instance. For the eight harnesses whose status edge is
+   terminal-driven, an ordinary chat turn could start inside a backed-off
+   sleep and the session would keep reporting `idle`. Moved to
+   `_publish_turn_status(…, "running")`,
+   which every dispatch path passes through — including the streaming branch
+   that never reaches `_run_turn_bg`, an additional gap found while fixing
+   this. Covered by an integration test through the real
+   registry→watcher→publisher chain, plus an end-to-end test that POSTs a turn
+   at the runner and asserts the wake reached the terminal.
+2. **Backoff could delay the idle edge it was supposed to trail.** The loop
+   timed quiescence from watcher start while the detector timed it from its
+   first snapshot, so growth could fire one tick early. Growth now keys off
+   `_IdleDetector.idle_notified`. The mutation test reproduces the original
+   defect exactly: the edge lands at 1.05 s instead of 0.55 s.
+3. **Fingerprint cost proportional to accumulated fan-out.** Halved by not
+   stat'ing the write-once `agent-*.meta.json` files while still recording
+   their names, and the residual is now measured and published as a budget
+   (§4) rather than left implicit.
+4. **Design promised transition logging that did not exist.** Implemented in
+   both loops (§3.4).
+
+Also added in this round: a wake grace window, without which the wake fixed in
+(1) would have been undone by the watcher re-ramping during turn setup — the
+wake marks output as *expected*, and setup can outlast the idle threshold.
+
+### 7.2 Third round — cross-vendor review
+
+No blocking findings. Three scoping/correctness fixes:
+
+1. **The wake was too broad.** It woke *every* terminal of *every* harness, so
+   a generic or auxiliary pane went to high-rate polling for a turn that had
+   nothing to do with it. Now filtered to
+   `PTY_STATUS_OWNING_TERMINAL_ROLES`, hoisted out of the watcher's inline set
+   so the wake and the status gate read one definition. The route test had
+   reinforced the wrong scope by asserting on a role-less pane; it now
+   registers the claude-native role, and a negative test covers a generic pane
+   and a codex-native one (whose forwarder, not its watcher, owns status).
+2. **Every wake armed the full 15 s grace, and nothing released it.** Client
+   interactions arrive per keystroke, so at the 0.2 s native base that was
+   ~75 captures per interaction. The grace is now opt-in via
+   `expect_output=True` (turn start only) and is released as soon as the pane
+   changes — a normal turn pays a few captures, the full window only when the
+   expected output never arrives.
+3. **A wake landing between a timed-out `wait` and the `clear` was destroyed.**
+   The caller was told it was not woken *and* the signal was gone, losing both
+   the interval reset and the grace, which reopens the late-`running` race the
+   wake exists to close. Only an observed wake is cleared now; an unobserved
+   one stays set and costs at most one base interval. Covered by a boundary
+   test using an event that fires the instant its wait times out.
+
+While fixing (1) a block replacement over-captured and deleted three live
+lines from `_start_terminal_activity_watcher` (the early return, `resource_id`,
+and `loop`). Caught by the registry suite (`NameError: name 'loop' is not
+defined`) and restored; the diff was then audited line by line to confirm
+nothing else was lost.
+
+### 7.3 Fourth round — cross-vendor review
+
+No blocking findings. Two fixes:
+
+1. **The wake and its reason were separate cross-thread state.** A
+   `threading.Event` plus a `bool`, set and cleared independently: a turn wake
+   landing between another wake's `clear` and the reason read had its halves
+   consumed by different ticks. Walking the interleavings showed the grace
+   still got armed in each one — but needing that walk at all was the defect.
+   Both now live in `_WakeSignal` and are taken together by `consume()` under
+   one lock, which also subsumes the round-3 "don't clear an unobserved wake"
+   patch: there is no longer a window in which a wake can be reported absent
+   *and* discarded. `expect_output` latches while a wake is pending, so a
+   client interaction racing a turn cannot downgrade it. Covered by
+   deterministic interleaving tests in both orders, plus retention and blocking
+   cases; two mutations (unlatched reason, non-clearing consume) both fail
+   them.
+2. **The watcher docstring still described Claude/Pi only** while eight roles
+   were supported. It now points at `PTY_STATUS_OWNING_TERMINAL_ROLES`.
+
+### 7.3.1 Post-deploy: the detector became the cost
+
+Field profile of the then-deployed fix on an idle runner reported the change
+*detector* as the top leaf — the deployed build's
+`_scan_into_fingerprint` and `_bridge_input_fingerprint` together ~41 % of
+forwarder on-CPU time — with the caveat that the sample was small and the
+ratios directional only. Those historical names are not present in the
+current tree. Re-profiled
+here over a 60 s steady-state window: the fingerprint was **61 %** of forwarder
+CPU, so the report was right and if anything understated.
+
+Two things came out of measuring rather than assuming:
+
+- The suspicion that the failing `scandir` on a missing `subagents/` directory
+  was expensive was **wrong** — 1.17 µs, noise.
+- Making the benchmark's bridge directory realistic (it had 4 files where
+  production has ~9-13, and no `message_deltas.jsonl`) exposed the
+  self-triggering gate above. The forwarder rows in §4 Set 2 were measured
+  against that sparse fixture, on both columns, and so were optimistic; §4
+  Set 1 supersedes them on the realistic fixture.
+
+The suggested fix of backing the poll interval off while idle was **declined**.
+It trades streaming latency, and unlike the terminal watcher there is no wake
+to recover it: `claude_native.py` runs `supervise_forwarder` in the native CLI
+wrapper process, so the runner-side turn-start wake cannot reach it. Cheapening
+the detector gets a larger win at zero latency cost.
+
+### 7.3.2 Integration build: the mtime granularity assumption
+
+The sub-agent membership cache keyed re-listing on the directory mtime
+changing. That assumption held on the development box and failed on an
+integration build, where
+`test_bridge_input_fingerprint_picks_up_a_subagent_added_after_priming` failed
+~90 % of runs: `st_mtime_ns` carries nanoseconds but Linux stamps directory
+mtimes from the jiffy clock, so an entry created inside the recorded tick left
+the mtime unchanged 194/200 times — and nothing moved it afterwards, so the
+sub-agent stayed unwatched until the resync.
+
+This was dismissed during design as "extremely unlikely (ns resolution)". The
+error was reading `st_mtime_ns`'s *units* as its *resolution*. APFS misses
+0/200, which is why local runs and every review round passed.
+
+Fixed with a racy window (§3.3.1). The regression test pins the directory mtime
+back with `os.utime` rather than racing for the collision, so it reproduces on
+any filesystem instead of only on a coarse one — the property the original test
+lacked.
+
+The first attempt at that window was itself incomplete, in two ways review
+caught by reproducing rather than reasoning: it did not carry the uncertainty
+forward, so a change landing late in a coarse bucket could age out of the
+window before the next tick and never be re-listed; and it used `abs()`, which
+called a future-dated stamp "settled" once it was far enough ahead. Both now
+have tests that fail against the versions that shipped past two review rounds.
+
+Those tests drive `_fingerprint_now_ns` rather than sleeping past a real
+window. The sleep-based first version had a failure mode of its own: a
+scheduler pause during setup ages the fixture out of the window before the
+first sample, so the test fails having never exercised the latch — noise
+indistinguishable from the bug. The indirection follows the same reasoning as
+`_supervisor_monotonic`, which exists so tests need not monkeypatch a module
+singleton.
+
+### 7.4 Fifth round — cross-vendor review
+
+No blocking findings. Two fixes:
+
+1. **`Condition.wait` was not predicate-looped.** `consume`'s timeout *is* the
+   watcher's backed-off poll interval, so a `wait` returning before its
+   timeout with nothing pending reads as "the interval elapsed" and forks tmux
+   early — precisely the cost the backoff removes. Now
+   `wait_for(lambda: self._pending, timeout)`, which loops against a monotonic
+   deadline. Two tests drive a `Condition` subclass whose `wait` always
+   returns early: one asserts the sleep is still served in full and the loop
+   re-waited, the other that a real wake landing mid-loop is still taken
+   promptly. Reverting to the bare `wait` fails both.
+2. **`wake_idle_watcher`'s thread-safety note still described a
+   `threading.Event`.** Updated to `_WakeSignal`'s lock and its retention
+   guarantee.
+
+The first spurious-wake stub held the condition's lock across its early
+return, which deadlocked the thread posting the wake — the opposite of the
+situation under test. It now releases and re-acquires around the return, as
+the real `wait` does.
+
+### 7.5 Rebase review — status-file ownership
+
+Upstream added `SessionStatusPoller` after this design began. Once active for
+claude-native, it is the sole source of running/idle status and is driven by
+the watcher's `on_tick`. Applying the original backoff unchanged would have
+stretched that authoritative poll from 0.2 s to as much as 2 s, delaying both
+permission-dialog `waiting` changes and reconnect resync publication.
+
+The interval policy is therefore caller-controlled: resource-registry passes
+a predicate that forbids backoff while the file poller is active. The terminal
+module only knows a generic dynamic policy, not session-status concepts. Tests
+cover both sides: active file ownership stays at base cadence, while a watcher
+without that ownership still backs off. The turn-start wake and grace remain
+for PTY-only roles and for claude-native's fallback periods.
+
+## 8. Residual risks
+
+1. **Late `running` edge on autonomous pane output.** A backoff-eligible
+   terminal that starts producing output with no preceding `send()` or client
+   interaction is noticed up to `max_interval` late (up to 2 s at a 0.2 s
+   base, 5 s at a 1 s base). Active claude-native status-file polling is not
+   eligible. Turn start, typing, and attach are wake-triggered, so this only
+   affects output originating entirely inside the pane after an idle period.
+2. **A lagging filesystem clock defeats the racy window.** `_mtime_is_racy`
+    measures a timestamp's age against the local clock, so a networked
+    filesystem whose server clock *trails* ours by more than the window makes a
+    fresh change look already settled, and membership falls back to mtime
+    equality. Bounded by the resync. A *leading* clock is safe — the check is
+    one-sided, so any future-dated stamp reads as untrustworthy at any
+    distance.
+3. **Fingerprint blind spot.** A same-inode, same-size, same-`mtime_ns` rewrite
+   would be missed for up to `_IDLE_RESYNC_SECONDS`. No current writer can
+   produce one; the resync bounds it regardless.
+4. **Settle window is a constant, not a derivation.** If a future time-based
+   transition longer than 8 s is added to the forwarder body without a matching
+   deadline check, it would be delayed to the next resync. Mitigated by the
+   constant carrying a comment naming what it must cover.
+5. **Late `running` under slow sustained output.** A backoff-eligible pane that changes less
+   often than its idle threshold already reads idle between changes (existing
+   detector semantics, unchanged). Backoff additionally delays the following
+   `running` edge by up to the ceiling. An active claude-native status poller
+   remains at base cadence.
+6. **A backed-off watcher reports a pane exit up to one interval late.** Only
+   reachable for a pane that dies after ≥1 idle threshold of silence — i.e. a
+   kill or crash, not a clean end-of-turn exit, which repaints first and so is
+   seen at base rate.
+7. **Merged tmux probe changes one error path.** Previously a failing
+   `list-panes` was treated as "pane alive"; now a failing sequence is treated
+   as "server gone" and fires `on_exit`. Both commands target the same session,
+   so they succeed and fail together in practice, but a tmux that could fail
+   `list-panes` while serving `capture-pane` would report an exit one interval
+   early.
+8. **Idle CPU still scales with accumulated fan-out** — ~0.65 % of a core per
+   idle session at 100 sub-agents on the Set 2 macOS host, ~2.4 % on the Set 1
+   Linux host (§4). Down ~11x, but not flat.
+9. **The turn-start wake walks the session's terminal list on every turn.** It
+   wakes nothing outside `PTY_STATUS_OWNING_TERMINAL_ROLES`, but the walk plus
+   a role lookup per terminal happens for every session, native or not. At the
+   sizes involved (a handful of terminals per session) that is a dict lookup
+   and a short loop, once per turn.
+10. **An unobserved wake costs one base interval.** A wake raised while the
+   tick body is running stays pending rather than being destroyed, but it is
+   serviced on the next sleep rather than immediately — up to 0.2 s late for
+   the native watcher.
+11. **The bridge-file classification contract is not fail-closed.** The
+    by-name sweep misses a producer nobody listed; the live-session test
+    misses a producer or branch its scenario does not reach; the disposition
+    table is manually maintained; and the real-loop audit covers `Path.open`
+    reads only on the exercised path (§3.3.1). An
+    unwatched *input* would have its changes surface on the 10 s resync rather
+    than the next tick: bounded staleness, not permanent loss. Whether that
+    staleness is merely late or actually wrong depends on what the input means
+    — the resync guarantees eventual observation, not correctness during the
+    gap, so a future input carrying something time-critical would need
+    watching, not just resyncing. An unwatched *output* is harmless, which is
+    what every miss so far has been.
+12. **The grace is released by any agent-attributed pane change, not only the
+    awaited turn's output.** A status-bar repaint during turn setup ends the
+    grace early, after which the ordinary idle threshold and backoff ramp
+    apply — so detection falls back to the ceiling (≤2 s native) rather than
+    staying pinned at base. Deliberate: `changed_this_tick` is the same signal
+    that drives `on_activity`/`running`, and giving the grace a private,
+    stricter notion of "real output" would put two definitions of activity in
+    one loop. Client-driven repaints are already excluded by
+    `suppress_activity`.
+13. **Fingerprint I/O is outside the iteration stall deadline.** The gate must
+    run before `asyncio.timeout(_FORWARD_LOOP_STALL_DEADLINE_S)` so an unchanged
+    tick never enters that 300 s scope. Its synchronous `stat` calls and
+    sub-agent `scandir` therefore have no deadline armed. A bridge directory on
+    a hung filesystem can stall the forwarder silently and, because synchronous
+    filesystem syscalls do not yield, can stall the event-loop thread; merely
+    moving them inside `asyncio.timeout` would not preempt the syscall. Accepted
+    because bridge directories are runner-local. Supporting remote or unreliable
+    filesystems would require moving the fingerprint I/O to an interruptible
+    worker and belongs in a separate architectural change.

--- a/dev/benchmarks/native_poll_cpu.py
+++ b/dev/benchmarks/native_poll_cpu.py
@@ -1,0 +1,529 @@
+"""Idle-CPU benchmarks for the two native-harness poll loops.
+
+Measures the per-unit steady-state cost that shows up on a runner hosting
+many concurrent native sessions:
+
+``terminal``
+    ``TerminalInstance._idle_watch_loop_threaded`` — one daemon thread per
+    live terminal, each tick fork+exec'ing tmux. Reported as child CPU
+    (``RUSAGE_CHILDREN``, i.e. the tmux processes) plus tmux exec count.
+
+``forwarder``
+    ``forward_claude_transcript_to_session`` — one asyncio task per live
+    session, each tick re-reading the bridge state files and rescanning the
+    transcript. Reported as self CPU (``RUSAGE_SELF``), all in-process.
+
+Both scenarios hold everything *idle*: no turns, no pane output, no
+transcript growth. That is the state the runner spends most of its life in,
+and the state that should cost near zero.
+
+Run::
+
+    uv run python -m dev.benchmarks.native_poll_cpu terminal --terminals 8 --seconds 20
+    uv run python -m dev.benchmarks.native_poll_cpu forwarder --sessions 8 --seconds 20
+
+Add ``--fanout`` to the forwarder run to give each session sub-agent
+transcripts (the fan-out shape from the issue reports).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import os
+import resource
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+# Terminals and forwarders are exercised through their public entry points so
+# the benchmark measures the shipped loop, not a re-implementation.
+import omnigent.claude_native_bridge as bridge_mod
+from omnigent.claude_native_bridge import prepare_bridge_dir, record_hook_event
+from omnigent.claude_native_forwarder import forward_claude_transcript_to_session
+from omnigent.inner.terminal import TerminalInstance
+
+
+@dataclass
+class CpuSample:
+    """CPU accounting for one timed window.
+
+    :param wall_s: Elapsed wall-clock seconds.
+    :param self_s: User+system CPU seconds burned by this process.
+    :param child_s: User+system CPU seconds burned by reaped children.
+    """
+
+    wall_s: float
+    self_s: float
+    child_s: float
+
+    def report(self, *, units: int, label: str) -> str:
+        """Render a one-line summary normalised per unit.
+
+        :param units: Number of terminals / sessions under measurement.
+        :param label: Unit noun for the report, e.g. ``"terminal"``.
+        :returns: Formatted multi-line report.
+        """
+        total = self.self_s + self.child_s
+        core = self.wall_s
+        return "\n".join(
+            [
+                f"wall            {self.wall_s:8.2f}s",
+                f"cpu self        {self.self_s:8.3f}s  ({self.self_s / core:6.2%} of one core)",
+                f"cpu children    {self.child_s:8.3f}s  ({self.child_s / core:6.2%} of one core)",
+                f"cpu total       {total:8.3f}s  ({total / core:6.2%} of one core)",
+                f"per {label:<11} {total / max(units, 1) / core:8.4%} of one core",
+            ]
+        )
+
+
+def _cpu_now() -> tuple[float, float]:
+    """Return (self, children) CPU seconds consumed so far.
+
+    :returns: Tuple of user+system seconds for this process and for
+        reaped children.
+    """
+    me = resource.getrusage(resource.RUSAGE_SELF)
+    kids = resource.getrusage(resource.RUSAGE_CHILDREN)
+    return (me.ru_utime + me.ru_stime, kids.ru_utime + kids.ru_stime)
+
+
+@contextmanager
+def measure() -> Iterator[list[CpuSample]]:
+    """Measure CPU across the ``with`` body.
+
+    :yields: A single-element list that receives the :class:`CpuSample`
+        once the body completes.
+    """
+    out: list[CpuSample] = []
+    self_before, child_before = _cpu_now()
+    wall_before = time.monotonic()
+    yield out
+    wall = time.monotonic() - wall_before
+    self_after, child_after = _cpu_now()
+    out.append(
+        CpuSample(
+            wall_s=wall,
+            self_s=self_after - self_before,
+            child_s=child_after - child_before,
+        )
+    )
+
+
+# --------------------------------------------------------------------------
+# Terminal idle-watcher scenario (#2702)
+# --------------------------------------------------------------------------
+
+
+class _ExecCounter:
+    """Count tmux subprocess invocations made by the watcher threads."""
+
+    def __init__(self) -> None:
+        """Initialise the counter and install nothing yet."""
+        self.count = 0
+        self._lock = threading.Lock()
+        self._original = subprocess.run
+
+    def install(self) -> None:
+        """Wrap :func:`subprocess.run` so every call is tallied."""
+
+        def _counting_run(*args: object, **kwargs: object) -> object:
+            with self._lock:
+                self.count += 1
+            return self._original(*args, **kwargs)  # type: ignore[arg-type]
+
+        subprocess.run = _counting_run  # type: ignore[assignment]
+
+    def restore(self) -> None:
+        """Put the original :func:`subprocess.run` back."""
+        subprocess.run = self._original  # type: ignore[assignment]
+
+
+async def _bench_terminal(
+    *, terminals: int, seconds: float, poll_interval: float, warmup: float, pin_base: bool
+) -> None:
+    """Run N idle terminals with status watchers and report CPU.
+
+    :param terminals: How many tmux terminals to launch.
+    :param seconds: Measurement window in seconds.
+    :param poll_interval: Watcher poll interval; matches the claude-native
+        status watcher's 0.2s by default.
+    :param warmup: Seconds to run before measuring, so the window captures
+        steady state rather than the settle period.
+    :param pin_base: Keep the base cadence, matching an active claude-native
+        status-file poller.
+    :returns: None.
+    """
+    if shutil.which("tmux") is None:
+        sys.exit("tmux not found on PATH — the terminal scenario needs it")
+
+    # Keep the tmux socket below the platform's Unix-domain path limit even
+    # when TMPDIR is a long worktree-local path.
+    root = Path(tempfile.mkdtemp(prefix="ob-"))
+    instances: list[TerminalInstance] = []
+    try:
+        for index in range(terminals):
+            private = root / f"t{index}"
+            private.mkdir(parents=True, exist_ok=True)
+            instance = TerminalInstance(
+                name="bench",
+                session_key=f"t{index}",
+                socket_path=private / "tmux.sock",
+                private_dir=private,
+                command="sleep",
+                args=["3600"],
+            )
+            await instance.launch(cwd=private)
+            instances.append(instance)
+
+        # Let the panes settle so the measurement window is genuinely idle
+        # (the first frames after launch still repaint).
+        await asyncio.sleep(2.0)
+
+        for instance in instances:
+            # Keep this kwarg absent unless requested so the harness also runs
+            # against base trees whose watcher predates the backoff predicate.
+            watcher_options: dict[str, object] = {}
+            if pin_base:
+                watcher_options["idle_poll_backoff_allowed"] = lambda: False
+            instance.start_idle_watcher_thread(
+                on_activity=lambda: None,
+                on_idle=lambda: None,
+                on_exit=lambda: None,
+                idle_threshold_s=1.0,
+                poll_interval_s=poll_interval,
+                **watcher_options,
+            )
+        # Let the watchers reach steady state before the window opens.
+        await asyncio.sleep(warmup)
+
+        counter = _ExecCounter()
+        counter.install()
+        try:
+            with measure() as samples:
+                await asyncio.sleep(seconds)
+        finally:
+            counter.restore()
+            for instance in instances:
+                instance._stop_idle_watcher_thread()
+
+        sample = samples[0]
+        cadence = "base pinned" if pin_base else "backoff allowed"
+        print(f"scenario        terminal idle watcher (poll={poll_interval}s, {cadence})")
+        print(f"terminals       {terminals}")
+        print(sample.report(units=terminals, label="terminal"))
+        print(f"tmux invocations{counter.count:8d}  ({counter.count / sample.wall_s:.1f}/s)")
+        print(
+            "per terminal    "
+            f"{counter.count / max(terminals, 1) / sample.wall_s:.2f} tmux invocations/s"
+        )
+    finally:
+        for instance in instances:
+            await instance.close()
+        shutil.rmtree(root, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------
+# Transcript forwarder scenario (#3000)
+# --------------------------------------------------------------------------
+
+
+class _SinkHandler(BaseHTTPRequestHandler):
+    """Accept and discard every request the forwarder posts."""
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Silence the stdlib access log.
+
+        :param format: Unused format string.
+        :param args: Unused format arguments.
+        :returns: None.
+        """
+        del format, args
+
+    def _respond(self, status: int) -> None:
+        """Send an empty JSON response.
+
+        :param status: HTTP status code to return.
+        :returns: None.
+        """
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            self.rfile.read(length)
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", "2")
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    def do_POST(self) -> None:
+        """Accept a posted event.
+
+        :returns: None.
+        """
+        self._respond(202)
+
+    def do_PATCH(self) -> None:
+        """Accept a conversation patch.
+
+        :returns: None.
+        """
+        self._respond(200)
+
+    def do_GET(self) -> None:
+        """Accept a read.
+
+        :returns: None.
+        """
+        self._respond(200)
+
+
+def _transcript_lines(turns: int) -> list[str]:
+    """Build a plausible finished-session transcript.
+
+    :param turns: How many user/assistant exchanges to synthesise.
+    :returns: JSONL lines for the transcript file.
+    """
+    lines: list[str] = []
+    for turn in range(turns):
+        lines.append(
+            json.dumps(
+                {
+                    "type": "user",
+                    "uuid": f"user-{turn}",
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": f"question {turn}"}],
+                    },
+                }
+            )
+        )
+        lines.append(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "uuid": f"assistant-{turn}",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "answer " * 40}],
+                        "usage": {"input_tokens": 1200, "output_tokens": 300},
+                    },
+                }
+            )
+        )
+    return lines
+
+
+def _make_session(root: Path, index: int, *, fanout: int) -> tuple[Path, str]:
+    """Create one idle bridge dir + transcript (+ sub-agent transcripts).
+
+    :param root: Directory holding the synthetic Claude project tree.
+    :param index: Session ordinal, used to build unique ids.
+    :param fanout: Number of sub-agent transcripts to create.
+    :returns: Tuple of (bridge_dir, omnigent session id).
+    """
+    session_id = f"conv_bench_{index}"
+    workspace = root / f"ws{index}"
+    workspace.mkdir(parents=True, exist_ok=True)
+    bridge_dir = prepare_bridge_dir(
+        session_id,
+        bridge_id=f"bridge_bench_{index}",
+        workspace=workspace,
+    )
+
+    claude_session = str(uuid.uuid4())
+    project_dir = root / "projects" / f"proj{index}"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    transcript = project_dir / f"{claude_session}.jsonl"
+    transcript.write_text("\n".join(_transcript_lines(12)) + "\n", encoding="utf-8")
+
+    subagents = project_dir / claude_session / "subagents"
+    if fanout:
+        subagents.mkdir(parents=True, exist_ok=True)
+        for agent in range(fanout):
+            (subagents / f"agent-{agent}.jsonl").write_text(
+                "\n".join(_transcript_lines(6)) + "\n", encoding="utf-8"
+            )
+            (subagents / f"agent-{agent}.meta.json").write_text(
+                json.dumps({"agent_id": f"agent-{agent}", "description": "bench"}),
+                encoding="utf-8",
+            )
+
+    # The rest of the bridge dir a live session accumulates. Without these the
+    # directory is far smaller than in production, which understates every
+    # per-tick cost that scales with how many files sit beside the transcript.
+    for name, payload in (
+        ("server.json", {"base_url": "http://127.0.0.1:6767"}),
+        ("tool_relay.json", {"port": 8123}),
+        ("tmux.json", {"socket_path": str(workspace / "tmux.sock"), "target": "main"}),
+        ("permission_hook.json", {"enabled": True}),
+    ):
+        (bridge_dir / name).write_text(json.dumps(payload), encoding="utf-8")
+    (bridge_dir / "message_deltas.jsonl").write_text(
+        json.dumps({"message_id": "m1", "text": "hi", "final": True}) + "\n",
+        encoding="utf-8",
+    )
+
+    # A statusLine snapshot, so the model/cost scans have real input.
+    (bridge_dir / "context.json").write_text(
+        json.dumps(
+            {
+                "context_window_size": 200000,
+                "model": {"display_name": "benchmark-model"},
+                "current_usage": {"input_tokens": 14400, "output_tokens": 3600},
+                "cost": {"total_cost_usd": 0.42},
+            }
+        ),
+        encoding="utf-8",
+    )
+    # Two hook events: a turn that ran, then stopped. This is the exact
+    # steady state the issue reports — harness stopped, forwarder polling.
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": claude_session,
+            "transcript_path": str(transcript),
+        },
+    )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "Stop",
+            "session_id": claude_session,
+            "transcript_path": str(transcript),
+        },
+    )
+    return bridge_dir, session_id
+
+
+async def _bench_forwarder(
+    *, sessions: int, seconds: float, fanout: int, poll_interval: float, warmup: float
+) -> None:
+    """Run N idle transcript forwarders and report CPU.
+
+    :param sessions: How many forwarder tasks to run concurrently.
+    :param seconds: Measurement window in seconds.
+    :param fanout: Sub-agent transcripts per session.
+    :param poll_interval: Forwarder poll interval in seconds.
+    :param warmup: Seconds to run before measuring. Must exceed the gate's
+        settle window, or the measurement captures the tail of the last
+        activity burst instead of steady-state idle.
+    :returns: None.
+    """
+    root = Path(tempfile.mkdtemp(prefix="omnigent-bench-fwd-"))
+    # Point the bridge root at the scratch tree so nothing touches a real
+    # ~/.omnigent or a live session's bridge dir.
+    bridge_mod._TRUSTED_PARENT = root
+    bridge_mod._BRIDGE_ROOT = root / "claude-native"
+    bridge_mod._BRIDGE_ROOT_PARENT = root
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _SinkHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{server.server_address[1]}"
+
+    tasks: list[asyncio.Task[None]] = []
+    try:
+        for index in range(sessions):
+            bridge_dir, session_id = _make_session(root, index, fanout=fanout)
+            tasks.append(
+                asyncio.create_task(
+                    forward_claude_transcript_to_session(
+                        base_url=base_url,
+                        headers={},
+                        session_id=session_id,
+                        bridge_dir=bridge_dir,
+                        agent_name="claude-native-bench",
+                        start_at_end=False,
+                        poll_interval_s=poll_interval,
+                    )
+                )
+            )
+
+        # Warm-up: let the first polls drain the backlog so the measured
+        # window is steady-state idle rather than initial catch-up.
+        await asyncio.sleep(warmup)
+
+        with measure() as samples:
+            await asyncio.sleep(seconds)
+
+        sample = samples[0]
+        print(f"scenario        transcript forwarder (poll={poll_interval}s, fanout={fanout})")
+        print(f"sessions        {sessions}")
+        print(sample.report(units=sessions, label="session"))
+    finally:
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5.0)
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Parse args and run the requested scenario.
+
+    :param argv: Command-line arguments, defaulting to ``sys.argv[1:]``.
+    :returns: None.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="scenario", required=True)
+
+    term = sub.add_parser("terminal", help="idle tmux watcher CPU (#2702)")
+    term.add_argument("--terminals", type=int, default=8)
+    term.add_argument("--seconds", type=float, default=20.0)
+    term.add_argument("--poll-interval", type=float, default=0.2)
+    term.add_argument("--warmup", type=float, default=6.0)
+    term.add_argument(
+        "--pin-base",
+        action="store_true",
+        help="pin the base cadence like an active claude-native status poller",
+    )
+
+    fwd = sub.add_parser("forwarder", help="idle transcript forwarder CPU (#3000)")
+    fwd.add_argument("--sessions", type=int, default=8)
+    fwd.add_argument("--seconds", type=float, default=20.0)
+    fwd.add_argument("--fanout", type=int, default=0)
+    fwd.add_argument("--poll-interval", type=float, default=0.25)
+    fwd.add_argument("--warmup", type=float, default=15.0)
+
+    args = parser.parse_args(argv)
+    print(f"python          {sys.version.split()[0]}  pid={os.getpid()}")
+    if args.scenario == "terminal":
+        asyncio.run(
+            _bench_terminal(
+                terminals=args.terminals,
+                seconds=args.seconds,
+                poll_interval=args.poll_interval,
+                warmup=args.warmup,
+                pin_base=args.pin_base,
+            )
+        )
+    else:
+        asyncio.run(
+            _bench_forwarder(
+                sessions=args.sessions,
+                seconds=args.seconds,
+                fanout=args.fanout,
+                poll_interval=args.poll_interval,
+                warmup=args.warmup,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -17,6 +17,8 @@ from pathlib import Path
 import httpx
 
 from omnigent._native_post_delivery import (
+    _DEAD_LETTER_BACKUP_FILE,
+    _DEAD_LETTER_FILE,
     append_dead_letter,
     post_external_session_status,
     post_may_have_been_delivered,
@@ -87,6 +89,30 @@ _DEFAULT_POLL_INTERVAL_S = 0.25
 # the loop resumes. Generous vs the 0.25s poll so a legitimately slow batch
 # (large backlog, slow posts) never trips it.
 _FORWARD_LOOP_STALL_DEADLINE_S = 300.0
+
+# Idle gating for the poll loop. The interval above is deliberately NOT backed
+# off — it is what makes streamed assistant text feel live — so instead a tick
+# whose inputs are all byte-identical to the previous tick skips the scan work
+# and costs one directory scan plus a handful of stats.
+#
+# Seconds of unchanged inputs before gating kicks in. Must comfortably exceed
+# every transition inside the loop body that fires on a timer rather than on a
+# file change: sub-agent idle quiescence (:data:`_SUBAGENT_IDLE_QUIESCENCE_S`,
+# 5s) and the cost retry backoff. Retries are checked explicitly, so they do not
+# otherwise constrain this.
+_IDLE_SETTLE_SECONDS = 8.0
+
+# Longest a gated loop goes without running the full body regardless of the
+# fingerprint. Purely a safety net: it bounds the damage of any change the
+# fingerprint cannot see.
+_IDLE_RESYNC_SECONDS = 10.0
+
+# Set to a falsy value to run the full body on every tick, restoring the
+# pre-gating behaviour without a rollback.
+_IDLE_GATE_ENV_VAR = "OMNIGENT_CLAUDE_FORWARDER_IDLE_GATE"
+
+# One ``(st_mtime_ns, st_size, st_ino)`` triple per watched path.
+_BridgeFingerprint = dict[str, tuple[int, int, int]]
 _POST_TIMEOUT_S = 10.0
 _MAX_SEEN_SOURCE_IDS = 2000
 _CURSOR_FINGERPRINT_BYTES = 256
@@ -657,6 +683,21 @@ class _PostRetryTracker:
             return None
         return remaining
 
+    def has_due_retry(self, now: float) -> bool:
+        """
+        Report whether any key's retry is due to be attempted now.
+
+        The poll loop consults this before skipping an unchanged tick: a
+        scheduled retry fires on a timer, not on a file change, so a gate
+        that only watched the transcript would strand it. Keys whose backoff
+        has not elapsed deliberately do *not* count — during a sustained
+        outage those would otherwise pin the loop at full rate forever.
+
+        :param now: Current monotonic time, e.g. ``time.monotonic()``.
+        :returns: ``True`` when at least one key is ready for another attempt.
+        """
+        return any(entry.next_attempt_at <= now for entry in self._entries.values())
+
     def clear(self, key: str) -> None:
         """
         Remove retry state for a successfully handled event.
@@ -709,6 +750,310 @@ class _PostRetryTracker:
             exhausted=False,
             permanent=permanent,
         )
+
+
+def _idle_gate_enabled() -> bool:
+    """
+    Report whether the poll loop may skip ticks whose inputs are unchanged.
+
+    :returns: ``True`` unless :envvar:`OMNIGENT_CLAUDE_FORWARDER_IDLE_GATE` is
+        set to a falsy value (``"0"``, ``"false"``, ``"no"``, ``"off"``).
+    """
+    raw = os.environ.get(_IDLE_GATE_ENV_VAR)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+# Bridge-owned files the poll loop reads. Stat'ed by name rather than found
+# with a directory scan: ``os.scandir`` plus a ``DirEntry.stat`` per entry
+# measures ~4.3us an entry against ~1.3us for a plain ``os.stat``, and the scan
+# also picked up the forwarder's own cursor files below — so writing one
+# churned the fingerprint and bought an extra full tick for no new input.
+#
+# Conservative on purpose: a couple of these are launch-time files the loop
+# never re-reads. Watching them costs one stat and cannot cause a miss, whereas
+# pruning the list to "what the loop reads today" would.
+_WATCHED_BRIDGE_FILES = (
+    "bridge.json",
+    "server.json",
+    "state.json",
+    "hooks.jsonl",
+    "tool_relay.json",
+    "tmux.json",
+    "permission_hook.json",
+    "context.json",
+    "claude-settings.json",
+    MESSAGE_DELTAS_FILE,
+)
+
+# Bridge files this module writes and the steady-state poll loop never reads.
+# The cursors are read once at startup to resume, but nothing re-reads them
+# per tick — so within the loop they change only because it just did work, and
+# watching them would re-open the gate on the forwarder's own output.
+_FORWARDER_OWNED_BRIDGE_FILES = (
+    _FORWARDER_STATE_FILE,
+    _HOOK_STATE_FILE,
+    _SUBAGENT_STATE_FILE,
+    _DELTA_STATE_FILE,
+    # Compaction-boundary cursor. Only this module reads or writes it, and
+    # every access sits inside the poll-loop body, so its changes are always
+    # our own output. A pending boundary whose POST failed is retried off
+    # ``status_retries`` / ``item_retries``, which the gate already consults —
+    # so nothing here needs the fingerprint to notice the write.
+    _COMPACTION_STATE_FILE,
+    # Sink for permanently-undeliverable payloads, shared by every native
+    # forwarder. Written for operators to inspect, not consumed by the loop.
+    _DEAD_LETTER_FILE,
+    _DEAD_LETTER_BACKUP_FILE,
+)
+
+# Bridge files written by adjacent routing components and never consumed by
+# this poll loop. They are classified separately from our own outputs so a new
+# producer file still requires an explicit watched/unwatched decision.
+_OTHER_PRODUCER_BRIDGE_FILES = (
+    "turn_router.json",
+    "turn_routing_done",
+    "turn_replay_pending.json",
+    "turn_routing.log",
+    "subagent_router.json",
+)
+
+# Sub-agent transcripts grow; their sibling ``agent-*.meta.json`` is read once
+# at discovery and never again. Membership changes (either file appearing) move
+# the directory's own mtime, which is in the fingerprint, so only the
+# transcripts need stat'ing for content.
+_APPENDING_SUBAGENT_SUFFIX = ".jsonl"
+
+# How recent a directory mtime has to be before it stops being trustworthy as
+# a change signal.
+#
+# ``st_mtime_ns`` reports nanoseconds but filesystems do not store them: Linux
+# stamps directory mtimes from the jiffy clock (4ms at the common CONFIG_HZ=250),
+# and older filesystems round to 1-2s. An entry created within one tick of the
+# previous stat therefore leaves the recorded mtime *unchanged* — and because
+# nothing moves it afterwards either, comparing mtimes alone would leave that
+# sub-agent unwatched until the resync. Measured on a CONFIG_HZ=250 box: adding
+# an entry left the directory mtime unchanged 194 times out of 200.
+#
+# So a directory whose mtime sits inside this window of now is re-listed
+# regardless of whether the mtime moved. The window is wide enough for the 1-2s
+# filesystems; it costs extra listings only just after a change, and nothing at
+# all once the directory has been quiet — which is the steady state this whole
+# gate exists to make cheap.
+_DIR_MTIME_RACY_WINDOW_NS = 2_000_000_000
+
+
+def _fingerprint_now_ns() -> int:
+    """
+    Wall-clock reading used to age filesystem timestamps.
+
+    Exists as a private indirection so tests can drive the racy-window boundary
+    deterministically instead of sleeping past a real one — a sleep-based test
+    fails whenever the scheduler pauses it during setup, which looks like the
+    bug it is meant to catch. Kept out of :func:`time.time_ns` monkeypatching
+    for the same module-singleton reason as :func:`_supervisor_monotonic`.
+
+    :returns: Nanoseconds since the epoch.
+    """
+    return time.time_ns()
+
+
+def _mtime_is_racy(mtime_ns: int) -> bool:
+    """
+    Report whether a timestamp is too recent to trust as a change signal.
+
+    A change landing in the same filesystem timestamp tick as the previous
+    stat is invisible to a later mtime comparison, so anything stamped within
+    :data:`_DIR_MTIME_RACY_WINDOW_NS` of now has to be re-examined rather than
+    compared.
+
+    The check is one-sided — an *age*, not a distance. A timestamp from the
+    future is never trustworthy no matter how far ahead it is, and a
+    two-sided comparison would call a stamp 5 s ahead "settled" simply because
+    it is far from now, which is the opposite of the intent.
+
+    :param mtime_ns: A stat's ``st_mtime_ns``.
+    :returns: ``True`` when the caller must not rely on mtime equality.
+    """
+    return _fingerprint_now_ns() - mtime_ns < _DIR_MTIME_RACY_WINDOW_NS
+
+
+class _BridgeInputPaths:
+    """
+    Pre-resolved stat targets for one session's poll loop.
+
+    The fingerprint runs four times a second forever, so everything that does
+    not change between ticks is resolved once here: the bridge dir's watched
+    files, the transcript, and the sub-agent transcripts. Paths are kept as
+    plain strings — building ``bridge_dir / name`` per tick costs more than
+    the ``os.stat`` it feeds, which is what made an earlier by-name version
+    slower than the directory scan it replaced.
+
+    Sub-agent membership is refreshed when the directory's own mtime moves, or
+    while that mtime is too recent to trust. Every sub-agent a session ever
+    spawned stays on disk, so re-listing at 4 Hz is the dominant fingerprint
+    cost under fan-out — but mtime inequality alone is not a sound dirtiness
+    signal, see :data:`_DIR_MTIME_RACY_WINDOW_NS`.
+    """
+
+    def __init__(self, bridge_dir: Path) -> None:
+        """
+        Resolve the fixed stat targets for *bridge_dir*.
+
+        :param bridge_dir: Native Claude bridge directory.
+        """
+        root = str(bridge_dir)
+        self._bridge_targets: tuple[tuple[str, str], ...] = tuple(
+            ("bridge/" + name, os.path.join(root, name)) for name in _WATCHED_BRIDGE_FILES
+        )
+        self._transcript: str | None = None
+        self._subagents_dir: str | None = None
+        self._subagent_dir_key: tuple[int, int] | None = None
+        self._subagent_targets: tuple[tuple[str, str], ...] = ()
+        # Whether the cached listing was taken while the directory's mtime was
+        # still racy, and so may already be stale. Latched until a listing is
+        # taken with the mtime settled — see :meth:`fingerprint`.
+        self._subagent_listing_provisional = False
+
+    def set_transcript(self, transcript_path: Path | None) -> None:
+        """
+        Point the fingerprint at a new transcript, dropping stale sub-agents.
+
+        Called when hooks first report a transcript and again after a /clear
+        or /fork rotation, which resolves a different ``subagents/`` directory
+        — so the cached membership belongs to the previous session and must go.
+
+        :param transcript_path: Transcript JSONL, or ``None`` when hooks have
+            not reported one yet.
+        :returns: None.
+        """
+        if transcript_path is None:
+            self._transcript = None
+            self._subagents_dir = None
+        else:
+            self._transcript = str(transcript_path)
+            self._subagents_dir = str(_subagents_dir_for_transcript(transcript_path))
+        self._subagent_dir_key = None
+        self._subagent_targets = ()
+        self._subagent_listing_provisional = False
+
+    def _refresh_subagents(self, dir_key: tuple[int, int], *, provisional: bool) -> None:
+        """
+        Re-list the sub-agent transcripts.
+
+        :param dir_key: The directory stat identity this listing belongs to.
+        :param provisional: Whether the directory's mtime was still racy when
+            this listing was taken, meaning an entry could have landed after
+            the scan without moving the mtime. Latched so a later tick knows
+            to take one more listing once the mtime settles.
+        :returns: None.
+        """
+        assert self._subagents_dir is not None
+        targets: list[tuple[str, str]] = []
+        try:
+            with os.scandir(self._subagents_dir) as entries:
+                for entry in entries:
+                    name = entry.name
+                    if name.startswith(".") or not name.endswith(_APPENDING_SUBAGENT_SUFFIX):
+                        continue
+                    targets.append(("subagent/" + name, entry.path))
+        except OSError:
+            return
+        targets.sort()
+        self._subagent_dir_key = dir_key
+        self._subagent_targets = tuple(targets)
+        self._subagent_listing_provisional = provisional
+
+    def fingerprint(self) -> _BridgeFingerprint:
+        """
+        Snapshot the watched inputs: :data:`_WATCHED_BRIDGE_FILES`, the
+        transcript, and the sub-agent directory with its transcripts.
+
+        Inode is part of the triple because the bridge writes its JSON state
+        via a temp file plus ``os.replace``, so every write lands a new inode
+        even when the size and timestamp would look unchanged. Append-only
+        files (hook events, message deltas, transcripts) always grow their
+        size. Between them, no writer can mutate a *watched* input invisibly;
+        an input missing from the watch list is a different failure, guarded
+        against by the classification tests and bounded by the resync.
+
+        :returns: Fingerprint of the watched inputs.
+        """
+        fingerprint: _BridgeFingerprint = {}
+        stat = os.stat
+        for key, path in self._bridge_targets:
+            try:
+                info = stat(path)
+            except OSError:
+                continue
+            fingerprint[key] = (info.st_mtime_ns, info.st_size, info.st_ino)
+        if self._transcript is not None:
+            try:
+                info = stat(self._transcript)
+            except OSError:
+                pass
+            else:
+                fingerprint["transcript"] = (info.st_mtime_ns, info.st_size, info.st_ino)
+        if self._subagents_dir is not None:
+            try:
+                info = stat(self._subagents_dir)
+            except OSError:
+                # No sub-agent has been spawned yet; drop any stale listing.
+                self._subagent_dir_key = None
+                self._subagent_targets = ()
+                self._subagent_listing_provisional = False
+            else:
+                fingerprint["subagents/"] = (info.st_mtime_ns, info.st_size, info.st_ino)
+                dir_key = (info.st_mtime_ns, info.st_ino)
+                racy = _mtime_is_racy(info.st_mtime_ns)
+                # The provisional latch is what makes the window sound. A
+                # coarse mtime records the START of its bucket, so a change
+                # late in the bucket can already look older than the window by
+                # the time the next tick runs — and with the key unchanged,
+                # nothing would ever re-list. Carrying the uncertainty forward
+                # forces exactly one more listing once the mtime settles.
+                if dir_key != self._subagent_dir_key or racy or self._subagent_listing_provisional:
+                    self._refresh_subagents(dir_key, provisional=racy)
+                for key, path in self._subagent_targets:
+                    try:
+                        info = stat(path)
+                    except OSError:
+                        continue
+                    fingerprint[key] = (info.st_mtime_ns, info.st_size, info.st_ino)
+        return fingerprint
+
+
+def _forwarder_tick_is_needed(
+    *,
+    now: float,
+    last_change_at: float,
+    last_full_poll_at: float,
+    retry_trackers: tuple[_PostRetryTracker, ...],
+    dedupe: _ForwardDedupeState,
+) -> bool:
+    """
+    Decide whether this tick must run the full forwarding body.
+
+    Called only after the inputs were found byte-identical to the previous
+    tick, so the question is purely "is there time-based work outstanding?".
+
+    :param now: Current monotonic time.
+    :param last_change_at: Monotonic time an input last changed.
+    :param last_full_poll_at: Monotonic time the body last ran.
+    :param retry_trackers: Every retry tracker the loop owns.
+    :param dedupe: Dedupe state carrying the cost-post retry gate.
+    :returns: ``True`` when the body must run.
+    """
+    if now - last_change_at < _IDLE_SETTLE_SECONDS:
+        return True
+    if now - last_full_poll_at >= _IDLE_RESYNC_SECONDS:
+        return True
+    # Due, not merely scheduled: a cost endpoint that keeps rejecting would
+    # otherwise hold the gate open permanently.
+    if 0.0 < dedupe.cost_retry_not_before <= now:
+        return True
+    return any(tracker.has_due_retry(now) for tracker in retry_trackers)
 
 
 async def forward_claude_transcript_to_session(
@@ -793,12 +1138,64 @@ async def forward_claude_transcript_to_session(
     task_subjects: dict[str, str] = {}
     task_statuses: dict[str, str] = {}
     task_order: list[str] = []
+    # Idle gating: a tick whose watched inputs are byte-identical to the
+    # previous tick has nothing to forward, so it skips the ~20 file reads and
+    # ~10 scans the body would otherwise redo. The poll interval is untouched,
+    # so a change to a watched input is still picked up on the very next tick.
+    gate_enabled = _idle_gate_enabled()
+    fingerprint: _BridgeFingerprint | None = None
+    known_transcript_path: Path | None = None
+    bridge_inputs = _BridgeInputPaths(bridge_dir)
+    last_input_change_at = time.monotonic()
+    last_full_poll_at = 0.0
+    # Whether the last tick skipped its body. Tracked only so the two
+    # transitions are logged once each instead of on every tick — a field
+    # regression shows up as "gate never engages" (no CPU win) or "gate
+    # engaged while a turn was live" (a bug), both visible without a rebuild.
+    gate_engaged = False
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
         while True:
             try:
+                if gate_enabled:
+                    now = time.monotonic()
+                    current = bridge_inputs.fingerprint()
+                    if fingerprint is None or current != fingerprint:
+                        fingerprint = current
+                        last_input_change_at = now
+                    elif not _forwarder_tick_is_needed(
+                        now=now,
+                        last_change_at=last_input_change_at,
+                        last_full_poll_at=last_full_poll_at,
+                        retry_trackers=(
+                            item_retries,
+                            status_retries,
+                            subagent_start_retries,
+                            subagent_item_retries,
+                            subagent_status_retries,
+                        ),
+                        dedupe=dedupe,
+                    ):
+                        if not gate_engaged:
+                            gate_engaged = True
+                            _logger.debug(
+                                "Claude transcript forwarder idle; skipping unchanged "
+                                "polls; session=%s bridge_dir=%s",
+                                session_id,
+                                bridge_dir,
+                            )
+                        await asyncio.sleep(poll_interval_s)
+                        continue
+                    if gate_engaged:
+                        gate_engaged = False
+                        _logger.debug(
+                            "Claude transcript forwarder resumed; session=%s bridge_dir=%s",
+                            session_id,
+                            bridge_dir,
+                        )
+                    last_full_poll_at = now
                 async with asyncio.timeout(_FORWARD_LOOP_STALL_DEADLINE_S):
                     current_session_id = read_active_session_id(bridge_dir) or session_id
                     if hook_state is None:
@@ -902,6 +1299,11 @@ async def forward_claude_transcript_to_session(
                             bridge_dir=bridge_dir,
                         )
                     transcript_path = read_transcript_path(bridge_dir)
+                    # The next tick must stat the active transcript and its
+                    # sub-agent directory, including after /clear or /fork.
+                    if transcript_path != known_transcript_path:
+                        known_transcript_path = transcript_path
+                        bridge_inputs.set_transcript(transcript_path)
                     if transcript_path is not None:
                         state = await _ensure_state_for_transcript(
                             bridge_dir=bridge_dir,
@@ -1000,6 +1402,7 @@ async def forward_claude_transcript_to_session(
                 # The deadline cancelled a stalled await mid-iteration; the
                 # traceback names it. Cursor state advances only after
                 # successful posts, so resuming retries the interrupted step.
+                fingerprint = None
                 _logger.warning(
                     "Claude transcript forwarder iteration exceeded %.0fs; "
                     "cancelled the stalled await and resuming; session=%s "
@@ -1010,6 +1413,7 @@ async def forward_claude_transcript_to_session(
                     exc_info=True,
                 )
             except Exception:
+                fingerprint = None
                 _logger.exception(
                     "Claude transcript forwarder loop failed; session=%s bridge_dir=%s",
                     session_id,

--- a/omnigent/claude_native_status_file.py
+++ b/omnigent/claude_native_status_file.py
@@ -252,12 +252,11 @@ def read_session_status(path: Path) -> SessionStatus | None:
     )
 
 
-# Attempts to resolve the file before giving up and leaving the PTY
-# watcher authoritative for the session's lifetime. At the claude-native
-# poll cadence (~0.2s) this is a few seconds — long enough for a booting
-# Claude to write its file and for the first hook to report the session
-# id, short enough that an old Claude (pre-v2.1.139, no file) or a broken
-# config dir falls back promptly without scanning forever.
+# Ticks spent resolving the file before leaving the PTY watcher authoritative
+# for the session's lifetime. Forty ticks are ~8s at the 0.2s base cadence and
+# up to ~66s once a quiet pre-resolution pane backs off. That gives booting
+# Claude time to publish its session id while still bounding scans for old
+# Claude versions (pre-v2.1.139) or a broken config directory.
 _MAX_RESOLVE_ATTEMPTS = 40
 
 

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -384,6 +384,32 @@ def _tmux_status_option_commands() -> list[list[str]]:
 _IDLE_THRESHOLD_SECONDS = 10.0
 _IDLE_POLL_INTERVAL_SECONDS = 1.0
 
+# Idle backoff for the threaded watcher. Once a pane has been unchanged for at
+# least its idle threshold — i.e. the idle edge has already fired — each
+# further quiet tick doubles the interval up to a ceiling, so a terminal that
+# nobody is using stops forking tmux several times a second. Growth is gated on
+# post-idle quiescence precisely so backoff can never bring an idle edge
+# forward: the detector measures wall-clock, not ticks, and a pane that is
+# still working changes every tick and holds the interval at its base.
+#
+# The ceiling is the lesser of ten base intervals and
+# :data:`_IDLE_POLL_MAX_INTERVAL_SECONDS`, so the fast claude-native watcher
+# (0.2s) settles at 2s and generic terminals (1s) settle at 5s.
+_IDLE_POLL_BACKOFF_FACTOR = 2.0
+_IDLE_POLL_BACKOFF_MAX_MULTIPLE = 10.0
+_IDLE_POLL_MAX_INTERVAL_SECONDS = 5.0
+
+# How long after a wake the watcher stays pinned at its base interval. A wake
+# says output is coming, not that it has arrived: the runner wakes the pane's
+# watcher when it starts dispatching a turn, and spec resolution, harness
+# dispatch and injection can outlast the idle threshold. Without the grace the
+# watcher would ramp back up during setup and miss the output it was woken for.
+_IDLE_POLL_WAKE_GRACE_SECONDS = 15.0
+
+# Set to a falsy value to pin the watcher at its base interval, restoring the
+# pre-backoff polling rate without a rollback.
+_IDLE_POLL_BACKOFF_ENV_VAR = "OMNIGENT_TERMINAL_IDLE_POLL_BACKOFF"
+
 # When a web client interacts with the terminal (attach/detach, focus
 # in/out, mouse, keystroke, resize — all stamped via
 # ``TerminalInstance.note_client_interaction``), the TUI repaints in
@@ -427,6 +453,34 @@ _IDLE_MARKER_THRESHOLD_SECONDS: float = _IDLE_THRESHOLD_SECONDS
 # that can outlast a single Python frame; it normally returns in <50ms.
 _IDLE_WATCHER_JOIN_TIMEOUT_S = 1.0
 
+
+def _idle_poll_backoff_enabled() -> bool:
+    """
+    Report whether the threaded watcher may back off when a pane goes quiet.
+
+    :returns: ``True`` unless :envvar:`OMNIGENT_TERMINAL_IDLE_POLL_BACKOFF` is
+        set to a falsy value (``"0"``, ``"false"``, ``"no"``, ``"off"``).
+    """
+    raw = os.environ.get(_IDLE_POLL_BACKOFF_ENV_VAR)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _next_idle_poll_interval(current: float, base: float) -> float:
+    """
+    Grow a quiet watcher's poll interval one step toward its ceiling.
+
+    :param current: The interval used for the tick that just ran, e.g. ``0.4``.
+    :param base: The watcher's configured base interval, e.g. ``0.2``.
+    :returns: The interval to use for the next tick, capped at the lesser of
+        :data:`_IDLE_POLL_BACKOFF_MAX_MULTIPLE` base intervals and
+        :data:`_IDLE_POLL_MAX_INTERVAL_SECONDS`.
+    """
+    ceiling = min(base * _IDLE_POLL_BACKOFF_MAX_MULTIPLE, _IDLE_POLL_MAX_INTERVAL_SECONDS)
+    return min(current * _IDLE_POLL_BACKOFF_FACTOR, max(ceiling, base))
+
+
 # tmux's client→server protocol rejects any single command larger than
 # its 16KB imsg cap — the client exits non-zero with "command too long".
 # Literal text typed via ``send-keys -l`` is therefore chunked so each
@@ -434,6 +488,78 @@ _IDLE_WATCHER_JOIN_TIMEOUT_S = 1.0
 # (1024 chars ≤ 4KB packed). tmux writes each invocation's bytes to the
 # pane in submission order, so the program sees one contiguous stream.
 _SEND_KEYS_LITERAL_CHARS_PER_CALL = 1024
+
+
+class _WakeSignal:
+    """
+    Cross-thread wake for the threaded idle watcher.
+
+    Couples the wake and its *reason* under one lock. They started out as a
+    :class:`threading.Event` plus a separate ``bool``, which meant a wake's
+    reason and its event could be observed and cleared independently: a turn
+    wake landing between another wake's ``clear`` and the reason read had its
+    two halves consumed by different ticks. Reasoning about that required
+    enumerating interleavings, which is the tell that the state wanted to be
+    one object.
+
+    Two properties the watcher depends on, both structural here rather than
+    argued:
+
+    1. :meth:`consume` returns the pending flag and its reason atomically, so
+       a wake can never be split.
+    2. A wake raised after :meth:`consume` returns stays pending for the next
+       call. Nothing is dropped — a wake the watcher has not observed is never
+       cleared, so at worst it is serviced one base interval late.
+    """
+
+    def __init__(self) -> None:
+        """Start with no wake pending."""
+        self._condition = threading.Condition()
+        self._pending = False
+        self._expects_output = False
+
+    def wake(self, *, expect_output: bool) -> None:
+        """
+        Raise a wake, optionally marking that output is expected to follow.
+
+        ``expect_output`` latches: if any wake still pending when the watcher
+        consumes expected output, the consumed wake does too. A turn-start
+        wake therefore cannot be downgraded by a client interaction racing it.
+
+        :param expect_output: Whether agent output is expected but has not
+            arrived yet, which earns the consumer a grace window.
+        :returns: None.
+        """
+        with self._condition:
+            self._pending = True
+            self._expects_output = self._expects_output or expect_output
+            self._condition.notify_all()
+
+    def consume(self, timeout: float) -> tuple[bool, bool]:
+        """
+        Wait for a wake and take it, clearing both halves together.
+
+        The wait is predicate-looped via :meth:`threading.Condition.wait_for`
+        against a monotonic deadline, not a bare ``wait``. A bare one may
+        return before its timeout without a wake pending, and the caller reads
+        that as "the poll interval elapsed" — so a spurious return would cut a
+        backed-off sleep short and fork tmux early, which is the cost the
+        backoff exists to avoid.
+
+        :param timeout: Longest time to wait in seconds. Values at or below
+            zero poll without blocking, which is how the watcher checks for a
+            wake while already at its base interval.
+        :returns: ``(was_woken, expects_output)``. ``expects_output`` is only
+            ever ``True`` alongside ``was_woken``.
+        """
+        with self._condition:
+            if timeout > 0:
+                self._condition.wait_for(lambda: self._pending, timeout)
+            woken = self._pending
+            expects_output = self._expects_output
+            self._pending = False
+            self._expects_output = False
+            return woken, expects_output
 
 
 class _IdleDetector:
@@ -494,6 +620,24 @@ class _IdleDetector:
         # PTY produced output" signal that powers the web activity badge,
         # without any client PTY attach.
         self.changed_this_tick: bool = False
+
+    @property
+    def idle_notified(self) -> bool:
+        """
+        Report whether this idle episode has already delivered its edge.
+
+        The threaded watcher reads this to decide when it may lengthen its
+        poll interval. Deriving the answer from the detector rather than
+        re-timing quiescence in the loop keeps the two from drifting: the
+        loop's clock starts when the watcher starts, the detector's when it
+        takes its first snapshot, and a loop-side timer would therefore
+        allow a backoff step one tick before the edge it is supposed to
+        follow.
+
+        :returns: ``True`` once either track has fired for the current
+            episode; ``False`` again after new output mutates the pane.
+        """
+        return self._idle_notified
 
     def tick(self, snapshot: str, suppress_activity: bool = False) -> bool:
         """
@@ -1024,6 +1168,12 @@ class TerminalInstance:
     # under ``_idle_stop_event``.
     _idle_thread: threading.Thread | None = field(default=None, repr=False)
     _idle_stop_event: threading.Event | None = field(default=None, repr=False)
+    # Cuts short a backed-off poll sleep. Set whenever something that is about
+    # to change the pane happens on another thread — the runner typing a turn
+    # into it, a web client interacting with it, or the close path — so a quiet
+    # watcher returns to its base interval immediately instead of discovering
+    # the change up to a full backed-off interval later.
+    _idle_wake_signal: _WakeSignal | None = field(default=None, repr=False)
     # Monotonic timestamp of the last client interaction observed on this
     # terminal's web attach (keystroke / focus / mouse / resize / connect /
     # disconnect — see :meth:`note_client_interaction`). The idle watcher
@@ -1063,6 +1213,39 @@ class TerminalInstance:
         :returns: None.
         """
         self._last_client_interaction_at = time.monotonic()
+        # No grace: a client interaction is a one-off repaint, not the start of
+        # agent work, so it only needs the watcher to look once at base rate.
+        self.wake_idle_watcher()
+
+    def wake_idle_watcher(self, *, expect_output: bool = False) -> None:
+        """Pull a backed-off idle watcher back to its base poll interval.
+
+        Called from whichever thread is about to make the pane change — the
+        runner dispatching a turn into it, the attach bridge forwarding a
+        keystroke, or the close path. A watcher polling at its base interval
+        is unaffected; only the extra backoff sleep is cut short, so a burst
+        of wakes can never poll tmux faster than the base rate.
+
+        Thread-safety is :class:`_WakeSignal`'s: the wake and its reason are
+        raised together under its lock, so a wake can be posted from any
+        thread without racing the watcher's read. A wake that arrives while
+        the watcher is mid-tick stays pending and shortens the following
+        sleep — it is never dropped, only serviced up to one base interval
+        later.
+
+        :param expect_output: ``True`` when agent output is expected to follow
+            but has not arrived yet (a turn being dispatched), which also pins
+            the base interval for :data:`_IDLE_POLL_WAKE_GRACE_SECONDS` so the
+            watcher cannot ramp back up while the turn is still starting. The
+            grace is released as soon as the pane actually changes, so it costs
+            a full window only when the expected output never comes. ``False``
+            (the default) requests a single prompt look and no grace — right
+            for client interactions, which repaint once and then stop.
+        :returns: None.
+        """
+        wake_signal = self._idle_wake_signal
+        if wake_signal is not None:
+            wake_signal.wake(expect_output=expect_output)
 
     def last_pane_text(self) -> str | None:
         """Return the last visible pane text captured for diagnostics.
@@ -1310,6 +1493,9 @@ class TerminalInstance:
         if not self.running:
             return {"error": "Terminal is not running"}
 
+        # The pane is about to repaint, so pull a quiesced watcher back to its
+        # base interval before the output arrives rather than after.
+        self.wake_idle_watcher()
         try:
             if text:
                 for start in range(0, len(text), _SEND_KEYS_LITERAL_CHARS_PER_CALL):
@@ -1571,6 +1757,7 @@ class TerminalInstance:
         on_activity: Callable[[], None] | None = None,
         on_exit: Callable[[], None] | None = None,
         on_tick: Callable[[], None] | None = None,
+        idle_poll_backoff_allowed: Callable[[], bool] | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
@@ -1615,6 +1802,10 @@ class TerminalInstance:
             status source — e.g. the claude-native watcher reading Claude's
             ``sessions/<pid>.json`` — on the same cadence without a second
             thread. Same non-blocking contract as *on_idle*.
+        :param idle_poll_backoff_allowed: Optional predicate evaluated after
+            *on_tick* on each live-pane poll. Returning ``False`` pins the
+            watcher to its base interval. ``None`` always permits backoff.
+            Must not block the polling daemon thread for long.
         :param idle_threshold_s: Per-watcher diff-track idle threshold in
             seconds passed to :class:`_IdleDetector`, e.g. ``1.0`` for the
             claude-native status watcher. ``None`` uses the module
@@ -1641,15 +1832,20 @@ class TerminalInstance:
                 return
             self._stop_idle_watcher_thread()
         stop_event = threading.Event()
+        # A fresh signal per watcher, so a wake raised while none was running
+        # cannot hand this one a grace window it never asked for.
+        wake_signal = _WakeSignal()
         self._idle_stop_event = stop_event
+        self._idle_wake_signal = wake_signal
         self._idle_thread = threading.Thread(
             target=self._idle_watch_loop_threaded,
-            args=(stop_event,),
+            args=(stop_event, wake_signal),
             kwargs={
                 "on_idle": on_idle,
                 "on_activity": on_activity,
                 "on_exit": on_exit,
                 "on_tick": on_tick,
+                "idle_poll_backoff_allowed": idle_poll_backoff_allowed,
                 "idle_threshold_s": idle_threshold_s,
                 "poll_interval_s": poll_interval_s,
             },
@@ -1661,11 +1857,13 @@ class TerminalInstance:
     def _idle_watch_loop_threaded(
         self,
         stop_event: threading.Event,
+        wake_signal: _WakeSignal | None = None,
         *,
         on_idle: Callable[[], None] | None = None,
         on_activity: Callable[[], None] | None = None,
         on_exit: Callable[[], None] | None = None,
         on_tick: Callable[[], None] | None = None,
+        idle_poll_backoff_allowed: Callable[[], bool] | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
     ) -> None:
@@ -1678,10 +1876,22 @@ class TerminalInstance:
         ``False`` (close path), and exits silently if ``tmux
         capture-pane`` fails (server likely gone).
 
+        A pane that has been unchanged for at least its idle threshold —
+        so the idle edge has already fired — doubles its poll interval on
+        each further quiet tick up to a ceiling, and drops straight back to
+        the base interval on any pane change or explicit wake. Backoff can
+        therefore only ever make the idle→running edge late; it can never
+        bring an idle edge forward, because a working pane changes every
+        tick and never reaches the growth branch.
+
         :param stop_event: Event the close path sets to signal
             shutdown. Doubles as the poll-interval sleep via
             :meth:`Event.wait` so the join window is bounded by
             one poll interval, not the full sleep.
+        :param wake_signal: Signal raised by :meth:`wake_idle_watcher` to
+            cut short the extra backoff sleep, carrying whether output is
+            expected. ``None`` disables early wake-up (the watcher still backs
+            off and still stops promptly).
         :param on_idle: Optional idle-edge callback (see
             :meth:`start_idle_watcher_thread`); skipped when ``None``.
         :param on_activity: Optional pane-changed callback; fired each
@@ -1691,6 +1901,10 @@ class TerminalInstance:
         :param on_tick: Optional per-tick callback fired every poll after
             the exit check (see :meth:`start_idle_watcher_thread`); skipped
             when ``None``.
+        :param idle_poll_backoff_allowed: Optional predicate controlling
+            whether a quiet watcher may grow its interval. Evaluated after
+            *on_tick*, so a state source driven there can pin this poll and
+            later polls to the base cadence.
         :param idle_threshold_s: Per-watcher diff-track idle threshold in
             seconds forwarded to :class:`_IdleDetector`, e.g. ``1.0``.
             ``None`` uses the module default.
@@ -1699,13 +1913,40 @@ class TerminalInstance:
             :data:`_IDLE_POLL_INTERVAL_SECONDS`.
         """
         detector = _IdleDetector(idle_threshold_s=idle_threshold_s)
-        interval = poll_interval_s if poll_interval_s is not None else _IDLE_POLL_INTERVAL_SECONDS
+        base_interval = (
+            poll_interval_s if poll_interval_s is not None else _IDLE_POLL_INTERVAL_SECONDS
+        )
+        backoff_enabled = _idle_poll_backoff_enabled()
+        interval = base_interval
+        # Monotonic time before which backoff may not resume. Only a wake that
+        # expects output arms it: the work producing that output (turn setup,
+        # harness dispatch, injection) can outlast the idle threshold, and
+        # without the grace the watcher would ramp back up and miss the very
+        # output it was woken for. Released the moment the pane changes, so a
+        # normal turn pays a few extra captures rather than the whole window.
+        hold_base_until = 0.0
         while self.running:
-            # ``Event.wait`` doubles as the poll-interval sleep, so
-            # ``stop_event.set()`` from :meth:`close` returns within
-            # one tick instead of waiting out the full interval.
-            if stop_event.wait(interval):
+            should_stop, woken, expects_output = self._wait_next_idle_tick(
+                stop_event, wake_signal, interval, base_interval
+            )
+            if should_stop:
                 return
+            if woken:
+                # Something that changes the pane just happened elsewhere (a
+                # turn being dispatched, a client interacting). Client-driven
+                # repaints are deliberately not counted as activity, so the
+                # change path below would not reset the interval on its own.
+                if interval != base_interval:
+                    logger.debug(
+                        "terminal %s:%s idle watcher woken; poll %.2fs -> %.2fs",
+                        self.name,
+                        self.session_key,
+                        interval,
+                        base_interval,
+                    )
+                interval = base_interval
+                if expects_output:
+                    hold_base_until = time.monotonic() + _IDLE_POLL_WAKE_GRACE_SECONDS
             if not self.running:
                 return
             capture = self._capture_pane_state_or_none()
@@ -1741,10 +1982,53 @@ class TerminalInstance:
             # is a client-driven repaint (attach/detach reflow, focus,
             # mouse, keystroke — stamped via note_client_interaction), not
             # agent output, so the detector discounts it.
+            now = time.monotonic()
             suppress = (
-                time.monotonic() - self._last_client_interaction_at
+                now - self._last_client_interaction_at
             ) < _CLIENT_INTERACTION_WINDOW_SECONDS
             idle_fired = detector.tick(snapshot, suppress_activity=suppress)
+            # Backoff follows the detector's own idle state rather than a
+            # second quiescence timer in this loop: the two baselines start
+            # one tick apart (the loop's at watcher start, the detector's at
+            # its first snapshot), and a loop-side timer would let the
+            # interval grow one tick before the idle edge it must follow.
+            if detector.changed_this_tick:
+                if interval != base_interval:
+                    logger.debug(
+                        "terminal %s:%s pane changed; poll %.2fs -> %.2fs",
+                        self.name,
+                        self.session_key,
+                        interval,
+                        base_interval,
+                    )
+                interval = base_interval
+                # The output the grace was holding out for arrived, so the
+                # grace has served its purpose. The idle threshold governs from
+                # here — backoff still cannot resume until the edge fires.
+                hold_base_until = 0.0
+            elif not backoff_enabled or (
+                idle_poll_backoff_allowed is not None and not idle_poll_backoff_allowed()
+            ):
+                if interval != base_interval:
+                    logger.debug(
+                        "terminal %s:%s idle backoff suppressed; poll %.2fs -> %.2fs",
+                        self.name,
+                        self.session_key,
+                        interval,
+                        base_interval,
+                    )
+                interval = base_interval
+            elif detector.idle_notified and now >= hold_base_until:
+                grown = _next_idle_poll_interval(interval, base_interval)
+                if grown != interval:
+                    logger.debug(
+                        "terminal %s:%s pane quiescent; poll %.2fs -> %.2fs",
+                        self.name,
+                        self.session_key,
+                        interval,
+                        grown,
+                    )
+                interval = grown
             # Activity edge first: a tick can both change the pane and
             # (much later) cross the idle threshold, but never both in
             # the same tick — a change resets the idle timer.
@@ -1760,6 +2044,45 @@ class TerminalInstance:
                 and not self._fire_watch_callback(on_idle, "idle")
             ):
                 return
+
+    def _wait_next_idle_tick(
+        self,
+        stop_event: threading.Event,
+        wake_signal: _WakeSignal | None,
+        interval: float,
+        base_interval: float,
+    ) -> tuple[bool, bool, bool]:
+        """
+        Sleep until the next watcher tick, honouring stop and wake signals.
+
+        Split in two so a burst of wakes cannot become a burst of tmux
+        subprocesses: the first *base_interval* is a floor that only
+        ``stop_event`` interrupts, and only the extra backoff beyond it is
+        cut short by ``wake_signal``. Polling therefore never exceeds the
+        watcher's configured base rate, however often a client interacts with
+        the pane. The close path sets ``stop_event`` and raises a wake, so
+        teardown never waits out a backed-off sleep.
+
+        The wake and its reason are taken together by
+        :meth:`_WakeSignal.consume`, so they cannot be split across ticks, and
+        a wake raised while the tick body runs stays pending for the next
+        sleep rather than being dropped.
+
+        :param stop_event: Set by the close path to end the watcher.
+        :param wake_signal: Signal cutting the backoff short, or ``None``.
+        :param interval: Total seconds to wait, e.g. ``1.6``.
+        :param base_interval: Un-interruptible floor, e.g. ``0.2``.
+        :returns: ``(should_stop, was_woken, expects_output)``.
+        """
+        if stop_event.wait(min(interval, base_interval)):
+            return True, False, False
+        remaining = interval - base_interval
+        if wake_signal is None:
+            if remaining > 0 and stop_event.wait(remaining):
+                return True, False, False
+            return stop_event.is_set(), False, False
+        woken, expects_output = wake_signal.consume(remaining)
+        return stop_event.is_set(), woken, expects_output
 
     def _capture_pane_state_or_none(self) -> tuple[bool, str] | None:
         """
@@ -1863,15 +2186,23 @@ class TerminalInstance:
         timeout the thread keeps running, but it's a daemon — it
         will exit when the process does, and the next iteration's
         ``self.running`` check will short-circuit it anyway.
+
+        Both signals fire: the stop event ends the loop, and a wake cuts short
+        a backed-off sleep so a quiesced watcher exits as promptly as a busy
+        one instead of lingering for its full interval.
         """
         thread = self._idle_thread
         stop_event = self._idle_stop_event
+        wake_signal = self._idle_wake_signal
         if thread is None:
             return
         self._idle_thread = None
         self._idle_stop_event = None
+        self._idle_wake_signal = None
         if stop_event is not None:
             stop_event.set()
+        if wake_signal is not None:
+            wake_signal.wake(expect_output=False)
         if thread.is_alive():
             thread.join(timeout=_IDLE_WATCHER_JOIN_TIMEOUT_S)
 

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import logging
 import os
 import re
@@ -273,8 +274,8 @@ def _tmux_session_persistence_commands() -> list[list[str]]:
     server — present after the inner process exits, so the socket stays usable
     and the pane's last output stays capturable for diagnostics. The idle
     watcher then reports the exit deterministically by detecting the dead pane
-    (see :meth:`TerminalInstance._pane_is_dead`) instead of racing the server's
-    disappearance. ``exit-empty off`` is belt-and-suspenders for the case where
+    (see :meth:`TerminalInstance._capture_pane_state_or_none`) instead of racing
+    the server's disappearance. ``exit-empty off`` is belt-and-suspenders for the case where
     the session is removed without the server being explicitly killed. Both use
     ``-q`` so a tmux too old to know the option does not fail launch;
     :meth:`TerminalInstance.close` still tears the server down unconditionally
@@ -716,6 +717,37 @@ def _tmux_available() -> bool:
     return shutil.which("tmux") is not None
 
 
+@functools.lru_cache(maxsize=8)
+def _tmux_executable_for_path(path_env: str) -> str:
+    """
+    Resolve tmux against one ``PATH`` value.
+
+    :param path_env: The ``PATH`` the lookup applies to. It is the cache key,
+        not an input to the search — :func:`shutil.which` reads the
+        environment itself — so a changed ``PATH`` resolves afresh instead of
+        returning a stale binary.
+    :returns: Absolute tmux path, or the bare name ``"tmux"``.
+    """
+    del path_env
+    return shutil.which("tmux") or "tmux"
+
+
+def _tmux_executable() -> str:
+    """
+    Resolve the tmux binary, caching per ``PATH``.
+
+    Spawning tmux with the bare name makes ``execvp`` walk ``PATH``, so a
+    single invocation costs one ``execve`` per directory it probes before the
+    hit — three wasted ``ENOENT`` calls on a typical developer ``PATH``. The
+    idle watcher runs this several times a second per terminal, so resolving
+    the absolute path up front removes most of the exec traffic outright.
+
+    :returns: Absolute tmux path, or the bare name ``"tmux"`` when it is not
+        on ``PATH`` (so the resulting failure reads the same as before).
+    """
+    return _tmux_executable_for_path(os.environ.get("PATH", ""))
+
+
 def _process_alive(pid: int) -> bool:
     """
     Return whether a process with *pid* currently exists.
@@ -1053,7 +1085,8 @@ class TerminalInstance:
         """Return the inner process's exit code, if the pane has died.
 
         Captured from tmux ``#{pane_dead_status}`` when a dead pane is first
-        observed (see :meth:`_pane_is_dead` / :meth:`_pane_is_dead_async`).
+        observed (see :meth:`_capture_pane_state_or_none` and
+        :meth:`_pane_is_dead_async`).
         Only meaningful for terminals launched with ``keep_alive_after_exit``
         (``remain-on-exit``); ``None`` otherwise or before exit.
         """
@@ -1086,9 +1119,9 @@ class TerminalInstance:
         differently across machines.
 
         :returns: Base argv for subprocess calls, e.g.
-            ``["tmux", "-S", "/tmp/.../tmux.sock", "-f", "/dev/null"]``.
+            ``["/usr/bin/tmux", "-S", "/tmp/.../tmux.sock", "-f", "/dev/null"]``.
         """
-        return ["tmux", "-S", str(self.socket_path), "-f", _TMUX_CONFIG_PATH]
+        return [_tmux_executable(), "-S", str(self.socket_path), "-f", _TMUX_CONFIG_PATH]
 
     async def set_conversation_link(self, conversation_link: str | None) -> None:
         """
@@ -1675,14 +1708,15 @@ class TerminalInstance:
                 return
             if not self.running:
                 return
-            snapshot = self._capture_pane_for_idle_or_none()
-            if snapshot is None:
+            capture = self._capture_pane_state_or_none()
+            if capture is None:
                 self.running = False
                 if on_exit is not None:
                     self._fire_watch_callback(on_exit, "exit")
                 return
+            pane_dead, snapshot = capture
             self._remember_pane_snapshot(snapshot)
-            if self._pane_is_dead():
+            if pane_dead:
                 # The inner CLI exited but remain-on-exit kept the server, so
                 # capture-pane still succeeds (the snapshot above is the final
                 # frame, now remembered for diagnostics). Report the exit
@@ -1727,44 +1761,47 @@ class TerminalInstance:
             ):
                 return
 
-    def _capture_pane_for_idle_or_none(self) -> str | None:
+    def _capture_pane_state_or_none(self) -> tuple[bool, str] | None:
         """
-        Capture the pane for an idle tick, or signal "tmux gone".
+        Capture the pane and its liveness for an idle tick, or signal "tmux gone".
 
-        :returns: Pane bytes from ``tmux capture-pane -p -e``, or
-            ``None`` when the tmux subprocess raised — the
-            threaded loop reads ``None`` as "stop watching, the
-            server is no longer there".
-        """
-        try:
-            return self._tmux_output_sync("capture-pane", "-t", self.tmux_target, "-p", "-e")
-        except RuntimeError:
-            return None
-
-    def _pane_is_dead(self) -> bool:
-        """
-        Report whether the pane's process exited while tmux kept the pane.
+        Both facts come from a single tmux command sequence. Two invocations
+        would be two fork+execs per tick per terminal — the dominant cost of
+        the watcher at fan-out — and would also read the pane and its liveness
+        at different instants, so a pane that died in between reported a
+        snapshot that did not match the verdict.
 
         With ``remain-on-exit on`` (see
         :func:`_tmux_session_persistence_commands`) the private server survives
         the inner CLI's exit, so a *dead pane* — not a vanished server — is how
-        a normal or early exit now presents. The threaded idle watcher uses this
-        to report the exit deterministically once ``capture-pane`` still
-        succeeds against the surviving server.
+        a normal or early exit presents, and ``capture-pane`` keeps succeeding
+        against the surviving server. ``#{pane_dead}`` is what distinguishes
+        that frozen final frame from a genuinely idle agent.
 
-        :returns: ``True`` when tmux reports ``#{pane_dead}`` as ``1``.
-            ``False`` when the pane is live, or when the probe itself fails
-            (server already gone) — the caller's capture step already handles
-            the vanished-server path.
+        :returns: ``(pane_dead, pane_bytes)`` where *pane_bytes* is the output
+            of ``capture-pane -p -e``, or ``None`` when the tmux subprocess
+            raised — the threaded loop reads ``None`` as "stop watching, the
+            server is no longer there".
         """
         try:
             out = self._tmux_output_sync(
-                "list-panes", "-t", self.tmux_target, "-F", "#{pane_dead} #{pane_dead_status}"
+                "list-panes",
+                "-t",
+                self.tmux_target,
+                "-F",
+                "#{pane_dead} #{pane_dead_status}",
+                ";",
+                "capture-pane",
+                "-t",
+                self.tmux_target,
+                "-p",
+                "-e",
             )
         except RuntimeError:
-            return False
-        self._remember_exit_status(out)
-        return out.split()[:1] == ["1"]
+            return None
+        dead_fields, _, snapshot = out.partition("\n")
+        self._remember_exit_status(dead_fields)
+        return dead_fields.split()[:1] == ["1"], snapshot
 
     def pane_pid_sync(self) -> int | None:
         """Return the pid of the pane's foreground process, or ``None``.
@@ -1886,7 +1923,7 @@ class TerminalInstance:
 
     async def _pane_is_dead_async(self) -> bool:
         """
-        Async sibling of :meth:`_pane_is_dead` for the asyncio idle watcher.
+        Async dead-pane probe for the asyncio idle watcher.
 
         :returns: ``True`` when tmux reports ``#{pane_dead}`` as ``1``;
             ``False`` when the pane is live or the probe fails (server gone,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -3867,6 +3867,16 @@ def create_runner_app(
         status: str,
         error: Mapping[str, object] | None = None,
     ) -> None:
+        # Pull this session's pane watchers back to their base poll interval
+        # before anything is dispatched. Every turn-start path publishes
+        # ``running`` here first, including the streaming branch that never
+        # reaches ``_run_turn_bg``. It runs BEFORE the harness suppression
+        # below on purpose: the harnesses whose status edge is terminal-owned
+        # are precisely the ones that inject through the bridge from the
+        # harness process, so their watcher gets no other signal that a turn
+        # began and a quiesced one would keep reporting ``idle`` into the turn.
+        if status == "running":
+            resource_registry.wake_session_terminal_watchers(conv_id)
         if status == "waiting" and not (
             _server_version is not None and _version_supports_waiting_status(_server_version)
         ):

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -75,6 +75,32 @@ HERMES_NATIVE_TERMINAL_ROLE = "hermes-native"
 # (the REPL exited or crashed) instead of rejecting the attach.
 OMNIGENT_REPL_TERMINAL_ROLE = "omnigent-repl"
 
+# Terminal roles whose pane watcher is responsible for keeping session status
+# current. Most derive both edges from pane activity. Claude-native instead
+# lets its status-file poller own the edges once active; that poller rides the
+# same watcher tick and the pane remains its fallback.
+#
+# Deliberately excludes codex-native and antigravity-native: their watcher runs
+# with status emission off (a forwarder / RPC read driver owns their edges), and
+# excludes generic and auxiliary panes, whose watcher only drives the activity
+# badge and exit detection.
+#
+# Read in two places that must agree: the watcher's status gate, and
+# :meth:`SessionResourceRegistry.wake_session_terminal_watchers`, which pulls
+# exactly these panes back to base rate at turn start.
+PTY_STATUS_OWNING_TERMINAL_ROLES = frozenset(
+    {
+        CLAUDE_NATIVE_TERMINAL_ROLE,
+        PI_NATIVE_TERMINAL_ROLE,
+        CURSOR_NATIVE_TERMINAL_ROLE,
+        KIRO_NATIVE_TERMINAL_ROLE,
+        GOOSE_NATIVE_TERMINAL_ROLE,
+        QWEN_NATIVE_TERMINAL_ROLE,
+        KIMI_NATIVE_TERMINAL_ROLE,
+        HERMES_NATIVE_TERMINAL_ROLE,
+    }
+)
+
 _IS_ALIVE_CACHE_TTL_S = 2.0
 _IS_ALIVE_CACHE_MAX = 256
 
@@ -445,6 +471,41 @@ class SessionResourceRegistry:
         :param publisher: Callable receiving a :class:`TerminalExitEvent`.
         """
         self._terminal_exit_publisher = publisher
+
+    def wake_session_terminal_watchers(self, session_id: str) -> None:
+        """Pull this session's status-driving pane watchers back to base rate.
+
+        Native harnesses inject a turn through the bridge, from the harness
+        process — not through :meth:`TerminalInstance.send` in the runner — so
+        the pane watcher gets no in-process signal that a turn is starting.
+        For the roles in :data:`PTY_STATUS_OWNING_TERMINAL_ROLES`, either the
+        pane diff or an out-of-band poller riding the same tick drives status.
+        A quiesced watcher must therefore resume promptly when a turn starts.
+        The runner calls this as it begins dispatching, the earliest point it
+        knows output is coming.
+
+        Scoped to those roles on purpose. A generic or auxiliary pane's watcher
+        drives only the activity badge and exit detection, and a session turn
+        implies nothing about whether that pane will produce output — waking it
+        would put it on high-rate polling for an unrelated turn, which is the
+        cost this whole change exists to remove.
+
+        Safe to call for any session: one with no terminals, no matching role,
+        or no running watcher is unaffected.
+
+        :param session_id: Session/conversation identifier, e.g.
+            ``"conv_abc123"``.
+        :returns: None.
+        """
+        registry = self._terminal_registry
+        if registry is None:
+            return
+        for entry in registry.list_for_conversation(session_id):
+            resource_id = terminal_resource_id(entry.terminal_name, entry.session_key)
+            with self._lock:
+                role = self._terminal_roles.get((session_id, resource_id))
+            if role in PTY_STATUS_OWNING_TERMINAL_ROLES:
+                entry.instance.wake_idle_watcher(expect_output=True)
 
     async def wait_for_terminal_exit_cleanup(self) -> None:
         """Await the scheduled terminal-exit cleanup to completion so its
@@ -1121,15 +1182,12 @@ class SessionResourceRegistry:
         aligned with the underlying tmux process. No-op when no publisher
         is installed (e.g. embedded/test runners).
 
-        For the claude-native *agent* terminal (``resource_role`` ==
-        :data:`CLAUDE_NATIVE_TERMINAL_ROLE` or
-        :data:`PI_NATIVE_TERMINAL_ROLE`) the same watcher also drives the
-        session's working status: pane activity → ``running`` and a short
-        quiescence → ``idle``, emitted via the session-status publisher.
-        This PTY-derived status catches cases lifecycle hooks can miss
-        because it observes the terminal directly. The status edges are
-        gated to these roles so a side shell's output never flips the
-        session's status.
+        For a terminal whose ``resource_role`` is in
+        :data:`PTY_STATUS_OWNING_TERMINAL_ROLES`, the watcher also keeps the
+        session's working status current. Most roles derive it from pane
+        activity and quiescence. Claude-native gives an active status-file
+        poller sole ownership and uses pane-derived edges only as fallback.
+        A side shell's output can therefore never flip session status.
 
         :param session_id: Session/conversation identifier.
         :param terminal_name: Terminal name from the agent spec.
@@ -1148,30 +1206,9 @@ class SessionResourceRegistry:
         exit_publisher = self._terminal_exit_publisher
         # Status edges are derived only from native agent terminals — a
         # generic shell's output must not move the session's working status.
-        emit_status = status_publisher is not None and resource_role in {
-            CLAUDE_NATIVE_TERMINAL_ROLE,
-            PI_NATIVE_TERMINAL_ROLE,
-            # cursor-native has no forwarder/hook (run_turn returns immediately
-            # after the paste), so — like pi/claude — the PTY watcher is its only
-            # status source. Without this the web "Working…" badge never clears.
-            CURSOR_NATIVE_TERMINAL_ROLE,
-            KIRO_NATIVE_TERMINAL_ROLE,
-            # goose-native injects then returns (its forwarder only mirrors the
-            # transcript, not status), so the PTY watcher is its status source too.
-            GOOSE_NATIVE_TERMINAL_ROLE,
-            # qwen-native appends then returns (its forwarder only mirrors the
-            # JSON event transcript, not status), so the PTY watcher is its
-            # status source too.
-            QWEN_NATIVE_TERMINAL_ROLE,
-            # kimi-native also has no forwarder/hook (the injection run_turn
-            # returns right after the tmux paste), so the PTY watcher is its
-            # only running/idle status source — same as cursor/pi/claude.
-            KIMI_NATIVE_TERMINAL_ROLE,
-            # hermes-native injects then returns (its forwarder only mirrors the
-            # SQLite transcript, not status), so the PTY watcher is its status
-            # source too.
-            HERMES_NATIVE_TERMINAL_ROLE,
-        }
+        emit_status = (
+            status_publisher is not None and resource_role in PTY_STATUS_OWNING_TERMINAL_ROLES
+        )
         if activity_publisher is None and not emit_status and exit_publisher is None:
             return
         resource_id = terminal_resource_id(terminal_name, session_key)
@@ -1211,9 +1248,9 @@ class SessionResourceRegistry:
         # claude-native additionally reads Claude's own ``sessions/<pid>.json``
         # status (present since Claude Code v2.1.139): it flips on the real
         # turn edge and knows when a dialog owns the input, neither of which
-        # the PTY frame-diff can see. It supplements the PTY watcher rather
-        # than replacing it — the file is written only on a value *change*, so
-        # it cannot be trusted to re-assert a status it already holds. Built
+        # the PTY frame-diff can see. Once resolved it replaces the PTY as the
+        # status publisher while continuing to ride the watcher tick; before
+        # resolution or after retirement the pane remains the fallback. Built
         # only for the claude-native role; other native roles stay PTY-only.
         status_poller = (
             self._build_claude_native_status_poller(
@@ -1340,6 +1377,9 @@ class SessionResourceRegistry:
             on_idle=_on_idle,
             on_exit=_on_exit,
             on_tick=_on_tick if status_poller is not None else None,
+            idle_poll_backoff_allowed=(
+                (lambda: not _file_owns_status()) if status_poller is not None else None
+            ),
             idle_threshold_s=_CLAUDE_NATIVE_STATUS_IDLE_THRESHOLD_SECONDS,
             poll_interval_s=_CLAUDE_NATIVE_STATUS_POLL_INTERVAL_SECONDS,
             replace=replace,

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -129,7 +129,7 @@ def test_threaded_idle_watcher_reports_terminal_exit(tmp_path: Path) -> None:
     )
     exited = threading.Event()
 
-    instance._capture_pane_for_idle_or_none = lambda: None  # type: ignore[method-assign]
+    instance._capture_pane_state_or_none = lambda: None  # type: ignore[method-assign]
 
     instance.start_idle_watcher_thread(
         on_exit=exited.set,
@@ -154,9 +154,9 @@ def test_threaded_idle_watcher_keeps_last_pane_text_on_exit(tmp_path: Path) -> N
         running=True,
     )
     exited = threading.Event()
-    snapshots = iter(["\x1b[31mstartup failed\x1b[0m\ntry config", None])
+    snapshots = iter([(False, "\x1b[31mstartup failed\x1b[0m\ntry config"), None])
 
-    instance._capture_pane_for_idle_or_none = lambda: next(snapshots)  # type: ignore[method-assign]
+    instance._capture_pane_state_or_none = lambda: next(snapshots)  # type: ignore[method-assign]
 
     instance.start_idle_watcher_thread(
         on_exit=exited.set,
@@ -181,8 +181,7 @@ def test_threaded_idle_watcher_fires_on_tick_each_poll(tmp_path: Path) -> None:
         running=True,
     )
     # A steady, unchanging pane: no activity edges, but ticks still fire.
-    instance._capture_pane_for_idle_or_none = lambda: "steady frame"  # type: ignore[method-assign]
-    instance._pane_is_dead = lambda: False  # type: ignore[method-assign]
+    instance._capture_pane_state_or_none = lambda: (False, "steady frame")  # type: ignore[method-assign]
     ticks = threading.Event()
     count = {"n": 0}
 
@@ -195,6 +194,42 @@ def test_threaded_idle_watcher_fires_on_tick_each_poll(tmp_path: Path) -> None:
     assert ticks.wait(timeout=1.0)
     instance._stop_idle_watcher_thread()
     assert count["n"] >= 3
+
+
+def test_folded_pane_capture_remembers_exit_status_in_one_tmux_call(tmp_path: Path) -> None:
+    """The threaded poll gets liveness, exit code, and frame from one tmux process."""
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    calls: list[tuple[str, ...]] = []
+
+    def _tmux_output(*args: str) -> str:
+        calls.append(args)
+        return "1 42\nfinal pane frame"
+
+    instance._tmux_output_sync = _tmux_output  # type: ignore[method-assign]
+
+    assert instance._capture_pane_state_or_none() == (True, "final pane frame")
+    assert instance.last_exit_status() == 42
+    assert calls == [
+        (
+            "list-panes",
+            "-t",
+            "main",
+            "-F",
+            "#{pane_dead} #{pane_dead_status}",
+            ";",
+            "capture-pane",
+            "-t",
+            "main",
+            "-p",
+            "-e",
+        )
+    ]
 
 
 def test_pane_pid_sync_returns_pane_process_pid(tmp_path: Path) -> None:
@@ -218,6 +253,32 @@ def test_pane_pid_sync_returns_pane_process_pid(tmp_path: Path) -> None:
 
     instance._tmux_output_sync = _raise  # type: ignore[method-assign]
     assert instance.pane_pid_sync() is None
+
+
+def test_tmux_executable_is_resolved_once_per_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated tmux spawns reuse one lookup until ``PATH`` changes."""
+    calls: list[str] = []
+
+    def _which(command: str) -> str:
+        assert command == "tmux"
+        path = terminal_mod.os.environ["PATH"]
+        calls.append(path)
+        return f"{path}/tmux"
+
+    terminal_mod._tmux_executable_for_path.cache_clear()
+    monkeypatch.setattr(terminal_mod.shutil, "which", _which)
+    try:
+        monkeypatch.setenv("PATH", "/first")
+        assert terminal_mod._tmux_executable() == "/first/tmux"
+        assert terminal_mod._tmux_executable() == "/first/tmux"
+
+        monkeypatch.setenv("PATH", "/second")
+        assert terminal_mod._tmux_executable() == "/second/tmux"
+        assert calls == ["/first", "/second"]
+    finally:
+        terminal_mod._tmux_executable_for_path.cache_clear()
 
 
 @dataclass
@@ -262,8 +323,7 @@ def test_threaded_idle_watcher_reports_exit_on_dead_pane(tmp_path: Path) -> None
     )
     exited = threading.Event()
     # capture-pane still succeeds (server alive); the pane is dead.
-    instance._capture_pane_for_idle_or_none = lambda: "claude exited: boom\nbye"  # type: ignore[method-assign]
-    instance._pane_is_dead = lambda: True  # type: ignore[method-assign]
+    instance._capture_pane_state_or_none = lambda: (True, "claude exited: boom\nbye")  # type: ignore[method-assign]
 
     instance.start_idle_watcher_thread(on_exit=exited.set, poll_interval_s=0.01)
 

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
 import shutil
 import subprocess
 import sys
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -138,6 +140,230 @@ def test_threaded_idle_watcher_reports_terminal_exit(tmp_path: Path) -> None:
 
     assert exited.wait(timeout=1.0)
     assert instance.running is False
+
+
+def test_threaded_idle_watcher_wake_pulls_a_backed_off_watcher_forward(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``wake_idle_watcher`` cuts short a backed-off sleep so activity is seen fast.
+
+    A quiesced watcher may be sleeping for many base intervals. Without the
+    wake path, a turn typed into the pane would not be noticed until that sleep
+    expired, so the session would read ``idle`` while it was already working.
+
+    :param tmp_path: Temporary directory used for placeholder tmux paths.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_MAX_INTERVAL_SECONDS", 30.0)
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_BACKOFF_MAX_MULTIPLE", 1000.0)
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    polled = threading.Semaphore(0)
+    pane = {"text": "quiet"}
+
+    def _capture() -> tuple[bool, str]:
+        polled.release()
+        return False, pane["text"]
+
+    instance._capture_pane_state_or_none = _capture  # type: ignore[method-assign]
+    activity = threading.Event()
+    instance.start_idle_watcher_thread(
+        on_activity=activity.set,
+        idle_threshold_s=0.0,
+        poll_interval_s=0.02,
+    )
+    try:
+        # Let the watcher settle: with a zero idle threshold every quiet tick
+        # doubles the interval, so the gap grows past a second within a couple
+        # of seconds of wall clock.
+        deadline = time.monotonic() + 15.0
+        while polled.acquire(timeout=1.0):
+            if time.monotonic() > deadline:
+                pytest.fail("watcher never backed off")
+        # The tick whose sleep outran the probe above may still be in flight;
+        # consume it so the window below starts from a fresh backed-off sleep.
+        polled.acquire(timeout=5.0)
+        assert not polled.acquire(timeout=0.5)
+
+        pane["text"] = "working"
+        instance.wake_idle_watcher()
+        assert activity.wait(timeout=2.0)
+    finally:
+        instance._stop_idle_watcher_thread()
+
+
+def test_threaded_idle_watcher_slow_output_never_reads_idle(tmp_path: Path) -> None:
+    """
+    A slow trickle of output keeps the watcher at its base rate and never idles.
+
+    This is the false-idle guard: a pane that changes less often than the poll
+    interval but more often than the idle threshold must neither fire ``on_idle``
+    nor let the interval grow, or a working session would be reported idle and
+    its next burst noticed late.
+
+    :param tmp_path: Temporary directory used for placeholder tmux paths.
+    :returns: None.
+    """
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    polls = itertools.count()
+    state = {"frame": 0, "changed_at": time.monotonic()}
+
+    def _capture() -> tuple[bool, str]:
+        next(polls)
+        now = time.monotonic()
+        if now - state["changed_at"] >= 0.15:
+            state["changed_at"] = now
+            state["frame"] += 1
+        return False, f"frame {state['frame']}"
+
+    instance._capture_pane_state_or_none = _capture  # type: ignore[method-assign]
+    went_idle = threading.Event()
+    instance.start_idle_watcher_thread(
+        on_activity=lambda: None,
+        on_idle=went_idle.set,
+        idle_threshold_s=0.5,
+        poll_interval_s=0.02,
+    )
+    try:
+        time.sleep(2.0)
+    finally:
+        instance._stop_idle_watcher_thread()
+
+    assert not went_idle.is_set()
+    # Base rate is 50 polls/s; allow generous slack for a loaded CI box, but a
+    # watcher that had backed off would land in the single digits.
+    assert next(polls) >= 40
+
+
+def test_threaded_idle_watcher_backoff_stops_promptly(tmp_path: Path) -> None:
+    """
+    A backed-off watcher still exits on ``close`` instead of lingering.
+
+    A daemon thread that outlives its terminal is exactly the ownerless-process
+    shape we do not want to introduce, so teardown must not wait out a
+    multi-second backoff sleep.
+
+    :param tmp_path: Temporary directory used for placeholder tmux paths.
+    :returns: None.
+    """
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    polled = threading.Semaphore(0)
+
+    def _capture() -> tuple[bool, str]:
+        polled.release()
+        return False, "quiet"
+
+    instance._capture_pane_state_or_none = _capture  # type: ignore[method-assign]
+    instance.start_idle_watcher_thread(
+        on_activity=lambda: None,
+        idle_threshold_s=0.0,
+        poll_interval_s=0.02,
+    )
+    for _ in range(10):
+        assert polled.acquire(timeout=2.0)
+    thread = instance._idle_thread
+    assert thread is not None
+
+    instance._stop_idle_watcher_thread()
+    assert not thread.is_alive()
+
+
+def test_threaded_idle_watcher_backoff_can_be_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The env kill-switch pins the watcher at its base interval.
+
+    :param tmp_path: Temporary directory used for placeholder tmux paths.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setenv(terminal_mod._IDLE_POLL_BACKOFF_ENV_VAR, "0")
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    polled = threading.Semaphore(0)
+
+    def _capture() -> tuple[bool, str]:
+        polled.release()
+        return False, "quiet"
+
+    instance._capture_pane_state_or_none = _capture  # type: ignore[method-assign]
+    instance.start_idle_watcher_thread(
+        on_activity=lambda: None,
+        idle_threshold_s=0.0,
+        poll_interval_s=0.02,
+    )
+    try:
+        # Without backoff the watcher keeps its base rate forever; 20 ticks at
+        # 20ms is well inside the timeout, but would take ~seconds if the
+        # interval had been allowed to grow.
+        for _ in range(20):
+            assert polled.acquire(timeout=1.0)
+    finally:
+        instance._stop_idle_watcher_thread()
+
+
+def test_threaded_idle_watcher_honors_dynamic_backoff_policy(tmp_path: Path) -> None:
+    """A caller can pin polling at base cadence while an out-of-band tick owns it."""
+
+    def _intervals(*, backoff_allowed: bool) -> list[float]:
+        instance = TerminalInstance(
+            name="runtime",
+            session_key="main",
+            socket_path=tmp_path / f"{backoff_allowed}.sock",
+            private_dir=tmp_path,
+            running=True,
+        )
+        observed: list[float] = []
+
+        def _wait(
+            _stop_event: threading.Event,
+            _wake_signal: object,
+            interval: float,
+            _base_interval: float,
+        ) -> tuple[bool, bool, bool]:
+            observed.append(interval)
+            return len(observed) > 5, False, False
+
+        instance._wait_next_idle_tick = _wait  # type: ignore[method-assign]
+        instance._capture_pane_state_or_none = lambda: (False, "quiet")  # type: ignore[method-assign]
+        instance._idle_watch_loop_threaded(
+            threading.Event(),
+            on_activity=lambda: None,
+            idle_poll_backoff_allowed=lambda: backoff_allowed,
+            idle_threshold_s=0.0,
+            poll_interval_s=0.2,
+        )
+        return observed
+
+    assert _intervals(backoff_allowed=False) == [0.2] * 6
+    assert any(interval > 0.2 for interval in _intervals(backoff_allowed=True))
 
 
 def test_threaded_idle_watcher_keeps_last_pane_text_on_exit(tmp_path: Path) -> None:
@@ -1523,3 +1749,384 @@ def test_apply_utf8_locale_default_noop_on_windows(
     _apply_utf8_locale_default(env)
     assert "LC_ALL" not in env
     assert env["LANG"] == ""
+
+
+def test_idle_detector_reports_notified_only_after_the_edge() -> None:
+    """
+    ``idle_notified`` tracks the episode the backoff decision keys off.
+
+    The watcher grows its poll interval only while this is set, so the flag
+    must be False until the edge fires and must clear again on new output.
+
+    :returns: None.
+    """
+    detector = terminal_mod._IdleDetector(idle_threshold_s=0.05)
+    assert detector.idle_notified is False
+
+    detector.tick("frame-a")
+    assert detector.idle_notified is False
+
+    time.sleep(0.06)
+    assert detector.tick("frame-a") is True
+    assert detector.idle_notified is True
+
+    # New output re-arms the episode.
+    detector.tick("frame-b")
+    assert detector.idle_notified is False
+
+
+def test_threaded_idle_watcher_backoff_does_not_delay_the_idle_edge(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Backoff follows the idle edge; it never pushes the edge out.
+
+    The loop's clock starts when the watcher starts, the detector's when it
+    takes its first snapshot. Timing backoff off a second, loop-side counter
+    lets the interval grow one tick BEFORE the edge, which delays the very
+    ``idle`` it is supposed to trail. An aggressive growth factor makes that
+    delay unmissable.
+
+    :param tmp_path: Temporary directory used for placeholder tmux paths.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_BACKOFF_FACTOR", 10.0)
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_BACKOFF_MAX_MULTIPLE", 1000.0)
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_MAX_INTERVAL_SECONDS", 60.0)
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    instance._capture_pane_state_or_none = lambda: (False, "quiet")  # type: ignore[method-assign]
+    went_idle = threading.Event()
+
+    started = time.monotonic()
+    instance.start_idle_watcher_thread(
+        on_idle=went_idle.set,
+        idle_threshold_s=0.5,
+        poll_interval_s=0.05,
+    )
+    try:
+        assert went_idle.wait(timeout=5.0)
+        elapsed = time.monotonic() - started
+    finally:
+        instance._stop_idle_watcher_thread()
+
+    # The edge is due one poll after the 0.5s threshold. Growing the interval
+    # before the edge would push the next poll to 0.5s and land it past 1.0s.
+    assert elapsed < 0.8, f"idle edge delayed by backoff: {elapsed:.2f}s"
+
+
+def test_threaded_idle_watcher_wake_holds_base_rate_through_slow_setup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A wake pins the base interval long enough for the expected output to land.
+
+    The runner wakes the watcher when it starts dispatching a turn, but spec
+    resolution, harness dispatch and injection all happen after that — and can
+    outlast the idle threshold. Without a grace window the watcher would ramp
+    straight back up during setup and miss the output it was woken for.
+
+    :param tmp_path: Temporary directory used for placeholder tmux paths.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_WAKE_GRACE_SECONDS", 5.0)
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_BACKOFF_FACTOR", 100.0)
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_BACKOFF_MAX_MULTIPLE", 1000.0)
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_MAX_INTERVAL_SECONDS", 60.0)
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    polled = threading.Semaphore(0)
+
+    def _capture() -> tuple[bool, str]:
+        polled.release()
+        return False, "quiet"
+
+    instance._capture_pane_state_or_none = _capture  # type: ignore[method-assign]
+    instance.start_idle_watcher_thread(
+        on_activity=lambda: None,
+        on_idle=lambda: None,
+        idle_threshold_s=0.1,
+        poll_interval_s=0.05,
+    )
+    try:
+        # Quiesce, then jump to a deep interval in one growth step.
+        assert polled.acquire(timeout=2.0)
+        time.sleep(0.5)
+        while polled.acquire(blocking=False):
+            pass
+        assert not polled.acquire(timeout=0.5)
+
+        instance.wake_idle_watcher(expect_output=True)
+        # The pane stays quiet — as it does during turn setup — so only the
+        # grace keeps the watcher at base rate. Well past the 0.1s idle
+        # threshold, it must still be polling.
+        time.sleep(1.0)
+        while polled.acquire(blocking=False):
+            pass
+        assert polled.acquire(timeout=0.5), "watcher re-ramped during the wake grace"
+    finally:
+        instance._stop_idle_watcher_thread()
+
+
+def test_wake_signal_retains_a_wake_raised_after_a_timed_out_consume() -> None:
+    """
+    A wake landing after ``consume`` returns stays pending for the next call.
+
+    ``consume`` takes the flag and its reason under one lock, so there is no
+    window in which a wake can be reported as absent *and* discarded. Losing
+    one would drop both the interval reset and the grace, reopening the
+    late-``running`` race the wake exists to close.
+
+    :returns: None.
+    """
+    signal = terminal_mod._WakeSignal()
+
+    # Nothing pending: a zero-timeout consume reports no wake and takes nothing.
+    assert signal.consume(0.0) == (False, False)
+
+    # A wake raised "after" that consume — i.e. while the tick body runs — is
+    # still there for the next sleep.
+    signal.wake(expect_output=True)
+    assert signal.consume(0.0) == (True, True)
+    # ...and only once.
+    assert signal.consume(0.0) == (False, False)
+
+
+def test_wake_signal_couples_reason_to_the_wake_under_interleaving() -> None:
+    """
+    Mixed client and turn wakes cannot have their halves consumed separately.
+
+    The reason used to live in a bool beside a :class:`threading.Event`, so a
+    turn wake landing between another wake's ``clear`` and the reason read had
+    its two halves taken by different ticks. Coupling them makes every
+    interleaving deterministic: whichever order they arrive in, one consume
+    returns both, and ``expect_output`` cannot be downgraded by a client
+    interaction racing a turn.
+
+    :returns: None.
+    """
+    # Client first, then a turn wake before the watcher looks.
+    signal = terminal_mod._WakeSignal()
+    signal.wake(expect_output=False)
+    signal.wake(expect_output=True)
+    assert signal.consume(0.0) == (True, True)
+    assert signal.consume(0.0) == (False, False)
+
+    # Turn first, then a client interaction races it. The grace survives.
+    signal = terminal_mod._WakeSignal()
+    signal.wake(expect_output=True)
+    signal.wake(expect_output=False)
+    assert signal.consume(0.0) == (True, True)
+    assert signal.consume(0.0) == (False, False)
+
+    # Client wakes alone never earn a grace, however many arrive.
+    signal = terminal_mod._WakeSignal()
+    signal.wake(expect_output=False)
+    signal.wake(expect_output=False)
+    assert signal.consume(0.0) == (True, False)
+
+
+class _SpuriousCondition(threading.Condition):
+    """Condition whose ``wait`` always returns early without a notify.
+
+    Stands in for a spurious wake-up so the predicate loop can be exercised
+    deterministically instead of hoping the platform produces one.
+
+    :param waits: Running count of ``wait`` calls, asserted by the test.
+    """
+
+    def __init__(self) -> None:
+        """Start with no waits recorded."""
+        super().__init__()
+        self.waits = 0
+
+    def wait(self, timeout: float | None = None) -> bool:
+        """Return early, as a spurious wake-up would.
+
+        Drops the lock around the (non-)wait exactly as the real ``wait``
+        does. A stub that held it would deadlock any thread trying to post a
+        wake, which is the opposite of the situation under test.
+
+        :param timeout: Ignored; the point is to return before it elapses.
+        :returns: ``False``, matching a timed-out wait.
+        """
+        del timeout
+        self.waits += 1
+        self.release()
+        try:
+            time.sleep(0.0005)
+        finally:
+            self.acquire()
+        return False
+
+
+def test_wake_signal_consume_survives_spurious_condition_returns() -> None:
+    """
+    A spurious ``wait`` return does not end the sleep early or invent a wake.
+
+    ``consume``'s timeout IS the watcher's backed-off poll interval. A bare
+    ``Condition.wait`` that returned early would be read as "the interval
+    elapsed", so the watcher would fork tmux ahead of schedule — the cost the
+    backoff exists to remove. The predicate loop keeps waiting until a wake is
+    actually pending or the monotonic deadline passes.
+
+    :returns: None.
+    """
+    signal = terminal_mod._WakeSignal()
+    spurious = _SpuriousCondition()
+    signal._condition = spurious
+
+    started = time.monotonic()
+    assert signal.consume(0.05) == (False, False)
+    elapsed = time.monotonic() - started
+
+    # Looped rather than accepting the first spurious return...
+    assert spurious.waits > 1
+    # ...and still waited out the requested interval.
+    assert elapsed >= 0.045, f"backoff sleep truncated to {elapsed:.4f}s"
+
+
+def test_wake_signal_consume_takes_a_wake_that_lands_during_spurious_returns() -> None:
+    """
+    A real wake arriving mid-loop is still picked up promptly.
+
+    The predicate loop must not be so busy re-waiting that it misses the wake
+    it is looping for.
+
+    :returns: None.
+    """
+    signal = terminal_mod._WakeSignal()
+    spurious = _SpuriousCondition()
+    signal._condition = spurious
+    waker = threading.Timer(0.02, lambda: signal.wake(expect_output=True))
+    waker.start()
+    try:
+        started = time.monotonic()
+        assert signal.consume(5.0) == (True, True)
+        # Returned on the wake, not by waiting out the (much longer) timeout.
+        assert time.monotonic() - started < 1.0
+    finally:
+        waker.cancel()
+
+
+def test_wake_signal_consume_blocks_until_a_wake_arrives() -> None:
+    """
+    ``consume`` waits out its timeout, and returns early when woken.
+
+    :returns: None.
+    """
+    signal = terminal_mod._WakeSignal()
+
+    started = time.monotonic()
+    assert signal.consume(0.05) == (False, False)
+    assert time.monotonic() - started >= 0.04
+
+    waker = threading.Timer(0.05, lambda: signal.wake(expect_output=True))
+    waker.start()
+    try:
+        assert signal.consume(2.0) == (True, True)
+    finally:
+        waker.cancel()
+
+
+def test_client_interaction_wake_does_not_arm_the_grace(tmp_path: Path) -> None:
+    """
+    A client interaction asks for one prompt look, not a grace window.
+
+    Interactions arrive per keystroke and mouse event. Arming the full
+    output-expected grace on each would hold the pane at base rate long after
+    the one-off repaint it caused, which at the native 0.2s base is a large
+    multiple of the captures the interaction warrants.
+
+    :param tmp_path: Temporary directory used for placeholder tmux paths.
+    :returns: None.
+    """
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    instance._idle_wake_signal = terminal_mod._WakeSignal()
+
+    instance.note_client_interaction()
+
+    assert instance._idle_wake_signal.consume(0.0) == (True, False)
+
+    instance.wake_idle_watcher(expect_output=True)
+
+    assert instance._idle_wake_signal.consume(0.0) == (True, True)
+
+
+def test_threaded_idle_watcher_releases_the_grace_once_output_arrives(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The grace ends when the expected output lands, not when its timer expires.
+
+    A turn-start wake pins the base interval so setup cannot outlast it. Once
+    the pane actually changes, that purpose is served — holding the rest of the
+    window would keep polling at full rate long after the turn went quiet.
+
+    :param tmp_path: Temporary directory used for placeholder tmux paths.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_WAKE_GRACE_SECONDS", 30.0)
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_BACKOFF_FACTOR", 100.0)
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_BACKOFF_MAX_MULTIPLE", 1000.0)
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_MAX_INTERVAL_SECONDS", 60.0)
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    polled = threading.Semaphore(0)
+    pane = {"text": "idle"}
+
+    def _capture() -> tuple[bool, str]:
+        polled.release()
+        return False, pane["text"]
+
+    instance._capture_pane_state_or_none = _capture  # type: ignore[method-assign]
+    instance.start_idle_watcher_thread(
+        on_activity=lambda: None,
+        on_idle=lambda: None,
+        idle_threshold_s=0.1,
+        poll_interval_s=0.05,
+    )
+    try:
+        assert polled.acquire(timeout=2.0)
+        # A turn is dispatched, and its output lands.
+        instance.wake_idle_watcher(expect_output=True)
+        pane["text"] = "output"
+        time.sleep(0.3)
+        pane["text"] = "output"  # quiet again
+
+        # With the grace released on that change, the watcher goes back to
+        # backing off after the idle threshold — well inside the 30s window it
+        # would otherwise still be holding.
+        time.sleep(0.5)
+        while polled.acquire(blocking=False):
+            pass
+        assert not polled.acquire(timeout=0.5), "grace held past the output it waited for"
+    finally:
+        instance._stop_idle_watcher_thread()

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -2368,11 +2368,19 @@ async def test_required_terminal_exit_publishes_deleted_and_failed(tmp_path: Pat
         on_activity: object | None = None,
         on_exit: object | None = None,
         on_tick: object | None = None,
+        idle_poll_backoff_allowed: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
     ) -> None:
-        del on_idle, on_activity, on_tick, idle_threshold_s, poll_interval_s
+        del (
+            on_idle,
+            on_activity,
+            on_tick,
+            idle_poll_backoff_allowed,
+            idle_threshold_s,
+            poll_interval_s,
+        )
         callbacks["on_exit"] = on_exit
         callbacks["replace"] = replace
 
@@ -2509,11 +2517,20 @@ async def test_required_terminal_exit_classifies_root_failure(tmp_path: Path) ->
         on_activity: object | None = None,
         on_exit: object | None = None,
         on_tick: object | None = None,
+        idle_poll_backoff_allowed: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
     ) -> None:
-        del on_idle, on_activity, on_tick, idle_threshold_s, poll_interval_s, replace
+        del (
+            on_idle,
+            on_activity,
+            on_tick,
+            idle_poll_backoff_allowed,
+            idle_threshold_s,
+            poll_interval_s,
+            replace,
+        )
         callbacks["on_exit"] = on_exit
 
     instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[method-assign]
@@ -2594,11 +2611,20 @@ async def test_required_terminal_exit_while_idle_does_not_fail_session(tmp_path:
         on_activity: object | None = None,
         on_exit: object | None = None,
         on_tick: object | None = None,
+        idle_poll_backoff_allowed: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
     ) -> None:
-        del on_idle, on_activity, on_tick, idle_threshold_s, poll_interval_s, replace
+        del (
+            on_idle,
+            on_activity,
+            on_tick,
+            idle_poll_backoff_allowed,
+            idle_threshold_s,
+            poll_interval_s,
+            replace,
+        )
         callbacks["on_exit"] = on_exit
 
     instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[method-assign]
@@ -2788,11 +2814,20 @@ async def test_external_idle_status_makes_required_terminal_exit_clean(tmp_path:
         on_activity: object | None = None,
         on_exit: object | None = None,
         on_tick: object | None = None,
+        idle_poll_backoff_allowed: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
     ) -> None:
-        del on_idle, on_activity, on_tick, idle_threshold_s, poll_interval_s, replace
+        del (
+            on_idle,
+            on_activity,
+            on_tick,
+            idle_poll_backoff_allowed,
+            idle_threshold_s,
+            poll_interval_s,
+            replace,
+        )
         callbacks["on_exit"] = on_exit
 
     instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[method-assign]

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -26,7 +26,8 @@ from omnigent.claude_native_bridge import (
     bridge_dir_for_bridge_id,
     prepare_bridge_dir,
 )
-from omnigent.entities.session_resources import SessionResourceView
+from omnigent.entities.session_resources import SessionResourceView, terminal_resource_id
+from omnigent.inner.terminal import TerminalInstance
 from omnigent.runner import create_runner_app
 from omnigent.runner.app import (
     ResolvedSpec,
@@ -35,10 +36,12 @@ from omnigent.runner.app import (
 )
 from omnigent.runner.resource_registry import (
     ANTIGRAVITY_NATIVE_TERMINAL_ROLE,
+    CLAUDE_NATIVE_TERMINAL_ROLE,
     CODEX_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
 )
 from omnigent.spec.types import AgentSpec, ExecutorSpec
+from omnigent.terminals import TerminalRegistry
 from tests.runner.conftest import (
     _FakeProcessManager,
     _runner_client,
@@ -3238,3 +3241,134 @@ async def test_cold_start_agy_conversation_accepts_a_locally_owned_cascade(
     assert result is not None
     state = bridge_mod.read_bridge_state(bridge_dir)
     assert state is not None and state.conversation_id == result
+
+
+async def _post_turn_and_collect_wakes(
+    tmp_path: Path,
+    *,
+    session_id: str,
+    terminal_role: str | None,
+) -> list[bool]:
+    """
+    Drive one runner turn and report the wakes its terminal received.
+
+    :param tmp_path: Temporary directory for placeholder tmux paths.
+    :param session_id: Session id to POST the turn to.
+    :param terminal_role: Runner-private role to register for the seeded
+        terminal, or ``None`` for a generic pane with no role.
+    :returns: One entry per wake, carrying its ``expect_output`` flag.
+    """
+    sse_frames = [
+        _sse({"type": "response.created", "response": {"id": "resp_wake"}}),
+        _sse({"type": "response.completed", "response": {"id": "resp_wake"}}),
+    ]
+    harness_client = _ScriptedHarnessClient(sse_frames)
+    pm = _FakeProcessManager(harness_client)
+    spec = AgentSpec(spec_version=1, name="plain-agent")
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    terminal_registry = TerminalRegistry()
+    instance = TerminalInstance(
+        name="claude",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path / "private",
+        running=True,
+    )
+    terminal_registry._by_conversation[session_id] = {("claude", "main"): instance}
+
+    wakes: list[bool] = []
+    instance.wake_idle_watcher = (  # type: ignore[method-assign]
+        lambda *, expect_output=False: wakes.append(expect_output)
+    )
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        terminal_registry=terminal_registry,
+    )
+    registry = app.state.session_resource_registry
+    if terminal_role is not None:
+        registry._terminal_roles[(session_id, terminal_resource_id("claude", "main"))] = (
+            terminal_role
+        )
+
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "e61df75e32ee590087e03aa37b33abac",
+                "model": "plain-agent",
+                "content": [{"type": "input_text", "text": "hi"}],
+                "harness": "openai-agents",
+            },
+        )
+        assert resp.status_code == 202
+        for _ in range(60):
+            if wakes:
+                break
+            await asyncio.sleep(0.05)
+    return wakes
+
+
+@pytest.mark.asyncio
+async def test_turn_start_wakes_the_status_owning_native_terminal(tmp_path: Path) -> None:
+    """
+    Starting a turn wakes the pane whose watcher owns the session's status.
+
+    Native harnesses inject through the bridge from the harness process, so
+    ``TerminalInstance.send`` is never called and that watcher — the *only*
+    running/idle source for these roles — gets no in-process signal that a turn
+    began. The wake hangs off the turn-start ``running`` edge because every
+    dispatch path publishes it first, including the streaming branch that never
+    reaches ``_run_turn_bg``.
+
+    :param tmp_path: Temporary directory for placeholder tmux paths.
+    :returns: None.
+    """
+    wakes = await _post_turn_and_collect_wakes(
+        tmp_path,
+        session_id="aa84b0dc308668bb715607e42ae268b0",
+        terminal_role=CLAUDE_NATIVE_TERMINAL_ROLE,
+    )
+
+    assert wakes, "turn start did not wake the status-owning terminal"
+    # Output is expected but has not arrived, so the wake must also arm the
+    # grace that keeps the watcher at base rate through turn setup.
+    assert all(wakes), wakes
+
+
+@pytest.mark.asyncio
+async def test_turn_start_leaves_generic_and_auxiliary_panes_alone(tmp_path: Path) -> None:
+    """
+    A turn does not wake panes whose watcher does not own the session's status.
+
+    A generic shell or an auxiliary pane drives only the activity badge and
+    exit detection, and a session turn implies nothing about whether it will
+    produce output. Waking it would put it on high-rate polling for an
+    unrelated turn — the exact cost this change exists to remove.
+
+    :param tmp_path: Temporary directory for placeholder tmux paths.
+    :returns: None.
+    """
+    generic = await _post_turn_and_collect_wakes(
+        tmp_path / "generic",
+        session_id="bb84b0dc308668bb715607e42ae268b0",
+        terminal_role=None,
+    )
+    assert generic == [], f"generic pane was woken: {generic}"
+
+    # codex-native's watcher runs with status emission off (its forwarder owns
+    # the edges), so it is out of scope too.
+    codex = await _post_turn_and_collect_wakes(
+        tmp_path / "codex",
+        session_id="cc84b0dc308668bb715607e42ae268b0",
+        terminal_role=CODEX_NATIVE_TERMINAL_ROLE,
+    )
+    assert codex == [], f"codex-native pane was woken: {codex}"

--- a/tests/runner/test_comment_relay.py
+++ b/tests/runner/test_comment_relay.py
@@ -82,7 +82,7 @@ class _StubResourceRegistry:
 
     def set_session_status_publisher(
         self,
-        publisher: Callable[[str, str], None],
+        publisher: Callable[[str, str, str | None], None],
     ) -> None:
         """
         Accept the session-status publisher installed by the runner app.
@@ -90,7 +90,7 @@ class _StubResourceRegistry:
         The stub never launches a real terminal, so it just retains the
         callback (unused) to satisfy ``create_runner_app``'s wiring.
 
-        :param publisher: Callable ``(session_id, status) -> None``.
+        :param publisher: Callable ``(session_id, status, blocked_on) -> None``.
         :returns: None.
         """
         self._session_status_publisher = publisher

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -11,7 +12,9 @@ from types import SimpleNamespace
 
 import pytest
 
+import omnigent.inner.terminal as terminal_mod
 from omnigent.entities import DEFAULT_ENVIRONMENT_ID
+from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
 from omnigent.inner.os_env import EditEntry, OpResult, OSEnvironment
 from omnigent.inner.terminal import TerminalInstance
@@ -335,11 +338,19 @@ async def test_auxiliary_terminal_exit_publishes_resource_exit_only(tmp_path: Pa
         on_activity: object | None = None,
         on_exit: object | None = None,
         on_tick: object | None = None,
+        idle_poll_backoff_allowed: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
     ) -> None:
-        del on_idle, on_activity, on_tick, idle_threshold_s, poll_interval_s
+        del (
+            on_idle,
+            on_activity,
+            on_tick,
+            idle_poll_backoff_allowed,
+            idle_threshold_s,
+            poll_interval_s,
+        )
         callbacks["on_exit"] = on_exit
         callbacks["replace"] = replace
 
@@ -380,6 +391,7 @@ async def _observe_native_agent_terminal_and_capture(
         on_activity: object | None = None,
         on_exit: object | None = None,
         on_tick: object | None = None,
+        idle_poll_backoff_allowed: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
@@ -389,6 +401,7 @@ async def _observe_native_agent_terminal_and_capture(
         callbacks["on_activity"] = on_activity
         callbacks["on_exit"] = on_exit
         callbacks["on_tick"] = on_tick
+        callbacks["idle_poll_backoff_allowed"] = idle_poll_backoff_allowed
 
     instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[attr-defined]
     # A status publisher is required for the native agent terminal's watcher to
@@ -474,6 +487,7 @@ async def _observe_native_with_fake_poller(
         on_activity: object | None = None,
         on_exit: object | None = None,
         on_tick: object | None = None,
+        idle_poll_backoff_allowed: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
@@ -483,6 +497,7 @@ async def _observe_native_with_fake_poller(
         callbacks["on_activity"] = on_activity
         callbacks["on_exit"] = on_exit
         callbacks["on_tick"] = on_tick
+        callbacks["idle_poll_backoff_allowed"] = idle_poll_backoff_allowed
 
     instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[attr-defined]
     await registry.observe_required_terminal(
@@ -504,6 +519,23 @@ async def test_claude_native_wires_status_poller_tick(tmp_path: Path) -> None:
     on_tick()
     on_tick()
     assert pollers[0].ticks == 2
+
+
+@pytest.mark.asyncio
+async def test_claude_native_status_poller_controls_idle_backoff(tmp_path: Path) -> None:
+    """Backoff is allowed only while the status-file poller is inactive."""
+    callbacks, _statuses, pollers, _registry = await _observe_native_with_fake_poller(
+        tmp_path, "conv_backoff_gate"
+    )
+    allowed = callbacks["idle_poll_backoff_allowed"]
+    assert callable(allowed)
+
+    poller = pollers[0]
+    assert allowed() is True
+    poller.active = True
+    assert allowed() is False
+    poller.retire()
+    assert allowed() is True
 
 
 @pytest.mark.asyncio
@@ -833,11 +865,20 @@ async def test_required_terminal_exit_without_observed_status_is_failure(tmp_pat
         on_activity: object | None = None,
         on_exit: object | None = None,
         on_tick: object | None = None,
+        idle_poll_backoff_allowed: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
     ) -> None:
-        del on_idle, on_activity, on_tick, idle_threshold_s, poll_interval_s, replace
+        del (
+            on_idle,
+            on_activity,
+            on_tick,
+            idle_poll_backoff_allowed,
+            idle_threshold_s,
+            poll_interval_s,
+            replace,
+        )
         callbacks["on_exit"] = on_exit
 
     instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[method-assign]
@@ -1445,11 +1486,12 @@ async def test_blocked_reason_survives_pane_redraws(tmp_path: Path) -> None:
         on_activity: object | None = None,
         on_exit: object | None = None,
         on_tick: object | None = None,
+        idle_poll_backoff_allowed: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
     ) -> None:
-        del idle_threshold_s, poll_interval_s, replace
+        del idle_poll_backoff_allowed, idle_threshold_s, poll_interval_s, replace
         callbacks["on_idle"] = on_idle
         callbacks["on_activity"] = on_activity
         callbacks["on_exit"] = on_exit
@@ -1524,3 +1566,113 @@ def test_sanitize_session_id_keeps_traversal_out_of_the_workspace_path(
     resolved = Path(_session_workspace("../../../../etc")).resolve()
 
     assert resolved.is_relative_to(tmp_path.resolve()), f"escaped the root: {resolved}"
+
+
+async def test_turn_start_wake_reaches_a_backed_off_native_status_watcher(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The runner's turn-start wake pulls a quiesced native watcher back to base rate.
+
+    Native harnesses inject a turn through the bridge from the harness process,
+    never through ``TerminalInstance.send``, so this watcher gets no in-process
+    signal that a turn began. It is also the only source of ``running``/``idle``
+    for those harnesses. Without the wake, a session the user just messaged
+    keeps reporting ``idle`` for a whole backed-off interval.
+
+    Exercises the real chain: registry → registered instance → status watcher →
+    session-status publisher.
+
+    :param tmp_path: Temporary directory for placeholder tmux paths.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    # Back off to a deep interval in one step, so the assertion window below
+    # can only be met by the wake — at the shipped 2s ceiling the watcher's
+    # own next tick would satisfy it and the test would pass without the fix.
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_BACKOFF_FACTOR", 100.0)
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_BACKOFF_MAX_MULTIPLE", 1000.0)
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_MAX_INTERVAL_SECONDS", 60.0)
+    terminal_registry = TerminalRegistry()
+    _seed_terminal(terminal_registry, "conv_wake", "claude", "main", tmp_path)
+    instance = terminal_registry.get("conv_wake", "claude", "main")
+    assert instance is not None
+
+    polled = threading.Semaphore(0)
+    pane = {"text": "idle prompt"}
+
+    def _capture() -> tuple[bool, str]:
+        polled.release()
+        return False, pane["text"]
+
+    instance._capture_pane_state_or_none = _capture  # type: ignore[method-assign]
+
+    statuses: list[tuple[str, str]] = []
+    running_seen = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _publish(session_id: str, status: str, blocked_on: str | None) -> None:
+        del blocked_on
+        statuses.append((session_id, status))
+        if status == "running":
+            running_seen.set()
+
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    registry.set_session_status_publisher(_publish)
+    # The wake is scoped to status-owning roles, so the role has to be
+    # registered exactly as the launch path registers it.
+    registry._terminal_roles[("conv_wake", terminal_resource_id("claude", "main"))] = (
+        CLAUDE_NATIVE_TERMINAL_ROLE
+    )
+    registry._start_terminal_activity_watcher(
+        "conv_wake",
+        "claude",
+        "main",
+        instance,
+        CLAUDE_NATIVE_TERMINAL_ROLE,
+        TerminalLifecycle.REQUIRED,
+    )
+    try:
+        # Let it quiesce and back off. The claude-native watcher polls at 0.2s
+        # with a 1s idle threshold, so a few seconds is comfortably past the
+        # idle edge and several doublings up the ramp.
+        # The idle edge lands ~1.2s in (0.2s poll, 1s threshold) and the same
+        # tick takes the single backoff step to a ~20s interval.
+        await asyncio.sleep(2.5)
+        while polled.acquire(blocking=False):
+            pass
+        assert ("conv_wake", "idle") in statuses
+        # Deeply backed off: nothing is going to poll on its own for ~20s.
+        assert not await loop.run_in_executor(None, lambda: polled.acquire(timeout=1.0))
+
+        # A turn starts. The runner cannot use ``send`` here — the harness
+        # process injects — so this is the only signal the watcher gets.
+        pane["text"] = "working on it"
+        registry.wake_session_terminal_watchers("conv_wake")
+
+        await asyncio.wait_for(running_seen.wait(), timeout=3.0)
+    finally:
+        instance._stop_idle_watcher_thread()
+
+    assert statuses[-1] == ("conv_wake", "running")
+
+
+def test_wake_session_terminal_watchers_is_safe_without_terminals(tmp_path: Path) -> None:
+    """
+    Waking a session with no terminals (or no registry) is a no-op, not an error.
+
+    The runner calls this on every turn, including for harnesses that own no
+    tmux pane at all.
+
+    :param tmp_path: Temporary directory for placeholder tmux paths.
+    :returns: None.
+    """
+    SessionResourceRegistry().wake_session_terminal_watchers("conv_missing")
+
+    terminal_registry = TerminalRegistry()
+    _seed_terminal(terminal_registry, "conv_other", "bash", "s1", tmp_path)
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    # No watcher was ever started on this instance.
+    registry.wake_session_terminal_watchers("conv_other")
+    registry.wake_session_terminal_watchers("conv_absent")

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -35,6 +35,7 @@ from omnigent.runner.resource_registry import (
     _CLAUDE_NATIVE_STATUS_POLL_INTERVAL_SECONDS,
     _TERMINAL_ACTIVITY_EMIT_MIN_INTERVAL_SECONDS,
     CLAUDE_NATIVE_TERMINAL_ROLE,
+    PI_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
 )
 from omnigent.spec.types import AgentSpec, ExecutorSpec
@@ -152,7 +153,7 @@ class _CapturingResourceRegistry:
 
     def set_session_status_publisher(
         self,
-        publisher: Callable[[str, str], None],
+        publisher: Callable[[str, str, str | None], None],
     ) -> None:
         """
         Accept the session-status publisher installed by the runner app.
@@ -160,7 +161,7 @@ class _CapturingResourceRegistry:
         The stub never launches a real terminal, so it just retains the
         callback (unused) to satisfy ``create_runner_app``'s wiring.
 
-        :param publisher: Callable ``(session_id, status) -> None``.
+        :param publisher: Callable ``(session_id, status, blocked_on) -> None``.
         :returns: None.
         """
         self._session_status_publisher = publisher
@@ -1477,6 +1478,8 @@ class _WatcherCapture:
         was wired.
     :param on_tick: The per-tick callback the registry passed (drives the
         claude-native status-file poller), or ``None`` if none was wired.
+    :param idle_poll_backoff_allowed: Dynamic backoff policy passed to the
+        watcher, or ``None`` when no caller policy was wired.
     :param idle_threshold_s: The per-watcher idle threshold the registry
         passed, or ``None`` for the module default.
     :param poll_interval_s: The per-watcher poll interval the registry
@@ -1488,6 +1491,7 @@ class _WatcherCapture:
     on_idle: Callable[[], None] | None = None
     on_exit: Callable[[], None] | None = None
     on_tick: Callable[[], None] | None = None
+    idle_poll_backoff_allowed: Callable[[], bool] | None = None
     idle_threshold_s: float | None = None
     poll_interval_s: float | None = None
     replace: bool = False
@@ -1523,6 +1527,7 @@ def _make_capturing_instance(
         on_activity: Callable[[], None] | None = None,
         on_exit: Callable[[], None] | None = None,
         on_tick: Callable[[], None] | None = None,
+        idle_poll_backoff_allowed: Callable[[], bool] | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
@@ -1532,6 +1537,7 @@ def _make_capturing_instance(
         capture.on_activity = on_activity
         capture.on_exit = on_exit
         capture.on_tick = on_tick
+        capture.idle_poll_backoff_allowed = idle_poll_backoff_allowed
         capture.idle_threshold_s = idle_threshold_s
         capture.poll_interval_s = poll_interval_s
         capture.replace = replace
@@ -1676,6 +1682,26 @@ async def test_claude_native_terminal_drives_session_status_from_pane_activity(
 
 
 @pytest.mark.asyncio
+async def test_pty_only_status_role_allows_idle_poll_backoff(tmp_path: Path) -> None:
+    """A status-owning role without a file poller retains adaptive backoff."""
+    capture = _WatcherCapture()
+    instance = _make_capturing_instance(tmp_path, capture, name="pi", session_key="main")
+    registry = SessionResourceRegistry(terminal_registry=_LaunchReturningRegistry(instance))
+    registry.set_session_status_publisher(lambda _sid, _status, _reason=None: None)
+
+    await registry.launch_required_terminal(
+        session_id="conv_pi",
+        terminal_name="pi",
+        session_key="main",
+        spec=_claude_terminal_spec(tmp_path),
+        resource_role=PI_NATIVE_TERMINAL_ROLE,
+    )
+
+    allowed = capture.idle_poll_backoff_allowed
+    assert allowed is None or allowed()
+
+
+@pytest.mark.asyncio
 async def test_generic_terminal_does_not_drive_session_status(
     tmp_path: Path,
 ) -> None:
@@ -1693,7 +1719,9 @@ async def test_generic_terminal_does_not_drive_session_status(
     activity_pulses: list[str] = []
     registry.set_terminal_activity_publisher(lambda _sid, tid: activity_pulses.append(tid))
     registry.set_session_status_publisher(
-        lambda sid, status: status_edges.append(_StatusEdge(session_id=sid, status=status))
+        lambda sid, status, _reason=None: status_edges.append(
+            _StatusEdge(session_id=sid, status=status)
+        )
     )
 
     await registry.launch_auxiliary_terminal(

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import io
 import json
 import logging
 import os
 import queue
 import threading
+import time
 from collections.abc import Callable, Generator, Iterator
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -23,7 +25,13 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+import omnigent._native_post_delivery as native_post_delivery
+import omnigent.claude_native_bridge as bridge_module
 import omnigent.claude_native_forwarder as forwarder
+import omnigent.claude_native_message_display_hook as claude_native_message_display_hook
+import omnigent.claude_native_status as claude_native_status
+import omnigent.runner.subagent_routing as subagent_routing
+import omnigent.runner.turn_routing as turn_routing
 from omnigent.claude_native_bridge import (
     BRIDGE_ID_LABEL_KEY,
     ClaudeMessageDelta,
@@ -7996,3 +8004,1109 @@ async def test_forward_loop_deadline_unsticks_a_stalled_iteration(
     assert stall_warnings, "the deadline trip must be loudly logged, never silent"
     # The warning's traceback names the stalled await for next-time forensics.
     assert stall_warnings[0].exc_info is not None
+
+
+async def _assert_failed_iteration_retries_unchanged_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: Exception,
+) -> None:
+    """Assert one failed full body cannot make its unchanged input skippable."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    monkeypatch.setattr(forwarder, "_IDLE_SETTLE_SECONDS", 0.0)
+    monkeypatch.setattr(forwarder, "_IDLE_RESYNC_SECONDS", 3600.0)
+    attempts = 0
+    retried = asyncio.Event()
+
+    async def _fail_once(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise failure
+        retried.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(forwarder, "_ensure_hook_state", _fail_once)
+    task = asyncio.create_task(
+        forward_claude_transcript_to_session(
+            base_url="http://127.0.0.1:9",
+            headers={},
+            session_id="conv_retry_failed_tick",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            start_at_end=False,
+            poll_interval_s=0.01,
+        )
+    )
+    try:
+        await asyncio.wait_for(retried.wait(), timeout=30.0)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_forwarder_retries_unchanged_inputs_after_timeout_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The timeout handler invalidates the fingerprint accepted before failure."""
+    await _assert_failed_iteration_retries_unchanged_inputs(
+        tmp_path,
+        monkeypatch,
+        TimeoutError("stalled iteration"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_forwarder_retries_unchanged_inputs_after_plain_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The generic error handler invalidates the fingerprint accepted before failure."""
+    await _assert_failed_iteration_retries_unchanged_inputs(
+        tmp_path,
+        monkeypatch,
+        RuntimeError("failed iteration"),
+    )
+
+
+def _user_record(uuid: str, text: str) -> str:
+    """
+    Build one transcript user record.
+
+    :param uuid: Record uuid, e.g. ``"user-1"``.
+    :param text: Message text, e.g. ``"hello"``.
+    :returns: A JSON line (no trailing newline).
+    """
+    return json.dumps({"type": "user", "uuid": uuid, "message": {"role": "user", "content": text}})
+
+
+def _seed_idle_session(tmp_path: Path) -> tuple[Path, Path]:
+    """
+    Lay down a bridge dir plus a one-turn transcript that has already stopped.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: ``(bridge_dir, transcript_path)``.
+    """
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(_user_record("user-1", "first") + "\n", encoding="utf-8")
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "Stop",
+            "session_id": "claude-session",
+            "transcript_path": str(transcript_path),
+        },
+    )
+    return bridge_dir, transcript_path
+
+
+def _count_full_polls(monkeypatch: pytest.MonkeyPatch) -> Callable[[], int]:
+    """
+    Instrument the loop so tests can see how often the full body ran.
+
+    ``read_transcript_path`` runs exactly once per full body and never on a
+    gated tick, so counting it distinguishes "polled and did the work" from
+    "polled and skipped".
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: Callable returning the number of full bodies so far.
+    """
+    calls = {"n": 0}
+    original = forwarder.read_transcript_path
+
+    def _counting(bridge_dir: Path) -> Path | None:
+        calls["n"] += 1
+        return original(bridge_dir)
+
+    monkeypatch.setattr(forwarder, "read_transcript_path", _counting)
+    return lambda: calls["n"]
+
+
+@pytest.mark.asyncio
+async def test_forwarder_gate_settles_when_idle_then_wakes_on_new_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An idle session stops doing per-tick work, and new output is still prompt.
+
+    Both halves matter: gating that never engages buys nothing, and gating
+    that misses an append would strand the transcript. The append is made
+    after the loop has demonstrably settled, so this exercises the wake path,
+    not just the skip path.
+
+    :param tmp_path: Per-test temp directory.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setattr(forwarder, "_IDLE_SETTLE_SECONDS", 0.05)
+    # High enough that the periodic resync cannot be mistaken for the gate
+    # failing to engage.
+    monkeypatch.setattr(forwarder, "_IDLE_RESYNC_SECONDS", 60.0)
+    bridge_dir, transcript_path = _seed_idle_session(tmp_path)
+    full_polls = _count_full_polls(monkeypatch)
+
+    server, thread, base_url = _start_recording_server()
+    task = asyncio.create_task(
+        forward_claude_transcript_to_session(
+            base_url=base_url,
+            headers={},
+            session_id="conv_gate",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            start_at_end=False,
+            poll_interval_s=0.01,
+        )
+    )
+    try:
+        first = await _get_recorded_item_request(server)
+        assert first["body"]["data"]["item_data"]["content"][0]["text"] == "first"
+
+        # Let the gate engage, then measure a quiet window. Ungated this would
+        # be ~40 full bodies; gated it should be a small handful.
+        await asyncio.sleep(0.4)
+        before = full_polls()
+        await asyncio.sleep(0.4)
+        while_idle = full_polls() - before
+        assert while_idle <= 5, f"gate did not engage: {while_idle} full polls while idle"
+
+        # New output must still be picked up on the very next tick.
+        with transcript_path.open("a", encoding="utf-8") as handle:
+            handle.write(_user_record("user-2", "second") + "\n")
+        second = await _get_recorded_item_request(server, timeout_s=5.0)
+        assert second["body"]["data"]["item_data"]["content"][0]["text"] == "second"
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_forwarder_gate_forwards_every_record_of_a_slow_trickle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A slow drip of transcript records is forwarded in full, none skipped.
+
+    The gate settles between records, so each append has to re-open it. A gate
+    that latched shut, or that only re-checked on the periodic resync, would
+    drop or badly delay records here.
+
+    :param tmp_path: Per-test temp directory.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setattr(forwarder, "_IDLE_SETTLE_SECONDS", 0.02)
+    monkeypatch.setattr(forwarder, "_IDLE_RESYNC_SECONDS", 60.0)
+    bridge_dir, transcript_path = _seed_idle_session(tmp_path)
+
+    server, thread, base_url = _start_recording_server()
+    task = asyncio.create_task(
+        forward_claude_transcript_to_session(
+            base_url=base_url,
+            headers={},
+            session_id="conv_trickle",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            start_at_end=False,
+            poll_interval_s=0.01,
+        )
+    )
+    try:
+        assert (await _get_recorded_item_request(server))["body"]["data"]["item_data"]["content"][
+            0
+        ]["text"] == "first"
+        for index in range(6):
+            # Longer than the settle window, so the gate closes between writes.
+            await asyncio.sleep(0.12)
+            with transcript_path.open("a", encoding="utf-8") as handle:
+                handle.write(_user_record(f"drip-{index}", f"drip {index}") + "\n")
+            request = await _get_recorded_item_request(server, timeout_s=5.0)
+            assert request["body"]["data"]["item_data"]["content"][0]["text"] == f"drip {index}"
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_forwarder_gate_can_be_disabled_by_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The kill-switch restores a full body on every tick.
+
+    :param tmp_path: Per-test temp directory.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setenv(forwarder._IDLE_GATE_ENV_VAR, "0")
+    monkeypatch.setattr(forwarder, "_IDLE_SETTLE_SECONDS", 0.05)
+    monkeypatch.setattr(forwarder, "_IDLE_RESYNC_SECONDS", 60.0)
+    bridge_dir, _transcript_path = _seed_idle_session(tmp_path)
+    full_polls = _count_full_polls(monkeypatch)
+
+    server, thread, base_url = _start_recording_server()
+    task = asyncio.create_task(
+        forward_claude_transcript_to_session(
+            base_url=base_url,
+            headers={},
+            session_id="conv_nogate",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            start_at_end=False,
+            poll_interval_s=0.01,
+        )
+    )
+    try:
+        await _get_recorded_item_request(server)
+        await asyncio.sleep(0.4)
+        before = full_polls()
+        await asyncio.sleep(0.4)
+        assert full_polls() - before >= 10
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5.0)
+
+
+def _subagents_dir(transcript: Path) -> Path:
+    """
+    Resolve a transcript's ``subagents/`` directory.
+
+    :param transcript: Parent transcript JSONL.
+    :returns: The sibling ``<stem>/subagents`` directory.
+    """
+    return transcript.parent / transcript.stem / "subagents"
+
+
+def _seed_transcript_with_subagents_dir(tmp_path: Path, *, stem: str = "session") -> Path:
+    """
+    Create a transcript plus the empty ``subagents/`` directory beside it.
+
+    :param tmp_path: Per-test temp directory.
+    :param stem: Transcript filename stem, so a test can model a rotation.
+    :returns: The transcript path.
+    """
+    transcript = tmp_path / f"{stem}.jsonl"
+    transcript.write_text("{}\n", encoding="utf-8")
+    _subagents_dir(transcript).mkdir(parents=True, exist_ok=True)
+    return transcript
+
+
+def _fingerprint_for(bridge_dir: Path, transcript: Path | None = None):
+    """
+    Build a fingerprint helper pointed at *bridge_dir*.
+
+    :param bridge_dir: Native Claude bridge directory.
+    :param transcript: Transcript to watch, or ``None``.
+    :returns: A primed :class:`_BridgeInputPaths`.
+    """
+    paths = forwarder._BridgeInputPaths(bridge_dir)
+    paths.set_transcript(transcript)
+    return paths
+
+
+# Modules that place files in a claude-native bridge directory. Swept by the
+# by-name contract below. Deliberately excludes claude_native_state, whose
+# launch.json lives under ~/.omnigent/claude-native rather than the bridge dir.
+_BRIDGE_DIR_PRODUCER_MODULES = (
+    bridge_module,
+    forwarder,
+    claude_native_status,
+    claude_native_message_display_hook,
+    native_post_delivery,
+    turn_routing,
+    subagent_routing,
+)
+
+
+def test_fingerprint_classifies_every_declared_bridge_file() -> None:
+    """
+    Every declared bridge-dir filename has an explicit poll-loop disposition.
+
+    The fingerprint stats a fixed list of names rather than scanning the
+    directory, which is ~2x cheaper but stops being self-maintaining: a file
+    added later would go unwatched, and its changes would only surface on the
+    periodic resync. This pins the classification so adding one without
+    deciding which side it falls on fails here instead of in production.
+
+    Sees only what a listed module declares, so it is paired with the
+    live-session test below, which checks what producers actually write.
+
+    :returns: None.
+    """
+    declared: dict[str, str] = {}
+    for module in _BRIDGE_DIR_PRODUCER_MODULES:
+        for name, value in vars(module).items():
+            if name.endswith("_FILE") and isinstance(value, str):
+                declared[value] = f"{module.__name__}.{name}"
+    assert declared, "no bridge file constants found — has the naming changed?"
+
+    _assert_all_classified(declared)
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_classifies_every_file_a_live_session_writes(tmp_path: Path) -> None:
+    """
+    Files a session actually writes are classified, not only declared ones.
+
+    The by-name sweep can only see filenames declared as a ``*_FILE`` constant
+    in a module it was told to look at, so it is blind to a producer nobody
+    listed and to a path built inline. Driving the producers and checking what
+    they leave on disk fails for a different set of mistakes.
+
+    Complementary rather than exhaustive: this sees only the producers and
+    branches the scenario below reaches, so a conditional output on an
+    unexercised path still escapes both checks. Together they narrow the gap;
+    neither closes it.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: None.
+    """
+    bridge_dir, _transcript = _seed_idle_session(tmp_path)
+
+    # Drive each producer through its real entry point, so the filenames come
+    # from the producers rather than from this test restating them.
+    claude_native_status._write_context_atomic(bridge_dir, {"context_window_size": 200000})
+    delta_payload = json.dumps(
+        {"hook_event_name": "MessageDisplay", "message_id": "m1", "final": True, "delta": "hi"}
+    )
+    with patch("sys.stdin", io.StringIO(delta_payload)):
+        claude_native_message_display_hook.main(["--bridge-dir", str(bridge_dir)])
+    native_post_delivery.append_dead_letter(
+        bridge_dir,
+        session_id="conv_dead",
+        event_type="external_conversation_item",
+        payload={"item": "x"},
+        reason="permanent_rejection",
+    )
+
+    # ...plus the forwarder's own cursors, written by an actual run.
+    server, thread, base_url = _start_recording_server()
+    task = asyncio.create_task(
+        forward_claude_transcript_to_session(
+            base_url=base_url,
+            headers={},
+            session_id="conv_files",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            start_at_end=False,
+            poll_interval_s=0.01,
+        )
+    )
+    try:
+        await _get_recorded_item_request(server)
+        await asyncio.sleep(0.2)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5.0)
+
+    on_disk = {
+        entry.name: "written by a live session"
+        for entry in bridge_dir.iterdir()
+        if entry.is_file() and not entry.name.startswith(".")
+    }
+    assert len(on_disk) > 5, f"session wrote too little to be a real check: {sorted(on_disk)}"
+
+    _assert_all_classified(on_disk)
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_never_watches_a_file_the_forwarder_itself_writes(
+    tmp_path: Path,
+) -> None:
+    """
+    Nothing the forwarder writes is in the watched set.
+
+    The classification tests catch a bridge file that is *unclassified*, but not
+    one misfiled as watched — and watching our own output is the specific defect
+    that made each full body trigger the next, holding gate engagement at ~54 %.
+    A new cursor added to the wrong tuple would reintroduce it silently.
+
+    So this asserts the invariant directly and without relying on naming: run a
+    real forwarder, diff the bridge directory around it to see what *it* wrote,
+    and require none of that to be watched.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: None.
+    """
+    bridge_dir, _transcript = _seed_idle_session(tmp_path)
+
+    def _snapshot() -> dict[str, tuple[int, int, int]]:
+        return {
+            entry.name: (
+                entry.stat().st_mtime_ns,
+                entry.stat().st_size,
+                entry.stat().st_ino,
+            )
+            for entry in bridge_dir.iterdir()
+            if entry.is_file() and not entry.name.startswith(".")
+        }
+
+    before = _snapshot()
+
+    server, thread, base_url = _start_recording_server()
+    task = asyncio.create_task(
+        forward_claude_transcript_to_session(
+            base_url=base_url,
+            headers={},
+            session_id="conv_own_writes",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            start_at_end=False,
+            poll_interval_s=0.01,
+        )
+    )
+    try:
+        # Let it forward the seeded turn, which is what makes it write cursors.
+        await _get_recorded_item_request(server)
+        await asyncio.sleep(0.3)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5.0)
+
+    after = _snapshot()
+    written = {name for name, stamp in after.items() if before.get(name) != stamp}
+    assert written, "forwarder wrote nothing — the check would be vacuous"
+
+    watched = set(forwarder._WATCHED_BRIDGE_FILES)
+    self_watched = sorted(written & watched)
+    assert not self_watched, (
+        f"the forwarder writes {self_watched}, which the fingerprint also watches — "
+        "each write re-opens the gate on our own output, so a full body triggers "
+        "the next. Move them to _FORWARDER_OWNED_BRIDGE_FILES."
+    )
+
+
+def _assert_all_classified(candidates: dict[str, str]) -> None:
+    """
+    Require every bridge-dir filename to have exactly one disposition.
+
+    :param candidates: Filename mapped to where it came from, for the message.
+    :returns: None.
+    """
+    watched = set(forwarder._WATCHED_BRIDGE_FILES)
+    owned = set(forwarder._FORWARDER_OWNED_BRIDGE_FILES)
+    other = set(forwarder._OTHER_PRODUCER_BRIDGE_FILES)
+
+    unclassified = {
+        name: origin for name, origin in candidates.items() if name not in watched | owned | other
+    }
+    assert not unclassified, (
+        f"bridge file(s) {sorted(unclassified)} ({sorted(unclassified.values())}) are "
+        "neither watched by the poll loop's fingerprint, declared forwarder-owned, "
+        "nor declared another producer's output; classify them in "
+        "_WATCHED_BRIDGE_FILES (an input the loop reads), "
+        "_FORWARDER_OWNED_BRIDGE_FILES (written by us), or "
+        "_OTHER_PRODUCER_BRIDGE_FILES (written elsewhere and never read here)"
+    )
+    # A file cannot be in two buckets: any overlap hides a contradictory
+    # watched/unwatched decision, and watching our output re-opens the gate.
+    assert not (watched & owned | watched & other | owned & other)
+
+
+@pytest.mark.parametrize(
+    ("name", "should_move"),
+    [
+        ("bridge.json", True),
+        ("server.json", True),
+        ("state.json", True),
+        ("hooks.jsonl", True),
+        ("tool_relay.json", True),
+        ("tmux.json", True),
+        ("permission_hook.json", True),
+        ("context.json", True),
+        ("claude-settings.json", True),
+        ("message_deltas.jsonl", True),
+        ("turn_router.json", False),
+        ("turn_routing_done", False),
+        ("turn_replay_pending.json", False),
+        ("turn_routing.log", False),
+        ("subagent_router.json", False),
+    ],
+)
+def test_bridge_file_disposition_controls_fingerprint(
+    tmp_path: Path,
+    name: str,
+    should_move: bool,
+) -> None:
+    """
+    Each classified producer file has its intended fingerprint behaviour.
+
+    The semantic table is independent of the production tuples, so moving a
+    watched input into the adjacent-producer bucket makes this test fail on the
+    fingerprint result instead of blessing the new classification.
+
+    :param tmp_path: Per-test temp directory.
+    :param name: Bridge filename whose disposition is pinned.
+    :param should_move: Whether replacing the file must move the fingerprint.
+    :returns: None.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    target = bridge_dir / name
+    target.write_text("old", encoding="utf-8")
+    paths = _fingerprint_for(bridge_dir)
+    before = paths.fingerprint()
+
+    replacement = bridge_dir / f".{name}.replacement"
+    replacement.write_text("new", encoding="utf-8")
+    os.replace(replacement, target)
+
+    assert (paths.fingerprint() != before) is should_move
+
+
+@pytest.mark.asyncio
+async def test_other_producer_bridge_files_are_not_opened_through_path_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A real forwarder tick never opens adjacent-producer-only files.
+
+    Fingerprint behaviour alone cannot catch code that starts reading the
+    unwatched tuple by index or iteration. Seed every file, observe
+    :meth:`Path.open` during real full ticks, and require no reads from it.
+
+    :param tmp_path: Per-test temp directory.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    bridge_dir, _transcript = _seed_idle_session(tmp_path)
+    for name in forwarder._OTHER_PRODUCER_BRIDGE_FILES:
+        (bridge_dir / name).write_text("{}", encoding="utf-8")
+
+    opened: set[str] = set()
+    original_open = Path.open
+
+    def _tracking_open(path: Path, *args: Any, **kwargs: Any) -> Any:
+        candidate = Path(path)
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if (
+            candidate.parent == bridge_dir
+            and candidate.name in forwarder._OTHER_PRODUCER_BRIDGE_FILES
+            and "r" in str(mode)
+        ):
+            opened.add(candidate.name)
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _tracking_open)
+    server, thread, base_url = _start_recording_server()
+    task = asyncio.create_task(
+        forward_claude_transcript_to_session(
+            base_url=base_url,
+            headers={},
+            session_id="conv_other_producer_reads",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            start_at_end=False,
+            poll_interval_s=0.01,
+        )
+    )
+    try:
+        await _get_recorded_item_request(server)
+        await asyncio.sleep(0.2)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5.0)
+
+    assert not opened, f"forwarder opened adjacent-producer-only files: {sorted(opened)}"
+
+
+def test_fingerprint_does_not_watch_the_forwarders_own_outputs(tmp_path: Path) -> None:
+    """
+    Writing anything the forwarder owns does not move the fingerprint.
+
+    Its cursors and the dead-letter sink all live in the bridge dir and change
+    whenever the loop does work. Counting them would re-open the gate on the
+    forwarder's own output and buy an extra full tick after every batch.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: None.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    paths = _fingerprint_for(bridge_dir)
+    before = paths.fingerprint()
+
+    for name in forwarder._FORWARDER_OWNED_BRIDGE_FILES:
+        (bridge_dir / name).write_text('{"byte_offset": 1}', encoding="utf-8")
+
+    assert paths.fingerprint() == before
+
+
+def test_bridge_input_fingerprint_sees_an_in_place_same_size_rewrite(tmp_path: Path) -> None:
+    """
+    A rewrite that keeps the byte count still changes the fingerprint.
+
+    Size alone would miss a same-length edit; the mtime and inode in the
+    triple are what make the detector safe for the bridge's small JSON state
+    files, which are replaced wholesale on every hook event.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: None.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    state = bridge_dir / "state.json"
+    state.write_text('{"a":1}', encoding="utf-8")
+    paths = _fingerprint_for(bridge_dir)
+    before = paths.fingerprint()
+
+    # Same length, different content, written the way the bridge writes it.
+    replacement = bridge_dir / "state.json.new"
+    replacement.write_text('{"a":2}', encoding="utf-8")
+    os.replace(replacement, state)
+
+    assert paths.fingerprint() != before
+
+
+def test_bridge_input_fingerprint_ignores_atomic_write_scratch_files(tmp_path: Path) -> None:
+    """
+    Dot-prefixed temp files must not churn the fingerprint.
+
+    The bridge's atomic writer creates ``.<name>.<rand>.tmp`` next to its
+    target. Counting those would re-open the gate on every write for no
+    reason.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: None.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    (bridge_dir / "state.json").write_text("{}", encoding="utf-8")
+    paths = _fingerprint_for(bridge_dir)
+    before = paths.fingerprint()
+
+    (bridge_dir / ".state.json.abc123.tmp").write_text("{}", encoding="utf-8")
+
+    assert paths.fingerprint() == before
+
+
+def test_bridge_input_fingerprint_sees_a_new_subagent_before_its_transcript(
+    tmp_path: Path,
+) -> None:
+    """
+    A sub-agent's meta file moves the fingerprint even though it is not stat'ed.
+
+    Only ``agent-*.jsonl`` is stat'ed — every sub-agent ever spawned stays on
+    disk, so stat'ing the write-once meta files too would inflate the per-tick
+    syscalls at high fan-out. Their *arrival* must still open the gate: Claude
+    can write the meta before the transcript, and that meta is what registers
+    the sub-agent. The directory's own stat is what carries it.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: None.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript = _seed_transcript_with_subagents_dir(tmp_path)
+    paths = _fingerprint_for(bridge_dir, transcript)
+    before = paths.fingerprint()
+
+    (_subagents_dir(transcript) / "agent-1.meta.json").write_text(
+        '{"agent_id": "1"}', encoding="utf-8"
+    )
+
+    assert paths.fingerprint() != before
+
+
+def test_bridge_input_fingerprint_sees_subagent_transcript_growth(tmp_path: Path) -> None:
+    """
+    Appends to a sub-agent transcript still move the fingerprint.
+
+    Membership is cached between directory-mtime changes, and an append moves
+    neither the directory mtime nor the member list — so this is the case a
+    membership-only check would miss.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: None.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript = _seed_transcript_with_subagents_dir(tmp_path)
+    child = _subagents_dir(transcript) / "agent-1.jsonl"
+    child.write_text("{}\n", encoding="utf-8")
+    paths = _fingerprint_for(bridge_dir, transcript)
+    before = paths.fingerprint()
+
+    with child.open("a", encoding="utf-8") as handle:
+        handle.write("{}\n")
+
+    assert paths.fingerprint() != before
+
+
+def test_bridge_input_fingerprint_picks_up_a_subagent_added_after_priming(
+    tmp_path: Path,
+) -> None:
+    """
+    A sub-agent appearing mid-session is watched from then on.
+
+    Membership is only re-listed when the directory's mtime moves, so a
+    sub-agent spawned after the cache was primed has to both move the
+    fingerprint on arrival *and* get added to the stat set — otherwise its
+    output would be invisible until the periodic resync.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: None.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript = _seed_transcript_with_subagents_dir(tmp_path)
+    paths = _fingerprint_for(bridge_dir, transcript)
+    paths.fingerprint()
+
+    child = _subagents_dir(transcript) / "agent-late.jsonl"
+    child.write_text("{}\n", encoding="utf-8")
+    after_arrival = paths.fingerprint()
+    assert "subagent/agent-late.jsonl" in after_arrival
+
+    with child.open("a", encoding="utf-8") as handle:
+        handle.write("{}\n")
+
+    assert paths.fingerprint() != after_arrival
+
+
+def test_bridge_input_fingerprint_sees_a_subagent_added_within_one_mtime_tick(
+    tmp_path: Path,
+) -> None:
+    """
+    A sub-agent whose arrival does not move the directory mtime is still watched.
+
+    ``st_mtime_ns`` reports nanoseconds but filesystems do not store them —
+    Linux stamps directory mtimes from the jiffy clock (4ms at CONFIG_HZ=250).
+    An entry created inside the same tick as the previous stat leaves the
+    recorded mtime unchanged, and nothing moves it afterwards either, so a
+    membership cache keyed on mtime inequality alone would leave that sub-agent
+    unwatched until the resync — its output surfacing in 10s chunks.
+
+    The directory mtime is pinned back deliberately rather than raced for: on a
+    fine-grained filesystem (APFS stamps at ~50us) the collision would almost
+    never occur, which is exactly how this escaped review.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: None.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript = _seed_transcript_with_subagents_dir(tmp_path)
+    subagents = _subagents_dir(transcript)
+    paths = _fingerprint_for(bridge_dir, transcript)
+    paths.fingerprint()
+
+    frozen = os.stat(subagents).st_mtime_ns
+    child = subagents / "agent-same-tick.jsonl"
+    child.write_text("{}\n", encoding="utf-8")
+    # Coarse-granularity filesystem: the create lands in the tick already
+    # recorded, so the directory's mtime does not advance.
+    os.utime(subagents, ns=(frozen, frozen))
+    assert os.stat(subagents).st_mtime_ns == frozen
+
+    after_arrival = paths.fingerprint()
+    assert "subagent/agent-same-tick.jsonl" in after_arrival
+
+    # ...and it stays watched, so its output is seen on the next tick.
+    with child.open("a", encoding="utf-8") as handle:
+        handle.write("{}\n")
+
+    assert paths.fingerprint() != after_arrival
+
+
+def test_bridge_input_fingerprint_relists_once_the_racy_window_expires(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An entry that arrived during the racy window is picked up after it expires.
+
+    A coarse mtime records the START of its bucket, so a change landing late in
+    the bucket can already look older than the window by the time the next tick
+    runs. With the directory key unchanged and the mtime no longer recent,
+    nothing would re-list — and nothing ever moves that key again, so the
+    sub-agent would stay unwatched permanently. Sampling while racy therefore
+    has to latch the uncertainty and force one more listing once the mtime
+    settles — exactly one, or the membership cache stops paying for itself.
+
+    The clock is driven rather than slept through: a sleep-based version fails
+    whenever the scheduler pauses it during setup, which is indistinguishable
+    from the bug under test.
+
+    :param tmp_path: Per-test temp directory.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    clock = {"now": 1_700_000_000 * 1_000_000_000}
+    monkeypatch.setattr(forwarder, "_fingerprint_now_ns", lambda: clock["now"])
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript = _seed_transcript_with_subagents_dir(tmp_path)
+    subagents = _subagents_dir(transcript)
+    paths = _fingerprint_for(bridge_dir, transcript)
+
+    listings = 0
+    original = paths._refresh_subagents
+
+    def _counting(dir_key: tuple[int, int], *, provisional: bool) -> None:
+        nonlocal listings
+        listings += 1
+        original(dir_key, provisional=provisional)
+
+    paths._refresh_subagents = _counting  # type: ignore[method-assign]
+
+    # First look: the directory carries the current bucket, so this listing is
+    # racy and cannot be trusted to be complete.
+    bucket = clock["now"]
+    os.utime(subagents, ns=(bucket, bucket))
+    paths.fingerprint()
+    listings_after_first = listings
+
+    # A sub-agent lands in the bucket already recorded, moving nothing.
+    child = subagents / "agent-late-in-bucket.jsonl"
+    child.write_text("{}\n", encoding="utf-8")
+    os.utime(subagents, ns=(bucket, bucket))
+
+    # The next tick lands after the window has expired, so the directory now
+    # reads as settled even though its listing was taken while it was not.
+    clock["now"] = bucket + forwarder._DIR_MTIME_RACY_WINDOW_NS * 2
+    assert not forwarder._mtime_is_racy(bucket)
+
+    assert "subagent/agent-late-in-bucket.jsonl" in paths.fingerprint()
+    assert listings == listings_after_first + 1, "expected exactly one settling re-list"
+
+    # ...and having settled, it stops re-listing.
+    settled = listings
+    for _ in range(5):
+        paths.fingerprint()
+    assert listings == settled
+
+
+def test_bridge_input_fingerprint_handles_a_future_dated_directory(
+    tmp_path: Path,
+) -> None:
+    """
+    A directory stamped in the future is never treated as settled.
+
+    A networked filesystem whose server clock leads ours stamps mtimes ahead of
+    local time. A two-sided comparison would call a stamp far enough ahead
+    "settled" precisely because it is distant from now, so a sub-agent arriving
+    under it would go unwatched — the same failure the window exists to prevent.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: None.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript = _seed_transcript_with_subagents_dir(tmp_path)
+    subagents = _subagents_dir(transcript)
+    paths = _fingerprint_for(bridge_dir, transcript)
+
+    ahead = time.time_ns() + 5 * 1_000_000_000
+    os.utime(subagents, ns=(ahead, ahead))
+    assert forwarder._mtime_is_racy(ahead)
+    paths.fingerprint()
+
+    child = subagents / "agent-skewed.jsonl"
+    child.write_text("{}\n", encoding="utf-8")
+    os.utime(subagents, ns=(ahead, ahead))
+
+    assert "subagent/agent-skewed.jsonl" in paths.fingerprint()
+
+
+def test_mtime_is_racy_only_inside_the_granularity_window() -> None:
+    """
+    Recent and future timestamps are untrustworthy; settled ones are not.
+
+    The window is what keeps a directory being re-listed just after a change.
+    If it never expired the membership cache would be pointless, and if it
+    ignored future stamps an NFS server whose clock leads ours would silently
+    pass the mtime comparison.
+
+    :returns: None.
+    """
+    now = time.time_ns()
+
+    assert forwarder._mtime_is_racy(now)
+    # Future stamps are untrustworthy at ANY distance — the check is an age,
+    # not a distance, so a badly skewed server cannot look settled.
+    assert forwarder._mtime_is_racy(now + forwarder._DIR_MTIME_RACY_WINDOW_NS // 2)
+    assert forwarder._mtime_is_racy(now + forwarder._DIR_MTIME_RACY_WINDOW_NS * 100)
+    # A settled stamp is what lets the membership cache do its job.
+    assert not forwarder._mtime_is_racy(now - forwarder._DIR_MTIME_RACY_WINDOW_NS * 2)
+
+
+def test_bridge_input_fingerprint_stops_relisting_once_a_subagent_dir_settles(
+    tmp_path: Path,
+) -> None:
+    """
+    A quiet sub-agent directory is not re-listed on every tick.
+
+    The racy window buys correctness just after a change; the membership cache
+    is what keeps steady-state idle cheap under fan-out. If the window applied
+    forever, every tick would pay a directory scan again.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: None.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript = _seed_transcript_with_subagents_dir(tmp_path)
+    subagents = _subagents_dir(transcript)
+    (subagents / "agent-1.jsonl").write_text("{}\n", encoding="utf-8")
+    paths = _fingerprint_for(bridge_dir, transcript)
+
+    # Age the directory well past the window, as an idle session's would be.
+    settled = time.time_ns() - forwarder._DIR_MTIME_RACY_WINDOW_NS * 2
+    os.utime(subagents, ns=(settled, settled))
+    paths.fingerprint()
+
+    listings = 0
+    original = paths._refresh_subagents
+
+    def _counting(dir_key: tuple[int, int]) -> None:
+        nonlocal listings
+        listings += 1
+        original(dir_key)
+
+    paths._refresh_subagents = _counting  # type: ignore[method-assign]
+    for _ in range(5):
+        paths.fingerprint()
+
+    assert listings == 0
+
+
+def test_bridge_input_fingerprint_drops_subagents_after_a_rotation(tmp_path: Path) -> None:
+    """
+    A /clear or /fork rotation retargets the fingerprint at the new session.
+
+    The rotated session resolves a different ``subagents/`` directory, so the
+    cached membership belongs to the old one and must not keep being stat'ed.
+
+    :param tmp_path: Per-test temp directory.
+    :returns: None.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    first = _seed_transcript_with_subagents_dir(tmp_path, stem="first")
+    (_subagents_dir(first) / "agent-1.jsonl").write_text("{}\n", encoding="utf-8")
+    paths = _fingerprint_for(bridge_dir, first)
+    assert "subagent/agent-1.jsonl" in paths.fingerprint()
+
+    second = _seed_transcript_with_subagents_dir(tmp_path, stem="second")
+    paths.set_transcript(second)
+
+    # Dropped eagerly, not merely on the next listing refresh: the refresh is
+    # keyed on the directory's stat, so leaving the old entries in place would
+    # rely on the new directory never presenting the same key.
+    assert paths._subagent_targets == ()
+    assert "subagent/agent-1.jsonl" not in paths.fingerprint()
+
+
+def test_forwarder_tick_is_needed_while_a_retry_is_outstanding() -> None:
+    """
+    A pending retry keeps the loop working even with no file change.
+
+    Retries fire on a timer, so a gate that only watched the transcript would
+    leave a failed post permanently unsent.
+
+    :returns: None.
+    """
+    tracker = forwarder._PostRetryTracker()
+    dedupe = forwarder._ForwardDedupeState()
+    # Retry deadlines are stamped from the real monotonic clock, so anchor the
+    # synthetic "now" to it rather than an arbitrary constant.
+    settled = {
+        "now": time.monotonic(),
+        "last_change_at": 0.0,
+        "last_full_poll_at": time.monotonic(),
+    }
+    assert not forwarder._forwarder_tick_is_needed(
+        now=settled["now"],
+        last_change_at=settled["last_change_at"],
+        last_full_poll_at=settled["last_full_poll_at"],
+        retry_trackers=(tracker,),
+        dedupe=dedupe,
+    )
+
+    # A retry that is scheduled but not yet due must NOT hold the gate open —
+    # a sustained outage would otherwise pin the loop at full rate forever.
+    tracker.record_failure("item:1", httpx.ConnectError("boom"))
+    assert not forwarder._forwarder_tick_is_needed(
+        now=settled["now"],
+        last_change_at=settled["last_change_at"],
+        last_full_poll_at=settled["last_full_poll_at"],
+        retry_trackers=(tracker,),
+        dedupe=dedupe,
+    )
+    # ...but once it comes due, the body has to run.
+    assert forwarder._forwarder_tick_is_needed(
+        now=settled["now"] + forwarder._HTTP_POST_RETRY_MAX_DELAY_S + 1.0,
+        last_change_at=settled["last_change_at"],
+        last_full_poll_at=settled["now"] + forwarder._HTTP_POST_RETRY_MAX_DELAY_S + 1.0,
+        retry_trackers=(tracker,),
+        dedupe=dedupe,
+    )
+
+    tracker.clear("item:1")
+    dedupe.cost_retry_not_before = settled["now"] - 1.0
+    assert forwarder._forwarder_tick_is_needed(
+        now=settled["now"],
+        last_change_at=settled["last_change_at"],
+        last_full_poll_at=settled["last_full_poll_at"],
+        retry_trackers=(tracker,),
+        dedupe=dedupe,
+    )
+    dedupe.cost_retry_not_before = settled["now"] + 5.0
+    assert not forwarder._forwarder_tick_is_needed(
+        now=settled["now"],
+        last_change_at=settled["last_change_at"],
+        last_full_poll_at=settled["last_full_poll_at"],
+        retry_trackers=(tracker,),
+        dedupe=dedupe,
+    )
+
+
+def test_forwarder_tick_is_needed_on_the_periodic_resync() -> None:
+    """
+    The resync floor runs the body even when nothing looks like it changed.
+
+    :returns: None.
+    """
+    assert forwarder._forwarder_tick_is_needed(
+        now=1000.0,
+        last_change_at=0.0,
+        last_full_poll_at=1000.0 - forwarder._IDLE_RESYNC_SECONDS,
+        retry_trackers=(),
+        dedupe=forwarder._ForwardDedupeState(),
+    )


### PR DESCRIPTION
## Related issue

Closes #2702
Closes #3000

*Two separate poll loops, but one runner idle-CPU problem and one measurement harness. Happy to split if maintainers prefer one issue per PR.*

## Summary

Two poll loops bill for sessions doing nothing:

- **#2702** — one daemon thread per live terminal, fork+exec'ing tmux twice per tick, `execvp` walking `PATH` every time (4 `execve` per invocation, 3 of them `ENOENT`).
- **#3000** — one asyncio task per live claude-native session, re-reading the entire bridge state every 0.25 s whether or not anything changed.

**Terminal watcher (#2702)** — resolve the tmux executable once per `PATH` value; fold the `#{pane_dead} #{pane_dead_status}` probe into the capture as one command sequence (also killing the die-between-calls race, `_remember_exit_status` preserved); back the interval off only when no status file owns the session's status, via `resource_registry`'s `lambda: not _file_owns_status()`. While claude-native's `SessionStatusPoller` is active that predicate is false and the watcher stays at its 0.2 s base interval; eligible watchers back off only after `_IdleDetector.idle_notified`.

**Forwarder (#3000)** — poll interval unchanged; after the settle window a tick whose watched inputs are unchanged skips the body unless a retry or resync is due. The fingerprint is `(mtime_ns, size, inode)` over the fixed bridge inputs, parent transcript, sub-agent directory, and cached sub-agent transcripts, excluding the forwarder's own cursors — including them makes one full body trigger the next. It sits above the 300 s iteration timeout; both recoverable handlers invalidate the accepted fingerprint.

Kill switches, each read once at loop start: `OMNIGENT_TERMINAL_IDLE_POLL_BACKOFF=0`, `OMNIGENT_CLAUDE_FORWARDER_IDLE_GATE=0`.

## Test Plan

```bash
# Current-tree role shapes
uv run python -m dev.benchmarks.native_poll_cpu terminal --terminals 8 --seconds 30 --warmup 6            # backoff eligible
uv run python -m dev.benchmarks.native_poll_cpu terminal --terminals 8 --seconds 30 --warmup 6 --pin-base # claude-native cadence
uv run python -m dev.benchmarks.native_poll_cpu forwarder --sessions 8 --seconds 30 --warmup 15 --fanout 6
```

The warm-up must extend past each loop's settle period; otherwise the window captures the tail of the last activity burst and understates the win ~3x. §4 of `designs/native-poll-cpu.md` has the full procedure and every raw row.

Tests run one file per invocation with `-p no:randomly`; `pre-commit` on changed paths exited 0.

```
tests/test_claude_native_forwarder.py                        188 passed
tests/inner/test_terminal.py                                  59 passed
tests/runner/test_resource_registry.py                        58 passed
tests/runner/test_session_resources.py                        47 passed
tests/runner/test_app_sessions_native_terminals_runtime.py    41 passed
```

Each listed guard is mutation-checked — reverting it fails the named test:

| mutation | test that must fail |
|---|---|
| drop `fingerprint = None` from `except TimeoutError` | `test_forwarder_retries_unchanged_inputs_after_timeout_error` |
| drop `fingerprint = None` from `except Exception` | `test_forwarder_retries_unchanged_inputs_after_plain_exception` |
| pin PTY-only roles to the base interval | `test_pty_only_status_role_allows_idle_poll_backoff` |
| let backoff grow before `_IdleDetector.idle_notified` | `test_threaded_idle_watcher_backoff_does_not_delay_the_idle_edge` |
| misfile a watched bridge file as adjacent-producer | `test_bridge_file_disposition_controls_fingerprint` |
| read an adjacent-producer file each tick | `test_other_producer_bridge_files_are_not_opened_through_path_open` |
| blind the fingerprint to parent-transcript growth | `test_forwarder_gate_settles_when_idle_then_wakes_on_new_output` |
| restore `abs()` in the mtime age check | `test_bridge_input_fingerprint_handles_a_future_dated_directory` |
| remove the provisional racy-listing latch | `test_bridge_input_fingerprint_relists_once_the_racy_window_expires` |

## Demo

`N/A` for visuals — non-UI change. Measurements instead.

All figures compare base `d720d2762` with this branch on one shared Linux host, everything idle, 30 s windows. The backoff terminal rows use 11 matched pairs from three campaigns and two independent samplers; the forwarder rows use three matched pairs per shape. The claude-native rows are corresponding-campaign marginal medians, not matched pairs.

| 8 idle terminals | base | this branch | factor |
|---|---:|---:|---:|
| 7 PTY-only native roles — tmux invocations/s | 8.37 | 0.50 | **16.7x** (16.5–16.9) |
| 7 PTY-only native roles — CPU / core / terminal | 15.33 % | 0.96 % | **15.7x** (10.5–20.3) |
| claude-native cadence floor (`--pin-base`) — tmux invocations/s | 8.35 | 4.55 | **1.84x** |
| claude-native cadence floor (`--pin-base`) — CPU / core / terminal | 15.62 % | 8.49 % | **1.84x** |

With an active poller, claude-native gets the fold and the tmux-path cache but not the interval reduction; `--pin-base` models that cadence veto and excludes `SessionStatusPoller.tick()` cost. Generic panes already poll at 1.0 s, so they start ~5x cheaper and gain proportionally less.

| forwarder, per session | base | this branch | factor |
|---|---:|---:|---:|
| no fan-out (8 sessions) | 4.33 % | 0.36 % | **11.9x** |
| fan-out 6 (8 sessions) | 7.44 % | 0.56 % | **13.4x** |
| fan-out 100 (4 sessions) | 26.24 % | 2.43 % | **≥10.8x** |

The fan-out 100 base is a lower bound: total process CPU reached 99.99–108.93 % of a core with four forwarders on one event-loop thread, so the baseline was near saturation. The branch side was unclipped at 9.24–9.79 %.

**Accepted trade-offs.** A backoff-eligible watcher may notice autonomous output or a pane exit up to its 2 s/5 s ceiling late; an input missing from the fingerprint waits for the 10 s resync; a failed folded `list-panes` ends the watcher rather than assuming the pane is alive; the fingerprint's filesystem calls sit outside the async iteration timeout.

## ELI5

The affected terminal helpers checked up to five times a second, each check starting two tmux programs — and each program tried four PATH locations to find tmux. Every live Claude session had another helper re-reading its bridge state four times a second, even when nothing had happened.

Now the terminal helper starts one tmux program and remembers where tmux lives; eligible terminals also check less often once quiet. The session helper still looks four times a second but only glances at file metadata; once settled, it stops there when nothing moved unless a retry or resync is due. Idle machines get quieter; real activity is still picked up.

## Diagram

```
TERMINAL
  before: [ tmux capture-pane ][ tmux dead-pane probe ]      2 processes/tick
  after:  [ tmux list-panes ; capture-pane ]                 1 process/tick
             ├─ active status-file owner → 0.2 s base cadence
             └─ no file owner + post-idle → adaptive backoff

FORWARDER
  before: full pipeline every 0.25 s
  after:  cheap stats every 0.25 s
             ├─ changed / settling / retry due / resync due → full body
             └─ settled + unchanged + no work due → skip body
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the detector, wake signal, backoff invariants, ownership predicate, and fingerprint contract; integration coverage drives a turn through the runner app and asserts the wake reaches the terminal.

Manual verification is the CPU measurement itself, since the acceptance bar is a number. Terminal runs launch real tmux and report `RUSAGE_SELF` + `RUSAGE_CHILDREN` plus a tmux-invocation counter; forwarder runs use real tasks against a local sink.

Two gaps: the codex-native forwarder is a separate module of the same shape, untouched and not exercised idle; and the bridge-file guards are partial, not fail-closed — an unlisted producer, inline filename, or read via builtin `open()`/`os.stat` can escape them. An unwatched input surfaces on the 10 s resync. Residual risk is in §8 of the design note.

## Changelog

Native terminal sessions and the claude-native bridge use substantially less runner CPU while idle.
