### PR TITLE
examples: add databricks_genie_analyst (Genie over managed MCP)

### DIFF
--- a/examples/databricks_genie_analyst/README.md
+++ b/examples/databricks_genie_analyst/README.md
@@ -16,7 +16,7 @@ does not mutate data):
 
 | Connector | Server | Transport | Auth |
 |---|---|---|---|
-| `genie` | Databricks-managed MCP (`/api/2.0/mcp/genie/<space-id>`) | `http` | OAuth via `databricks_profile` |
+| `genie` | Databricks-managed MCP (`/api/2.0/mcp/genie/<space-id>`) | `http` | OAuth via the tool's `auth:` block |
 
 ## Prerequisites
 
@@ -45,10 +45,25 @@ DATABRICKS_PROFILE=my-profile \
 
 ## Notes
 
-- The connector uses omnigent's built-in Databricks auth (`databricks_profile`):
-  it mints a short-lived OAuth bearer token per connection instead of hardcoding
-  one. If you'd rather pass a token explicitly, drop `databricks_profile` and set
-  `headers: { Authorization: "Bearer ${DATABRICKS_TOKEN}" }` instead.
+- The connector uses omnigent's built-in Databricks auth — the `auth:` block on
+  the `genie` tool in `config.yaml`:
+
+  ```yaml
+      auth:
+        type: databricks
+        profile: ${DATABRICKS_PROFILE}
+  ```
+
+  omnigent mints a short-lived OAuth bearer token per connection from that
+  profile instead of hardcoding one. If you'd rather pass a token explicitly,
+  **replace that `auth:` block** with an explicit header:
+
+  ```yaml
+      headers:
+        Authorization: Bearer ${DATABRICKS_TOKEN}
+  ```
+
+  Keep one or the other, not both.
 - The managed MCP URL follows the documented pattern
   `https://<workspace-hostname>/api/2.0/mcp/genie/<space-id>`; on-behalf-of-user
   auth uses the `genie` OAuth scope.

