### PR TITLE
Fix base64 leaks in compaction and replay

### DIFF
--- a/omnigent/inner/open_responses_sdk.py
+++ b/omnigent/inner/open_responses_sdk.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import pydantic
 
+from omnigent.llms.adapters._content import redact_inline_data_uris
 from omnigent.spec.types import RetryPolicy
 
 if TYPE_CHECKING:
@@ -56,6 +57,17 @@ OpenAIKwargs: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
 
 # Plain JSON value — recursive union used by ``_to_plain_data``.
 JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+def _redact_inline_base64(value: Any) -> Any:  # type: ignore[explicit-any]
+    """Replace inline attachment bytes before history content is stringified."""
+    return redact_inline_data_uris(
+        value,
+        lambda media_type, payload_length: (
+            f"[image/attachment: {media_type}, {payload_length} base64 chars]"
+        ),
+    )
+
 
 # Placeholder for the OpenAI SDK's ``api_key`` kwarg on OpenAI-compatible
 # endpoints (e.g. Databricks model serving) that authenticate through a
@@ -267,9 +279,9 @@ def _convert_messages_to_responses(
                 if raw_tool_output is None:
                     output_str = ""
                 elif isinstance(raw_tool_output, str):
-                    output_str = raw_tool_output
+                    output_str = _redact_inline_base64(raw_tool_output)
                 else:
-                    output_str = json.dumps(raw_tool_output)
+                    output_str = json.dumps(_redact_inline_base64(raw_tool_output))
                 result.append(
                     {
                         "type": "function_call_output",
@@ -279,7 +291,12 @@ def _convert_messages_to_responses(
                 )
 
         elif role == "tool_result":
-            tool_output = content if isinstance(content, str) else json.dumps(content)
+            redacted_content = _redact_inline_base64(content)
+            tool_output = (
+                redacted_content
+                if isinstance(redacted_content, str)
+                else json.dumps(redacted_content)
+            )
             result.append(
                 {
                     "type": "message",
@@ -293,7 +310,7 @@ def _convert_messages_to_responses(
                 {
                     "type": "message",
                     "role": "user",
-                    "content": str(content),
+                    "content": str(_redact_inline_base64(content)),
                 }
             )
 
@@ -484,9 +501,9 @@ class OpenResponsesExecutor(Executor):
                 if content is None:
                     output_str = ""
                 elif isinstance(content, str):
-                    output_str = content
+                    output_str = _redact_inline_base64(content)
                 else:
-                    output_str = json.dumps(content)
+                    output_str = json.dumps(_redact_inline_base64(content))
                 result.append(
                     {
                         "type": "function_call_output",

--- a/omnigent/llms/adapters/_content.py
+++ b/omnigent/llms/adapters/_content.py
@@ -1,13 +1,19 @@
-"""Shared helpers for translating multimodal content across adapters.
+"""Shared helpers for translating multimodal content.
 
 Provides data-URI parsing used by Anthropic, Gemini, and Bedrock
 adapters when converting Chat Completions ``image_url`` parts to
-their provider-native image formats.
+their provider-native image formats, plus recursive redaction for
+history paths that serialize inline attachments as text.
 """
 
 from __future__ import annotations
 
+import re
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
+
+_INLINE_BASE64_DATA_URI = re.compile(r"data:([^;,\s]+);base64,([A-Za-z0-9+/=_-]+)")
 
 
 @dataclass
@@ -50,3 +56,29 @@ def parse_data_uri(uri: str) -> DataUriParts | None:
     media_type = rest[:sep_idx]
     data = rest[sep_idx + len(separator) :]
     return DataUriParts(media_type=media_type, data=data)
+
+
+def redact_inline_data_uris(
+    value: Any,  # type: ignore[explicit-any]
+    marker: Callable[[str, int], str],
+) -> Any:  # type: ignore[explicit-any]
+    """Recursively replace inline base64 data URIs with compact markers.
+
+    Dict keys and all non-data-URI values are preserved. String values may
+    contain surrounding text; only matching ``data:*;base64,...`` spans are
+    replaced.
+
+    :param value: Arbitrarily nested dict/list/string content.
+    :param marker: Builds replacement text from media type and payload length.
+    :returns: A copy with inline base64 payloads redacted.
+    """
+    if isinstance(value, str):
+        return _INLINE_BASE64_DATA_URI.sub(
+            lambda match: marker(match.group(1), len(match.group(2))),
+            value,
+        )
+    if isinstance(value, list):
+        return [redact_inline_data_uris(item, marker) for item in value]
+    if isinstance(value, dict):
+        return {key: redact_inline_data_uris(item, marker) for key, item in value.items()}
+    return value

--- a/omnigent/runtime/compaction.py
+++ b/omnigent/runtime/compaction.py
@@ -26,6 +26,7 @@ from omnigent.entities import (
     ConversationItem,
     MessageData,
 )
+from omnigent.llms.adapters._content import redact_inline_data_uris
 from omnigent.llms.summarize import (
     build_summarization_input,
     build_summarization_prompt,
@@ -246,12 +247,17 @@ def _clear_binary_content(
         if not isinstance(content, list):
             continue
         for block in content:
-            if (
-                isinstance(block, dict)
-                and block.get("type") in ("image", "file")
-                and "data" in block
-            ):
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") in ("image", "file") and "data" in block:
                 block["data"] = _BINARY_CONTENT_CLEARED
+            for key, value in block.items():
+                if not isinstance(value, str):
+                    continue
+                block[key] = redact_inline_data_uris(
+                    value,
+                    lambda _media_type, _payload_length: _BINARY_CONTENT_CLEARED,
+                )
     return messages
 
 

--- a/tests/inner/test_open_responses_sdk.py
+++ b/tests/inner/test_open_responses_sdk.py
@@ -183,6 +183,42 @@ class TestConvertMessages(unittest.TestCase):
         self.assertEqual(result[0]["name"], "calc")
         self.assertEqual(result[1]["type"], "function_call_output")
 
+    def test_tool_result_redacts_inline_base64_data_uri(self):
+        payload = "QUJD" * 100
+        msgs = [
+            {"role": "tool_call", "content": {"tool": "screenshot", "args": {}}},
+            {
+                "role": "tool_result",
+                "content": [
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/png;base64,{payload}",
+                    }
+                ],
+            },
+        ]
+
+        result = _convert_messages_to_responses(msgs)
+        output = result[1]["output"]
+
+        self.assertIn("[image/attachment: image/png, 400 base64 chars]", output)
+        self.assertNotIn(payload, output)
+
+    def test_orphan_tool_result_and_unknown_role_redact_inline_base64(self):
+        payload = "QUJD" * 100
+        content = {"preview": f"prefix data:image/jpeg;base64,{payload} suffix"}
+
+        result = _convert_messages_to_responses(
+            [
+                {"role": "tool_result", "content": content},
+                {"role": "unknown", "content": content},
+            ]
+        )
+
+        for item in result:
+            self.assertIn("[image/attachment: image/jpeg, 400 base64 chars]", item["content"])
+            self.assertNotIn(payload, item["content"])
+
     def test_invalid_tool_name_is_normalized_in_history_replay(self):
         msgs = [
             {
@@ -315,6 +351,31 @@ class TestNormalizeResponseOutput(unittest.TestCase):
 
 
 class TestOpenResponsesExecutor(unittest.TestCase):
+    def test_delta_tool_result_redacts_inline_base64_data_uri(self):
+        payload = "QUJD" * 100
+        executor = OpenResponsesExecutor(client=FakeClient(FakeResponse()))
+        state = executor._get_or_create_session_state("session_1")
+        state.previous_response_id = "resp_1"
+        state.pending_function_calls.append(
+            {"call_id": "call_1", "name": "screenshot", "arguments": "{}"}
+        )
+
+        result = executor._build_delta_input(
+            state,
+            [
+                {
+                    "role": "tool_result",
+                    "content": {
+                        "image_url": f"data:image/png;base64,{payload}",
+                    },
+                }
+            ],
+        )
+        output = result[0]["output"]
+
+        self.assertIn("[image/attachment: image/png, 400 base64 chars]", output)
+        self.assertNotIn(payload, output)
+
     def test_simple_text_response(self):
         async def _t():
             @dataclass

--- a/tests/runtime/test_compaction.py
+++ b/tests/runtime/test_compaction.py
@@ -19,6 +19,7 @@ from omnigent.llms.types import MessageOutput, OutputText, Response
 from omnigent.runtime.compaction import (
     _BINARY_CONTENT_CLEARED,
     _TOOL_RESULT_CLEARED,
+    _clear_binary_content,
     _is_summary_auth_error,
     _pair_aware_drop_count,
     _truncate_oldest,
@@ -458,6 +459,43 @@ async def test_layer1_clears_binary_content_and_preserves_file_id(
     )
     # Text block in the same message must be untouched.
     assert text_block["text"] == "Please describe this image"
+
+
+def test_clear_binary_content_handles_resolver_shapes() -> None:
+    """Resolver-produced attachment payloads are cleared before token counting."""
+    payload = "A" * 100_000
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": f"data:image/png;base64,{payload}",
+                    "file_id": "file_image",
+                    "filename": "screenshot.png",
+                },
+                {
+                    "type": "input_file",
+                    "file_data": f"data:application/pdf;base64,{payload}",
+                    "file_id": "file_pdf",
+                    "filename": "report.pdf",
+                },
+            ],
+        }
+    ]
+
+    tokens_before = count_tokens(messages, "openai/gpt-4o")
+    _clear_binary_content(messages, protect_from=len(messages))
+    tokens_after = count_tokens(messages, "openai/gpt-4o")
+
+    image_block, file_block = messages[0]["content"]
+    assert image_block["image_url"] == _BINARY_CONTENT_CLEARED
+    assert file_block["file_data"] == _BINARY_CONTENT_CLEARED
+    assert image_block["file_id"] == "file_image"
+    assert image_block["filename"] == "screenshot.png"
+    assert file_block["file_id"] == "file_pdf"
+    assert file_block["filename"] == "report.pdf"
+    assert tokens_after < tokens_before / 10
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Clear resolver-produced `input_image.image_url` and `input_file.file_data` base64 data URIs during compaction while preserving attachment metadata and the recent-window boundary.
- Redact inline base64 data URIs before Open Responses tool results or unknown-role history are serialized as text.
- Add a shared recursive data-URI redactor plus regression coverage for full replay, orphan results, unknown roles, and stateful delta replay.

**ELI5:** attachments can contain very large encoded byte strings. Older history paths were accidentally treating those bytes as ordinary text; this replaces them with small descriptive markers before token counting or replay.

```text
resolved attachment/tool output
              |
              v
      detect data:*;base64
         /              \
compaction marker   replay marker + size
         \              /
          no raw base64 text
```

## Test Plan

- `~/omnigent/.venv/bin/python -m pytest tests/runtime/test_compaction.py -q`
- `~/omnigent/.venv/bin/python -m pytest tests/inner/test_open_responses_sdk.py -q`
- `~/omnigent/.venv/bin/python -m pytest tests/llms/test_content_helpers.py -q`
- `~/omnigent/.venv/bin/python -m ruff check .`
- `git diff --check`

## Demo

N/A — non-visual backend fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression tests verify resolver-shaped compaction payloads shrink token estimates and every affected Open Responses serialization path emits markers without raw base64.