### PR TITLE
[ci] Add waiting-on-author PR hygiene

### DIFF
--- a/.github/scripts/waiting_on_author.py
+++ b/.github/scripts/waiting_on_author.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Keep the waiting-on-author pull request label actionable."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import UTC, datetime
+from email.message import Message
+from typing import Any
+
+LABEL = "waiting-on-author"
+WAITING_DAYS = 7
+CANONICAL_REPO = "omnigent-ai/omnigent"
+MAX_CLOSURES_PER_RUN = 30
+
+
+def label_names(item: dict[str, Any]) -> list[str]:
+    return [
+        label.get("name", label) if isinstance(label, dict) else label
+        for label in item.get("labels", [])
+    ]
+
+
+def has_waiting_label(item: dict[str, Any]) -> bool:
+    return LABEL in label_names(item)
+
+
+def parse_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def days_between(start: str, end: datetime) -> int:
+    return int((end - parse_time(start)).total_seconds() // 86400)
+
+
+def latest_waiting_label_at(timeline: list[dict[str, Any]]) -> str | None:
+    latest: str | None = None
+    for event in timeline:
+        if event.get("event") != "labeled" or not event.get("created_at"):
+            continue
+        label = event.get("label") or {}
+        name = label.get("name") if isinstance(label, dict) else label
+        if name != LABEL:
+            continue
+        if latest is None or parse_time(event["created_at"]) > parse_time(latest):
+            latest = event["created_at"]
+    return latest
+
+
+def close_message(label_applied_at: str) -> str:
+    return "\n".join(
+        [
+            f"Closing this PR because it has been labeled `{LABEL}` for "
+            f"{WAITING_DAYS} days without an author reply or new commit.",
+            "",
+            f"The label was last applied on {label_applied_at}. If you are "
+            "ready to continue, please reopen this PR or open a new one.",
+        ]
+    )
+
+
+class GitHubAPI:
+    def __init__(self, token: str, repo: str):
+        self.token = token
+        self.repo = repo
+
+    def request(
+        self, method: str, path: str, body: dict[str, Any] | None = None
+    ) -> tuple[Any, Message]:
+        data = None if body is None else json.dumps(body).encode()
+        request = urllib.request.Request(
+            f"https://api.github.com{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        with urllib.request.urlopen(request) as response:
+            raw = response.read()
+            parsed = json.loads(raw.decode()) if raw else None
+            return parsed, response.headers
+
+    def paginated(self, path: str) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        next_path: str | None = path
+        while next_path:
+            page, headers = self.request("GET", next_path)
+            items.extend(page or [])
+            next_path = next_link(headers.get("Link", ""))
+        return items
+
+    def get_pull(self, pull_number: int) -> dict[str, Any]:
+        pull, _ = self.request("GET", f"/repos/{self.repo}/pulls/{pull_number}")
+        return pull
+
+    def remove_label(self, issue_number: int, label: str) -> bool:
+        quoted = urllib.parse.quote(label, safe="")
+        try:
+            self.request("DELETE", f"/repos/{self.repo}/issues/{issue_number}/labels/{quoted}")
+        except urllib.error.HTTPError as error:
+            if error.code == 404:
+                return False
+            raise
+        return True
+
+    def list_waiting_issues(self) -> list[dict[str, Any]]:
+        query = urllib.parse.urlencode({"state": "open", "labels": LABEL, "per_page": 100})
+        return self.paginated(f"/repos/{self.repo}/issues?{query}")
+
+    def list_timeline(self, issue_number: int) -> list[dict[str, Any]]:
+        return self.paginated(f"/repos/{self.repo}/issues/{issue_number}/timeline?per_page=100")
+
+    def close_pull(self, pull_number: int) -> None:
+        self.request("PATCH", f"/repos/{self.repo}/pulls/{pull_number}", {"state": "closed"})
+
+    def create_comment(self, issue_number: int, body: str) -> None:
+        self.request("POST", f"/repos/{self.repo}/issues/{issue_number}/comments", {"body": body})
+
+
+def next_link(link_header: str) -> str | None:
+    for part in link_header.split(","):
+        url_part, _, rel_part = part.partition(";")
+        if 'rel="next"' not in rel_part:
+            continue
+        url = url_part.strip()[1:-1]
+        parsed = urllib.parse.urlparse(url)
+        return f"{parsed.path}?{parsed.query}"
+    return None
+
+
+def remove_waiting_label(api: GitHubAPI, issue_number: int, reason: str) -> bool:
+    removed = api.remove_label(issue_number, LABEL)
+    if removed:
+        print(f"Removed {LABEL} from #{issue_number}: {reason}")
+    else:
+        print(f"#{issue_number} no longer has {LABEL}; nothing to remove.")
+    return removed
+
+
+def clear_on_author_activity(event_name: str, payload: dict[str, Any], api: GitHubAPI) -> bool:
+    pull_number: int | None = None
+    actor: str | None = None
+    reason: str | None = None
+    author_activity = False
+
+    if event_name in {"pull_request", "pull_request_target"} and payload.get("pull_request"):
+        if payload.get("action") != "synchronize":
+            return False
+        pull_number = payload["pull_request"]["number"]
+        reason = "new commits were pushed"
+        author_activity = True
+    elif event_name == "issue_comment" and "pull_request" in payload.get("issue", {}):
+        pull_number = payload["issue"]["number"]
+        actor = payload.get("comment", {}).get("user", {}).get("login")
+        reason = "the author commented"
+    elif event_name == "pull_request_review_comment" and payload.get("pull_request"):
+        pull_number = payload["pull_request"]["number"]
+        actor = payload.get("comment", {}).get("user", {}).get("login")
+        reason = "the author replied to a review comment"
+    elif event_name == "pull_request_review" and payload.get("pull_request"):
+        pull_number = payload["pull_request"]["number"]
+        actor = payload.get("review", {}).get("user", {}).get("login")
+        reason = "the author submitted a review response"
+    else:
+        return False
+
+    if pull_number is None or reason is None:
+        return False
+    pull = api.get_pull(pull_number)
+    if pull.get("state") != "open" or not has_waiting_label(pull):
+        return False
+
+    if not author_activity:
+        author = pull.get("user", {}).get("login")
+        author_activity = bool(actor and author and actor.lower() == author.lower())
+
+    if not author_activity:
+        return False
+    return remove_waiting_label(api, pull_number, reason)
+
+
+def close_stale_waiting_prs(api: GitHubAPI, now: datetime | None = None) -> int:
+    now = now or datetime.now(UTC)
+    closed = 0
+    for issue in api.list_waiting_issues():
+        if closed >= MAX_CLOSURES_PER_RUN:
+            break
+        if "pull_request" not in issue or not has_waiting_label(issue):
+            continue
+
+        try:
+            label_applied_at = latest_waiting_label_at(api.list_timeline(issue["number"]))
+            if label_applied_at is None:
+                print(
+                    f"::warning::#{issue['number']} has {LABEL} but no label timestamp "
+                    "in the timeline; skipping."
+                )
+                continue
+            if days_between(label_applied_at, now) < WAITING_DAYS:
+                continue
+
+            api.close_pull(issue["number"])
+            api.create_comment(issue["number"], close_message(label_applied_at))
+            closed += 1
+            print(f"Closed #{issue['number']}; {LABEL} was applied at {label_applied_at}.")
+        except Exception as error:  # noqa: BLE001 - keep the sweep moving across PRs.
+            print(f"::warning::Could not close #{issue['number']}: {error}")
+    print(f"Closed {closed} PR(s) labeled {LABEL}.")
+    return closed
+
+
+def run(
+    event_name: str,
+    payload: dict[str, Any],
+    api: GitHubAPI,
+    repo: str,
+    now: datetime | None = None,
+) -> None:
+    if repo != CANONICAL_REPO:
+        print(f"Skipping {repo}; waiting-on-author hygiene only runs for {CANONICAL_REPO}.")
+        return
+
+    if event_name in {"schedule", "workflow_dispatch"}:
+        close_stale_waiting_prs(api, now=now)
+        return
+
+    clear_on_author_activity(event_name, payload, api)
+
+
+def load_event_payload() -> dict[str, Any]:
+    path = os.environ.get("GITHUB_EVENT_PATH")
+    if not path:
+        return {}
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> int:
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN is required", file=sys.stderr)
+        return 1
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    run(event_name, load_event_payload(), GitHubAPI(token, repo), repo)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/waiting_on_author_test.py
+++ b/.github/scripts/waiting_on_author_test.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Offline tests for waiting_on_author.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+from datetime import UTC, datetime
+from typing import Any
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("waiting_on_author.py")
+SPEC = importlib.util.spec_from_file_location("waiting_on_author", SCRIPT_PATH)
+waiting_on_author = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(waiting_on_author)
+
+
+def pr(
+    number: int = 12, author: str = "alice", labels: list[str] | None = None, state: str = "open"
+) -> dict[str, Any]:
+    labels = [waiting_on_author.LABEL] if labels is None else labels
+    return {
+        "number": number,
+        "state": state,
+        "user": {"login": author},
+        "labels": [{"name": label} for label in labels],
+    }
+
+
+def issue(number: int, labels: list[str] | None = None, is_pr: bool = True) -> dict[str, Any]:
+    labels = [waiting_on_author.LABEL] if labels is None else labels
+    item: dict[str, Any] = {"number": number, "labels": [{"name": label} for label in labels]}
+    if is_pr:
+        item["pull_request"] = {}
+    return item
+
+
+def labeled_at(iso: str, label: str | None = None) -> dict[str, Any]:
+    return {
+        "event": "labeled",
+        "label": {"name": label or waiting_on_author.LABEL},
+        "created_at": iso,
+    }
+
+
+class FakeAPI:
+    def __init__(
+        self,
+        *,
+        pull: dict[str, Any] | None = None,
+        issues: list[dict[str, Any]] | None = None,
+        timeline_by_issue: dict[int, list[dict[str, Any]]] | None = None,
+    ):
+        self.pull = pull or pr()
+        self.issues = issues or []
+        self.timeline_by_issue = timeline_by_issue or {}
+        self.removed: list[tuple[int, str]] = []
+        self.closed: list[int] = []
+        self.comments: list[tuple[int, str]] = []
+
+    def get_pull(self, pull_number: int) -> dict[str, Any]:
+        return self.pull | {"number": pull_number}
+
+    def remove_label(self, issue_number: int, label: str) -> bool:
+        self.removed.append((issue_number, label))
+        return True
+
+    def list_waiting_issues(self) -> list[dict[str, Any]]:
+        return self.issues
+
+    def list_timeline(self, issue_number: int) -> list[dict[str, Any]]:
+        return self.timeline_by_issue.get(issue_number, [])
+
+    def close_pull(self, pull_number: int) -> None:
+        self.closed.append(pull_number)
+
+    def create_comment(self, issue_number: int, body: str) -> None:
+        self.comments.append((issue_number, body))
+
+
+class WaitingOnAuthorTest(unittest.TestCase):
+    def test_latest_waiting_label_at_uses_latest_matching_label(self) -> None:
+        self.assertEqual(
+            waiting_on_author.latest_waiting_label_at(
+                [
+                    labeled_at("2026-07-01T00:00:00Z"),
+                    labeled_at("2026-07-10T00:00:00Z", "other"),
+                    labeled_at("2026-07-12T00:00:00Z"),
+                ]
+            ),
+            "2026-07-12T00:00:00Z",
+        )
+
+    def test_author_issue_comment_removes_waiting_label(self) -> None:
+        api = FakeAPI(pull=pr(author="Alice"))
+        waiting_on_author.clear_on_author_activity(
+            "issue_comment",
+            {"issue": {"number": 12, "pull_request": {}}, "comment": {"user": {"login": "alice"}}},
+            api,
+        )
+        self.assertEqual(api.removed, [(12, waiting_on_author.LABEL)])
+
+    def test_author_review_thread_reply_removes_waiting_label(self) -> None:
+        api = FakeAPI(pull=pr(author="alice"))
+        waiting_on_author.clear_on_author_activity(
+            "pull_request_review_comment",
+            {"pull_request": {"number": 12}, "comment": {"user": {"login": "alice"}}},
+            api,
+        )
+        self.assertEqual(api.removed, [(12, waiting_on_author.LABEL)])
+
+    def test_maintainer_comment_keeps_waiting_label(self) -> None:
+        api = FakeAPI(pull=pr(author="alice"))
+        waiting_on_author.clear_on_author_activity(
+            "issue_comment",
+            {
+                "issue": {"number": 12, "pull_request": {}},
+                "comment": {"user": {"login": "maintainer"}},
+            },
+            api,
+        )
+        self.assertEqual(api.removed, [])
+
+    def test_new_commits_remove_waiting_label(self) -> None:
+        api = FakeAPI(pull=pr(author="alice"))
+        waiting_on_author.clear_on_author_activity(
+            "pull_request_target",
+            {"action": "synchronize", "pull_request": {"number": 12}},
+            api,
+        )
+        self.assertEqual(api.removed, [(12, waiting_on_author.LABEL)])
+
+    def test_scheduled_sweep_closes_pr_after_7_days(self) -> None:
+        api = FakeAPI(
+            issues=[issue(20)], timeline_by_issue={20: [labeled_at("2026-07-17T00:00:00Z")]}
+        )
+        waiting_on_author.close_stale_waiting_prs(api, now=datetime(2026, 7, 24, tzinfo=UTC))
+        self.assertEqual(api.closed, [20])
+        self.assertEqual(len(api.comments), 1)
+        self.assertIn(waiting_on_author.LABEL, api.comments[0][1])
+
+    def test_scheduled_sweep_leaves_6_day_pr_open(self) -> None:
+        api = FakeAPI(
+            issues=[issue(21)], timeline_by_issue={21: [labeled_at("2026-07-18T00:00:00Z")]}
+        )
+        waiting_on_author.close_stale_waiting_prs(api, now=datetime(2026, 7, 24, tzinfo=UTC))
+        self.assertEqual(api.closed, [])
+        self.assertEqual(api.comments, [])
+
+    def test_scheduled_sweep_skips_missing_label_timestamp(self) -> None:
+        api = FakeAPI(issues=[issue(22)], timeline_by_issue={22: []})
+        waiting_on_author.close_stale_waiting_prs(api, now=datetime(2026, 7, 24, tzinfo=UTC))
+        self.assertEqual(api.closed, [])
+
+    def test_scheduled_sweep_caps_closures_per_run(self) -> None:
+        issues = [issue(100 + idx) for idx in range(waiting_on_author.MAX_CLOSURES_PER_RUN + 3)]
+        timeline = {item["number"]: [labeled_at("2026-07-01T00:00:00Z")] for item in issues}
+        api = FakeAPI(issues=issues, timeline_by_issue=timeline)
+        waiting_on_author.close_stale_waiting_prs(api, now=datetime(2026, 7, 24, tzinfo=UTC))
+        self.assertEqual(len(api.closed), waiting_on_author.MAX_CLOSURES_PER_RUN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/waiting-on-author-test.yml
+++ b/.github/workflows/waiting-on-author-test.yml
@@ -1,0 +1,31 @@
+name: Waiting on Author Test
+
+# Offline unit test for waiting-on-author hygiene. Runs on PR head without
+# secrets or network and only when the workflow logic changes.
+
+on:
+  pull_request:
+    paths:
+      - .github/scripts/waiting_on_author.py
+      - .github/scripts/waiting_on_author_test.py
+      - .github/workflows/waiting-on-author.yml
+      - .github/workflows/waiting-on-author-test.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: waiting-on-author-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run waiting-on-author unit test
+        run: python3 .github/scripts/waiting_on_author_test.py

--- a/.github/workflows/waiting-on-author.yml
+++ b/.github/workflows/waiting-on-author.yml
@@ -1,0 +1,46 @@
+name: Waiting on Author Hygiene
+
+# Keeps the `waiting-on-author` PR label actionable: author activity clears it,
+# and PRs that sit in that state for 7 days are closed. The workflow runs from
+# trusted default-branch code and never checks out PR-authored files.
+
+on:
+  pull_request_target:
+    types: [synchronize]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  schedule:
+    - cron: "0 */12 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: waiting-on-author-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  hygiene:
+    if: github.repository == 'omnigent-ai/omnigent'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Check out .github
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github
+          persist-credentials: false
+      - name: Update waiting-on-author state
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/waiting_on_author.py


### PR DESCRIPTION
## Related issue

N/A

## Summary

PRs labeled `waiting-on-author` currently rely on humans to clear or close them, which can leave stale contributor work sitting open indefinitely. This adds trusted default-branch automation that keeps that state actionable without checking out PR-authored code.

- Remove `waiting-on-author` when the PR author comments, replies to a review thread, submits a review response, or pushes new commits
- Close open PRs that have carried the latest `waiting-on-author` label for 7 calendar days, with a per-run closure cap
- Add an offline mocked Python test and a PR-only test workflow for the hygiene logic

ELI5: if we ask a PR author for changes, the label goes away when they come back. If they do not come back for a week, the bot closes the PR with a note.

```mermaid
flowchart TD
  A[waiting-on-author label] --> B{Author activity?}
  B -- Comment / review reply / commit --> C[Remove label]
  B -- No activity --> D{7 days since label?}
  D -- No --> E[Keep open]
  D -- Yes --> F[Close PR and comment]
```

## Test Plan

- `python3 .github/scripts/waiting_on_author_test.py`
- `git diff --check`
- `pre-commit run --files .github/scripts/waiting_on_author.py .github/scripts/waiting_on_author_test.py .github/workflows/waiting-on-author.yml .github/workflows/waiting-on-author-test.yml`
- `pre-commit run`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added an offline mocked unit test for the workflow decision logic and manually verified the exact local commands listed in the test plan. No UI demo is included because this is GitHub Actions automation only.
