### PR TITLE
fix(codex-native): stop runner hanging on delta-coalescer close

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -1075,14 +1075,23 @@ class _OutputTextDeltaCoalescer:
         """
         Flush all deltas queued before this call.
 
-        :returns: None after all earlier deltas have been posted.
+        Callers use this as an ordering fence before posting a boundary
+        event, so a stopped worker drops its undelivered deltas rather
+        than letting a replacement post them after the boundary.
+
+        :returns: None after all earlier deltas have been posted or
+            dropped.
         """
-        if self._worker_task is None:
+        worker = self._worker_task
+        if worker is None or self._release_stopped_worker(worker):
             return
         loop = asyncio.get_running_loop()
         done: asyncio.Future[None] = loop.create_future()
         self._queue.put_nowait(_DeltaFlushBarrier(done=done))
-        await done
+        # Wait on the worker too. Only the worker resolves the barrier, so
+        # awaiting the barrier alone never returns once the worker stops.
+        await asyncio.wait({done, worker}, return_when=asyncio.FIRST_COMPLETED)
+        self._release_stopped_worker(worker)
 
     async def close(self) -> None:
         """
@@ -1090,14 +1099,62 @@ class _OutputTextDeltaCoalescer:
 
         :returns: None after the worker has stopped.
         """
-        if self._worker_task is None:
+        worker = self._worker_task
+        if worker is None:
             return
