### PR TITLE
fix(benchmark-pr): use marker-based comment upsert instead of --edit-last

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -158,12 +158,20 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr comment "${{ github.event.pull_request.number }}" \
-            --edit-last \
-            --body-file comment_body.md || \
-          gh pr comment "${{ github.event.pull_request.number }}" \
-            --body-file comment_body.md
+          COMMENT_MARKER="<!-- benchmark-pr-comment -->"
+          COMMENT_ID=$(gh api --paginate \
+            "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"$COMMENT_MARKER\")) | .id" \
+            | head -1)
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="$(cat comment_body.md)"
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file comment_body.md
+          fi
 
       - name: Upload candidate results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary
- `gh pr comment --edit-last` edits the most recent PR comment regardless of author/content, so when both the benchmark and UI preview workflows ran on the same PR, the benchmark was overwriting the UI preview comment
- Switched to the same find-by-marker + `PATCH` approach used by `ui-preview.yml`: look up the existing `<!-- benchmark-pr-comment -->` comment by its marker, update it if found, otherwise create a new one

## Test Plan
- Manually reviewed that the marker `<!-- benchmark-pr-comment -->` is already written into `comment_body.md` in the "Build PR comment body" step, so the lookup will correctly identify and update only the benchmark comment

## Demo
N/A (workflow-only change)

## Type of change
- [x] Bug fix

## Test coverage
- [x] Manual verification completed

## Coverage notes
Workflow logic change; verified by code review that the marker already present in the comment body matches what the new lookup uses.