### PR TITLE
fix(web): make session rename optimistic so the new name shows instantly

### DIFF
--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -2,7 +2,7 @@
 // query-invalidation contract of the stop mutation hook.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConversationsInfiniteData } from "@/lib/sessionListCache";
@@ -607,6 +607,221 @@ describe("useRenameConversation cache patching", () => {
     expect(invalidateSpy).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect((fetchMock.mock.calls[0] as [string, RequestInit])[1].method).toBe("PATCH");
+  });
+
+  it("paints the new title optimistically before the PATCH resolves", async () => {
+    // Hold the PATCH open so we can observe the cache between mutate() and
+    // the server response — the window where the sidebar used to show the
+    // stale name.
+    let resolvePatch: (value: Response) => void = () => {};
+    fetchMock.mockReset();
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolvePatch = resolve;
+      }),
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([conversation({ id: "conv_x" })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const rendered = renderHook(() => useRenameConversation(), { wrapper });
+
+    rendered.result.current.mutate({ id: "conv_x", title: "New name" });
+
+    // Before the PATCH resolves, the cached row already shows the new title.
+    await waitFor(() => {
+      const data = queryClient.getQueryData<ConversationsInfiniteData>([
+        "conversations",
+        "",
+        false,
+      ]);
+      expect(data!.pages[0].data.find((c) => c.id === "conv_x")!.title).toBe("New name");
+    });
+
+    resolvePatch(
+      mockResponse({
+        id: "conv_x",
+        object: "conversation",
+        title: "New name",
+        created_at: 0,
+        updated_at: 200,
+        labels: {},
+      }),
+    );
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+  });
+
+  it("rolls back to the old title when the PATCH fails", async () => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValueOnce(mockResponse({ error: "boom" }, { ok: false, status: 500 }));
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([conversation({ id: "conv_x" })]),
+    );
+    queryClient.setQueryData(["conversation-backfill", "conv_x"], conversation({ id: "conv_x" }));
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const rendered = renderHook(() => useRenameConversation(), { wrapper });
+
+    rendered.result.current.mutate({ id: "conv_x", title: "New name" });
+    await waitFor(() => expect(rendered.result.current.isError).toBe(true));
+
+    // A failed rename must not leave the optimistic title stranded in the
+    // cache — the row reverts to what it showed before.
+    const data = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
+    expect(data!.pages[0].data.find((c) => c.id === "conv_x")!.title).toBe("Old name");
+    const backfill = queryClient.getQueryData<Conversation>(["conversation-backfill", "conv_x"]);
+    expect(backfill!.title).toBe("Old name");
+  });
+
+  it("re-renders a subscribed list component with the new title before the PATCH resolves", async () => {
+    // The cache-level assertions above prove onMutate writes the cache, but
+    // not that a component reading it through useConversations actually
+    // re-paints. This renders the real subscription + the real rename hook
+    // together so a regression to server-first (or a stale subscription)
+    // fails here — this is the path the user sees in the sidebar.
+    let resolvePatch: (value: Response) => void = () => {};
+    fetchMock.mockReset();
+    // useConversations does an initial fetch on mount, then the PATCH.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        data: [
+          {
+            id: "conv_x",
+            object: "conversation",
+            title: "Old name",
+            created_at: 0,
+            updated_at: 100,
+            labels: {},
+          },
+        ],
+        first_id: "conv_x",
+        last_id: "conv_x",
+        has_more: false,
+      }),
+    );
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolvePatch = resolve;
+      }),
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    function Harness() {
+      const { data } = useConversations();
+      const rename = useRenameConversation();
+      const title = data?.pages.flatMap((p) => p.data).find((c) => c.id === "conv_x")?.title;
+      return createElement(
+        "div",
+        null,
+        createElement("span", { "data-testid": "title" }, title ?? ""),
+        createElement(
+          "button",
+          { onClick: () => rename.mutate({ id: "conv_x", title: "New name" }) },
+          "rename",
+        ),
+      );
+    }
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    render(createElement(Harness), { wrapper });
+
+    // The list loads the old title.
+    await waitFor(() => expect(screen.getByTestId("title").textContent).toBe("Old name"));
+
+    // Fire the rename; the subscribed span must flip to the new title while
+    // the PATCH is still in flight (optimistic), not after it resolves.
+    screen.getByRole("button").click();
+    await waitFor(() => expect(screen.getByTestId("title").textContent).toBe("New name"));
+
+    resolvePatch(
+      mockResponse({
+        id: "conv_x",
+        object: "conversation",
+        title: "New name",
+        created_at: 0,
+        updated_at: 200,
+        labels: {},
+      }),
+    );
+    await waitFor(() => expect(screen.getByTestId("title").textContent).toBe("New name"));
+  });
+
+  it("re-renders a project-folder row (['project-sessions']) with the new title optimistically", async () => {
+    // A session filed in a project renders from its own
+    // ["project-sessions", name] cache, NOT the flat ["conversations"] list.
+    // Renaming it must overlay that cache too, or the folder row keeps the
+    // stale title until the WS reconcile — the reported bug.
+    let resolvePatch: (value: Response) => void = () => {};
+    fetchMock.mockReset();
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolvePatch = resolve;
+      }),
+    );
+    const queryClient = new QueryClient({
+      // staleTime Infinity so the seeded folder cache doesn't background-refetch
+      // on mount and consume the PATCH mock below.
+      defaultOptions: {
+        queries: { retry: false, staleTime: Infinity },
+        mutations: { retry: false },
+      },
+    });
+    // Seed only the project-folder cache; the flat list is empty (the folder
+    // is the sole place this row appears).
+    queryClient.setQueryData(
+      ["project-sessions", "Sprint 42"],
+      infinitePage([conversation({ id: "conv_x" })]),
+    );
+
+    function Harness() {
+      const { data } = useProjectSessions("Sprint 42", true);
+      const rename = useRenameConversation();
+      const title = data?.pages.flatMap((p) => p.data).find((c) => c.id === "conv_x")?.title;
+      return createElement(
+        "div",
+        null,
+        createElement("span", { "data-testid": "title" }, title ?? ""),
+        createElement(
+          "button",
+          { onClick: () => rename.mutate({ id: "conv_x", title: "New name" }) },
+          "rename",
+        ),
+      );
+    }
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    render(createElement(Harness), { wrapper });
+
+    await waitFor(() => expect(screen.getByTestId("title").textContent).toBe("Old name"));
+
+    screen.getByRole("button").click();
+    // The folder row flips to the new title while the PATCH is still in flight.
+    await waitFor(() => expect(screen.getByTestId("title").textContent).toBe("New name"));
+
+    resolvePatch(
+      mockResponse({
+        id: "conv_x",
+        object: "conversation",
+        title: "New name",
+        created_at: 0,
+        updated_at: 200,
+        labels: {},
+      }),
+    );
+    await waitFor(() => expect(screen.getByTestId("title").textContent).toBe("New name"));
   });
 });
 

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -609,6 +609,20 @@ describe("useRenameConversation cache patching", () => {
     expect((fetchMock.mock.calls[0] as [string, RequestInit])[1].method).toBe("PATCH");
   });
 
