### PR TITLE
refactor(cli): replace `omni integration slack start` with `omni integration slack --background`

### DIFF
--- a/integrations/slack/README.md
+++ b/integrations/slack/README.md
@@ -80,17 +80,17 @@ Under **Event Subscriptions → Subscribe to bot events**, add:
 With the `omni` CLI installed, the Slack bot is managed as a background daemon:
 
 ```bash
-omni integration slack           # run in the foreground (Ctrl-C to stop)
-omni integration slack start     # run in the background (detached)
-omni integration slack status    # is the background bot running?
-omni integration slack stop      # stop the background bot
-omni integration slack logs      # print the background bot's log path
-omni integration slack logs -f   # follow the log (like tail -f)
+omni integration slack              # run in the foreground (Ctrl-C to stop)
+omni integration slack --background # run in the background (detached)
+omni integration slack status       # is the background bot running?
+omni integration slack stop         # stop the background bot
+omni integration slack logs         # print the background bot's log path
+omni integration slack logs -f      # follow the log (like tail -f)
 ```
 
-`omni integration slack start` spawns a detached daemon and returns
-immediately; `status`/`stop`/`logs` manage it. Running `start` again while it's
-already up is a no-op that reports the existing process.
+`omni integration slack --background` spawns a detached daemon and returns
+immediately; `status`/`stop`/`logs` manage it. Running `--background` again
+while it's already up is a no-op that reports the existing process.
 
 All configuration (the two Slack tokens, `OMNIGENT_SERVER_URL`, and the
 optional `OMNIGENT_DEVICE_CLIENT_SECRET` / `OMNIGENT_SLACK_TOKEN_ENCRYPTION_KEY`)

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -7726,33 +7726,56 @@ def integration(ctx: click.Context) -> None:
       slack   The @omnigent Slack socket-mode bot.
 
     Run ``omni integration slack`` to start the Slack bot in the foreground,
-    or ``omni integration slack start`` to run it in the background.
+    or ``omni integration slack --background`` to run it in the background.
     """
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
 
 
 @integration.group("slack", invoke_without_command=True)
+@click.option(
+    "--background",
+    "background",
+    is_flag=True,
+    default=False,
+    help=(
+        "Spawn the Slack bot as a detached background daemon (returning "
+        "immediately) instead of running it in the foreground. Reuses a "
+        "healthy background daemon if one is already up."
+    ),
+)
 @click.pass_context
-def slack(ctx: click.Context) -> None:
-    """Run the @omnigent Slack socket-mode bot (foreground).
+def slack(ctx: click.Context, background: bool) -> None:
+    """Run the @omnigent Slack socket-mode bot.
 
     \b
     Bare invocation runs in the FOREGROUND (Ctrl-C to stop):
       omni integration slack
-    Manage a BACKGROUND daemon with the subcommands:
-      omni integration slack start    # spawn detached, return immediately
+    Pass --background to spawn it as a detached daemon instead:
+      omni integration slack --background   # spawn detached, return immediately
+    Manage that background daemon with the subcommands:
       omni integration slack status   # is it running?
       omni integration slack stop     # terminate the daemon
       omni integration slack logs     # where the daemon logs (-f to tail)
 
     Config (Slack tokens, OMNIGENT_SERVER_URL, …) comes from the environment
     and the integration's .env file — see integrations/slack/.env.example.
+
+    :param background: When True, spawn the detached background daemon (the
+        former ``slack start`` behavior) instead of running in the foreground.
     """
     if ctx.invoked_subcommand is not None:
+        # A subcommand (stop/status/logs) handles this invocation.
         return
     if not _slack_installed():
         raise click.ClickException(_SLACK_INSTALL_HINT)
+
+    if background:
+        # `omni integration slack --background` replaces the removed `start`
+        # subcommand: spawn (or reuse) the detached daemon and return.
+        _start_slack_background()
+        return
+
     # A background daemon already holds the Slack socket; a second foreground
     # bot would contend on the same connection. Refuse rather than double-run.
     existing = _slack_daemon().running_record()
@@ -7768,11 +7791,13 @@ def slack(ctx: click.Context) -> None:
     raise SystemExit(result.returncode)
 
 
-@slack.command("start")
-def slack_start() -> None:
-    """Start the Slack bot as a background daemon."""
-    if not _slack_installed():
-        raise click.ClickException(_SLACK_INSTALL_HINT)
+def _start_slack_background() -> None:
+    """Spawn (or reuse) the detached background Slack daemon and report it.
+
+    The background counterpart to the foreground bare ``omni integration
+    slack``, invoked by the ``--background`` flag (the former ``start``
+    subcommand).
+    """
     daemon = _slack_daemon()
     existing = daemon.running_record()
     if existing is not None:

