### PR TITLE
feat(scheduled tasks): edit flow + text time inputs

### DIFF
--- a/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
+++ b/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
@@ -43,20 +43,33 @@ def _builtin_agent_id(base_url: str, name: str) -> str:
     return matches[0]
 
 
-def _create_task(base_url: str, agent_id: str, name: str, rrule: str) -> str:
+def _create_task(
+    base_url: str,
+    agent_id: str,
+    name: str,
+    rrule: str,
+    *,
+    host_id: str | None = None,
+    workspace: str | None = None,
+) -> str:
     """Seed one scheduled task via ``POST /v1/scheduled-tasks``.
 
     :returns: The created task id.
     """
+    body = {
+        "name": name,
+        "prompt": "Do the thing.",
+        "rrule": rrule,
+        "agent_id": agent_id,
+        "timezone": "UTC",
+    }
+    if host_id is not None:
+        body["host_id"] = host_id
+    if workspace is not None:
+        body["workspace"] = workspace
     resp = httpx.post(
         f"{base_url}/v1/scheduled-tasks",
-        json={
-            "name": name,
-            "prompt": "Do the thing.",
-            "rrule": rrule,
-            "agent_id": agent_id,
-            "timezone": "UTC",
-        },
+        json=body,
         timeout=10.0,
     )
     resp.raise_for_status()