+  it("cancels in-flight list queries so a stale reconcile can't clobber the new title", async () => {
+    const { queryClient, rendered } = seedAndRename();
+    const cancelSpy = vi.spyOn(queryClient, "cancelQueries");
+
+    rendered.result.current.mutate({ id: "conv_x", title: "New name" });
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+
+    // onMutate must cancel both list-cache families before overlaying, or an
+    // in-flight reconcile poll / WS-triggered fetch could resolve afterward
+    // and overwrite the optimistic title with the stale search-indexed name.
+    expect(cancelSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+    expect(cancelSpy).toHaveBeenCalledWith({ queryKey: ["project-sessions"] });
+  });
+
   it("paints the new title optimistically before the PATCH resolves", async () => {
     // Hold the PATCH open so we can observe the cache between mutate() and
     // the server response — the window where the sidebar used to show the

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -440,7 +440,14 @@ export function useRenameConversation() {
     // failed PATCH can roll back to whatever the caches held before. The
     // sidebar reads from the ["conversations"] lists, so prefer that row's
     // title and fall back to the snapshot / backfill caches.
-    onMutate: ({ id, title }) => {
+    onMutate: async ({ id, title }) => {
+      // Cancel any in-flight list refetch (the reconcile poll or a WS-triggered
+      // fetch) so it can't resolve after this overlay and clobber the new title
+      // with the stale search-indexed name.
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: ["conversations"] }),
+        queryClient.cancelQueries({ queryKey: ["project-sessions"] }),
+      ]);
       // Find the row's current title in whichever list cache holds it — the
       // flat sidebar list or a project folder — so a failed PATCH can revert.
       let listTitle: string | null | undefined;

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -363,59 +363,128 @@ export async function deleteConversation(id: string, deleteBranch = false): Prom
 /**
  * Rename a conversation via `PATCH /v1/sessions/{id}`.
  *
- * Patches the new title into every cached list/snapshot query in
- * place instead of invalidating. `GET /v1/sessions` may serve titles
- * from a search index that catches up to the rename asynchronously
- * (the Databricks deployment lists via search-midtier over WHS), so
- * an immediate refetch races the reindex and loses — the sidebar
- * would keep the old name until the next reconciliation. The PATCH
- * response is server-confirmed truth; overlaying it is always safe.
- * List membership and ordering converge later via the
+ * Optimistic: the new title is overlaid into every cached list/snapshot
+ * query in `onMutate`, so the sidebar row repaints on the next frame
+ * rather than after the PATCH round-trips (which showed the old name
+ * for the request's duration). `onSuccess` re-overlays the
+ * server-confirmed row to pick up the authoritative `updated_at`;
+ * `onError` restores the pre-rename title.
+ *
+ * Overlaying in place instead of invalidating is deliberate:
+ * `GET /v1/sessions` may serve titles from a search index that catches
+ * up to the rename asynchronously (the Databricks deployment lists via
+ * search-midtier over WHS), so an immediate refetch races the reindex
+ * and loses — the sidebar would keep the old name until the next
+ * reconciliation. List membership and ordering converge later via the
  * `WS /v1/sessions/updates` stream and the low-rate reconciliation
  * polls. Callers (the sidebar row) trigger this on blur / Enter in
  * the inline-edit input.
  */
+// Project folders (["project-sessions", name]) are non-archived, unsearched
+// lists — the same filters the push-delta merge uses to overlay them.
+const PROJECT_FOLDER_FILTERS = { searchQuery: "", includeArchived: false } as const;
+
 export function useRenameConversation() {
   const queryClient = useQueryClient();
+
+  // Overlay a title into every cache that holds a row for this session.
+  // Only the fields the rename changes are written — the full PATCH
+  // snapshot carries nulls for absent fields that would clobber
+  // list-shaped rows (see `nullsToUndefined` in sessionListCache).
+  const overlayTitle = (id: string, title: string | null, updatedAt?: number) => {
+    const wire: SessionListWireItem = {
+      id,
+      title,
+      ...(updatedAt !== undefined ? { updated_at: updatedAt } : {}),
+    };
+    const itemsById = new Map([[id, wire]]);
+    for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+      queryKey: ["conversations"],
+    })) {
+      const { data: next } = mergeItemsIntoPages(
+        data,
+        itemsById,
+        filtersFromConversationQueryKey(key),
+        // activeId only gates `needsRefetch`, which is unused here —
+        // we deliberately skip the refetch (see hook docstring).
+        undefined,
+      );
+      if (next !== data) queryClient.setQueryData(key, next);
+    }
+    // A filed session renders from its own ["project-sessions", name] list,
+    // not the flat ["conversations"] cache, so patch those (non-archived,
+    // unsearched — PROJECT_FOLDER_FILTERS) too or the folder row stays stale.
+    for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+      queryKey: ["project-sessions"],
+    })) {
+      const { data: next } = mergeItemsIntoPages(
+        data,
+        itemsById,
+        PROJECT_FOLDER_FILTERS,
+        undefined,
+      );
+      if (next !== data) queryClient.setQueryData(key, next);
+    }
+    // The pinned-row backfill cache (staleTime 60s) and the per-session
+    // snapshot (staleTime Infinity) are not covered by the list patch and
+    // would serve the old title long after.
+    queryClient.setQueryData<Conversation | null>(["conversation-backfill", id], (old) =>
+      old ? { ...old, title, ...(updatedAt !== undefined ? { updated_at: updatedAt } : {}) } : old,
+    );
+    queryClient.setQueryData<Session>(["session", id], (old) => (old ? { ...old, title } : old));
+  };
+
   return useMutation({
     mutationFn: ({ id, title }: { id: string; title: string }) => renameConversation(id, title),
+    // Paint the new name immediately; snapshot the current title so a
+    // failed PATCH can roll back to whatever the caches held before. The
+    // sidebar reads from the ["conversations"] lists, so prefer that row's
+    // title and fall back to the snapshot / backfill caches.
+    onMutate: ({ id, title }) => {
+      // Find the row's current title in whichever list cache holds it — the
+      // flat sidebar list or a project folder — so a failed PATCH can revert.
+      let listTitle: string | null | undefined;
+      for (const queryKey of [["conversations"], ["project-sessions"]]) {
+        for (const [, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+          queryKey,
+        })) {
+          const row = data?.pages.flatMap((page) => page.data).find((conv) => conv.id === id);
+          if (row) {
+            listTitle = row.title;
+            break;
+          }
+        }
+        if (listTitle !== undefined) break;
+      }
+      const previous = {
+        list: listTitle,
+        session: queryClient.getQueryData<Session>(["session", id])?.title,
+        backfill: queryClient.getQueryData<Conversation | null>(["conversation-backfill", id])
+          ?.title,
+      };
+      overlayTitle(id, title);
+      return previous;
+    },
+    onError: (_err, { id }, previous) => {
+      // Restore the first title we managed to snapshot. A snapshotted null
+      // (previously-untitled row) is a real value to restore; only skip
+      // when we never captured a title at all (all sources undefined).
+      const restored =
+        previous?.list !== undefined
+          ? previous.list
+          : previous?.session !== undefined
+            ? previous.session
+            : previous?.backfill;
+      if (restored !== undefined) overlayTitle(id, restored);
+    },
     onSuccess: (updated) => {
       // The PATCH bumps server `updated_at`, which the unseen tracker
       // would otherwise read as new messages even though the user
       // initiated this themselves. Anchor the seen-baseline to the
       // server's new updated_at so the next refetch reports not unseen.
       markConversationSeen(updated.id, updated.updated_at);
-      // Overlay only the fields the rename changes — the full PATCH
-      // snapshot carries nulls for absent fields that would clobber
-      // list-shaped rows (see `nullsToUndefined` in sessionListCache).
-      const wire: SessionListWireItem = {
-        id: updated.id,
-        title: updated.title,
-        updated_at: updated.updated_at,
-      };
-      const itemsById = new Map([[updated.id, wire]]);
-      for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
-        queryKey: ["conversations"],
-      })) {
-        const { data: next } = mergeItemsIntoPages(
-          data,
-          itemsById,
-          filtersFromConversationQueryKey(key),
-          // activeId only gates `needsRefetch`, which is unused here —
-          // we deliberately skip the refetch (see hook docstring).
-          undefined,
-        );
-        if (next !== data) queryClient.setQueryData(key, next);
-      }
-      // The pinned-row backfill cache (staleTime 60s) and the
-      // per-session snapshot (staleTime Infinity) are not covered by
-      // the list patch and would serve the old title long after.
-      queryClient.setQueryData<Conversation | null>(["conversation-backfill", updated.id], (old) =>
-        old ? { ...old, title: updated.title, updated_at: updated.updated_at } : old,
-      );
-      queryClient.setQueryData<Session>(["session", updated.id], (old) =>
-        old ? { ...old, title: updated.title } : old,
-      );
+      // Reconcile with the server-confirmed title + authoritative updated_at.
+      overlayTitle(updated.id, updated.title, updated.updated_at);
     },
   });
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Renaming a session left the **stale name** in the sidebar for the duration of the `PATCH /v1/sessions/{id}` round-trip: all cache patching happened in the mutation's `onSuccess`, so the row only repainted once the server responded.
- Make the rename **optimistic** — overlay the new title into every cache in `onMutate` (so the row repaints on the next frame), snapshot the old title, and restore it in `onError` if the PATCH fails. `onSuccess` still reconciles with the server-confirmed title + authoritative `updated_at` and keeps the deliberate no-refetch behavior (an immediate `GET /v1/sessions` races the server's async search-index reindex and would resurrect the old name).
- Also patch the `["project-sessions", name]` caches that **project folders** render from. The original overlay only touched the flat `["conversations"]` list, so a session filed inside a project folder kept its old name until the ~4s WebSocket reconcile — which was the case originally reported.

## Test Plan

- `cd web && npm test` — full vitest suite green (4467 passed, 3 expected-fail, 1 skipped).
- `cd web && npm run build` — `tsc -b && vite build` succeeds.
- Added unit + integration tests to `useConversations.test.ts`:
  - optimistic cache write before the PATCH resolves,
  - rollback to the old title on PATCH failure,
  - a **subscribed component** re-rendering with the new title (flat list),
  - a **project-folder row** (`["project-sessions"]`) re-rendering optimistically — the reported bug.
- Manual: rename a session in the flat list and inside a project folder — the new name appears instantly; throttle/500 the PATCH to confirm rollback.

## Demo

N/A — behavioral timing fix (no new UI surface). The visible change is that the renamed name appears immediately instead of after a network round-trip.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: reproduced the stale-name lag on a session filed in a project folder, applied the fix, and confirmed the new name now appears on the next frame. Added a `["project-sessions"]` integration test that fails against the pre-fix overlay and passes after it.

## Changelog

Renaming a session now updates the name in the sidebar instantly instead of after a short delay.

This pull request and its description were written by Isaac.
