### PR TITLE
fix(runner): reconcile web_fetch dispatch gate with sub-agent spec lookup (#2426)

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1209,6 +1209,25 @@ def _find_subagent_spec(sub_agent_name: str, agent_spec: Any | None) -> Any | No
     for sa in getattr(agent_spec, "sub_agents", None) or []:
         if getattr(sa, "name", None) == sub_agent_name:
             return sa
+    # Built-in web_fetch researcher: ``WebFetchTool.__init__`` appends
+    # ``__web_researcher`` to the owner's live ``sub_agents`` in memory but
+    # never serializes it, so it is absent from the runner's re-parsed spec.
+    # Reconstruct it deterministically -- the same pure builder the
+    # child-boot resolver (``workflow.py::_find_spec_by_name``) uses -- so
+    # this lookup and the dispatch gate agree the sub-agent exists. Without
+    # it, ``_has_subagent`` returns True while ``_subagent_harness`` /
+    # ``_subagent_allowed_harnesses`` (both routed through here) return
+    # ``None``, i.e. the gate and the spec lookup disagree about the same
+    # name. Reconstruction is gated inside the helper on the tree actually
+    # declaring ``web_fetch``, so a caller-supplied name cannot coerce an
+    # arbitrary parent into a shell-capable researcher.
+    from omnigent.tools.builtins.web_fetch import (
+        RESEARCHER_NAME,
+        reconstruct_researcher_spec,
+    )
+
+    if sub_agent_name == RESEARCHER_NAME:
+        return reconstruct_researcher_spec(agent_spec)
     return None
 
 
@@ -2726,11 +2745,12 @@ def _has_subagent(
     """
     if agent_spec is None:
         return False
-    # AP-style spec: sub_agents list
-    sub_agents = getattr(agent_spec, "sub_agents", None) or []
-    for sa in sub_agents:
-        if getattr(sa, "name", None) == sub_agent_name:
-            return True
+    # AP-style spec: sub_agents list, including the synthesized
+    # ``__web_researcher``. Routed through the single resolver so the gate
+    # and every downstream harness / allowlist lookup agree about whether a
+    # name exists (see :func:`_find_subagent_spec`).
+    if _find_subagent_spec(sub_agent_name, agent_spec) is not None:
+        return True
     # Omnigent inner loader: tools dict with AgentTool entries
     tools = getattr(agent_spec, "tools", None)
     if isinstance(tools, dict) and sub_agent_name in tools:

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -2743,7 +2743,8 @@ def _find_spec_by_name(
     The owning node need not be the root: a nested sub-agent may own
     ``web_fetch`` while the handed-in root does not. The gate locates the
     ``web_fetch`` owner via a root-first pre-order walk
-    (:func:`_find_web_fetch_owner`) and reconstructs from THAT owner, not the
+    (:func:`omnigent.tools.builtins.web_fetch.find_web_fetch_owner`) and
+    reconstructs from THAT owner, not the
     root, so the researcher inherits the owner's LLM and sandbox/egress
     boundary (``build_researcher_spec`` derives both from its argument). When
     several nodes own ``web_fetch`` the first pre-order owner wins; this is a
@@ -2770,35 +2771,13 @@ def _find_spec_by_name(
     # so reconstruct from the owner (root-first pre-order) — never the root —
     # to inherit the owner's LLM and sandbox/egress boundary. Imported lazily
     # to keep the tools layer off this module's import path.
-    from omnigent.tools.builtins.web_fetch import RESEARCHER_NAME
+    from omnigent.tools.builtins.web_fetch import (
+        RESEARCHER_NAME,
+        reconstruct_researcher_spec,
+    )
 
     if name == RESEARCHER_NAME:
-        owner = _find_web_fetch_owner(spec)
-        if owner is not None:
-            from omnigent.tools.builtins.web_fetch import build_researcher_spec
-
-            return build_researcher_spec(owner)
-    return None
-
-
-def _find_web_fetch_owner(spec: AgentSpec) -> AgentSpec | None:
-    """
-    Find the first node owning the ``web_fetch`` builtin, root-first.
-
-    Pre-order DFS (root, then children left-to-right), mirroring
-    :func:`_search_sub_agent_tree`. The ``web_fetch`` owner is the node whose
-    ``tools.builtins`` carries an entry named ``web_fetch``; that node's spec
-    is the correct parent for ``build_researcher_spec`` (its LLM + sandbox).
-
-    :param spec: The agent spec whose sub-tree to search.
-    :returns: The first node (root-first) owning ``web_fetch``, or ``None``.
-    """
-    if any(entry.name == "web_fetch" for entry in spec.tools.builtins):
-        return spec
-    for sa in spec.sub_agents:
-        owner = _find_web_fetch_owner(sa)
-        if owner is not None:
-            return owner
+        return reconstruct_researcher_spec(spec)
     return None
 
 

--- a/omnigent/tools/builtins/web_fetch.py
+++ b/omnigent/tools/builtins/web_fetch.py
@@ -248,6 +248,65 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
     )
 
 
+def find_web_fetch_owner(spec: AgentSpec) -> AgentSpec | None:
+    """
+    Find the first node owning the ``web_fetch`` builtin, root-first.
+
+    Pre-order DFS (root, then children left-to-right). The ``web_fetch``
+    owner is the node whose ``tools.builtins`` carries an entry named
+    ``web_fetch``; that node's spec is the correct parent for
+    :func:`build_researcher_spec` (its LLM + sandbox/egress boundary).
+
+    Attribute access is defensive (``getattr``) so the same walk is safe
+    over the runner's structural spec stubs, not only a typed
+    :class:`AgentSpec`.
+
+    :param spec: The agent spec whose sub-tree to search.
+    :returns: The first node (root-first) owning ``web_fetch``, or ``None``.
+    """
+    tools = getattr(spec, "tools", None)
+    builtins = getattr(tools, "builtins", None) or []
+    if any(getattr(entry, "name", None) == "web_fetch" for entry in builtins):
+        return spec
+    for sa in getattr(spec, "sub_agents", None) or []:
+        owner = find_web_fetch_owner(sa)
+        if owner is not None:
+            return owner
+    return None
+
+
+def reconstruct_researcher_spec(spec: AgentSpec) -> AgentSpec | None:
+    """
+    Rebuild the synthesized ``__web_researcher`` spec from ``spec``'s tree.
+
+    ``WebFetchTool.__init__`` appends the researcher to the owner's live
+    ``sub_agents`` list in memory but never serializes it, so every layer
+    that resolves sub-agent names from the persisted / re-parsed bundle
+    finds it missing. This is the single deterministic reconstruction those
+    layers share (the runner dispatch gate in
+    ``runner/tool_dispatch.py`` and the child-boot resolver
+    ``runtime/workflow.py::_find_spec_by_name``): it locates the
+    ``web_fetch`` owner (root-first, possibly nested) and rebuilds the
+    researcher from THAT owner via the same pure builder
+    :func:`build_researcher_spec`, so the child inherits the owner's LLM and
+    sandbox/egress boundary.
+
+    Gated on some node in the tree actually declaring the ``web_fetch``
+    builtin -- the sole reason the researcher exists. A tree without it has
+    no such child, so the name falls through to ``None`` rather than let a
+    caller-supplied name coerce an arbitrary parent into a shell-capable
+    researcher (:func:`build_researcher_spec` synthesizes an ``OSEnvSpec``).
+
+    :param spec: The root agent spec to reconstruct against.
+    :returns: The rebuilt ``__web_researcher`` spec, or ``None`` when no
+        node in the tree declares ``web_fetch``.
+    """
+    owner = find_web_fetch_owner(spec)
+    if owner is None:
+        return None
+    return build_researcher_spec(owner)
+
+
 class WebFetchTool(Tool):
     """
     Web research tool that spawns a sub-agent with a persistent shell.

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -56,7 +56,14 @@ from omnigent.runner.app import (
 from omnigent.runtime.harnesses import _HARNESS_MODULES
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
 from omnigent.session_lifecycle import CLOSED_LABEL_KEY, CLOSED_LABEL_VALUE
-from omnigent.spec.types import AgentSpec, ExecutorSpec, SharePolicy
+from omnigent.spec.types import (
+    AgentSpec,
+    BuiltinToolConfig,
+    ExecutorSpec,
+    LLMConfig,
+    SharePolicy,
+    ToolsConfig,
+)
 from tests.runner.helpers import NullServerClient
 
 _TEST_HARNESS_NAME = "runner-test-default"
@@ -7319,3 +7326,89 @@ async def test_spawn_async_tool_cancels_losing_future_no_leak(
     await asyncio.sleep(0)
     assert inbox.get_nowait()["status"] == "cancelled"
     assert _leaked(before) == []
+
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_dispatch_admits_researcher_without_harness_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """web_fetch's synthesized ``__web_researcher`` passes the dispatch gate,
+    and the child create carries no ``harness_override`` / ``model_override``
+    (#2426).
+
+    The runner never persists ``__web_researcher``, so before the gate/lookup
+    reconciliation the dispatch aborted with "sub-agent '__web_researcher' not
+    found in agent spec". After it, the gate admits the researcher AND the
+    create body is unchanged: ``harness_override`` stays absent (it comes only
+    from an explicit ``args.harness``, never set on the web_fetch path), so the
+    server-side reconstruction that resolves the researcher spec remains
+    authoritative. This locks down that the fix reconciled the local resolvers
+    without altering what is POSTed to ``/v1/sessions``.
+    """
+    import shutil
+
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+    from omnigent.tools.builtins.web_fetch import RESEARCHER_NAME
+
+    # Hermetic bwrap probe: ``build_researcher_spec`` probes PATH for a
+    # no-``os_env`` parent; don't depend on bubblewrap on the test host.
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(runner_app, "get_session_agent_id", lambda _sid: "ag_parent")
+
+    parent = AgentSpec(
+        spec_version=1,
+        name="coordinator",
+        llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(max_iterations=40, config={"harness": "claude-sdk"}),
+        tools=ToolsConfig(builtins=[BuiltinToolConfig(name="web_fetch")]),
+    )
+    # Precondition: the re-parsed bundle does not carry the researcher.
+    assert RESEARCHER_NAME not in [s.name for s in parent.sub_agents]
+
+    create_bodies: list[dict[str, Any]] = []
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if (
+            request.method == "GET"
+            and request.url.path == "/v1/sessions/conv_wf_parent/child_sessions"
+        ):
+            return httpx.Response(200, json={"data": []})
+        if request.method == "POST" and request.url.path == "/v1/sessions":
+            create_bodies.append(json.loads(request.content))
+            return httpx.Response(201, json={"id": "conv_wf_child"})
+        if (
+            request.method == "POST"
+            and request.url.path == "/v1/sessions/conv_wf_child/events"
+        ):
+            return httpx.Response(202, json={"queued": True})
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        try:
+            output = await execute_tool(
+                tool_name="web_fetch",
+                arguments=json.dumps({"query": "latest score"}),
+                server_client=server_client,
+                conversation_id="conv_wf_parent",
+                agent_spec=parent,
+                task_id="t1",
+                session_inbox=session_inbox,
+            )
+        finally:
+            runner_app.unregister_subagent_work("conv_wf_child")
+            runner_app._session_inboxes_ref.pop("conv_wf_parent", None)
+
+    # The gate admitted the researcher -- no "not found in agent spec" error.
+    assert "not found in agent spec" not in output
+    assert len(create_bodies) == 1, "web_fetch must create exactly one researcher child"
+    body = create_bodies[0]
+    assert body["sub_agent_name"] == RESEARCHER_NAME
+    # Acceptance C: server-side reconstruction stays authoritative.
+    assert "harness_override" not in body
+    assert "model_override" not in body

--- a/tests/runner/test_web_fetch_dispatch_gate.py
+++ b/tests/runner/test_web_fetch_dispatch_gate.py
@@ -1,0 +1,134 @@
+"""Regression (#2426): the runner dispatch gate and the sub-agent spec
+lookup must AGREE about web_fetch's synthesized ``__web_researcher``.
+
+``WebFetchTool.__init__`` appends ``__web_researcher`` to the owner's live
+``sub_agents`` in memory but never serializes it, so the runner's re-parsed
+spec lacks it. An earlier fix admitted the researcher through the gate
+(``_has_subagent``) alone, but ``_find_subagent_spec`` / ``_subagent_harness``
+/ ``_subagent_allowed_harnesses`` still returned ``None`` -- the gate said the
+sub-agent existed while every downstream resolver disagreed (the
+CHANGES_REQUESTED objection on #2439). Routing them all through a single
+resolver that reconstructs the researcher from its ``web_fetch`` owner makes
+the answers consistent.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from omnigent.runner.tool_dispatch import (
+    _find_subagent_spec,
+    _has_subagent,
+    _subagent_allowed_harnesses,
+    _subagent_harness,
+)
+from omnigent.spec.types import (
+    AgentSpec,
+    BuiltinToolConfig,
+    ExecutorSpec,
+    LLMConfig,
+    ToolsConfig,
+)
+from omnigent.tools.builtins.web_fetch import RESEARCHER_NAME
+
+
+@pytest.fixture(autouse=True)
+def _default_sandbox_binary_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the seed-time sandbox probe host-independent (bwrap / sandbox-exec).
+
+    ``build_researcher_spec`` probes the host PATH for a no-``os_env`` parent;
+    these resolution tests must not depend on bubblewrap being installed.
+    """
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+
+def _parent(*, web_fetch: bool = True, harness: str = "claude-sdk") -> AgentSpec:
+    """A coordinator as re-parsed from its bundle -- researcher NOT persisted."""
+    builtins = [BuiltinToolConfig(name="web_fetch")] if web_fetch else []
+    return AgentSpec(
+        spec_version=1,
+        name="coordinator",
+        llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(max_iterations=40, config={"harness": harness}),
+        tools=ToolsConfig(builtins=builtins),
+    )
+
+
+def test_gate_and_lookup_agree_for_researcher() -> None:
+    """All resolvers give consistent answers for ``__web_researcher``.
+
+    Before the fix ``_has_subagent`` returned True while ``_subagent_harness``
+    returned ``None`` for the same name -- the exact disagreement flagged on
+    #2439.
+    """
+    parent = _parent(web_fetch=True)
+    assert RESEARCHER_NAME not in [s.name for s in parent.sub_agents]
+
+    assert _has_subagent(RESEARCHER_NAME, parent) is True
+    spec = _find_subagent_spec(RESEARCHER_NAME, parent)
+    assert spec is not None
+    assert spec.name == RESEARCHER_NAME
+    # The lean researcher, not a parent clone.
+    assert spec.executor.max_iterations == 5
+    assert spec.interaction.conversational is False
+    # Gate agreeing means the harness resolves too (no longer None).
+    assert _subagent_harness(RESEARCHER_NAME, parent) == "claude-sdk"
+    # The researcher opts into no per-dispatch harness override.
+    assert _subagent_allowed_harnesses(RESEARCHER_NAME, parent) == frozenset()
+
+
+def test_researcher_inherits_owner_harness() -> None:
+    parent = _parent(web_fetch=True, harness="codex")
+    assert _subagent_harness(RESEARCHER_NAME, parent) == "codex"
+
+
+def test_no_researcher_without_web_fetch_builtin() -> None:
+    """Security boundary: no ``web_fetch`` builtin -> the name resolves to nothing.
+
+    Reconstructing unconditionally would let a caller-supplied name coerce an
+    arbitrary parent into a shell-capable researcher.
+    """
+    parent = _parent(web_fetch=False)
+    assert _has_subagent(RESEARCHER_NAME, parent) is False
+    assert _find_subagent_spec(RESEARCHER_NAME, parent) is None
+    assert _subagent_harness(RESEARCHER_NAME, parent) is None
+    assert _subagent_allowed_harnesses(RESEARCHER_NAME, parent) == frozenset()
+
+
+def test_researcher_resolves_from_nested_owner() -> None:
+    """The ``web_fetch`` owner may be a nested sub-agent, not the root."""
+    owner = _parent(web_fetch=True)
+    owner.name = "researcher_host"
+    owner.llm = LLMConfig(model="anthropic/claude-nested-7")
+    root = AgentSpec(
+        spec_version=1,
+        name="coordinator",
+        llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(max_iterations=40, config={"harness": "claude-sdk"}),
+        tools=ToolsConfig(builtins=[]),
+        sub_agents=[owner],
+    )
+    assert _has_subagent(RESEARCHER_NAME, root) is True
+    spec = _find_subagent_spec(RESEARCHER_NAME, root)
+    assert spec is not None
+    # Rebuilt from the OWNER -> inherits the owner's LLM, not the root's.
+    assert spec.llm is not None
+    assert spec.llm.model == "anthropic/claude-nested-7"
+
+
+def test_declared_sub_agent_still_resolves() -> None:
+    """A normally declared sub-agent still resolves via the top-level list."""
+    child = AgentSpec(spec_version=1, name="reviewer")
+    parent = _parent(web_fetch=True)
+    parent.sub_agents.append(child)
+    assert _has_subagent("reviewer", parent) is True
+    assert _find_subagent_spec("reviewer", parent) is child
+
+
+def test_unknown_name_still_missing() -> None:
+    """The researcher fallback is scoped to ``__web_researcher`` only."""
+    parent = _parent(web_fetch=True)
+    assert _has_subagent("does-not-exist", parent) is False
+    assert _find_subagent_spec("does-not-exist", parent) is None

--- a/tests/tools/builtins/test_web_fetch.py
+++ b/tests/tools/builtins/test_web_fetch.py
@@ -10,14 +10,18 @@ import pytest
 from omnigent.errors import OmnigentError
 from omnigent.spec.types import (
     AgentSpec,
+    BuiltinToolConfig,
     ExecutorSpec,
     LLMConfig,
     ProviderAuth,
+    ToolsConfig,
 )
 from omnigent.tools.builtins.web_fetch import (
     RESEARCHER_NAME,
     WebFetchTool,
     build_researcher_spec,
+    find_web_fetch_owner,
+    reconstruct_researcher_spec,
 )
 
 # ── Helpers ──────────────────────────────────────────
@@ -554,3 +558,101 @@ def test_web_fetch_is_sync_in_sessions_native_mode() -> None:
     # ``Tool.dispatch_async`` raises ``NotImplementedError``.
     # Calling it would be a routing bug because ``is_async`` is
     # False; we don't exercise that path here.
+
+
+# ── web_fetch owner walk + researcher reconstruction ─────────────────
+#
+# The synthesized ``__web_researcher`` is appended to the owner's live
+# ``sub_agents`` in memory by ``WebFetchTool.__init__`` and never
+# serialized, so every layer that resolves sub-agent names from the
+# persisted / re-parsed bundle reconstructs it from its owner instead.
+# These cover the shared owner walk + reconstruction both the runtime
+# resolver (``workflow.py``) and the runner dispatch gate now use.
+
+
+def _owner_spec(model: str = "openai/gpt-5.4") -> AgentSpec:
+    """A parent that declares the ``web_fetch`` builtin (owns the researcher)."""
+    return AgentSpec(
+        spec_version=1,
+        name="owner",
+        llm=LLMConfig(model=model),
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}),
+        tools=ToolsConfig(builtins=[BuiltinToolConfig(name="web_fetch")]),
+    )
+
+
+def _plain_spec() -> AgentSpec:
+    """A parent that never enabled ``web_fetch`` -- no researcher child."""
+    return AgentSpec(
+        spec_version=1,
+        name="plain",
+        llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}),
+        tools=ToolsConfig(builtins=[]),
+    )
+
+
+def test_find_web_fetch_owner_returns_root_when_root_owns() -> None:
+    spec = _owner_spec()
+    assert find_web_fetch_owner(spec) is spec
+
+
+def test_find_web_fetch_owner_walks_to_nested_owner() -> None:
+    owner = _owner_spec(model="anthropic/claude-nested-7")
+    owner.name = "nested-owner"
+    root = AgentSpec(
+        spec_version=1,
+        name="root",
+        llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}),
+        tools=ToolsConfig(builtins=[]),
+        sub_agents=[owner],
+    )
+    assert find_web_fetch_owner(root) is owner
+
+
+def test_find_web_fetch_owner_none_without_builtin() -> None:
+    assert find_web_fetch_owner(_plain_spec()) is None
+
+
+def test_reconstruct_researcher_spec_from_owner() -> None:
+    researcher = reconstruct_researcher_spec(_owner_spec())
+    assert researcher is not None
+    assert researcher.name == RESEARCHER_NAME
+    assert researcher.executor.max_iterations == 5
+    assert researcher.interaction.conversational is False
+    assert researcher.llm is not None
+    assert researcher.llm.model == "openai/gpt-5.4"
+
+
+def test_reconstruct_researcher_spec_inherits_nested_owner_llm() -> None:
+    owner = _owner_spec(model="anthropic/claude-nested-7")
+    owner.name = "nested-owner"
+    root = AgentSpec(
+        spec_version=1,
+        name="root",
+        llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}),
+        tools=ToolsConfig(builtins=[]),
+        sub_agents=[owner],
+    )
+    researcher = reconstruct_researcher_spec(root)
+    assert researcher is not None
+    assert researcher.llm is not None
+    assert researcher.llm.model == "anthropic/claude-nested-7"
+
+
+def test_reconstruct_researcher_spec_none_without_web_fetch() -> None:
+    assert reconstruct_researcher_spec(_plain_spec()) is None
+
+
+def test_reconstruct_matches_what_webfetchtool_appends() -> None:
+    """The reconstruction equals the spec WebFetchTool synthesizes in memory."""
+    spec = _owner_spec()
+    tool = WebFetchTool(spec)  # appends the researcher to spec.sub_agents
+    rebuilt = reconstruct_researcher_spec(spec)
+    assert rebuilt is not None
+    assert rebuilt.name == tool.researcher_spec.name
+    assert rebuilt.executor.max_iterations == tool.researcher_spec.executor.max_iterations
+    assert rebuilt.instructions == tool.researcher_spec.instructions
+    assert rebuilt.interaction.conversational is tool.researcher_spec.interaction.conversational


