### PR TITLE
perf(spec): parse spec YAML with libyaml

### DIFF
--- a/omnigent/_yaml_compat.py
+++ b/omnigent/_yaml_compat.py
@@ -3,20 +3,25 @@
 PyYAML ships two implementations of the same safe loader: the pure-Python
 ``SafeLoader`` and ``CSafeLoader``, which wraps libyaml. Both accept the
 same grammar, share the same constructor and resolver classes, and build
-identical Python objects — the C one is just far faster. Parsing the 19.2 KB
-``examples/polly/config.yaml`` takes 3.14 ms pure-Python and 0.18 ms through
-libyaml.
+identical Python objects — the C one is just far faster. Parsing the
+19.2 KB ``examples/polly/config.yaml`` takes 3.14 ms pure-Python and
+0.18 ms through libyaml.
 
-Spec and config parsing sits on the runner's hot path (every sub-agent
-fan-out re-reads the bundle), so those loaders build on the C parser when
-it is available. PyYAML wheels bundle libyaml, but a source install built
-without the libyaml headers exposes no ``CSafeLoader`` at all — hence the
-fallback.
+Spec and config parsing is the bulk of the cost of loading an agent bundle,
+so those loaders build on the C parser where it is available. PyYAML wheels
+bundle libyaml, but a source install built without the libyaml headers
+exposes no ``CSafeLoader`` at all — hence the fallback.
+
+libyaml reports the line and column of a syntax error but not the echoed
+source line and caret that the pure-Python parser prints. :func:`load`
+restores those by reparsing failed documents, so the speedup costs nothing
+in authoring diagnostics.
 """
 
 from __future__ import annotations
 
-from typing import IO, TYPE_CHECKING, Any
+import re
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -33,19 +38,93 @@ else:
 # need to report which base they exercised.
 USING_LIBYAML = SafeLoaderBase is not yaml.SafeLoader
 
+_BOOL_TAG = "tag:yaml.org,2002:bool"
+# YAML 1.2 spellings only — the 1.1 aliases keyed on o/O/y/Y/n/N are dropped.
+_YAML_1_2_BOOL_RE = re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$")
+
+
+def narrow_bools_to_yaml_1_2(loader: type[yaml.SafeLoader]) -> None:
+    """Stop *loader* resolving ``on``/``off``/``yes``/``no`` as booleans.
+
+    Default PyYAML follows YAML 1.1, where those spellings are bools — a
+    trap for our specs, whose policy system uses ``on:`` as the selector
+    field. Without this, ``on: [request]`` yields a dict keyed by ``True``.
+    ``true``/``false`` keep resolving as bools.
+
+    Safe on either base: libyaml scans tokens itself but calls back into
+    the Python resolver to tag them, so the narrowed table applies to the
+    C parser too.
+
+    :param loader: A ``SafeLoader``/``CSafeLoader`` subclass to narrow
+        in place. Must be a dedicated subclass, never a PyYAML loader
+        itself — see the copy below.
+    """
+    # Copy before mutating. ``yaml_implicit_resolvers`` lives on PyYAML's
+    # shared ``BaseResolver``, so the same dict object backs SafeLoader and
+    # CSafeLoader alike; an in-place edit would strip bool parsing from
+    # every yaml.safe_load caller in the process.
+    loader.yaml_implicit_resolvers = {
+        key: [(tag, regexp) for tag, regexp in value if tag != _BOOL_TAG]
+        for key, value in loader.yaml_implicit_resolvers.items()
+    }
+    # mypy flags BaseResolver.add_implicit_resolver as untyped (PyYAML ships
+    # no stubs for this classmethod); it is the only way to register one.
+    loader.add_implicit_resolver(  # type: ignore[no-untyped-call]
+        _BOOL_TAG,
+        _YAML_1_2_BOOL_RE,
+        list("tTfF"),
+    )
+
 
 # YAML documents are open-ended trees whose shape is only known after the
 # caller's isinstance checks, so the return type is the same ``Any`` that
 # ``yaml.safe_load`` itself returns.
-def safe_load(stream: str | bytes | IO[str] | IO[bytes]) -> Any:  # type: ignore[explicit-any]
+def load(text: str, loader: type[yaml.SafeLoader]) -> Any:  # type: ignore[explicit-any]
+    """Parse *text* with *loader*, keeping pure-Python error detail.
+
+    libyaml's messages carry the line and column but drop the echoed
+    source line and caret, which are what make a typo in a hand-written
+    config obvious. A document that failed to parse is already off the
+    hot path, so reparsing it with the pure-Python scanner costs nothing
+    in the success case and restores the better message.
+
+    The retry uses stock ``SafeLoader`` rather than a pure-Python twin of
+    *loader*: scanner and parser errors are raised before any tag is
+    resolved, so a narrowed bool resolver cannot change whether — or
+    where — a document fails.
+
+    :param text: The YAML source. Must be text rather than a stream, so
+        the retry can reread it.
+    :param loader: Loader class to parse with, typically built on
+        :data:`SafeLoaderBase`.
+    :returns: The parsed document, or ``None`` for an empty string.
+    :raises yaml.YAMLError: If *text* is not valid YAML.
+    """
+    try:
+        return yaml.load(text, Loader=loader)
+    except yaml.YAMLError as fast_error:
+        if not USING_LIBYAML:
+            raise
+        try:
+            yaml.load(text, Loader=yaml.SafeLoader)
+        except yaml.YAMLError as detailed_error:
+            # Same failure, better message. Drop the libyaml error from the
+            # chain so the traceback shows one diagnosis, not two.
+            raise detailed_error from None
+        # Only the C parser objected. Nothing better to report, so surface
+        # the original rather than pretending the document was fine.
+        raise fast_error
+
+
+def safe_load(text: str) -> Any:  # type: ignore[explicit-any]
     """Drop-in ``yaml.safe_load`` that prefers the libyaml parser.
 
     Resolver and constructor behaviour match ``yaml.safe_load`` exactly,
-    including YAML 1.1 booleans (``on``/``off``/``yes``/``no``). Loaders
+    including YAML 1.1 booleans (``on``/``off``/``yes``/``no``). Callers
     that need YAML 1.2 boolean semantics subclass :data:`SafeLoaderBase`
