### PR TITLE
feat(web): swipe session rows to archive or delete on touch

### DIFF
--- a/tests/e2e_ui/mobile/test_sidebar_swipe_actions.py
+++ b/tests/e2e_ui/mobile/test_sidebar_swipe_actions.py
@@ -1,0 +1,204 @@
+"""E2E: touch swipe actions on sidebar session rows (phone viewport).
+
+``Sidebar.rowActions.test.tsx`` covers the ``useRowSwipe`` gesture logic
+in jsdom, but jsdom has no real touch surface and no Tailwind ``md:``
+media queries — so it can't prove the gesture actually arms on a phone,
+where it is gated to ``useIsMobileViewport`` and a ``pointerType ===
+"touch"`` primary pointer. These tests run a real browser with a
+touchscreen at a 390px viewport and drive a horizontal swipe with CDP
+touch events, asserting the two configured directions:
+
+  - swipe-left → archive (the default) flips the server ``archived`` flag;
+  - swipe-right → delete opens the same confirm dialog the kebab uses
+    (no immediate delete), which then cancels cleanly.
+
+A committed swipe crosses the 72px threshold with ``touch-action: pan-y``
+reserving the horizontal axis, so this also exercises that the browser
+doesn't hand the gesture off to native scroll mid-swipe.
+
+Both tests park the page on session A and swipe a *different* session's
+row (B), then assert the URL never moved to B — so a regressed
+trailing-click suppression (the row is a ``<Link>``) surfaces as a real,
+visible navigation rather than a same-route no-op.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+import httpx
+import pytest
+from playwright.sync_api import Locator, Page, expect
+
+# iPhone-12-class portrait viewport — below the Tailwind ``md`` breakpoint
+# (768px) so ``useIsMobileViewport`` reports mobile and the swipe arms.
+_MOBILE_VIEWPORT = {"width": 390, "height": 844}
+
+
+@pytest.fixture
+def browser_context_args(browser_context_args: dict[str, Any]) -> dict[str, Any]:
+    """Give the context a real touchscreen and a phone viewport.
+
+    The swipe is touch-only (``pointerType === "touch"``) and mobile-gated,
+    so the default desktop context (no touch) would never arm it.
+    """
+    return {
+        **browser_context_args,
+        "has_touch": True,
+        "viewport": _MOBILE_VIEWPORT,
+    }
+
+
+def _set_title(base_url: str, session_id: str, title: str) -> None:
+    """Give a session a unique title via ``PATCH /v1/sessions/{id}``."""
+    httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        timeout=10.0,
+    ).raise_for_status()
+
+
+def _reveal_row(page: Page, title: str) -> Locator:
+    """Open the phone sidebar overlay and return the row once it's fully on-screen.
+
+    On a phone the sidebar starts as a closed overlay; the chat header's
+    "Open sidebar" button slides it in. The drawer animates, so wait until the
+    row's left edge clears x=0 — a swipe measured mid-slide would land off the
+    row (and the browser would ``pointercancel`` the gesture).
+    """
+    page.get_by_role("button", name="Open sidebar").click()
+    row = page.get_by_role("link", name=title, exact=True)
+    expect(row).to_be_visible()
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        box = row.bounding_box()
+        if box is not None and box["x"] >= 0:
+            return row
+        page.wait_for_timeout(50)
+    raise AssertionError("sidebar drawer did not settle on-screen")
+
+
+def _swipe_row(page: Page, row: Locator, dx: float) -> None:
+    """Drive a horizontal touch swipe of ``dx`` px across ``row``'s centre.
+
+    Uses CDP ``Input.dispatchTouchEvent`` so Chromium synthesizes a *trusted*
+    primary touch pointer. The gesture calls ``setPointerCapture`` mid-swipe,
+    which the browser only honours for a real active pointer — a Playwright
+    ``dispatch_event`` (untrusted, no active pointer) would throw instead.
+    """
+    box = row.bounding_box()
+    assert box is not None, "row must be visible to swipe"
+    cx = box["x"] + box["width"] / 2
+    cy = box["y"] + box["height"] / 2
+    sign = 1 if dx > 0 else -1
+    cdp = page.context.new_cdp_session(page)
+
+    def touch(kind: str, x: float) -> None:
+        # A stable ``id`` ties start→move→end into one active pointer, so
+        # Chromium fires correlated primary-touch pointer events (and honours
+        # setPointerCapture). A brief settle lets React commit each move's dx
+        # before the next event / release reads it.
+        points = [] if kind == "touchEnd" else [{"x": x, "y": cy, "id": 0}]
+        cdp.send("Input.dispatchTouchEvent", {"type": kind, "touchPoints": points})
+        page.wait_for_timeout(20)
+
+    try:
+        cdp.send("Emulation.setTouchEmulationEnabled", {"enabled": True, "maxTouchPoints": 1})
+        touch("touchStart", cx)
+        # First move locks the axis (past the 12px activation); the rest carry
+        # it past the 72px commit threshold.
+        touch("touchMove", cx + sign * 24)
+        touch("touchMove", cx + dx * 0.6)
+        touch("touchMove", cx + dx)
+        touch("touchEnd", cx + dx)
+    finally:
+        cdp.detach()
+
+
+def test_swipe_left_archives_session(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """Swiping a row left runs the archive path and durably archives the session.
+
+    The default direction map (swipe-left → archive) drives ``runArchive``
+    (stop→archive), the same handler the kebab's Archive item uses. Parked on
+    session A, swipe session B's row: the server ``archived`` flag on B must
+    flip, and the page must stay on A (no trailing-click navigation into B).
+    """
+    base_url, session_a, session_b = seeded_session_pair
+    title_b = f"e2e-swipe-archive-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_b, title_b)
+
+    page.goto(f"{base_url}/c/{session_a}")
+    url_before = page.url
+    row = _reveal_row(page, title_b)
+
+    _swipe_row(page, row, -90)
+
+    # Trailing-click suppression: the committed swipe must not let session B's
+    # <Link> navigate. Give a stray click time to land, then assert we're still
+    # on session A's route.
+    page.wait_for_timeout(200)
+    assert page.url == url_before, "swipe must not navigate into the swiped row"
+
+    deadline = time.monotonic() + 15.0
+    archived = False
+    while time.monotonic() < deadline:
+        resp = httpx.get(f"{base_url}/v1/sessions/{session_b}", timeout=10.0)
+        if resp.status_code == 200 and resp.json().get("archived") is True:
+            archived = True
+            break
+        time.sleep(0.5)
+    assert archived, "swipe-left should archive the session on the server"
+
+    # Restore so the shared session-scoped server isn't left with a hidden row.
+    httpx.patch(
+        f"{base_url}/v1/sessions/{session_b}",
+        json={"archived": False},
+        timeout=10.0,
+    ).raise_for_status()
+
+
+def test_swipe_right_opens_delete_confirm_and_cancels(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """Swiping right (mapped to delete) opens the confirm dialog; Cancel deletes nothing.
+
+    Swipe→delete never deletes immediately — it opens the same dialog the kebab
+    uses. Parked on session A, swipe session B's row: the dialog opens, the page
+    stays on A (no trailing-click navigation into B), and cancelling leaves B in
+    place on the server.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+    title_b = f"e2e-swipe-delete-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_b, title_b)
+
+    # Map swipe-right → delete for this device before the app boots and reads it.
+    page.add_init_script(
+        "window.localStorage.setItem('omnigent:swipe-actions',"
+        " JSON.stringify({left: 'archive', right: 'delete'}))"
+    )
+    page.goto(f"{base_url}/c/{session_a}")
+    url_before = page.url
+    row = _reveal_row(page, title_b)
+
+    _swipe_row(page, row, 90)
+
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_be_visible()
+    expect(dialog).to_contain_text("Delete conversation?")
+    # Neither the swipe's trailing click nor opening the dialog navigated away.
+    assert page.url == url_before, "swipe must not navigate into the swiped row"
+    # The dialog gates the delete — nothing is removed while it's open.
+    assert httpx.get(f"{base_url}/v1/sessions/{session_b}", timeout=10.0).status_code == 200
+
+    dialog.get_by_role("button", name="Cancel").click()
+    expect(dialog).to_have_count(0)
+    expect(row).to_be_visible()
+    # Still on session A, and B is still present on the server after cancelling.
+    assert page.url == url_before
+    assert httpx.get(f"{base_url}/v1/sessions/{session_b}", timeout=10.0).status_code == 200

