### PR TITLE
Simplify env variables for Slack integration on Databricks apps

### DIFF
--- a/integrations/slack/.env.example
+++ b/integrations/slack/.env.example
@@ -48,17 +48,13 @@ OMNIGENT_SERVER_URL=https://omnigent.example.com
 # OAuth client secret. At least 32 chars of real entropy (e.g. `openssl rand
 # -hex 32`); a weak value is brute-forceable and lets an attacker forge a state.
 # OMNIGENT_SLACK_DATABRICKS_STATE_SECRET=
-# Workspace host the OAuth app is registered in. Defaults to the injected
-# DATABRICKS_HOST; set only for a laptop run where it's unset.
-# OMNIGENT_SLACK_DATABRICKS_WORKSPACE_HOST=
 # Requested scopes (space-separated). Defaults to all-apis; openid +
 # offline_access are always added. Narrow it as far as the server proxy allows.
 # OMNIGENT_SLACK_DATABRICKS_SCOPES=
 # Public base URL of this bot's own Databricks App (the enrollment link base +
-# OAuth redirect URI). Defaults to the injected DATABRICKS_APP_URL.
-# OMNIGENT_SLACK_WEBAUTH_BASE_URL=
-# Port the enrollment web server binds. Defaults to DATABRICKS_APP_PORT (8000).
-# OMNIGENT_SLACK_WEBAUTH_PORT=
+# OAuth redirect URI). Operator-supplied — the platform injects no app-URL var,
+# and the URL only exists after the app's first deploy.
+# OMNIGENT_SLACK_DATABRICKS_APP_URL=
 #
 # A Fernet key that encrypts each user's delegated token at rest so a stolen
 # database file can't impersonate them — generate one with:

--- a/integrations/slack/deploy/databricks/.gitignore
+++ b/integrations/slack/deploy/databricks/.gitignore
@@ -2,8 +2,9 @@
 .databricks/
 
 # NOTE: the per-deploy app payload deploy.py generates under src/
-# (src/*.whl, src/pyproject.toml, src/uv.lock) is deliberately NOT ignored.
+# (src/*.whl, src/pyproject.toml) is deliberately NOT ignored.
 # `databricks bundle deploy` respects .gitignore for its file sync, so
 # ignoring those would silently drop them from the upload and the app would
 # fail with "No module named 'omnigent_slack'". Keep them untracked (don't
-# `git add` them) rather than gitignored.
+# `git add` them) rather than gitignored. No uv.lock is generated — the app
+# resolves deps in-container via `uv run`.

--- a/integrations/slack/deploy/databricks/README.md
+++ b/integrations/slack/deploy/databricks/README.md
@@ -14,18 +14,17 @@ for the full design, and the integration `[README.md](../../README.md)` for how
 the bot works otherwise.
 
 Unlike the server app, the bot needs **no Lakebase and no UC volume** — it's a
-stateless pure-PyPI package. Mirroring the server deploy, `deploy.py` builds an
-`omnigent_slack` wheel, generates an app-level `src/pyproject.toml` + `src/uv.lock`
-that point at it, copies the wheel into `src/`, then runs `databricks bundle
-deploy` + `bundle run`. The Databricks Apps runtime installs the source
-directory with `uv sync`, so the app imports `omnigent_slack` from the built
-wheel. Runs unchanged from a laptop; re-runnable.
+stateless pure-PyPI package. `deploy.py` builds an `omnigent_slack` wheel,
+generates an app-level `src/pyproject.toml` that points at it (with the bot's
+runtime deps inlined from the source pyproject), copies the wheel into `src/`,
+then runs `databricks bundle deploy` + `bundle run`. No lockfile is generated:
+the app starts with `uv run`, so the Databricks Apps runtime resolves
+dependencies in-container at boot. Runs unchanged from a laptop; re-runnable.
 
-> The generated `src/*.whl`, `src/pyproject.toml`, and `src/uv.lock` are kept
-> **untracked but not git-ignored** — `bundle deploy` respects `.gitignore` for
-> its file sync, so git-ignoring them would silently drop them from the upload
-> and the app would fail with `ModuleNotFoundError: No module named
-> 'omnigent_slack'`.
+> The generated `src/*.whl` and `src/pyproject.toml` are kept **untracked but
+> not git-ignored** — `bundle deploy` respects `.gitignore` for its file sync,
+> so git-ignoring them would silently drop them from the upload and the app
+> would fail with `ModuleNotFoundError: No module named 'omnigent_slack'`.
 
 ## Prerequisites
 
@@ -91,7 +90,7 @@ databricks secrets put-secret omnigent-slack databricks_state_secret \
 > the token's scopes must be a superset of the target server app's scopes, so
 > `all-apis` always works; `openid` + `offline_access` are added automatically),
 > and register the redirect URI **`<this-app-url>/auth/callback`**
-> (the same app URL you pass as `--webauth-base-url`). Because the app URL only
+> (the same app URL you pass as `--app-url`). Because the app URL only
 > exists after the first deploy, register the redirect URI between the first and
 > second deploy passes.
 
@@ -139,19 +138,17 @@ uv run python integrations/slack/deploy/databricks/deploy.py \
     --secret-scope omnigent-slack \
     --oauth-client-id <oauth-app-client-id> \
     --server-url https://<server-app>.databricksapps.com \
