### PR TITLE
feat(policy): add detect_loop builtin contextual policy to catch agent retry loops

### DIFF
--- a/omnigent/policies/builtins/safety.py
+++ b/omnigent/policies/builtins/safety.py
@@ -136,10 +136,11 @@ def _args_hash(tool_name: str, arguments: Any) -> str:  # type: ignore[explicit-
 def detect_loop(window: int = 10, threshold: int = 3) -> PolicyCallable:
     """Factory: detect repeated identical tool calls.
 
-    Tracks recent ``(tool_name, args_hash)`` tuples in
-    ``session_state``.  When the same call repeats *threshold*
-    times within the last *window* calls, returns ASK so the
-    user can break the loop.
+    Tracks recent tool-call hashes in ``session_state`` as a
+    bounded list of SHA-256 hex digests keyed by
+    ``_policy_loop_recent_hashes``.  When the same hash
+    appears *threshold* times within the last *window* calls,
+    returns ASK so the user can break the loop.
 
     This catches the #1 token-waste pattern — an agent retrying
     the exact same failing tool call — which
@@ -147,12 +148,15 @@ def detect_loop(window: int = 10, threshold: int = 3) -> PolicyCallable:
     counts total calls.
 
     :param window: Number of recent calls to consider.
-        Defaults to ``10``.
+        Defaults to ``10``. Clamped to a minimum of ``1``.
     :param threshold: How many times a call must repeat within
-        *window* to trigger. Defaults to ``3``.
+        *window* to trigger. Defaults to ``3``. Clamped to a
+        minimum of ``1``.
     :returns: A policy callable that ASKs when a loop is
         detected.
     """
+    window = max(1, window)
+    threshold = max(1, threshold)
 
     def evaluate(event: PolicyEvent) -> PolicyResponse:
         """Evaluate whether the current tool call is a repeated loop.
@@ -672,11 +676,13 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
             "properties": {
                 "window": {
                     "type": "integer",
+                    "minimum": 1,
                     "description": "Number of recent tool calls to consider",
                     "default": 10,
                 },
                 "threshold": {
                     "type": "integer",
+                    "minimum": 1,
                     "description": "Number of identical repeats within the window to trigger",
                     "default": 3,
                 },

--- a/omnigent/policies/builtins/safety.py
+++ b/omnigent/policies/builtins/safety.py
@@ -127,10 +127,10 @@ def _args_hash(tool_name: str, arguments: Any) -> str:  # type: ignore[explicit-
 
     :param tool_name: Tool being called.
     :param arguments: Arguments dict (or any JSON-serializable value).
-    :returns: Hex digest uniquely identifying this (tool, args) pair.
+    :returns: SHA-256 hex digest identifying this (tool, args) pair.
     """
     blob = _json.dumps({"t": tool_name, "a": arguments}, sort_keys=True, default=str)
-    return _hashlib.sha256(blob.encode()).hexdigest()[:16]
+    return _hashlib.sha256(blob.encode()).hexdigest()
 
 
 def detect_loop(window: int = 10, threshold: int = 3) -> PolicyCallable:

--- a/omnigent/policies/builtins/safety.py
+++ b/omnigent/policies/builtins/safety.py
@@ -8,6 +8,8 @@ Python. Each callable follows the :class:`PolicyEvent` →
 
 from __future__ import annotations
 
+import hashlib as _hashlib
+import json as _json
 import re as _re
 from typing import Any
 
