### PR TITLE
[polly] Add Codex goal mode

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -1044,6 +1044,25 @@ def _extract_latest_user_content(
     return ""
 
 
+def _goal_objective_from_content(content: str | list[dict[str, Any]]) -> str | None:
+    """Return the objective from a standalone ``/goal`` user command."""
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        for block in content:
+            if block.get("type") not in {"input_text", "text"}:
+                return None
+            text = block.get("text")
+            if not isinstance(text, str):
+                return None
+            text_parts.append(text)
+        content = "".join(text_parts)
+    command, separator, objective = content.strip().partition(" ")
+    if command != "/goal" or not separator:
+        return None
+    objective = objective.strip()
+    return objective or None
+
+
 def _build_initial_prompt(
     messages: list[Message],
 ) -> str | list[dict[str, Any]]:
@@ -1573,7 +1592,17 @@ class _CodexAppServerSession:
             self._applied_effort = None
 
         assert self.thread_id is not None
-        prompt = _prompt_for_turn(messages, is_new_thread=is_new_thread)
+        latest_user_content = _extract_latest_user_content(messages)
+        goal_objective = _goal_objective_from_content(latest_user_content)
+        if goal_objective is not None:
+            await self._request(
+                "thread/goal/set",
+                {
+                    "threadId": self.thread_id,
+                    "objective": goal_objective,
+                },
+            )
+        prompt = goal_objective or _prompt_for_turn(messages, is_new_thread=is_new_thread)
         if isinstance(prompt, list):
             turn_input = _to_codex_input_items(prompt)
         else:

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -1594,6 +1594,7 @@ class _CodexAppServerSession:
         assert self.thread_id is not None
         latest_user_content = _extract_latest_user_content(messages)
         goal_objective = _goal_objective_from_content(latest_user_content)
+        prompt_messages = messages
         if goal_objective is not None:
             await self._request(
                 "thread/goal/set",
@@ -1602,7 +1603,14 @@ class _CodexAppServerSession:
                     "objective": goal_objective,
                 },
             )
-        prompt = goal_objective or _prompt_for_turn(messages, is_new_thread=is_new_thread)
+            # A reset thread still needs prior history, with the command
+            # replaced by the clean objective sent to Codex.
+            prompt_messages = [message.copy() for message in messages]
+            for message in reversed(prompt_messages):
+                if message.get("role") == "user":
+                    message["content"] = goal_objective
+                    break
+        prompt = _prompt_for_turn(prompt_messages, is_new_thread=is_new_thread)
         if isinstance(prompt, list):
             turn_input = _to_codex_input_items(prompt)
         else:

--- a/tests/e2e_ui/chat/test_polly_codex_goal_mode.py
+++ b/tests/e2e_ui/chat/test_polly_codex_goal_mode.py
@@ -1,0 +1,69 @@
+"""E2E: Polly sends Codex goals through the normal message path."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+
+def _patch_session_as_polly_codex(page: Page, session_id: str) -> None:
+    """Expose the seeded session as top-level Polly on Codex."""
+
+    def _handle(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+
+        response = route.fetch()
+        payload = response.json()
+        payload["agent_name"] = "polly"
+        payload["harness"] = "codex"
+        payload["parent_session_id"] = None
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route("**/v1/sessions/**", _handle)
+
+
+def test_polly_codex_goal_sends_native_command(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The Goal dialog posts the exact Codex slash command."""
+    base_url, session_id = seeded_session
+    _patch_session_as_polly_codex(page, session_id)
+
+    def _ack_event(route: Route) -> None:
+        route.fulfill(
+            status=202,
+            content_type="application/json",
+            body=json.dumps({"queued": True, "item_id": "ci_goal_e2e"}),
+        )
+
+    page.route(f"**/v1/sessions/{session_id}/events", _ack_event)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    goal_toggle = page.get_by_test_id("goal-toggle")
+    expect(goal_toggle).to_be_visible(timeout=15_000)
+    expect(goal_toggle).to_have_attribute("aria-label", "Start Codex goal")
+    goal_toggle.click()
+
+    condition = "Finish the implementation and pass all tests"
+    page.get_by_test_id("goal-condition").fill(f"  {condition}  ")
+    with page.expect_request(
+        lambda request: (
+            request.method == "POST"
+            and urlparse(request.url).path == f"/v1/sessions/{session_id}/events"
+        )
+    ) as sent:
+        page.get_by_test_id("goal-start").click()
+
+    body = sent.value.post_data_json
+    assert body["data"]["content"][0]["text"] == f"/goal {condition}"
+    expect(page.get_by_role("dialog", name="Goal")).to_have_count(0)

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -603,6 +603,70 @@ class TestCodexExecutor(unittest.TestCase):
 
         _run(_t())
 