-    --webauth-base-url "${APP_URL}"
+    --app-url "${APP_URL}"
 ```
 
-`deploy.py` builds the wheel, writes `src/pyproject.toml` + `src/uv.lock`, copies
-the wheel into `src/`, runs `bundle deploy --target prod`, then
-`bundle run omnigent-slack --target prod`. Pass `--skip-run` to deploy without
-starting, or `--skip-build` to reuse the existing `src/` wheel + lock. Subsequent
-redeploys are a single invocation (keep `--webauth-base-url`).
-
-> On the Databricks network, public PyPI is blocked, so point uv at the internal
-> proxy for the lock step — either `--index-url https://pypi-proxy.cloud.databricks.com/simple`
-> or `UV_INDEX_URL=…` (the lock is then normalized back to public PyPI for
-> reproducibility). See [go/pypi-registry-access](http://go/pypi-registry-access).
+`deploy.py` builds the wheel, writes `src/pyproject.toml` (the bot pinned to the
+co-located wheel, with its runtime deps inlined from the source pyproject),
+copies the wheel into `src/`, runs `bundle deploy --target prod`, then
+`bundle run omnigent-slack --target prod`. No lockfile is generated: the app
+starts with `uv run`, so the Apps runtime resolves dependencies in-container at
+boot. Pass `--skip-run` to deploy without starting, or `--skip-build` to reuse
+the existing `src/` wheel + pyproject. Subsequent redeploys are a single
+invocation (keep `--app-url`).
 
 ## After deploy
 
@@ -169,9 +166,8 @@ redeploys are a single invocation (keep `--webauth-base-url`).
 
 ## How it works
 
-- The app binds `DATABRICKS_APP_PORT` (8000) with the OAuth callback web server
-(`omnigent_slack/webauth.py`) and, in the same process, runs the Socket-Mode
-bot that connects out to Slack.
+- The app runs the OAuth callback web server (`omnigent_slack/webauth.py`) and,
+in the same process, the Socket-Mode bot that connects out to Slack.
 - **Custom U2M OAuth app (authorization code + PKCE).** The enrollment link is
 the workspace `/oidc/v1/authorize` URL; the user signs in and Databricks
 redirects back to `/auth/callback` with a single-use, PKCE-bound code. The bot
@@ -203,12 +199,10 @@ Environment wired by `databricks.yml` (secrets via `value_from`, rest inline):
 | `OMNIGENT_SLACK_DATABRICKS_CLIENT_SECRET`| secret               | Custom U2M OAuth app client secret               |
 | `OMNIGENT_SLACK_DATABRICKS_STATE_SECRET` | secret               | HMAC key signing the enrollment `state`          |
 | `OMNIGENT_SLACK_DATABRICKS_SCOPES`       | inline (optional)    | Requested scopes (default `all-apis`; must be a superset of the server app's scopes; `openid` + `offline_access` forced on) |
-| `OMNIGENT_SLACK_DATABRICKS_WORKSPACE_HOST` | inline (optional)  | OAuth app's workspace host (defaults to `DATABRICKS_HOST`) |
 | `OMNIGENT_SLACK_SERVER_AUTH`             | inline               | `databricks` (selects the OAuth mode)            |
 | `OMNIGENT_SERVER_URL`                    | `--server-url`       | Omnigent server the bot drives                   |
-| `OMNIGENT_SLACK_WEBAUTH_BASE_URL`        | `--webauth-base-url` | This app's public URL — link base + redirect URI |
+| `OMNIGENT_SLACK_DATABRICKS_APP_URL`      | `--app-url`          | This app's public URL — link base + redirect URI |
 | `OMNIGENT_DATA_DIR`                      | inline               | Ephemeral SQLite store dir                       |
-| `DATABRICKS_APP_PORT`                    | Databricks runtime   | Port the callback server binds (8000)            |
 
 
 
@@ -218,13 +212,12 @@ Environment wired by `databricks.yml` (secrets via `value_from`, rest inline):
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| `ModuleNotFoundError: No module named 'omnigent_slack'` | The wheel/`pyproject.toml`/`uv.lock` were git-ignored, so `bundle deploy` didn't sync them | Ensure `src/*.whl`, `src/pyproject.toml`, `src/uv.lock` are untracked but NOT git-ignored; re-run `deploy.py` (not `--skip-build` on a clean `src/`) |
-| `uv lock` fails with a PyPI DNS error | Public PyPI blocked on the Databricks network | Re-run with `UV_INDEX_URL=https://pypi-proxy.cloud.databricks.com/simple` |
-| App install fails; `/logz` shows an `exclude-newer` re-resolve then a PyPI timeout | Runtime's uv `exclude-newer` cutoff differs from the lock's | Read the cutoff from `/logz` and pass it via `--exclude-newer <cutoff>`, then redeploy |
+| `ModuleNotFoundError: No module named 'omnigent_slack'` | The wheel/`pyproject.toml` were git-ignored, so `bundle deploy` didn't sync them | Ensure `src/*.whl`, `src/pyproject.toml` are untracked but NOT git-ignored; re-run `deploy.py` (not `--skip-build` on a clean `src/`) |
+| App fails to boot; `/logz` shows a `uv run` resolve error or PyPI timeout | Dependency resolution runs in-container at boot; the runtime couldn't reach PyPI | Confirm the app egress can reach PyPI (or the Databricks proxy); retry the `bundle run` |
 | Sign-in ends on an OAuth error page (redirect mismatch) | The OAuth app's redirect URI ≠ `<this-app-url>/auth/callback` | Register the exact `/auth/callback` URL on the custom OAuth app |
 | Sign-in page says the link was already used or expired | The redirect was replayed, or the bot restarted between link-issue and callback (in-memory PKCE verifier lost) | Run `/omnigent` again for a fresh link |
 | Enrolled, but turns fail auth against the server                      | User lacks access to the server app, or the token's scopes don't satisfy the server proxy | Grant the user server-app access; widen `OMNIGENT_SLACK_DATABRICKS_SCOPES` if the server proxy needs more |
-| App boots but Slack shows no sign-in link                             | `--webauth-base-url` not passed (the app URL only exists after first deploy) | Re-deploy with `--webauth-base-url "$(databricks apps get <app> -o json | jq -r .url)"` |
+| App boots but Slack shows no sign-in link                             | `--app-url` not passed (the app URL only exists after first deploy) | Re-deploy with `--app-url "$(databricks apps get <app> -o json | jq -r .url)"` |
 | App can't read secrets                                                | App SP missing scope ACL                                                     | `databricks secrets put-acl <scope> <sp> READ`, redeploy                                |
 | Plan shows destroy/replace of the app                                 | `--app-name` mismatch vs. tracked state                                      | Re-check `--app-name`; state is per-app under `root_path`                               |
 
@@ -237,9 +230,9 @@ Environment wired by `databricks.yml` (secrets via `value_from`, rest inline):
 | File | Purpose |
 | --- | --- |
 | `databricks.yml` | DAB bundle config — app resource, secrets, env. |
-| `deploy.py` | Orchestrator: build wheel → write `pyproject.toml`/`uv.lock` → deploy + run. |
+| `deploy.py` | Orchestrator: build wheel → write `pyproject.toml` → deploy + run. |
 | `src/app.py` | App entry point — runs `omnigent_slack.app.run()`. |
 | `src/app.yaml` | App startup config (command + env). |
-| `src/*.whl`, `src/pyproject.toml`, `src/uv.lock` | Generated per deploy by `deploy.py`; untracked, not git-ignored. |
+| `src/*.whl`, `src/pyproject.toml` | Generated per deploy by `deploy.py`; untracked, not git-ignored. |
 
 

--- a/integrations/slack/deploy/databricks/databricks.yml
+++ b/integrations/slack/deploy/databricks/databricks.yml
@@ -23,7 +23,7 @@ variables:
       Custom U2M OAuth app client id. Public (not a secret) — passed inline.
   server_url:
     description: "Base URL of the Omnigent server app (the bot talks to this)."
-  webauth_base_url:
+  app_url:
     description: >
       This bot app's own public URL, used to build the enrollment link posted
       into Slack. The platform does NOT inject an app-URL env var, so it must be
@@ -77,7 +77,7 @@ resources:
             permission: READ
 
       config:
-        command: ["python", "app.py"]
+        command: ["uv", "run", "python", "app.py"]
         env:
           # Slack credentials + at-rest encryption + enrollment state secret.
           - name: OMNIGENT_SLACK_BOT_TOKEN
@@ -96,17 +96,15 @@ resources:
           # from the OAuth client secret so rotating one doesn't affect the other.
           - name: OMNIGENT_SLACK_DATABRICKS_STATE_SECRET
             value_from: databricks-state-secret
-          # Databricks web-auth mode + non-secret config. The workspace host
-          # defaults to the platform-injected DATABRICKS_HOST, and the bot's own
-          # public URL to DATABRICKS_APP_URL, so they need no value here.
+          # Databricks web-auth mode + non-secret config.
           - name: OMNIGENT_SLACK_SERVER_AUTH
             value: databricks
           - name: OMNIGENT_SERVER_URL
             value: ${var.server_url}
           # This app's own public URL (the enrollment link base). The platform
           # injects no app-URL env var, so it's passed explicitly.
-          - name: OMNIGENT_SLACK_WEBAUTH_BASE_URL
-            value: ${var.webauth_base_url}
+          - name: OMNIGENT_SLACK_DATABRICKS_APP_URL
+            value: ${var.app_url}
           # SQLite store on ephemeral disk — tokens are encrypted and
           # re-enrolled after a restart, so no durable volume is needed.
           - name: OMNIGENT_DATA_DIR

--- a/integrations/slack/deploy/databricks/deploy.py
+++ b/integrations/slack/deploy/databricks/deploy.py
@@ -35,8 +35,9 @@ import shutil
 import subprocess
 import sys
 import time
-import tomllib
 from pathlib import Path
+
+import tomllib
 
 # Must match resources.apps.<key> and bundle.name in databricks.yml.
 _BUNDLE_RESOURCE_KEY = "omnigent-slack"

--- a/integrations/slack/deploy/databricks/deploy.py
+++ b/integrations/slack/deploy/databricks/deploy.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 """Deploy the Omnigent Slack bot to a Databricks App via Asset Bundles.
 
-Mirrors the server deploy (``deploy/databricks/deploy.py``): builds a wheel
-for the ``omnigent-slack`` package, generates an app-level ``pyproject.toml`` +
-``uv.lock`` that point at that wheel, copies the wheel into ``src/``, then wraps
-``databricks bundle deploy`` + ``databricks bundle run``. The Databricks Apps
-runtime installs the source directory with ``uv sync``, so the app imports
-``omnigent_slack`` from the built wheel — not from loose source files.
+Builds a wheel for the ``omnigent-slack`` package, generates an app-level
+``pyproject.toml`` that depends on that wheel (with the bot's runtime deps
+inlined from the source ``pyproject.toml``), copies the wheel into ``src/``,
+then wraps ``databricks bundle deploy`` + ``databricks bundle run``.
+
+No lockfile is generated or committed: the app starts with ``uv run``, so the
+Databricks Apps runtime resolves dependencies in-container at boot (the same
+pattern as the ``databricks/app-templates`` examples). This keeps the deploy
+step offline-simple — no ``uv lock``, no registry normalization, no
+``--exclude-newer`` juggling to match the runtime's pinned cutoff.
 
 Simpler than the server deploy: one wheel, pure-PyPI deps, no Lakebase / UC
 volume and no cross-package version lockstep.
@@ -26,12 +30,12 @@ creation, user-authorization enablement, and the enrollment flow).
 from __future__ import annotations
 
 import argparse
-import os
 import re
 import shutil
 import subprocess
 import sys
 import time
+import tomllib
 from pathlib import Path
 
 # Must match resources.apps.<key> and bundle.name in databricks.yml.
@@ -42,9 +46,6 @@ _DIST_NAME = "omnigent-slack"
 _WHEEL_PREFIX = "omnigent_slack-"
 
 _APP_REQUIRES_PYTHON = ">=3.12,<3.13"
-# Public PyPI by default. Set UV_INDEX_URL to lock against a private mirror or
-# proxy (e.g. the Databricks internal proxy) instead.
-_UV_DEFAULT_INDEX_URL = "https://pypi.org/simple"
 
 
 def _log(msg: str) -> None:
@@ -135,21 +136,28 @@ def _toml_string(value: str) -> str:
     return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
 
-def _write_uv_dependency_files(
-    wheel: Path,
-    deploy_version: str,
-    index_url: str | None = None,
-    exclude_newer: str | None = None,
-) -> None:
-    """Copy the wheel into src/ and write the app pyproject.toml + uv.lock.
+def _read_runtime_dependencies() -> list[str]:
+    """Read the bot's runtime deps from its source pyproject.toml.
 
-    The Apps runtime runs ``uv sync`` in the synced source directory, so it
-    needs a ``pyproject.toml`` whose only dependency is the bot, sourced from
-    the co-located wheel, plus a matching ``uv.lock``.
+    Inlining them into the generated app pyproject (rather than relying on the
+    wheel's own metadata) keeps the app's dependency set visible and in lockstep
+    with the package: ``uv run`` resolves this list plus the wheel in-container.
+    """
+    data = tomllib.loads((_slack_root() / "pyproject.toml").read_text())
+    deps = data.get("project", {}).get("dependencies", [])
+    if not deps:
+        _fail("no [project.dependencies] found in integrations/slack/pyproject.toml")
+    return list(deps)
 
-    :param index_url: Optional index URL forwarded to the lock step.
-    :param exclude_newer: Optional uv ``--exclude-newer`` cutoff forwarded to
-        the lock step.
+
+def _write_app_pyproject(wheel: Path, deploy_version: str) -> None:
+    """Copy the wheel into src/ and write the app pyproject.toml (no lockfile).
+
+    The app starts with ``uv run``, so the Apps runtime resolves this project
+    in-container at boot — no ``uv.lock`` is generated or shipped. The generated
+    project pins the bot to the co-located wheel and inlines its runtime deps
+    (read from the source pyproject) so the resolved set is explicit and stays in
+    sync with the package.
     """
     src = _src_dir()
     _sweep_src_wheels()
@@ -160,72 +168,42 @@ def _write_uv_dependency_files(
     requirements = src / "requirements.txt"
     if requirements.exists():
         requirements.unlink()
+    # A stale lockfile from an older wheel-and-lock deploy would pin the wrong
+    # version; drop it so `uv run` resolves fresh in-container.
+    lockfile = src / "uv.lock"
+    if lockfile.exists():
+        lockfile.unlink()
 
+    deps = [f"{_DIST_NAME}=={deploy_version}", *_read_runtime_dependencies()]
+    dep_lines = "".join(f"  {_toml_string(d)},\n" for d in deps)
     pyproject = (
         "[project]\n"
         'name = "omnigent-slack-databricks-app"\n'
         'version = "0.0.0"\n'
         f"requires-python = {_toml_string(_APP_REQUIRES_PYTHON)}\n"
         "dependencies = [\n"
-        f'  "{_DIST_NAME}=={deploy_version}",\n'
+        f"{dep_lines}"
         "]\n\n"
+        # Not an installable package itself — just an environment for `uv run`.
+        "[tool.uv]\n"
+        "package = false\n\n"
         "[tool.uv.sources]\n"
         f"{_DIST_NAME} = {{ path = {_toml_string('./' + wheel.name)} }}\n"
     )
     (src / "pyproject.toml").write_text(pyproject)
     _log("src/pyproject.toml:\n" + pyproject)
-    _run_uv_lock(src, index_url, exclude_newer)
-
-
-def _run_uv_lock(
-    src: Path, index_url: str | None = None, exclude_newer: str | None = None
-) -> None:
-    """Generate src/uv.lock, then normalize its registry to public PyPI.
-
-    Locking honors the index override (``--index-url`` or ``UV_INDEX_URL``,
-    default public PyPI) so a Databricks-network machine can resolve via the
-    internal proxy; the normalize step then rewrites every registry URL back to
-    public PyPI so the uploaded lock is canonical, mirroring the server deploy.
-
-    :param index_url: Explicit index URL (from ``--index-url``); falls back to
-        ``UV_INDEX_URL`` then public PyPI.
-    :param exclude_newer: Optional uv ``--exclude-newer`` cutoff. The Apps runtime
-        pins a global cutoff; passing the same one keeps the in-container
-        re-resolve from refetching (and timing out) on PyPI. Omitted → no cutoff.
-    """
-    index_url = index_url or os.environ.get("UV_INDEX_URL") or _UV_DEFAULT_INDEX_URL
-    env = os.environ.copy()
-    env.pop("UV_INDEX", None)
-    env.pop("UV_DEFAULT_INDEX", None)
-    env["UV_INDEX_URL"] = index_url
-    cmd = ["uv", "lock", "--python", "3.12", "--index-url", index_url]
-    if exclude_newer:
-        cmd += ["--exclude-newer", exclude_newer]
-    _log(f"$ {' '.join(cmd)}")
-    subprocess.run(cmd, cwd=src, env=env, check=True)
-    # Rewrite proxy/registry URLs to public PyPI so the uploaded lock is
-    # reproducible regardless of the machine that generated it.
-    normalize = _repo_root() / "scripts" / "normalize_uv_lock_registry.py"
-    if normalize.exists():
-        _log("normalizing uv.lock registry → public PyPI")
-        subprocess.run([sys.executable, str(normalize), str(src / "uv.lock")], env=env)
-
-
-def _repo_root() -> Path:
-    # integrations/slack/deploy/databricks/deploy.py → repo root (4 parents up).
-    return Path(__file__).resolve().parents[4]
 
 
 def _bundle_vars(args: argparse.Namespace) -> list[str]:
     # The app's own URL isn't known until it exists — empty on the first
-    # deploy, then passed via --webauth-base-url on the second (see main()).
-    webauth_base_url = args.webauth_base_url or ""
+    # deploy, then passed via --app-url on the second (see main()).
+    app_url = args.app_url or ""
     pairs = {
         "app_name": args.app_name,
         "secret_scope": args.secret_scope,
         "oauth_client_id": args.oauth_client_id,
         "server_url": args.server_url.rstrip("/"),
-        "webauth_base_url": webauth_base_url.rstrip("/"),
+        "app_url": app_url.rstrip("/"),
     }
     out: list[str] = []
     for key, value in pairs.items():
@@ -268,7 +246,7 @@ def main() -> None:
         help="Custom U2M OAuth app client id (public; passed inline, not a secret).",
     )
     parser.add_argument(
-        "--webauth-base-url",
+        "--app-url",
         default=None,
         help=(
             "This app's own public URL (the enrollment link base). Unknown "
@@ -283,29 +261,9 @@ def main() -> None:
         help="Explicit PEP 440 version to stamp. Default: <base>.post<unix-ts>.",
     )
     parser.add_argument(
-        "--index-url",
-        default=None,
-        help=(
-            "PyPI index URL for the uv lock step. Overrides UV_INDEX_URL; "
-            "defaults to public PyPI. On the Databricks network use the proxy: "
-            "https://pypi-proxy.cloud.databricks.com/simple (the lock is "
-            "normalized back to public PyPI afterward)."
-        ),
-    )
-    parser.add_argument(
-        "--exclude-newer",
-        default=None,
-        help=(
-            "uv --exclude-newer cutoff (e.g. 2026-07-19T00:00:00Z) for the lock "
-            "step. Match the Apps runtime's pinned cutoff so the in-container "
-            "re-resolve doesn't refetch (and time out) on PyPI — read it from "
-            "/logz. Omit for no cutoff."
-        ),
-    )
-    parser.add_argument(
         "--skip-build",
         action="store_true",
-        help="Reuse the existing src/ wheel + lock — skip the wheel build.",
+        help="Reuse the existing src/ wheel + pyproject — skip the wheel build.",
     )
     parser.add_argument(
         "--skip-run",
@@ -314,11 +272,11 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if not args.webauth_base_url:
+    if not args.app_url:
         _log(
-            "WARNING: --webauth-base-url not set. The enrollment link needs this "
+            "WARNING: --app-url not set. The enrollment link needs this "
             "app's public URL, which only exists after the first deploy. Re-run "
-            "with --webauth-base-url once you can read it: "
+            "with --app-url once you can read it: "
             f"databricks apps get {args.app_name} -o json | jq -r .url"
         )
 
@@ -327,12 +285,12 @@ def main() -> None:
         original_pyproject = _stamp_version(deploy_version)
         try:
             wheel = _build_wheel()
-            _write_uv_dependency_files(wheel, deploy_version, args.index_url, args.exclude_newer)
+            _write_app_pyproject(wheel, deploy_version)
         finally:
             # Restore the working-tree version so the deploy leaves no diff.
             (_slack_root() / "pyproject.toml").write_text(original_pyproject)
     else:
-        _log("--skip-build: reusing existing src/ wheel + lock")
+        _log("--skip-build: reusing existing src/ wheel + pyproject")
         if not list(_src_dir().glob(f"{_WHEEL_PREFIX}*.whl")):
             _fail("no wheel in src/ to reuse; run without --skip-build first")
 

--- a/integrations/slack/deploy/databricks/src/app.py
+++ b/integrations/slack/deploy/databricks/src/app.py
@@ -1,10 +1,11 @@
 """Databricks Apps entry point for the Omnigent Slack bot.
 
 Runs the Socket-Mode bot and, in Databricks web-auth mode, the enrollment web
-server that binds ``DATABRICKS_APP_PORT``. The package source (``omnigent_slack``)
-is copied next to this file by ``deploy.py``; its runtime deps come from the
-generated ``requirements.txt``. Startup failures are logged and the process is
-held open briefly so the platform captures them in ``/logz``.
+server. The ``omnigent_slack`` package is installed from the wheel ``deploy.py``
+copies next to this file; the app's ``uv run`` command resolves it (and the
+inlined runtime deps) from the generated ``pyproject.toml`` in-container at boot.
+Startup failures are logged and the process is held open briefly so the platform
+captures them in ``/logz``.
 """
 
 from __future__ import annotations

--- a/integrations/slack/deploy/databricks/src/app.yaml
+++ b/integrations/slack/deploy/databricks/src/app.yaml
@@ -1,4 +1,4 @@
-command: ["python", "app.py"]
+command: ["uv", "run", "python", "app.py"]
 env:
   - name: OMNIGENT_SLACK_SERVER_AUTH
     value: databricks

--- a/integrations/slack/src/omnigent_slack/config.py
+++ b/integrations/slack/src/omnigent_slack/config.py
@@ -162,18 +162,6 @@ class Settings(BaseSettings):
         validation_alias="OMNIGENT_SLACK_SERVER_AUTH",
     )
 
-    # Databricks workspace host the custom U2M OAuth app is registered in, e.g.
-    # ``https://my-workspace.cloud.databricks.com``. The bot hits its
-    # ``/oidc/v1/authorize`` and ``/oidc/v1/token`` endpoints. Distinct from
-    # server_url (the *.databricksapps.com app). Defaults to the platform-
-    # injected DATABRICKS_HOST when unset (the OAuth app lives in the same
-    # workspace the bot runs in); required — directly or via DATABRICKS_HOST —
-    # in databricks mode.
-    databricks_workspace_host: str | None = Field(
-        default_factory=lambda: _normalize_host(os.environ.get("DATABRICKS_HOST")),
-        validation_alias="OMNIGENT_SLACK_DATABRICKS_WORKSPACE_HOST",
-    )
-
     # Custom U2M OAuth app credentials (client id + secret) registered in the
     # workspace above. The client id is public; the secret authenticates the
     # token/refresh calls. Both required in databricks mode.
@@ -209,18 +197,12 @@ class Settings(BaseSettings):
     )
 
     # Public base URL of this bot's own Databricks App (where the enrollment
-    # page is reachable), used to build the link posted into Slack. Defaults to
-    # DATABRICKS_APP_URL when the platform injects it.
-    databricks_webauth_base_url: str | None = Field(
+    # page is reachable), used to build the link posted into Slack and as the
+    # OAuth redirect base. The operator must supply it: the platform injects no
+    # app-URL env var, and the app's URL only exists after its first deploy.
+    databricks_app_url: str | None = Field(
         default=None,
-        validation_alias="OMNIGENT_SLACK_WEBAUTH_BASE_URL",
-    )
-
-    # Port the enrollment web server binds. Databricks Apps route to
-    # DATABRICKS_APP_PORT (8000 by convention); honour it by default.
-    databricks_webauth_port: int = Field(
-        default_factory=lambda: int(os.environ.get("DATABRICKS_APP_PORT", "8000")),
-        validation_alias="OMNIGENT_SLACK_WEBAUTH_PORT",
+        validation_alias="OMNIGENT_SLACK_DATABRICKS_APP_URL",
     )
 
     @field_validator("server_url")
@@ -241,9 +223,31 @@ class Settings(BaseSettings):
         return value
 
     @property
+    def databricks_workspace_host(self) -> str | None:
+        """Workspace host the custom U2M OAuth app is registered in.
+
+        The bot hits this host's ``/oidc/v1/authorize`` and ``/oidc/v1/token``
+        endpoints. Distinct from ``server_url`` (the *.databricksapps.com app).
+        Read from the platform-injected ``DATABRICKS_HOST`` — the OAuth app lives
+        in the same workspace the bot runs in. A scheme-less value is defaulted
+        to https; ``None`` when unset (a laptop run must export ``DATABRICKS_HOST``).
+        """
+        return _normalize_host(os.environ.get("DATABRICKS_HOST"))
+
+    @property
+    def databricks_webauth_port(self) -> int:
+        """Port the enrollment web server binds.
+
+        Databricks Apps route inbound traffic to ``DATABRICKS_APP_PORT`` (8000
+        by convention) and inject it into the container, so the server binds
+        that. Falls back to 8000 for a laptop run where it's unset.
+        """
+        return int(os.environ.get("DATABRICKS_APP_PORT", "8000"))
+
+    @property
     def webauth_base_url(self) -> str | None:
         """Public base URL of this bot's enrollment page (for the Slack link)."""
-        base = self.databricks_webauth_base_url or os.environ.get("DATABRICKS_APP_URL")
+        base = self.databricks_app_url
         return base.strip().rstrip("/") if base else None
 
     @property
@@ -262,14 +266,6 @@ class Settings(BaseSettings):
         """Requested scopes with ``openid`` + ``offline_access`` forced on."""
         return _normalize_oauth_scopes(self.databricks_oauth_scopes)
 
-    @field_validator("databricks_workspace_host")
-    @classmethod
-    def _normalize_workspace_host(cls, value: str | None) -> str | None:
-        # A scheme-less host (e.g. DATABRICKS_HOST, or an operator typing just the
-        # hostname) is defaulted to https. The model validator then enforces https
-        # for any non-loopback host.
-        return _normalize_host(value)
-
     @model_validator(mode="after")
     def _check_databricks_config(self) -> Settings:
         """Fail fast when databricks mode is missing required config.
@@ -285,9 +281,9 @@ class Settings(BaseSettings):
                 ("OMNIGENT_SLACK_DATABRICKS_CLIENT_ID", self.databricks_oauth_client_id),
                 ("OMNIGENT_SLACK_DATABRICKS_CLIENT_SECRET", self.databricks_oauth_client_secret),
                 ("OMNIGENT_SLACK_DATABRICKS_STATE_SECRET", self.databricks_state_secret),
-                # workspace_host defaults to DATABRICKS_HOST (injected on the
-                # platform); still required for a laptop run where it's unset.
-                ("OMNIGENT_SLACK_DATABRICKS_WORKSPACE_HOST", self.databricks_workspace_host),
+                # workspace_host is DATABRICKS_HOST (injected on the platform);
+                # still required for a laptop run where it's unset.
+                ("DATABRICKS_HOST", self.databricks_workspace_host),
             )
             if not value
         ]
@@ -305,7 +301,7 @@ class Settings(BaseSettings):
         host = self.databricks_workspace_host or ""
         if host.startswith("http://") and not _is_loopback_url(host):
             raise ValueError(
-                "OMNIGENT_SLACK_DATABRICKS_WORKSPACE_HOST must use https:// "
+                "DATABRICKS_HOST must use https:// "
                 "(plaintext exposes the client secret and lets an on-path "
                 "attacker forge the id_token identity)"
             )
@@ -317,7 +313,7 @@ class Settings(BaseSettings):
         base = self.webauth_base_url or ""
         if base.startswith("http://") and not _is_loopback_url(base):
             raise ValueError(
-                "OMNIGENT_SLACK_WEBAUTH_BASE_URL must use https:// "
+                "OMNIGENT_SLACK_DATABRICKS_APP_URL must use https:// "
                 "(it is the OAuth redirect target — plaintext would expose the "
                 "authorization code and the consent page's identity data)"
             )

--- a/integrations/slack/src/omnigent_slack/webauth.py
+++ b/integrations/slack/src/omnigent_slack/webauth.py
@@ -134,10 +134,9 @@ class WebAuthServer:
         is the Slack user's email (from ``users.info``); it is signed into the
         state and later matched against the OAuth-authenticated email, so the
         enrolled token can only be the requesting user's own. ``None`` when the
-        redirect URI isn't configured (no ``OMNIGENT_SLACK_WEBAUTH_BASE_URL`` /
-        ``DATABRICKS_APP_URL``), the state secret is missing, or the email is
-        absent — so the caller surfaces a clear message instead of a broken (or
-        unverifiable) link.
+        redirect URI isn't configured (no ``OMNIGENT_SLACK_DATABRICKS_APP_URL``),
+        the state secret is missing, or the email is absent — so the caller
+        surfaces a clear message instead of a broken (or unverifiable) link.
         """
         secret = self._settings.databricks_state_secret
         if not self._settings.databricks_redirect_uri or not secret or not email:

--- a/integrations/slack/tests/test_config.py
+++ b/integrations/slack/tests/test_config.py
@@ -30,18 +30,17 @@ def _set_env(monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
         "OMNIGENT_SLACK_DATABASE_PATH",
         "OMNIGENT_SLACK_SERVER_AUTH",
         "OMNIGENT_SLACK_DATABRICKS_STATE_SECRET",
-        "OMNIGENT_SLACK_DATABRICKS_WORKSPACE_HOST",
         "OMNIGENT_SLACK_DATABRICKS_CLIENT_ID",
         "OMNIGENT_SLACK_DATABRICKS_CLIENT_SECRET",
         "OMNIGENT_SLACK_DATABRICKS_SCOPES",
-        "OMNIGENT_SLACK_WEBAUTH_BASE_URL",
-        "OMNIGENT_SLACK_WEBAUTH_PORT",
-        "DATABRICKS_APP_URL",
-        "DATABRICKS_APP_PORT",
+        "OMNIGENT_SLACK_DATABRICKS_APP_URL",
         "DATABRICKS_HOST",
     ):
         monkeypatch.delenv(key, raising=False)
-    env = {**_REQUIRED, **overrides}
+    # DATABRICKS_HOST is injected by the platform at runtime (a bare workspace
+    # host); simulate that so databricks-mode Settings construct. Not a user
+    # knob — the bot never lets it be overridden.
+    env = {"DATABRICKS_HOST": "ws.cloud.databricks.com", **_REQUIRED, **overrides}
     for key, value in env.items():
         monkeypatch.setenv(key, value)
 
@@ -178,7 +177,6 @@ def test_server_auth_mode_defaults_auto(monkeypatch: pytest.MonkeyPatch) -> None
 
 _DATABRICKS_KNOBS = {
     "OMNIGENT_SLACK_SERVER_AUTH": "databricks",
-    "OMNIGENT_SLACK_DATABRICKS_WORKSPACE_HOST": "https://ws.cloud.databricks.com",
     "OMNIGENT_SLACK_DATABRICKS_CLIENT_ID": "client-id",
     "OMNIGENT_SLACK_DATABRICKS_CLIENT_SECRET": "client-secret",
     "OMNIGENT_SLACK_DATABRICKS_STATE_SECRET": "state-secret-0123456789abcdef0123456789",
@@ -209,7 +207,6 @@ def test_databricks_mode_valid_with_required_knobs(monkeypatch: pytest.MonkeyPat
     _set_env(monkeypatch, **_DATABRICKS_KNOBS)
     settings = _load()
     assert settings.server_auth_mode == "databricks"
-    assert settings.databricks_workspace_host == "https://ws.cloud.databricks.com"
     assert settings.databricks_oauth_client_id == "client-id"
     # The state HMAC key is its own required knob, distinct from the client secret.
     assert settings.databricks_state_secret == "state-secret-0123456789abcdef0123456789"
@@ -224,16 +221,17 @@ def test_databricks_mode_rejects_short_state_secret(monkeypatch: pytest.MonkeyPa
         _load()
 
 
-def test_databricks_workspace_host_defaults_to_databricks_host(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # On the platform the workspace host is injected as DATABRICKS_HOST — a bare
-    # host with no scheme — so the operator needn't set it explicitly, and it's
-    # normalized to https.
-    knobs = {k: v for k, v in _DATABRICKS_KNOBS.items() if "WORKSPACE_HOST" not in k}
-    _set_env(monkeypatch, **knobs)
-    monkeypatch.setenv("DATABRICKS_HOST", "ws.cloud.databricks.com")
-    assert _load().databricks_workspace_host == "https://ws.cloud.databricks.com"
+def test_databricks_workspace_host_rejects_plaintext_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    # http:// defeats the TLS assumption behind skipping id_token verification.
+    _set_env(
+        monkeypatch,
+        **{
+            **_DATABRICKS_KNOBS,
+            "DATABRICKS_HOST": "http://ws.databricks.com",
+        },
+    )
+    with pytest.raises(ValidationError):
+        _load()
 
 
 def test_databricks_scopes_force_openid_and_offline(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -250,90 +248,54 @@ def test_databricks_redirect_uri_reuses_callback(monkeypatch: pytest.MonkeyPatch
     _set_env(
         monkeypatch,
         **_DATABRICKS_KNOBS,
-        OMNIGENT_SLACK_WEBAUTH_BASE_URL="https://bot.example.com",
+        OMNIGENT_SLACK_DATABRICKS_APP_URL="https://bot.example.com",
     )
     assert _load().databricks_redirect_uri == "https://bot.example.com/auth/callback"
 
 
-def test_databricks_rejects_plaintext_webauth_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    # The web-auth base URL is the OAuth redirect target (code + PII consent land
-    # there), so it must be https for any non-loopback host — same rule as the
-    # workspace host and server_url.
+def test_databricks_rejects_plaintext_app_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The app URL is the OAuth redirect target (code + PII consent land there),
+    # so it must be https for any non-loopback host — same rule as the workspace
+    # host and server_url.
     _set_env(
         monkeypatch,
         **_DATABRICKS_KNOBS,
-        OMNIGENT_SLACK_WEBAUTH_BASE_URL="http://bot.example.com",
+        OMNIGENT_SLACK_DATABRICKS_APP_URL="http://bot.example.com",
     )
     with pytest.raises(ValidationError):
         _load()
 
 
-def test_databricks_allows_loopback_webauth_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_databricks_allows_loopback_app_url(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_env(
         monkeypatch,
         **_DATABRICKS_KNOBS,
-        OMNIGENT_SLACK_WEBAUTH_BASE_URL="http://localhost:8000",
+        OMNIGENT_SLACK_DATABRICKS_APP_URL="http://localhost:8000",
     )
     assert _load().databricks_redirect_uri == "http://localhost:8000/auth/callback"
 
 
-def test_databricks_valid_without_webauth_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_databricks_valid_without_app_url(monkeypatch: pytest.MonkeyPatch) -> None:
     # Legitimately absent on the first deploy (app URL doesn't exist yet); that's
     # not a plaintext leak, just "no enrollment link yet".
-    monkeypatch.delenv("DATABRICKS_APP_URL", raising=False)
     _set_env(monkeypatch, **_DATABRICKS_KNOBS)
     settings = _load()
     assert settings.webauth_base_url is None
     assert settings.databricks_redirect_uri is None
 
 
-def test_databricks_workspace_host_defaults_scheme_to_https(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # A scheme-less host (DATABRICKS_HOST returns e.g. "ws.databricks.com") is
-    # normalized to https rather than rejected.
+def test_app_url_trailing_slash_trimmed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The operator supplies the app URL; the enrollment-link base trims a
+    # trailing slash so the redirect URI joins cleanly.
     _set_env(
         monkeypatch,
-        **{**_DATABRICKS_KNOBS, "OMNIGENT_SLACK_DATABRICKS_WORKSPACE_HOST": "ws.databricks.com"},
+        **_DATABRICKS_KNOBS,
+        OMNIGENT_SLACK_DATABRICKS_APP_URL="https://bot.example.com/",
     )
-    assert _load().databricks_workspace_host == "https://ws.databricks.com"
-
-
-def test_databricks_workspace_host_rejects_plaintext_http(monkeypatch: pytest.MonkeyPatch) -> None:
-    # http:// defeats the TLS assumption behind skipping id_token verification.
-    _set_env(
-        monkeypatch,
-        **{
-            **_DATABRICKS_KNOBS,
-            "OMNIGENT_SLACK_DATABRICKS_WORKSPACE_HOST": "http://ws.databricks.com",
-        },
-    )
-    with pytest.raises(ValidationError):
-        _load()
-
-
-def test_databricks_workspace_host_allows_http_loopback(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Loopback is exempt so local testing against a fake token endpoint works.
-    _set_env(
-        monkeypatch,
-        **{
-            **_DATABRICKS_KNOBS,
-            "OMNIGENT_SLACK_DATABRICKS_WORKSPACE_HOST": "http://127.0.0.1:8080",
-        },
-    )
-    assert _load().databricks_workspace_host == "http://127.0.0.1:8080"
-
-
-def test_webauth_base_url_falls_back_to_app_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    # The platform injects DATABRICKS_APP_URL; the enrollment-link base uses it
-    # when not set explicitly (trailing slash trimmed).
-    _set_env(monkeypatch)
-    monkeypatch.setenv("DATABRICKS_APP_URL", "https://bot.example.com/")
     assert _load().webauth_base_url == "https://bot.example.com"
 
 
-def test_webauth_port_defaults_to_databricks_app_port(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Databricks Apps route to DATABRICKS_APP_PORT; the web server binds it.
+def test_webauth_port_defaults_to_8000(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Laptop run without the platform var: fall back to the 8000 convention.
     _set_env(monkeypatch)
-    monkeypatch.setenv("DATABRICKS_APP_PORT", "9001")
-    assert _load().databricks_webauth_port == 9001
+    assert _load().databricks_webauth_port == 8000

--- a/integrations/slack/tests/test_webauth.py
+++ b/integrations/slack/tests/test_webauth.py
@@ -19,6 +19,13 @@ _WORKSPACE = "https://ws.cloud.databricks.com"
 _STATE_SECRET = "state-secret-0123456789abcdef0123456789"
 
 
+@pytest.fixture(autouse=True)
+def _workspace_host_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The workspace host is sourced from the platform-injected DATABRICKS_HOST
+    # (no bot-specific override), so provide it for the databricks-mode Settings.
+    monkeypatch.setenv("DATABRICKS_HOST", _WORKSPACE)
+
+
 def _settings() -> Settings:
     return Settings(
         _env_file=None,  # type: ignore[call-arg]
@@ -26,8 +33,7 @@ def _settings() -> Settings:
         OMNIGENT_SLACK_APP_TOKEN="xapp-x",
         OMNIGENT_SERVER_URL="https://omnigent.example.com",
         OMNIGENT_SLACK_SERVER_AUTH="databricks",
-        OMNIGENT_SLACK_WEBAUTH_BASE_URL="https://slackbot.example.com",
-        OMNIGENT_SLACK_DATABRICKS_WORKSPACE_HOST=_WORKSPACE,
+        OMNIGENT_SLACK_DATABRICKS_APP_URL="https://slackbot.example.com",
         OMNIGENT_SLACK_DATABRICKS_CLIENT_ID="client-id",
         OMNIGENT_SLACK_DATABRICKS_CLIENT_SECRET="client-secret",
         OMNIGENT_SLACK_DATABRICKS_STATE_SECRET=_STATE_SECRET,
@@ -144,8 +150,7 @@ def test_enrollment_url_none_without_email() -> None:
 
 
 def test_enrollment_url_none_without_base(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("DATABRICKS_APP_URL", raising=False)
-    settings = _settings().model_copy(update={"databricks_webauth_base_url": None})
+    settings = _settings().model_copy(update={"databricks_app_url": None})
     server = WebAuthServer(settings, InMemoryTokenStore(), oauth_client=FakeOAuthClient(_tokens()))  # type: ignore[arg-type]
     assert settings.webauth_base_url is None
     assert server.enrollment_url("T1", "U1", _EMAIL) is None


### PR DESCRIPTION
## Related issue

N/A

## Summary

Simplifies the Slack integration's Databricks-Apps configuration surface — fewer
knobs now, easy to open back up later — and drops the deploy-time `uv lock` step
in favor of in-container resolution.

- **Collapse platform-injected knobs.** The enrollment web server's bind port
  now comes straight from the injected `DATABRICKS_APP_PORT` (was
  `OMNIGENT_SLACK_WEBAUTH_PORT`), and the OAuth workspace host straight from the
  injected `DATABRICKS_HOST` (was `OMNIGENT_SLACK_DATABRICKS_WORKSPACE_HOST`).
  Both overrides are removed. These two vars are platform-managed, not knobs, so
  they're no longer documented or tested as such (the bare `DATABRICKS_HOST` is
  still prefixed with `https://` and https-validated at startup).
- **Rename the one operator-supplied URL knob.**
  `OMNIGENT_SLACK_WEBAUTH_BASE_URL` → `OMNIGENT_SLACK_DATABRICKS_APP_URL`
  (deploy flag `--webauth-base-url` → `--app-url`). Also removes a dead
  `DATABRICKS_APP_URL` fallback — the platform injects no app-URL var, so the app
  URL must be operator-supplied.
- **No more deploy-time `uv lock`.** `deploy.py` still builds the wheel, but the
  generated `src/pyproject.toml` now inlines the bot's runtime deps (read from
  the package `pyproject.toml`) and the app starts with `uv run`, so the Apps
  runtime resolves dependencies in-container at boot. Drops the `uv.lock`
  generation, registry-normalization, and the `--index-url` / `--exclude-newer`
  flags that only fed it.

### ELI5

The Slack bot runs as a Databricks App. Databricks already tells the app which
port and workspace it's in, so we stopped asking the operator to repeat that.
The one thing Databricks *can't* tell the app — its own public URL — we now name
clearly (`...DATABRICKS_APP_URL`). And instead of freezing an exact dependency
list at deploy time, the app just installs what it needs when it boots.

## Test Plan

- `cd integrations/slack && .venv/bin/python -m pytest tests/ --ignore=tests/e2e_ui`
  → all pass (config + webauth suites updated for the renames and knob removals).
- `python deploy/databricks/deploy.py --help` → shows `--app-url`, no
  `--index-url` / `--exclude-newer`.
- Generated-payload check: built a real wheel, wrote the generated
  `src/pyproject.toml`, ran `uv run --no-cache python -c "import omnigent_slack"`
  → uv resolved wheel + inlined deps, installed, imported successfully (the exact
  in-container boot path).
- Live config checks: `OMNIGENT_SLACK_DATABRICKS_APP_URL` supplies the enrollment
  base + redirect URI; the removed `DATABRICKS_APP_URL` fallback no longer fires;
  `DATABRICKS_HOST` / `DATABRICKS_APP_PORT` are read from the injected env.

## Demo

N/A — backend/config + deploy tooling; no UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [x] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Config renames and knob removals are covered by updated unit tests
(`tests/test_config.py`, `tests/test_webauth.py`), including the retained
plaintext-`http` `DATABRICKS_HOST` rejection. The deploy tooling has no unit
tests, so the `uv run` / generated-`pyproject.toml` path was verified manually:
built a wheel and confirmed `uv run` resolves and imports the package in a fresh
env (see Test Plan).

## Changelog

Slack-on-Databricks deploy: renamed `OMNIGENT_SLACK_WEBAUTH_BASE_URL` to `OMNIGENT_SLACK_DATABRICKS_APP_URL` (`--app-url`), removed the `WEBAUTH_PORT` / `DATABRICKS_WORKSPACE_HOST` overrides, and dropped deploy-time `uv lock` in favor of in-container `uv run`.