@@ -111,6 +113,88 @@ def max_tool_calls_per_session(limit: int = 100) -> PolicyCallable:
             "result": "ALLOW",
             "state_updates": [
                 {"key": "_policy_tool_call_count", "action": "increment", "value": 1},
+            ],
+        }
+
+    return evaluate  # type: ignore[return-value]
+
+
+_LOOP_STATE_KEY = "_policy_loop_recent_hashes"
+
+
+def _args_hash(tool_name: str, arguments: Any) -> str:  # type: ignore[explicit-any]
+    """Deterministic hash of (tool_name, arguments).
+
+    :param tool_name: Tool being called.
+    :param arguments: Arguments dict (or any JSON-serializable value).
+    :returns: Hex digest uniquely identifying this (tool, args) pair.
+    """
+    blob = _json.dumps({"t": tool_name, "a": arguments}, sort_keys=True, default=str)
+    return _hashlib.sha256(blob.encode()).hexdigest()[:16]
+
+
+def detect_loop(window: int = 10, threshold: int = 3) -> PolicyCallable:
+    """Factory: detect repeated identical tool calls.
+
+    Tracks recent ``(tool_name, args_hash)`` tuples in
+    ``session_state``.  When the same call repeats *threshold*
+    times within the last *window* calls, returns ASK so the
+    user can break the loop.
+
+    This catches the #1 token-waste pattern — an agent retrying
+    the exact same failing tool call — which
+    ``max_tool_calls_per_session`` cannot detect because it only
+    counts total calls.
+
+    :param window: Number of recent calls to consider.
+        Defaults to ``10``.
+    :param threshold: How many times a call must repeat within
+        *window* to trigger. Defaults to ``3``.
+    :returns: A policy callable that ASKs when a loop is
+        detected.
+    """
+
+    def evaluate(event: PolicyEvent) -> PolicyResponse:
+        """Evaluate whether the current tool call is a repeated loop.
+
+        :param event: Policy event dict.
+        :returns: ASK if loop detected, ALLOW otherwise.
+        """
+        if event.get("type") != "tool_call":
+            return _ALLOW
+        data = event.get("data")
+        if not isinstance(data, dict):
+            return _ALLOW
+
+        tool_name = data.get("name", "")
+        arguments = data.get("arguments", {})
+        h = _args_hash(tool_name, arguments)
+
+        state = event.get("session_state") or {}
+        recent: list[str] = list(state.get(_LOOP_STATE_KEY) or [])
+
+        recent.append(h)
+        # Trim to sliding window.
+        recent = recent[-window:]
+
+        count = recent.count(h)
+        if count >= threshold:
+            return {
+                "result": "ASK",
+                "reason": (
+                    f"The agent appears stuck in a retry loop — "
+                    f"tool '{tool_name}' called with identical arguments "
+                    f"{count} times in the last {len(recent)} calls."
+                ),
+                "state_updates": [
+                    {"key": _LOOP_STATE_KEY, "action": "set", "value": recent},
+                ],
+            }
+
+        return {
+            "result": "ALLOW",
+            "state_updates": [
+                {"key": _LOOP_STATE_KEY, "action": "set", "value": recent},
             ],
         }
 
@@ -574,6 +658,29 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                 },
             },
             "required": ["limit"],
