### PR TITLE
fix(scheduled): force native-harness permission bypass on headless runs

### DIFF
--- a/omnigent/server/scheduled/fire.py
+++ b/omnigent/server/scheduled/fire.py
@@ -45,6 +45,7 @@ fire path.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import logging
 import time
 import uuid
@@ -507,17 +508,61 @@ async def _resolve_default_workspace(deps: FireDeps, host_id: str) -> str:
     return canonical
 
 
+async def _headless_terminal_launch_args(deps: FireDeps, task: ScheduledTask) -> list[str] | None:
+    """Force a native harness to skip its tool-permission prompt for this run.
+
+    A scheduled task fires with no human present, so a native-terminal harness
+    that stops to ask (Claude Code's approval menu, agy's request-review, kimi's
+    in-TUI menu) parks forever and the run times out on terminal readiness.
+    Force the harness's don't-prompt flag — omnigent's own PreToolUse policy
+    hook still gates every tool call, so this only suppresses the interactive
+    prompt, mirroring the headless polly sub-agent contract.
+
+    Best-effort: any resolution failure returns ``None`` and the run proceeds
+    at the harness default rather than being blocked.
+    """
+    if deps.agent_cache is None:
+        return None
+    agent = await asyncio.to_thread(deps.agent_store.get, task.agent_id)
+    if agent is None or getattr(agent, "bundle_location", None) is None:
+        return None
+    try:
+        loaded = await asyncio.to_thread(deps.agent_cache.load, agent.id, agent.bundle_location)
+        spec = loaded.spec
+        # Synthesize the opt-in the sub-agent path reads so every native harness
+        # yields its own bypass flag (and non-native harnesses yield None),
+        # reusing the single source of truth for the per-harness flag mapping.
+        forced_config = {**(spec.executor.config or {}), "permission_mode": "bypassPermissions"}
+        forced_spec = dataclasses.replace(
+            spec, executor=dataclasses.replace(spec.executor, config=forced_config)
+        )
+        from omnigent.server.routes._sessions.helpers import (
+            _derive_terminal_launch_args_from_spec,
+        )
+
+        return _derive_terminal_launch_args_from_spec(forced_spec)
+    except Exception:
+        _logger.exception(
+            "scheduled fire: could not derive headless launch args for task %s; "
+            "running at harness default",
+            task.id,
+        )
+        return None
+
+
 async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
     """Create a conversation bound to the task's agent, carrying the stored spec."""
     # Connected-host, existing-workspace runs create the conversation directly.
     # Future execution modes such as managed sandbox, branch selection, and
     # replay/backfill must use shared session-create orchestration.
