### PR TITLE
fix(loader): reject the bundle type:/config: nesting in single-file executor blocks

### DIFF
--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -616,6 +616,18 @@ def _parse_executor_spec(data: YamlData | str | bool | None) -> ExecutorSpec | N
     if isinstance(data, str):
         return ExecutorSpec(model=data)
     if isinstance(data, dict):
+        # ``type:``/``config:`` are the bundle config.yaml nesting — skipped
+        # silently, they'd drop the declared harness and let a different one
+        # be inferred from the model prefix. Only these two are rejected:
+        # other extra keys (``use_responses``, ``extra``, …) are read from
+        # the raw YAML by the compat loader and must keep loading.
+        nested = sorted(key for key in ("config", "type") if key in data)
+        if nested:
+            raise ValueError(
+                f"executor: key(s) {', '.join(nested)} belong to the bundle "
+                "config.yaml format; this format spells the executor flat, "
+                "e.g. executor: {harness: codex-native, model: gpt-5.4-mini}"
+            )
         # ``ExecutorSpec.{model,harness,profile}`` are ``str | None``;
         # missing keys map to ``None`` directly. ``data.get`` happens to
         # already return ``None`` for missing keys, so the assignment

--- a/tests/e2e_ui/chat/test_chat_file_path_links.py
+++ b/tests/e2e_ui/chat/test_chat_file_path_links.py
@@ -64,8 +64,7 @@ prompt: You are a deterministic test assistant.
 
 executor:
   model: gpt-4o-mini
-  config:
-    harness: openai-agents
+  harness: openai-agents
 
 os_env:
   type: caller_process

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -133,8 +133,7 @@ prompt: You are a friendly assistant. Say hello and answer questions.
 
 executor:
   model: gpt-4o-mini
-  config:
-    harness: openai-agents
+  harness: openai-agents
 
 # Required for PUT /filesystem/{path} seeding in UI tests (e.g. markdown
 # editor comments) — the runner returns 404 when os_env is absent.
@@ -200,8 +199,7 @@ prompt: You are a terse assistant with no filesystem.
 
 executor:
   model: gpt-4o-mini
-  config:
-    harness: openai-agents
+  harness: openai-agents
 """
 _FILES_PROBE_ENV_AGENT_YAML = f"""\
 name: {_FILES_PROBE_ENV_AGENT_NAME}
@@ -209,8 +207,7 @@ prompt: You are a terse assistant with a filesystem.
 
 executor:
   model: gpt-4o-mini
-  config:
-    harness: openai-agents
+  harness: openai-agents
 
 os_env:
   type: caller_process
@@ -1330,8 +1327,7 @@ prompt: |
 
 executor:
   model: gpt-4o-mini
-  config:
-    harness: openai-agents
+  harness: openai-agents
 
 os_env:
   type: caller_process

--- a/tests/inner/test_loader.py
+++ b/tests/inner/test_loader.py
@@ -69,6 +69,43 @@ class TestLoadFromDict(unittest.TestCase):
         a = load_agent_def({"name": "t", "executor": {"model": "claude-sonnet-4"}})
         self.assertEqual(a.executor.model, "claude-sonnet-4")
 
