### PR TITLE
release: omnigent-slack 0.6.0

### DIFF
--- a/integrations/slack/pyproject.toml
+++ b/integrations/slack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-slack"
-version = "0.1.0"
+version = "0.6.0"
 description = "Slack Socket Mode bot that drives Omnigent sessions."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Bump the `omnigent-slack` package version to `0.6.0` so it can be released from the `release/v0.6.0` branch alongside the core `v0.6.0` release.

## Context

`omnigent-slack` (at `integrations/slack`) is an independent package with its own version line and its own `omnigent-slack-<version>` tag. It was sitting at `0.1.0` on the `release/v0.6.0` branch. This bumps it to `0.6.0` to align with the core `v0.6.0` release, and the corresponding `omnigent-slack-0.6.0` tag has been pushed pointing at this commit.

## Changes

- `integrations/slack/pyproject.toml`: `version = "0.1.0"` → `"0.6.0"`

## Test plan

- [ ] CI passes (the secure-release repo's `omnigent.yml` PR build exercises the slack build + smoke-install)
