### PR TITLE
fix(web): keep sidebar wordmark visible in dark mode

### DIFF
--- a/tests/e2e_ui/sessions/test_theme_toggle.py
+++ b/tests/e2e_ui/sessions/test_theme_toggle.py
@@ -45,6 +45,14 @@ def _open_appearance(page: Page, base_url: str) -> None:
     expect(_theme_radiogroup(page)).to_be_visible(timeout=30_000)
 
 
+def _open_session_wordmark(page: Page, base_url: str, session_id: str) -> Locator:
+    """Navigate to a session and wait for the sidebar wordmark."""
+    page.goto(f"{base_url}/c/{session_id}")
+    wordmark = page.get_by_test_id("sidebar-wordmark")
+    expect(wordmark).to_be_visible(timeout=30_000)
+    return wordmark
+
+
 def test_theme_toggle_cycles_and_persists(page: Page, seeded_session: tuple[str, str]) -> None:
     """On a light OS, selecting Dark then System flips the class and persists.
 
@@ -81,6 +89,34 @@ def test_theme_toggle_cycles_and_persists(page: Page, seeded_session: tuple[str,
     expect(system).to_have_attribute("aria-checked", "true")
     assert not _html_has_dark(page), "<html> kept the dark class after returning to System"
     assert _stored_theme(page) == "system"
+
+
+def test_sidebar_wordmark_filter_tracks_theme(page: Page, seeded_session: tuple[str, str]) -> None:
+    """The sidebar wordmark is inverted in Dark mode and unchanged in Light."""
+    page.emulate_media(color_scheme="light")
+    base_url, session_id = seeded_session
+
+    _open_session_wordmark(page, base_url, session_id)
+
+    _open_appearance(page, base_url)
+    dark = _theme_radiogroup(page).get_by_role("radio", name="Dark")
+    dark.click()
+    expect(dark).to_have_attribute("aria-checked", "true")
+    assert _html_has_dark(page), "<html> did not gain the dark class after selecting Dark"
+
+    wordmark = _open_session_wordmark(page, base_url, session_id)
+    assert _html_has_dark(page), "dark class was lost after returning to the session"
+    expect(wordmark).to_have_css("filter", "invert(1)")
+
+    _open_appearance(page, base_url)
+    light = _theme_radiogroup(page).get_by_role("radio", name="Light")
+    light.click()
+    expect(light).to_have_attribute("aria-checked", "true")
+    assert not _html_has_dark(page), "<html> kept the dark class after selecting Light"
+
+    wordmark = _open_session_wordmark(page, base_url, session_id)
+    assert not _html_has_dark(page), "dark class returned after navigating to the session"
+    expect(wordmark).to_have_css("filter", "none")
 
 
 def test_theme_toggle_reaches_explicit_light_on_dark_os(

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -470,6 +470,16 @@
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+/* The source SVG is black; keep this root-theme rule flat for WebViews that
+ * do not apply nested dark variants. */
+.sidebar-wordmark {
+  filter: none;
+}
+
+.dark .sidebar-wordmark {
+  filter: invert(1);
+}
+
 /* Electron desktop shell on macOS (AppShell sets data-electron-mac when the
  * preload bridge is present on a Mac). The shell hides the native title bar
  * (titleBarStyle "hiddenInset"), which means (a) the traffic lights float

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -130,3 +130,36 @@ describe("index.css bg-card glass rule selector", () => {
     aside.remove();
   });
 });
+
+describe("index.css sidebar wordmark theme rule", () => {
+  const wordmarkRules = (cssSource.match(/[^{}]+\{[^{}]*\}/g) ?? [])
+    .filter((rule) => rule.includes(".sidebar-wordmark"))
+    .join("\n");
+
+  it("updates the black wordmark filter when the root dark class changes", () => {
+    expect(wordmarkRules).toMatch(/\.sidebar-wordmark\s*\{[^}]*filter:\s*none/);
+    expect(wordmarkRules).toMatch(/\.dark\s+\.sidebar-wordmark\s*\{[^}]*filter:\s*invert\(1\)/);
+
+    const style = document.createElement("style");
+    style.textContent = wordmarkRules;
+    const wordmark = document.createElement("img");
+    wordmark.className = "sidebar-wordmark";
+    document.head.appendChild(style);
+    document.body.appendChild(wordmark);
+
+    try {
+      document.documentElement.classList.remove("dark");
+      expect(getComputedStyle(wordmark).filter).toBe("none");
+
+      document.documentElement.classList.add("dark");
+      expect(getComputedStyle(wordmark).filter).toBe("invert(1)");
+
+      document.documentElement.classList.remove("dark");
+      expect(getComputedStyle(wordmark).filter).toBe("none");
+    } finally {
+      document.documentElement.classList.remove("dark");
+      wordmark.remove();
+      style.remove();
+    }
+  });
+});

--- a/web/src/shell/Sidebar.subagentHighlight.test.tsx
+++ b/web/src/shell/Sidebar.subagentHighlight.test.tsx
@@ -143,7 +143,7 @@ describe("sidebar highlight while viewing a sub-agent", () => {
 
     const wordmark = screen.getByTestId("sidebar-wordmark");
     expect(wordmark).toHaveAttribute("alt", "Omnigent");
-    expect(wordmark).toHaveClass("h-[15px]", "dark:invert");
+    expect(wordmark).toHaveClass("h-[15px]", "sidebar-wordmark");
     expect(wordmark.getAttribute("src")).toContain("omnigent-wordmark");
   });
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -603,7 +603,7 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
                 src={omnigentWordmark}
                 alt="Omnigent"
                 data-testid="sidebar-wordmark"
-                className="h-[15px] w-auto shrink-0 dark:invert"
+                className="sidebar-wordmark h-[15px] w-auto shrink-0"
               />
             </Link>
             <div className="flex items-center gap-1" data-testid="sidebar-header-actions">


### PR DESCRIPTION
## Related issue

Fixes #3192

## Summary

- Replace the sidebar wordmark's `dark:invert` dependency with a flat `.dark .sidebar-wordmark` rule while keeping the existing single black SVG asset.
- Tailwind v4 compiles the custom dark variant (`@custom-variant dark (&:is(.dark *))`) into a selector wrapped in `:is(.dark *)`. The affected WebView does not reliably apply that complex-selector rule, so the wordmark's computed `filter` stayed `none` in dark mode. A plain descendant selector (`.dark .sidebar-wordmark`) sidesteps both `:is()` and any nesting, so it applies reliably across WebViews and build modes.
- Add a computed-style regression test that verifies the live light -> dark -> light filter transition instead of only checking a class string.

ELI5: the logo relied on a generated dark-mode rule that some WebViews could not read; it now uses a plain CSS rule they can.

## Test Plan

- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/index.css.test.ts src/shell/Sidebar.subagentHighlight.test.tsx` — 2 files passed, 13 tests passed.
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run` — 259 files passed, 1 skipped; 4,523 tests passed, 3 expected failures, 1 skipped.
- `npm run build` — passed; 4,237 modules transformed, with 2 existing `::highlight(...)` CSS optimizer warnings. Production CSS contains the flat wordmark selectors.
- `./node_modules/.bin/oxlint src/index.css.test.ts src/shell/Sidebar.subagentHighlight.test.tsx src/shell/Sidebar.tsx` — 0 errors; 1 pre-existing warning in an unchanged `Sidebar.tsx` region.
- `npm run lint` — reproduces the current `origin/main` baseline exactly: 10 errors and 125 warnings, all unrelated to this PR.
- `uvx pre-commit run --all-files` — 20/20 hooks passed.
- Verified on-device via Chrome DevTools that the flat `.dark .sidebar-wordmark` rule computes `filter: invert(1)` under a genuine `.dark` root, where the original `dark:invert` utility computed `filter: none`.

## Demo

Before:

![Black wordmark on the dark sidebar](https://raw.githubusercontent.com/btli/omnigent/issue-assets/wordmark-dark/wordmark-dark-bug-crop.png)

After:

![White wordmark on the dark sidebar](https://raw.githubusercontent.com/btli/omnigent/issue-assets/wordmark-dark/wordmark-dark-fixed.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Loaded the app in Chrome, toggled the root `.dark` class without reloading, and confirmed the wordmark's computed `filter` changes `none -> invert(1) -> none`. The after screenshot was captured from that dark-mode state. The automated test now pins the same computed-style behavior.

## Changelog

The sidebar Omnigent wordmark now stays visible in dark mode.
