### PR TITLE
feat(telemetry): log agent_name for polly and debby in SessionCreatedEvent

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -5451,6 +5451,10 @@ async def _create_session_from_existing_agent(
                     expand_env=agent.session_id is None,
                 )
                 _tel_harness = _spec_harness(_tel_loaded.spec)
+            # Only log agent name for known built-in orchestrators to avoid
+            # leaking user-defined agent names.
+            _NAMED_AGENTS = {"polly", "debby"}
+            _tel_agent_name = agent.name if agent.name in _NAMED_AGENTS else None
             _tel_emit(
                 _TelSessionCreatedEvent(
                     session_id=conv.id,
@@ -5462,6 +5466,7 @@ async def _create_session_from_existing_agent(
                     host_installation_id=_host_install_id,
                     is_fork=body.parent_session_id is not None,
                     is_sub_agent=body.sub_agent_name is not None,
+                    agent_name=_tel_agent_name,
                 )
             )
     except Exception:  # noqa: BLE001 — telemetry must not disrupt session creation

--- a/omnigent/telemetry/events.py
+++ b/omnigent/telemetry/events.py
@@ -29,6 +29,9 @@ class SessionCreatedEvent:
         (``omnigent host``); ``None`` for CLI sessions.
     :param is_fork: ``True`` when the session was forked from another.
     :param is_sub_agent: ``True`` when ``sub_agent_name`` is set.
+    :param agent_name: Agent name for known multi-agent orchestrators
+        (e.g. ``"polly"``, ``"debby"``); ``None`` for all other agents to
+        avoid leaking user-defined agent names.
     """
 
     installation_id: str | None
@@ -40,6 +43,7 @@ class SessionCreatedEvent:
     host_installation_id: str | None
     is_fork: bool
     is_sub_agent: bool
+    agent_name: str | None = None
 
 
 @dataclass

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -497,6 +497,43 @@ def test_build_record_promotes_host_installation_id() -> None:
     assert "host_installation_id" not in params
 
 
+def test_session_created_event_agent_name_polly() -> None:
+    """``agent_name`` is set for polly sessions."""
+    from omnigent.telemetry.events import SessionCreatedEvent
+
+    event = SessionCreatedEvent(
+        installation_id=None,
+        session_id="sess_polly",
+        agent_id="ag_001",
+        harness="claude-sdk",
+        surface="web",
+        anon_user_id=None,
+        host_installation_id=None,
+        is_fork=False,
+        is_sub_agent=False,
+        agent_name="polly",
+    )
+    assert event.agent_name == "polly"
+
+
+def test_session_created_event_agent_name_none_for_custom() -> None:
+    """``agent_name`` defaults to ``None`` for custom (non-built-in) agents."""
+    from omnigent.telemetry.events import SessionCreatedEvent
+
+    event = SessionCreatedEvent(
+        installation_id=None,
+        session_id="sess_custom",
+        agent_id="ag_002",
+        harness="claude-sdk",
+        surface="web",
+        anon_user_id=None,
+        host_installation_id=None,
+        is_fork=False,
+        is_sub_agent=False,
+    )
+    assert event.agent_name is None
+
+
 # ── _resolve_harness ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds `agent_name: str | None = None` to `SessionCreatedEvent`
- Populates it only when the agent is `polly` or `debby` — all other agent names are left as `None` to avoid leaking user-defined agent names in telemetry

## Test Plan

```
python -m pytest tests/test_telemetry.py -v -k "agent_name"
```

## Demo

N/A

## Type of change

- [x] Feature

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

Two new tests: one asserting `agent_name="polly"` is preserved, one asserting custom agents default to `None`.

## Changelog

Telemetry now records the agent name for Polly and Debby sessions.