--- a/web/src/lib/swipeActionPreferences.test.ts
+++ b/web/src/lib/swipeActionPreferences.test.ts
@@ -1,0 +1,148 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_SWIPE_ACTIONS,
+  isSwipeAction,
+  normalizeSwipeActions,
+  readSwipeActions,
+  useSwipeActions,
+  writeSwipeActions,
+} from "./swipeActionPreferences";
+
+const STORAGE_KEY = "omnigent:swipe-actions";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("swipeActionPreferences — read/write", () => {
+  it("returns the defaults when nothing is stored", () => {
+    expect(readSwipeActions()).toEqual(DEFAULT_SWIPE_ACTIONS);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("round-trips a written preference", () => {
+    writeSwipeActions({ left: "delete", right: "archive" });
+    expect(readSwipeActions()).toEqual({ left: "delete", right: "archive" });
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual({
+      left: "delete",
+      right: "archive",
+    });
+  });
+
+  it("allows both directions to map to the same action", () => {
+    writeSwipeActions({ left: "archive", right: "archive" });
+    expect(readSwipeActions()).toEqual({ left: "archive", right: "archive" });
+  });
+
+  it("persists a 'none' direction", () => {
+    writeSwipeActions({ left: "none", right: "delete" });
+    expect(readSwipeActions()).toEqual({ left: "none", right: "delete" });
+  });
+});
+
+describe("isSwipeAction", () => {
+  it("accepts the known actions and rejects everything else", () => {
+    expect(isSwipeAction("archive")).toBe(true);
+    expect(isSwipeAction("delete")).toBe(true);
+    expect(isSwipeAction("none")).toBe(true);
+    expect(isSwipeAction("bogus")).toBe(false);
+    expect(isSwipeAction(null)).toBe(false);
+    expect(isSwipeAction(undefined)).toBe(false);
+    expect(isSwipeAction(42)).toBe(false);
+  });
+});
+
+describe("normalizeSwipeActions", () => {
+  it("passes through a valid object", () => {
+    expect(normalizeSwipeActions({ left: "delete", right: "none" })).toEqual({
+      left: "delete",
+      right: "none",
+    });
+  });
+
+  it("fills missing/unknown directions from the defaults", () => {
+    expect(normalizeSwipeActions({ left: "delete" })).toEqual({
+      left: "delete",
+      right: DEFAULT_SWIPE_ACTIONS.right,
+    });
+    expect(normalizeSwipeActions({ left: "bogus", right: "archive" })).toEqual({
+      left: DEFAULT_SWIPE_ACTIONS.left,
+      right: "archive",
+    });
+  });
+
+  it("maps null, arrays, and primitives to the defaults", () => {
+    expect(normalizeSwipeActions(null)).toEqual(DEFAULT_SWIPE_ACTIONS);
+    expect(normalizeSwipeActions("nope")).toEqual(DEFAULT_SWIPE_ACTIONS);
+    expect(normalizeSwipeActions(123)).toEqual(DEFAULT_SWIPE_ACTIONS);
+    expect(normalizeSwipeActions([])).toEqual(DEFAULT_SWIPE_ACTIONS);
+  });
+});
+
+describe("readSwipeActions — corrupt storage", () => {
+  it("falls back to the defaults on unparseable JSON", () => {
+    localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(readSwipeActions()).toEqual(DEFAULT_SWIPE_ACTIONS);
+  });
+
+  it("normalizes a partially-valid stored object", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ left: "delete", right: "bogus" }));
+    expect(readSwipeActions()).toEqual({ left: "delete", right: DEFAULT_SWIPE_ACTIONS.right });
+  });
+});
+
+describe("useSwipeActions — live updates", () => {
+  it("starts at the current stored value", () => {
+    writeSwipeActions({ left: "delete", right: "archive" });
+    const { result } = renderHook(() => useSwipeActions());
+    expect(result.current).toEqual({ left: "delete", right: "archive" });
+  });
+
+  it("re-renders on a same-tab write (Settings change updates mounted rows)", () => {
+    const { result } = renderHook(() => useSwipeActions());
+    expect(result.current).toEqual(DEFAULT_SWIPE_ACTIONS);
+
+    act(() => {
+      writeSwipeActions({ left: "delete", right: "delete" });
+    });
+    expect(result.current).toEqual({ left: "delete", right: "delete" });
+  });
+
+  it("re-renders on a cross-tab storage event", () => {
+    const { result } = renderHook(() => useSwipeActions());
+
+    // Another tab wrote the new value; simulate the DOM `storage` broadcast.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ left: "none", right: "archive" }));
+    act(() => {
+      window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+    });
+    expect(result.current).toEqual({ left: "none", right: "archive" });
+  });
+
+  it("ignores storage events for unrelated keys", () => {
+    const { result } = renderHook(() => useSwipeActions());
+    const before = result.current;
+
+    localStorage.setItem("some:other:key", "x");
+    act(() => {
+      window.dispatchEvent(new StorageEvent("storage", { key: "some:other:key" }));
+    });
+    // Same reference — no spurious re-render/value change.
+    expect(result.current).toBe(before);
+  });
+
+  it("keeps a stable snapshot reference when the value is unchanged", () => {
+    writeSwipeActions({ left: "archive", right: "delete" });
+    const { result } = renderHook(() => useSwipeActions());
+    const first = result.current;
+
+    // A write of the identical value still pings subscribers; the value must
+    // stay referentially stable so consumers don't needlessly re-run effects.
+    act(() => {
+      writeSwipeActions({ left: "archive", right: "delete" });
+    });
+    expect(result.current).toBe(first);
+  });
+});

--- a/web/src/lib/swipeActionPreferences.ts
+++ b/web/src/lib/swipeActionPreferences.ts
@@ -1,0 +1,124 @@
+// Persisted, per-device preference for what a horizontal swipe on a session
+// row does on touch devices. Two independent directions — swipe-left and
+// swipe-right — each map to an action. Modeled after the other `*Preferences`
+// helpers: a localStorage-backed value, SSR-safe reads, and writes that swallow
+// quota/access errors so a corrupt entry can't break app boot.
+//
+// Unlike the simpler helpers this one also exposes a live subscription
+// (useSwipeActions): Settings and every mounted session row read one source, so
+// changing the preference updates open rows in the same session without a
+// reload. writeSwipeActions notifies same-tab subscribers; a `storage` listener
+// covers other tabs.
+//
+// Defaults mirror a phone mail app: swipe-left archives (the common tidy-away
+// gesture), swipe-right is inert. Both directions may map to the SAME action —
+// nothing prevents e.g. archiving on either side.
+
+import { useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "omnigent:swipe-actions";
+// Same-tab change signal. The DOM `storage` event only fires in OTHER tabs, so
+// writeSwipeActions dispatches this to refresh subscribers in the writing tab.
+const SWIPE_ACTIONS_EVENT = "omnigent:swipe-actions-changed";
+
+export const swipeActions = ["archive", "delete", "none"] as const;
+export type SwipeAction = (typeof swipeActions)[number];
+
+export type SwipeDirection = "left" | "right";
+
+export interface SwipeActionPreferences {
+  left: SwipeAction;
+  right: SwipeAction;
+}
+
+/** Default: swipe-left archives, swipe-right does nothing. */
+export const DEFAULT_SWIPE_ACTIONS: SwipeActionPreferences = {
+  left: "archive",
+  right: "none",
+};
+
+/** Return whether a string is one of the selectable swipe actions. */
+export function isSwipeAction(value: unknown): value is SwipeAction {
+  return value === "archive" || value === "delete" || value === "none";
+}
+
+/**
+ * Normalize an arbitrary parsed value to a valid preferences object, filling
+ * each missing/unknown direction from {@link DEFAULT_SWIPE_ACTIONS}. Used both
+ * on read (localStorage drift / manual edits) and to sanitize writes.
+ */
+export function normalizeSwipeActions(value: unknown): SwipeActionPreferences {
+  const obj = typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+  return {
+    left: isSwipeAction(obj.left) ? obj.left : DEFAULT_SWIPE_ACTIONS.left,
+    right: isSwipeAction(obj.right) ? obj.right : DEFAULT_SWIPE_ACTIONS.right,
+  };
+}
+
+/**
+ * Read the persisted swipe actions. Returns the defaults when nothing is
+ * stored, on a server render (no `window`), or when the stored value is
+ * missing/malformed — never throws, so a corrupt entry can't break app boot.
+ */
+export function readSwipeActions(): SwipeActionPreferences {
+  if (typeof window === "undefined") return { ...DEFAULT_SWIPE_ACTIONS };
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_SWIPE_ACTIONS };
+    return normalizeSwipeActions(JSON.parse(raw));
+  } catch {
+    return { ...DEFAULT_SWIPE_ACTIONS };
+  }
+}
+
+/**
+ * Persist the swipe actions. Normalizes first so only valid values land in
+ * storage. Swallows quota/access errors so a failed write can't break the app.
+ */
+export function writeSwipeActions(value: SwipeActionPreferences): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(normalizeSwipeActions(value)));
+  } catch {
+    // localStorage quota or access errors shouldn't break the app.
+  }
+  // Refresh same-tab subscribers (the `storage` event only fires in other tabs).
+  window.dispatchEvent(new Event(SWIPE_ACTIONS_EVENT));
+}
+
+// Cached snapshot so useSyncExternalStore's getSnapshot returns a stable
+// reference between changes — a fresh object every call would loop it. Kept
+// current by getSnapshot (re-reads and swaps only on a real change), so it's
+// never stale even after a write that had no active subscriber.
+let snapshot: SwipeActionPreferences = readSwipeActions();
+
+function getSnapshot(): SwipeActionPreferences {
+  const next = readSwipeActions();
+  if (next.left !== snapshot.left || next.right !== snapshot.right) snapshot = next;
+  return snapshot;
+}
+
+function subscribe(onChange: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const handler = (e: Event) => {
+    // Ignore unrelated `storage` events; refresh on our key or the same-tab ping.
+    if (e instanceof StorageEvent && e.key !== null && e.key !== STORAGE_KEY) return;
+    onChange();
+  };
+  window.addEventListener("storage", handler);
+  window.addEventListener(SWIPE_ACTIONS_EVENT, handler);
+  return () => {
+    window.removeEventListener("storage", handler);
+    window.removeEventListener(SWIPE_ACTIONS_EVENT, handler);
+  };
+}
+
+/**
+ * Subscribe to the live swipe-action preference. Returns the current value and
+ * re-renders on same-tab writes (via writeSwipeActions) and cross-tab `storage`
+ * events, so Settings and every mounted session row share one source of truth.
+ * SSR-safe: renders the defaults on the server.
+ */
+export function useSwipeActions(): SwipeActionPreferences {
+  return useSyncExternalStore(subscribe, getSnapshot, () => DEFAULT_SWIPE_ACTIONS);
+}