--- a/examples/databricks_genie_analyst/README.md
+++ b/examples/databricks_genie_analyst/README.md
@@ -1,0 +1,60 @@
+# Databricks Genie Analyst
+
+An example Omnigent agent that answers natural-language questions over
+**Unity Catalog-governed data** through a [Databricks Genie](https://docs.databricks.com/aws/en/genie/)
+space — reached over the **Databricks-managed MCP server**, no custom connector
+code required.
+
+This is the Databricks-on-AWS companion to the [`aws_analyst`](../aws_analyst/)
+example. Where `aws_analyst` reaches Amazon Redshift + S3 Tables through the AWS
+Labs MCP servers, this agent reaches Databricks Genie through its managed MCP
+server — the two together make a "better together" analyst that reasons across
+both platforms.
+
+Wired connector (**read-only** — Genie answers questions and returns SQL, it
+does not mutate data):
+
+| Connector | Server | Transport | Auth |
+|---|---|---|---|
+| `genie` | Databricks-managed MCP (`/api/2.0/mcp/genie/<space-id>`) | `http` | OAuth via `databricks_profile` |
+
+## Prerequisites
+
+- A Databricks workspace on AWS with a **Genie space** you can query.
+- The [Databricks CLI](https://docs.databricks.com/aws/en/dev-tools/cli/) with a
+  configured profile that can reach that space:
+  ```bash
+  databricks auth login --profile my-profile
+  ```
+  omnigent resolves an OAuth token from that profile at connection time and
+  injects it as the `Authorization` header — **no token is written into the
+  config**.
+
+## Run
+
+```bash
+DATABRICKS_HOSTNAME=my-workspace.cloud.databricks.com \
+DATABRICKS_GENIE_SPACE_ID=01ef1234-5678-90ab-cdef-1234567890ab \
+DATABRICKS_PROFILE=my-profile \
+  omnigent run examples/databricks_genie_analyst
+```
+
+- `DATABRICKS_HOSTNAME` — your workspace hostname (no scheme).
+- `DATABRICKS_GENIE_SPACE_ID` — the id of the Genie space (from its URL).
+- `DATABRICKS_PROFILE` — the `~/.databrickscfg` profile to authenticate with.
+
+## Notes
+
+- The connector uses omnigent's built-in Databricks auth (`databricks_profile`):
+  it mints a short-lived OAuth bearer token per connection instead of hardcoding
+  one. If you'd rather pass a token explicitly, drop `databricks_profile` and set
+  `headers: { Authorization: "Bearer ${DATABRICKS_TOKEN}" }` instead.
+- The managed MCP URL follows the documented pattern
+  `https://<workspace-hostname>/api/2.0/mcp/genie/<space-id>`; on-behalf-of-user
+  auth uses the `genie` OAuth scope.
+- Genie is inherently read-only from the MCP surface — it turns questions into
+  governed SQL over Unity Catalog and returns the SQL alongside the answer, so
+  every result is auditable.
+- Pairs naturally with [`aws_analyst`](../aws_analyst/) for a Databricks-on-AWS
+  "better together" analyst that reasons across Databricks **and** native AWS
+  data sources.

--- a/examples/databricks_genie_analyst/config.yaml
+++ b/examples/databricks_genie_analyst/config.yaml
@@ -1,0 +1,77 @@
+# Databricks Genie Analyst — ask natural-language questions of governed data in
+# Databricks through a Genie space, over the Databricks-managed MCP server.
+#
+# This is the Databricks-on-AWS companion to the aws_analyst example: where
+# aws_analyst reaches Amazon Redshift + S3 Tables through the AWS Labs MCP
+# servers, this agent reaches Unity Catalog-governed tables through Databricks
+# Genie — the two together make a "better together" analyst that reasons across
+# both platforms.
+#
+# The Genie space is reached through the Databricks-managed MCP server (no custom
+# connector code): a plain HTTP MCP endpoint whose URL embeds the Genie space id.
+# Auth is handled by `databricks_profile` — omnigent resolves an OAuth token from
+# ~/.databrickscfg at connection time and injects it as `Authorization: Bearer …`,
+# so no token is ever written into this file.
+#
+# Prerequisites:
+#   - A Databricks workspace on AWS with a Genie space you can query.
+#   - The Databricks CLI configured with a profile (`databricks auth login
+#     --profile <name>`) that has access to that Genie space.
+#
+# Usage:
+#   DATABRICKS_HOSTNAME=my-workspace.cloud.databricks.com \
+#   DATABRICKS_GENIE_SPACE_ID=01ef... \
+#   DATABRICKS_PROFILE=my-profile \
+#     omnigent run examples/databricks_genie_analyst
+
+spec_version: 1
+name: databricks_genie_analyst
+description: >-
+  An analyst agent that answers natural-language questions over Unity
+  Catalog-governed data through a Databricks Genie space, reached over the
+  Databricks-managed MCP server (read-only, OAuth via a Databricks profile).
+
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+tools:
+  # Databricks Genie — the managed MCP server for a single Genie space. The URL
+  # follows the documented managed-MCP pattern:
+  #   https://<workspace-hostname>/api/2.0/mcp/genie/<space-id>
+  # `databricks_profile` makes omnigent mint an OAuth bearer token from
+  # ~/.databrickscfg at connect time (the `genie` scope) — nothing secret lives
+  # in this config. The Genie MCP surface is inherently read-only: it answers
+  # questions and returns SQL results; it does not mutate data.
+  genie:
+    type: mcp
+    transport: http
+    url: https://${DATABRICKS_HOSTNAME}/api/2.0/mcp/genie/${DATABRICKS_GENIE_SPACE_ID}
+    auth:
+      type: databricks
+      profile: ${DATABRICKS_PROFILE}
+    description: >-
+      Databricks Genie space over the managed MCP server — natural-language
+      questions become governed SQL over Unity Catalog tables.
+
+prompt: |
+  You are a Databricks data analyst. You answer questions over Unity
+  Catalog-governed data through a single toolset:
+
+  - `genie` — a Databricks Genie space, reached over the Databricks-managed MCP
+    server. You ask Genie natural-language questions about the data domain the
+    space is configured for; Genie translates them into governed SQL over Unity
+    Catalog and returns results (and the SQL it ran).
+
+  Rules:
+  - Genie is the source of truth for what data exists — don't assume tables or
+    columns. If a question is ambiguous or spans data the space may not cover,
+    ask Genie a scoping question first (or tell the user what the space covers).
+  - This surface is read-only: it answers analytical questions. Never imply you
+    can insert, update, or delete data.
+  - When Genie returns the SQL it ran, surface it — the value of a governed
+    analytics layer is that every answer is auditable back to a query.
+  - If Genie can't answer (the data isn't in this space), say so plainly rather
+    than guessing. In a Databricks-on-AWS "better together" setup, that data may
+    live in a source the aws_analyst example covers (Amazon Redshift / S3 Tables).

--- a/examples/databricks_genie_analyst/config.yaml
+++ b/examples/databricks_genie_analyst/config.yaml
@@ -9,9 +9,9 @@
 #
 # The Genie space is reached through the Databricks-managed MCP server (no custom
 # connector code): a plain HTTP MCP endpoint whose URL embeds the Genie space id.
-# Auth is handled by `databricks_profile` — omnigent resolves an OAuth token from
-# ~/.databrickscfg at connection time and injects it as `Authorization: Bearer …`,
-# so no token is ever written into this file.
+# Auth is handled by the `auth:` block on the tool below — omnigent resolves an
+# OAuth token from ~/.databrickscfg at connection time and injects it as
+# `Authorization: Bearer …`, so no token is ever written into this file.
 #
 # Prerequisites:
 #   - A Databricks workspace on AWS with a Genie space you can query.
@@ -40,7 +40,7 @@ tools:
   # Databricks Genie — the managed MCP server for a single Genie space. The URL
   # follows the documented managed-MCP pattern:
   #   https://<workspace-hostname>/api/2.0/mcp/genie/<space-id>
-  # `databricks_profile` makes omnigent mint an OAuth bearer token from
+  # The `auth:` block below makes omnigent mint an OAuth bearer token from
   # ~/.databrickscfg at connect time (the `genie` scope) — nothing secret lives
   # in this config. The Genie MCP surface is inherently read-only: it answers
   # questions and returns SQL results; it does not mutate data.

--- a/tests/e2e/omnigent/test_example_databricks_genie_analyst.py
+++ b/tests/e2e/omnigent/test_example_databricks_genie_analyst.py
@@ -103,7 +103,6 @@ def test_genie_auth_is_profile_based_no_baked_secret(genie_spec: AgentSpec) -> N
     auth = (genie.headers or {}).get("Authorization")
     if auth is not None:
         assert "${" in auth, "Authorization header must reference an env var, not a baked token"
-        assert "Bearer ${" in auth or "${" in auth
 
 
 def test_genie_is_read_only(genie_spec: AgentSpec) -> None:

--- a/tests/e2e/omnigent/test_example_databricks_genie_analyst.py
+++ b/tests/e2e/omnigent/test_example_databricks_genie_analyst.py
@@ -1,0 +1,120 @@
+"""Structural test for the Databricks Genie Analyst example
+(examples/databricks_genie_analyst).
+
+Databricks Genie Analyst is a single-agent recipe that answers natural-language
+questions over Unity Catalog-governed data through a Databricks Genie space,
+wired as an inline ``type: mcp`` HTTP connector against the Databricks-managed
+MCP server (``/api/2.0/mcp/genie/<space-id>``). Auth is handled by
+``databricks_profile`` (omnigent mints an OAuth bearer token at connect time),
+so no secret lives in the spec. Pure spec-load — no LLM, no credentials, no live
+workspace (``expand_env=False`` so the ``${DATABRICKS_*}`` refs don't need to
+resolve).
+
+What breaks if this fails:
+- the Genie connector is dropped or renamed (the agent loses its only data source),
+- the connector stops being HTTP transport / loses its ``url`` (the managed-MCP
+  shape the README promises regresses),
+- the managed-MCP URL path drifts away from ``/api/2.0/mcp/genie/`` (the recipe
+  no longer targets a Genie space),
+- ``databricks_profile`` auth is dropped OR a literal token is baked into the
+  spec (the "no secret in the config" guarantee breaks),
+- the agent silently pins a model (re-coupling it to one provider — a
+  Databricks-only id would 404 on a plain Anthropic / OpenAI key),
+- a sub-agent appears (this is deliberately a single agent, not an orchestrator).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec import load
+from omnigent.spec.types import AgentSpec
+
+# tests/e2e/omnigent/test_example_databricks_genie_analyst.py -> repo root is 3 parents up.
+_GENIE_BUNDLE = Path(__file__).resolve().parents[3] / "examples" / "databricks_genie_analyst"
+
+
+@pytest.fixture(scope="module")
+def genie_spec() -> AgentSpec:
+    """Load and validate the databricks_genie_analyst bundle once for the module.
+
+    ``expand_env=False`` so the structural tests run without a live
+    ``DATABRICKS_HOSTNAME`` / ``DATABRICKS_GENIE_SPACE_ID`` / ``DATABRICKS_PROFILE``
+    in the environment.
+    """
+    return load(_GENIE_BUNDLE, expand_env=False)
+
+
+def test_genie_name_and_harness(genie_spec: AgentSpec) -> None:
+    """
+    The agent is named ``databricks_genie_analyst`` and runs on the claude-sdk
+    harness with no pinned model or profile, so it inherits whatever Claude
+    provider the user configured. Re-introducing a pin would re-couple the recipe
+    to one provider.
+    """
+    assert genie_spec.name == "databricks_genie_analyst"
+    assert genie_spec.executor.config.get("harness") == "claude-sdk"
+    assert genie_spec.executor.model is None
+    assert genie_spec.executor.profile is None
+
+
+def test_genie_is_single_agent(genie_spec: AgentSpec) -> None:
+    """Genie Analyst is a single agent — no sub-agents, no delegation."""
+    assert genie_spec.sub_agents == []
+    assert genie_spec.tools.agents == []
+
+
+def test_genie_wires_managed_mcp_over_http(genie_spec: AgentSpec) -> None:
+    """
+    The single connector is the Databricks-managed Genie MCP server, wired as an
+    HTTP connector whose URL targets the documented managed-MCP Genie path.
+
+    A dropped/renamed connector, a non-http transport, or a URL that no longer
+    points at ``/api/2.0/mcp/genie/`` all break the "reach a Genie space over the
+    managed MCP server, no custom connector code" promise the README makes.
+    """
+    by_name = {s.name: s for s in genie_spec.mcp_servers}
+    assert sorted(by_name) == ["genie"]
+
+    genie = by_name["genie"]
+    assert genie.transport == "http"
+    assert genie.url is not None
+    assert "/api/2.0/mcp/genie/" in genie.url
+    # stdio-only fields must be absent on an HTTP connector.
+    assert genie.command is None
+
+
+def test_genie_auth_is_profile_based_no_baked_secret(genie_spec: AgentSpec) -> None:
+    """
+    Auth goes through ``databricks_profile`` (omnigent mints an OAuth token at
+    connect time), and no literal bearer token is baked into the spec. If someone
+    swaps to an explicit ``Authorization`` header it must reference an env var,
+    never a hardcoded secret.
+    """
+    genie = next(s for s in genie_spec.mcp_servers if s.name == "genie")
+
+    # Profile-based auth is the recipe's default.
+    assert genie.databricks_profile is not None
+
+    # No literal token anywhere: with expand_env=False any Authorization header
+    # value must still be an unexpanded ${...} ref, never a real token.
+    auth = (genie.headers or {}).get("Authorization")
+    if auth is not None:
+        assert "${" in auth, "Authorization header must reference an env var, not a baked token"
+        assert "Bearer ${" in auth or "${" in auth
+
+
+def test_genie_is_read_only(genie_spec: AgentSpec) -> None:
+    """
+    The Genie MCP surface is read-only (question -> governed SQL -> results). The
+    recipe must not carry any write-enabling flag or tool allow-list entry that
+    implies mutation.
+    """
+    genie = next(s for s in genie_spec.mcp_servers if s.name == "genie")
+    for tool in genie.tools or []:
+        assert not any(
+            verb in tool.lower()
+            for verb in ("insert", "update", "delete", "write", "create", "drop")
+        ), tool


### PR DESCRIPTION
## What

A new single-agent example — `examples/databricks_genie_analyst` — that answers natural-language questions over **Unity Catalog-governed data** through a **Databricks Genie** space, wired as an inline `type: mcp` HTTP connector against the Databricks-managed MCP server (`/api/2.0/mcp/genie/<space-id>`). No custom connector code.

This is the **Databricks-on-AWS companion to `examples/aws_analyst`** (#2497): where aws_analyst reaches Amazon Redshift + S3 Tables via the AWS Labs MCP servers, this reaches Databricks Genie via its managed MCP server. Together they make a "better together" analyst that reasons across both platforms — exactly the pairing the aws_analyst README calls out.

## How it works

- **Managed MCP over HTTP.** The connector uses `transport: http` with the documented Genie managed-MCP URL `https://<workspace-hostname>/api/2.0/mcp/genie/<space-id>`.
- **Auth with no baked secret.** It uses omnigent's built-in `databricks_profile` — a Databricks profile from `~/.databrickscfg` — so omnigent mints a short-lived OAuth bearer token at connection time and injects the `Authorization` header. Nothing secret lives in the spec. (The README documents the explicit-`headers` alternative for those who prefer it.)
- **Read-only.** The Genie MCP surface turns questions into governed SQL over Unity Catalog and returns the SQL alongside the answer, so every result is auditable. The prompt tells the agent to surface that SQL.

## Files

- `examples/databricks_genie_analyst/config.yaml` — the agent spec.
- `examples/databricks_genie_analyst/README.md` — prerequisites, run command, notes.
- `tests/e2e/omnigent/test_example_databricks_genie_analyst.py` — a structural test mirroring `test_example_aws_analyst.py` (pure spec-load, `expand_env=False`, no creds): asserts the managed-MCP Genie URL shape, http transport, profile-based auth with no baked token, single-agent, no model pin, read-only.

## Verification

YAML parses and every field the structural test asserts is present and correct (cross-checked locally). The e2e test is spec-load only — no live workspace or credentials required, same as the aws_analyst test. Managed-MCP URL pattern and auth verified against the Databricks managed-MCP docs.
