### PR TITLE
fix(web): soften runner disconnect recovery message

### DIFF
--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -1,8 +1,37 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { RoutingDecisionCard, RoutingDecisionChip } from "./StatusBlocks";
+import { ErrorBanner, RoutingDecisionCard, RoutingDecisionChip } from "./StatusBlocks";
 
 afterEach(cleanup);
+
+describe("ErrorBanner", () => {
+  it("renders runner disconnects as a quiet, recoverable session notice", () => {
+    render(
+      <ErrorBanner
+        message="Runner disconnected unexpectedly."
+        source=""
+        code="runner_disconnected"
+      />,
+    );
+
+    const notice = screen.getByTestId("runner-disconnected-notice");
+    expect(notice).toHaveAttribute("role", "status");
+    expect(notice).toHaveClass("w-[48rem]", "max-w-full", "items-center", "border");
+    expect(notice).toHaveTextContent("Connection interrupted.");
+    expect(notice).toHaveTextContent("Send a message to reconnect and continue.");
+    expect(notice).not.toHaveTextContent("runner_disconnected");
+    expect(notice).not.toHaveTextContent("unexpectedly");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("keeps genuine task failures as destructive alerts", () => {
+    render(<ErrorBanner message="Turn setup failed" source="runtime" code="turn_error" />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Error · runtime · turn_error");
+    expect(alert).toHaveTextContent("Turn setup failed");
+  });
+});
 
 describe("RoutingDecisionChip — intelligent model router", () => {
   it("applied verdict: names the active model with its tier, plus the rationale line", () => {

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -1,7 +1,7 @@
 // Inline status indicators for non-tool, non-text, non-reasoning blocks.
 // Each is small enough to live in one file.
 //
-// - ErrorBanner: destructive Alert with `[source]` + code + message.
+// - ErrorBanner: recoverable session notice or destructive error Alert.
 // - RetryIndicator: muted one-liner about an in-flight retry.
 // - CompactionMarker: permanent marker shown after compaction completes.
 //   The in-progress state renders as a Shimmer in ChatPage, mirroring
@@ -14,6 +14,7 @@ import {
   RotateCcwIcon,
   ShieldXIcon,
   ShrinkIcon,
+  WifiOffIcon,
 } from "lucide-react";
 import { useMemo } from "react";
 import { CodeBlock, CodeBlockHeader, CodeBlockTitle } from "@/components/ai-elements/code-block";
@@ -30,11 +31,30 @@ interface ErrorBannerProps {
 }
 
 /**
- * Loud destructive banner for `error` blocks. Falls back to `code` when
- * `message` is empty (matches the reducer's intent — never show a blank
- * panel even when the LLM error payload omits the message).
+ * Renders recoverable runner disconnects as a quiet prompt to continue.
+ * Other `error` blocks use a destructive banner and fall back to `code`
+ * when `message` is empty so the panel is never blank.
  */
 export function ErrorBanner({ message, source, code }: ErrorBannerProps) {
+  if (code === "runner_disconnected") {
+    return (
+      <div
+        role="status"
+        data-testid="runner-disconnected-notice"
+        className={cn(
+          "flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2 text-muted-foreground text-xs",
+          TOOL_SURFACE_WIDTH_CLASS,
+        )}
+      >
+        <WifiOffIcon className="size-3.5 shrink-0" />
+        <span className="min-w-0">
+          <span className="font-medium text-foreground">Connection interrupted.</span> Send a
+          message to reconnect and continue.
+        </span>
+      </div>
+    );
+  }
+
   const display = message || code || "Unknown error";
   return (
     <Alert

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1183,7 +1183,7 @@ describe("Composer placeholder", () => {
     // Host online but runner offline — sending relaunches the runner, so the
     // composer stays writable and the placeholder is the affordance.
     render(<Composer {...composerProps({ reconnectHint: true })} />);
-    expect(textarea().placeholder).toBe("Send a message to reconnect this session");
+    expect(textarea().placeholder).toBe("Send a message to continue");
     expect(textarea().disabled).toBe(false);
   });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4812,7 +4812,7 @@ export function Composer({
                           : sandboxAsleepHint
                             ? "Current session's host is offline. Next message will resume the sandbox host which can take minutes"
                             : reconnectHint
-                              ? "Send a message to reconnect this session"
+                              ? "Send a message to continue"
                               : "Ask the agent anything…"
             }
             rows={1}


### PR DESCRIPTION
## Related issue

N/A

## Summary

Recoverable runner disconnects currently look like hard task failures: the chat shows a destructive red alert with the internal `runner_disconnected` code even though the user can continue by sending another message.

- Render `runner_disconnected` as a muted, full-width connection notice with plain-language recovery guidance while leaving genuine errors destructive.
- Simplify the reconnecting composer placeholder to “Send a message to continue.”
- Add regression coverage for both the recoverable notice and unchanged genuine-error behavior.

**ELI5:** The agent briefly lost its connection, but the conversation is still usable, so the UI now explains how to continue instead of presenting a scary error.

```text
runner_disconnected → quiet recovery notice → next message → reconnect and continue
other error codes   → destructive error alert
```

## Test Plan

- `.venv/bin/pre-commit run --all-files`
- `cd web && npm test -- --run src/components/blocks/StatusBlocks.test.tsx src/pages/ChatPage.composer.test.tsx` — 111 tests passed
- `cd web && npm run type-check`
- `cd web && npx prettier --check src/components/blocks/StatusBlocks.tsx src/components/blocks/StatusBlocks.test.tsx src/pages/ChatPage.tsx src/pages/ChatPage.composer.test.tsx`
- `cd web && npx oxlint src/components/blocks/StatusBlocks.tsx src/components/blocks/StatusBlocks.test.tsx src/pages/ChatPage.tsx src/pages/ChatPage.composer.test.tsx`
- Manual verification: confirmed the recoverable disconnect renders as a wide muted notice, the composer invites the user to continue, and sending another message resumes the session.
- Repository-wide `npm run lint` remains blocked by the pre-existing `typescript(no-this-alias)` violation in `src/components/blocks/TerminalSession.test.ts:318`; the changed files pass targeted lint.

## Demo

Before:
<img width="948" height="580" alt="Screenshot 2026-07-23 at 20 22 11" src="https://github.com/user-attachments/assets/6b58953e-9b7b-4a10-973d-c30ad007f3bd" />

After:
<img width="917" height="512" alt="Screenshot 2026-07-23 at 20 22 06" src="https://github.com/user-attachments/assets/0dff6bc7-89b5-409c-9898-d15eb0db6386" />

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the wide recoverable notice, calmer copy, enabled composer, and continue/reconnect flow in a local session. Unit tests assert that `runner_disconnected` avoids destructive alert semantics while genuine task errors retain them.

## Changelog

Runner disconnects now appear as a subtle recovery notice instead of a destructive error.