--- a/web/src/lib/swipeActionPreferences.ts
+++ b/web/src/lib/swipeActionPreferences.ts
@@ -82,27 +82,38 @@ export function writeSwipeActions(value: SwipeActionPreferences): void {
   } catch {
     // localStorage quota or access errors shouldn't break the app.
   }
-  // Refresh same-tab subscribers (the `storage` event only fires in other tabs).
+  // Update the cached snapshot from what we just persisted, then refresh
+  // same-tab subscribers (the `storage` event only fires in other tabs).
+  refreshSnapshot();
   window.dispatchEvent(new Event(SWIPE_ACTIONS_EVENT));
 }
 
 // Cached snapshot so useSyncExternalStore's getSnapshot returns a stable
-// reference between changes — a fresh object every call would loop it. Kept
-// current by getSnapshot (re-reads and swaps only on a real change), so it's
-// never stale even after a write that had no active subscriber.
+// reference — a fresh object every call would loop it, and re-reading
+// localStorage on every call (getSnapshot runs each render of every subscribed
+// row) is needless parsing work. The cache is refreshed only on a real change:
+// same-tab writes (writeSwipeActions), cross-tab `storage` events, and on
+// subscribe (to catch a write that landed before this tab had a subscriber).
 let snapshot: SwipeActionPreferences = readSwipeActions();
 
