### PR TITLE
fix(runner): patch heartbeat cadence on the app module

### DIFF
--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -1440,7 +1440,7 @@ async def test_session_stream_receives_events() -> None:
 @pytest.mark.asyncio
 async def test_session_stream_emits_heartbeat_on_idle() -> None:
     """The session stream emits an immediate and idle ``session.heartbeat``."""
-    runner_app_module = sys.modules[_session_labels_for_runner_spawn.__module__]
+    runner_app_module = sys.modules[create_runner_app.__module__]
     original = runner_app_module._SESSION_STREAM_HEARTBEAT_S
     runner_app_module._SESSION_STREAM_HEARTBEAT_S = 0.05
     try:


### PR DESCRIPTION
## Summary

Fixes the `Pytest (runner-app)` failure currently on `main`.

`test_session_stream_emits_heartbeat_on_idle` raised:
```
AttributeError: module 'omnigent.runner.native.orchestration' has no attribute '_SESSION_STREAM_HEARTBEAT_S'
```

### Root cause

PR #3148 ("[runner] Extract native terminal orchestration") moved `_session_labels_for_runner_spawn` from `omnigent/runner/app.py` into `omnigent/runner/native/orchestration.py`. However `_SESSION_STREAM_HEARTBEAT_S` and the `stream_session` loop that reads it stayed behind in `omnigent/runner/app.py`.

The test located the module to patch via `_session_labels_for_runner_spawn.__module__`, which now resolves to `omnigent.runner.native.orchestration` — a module that has no `_SESSION_STREAM_HEARTBEAT_S` attribute — so the test raised `AttributeError` and broke CI on `main`.

### Fix

Patch `omnigent.runner.app` directly, which is where the heartbeat cadence constant and its consumer actually live.

## Test Plan

- [x] `pytest tests/runner/test_app_sessions_native_workflow_init.py::test_session_stream_emits_heartbeat_on_idle` — now passes (was failing on `main`).
- [x] `pytest tests/runner/test_app_sessions_native_workflow_init.py` — all 31 tests pass.
- [x] `ruff check` — clean.

## Type of change

- [x] Test / CI

## Changelog

Fix `test_session_stream_emits_heartbeat_on_idle` after `_session_labels_for_runner_spawn` was extracted into `omnigent.runner.native.orchestration`; patch the heartbeat cadence on `omnigent.runner.app` where it is defined and consumed.