### PR TITLE
fix(crash-handler): stop same-second crash reports overwriting each other

### DIFF
--- a/omnigent/crash_handler.py
+++ b/omnigent/crash_handler.py
@@ -347,8 +347,17 @@ def _save_report(report_md: str) -> Path:
     d.mkdir(parents=True, exist_ok=True)
     stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     path = d / f"crash-{stamp}.md"
-    if path.exists():  # same-second collision — disambiguate by pid.
-        path = d / f"crash-{stamp}-{os.getpid()}.md"
+    if path.exists():
+        # Same-second collision. The pid separates concurrent processes, but a
+        # process that crashes twice in one second reuses its own pid — so keep
+        # counting until the name is free, else the second report would
+        # overwrite the first and the earlier crash would be lost.
+        base = f"crash-{stamp}-{os.getpid()}"
+        path = d / f"{base}.md"
+        suffix = 1
+        while path.exists():
+            path = d / f"{base}-{suffix}.md"
+            suffix += 1
     path.write_text(report_md, encoding="utf-8")
     with contextlib.suppress(OSError):
         os.chmod(path, 0o600)

--- a/tests/cli/test_crash_handler.py
+++ b/tests/cli/test_crash_handler.py
@@ -103,12 +103,34 @@ def test_command_line_redacts_tokens_in_argv(
 def test_save_report_writes_and_rotates(data_dir: Path) -> None:
     ch.install_crash_handler("omnigent", "omnigent-ai/omnigent", keep_reports=2)
     paths = [ch._save_report(f"report {i}\n") for i in range(5)]
-    assert all(p.exists() for p in paths)
+    # The newest report always survives its own rotation pass. Earlier paths
+    # may legitimately be gone: rotation prunes between saves, which also frees
+    # those names for reuse — so this deliberately does not assert 5 distinct
+    # paths (see test_save_report_keeps_every_same_second_report, which pins
+    # the no-overwrite guarantee with rotation held wide).
+    assert paths[-1].exists()
     # Only the newest 2 remain on disk.
     remaining = sorted((data_dir / "crashes").glob("crash-*.md"))
     assert len(remaining) == 2
     # Permissions are tight.
     assert all((p.stat().st_mode & 0o077) == 0 for p in remaining)
+
+
+def test_save_report_keeps_every_same_second_report(data_dir: Path) -> None:
+    """Repeated crashes inside one second/process must not overwrite each other.
+
+    The regression: the same-second fallback disambiguated by pid alone, so a
+    process crashing more than twice per second reused one filename and every
+    report but the last was silently destroyed. Rotation is held wide here so
+    only overwriting could lose a report.
+    """
+    ch.install_crash_handler("omnigent", "omnigent-ai/omnigent", keep_reports=10)
+    paths = [ch._save_report(f"report {i}\n") for i in range(5)]
+
+    assert len(set(paths)) == 5
+    assert {p.read_text(encoding="utf-8").strip() for p in paths} == {
+        f"report {i}" for i in range(5)
+    }
 
 
 def test_save_report_collision_disambiguates(data_dir: Path) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

`_save_report` disambiguated a same-second filename collision by pid alone. A pid is only unique *across* processes — a process that crashes more than twice within one second reuses its own pid, so every report after the first collision was written to the same path and silently destroyed its predecessor.

Reproduced with rotation held wide (`keep_reports=10`, so nothing should be pruned):

```
saves attempted: 5      distinct paths returned: 2      files on disk: 2
survived: report-0, report-4
LOST:     report-1, report-2, report-3
```

Three crash reports gone. Fix: keep counting past the pid-suffixed name until the path is free.

This also explains an intermittent CI failure. `test_save_report_writes_and_rotates` encoded the bug — it asserted all five returned paths still existed while rotation kept only two, which can only hold when the collision collapses them onto two names. It passed when all five saves landed in one second and failed when they straddled a second boundary.

## Test Plan

- `pytest tests/cli/test_crash_handler.py` — 22 passed, run 8 consecutive times to confirm the intermittent failure is gone (previously `1 failed, 21 passed` on this branch's parent, non-deterministically).
- New `test_save_report_keeps_every_same_second_report` pins the guarantee: five saves in one second yield five distinct paths and all five report bodies survive, with `keep_reports=10` so only overwriting could lose one.
- `test_save_report_writes_and_rotates` now asserts the newest report survives its own rotation pass. It deliberately does not assert five distinct paths: rotation prunes between saves, which also frees those names for reuse — that is correct behaviour, so the no-overwrite guarantee is pinned by the dedicated test instead.
- `ruff format` / `ruff check` clean.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification ran `_save_report` five times inside one second against a temp data dir and diffed the surviving report bodies against what was written — three were missing before the fix, none after. The new unit test encodes that same check.

## Changelog

Crash reports are no longer lost when a process crashes more than once in the same second.