### PR DESCRIPTION
## Related issue

Closes #2426

## Summary

- `WebFetchTool.__init__` appends the synthesized `__web_researcher` sub-agent to the owner's **in-memory** `sub_agents` list but never serializes it into the persisted bundle. The runner resolves sub-agent names from the re-parsed bundle, so every `web_fetch` call from a wrapped-harness parent fails at the dispatch gate with `sub-agent '__web_researcher' not found in agent spec` before any fetch.
- Implements **Option A** from @fanzeyi's review of #2439 (full credit to @abhay-codes07 for the original diagnosis): route all four runner resolvers — `_has_subagent`, `_find_subagent_spec`, `_subagent_harness`, `_subagent_allowed_harnesses` — through a single spec resolver that reconstructs `__web_researcher` from its `web_fetch` owner on a resolve-miss, so the existence check and the spec lookup can never disagree. Patching only `_has_subagent` (the #2439 approach) left the gate saying "exists" while every downstream resolver returned `None`.
- The owner walk + reconstruction is factored into two shared pure helpers in `tools/builtins/web_fetch.py` (`find_web_fetch_owner`, `reconstruct_researcher_spec`), used by both `runner/tool_dispatch.py` and `runtime/workflow.py` — removing the two near-duplicate tree walks the review also flagged. Reconstruction stays gated on some node in the tree actually declaring the `web_fetch` builtin, so a caller-supplied `sub_agent_name` cannot coerce an arbitrary parent into a shell-capable researcher. **No change to the `/v1/sessions` create body** — `harness_override` still comes only from an explicit `args.harness`, so server-side reconstruction stays authoritative.