--- a/omnigent/integration_daemon.py
+++ b/omnigent/integration_daemon.py
@@ -1,6 +1,6 @@
 """Background-daemon lifecycle for CLI-managed integration processes.
 
-Backs ``omni integration slack [start|status|stop|logs]``. A single daemon
+Backs ``omni integration slack [--background|status|stop|logs]``. A single daemon
 per machine is tracked by a small JSON record (PID + log path + start time)
 under the runtime data dir. The daemon itself is an ordinary subprocess (e.g.
 ``python -m omnigent_slack``); this module only owns spawning it detached,

--- a/tests/cli/test_integration_slack.py
+++ b/tests/cli/test_integration_slack.py
@@ -88,10 +88,10 @@ def test_confirm_alive_prunes_dead_record(tmp_path: Path) -> None:
 # ── CLI wiring ────────────────────────────────────────────────────
 
 
-def test_slack_start_hint_when_not_installed(data_dir: Path) -> None:
+def test_slack_background_hint_when_not_installed(data_dir: Path) -> None:
     runner = CliRunner()
     with mock.patch("omnigent.cli._slack_installed", return_value=False):
-        result = runner.invoke(cli, ["integration", "slack", "start"])
+        result = runner.invoke(cli, ["integration", "slack", "--background"])
     assert result.exit_code != 0
     assert "isn't installed" in result.output
     assert "omnigent-slack" in result.output
@@ -112,7 +112,7 @@ def test_slack_status_reports_not_running(data_dir: Path) -> None:
     assert "not running" in result.output
 
 
-def test_slack_start_status_stop_lifecycle(data_dir: Path) -> None:
+def test_slack_background_status_stop_lifecycle(data_dir: Path) -> None:
     runner = CliRunner()
     with (
         mock.patch("omnigent.cli._slack_installed", return_value=True),
@@ -125,7 +125,7 @@ def test_slack_start_status_stop_lifecycle(data_dir: Path) -> None:
         mock.patch.object(IntegrationDaemon, "confirm_alive", return_value=True),
     ):
         popen.return_value.pid = 9911
-        start = runner.invoke(cli, ["integration", "slack", "start"])
+        start = runner.invoke(cli, ["integration", "slack", "--background"])
         assert start.exit_code == 0, start.output
         assert "9911" in start.output
         # Argv targets the slack package in the current interpreter.
@@ -135,9 +135,9 @@ def test_slack_start_status_stop_lifecycle(data_dir: Path) -> None:
         status = runner.invoke(cli, ["integration", "slack", "status"])
         assert "running" in status.output and "9911" in status.output
 
-        # start again is idempotent — reports the existing pid, no 2nd spawn.
+        # --background again is idempotent — reports the existing pid, no 2nd spawn.
         popen.reset_mock()
-        again = runner.invoke(cli, ["integration", "slack", "start"])
+        again = runner.invoke(cli, ["integration", "slack", "--background"])
         assert "already running" in again.output
         popen.assert_not_called()
 
@@ -154,7 +154,7 @@ def test_slack_start_status_stop_lifecycle(data_dir: Path) -> None:
     assert "not running" in runner.invoke(cli, ["integration", "slack", "status"]).output
 
 
-def test_slack_start_reports_immediate_exit(data_dir: Path) -> None:
+def test_slack_background_reports_immediate_exit(data_dir: Path) -> None:
     """A daemon that dies on startup fails loudly with a log tail, not a lie."""
     runner = CliRunner()
     with (
@@ -165,7 +165,7 @@ def test_slack_start_reports_immediate_exit(data_dir: Path) -> None:
         mock.patch.object(IntegrationDaemon, "read_log_tail", return_value="Traceback: boom"),
     ):
         popen.return_value.pid = 5150
-        result = runner.invoke(cli, ["integration", "slack", "start"])
+        result = runner.invoke(cli, ["integration", "slack", "--background"])
     assert result.exit_code != 0
     assert "exited immediately" in result.output
     assert "boom" in result.output
@@ -184,6 +184,18 @@ def test_slack_foreground_runs_subprocess(data_dir: Path) -> None:
     assert result.exit_code == 0
     argv = run.call_args.args[0]
     assert argv[1:] == ["-m", "omnigent_slack"]
+
+
+def test_slack_start_subcommand_removed(data_dir: Path) -> None:
+    """The old ``start`` subcommand is gone — ``--background`` replaces it.
+
+    Guards the migration: a lingering ``start`` would be treated by Click as an
+    unknown subcommand (usage error), so this asserts the flag is the only way
+    in and the subcommand isn't silently re-added."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["integration", "slack", "start"])
+    assert result.exit_code != 0
+    assert "No such command 'start'" in result.output
 
 
 def test_slack_foreground_refuses_when_daemon_running(data_dir: Path) -> None:


### PR DESCRIPTION
## Related issue

N/A

See, also #3105

## Summary

- Removes the `omni integration slack start` subcommand. `omni integration slack` already starts
the Slack socket server (in the foreground), so start was a redundant way to launch it;
the only thing it added was the detached/background mode.
- Adds a `--background` flag to `omni integration slack` that reproduces the former
start behavior: spawn (or reuse) the managed detached local server instead
of running uvicorn in the foreground. omni server stop / omni server status are unchanged.

## Test Plan

- `omni integration slack start` now exits 2 with "No such command 'start'" (verified
via CliRunner).
- `omni integration slack --background` prints the URL and
captured log path on spawn, "already running" on reuse, and omits the log
line when log_path is unknown.
- `omni integration slack stop` /  `omni integration slack status`  behave as before
- `omni integration slack --help` lists --background and only the stop/status
subcommands.


## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [x] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

`omni integration slack start` is removed; use `omni integration slack --background` to launch the
detached slack socket server instead.
