### PR TITLE
fix(codex-native): launch on the spec's declared model, not the provider default

### DIFF
--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4675,6 +4675,12 @@ def _codex_native_model_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) -
     """
     Read the Codex model default from a resolved agent spec.
 
+    Reads the canonical ``spec.executor.model`` field (the same field the
+    in-process codex harness consumes via ``_resolve_spec_model``), falling
+    back to ``executor.config["model"]`` for bundle specs that pin the model
+    inside the harness config block. Gateway-routed ``databricks-*`` ids are
+    valid Codex models on the Databricks path, so they pass through.
+
     :param agent_spec: Agent spec object, or a resolved wrapper carrying a
         ``spec`` attribute. ``None`` means no spec was available.
     :returns: Model id, e.g. ``"gpt-5.4-mini"``, or ``None``.
@@ -4682,8 +4688,11 @@ def _codex_native_model_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) -
     spec = agent_spec.spec if isinstance(agent_spec, ResolvedSpec) else agent_spec
     if spec is None:
         return None
-    model = spec.executor.config.get("model")
-    return model if isinstance(model, str) and model else None
+    model = spec.executor.model
+    if isinstance(model, str) and model:
+        return model
+    config_model = spec.executor.config.get("model")
+    return config_model if isinstance(config_model, str) and config_model else None
 
 
 def _claude_native_model_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) -> str | None:

--- a/tests/runner/test_app_codex_native_model.py
+++ b/tests/runner/test_app_codex_native_model.py
@@ -1,0 +1,86 @@
+"""Tests for codex-native model resolution from the agent spec.
+
+``_codex_native_model_from_spec`` is the seam that turns a session's
+``executor.model`` (set via a config.yaml ``model:`` key) into the model
+the native Codex TUI launches with. The canonical ``executor.model`` field
+wins — the same field every in-process harness consumes — with a fallback
+to ``executor.config["model"]`` for bundle specs that pin the model inside
+the harness config block. Gateway-routed ``databricks-*`` ids are valid
+Codex models on the Databricks path, so they pass through (unlike
+cursor-native).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.runner.app import ResolvedSpec, _codex_native_model_from_spec
+from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+
+def _spec(model: str | None, config_model: str | None = None) -> AgentSpec:
+    """Build a minimal agent spec carrying *model* on its executor block."""
+    config: dict[str, str] = {"harness": "codex-native"}
+    if config_model is not None:
+        config["model"] = config_model
+    return AgentSpec(
+        spec_version=1,
+        name="codex",
+        executor=ExecutorSpec(model=model, config=config),
+    )
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("gpt-5.4-mini", "gpt-5.4-mini"),
+        ("databricks-gpt-5-4-mini", "databricks-gpt-5-4-mini"),
+        (None, None),
+        ("", None),
+    ],
+    ids=[
+        "openai-model",
+        "databricks-passthrough",
+        "no-model",
+        "empty-model",
+    ],
+)
+def test_codex_native_model_from_spec(model: str | None, expected: str | None) -> None:
+    """A pinned model id on ``executor.model`` is returned; missing/empty pins resolve to None."""
+    assert _codex_native_model_from_spec(_spec(model)) == expected
+
+
+def test_codex_native_model_from_spec_config_fallback() -> None:
+    """A bundle spec pinning the model inside ``executor.config`` still resolves."""
+    assert (
+        _codex_native_model_from_spec(_spec(None, config_model="gpt-5.4-mini")) == "gpt-5.4-mini"
+    )
+
+
+def test_codex_native_model_from_spec_canonical_field_wins() -> None:
+    """When both slots are set, the canonical ``executor.model`` wins."""
+    spec = _spec("databricks-gpt-5-4-mini", config_model="gpt-5.5")
+    assert _codex_native_model_from_spec(spec) == "databricks-gpt-5-4-mini"
+
+
+def test_codex_native_model_from_spec_non_string_config_model() -> None:
+    """A non-string ``config["model"]`` is ignored rather than propagated."""
+    spec = AgentSpec(
+        spec_version=1,
+        name="codex",
+        executor=ExecutorSpec(config={"harness": "codex-native", "model": 5}),
+    )
+    assert _codex_native_model_from_spec(spec) is None
+
+
+def test_codex_native_model_from_spec_none_spec() -> None:
+    """A missing spec yields no model (provider default applies)."""
+    assert _codex_native_model_from_spec(None) is None
+
+
+def test_codex_native_model_from_spec_resolved_wrapper() -> None:
+    """A ResolvedSpec wrapper unwraps to the same model pin."""
+    wrapped = ResolvedSpec(spec=_spec("gpt-5.4-mini"), workdir=Path("/tmp"))
+    assert _codex_native_model_from_spec(wrapped) == "gpt-5.4-mini"


### PR DESCRIPTION
## Related issue

Closes #2746

## Summary

- The codex-native launch read the spec model only from `executor.config["model"]` — a key the single-file agent loader never populates — so a custom codex-native agent's declared `model:` was silently replaced by the provider default at launch.
- `_codex_native_model_from_spec` now reads the canonical `spec.executor.model` first (the field `ExecutorSpec` documents as the single source of truth for the model across all executor types, and the same field the in-process codex harness and the claude-native/cursor-native launches consume), falling back to `executor.config["model"]` for bundle specs that pin the model inside the harness config block.
- Both call sites pick this up: the native launch default and the plan-mode settings fallback.

ELI5: if your agent YAML says `model: databricks-gpt-5-4-mini`, the native Codex terminal now actually starts on that model instead of quietly using the default.

## Test Plan

- New unit tests in `tests/runner/test_app_codex_native_model.py`, mirroring the existing claude-native/cursor-native reader tests: canonical field, config fallback, precedence when both slots are set, non-string config value, empty/None model, `ResolvedSpec` unwrap.
- `pytest tests/runner/test_app_codex_native_model.py tests/runner/test_app_claude_native_model.py tests/runner/test_app_cursor_native_model.py tests/runner/test_codex_native_launch_config.py` — 47 passed.
- `tests/runner/test_app_sessions_native_{wake_forwarders,terminals_runtime,events_lifecycle}.py` — identical pass/fail set before and after the change (6 pre-existing failures in `events_lifecycle` require a terminal registry this environment doesn't provide; unrelated to this diff).

## Demo

N/A (non-visual change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The reader is a pure function and the unit tests cover every input shape; the launch-flow wiring around it (`launch_config.model_override or _codex_native_model_from_spec(...)`) is unchanged.

## Changelog

Custom codex-native agents launch on the model declared in the agent spec (`executor.model`) instead of silently falling back to the provider default

This pull request and its description were written by Isaac.