**ELI5:** `web_fetch` gives an agent a built-in helper (`__web_researcher`), but it only pencils the helper into its own in-memory copy of the roster — the saved roster the runner reads never lists it. So the runner's doorman checks the saved roster and turns the helper away. This change teaches the doorman and the badge desk one shared rule: "if the name is `__web_researcher` and someone in this tree really has `web_fetch`, rebuild the helper's badge from that owner" — so the door check and the badge lookup always agree.

```
_has_subagent ──────────────┐
_subagent_harness ──────────┼──► _find_subagent_spec ──► declared sub-agent? → use it
_subagent_allowed_harnesses ┘                │ miss on "__web_researcher"
                                             ▼
                            web_fetch.py shared helpers          ◄── also used by
                            find_web_fetch_owner(tree)               workflow.py::
                            reconstruct_researcher_spec(owner)       _find_spec_by_name
```

## Test Plan

- New `tests/runner/test_web_fetch_dispatch_gate.py`: gate/lookup agreement for `__web_researcher`; owner-harness inheritance; nested-owner resolution; the no-`web_fetch` security boundary (all four resolvers agree the researcher does not exist); declared and unknown-name behavior unchanged.
- New unit coverage in `tests/tools/builtins/test_web_fetch.py` for the shared helpers, including that reconstruction equals the spec `WebFetchTool.__init__` appends in memory.
- Call-site test in `tests/runner/test_runner_dispatch.py`: `web_fetch` dispatch admits the researcher and creates the child with **no** `harness_override` / `model_override`.
- Ran on this branch rebased onto current `main` (`a28643e6`): `pytest tests/runner/test_runner_dispatch.py tests/runner/test_web_fetch_dispatch_gate.py tests/tools/builtins/test_web_fetch.py` → **178 passed, 1 skipped**; `tests/runtime/test_workflow_subagent_resolution.py` + `test_workflow_history.py` → **7 passed**; `ruff check` and `ruff format --check` clean on all touched files.