@@ -116,3 +129,92 @@ def test_scheduled_task_rows_show_schedule_summary_without_countdown(
     # The "Next run in Xh" countdown was removed — it must not appear anywhere
     # on the page (this pins the decision so it can't silently regress).
     expect(page.get_by_text("Next run", exact=False)).to_have_count(0)
+
+
+def test_scheduled_task_create_edit_modal_and_time_picker(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Create/edit modal supports typed time input and the compact minute picker.
+
+    This stays LLM-free: creating and editing scheduled tasks only exercise
+    REST + client state, and no scheduled run fires.
+    """
+    agent_id = _builtin_agent_id(live_server, "hello_world")
+
+    page.goto(f"{live_server}/tasks")
+
+    page.get_by_test_id("new-task-button").click()
+    expect(page.get_by_test_id("create-scheduled-task-dialog")).to_be_visible(timeout=30_000)
+    page.get_by_test_id("task-name-input").fill("Typed time daily")
+    page.get_by_test_id("task-prompt-input").fill("Summarize the day.")
+    agent_trigger = page.get_by_test_id("task-agent-picker").get_by_test_id(
+        "new-chat-landing-agent-select"
+    )
+    expect(agent_trigger).to_contain_text("Claude Code", timeout=30_000)
+    agent_trigger.click()
+    page.get_by_role("menuitem").filter(has_text="Claude Code").click()
+    expect(page.get_by_test_id("schedule-preset-trigger")).to_contain_text("Daily")
+
+    time_input = page.get_by_test_id("schedule-time")
+    time_input.fill("")
+    time_input.click()
+    page.keyboard.type("9:37")
+    assert time_input.input_value() == "9:37"
+    page.get_by_test_id("task-name-input").click()
+    expect(time_input).to_have_value("09:37 AM")
+    page.get_by_test_id("schedule-time-picker-trigger").click()
+    minute_column = page.get_by_test_id("schedule-minute-column")
+    expect(minute_column.locator('[data-testid^="schedule-minute-"]')).to_have_count(
+        60,
+        timeout=30_000,
+    )
+    expect(page.get_by_test_id("schedule-minute-37")).to_be_visible()
+    page.get_by_test_id("schedule-minute-37").click(force=True)
+    expect(time_input).to_have_value("09:37 AM")
+    page.get_by_test_id("create-scheduled-task-submit").click()
+
+    created_row = _row_by_name(page, "Typed time daily")
+    expect(created_row).to_be_visible(timeout=30_000)
+    expect(created_row.get_by_test_id("task-schedule-line")).to_have_text(
+        "Every day at 9:37 AM",
+        timeout=30_000,
+    )
+
+    _create_task(
+        live_server,
+        agent_id,
+        "Edit footer task",
+        "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+    )
+    page.set_viewport_size({"width": 900, "height": 520})
+    page.reload()
+
+    edit_row = _row_by_name(page, "Edit footer task")
+    expect(edit_row).to_be_visible(timeout=30_000)
+    edit_row.hover()
+    edit_row.get_by_test_id("task-row-menu").click()
+    page.get_by_test_id("task-edit").click()
+
+    dialog = page.get_by_test_id("create-scheduled-task-dialog")
+    submit = page.get_by_test_id("create-scheduled-task-submit")
+    expect(dialog).to_be_visible(timeout=30_000)
+    expect(page.get_by_role("button", name="Cancel")).to_be_visible()
+    expect(submit).to_be_visible()
+    dialog_box = dialog.bounding_box()
+    submit_box = submit.bounding_box()
+    assert dialog_box is not None
+    assert submit_box is not None
+    assert submit_box["y"] + submit_box["height"] <= dialog_box["y"] + dialog_box["height"] + 1
+
+    time_input.fill("")
+    time_input.click()
+    page.keyboard.type("10:37")
+    page.get_by_test_id("task-name-input").click()
+    expect(time_input).to_have_value("10:37 AM")
+    submit.click()
+
+    expect(edit_row.get_by_test_id("task-schedule-line")).to_have_text(
+        "Every day at 10:37 AM",
+        timeout=30_000,
+    )

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -433,11 +433,11 @@ describe("CreateScheduledTaskDialog submit", () => {
     expect(screen.getByTestId("schedule-preset-trigger")).toHaveClass("w-full");
   });
 
-  it("keeps Host compact instead of stretching it full-width", () => {
+  it("lays out Host full-width like the other top-level fields", () => {
     renderDialog();
     const hostField = screen.getByTestId("task-host-field");
     const hostTrigger = screen.getByTestId("task-host-trigger");
-    expect(hostField).toHaveClass("sm:w-64");
+    expect(hostField).not.toHaveClass("sm:w-64");
     expect(hostField).toContainElement(hostTrigger);
     expect(hostTrigger).toHaveClass("w-full");
   });

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -291,7 +291,7 @@ describe("CreateScheduledTaskDialog edit mode", () => {
     );
     expect(screen.getByTestId("task-agent-readonly")).toHaveTextContent("Polly");
     expect(screen.queryByTestId("agent-picker-stub")).not.toBeInTheDocument();
-    expect(screen.getByTestId("schedule-time")).toHaveValue("8:30 AM");
+    expect(screen.getByTestId("schedule-time")).toHaveValue("08:30 AM");
   });
 
   it("round-trips non-quarter-hour edit times through the update payload", async () => {
@@ -302,7 +302,11 @@ describe("CreateScheduledTaskDialog edit mode", () => {
         editingTask={scheduledTask({ rrule: "FREQ=DAILY;BYHOUR=17;BYMINUTE=7" })}
       />,
     );
-    expect(screen.getByTestId("schedule-time")).toHaveValue("5:07 PM");
+    expect(screen.getByTestId("schedule-time")).toHaveValue("05:07 PM");
+    fireEvent.click(screen.getByTestId("schedule-time-picker-trigger"));
+    expect(screen.getByTestId("schedule-hour-05")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("schedule-minute-07")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("schedule-period-PM")).toHaveAttribute("aria-pressed", "true");
     fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
     await waitFor(() => expect(updateMutateAsync).toHaveBeenCalledTimes(1));
     expect(updateMutateAsync.mock.calls[0][0].input.rrule).toBe("FREQ=DAILY;BYHOUR=17;BYMINUTE=7");
@@ -407,11 +411,27 @@ describe("CreateScheduledTaskDialog submit", () => {
     expect(screen.queryByTestId("task-timezone-trigger")).toBeNull();
   });
 
-  it("renders the Time field as a text input", () => {
+  it("renders the Time field as an input with a compact picker trigger", () => {
     renderDialog();
     const timeField = screen.getByTestId("schedule-time");
     expect(timeField.tagName).toBe("INPUT");
     expect(timeField).toHaveAttribute("placeholder", "5:00 PM");
+    expect(screen.getByTestId("schedule-time-picker-trigger")).toBeInTheDocument();
+  });
+
+  it("chooses a non-quarter-hour time from the compact picker", async () => {
+    renderDialog();
+    fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "T" } });
+    fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
+    fireEvent.click(screen.getByTestId("schedule-time-picker-trigger"));
+    fireEvent.click(await screen.findByTestId("schedule-hour-05"));
+    fireEvent.click(screen.getByTestId("schedule-minute-07"));
+    fireEvent.click(screen.getByTestId("schedule-period-PM"));
+    expect(screen.getByTestId("schedule-time")).toHaveValue("05:07 PM");
+
+    fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=DAILY;BYHOUR=17;BYMINUTE=7");
   });
 
   it("typing a non-quarter-hour time flows into the submitted RRULE", async () => {
@@ -426,6 +446,14 @@ describe("CreateScheduledTaskDialog submit", () => {
     await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
     // Default preset is Daily -> 17:07.
     expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=DAILY;BYHOUR=17;BYMINUTE=7");
+  });
+
+  it("canonicalizes typed time on blur", () => {
+    renderDialog();
+    const timeField = screen.getByTestId("schedule-time");
+    fireEvent.change(timeField, { target: { value: "17:07" } });
+    fireEvent.blur(timeField);
+    expect(timeField).toHaveValue("05:07 PM");
   });
 
   it("blocks submit while the typed time is invalid", async () => {
@@ -443,6 +471,7 @@ describe("CreateScheduledTaskDialog submit", () => {
     fireEvent.click(await screen.findByRole("option", { name: "Hourly" }));
     const minuteField = screen.getByTestId("schedule-minute");
     expect(minuteField.tagName).toBe("INPUT");
+    expect(screen.queryByTestId("schedule-time-picker-trigger")).toBeNull();
     fireEvent.change(minuteField, { target: { value: ":07" } });
     fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "T" } });
     fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -284,7 +284,7 @@ describe("CreateScheduledTaskDialog edit mode", () => {
     );
     expect(screen.getByText("Edit scheduled task")).toBeInTheDocument();
     expect(screen.getByText(/Update this recurring agent session/i)).toBeInTheDocument();
-    expect(screen.getByTestId("create-scheduled-task-submit")).toHaveTextContent("Update task");
+    expect(screen.getByTestId("create-scheduled-task-submit")).toHaveTextContent("Save changes");
     expect((screen.getByTestId("task-name-input") as HTMLInputElement).value).toBe("Morning brief");
     expect((screen.getByTestId("task-prompt-input") as HTMLTextAreaElement).value).toBe(
       "Summarize overnight activity",
@@ -417,6 +417,15 @@ describe("CreateScheduledTaskDialog submit", () => {
     expect(timeField.tagName).toBe("INPUT");
     expect(timeField).toHaveAttribute("placeholder", "5:00 PM");
     expect(screen.getByTestId("schedule-time-picker-trigger")).toBeInTheDocument();
+  });
+
+  it("lays out Frequency and Time in one compact row", () => {
+    renderDialog();
+    const row = screen.getByTestId("schedule-frequency-time-row");
+    expect(row).toContainElement(screen.getByText("Frequency"));
+    expect(row).toContainElement(screen.getByText("Time"));
+    expect(row).toContainElement(screen.getByTestId("schedule-preset-trigger"));
+    expect(row).toContainElement(screen.getByTestId("schedule-time"));
   });
 
   it("chooses a non-quarter-hour time from the compact picker", async () => {

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -20,7 +20,10 @@ import type { AvailableAgent } from "@/hooks/useAvailableAgents";
 
 vi.mock("@/hooks/useAvailableAgents", () => ({ useAvailableAgents: vi.fn() }));
 vi.mock("@/hooks/useHosts", () => ({ useHosts: vi.fn() }));
-vi.mock("@/hooks/useScheduledTasks", () => ({ useCreateScheduledTask: vi.fn() }));
+vi.mock("@/hooks/useScheduledTasks", () => ({
+  useCreateScheduledTask: vi.fn(),
+  useUpdateScheduledTask: vi.fn(),
+}));
 vi.mock("@/lib/agentLabels", () => ({ useBrainHarnessLabels: () => ({}) }));
 vi.mock("@/shell/WorkspacePicker", () => ({
   WorkspacePicker: ({ onNavigate }: { onNavigate?: (p: string) => void }) => (
@@ -134,9 +137,11 @@ const AGENTS: AvailableAgent[] = [
 ];
 
 const mutateAsync = vi.fn();
+const updateMutateAsync = vi.fn();
 
 beforeEach(() => {
   mutateAsync.mockReset().mockResolvedValue({ id: "st_new" });
+  updateMutateAsync.mockReset().mockResolvedValue({ id: "st_1" });
   vi.mocked(agentsHook.useAvailableAgents).mockReturnValue({
     data: AGENTS,
   } as unknown as ReturnType<typeof agentsHook.useAvailableAgents>);
@@ -147,12 +152,38 @@ beforeEach(() => {
     mutateAsync,
     isPending: false,
   } as unknown as ReturnType<typeof scheduledHooks.useCreateScheduledTask>);
+  vi.mocked(scheduledHooks.useUpdateScheduledTask).mockReturnValue({
+    mutateAsync: updateMutateAsync,
+    isPending: false,
+  } as unknown as ReturnType<typeof scheduledHooks.useUpdateScheduledTask>);
 });
 
 afterEach(() => cleanup());
 
 function renderDialog(onOpenChange: (open: boolean) => void = vi.fn()) {
   return render(<CreateScheduledTaskDialog open onOpenChange={onOpenChange} />);
+}
+
+function scheduledTask(overrides: Partial<import("@/lib/scheduledTasksApi").ScheduledTask> = {}) {
+  return {
+    id: "st_1",
+    name: "Morning brief",
+    prompt: "Summarize overnight activity",
+    rrule: "FREQ=DAILY;BYHOUR=8;BYMINUTE=30",
+    ownerUserId: null,
+    agentId: "ag_1",
+    timezone: "America/Los_Angeles",
+    createdAt: 1,
+    updatedAt: 2,
+    modelOverride: null,
+    reasoningEffort: null,
+    workspace: null,
+    hostId: null,
+    state: "active",
+    lastRunAt: null,
+    lastRunConversationId: null,
+    ...overrides,
+  } satisfies import("@/lib/scheduledTasksApi").ScheduledTask;
 }
 
 describe("agent picker readiness (needs-setup badges)", () => {
@@ -239,6 +270,63 @@ describe("CreateScheduledTaskDialog prefill (seed-on-open + reset)", () => {
     rerender(<CreateScheduledTaskDialog open={false} onOpenChange={vi.fn()} />);
     rerender(<CreateScheduledTaskDialog open onOpenChange={vi.fn()} />);
     expect((screen.getByTestId("task-name-input") as HTMLInputElement).value).toBe("");
+  });
+});
+
+describe("CreateScheduledTaskDialog edit mode", () => {
+  it("seeds fields from the scheduled task and uses edit copy", () => {
+    render(
+      <CreateScheduledTaskDialog
+        open
+        onOpenChange={vi.fn()}
+        editingTask={scheduledTask({ agentId: "ag_1" })}
+      />,
+    );
+    expect(screen.getByText("Edit scheduled task")).toBeInTheDocument();
+    expect(screen.getByText(/Update this recurring agent session/i)).toBeInTheDocument();
+    expect(screen.getByTestId("create-scheduled-task-submit")).toHaveTextContent("Update task");
+    expect((screen.getByTestId("task-name-input") as HTMLInputElement).value).toBe("Morning brief");
+    expect((screen.getByTestId("task-prompt-input") as HTMLTextAreaElement).value).toBe(
+      "Summarize overnight activity",
+    );
+    expect(screen.getByTestId("task-agent-readonly")).toHaveTextContent("Polly");
+    expect(screen.queryByTestId("agent-picker-stub")).not.toBeInTheDocument();
+    expect(screen.getByTestId("schedule-time")).toHaveTextContent("8:30 AM");
+  });
+
+  it("submits supported edits through the update mutation without changing agent defaults", async () => {
+    render(<CreateScheduledTaskDialog open onOpenChange={vi.fn()} editingTask={scheduledTask()} />);
+    fireEvent.change(screen.getByTestId("task-name-input"), {
+      target: { value: "Updated brief" },
+    });
+    fireEvent.change(screen.getByTestId("task-prompt-input"), {
+      target: { value: "Updated prompt" },
+    });
+    fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
+
+    await waitFor(() => expect(updateMutateAsync).toHaveBeenCalledTimes(1));
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(updateMutateAsync.mock.calls[0][0]).toEqual({
+      id: "st_1",
+      input: {
+        name: "Updated brief",
+        prompt: "Updated prompt",
+        rrule: "FREQ=DAILY;BYHOUR=8;BYMINUTE=30",
+        timezone: "America/Los_Angeles",
+      },
+    });
+  });
+
+  it("blocks update when the existing RRULE cannot be represented by the form", () => {
+    render(
+      <CreateScheduledTaskDialog
+        open
+        onOpenChange={vi.fn()}
+        editingTask={scheduledTask({ rrule: "FREQ=DAILY;INTERVAL=2;BYHOUR=9;BYMINUTE=0" })}
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("This schedule can't be edited");
+    expect(screen.getByTestId("create-scheduled-task-submit")).toBeDisabled();
   });
 });
 

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -442,6 +442,17 @@ describe("CreateScheduledTaskDialog submit", () => {
     expect(hostTrigger).toHaveClass("w-full");
   });
 
+  it("keeps the footer visible by letting only the dialog body scroll", () => {
+    renderDialog();
+    expect(screen.getByTestId("create-scheduled-task-dialog")).toHaveClass("flex", "flex-col");
+    expect(screen.getByTestId("scheduled-task-dialog-body")).toHaveClass(
+      "min-h-0",
+      "flex-1",
+      "overflow-y-auto",
+    );
+    expect(document.querySelector('[data-slot="dialog-footer"]')).toHaveClass("shrink-0");
+  });
+
   it("chooses a non-quarter-hour time from the compact picker", async () => {
     renderDialog();
     fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "T" } });

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -291,7 +291,21 @@ describe("CreateScheduledTaskDialog edit mode", () => {
     );
     expect(screen.getByTestId("task-agent-readonly")).toHaveTextContent("Polly");
     expect(screen.queryByTestId("agent-picker-stub")).not.toBeInTheDocument();
-    expect(screen.getByTestId("schedule-time")).toHaveTextContent("8:30 AM");
+    expect(screen.getByTestId("schedule-time")).toHaveValue("8:30 AM");
+  });
+
+  it("round-trips non-quarter-hour edit times through the update payload", async () => {
+    render(
+      <CreateScheduledTaskDialog
+        open
+        onOpenChange={vi.fn()}
+        editingTask={scheduledTask({ rrule: "FREQ=DAILY;BYHOUR=17;BYMINUTE=7" })}
+      />,
+    );
+    expect(screen.getByTestId("schedule-time")).toHaveValue("5:07 PM");
+    fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
+    await waitFor(() => expect(updateMutateAsync).toHaveBeenCalledTimes(1));
+    expect(updateMutateAsync.mock.calls[0][0].input.rrule).toBe("FREQ=DAILY;BYHOUR=17;BYMINUTE=7");
   });
 
   it("submits supported edits through the update mutation without changing agent defaults", async () => {
@@ -393,42 +407,48 @@ describe("CreateScheduledTaskDialog submit", () => {
     expect(screen.queryByTestId("task-timezone-trigger")).toBeNull();
   });
 
-  it("renders the Time field as a 15-minute-slot dropdown (96 options, no free input)", async () => {
+  it("renders the Time field as a text input", () => {
     renderDialog();
     const timeField = screen.getByTestId("schedule-time");
-    // It's a Select trigger (combobox), not a free-form <input type=time>.
-    expect(timeField.getAttribute("type")).not.toBe("time");
-    fireEvent.keyDown(timeField, { key: "Enter" });
-    const options = await screen.findAllByRole("option");
-    expect(options).toHaveLength(96);
-    // First and last slots span the day at 15-min granularity.
-    expect(options[0]).toHaveTextContent("12:00 AM");
-    expect(options[options.length - 1]).toHaveTextContent("11:45 PM");
+    expect(timeField.tagName).toBe("INPUT");
+    expect(timeField).toHaveAttribute("placeholder", "5:00 PM");
   });
 
-  it("picking a time slot flows into the submitted RRULE", async () => {
+  it("typing a non-quarter-hour time flows into the submitted RRULE", async () => {
     renderDialog();
     fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "T" } });
     fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
-    // Agent defaults to the first (polly); just pick 2:30 PM from the Time dropdown.
-    fireEvent.keyDown(screen.getByTestId("schedule-time"), { key: "Enter" });
-    fireEvent.click(await screen.findByRole("option", { name: "2:30 PM" }));
+    fireEvent.change(screen.getByTestId("schedule-time"), { target: { value: "5:07 PM" } });
 
     const submit = screen.getByTestId("create-scheduled-task-submit");
     await waitFor(() => expect(submit).toBeEnabled());
     fireEvent.click(submit);
     await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
-    // Default preset is Daily → 14:30.
-    expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=DAILY;BYHOUR=14;BYMINUTE=30");
+    // Default preset is Daily -> 17:07.
+    expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=DAILY;BYHOUR=17;BYMINUTE=7");
   });
 
-  it("Hourly preset shows a minute-only dropdown of 15-min slots", async () => {
+  it("blocks submit while the typed time is invalid", async () => {
+    renderDialog();
+    fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "T" } });
+    fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
+    fireEvent.change(screen.getByTestId("schedule-time"), { target: { value: "25:99" } });
+    expect(screen.getByTestId("schedule-error")).toHaveTextContent("Enter a valid time");
+    expect(screen.getByTestId("create-scheduled-task-submit")).toBeDisabled();
+  });
+
+  it("Hourly preset shows a minute-only text input", async () => {
     renderDialog();
     fireEvent.keyDown(screen.getByTestId("schedule-preset-trigger"), { key: "Enter" });
     fireEvent.click(await screen.findByRole("option", { name: "Hourly" }));
-    fireEvent.keyDown(screen.getByTestId("schedule-minute"), { key: "Enter" });
-    const options = (await screen.findAllByRole("option")).map((o) => o.textContent);
-    expect(options).toEqual([":00", ":15", ":30", ":45"]);
+    const minuteField = screen.getByTestId("schedule-minute");
+    expect(minuteField.tagName).toBe("INPUT");
+    fireEvent.change(minuteField, { target: { value: ":07" } });
+    fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "T" } });
+    fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
+    fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=HOURLY;BYMINUTE=7");
   });
 
   it("offers exactly the four frequency presets with no Custom entry point", async () => {

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -592,13 +592,32 @@ describe("CreateScheduledTaskDialog submit", () => {
     const minuteField = screen.getByTestId("schedule-minute");
     expect(minuteField.tagName).toBe("INPUT");
     expect(minuteField).toHaveClass("text-sm");
+    expect(minuteField).toHaveAttribute("placeholder", "0");
     expect(screen.queryByTestId("schedule-time-picker-trigger")).toBeNull();
-    fireEvent.change(minuteField, { target: { value: ":07" } });
+    fireEvent.change(minuteField, { target: { value: "7" } });
     fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "T" } });
     fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
     fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
     await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
     expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=HOURLY;BYMINUTE=7");
+  });
+
+  it("Hourly preset strips non-digits, caps to two digits, and clamps above 59", async () => {
+    renderDialog();
+    fireEvent.keyDown(screen.getByTestId("schedule-preset-trigger"), { key: "Enter" });
+    fireEvent.click(await screen.findByRole("option", { name: "Hourly" }));
+    const minuteField = screen.getByTestId("schedule-minute");
+
+    fireEvent.change(minuteField, { target: { value: "a:-" } });
+    expect(minuteField).toHaveValue("");
+    fireEvent.change(minuteField, { target: { value: "3a" } });
+    expect(minuteField).toHaveValue("3");
+    fireEvent.blur(minuteField);
+    expect(minuteField).toHaveValue("3");
+    fireEvent.change(minuteField, { target: { value: "75" } });
+    expect(minuteField).toHaveValue("59");
+    fireEvent.change(minuteField, { target: { value: "123" } });
+    expect(minuteField).toHaveValue("12");
   });
 
   it("offers exactly the four frequency presets with no Custom entry point", async () => {

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -511,6 +511,24 @@ describe("CreateScheduledTaskDialog submit", () => {
     expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=DAILY;BYHOUR=17;BYMINUTE=7");
   });
 
+  it("does not canonicalize partial time input while the field is focused", () => {
+    renderDialog();
+    const timeField = screen.getByTestId("schedule-time");
+
+    timeField.focus();
+    fireEvent.change(timeField, { target: { value: "" } });
+    fireEvent.change(timeField, { target: { value: "1" } });
+    expect(timeField).toHaveValue("1");
+    fireEvent.change(timeField, { target: { value: "1:" } });
+    expect(timeField).toHaveValue("1:");
+    fireEvent.change(timeField, { target: { value: "1:15" } });
+    expect(timeField).toHaveValue("1:15");
+    expect(screen.queryByTestId("schedule-error")).toBeNull();
+
+    fireEvent.blur(timeField);
+    expect(timeField).toHaveValue("01:15 AM");
+  });
+
   it("canonicalizes typed time on blur", () => {
     renderDialog();
     const timeField = screen.getByTestId("schedule-time");

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -416,6 +416,7 @@ describe("CreateScheduledTaskDialog submit", () => {
     const timeField = screen.getByTestId("schedule-time");
     expect(timeField.tagName).toBe("INPUT");
     expect(timeField).toHaveAttribute("placeholder", "5:00 PM");
+    expect(timeField).toHaveClass("text-sm");
     expect(screen.getByTestId("schedule-time-picker-trigger")).toBeInTheDocument();
   });
 
@@ -426,6 +427,19 @@ describe("CreateScheduledTaskDialog submit", () => {
     expect(row).toContainElement(screen.getByText("Time"));
     expect(row).toContainElement(screen.getByTestId("schedule-preset-trigger"));
     expect(row).toContainElement(screen.getByTestId("schedule-time"));
+    expect(row).toHaveClass("sm:grid-cols-2", "sm:gap-6");
+    expect(screen.getByTestId("schedule-frequency-control")).toHaveClass("w-full");
+    expect(screen.getByTestId("schedule-time-control")).toHaveClass("w-full");
+    expect(screen.getByTestId("schedule-preset-trigger")).toHaveClass("w-full");
+  });
+
+  it("keeps Host compact instead of stretching it full-width", () => {
+    renderDialog();
+    const hostField = screen.getByTestId("task-host-field");
+    const hostTrigger = screen.getByTestId("task-host-trigger");
+    expect(hostField).toHaveClass("sm:w-64");
+    expect(hostField).toContainElement(hostTrigger);
+    expect(hostTrigger).toHaveClass("w-full");
   });
 
   it("chooses a non-quarter-hour time from the compact picker", async () => {
@@ -434,13 +448,53 @@ describe("CreateScheduledTaskDialog submit", () => {
     fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
     fireEvent.click(screen.getByTestId("schedule-time-picker-trigger"));
     fireEvent.click(await screen.findByTestId("schedule-hour-05"));
-    fireEvent.click(screen.getByTestId("schedule-minute-07"));
+    expect(screen.queryByTestId("schedule-minute-07")).toBeNull();
+    fireEvent.click(screen.getByTestId("schedule-minute-15"));
     fireEvent.click(screen.getByTestId("schedule-period-PM"));
-    expect(screen.getByTestId("schedule-time")).toHaveValue("05:07 PM");
+    expect(screen.getByTestId("schedule-time")).toHaveValue("05:15 PM");
 
     fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
     await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
-    expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=DAILY;BYHOUR=17;BYMINUTE=7");
+    expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=DAILY;BYHOUR=17;BYMINUTE=15");
+  });
+
+  it("shows quarter-hour minute choices in the compact picker", async () => {
+    renderDialog();
+    fireEvent.click(screen.getByTestId("schedule-time-picker-trigger"));
+    expect(await screen.findByTestId("schedule-minute-00")).toBeInTheDocument();
+    expect(screen.getByTestId("schedule-minute-15")).toBeInTheDocument();
+    expect(screen.getByTestId("schedule-minute-30")).toBeInTheDocument();
+    expect(screen.getByTestId("schedule-minute-45")).toBeInTheDocument();
+    expect(screen.queryByTestId("schedule-minute-01")).toBeNull();
+    expect(screen.queryByTestId("schedule-minute-59")).toBeNull();
+  });
+
+  it("makes overflowing picker columns scrollable without closing the picker", async () => {
+    renderDialog();
+    fireEvent.click(screen.getByTestId("schedule-time-picker-trigger"));
+    const hourColumn = await screen.findByTestId("schedule-hour-column");
+    expect(hourColumn).toHaveClass("overflow-y-auto", "overscroll-contain");
+    expect(screen.getByTestId("schedule-minute-column")).toHaveClass("overflow-y-auto");
+
+    fireEvent.wheel(hourColumn, { deltaY: 120 });
+    expect(screen.getByTestId("schedule-time-picker")).toBeInTheDocument();
+  });
+
+  it("includes the current off-grid minute as the selected picker value", () => {
+    render(
+      <CreateScheduledTaskDialog
+        open
+        onOpenChange={vi.fn()}
+        editingTask={scheduledTask({ rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=7" })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("schedule-time-picker-trigger"));
+    expect(screen.getByTestId("schedule-minute-00")).toBeInTheDocument();
+    expect(screen.getByTestId("schedule-minute-07")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("schedule-minute-15")).toBeInTheDocument();
+    expect(screen.getByTestId("schedule-minute-30")).toBeInTheDocument();
+    expect(screen.getByTestId("schedule-minute-45")).toBeInTheDocument();
+    expect(screen.queryByTestId("schedule-minute-08")).toBeNull();
   });
 
   it("typing a non-quarter-hour time flows into the submitted RRULE", async () => {
@@ -480,6 +534,7 @@ describe("CreateScheduledTaskDialog submit", () => {
     fireEvent.click(await screen.findByRole("option", { name: "Hourly" }));
     const minuteField = screen.getByTestId("schedule-minute");
     expect(minuteField.tagName).toBe("INPUT");
+    expect(minuteField).toHaveClass("text-sm");
     expect(screen.queryByTestId("schedule-time-picker-trigger")).toBeNull();
     fireEvent.change(minuteField, { target: { value: ":07" } });
     fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "T" } });

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -448,25 +448,26 @@ describe("CreateScheduledTaskDialog submit", () => {
     fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
     fireEvent.click(screen.getByTestId("schedule-time-picker-trigger"));
     fireEvent.click(await screen.findByTestId("schedule-hour-05"));
-    expect(screen.queryByTestId("schedule-minute-07")).toBeNull();
-    fireEvent.click(screen.getByTestId("schedule-minute-15"));
+    fireEvent.click(screen.getByTestId("schedule-minute-07"));
     fireEvent.click(screen.getByTestId("schedule-period-PM"));
-    expect(screen.getByTestId("schedule-time")).toHaveValue("05:15 PM");
+    expect(screen.getByTestId("schedule-time")).toHaveValue("05:07 PM");
 
     fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
     await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
-    expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=DAILY;BYHOUR=17;BYMINUTE=15");
+    expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=DAILY;BYHOUR=17;BYMINUTE=7");
   });
 
-  it("shows quarter-hour minute choices in the compact picker", async () => {
+  it("shows all minute choices in the compact picker", async () => {
     renderDialog();
     fireEvent.click(screen.getByTestId("schedule-time-picker-trigger"));
-    expect(await screen.findByTestId("schedule-minute-00")).toBeInTheDocument();
+    const minuteColumn = await screen.findByTestId("schedule-minute-column");
+    expect(minuteColumn.querySelectorAll('[data-testid^="schedule-minute-"]')).toHaveLength(60);
+    expect(screen.getByTestId("schedule-minute-00")).toBeInTheDocument();
+    expect(screen.getByTestId("schedule-minute-01")).toBeInTheDocument();
     expect(screen.getByTestId("schedule-minute-15")).toBeInTheDocument();
     expect(screen.getByTestId("schedule-minute-30")).toBeInTheDocument();
     expect(screen.getByTestId("schedule-minute-45")).toBeInTheDocument();
-    expect(screen.queryByTestId("schedule-minute-01")).toBeNull();
-    expect(screen.queryByTestId("schedule-minute-59")).toBeNull();
+    expect(screen.getByTestId("schedule-minute-59")).toBeInTheDocument();
   });
 
   it("makes overflowing picker columns scrollable without closing the picker", async () => {
@@ -480,7 +481,28 @@ describe("CreateScheduledTaskDialog submit", () => {
     expect(screen.getByTestId("schedule-time-picker")).toBeInTheDocument();
   });
 
-  it("includes the current off-grid minute as the selected picker value", () => {
+  it("renders all minute values and selects a non-quarter-hour minute", async () => {
+    renderDialog();
+    fireEvent.click(screen.getByTestId("schedule-time-picker-trigger"));
+    const minuteColumn = screen.getByTestId("schedule-minute-column");
+    expect(minuteColumn.querySelectorAll('[data-testid^="schedule-minute-"]')).toHaveLength(60);
+    expect(screen.getByTestId("schedule-minute-00")).toBeInTheDocument();
+    expect(screen.getByTestId("schedule-minute-37")).toBeInTheDocument();
+    expect(screen.getByTestId("schedule-minute-59")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("schedule-minute-37"));
+    expect(screen.getByTestId("schedule-time")).toHaveValue("09:37 AM");
+
+    fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "T" } });
+    fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
+    const submit = screen.getByTestId("create-scheduled-task-submit");
+    await waitFor(() => expect(submit).toBeEnabled());
+    fireEvent.click(submit);
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mutateAsync.mock.calls[0][0].rrule).toBe("FREQ=DAILY;BYHOUR=9;BYMINUTE=37");
+  });
+
+  it("round-trips the current non-quarter-hour minute as the selected picker value", () => {
     render(
       <CreateScheduledTaskDialog
         open
@@ -494,7 +516,7 @@ describe("CreateScheduledTaskDialog submit", () => {
     expect(screen.getByTestId("schedule-minute-15")).toBeInTheDocument();
     expect(screen.getByTestId("schedule-minute-30")).toBeInTheDocument();
     expect(screen.getByTestId("schedule-minute-45")).toBeInTheDocument();
-    expect(screen.queryByTestId("schedule-minute-08")).toBeNull();
+    expect(screen.getByTestId("schedule-minute-08")).toBeInTheDocument();
   });
 
   it("typing a non-quarter-hour time flows into the submitted RRULE", async () => {
@@ -535,6 +557,12 @@ describe("CreateScheduledTaskDialog submit", () => {
     fireEvent.change(timeField, { target: { value: "17:07" } });
     fireEvent.blur(timeField);
     expect(timeField).toHaveValue("05:07 PM");
+  });
+
+  it("uses text-sm for dialog text fields that wrap shared primitives", () => {
+    renderDialog();
+    expect(screen.getByTestId("task-name-input")).toHaveClass("text-sm");
+    expect(screen.getByTestId("task-prompt-input")).toHaveClass("text-sm");
   });
 
   it("blocks submit while the typed time is invalid", async () => {

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -395,7 +395,7 @@ export function CreateScheduledTaskDialog({
 
           {/* Optional host + workspace pin. Left unset, the server resolves the
               owner's connected host and its home directory at fire time. */}
-          <div className="flex flex-col gap-1.5">
+          <div className="flex flex-col gap-1.5 sm:w-64" data-testid="task-host-field">
             <Label htmlFor="task-host">Host (optional)</Label>
             <Select
               value={hostId === "" ? UNSET_HOST : hostId}
@@ -408,7 +408,7 @@ export function CreateScheduledTaskDialog({
               }}
               onOpenChange={handleSelectOpenChange}
             >
-              <SelectTrigger id="task-host" data-testid="task-host-trigger">
+              <SelectTrigger id="task-host" data-testid="task-host-trigger" className="w-full">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent position="popper" align="start">

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -268,7 +268,7 @@ export function CreateScheduledTaskDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="max-h-[90vh] overflow-hidden p-0 sm:max-w-[560px]"
+        className="flex max-h-[90vh] flex-col overflow-hidden p-0 sm:max-w-[560px]"
         data-testid="create-scheduled-task-dialog"
         // Keep a nested Select's dismiss (pick an option, OR click empty modal
         // body / trigger while it's open) from closing the whole Dialog. See
@@ -278,7 +278,7 @@ export function CreateScheduledTaskDialog({
         onPointerDownOutside={guardDialogDismiss}
         onInteractOutside={guardDialogDismiss}
       >
-        <DialogHeader className="px-6 pt-6 pb-0">
+        <DialogHeader className="shrink-0 px-6 pt-6 pb-0">
           <DialogTitle>{isEdit ? "Edit scheduled task" : "New scheduled task"}</DialogTitle>
           <DialogDescription>
             {isEdit
@@ -287,7 +287,10 @@ export function CreateScheduledTaskDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex max-h-[calc(90vh-8.5rem)] flex-col gap-4 overflow-y-auto px-6 py-4">
+        <div
+          className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-4"
+          data-testid="scheduled-task-dialog-body"
+        >
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="task-name">Name</Label>
             <Input
@@ -469,7 +472,7 @@ export function CreateScheduledTaskDialog({
           )}
         </div>
 
-        <DialogFooter className="mx-0 mb-0 rounded-none border-t-0 bg-transparent px-6 py-4 sm:justify-end">
+        <DialogFooter className="mx-0 mb-0 shrink-0 rounded-none border-t-0 bg-transparent px-6 py-4 sm:justify-end">
           <Button variant="outline" onClick={() => handleOpenChange(false)}>
             Cancel
           </Button>

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -395,7 +395,7 @@ export function CreateScheduledTaskDialog({
 
           {/* Optional host + workspace pin. Left unset, the server resolves the
               owner's connected host and its home directory at fire time. */}
-          <div className="flex flex-col gap-1.5 sm:w-64" data-testid="task-host-field">
+          <div className="flex flex-col gap-1.5" data-testid="task-host-field">
             <Label htmlFor="task-host">Host (optional)</Label>
             <Select
               value={hostId === "" ? UNSET_HOST : hostId}

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -295,6 +295,7 @@ export function CreateScheduledTaskDialog({
               value={name}
               placeholder="daily-brief"
               data-testid="task-name-input"
+              className="text-sm"
               onChange={(e) => setName(e.target.value)}
             />
           </div>
@@ -308,7 +309,7 @@ export function CreateScheduledTaskDialog({
               placeholder="What should the agent do each run?"
               data-testid="task-prompt-input"
               // No native resize grip — match the clean styling of the other fields.
-              className="resize-none"
+              className="resize-none text-sm"
               onChange={(e) => setPrompt(e.target.value)}
             />
           </div>

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -1,14 +1,5 @@
-// The "Set up manually" create dialog for a scheduled task. Fully wires the
-// form to POST /v1/scheduled-tasks via useCreateScheduledTask, invalidating the
-// list and closing on success. Reuses the existing agent picker
-// (useAvailableAgents), host picker (useHosts), and directory picker
-// (WorkspacePicker) rather than reinventing them.
-//
-// Field contract mirrors omnigent/server/routes/scheduled_tasks.py:
-//   REQUIRED: name, prompt, rrule (built from the ScheduleFields model),
-//     agent_id. OPTIONAL: timezone (default UTC), model_override,
-//     reasoning_effort, host_id + workspace (validated as a pair — a workspace
-//     without a host is rejected client- and server-side).
+// Dialog for creating or editing a scheduled task. Reuses the existing agent,
+// host, and workspace pickers where the backend can persist those fields.
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Loader2Icon, TriangleAlertIcon } from "lucide-react";
@@ -36,16 +27,17 @@ import { WorkspacePicker } from "@/shell/WorkspacePicker";
 import { AgentHarnessPicker } from "@/shell/NewChatDialog";
 import { useAvailableAgents, type AvailableAgent } from "@/hooks/useAvailableAgents";
 import { useHosts } from "@/hooks/useHosts";
-import { useCreateScheduledTask } from "@/hooks/useScheduledTasks";
+import { useCreateScheduledTask, useUpdateScheduledTask } from "@/hooks/useScheduledTasks";
 import { isNativeCodingAgent } from "@/lib/nativeCodingAgents";
 import { sortAgentsForDisplay } from "@/lib/agentGrouping";
 import {
   buildRRule,
   DEFAULT_SCHEDULE_MODEL,
+  parseRRuleToScheduleModel,
   validateSchedule,
   type ScheduleModel,
 } from "@/lib/scheduleBuilder";
-import { ScheduledTaskApiError } from "@/lib/scheduledTasksApi";
+import { ScheduledTaskApiError, type ScheduledTask } from "@/lib/scheduledTasksApi";
 import { localTimezone } from "@/lib/timezones";
 
 // Agents hidden from the scheduled-task picker (mirrors NewChatDialog's set):
@@ -57,6 +49,7 @@ export function CreateScheduledTaskDialog({
   onOpenChange,
   initialName,
   initialPrompt,
+  editingTask = null,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -64,10 +57,13 @@ export function CreateScheduledTaskDialog({
    *  "Suggestions" suggestion chip). Omitted → the fields start empty. */
   initialName?: string;
   initialPrompt?: string;
+  editingTask?: ScheduledTask | null;
 }) {
   const { data: agents } = useAvailableAgents({ enabled: open });
   const { data: hosts } = useHosts({ enabled: open });
   const createMutation = useCreateScheduledTask();
+  const updateMutation = useUpdateScheduledTask();
+  const isEdit = editingTask !== null;
 
   const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
@@ -102,7 +98,11 @@ export function CreateScheduledTaskDialog({
   const effectiveAgentId =
     (agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ?? null;
   const selectedAgent = agentList.find((a) => a.id === effectiveAgentId);
-  const agentLabel = selectedAgent ? selectedAgent.display_name : "Select agent";
+  const agentLabel = selectedAgent
+    ? selectedAgent.display_name
+    : isEdit && editingTask
+      ? editingTask.agentId
+      : "Select agent";
 
   function handleSelectAgent(agent: AvailableAgent) {
     setPickedAgentId(agent.id);
@@ -151,6 +151,7 @@ export function CreateScheduledTaskDialog({
   const [hostId, setHostId] = useState<string>("");
   const [workspace, setWorkspace] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
+  const [scheduleUnsupported, setScheduleUnsupported] = useState(false);
 
   // Seed Name/Prompt on the closed→open transition ONLY. Keying off the
   // transition (not `open` being true) means we never clobber the user's edits
@@ -161,13 +162,31 @@ export function CreateScheduledTaskDialog({
   const wasOpen = useRef(false);
   useEffect(() => {
     if (open && !wasOpen.current) {
-      setName(initialName ?? "");
-      setPrompt(initialPrompt ?? "");
+      if (editingTask) {
+        const parsedSchedule = parseRRuleToScheduleModel(editingTask.rrule);
+        setName(editingTask.name);
+        setPrompt(editingTask.prompt);
+        setPickedAgentId(editingTask.agentId);
+        setSchedule(parsedSchedule ?? DEFAULT_SCHEDULE_MODEL);
+        setScheduleUnsupported(parsedSchedule === null);
+        setHostId(editingTask.hostId ?? "");
+        setWorkspace(editingTask.workspace ?? "");
+      } else {
+        setName(initialName ?? "");
+        setPrompt(initialPrompt ?? "");
+        setPickedAgentId(null);
+        setSchedule(DEFAULT_SCHEDULE_MODEL);
+        setScheduleUnsupported(false);
+        setHostId("");
+        setWorkspace("");
+      }
+      setError(null);
     }
     wasOpen.current = open;
-  }, [open, initialName, initialPrompt]);
+  }, [open, initialName, initialPrompt, editingTask]);
 
   const hostOptions = hosts ?? [];
+  const preservePinnedHost = isEdit && editingTask?.hostId != null;
   // The resolved Host for the pinned id, or undefined when none is pinned.
   const selectedHost = hostId === "" ? undefined : hostOptions.find((h) => h.host_id === hostId);
   // Host whose `configured_harnesses` drives the picker's "needs setup" badges.
@@ -186,14 +205,15 @@ export function CreateScheduledTaskDialog({
   const workspaceWithoutHost = workspace.trim() !== "" && hostId === "";
   // Block submit on an invalid schedule (bad interval, empty multi-select) so
   // the form never posts an RRULE the server's validate_rrule would 400.
-  const scheduleInvalid = validateSchedule(schedule) !== null;
+  const scheduleInvalid = scheduleUnsupported || validateSchedule(schedule) !== null;
+  const mutationPending = createMutation.isPending || updateMutation.isPending;
   const canSubmit =
     name.trim() !== "" &&
     prompt.trim() !== "" &&
-    effectiveAgentId !== null &&
+    (isEdit || effectiveAgentId !== null) &&
     !workspaceWithoutHost &&
     !scheduleInvalid &&
-    !createMutation.isPending;
+    !mutationPending;
 
   function resetForm() {
     setName("");
@@ -203,6 +223,7 @@ export function CreateScheduledTaskDialog({
     setHostId("");
     setWorkspace("");
     setError(null);
+    setScheduleUnsupported(false);
   }
 
   function handleOpenChange(next: boolean) {
@@ -211,28 +232,25 @@ export function CreateScheduledTaskDialog({
   }
 
   async function handleSubmit() {
-    if (effectiveAgentId === null) return;
     setError(null);
     try {
-      await createMutation.mutateAsync({
+      const input = {
         name: name.trim(),
         prompt: prompt.trim(),
         rrule: buildRRule(schedule),
-        // Both a bare-harness pick and an agent pick resolve to a real agent id
-        // here (harness rows are the `*-native-ui` agents), matching what the
-        // interactive dialog sends as `agent_id`.
-        agentId: effectiveAgentId,
-        // Model/effort overrides are omitted so the fire path uses the selected
-        // agent's configured defaults.
-        // Timezone is inferred from the browser (Intl) and not user-editable in
-        // this dialog. Still sent so the server evaluates the RRULE in the
-        // user's local zone rather than defaulting to UTC.
-        timezone: localTimezone(),
-        // Send the host/workspace pair only when a host was pinned. A pinned
-        // host with no workspace is allowed (server defaults to the host home).
+        timezone: editingTask?.timezone ?? localTimezone(),
         ...(hostId !== "" ? { hostId } : {}),
         ...(hostId !== "" && workspace.trim() !== "" ? { workspace: workspace.trim() } : {}),
-      });
+      };
+      if (editingTask) {
+        await updateMutation.mutateAsync({ id: editingTask.id, input });
+      } else {
+        if (effectiveAgentId === null) return;
+        await createMutation.mutateAsync({
+          ...input,
+          agentId: effectiveAgentId,
+        });
+      }
       handleOpenChange(false);
     } catch (err) {
       setError(
@@ -240,7 +258,9 @@ export function CreateScheduledTaskDialog({
           ? err.message
           : err instanceof Error
             ? err.message
-            : "Couldn't create the scheduled task.",
+            : isEdit
+              ? "Couldn't update the scheduled task."
+              : "Couldn't create the scheduled task.",
       );
     }
   }
@@ -259,9 +279,11 @@ export function CreateScheduledTaskDialog({
         onInteractOutside={guardDialogDismiss}
       >
         <DialogHeader>
-          <DialogTitle>New scheduled task</DialogTitle>
+          <DialogTitle>{isEdit ? "Edit scheduled task" : "New scheduled task"}</DialogTitle>
           <DialogDescription>
-            Runs an agent session on a recurring schedule. Fires on a connected host.
+            {isEdit
+              ? "Update this recurring agent session. It fires on a connected host."
+              : "Runs an agent session on a recurring schedule. Fires on a connected host."}
           </DialogDescription>
         </DialogHeader>
 
@@ -296,64 +318,58 @@ export function CreateScheduledTaskDialog({
                 Code / Codex / Pi …) and agents (Polly / Debby), so "Agent" would
                 be misleading. */}
             <Label>Runs with</Label>
-            {/* Shared unified picker (same component the interactive NewChatDialog
-                uses): a "Harnesses" section (Claude Code / Codex / Pi …) + an
-                "Agents" section (Polly / Debby / custom), with per-entry
-                model/effort knobs. onOpenChange feeds the dialog's dismiss guard
-                so opening the picker doesn't close the modal. Custom-agent
-                creation, sandbox, and the mode knobs that scheduled-tasks can't
-                persist are wired to no-ops / dropped (see handleSubmit). */}
-            <div data-testid="task-agent-picker">
-              <AgentHarnessPicker
-                agentEntries={agentEntries}
-                harnessEntries={harnessEntries}
-                effectiveAgentId={effectiveAgentId}
-                agentLabel={agentLabel}
-                hasAgents={agentList.length > 0}
-                // Drives the per-row "needs setup" badges from
-                // host.configured_harnesses. Uses the pinned host if any, else
-                // falls back to the first online host so the badges show in the
-                // fresh/default state (host is optional here — see `badgeHost`).
-                host={badgeHost}
-                onSelectAgent={handleSelectAgent}
-                pendingAgent={null}
-                pendingAgentId="__unused_pending_agent__"
-                onSelectPending={() => {}}
-                // TODO(OMNI-1193): "Create custom agent" is a no-op here. The
-                // interactive flow (NewChatDialog) opens CreateAgentDialog, holds
-                // the returned bundle as a PENDING agent, and only PERSISTS it at
-                // session-create time via the multipart createBundledSession
-                // (which also mints a session). A scheduled task needs a concrete
-                // `agent_id` up front and has no session to ride, and there is no
-                // standalone "persist agent bundle → agent_id" endpoint yet — so
-                // wiring this correctly is blocked on backend support (a persist
-                // route, or a bundle-aware POST /v1/scheduled-tasks). Left inert
-                // rather than forking a flow that creates a phantom session.
-                onCreateCustomAgent={() => {}}
-                sandboxSelected={false}
-                // Forward the dropdown open/close into the dialog's outside-click
-                // dismiss guard so opening the picker doesn't close the modal.
-                onOpenChange={handleSelectOpenChange}
-                // This picker is nested inside a Dialog. Radix DropdownMenu's
-                // default modal mode can turn an inside-dialog click into a
-                // parent Dialog outside interaction while the menu dismisses.
-                dropdownModal={false}
-                // Bound the dropdown height so it scrolls in the modal instead
-                // of running off the bottom of the screen (the trigger sits near
-                // the top of a tall dialog, unlike the composer footer). Width
-                // matches the interactive picker so the "needs setup" pills +
-                // agent descriptions fit without cramping (the shared default is
-                // only min-w-64; pin a comfortable fixed width like interactive).
-                contentClassName="max-h-80 w-80"
-                // Full-width trigger → left-align the menu's edge to it.
-                contentAlign="start"
-                // Match the sibling <Select> fields (Frequency / host): full
-                // width, bordered, h-8, normal foreground text — not the compact
-                // muted ghost styling the composer footer uses.
-                triggerClassName="h-8 w-full justify-between rounded-lg border border-input bg-transparent px-2.5 text-foreground hover:bg-transparent hover:text-foreground dark:bg-input/30"
-                triggerLabelClassName="max-w-none text-sm"
-              />
-            </div>
+            {isEdit ? (
+              <div
+                className="flex h-8 w-full items-center rounded-lg border border-input bg-transparent px-2.5 text-sm text-foreground dark:bg-input/30"
+                data-testid="task-agent-readonly"
+              >
+                {agentLabel}
+              </div>
+            ) : (
+              <div data-testid="task-agent-picker">
+                <AgentHarnessPicker
+                  agentEntries={agentEntries}
+                  harnessEntries={harnessEntries}
+                  effectiveAgentId={effectiveAgentId}
+                  agentLabel={agentLabel}
+                  hasAgents={agentList.length > 0}
+                  // Drives the per-row "needs setup" badges from
+                  // host.configured_harnesses. Uses the pinned host if any, else
+                  // falls back to the first online host so the badges show in the
+                  // fresh/default state (host is optional here — see `badgeHost`).
+                  host={badgeHost}
+                  onSelectAgent={handleSelectAgent}
+                  pendingAgent={null}
+                  pendingAgentId="__unused_pending_agent__"
+                  onSelectPending={() => {}}
+                  // Custom-agent creation is inert until there is a way to
+                  // persist a new agent independently of creating a session.
+                  onCreateCustomAgent={() => {}}
+                  sandboxSelected={false}
+                  // Forward the dropdown open/close into the dialog's outside-click
+                  // dismiss guard so opening the picker doesn't close the modal.
+                  onOpenChange={handleSelectOpenChange}
+                  // This picker is nested inside a Dialog. Radix DropdownMenu's
+                  // default modal mode can turn an inside-dialog click into a
+                  // parent Dialog outside interaction while the menu dismisses.
+                  dropdownModal={false}
+                  // Bound the dropdown height so it scrolls in the modal instead
+                  // of running off the bottom of the screen (the trigger sits near
+                  // the top of a tall dialog, unlike the composer footer). Width
+                  // matches the interactive picker so the "needs setup" pills +
+                  // agent descriptions fit without cramping (the shared default is
+                  // only min-w-64; pin a comfortable fixed width like interactive).
+                  contentClassName="max-h-80 w-80"
+                  // Full-width trigger → left-align the menu's edge to it.
+                  contentAlign="start"
+                  // Match the sibling <Select> fields (Frequency / host): full
+                  // width, bordered, h-8, normal foreground text — not the compact
+                  // muted ghost styling the composer footer uses.
+                  triggerClassName="h-8 w-full justify-between rounded-lg border border-input bg-transparent px-2.5 text-foreground hover:bg-transparent hover:text-foreground dark:bg-input/30"
+                  triggerLabelClassName="max-w-none text-sm"
+                />
+              </div>
+            )}
             <p className="text-[11px] text-muted-foreground">
               Uses this agent&apos;s default model, effort, and permission settings
             </p>
@@ -361,9 +377,17 @@ export function CreateScheduledTaskDialog({
 
           <ScheduleFields
             model={schedule}
-            onChange={setSchedule}
+            onChange={(next) => {
+              setScheduleUnsupported(false);
+              setSchedule(next);
+            }}
             onSelectOpenChange={handleSelectOpenChange}
           />
+          {scheduleUnsupported && (
+            <p className="text-xs text-destructive" role="alert">
+              This schedule can&apos;t be edited in this form yet.
+            </p>
+          )}
 
           {/* Timezone is inferred from the browser (localTimezone via Intl) and
               intentionally has no visible control. It is still sent in the create
@@ -376,6 +400,7 @@ export function CreateScheduledTaskDialog({
             <Select
               value={hostId === "" ? UNSET_HOST : hostId}
               onValueChange={(v) => {
+                if (preservePinnedHost && v === UNSET_HOST) return;
                 const next = v === UNSET_HOST ? "" : v;
                 setHostId(next);
                 // Clearing the host invalidates any pinned workspace.
@@ -387,7 +412,9 @@ export function CreateScheduledTaskDialog({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent position="popper" align="start">
-                <SelectItem value={UNSET_HOST}>Resolve at fire time</SelectItem>
+                <SelectItem value={UNSET_HOST} disabled={preservePinnedHost}>
+                  Resolve at fire time
+                </SelectItem>
                 {hostOptions.map((host) => (
                   <SelectItem key={host.host_id} value={host.host_id}>
                     {host.name} {host.status === "offline" ? "(offline)" : ""}
@@ -450,8 +477,8 @@ export function CreateScheduledTaskDialog({
             disabled={!canSubmit}
             data-testid="create-scheduled-task-submit"
           >
-            {createMutation.isPending && <Loader2Icon className="mr-1 size-4 animate-spin" />}
-            Create task
+            {mutationPending && <Loader2Icon className="mr-1 size-4 animate-spin" />}
+            {isEdit ? "Update task" : "Create task"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -468,7 +468,7 @@ export function CreateScheduledTaskDialog({
           )}
         </div>
 
-        <DialogFooter className="mx-0 mb-0 rounded-none border-t bg-muted/20 px-6 py-4 sm:justify-end">
+        <DialogFooter className="mx-0 mb-0 rounded-none border-t-0 bg-transparent px-6 py-4 sm:justify-end">
           <Button variant="outline" onClick={() => handleOpenChange(false)}>
             Cancel
           </Button>

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -268,7 +268,7 @@ export function CreateScheduledTaskDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="max-h-[90vh] overflow-y-auto sm:max-w-lg"
+        className="max-h-[90vh] overflow-hidden p-0 sm:max-w-[560px]"
         data-testid="create-scheduled-task-dialog"
         // Keep a nested Select's dismiss (pick an option, OR click empty modal
         // body / trigger while it's open) from closing the whole Dialog. See
@@ -278,7 +278,7 @@ export function CreateScheduledTaskDialog({
         onPointerDownOutside={guardDialogDismiss}
         onInteractOutside={guardDialogDismiss}
       >
-        <DialogHeader>
+        <DialogHeader className="px-6 pt-6 pb-0">
           <DialogTitle>{isEdit ? "Edit scheduled task" : "New scheduled task"}</DialogTitle>
           <DialogDescription>
             {isEdit
@@ -287,13 +287,13 @@ export function CreateScheduledTaskDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex flex-col gap-4 py-1">
+        <div className="flex max-h-[calc(90vh-8.5rem)] flex-col gap-4 overflow-y-auto px-6 py-4">
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="task-name">Name</Label>
             <Input
               id="task-name"
               value={name}
-              placeholder="Nightly triage"
+              placeholder="daily-brief"
               data-testid="task-name-input"
               onChange={(e) => setName(e.target.value)}
             />
@@ -304,8 +304,8 @@ export function CreateScheduledTaskDialog({
             <Textarea
               id="task-prompt"
               value={prompt}
-              rows={4}
-              placeholder="What should the agent do each time it runs?"
+              rows={3}
+              placeholder="What should the agent do each run?"
               data-testid="task-prompt-input"
               // No native resize grip — match the clean styling of the other fields.
               className="resize-none"
@@ -468,8 +468,8 @@ export function CreateScheduledTaskDialog({
           )}
         </div>
 
-        <DialogFooter>
-          <Button variant="ghost" onClick={() => handleOpenChange(false)}>
+        <DialogFooter className="mx-0 mb-0 rounded-none border-t bg-muted/20 px-6 py-4 sm:justify-end">
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
             Cancel
           </Button>
           <Button
@@ -478,7 +478,7 @@ export function CreateScheduledTaskDialog({
             data-testid="create-scheduled-task-submit"
           >
             {mutationPending && <Loader2Icon className="mr-1 size-4 animate-spin" />}
-            {isEdit ? "Update task" : "Create task"}
+            {isEdit ? "Save changes" : "Create task"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/web/src/components/scheduled/ScheduleFields.tsx
+++ b/web/src/components/scheduled/ScheduleFields.tsx
@@ -12,9 +12,11 @@
 // (scheduleBuilder.ts, scheduleText.ts) so they stay robust; they are not
 // reachable from this form today.
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { ClockIcon } from "lucide-react";
 import { Label } from "@/components/scheduled/Label";
 import { Input } from "@/components/ui/input";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -24,6 +26,7 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import {
+  DEFAULT_SCHEDULE_MODEL,
   WEEKDAY_CODES,
   parseMinuteOfHourInput,
   parseTimeOfDayInput,
@@ -32,7 +35,6 @@ import {
   type SchedulePreset,
   type WeekdayCode,
 } from "@/lib/scheduleBuilder";
-import { formatClockTime } from "@/lib/scheduleText";
 
 // Presets only: "custom" is deferred (see file header) and is
 // deliberately absent from this list, so it's unreachable from the dropdown.
@@ -42,6 +44,11 @@ const PRESET_OPTIONS: { value: SchedulePreset; label: string }[] = [
   { value: "weekdays", label: "Weekdays" },
   { value: "weekly", label: "Weekly" },
 ];
+
+const HOURS_12 = Array.from({ length: 12 }, (_, i) => i + 1);
+const MINUTES = Array.from({ length: 60 }, (_, i) => i);
+const PERIODS = ["AM", "PM"] as const;
+type Period = (typeof PERIODS)[number];
 
 const WEEKDAY_LABELS: Record<WeekdayCode, string> = {
   MO: "Mon",
@@ -71,12 +78,23 @@ export function ScheduleFields({
 
   const error = validateSchedule(model);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const hourColumnRef = useRef<HTMLDivElement | null>(null);
+  const minuteColumnRef = useRef<HTMLDivElement | null>(null);
   const [timeText, setTimeText] = useState(() => formatInputValue(model, isHourly));
+  const [timePickerOpen, setTimePickerOpen] = useState(false);
 
   useEffect(() => {
     if (document.activeElement === inputRef.current) return;
     setTimeText(formatInputValue(model, isHourly));
   }, [isHourly, model.hour, model.minute]);
+
+  const pickerParts = toPickerParts(getPickerTime());
+
+  useEffect(() => {
+    if (!timePickerOpen || isHourly) return;
+    scrollSelectedIntoView(hourColumnRef.current);
+    scrollSelectedIntoView(minuteColumnRef.current);
+  }, [isHourly, pickerParts.hour12, pickerParts.minute, timePickerOpen]);
 
   function toggleWeekday(code: WeekdayCode) {
     const has = model.weekdays.includes(code);
@@ -108,7 +126,31 @@ export function ScheduleFields({
     }
 
     const parsed = parseTimeOfDayInput(timeText);
-    if (parsed !== null) setTimeText(formatClockTime(parsed.hour, parsed.minute));
+    if (parsed !== null) setTimeText(formatTimeInput(parsed.hour, parsed.minute));
+  }
+
+  function handleTimePickerOpenChange(next: boolean) {
+    setTimePickerOpen(next);
+    onSelectOpenChange?.(next);
+  }
+
+  function getPickerTime(): { hour: number; minute: number } {
+    const parsed = parseTimeOfDayInput(timeText);
+    if (parsed !== null) return parsed;
+    if (Number.isInteger(model.hour) && Number.isInteger(model.minute)) {
+      return { hour: model.hour, minute: model.minute };
+    }
+    return { hour: DEFAULT_SCHEDULE_MODEL.hour, minute: DEFAULT_SCHEDULE_MODEL.minute };
+  }
+
+  function applyPickerTime(next: Partial<{ hour12: number; minute: number; period: Period }>) {
+    const current = toPickerParts(getPickerTime());
+    const hour12 = next.hour12 ?? current.hour12;
+    const minute = next.minute ?? current.minute;
+    const period = next.period ?? current.period;
+    const hour = to24Hour(hour12, period);
+    setTimeText(formatTimeInput(hour, minute));
+    onChange({ ...model, hour, minute });
   }
 
   return (
@@ -168,17 +210,91 @@ export function ScheduleFields({
 
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="schedule-time">{isHourly ? "Minute" : "Time"}</Label>
-        <Input
-          ref={inputRef}
-          id="schedule-time"
-          value={timeText}
-          data-testid={isHourly ? "schedule-minute" : "schedule-time"}
-          placeholder={isHourly ? ":15" : "5:00 PM"}
-          className={isHourly ? "w-28" : "w-40"}
-          aria-invalid={error ? true : undefined}
-          onChange={(e) => handleTimeTextChange(e.target.value)}
-          onBlur={canonicalizeTimeText}
-        />
+        {isHourly ? (
+          <Input
+            ref={inputRef}
+            id="schedule-time"
+            value={timeText}
+            data-testid="schedule-minute"
+            placeholder=":15"
+            className="w-28"
+            aria-invalid={error ? true : undefined}
+            onChange={(e) => handleTimeTextChange(e.target.value)}
+            onBlur={canonicalizeTimeText}
+          />
+        ) : (
+          <Popover open={timePickerOpen} onOpenChange={handleTimePickerOpenChange}>
+            <PopoverAnchor asChild>
+              <div className="relative w-40">
+                <Input
+                  ref={inputRef}
+                  id="schedule-time"
+                  value={timeText}
+                  data-testid="schedule-time"
+                  placeholder="5:00 PM"
+                  className="pr-8"
+                  aria-invalid={error ? true : undefined}
+                  onFocus={() => handleTimePickerOpenChange(true)}
+                  onChange={(e) => handleTimeTextChange(e.target.value)}
+                  onBlur={canonicalizeTimeText}
+                />
+                <button
+                  type="button"
+                  aria-label="Open time picker"
+                  data-testid="schedule-time-picker-trigger"
+                  className="absolute top-1/2 right-2 flex size-4 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
+                  onClick={() => handleTimePickerOpenChange(!timePickerOpen)}
+                >
+                  <ClockIcon className="size-3.5" />
+                </button>
+              </div>
+            </PopoverAnchor>
+            <PopoverContent
+              align="start"
+              className="w-44 rounded-sm p-1.5"
+              onOpenAutoFocus={(event) => event.preventDefault()}
+            >
+              <div className="grid grid-cols-3 gap-1" data-testid="schedule-time-picker">
+                <div ref={hourColumnRef} className="max-h-64 overflow-y-auto">
+                  {HOURS_12.map((hour) => (
+                    <PickerCell
+                      key={hour}
+                      testId={`schedule-hour-${pad(hour)}`}
+                      selected={pickerParts.hour12 === hour}
+                      onClick={() => applyPickerTime({ hour12: hour })}
+                    >
+                      {pad(hour)}
+                    </PickerCell>
+                  ))}
+                </div>
+                <div ref={minuteColumnRef} className="max-h-64 overflow-y-auto">
+                  {MINUTES.map((minute) => (
+                    <PickerCell
+                      key={minute}
+                      testId={`schedule-minute-${pad(minute)}`}
+                      selected={pickerParts.minute === minute}
+                      onClick={() => applyPickerTime({ minute })}
+                    >
+                      {pad(minute)}
+                    </PickerCell>
+                  ))}
+                </div>
+                <div className="max-h-64 overflow-y-auto">
+                  {PERIODS.map((period) => (
+                    <PickerCell
+                      key={period}
+                      testId={`schedule-period-${period}`}
+                      selected={pickerParts.period === period}
+                      onClick={() => applyPickerTime({ period })}
+                    >
+                      {period}
+                    </PickerCell>
+                  ))}
+                </div>
+              </div>
+            </PopoverContent>
+          </Popover>
+        )}
       </div>
 
       {/* describeSchedule/buildRRule stay in the lib for list rows and possible
@@ -199,10 +315,67 @@ function pad(n: number): string {
 function formatInputValue(model: ScheduleModel, isHourly: boolean): string {
   if (isHourly) return formatMinuteInput(model.minute);
   if (!Number.isInteger(model.hour) || !Number.isInteger(model.minute)) return "";
-  return formatClockTime(model.hour, model.minute);
+  return formatTimeInput(model.hour, model.minute);
 }
 
 function formatMinuteInput(minute: number): string {
   if (!Number.isInteger(minute) || minute < 0 || minute > 59) return "";
   return `:${pad(minute)}`;
+}
+
+function formatTimeInput(hour: number, minute: number): string {
+  if (!Number.isInteger(hour) || !Number.isInteger(minute)) return "";
+  const parts = toPickerParts({ hour, minute });
+  return `${pad(parts.hour12)}:${pad(parts.minute)} ${parts.period}`;
+}
+
+function toPickerParts(time: { hour: number; minute: number }): {
+  hour12: number;
+  minute: number;
+  period: Period;
+} {
+  const hour = Math.min(23, Math.max(0, time.hour));
+  return {
+    hour12: hour % 12 === 0 ? 12 : hour % 12,
+    minute: Math.min(59, Math.max(0, time.minute)),
+    period: hour >= 12 ? "PM" : "AM",
+  };
+}
+
+function to24Hour(hour12: number, period: Period): number {
+  return (hour12 % 12) + (period === "PM" ? 12 : 0);
+}
+
+function scrollSelectedIntoView(column: HTMLDivElement | null) {
+  column
+    ?.querySelector<HTMLElement>('[data-selected="true"]')
+    ?.scrollIntoView?.({ block: "center" });
+}
+
+function PickerCell({
+  children,
+  onClick,
+  selected,
+  testId,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+  selected: boolean;
+  testId: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      data-selected={selected ? "true" : undefined}
+      data-testid={testId}
+      className={cn(
+        "flex h-8 w-full items-center justify-center rounded-sm text-sm transition-colors",
+        selected ? "bg-primary text-primary-foreground" : "text-foreground hover:bg-muted",
+      )}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
 }

--- a/web/src/components/scheduled/ScheduleFields.tsx
+++ b/web/src/components/scheduled/ScheduleFields.tsx
@@ -155,29 +155,119 @@ export function ScheduleFields({
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="schedule-preset">Frequency</Label>
-        <Select
-          value={model.preset}
-          onValueChange={(value) => onChange({ ...model, preset: value as SchedulePreset })}
-          onOpenChange={onSelectOpenChange}
-        >
-          <SelectTrigger id="schedule-preset" data-testid="schedule-preset-trigger">
-            <SelectValue />
-          </SelectTrigger>
-          {/* position="popper" opens the list anchored BELOW the trigger (auto-
-              flips up when no room) so it never overlaps the field label above,
-              unlike the default item-aligned mode. align="start" lines the
-              dropdown's left edge up with the trigger (Radix defaults to
-              center, which shifts it left). */}
-          <SelectContent position="popper" align="start">
-            {PRESET_OPTIONS.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+      <div className="grid gap-3 sm:grid-cols-2" data-testid="schedule-frequency-time-row">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="schedule-preset">Frequency</Label>
+          <Select
+            value={model.preset}
+            onValueChange={(value) => onChange({ ...model, preset: value as SchedulePreset })}
+            onOpenChange={onSelectOpenChange}
+          >
+            <SelectTrigger id="schedule-preset" data-testid="schedule-preset-trigger">
+              <SelectValue />
+            </SelectTrigger>
+            {/* position="popper" opens the list anchored BELOW the trigger (auto-
+                flips up when no room) so it never overlaps the field label above,
+                unlike the default item-aligned mode. align="start" lines the
+                dropdown's left edge up with the trigger (Radix defaults to
+                center, which shifts it left). */}
+            <SelectContent position="popper" align="start">
+              {PRESET_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="schedule-time">{isHourly ? "Minute" : "Time"}</Label>
+          {isHourly ? (
+            <Input
+              ref={inputRef}
+              id="schedule-time"
+              value={timeText}
+              data-testid="schedule-minute"
+              placeholder=":15"
+              aria-invalid={error ? true : undefined}
+              onChange={(e) => handleTimeTextChange(e.target.value)}
+              onBlur={canonicalizeTimeText}
+            />
+          ) : (
+            <Popover open={timePickerOpen} onOpenChange={handleTimePickerOpenChange}>
+              <PopoverAnchor asChild>
+                <div className="relative">
+                  <Input
+                    ref={inputRef}
+                    id="schedule-time"
+                    value={timeText}
+                    data-testid="schedule-time"
+                    placeholder="5:00 PM"
+                    className="pr-8"
+                    aria-invalid={error ? true : undefined}
+                    onFocus={() => handleTimePickerOpenChange(true)}
+                    onChange={(e) => handleTimeTextChange(e.target.value)}
+                    onBlur={canonicalizeTimeText}
+                  />
+                  <button
+                    type="button"
+                    aria-label="Open time picker"
+                    data-testid="schedule-time-picker-trigger"
+                    className="absolute top-1/2 right-2 flex size-4 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
+                    onClick={() => handleTimePickerOpenChange(!timePickerOpen)}
+                  >
+                    <ClockIcon className="size-3.5" />
+                  </button>
+                </div>
+              </PopoverAnchor>
+              <PopoverContent
+                align="start"
+                className="w-44 rounded-sm p-1.5"
+                onOpenAutoFocus={(event) => event.preventDefault()}
+              >
+                <div className="grid grid-cols-3 gap-1" data-testid="schedule-time-picker">
+                  <div ref={hourColumnRef} className="max-h-64 overflow-y-auto">
+                    {HOURS_12.map((hour) => (
+                      <PickerCell
+                        key={hour}
+                        testId={`schedule-hour-${pad(hour)}`}
+                        selected={pickerParts.hour12 === hour}
+                        onClick={() => applyPickerTime({ hour12: hour })}
+                      >
+                        {pad(hour)}
+                      </PickerCell>
+                    ))}
+                  </div>
+                  <div ref={minuteColumnRef} className="max-h-64 overflow-y-auto">
+                    {MINUTES.map((minute) => (
+                      <PickerCell
+                        key={minute}
+                        testId={`schedule-minute-${pad(minute)}`}
+                        selected={pickerParts.minute === minute}
+                        onClick={() => applyPickerTime({ minute })}
+                      >
+                        {pad(minute)}
+                      </PickerCell>
+                    ))}
+                  </div>
+                  <div className="max-h-64 overflow-y-auto">
+                    {PERIODS.map((period) => (
+                      <PickerCell
+                        key={period}
+                        testId={`schedule-period-${period}`}
+                        selected={pickerParts.period === period}
+                        onClick={() => applyPickerTime({ period })}
+                      >
+                        {period}
+                      </PickerCell>
+                    ))}
+                  </div>
+                </div>
+              </PopoverContent>
+            </Popover>
+          )}
+        </div>
       </div>
 
       {showWeekdays && (
@@ -207,95 +297,6 @@ export function ScheduleFields({
           </div>
         </div>
       )}
-
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="schedule-time">{isHourly ? "Minute" : "Time"}</Label>
-        {isHourly ? (
-          <Input
-            ref={inputRef}
-            id="schedule-time"
-            value={timeText}
-            data-testid="schedule-minute"
-            placeholder=":15"
-            className="w-28"
-            aria-invalid={error ? true : undefined}
-            onChange={(e) => handleTimeTextChange(e.target.value)}
-            onBlur={canonicalizeTimeText}
-          />
-        ) : (
-          <Popover open={timePickerOpen} onOpenChange={handleTimePickerOpenChange}>
-            <PopoverAnchor asChild>
-              <div className="relative w-40">
-                <Input
-                  ref={inputRef}
-                  id="schedule-time"
-                  value={timeText}
-                  data-testid="schedule-time"
-                  placeholder="5:00 PM"
-                  className="pr-8"
-                  aria-invalid={error ? true : undefined}
-                  onFocus={() => handleTimePickerOpenChange(true)}
-                  onChange={(e) => handleTimeTextChange(e.target.value)}
-                  onBlur={canonicalizeTimeText}
-                />
-                <button
-                  type="button"
-                  aria-label="Open time picker"
-                  data-testid="schedule-time-picker-trigger"
-                  className="absolute top-1/2 right-2 flex size-4 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
-                  onClick={() => handleTimePickerOpenChange(!timePickerOpen)}
-                >
-                  <ClockIcon className="size-3.5" />
-                </button>
-              </div>
-            </PopoverAnchor>
-            <PopoverContent
-              align="start"
-              className="w-44 rounded-sm p-1.5"
-              onOpenAutoFocus={(event) => event.preventDefault()}
-            >
-              <div className="grid grid-cols-3 gap-1" data-testid="schedule-time-picker">
-                <div ref={hourColumnRef} className="max-h-64 overflow-y-auto">
-                  {HOURS_12.map((hour) => (
-                    <PickerCell
-                      key={hour}
-                      testId={`schedule-hour-${pad(hour)}`}
-                      selected={pickerParts.hour12 === hour}
-                      onClick={() => applyPickerTime({ hour12: hour })}
-                    >
-                      {pad(hour)}
-                    </PickerCell>
-                  ))}
-                </div>
-                <div ref={minuteColumnRef} className="max-h-64 overflow-y-auto">
-                  {MINUTES.map((minute) => (
-                    <PickerCell
-                      key={minute}
-                      testId={`schedule-minute-${pad(minute)}`}
-                      selected={pickerParts.minute === minute}
-                      onClick={() => applyPickerTime({ minute })}
-                    >
-                      {pad(minute)}
-                    </PickerCell>
-                  ))}
-                </div>
-                <div className="max-h-64 overflow-y-auto">
-                  {PERIODS.map((period) => (
-                    <PickerCell
-                      key={period}
-                      testId={`schedule-period-${period}`}
-                      selected={pickerParts.period === period}
-                      onClick={() => applyPickerTime({ period })}
-                    >
-                      {period}
-                    </PickerCell>
-                  ))}
-                </div>
-              </div>
-            </PopoverContent>
-          </Popover>
-        )}
-      </div>
 
       {/* describeSchedule/buildRRule stay in the lib for list rows and possible
           future previews; only the inline validation error renders here now. */}

--- a/web/src/components/scheduled/ScheduleFields.tsx
+++ b/web/src/components/scheduled/ScheduleFields.tsx
@@ -12,7 +12,9 @@
 // (scheduleBuilder.ts, scheduleText.ts) so they stay robust; they are not
 // reachable from this form today.
 
+import { useEffect, useRef, useState } from "react";
 import { Label } from "@/components/scheduled/Label";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -23,6 +25,8 @@ import {
 import { cn } from "@/lib/utils";
 import {
   WEEKDAY_CODES,
+  parseMinuteOfHourInput,
+  parseTimeOfDayInput,
   validateSchedule,
   type ScheduleModel,
   type SchedulePreset,
@@ -38,15 +42,6 @@ const PRESET_OPTIONS: { value: SchedulePreset; label: string }[] = [
   { value: "weekdays", label: "Weekdays" },
   { value: "weekly", label: "Weekly" },
 ];
-
-/** Time-of-day is constrained to 15-minute slots (no free typing). */
-const MINUTE_SLOTS = [0, 15, 30, 45] as const;
-
-/** Every 15-minute slot across the day (96 options), for the Time dropdown. */
-const TIME_SLOTS: { hour: number; minute: number }[] = Array.from({ length: 96 }, (_, i) => ({
-  hour: Math.floor(i / 4),
-  minute: (i % 4) * 15,
-}));
 
 const WEEKDAY_LABELS: Record<WeekdayCode, string> = {
   MO: "Mon",
@@ -75,11 +70,45 @@ export function ScheduleFields({
   const showWeekdays = model.preset === "weekly";
 
   const error = validateSchedule(model);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [timeText, setTimeText] = useState(() => formatInputValue(model, isHourly));
+
+  useEffect(() => {
+    if (document.activeElement === inputRef.current) return;
+    setTimeText(formatInputValue(model, isHourly));
+  }, [isHourly, model.hour, model.minute]);
 
   function toggleWeekday(code: WeekdayCode) {
     const has = model.weekdays.includes(code);
     const next = has ? model.weekdays.filter((c) => c !== code) : [...model.weekdays, code];
     onChange({ ...model, weekdays: next });
+  }
+
+  function handleTimeTextChange(value: string) {
+    setTimeText(value);
+    if (isHourly) {
+      const minute = parseMinuteOfHourInput(value);
+      onChange({ ...model, minute: minute ?? Number.NaN });
+      return;
+    }
+
+    const parsed = parseTimeOfDayInput(value);
+    onChange({
+      ...model,
+      hour: parsed?.hour ?? Number.NaN,
+      minute: parsed?.minute ?? Number.NaN,
+    });
+  }
+
+  function canonicalizeTimeText() {
+    if (isHourly) {
+      const minute = parseMinuteOfHourInput(timeText);
+      if (minute !== null) setTimeText(formatMinuteInput(minute));
+      return;
+    }
+
+    const parsed = parseTimeOfDayInput(timeText);
+    if (parsed !== null) setTimeText(formatClockTime(parsed.hour, parsed.minute));
   }
 
   return (
@@ -139,80 +168,17 @@ export function ScheduleFields({
 
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="schedule-time">{isHourly ? "Minute" : "Time"}</Label>
-        {isHourly ? (
-          // Hourly fires every hour; only the minute-of-hour matters. Constrain
-          // to 15-min slots (0/15/30/45) via a dropdown — no free typing.
-          <Select
-            value={String(snapMinute(model.minute))}
-            onValueChange={(v) => onChange({ ...model, minute: Number(v) })}
-            onOpenChange={onSelectOpenChange}
-          >
-            <SelectTrigger id="schedule-time" data-testid="schedule-minute" className="w-28">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent position="popper" align="start">
-              {MINUTE_SLOTS.map((m) => (
-                <SelectItem key={m} value={String(m)}>
-                  {`:${pad(m)}`}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        ) : (
-          // Time-of-day constrained to 15-min slots (96/day) via a dropdown.
-          // Value encodes "H:M"; labels use the same 12h clock as the list rows.
-          <Select
-            value={`${snapHour(model)}:${snapMinute(model.minute)}`}
-            onValueChange={(v) => {
-              const [h, m] = v.split(":");
-              onChange({ ...model, hour: Number(h), minute: Number(m) });
-            }}
-            onOpenChange={(next) => {
-              onSelectOpenChange?.(next);
-              // Radix scrolls the SELECTED slot into view on open (even in
-              // popper mode), so a 9:00 AM default would land mid-list and hide
-              // 12:00 AM. Pin the viewport to the top so the list always starts
-              // at 12:00 AM (index 0), per product. Radix's scroll-into-view
-              // runs in a layout effect + a follow-up frame after open, so we
-              // pin on a short interval for a few ticks to reliably win the
-              // race regardless of machine speed, then stop.
-              if (next) {
-                let ticks = 0;
-                const pinTop = () => {
-                  document
-                    .querySelectorAll<HTMLElement>("[data-radix-select-viewport]")
-                    .forEach((vp) => {
-                      vp.scrollTop = 0;
-                    });
-                };
-                const timer = setInterval(() => {
-                  pinTop();
-                  if (++ticks >= 6) clearInterval(timer);
-                }, 16);
-                pinTop();
-              }
-            }}
-          >
-            <SelectTrigger id="schedule-time" data-testid="schedule-time" className="w-40">
-              <SelectValue />
-            </SelectTrigger>
-            {/* position="popper" + align="start" opens the list below the
-                trigger, left-aligned. We also reset the viewport scroll to top
-                on open (see onOpenChange) so the list starts at 12:00 AM (index
-                0) rather than scrolled to the selected slot. max-h ≈ 12 rows
-                (~28px each) so the 96 slots scroll inside the popover. */}
-            <SelectContent position="popper" align="start" className="max-h-[21rem]">
-              {TIME_SLOTS.map((slot) => (
-                <SelectItem
-                  key={`${slot.hour}:${slot.minute}`}
-                  value={`${slot.hour}:${slot.minute}`}
-                >
-                  {formatClockTime(slot.hour, slot.minute)}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
+        <Input
+          ref={inputRef}
+          id="schedule-time"
+          value={timeText}
+          data-testid={isHourly ? "schedule-minute" : "schedule-time"}
+          placeholder={isHourly ? ":15" : "5:00 PM"}
+          className={isHourly ? "w-28" : "w-40"}
+          aria-invalid={error ? true : undefined}
+          onChange={(e) => handleTimeTextChange(e.target.value)}
+          onBlur={canonicalizeTimeText}
+        />
       </div>
 
       {/* describeSchedule/buildRRule stay in the lib for list rows and possible
@@ -226,26 +192,17 @@ export function ScheduleFields({
   );
 }
 
-/** Zero-pad a number to two digits (minute labels, e.g. ":05"). */
 function pad(n: number): string {
   return n.toString().padStart(2, "0");
 }
 
-/**
- * Snap a stored minute onto the nearest 15-min slot (0/15/30/45) so the Select's
- * controlled value always matches one of its options — otherwise a model minute
- * left off-grid (e.g. from the default 0, or a future preset) would show a blank
- * trigger. Rounds to nearest; 53 → 45, 8 → 15.
- */
-function snapMinute(n: number): number {
-  if (!Number.isFinite(n)) return 0;
-  const slot = Math.round(Math.min(59, Math.max(0, n)) / 15) * 15;
-  return slot === 60 ? 45 : slot;
+function formatInputValue(model: ScheduleModel, isHourly: boolean): string {
+  if (isHourly) return formatMinuteInput(model.minute);
+  if (!Number.isInteger(model.hour) || !Number.isInteger(model.minute)) return "";
+  return formatClockTime(model.hour, model.minute);
 }
 
-/** The stored hour clamped to 0–23 for the Time dropdown's value. */
-function snapHour(model: ScheduleModel): number {
-  const h = model.hour;
-  if (!Number.isFinite(h)) return 0;
-  return Math.min(23, Math.max(0, Math.trunc(h)));
+function formatMinuteInput(minute: number): string {
+  if (!Number.isInteger(minute) || minute < 0 || minute > 59) return "";
+  return `:${pad(minute)}`;
 }

--- a/web/src/components/scheduled/ScheduleFields.tsx
+++ b/web/src/components/scheduled/ScheduleFields.tsx
@@ -46,7 +46,7 @@ const PRESET_OPTIONS: { value: SchedulePreset; label: string }[] = [
 ];
 
 const HOURS_12 = Array.from({ length: 12 }, (_, i) => i + 1);
-const MINUTES = Array.from({ length: 60 }, (_, i) => i);
+const QUARTER_HOUR_MINUTES = [0, 15, 30, 45] as const;
 const PERIODS = ["AM", "PM"] as const;
 type Period = (typeof PERIODS)[number];
 
@@ -80,6 +80,7 @@ export function ScheduleFields({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const hourColumnRef = useRef<HTMLDivElement | null>(null);
   const minuteColumnRef = useRef<HTMLDivElement | null>(null);
+  const periodColumnRef = useRef<HTMLDivElement | null>(null);
   const [timeText, setTimeText] = useState(() => formatInputValue(model, isHourly));
   const [timePickerOpen, setTimePickerOpen] = useState(false);
 
@@ -89,12 +90,38 @@ export function ScheduleFields({
   }, [isHourly, model.hour, model.minute]);
 
   const pickerParts = toPickerParts(getPickerTime());
+  const pickerMinuteOptions = minuteOptionsFor(pickerParts.minute);
 
   useEffect(() => {
     if (!timePickerOpen || isHourly) return;
     scrollSelectedIntoView(hourColumnRef.current);
     scrollSelectedIntoView(minuteColumnRef.current);
   }, [isHourly, pickerParts.hour12, pickerParts.minute, timePickerOpen]);
+
+  useEffect(() => {
+    if (isHourly) return;
+    const handleWheel = (event: WheelEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      const columns = [
+        hourColumnRef.current ?? document.querySelector('[data-testid="schedule-hour-column"]'),
+        minuteColumnRef.current ?? document.querySelector('[data-testid="schedule-minute-column"]'),
+        periodColumnRef.current ?? document.querySelector('[data-testid="schedule-period-column"]'),
+      ];
+      const column = columns.find((col) => col?.contains(target));
+      if (!column) return;
+      if (column.scrollHeight > column.clientHeight) {
+        column.scrollTop += event.deltaY;
+      }
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      event.stopPropagation();
+    };
+    window.addEventListener("wheel", handleWheel, { capture: true, passive: false });
+    return () => {
+      window.removeEventListener("wheel", handleWheel, true);
+    };
+  }, [isHourly]);
 
   function toggleWeekday(code: WeekdayCode) {
     const has = model.weekdays.includes(code);
@@ -155,15 +182,22 @@ export function ScheduleFields({
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="grid gap-3 sm:grid-cols-2" data-testid="schedule-frequency-time-row">
-        <div className="flex flex-col gap-1.5">
+      <div className="grid gap-3 sm:grid-cols-2 sm:gap-6" data-testid="schedule-frequency-time-row">
+        <div
+          className="flex w-full min-w-0 flex-col gap-1.5"
+          data-testid="schedule-frequency-control"
+        >
           <Label htmlFor="schedule-preset">Frequency</Label>
           <Select
             value={model.preset}
             onValueChange={(value) => onChange({ ...model, preset: value as SchedulePreset })}
             onOpenChange={onSelectOpenChange}
           >
-            <SelectTrigger id="schedule-preset" data-testid="schedule-preset-trigger">
+            <SelectTrigger
+              id="schedule-preset"
+              data-testid="schedule-preset-trigger"
+              className="w-full"
+            >
               <SelectValue />
             </SelectTrigger>
             {/* position="popper" opens the list anchored BELOW the trigger (auto-
@@ -181,7 +215,7 @@ export function ScheduleFields({
           </Select>
         </div>
 
-        <div className="flex flex-col gap-1.5">
+        <div className="flex w-full min-w-0 flex-col gap-1.5" data-testid="schedule-time-control">
           <Label htmlFor="schedule-time">{isHourly ? "Minute" : "Time"}</Label>
           {isHourly ? (
             <Input
@@ -190,6 +224,7 @@ export function ScheduleFields({
               value={timeText}
               data-testid="schedule-minute"
               placeholder=":15"
+              className="text-sm"
               aria-invalid={error ? true : undefined}
               onChange={(e) => handleTimeTextChange(e.target.value)}
               onBlur={canonicalizeTimeText}
@@ -204,7 +239,7 @@ export function ScheduleFields({
                     value={timeText}
                     data-testid="schedule-time"
                     placeholder="5:00 PM"
-                    className="pr-8"
+                    className="pr-8 text-sm"
                     aria-invalid={error ? true : undefined}
                     onFocus={() => handleTimePickerOpenChange(true)}
                     onChange={(e) => handleTimeTextChange(e.target.value)}
@@ -223,11 +258,15 @@ export function ScheduleFields({
               </PopoverAnchor>
               <PopoverContent
                 align="start"
-                className="w-44 rounded-sm p-1.5"
+                className="w-64 rounded-sm p-1.5"
                 onOpenAutoFocus={(event) => event.preventDefault()}
               >
                 <div className="grid grid-cols-3 gap-1" data-testid="schedule-time-picker">
-                  <div ref={hourColumnRef} className="max-h-64 overflow-y-auto">
+                  <div
+                    ref={hourColumnRef}
+                    className="max-h-40 overflow-y-auto overscroll-contain pr-0.5"
+                    data-testid="schedule-hour-column"
+                  >
                     {HOURS_12.map((hour) => (
                       <PickerCell
                         key={hour}
@@ -239,8 +278,12 @@ export function ScheduleFields({
                       </PickerCell>
                     ))}
                   </div>
-                  <div ref={minuteColumnRef} className="max-h-64 overflow-y-auto">
-                    {MINUTES.map((minute) => (
+                  <div
+                    ref={minuteColumnRef}
+                    className="max-h-40 overflow-y-auto overscroll-contain pr-0.5"
+                    data-testid="schedule-minute-column"
+                  >
+                    {pickerMinuteOptions.map((minute) => (
                       <PickerCell
                         key={minute}
                         testId={`schedule-minute-${pad(minute)}`}
@@ -251,7 +294,11 @@ export function ScheduleFields({
                       </PickerCell>
                     ))}
                   </div>
-                  <div className="max-h-64 overflow-y-auto">
+                  <div
+                    ref={periodColumnRef}
+                    className="max-h-40 overflow-y-auto overscroll-contain pr-0.5"
+                    data-testid="schedule-period-column"
+                  >
                     {PERIODS.map((period) => (
                       <PickerCell
                         key={period}
@@ -322,6 +369,10 @@ function formatInputValue(model: ScheduleModel, isHourly: boolean): string {
 function formatMinuteInput(minute: number): string {
   if (!Number.isInteger(minute) || minute < 0 || minute > 59) return "";
   return `:${pad(minute)}`;
+}
+
+function minuteOptionsFor(currentMinute: number): number[] {
+  return [...new Set([...QUARTER_HOUR_MINUTES, currentMinute])].sort((a, b) => a - b);
 }
 
 function formatTimeInput(hour: number, minute: number): string {

--- a/web/src/components/scheduled/ScheduleFields.tsx
+++ b/web/src/components/scheduled/ScheduleFields.tsx
@@ -46,7 +46,7 @@ const PRESET_OPTIONS: { value: SchedulePreset; label: string }[] = [
 ];
 
 const HOURS_12 = Array.from({ length: 12 }, (_, i) => i + 1);
-const QUARTER_HOUR_MINUTES = [0, 15, 30, 45] as const;
+const MINUTES = Array.from({ length: 60 }, (_, i) => i);
 const PERIODS = ["AM", "PM"] as const;
 type Period = (typeof PERIODS)[number];
 
@@ -90,7 +90,6 @@ export function ScheduleFields({
   }, [isHourly, model.hour, model.minute]);
 
   const pickerParts = toPickerParts(getPickerTime());
-  const pickerMinuteOptions = minuteOptionsFor(pickerParts.minute);
 
   useEffect(() => {
     if (!timePickerOpen || isHourly) return;
@@ -283,7 +282,7 @@ export function ScheduleFields({
                     className="max-h-40 overflow-y-auto overscroll-contain pr-0.5"
                     data-testid="schedule-minute-column"
                   >
-                    {pickerMinuteOptions.map((minute) => (
+                    {MINUTES.map((minute) => (
                       <PickerCell
                         key={minute}
                         testId={`schedule-minute-${pad(minute)}`}
@@ -369,10 +368,6 @@ function formatInputValue(model: ScheduleModel, isHourly: boolean): string {
 function formatMinuteInput(minute: number): string {
   if (!Number.isInteger(minute) || minute < 0 || minute > 59) return "";
   return `:${pad(minute)}`;
-}
-
-function minuteOptionsFor(currentMinute: number): number[] {
-  return [...new Set([...QUARTER_HOUR_MINUTES, currentMinute])].sort((a, b) => a - b);
 }
 
 function formatTimeInput(hour: number, minute: number): string {

--- a/web/src/components/scheduled/ScheduleFields.tsx
+++ b/web/src/components/scheduled/ScheduleFields.tsx
@@ -129,13 +129,17 @@ export function ScheduleFields({
   }
 
   function handleTimeTextChange(value: string) {
-    setTimeText(value);
     if (isHourly) {
-      const minute = parseMinuteOfHourInput(value);
-      onChange({ ...model, minute: minute ?? Number.NaN });
+      const digits = value.replace(/\D/g, "").slice(0, 2);
+      let minute = digits === "" ? Number.NaN : Number(digits);
+      if (Number.isInteger(minute) && minute > 59) minute = 59;
+      const text = Number.isInteger(minute) ? String(minute) : "";
+      setTimeText(text);
+      onChange({ ...model, minute: Number.isInteger(minute) ? minute : Number.NaN });
       return;
     }
 
+    setTimeText(value);
     const parsed = parseTimeOfDayInput(value);
     onChange({
       ...model,
@@ -222,7 +226,7 @@ export function ScheduleFields({
               id="schedule-time"
               value={timeText}
               data-testid="schedule-minute"
-              placeholder=":15"
+              placeholder="0"
               className="text-sm"
               aria-invalid={error ? true : undefined}
               onChange={(e) => handleTimeTextChange(e.target.value)}
@@ -366,8 +370,8 @@ function formatInputValue(model: ScheduleModel, isHourly: boolean): string {
 }
 
 function formatMinuteInput(minute: number): string {
-  if (!Number.isInteger(minute) || minute < 0 || minute > 59) return "";
-  return `:${pad(minute)}`;
+  if (!Number.isInteger(minute)) return "";
+  return String(Math.min(59, Math.max(0, minute)));
 }
 
 function formatTimeInput(hour: number, minute: number): string {

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -10,7 +10,7 @@
 // right. No leading or trailing status circles — the ⋯ menu is the only affordance.
 
 import { useMemo, useState } from "react";
-import { MoreHorizontalIcon, PauseIcon, PlayIcon, Trash2Icon } from "lucide-react";
+import { MoreHorizontalIcon, PauseIcon, PencilIcon, PlayIcon, Trash2Icon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -24,11 +24,13 @@ import type { ScheduledTask } from "@/lib/scheduledTasksApi";
 
 export function ScheduledTaskRow({
   task,
+  onEdit,
   onPauseToggle,
   onDelete,
   busy,
 }: {
   task: ScheduledTask;
+  onEdit: (task: ScheduledTask) => void;
   onPauseToggle: (task: ScheduledTask) => void;
   onDelete: (task: ScheduledTask) => void;
   busy: boolean;
@@ -98,6 +100,10 @@ export function ScheduledTaskRow({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={() => onEdit(task)} data-testid="task-edit">
+            <PencilIcon className="size-4" />
+            Edit
+          </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => onPauseToggle(task)} data-testid="task-pause-toggle">
             {paused ? (
               <>

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -2,18 +2,23 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
-  return (
-    <input
-      type={type}
-      data-slot="input"
-      className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        data-slot="input"
+        className={cn(
+          "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+Input.displayName = "Input";
 
 export { Input };

--- a/web/src/lib/scheduleBuilder.test.ts
+++ b/web/src/lib/scheduleBuilder.test.ts
@@ -69,7 +69,49 @@ describe("parseRRuleToScheduleModel", () => {
     expect(parseRRuleToScheduleModel("FREQ=DAILY;INTERVAL=2;BYHOUR=9;BYMINUTE=0")).toBeNull();
   });
 
-  it("rejects minute values the visible picker would have to snap", () => {
-    expect(parseRRuleToScheduleModel("FREQ=DAILY;BYHOUR=9;BYMINUTE=17")).toBeNull();
+  it("round-trips non-quarter-hour daily minutes", () => {
+    expect(parseRRuleToScheduleModel("FREQ=DAILY;BYHOUR=17;BYMINUTE=7")).toMatchObject({
+      preset: "daily",
+      hour: 17,
+      minute: 7,
+    });
+  });
+
+  it("round-trips non-quarter-hour hourly minute selections", () => {
+    expect(parseRRuleToScheduleModel("FREQ=HOURLY;BYMINUTE=7")).toMatchObject({
+      preset: "hourly",
+      minute: 7,
+    });
+  });
+});
+
+describe("parseTimeOfDayInput", () => {
+  it("accepts common 12-hour and 24-hour time input", async () => {
+    const { parseTimeOfDayInput } = await import("./scheduleBuilder");
+    expect(parseTimeOfDayInput("5:00 PM")).toEqual({ hour: 17, minute: 0 });
+    expect(parseTimeOfDayInput("5:07 PM")).toEqual({ hour: 17, minute: 7 });
+    expect(parseTimeOfDayInput("17:07")).toEqual({ hour: 17, minute: 7 });
+  });
+
+  it("rejects invalid times", async () => {
+    const { parseTimeOfDayInput } = await import("./scheduleBuilder");
+    expect(parseTimeOfDayInput("25:00")).toBeNull();
+    expect(parseTimeOfDayInput("5:99 PM")).toBeNull();
+    expect(parseTimeOfDayInput("not a time")).toBeNull();
+  });
+});
+
+describe("parseMinuteOfHourInput", () => {
+  it("accepts any minute in an hour", async () => {
+    const { parseMinuteOfHourInput } = await import("./scheduleBuilder");
+    expect(parseMinuteOfHourInput(":00")).toBe(0);
+    expect(parseMinuteOfHourInput("7")).toBe(7);
+    expect(parseMinuteOfHourInput(":59")).toBe(59);
+  });
+
+  it("rejects invalid minute input", async () => {
+    const { parseMinuteOfHourInput } = await import("./scheduleBuilder");
+    expect(parseMinuteOfHourInput(":60")).toBeNull();
+    expect(parseMinuteOfHourInput("abc")).toBeNull();
   });
 });

--- a/web/src/lib/scheduleBuilder.test.ts
+++ b/web/src/lib/scheduleBuilder.test.ts
@@ -6,7 +6,12 @@
 // rather than hard-coding :00, so "Hourly at :30" actually fires at :30.
 
 import { describe, expect, it } from "vitest";
-import { buildRRule, DEFAULT_SCHEDULE_MODEL, type ScheduleModel } from "./scheduleBuilder";
+import {
+  buildRRule,
+  DEFAULT_SCHEDULE_MODEL,
+  parseRRuleToScheduleModel,
+  type ScheduleModel,
+} from "./scheduleBuilder";
 
 /** A schedule model with overrides on top of the default. */
 function model(overrides: Partial<ScheduleModel>): ScheduleModel {
@@ -20,5 +25,51 @@ describe("buildRRule — Hourly minute-of-hour", () => {
 
   it("honors a non-zero snapped minute (30 → :30, not the hard-coded :00)", () => {
     expect(buildRRule(model({ preset: "hourly", minute: 30 }))).toBe("FREQ=HOURLY;BYMINUTE=30");
+  });
+});
+
+describe("parseRRuleToScheduleModel", () => {
+  it("round-trips daily rules into the visible schedule controls", () => {
+    expect(parseRRuleToScheduleModel("FREQ=DAILY;BYHOUR=14;BYMINUTE=30")).toMatchObject({
+      preset: "daily",
+      hour: 14,
+      minute: 30,
+    });
+  });
+
+  it("recognizes weekdays as the dedicated preset", () => {
+    expect(
+      parseRRuleToScheduleModel("FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=8;BYMINUTE=0"),
+    ).toMatchObject({
+      preset: "weekdays",
+      hour: 8,
+      minute: 0,
+    });
+  });
+
+  it("round-trips weekly day selections", () => {
+    expect(parseRRuleToScheduleModel("FREQ=WEEKLY;BYDAY=WE,MO;BYHOUR=9;BYMINUTE=15")).toMatchObject(
+      {
+        preset: "weekly",
+        hour: 9,
+        minute: 15,
+        weekdays: ["MO", "WE"],
+      },
+    );
+  });
+
+  it("round-trips hourly minute selections", () => {
+    expect(parseRRuleToScheduleModel("FREQ=HOURLY;BYMINUTE=45")).toMatchObject({
+      preset: "hourly",
+      minute: 45,
+    });
+  });
+
+  it("rejects interval rules the visible form cannot represent", () => {
+    expect(parseRRuleToScheduleModel("FREQ=DAILY;INTERVAL=2;BYHOUR=9;BYMINUTE=0")).toBeNull();
+  });
+
+  it("rejects minute values the visible picker would have to snap", () => {
+    expect(parseRRuleToScheduleModel("FREQ=DAILY;BYHOUR=9;BYMINUTE=17")).toBeNull();
   });
 });

--- a/web/src/lib/scheduleBuilder.ts
+++ b/web/src/lib/scheduleBuilder.ts
@@ -80,6 +80,42 @@ export function buildRRule(model: ScheduleModel): string {
   }
 }
 
+export function parseRRuleToScheduleModel(rrule: string): ScheduleModel | null {
+  const parts = parseRuleParts(rrule);
+  if (parts === null) return null;
+  const freq = parts.get("FREQ");
+  const interval = parts.get("INTERVAL");
+  if (interval !== undefined && interval !== "1") return null;
+
+  const hour = parseNumberPart(parts.get("BYHOUR"), 0, 23);
+  const minute = parseNumberPart(parts.get("BYMINUTE"), 0, 59);
+  if (minute === null || !isVisibleMinuteOption(minute)) return null;
+
+  if (freq === "HOURLY") {
+    if (hasUnsupportedParts(parts, ["FREQ", "INTERVAL", "BYMINUTE"])) return null;
+    return { ...DEFAULT_SCHEDULE_MODEL, preset: "hourly", minute };
+  }
+
+  if (hour === null) return null;
+
+  if (freq === "DAILY") {
+    if (hasUnsupportedParts(parts, ["FREQ", "INTERVAL", "BYHOUR", "BYMINUTE"])) return null;
+    return { ...DEFAULT_SCHEDULE_MODEL, preset: "daily", hour, minute };
+  }
+
+  if (freq === "WEEKLY") {
+    if (hasUnsupportedParts(parts, ["FREQ", "INTERVAL", "BYDAY", "BYHOUR", "BYMINUTE"])) {
+      return null;
+    }
+    const weekdays = parseWeekdaysPart(parts.get("BYDAY"));
+    if (weekdays === null || weekdays.length === 0) return null;
+    const preset = weekdays.join(",") === "MO,TU,WE,TH,FR" ? "weekdays" : "weekly";
+    return { ...DEFAULT_SCHEDULE_MODEL, preset, hour, minute, weekdays };
+  }
+
+  return null;
+}
+
 function buildCustomRRule(model: ScheduleModel): string {
   const { hour, minute } = model;
   const interval = clampInterval(model.interval);
@@ -105,6 +141,49 @@ function buildCustomRRule(model: ScheduleModel): string {
     default:
       return `FREQ=DAILY;INTERVAL=${interval};BYHOUR=${hour};BYMINUTE=${minute}`;
   }
+}
+
+function parseRuleParts(rrule: string): Map<string, string> | null {
+  const body = rrule.startsWith("RRULE:") ? rrule.slice("RRULE:".length) : rrule;
+  const parts = new Map<string, string>();
+  for (const segment of body.split(";")) {
+    const [rawKey, rawValue] = segment.split("=");
+    if (!rawKey || rawValue == null || rawValue === "") return null;
+    parts.set(rawKey.toUpperCase(), rawValue.toUpperCase());
+  }
+  return parts;
+}
+
+function hasUnsupportedParts(parts: Map<string, string>, supported: string[]): boolean {
+  const supportedSet = new Set(supported);
+  for (const key of parts.keys()) {
+    if (!supportedSet.has(key)) return true;
+  }
+  return false;
+}
+
+function parseNumberPart(value: string | undefined, min: number, max: number): number | null {
+  if (value == null) return null;
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) return null;
+  return parsed;
+}
+
+function parseWeekdaysPart(value: string | undefined): WeekdayCode[] | null {
+  if (value == null) return null;
+  const rawCodes = value.split(",");
+  if (rawCodes.length === 0) return null;
+  const codes: WeekdayCode[] = [];
+  for (const rawCode of rawCodes) {
+    if (!WEEKDAY_CODES.includes(rawCode as WeekdayCode)) return null;
+    codes.push(rawCode as WeekdayCode);
+  }
+  return normalizeWeekdays(codes);
+}
+
+function isVisibleMinuteOption(minute: number): boolean {
+  return minute === 0 || minute === 15 || minute === 30 || minute === 45;
 }
 
 /**

--- a/web/src/lib/scheduleBuilder.ts
+++ b/web/src/lib/scheduleBuilder.ts
@@ -89,7 +89,7 @@ export function parseRRuleToScheduleModel(rrule: string): ScheduleModel | null {
 
   const hour = parseNumberPart(parts.get("BYHOUR"), 0, 23);
   const minute = parseNumberPart(parts.get("BYMINUTE"), 0, 59);
-  if (minute === null || !isVisibleMinuteOption(minute)) return null;
+  if (minute === null) return null;
 
   if (freq === "HOURLY") {
     if (hasUnsupportedParts(parts, ["FREQ", "INTERVAL", "BYMINUTE"])) return null;
@@ -182,10 +182,6 @@ function parseWeekdaysPart(value: string | undefined): WeekdayCode[] | null {
   return normalizeWeekdays(codes);
 }
 
-function isVisibleMinuteOption(minute: number): boolean {
-  return minute === 0 || minute === 15 || minute === 30 || minute === 45;
-}
-
 /**
  * Validate the schedule model against the form's constraints. Returns a
  * human-readable error string when invalid (shown inline + gates submit), or
@@ -193,6 +189,16 @@ function isVisibleMinuteOption(minute: number): boolean {
  * schedule fails fast in the form rather than as a 400.
  */
 export function validateSchedule(model: ScheduleModel): string | null {
+  if (!Number.isInteger(model.minute) || model.minute < 0 || model.minute > 59) {
+    return model.preset === "hourly" ? "Enter a valid minute from 0 to 59." : "Enter a valid time.";
+  }
+  if (
+    model.preset !== "hourly" &&
+    (!Number.isInteger(model.hour) || model.hour < 0 || model.hour > 23)
+  ) {
+    return "Enter a valid time.";
+  }
+
   // Multi-selects must have at least one selection.
   if (model.preset === "weekly" && model.weekdays.length === 0) {
     return "Pick at least one day of the week.";
@@ -252,4 +258,33 @@ function clampMonthDay(day: number): number | null {
 function clampMonth(m: number): number {
   if (!Number.isFinite(m)) return 1;
   return Math.min(12, Math.max(1, Math.trunc(m)));
+}
+
+export function parseTimeOfDayInput(input: string): { hour: number; minute: number } | null {
+  const value = input.trim().toUpperCase().replace(/\s+/g, " ");
+  const match = value.match(/^(\d{1,2})(?::(\d{1,2}))?\s*(AM|PM)?$/);
+  if (!match) return null;
+
+  const rawHour = Number(match[1]);
+  const minute = match[2] == null ? 0 : Number(match[2]);
+  const meridiem = match[3];
+  if (!Number.isInteger(rawHour) || !Number.isInteger(minute) || minute < 0 || minute > 59) {
+    return null;
+  }
+
+  if (meridiem != null) {
+    if (rawHour < 1 || rawHour > 12) return null;
+    const hour = (rawHour % 12) + (meridiem === "PM" ? 12 : 0);
+    return { hour, minute };
+  }
+
+  if (rawHour < 0 || rawHour > 23) return null;
+  return { hour: rawHour, minute };
+}
+
+export function parseMinuteOfHourInput(input: string): number | null {
+  const value = input.trim().replace(/^:/, "");
+  if (!/^\d{1,2}$/.test(value)) return null;
+  const minute = Number(value);
+  return Number.isInteger(minute) && minute >= 0 && minute <= 59 ? minute : null;
 }

--- a/web/src/lib/scheduleText.test.ts
+++ b/web/src/lib/scheduleText.test.ts
@@ -5,6 +5,7 @@
 // yearly BYMONTH), plus the 1-hour-floor validation.
 
 import { describe, expect, it } from "vitest";
+import { RRule, rrulestr } from "rrule";
 import { describeSchedule, formatClockTime, nextRunAtMs } from "./scheduleText";
 import {
   buildRRule,
@@ -16,6 +17,15 @@ import {
 /** Convenience: a model with overrides on top of the default. */
 function model(overrides: Partial<ScheduleModel>): ScheduleModel {
   return { ...DEFAULT_SCHEDULE_MODEL, ...overrides };
+}
+
+const REFERENCE_OCCURRENCE_ANCHOR = new Date(Date.UTC(2000, 0, 1, 0, 0, 0));
+
+function referenceNextRunAtMs(rrule: string, now: Date): number | null {
+  const parsed = rrulestr(rrule);
+  if (!(parsed instanceof RRule)) return null;
+  const rule = new RRule({ ...parsed.origOptions, dtstart: REFERENCE_OCCURRENCE_ANCHOR });
+  return rule.after(now, false)?.getTime() ?? null;
 }
 
 describe("formatClockTime", () => {
@@ -318,5 +328,27 @@ describe("nextRunAtMs", () => {
 
   it("returns null for an unparseable rule", () => {
     expect(nextRunAtMs("garbage", "UTC")).toBeNull();
+  });
+
+  it.each([
+    "FREQ=HOURLY;BYMINUTE=3",
+    "FREQ=HOURLY;INTERVAL=3",
+    "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+    "FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=8",
+    "FREQ=DAILY;INTERVAL=3",
+    "FREQ=MONTHLY;BYMONTHDAY=15",
+    "FREQ=YEARLY;BYMONTH=3",
+  ])("matches the deterministic 2000-anchor result for %s", (rrule) => {
+    const now = new Date("2026-07-24T05:00:00Z");
+    expect(nextRunAtMs(rrule, "UTC", now)).toBe(referenceNextRunAtMs(rrule, now));
+  });
+
+  it("computes hourly next-run values without iterating from the 2000 anchor", () => {
+    const start = performance.now();
+    const next = nextRunAtMs("FREQ=HOURLY;BYMINUTE=30", "UTC", new Date("2026-07-24T05:00:00Z"));
+    const elapsedMs = performance.now() - start;
+
+    expect(next).not.toBeNull();
+    expect(elapsedMs).toBeLessThan(30);
   });
 });

--- a/web/src/lib/scheduleText.ts
+++ b/web/src/lib/scheduleText.ts
@@ -27,6 +27,7 @@ import { RRule, rrulestr } from "rrule";
 // date makes BY* rules fully determine the schedule. Matches the server's
 // fixed-deterministic-anchor approach.
 const OCCURRENCE_ANCHOR = new Date(Date.UTC(2000, 0, 1, 0, 0, 0));
+const FIXED_PERIOD_SAFETY_MARGIN = 2;
 
 /** Days-of-week bit set helpers. RRule weekday order is MO..SU (0..6). */
 const WEEKDAYS = [RRule.MO, RRule.TU, RRule.WE, RRule.TH, RRule.FR].map((d) => d.weekday);
@@ -197,18 +198,21 @@ export function nextRunAtMs(
 ): number | null {
   const base = tryParse(rrule);
   if (!base) return null;
-  // Rebuild with a fixed dtstart so occurrence generation is anchored
-  // deterministically (see OCCURRENCE_ANCHOR) rather than to import-time now.
-  let rule: RRule;
-  try {
-    rule = new RRule({ ...base.origOptions, dtstart: OCCURRENCE_ANCHOR });
-  } catch {
-    return null;
-  }
   // rrule's `.after` treats the DTSTART/occurrences as UTC-naive wall times.
   // Query against a "now" that is itself the current wall time in the task's
   // timezone, so the comparison happens in the rule's frame.
   const nowInTz = shiftWallClock(now, timezone);
+  // Rebuild with a fixed dtstart so occurrence generation is anchored
+  // deterministically (see OCCURRENCE_ANCHOR) rather than to import-time now.
+  // For fixed-period rules, move that anchor forward by whole periods so rrule
+  // only iterates near "now" while preserving the original 2000-based phase.
+  const dtstart = occurrenceAnchorNear(base, nowInTz);
+  let rule: RRule;
+  try {
+    rule = new RRule({ ...base.origOptions, dtstart });
+  } catch {
+    return null;
+  }
   let occurrence: Date | null;
   try {
     occurrence = rule.after(nowInTz, false);
@@ -227,6 +231,40 @@ export function nextRunAtMs(
 function firstOf(v: number | number[] | null | undefined): number | null {
   if (v == null) return null;
   return Array.isArray(v) ? (v.length > 0 ? v[0]! : null) : v;
+}
+
+function occurrenceAnchorNear(rule: RRule, nowInRuleFrame: Date): Date {
+  const periodMs = fixedPeriodMs(rule);
+  if (periodMs == null) return OCCURRENCE_ANCHOR;
+
+  const elapsedMs = nowInRuleFrame.getTime() - OCCURRENCE_ANCHOR.getTime();
+  if (elapsedMs <= 0) return OCCURRENCE_ANCHOR;
+
+  const periodsSinceAnchor = Math.floor(elapsedMs / periodMs);
+  const periodsToAdvance = Math.max(0, periodsSinceAnchor - FIXED_PERIOD_SAFETY_MARGIN);
+  return new Date(OCCURRENCE_ANCHOR.getTime() + periodsToAdvance * periodMs);
+}
+
+function fixedPeriodMs(rule: RRule): number | null {
+  const interval =
+    typeof rule.origOptions.interval === "number" && rule.origOptions.interval > 1
+      ? rule.origOptions.interval
+      : 1;
+
+  switch (rule.origOptions.freq) {
+    case RRule.SECONDLY:
+      return interval * 1000;
+    case RRule.MINUTELY:
+      return interval * 60_000;
+    case RRule.HOURLY:
+      return interval * 3_600_000;
+    case RRule.DAILY:
+      return interval * 86_400_000;
+    case RRule.WEEKLY:
+      return interval * 604_800_000;
+    default:
+      return null;
+  }
 }
 
 /** Normalize a scalar-or-array RRULE option (e.g. bymonthday, bymonth) to a

--- a/web/src/pages/TasksPage.test.tsx
+++ b/web/src/pages/TasksPage.test.tsx
@@ -28,16 +28,20 @@ vi.mock("@/components/scheduled/CreateScheduledTaskDialog", () => ({
     open,
     initialName,
     initialPrompt,
+    editingTask,
   }: {
     open: boolean;
     initialName?: string;
     initialPrompt?: string;
+    editingTask?: ScheduledTask | null;
   }) =>
     open ? (
       <div
         data-testid="manual-dialog-open"
         data-initial-name={initialName ?? ""}
         data-initial-prompt={initialPrompt ?? ""}
+        data-editing-task-id={editingTask?.id ?? ""}
+        data-editing-task-name={editingTask?.name ?? ""}
       />
     ) : null,
 }));
@@ -334,6 +338,17 @@ describe("suggestion prefill", () => {
 });
 
 describe("row actions", () => {
+  it("opens edit mode for a task from the row menu", () => {
+    setTasks([task({ id: "st_edit", name: "Morning brief" })]);
+    renderPage();
+    fireEvent.pointerDown(screen.getByTestId("task-row-menu"), { button: 0 });
+    fireEvent.click(screen.getByTestId("task-edit"));
+    const dialog = screen.getByTestId("manual-dialog-open");
+    expect(dialog.getAttribute("data-editing-task-id")).toBe("st_edit");
+    expect(dialog.getAttribute("data-editing-task-name")).toBe("Morning brief");
+    expect(dialog.getAttribute("data-initial-name")).toBe("");
+  });
+
   it("pauses an active task via the row menu (Pause label reflects state)", () => {
     setTasks([task({ id: "st_1", state: "active" })]);
     renderPage();

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -46,6 +46,7 @@ export function TasksPage() {
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<FilterTab>("all");
   const [manualOpen, setManualOpen] = useState(false);
+  const [editingTask, setEditingTask] = useState<ScheduledTask | null>(null);
   // Prefill for the manual create dialog when opened from a "Suggestions" chip.
   // Null → the normal manual path (empty fields). Cleared on dialog close so a
   // stale prefill never leaks into a subsequent plain "New task" open.
@@ -53,17 +54,22 @@ export function TasksPage() {
 
   function openManual() {
     setPrefill(null);
+    setEditingTask(null);
     setManualOpen(true);
   }
 
   function openFromSuggestion(s: ScheduledTaskSuggestion) {
     setPrefill(s.prefill);
+    setEditingTask(null);
     setManualOpen(true);
   }
 
   function handleManualOpenChange(next: boolean) {
     setManualOpen(next);
-    if (!next) setPrefill(null);
+    if (!next) {
+      setPrefill(null);
+      setEditingTask(null);
+    }
   }
 
   const filtered = useMemo(() => {
@@ -110,6 +116,12 @@ export function TasksPage() {
 
   function handleDelete(task: ScheduledTask) {
     deleteMutation.mutate(task.id);
+  }
+
+  function handleEdit(task: ScheduledTask) {
+    setPrefill(null);
+    setEditingTask(task);
+    setManualOpen(true);
   }
 
   const hasAnyTasks = (tasks ?? []).length > 0;
@@ -198,6 +210,7 @@ export function TasksPage() {
               key={task.id}
               task={task}
               busy={busyId === task.id}
+              onEdit={handleEdit}
               onPauseToggle={handlePauseToggle}
               onDelete={handleDelete}
             />
@@ -218,6 +231,7 @@ export function TasksPage() {
         onOpenChange={handleManualOpenChange}
         initialName={prefill?.name}
         initialPrompt={prefill?.prompt}
+        editingTask={editingTask}
       />
     </PageScroll>
   );

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -81,6 +81,11 @@ export function TasksPage() {
       if (q && !t.name.toLowerCase().includes(q)) return false;
       return true;
     });
+    const nextRunByTaskId = new Map(
+      matches
+        .filter((t) => t.state === "active")
+        .map((t) => [t.id, nextRunAtMs(t.rrule, t.timezone)]),
+    );
     // Sort: ACTIVE first (soonest next-run at the top), PAUSED last. The
     // least-actionable (paused) rows sink to the bottom rather than leading the
     // list. Active rows with no computable next-run sort after those that have
@@ -90,8 +95,8 @@ export function TasksPage() {
       const bPaused = b.state === "paused";
       if (aPaused !== bPaused) return aPaused ? 1 : -1;
       if (aPaused && bPaused) return a.name.localeCompare(b.name);
-      const aNext = nextRunAtMs(a.rrule, a.timezone);
-      const bNext = nextRunAtMs(b.rrule, b.timezone);
+      const aNext = nextRunByTaskId.get(a.id) ?? null;
+      const bNext = nextRunByTaskId.get(b.id) ?? null;
       if (aNext == null && bNext == null) return a.name.localeCompare(b.name);
       if (aNext == null) return 1;
       if (bNext == null) return -1;


### PR DESCRIPTION
## Related issue

N/A - tracked in Linear ([OMNI-1193](https://linear.app/omnigent/issue/OMNI-1193)).

## Summary

Adds the Scheduled Tasks **edit flow**, replaces enumerated time dropdowns with a **typed time input + compact picker**, and hardens the create/edit dialog after a round of interaction/layout bug fixes.

- **Edit flow** — update an existing scheduled task from `/tasks`; changes persist via the scheduled-task PATCH path, and existing RRULEs round-trip through the form (no rejection/snapping of non-quarter-hour values).
- **Typed time input** — enter precise times (`5:00 PM`, `5:07 PM`, `17:07`) instead of a long menu; hourly schedules accept any minute `0–59`. Invalid input shows inline validation and blocks submit.
- **Time picker** — a compact hour/minute/AM-PM popover; the minute column lists **all 0–59** (quarter-hours were never a real constraint — any `BYMINUTE` is a valid RRULE under the 1-hour floor), and it coexists with the text field.
- **Dialog polish / bug fixes** (this branch):
  - **Picker scroll** — the modal's scroll-lock (`react-remove-scroll`) was swallowing wheel events over the portalled picker; a window-capture wheel handler restores trackpad/wheel scroll in the columns.
  - **Type-through** — the shared `Input` primitive now `forwardRef`s, so the "don't reformat while focused" guard works and typing `1:15` no longer gets rewritten to `01:00 AM` mid-entry.
  - **Layout** — Host field is full-width (matches Name/Prompt), all dialog fields render at a consistent `text-sm`, and the grey footer band was removed.
  - **Footer clip** — the edit modal (tall body when a host/workspace picker renders) no longer clips the Cancel/Save buttons; the dialog is now a proper flex column instead of a fragile `calc()` height.

**ELI5:** You can now edit a scheduled task and type the exact time it should run (like `5:07 PM`), and the time picker scrolls, the fields line up, and the Save button no longer gets cut off.

## Test Plan

Automated:

~~~bash
cd web
npx tsc -b            # typecheck
npx vitest run        # full web unit/component suite
~~~

Results:

- `npx tsc -b`: exit 0.
- Full Vitest suite: **4488 passed**, 3 expected-fail, 1 skipped (259 files) — the shared `Input` `forwardRef` change caused zero fallout.

E2E (added to satisfy the "E2E UI Required" gate):

~~~bash
pytest tests/e2e_ui/scheduled/   # create/edit modal journey
~~~

- New Playwright test in `tests/e2e_ui/scheduled/` covering: create-via-typing a precise time, selecting an off-grid minute (`:37`) from the picker, and an edit round-trip with the Save/Cancel footer asserted visible.

Manual (browser):

- Verified on the dev server at `http://127.0.0.1:5173/tasks`: wheel-scroll works in the picker; typing `1:15` stays as typed; minute column shows 00–59; Name/Prompt/Frequency/Time/Host render at the same size; grey footer gone; edit-modal Save/Cancel fully visible with a pinned host.
- Note: SP2K browser-pane pixel screenshots came back empty (embed-root quirk), so the above were verified via live DOM/measurement, not screenshots — a manual recording should be attached before final review.

## Demo


https://github.com/user-attachments/assets/5ae67b18-5f25-4452-9a82-1eb20f3bb68a





## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit/component tests (Vitest) cover time parsing, RRULE building, the focused-typing guard, and field styling. A Playwright e2e_ui test covers the create/edit modal journey end-to-end. Manual browser verification covered the interaction/layout fixes (scroll-lock, footer clip) that unit tests can't reproduce; a visual recording is still to be attached.

## Changelog

Edit scheduled tasks and type exact run times, with a scrollable time picker and a consistent, fully-visible dialog.