### PR TITLE
Add AGI launch animation

### DIFF
--- a/web/src/App.animation.test.tsx
+++ b/web/src/App.animation.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import App from "./App";
+import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
+import type { ServerInfo } from "@/lib/capabilities";
+
+vi.mock("@/shell/AppShell", () => ({
+  AppShell: () => <main data-testid="app-shell" />,
+}));
+
+vi.mock("@/pages/SetupPage", () => ({
+  SetupPage: () => <main data-testid="setup-page" />,
+}));
+
+const serverInfo: ServerInfo = {
+  accounts_enabled: false,
+  single_user: false,
+  login_url: null,
+  needs_setup: false,
+  databricks_features: false,
+  managed_sandboxes_enabled: false,
+  sandbox_provider: null,
+  sharing_mode: "on",
+  public_sharing_enabled: true,
+  server_version: null,
+  smart_routing_enabled: false,
+};
+
+describe("App launch animation", () => {
+  it("renders the exact animated announcement on load", () => {
+    render(
+      <CapabilitiesProvider info={serverInfo}>
+        <MemoryRouter initialEntries={["/"]}>
+          <App />
+        </MemoryRouter>
+      </CapabilitiesProvider>,
+    );
+
+    const announcement = screen.getByText("AGI is here");
+    expect(announcement).toBeInTheDocument();
+    expect(announcement).toHaveClass("agi-launch-text");
+    expect(announcement.closest("[aria-label='AGI is here']")).toHaveClass("agi-launch");
+  });
+
+  it("also renders the animated announcement on the first-run setup route", () => {
+    render(
+      <CapabilitiesProvider
+        info={{
+          ...serverInfo,
+          accounts_enabled: true,
+          needs_setup: true,
+        }}
+      >
+        <MemoryRouter initialEntries={["/setup"]}>
+          <App />
+        </MemoryRouter>
+      </CapabilitiesProvider>,
+    );
+
+    const announcement = screen.getByText("AGI is here");
+    expect(announcement).toHaveClass("agi-launch-text");
+    expect(announcement.closest("[aria-label='AGI is here']")).toHaveClass("agi-launch");
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { ChatPage } from "@/pages/ChatPage";
 import { NotFoundPage } from "@/pages/NotFoundPage";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { AppShell } from "@/shell/AppShell";
+import { AgiLaunchAnimation } from "@/components/AgiLaunchAnimation";
 
 // Lazy-load the accounts pages so the bundle a header / OIDC
 // deploy ships (where accounts is off) doesn't include them in the
@@ -97,54 +98,60 @@ function App({ basename }: AppProps = {}) {
   // after the first admin exists.
   if (info.accounts_enabled && info.needs_setup) {
     return (
-      <Suspense fallback={null}>
-        <Routes>
-          <Route path={basename ? `${prefix}/*` : "*"} element={<SetupPage />} />
-        </Routes>
-      </Suspense>
+      <>
+        <AgiLaunchAnimation />
+        <Suspense fallback={null}>
+          <Routes>
+            <Route path={basename ? `${prefix}/*` : "*"} element={<SetupPage />} />
+          </Routes>
+        </Suspense>
+      </>
     );
   }
 
   return (
-    <Suspense fallback={null}>
-      <Routes>
-        {info.accounts_enabled && (
-          <>
-            <Route path={`${prefix}/login`} element={<LoginPage />} />
-            <Route path={`${prefix}/register`} element={<RegisterPage />} />
-          </>
-        )}
-        <Route path={`${prefix}/approve/:sessionId/:elicitationId`} element={<ApprovePage />} />
-        <Route element={<AppShell />}>
-          <Route path={prefix || "/"} element={<ChatPage />} />
-          <Route path={`${prefix}/c/:conversationId`} element={<ChatPage />} />
-          <Route path={`${prefix}/inbox`} element={<InboxPage />} />
-          {/* Settings renders into the chat outlet so the conversations
+    <>
+      <AgiLaunchAnimation />
+      <Suspense fallback={null}>
+        <Routes>
+          {info.accounts_enabled && (
+            <>
+              <Route path={`${prefix}/login`} element={<LoginPage />} />
+              <Route path={`${prefix}/register`} element={<RegisterPage />} />
+            </>
+          )}
+          <Route path={`${prefix}/approve/:sessionId/:elicitationId`} element={<ApprovePage />} />
+          <Route element={<AppShell />}>
+            <Route path={prefix || "/"} element={<ChatPage />} />
+            <Route path={`${prefix}/c/:conversationId`} element={<ChatPage />} />
+            <Route path={`${prefix}/inbox`} element={<InboxPage />} />
+            {/* Settings renders into the chat outlet so the conversations
               sidebar stays put — entering settings only swaps the card's
               content (the section nav) and the main area. The active section
               is carried in the URL (/settings/<section>); bare /settings
               defaults to Appearance. */}
-          <Route path={`${prefix}/settings`} element={<SettingsPage />} />
-          <Route path={`${prefix}/settings/:section`} element={<SettingsPage />} />
-          {/* Members / Policies are now settings sub-categories
+            <Route path={`${prefix}/settings`} element={<SettingsPage />} />
+            <Route path={`${prefix}/settings/:section`} element={<SettingsPage />} />
+            {/* Members / Policies are now settings sub-categories
               (/settings/members, /settings/policies) so entering them
               keeps the settings sidebar nav instead of dropping back to
               the conversation list. Redirect the old standalone paths so
               existing bookmarks / links still land in the right place.
               Registered in every multi-user mode (accounts AND OIDC) —
               the sections self-gate to admins. */}
-          <Route
-            path={`${prefix}/members`}
-            element={<Navigate to={`${prefix}/settings/members`} replace />}
-          />
-          <Route
-            path={`${prefix}/policies`}
-            element={<Navigate to={`${prefix}/settings/policies`} replace />}
-          />
-          <Route path={basename ? `${prefix}/*` : "*"} element={<NotFoundPage />} />
-        </Route>
-      </Routes>
-    </Suspense>
+            <Route
+              path={`${prefix}/members`}
+              element={<Navigate to={`${prefix}/settings/members`} replace />}
+            />
+            <Route
+              path={`${prefix}/policies`}
+              element={<Navigate to={`${prefix}/settings/policies`} replace />}
+            />
+            <Route path={basename ? `${prefix}/*` : "*"} element={<NotFoundPage />} />
+          </Route>
+        </Routes>
+      </Suspense>
+    </>
   );
 }
 

--- a/web/src/components/AgiLaunchAnimation.tsx
+++ b/web/src/components/AgiLaunchAnimation.tsx
@@ -1,0 +1,7 @@
+export function AgiLaunchAnimation() {
+  return (
+    <div className="agi-launch" aria-label="AGI is here">
+      <span className="agi-launch-text">AGI is here</span>
+    </div>
+  );
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -12,6 +12,83 @@
 
 @custom-variant dark (&:is(.dark *));
 
+.agi-launch {
+  position: fixed;
+  z-index: 60;
+  top: calc(var(--omnigent-inset-top, 0px) + 0.875rem);
+  left: 50%;
+  pointer-events: none;
+  transform: translateX(-50%);
+  animation: agi-launch-enter 900ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.agi-launch-text {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.25rem;
+  max-width: calc(100vw - 2rem);
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, var(--foreground) 12%, transparent);
+  border-radius: 999px;
+  background:
+    linear-gradient(120deg, transparent 0%, rgba(255, 255, 255, 0.72) 45%, transparent 58%),
+    color-mix(in oklab, var(--card-solid, var(--card)) 92%, transparent);
+  background-size:
+    220% 100%,
+    100% 100%;
+  box-shadow: 0 14px 42px rgba(17, 23, 28, 0.16);
+  color: var(--foreground);
+  font-size: 0.875rem;
+  font-weight: 650;
+  line-height: 1;
+  padding: 0 1rem;
+  white-space: nowrap;
+  animation:
+    agi-launch-shimmer 2.4s 350ms ease-in-out infinite,
+    agi-launch-float 3.2s 900ms ease-in-out infinite;
+}
+
+@keyframes agi-launch-enter {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -0.75rem) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+}
+
+@keyframes agi-launch-shimmer {
+  from {
+    background-position:
+      180% 0,
+      0 0;
+  }
+  to {
+    background-position:
+      -80% 0,
+      0 0;
+  }
+}
+
+@keyframes agi-launch-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(0.1875rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agi-launch,
+  .agi-launch-text {
+    animation: none;
+  }
+}
+
 @theme inline {
   --font-heading: var(--font-sans);
   /* Native system UI font stack — defers to whatever the OS ships


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds a small global launch animation that renders the exact text `AGI is here` on app load.
- Mounts the animation for the normal app routes and the first-run setup route.
- Adds an App-level regression test that pins the exact text and animation hook classes.

## Test Plan

- `npm test -- App.animation.test.tsx`
- `npx prettier --check src/App.tsx src/App.animation.test.tsx src/components/AgiLaunchAnimation.tsx src/index.css`
- `npx oxlint src/App.tsx src/App.animation.test.tsx src/components/AgiLaunchAnimation.tsx`
- `npm run type-check`
- `npm run build`
- `pipx run pre-commit run --all-files` (web prettier and file hygiene hooks passed; Python-backed hooks failed because this worktree has no `.venv/bin/python`)

## Demo

Manual browser smoke via Vite + Playwright confirmed visible exact text `AGI is here`, wrapper animation `agi-launch-enter`, and text animations `agi-launch-shimmer, agi-launch-float` on load.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used a real browser load of the Vite app at `http://127.0.0.1:4175/` and inspected the rendered element text, visibility, ARIA label, and computed CSS animation names.

## Changelog

Show a polished animated `AGI is here` launch badge when the web app loads.