## Demo

No UI surface — the change is in the runner's dispatch-time resolvers — so here is a terminal before/after driving all four resolvers with the same re-parsed coordinator spec (`web_fetch` declared, claude-sdk harness, researcher **not** persisted: the #2426 condition):

```console
$ python demo_2426.py   # upstream main @ a28643e6 (BEFORE)
omnigent tree: …/omnigent-main-demo  (git a28643e6)
  _has_subagent            -> False
  _find_subagent_spec      -> None
  _subagent_harness        -> None
  _subagent_allowed_harnesses -> frozenset()
  dispatch gate            -> Error: sub-agent '__web_researcher' not found in agent spec

$ python demo_2426.py   # this PR (AFTER)
omnigent tree: …/2426-dispatch-gate  (git e6e7d3b4)
  _has_subagent            -> True
  _find_subagent_spec      -> resolved spec (name=__web_researcher)
  _subagent_harness        -> claude-sdk
  _subagent_allowed_harnesses -> frozenset()
  dispatch gate            -> admitted; child boots with harness='claude-sdk'
```

(The empty `_subagent_allowed_harnesses` set in the AFTER run is the "none declared" default — the researcher opts into no `args.harness` overrides — not a disagreement.) The same before/after is locked in CI by the new `tests/runner/test_web_fetch_dispatch_gate.py`.

