### PR TITLE
Enable background session titles by default

### DIFF
--- a/omnigent/server/background_session_titles.py
+++ b/omnigent/server/background_session_titles.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import re
 import time
 from collections.abc import Awaitable, Callable
@@ -25,11 +24,6 @@ _logger = logging.getLogger(__name__)
 # Start with harnesses whose isolated title-generation paths are verified;
 # additional harnesses can be added once they have equivalent coverage.
 _SUPPORTED_BACKGROUND_TITLE_HARNESSES = frozenset({"claude-sdk", "claude-native", "codex"})
-
-
-def background_session_titles_enabled() -> bool:
-    """Return whether automatic background titles are explicitly enabled."""
-    return os.environ.get("OMNIGENT_SESSION_RENAME") == "1"
 
 
 def _background_session_title_harness_supported(harness: str | None) -> bool:
@@ -286,7 +280,6 @@ def prepare_background_session_title(
     """Prepare a guarded first-turn title attempt for a top-level session."""
     if (
         coordinator is None
-        or not background_session_titles_enabled()
         or conversation.title is not None
         or conversation.parent_conversation_id is not None
         or not _background_session_title_harness_supported(conversation.harness_override)

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -146,7 +146,6 @@ async def test_first_message_schedules_background_semantic_title(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The first user turn returns normally while title generation runs separately."""
-    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "1")
     agent = await create_test_agent(client)
     session = await _create_session(client, agent["id"])
     generated = asyncio.Event()
@@ -212,7 +211,6 @@ async def test_background_title_failure_does_not_break_subsequent_user_turn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A failed title job leaves the session able to accept later user turns."""
-    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "1")
     agent = await create_test_agent(client)
     session = await _create_session(client, agent["id"])
     generator_started = asyncio.Event()
@@ -291,7 +289,6 @@ async def test_initial_item_schedules_background_semantic_title(
     app: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "1")
     generated = asyncio.Event()
 
     async def generator(request: BackgroundTitleRequest) -> str:
@@ -334,9 +331,7 @@ async def test_initial_item_schedules_background_semantic_title(
 async def test_native_user_item_schedules_background_semantic_title(
     client: httpx.AsyncClient,
     app: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "1")
     agent = await create_test_agent(client)
     session = await _create_session(client, agent["id"])
     generated = asyncio.Event()

--- a/tests/server/test_background_session_titles.py
+++ b/tests/server/test_background_session_titles.py
@@ -10,7 +10,6 @@ from omnigent.server.background_session_titles import (
     BackgroundSessionTitleCoordinator,
     BackgroundTitleRequest,
     RunnerBackgroundTitleGenerator,
-    background_session_titles_enabled,
     normalize_background_title,
     prepare_background_session_title,
 )
@@ -20,21 +19,12 @@ from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConver
 pytestmark = pytest.mark.asyncio
 
 
-@pytest.fixture(autouse=True)
-def _enable_background_titles(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "1")
-
-
 def _seed_session(store: SqlAlchemyConversationStore, title: str) -> str:
     conversation = store.create_conversation(kind="default", title=title)
     return conversation.id
 
 
-async def test_prepare_background_title_is_disabled_by_default(
-    db_uri: str,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("OMNIGENT_SESSION_RENAME")
+async def test_prepare_background_title_for_eligible_session(db_uri: str) -> None:
     store = SqlAlchemyConversationStore(db_uri)
     conversation = store.create_conversation(kind="default")
 
@@ -53,17 +43,7 @@ async def test_prepare_background_title_is_disabled_by_default(
         ),
     )
 
-    assert pending is None
-
-
-@pytest.mark.parametrize("value", ["", "0", "true", "yes", "on", "banana", " 1 "])
-async def test_background_titles_require_exact_opt_in(
-    monkeypatch: pytest.MonkeyPatch,
-    value: str,
-) -> None:
-    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", value)
-
-    assert background_session_titles_enabled() is False
+    assert pending is not None
 
 
 async def test_prepare_background_title_from_message(db_uri: str) -> None:
@@ -158,10 +138,8 @@ async def test_prepare_background_title_skips_non_initial_sessions(
 @pytest.mark.parametrize("harness_override", ["codex-native", "pi"])
 async def test_prepare_background_title_skips_unsupported_explicit_harnesses(
     db_uri: str,
-    monkeypatch: pytest.MonkeyPatch,
     harness_override: str,
 ) -> None:
-    monkeypatch.setenv("OMNIGENT_SESSION_RENAME", "1")
     store = SqlAlchemyConversationStore(db_uri)
     conversation = store.create_conversation(
         title=None,


### PR DESCRIPTION
## Related issue

N/A — follow-up to #3024.

## Summary

- Make non-blocking semantic session titles an unconditional default instead of requiring `OMNIGENT_SESSION_RENAME=1`.
- Remove the environment-variable gate entirely; eligible first turns automatically schedule background title generation.
- Update unit and Sessions API integration tests for the always-on behavior.

**ELI5:** New sessions now get useful short titles automatically without users or server operators configuring anything.

```text
first user message
       |
       v
immediate fallback title ---> main agent turn continues
       |
       v
background semantic title replaces fallback
```

## Test Plan

- `pytest -q tests/server/test_background_session_titles.py tests/server/integration/test_sessions_endpoints.py` — 215 passed.
- `ruff check` passed for all changed files.
- `ruff format --check` passed for all changed files.
- `python -m compileall` passed for the affected module and tests.
- `git diff --check` passed.

## Demo

N/A — non-visual server behavior.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated tests cover unconditional scheduling for eligible sessions and retain the existing harness, first-turn, and title-race guards.

## Changelog

New sessions now receive concise semantic titles automatically without additional configuration.