-    and narrow the bool resolver themselves.
+    and apply :func:`narrow_bools_to_yaml_1_2`.
 
-    :param stream: YAML text, bytes, or an open file object.
-    :returns: The parsed document, or ``None`` for an empty stream.
+    :param text: The YAML source.
+    :returns: The parsed document, or ``None`` for an empty string.
     """
-    return yaml.load(stream, Loader=SafeLoaderBase)
+    return load(text, SafeLoaderBase)

--- a/omnigent/_yaml_compat.py
+++ b/omnigent/_yaml_compat.py
@@ -38,6 +38,17 @@ else:
 # need to report which base they exercised.
 USING_LIBYAML = SafeLoaderBase is not yaml.SafeLoader
 
+# Failures raised while reading the document's structure, before any tag is
+# resolved or any constructor runs. Both parsers raise these same classes,
+# and at this stage a loader's resolver and constructor tables cannot have
+# influenced the outcome — which is what makes the reparse in :func:`load`
+# a faithful substitution.
+_PARSE_STAGE_ERRORS = (
+    yaml.scanner.ScannerError,
+    yaml.parser.ParserError,
+    yaml.composer.ComposerError,
+)
+
 _BOOL_TAG = "tag:yaml.org,2002:bool"
 # YAML 1.2 spellings only — the 1.1 aliases keyed on o/O/y/Y/n/N are dropped.
 _YAML_1_2_BOOL_RE = re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$")
@@ -88,10 +99,13 @@ def load(text: str, loader: type[yaml.SafeLoader]) -> Any:  # type: ignore[expli
     hot path, so reparsing it with the pure-Python scanner costs nothing
     in the success case and restores the better message.
 
-    The retry uses stock ``SafeLoader`` rather than a pure-Python twin of
-    *loader*: scanner and parser errors are raised before any tag is
-    resolved, so a narrowed bool resolver cannot change whether — or
-    where — a document fails.
+    Only :data:`_PARSE_STAGE_ERRORS` are retried, and the retry uses stock
+    ``SafeLoader`` rather than a pure-Python twin of *loader*. Those errors
+    are raised before any tag is resolved, so *loader*'s resolver and
+    constructor tables cannot have affected whether — or where — the
+    document failed. Constructor errors are left alone: a loader carrying
+    its own constructors would see its real error replaced by an unrelated
+    "could not determine a constructor" from the stock loader.
 
     :param text: The YAML source. Must be text rather than a stream, so
         the retry can reread it.
@@ -102,12 +116,12 @@ def load(text: str, loader: type[yaml.SafeLoader]) -> Any:  # type: ignore[expli
     """
     try:
         return yaml.load(text, Loader=loader)
-    except yaml.YAMLError as fast_error:
+    except _PARSE_STAGE_ERRORS as fast_error:
         if not USING_LIBYAML:
             raise
         try:
             yaml.load(text, Loader=yaml.SafeLoader)
-        except yaml.YAMLError as detailed_error:
+        except _PARSE_STAGE_ERRORS as detailed_error:
             # Same failure, better message. Drop the libyaml error from the
             # chain so the traceback shows one diagnosis, not two.
             raise detailed_error from None

--- a/omnigent/_yaml_compat.py
+++ b/omnigent/_yaml_compat.py
@@ -125,9 +125,16 @@ def load(text: str, loader: type[yaml.SafeLoader]) -> Any:  # type: ignore[expli
             # Same failure, better message. Drop the libyaml error from the
             # chain so the traceback shows one diagnosis, not two.
             raise detailed_error from None
-        # Only the C parser objected. Nothing better to report, so surface
-        # the original rather than pretending the document was fine.
-        raise fast_error
+        except Exception:  # noqa: BLE001 - any other outcome is not our failure
+            # The two parsers disagree about where the document breaks: ``!] ``
+            # fails libyaml's scanner but scans clean for pure-Python, which
+            # then dies in the constructor. That diagnosis describes a
+            # different problem, so it must not be substituted.
+            pass
+        # The retry either succeeded or failed elsewhere. Either way libyaml's
+        # error is the accurate one; surface it rather than pretending the
+        # document was fine or reporting an unrelated failure.
+        raise fast_error from None
 
 
 def safe_load(text: str) -> Any:  # type: ignore[explicit-any]

--- a/omnigent/_yaml_compat.py
+++ b/omnigent/_yaml_compat.py
@@ -1,0 +1,51 @@
+"""libyaml-backed YAML loading, with a pure-Python fallback.
+
+PyYAML ships two implementations of the same safe loader: the pure-Python
+``SafeLoader`` and ``CSafeLoader``, which wraps libyaml. Both accept the
+same grammar, share the same constructor and resolver classes, and build
+identical Python objects — the C one is just far faster. Parsing the 19.2 KB
+``examples/polly/config.yaml`` takes 3.14 ms pure-Python and 0.18 ms through
+libyaml.
+
+Spec and config parsing sits on the runner's hot path (every sub-agent
+fan-out re-reads the bundle), so those loaders build on the C parser when
+it is available. PyYAML wheels bundle libyaml, but a source install built
+without the libyaml headers exposes no ``CSafeLoader`` at all — hence the
+fallback.
+"""
+
+from __future__ import annotations
+
+from typing import IO, TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    # ``CSafeLoader`` is not a subclass of ``SafeLoader`` — the two are
+    # siblings sharing ``SafeConstructor`` and ``Resolver``. mypy also
+    # cannot subclass a value chosen at runtime, so the pure-Python
+    # loader stands in as the static base for both.
+    SafeLoaderBase = yaml.SafeLoader
+else:
+    SafeLoaderBase = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+
+# True when the libyaml-backed parser is in use. Exposed for tests that
+# need to report which base they exercised.
+USING_LIBYAML = SafeLoaderBase is not yaml.SafeLoader
+
+
+# YAML documents are open-ended trees whose shape is only known after the
+# caller's isinstance checks, so the return type is the same ``Any`` that
+# ``yaml.safe_load`` itself returns.
+def safe_load(stream: str | bytes | IO[str] | IO[bytes]) -> Any:  # type: ignore[explicit-any]
+    """Drop-in ``yaml.safe_load`` that prefers the libyaml parser.
+
+    Resolver and constructor behaviour match ``yaml.safe_load`` exactly,
+    including YAML 1.1 booleans (``on``/``off``/``yes``/``no``). Loaders
+    that need YAML 1.2 boolean semantics subclass :data:`SafeLoaderBase`
+    and narrow the bool resolver themselves.
+
+    :param stream: YAML text, bytes, or an open file object.
+    :returns: The parsed document, or ``None`` for an empty stream.
+    """
+    return yaml.load(stream, Loader=SafeLoaderBase)