<details><summary>demo_2426.py</summary>

```python
import omnigent, subprocess, pathlib
from omnigent.runner.tool_dispatch import (
    _find_subagent_spec, _has_subagent,
    _subagent_allowed_harnesses, _subagent_harness,
)
from omnigent.spec.types import (
    AgentSpec, BuiltinToolConfig, ExecutorSpec, LLMConfig, ToolsConfig,
)

tree = pathlib.Path(omnigent.__file__).resolve().parents[1]
rev = subprocess.run(["git", "-C", str(tree), "rev-parse", "--short", "HEAD"],
                     capture_output=True, text=True).stdout.strip()
print(f"omnigent tree: {tree}  (git {rev})")

NAME = "__web_researcher"
spec = AgentSpec(
    spec_version=1,
    name="coordinator",
    llm=LLMConfig(model="openai/gpt-5.4"),
    executor=ExecutorSpec(max_iterations=40, config={"harness": "claude-sdk"}),
    tools=ToolsConfig(builtins=[BuiltinToolConfig(name="web_fetch")]),
)

has = _has_subagent(NAME, spec)
found = _find_subagent_spec(NAME, spec)
print(f"  _has_subagent            -> {has}")
print(f"  _find_subagent_spec      -> {'resolved spec (name=%s)' % found.name if found is not None else None}")
print(f"  _subagent_harness        -> {_subagent_harness(NAME, spec)}")
print(f"  _subagent_allowed_harnesses -> {_subagent_allowed_harnesses(NAME, spec)}")
if not has:
    print(f"  dispatch gate            -> Error: sub-agent {NAME!r} not found in agent spec")
else:
    print(f"  dispatch gate            -> admitted; child boots with harness={_subagent_harness(NAME, spec)!r}")
```

</details>

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

All verification is automated (see Test Plan); the previously-failing path is locked by the new dispatch-gate suite.

## Changelog

`web_fetch` no longer fails with `sub-agent '__web_researcher' not found in agent spec` when called from a wrapped-harness agent on an external runner