+        },
+    },
+    {
+        "handler": "omnigent.policies.builtins.safety.detect_loop",
+        "kind": "factory",
+        "name": "Detect Tool Call Retry Loops",
+        "description": "Detects when the agent is stuck retrying the same tool call with "
+        "identical arguments. ASKs for user approval when the same (tool, args) "
+        "repeats N times within a sliding window of recent calls",
+        "params_schema": {
+            "type": "object",
+            "properties": {
+                "window": {
+                    "type": "integer",
+                    "description": "Number of recent tool calls to consider",
+                    "default": 10,
+                },
+                "threshold": {
+                    "type": "integer",
+                    "description": "Number of identical repeats within the window to trigger",
+                    "default": 3,
+                },
+            },
         },
     },
     {

--- a/tests/e2e/test_detect_loop_policy_e2e.py
+++ b/tests/e2e/test_detect_loop_policy_e2e.py
@@ -36,13 +36,17 @@ guardrails:
 """
 
 
+@pytest.fixture()
+def conversation_store(db_uri: str) -> SqlAlchemyConversationStore:
+    """Conversation store backed by a per-test SQLite DB."""
+    return SqlAlchemyConversationStore(db_uri)
+
+
 def _build(tmp_path: Path, store: SqlAlchemyConversationStore) -> PolicyEngine:
     (tmp_path / "config.yaml").write_text(_YAML)
     spec = parse(tmp_path)
     conv = store.create_conversation()
-    return build_policy_engine(
-        spec=spec, conversation_id=conv.id, conversation_store=store
-    )
+    return build_policy_engine(spec=spec, conversation_id=conv.id, conversation_store=store)
 
 
 def _tool_ctx(name: str, args: dict | None = None) -> EvaluationContext:
@@ -124,8 +128,6 @@ async def test_detect_loop_non_tool_call_phases_pass_through(
 
     for _ in range(5):
         r = await engine.evaluate(
-            EvaluationContext(
-                phase=Phase.REQUEST, content="same message", tool_name=None
-            )
+            EvaluationContext(phase=Phase.REQUEST, content="same message", tool_name=None)
         )
         assert r.action == PolicyAction.ALLOW

--- a/tests/policies/builtins/test_detect_loop.py
+++ b/tests/policies/builtins/test_detect_loop.py
@@ -1,0 +1,226 @@
+"""Tests for the ``detect_loop`` builtin policy.
+
+Covers:
+
+- Basic loop detection when a tool call repeats ≥ threshold times.
+- Distinct calls within the window do not trigger.
+- Sliding window eviction: old entries drop off and no longer count.
+- Different arguments produce different hashes (no false positives).
+- Non-tool_call phases pass through.
+- State updates are always emitted (the window advances on every call).
+- Custom window/threshold parameters.
+"""
+
+from __future__ import annotations
+
+from omnigent.policies.builtins.safety import _LOOP_STATE_KEY, _args_hash, detect_loop
+from tests.policies.builtins.helpers import tool_call_event as tc
+
+
+def _state_with_hashes(hashes: list[str]) -> dict:
+    return {_LOOP_STATE_KEY: list(hashes)}
+
+
+# ── Basic detection ─────────────────────────────────────────────────────────
+
+
+def test_detect_loop_triggers_on_repeated_calls() -> None:
+    """Three identical calls in a row trigger ASK."""
+    policy = detect_loop(window=10, threshold=3)
+    h = _args_hash("sys_os_shell", {"command": "ls"})
+
+    result = policy(tc("sys_os_shell", {"command": "ls"}, _state_with_hashes([h, h])))
+    assert result["result"] == "ASK"
+    assert "retry loop" in result["reason"]
+    assert "sys_os_shell" in result["reason"]
+
+
+def test_detect_loop_allows_below_threshold() -> None:
+    """Two identical calls (below threshold=3) are allowed."""
+    policy = detect_loop(window=10, threshold=3)
+    h = _args_hash("sys_os_shell", {"command": "ls"})
+
+    result = policy(tc("sys_os_shell", {"command": "ls"}, _state_with_hashes([h])))
+    assert result["result"] == "ALLOW"
+
+
+def test_detect_loop_first_call_allows() -> None:
+    """The very first call (empty state) is allowed."""
+    policy = detect_loop(window=10, threshold=3)
+    result = policy(tc("sys_os_shell", {"command": "ls"}))
+    assert result["result"] == "ALLOW"
+
+
+# ── Different args ──────────────────────────────────────────────────────────
+
+
+def test_detect_loop_different_args_no_trigger() -> None:
+    """Same tool with different arguments does not trigger."""
+    policy = detect_loop(window=10, threshold=3)
+    h1 = _args_hash("sys_os_shell", {"command": "ls"})
+    h2 = _args_hash("sys_os_shell", {"command": "pwd"})
+
+    result = policy(tc("sys_os_shell", {"command": "cat foo"}, _state_with_hashes([h1, h2])))
+    assert result["result"] == "ALLOW"
+
+
+def test_detect_loop_different_tools_no_trigger() -> None:
+    """Different tools with same arguments do not trigger."""
+    policy = detect_loop(window=10, threshold=3)
+    h1 = _args_hash("Read", {"path": "/tmp/f"})
+    h2 = _args_hash("Write", {"path": "/tmp/f"})
+
+    result = policy(tc("Edit", {"path": "/tmp/f"}, _state_with_hashes([h1, h2])))
+    assert result["result"] == "ALLOW"
+
+
+# ── Sliding window ──────────────────────────────────────────────────────────
+
+
+def test_detect_loop_window_eviction() -> None:
+    """Old entries outside the window no longer count.
+
+    With window=4 and threshold=3, two old matching hashes plus
+    two intervening different calls means only one match remains
+    in the window when the third identical call arrives.
+    """
+    policy = detect_loop(window=4, threshold=3)
+    h_target = _args_hash("Bash", {"command": "fail"})
+    h_other = _args_hash("Read", {"path": "x"})
+
+    # History: [target, target, other, other] — window=4 keeps all four.
+    # The current call adds a third target, but the window trims to last 4:
+    # [target, other, other, target] → only 2 matches, below threshold=3.
+    state = _state_with_hashes([h_target, h_target, h_other, h_other])
+    result = policy(tc("Bash", {"command": "fail"}, state))
+    assert result["result"] == "ALLOW"
+
+
+def test_detect_loop_window_keeps_recent() -> None:
+    """Matches within the window still trigger.
+
+    With window=4, threshold=3: history is [other, target, target],
+    current call is target → window is [other, target, target, target]
+    → 3 matches → ASK.
+    """
+    policy = detect_loop(window=4, threshold=3)
+    h_target = _args_hash("Bash", {"command": "fail"})
+    h_other = _args_hash("Read", {"path": "x"})
+
+    state = _state_with_hashes([h_other, h_target, h_target])
+    result = policy(tc("Bash", {"command": "fail"}, state))
+    assert result["result"] == "ASK"
+
+
+# ── State updates ───────────────────────────────────────────────────────────
+
+
+def test_detect_loop_emits_state_updates_on_allow() -> None:
+    """ALLOW results still carry state_updates to advance the window."""
+    policy = detect_loop(window=10, threshold=3)
+    result = policy(tc("web_search", {"query": "hello"}))
+    assert result["result"] == "ALLOW"
+    updates = result.get("state_updates", [])
+    assert len(updates) == 1
+    assert updates[0]["key"] == _LOOP_STATE_KEY
+    assert updates[0]["action"] == "set"
+
+
+def test_detect_loop_emits_state_updates_on_ask() -> None:
+    """ASK results carry state_updates too (the window still advances)."""
+    policy = detect_loop(window=10, threshold=3)
+    h = _args_hash("Bash", {"command": "fail"})
+    state = _state_with_hashes([h, h])
+    result = policy(tc("Bash", {"command": "fail"}, state))
+    assert result["result"] == "ASK"
+    updates = result.get("state_updates", [])
+    assert len(updates) == 1
+    assert updates[0]["key"] == _LOOP_STATE_KEY
+
+
+def test_detect_loop_window_trimmed_in_state() -> None:
+    """The state_updates value is trimmed to the window size."""
+    policy = detect_loop(window=3, threshold=3)
+    h = _args_hash("Bash", {"command": "x"})
+    # Pre-fill with 5 entries — more than the window.
+    state = _state_with_hashes([h, h, h, h, h])
+    result = policy(tc("Bash", {"command": "x"}, state))
+    updates = result.get("state_updates", [])
+    stored = updates[0]["value"]
+    assert len(stored) == 3
+
+
+# ── Phase filtering ─────────────────────────────────────────────────────────
+
+
+def test_detect_loop_ignores_non_tool_call_phase() -> None:
+    """Non-tool_call phases pass through with ALLOW."""
+    policy = detect_loop()
+    result = policy(
+        {
+            "type": "response",
+            "target": None,
+            "data": "some response",
+            "context": {"actor": {}, "usage": {}},
+            "session_state": {},
+        }
+    )
+    assert result["result"] == "ALLOW"
+
+
+def test_detect_loop_ignores_non_dict_data() -> None:
+    """tool_call with non-dict data passes through."""
+    policy = detect_loop()
+    result = policy(
+        {
+            "type": "tool_call",
+            "target": None,
+            "data": "not a dict",
+            "context": {"actor": {}, "usage": {}},
+            "session_state": {},
+        }
+    )
+    assert result["result"] == "ALLOW"
+
+
+# ── Custom parameters ──────────────────────────────────────────────────────
+
+
+def test_detect_loop_custom_threshold() -> None:
+    """Higher threshold requires more repeats."""
+    policy = detect_loop(window=20, threshold=5)
+    h = _args_hash("Bash", {"command": "x"})
+
+    # 4 prior calls + current = 5 → triggers at threshold=5.
+    state = _state_with_hashes([h, h, h, h])
+    result = policy(tc("Bash", {"command": "x"}, state))
+    assert result["result"] == "ASK"
+
+    # 3 prior + current = 4 → below threshold=5.
+    state = _state_with_hashes([h, h, h])
+    result = policy(tc("Bash", {"command": "x"}, state))
+    assert result["result"] == "ALLOW"
+
+
+# ── Args hash determinism ──────────────────────────────────────────────────
+
+
+def test_args_hash_deterministic() -> None:
+    """Same inputs produce the same hash."""
+    h1 = _args_hash("tool", {"a": 1, "b": "x"})
+    h2 = _args_hash("tool", {"b": "x", "a": 1})
+    assert h1 == h2
+
+
+def test_args_hash_different_tools() -> None:
+    """Different tool names produce different hashes."""
+    h1 = _args_hash("tool_a", {"x": 1})
+    h2 = _args_hash("tool_b", {"x": 1})
+    assert h1 != h2
+
+
+def test_args_hash_different_args() -> None:
+    """Different arguments produce different hashes."""
+    h1 = _args_hash("tool", {"x": 1})
+    h2 = _args_hash("tool", {"x": 2})
+    assert h1 != h2

--- a/tests/runtime/policies/test_detect_loop_e2e.py
+++ b/tests/runtime/policies/test_detect_loop_e2e.py
@@ -1,0 +1,131 @@
+"""End-to-end test for the ``detect_loop`` builtin policy.
+
+Exercises the full YAML → parser → PolicyEngine → evaluate path
+with real session-state persistence, verifying that repeated
+identical tool calls trigger ASK and that diverse calls pass
+through.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.policies.types import EvaluationContext
+from omnigent.runtime.policies import build_policy_engine
+from omnigent.runtime.policies.engine import PolicyEngine
+from omnigent.spec.parser import parse
+from omnigent.spec.types import Phase, PolicyAction
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+
+_YAML = """\
+spec_version: 1
+name: loop-detect-agent
+guardrails:
+  policies:
+    loop_guard:
+      type: function
+      function:
+        path: omnigent.policies.builtins.safety.detect_loop
+        arguments:
+          window: 5
+          threshold: 3
+"""
+
+
+def _build(tmp_path: Path, store: SqlAlchemyConversationStore) -> PolicyEngine:
+    (tmp_path / "config.yaml").write_text(_YAML)
+    spec = parse(tmp_path)
+    conv = store.create_conversation()
+    return build_policy_engine(
+        spec=spec, conversation_id=conv.id, conversation_store=store
+    )
+
+
+def _tool_ctx(name: str, args: dict | None = None) -> EvaluationContext:
+    return EvaluationContext(
+        phase=Phase.TOOL_CALL,
+        content={"name": name, "arguments": args or {}},
+        tool_name=name,
+    )
+
+
+@pytest.mark.asyncio
+async def test_detect_loop_asks_on_repeated_tool_calls(
+    tmp_path: Path,
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Three identical tool calls within the window trigger ASK."""
+    engine = _build(tmp_path, conversation_store)
+    ctx = _tool_ctx("Bash", {"command": "cat /nonexistent"})
+
+    r1 = await engine.evaluate(ctx)
+    assert r1.action == PolicyAction.ALLOW
+
+    r2 = await engine.evaluate(ctx)
+    assert r2.action == PolicyAction.ALLOW
+
+    r3 = await engine.evaluate(ctx)
+    assert r3.action == PolicyAction.ASK
+    assert "retry loop" in (r3.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_detect_loop_allows_diverse_tool_calls(
+    tmp_path: Path,
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Distinct tool calls never trigger, even with many calls."""
+    engine = _build(tmp_path, conversation_store)
+
+    for i in range(10):
+        r = await engine.evaluate(_tool_ctx("Bash", {"command": f"echo {i}"}))
+        assert r.action == PolicyAction.ALLOW
+
+
+@pytest.mark.asyncio
+async def test_detect_loop_window_evicts_old_entries(
+    tmp_path: Path,
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Old entries outside the window stop counting.
+
+    With window=5, threshold=3: two identical calls, then three
+    different calls push the first two out of the window, so a
+    third identical call does not trigger.
+    """
+    engine = _build(tmp_path, conversation_store)
+    repeated = _tool_ctx("Bash", {"command": "fail"})
+
+    r1 = await engine.evaluate(repeated)
+    assert r1.action == PolicyAction.ALLOW
+    r2 = await engine.evaluate(repeated)
+    assert r2.action == PolicyAction.ALLOW
+
+    for i in range(3):
+        r = await engine.evaluate(_tool_ctx("Read", {"path": f"/file{i}"}))
+        assert r.action == PolicyAction.ALLOW
+
+    # The two early "fail" calls have been evicted from the window.
+    r3 = await engine.evaluate(repeated)
+    assert r3.action == PolicyAction.ALLOW
+
+
+@pytest.mark.asyncio
+async def test_detect_loop_non_tool_call_phases_pass_through(
+    tmp_path: Path,
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Request and response phases are not affected."""
+    engine = _build(tmp_path, conversation_store)
+
+    for _ in range(5):
+        r = await engine.evaluate(
+            EvaluationContext(
+                phase=Phase.REQUEST, content="same message", tool_name=None
+            )
+        )
+        assert r.action == PolicyAction.ALLOW


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add `detect_loop` builtin contextual policy that fires on `tool_call` and tracks recent `(tool_name, args_hash)` tuples in `session_state`. When the same call repeats N times (default 3) within a sliding window (default 10), returns ASK with "the agent appears stuck in a retry loop."
- Configurable via `window` (sliding window size) and `threshold` (repeat count to trigger) factory params.

## Test Plan

- 16 unit tests in `tests/policies/builtins/test_detect_loop.py` covering:
  - Basic loop detection and below-threshold allowing
  - Different args/tools producing no false positives
  - Sliding window eviction (old entries drop off)
  - State updates emitted on both ALLOW and ASK
  - Window trimming in persisted state
  - Phase filtering (non-tool_call passes through)
  - Custom window/threshold parameters
  - Args hash determinism and collision resistance

```bash
python -m pytest tests/policies/builtins/test_detect_loop.py -v
```

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

`detect_loop` builtin policy catches agents stuck retrying the same tool call and prompts for approval to break the loop