-        loop = asyncio.get_running_loop()
-        done: asyncio.Future[None] = loop.create_future()
-        self._queue.put_nowait(_DeltaFlushStop(done=done))
-        await done
-        await self._worker_task
-        self._worker_task = None
+        if not worker.done():
+            loop = asyncio.get_running_loop()
+            done: asyncio.Future[None] = loop.create_future()
+            self._queue.put_nowait(_DeltaFlushStop(done=done))
+            # Wait for the worker itself: it exits right after acknowledging
+            # the stop marker, and a worker cancelled by interpreter shutdown
+            # never drains the queue at all.
+            await asyncio.wait({worker})
+        self._release_stopped_worker(worker)
+
+    def _release_stopped_worker(self, worker: asyncio.Task[None]) -> bool:
+        """
+        Drop and report a worker that stopped without draining its queue.
+
+        Clearing the slot lets the next :meth:`append` start a replacement,
+        so later deltas still reach AP; keeping a dead worker would buffer
+        them forever.
+
+        :param worker: Background delta worker.
+        :returns: ``True`` when the worker had stopped.
+        """
+        if not worker.done():
+            return False
+        if not worker.cancelled() and worker.exception() is not None:
+            _logger.warning(
+                "Codex forwarder delta worker stopped early",
+                exc_info=worker.exception(),
+            )
+        if self._worker_task is worker:
+            self._worker_task = None
+            self._discard_queued()
+        return True
+
+    def _discard_queued(self) -> None:
+        """
+        Drop the queue a stopped worker left behind.
+
+        These deltas are already past the ordering fence their flush
+        promised, so a replacement worker must not post them after the
+        boundary event that followed.
+
+        :returns: None.
+        """
+        while True:
+            try:
+                item = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+            if isinstance(item, _DeltaChunk):
+                continue
+            # Release any concurrent waiter parked on a dropped barrier.
+            if not item.done.done():
+                item.done.set_result(None)
 
     def _ensure_worker(self) -> None:
         """

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
+import subprocess
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -9933,3 +9936,374 @@ def test_rollout_records_without_compaction_item_has_no_compacted_entry() -> Non
     )
     types = [r["type"] for r in records]
     assert "compacted" not in types
+
+
+_COALESCER_SHUTDOWN_SCRIPT = '''\
+"""Drive a forwarder-shaped task through asyncio.run()'s shutdown cancellation."""
+
+import asyncio
+
+import omnigent.codex_native_forwarder as fwd
+
+
+async def _noop_post(*args, **kwargs):
+    """Swallow event posts so the coalescer needs no HTTP client."""
+    return None
+
+
+async def _forwarder_like(coalescer):
+    """Mirror supervise_forwarder: block, then clean up in a finally."""
+    try:
+        await asyncio.sleep(3600)
+    finally:
+        __CLEANUP__
+
+
+async def _main():
+    """Start a coalescer worker, then return so asyncio.run() cancels it."""
+    fwd._post_output_text_delta = _noop_post
+    coalescer = fwd._OutputTextDeltaCoalescer(None, "conv_repro")
+    await coalescer.append("hello\\n")
+    asyncio.create_task(_forwarder_like(coalescer), name="codex-forwarder-repro")
+    await asyncio.sleep(0.2)
+
+
+asyncio.run(_main())
+'''
+
+
+def _run_coalescer_shutdown_script(tmp_path: Path, cleanup: str) -> None:
+    """
+    Run the shutdown repro in a subprocess and require a clean exit.
+
+    :param tmp_path: Directory for the generated script.
+    :param cleanup: Cleanup statement placed in the task's ``finally``,
+        e.g. ``"await coalescer.close()"``.
+    :returns: None.
+    """
+    script = tmp_path / "coalescer_shutdown.py"
+    script.write_text(_COALESCER_SHUTDOWN_SCRIPT.replace("__CLEANUP__", cleanup), encoding="utf-8")
+    repo_root = Path(codex_native_forwarder.__file__).resolve().parents[1]
+    try:
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=repo_root,
+            env={**os.environ, "PYTHONPATH": str(repo_root)},
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"interpreter shutdown hung with cleanup {cleanup!r}")
+    assert result.returncode == 0, result.stderr
+
+
+def test_interpreter_shutdown_completes_with_coalescer_close(tmp_path: Path) -> None:
+    """
+    A forwarder closing its delta coalescer on shutdown still exits.
+
+    ``asyncio.run()`` cancels the coalescer worker along with every other
+    task, so a ``close()`` that waits for the worker to acknowledge a stop
+    marker waits forever and the runner process never exits.
+    """
+    _run_coalescer_shutdown_script(tmp_path, "await coalescer.close()")
+
+
+def test_interpreter_shutdown_completes_with_coalescer_flush(tmp_path: Path) -> None:
+    """A forwarder flushing its delta coalescer on shutdown still exits."""
+    _run_coalescer_shutdown_script(tmp_path, "await coalescer.flush()")
+
+
+def test_interpreter_shutdown_completes_without_coalescer(tmp_path: Path) -> None:
+    """Control: the same task shape without the coalescer exits cleanly."""
+    _run_coalescer_shutdown_script(tmp_path, "await asyncio.sleep(0)")
+
+
+class _BlockingDeltaPost:
+    """Delta post that parks in flight until the test releases it."""
+
+    def __init__(self) -> None:
+        """
+        Initialize the post stub.
+
+        :returns: None.
+        """
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+        self.posted: list[str] = []
+
+    async def __call__(self, client: Any, session_id: str, delta: str, **kwargs: Any) -> None:
+        """
+        Park the worker mid-post, then record the delivered delta.
+
+        :param client: Unused HTTP client.
+        :param session_id: Unused conversation id.
+        :param delta: Assistant text fragment, e.g. ``"hello\\n"``.
+        :param kwargs: Remaining stream-id keyword arguments.
+        :returns: None.
+        """
+        self.entered.set()
+        await self.release.wait()
+        self.posted.append(delta)
+
+
+def _new_coalescer() -> Any:
+    """
+    Build a client-less delta coalescer for direct lifecycle tests.
+
+    :returns: Coalescer bound to ``"conv_123"``.
+    """
+    return codex_native_forwarder._OutputTextDeltaCoalescer(
+        None,  # type: ignore[arg-type]
+        "conv_123",
+    )
+
+
+async def _coalescer_with_blocked_worker(
+    post: _BlockingDeltaPost,
+) -> tuple[Any, asyncio.Task[None]]:
+    """
+    Start a coalescer whose worker is parked inside a delta post.
+
+    :param post: Blocking post stub installed on the module.
+    :returns: The coalescer and its live worker task.
+    """
+    coalescer = _new_coalescer()
+    await coalescer.append("hello\n")
+    await post.entered.wait()
+    worker = coalescer._worker_task
+    assert worker is not None
+    assert not worker.done()
+    return coalescer, worker
+
+
+def _live_worker_coalescer_run(
+    monkeypatch: pytest.MonkeyPatch,
+    call: Callable[[Any], Any],
+) -> None:
+    """
+    Cancel a live worker mid-wait and require the caller to return.
+
+    Exercises the wait itself rather than the already-stopped guard: the
+    call is in flight, with the worker still running, before the cancel.
+
+    :param monkeypatch: Fixture used to stub the delta post.
+    :param call: Coalescer method to await, e.g. ``lambda c: c.close()``.
+    :returns: None.
+    """
+    post = _BlockingDeltaPost()
+    monkeypatch.setattr(codex_native_forwarder, "_post_output_text_delta", post)
+
+    async def run() -> None:
+        """
+        Start the call, then cancel the worker under it.
+
+        :returns: None.
+        """
+        coalescer, worker = await _coalescer_with_blocked_worker(post)
+        waiter = asyncio.ensure_future(call(coalescer))
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert not waiter.done(), "call returned before the worker stopped"
+        worker.cancel()
+        await asyncio.wait_for(waiter, 5)
+        assert coalescer._worker_task is None
+
+    asyncio.run(run())
+
+
+def test_delta_coalescer_close_returns_when_live_worker_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``close()`` returns when the worker is cancelled while it waits."""
+    _live_worker_coalescer_run(monkeypatch, lambda coalescer: coalescer.close())
+
+
+def test_delta_coalescer_flush_returns_when_live_worker_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``flush()`` returns when the worker is cancelled while it waits."""
+    _live_worker_coalescer_run(monkeypatch, lambda coalescer: coalescer.flush())
+
+
+def _stopped_worker_coalescer_run(
+    monkeypatch: pytest.MonkeyPatch,
+    call: Callable[[Any], Any],
+) -> None:
+    """
+    Require the given call to return against an already-stopped worker.
+
+    :param monkeypatch: Fixture used to stub the delta post.
+    :param call: Coalescer method to await, e.g. ``lambda c: c.close()``.
+    :returns: None.
+    """
+
+    async def _noop_post(*args: Any, **kwargs: Any) -> None:
+        """Swallow delta posts."""
+        return
+
+    monkeypatch.setattr(codex_native_forwarder, "_post_output_text_delta", _noop_post)
+
+    async def run() -> None:
+        """
+        Cancel the worker behind the coalescer's back and clean up.
+
+        :returns: None.
+        """
+        coalescer = _new_coalescer()
+        await coalescer.append("hello\n")
+        await asyncio.sleep(0)
+        worker = coalescer._worker_task
+        assert worker is not None
+        worker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker
+        await asyncio.wait_for(call(coalescer), 5)
+        assert coalescer._worker_task is None
+
+    asyncio.run(run())
+
+
+def test_delta_coalescer_close_returns_when_worker_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``close()`` returns once the worker is gone instead of deadlocking."""
+    _stopped_worker_coalescer_run(monkeypatch, lambda coalescer: coalescer.close())
+
+
+def test_delta_coalescer_flush_returns_when_worker_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``flush()`` returns once the worker is gone instead of deadlocking."""
+    _stopped_worker_coalescer_run(monkeypatch, lambda coalescer: coalescer.flush())
+
+
+def test_delta_coalescer_restarts_worker_after_it_stops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Deltas queued after a worker dies are still delivered.
+
+    A stopped worker leaves nothing draining the queue, so the coalescer
+    has to drop it and let the next append start a replacement.
+    """
+    posted: list[str] = []
+
+    async def _record_post(client: Any, session_id: str, delta: str, **kwargs: Any) -> None:
+        """Record a delivered delta."""
+        posted.append(delta)
+
+    monkeypatch.setattr(codex_native_forwarder, "_post_output_text_delta", _record_post)
+
+    async def run() -> None:
+        """
+        Kill the worker, then keep using the coalescer.
+
+        :returns: None.
+        """
+        coalescer = _new_coalescer()
+        await coalescer.append("first\n")
+        await asyncio.sleep(0)
+        worker = coalescer._worker_task
+        assert worker is not None
+        worker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker
+        await asyncio.wait_for(coalescer.flush(), 5)
+        await coalescer.append("second\n")
+        assert coalescer._worker_task is not worker
+        await asyncio.wait_for(coalescer.close(), 5)
+
+    asyncio.run(run())
+
+    assert "second\n" in posted
+
+
+def test_delta_coalescer_flush_fences_deltas_a_stopped_worker_left(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Deltas stranded by a stopped worker never cross their flush.
+
+    Callers flush before posting a boundary event. If the coalescer kept
+    the stranded queue, the replacement worker would post that text after
+    the boundary and the transcript would read out of order.
+    """
+    events: list[str] = []
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _blocking_first_post(
+        client: Any,
+        session_id: str,
+        delta: str,
+        **kwargs: Any,
+    ) -> None:
+        """Park the first post forever, record every later one."""
+        if not entered.is_set():
+            entered.set()
+            await release.wait()
+        events.append(delta)
+
+    monkeypatch.setattr(codex_native_forwarder, "_post_output_text_delta", _blocking_first_post)
+
+    async def run() -> None:
+        """
+        Strand a queued delta, fence it, then keep streaming.
+
+        :returns: None.
+        """
+        coalescer = _new_coalescer()
+        await coalescer.append("in flight\n")
+        await entered.wait()
+        worker = coalescer._worker_task
+        assert worker is not None
+        await coalescer.append("stranded\n")
+        worker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker
+        await asyncio.wait_for(coalescer.flush(), 5)
+        events.append("boundary")
+        await coalescer.append("after boundary\n")
+        await asyncio.wait_for(coalescer.close(), 5)
+
+    asyncio.run(run())
+
+    assert events == ["boundary", "after boundary\n"]
+
+
+def test_delta_coalescer_survives_cancelled_flush_waiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Cancelling a caller mid-flush leaves the worker able to finish.
+
+    The worker resolves the flush barrier after the caller is gone, so the
+    barrier future must still be pending rather than cancelled underneath
+    it — otherwise the worker dies on ``set_result`` and leaks its Codex
+    app-server.
+    """
+    post = _BlockingDeltaPost()
+    monkeypatch.setattr(codex_native_forwarder, "_post_output_text_delta", post)
+
+    async def run() -> None:
+        """
+        Cancel a flush waiter, release the worker, then close.
+
+        :returns: None.
+        """
+        coalescer, worker = await _coalescer_with_blocked_worker(post)
+        waiter = asyncio.ensure_future(coalescer.flush())
+        for _ in range(3):
+            await asyncio.sleep(0)
+        waiter.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await waiter
+        post.release.set()
+        await asyncio.wait_for(coalescer.close(), 5)
+        assert not worker.cancelled()
+        assert worker.exception() is None
+
+    asyncio.run(run())
+
+    assert post.posted == ["hello\n"]


### PR DESCRIPTION
## Related issue

Closes #3180

## Summary

A runner that hits its idle timeout never exits. `asyncio.run()`'s `_cancel_all_tasks()` cancels **every** task, including `_OutputTextDeltaCoalescer`'s background worker. The codex forwarder's `finally` then calls `delta_coalescer.close()`, which enqueues a `_DeltaFlushStop` and bare-awaits a future that only that worker resolves. The worker is gone, so nothing resolves it: the forwarder task never completes, `_cancel_all_tasks()` never returns, and the process stays alive holding its `codex app-server` children, websockets, and terminals. In production 7 of 9 runners that announced idle-exit survived 34 minutes to 16 hours — every one of them with a codex app-server, and both runners without one exited in 0.0 minutes.

- `close()` and `flush()` now wait on the **worker task** alongside the barrier, so a stopped worker ends the wait instead of deadlocking it. A healthy worker still drains its buffer first, so a normal close loses no deltas — and no timeout is involved.
- A stopped worker is dropped from the coalescer and its failure logged, so later `append()`s start a replacement instead of buffering deltas nobody delivers.
- The queue that worker left behind is discarded with it. Callers use `flush()` as an ordering fence before posting a boundary event; a replacement worker must not post pre-fence text after that boundary.

**ELI5.** The coalescer is a mail clerk. `close()` puts a "last letter, then go home" note in the tray and waits by the door for the clerk to walk out. If the clerk was already sent home, nobody ever picks up the note — so we wait by that door forever. Now we watch the clerk instead of the note: if they're gone, we stop waiting.

```
shutdown: _cancel_all_tasks() cancels every task
   |
   +-- coalescer worker  --> CANCELLED (was the only reader of the queue)
   |
   +-- codex forwarder   --> finally: await delta_coalescer.close()
                                        |
                              before:   await done ......... never resolved -> HANG
                              after:    await wait({worker}) worker is done  -> return
```

### Why this shape, not the alternatives

`close()`'s only guard was `if self._worker_task is None` — no `.done()` / `.cancelled()` check. Three fixes were on the table:

| approach | why not |
|---|---|
| early-return on `worker.done()` | drops undelivered deltas every time it fires, including races where the worker is merely about to finish |
| bound the await with `asyncio.wait_for` | needs an invented timeout and still burns it per coalescer on every shutdown |
| **wait on the worker too** | the worker is the *only* thing that can resolve the barrier, so the wait ends exactly when it is satisfied or provably unsatisfiable |

The third also covers the race the `.done()` check alone misses: the forwarder's `finally` can run before the worker has finished processing its own cancellation, where `.done()` still reads `False` and the old code re-deadlocks.

On the fence: when a worker dies with deltas still queued, `flush()` drops them rather than raising or restarting-and-draining. These are `external_output_text_delta` posts — transient UI text; durable history rides on the conversation item the caller is about to post. Raising from the fence would take down that item post, and restarting on the cancellation path means spawning a task during interpreter shutdown, which is the failure class this PR removes.

### Distinct from #1898 / #1899

Same wedge point, different cause, worse consequence. #1899 (closed unmerged) guards `set_result` inside `_run()` — code a cancelled worker never reaches, so it does not fix this. In the captured specimens the worker is `cancelled=True`, not dead-by-exception. The bounded-vs-unbounded difference is what turns a leak into a wedged process: `_cancel_auto_forwarder_task` waits 10s and gives up, `_cancel_all_tasks()` has no timeout at all.

That said, waiting through `asyncio.wait()` does also close #1898's poisoning path as a side effect — it never touches the futures passed to it, so a caller cancelled mid-`flush()` leaves the barrier pending instead of cancelling it out from under the worker. Verified directly:

| | worker after its `flush()` caller is cancelled |
|---|---|
| `main` | `done=True`, `InvalidStateError('invalid state')` |
| this PR | alive, delta delivered normally |

There is a regression test for it here, but #1898 should get its own review — this PR is scoped to the shutdown deadlock.

### Not addressed

The issue also suggests `_entry.py` reap harness children before cancelling tasks, so a wedged forwarder cannot strand app-servers. That is a separate change and is not in this PR.

## Test Plan

Seven new tests in `tests/test_codex_native.py`. All seven fail on `main` and pass here:

```bash
.venv/bin/python -m pytest tests/test_codex_native.py -k "coalescer or shutdown_completes" -q
```

**Shutdown path (subprocess, 30s cap)** — reproduces through the real `asyncio.run()` shutdown with nothing cancelled by hand:

| test | on `main` |
|---|---|
| forwarder-shaped task closing its coalescer | hangs, killed at 30s |
| same, flushing | hangs, killed at 30s |
| control: same task shape, no coalescer | exits clean — the coalescer is the cause, not "a `finally` that awaits" |

**Direct**

- `close()` / `flush()` against an already-stopped worker return instead of deadlocking.
- `close()` / `flush()` **started against a live worker** which is then cancelled mid-wait — asserts the call had not yet returned before the cancel, so this covers the wait itself rather than the entry guard.
- A cancelled `flush()` caller leaves the worker able to finish (the #1898 case above).
- Deltas stranded by a stopped worker never cross their flush: without the fence, the replacement posts `stranded` *after* `boundary`.

**Full suite for the touched module**: `207 passed`. `pre-commit run --files omnigent/codex_native_forwarder.py tests/test_codex_native.py` — all hooks pass. mypy reports the same 132 pre-existing errors before and after, none in the changed region.

## Demo

N/A — non-visual.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The production forensics in #3180 (py-spy stacks, `gdb` interpreter dumps, `/proc/<tid>/syscall` on the blocked `wait4` threads) came from two live wedged runners and are not reproduced here; the subprocess tests reproduce the same deadlock through the real `asyncio.run()` shutdown path instead.

## Changelog

Runners with a native Codex session now exit on idle timeout instead of staying alive holding their app-server, websockets, and terminals.