+    def test_app_server_new_goal_thread_replays_history_without_command(self):
+        async def _t():
+            session = _CodexAppServerSession(
+                codex_path="/bin/echo",
+                cwd="/tmp/workspace",
+                env={},
+                tool_executor=None,
+            )
+            session.start = AsyncMock()
+            session._proc = _FakeProcess()
+            session._request = AsyncMock(
+                side_effect=[
+                    {"result": {"thread": {"id": "thread-1"}}},
+                    {"result": {"goal": {"objective": "Finish and test"}}},
+                    {"result": {"turn": {"id": "turn-1"}}},
+                ]
+            )
+
+            async def _inject_turn_completed() -> None:
+                await asyncio.sleep(0.01)
+                session._events.put_nowait(
+                    {"method": "turn/completed", "params": {"turn": {"id": "turn-1"}}}
+                )
+
+            inject_task = asyncio.create_task(_inject_turn_completed())
+            async for _event in session.run_turn(
+                messages=[
+                    {"role": "user", "content": "Remember the passphrase is ORCHID."},
+                    {"role": "assistant", "content": "I will remember it."},
+                    {"role": "user", "content": "/goal Finish and test"},
+                ],
+                tools=[],
+                system_prompt="",
+                model="gpt-5.4-mini",
+                cwd=".",
+                sandbox="workspace-write",
+            ):
+                pass
+            await inject_task
+
+            calls = session._request.await_args_list
+            self.assertEqual(
+                calls[1].args[1],
+                {"threadId": "thread-1", "objective": "Finish and test"},
+            )
+            self.assertEqual(
+                calls[2].args[1]["input"],
+                [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Conversation so far:\n"
+                            "user: Remember the passphrase is ORCHID.\n"
+                            "assistant: I will remember it.\n"
+                            "user: Finish and test\n\n"
+                            "Respond to the latest user message, using the conversation "
+                            "above as context."
+                        ),
+                    }
+                ],
+            )
+
+        _run(_t())
+
     def test_app_server_run_turn_applies_effort_via_thread_settings_update(self):
         """Reasoning effort rides thread/settings/update, not turn/start.
 

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -21,6 +21,7 @@ from omnigent.inner.codex_executor import (
     _CodexAppServerSession,
     _databricks_codex_config_overrides,
     _dynamic_tool_result_payload,
+    _goal_objective_from_content,
     _prompt_for_turn,
     _to_codex_input_items,
 )
@@ -346,6 +347,28 @@ class TestCodexExecutor(unittest.TestCase):
         prompt = _prompt_for_turn(messages, is_new_thread=False)
         self.assertEqual(prompt, "Summarize our conversation.")
 
+    def test_goal_objective_requires_a_standalone_command(self):
+        self.assertEqual(
+            _goal_objective_from_content("  /goal Finish the implementation  "),
+            "Finish the implementation",
+        )
+        self.assertIsNone(_goal_objective_from_content("/goal"))
+        self.assertIsNone(_goal_objective_from_content("Please run /goal now"))
+        self.assertEqual(
+            _goal_objective_from_content(
+                [{"type": "input_text", "text": "/goal Finish from the web"}]
+            ),
+            "Finish from the web",
+        )
+        self.assertIsNone(
+            _goal_objective_from_content(
+                [
+                    {"type": "input_text", "text": "/goal nope"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,AA=="},
+                ]
+            )
+        )
+
     def test_run_turn_delegates_to_app_server_session(self):
         async def _t():
             fake_session = _FakeAppSession(
@@ -520,6 +543,63 @@ class TestCodexExecutor(unittest.TestCase):
             params = thread_start_call.args[1]
             self.assertNotIn("shell_tool", params["config"]["features"])
             self.assertEqual(params["dynamicTools"][0]["name"], "sys_os_shell")
+
+        _run(_t())
+
+    def test_app_server_run_turn_starts_goal_before_objective_turn(self):
+        async def _t():
+            session = _CodexAppServerSession(
+                codex_path="/bin/echo",
+                cwd="/tmp/workspace",
+                env={},
+                tool_executor=None,
+            )
+            session.start = AsyncMock()
+            session._proc = _FakeProcess()
+            session._request = AsyncMock(
+                side_effect=[
+                    {"result": {"thread": {"id": "thread-1"}}},
+                    {"result": {"goal": {"objective": "Finish and test"}}},
+                    {"result": {"turn": {"id": "turn-1"}}},
+                ]
+            )
+
+            async def _inject_turn_completed() -> None:
+                await asyncio.sleep(0.01)
+                session._events.put_nowait(
+                    {"method": "turn/completed", "params": {"turn": {"id": "turn-1"}}}
+                )
+
+            inject_task = asyncio.create_task(_inject_turn_completed())
+            async for _event in session.run_turn(
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "/goal Finish and test"}],
+                    }
+                ],
+                tools=[],
+                system_prompt="",
+                model="gpt-5.4-mini",
+                cwd=".",
+                sandbox="workspace-write",
+            ):
+                pass
+            await inject_task
+
+            calls = session._request.await_args_list
+            self.assertEqual(
+                [call.args[0] for call in calls],
+                ["thread/start", "thread/goal/set", "turn/start"],
+            )
+            self.assertEqual(
+                calls[1].args[1],
+                {"threadId": "thread-1", "objective": "Finish and test"},
+            )
+            self.assertEqual(
+                calls[2].args[1]["input"],
+                [{"type": "text", "text": "Finish and test"}],
+            )
 
         _run(_t())
 

--- a/web/src/components/goal/CommandGoalDialog.test.tsx
+++ b/web/src/components/goal/CommandGoalDialog.test.tsx
@@ -26,6 +26,20 @@ describe("CommandGoalDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("describes the selected goal backend", () => {
+    render(
+      <CommandGoalDialog
+        open
+        onOpenChange={vi.fn()}
+        readOnly={false}
+        onStartGoal={vi.fn()}
+        backendLabel="Codex"
+      />,
+    );
+
+    expect(screen.getByText(/Codex keeps working until this condition is met/)).toBeInTheDocument();
+  });
+
   it("rejects an empty condition", () => {
     const onStartGoal = vi.fn();
     render(

--- a/web/src/components/goal/CommandGoalDialog.tsx
+++ b/web/src/components/goal/CommandGoalDialog.tsx
@@ -16,14 +16,16 @@ export interface CommandGoalDialogProps {
   onOpenChange: (open: boolean) => void;
   readOnly: boolean;
   onStartGoal: (condition: string) => void;
+  backendLabel?: string;
 }
 
-/** Start a Claude goal by sending its native slash command as the next turn. */
+/** Start a vendor goal by sending its native slash command as the next turn. */
 export function CommandGoalDialog({
   open,
   onOpenChange,
   readOnly,
   onStartGoal,
+  backendLabel = "The agent",
 }: CommandGoalDialogProps) {
   const [condition, setCondition] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -56,8 +58,8 @@ export function CommandGoalDialog({
               <span>Goal</span>
             </DialogTitle>
             <DialogDescription>
-              Claude keeps working until this condition is met. Progress and completion appear in
-              the conversation.
+              {backendLabel} keeps working until this condition is met. Progress and completion
+              appear in the conversation.
             </DialogDescription>
           </DialogHeader>
 

--- a/web/src/components/goal/GoalControl.tsx
+++ b/web/src/components/goal/GoalControl.tsx
@@ -75,6 +75,7 @@ export function GoalControl(props: GoalControlProps) {
           onOpenChange={setOpen}
           readOnly={readOnly}
           onStartGoal={props.onStartGoal}
+          backendLabel={backendLabel}
         />
       ) : (
         <GoalDialog

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -126,6 +126,30 @@ describe("Composer Claude goal control", () => {
   });
 });
 
+describe("Composer Codex goal control", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("sends the completion condition as a Codex /goal command", () => {
+    const onSend = vi.fn();
+    useChatStore.setState({ conversationId: "conv_polly" });
+    renderWithTooltips(
+      <Composer {...composerProps({ onSend, showPollyCodexGoalControl: true })} />,
+    );
+
+    fireEvent.click(screen.getByTestId("goal-toggle"));
+    expect(screen.getByText(/Codex keeps working until this condition is met/)).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("goal-condition"), {
+      target: { value: "  Finish the implementation and pass tests  " },
+    });
+    fireEvent.click(screen.getByTestId("goal-start"));
+
+    expect(onSend).toHaveBeenCalledWith("/goal Finish the implementation and pass tests");
+  });
+});
+
 describe("Composer slash-command menu", () => {
   beforeEach(() => {
     // Two skills so the menu has skill rows distinct from the built-ins.

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1135,6 +1135,7 @@ export function ChatPage() {
       showCodexPlanMode={shouldShowCodexPlanModeControl(capabilitySource)}
       showGoalControl={shouldShowGoalControl(capabilitySource)}
       showClaudeGoalControl={shouldShowPollyClaudeGoalControl(activeSession)}
+      showPollyCodexGoalControl={shouldShowPollyCodexGoalControl(activeSession)}
       costRoutingEligible={costRoutingEligible}
       subAgentLabel={subAgentLabel}
     />
@@ -1366,6 +1367,8 @@ interface MainAgentSurfaceProps {
   showGoalControl?: boolean;
   /** Show Polly's Claude SDK command-backed Goal control. */
   showClaudeGoalControl?: boolean;
+  /** Show Polly's Codex command-backed Goal control. */
+  showPollyCodexGoalControl?: boolean;
   /** Session passes `isCostRoutingSession` (polly orchestrator, not a child). */
   costRoutingEligible: boolean;
   /**
@@ -1437,6 +1440,7 @@ function MainAgentSurface({
   showCodexPlanMode,
   showGoalControl = false,
   showClaudeGoalControl = false,
+  showPollyCodexGoalControl = false,
   costRoutingEligible,
   subAgentLabel,
 }: MainAgentSurfaceProps) {
@@ -1845,6 +1849,7 @@ function MainAgentSurface({
         showCodexPlanMode={showCodexPlanMode}
         showGoalControl={showGoalControl}
         showClaudeGoalControl={showClaudeGoalControl}
+        showPollyCodexGoalControl={showPollyCodexGoalControl}
         isTerminalFirst={isTerminalFirst}
         isNativeWrapper={isNativeWrapper}
         reconnectHint={liveness.kind === "runner_asleep" || liveness.kind === "host_asleep"}
@@ -3367,6 +3372,8 @@ interface ComposerProps {
   showGoalControl?: boolean;
   /** Show Polly's Claude SDK command-backed Goal control. */
   showClaudeGoalControl?: boolean;
+  /** Show Polly's Codex command-backed Goal control. */
+  showPollyCodexGoalControl?: boolean;
   /**
    * Terminal-first session (Chat/Terminal pill present). Presentation
    * only: tightens the composer's bottom padding to `pb-1.5` so it sits
@@ -3835,6 +3842,7 @@ export function Composer({
   showCodexPlanMode,
   showGoalControl = false,
   showClaudeGoalControl = false,
+  showPollyCodexGoalControl = false,
   isTerminalFirst = false,
   isNativeWrapper = false,
   reconnectHint = false,
@@ -5000,6 +5008,15 @@ export function Composer({
                 backendLabel="Claude"
               />
             )}
+            {showPollyCodexGoalControl && (
+              <GoalControl
+                mode="command"
+                conversationId={conversationId}
+                readOnly={isReadOnly}
+                onStartGoal={(condition) => onSend(`/goal ${condition}`)}
+                backendLabel="Codex"
+              />
+            )}
             <ComposerModelEffortLabel
               showModels={showModels}
               showEffort={showEffort}
@@ -5375,6 +5392,17 @@ export function shouldShowPollyClaudeGoalControl(
     session?.parentSessionId == null &&
     session?.agentName?.toLowerCase() === "polly" &&
     session?.harness === "claude-sdk"
+  );
+}
+
+/** True for top-level Polly sessions running on the Codex harness. */
+export function shouldShowPollyCodexGoalControl(
+  session: Pick<Session, "agentName" | "harness" | "parentSessionId"> | null | undefined,
+): boolean {
+  return (
+    session?.parentSessionId == null &&
+    session?.agentName?.toLowerCase() === "polly" &&
+    session?.harness === "codex"
   );
 }
 

--- a/web/src/pages/effortLevels.test.ts
+++ b/web/src/pages/effortLevels.test.ts
@@ -8,6 +8,7 @@ import {
   shouldShowGoalControl,
   shouldShowModelPicker,
   shouldShowPollyClaudeGoalControl,
+  shouldShowPollyCodexGoalControl,
 } from "./ChatPage";
 
 const CODEX_MODEL_OPTIONS: NativeModelOption[] = [
@@ -204,6 +205,39 @@ describe("shouldShowPollyClaudeGoalControl", () => {
       shouldShowPollyClaudeGoalControl({
         agentName: "claude",
         harness: "claude-sdk",
+        parentSessionId: null,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldShowPollyCodexGoalControl", () => {
+  it("returns true only for top-level Polly sessions on Codex", () => {
+    expect(
+      shouldShowPollyCodexGoalControl({
+        agentName: "polly",
+        harness: "codex",
+        parentSessionId: null,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowPollyCodexGoalControl({
+        agentName: "polly",
+        harness: "claude-sdk",
+        parentSessionId: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowPollyCodexGoalControl({
+        agentName: "polly",
+        harness: "codex",
+        parentSessionId: "conv_parent",
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowPollyCodexGoalControl({
+        agentName: "codex",
+        harness: "codex",
         parentSessionId: null,
       }),
     ).toBe(false);


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add Codex goal mode to Polly without changing the server API: the existing Goal control sends `/goal <condition>` through the normal message path.
- Translate that command at the Codex harness boundary into the native app-server `thread/goal/set` request, then start the turn with the clean objective.
- Preserve replayed conversation history when a goal starts on a fresh/reset Codex thread while sanitizing the slash command from the prompt.
- Keep the control limited to top-level Codex sessions and generalize the goal dialog copy for its active backend.

ELI5: Polly keeps speaking its normal chat protocol; the Codex adapter recognizes the goal command and switches on Codex's persisted goal lifecycle before asking it to work.

```text
Goal dialog -> /goal <condition> -> Codex executor -> thread/goal/set -> turn/start
```

Codex officially supports persisted goals through `thread/goal/set`, `thread/goal/get`, and `thread/goal/clear`. The other Polly SDKs were audited separately; Cursor exposes agent/plan modes but no goal lifecycle, and Pi, Antigravity, and Copilot do not currently expose a native goal mode.

## Test Plan

- `pytest tests/inner/test_codex_executor.py` (99 passed), including fresh-thread multi-turn goal replay
- Targeted Vitest suites for the goal dialog, chat composer, and harness visibility (131 passed)
- `npm run type-check`
- `pytest tests/e2e_ui/chat/test_polly_codex_goal_mode.py --browser chromium` (1 passed after rebasing onto latest `main`)
- `pre-commit run` on the PR diff
- Manual live E2E with separate `omnigent server`, `omnigent host`, and Vite processes plus the real Codex SDK: created a Codex session, set two native goals, observed `Goal active`, received the requested completion responses, and reopened the dialog to verify persisted `complete` state and token usage. No files were modified.

## Demo

Real server + host + Codex SDK screen recording:

![Codex goal mode live E2E](https://raw.githubusercontent.com/omnigent-ai/omnigent/2c6e7b872ff9594fcd4127c59dd2f7c4ab707fb1/docs/images/pr-3181/codex-goal-mode-live-e2e.gif)

[Download the MP4 recording](https://raw.githubusercontent.com/omnigent-ai/omnigent/2c6e7b872ff9594fcd4127c59dd2f7c4ab707fb1/docs/images/pr-3181/codex-goal-mode-live-e2e.mp4)

Goal objective:

![Codex goal objective](https://raw.githubusercontent.com/omnigent-ai/omnigent/2c6e7b872ff9594fcd4127c59dd2f7c4ab707fb1/docs/images/pr-3181/goal-objective.jpg)

Live Codex completion:

![Codex goal verified](https://raw.githubusercontent.com/omnigent-ai/omnigent/2c6e7b872ff9594fcd4127c59dd2f7c4ab707fb1/docs/images/pr-3181/goal-verified.jpg)

Persisted native goal state:

![Codex goal complete](https://raw.githubusercontent.com/omnigent-ai/omnigent/2c6e7b872ff9594fcd4127c59dd2f7c4ab707fb1/docs/images/pr-3181/goal-complete.jpg)

## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated tests cover executor behavior, fresh-thread history replay, UI command construction, harness visibility, and the Chromium flow. Manual verification used real server, host, frontend, and Codex SDK processes and confirmed goal creation, active execution, completion, persistence, and token reporting without filesystem changes.

## Changelog

Use native Codex goal mode from Polly's Goal control
