### PR TITLE
fix(kimi): re-park the same approval elicitation on hook re-fire

### DIFF
--- a/omnigent/kimi_native_hook.py
+++ b/omnigent/kimi_native_hook.py
@@ -222,11 +222,23 @@ def _main_permission_request(argv: list[str]) -> int:
     tool_name = payload.get("tool_name")
     if not isinstance(tool_name, str) or not tool_name:
         return 0
+    # Re-attach id keyed on kimi's per-tool-call id so a hook re-fired after a
+    # severed long-poll (reconnect / transient 5xx) re-parks the SAME server
+    # elicitation and picks up a verdict answered while it was disconnected —
+    # rather than minting a fresh card and orphaning the one the human answered,
+    # which leaves kimi's TUI menu parked forever. Unlike claude-native (whose
+    # hook blocks and is invoked once), kimi fires PermissionRequest
+    # fire-and-forget and can re-fire, so a random-per-call id defeats re-attach.
+    # A distinct call id keeps distinct approvals distinct; fall back to a random
+    # id only when kimi omits the call id, preserving the old behaviour.
+    tool_call_id = payload.get("tool_call_id")
+    if isinstance(tool_call_id, str) and tool_call_id:
+        elicitation_id = f"elicit_kimi_{session_id}_{tool_call_id}"
+    else:
+        elicitation_id = f"elicit_kimi_{secrets.token_hex(16)}"
     body: dict[str, object] = {
         "tool_name": tool_name,
-        # Stable re-attach id so a severed long-poll re-parks the SAME
-        # elicitation (mirrors the claude permission hook).
-        "_omnigent_elicitation_id": f"elicit_kimi_{secrets.token_hex(16)}",
+        "_omnigent_elicitation_id": elicitation_id,
     }
     tool_input = payload.get("tool_input")
     if isinstance(tool_input, dict):

--- a/tests/test_kimi_native_hook.py
+++ b/tests/test_kimi_native_hook.py
@@ -189,6 +189,53 @@ def test_permission_request_injects_keystroke_for_verdict(
     assert keys == [expected_key]
 
 
+def test_permission_request_elicitation_id_is_stable_per_tool_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A re-fired hook re-parks the same elicitation; distinct calls stay distinct."""
+    bridge_dir = _governed_bridge(tmp_path)
+    ids: list[str] = []
+
+    def _capture(url: object, headers: object, body: dict[str, object]) -> None:
+        ids.append(body["_omnigent_elicitation_id"])
+        return
+
+    monkeypatch.setattr(kimi_native_hook, "_request_web_approval", _capture)
+    _capture_injection(monkeypatch)
+
+    for call_id in ("tc_1", "tc_1", "tc_2"):
+        _feed_stdin(
+            monkeypatch,
+            {"hook_event_name": "PermissionRequest", "tool_name": "Bash", "tool_call_id": call_id},
+        )
+        assert kimi_native_hook.main(["permission-request", "--bridge-dir", str(bridge_dir)]) == 0
+
+    assert ids[0] == ids[1], "same tool_call_id must re-park the same elicitation"
+    assert ids[2] != ids[0], "a different tool_call_id must be a distinct elicitation"
+
+
+def test_permission_request_elicitation_id_random_without_call_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No tool_call_id → fall back to a random id (old behaviour preserved)."""
+    bridge_dir = _governed_bridge(tmp_path)
+    ids: list[str] = []
+    monkeypatch.setattr(
+        kimi_native_hook,
+        "_request_web_approval",
+        lambda url, headers, body: ids.append(body["_omnigent_elicitation_id"]) or None,
+    )
+    _capture_injection(monkeypatch)
+
+    for _ in range(2):
+        _feed_stdin(monkeypatch, {"hook_event_name": "PermissionRequest", "tool_name": "Bash"})
+        assert kimi_native_hook.main(["permission-request", "--bridge-dir", str(bridge_dir)]) == 0
+
+    assert ids[0] != ids[1], "absent a call id, each request is its own elicitation"
+
+
 def test_permission_request_no_verdict_injects_nothing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Related issue

N/A

## Summary

The kimi permission-request hook mints a fresh random `_omnigent_elicitation_id`
on **every** invocation, while the comment right above it claims a stable
re-attach id:

```python
# Stable re-attach id so a severed long-poll re-parks the SAME
# elicitation (mirrors the claude permission hook).
"_omnigent_elicitation_id": f"elicit_kimi_{secrets.token_hex(16)}",
```

The comment describes claude-native's model, where the hook **blocks** and is
therefore invoked exactly once. kimi fires `PermissionRequest`
fire-and-forget and re-fires the hook after a severed long-poll (reconnect or a
transient 5xx). Under that model a random-per-call id defeats re-attach
entirely.

The failure: the re-fire mints a *new* approval card and orphans the one the
human already answered. The live hook's long-poll never sees a verdict,
`_request_web_approval` returns `None`, and the keystroke is never injected — so
kimi sits at its own in-TUI approval menu forever, while the server marks the
answered card resolved and reports "continuing" to the parent. The session is
wedged with no error anywhere.

Key the id on kimi's per-tool-call id instead, so a re-fire re-parks the same
elicitation and picks up a verdict answered while it was disconnected. Distinct
tool calls still get distinct ids, so concurrent approvals stay separate. When
kimi omits the call id the random-id behaviour is preserved unchanged.

## Test Plan

- `pytest tests/test_kimi_native_hook.py` — 21 passed, including a new case
  asserting both directions: a re-fired hook for the same `tool_call_id`
  produces the same elicitation id, and two different tool calls stay distinct.
- `pre-commit run --files omnigent/kimi_native_hook.py tests/test_kimi_native_hook.py`.

## Demo

N/A — no visual surface; the change is which elicitation id the hook sends.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — the id-derivation contract is fully covered by the new unit tests, and the
existing hook tests cover the surrounding request/verdict path.

## Changelog

A kimi approval prompt answered while the connection dropped now takes effect instead of leaving the session parked.