-function getSnapshot(): SwipeActionPreferences {
+/** Re-read storage and swap the cache only when a direction actually changed. */
+function refreshSnapshot(): void {
   const next = readSwipeActions();
   if (next.left !== snapshot.left || next.right !== snapshot.right) snapshot = next;
+}
+
+function getSnapshot(): SwipeActionPreferences {
   return snapshot;
 }
 
 function subscribe(onChange: () => void): () => void {
   if (typeof window === "undefined") return () => {};
+  // Catch up to any write that landed while this tab had no subscriber.
+  refreshSnapshot();
   const handler = (e: Event) => {
     // Ignore unrelated `storage` events; refresh on our key or the same-tab ping.
     if (e instanceof StorageEvent && e.key !== null && e.key !== STORAGE_KEY) return;
+    refreshSnapshot();
     onChange();
   };
   window.addEventListener("storage", handler);

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -143,6 +143,14 @@ import {
   writeHideUnconfiguredHarnesses,
 } from "@/lib/harnessVisibilityPreferences";
 import {
+  isSwipeAction,
+  type SwipeAction,
+  swipeActions as swipeActionOptions,
+  type SwipeDirection,
+  useSwipeActions,
+  writeSwipeActions,
+} from "@/lib/swipeActionPreferences";
+import {
   applyThemePalette,
   isThemeSelection,
   PALETTES,
@@ -810,6 +818,75 @@ function HideUnconfiguredHarnessesControl() {
   );
 }
 
+const SWIPE_ACTION_LABELS: Record<SwipeAction, string> = {
+  archive: "Archive",
+  delete: "Delete",
+  none: "None",
+};
+
+/**
+ * Per-device swipe-action preference for session rows on touch devices. Two
+ * selects — one per direction — each mapping a horizontal swipe to Archive,
+ * Delete, or None. Both directions may map to the same action. Delete stays
+ * behind the row's confirm dialog; None makes that direction inert.
+ */
+function SwipeActionsControl() {
+  // Live subscription so the selects reflect writes from anywhere (other tabs,
+  // and the shared source every session row reads). writeSwipeActions notifies.
+  const actions = useSwipeActions();
+  const labelId = useId();
+
+  const choose = useCallback(
+    (direction: SwipeDirection, next: SwipeAction) => {
+      writeSwipeActions({ ...actions, [direction]: next });
+    },
+    [actions],
+  );
+
+  return (
+    <ThemeSubsection
+      labelId={labelId}
+      title="Swipe actions"
+      helper="On touch devices, swipe a session row horizontally to run an action. Delete still asks to confirm."
+    >
+      <div className="flex flex-col gap-3">
+        {(["left", "right"] as const).map((direction) => (
+          <div key={direction} className="flex items-center justify-between gap-4">
+            <span className="text-sm">
+              Swipe {direction} <span aria-hidden>→</span>
+            </span>
+            <Select
+              value={actions[direction]}
+              onValueChange={(next) => {
+                if (isSwipeAction(next)) choose(direction, next);
+              }}
+            >
+              <SelectTrigger
+                aria-label={`Swipe ${direction} action`}
+                data-testid={`swipe-action-${direction}`}
+                className="w-40"
+              >
+                <SelectValue>{SWIPE_ACTION_LABELS[actions[direction]]}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {swipeActionOptions.map((action) => (
+                  <SelectItem
+                    key={action}
+                    value={action}
+                    data-testid={`swipe-action-${direction}-${action}`}
+                  >
+                    {SWIPE_ACTION_LABELS[action]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ))}
+      </div>
+    </ThemeSubsection>
+  );
+}
+
 function AppearanceSection() {
   // Embedded: the host owns light/dark, so the Mode and Color theme pickers
   // would be no-ops — hide them and say so (matching ThemeModeMenu). Terminal
@@ -840,6 +917,8 @@ function AppearanceSection() {
         <HideUnconfiguredHarnessesControl />
 
         <SidebarAppearanceGroup />
+
+        <SwipeActionsControl />
 
         <UiFontSizeControl />
 

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -6,9 +6,17 @@
 //      `onDoubleClick`), gated on edit permission.
 // See ConversationRow / ConversationEditRow in Sidebar.tsx.
 
-import { useSyncExternalStore } from "react";
+import { type PointerEvent as ReactPointerEvent, useSyncExternalStore } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  within,
+} from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -52,6 +60,11 @@ const mocks = vi.hoisted(() => {
     moveToProject: { mutate: vi.fn() },
     conversations: [] as unknown[],
     pinnedStore,
+    // Archive + stop mutations, so the swipe tests can assert the swipe→archive
+    // path drives the same stop→archive handler the kebab uses.
+    archive: { mutate: vi.fn() },
+    stopSession: { mutate: vi.fn() },
+    del: { mutate: vi.fn(), reset: vi.fn() },
   };
 });
 
@@ -66,8 +79,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useConversations: vi.fn(),
   useConnectedConversations: () => [],
   useStopAndDeleteConversation: () => ({
-    mutate: vi.fn(),
-    reset: vi.fn(),
+    mutate: mocks.del.mutate,
+    reset: mocks.del.reset,
     isPending: false,
     isError: false,
     variables: undefined,
@@ -89,11 +102,11 @@ vi.mock("@/hooks/useConversations", () => ({
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
   useRenameConversation: () => mocks.rename,
-  useArchiveConversation: () => ({ mutate: vi.fn() }),
+  useArchiveConversation: () => mocks.archive,
   useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
-  useStopSession: () => ({ mutate: vi.fn() }),
+  useStopSession: () => mocks.stopSession,
   useProjects: () => ({ data: mocks.projects.map((name: string) => ({ id: `p_${name}`, name })) }),
   // A non-empty `useProjects` renders a project folder, which queries its
   // sessions — return the collapsed (disabled) shape so the folder is inert
@@ -127,7 +140,8 @@ vi.mock("@/lib/serverOrigin", () => ({ isCurrentServerLocal: () => false }));
 
 import { type Conversation, useConversations } from "@/hooks/useConversations";
 import { __resetReadStateForTests, seedReadState } from "@/hooks/useUnseenConversations";
-import { Sidebar } from "./Sidebar";
+import { writeSwipeActions } from "@/lib/swipeActionPreferences";
+import { Sidebar, useRowSwipe } from "./Sidebar";
 
 const useConvMock = vi.mocked(useConversations);
 
@@ -219,6 +233,24 @@ function renderSidebar(activeId?: string, info?: ServerInfo) {
 beforeEach(() => {
   mocks.rename.mutate.mockReset();
   mocks.moveToProject.mutate.mockReset();
+  // Resolve archive callbacks synchronously so the transient "Archiving…"
+  // status row settles back to the interactive row within the test.
+  mocks.archive.mutate.mockReset();
+  mocks.archive.mutate.mockImplementation(
+    (_args: unknown, opts?: { onSuccess?: () => void; onSettled?: () => void }) => {
+      opts?.onSuccess?.();
+      opts?.onSettled?.();
+    },
+  );
+  // The stop that precedes archiving (runArchive) fires its `onSettled` once
+  // the runner stop resolves; invoke it synchronously so the follow-on
+  // archive.mutate runs in tests.
+  mocks.stopSession.mutate.mockReset();
+  mocks.stopSession.mutate.mockImplementation((_id: string, opts?: { onSettled?: () => void }) => {
+    opts?.onSettled?.();
+  });
+  mocks.del.mutate.mockReset();
+  mocks.del.reset.mockReset();
   mocks.projects = [];
   // Default every test to the desktop viewport; the mobile flyout test opts in.
   mocks.isMobile = false;
@@ -672,6 +704,219 @@ describe("right-click context menu", () => {
     // inline rename input appears.
     fireEvent.click(screen.getByTestId("rename-conversation"));
     expect(screen.getByTestId("rename-conversation-input")).toBeInTheDocument();
+  });
+});
+
+describe("touch swipe actions", () => {
+  // jsdom has no real touch, so drive the gesture with pointer events. The row
+  // handlers gate on a primary, non-mouse pointer (see useRowSwipe); default
+  // jsdom PointerEvents omit those, so set them explicitly. A swipe is a
+  // down → horizontal move past the commit threshold → up on the row's <li>.
+  const POINTER = { pointerId: 1, isPrimary: true, pointerType: "touch" as const };
+
+  function swipeRow(dx: number) {
+    const li = screen.getByRole("link", { name: /My Session/ }).closest("li")!;
+    fireEvent.pointerDown(li, { ...POINTER, clientX: 100, clientY: 100 });
+    // First move locks the axis; the second carries it past the commit point.
+    fireEvent.pointerMove(li, { ...POINTER, clientX: 100 + Math.sign(dx) * 20, clientY: 100 });
+    fireEvent.pointerMove(li, { ...POINTER, clientX: 100 + dx, clientY: 100 });
+    fireEvent.pointerUp(li, { ...POINTER, clientX: 100 + dx, clientY: 100 });
+  }
+
+  it("runs the archive path when swiping the archive-configured direction", () => {
+    // Default: swipe-left → archive. Swipe left past the commit threshold.
+    mocks.isMobile = true;
+    renderSidebar();
+
+    swipeRow(-90);
+
+    // runArchive stops the runner first, then flips the archive flag — the same
+    // stop→archive handler the kebab's Archive item uses.
+    expect(mocks.stopSession.mutate).toHaveBeenCalledWith("conv_1", expect.anything());
+    expect(mocks.archive.mutate).toHaveBeenCalledWith(
+      { id: "conv_1", archived: true },
+      expect.anything(),
+    );
+    // Archive never routes through delete.
+    expect(mocks.del.mutate).not.toHaveBeenCalled();
+  });
+
+  it("opens the delete confirm dialog (no immediate delete) when swiping the delete direction", () => {
+    // Map swipe-right → delete, then swipe right.
+    writeSwipeActions({ left: "archive", right: "delete" });
+    mocks.isMobile = true;
+    renderSidebar();
+
+    swipeRow(90);
+
+    // The confirm dialog opens — delete stays behind it, so no mutation yet.
+    expect(screen.getByText("Delete conversation?")).toBeInTheDocument();
+    expect(mocks.del.mutate).not.toHaveBeenCalled();
+
+    // Confirming in the dialog fires the same delete the kebab flow uses.
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(mocks.del.mutate).toHaveBeenCalledWith(
+      { id: "conv_1", deleteBranch: false },
+      expect.anything(),
+    );
+  });
+
+  it("does nothing when swiping a direction mapped to none", () => {
+    // Default: swipe-right → none. Swipe right; nothing should fire.
+    mocks.isMobile = true;
+    renderSidebar();
+
+    swipeRow(90);
+
+    expect(mocks.archive.mutate).not.toHaveBeenCalled();
+    expect(mocks.del.mutate).not.toHaveBeenCalled();
+    expect(screen.queryByText("Delete conversation?")).toBeNull();
+  });
+
+  it("supports both directions mapped to the same action", () => {
+    // Both directions archive — a swipe either way runs the archive path.
+    writeSwipeActions({ left: "archive", right: "archive" });
+    mocks.isMobile = true;
+    renderSidebar();
+
+    swipeRow(90);
+    expect(mocks.archive.mutate).toHaveBeenCalledWith(
+      { id: "conv_1", archived: true },
+      expect.anything(),
+    );
+
+    mocks.archive.mutate.mockClear();
+    swipeRow(-90);
+    expect(mocks.archive.mutate).toHaveBeenCalledWith(
+      { id: "conv_1", archived: true },
+      expect.anything(),
+    );
+  });
+
+  it("does not fire the action for a short swipe below the commit threshold", () => {
+    mocks.isMobile = true;
+    renderSidebar();
+
+    // Past the activation lock (20px) but short of the commit distance (72px).
+    swipeRow(-40);
+    expect(mocks.archive.mutate).not.toHaveBeenCalled();
+  });
+
+  it("ignores swipes on desktop (non-touch viewport)", () => {
+    // Desktop (default isMobile=false) leaves the gesture disabled entirely.
+    renderSidebar();
+
+    swipeRow(-90);
+    expect(mocks.archive.mutate).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-touch pointers (pen/stylus/mouse) on mobile", () => {
+    // The gesture is touch-only; a pen swipe past the threshold must not fire.
+    mocks.isMobile = true;
+    renderSidebar();
+
+    const li = screen.getByRole("link", { name: /My Session/ }).closest("li")!;
+    const pen = { pointerId: 1, isPrimary: true, pointerType: "pen" as const };
+    fireEvent.pointerDown(li, { ...pen, clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(li, { ...pen, clientX: 120, clientY: 100 });
+    fireEvent.pointerMove(li, { ...pen, clientX: 190, clientY: 100 });
+    fireEvent.pointerUp(li, { ...pen, clientX: 190, clientY: 100 });
+
+    expect(mocks.archive.mutate).not.toHaveBeenCalled();
+    expect(mocks.del.mutate).not.toHaveBeenCalled();
+  });
+
+  it("yields a primarily-vertical drag to scroll (no action)", () => {
+    // A mostly-vertical move is scroll intent — the gesture bails and never
+    // fires, even though it travels well past the commit distance horizontally.
+    mocks.isMobile = true;
+    renderSidebar();
+
+    const li = screen.getByRole("link", { name: /My Session/ }).closest("li")!;
+    fireEvent.pointerDown(li, { ...POINTER, clientX: 100, clientY: 100 });
+    // First move is dominated by the vertical axis → decided="other".
+    fireEvent.pointerMove(li, { ...POINTER, clientX: 105, clientY: 140 });
+    fireEvent.pointerMove(li, { ...POINTER, clientX: 10, clientY: 180 });
+    fireEvent.pointerUp(li, { ...POINTER, clientX: 10, clientY: 180 });
+
+    expect(mocks.archive.mutate).not.toHaveBeenCalled();
+    expect(mocks.del.mutate).not.toHaveBeenCalled();
+  });
+});
+
+describe("useRowSwipe — dnd coexistence", () => {
+  // Focused hook tests: driving real dnd-kit dragging in jsdom is unreliable,
+  // so control `isDragging` directly to prove the swipe yields to the drag.
+  const ACTIONS = { left: "archive", right: "none" } as const;
+
+  function makePointer(over: { pointerId: number; clientX: number; clientY: number }) {
+    // Minimal ReactPointerEvent stand-in — only the fields useRowSwipe reads,
+    // plus pointer-capture no-ops (jsdom's are stubbed in test-setup).
+    return {
+      pointerType: "touch",
+      isPrimary: true,
+      preventDefault: () => {},
+      currentTarget: {
+        setPointerCapture: () => {},
+        releasePointerCapture: () => {},
+        hasPointerCapture: () => false,
+      },
+      ...over,
+    } as unknown as ReactPointerEvent;
+  }
+
+  it("(a) yields a primarily-vertical move: decided=other, no translate, no action", () => {
+    const onAction = vi.fn();
+    const { result } = renderHook(() =>
+      useRowSwipe({ enabled: true, actions: ACTIONS, isDragging: false, onAction }),
+    );
+
+    act(() => {
+      result.current.onPointerDown(makePointer({ pointerId: 1, clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      // Vertical dominates → the gesture hands off to scroll/drag.
+      result.current.onPointerMove(makePointer({ pointerId: 1, clientX: 105, clientY: 140 }));
+    });
+    // No translate offset accumulated.
+    expect(result.current.dx).toBe(0);
+
+    act(() => {
+      result.current.onPointerUp(makePointer({ pointerId: 1, clientX: 105, clientY: 140 }));
+    });
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("(b) bails once a dnd-kit drag begins mid-gesture: dx resets, no action on release", () => {
+    const onAction = vi.fn();
+    let isDragging = false;
+    const { result, rerender } = renderHook(() =>
+      useRowSwipe({ enabled: true, actions: ACTIONS, isDragging, onAction }),
+    );
+
+    act(() => {
+      result.current.onPointerDown(makePointer({ pointerId: 1, clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      // A real horizontal swipe left (the archive-configured direction) locks
+      // in and translates the row.
+      result.current.onPointerMove(makePointer({ pointerId: 1, clientX: 70, clientY: 100 }));
+    });
+    expect(result.current.dx).not.toBe(0);
+
+    // dnd-kit's long-press drag activates; re-render with isDragging=true.
+    isDragging = true;
+    rerender();
+    act(() => {
+      result.current.onPointerMove(makePointer({ pointerId: 1, clientX: 20, clientY: 100 }));
+    });
+    // The swipe bailed: translate snaps back to rest.
+    expect(result.current.dx).toBe(0);
+
+    act(() => {
+      result.current.onPointerUp(makePointer({ pointerId: 1, clientX: 20, clientY: 100 }));
+    });
+    expect(onAction).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -217,17 +217,26 @@ export function useRowSwipe({
     decided: "swipe" | "other" | null;
     target: Element | null;
   } | null>(null);
+  // Set when a swipe commits so the click the browser synthesizes after
+  // pointer-up (the row is a <Link>) is swallowed instead of navigating into
+  // the session being archived/deleted. Cleared on the next tick.
+  const justCommittedRef = useRef(false);
 
-  const reset = useCallback(() => {
+  // Release pointer capture if we took it — guarded so it's safe when we never
+  // captured (vertical/none gestures) or the element is already gone.
+  const releaseCapture = useCallback(() => {
     const s = state.current;
-    // Release pointer capture if we took it — guarded so it's safe when we
-    // never captured (vertical/none gestures) or the element is already gone.
     if (s?.target && s.target.hasPointerCapture(s.pointerId)) {
       s.target.releasePointerCapture(s.pointerId);
+      s.target = null;
     }
+  }, []);
+
+  const reset = useCallback(() => {
+    releaseCapture();
     state.current = null;
     setDx(0);
-  }, []);
+  }, [releaseCapture]);
 
   const onPointerDown = useCallback(
     (e: ReactPointerEvent) => {
@@ -249,7 +258,10 @@ export function useRowSwipe({
       const s = state.current;
       if (!s || s.pointerId !== e.pointerId) return;
       // Once dnd-kit takes over (long-press drag), the swipe yields entirely.
+      // Release any capture we grabbed while locked so the drag's own pointer
+      // tracking isn't fighting a stale capture on this row.
       if (isDragging) {
+        releaseCapture();
         s.decided = "other";
         setDx(0);
         return;
@@ -278,7 +290,7 @@ export function useRowSwipe({
       const clamped = Math.max(-SWIPE_MAX_PX, Math.min(SWIPE_MAX_PX, deltaX));
       setDx(clamped);
     },
-    [actions.left, actions.right, isDragging],
+    [actions.left, actions.right, isDragging, releaseCapture],
   );
 
   const onPointerUp = useCallback(
@@ -288,12 +300,30 @@ export function useRowSwipe({
       const committed = s.decided === "swipe" && Math.abs(dx) >= SWIPE_COMMIT_PX;
       const action = dx < 0 ? actions.left : actions.right;
       reset();
-      if (committed && action !== "none") onAction(action);
+      if (committed && action !== "none") {
+        // Flag the commit so the trailing synthesized click is swallowed
+        // (see onClickCapture); clear on the next tick once that click passed.
+        justCommittedRef.current = true;
+        setTimeout(() => {
+          justCommittedRef.current = false;
+        }, 0);
+        onAction(action);
+      }
     },
     [actions.left, actions.right, dx, onAction, reset],
   );
 
-  return { dx, onPointerDown, onPointerMove, onPointerUp, onPointerCancel: reset };
+  // Capture-phase click guard: after a committed swipe the row's <Link> would
+  // otherwise navigate on the click the browser synthesizes post-pointer-up.
+  // Swallow that one click before it reaches the link.
+  const onClickCapture = useCallback((e: MouseEvent) => {
+    if (!justCommittedRef.current) return;
+    justCommittedRef.current = false;
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  return { dx, onPointerDown, onPointerMove, onPointerUp, onPointerCancel: reset, onClickCapture };
 }
 
 // Highlight applied to a drop target while a draggable session hovers it: a
@@ -2841,17 +2871,20 @@ function ConversationRow({
   // runArchive; swipe→delete opens the same confirm dialog the kebab uses
   // (never an immediate delete).
   const swipeActions = useSwipeActions();
-  const onSwipeAction = useCallback(
-    (action: Exclude<SwipeAction, "none">) => {
-      if (action === "archive") runArchive();
-      else setDeleteOpen(true);
-    },
-    // runArchive is a stable hoisted declaration; setDeleteOpen is a stable setter.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
+  // Keep the live handler in a ref refreshed each render so the stable callback
+  // handed to useRowSwipe always runs the current runArchive (and thus the live
+  // isArchived) rather than a closure captured at mount.
+  const swipeActionHandlerRef = useRef<(action: Exclude<SwipeAction, "none">) => void>(() => {});
+  swipeActionHandlerRef.current = (action) => {
+    if (action === "archive") runArchive();
+    else setDeleteOpen(true);
+  };
+  const onSwipeAction = useCallback((action: Exclude<SwipeAction, "none">) => {
+    swipeActionHandlerRef.current(action);
+  }, []);
+  const swipeEnabled = isMobile && !selectionMode && isOwner && !isEditing;
   const swipe = useRowSwipe({
-    enabled: isMobile && !selectionMode && isOwner && !isEditing,
+    enabled: swipeEnabled,
     actions: swipeActions,
     isDragging,
     onAction: onSwipeAction,
@@ -3054,6 +3087,82 @@ function ConversationRow({
     swipe.dx < 0 ? swipeActions.left : swipe.dx > 0 ? swipeActions.right : "none";
   const swipeCommitted = Math.abs(swipe.dx) >= SWIPE_COMMIT_PX;
 
+  // The interactive row surface (link + its context/hover/tooltip wrappers).
+  // Right-click anywhere on the row opens the same actions as the kebab.
+  // Suppressed in selection mode (bulk-select owns the row), where the bare
+  // link is rendered instead. ContextMenuTrigger preventDefaults the native
+  // contextmenu event, so right-click never navigates; asChild merges its
+  // handler onto the Link, preserving left-click / double-click. Pinned,
+  // project-owned rows nest a HoverCardTrigger around the Link so hovering
+  // surfaces the project flyout — the trigger sits innermost so both the
+  // context menu and the hover card keep their handlers/refs on the Link.
+  const rowSurface = selectionMode ? (
+    projectFlyoutName ? (
+      <HoverCard openDelay={150} closeDelay={0}>
+        <HoverCardTrigger asChild>{rowLink}</HoverCardTrigger>
+        <PinnedProjectFlyoutContent
+          title={conversation.title ?? conversation.id}
+          projectName={projectFlyoutName}
+        />
+      </HoverCard>
+    ) : isMobile ? (
+      rowLink
+    ) : (
+      <Tooltip>
+        <TooltipTrigger asChild>{rowLink}</TooltipTrigger>
+        <SessionTooltipContent conversation={conversation} hostsById={hostsById} />
+      </Tooltip>
+    )
+  ) : projectFlyoutName ? (
+    <HoverCard openDelay={150} closeDelay={0}>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <HoverCardTrigger asChild>{rowLink}</HoverCardTrigger>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
+          <ConversationMenuItems
+            components={contextBundle}
+            setMenuOpen={() => {}}
+            {...menuItemProps}
+          />
+        </ContextMenuContent>
+      </ContextMenu>
+      <PinnedProjectFlyoutContent
+        title={conversation.title ?? conversation.id}
+        projectName={projectFlyoutName}
+      />
+    </HoverCard>
+  ) : isMobile ? (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{rowLink}</ContextMenuTrigger>
+      <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
+        <ConversationMenuItems
+          components={contextBundle}
+          setMenuOpen={() => {}}
+          {...menuItemProps}
+        />
+      </ContextMenuContent>
+    </ContextMenu>
+  ) : (
+    <Tooltip>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div className="w-full">
+            <TooltipTrigger asChild>{rowLink}</TooltipTrigger>
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
+          <ConversationMenuItems
+            components={contextBundle}
+            setMenuOpen={() => {}}
+            {...menuItemProps}
+          />
+        </ContextMenuContent>
+      </ContextMenu>
+      <SessionTooltipContent conversation={conversation} hostsById={hostsById} />
+    </Tooltip>
+  );
+
   return (
     // Drag props on the <li> so the whole row is grabbable; `isDragging` dims
     // it. `setRowRef` merges the drag node ref with the scroll-into-view ref.
@@ -3066,115 +3175,62 @@ function ConversationRow({
       onPointerMove={swipe.onPointerMove}
       onPointerUp={swipe.onPointerUp}
       onPointerCancel={swipe.onPointerCancel}
-      className={cn("group relative", isDragging && "opacity-40")}
+      // `touch-pan-y` (only while the swipe is live) keeps vertical scroll
+      // native and reserves horizontal travel for the gesture, so the browser
+      // doesn't commit to a scroll and pointercancel the pre-activation window.
+      className={cn("group relative", isDragging && "opacity-40", swipeEnabled && "touch-pan-y")}
     >
-      {/* Swipe reveal hint: sits behind the moving surface, showing the
-          configured action's icon on the side being revealed. Inert (no
-          pointer events); only visible while the row is mid-swipe. */}
-      {swipingAction !== "none" && (
-        <div
-          aria-hidden
-          className={cn(
-            "pointer-events-none absolute inset-0 flex items-center rounded-md px-4",
-            swipe.dx > 0 ? "justify-start" : "justify-end",
-            swipingAction === "delete" ? "bg-destructive/15" : "bg-primary/15",
-            swipeCommitted
-              ? swipingAction === "delete"
-                ? "text-destructive"
-                : "text-primary"
-              : "text-muted-foreground",
+      {/* The moving surface only exists while the swipe gesture is live. When
+          it isn't (selection mode, desktop, non-owner), the row surface is
+          rendered directly under the <li> so the DOM stays `<li> > link` and
+          the sibling checkbox/state slots keep their expected structure. */}
+      {swipeEnabled ? (
+        <>
+          {/* Swipe reveal hint: sits behind the moving surface, showing the
+              configured action's icon on the side being revealed. Inert (no
+              pointer events); only visible while the row is mid-swipe. */}
+          {swipingAction !== "none" && (
+            <div
+              aria-hidden
+              className={cn(
+                "pointer-events-none absolute inset-0 flex items-center rounded-md px-4",
+                swipe.dx > 0 ? "justify-start" : "justify-end",
+                swipingAction === "delete" ? "bg-destructive/15" : "bg-primary/15",
+                swipeCommitted
+                  ? swipingAction === "delete"
+                    ? "text-destructive"
+                    : "text-primary"
+                  : "text-muted-foreground",
+              )}
+            >
+              {swipingAction === "delete" ? (
+                <Trash2Icon className="size-4" />
+              ) : (
+                <ArchiveIcon className="size-4" />
+              )}
+            </div>
           )}
-        >
-          {swipingAction === "delete" ? (
-            <Trash2Icon className="size-4" />
-          ) : (
-            <ArchiveIcon className="size-4" />
-          )}
-        </div>
+          {/* Moving surface: translates 1:1 with the swipe over the hint above.
+              `bg-sidebar` keeps it opaque so the hint only shows in the gap it
+              opens. Transitions back to rest when the gesture ends (dx → 0).
+              `onClickCapture` is scoped here (not the <li>) so it swallows only
+              the synthesized click on the row link after a committed swipe —
+              never a click in the delete-confirm dialog, which lives outside
+              this surface but portals through the row's React subtree. */}
+          <div
+            className={cn(
+              "relative bg-sidebar",
+              swipe.dx === 0 && "transition-transform duration-200",
+            )}
+            style={swipe.dx !== 0 ? { transform: `translateX(${swipe.dx}px)` } : undefined}
+            onClickCapture={swipe.onClickCapture}
+          >
+            {rowSurface}
+          </div>
+        </>
+      ) : (
+        rowSurface
       )}
-      {/* Moving surface: translates 1:1 with the swipe over the hint above.
-          `bg-sidebar` keeps it opaque so the hint only shows in the gap it
-          opens. Transitions back to rest when the gesture ends (dx → 0). */}
-      <div
-        className={cn("relative bg-sidebar", swipe.dx === 0 && "transition-transform duration-200")}
-        style={swipe.dx !== 0 ? { transform: `translateX(${swipe.dx}px)` } : undefined}
-      >
-        {/* Right-click anywhere on the row opens the same actions as the kebab.
-          Suppressed in selection mode (bulk-select owns the row), where the
-          bare link is rendered instead. ContextMenuTrigger preventDefaults the
-          native contextmenu event, so right-click never navigates; asChild
-          merges its handler onto the Link, preserving left-click / double-click.
-          Pinned, project-owned rows nest a HoverCardTrigger around the Link so
-          hovering surfaces the project flyout — the trigger sits innermost so
-          both the context menu and the hover card keep their handlers/refs on
-          the Link. */}
-        {selectionMode ? (
-          projectFlyoutName ? (
-            <HoverCard openDelay={150} closeDelay={0}>
-              <HoverCardTrigger asChild>{rowLink}</HoverCardTrigger>
-              <PinnedProjectFlyoutContent
-                title={conversation.title ?? conversation.id}
-                projectName={projectFlyoutName}
-              />
-            </HoverCard>
-          ) : isMobile ? (
-            rowLink
-          ) : (
-            <Tooltip>
-              <TooltipTrigger asChild>{rowLink}</TooltipTrigger>
-              <SessionTooltipContent conversation={conversation} hostsById={hostsById} />
-            </Tooltip>
-          )
-        ) : projectFlyoutName ? (
-          <HoverCard openDelay={150} closeDelay={0}>
-            <ContextMenu>
-              <ContextMenuTrigger asChild>
-                <HoverCardTrigger asChild>{rowLink}</HoverCardTrigger>
-              </ContextMenuTrigger>
-              <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
-                <ConversationMenuItems
-                  components={contextBundle}
-                  setMenuOpen={() => {}}
-                  {...menuItemProps}
-                />
-              </ContextMenuContent>
-            </ContextMenu>
-            <PinnedProjectFlyoutContent
-              title={conversation.title ?? conversation.id}
-              projectName={projectFlyoutName}
-            />
-          </HoverCard>
-        ) : isMobile ? (
-          <ContextMenu>
-            <ContextMenuTrigger asChild>{rowLink}</ContextMenuTrigger>
-            <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
-              <ConversationMenuItems
-                components={contextBundle}
-                setMenuOpen={() => {}}
-                {...menuItemProps}
-              />
-            </ContextMenuContent>
-          </ContextMenu>
-        ) : (
-          <Tooltip>
-            <ContextMenu>
-              <ContextMenuTrigger asChild>
-                <div className="w-full">
-                  <TooltipTrigger asChild>{rowLink}</TooltipTrigger>
-                </div>
-              </ContextMenuTrigger>
-              <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
-                <ConversationMenuItems
-                  components={contextBundle}
-                  setMenuOpen={() => {}}
-                  {...menuItemProps}
-                />
-              </ContextMenuContent>
-            </ContextMenu>
-            <SessionTooltipContent conversation={conversation} hostsById={hostsById} />
-          </Tooltip>
-        )}
-      </div>
       {selectionMode ? (
         <span className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-2.5 flex items-center">
           {isSelected ? (

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3,6 +3,7 @@ import {
   type CSSProperties,
   type KeyboardEvent,
   type MouseEvent,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
   type RefObject,
   createContext,
@@ -140,6 +141,11 @@ import {
   useUnseenTick,
 } from "@/hooks/useUnseenConversations";
 import { cn } from "@/lib/utils";
+import {
+  type SwipeAction,
+  type SwipeActionPreferences,
+  useSwipeActions,
+} from "@/lib/swipeActionPreferences";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
@@ -167,6 +173,128 @@ import {
 // mobile it sits left of the always-visible controls (right-[4.5rem]).
 const SESSION_STATE_SLOT_CLASS =
   "-translate-y-1/2 pointer-events-none absolute top-1/2 right-[4.5rem] flex h-5 items-center transition-opacity md:right-2 md:group-hover:opacity-0 md:group-has-[:focus-visible]:opacity-0 md:group-has-[[aria-expanded=true]]:opacity-0";
+
+// Horizontal-swipe thresholds for the mobile row gesture (see useRowSwipe).
+// ACTIVATE locks the gesture to a swipe once horizontal travel dominates;
+// COMMIT is how far the row must be dragged to fire the action on release.
+const SWIPE_ACTIVATE_PX = 12;
+const SWIPE_COMMIT_PX = 72;
+// Cap the visual translate a little past the commit point so the row can't be
+// dragged clear across the panel.
+const SWIPE_MAX_PX = 96;
+
+/**
+ * Touch swipe gesture for a session row. Tracks a horizontal drag and, on
+ * release past {@link SWIPE_COMMIT_PX}, invokes the action configured for that
+ * direction (see swipeActionPreferences). Disambiguates from dnd-kit's
+ * drag-to-project by axis (vertical movement yields to scroll/drag) and by
+ * bailing once a dnd-kit drag is active. A direction mapped to "none" is inert.
+ *
+ * Returns the live translate offset (for the row transform + reveal hint) and
+ * pointer handlers to spread on the row element.
+ */
+export function useRowSwipe({
+  enabled,
+  actions,
+  isDragging,
+  onAction,
+}: {
+  enabled: boolean;
+  actions: SwipeActionPreferences;
+  isDragging: boolean;
+  onAction: (action: Exclude<SwipeAction, "none">) => void;
+}) {
+  const [dx, setDx] = useState(0);
+  // `decided` is null until the first qualifying move locks the gesture to a
+  // horizontal swipe ("swipe") or hands it back to scroll/drag ("other").
+  // `target` holds the element we called setPointerCapture on, so reset() can
+  // release it (capture lives on the translating <li>; a leak would interfere
+  // with adjacent rows and the dnd-kit handoff).
+  const state = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    decided: "swipe" | "other" | null;
+    target: Element | null;
+  } | null>(null);
+
+  const reset = useCallback(() => {
+    const s = state.current;
+    // Release pointer capture if we took it — guarded so it's safe when we
+    // never captured (vertical/none gestures) or the element is already gone.
+    if (s?.target && s.target.hasPointerCapture(s.pointerId)) {
+      s.target.releasePointerCapture(s.pointerId);
+    }
+    state.current = null;
+    setDx(0);
+  }, []);
+
+  const onPointerDown = useCallback(
+    (e: ReactPointerEvent) => {
+      // Touch-only: pen/stylus/mouse never trigger a swipe.
+      if (!enabled || e.pointerType !== "touch" || !e.isPrimary) return;
+      state.current = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        decided: null,
+        target: null,
+      };
+    },
+    [enabled],
+  );
+
+  const onPointerMove = useCallback(
+    (e: ReactPointerEvent) => {
+      const s = state.current;
+      if (!s || s.pointerId !== e.pointerId) return;
+      // Once dnd-kit takes over (long-press drag), the swipe yields entirely.
+      if (isDragging) {
+        s.decided = "other";
+        setDx(0);
+        return;
+      }
+      if (s.decided === "other") return;
+      const deltaX = e.clientX - s.startX;
+      const deltaY = e.clientY - s.startY;
+      if (s.decided === null) {
+        // Vertical intent → let the list scroll; horizontal → lock to a swipe.
+        if (Math.abs(deltaY) > Math.abs(deltaX) && Math.abs(deltaY) > SWIPE_ACTIVATE_PX) {
+          s.decided = "other";
+          return;
+        }
+        if (Math.abs(deltaX) < SWIPE_ACTIVATE_PX || Math.abs(deltaX) <= Math.abs(deltaY)) return;
+        // A direction mapped to "none" is inert — hand back to scroll/drag.
+        const action = deltaX < 0 ? actions.left : actions.right;
+        if (action === "none") {
+          s.decided = "other";
+          return;
+        }
+        s.decided = "swipe";
+        s.target = e.currentTarget;
+        e.currentTarget.setPointerCapture(e.pointerId);
+      }
+      e.preventDefault();
+      const clamped = Math.max(-SWIPE_MAX_PX, Math.min(SWIPE_MAX_PX, deltaX));
+      setDx(clamped);
+    },
+    [actions.left, actions.right, isDragging],
+  );
+
+  const onPointerUp = useCallback(
+    (e: ReactPointerEvent) => {
+      const s = state.current;
+      if (!s || s.pointerId !== e.pointerId) return;
+      const committed = s.decided === "swipe" && Math.abs(dx) >= SWIPE_COMMIT_PX;
+      const action = dx < 0 ? actions.left : actions.right;
+      reset();
+      if (committed && action !== "none") onAction(action);
+    },
+    [actions.left, actions.right, dx, onAction, reset],
+  );
+
+  return { dx, onPointerDown, onPointerMove, onPointerUp, onPointerCancel: reset };
+}
 
 // Highlight applied to a drop target while a draggable session hovers it: a
 // subtle background tint — no border, no shadow. Keyed on --primary like the
@@ -2706,6 +2834,29 @@ function ConversationRow({
     [setDragNodeRef],
   );
 
+  // Touch swipe → archive/delete. `useSwipeActions` is a live subscription, so
+  // changing the Settings selects updates open rows in the same session (no
+  // remount needed). Gated to mobile and to editable, non-selection rows so it
+  // can't fight desktop hover controls or bulk-select. Swipe→archive reuses
+  // runArchive; swipe→delete opens the same confirm dialog the kebab uses
+  // (never an immediate delete).
+  const swipeActions = useSwipeActions();
+  const onSwipeAction = useCallback(
+    (action: Exclude<SwipeAction, "none">) => {
+      if (action === "archive") runArchive();
+      else setDeleteOpen(true);
+    },
+    // runArchive is a stable hoisted declaration; setDeleteOpen is a stable setter.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const swipe = useRowSwipe({
+    enabled: isMobile && !selectionMode && isOwner && !isEditing,
+    actions: swipeActions,
+    isDragging,
+    onAction: onSwipeAction,
+  });
+
   if (isEditing) {
     return (
       <li>
@@ -2897,15 +3048,58 @@ function ConversationRow({
     </Link>
   );
 
+  // The action revealed behind the row for the direction currently being
+  // swiped (drives the reveal hint's icon/tint). null when idle.
+  const swipingAction =
+    swipe.dx < 0 ? swipeActions.left : swipe.dx > 0 ? swipeActions.right : "none";
+  const swipeCommitted = Math.abs(swipe.dx) >= SWIPE_COMMIT_PX;
+
   return (
     // Drag props on the <li> so the whole row is grabbable; `isDragging` dims
     // it. `setRowRef` merges the drag node ref with the scroll-into-view ref.
+    // Pointer handlers drive the touch swipe-to-action gesture (see useRowSwipe);
+    // the moving surface below translates with the finger over a fixed hint.
     <li
       ref={setRowRef}
       {...dragListeners}
+      onPointerDown={swipe.onPointerDown}
+      onPointerMove={swipe.onPointerMove}
+      onPointerUp={swipe.onPointerUp}
+      onPointerCancel={swipe.onPointerCancel}
       className={cn("group relative", isDragging && "opacity-40")}
     >
-      {/* Right-click anywhere on the row opens the same actions as the kebab.
+      {/* Swipe reveal hint: sits behind the moving surface, showing the
+          configured action's icon on the side being revealed. Inert (no
+          pointer events); only visible while the row is mid-swipe. */}
+      {swipingAction !== "none" && (
+        <div
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute inset-0 flex items-center rounded-md px-4",
+            swipe.dx > 0 ? "justify-start" : "justify-end",
+            swipingAction === "delete" ? "bg-destructive/15" : "bg-primary/15",
+            swipeCommitted
+              ? swipingAction === "delete"
+                ? "text-destructive"
+                : "text-primary"
+              : "text-muted-foreground",
+          )}
+        >
+          {swipingAction === "delete" ? (
+            <Trash2Icon className="size-4" />
+          ) : (
+            <ArchiveIcon className="size-4" />
+          )}
+        </div>
+      )}
+      {/* Moving surface: translates 1:1 with the swipe over the hint above.
+          `bg-sidebar` keeps it opaque so the hint only shows in the gap it
+          opens. Transitions back to rest when the gesture ends (dx → 0). */}
+      <div
+        className={cn("relative bg-sidebar", swipe.dx === 0 && "transition-transform duration-200")}
+        style={swipe.dx !== 0 ? { transform: `translateX(${swipe.dx}px)` } : undefined}
+      >
+        {/* Right-click anywhere on the row opens the same actions as the kebab.
           Suppressed in selection mode (bulk-select owns the row), where the
           bare link is rendered instead. ContextMenuTrigger preventDefaults the
           native contextmenu event, so right-click never navigates; asChild
@@ -2914,72 +3108,73 @@ function ConversationRow({
           hovering surfaces the project flyout — the trigger sits innermost so
           both the context menu and the hover card keep their handlers/refs on
           the Link. */}
-      {selectionMode ? (
-        projectFlyoutName ? (
+        {selectionMode ? (
+          projectFlyoutName ? (
+            <HoverCard openDelay={150} closeDelay={0}>
+              <HoverCardTrigger asChild>{rowLink}</HoverCardTrigger>
+              <PinnedProjectFlyoutContent
+                title={conversation.title ?? conversation.id}
+                projectName={projectFlyoutName}
+              />
+            </HoverCard>
+          ) : isMobile ? (
+            rowLink
+          ) : (
+            <Tooltip>
+              <TooltipTrigger asChild>{rowLink}</TooltipTrigger>
+              <SessionTooltipContent conversation={conversation} hostsById={hostsById} />
+            </Tooltip>
+          )
+        ) : projectFlyoutName ? (
           <HoverCard openDelay={150} closeDelay={0}>
-            <HoverCardTrigger asChild>{rowLink}</HoverCardTrigger>
+            <ContextMenu>
+              <ContextMenuTrigger asChild>
+                <HoverCardTrigger asChild>{rowLink}</HoverCardTrigger>
+              </ContextMenuTrigger>
+              <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
+                <ConversationMenuItems
+                  components={contextBundle}
+                  setMenuOpen={() => {}}
+                  {...menuItemProps}
+                />
+              </ContextMenuContent>
+            </ContextMenu>
             <PinnedProjectFlyoutContent
               title={conversation.title ?? conversation.id}
               projectName={projectFlyoutName}
             />
           </HoverCard>
         ) : isMobile ? (
-          rowLink
+          <ContextMenu>
+            <ContextMenuTrigger asChild>{rowLink}</ContextMenuTrigger>
+            <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
+              <ConversationMenuItems
+                components={contextBundle}
+                setMenuOpen={() => {}}
+                {...menuItemProps}
+              />
+            </ContextMenuContent>
+          </ContextMenu>
         ) : (
           <Tooltip>
-            <TooltipTrigger asChild>{rowLink}</TooltipTrigger>
+            <ContextMenu>
+              <ContextMenuTrigger asChild>
+                <div className="w-full">
+                  <TooltipTrigger asChild>{rowLink}</TooltipTrigger>
+                </div>
+              </ContextMenuTrigger>
+              <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
+                <ConversationMenuItems
+                  components={contextBundle}
+                  setMenuOpen={() => {}}
+                  {...menuItemProps}
+                />
+              </ContextMenuContent>
+            </ContextMenu>
             <SessionTooltipContent conversation={conversation} hostsById={hostsById} />
           </Tooltip>
-        )
-      ) : projectFlyoutName ? (
-        <HoverCard openDelay={150} closeDelay={0}>
-          <ContextMenu>
-            <ContextMenuTrigger asChild>
-              <HoverCardTrigger asChild>{rowLink}</HoverCardTrigger>
-            </ContextMenuTrigger>
-            <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
-              <ConversationMenuItems
-                components={contextBundle}
-                setMenuOpen={() => {}}
-                {...menuItemProps}
-              />
-            </ContextMenuContent>
-          </ContextMenu>
-          <PinnedProjectFlyoutContent
-            title={conversation.title ?? conversation.id}
-            projectName={projectFlyoutName}
-          />
-        </HoverCard>
-      ) : isMobile ? (
-        <ContextMenu>
-          <ContextMenuTrigger asChild>{rowLink}</ContextMenuTrigger>
-          <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
-            <ConversationMenuItems
-              components={contextBundle}
-              setMenuOpen={() => {}}
-              {...menuItemProps}
-            />
-          </ContextMenuContent>
-        </ContextMenu>
-      ) : (
-        <Tooltip>
-          <ContextMenu>
-            <ContextMenuTrigger asChild>
-              <div className="w-full">
-                <TooltipTrigger asChild>{rowLink}</TooltipTrigger>
-              </div>
-            </ContextMenuTrigger>
-            <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
-              <ConversationMenuItems
-                components={contextBundle}
-                setMenuOpen={() => {}}
-                {...menuItemProps}
-              />
-            </ContextMenuContent>
-          </ContextMenu>
-          <SessionTooltipContent conversation={conversation} hostsById={hostsById} />
-        </Tooltip>
-      )}
+        )}
+      </div>
       {selectionMode ? (
         <span className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-2.5 flex items-center">
           {isSelected ? (


### PR DESCRIPTION
## Related issue

N/A

## Summary

Session rows in the left panel had no touch-friendly quick actions — on
mobile you had to open the kebab to archive or delete. This adds a
configurable horizontal **swipe** gesture on each row:

- Swipe a row left or right to run an action. Each direction independently
  maps to **Archive**, **Delete**, or **None**, persisted per-device.
- Configure it in **Settings → Appearance → Swipe actions** (two selects,
  one per direction). Defaults: swipe-left → Archive, swipe-right → None.
- Swipe→archive reuses the kebab's existing stop-then-archive handler;
  swipe→delete opens the **same delete confirm dialog** the kebab uses (no
  immediate delete, no separate undo path). "None" is inert.
- Coexists with the existing dnd-kit drag-to-project: the swipe locks by
  axis (horizontal past a threshold) and yields to the long-press drag, so
  drag-to-file-into-project is unaffected. Gated to touch/mobile so desktop
  hover controls don't regress.

## Test Plan

Run in `web/` (Node 20):

- `npm run type-check` — clean
- `npm run lint` — no new issues in changed files (pre-existing warnings/errors only)
- `npm run test` — 4099 passed | 3 expected fail | 2 skipped
- `npm run format:check` — all files match Prettier style

New/updated tests:
- `web/src/lib/swipeActionPreferences.test.ts` — read/write/validate/defaults round-trip.
- `web/src/shell/Sidebar.rowActions.test.tsx` — swipe→archive drives the
  stop→archive handler; swipe→delete opens the confirm dialog (deletes only
  after confirm); "none" is inert; both-directions-same-action; sub-threshold
  swipe is a no-op; desktop ignores the gesture. Driven with
  `fireEvent.pointerDown/Move/Up` since jsdom has no real touch.

## Demo

Recorded on a mobile viewport (touch emulation). The clip shows: opening
**Settings → Appearance → Swipe actions** and setting **Swipe left → Archive**
and **Swipe right → Delete**, then back on the session list a **swipe-left**
archives a row (it slides over the archive hint and leaves the list), and a
**swipe-right** on another row opens the **Delete confirmation dialog** — delete
stays gated behind confirm, never immediate.

![Swipe a session row to archive or delete on touch](https://raw.githubusercontent.com/btli/omnigent/demo-assets/mobile-swipe/mobile-slide-actions-demo.gif)

[Download MP4](https://raw.githubusercontent.com/btli/omnigent/demo-assets/mobile-swipe/mobile-slide-actions-demo.mp4)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behavior is covered by unit tests (preference round-trip + swipe gesture via
synthetic pointer events). The live touch gesture / visual affordance is shown in the Demo section above.

## Changelog

Swipe left or right on a session row (touch devices) to archive or delete it, configurable in Settings → Appearance.

This pull request and its description were written by Isaac.