+    def test_executor_bundle_nesting_rejected(self):
+        # The bundle config.yaml shape inside a single-file agent used to be
+        # silently dropped, replacing the declared harness with one inferred
+        # from the model prefix.
+        with self.assertRaisesRegex(ValueError, r"config, type.*spells the executor flat"):
+            load_agent_def(
+                {
+                    "name": "t",
+                    "executor": {
+                        "type": "omnigent",
+                        "config": {"harness": "codex-native"},
+                        "model": "databricks-gpt-5-4-mini",
+                    },
+                }
+            )
+
+    def test_executor_extra_keys_tolerated(self):
+        # The compat loader reads raw executor keys this parser doesn't
+        # model (use_responses, extra, …); they must not fail the load.
+        a = load_agent_def({"name": "t", "executor": {"model": "gpt-5", "use_responses": False}})
+        self.assertEqual(a.executor.model, "gpt-5")
+
+    def test_tools_agent_executor_bundle_nesting_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"key\(s\) config belong to the bundle"):
+            load_agent_def(
+                {
+                    "name": "t",
+                    "tools": {
+                        "h": {
+                            "type": "agent",
+                            "prompt": "Help.",
+                            "executor": {"config": {"harness": "codex-native"}},
+                        }
+                    },
+                }
+            )
+
     def test_tools_function(self):
         a = load_agent_def(
             {"name": "t", "tools": {"f": {"type": "function", "catalog_path": "a.b.c"}}}

--- a/tests/server/integration/test_session_mcp_servers.py
+++ b/tests/server/integration/test_session_mcp_servers.py
@@ -189,8 +189,7 @@ name: single_yaml_agent
 prompt: Say hello.
 executor:
   model: gpt-4o-mini
-  config:
-    harness: openai-agents
+  harness: openai-agents
 """
                 ),
                 "application/gzip",


### PR DESCRIPTION
## Related issue

Closes #2747

## Summary

- A single-file agent YAML written with the bundle config.yaml shape (`executor: {type: omnigent, config: {harness: codex-native}, model: ...}`) loaded without complaint: the parser silently dropped `type:`/`config:`, the declared harness with them, and then a **different harness was inferred from the model prefix** (`databricks-gpt-*` → openai-agents, `databricks-claude-*` → claude-sdk). The substituted harness depends on the model string, which makes the resulting behavior differences (missing terminal, different tool surface) very hard to attribute.
- `_parse_executor_spec` now rejects exactly those two keys with an error that shows the flat spelling. The rejection is deliberately scoped to `type:`/`config:` — other extra executor keys (`use_responses`, `extra`, …) are read from the raw YAML by the compat loader and keep loading. All three surfaces sharing this parser are covered: the agent's own `executor:`, inline AgentTool sub-agents, and prompt-policy executors.
- The new error immediately caught six of our own runtime-generated test fixtures (e2e_ui conftest, chat file-links, server MCP integration) that used the nesting and only worked because the dropped harness happened to match the model-prefix inference — spelled flat in this PR. The two `spec_version: 1` bundle fixtures keep the nesting, which is correct on the strict-parser path.

ELI5: pasting the shape you see from `GET /v1/agents` into a single-file agent YAML used to silently run a harness you never asked for; now it fails at load time with the correct spelling in the error.

## Test Plan

- New tests in `tests/inner/test_loader.py`: the exact bundle-nesting shape from the issue is rejected with the flat-spelling hint, the inline-AgentTool executor path rejects too, and extra keys (`use_responses`) still load.
- `pytest tests/inner/test_loader.py tests/spec/test_load.py` — 89 passed (includes the compat tests for `use_responses` / `executor.extra` raw-key reads).
- Full sweep `pytest tests/spec/ tests/inner/` — 2365 passed, 46 skipped (two files excluded for a missing optional `databricks-sdk` dependency in the local venv, unrelated to this change).
- Fixture fix verified by replicating the `omnigent server` preregistration path locally (`omnigent.spec.load` on a dir holding the fixed `hello_world.yaml` → harness lands in `executor.config["harness"]`), plus `pytest tests/server/integration/test_session_mcp_servers.py` — 8 passed.

## Demo

N/A (non-visual change; the new failure mode is a load-time error message).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Specs that relied on the silent drop were already running a harness other than the one they declared — the six in-tree fixtures this PR re-spells are the proof (they survived only because inference coincidentally agreed). On-disk repo YAMLs were surveyed separately: no non-bundle file uses the nesting.

## Changelog

Single-file agent YAMLs that nest the executor under `type:`/`config:` (the bundle config.yaml shape) now fail at load time with the correct flat spelling, instead of silently running a harness inferred from the model prefix

This pull request and its description were written by Isaac.