--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -10,6 +10,8 @@ from typing import Any, TypeAlias
 
 import yaml
 
+from omnigent._yaml_compat import SafeLoaderBase
+
 from .datamodel import (
     AgentDef,
     ExecutorSpec,
@@ -47,18 +49,25 @@ YamlData: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
 DynamicCallable: TypeAlias = Callable[..., object]  # type: ignore[explicit-any]
 
 
-class _OmnigentYamlLoader(yaml.SafeLoader):
+class _OmnigentYamlLoader(SafeLoaderBase):
     """YAML loader with YAML 1.2-style booleans.
 
     PyYAML's default YAML 1.1 resolver treats unquoted keys like ``on`` as a
     boolean. That breaks policy definitions such as ``on: [tool_call]``.
     Keep ``true``/``false`` boolean parsing, but stop treating ``on``/``off``
     and similar legacy literals as booleans.
+
+    The base is libyaml-backed where available (see
+    ``omnigent._yaml_compat``); libyaml's parser calls back into the Python
+    resolver, so the override below applies either way.
     """
 
 
+# Copy before mutating — the resolver dict is shared by reference across
+# every PyYAML loader, so an in-place edit would strip bool parsing
+# process-wide.
 _OmnigentYamlLoader.yaml_implicit_resolvers = {
-    key: value[:] for key, value in yaml.SafeLoader.yaml_implicit_resolvers.items()
+    key: value[:] for key, value in SafeLoaderBase.yaml_implicit_resolvers.items()
 }
 for key, resolvers in list(_OmnigentYamlLoader.yaml_implicit_resolvers.items()):
     _OmnigentYamlLoader.yaml_implicit_resolvers[key] = [

--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import importlib
-import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypeAlias
 
-import yaml
-
-from omnigent._yaml_compat import SafeLoaderBase
+from omnigent._yaml_compat import SafeLoaderBase, narrow_bools_to_yaml_1_2
+from omnigent._yaml_compat import load as _yaml_load
 
 from .datamodel import (
     AgentDef,
@@ -59,26 +57,11 @@ class _OmnigentYamlLoader(SafeLoaderBase):
 
     The base is libyaml-backed where available (see
     ``omnigent._yaml_compat``); libyaml's parser calls back into the Python
-    resolver, so the override below applies either way.
+    resolver, so the override applies either way.
     """
 
 
-# Copy before mutating — the resolver dict is shared by reference across
-# every PyYAML loader, so an in-place edit would strip bool parsing
-# process-wide.
-_OmnigentYamlLoader.yaml_implicit_resolvers = {
-    key: value[:] for key, value in SafeLoaderBase.yaml_implicit_resolvers.items()
-}
-for key, resolvers in list(_OmnigentYamlLoader.yaml_implicit_resolvers.items()):
-    _OmnigentYamlLoader.yaml_implicit_resolvers[key] = [
-        (tag, regexp) for tag, regexp in resolvers if tag != "tag:yaml.org,2002:bool"
-    ]
-# types-PyYAML declares add_implicit_resolver without return annotations.
-_OmnigentYamlLoader.add_implicit_resolver(  # type: ignore[no-untyped-call]
-    "tag:yaml.org,2002:bool",
-    re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$"),
-    list("tTfF"),
-)
+narrow_bools_to_yaml_1_2(_OmnigentYamlLoader)
 
 
 def load_agent_def(
@@ -114,8 +97,7 @@ def load_agent_def(
     """
     if isinstance(path_or_dict, (str, Path)):
         path = Path(path_or_dict)
-        with open(path) as f:
-            data = yaml.load(f, Loader=_OmnigentYamlLoader)
+        data = _yaml_load(path.read_text(), _OmnigentYamlLoader)
         instructions_root: Path | None = path.parent
     else:
         data = path_or_dict

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -40,6 +40,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from omnigent._yaml_compat import load as _yaml_load
 from omnigent._yaml_compat import safe_load as _yaml_safe_load
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_aliases import canonicalize_harness
@@ -364,8 +365,6 @@ def load_omnigent_yaml(
             code=ErrorCode.INVALID_INPUT,
         ) from exc
 
-    import yaml as _yaml
-
     from omnigent.inner.loader import _OmnigentYamlLoader
     from omnigent.spec.omnigent import agent_def_to_agent_spec
     from omnigent.spec.validator import validate
@@ -378,11 +377,11 @@ def load_omnigent_yaml(
     # ``match_tools``, ``action``, ``reason``, ``set_labels``).
     # Non-mapping roots are tolerated as an empty dict — the
     # omnigent loader would already have rejected them above.
-    # Use _OmnigentYamlLoader (not yaml.safe_load) so this raw
+    # Use _OmnigentYamlLoader (not a plain safe_load) so this raw
     # read resolves booleans the same way load_agent_def's YAML
     # parsing did — both loaders keep on/off as plain strings
     # instead of the YAML 1.1 bool aliases.
-    raw = _yaml.load(path.read_text(), Loader=_OmnigentYamlLoader) or {}
+    raw = _yaml_load(path.read_text(), _OmnigentYamlLoader) or {}
     if not isinstance(raw, dict):
         raw = {}
     spec = agent_def_to_agent_spec(agent_def, raw_yaml=raw)

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -40,6 +40,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from omnigent._yaml_compat import safe_load as _yaml_safe_load
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_plugins import (
@@ -229,7 +230,7 @@ def is_omnigent_yaml(path: Path) -> bool:
     if path.suffix.lower() not in {".yaml", ".yml"}:
         return False
     try:
-        raw = yaml.safe_load(path.read_text())
+        raw = _yaml_safe_load(path.read_text())
     except yaml.YAMLError:
         return False
     if not isinstance(raw, dict):
@@ -271,6 +272,10 @@ def diagnose_yaml_rejection(path: Path) -> str:
     try:
         raw = yaml.safe_load(path.read_text())
     except yaml.YAMLError as exc:
+        # Pure-Python loader on purpose: this runs once, only to explain a
+        # file the user already got wrong, and its error echoes the offending
+        # source line with a caret. libyaml reports line/column but drops
+        # that echo, so the faster parser would make the diagnosis worse.
         # Strip trailing whitespace so the message stays one line —
         # PyYAML embeds the source location in its error string,
         # which is exactly what the user needs to fix the typo.

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -12,6 +12,8 @@ from typing import Any, Literal
 import yaml
 from pydantic import BaseModel, ConfigDict, ValidationError, field_validator, model_validator
 
+from omnigent._yaml_compat import SafeLoaderBase
+from omnigent._yaml_compat import safe_load as _yaml_safe_load
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.inner.datamodel import (
     DEFAULT_BASIC_USERNAME,
@@ -60,7 +62,7 @@ _CONTEXT_FILE_PRIORITY: tuple[str, ...] = ("AGENTS.md", "CLAUDE.md", ".cursorrul
 _FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n(.*)", re.DOTALL)
 
 
-class _ConfigYamlLoader(yaml.SafeLoader):
+class _ConfigYamlLoader(SafeLoaderBase):
     """
     SafeLoader variant that does NOT treat ``on``/``off``/
     ``yes``/``no`` as booleans.
@@ -77,6 +79,10 @@ class _ConfigYamlLoader(yaml.SafeLoader):
     YAML 1.2 drops these bool aliases entirely; this override
     makes our loader YAML-1.2-aligned for the narrow set of
     aliases that matter here.
+
+    The base is libyaml-backed where available (see
+    ``omnigent._yaml_compat``). libyaml's parser calls back into
+    the Python resolver, so the override below applies either way.
     """
 
 
@@ -92,10 +98,11 @@ _YAML_1_2_BOOL_RE = re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$")
 _STRUCTURED_EXECUTOR_CONFIG_KEYS: frozenset[str] = frozenset()
 
 # Copy the resolver dict onto the subclass before mutating — it's inherited
-# from SafeLoader by reference, so in-place edits below would strip
-# SafeLoader's bool resolver process-wide.
+# from PyYAML's shared Resolver by reference (the same dict object backs
+# SafeLoader and CSafeLoader), so in-place edits below would strip the bool
+# resolver process-wide.
 _ConfigYamlLoader.yaml_implicit_resolvers = {
-    key: value[:] for key, value in yaml.SafeLoader.yaml_implicit_resolvers.items()
+    key: value[:] for key, value in SafeLoaderBase.yaml_implicit_resolvers.items()
 }
 for _ch in list(_ConfigYamlLoader.yaml_implicit_resolvers.keys()):
     _ConfigYamlLoader.yaml_implicit_resolvers[_ch] = [
@@ -2143,6 +2150,9 @@ def _parse_skill(skill_md: Path) -> SkillSpec:
         )
     frontmatter_str, content = match.groups()
     try:
+        # Pure-Python loader on purpose: frontmatter is a few hundred bytes,
+        # so libyaml buys nothing measurable, and its errors drop the source
+        # line and caret that make a malformed SKILL.md easy to fix.
         frontmatter = yaml.safe_load(frontmatter_str)
     except yaml.YAMLError as exc:
         raise OmnigentError(
@@ -2393,7 +2403,7 @@ def _discover_mcp_servers(
         return []
     servers: list[MCPServerConfig] = []
     for yaml_file in sorted(mcp_dir.glob("*.yaml")):
-        raw = yaml.safe_load(yaml_file.read_text())
+        raw = _yaml_safe_load(yaml_file.read_text())
         if not isinstance(raw, dict):
             raise OmnigentError(
                 f"MCP config must be a YAML mapping: {yaml_file}",

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -12,7 +12,8 @@ from typing import Any, Literal
 import yaml
 from pydantic import BaseModel, ConfigDict, ValidationError, field_validator, model_validator
 
-from omnigent._yaml_compat import SafeLoaderBase
+from omnigent._yaml_compat import SafeLoaderBase, narrow_bools_to_yaml_1_2
+from omnigent._yaml_compat import load as _yaml_load
 from omnigent._yaml_compat import safe_load as _yaml_safe_load
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.inner.datamodel import (
@@ -82,47 +83,15 @@ class _ConfigYamlLoader(SafeLoaderBase):
 
     The base is libyaml-backed where available (see
     ``omnigent._yaml_compat``). libyaml's parser calls back into
-    the Python resolver, so the override below applies either way.
+    the Python resolver, so the override applies either way.
     """
 
 
-# Replace the YAML 1.1 bool resolver pattern with a YAML 1.2
-# pattern that accepts only ``true`` / ``false`` (and their
-# title/upper-case variants). Strip the old bool resolvers
-# first, then add back the narrowed one.
-_BOOL_TAG = "tag:yaml.org,2002:bool"
-_YAML_1_2_BOOL_RE = re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$")
+narrow_bools_to_yaml_1_2(_ConfigYamlLoader)
 
 # ``executor.config`` keys kept as their nested YAML structure instead of
 # string-coerced — their consumers read the nested mapping/list shape.
 _STRUCTURED_EXECUTOR_CONFIG_KEYS: frozenset[str] = frozenset()
-
-# Copy the resolver dict onto the subclass before mutating — it's inherited
-# from PyYAML's shared Resolver by reference (the same dict object backs
-# SafeLoader and CSafeLoader), so in-place edits below would strip the bool
-# resolver process-wide.
-_ConfigYamlLoader.yaml_implicit_resolvers = {
-    key: value[:] for key, value in SafeLoaderBase.yaml_implicit_resolvers.items()
-}
-for _ch in list(_ConfigYamlLoader.yaml_implicit_resolvers.keys()):
-    _ConfigYamlLoader.yaml_implicit_resolvers[_ch] = [
-        (tag, regexp)
-        for tag, regexp in _ConfigYamlLoader.yaml_implicit_resolvers[_ch]
-        if tag != _BOOL_TAG
-    ]
-# Re-register a narrowed bool resolver keyed on ``t`` / ``T`` /
-# ``f`` / ``F`` only (the YAML 1.1 aliases keyed on o/O/y/Y/n/N
-# are now gone, so those characters parse as plain strings).
-# mypy flags BaseResolver.add_implicit_resolver as untyped
-# (PyYAML lacks type stubs on this classmethod); the call
-# is the only way to register an implicit resolver, so the
-# ignore is narrowly scoped to this YAML-1.2 compatibility
-# override.
-_ConfigYamlLoader.add_implicit_resolver(  # type: ignore[no-untyped-call]
-    _BOOL_TAG,
-    _YAML_1_2_BOOL_RE,
-    list("tTfF"),
-)
 
 
 def _parse_int_field(raw: object, field_name: str) -> int:
@@ -189,7 +158,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
     if not config_path.exists():
         raise FileNotFoundError(f"config.yaml not found in {root}")
 
-    raw = yaml.load(config_path.read_text(), Loader=_ConfigYamlLoader)
+    raw = _yaml_load(config_path.read_text(), _ConfigYamlLoader)
     if not isinstance(raw, dict):
         raise OmnigentError(
             f"config.yaml must be a YAML mapping, got {type(raw).__name__}",

--- a/tests/test_yaml_compat.py
+++ b/tests/test_yaml_compat.py
@@ -8,9 +8,14 @@ loaders rely on is asserted here against whichever base is actually active.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+import textwrap
+
+import pytest
 import yaml
 
-from omnigent._yaml_compat import USING_LIBYAML, SafeLoaderBase, safe_load
+from omnigent._yaml_compat import USING_LIBYAML, SafeLoaderBase, load, safe_load
 from omnigent.inner.loader import _OmnigentYamlLoader
 from omnigent.spec.parser import _ConfigYamlLoader
 
@@ -95,21 +100,106 @@ def test_safe_load_handles_empty_and_non_mapping_documents() -> None:
         assert safe_load(source) == yaml.safe_load(source), source
 
 
+# A description with an unquoted colon — the classic hand-authoring typo.
+_BROKEN = "name: agent\ndescription: has: unquoted colon\n"
+
+
 def test_parse_errors_stay_marked_yaml_errors() -> None:
     """Call sites catch ``yaml.YAMLError`` and report the mark's line/column.
 
-    libyaml words its messages differently and drops the echoed source line,
-    but the exception type and the mark must survive — ``diagnose_yaml_rejection``
-    promises the user a location.
+    ``diagnose_yaml_rejection`` promises the user a location, so the exception
+    type and the mark must survive whichever parser produced them.
     """
-    broken = "name: agent\ndescription: has: unquoted colon\n"
-    for load in (safe_load, lambda s: yaml.load(s, Loader=_ConfigYamlLoader)):
-        try:
-            load(broken)
-        except yaml.YAMLError as exc:
-            assert isinstance(exc, yaml.MarkedYAMLError)
-            assert exc.problem_mark is not None
-            assert exc.problem_mark.line == 1
-            assert exc.problem_mark.column == 16
-        else:  # pragma: no cover - the document is malformed by construction
-            raise AssertionError("expected a YAMLError")
+    for parse in (safe_load, lambda s: load(s, _ConfigYamlLoader)):
+        with pytest.raises(yaml.YAMLError) as excinfo:
+            parse(_BROKEN)
+        exc = excinfo.value
+        assert isinstance(exc, yaml.MarkedYAMLError)
+        assert exc.problem_mark is not None
+        assert exc.problem_mark.line == 1
+        assert exc.problem_mark.column == 16
+
+
+def test_load_keeps_the_source_excerpt_in_parse_errors() -> None:
+    """A failed parse must still echo the offending line and caret.
+
+    libyaml reports line/column but drops that echo, which is the part that
+    makes a typo obvious. :func:`load` reparses failures with the pure-Python
+    scanner so the diagnostic never regresses — the whole reason spec parsing
+    can take the fast path at all.
+    """
+    for parse in (safe_load, lambda s: load(s, _ConfigYamlLoader)):
+        with pytest.raises(yaml.YAMLError) as excinfo:
+            parse(_BROKEN)
+        message = str(excinfo.value)
+        assert "description: has: unquoted colon" in message, message
+        assert "^" in message, message
+        # The retry must not print the libyaml attempt above the real
+        # diagnosis — one traceback, one error.
+        assert excinfo.value.__cause__ is None
+        assert excinfo.value.__suppress_context__ is True
+
+
+def test_load_does_not_reparse_documents_that_succeed() -> None:
+    """The retry is failure-only, so the hot path pays nothing for it."""
+    calls: list[object] = []
+    real_load = yaml.load
+
+    def counting_load(stream: object, Loader: object) -> object:
+        calls.append(Loader)
+        return real_load(stream, Loader=Loader)  # type: ignore[arg-type]
+
+    yaml.load = counting_load  # type: ignore[assignment]
+    try:
+        assert load("a: 1\n", _ConfigYamlLoader) == {"a": 1}
+    finally:
+        yaml.load = real_load  # type: ignore[assignment]
+    assert calls == [_ConfigYamlLoader]
+
+
+def test_pure_python_fallback_when_libyaml_is_absent() -> None:
+    """A PyYAML built without libyaml must still import and resolve correctly.
+
+    Runs in a subprocess that deletes ``yaml.CSafeLoader`` before omnigent is
+    imported, which is the only way to exercise the fallback branch: the base
+    is chosen once at import time.
+    """
+    script = textwrap.dedent(
+        """
+        import yaml
+
+        del yaml.CSafeLoader  # simulate a source install without libyaml
+
+        from omnigent._yaml_compat import USING_LIBYAML, SafeLoaderBase
+        from omnigent.inner.loader import _OmnigentYamlLoader
+        from omnigent.spec.parser import _ConfigYamlLoader
+
+        assert SafeLoaderBase is yaml.SafeLoader, SafeLoaderBase
+        assert USING_LIBYAML is False
+
+        src = "a: on\\nb: off\\nc: yes\\nd: no\\ne: true\\nf: false\\n"
+        expected = {"a": "on", "b": "off", "c": "yes", "d": "no", "e": True, "f": False}
+        for loader in (_ConfigYamlLoader, _OmnigentYamlLoader):
+            assert issubclass(loader, yaml.SafeLoader), loader
+            got = yaml.load(src, Loader=loader)
+            assert got == expected, (loader, got)
+            assert got["e"] is True and got["f"] is False, loader
+            assert (
+                loader.yaml_implicit_resolvers
+                is not yaml.SafeLoader.yaml_implicit_resolvers
+            )
+
+        assert yaml.safe_load("on") is True
+        assert yaml.safe_load("false") is False
+        print("OK")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("OK")

--- a/tests/test_yaml_compat.py
+++ b/tests/test_yaml_compat.py
@@ -1,0 +1,115 @@
+"""Resolver behaviour must survive the libyaml-backed loader base.
+
+``omnigent._yaml_compat.SafeLoaderBase`` is ``yaml.CSafeLoader`` wherever
+PyYAML was built against libyaml, and ``yaml.SafeLoader`` otherwise. The two
+parsers are different C/Python implementations, so every guarantee the spec
+loaders rely on is asserted here against whichever base is actually active.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from omnigent._yaml_compat import USING_LIBYAML, SafeLoaderBase, safe_load
+from omnigent.inner.loader import _OmnigentYamlLoader
+from omnigent.spec.parser import _ConfigYamlLoader
+
+# Both spec loaders narrow the bool resolver the same way, so they carry the
+# same expectations.
+_NARROWED_LOADERS = (_ConfigYamlLoader, _OmnigentYamlLoader)
+
+# ``on``/``off``/``yes``/``no`` are YAML 1.1 bool aliases. The policy system
+# keys on ``on:``, so they must stay strings; ``true``/``false`` must not.
+_YAML_1_2_BOOLS = """\
+a: on
+b: off
+c: yes
+d: no
+e: true
+f: false
+"""
+
+
+def test_base_is_libyaml_when_available() -> None:
+    """The base tracks libyaml availability rather than being hard-coded."""
+    assert SafeLoaderBase is getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+    assert USING_LIBYAML is (SafeLoaderBase is not yaml.SafeLoader)
+
+
+def test_narrowed_loaders_build_on_the_active_base() -> None:
+    """Both spec loaders subclass the shared base, not a hard-coded loader."""
+    for loader in _NARROWED_LOADERS:
+        assert issubclass(loader, SafeLoaderBase), loader
+
+
+def test_narrowed_loaders_keep_yaml_1_1_bool_aliases_as_strings() -> None:
+    """``on``/``off``/``yes``/``no`` stay strings; ``true``/``false`` stay bools.
+
+    This is the one behaviour the C parser could plausibly break — libyaml
+    scans tokens itself, and only calls back into the Python resolver to tag
+    them. If that callback ever stopped honouring the subclass's resolver
+    table, ``on:`` would silently become the key ``True`` and every policy
+    selector in the repo would break.
+    """
+    for loader in _NARROWED_LOADERS:
+        parsed = yaml.load(_YAML_1_2_BOOLS, Loader=loader)
+        assert parsed == {
+            "a": "on",
+            "b": "off",
+            "c": "yes",
+            "d": "no",
+            "e": True,
+            "f": False,
+        }, loader
+        # Bools must be real bools, not the strings "true"/"false".
+        assert parsed["e"] is True, loader
+        assert parsed["f"] is False, loader
+
+
+def test_narrowed_loaders_own_their_resolver_table() -> None:
+    """Narrowing must not mutate the resolver dict shared by every loader.
+
+    ``yaml_implicit_resolvers`` lives on PyYAML's ``BaseResolver`` and is the
+    same object for ``SafeLoader`` and ``CSafeLoader`` alike, so an in-place
+    edit would strip bool parsing from every ``yaml.safe_load`` caller in the
+    process.
+    """
+    for loader in _NARROWED_LOADERS:
+        assert loader.yaml_implicit_resolvers is not SafeLoaderBase.yaml_implicit_resolvers
+        assert loader.yaml_implicit_resolvers is not yaml.SafeLoader.yaml_implicit_resolvers
+    assert yaml.safe_load("on") is True
+    assert yaml.safe_load("false") is False
+
+
+def test_safe_load_matches_yaml_safe_load() -> None:
+    """The drop-in keeps stock ``safe_load`` semantics, YAML 1.1 bools included."""
+    source = _YAML_1_2_BOOLS + "g: 2026-07-24\nh: [1, 2]\ni: null\n"
+    assert safe_load(source) == yaml.safe_load(source)
+    # Unlike the narrowed loaders, this one still resolves the 1.1 aliases.
+    assert safe_load("on") is True
+
+
+def test_safe_load_handles_empty_and_non_mapping_documents() -> None:
+    """Callers isinstance-check the result, so the empty cases must match."""
+    for source in ("", "# comment only\n", "- a\n- b\n", "just a string\n"):
+        assert safe_load(source) == yaml.safe_load(source), source
+
+
+def test_parse_errors_stay_marked_yaml_errors() -> None:
+    """Call sites catch ``yaml.YAMLError`` and report the mark's line/column.
+
+    libyaml words its messages differently and drops the echoed source line,
+    but the exception type and the mark must survive — ``diagnose_yaml_rejection``
+    promises the user a location.
+    """
+    broken = "name: agent\ndescription: has: unquoted colon\n"
+    for load in (safe_load, lambda s: yaml.load(s, Loader=_ConfigYamlLoader)):
+        try:
+            load(broken)
+        except yaml.YAMLError as exc:
+            assert isinstance(exc, yaml.MarkedYAMLError)
+            assert exc.problem_mark is not None
+            assert exc.problem_mark.line == 1
+            assert exc.problem_mark.column == 16
+        else:  # pragma: no cover - the document is malformed by construction
+            raise AssertionError("expected a YAMLError")

--- a/tests/test_yaml_compat.py
+++ b/tests/test_yaml_compat.py
@@ -182,6 +182,31 @@ def test_load_does_not_substitute_constructor_errors() -> None:
     assert "could not determine a constructor" not in message, message
 
 
+# Inputs the two parsers classify into different stages: libyaml rejects the
+# tag while scanning, pure-Python scans it clean and then fails in the
+# constructor. The retry must not swap one diagnosis for the other.
+_STAGE_DIVERGENT = ("!] ", "!]", "!!] x", "a: !] b\n")
+
+
+@pytest.mark.parametrize("source", _STAGE_DIVERGENT)
+def test_load_keeps_libyaml_error_when_the_parsers_disagree(source: str) -> None:
+    """A retry that fails somewhere else entirely must not replace the original.
+
+    ``!]`` is a scanner error for libyaml but a constructor error for the
+    pure-Python parser. Reporting the latter would point the user at a
+    "could not determine a constructor" problem the document does not have.
+    """
+    with pytest.raises(yaml.YAMLError) as excinfo:
+        load(source, _ConfigYamlLoader)
+    exc = excinfo.value
+    assert "could not determine a constructor" not in str(exc), str(exc)
+    if USING_LIBYAML:
+        assert isinstance(exc, yaml.scanner.ScannerError), type(exc)
+        # One diagnosis, not a chain of two.
+        assert exc.__suppress_context__ is True
+        assert exc.__cause__ is None
+
+
 def test_pure_python_fallback_when_libyaml_is_absent() -> None:
     """A PyYAML built without libyaml must still import and resolve correctly.
 

--- a/tests/test_yaml_compat.py
+++ b/tests/test_yaml_compat.py
@@ -157,6 +157,31 @@ def test_load_does_not_reparse_documents_that_succeed() -> None:
     assert calls == [_ConfigYamlLoader]
 
 
+def test_load_does_not_substitute_constructor_errors() -> None:
+    """A loader's own constructor error must reach the caller intact.
+
+    The reparse only ever runs stock ``SafeLoader``, which knows nothing of
+    a caller's custom tags. Retrying a constructor failure would swap a
+    precise error for the stock loader's unrelated "could not determine a
+    constructor for the tag" — so construction-stage failures are not
+    retried at all.
+    """
+
+    class _CustomLoader(_ConfigYamlLoader):  # type: ignore[valid-type,misc]
+        pass
+
+    def _reject(loader: object, node: object) -> object:
+        raise yaml.constructor.ConstructorError(None, None, "tag !secret is not permitted here")
+
+    _CustomLoader.add_constructor("!secret", _reject)
+
+    with pytest.raises(yaml.constructor.ConstructorError) as excinfo:
+        load("token: !secret abc\n", _CustomLoader)
+    message = str(excinfo.value)
+    assert "tag !secret is not permitted here" in message, message
+    assert "could not determine a constructor" not in message, message
+
+
 def test_pure_python_fallback_when_libyaml_is_absent() -> None:
     """A PyYAML built without libyaml must still import and resolve correctly.
 
@@ -168,7 +193,11 @@ def test_pure_python_fallback_when_libyaml_is_absent() -> None:
         """
         import yaml
 
-        del yaml.CSafeLoader  # simulate a source install without libyaml
+        # Simulate a source install without libyaml. Guarded because this
+        # test must also pass where libyaml is genuinely absent — the very
+        # environment it exists to cover.
+        if hasattr(yaml, "CSafeLoader"):
+            del yaml.CSafeLoader
 
         from omnigent._yaml_compat import USING_LIBYAML, SafeLoaderBase
         from omnigent.inner.loader import _OmnigentYamlLoader

--- a/tests/test_yaml_compat.py
+++ b/tests/test_yaml_compat.py
@@ -134,10 +134,12 @@ def test_load_keeps_the_source_excerpt_in_parse_errors() -> None:
         message = str(excinfo.value)
         assert "description: has: unquoted colon" in message, message
         assert "^" in message, message
-        # The retry must not print the libyaml attempt above the real
-        # diagnosis — one traceback, one error.
-        assert excinfo.value.__cause__ is None
-        assert excinfo.value.__suppress_context__ is True
+        if USING_LIBYAML:
+            # The retry must not print the libyaml attempt above the real
+            # diagnosis — one traceback, one error. Without libyaml nothing
+            # is retried, so there is no chained attempt to suppress.
+            assert excinfo.value.__cause__ is None
+            assert excinfo.value.__suppress_context__ is True
 
 
 def test_load_does_not_reparse_documents_that_succeed() -> None:
@@ -188,6 +190,11 @@ def test_load_does_not_substitute_constructor_errors() -> None:
 _STAGE_DIVERGENT = ("!] ", "!]", "!!] x", "a: !] b\n")
 
 
+@pytest.mark.skipif(
+    not USING_LIBYAML,
+    reason="no libyaml here, so there is no second parser to disagree with — "
+    "pure-Python's constructor error is then the document's genuine diagnosis",
+)
 @pytest.mark.parametrize("source", _STAGE_DIVERGENT)
 def test_load_keeps_libyaml_error_when_the_parsers_disagree(source: str) -> None:
     """A retry that fails somewhere else entirely must not replace the original.
@@ -196,15 +203,13 @@ def test_load_keeps_libyaml_error_when_the_parsers_disagree(source: str) -> None
     pure-Python parser. Reporting the latter would point the user at a
     "could not determine a constructor" problem the document does not have.
     """
-    with pytest.raises(yaml.YAMLError) as excinfo:
+    with pytest.raises(yaml.scanner.ScannerError) as excinfo:
         load(source, _ConfigYamlLoader)
     exc = excinfo.value
     assert "could not determine a constructor" not in str(exc), str(exc)
-    if USING_LIBYAML:
-        assert isinstance(exc, yaml.scanner.ScannerError), type(exc)
-        # One diagnosis, not a chain of two.
-        assert exc.__suppress_context__ is True
-        assert exc.__cause__ is None
+    # One diagnosis, not a chain of two.
+    assert exc.__suppress_context__ is True
+    assert exc.__cause__ is None
 
 
 def test_pure_python_fallback_when_libyaml_is_absent() -> None:


### PR DESCRIPTION
## Related issue

Contributes to #2703

<!-- No closing keyword: #2703 also covers the repeat-parsing half, which #2819 fixes. -->

## Summary

The runner parses agent-bundle YAML with PyYAML's pure-Python `SafeLoader`. PyYAML also ships `CSafeLoader`, which wraps libyaml — same grammar, same constructors, same resolver classes, roughly an order of magnitude less CPU.

- Rebase both spec loaders (`_ConfigYamlLoader`, `_OmnigentYamlLoader`) onto a shared base that resolves to `CSafeLoader` when PyYAML was built against libyaml, and falls back to `SafeLoader` otherwise — a source install may lack the C extension entirely.
- Keep the YAML-1.2 bool narrowing that makes `on`/`off`/`yes`/`no` parse as strings. libyaml scans tokens itself but calls back into the Python resolver to tag them, so the override survives; a test asserts it against whichever base is active.
- Preserve authoring diagnostics. libyaml reports a syntax error's line and column but drops the echoed source line and caret, so `_yaml_compat.load()` reparses failed documents with the pure-Python scanner and raises that error instead.

**This complements #2819 rather than replacing it.** They address orthogonal terms in `N × parse_cost`: #2819 collapses **N** by memoizing the parsed spec, this collapses **parse_cost**. Neither subsumes the other, and they merge cleanly (verified by trial merge — no conflicts, both suites green).

<details>
<summary>ELI5 and the diagnostic tradeoff</summary>

PyYAML can read YAML two ways: a Python implementation, and a thin wrapper around the C library `libyaml`. They agree on everything that matters — same grammar, same resulting objects — but the C one is much faster. We were using the slow one everywhere.

The catch is error messages. The Python parser prints the offending line with a caret under it; libyaml gives you only a line and column number:

```
                     pure-Python                          libyaml
  mapping values are not allowed here          mapping values are not allowed in this context
    in "<string>", line 2, column 17:            in "<string>", line 2, column 17
      description: has: unquoted colon
                      ^
```

Since a document that failed to parse is already off the hot path, `load()` parses it a second time with the Python parser purely to produce the better message. The fast path never pays for this.

```mermaid
flowchart LR
    A[config.yaml] --> B{libyaml parse}
    B -->|ok| C[spec]
    B -->|scanner/parser/composer error| D[reparse pure-Python]
    D -->|same stage fails| E[raise richer error]
    D -->|succeeds or fails elsewhere| F[raise libyaml's error]
```

Only scanner/parser/composer failures are retried. Those stages run before any tag is resolved or constructor invoked, so the loader's resolver and constructor tables provably cannot have affected the outcome — which is what makes substituting the stock loader's message faithful. Construction failures propagate untouched, and a retry that diverges (`!] ` fails libyaml's scanner but reaches pure-Python's constructor) keeps libyaml's diagnosis.

</details>

### Scope

Two call sites deliberately stay on the pure-Python loader, each commented in place: `diagnose_yaml_rejection` and SKILL.md frontmatter both exist to explain a file the user got wrong, and neither parses enough bytes for the speed to matter. The other ~29 `yaml.safe_load` sites repo-wide are cold and untouched.

## Test Plan

New `tests/test_yaml_compat.py` (15 tests) covers the resolver guarantee, the drop-in's equivalence to `yaml.safe_load`, error-mark preservation, the diagnostic retry, and the pure-Python fallback.

```bash
uv run pytest -q tests/test_yaml_compat.py tests/spec tests/inner/test_loader.py
```

Verified beyond the suite:

- **Both bases.** The fallback branch is chosen at import time, so it is exercised by a subprocess test that removes `yaml.CSafeLoader` before importing omnigent. The whole suite was also run under a `sitecustomize` shim doing the same: **605 passed, 4 skipped** with libyaml absent.
- **Output identity.** Parsed output byte-identical across both loaders on the polly bundle.
- **Diagnostics end-to-end.** A typo'd `config.yaml` through `spec.load()` still returns the source line and caret.
- **Guards are load-bearing.** Both error-handling guards were mutation-checked — reverting each makes its test fail with exactly the regression it prevents.
- **Composition.** Trial-merged with #2819: clean, 615 passed across both PRs' suites.
- **No new type errors.** mypy reports 59 errors in these modules before and after — all pre-existing.

Pre-existing failures on macOS (`bwrap`, `seccomp`, `AF_UNIX`, tmux, and the `databricks` extra) were confirmed identical on unmodified `main`.

## Demo

Nothing visual to show, so here are the numbers instead.

`examples/polly`, Python 3.12.13, PyYAML 6.0.3. Before/after come from the same script with `yaml.CSafeLoader` hidden, so this is exactly the diff's effect:

| | before | after | |
|---|---|---|---|
| root `config.yaml` (19.2 KB) | 3.14 ms | 0.18 ms | **17.5×** |
| all 7 bundle configs (36.0 KB) | 7.07 ms | 0.49 ms | **14.4×** |
| full `parse_spec()` | 7.89 ms | 1.18 ms | **6.7×** |

Parsed output is identical across both loaders (`sha256(repr(parsed))` matches). YAML was ~85% of bundle-load cost; it is now ~40%.

Stacked with #2819, for a fan-out of N sub-agents sharing a bundle:

```
  N    neither      #2819       mine       both   both vs neither
  1      7.60ms      7.60ms     1.18ms     1.18ms          6.4x
  4     30.39ms      8.35ms     4.71ms     1.92ms         15.8x
  8     60.78ms      9.34ms     9.42ms     2.92ms         20.8x
 16    121.57ms     11.33ms    18.85ms     4.91ms         24.7x
```

#2819 replaces a repeat parse with a `deepcopy`, which stays ~5× cheaper than even a libyaml parse — so its memo remains clearly worthwhile. Its headline ratio does shrink once this lands (the parse it avoids gets cheaper), so the two savings should not be added when closing #2703.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the parts a unit test cannot reach: the before/after benchmarks above, the no-libyaml environment via a `sitecustomize` shim (a base chosen at import time can't be monkeypatched in-process), the trial merge with #2819, and the mutation checks on both error-handling guards.

The existing spec suites are load-bearing here: they parse real bundles through the swapped loaders, so any resolver or constructor drift surfaces there rather than only in the new module.

## Changelog

Agent bundles load faster — spec YAML now parses through libyaml where available