+    launch_args = await _headless_terminal_launch_args(deps, task)
     conv = await asyncio.to_thread(
         deps.conversation_store.create_conversation,
         agent_id=task.agent_id,
         title=task.name,
         host_id=task.host_id,
         workspace=task.workspace,
+        terminal_launch_args=launch_args,
     )
     if task.model_override is not None or task.reasoning_effort is not None:
         updated = await asyncio.to_thread(

--- a/tests/server/scheduled/test_fire.py
+++ b/tests/server/scheduled/test_fire.py
@@ -57,6 +57,21 @@ class FakeAgentStore:
         return self.agents.get(agent_id)
 
 
+class _FakeLoadedAgent:
+    def __init__(self, spec: Any) -> None:
+        self.spec = spec
+
+
+class FakeAgentCache:
+    """Returns a fixed spec for load(); stands in for the bundle loader."""
+
+    def __init__(self, spec: Any) -> None:
+        self._spec = spec
+
+    def load(self, agent_id: str, bundle_location: str) -> _FakeLoadedAgent:
+        return _FakeLoadedAgent(self._spec)
+
+
 class FakeScheduledTaskStore:
     """Records update/create_run calls and serves get() from a dict."""
 
@@ -978,3 +993,77 @@ async def test_managed_sandbox_is_skipped_and_recorded() -> None:
     assert launched == []
     assert len(store.runs) == 1
     assert store.runs[0]["status"] == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_native_harness_run_forces_permission_bypass() -> None:
+    """A scheduled native-terminal run launches with the harness bypass flag.
+
+    A scheduled task has no human to answer a native harness's tool-permission
+    prompt, so the fire path must force the don't-prompt flag or the terminal
+    parks on readiness. omnigent's own policy hook still gates tool use.
+    """
+    from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="news",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-native"}),
+    )
+    conv_store = FakeConversationStore()
+    agent_store = FakeAgentStore({"ag_1": _FakeAgent("ag_1", bundle_location="bundle://ag_1")})
+    store = FakeScheduledTaskStore(rows={"task_1": _task()})
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    on_fire = build_on_fire(
+        _deps(
+            store,
+            conversation_store=conv_store,
+            agent_store=agent_store,
+            agent_cache=FakeAgentCache(spec),
+        ),
+        launch_dispatch=_launch,
+    )
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert len(conv_store.created) == 1
+    assert conv_store.created[0]["terminal_launch_args"] == [
+        "--permission-mode",
+        "bypassPermissions",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_non_native_harness_run_sets_no_launch_args() -> None:
+    """A non-native (SDK) scheduled run passes no launch args (nothing to bypass)."""
+    from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="sdk",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-sdk"}),
+    )
+    conv_store = FakeConversationStore()
+    agent_store = FakeAgentStore({"ag_1": _FakeAgent("ag_1", bundle_location="bundle://ag_1")})
+    store = FakeScheduledTaskStore(rows={"task_1": _task()})
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    on_fire = build_on_fire(
+        _deps(
+            store,
+            conversation_store=conv_store,
+            agent_store=agent_store,
+            agent_cache=FakeAgentCache(spec),
+        ),
+        launch_dispatch=_launch,
+    )
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert len(conv_store.created) == 1
+    assert conv_store.created[0]["terminal_launch_args"] is None


### PR DESCRIPTION
## Related issue

N/A

## Summary

A scheduled task fires with no human present, but a native-terminal harness (claude-native / codex-native / cursor-native / antigravity-native / kimi-native) stops to ask for tool permission — Claude Code's approval menu, agy's request-review, kimi's in-TUI menu. With nobody to answer, the terminal never renders its input prompt and the run fails on readiness:

```
inner executor error: Claude Code terminal did not become ready within 30.0s
(input prompt never rendered ...). Last terminal output:
  ● Web Search("markets ...")
    ▶ Run this command?  1. Yes  2. Yes, and don't ask again  3. No
```

Observed on a claude-native "news digest" task whose web-search tool triggered Claude Code's approval prompt.

Root cause: `fire.py:_create_session` created the conversation without `terminal_launch_args`, so the harness always launched at its prompting default — there was no headless equivalent of `_derive_terminal_launch_args_from_spec` (which only runs for polly sub-agents).

Fix: derive the harness's don't-prompt flag for the run by synthesizing `permission_mode: bypassPermissions` into the spec and reusing `_derive_terminal_launch_args_from_spec` — the same single source of truth the headless polly sub-agent path uses (claude-native → `--permission-mode bypassPermissions`, codex → `--dangerously-bypass-approvals-and-sandbox`, cursor/kimi → `--yolo`, agy → `--dangerously-skip-permissions`). omnigent's own PreToolUse policy hook still gates every tool call; only the interactive prompt is suppressed. Non-native (SDK) harnesses derive no args. Best-effort: any resolution failure leaves the run at the harness default rather than blocking it.

## Test Plan

- `pytest tests/server/scheduled/test_fire.py` — 29 passed, including two new cases: a claude-native scheduled run creates its conversation with `terminal_launch_args == ["--permission-mode", "bypassPermissions"]`; a claude-sdk run passes `None`.
- Verified the derive mapping for every native harness (claude/codex/cursor/antigravity/kimi → their bypass flag; claude-sdk / openai-agents → None).
- `ruff check` / `ruff format` clean.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests pin both directions (native harness forces the bypass flag; SDK harness sets none). Manual verification reproduced the original readiness timeout on a live claude-native scheduled task and confirmed the derived flag per harness.

## Changelog

Scheduled tasks that run a native-terminal harness no longer stall on the harness's tool-permission prompt.
