### PR TITLE
feat(auto-native): route native terminal harness + model via "Auto" picker

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -45,6 +45,7 @@ from omnigent.host.frames import (
 from omnigent.llms.context_window import resolve_effective_context_window
 from omnigent.native_coding_agents import (
     native_coding_agent_for_agent_name,
+    native_coding_agent_for_harness,
 )
 from omnigent.policies.types import (
     ElicitationRequest,
@@ -5111,6 +5112,94 @@ def _native_subagent_wrapper_labels(
     return _native_subagent_wrapper_labels_from_spec(sub_spec)
 
 
+# Native harness ids offered to "Auto (native)" routing, cheapest-first (matches
+# _AUTO_NATIVE_ROUTING_HARNESSES on the routing side). Used as the deterministic
+# fallback order when routing is unavailable.
+_AUTO_NATIVE_CANDIDATE_HARNESSES: tuple[str, ...] = (
+    "claude-native",
+    "codex-native",
+    "pi-native",
+)
+# Host readiness values that mean the native CLI is NOT usable for routing: a
+# routed session that lands on an uninstalled / unauthenticated CLI would fail
+# to launch, so exclude these.
+_NATIVE_UNAVAILABLE_READINESS: frozenset[Any] = frozenset({False, "binary-missing", "needs-auth"})
+
+
+def _installed_native_harnesses(host: Host | None) -> set[str]:
+    """Return the native harness ids ready to launch on *host*.
+
+    Reads the host's ``configured_harnesses`` readiness map (the same signal the
+    picker uses to gate "needs setup" rows). A harness is installed when present
+    and its value is not a not-ready marker (:data:`_NATIVE_UNAVAILABLE_READINESS`).
+    Fails open (all candidates) when the host or its readiness map is absent, so
+    an older host that reports nothing does not silently disable native routing.
+    """
+    readiness = getattr(host, "configured_harnesses", None) if host is not None else None
+    if not readiness:
+        return set(_AUTO_NATIVE_CANDIDATE_HARNESSES)
+    installed: set[str] = set()
+    for harness in _AUTO_NATIVE_CANDIDATE_HARNESSES:
+        value = readiness.get(harness)
+        if value is None or value in _NATIVE_UNAVAILABLE_READINESS:
+            continue
+        installed.add(harness)
+    return installed
+
+
+async def _resolve_native_auto(
+    body: SessionCreateRequest,
+    request: Request,
+) -> tuple[str | None, str | None, dict[str, Any] | None, str | None]:
+    """Route the "Auto (native)" pick at create time.
+
+    Reads the host's installed native CLIs (no runner needed — native candidates
+    come from the static ``infer_models`` table) and asks the router to pick a
+    native harness + model from ``body.native_auto_message``. On success returns
+    the chosen native **wrapper agent name** (e.g. ``"claude-native-ui"``) so the
+    caller can bind the session to it exactly like a normal native create. When
+    routing is unavailable, falls back to the cheapest installed native CLI (so
+    the session still lands on a terminal) and returns its wrapper agent name
+    with no model (the CLI keeps its own default).
+
+    :returns: ``(agent_name, model, verdict, error)``. ``agent_name`` is ``None``
+        only when no native CLI is installed at all; ``error`` carries a
+        human-readable reason for the routing card when routing didn't apply.
+    """
+    from omnigent.server.smart_routing import route_session_harness
+
+    host_store = getattr(request.app.state, "host_store", None)
+    host = (
+        await asyncio.to_thread(host_store.get_host, body.host_id)
+        if host_store is not None and body.host_id is not None
+        else None
+    )
+    installed = _installed_native_harnesses(host)
+    if not installed:
+        return None, None, None, "No native CLI is installed on this host."
+
+    harness, model, verdict, error = await route_session_harness(
+        body.native_auto_message or "",
+        native=True,
+        installed_native_harnesses=installed,
+    )
+    if harness is None:
+        # Routing unavailable — land on the cheapest installed native CLI so the
+        # session still opens a terminal; the CLI uses its own default model.
+        fallback = next((h for h in _AUTO_NATIVE_CANDIDATE_HARNESSES if h in installed), None)
+        native_agent = native_coding_agent_for_harness(fallback) if fallback else None
+        return (
+            native_agent.agent_name if native_agent is not None else None,
+            None,
+            None,
+            error or "Routing unavailable; using the default native harness.",
+        )
+    native_agent = native_coding_agent_for_harness(harness)
+    if native_agent is None:
+        return None, None, None, error or "Routed harness is not a native terminal harness."
+    return native_agent.agent_name, model, verdict, None
+
+
 async def _create_session_from_existing_agent(
     conversation_store: ConversationStore,
     agent_store: AgentStore,
@@ -5161,9 +5250,39 @@ async def _create_session_from_existing_agent(
     _reject_reserved_cost_control_label_seed(body.labels)
     _reject_server_reserved_label_seed(body.labels)
 
+    # "Auto (native)": route among the host's installed native CLIs from the
+    # first-message text and bind the chosen native WRAPPER agent, so the rest of
+    # this function treats it as a normal native terminal create (no sentinel, no
+    # harness_override). Resolved before agent validation so the effective
+    # agent_id is the real wrapper agent. The routed model + a routing card are
+    # applied after the row exists (see below).
+    _native_auto_model: str | None = None
+    _native_auto_verdict: dict[str, Any] | None = None
+    _native_auto_error: str | None = None
+    _effective_agent_id = body.agent_id
+    if body.native_auto:
+        (
+            _na_agent_name,
+            _native_auto_model,
+            _native_auto_verdict,
+            _native_auto_error,
+        ) = await _resolve_native_auto(body, request)
+        if _na_agent_name is None:
+            raise OmnigentError(
+                _native_auto_error or "No native CLI is available for Auto routing on this host.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        _na_agent = await asyncio.to_thread(agent_store.get_by_name, _na_agent_name)
+        if _na_agent is None:
+            raise OmnigentError(
+                f"Native wrapper agent {_na_agent_name!r} is not registered on this server.",
+                code=ErrorCode.INTERNAL_ERROR,
+            )
+        _effective_agent_id = _na_agent.id
+
     agent = await validate_session_agent(
         user_id=user_id,
-        agent_id=body.agent_id,
+        agent_id=_effective_agent_id,
         agent_store=agent_store,
         permission_store=permission_store,
         conversation_store=conversation_store,
@@ -5187,7 +5306,8 @@ async def _create_session_from_existing_agent(
     # element at terminal launch, so reject shell-/flag-shaped values
     # before any row or worktree exists.
     model_override, reasoning_effort = validate_session_model_metadata(
-        model_override=body.model_override,
+        # For Auto (native), the routed model wins; the client sends no model.
+        model_override=_native_auto_model if body.native_auto else body.model_override,
         reasoning_effort=body.reasoning_effort,
     )
 
@@ -5446,6 +5566,22 @@ async def _create_session_from_existing_agent(
         conv = await asyncio.to_thread(conversation_store.get_conversation, conv.id)
     elif body.labels:
         await asyncio.to_thread(conversation_store.set_labels, conv.id, body.labels)
+
+    # Auto (native): surface the routing decision as a transcript card so the
+    # user sees which native harness + model was picked (or why routing fell
+    # back). Emitted after the row exists.
+    if body.native_auto:
+        if _native_auto_model is not None and _native_auto_verdict is not None:
+            await _emit_server_routing_decision(
+                conv.id, conversation_store, _native_auto_model, _native_auto_verdict
+            )
+        elif _native_auto_error is not None:
+            await _emit_server_routing_decision(
+                conv.id,
+                conversation_store,
+                "unavailable",
+                {"rationale": _native_auto_error, "applied": False},
+            )
 
     # Emit session.created exactly once at creation time.
     # Best-effort: skip if the host opted out via HostHelloFrame.

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1330,6 +1330,16 @@ class SessionCreateRequest(BaseModel):
         the spec's declared harness. Create-time only — there is no
         PATCH path, since the harness process spawns on the first
         turn.
+    :param native_auto: When ``True``, the new-chat "Auto" native option:
+        the server routes among the host's installed native terminal
+        harnesses (claude-native / codex-native / pi-native) using
+        ``native_auto_message`` and binds the session to the chosen native
+        wrapper agent. ``agent_id`` is ignored on this path. The user's
+        message is still delivered by the client after navigation, as usual.
+    :param native_auto_message: The user's first-message text used to route
+        the native harness when ``native_auto`` is set. Routing-only — it is
+        not persisted or dispatched (the client sends the actual message
+        after the create returns).
     """
 
     agent_id: str
@@ -1347,6 +1357,8 @@ class SessionCreateRequest(BaseModel):
     reasoning_effort: str | None = None
     cost_control_mode_override: str | None = None
     harness_override: str | None = None
+    native_auto: bool = False
+    native_auto_message: str | None = None
 
     @model_validator(mode="after")
     def _check_git_requires_host(self) -> SessionCreateRequest:

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -58,6 +58,7 @@ _HARNESS_FAMILY: dict[str, str] = {
     "claude_sdk": "claude",
     "claude-native": "claude",
     "pi": "pi",
+    "pi-native": "pi",
     "codex": "gpt",
     "codex-native": "gpt",
     "openai-agents": "gpt",
@@ -602,6 +603,18 @@ class ExternalRoutingClient:
 # them. claude-sdk owns Claude models; pi is the last-resort multi-model home.
 _AUTO_ROUTING_HARNESSES: tuple[str, ...] = ("claude-sdk", "codex", "pi")
 
+# Native terminal harnesses offered when the user picks "Auto (native)" in the
+# native picker. Unlike the SDK set above, these land as terminal sessions
+# (embedded CLI TUI) and bake the model into the launch argv once. Candidates
+# are intersected with the host's installed native CLIs at routing time (an
+# uninstalled CLI can't launch), so this tuple is the full menu and the caller
+# supplies the installed subset. Same cheapest-first tiebreak order.
+_AUTO_NATIVE_ROUTING_HARNESSES: tuple[str, ...] = (
+    "claude-native",
+    "codex-native",
+    "pi-native",
+)
+
 # The live runner catalog (fetch_runner_models) keys rows by WORKER name — the
 # sub-agent names declared in the parent spec (e.g. "claude_code") plus "self"
 # for the session's own harness — NOT by harness id. Map the common worker
@@ -681,6 +694,8 @@ async def route_session_harness(
     session_id: str | None = None,
     catalog_session_id: str | None = None,
     runner_client: httpx.AsyncClient | None = None,
+    native: bool = False,
+    installed_native_harnesses: set[str] | None = None,
 ) -> tuple[str | None, str | None, dict[str, Any] | None, str | None]:
     """Pick the best harness + model for a new session via the routing client.
 
@@ -688,7 +703,8 @@ async def route_session_harness(
     (defaulting to *session_id*) and *runner_client* are provided, falling back
     to the static ``infer_models`` table for any harness not represented in the
     live data.  Only harnesses in :data:`_AUTO_ROUTING_HARNESSES` are offered as
-    candidates.
+    candidates — or, when *native* is set, :data:`_AUTO_NATIVE_ROUTING_HARNESSES`
+    intersected with *installed_native_harnesses*.
 
     :param user_message: The user's first message text, used to size the task.
     :param session_id: Session being routed (optional).
@@ -699,6 +715,14 @@ async def route_session_harness(
         ``"self"`` row and would force the static fallback. Defaults to
         *session_id* when unset.
     :param runner_client: HTTP client pointed at the runner (optional).
+    :param native: When set, route among native terminal harnesses
+        (:data:`_AUTO_NATIVE_ROUTING_HARNESSES`) so the session lands as a native
+        terminal, instead of the in-process SDK harnesses. Candidates come from
+        the static ``infer_models`` table (no runner catalog needed).
+    :param installed_native_harnesses: Native harness ids actually installed on
+        the session's host. Only meaningful with *native*; candidates are
+        intersected with this set so routing never picks an uninstalled CLI. An
+        empty/``None`` set yields no candidates (returns the standard error).
     :returns: ``(harness, model, verdict, error)`` — on success ``error`` is
         ``None``; on failure ``harness``, ``model``, and ``verdict`` are ``None``
         and ``error`` carries a human-readable reason shown in the UI.
@@ -713,40 +737,54 @@ async def route_session_harness(
     if _caps is None or _caps.routing_client is None:
         return None, None, None, "Intelligent routing is not configured on this server."
 
-    # Fetch the live catalog. Its rows are keyed by worker name (sub-agent
-    # names + "self"), so normalize those to harness ids before matching
-    # against _AUTO_ROUTING_HARNESSES. Prefer catalog_session_id (the parent
-    # for a sub-agent) so the candidate set is the full spawnable-worker map,
-    # independent of whether the routed session is top-level or a sub-agent.
-    _catalog_sid = catalog_session_id or session_id
-    live_catalog: dict[str, list[str]] | None = None
-    if _catalog_sid and runner_client is not None:
-        live_catalog = await fetch_runner_models(_catalog_sid, runner_client)
-
-    # NOTE: we do NOT filter incompatible (harness, model) pairs out of the
-    # candidate set here. The external router (task_v0) enforces a required
-    # model set and 400s if any required model is missing, so dropping e.g.
-    # gpt-5-6-luna would break the whole request. Instead we send the full set
-    # and correct an incompatible verdict afterward via
-    # _redirect_incompatible_pick.
     harness_models: dict[str, list[str]] = {}
-    if live_catalog:
-        for worker_name, worker_models in live_catalog.items():
-            harness = _WORKER_NAME_TO_HARNESS.get(worker_name)
-            if harness is None or harness not in _AUTO_ROUTING_HARNESSES:
+    if native:
+        # Native terminal harnesses are not in the live runner catalog (its rows
+        # are the in-process SDK workers), so build candidates from the static
+        # infer_models table, restricted to the native CLIs installed on the
+        # host. No runner is needed. An empty install set leaves harness_models
+        # empty → the standard "no routable" error below.
+        installed = installed_native_harnesses or set()
+        for h in _AUTO_NATIVE_ROUTING_HARNESSES:
+            if h not in installed:
                 continue
-            if worker_models:
-                # First worker wins for a given harness id (dedupe).
-                harness_models.setdefault(harness, worker_models)
-
-    # Fall back to the static table when the live catalog produced no
-    # routable candidates (e.g. a child session whose catalog only lists
-    # "self" under an unrecognized worker name, or the runner was unreachable).
-    if not harness_models:
-        for h in _AUTO_ROUTING_HARNESSES:
             models = infer_models(h)
             if models:
                 harness_models[h] = models
+    else:
+        # Fetch the live catalog. Its rows are keyed by worker name (sub-agent
+        # names + "self"), so normalize those to harness ids before matching
+        # against _AUTO_ROUTING_HARNESSES. Prefer catalog_session_id (the parent
+        # for a sub-agent) so the candidate set is the full spawnable-worker map,
+        # independent of whether the routed session is top-level or a sub-agent.
+        _catalog_sid = catalog_session_id or session_id
+        live_catalog: dict[str, list[str]] | None = None
+        if _catalog_sid and runner_client is not None:
+            live_catalog = await fetch_runner_models(_catalog_sid, runner_client)
+
+        # NOTE: we do NOT filter incompatible (harness, model) pairs out of the
+        # candidate set here. The external router (task_v0) enforces a required
+        # model set and 400s if any required model is missing, so dropping e.g.
+        # gpt-5-6-luna would break the whole request. Instead we send the full
+        # set and correct an incompatible verdict afterward via
+        # _redirect_incompatible_pick.
+        if live_catalog:
+            for worker_name, worker_models in live_catalog.items():
+                harness = _WORKER_NAME_TO_HARNESS.get(worker_name)
+                if harness is None or harness not in _AUTO_ROUTING_HARNESSES:
+                    continue
+                if worker_models:
+                    # First worker wins for a given harness id (dedupe).
+                    harness_models.setdefault(harness, worker_models)
+
+        # Fall back to the static table when the live catalog produced no
+        # routable candidates (e.g. a child session whose catalog only lists
+        # "self" under an unrecognized worker name, or the runner was unreachable).
+        if not harness_models:
+            for h in _AUTO_ROUTING_HARNESSES:
+                models = infer_models(h)
+                if models:
+                    harness_models[h] = models
 
     if not harness_models:
         return None, None, None, "No routable harnesses are available on this runner."
@@ -795,8 +833,12 @@ async def route_session_harness(
     # Redirect an incompatible (harness, model) pick the router may have
     # returned despite our filtered candidate set (some external routers
     # ignore it): a Claude model or gpt-5.5+ reasoning model on pi is
-    # redirected to claude-sdk / codex respectively.
-    _redirected = _redirect_incompatible_pick(chosen_harness, result.model)
+    # redirected to claude-sdk / codex respectively. Native routing keeps its
+    # pick verbatim — the redirect targets are SDK harnesses and would break the
+    # native terminal landing.
+    _redirected = (
+        chosen_harness if native else _redirect_incompatible_pick(chosen_harness, result.model)
+    )
     if _redirected != chosen_harness:
         _logger.info(
             "smart_routing: redirecting incompatible pick harness=%s model=%s -> harness=%s",

--- a/tests/e2e_ui/chat/test_auto_native_harness.py
+++ b/tests/e2e_ui/chat/test_auto_native_harness.py
@@ -1,0 +1,195 @@
+"""E2E: the New Chat picker's "Auto" native-routing option.
+
+The landing composer (``NewChatLandingScreen`` in
+``web/src/shell/NewChatDialog.tsx``) offers an **"Auto"** row at the top of the
+**Harnesses** group when smart routing is enabled (``/v1/info`` →
+``smart_routing_enabled``) and at least one native CLI (claude-native /
+codex-native / pi-native) is ready on the selected host
+(``configured_harnesses``). The row binds to no real agent (its active state is
+independent of the selected agent), and Send posts ``native_auto: true`` +
+``native_auto_message`` so the server routes among installed native CLIs and
+binds the chosen wrapper agent. The typed message is delivered normally after
+navigation, as usual.
+
+The ``page.route`` stubbing and async-in-a-fresh-thread shape are inherited from
+``chat/test_hide_unconfigured_harnesses.py`` and
+``start_session/test_start_session.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+from collections.abc import Coroutine
+from typing import Any
+
+from playwright.async_api import Route, async_playwright, expect
+
+_HOST_ID = "host_e2e"
+_HOST_NAME = "e2e-host"
+_CLAUDE_AGENT_ID = "ag_claude_e2e"
+
+# Bare create endpoint: ``/v1/sessions`` with an optional query, but NOT
+# ``/v1/sessions/{id}/...``.
+_SESSIONS_RE = re.compile(r"/v1/sessions(\?.*)?$")
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* in a dedicated thread with its own event loop."""
+    captured: dict[str, Exception] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except Exception as exc:  # surfaced on the calling thread
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+async def _wait_until(predicate, *, timeout_s: float = 15.0) -> None:
+    """Poll ``predicate`` on the event loop until true or timeout."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"condition not met within {timeout_s:.0f}s")
+
+
+def _hosts_body() -> str:
+    """Stub ``GET /v1/hosts``: one online host with claude-native ready."""
+    return json.dumps(
+        {
+            "hosts": [
+                {
+                    "host_id": _HOST_ID,
+                    "name": _HOST_NAME,
+                    "owner": "e2e",
+                    "status": "online",
+                    "configured_harnesses": {"claude-native": True},
+                }
+            ]
+        }
+    )
+
+
+def _agents_body() -> str:
+    """Stub ``GET /v1/agents``: a native Claude agent (makes the group exist)."""
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": _CLAUDE_AGENT_ID,
+                    "name": "claude-native-ui",
+                    "display_name": "Claude Code",
+                    "description": "Anthropic's coding agent",
+                    "harness": "claude-native",
+                    "skills": [],
+                }
+            ]
+        }
+    )
+
+
+async def _register_routes(page, create_bodies: list[Any]) -> None:
+    """Stub host/agent discovery, force smart routing on, capture the create POST."""
+
+    async def handle_hosts(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_hosts_body())
+
+    async def handle_agents(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_agents_body())
+
+    async def handle_events(route: Route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+        )
+
+    async def handle_info(route: Route) -> None:
+        # Patch only smart_routing_enabled on the real /v1/info body so the Auto
+        # row is offered without hard-coding the full (evolving) info shape.
+        resp = await route.fetch()
+        body = await resp.json()
+        body["smart_routing_enabled"] = True
+        await route.fulfill(status=200, content_type="application/json", body=json.dumps(body))
+
+    async def handle_sessions(route: Route) -> None:
+        if route.request.method == "POST":
+            create_bodies.append(route.request.post_data_json)
+            await route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({"id": "conv_auto_native_e2e"}),
+            )
+        else:
+            await route.continue_()
+
+    await page.route("**/v1/info", handle_info)
+    await page.route("**/v1/hosts", handle_hosts)
+    await page.route("**/v1/agents", handle_agents)
+    await page.route("**/v1/sessions/*/events", handle_events)
+    await page.route(_SESSIONS_RE, handle_sessions)
+
+
+def test_auto_native_row_appears_and_posts_native_auto(
+    seeded_session: tuple[str, str],
+) -> None:
+    """The Auto row shows under Harnesses; Send posts native_auto + message.
+
+    1. With smart routing on and claude-native ready, the picker's Harnesses
+       group leads with an "Auto" row.
+    2. Selecting it and hitting Send posts ``native_auto: true`` +
+       ``native_auto_message`` with no ``harness_override``/``model_override``.
+    """
+    base_url, session_id = seeded_session
+    del session_id  # this flow creates its own (stubbed) session
+    _run_in_fresh_loop(_drive(base_url))
+
+
+async def _drive(base_url: str) -> None:
+    create_bodies: list[Any] = []
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await _register_routes(page, create_bodies)
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # 1. The Auto row leads the Harnesses group.
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            auto_row = page.get_by_test_id("new-chat-landing-harness-auto-native")
+            await expect(auto_row).to_be_visible(timeout=30_000)
+
+            # 2. Select it, type a task, and Send.
+            await auto_row.click()
+            await page.get_by_test_id("new-chat-landing-input").fill("build me a feature")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body.get("native_auto") is True, body
+            assert body.get("native_auto_message") == "build me a feature", body
+            assert body.get("cost_control_mode_override") == "on", body
+            assert body.get("harness_override") is None, body
+            assert body.get("model_override") is None, body
+        finally:
+            await browser.close()

--- a/tests/e2e_ui/start_session/test_harness_install.py
+++ b/tests/e2e_ui/start_session/test_harness_install.py
@@ -207,11 +207,17 @@ async def _drive_install(base_url: str) -> None:
                 state="visible", timeout=30_000
             )
 
-            # Commit the Codex agent. Unconfigured harnesses intentionally fold
-            # into the More submenu once host readiness has loaded.
+            # Commit the Codex agent. Codex is the only agent here, so it is the
+            # effective selection and stays inline in the Harnesses group even
+            # though the host reports it unconfigured (the split keeps the active
+            # pick inline: `!unconfigured || a.id === effectiveAgentId`). Wait for
+            # the row to render before clicking — the agent list + host readiness
+            # load async, and clicking before the menu populates races the "needs
+            # setup" classification.
             await page.get_by_test_id("new-chat-landing-agent-select").click()
-            await page.get_by_test_id("new-chat-landing-harness-more").click()
-            await page.get_by_test_id("new-chat-landing-agent-ag_codex_e2e").click()
+            codex_row = page.get_by_test_id("new-chat-landing-agent-ag_codex_e2e")
+            await expect(codex_row).to_be_visible(timeout=30_000)
+            await codex_row.click()
 
             # The composer notice offers "Set up →", which opens the setup dialog.
             setup = page.get_by_test_id("new-chat-landing-harness-setup")

--- a/tests/server/routes/test_native_auto_routing.py
+++ b/tests/server/routes/test_native_auto_routing.py
@@ -1,0 +1,137 @@
+"""Unit tests for "Auto (native)" create-time routing helpers.
+
+Covers :func:`_installed_native_harnesses` (host readiness → installed set) and
+:func:`_resolve_native_auto` (route the native harness at create and resolve the
+wrapper agent name), which back the new-chat "Auto" native picker option.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from omnigent.server.routes._sessions.orchestration import (
+    _installed_native_harnesses,
+    _resolve_native_auto,
+)
+from omnigent.server.smart_routing import RoutingResult
+
+
+@dataclass
+class _FakeHost:
+    """Minimal stand-in exposing only ``configured_harnesses``."""
+
+    configured_harnesses: dict[str, Any] | None
+
+
+# ── _installed_native_harnesses ──────────────────────────────────────
+
+
+def test_installed_native_harnesses_filters_not_ready() -> None:
+    host = _FakeHost(
+        configured_harnesses={
+            "claude-native": True,
+            "codex-native": "binary-missing",
+            "pi-native": "needs-auth",
+        }
+    )
+    assert _installed_native_harnesses(host) == {"claude-native"}
+
+
+def test_installed_native_harnesses_fails_open_without_readiness() -> None:
+    # No host / no readiness map → all candidates (older host reports nothing).
+    assert _installed_native_harnesses(None) == {
+        "claude-native",
+        "codex-native",
+        "pi-native",
+    }
+    assert _installed_native_harnesses(_FakeHost(configured_harnesses=None)) == {
+        "claude-native",
+        "codex-native",
+        "pi-native",
+    }
+
+
+# ── _resolve_native_auto ─────────────────────────────────────────────
+
+
+class _FakeRoutingClient:
+    def __init__(self, result: RoutingResult | None) -> None:
+        self._result = result
+
+    async def route(self, message: str, available_models: dict[str, list[str]]) -> Any:
+        del message, available_models
+        return self._result
+
+
+def _request_with_host(host: _FakeHost | None) -> Any:
+    """Build a fake FastAPI request whose app.state.host_store returns *host*."""
+    host_store = SimpleNamespace(get_host=lambda _host_id: host)
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(host_store=host_store)))
+
+
+def _body(*, message: str = "refactor auth", host_id: str | None = "host_1") -> Any:
+    return SimpleNamespace(native_auto_message=message, host_id=host_id)
+
+
+@pytest.mark.asyncio
+async def test_resolve_native_auto_binds_routed_wrapper_agent() -> None:
+    """A successful route resolves to the matching native wrapper agent name."""
+    host = _FakeHost(configured_harnesses={"claude-native": True, "codex-native": True})
+    caps = SimpleNamespace(
+        routing_client=_FakeRoutingClient(
+            RoutingResult(
+                model="databricks-claude-opus-4-8",
+                rationale="complex task",
+                harness="claude-native",
+            )
+        )
+    )
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        agent_name, model, verdict, error = await _resolve_native_auto(
+            _body(), _request_with_host(host)
+        )
+    assert agent_name == "claude-native-ui"
+    assert model == "databricks-claude-opus-4-8"
+    assert verdict is not None
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_native_auto_no_installed_cli_returns_error() -> None:
+    """No installed native CLI → no agent + an error (caller 400s)."""
+    host = _FakeHost(
+        configured_harnesses={
+            "claude-native": False,
+            "codex-native": "binary-missing",
+            "pi-native": "needs-auth",
+        }
+    )
+    caps = SimpleNamespace(routing_client=_FakeRoutingClient(None))
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        agent_name, model, _verdict, error = await _resolve_native_auto(
+            _body(), _request_with_host(host)
+        )
+    assert agent_name is None
+    assert model is None
+    assert error is not None
+
+
+@pytest.mark.asyncio
+async def test_resolve_native_auto_falls_back_when_routing_unavailable() -> None:
+    """Routing returns nothing but a native CLI is installed → cheapest fallback."""
+    host = _FakeHost(configured_harnesses={"codex-native": True, "pi-native": True})
+    # Router yields no verdict (e.g. not configured) → fallback to cheapest
+    # installed native (codex-native precedes pi-native), no model.
+    caps = SimpleNamespace(routing_client=_FakeRoutingClient(None))
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        agent_name, model, _verdict, error = await _resolve_native_auto(
+            _body(), _request_with_host(host)
+        )
+    assert agent_name == "codex-native-ui"
+    assert model is None
+    assert error is not None  # surfaced as a routing-fallback card

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from omnigent.server.smart_routing import (
+    _AUTO_NATIVE_ROUTING_HARNESSES,
     _AUTO_ROUTING_HARNESSES,
     LLMRoutingClient,
     RoutingResult,
@@ -90,6 +91,8 @@ def test_infer_models_claude_sdk() -> None:
 def test_infer_models_native_harnesses() -> None:
     assert infer_models("claude-native") is not None
     assert infer_models("codex-native") is not None
+    # pi-native must resolve so "Auto (native)" can offer it as a candidate.
+    assert infer_models("pi-native") is not None
 
 
 def test_infer_models_codex() -> None:
@@ -1153,3 +1156,78 @@ async def test_route_session_harness_falls_back_by_model_when_harness_absent() -
     # deterministically resolves to codex.
     assert harness == "codex"
     assert model == "databricks-gpt-5-4-nano"
+
+
+# ── Native (Auto native) routing ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_route_session_harness_native_offers_only_installed_candidates() -> None:
+    """native=True offers only the installed native harnesses as candidates."""
+    received: list[str] = []
+
+    class _CapturingClient:
+        async def route(
+            self, _message: str, available_models: dict[str, list[str]]
+        ) -> RoutingResult | None:
+            received.extend(available_models.keys())
+            return RoutingResult(
+                model="databricks-claude-opus-4-8", rationale="x", harness="claude-native"
+            )
+
+    caps = _FakeCaps(routing_client=_CapturingClient())
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        harness, model, verdict, error = await route_session_harness(
+            "refactor auth",
+            native=True,
+            installed_native_harnesses={"claude-native", "pi-native"},
+        )
+    # Only the installed natives are candidates — codex-native is excluded.
+    assert set(received) == {"claude-native", "pi-native"}
+    assert "codex-native" not in received
+    # The native pick is kept verbatim (no SDK redirect).
+    assert harness == "claude-native"
+    assert model == "databricks-claude-opus-4-8"
+    assert verdict is not None
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_route_session_harness_native_empty_install_set_errors() -> None:
+    """No installed native CLI → the standard no-routable error (degrades safely)."""
+    caps = _FakeCaps(
+        routing_client=_FakeRoutingClient(
+            RoutingResult(
+                model="databricks-claude-opus-4-8", rationale="x", harness="claude-native"
+            )
+        )
+    )
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        harness, model, verdict, error = await route_session_harness(
+            "do work",
+            native=True,
+            installed_native_harnesses=set(),
+        )
+    assert harness is None
+    assert model is None
+    assert verdict is None
+    assert error is not None
+
+
+@pytest.mark.asyncio
+async def test_route_session_harness_native_keeps_pick_without_sdk_redirect() -> None:
+    """A native pick that would trip the SDK redirect (claude on pi) is kept as-is."""
+    expected = RoutingResult(
+        model="databricks-claude-haiku-4-5", rationale="cheap", harness="pi-native"
+    )
+    caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        harness, model, _verdict, error = await route_session_harness(
+            "quick q",
+            native=True,
+            installed_native_harnesses=set(_AUTO_NATIVE_ROUTING_HARNESSES),
+        )
+    # pi-native is not the SDK "pi", so no redirect; the native landing is kept.
+    assert harness == "pi-native"
+    assert model == "databricks-claude-haiku-4-5"
+    assert error is None

--- a/web/src/lib/agentLabels.ts
+++ b/web/src/lib/agentLabels.ts
@@ -91,6 +91,15 @@ function useHarnessCatalog<T>(select: (c: HarnessCatalog) => T, fallback: T): T 
  */
 export const AUTO_HARNESS_ID = "auto";
 
+/**
+ * Picker sentinel for the native "Auto" option. Not sent as `harness_override`
+ * (native wrapper agents reject it); instead the create request carries
+ * `native_auto: true` + `native_auto_message`, and the server routes among the
+ * host's installed native CLIs and binds the chosen wrapper agent. Used only as
+ * a client-side marker for the picker's active state.
+ */
+export const AUTO_NATIVE_HARNESS_ID = "auto-native";
+
 export function useBrainHarnessLabels(smartRoutingEnabled = false): Record<string, string> {
   const base = useHarnessCatalog((c) => c.labels, BRAIN_HARNESS_LABELS);
   if (!smartRoutingEnabled) return base;

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2757,3 +2757,73 @@ describe("NewChatLandingScreen agent picker (mobile drill-in)", () => {
     expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
   });
 });
+
+describe("NewChatLandingScreen Auto (native) harness", () => {
+  beforeEach(setupLandingMocks);
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("shows the Auto row only when smart routing is enabled", () => {
+    // Routing off → no Auto row.
+    const { unmount } = renderLanding({ smart_routing_enabled: false });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    expect(screen.queryByTestId("new-chat-landing-harness-auto-native")).toBeNull();
+    unmount();
+    cleanup();
+    // Routing on → Auto row present (default host has native CLIs ready).
+    renderLanding({ smart_routing_enabled: true });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    expect(screen.getByTestId("new-chat-landing-harness-auto-native")).toBeTruthy();
+  });
+
+  it("hides the Auto row when no native CLI is ready on the host", () => {
+    mockHosts([
+      {
+        ...host("online"),
+        configured_harnesses: {
+          "claude-native": false,
+          "codex-native": "binary-missing",
+          "pi-native": "needs-auth",
+        },
+      } as Host,
+    ]);
+    renderLanding({ smart_routing_enabled: true });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    expect(screen.queryByTestId("new-chat-landing-harness-auto-native")).toBeNull();
+  });
+
+  it("posts native_auto + native_auto_message and no harness_override", async () => {
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    renderLanding({ smart_routing_enabled: true });
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-harness-auto-native"));
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "build me a feature" },
+    });
+    fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
+
+    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = authenticatedFetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string) as {
+      native_auto?: boolean;
+      native_auto_message?: string;
+      harness_override?: string;
+      model_override?: string;
+      cost_control_mode_override?: string;
+    };
+    expect(body.native_auto).toBe(true);
+    expect(body.native_auto_message).toBe("build me a feature");
+    expect(body.cost_control_mode_override).toBe("on");
+    // Native wrappers reject harness_override; the server routes + binds.
+    expect(body.harness_override).toBeUndefined();
+    expect(body.model_override).toBeUndefined();
+  });
+});

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -111,7 +111,7 @@ import { readLastHarness, writeLastHarness } from "@/lib/harnessPreferences";
 import { readHideUnconfiguredHarnesses } from "@/lib/harnessVisibilityPreferences";
 import { readDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import { readHarnessOptions, writeHarnessOption } from "@/lib/modePreferences";
-import { AUTO_HARNESS_ID, useBrainHarnessLabels } from "@/lib/agentLabels";
+import { AUTO_HARNESS_ID, AUTO_NATIVE_HARNESS_ID, useBrainHarnessLabels } from "@/lib/agentLabels";
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
 import { partitionAgentsByKind, sortAgentsForDisplay } from "@/lib/agentGrouping";
 import { cn } from "@/lib/utils";
@@ -979,6 +979,9 @@ export function AgentHarnessPicker({
   contentAlign = "end",
   triggerClassName,
   triggerLabelClassName,
+  autoNativeAvailable = false,
+  autoNativeActive = false,
+  onSelectAutoNative,
 }: {
   agentEntries: AvailableAgent[];
   harnessEntries: AvailableAgent[];
@@ -1013,6 +1016,14 @@ export function AgentHarnessPicker({
   triggerClassName?: string;
   /** Extra classes merged onto the trigger's label span. */
   triggerLabelClassName?: string;
+  /** Whether the "Auto" native-routing row is offered (routing on + a native
+   *  CLI ready). Defaults off, so an embedding host that doesn't wire routing
+   *  simply never shows the row. */
+  autoNativeAvailable?: boolean;
+  /** Whether "Auto" is the current pick (drives the row's active state,
+   *  independent of the selected agent). */
+  autoNativeActive?: boolean;
+  onSelectAutoNative?: () => void;
 }) {
   // Controlled so picking a row can close the menu.
   const [open, setOpen] = useState(false);
@@ -1264,9 +1275,29 @@ export function AgentHarnessPicker({
             {/* Harnesses group first — the native terminal CLIs (Claude Code is
             the default), so the most-used picks lead. Ready-to-use harnesses
             list inline; "needs setup" ones fold into a "More" group. */}
-            {(readyHarnessEntries.length > 0 || moreHarnessEntries.length > 0) && (
+            {(readyHarnessEntries.length > 0 ||
+              moreHarnessEntries.length > 0 ||
+              autoNativeAvailable) && (
               <>
                 <PickerSectionHeader>Harnesses</PickerSectionHeader>
+                {autoNativeAvailable && (
+                  <DropdownMenuItem
+                    data-testid="new-chat-landing-harness-auto-native"
+                    data-active={autoNativeActive ? "true" : undefined}
+                    onSelect={() => {
+                      onSelectAutoNative?.();
+                      setOpen(false);
+                    }}
+                    className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
+                  >
+                    <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
+                      <span className="truncate">Auto</span>
+                      <span className="truncate text-[11px] text-muted-foreground/70">
+                        Pick a native CLI + model
+                      </span>
+                    </div>
+                  </DropdownMenuItem>
+                )}
                 {readyHarnessEntries.map(renderEntry)}
                 {moreHarnessEntries.length > 0 &&
                   (isMobile ? (
@@ -2825,7 +2856,14 @@ export function NewChatLandingScreen() {
   // The trigger label is just the agent name; the run-config knobs live in
   // the picker's per-entry submenu, so duplicating their values here would be
   // redundant.
-  const agentLabel = selectedAgent ? selectedAgent.display_name : "Select agent";
+  // "Auto (native)" rides on no real agent, so the trigger reads "Auto" rather
+  // than the fallback selected agent's name.
+  const agentLabel =
+    pickedHarness === AUTO_NATIVE_HARNESS_ID
+      ? "Auto"
+      : selectedAgent
+        ? selectedAgent.display_name
+        : "Select agent";
 
   // Wrap the harness setter so every explicit pick is persisted to
   // localStorage. The caller can pass an explicit `agentId` for the
@@ -2836,11 +2874,32 @@ export function NewChatLandingScreen() {
     (harness: string | null, agentId?: string) => {
       setPickedHarness(harness);
       writeLastHarness(agentId ?? effectiveAgentId, harness);
-      // Light up the routing icon when "Auto" is picked; turn it off otherwise.
-      _setCostControlMode(harness === AUTO_HARNESS_ID ? "on" : null);
+      // Light up the routing icon when either "Auto" variant is picked; both
+      // route (harness + model) and land with routing on.
+      _setCostControlMode(
+        harness === AUTO_HARNESS_ID || harness === AUTO_NATIVE_HARNESS_ID ? "on" : null,
+      );
     },
     [effectiveAgentId],
   );
+
+  // "Auto (native)": route among the host's installed native CLIs + model,
+  // landing as a native terminal. Purely a picker sentinel — it binds to NO
+  // real agent (the server routes at create and binds the chosen wrapper
+  // agent), so its active state is independent of the selected agent.
+  const anyNativeReady = useMemo(
+    () =>
+      ["claude-native", "codex-native", "pi-native"].some(
+        (h) => !harnessUnconfiguredOnHost(h, harnessWarningHost),
+      ),
+    [harnessWarningHost],
+  );
+  const autoNativeAvailable = smartRoutingEnabled && anyNativeReady;
+  const autoNativeActive = pickedHarness === AUTO_NATIVE_HARNESS_ID;
+  const handleSelectAutoNative = useCallback(() => {
+    setPickedHarness(AUTO_NATIVE_HARNESS_ID);
+    _setCostControlMode("on");
+  }, []);
 
   // Select an agent/harness from the picker. Switching agents seeds the
   // harness override from the user's last pick for that agent (so a
@@ -3021,12 +3080,20 @@ export function NewChatLandingScreen() {
             // it when routing is eligible for the effective harness, so a stale
             // "on" can't ride along invisibly with no control to clear it.
             cost_control_mode_override:
-              pickedHarness === AUTO_HARNESS_ID
+              pickedHarness === AUTO_HARNESS_ID || pickedHarness === AUTO_NATIVE_HARNESS_ID
                 ? "on"
                 : smartRoutingEligible
                   ? (costControlMode ?? undefined)
                   : undefined,
-            harness_override: pickedHarness ?? undefined,
+            // "Auto (native)": the server routes among installed native CLIs
+            // from native_auto_message and binds the chosen wrapper agent, so
+            // no harness_override is sent (native wrappers reject it). The
+            // message is still delivered normally after navigation; this copy
+            // is routing-only. The brain "auto" sentinel still rides
+            // harness_override.
+            ...(pickedHarness === AUTO_NATIVE_HARNESS_ID
+              ? { native_auto: true, native_auto_message: message }
+              : { harness_override: pickedHarness ?? undefined }),
           }),
         });
         if (!res.ok) {
@@ -3429,6 +3496,9 @@ export function NewChatLandingScreen() {
                   onSelectPending={handleSelectPending}
                   onCreateCustomAgent={() => setCreateAgentOpen(true)}
                   sandboxSelected={sandboxSelected}
+                  autoNativeAvailable={autoNativeAvailable}
+                  autoNativeActive={autoNativeActive}
+                  onSelectAutoNative={handleSelectAutoNative}
                 />
                 {/* Gear — opens the selected agent's run-config modal. Hidden
                   when the selected agent has no knobs to configure. Hovering


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds an **"Auto"** option to the New Chat native-harness picker that routes among the host's **installed native terminal harnesses** (claude-native / codex-native / pi-native) + a model from the user's first message, landing as a native **terminal** session.

Routing happens **at create time** and binds the session directly to the chosen native **wrapper agent** — so it's byte-identical to a normal native create (terminal launches, `--model` baked). No sentinel harness_override, no orchestrator involvement.

- **schemas**: `SessionCreateRequest` gains `native_auto` + `native_auto_message` (routing-only text; the message is still delivered by the client after navigation, as usual).
- **orchestration** (`_create_session_from_existing_agent`): when `native_auto`, resolve the native harness before the row is created (`route_session_harness(native=True)` over `host.configured_harnesses` — no runner needed, native candidates come from the static `infer_models` table), then bind the routed wrapper agent with the routed `model_override`. Cheapest-installed fallback when routing is unavailable; 400 only when no native CLI is installed. Emits a routing-decision card.
- **smart_routing**: `route_session_harness` gains `native` / `installed_native_harnesses`; native candidates = `_AUTO_NATIVE_ROUTING_HARNESSES` ∩ installed; `pi-native` added to `_HARNESS_FAMILY`; native picks skip the SDK-incompatibility redirect.
- **frontend**: the Auto row binds to **no real agent** — its active state is independent of the selected agent (fixes an earlier double-highlight bug where it rode on Polly). Gated on smart routing + a ready native CLI. Send posts `native_auto: true` + `native_auto_message` + `cost_control_mode_override: "on"`, no `harness_override`.

### Why the rework

An earlier iteration bound the session to the first omnigent agent (Polly, an orchestrator) with `harness_override="auto-native"`. That highlighted both the Auto and Polly picker rows and never produced a terminal (orchestrators delegate to sub-agents; native wrapper agents reject `harness_override`). This version routes → binds the real wrapper agent instead.

Note: the `OMNIGENT_SMART_ROUTING` env-gate removal that briefly lived on this branch is now the standalone #3215; it is not part of this PR.

## Test Plan

- `pytest tests/server/test_smart_routing.py` → native candidate filtering / empty-set degrade / no-redirect (51 passed).
- `pytest tests/server/routes/test_native_auto_routing.py` → `_resolve_native_auto` + `_installed_native_harnesses` unit tests (5 passed).
- `pytest tests/server/integration/test_sessions_model_override.py` → existing create paths unregressed (22 passed).
- `vitest run src/shell/NewChatDialog.test.tsx` → Auto row gating + payload shape + independent active state (153 passed).
- `pytest tests/e2e_ui/chat/test_auto_native_harness.py` → real-browser: Auto row appears, Send posts `native_auto` + message (passed).
- `tsc --noEmit` clean; `ruff` clean.

Live smoke recommended before merge: boot a server + runner with a native CLI installed, pick Auto, send a message → native terminal launches with the routed model, message appears once, routing card shows.

## Demo

N/A — will attach a recording before merge if reviewers want one.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Server routing + wrapper-agent resolution is unit-tested (`test_native_auto_routing.py`); the picker row + payload is covered by web unit + an e2e_ui browser test. The live terminal-launch path (create → native TUI) is validated manually per the Test Plan, as the mock harness doesn't boot a real CLI.

## Changelog

The native harness picker now offers an "Auto" option that picks the best installed native CLI and model for your first message

This pull request and its description were written by Isaac.