### PR TITLE
fix(antigravity): re-resolve the connect-RPC port when agy rebinds

### DIFF
--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -773,7 +773,7 @@ async def _discover(
 
 async def _watch_for_rotation(
     *,
-    port: int,
+    state: _ReaderState,
     bound_cascade_id: str,
     interval_s: float,
     skip_cascade_ids: frozenset[str],
@@ -808,7 +808,8 @@ async def _watch_for_rotation(
     ``httpx.HTTPError`` (e.g. a hung-but-listening port raising ``ReadTimeout``)
     still WARNs because it signals a real fault.
 
-    :param port: Validated connect-RPC port (the bound reader's port).
+    :param state: Per-run shared trackers; ``state.port`` is read each tick so the
+        detector follows the reader when a dead port is re-resolved.
     :param bound_cascade_id: The cascade id the reader is currently bound to.
     :param interval_s: Seconds between rotation checks (kept coarse — a few seconds
         — so the loopback RPC is not hammered).
@@ -826,6 +827,7 @@ async def _watch_for_rotation(
     idle_ticks = 0
     while True:
         await _sleep(interval_s)
+        port = state.port
         try:
             body = await asyncio.to_thread(get_all_cascade_trajectories, port)
         except httpx.ConnectError as exc:
@@ -1052,7 +1054,6 @@ async def supervise_reader(
                 exc,
             )
             await _poll_loop(
-                port=port,
                 cascade_id=cascade_id,
                 client=client,
                 session_id=session_id,
@@ -1069,7 +1070,7 @@ async def supervise_reader(
     # the task is available to cancel (the holder is already populated).
     rotation_task = asyncio.create_task(
         _watch_for_rotation(
-            port=port,
+            state=state,
             bound_cascade_id=cascade_id,
             interval_s=detect_rotation_interval_s,
             skip_cascade_ids=skip_cascade_ids,
@@ -1218,7 +1219,6 @@ class _ReaderState:
 
 async def _poll_loop(
     *,
-    port: int,
     cascade_id: str,
     client: httpx.AsyncClient,
     session_id: str,
@@ -1237,9 +1237,10 @@ async def _poll_loop(
 
     A poll failure — ``httpx.HTTPError`` (transport AND non-2xx) or ``ValueError``
     (a non-JSON 200 body) — is logged and swallowed so a transient fault never
-    kills the loop; the next poll recovers.
+    kills the loop; the next poll recovers. A ``httpx.ConnectError`` means the
+    bound port is dead (agy rebound its connect-RPC server), so the port is
+    re-resolved into ``state`` instead of being retried forever.
 
-    :param port: Validated connect-RPC port.
     :param cascade_id: agy cascade id (equal to the conversation id).
     :param client: HTTP client for Omnigent event posts.
     :param session_id: Omnigent conversation id to mirror into.
@@ -1251,8 +1252,32 @@ async def _poll_loop(
     :returns: None.
     """
     while not stop():
+        port = state.port
         try:
             steps = await asyncio.to_thread(get_trajectory_steps, port, cascade_id)
+        except httpx.ConnectError as exc:
+            # Connection refused: nothing owns this port any more because agy
+            # rebound its connect-RPC server (language-server restart). Retrying
+            # the dead port would spin forever and mirror nothing, so re-resolve
+            # the cascade's current port before the next poll. A failed
+            # re-resolution just keeps the old port and retries.
+            _logger.warning(
+                "agy RPC reader poll hit a dead port; re-resolving: cascade=%s port=%s error=%r",
+                cascade_id,
+                port,
+                exc,
+            )
+            resolved = await asyncio.to_thread(_resolve_rpc_port, cascade_id)
+            if resolved is not None and resolved != port:
+                _logger.info(
+                    "agy RPC reader rebound to a new port: cascade=%s old_port=%s new_port=%s",
+                    cascade_id,
+                    port,
+                    resolved,
+                )
+                state.port = resolved
+            await _sleep(poll_interval_s)
+            continue
         except httpx.HTTPError as exc:
             _logger.warning(
                 "agy RPC reader poll failed (transport/status); retrying: "

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -3236,7 +3236,12 @@ async def _watch_until_cancelled(
     with caplog.at_level(logging.DEBUG, logger=reader.__name__):
         with pytest.raises(asyncio.CancelledError):
             await reader._watch_for_rotation(
-                port=_PORT,
+                state=reader._ReaderState(
+                    allocator=reader._ToolCallIdAllocator(conversation_id=_BOUND_CASCADE),
+                    seen=set(),
+                    interacted=set(),
+                    port=_PORT,
+                ),
                 bound_cascade_id=_BOUND_CASCADE,
                 interval_s=0.0,
                 skip_cascade_ids=frozenset(),
@@ -3846,7 +3851,12 @@ async def test_watch_for_rotation_signals_quiescence_only_after_consecutive_idle
 
     with pytest.raises(asyncio.CancelledError):
         await reader._watch_for_rotation(
-            port=_PORT,
+            state=reader._ReaderState(
+                allocator=reader._ToolCallIdAllocator(conversation_id=_BOUND_CASCADE),
+                seen=set(),
+                interacted=set(),
+                port=_PORT,
+            ),
             bound_cascade_id=_BOUND_CASCADE,
             interval_s=0.0,
             skip_cascade_ids=frozenset(),
@@ -3855,3 +3865,56 @@ async def test_watch_for_rotation_signals_quiescence_only_after_consecutive_idle
         )
 
     assert calls == [1], "expected exactly one quiescence signal, after two idle ticks"
+
+
+@pytest.mark.asyncio
+async def test_poll_loop_reresolves_port_when_agy_rebinds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refused poll re-resolves the cascade's port instead of retrying a dead one.
+
+    The regression: the connect-RPC port was resolved once at bind, so when agy
+    rebound its language server onto a new port every poll raised
+    ``ConnectError`` forever and the session mirrored nothing.
+    """
+    dead_port = 58169
+    live_port = 56822
+    seen_ports: list[int] = []
+
+    def _steps(port: int, _cascade_id: str) -> list[dict[str, object]]:
+        seen_ports.append(port)
+        if port != live_port:
+            raise httpx.ConnectError("[Errno 61] Connection refused")
+        return []
+
+    monkeypatch.setattr(reader, "get_trajectory_steps", _steps)
+    monkeypatch.setattr(reader, "_resolve_rpc_port", lambda _cascade_id: live_port)
+
+    async def _noop_sleep(_seconds: float) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(reader, "_sleep", _noop_sleep)
+
+    state = reader._ReaderState(
+        allocator=reader._ToolCallIdAllocator(conversation_id=_CASCADE_ID),
+        seen=set(),
+        interacted=set(),
+        port=dead_port,
+    )
+    ticks = iter([False, False, True])
+
+    await asyncio.wait_for(
+        reader._poll_loop(
+            cascade_id=_CASCADE_ID,
+            client=cast(httpx.AsyncClient, object()),
+            session_id=_SESSION_ID,
+            on_pending_interaction=cast(Any, None),
+            state=state,
+            poll_interval_s=0.0,
+            stop=lambda: next(ticks, True),
+        ),
+        timeout=5,
+    )
+
+    assert seen_ports == [dead_port, live_port]
+    assert state.port == live_port


### PR DESCRIPTION
## Related issue

N/A

## Summary

The antigravity (agy) native reader resolves agy's connect-RPC port once at bind
and holds it for the life of the run. When agy restarts its language server the
port moves, so every subsequent poll raises `ConnectError` against the dead port
and the loop retries it forever — the session mirrors nothing and no output ever
reaches the web UI. The rotation detector, pinned to the same stale port, goes
blind at the same moment.

`_resolve_rpc_port` already exists and already knows how to find the cascade's
current port; nothing was calling it after the initial bind.

Make `state.port` the single source of truth:

- `_poll_loop` reads it each tick and, on a refused connect, re-resolves and
  stores the new port before the next poll. A failed re-resolution keeps the old
  port and retries, so this can only ever improve on the current behaviour.
- `_watch_for_rotation` takes the same `state` and reads `state.port` each tick,
  so the detector follows the reader across a rebind instead of being pinned to
  the port captured at construction.

`ConnectError` is handled specifically rather than widening the existing
`httpx.HTTPError` arm: a hung-but-listening port raising `ReadTimeout` is a real
fault and must keep WARNing, not silently trigger a re-resolve.

## Test Plan

- `pytest tests/test_antigravity_native_reader.py` — 86 passed. New case
  `test_poll_loop_reresolves_port_when_agy_rebinds` asserts the poll sequence
  visits the dead port, re-resolves, and lands on the live one, and that
  `state.port` is updated.
- `pre-commit run --files omnigent/antigravity_native_reader.py tests/test_antigravity_native_reader.py`.
- Rebased onto current `main` (over #3499). The quiescence-backstop test added
  there calls `_watch_for_rotation`, so it was updated to the `state=` signature
  in the same commit; it still passes unchanged in behaviour.

## Demo

N/A — no visual surface; the change is which port the reader polls after agy
rebinds.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — the re-resolution path is covered end to end by the new unit test, which
exercises the real `_poll_loop` with the RPC seam stubbed.

## Changelog

Antigravity sessions keep mirroring after agy restarts its language server, instead of going silent for the rest of the session.
