### PR TITLE
Enable AI Gateway supported experimental beta features

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -1640,8 +1640,11 @@ def _ucode_config_for_profile(
     env: dict[str, str] = {
         _UCODE_CLAUDE_BASE_URL_ENV: base_url,
         _CLAUDE_CODE_API_KEY_HELPER_TTL_ENV: str(refresh_interval_ms),
-        _CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS_ENV: "1",
     }
+    # Don't disable betas when gateway-aware mode (CLAUDE_CODE_USE_GATEWAY=1)
+    # is selected: that mode keeps tool search on so MCP schemas load on demand.
+    if os.environ.get("CLAUDE_CODE_USE_GATEWAY") != "1":
+        env[_CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS_ENV] = "1"
     # Pin each Claude Code model-tier alias to the corresponding Databricks
     # gateway model ID so that the /model picker natively shows gateway model
     # names.  Without this Claude Code normalises the picked model to a
@@ -1746,13 +1749,13 @@ def _provider_config_for_native_claude(entry: ProviderEntry) -> ClaudeNativeUcod
     return ClaudeNativeUcodeConfig(
         env={
             _UCODE_CLAUDE_BASE_URL_ENV: family.base_url,
-            # Disable Claude Code's experimental anthropic-beta flags. Gateways
-            # (Databricks serving-endpoints and the like) reject beta flags they
-            # don't implement with a 400 "invalid beta flag", which kills every
-            # turn. The ucode/databricks path already sets this; mirror it here
-            # so the generic key/gateway/local provider path is equally
-            # gateway-safe.
-            _CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS_ENV: "1",
+            # Disable beta flags gateways reject (400 "invalid beta flag");
+            # skip when CLAUDE_CODE_USE_GATEWAY=1 to keep tool search enabled.
+            **(
+                {_CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS_ENV: "1"}
+                if os.environ.get("CLAUDE_CODE_USE_GATEWAY") != "1"
+                else {}
+            ),
         },
         api_key_helper=api_key_helper,
         model=family.default_model,


### PR DESCRIPTION
## Summary

- We previously always set `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` unconditionally, which always disabled experimental beta features.
- `CLAUDE_CODE_USE_GATEWAY` tells Claude to only pass in AI Gateway supported experimental beta features
- When the launching process sets `CLAUDE_CODE_USE_GATEWAY=1`, that gateway-aware mode keeps tool search enabled so MCP schemas load on demand. Setting `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` alongside it overrides that mode, disabling all betas and inflating startup token usage because we aren't able to use tool search to load MCPs

## Test Plan

- [x] `python3 -c "import ast; ast.parse(open('omnigent/claude_native.py').read())"` — syntax valid.
- [ ] Manual: launch `omnigent claude` with `CLAUDE_CODE_USE_GATEWAY=1` and confirm `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` is absent from the spawned env; launch without it and confirm `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` is present.

## Demo

N/A — non-visual change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Changelog

`omnigent claude` keeps tool search enabled when launched with `CLAUDE_CODE_USE_GATEWAY=1`.