### PR TITLE
test(runner): fix heartbeat test patching a module that lost the const

### DIFF
--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -6,7 +6,6 @@ import asyncio
 import contextlib
 import json
 import logging
-import sys
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -1440,7 +1439,8 @@ async def test_session_stream_receives_events() -> None:
 @pytest.mark.asyncio
 async def test_session_stream_emits_heartbeat_on_idle() -> None:
     """The session stream emits an immediate and idle ``session.heartbeat``."""
-    runner_app_module = sys.modules[_session_labels_for_runner_spawn.__module__]
+    import omnigent.runner.app as runner_app_module
+
     original = runner_app_module._SESSION_STREAM_HEARTBEAT_S
     runner_app_module._SESSION_STREAM_HEARTBEAT_S = 0.05
     try:


### PR DESCRIPTION
## Related issue

N/A

## Summary

`test_session_stream_emits_heartbeat_on_idle` fails on `main` with `AttributeError: module 'omnigent.runner.native.orchestration' has no attribute '_SESSION_STREAM_HEARTBEAT_S'`. The test picked the module to monkeypatch via `sys.modules[_session_labels_for_runner_spawn.__module__]`, assuming that helper is co-located with `_SESSION_STREAM_HEARTBEAT_S`. The helper was moved to `omnigent.runner.native.orchestration`, but the const — and the SSE stream generator that reads it as a module global — stayed in `omnigent.runner.app`, so the indirection resolves to the wrong module and the test errors before running.

Reference `omnigent.runner.app` directly (the module that defines the const and reads it in the generator, so the patch takes effect), and drop the now-unused `sys` import. Test-only; no runtime behaviour changes.

## Test Plan

- `pytest tests/runner/test_app_sessions_native_workflow_init.py::test_session_stream_emits_heartbeat_on_idle` — passes (was erroring with `AttributeError` on `main`).
- `ruff check tests/runner/test_app_sessions_native_workflow_init.py` — clean.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The fixed test is itself the coverage — it was erroring on `main` and now passes. No production code changed; the SSE generator already reads the const as an `omnigent.runner.app` module global, which the corrected monkeypatch target exercises.
