### PR TITLE
feat(deploy): add reusable authenticated Compose deployment

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -1,0 +1,63 @@
+name: Deploy Compose
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: Immutable image reference to deploy
+        required: true
+        type: string
+      environment:
+        description: GitHub deployment environment
+        required: true
+        default: production
+        type: environment
+  workflow_call:
+    inputs:
+      image:
+        description: Immutable image reference to deploy
+        required: true
+        type: string
+      environment:
+        description: GitHub deployment environment
+        required: true
+        type: string
+    secrets:
+      postgres_password:
+        required: true
+      accounts_cookie_secret:
+        required: true
+      accounts_admin_password:
+        required: true
+      device_client_secret:
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: compose-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy ${{ inputs.environment }}
+    environment: ${{ inputs.environment }}
+    runs-on: [self-hosted, linux]
+    timeout-minutes: 15
+    env:
+      OMNIGENT_DEPLOY_IMAGE: ${{ inputs.image }}
+      OMNIGENT_DEPLOY_POSTGRES_PASSWORD: ${{ secrets.postgres_password }}
+      OMNIGENT_DEPLOY_ACCOUNTS_COOKIE_SECRET: ${{ secrets.accounts_cookie_secret }}
+      OMNIGENT_DEPLOY_ACCOUNTS_ADMIN_PASSWORD: ${{ secrets.accounts_admin_password }}
+      OMNIGENT_DEPLOY_DEVICE_CLIENT_SECRET: ${{ secrets.device_client_secret }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Task
+        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1
+
+      - name: Deploy and verify
+        working-directory: deploy/docker
+        run: task deploy

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -33,6 +33,58 @@ to launch a local runner against it. From your laptop:
 omnigent run path/to/agent.yaml --server http://localhost:8000
 ```
 
+### Reusable deployment pipeline
+
+The checked-in `Taskfile.yml` is the deployment entry point for both local
+operators and CI. It validates the Compose model, deploys with health-check
+waiting, and verifies the health and OAuth device-grant endpoints.
+
+For local deployment using the GPG-backed `pass` password manager, store:
+
+```text
+omnigent/rtx-3090/postgres-password
+omnigent/rtx-3090/accounts-cookie-secret
+omnigent/rtx-3090/accounts-admin-password
+omnigent/rtx-3090/device-client-secret
+```
+
+Then run the local secret-provider adapter:
+
+```bash
+task deploy:pass
+```
+
+Set `OMNIGENT_PASS_PREFIX` to use another password-store namespace and
+`OMNIGENT_DEPLOY_IMAGE` to select an immutable prebuilt image. The task reads
+only the first line of each entry and passes it to Compose's host-environment
+secret source. Compose mounts the values under `/run/secrets`; they are not
+included in the containers' environment or image. Neither the password store
+nor its GPG key is mounted into a container.
+
+CI uses the same provider-neutral task:
+
+```bash
+task deploy
+```
+
+The runner supplies these secret inputs:
+
+```text
+OMNIGENT_DEPLOY_POSTGRES_PASSWORD
+OMNIGENT_DEPLOY_ACCOUNTS_COOKIE_SECRET
+OMNIGENT_DEPLOY_ACCOUNTS_ADMIN_PASSWORD
+OMNIGENT_DEPLOY_DEVICE_CLIENT_SECRET
+```
+
+`.github/workflows/deploy-compose.yml` maps GitHub Environment secrets to
+those inputs on a self-hosted deployment runner. Other CI providers only need
+the equivalent secret mapping before invoking `task deploy`.
+
+Postgres consumes its native `POSTGRES_PASSWORD_FILE`. The OmniGent entrypoint
+accepts allowlisted `*_FILE` variables for its database password, accounts
+cookie secret, initial admin password, and device-client secret. The pass
+overlay also enables accounts authentication and OAuth device grants.
+
 Reset everything (drops the DB and the artifact store):
 
 ```bash

--- a/deploy/docker/Taskfile.yml
+++ b/deploy/docker/Taskfile.yml
@@ -1,0 +1,71 @@
+version: "3"
+
+vars:
+  COMPOSE: docker compose -f docker-compose.yaml -f docker-compose.pass.yaml
+  PASS_PREFIX: '{{default "omnigent/rtx-3090" .OMNIGENT_PASS_PREFIX}}'
+  HEALTH_TIMEOUT: '{{default "60" .OMNIGENT_HEALTH_TIMEOUT}}'
+
+tasks:
+  default:
+    desc: List the available deployment tasks
+    cmds:
+      - task --list
+
+  validate:
+    desc: Validate the resolved Compose deployment
+    preconditions:
+      - sh: test -n "$OMNIGENT_DEPLOY_POSTGRES_PASSWORD"
+        msg: OMNIGENT_DEPLOY_POSTGRES_PASSWORD is required
+      - sh: test -n "$OMNIGENT_DEPLOY_ACCOUNTS_COOKIE_SECRET"
+        msg: OMNIGENT_DEPLOY_ACCOUNTS_COOKIE_SECRET is required
+      - sh: test -n "$OMNIGENT_DEPLOY_ACCOUNTS_ADMIN_PASSWORD"
+        msg: OMNIGENT_DEPLOY_ACCOUNTS_ADMIN_PASSWORD is required
+      - sh: test -n "$OMNIGENT_DEPLOY_DEVICE_CLIENT_SECRET"
+        msg: OMNIGENT_DEPLOY_DEVICE_CLIENT_SECRET is required
+    cmds:
+      - "{{.COMPOSE}} config --quiet"
+
+  deploy:
+    desc: Run the provider-neutral Compose deployment pipeline
+    deps: [validate]
+    cmds:
+      - "{{.COMPOSE}} up -d --wait --wait-timeout {{.HEALTH_TIMEOUT}}"
+      - task: verify
+
+  verify:
+    desc: Verify container health and the OAuth contract
+    cmds:
+      - |
+        set -euo pipefail
+        endpoint="$({{.COMPOSE}} port omnigent 8000 | tail -n 1)"
+        host_port="${endpoint##*:}"
+        base_url="http://127.0.0.1:${host_port}"
+        curl --fail --silent --show-error "${base_url}/health"
+        curl --fail --silent --show-error "${base_url}/openapi.json" |
+          jq -e '
+            .paths["/oauth/device/authorize"] != null and
+            .paths["/oauth/token"] != null and
+            .paths["/oauth/revoke"] != null
+          ' >/dev/null
+        echo
+        echo "Deployment verified at ${base_url}"
+
+  status:
+    desc: Show deployment status
+    cmds:
+      - "{{.COMPOSE}} ps"
+
+  deploy:pass:
+    desc: Deploy locally using secrets from pass
+    silent: true
+    preconditions:
+      - sh: command -v pass >/dev/null
+        msg: pass is required for local secret resolution
+    cmds:
+      - |
+        set -euo pipefail
+        export OMNIGENT_DEPLOY_POSTGRES_PASSWORD="$(pass show '{{.PASS_PREFIX}}/postgres-password' | sed -n '1p')"
+        export OMNIGENT_DEPLOY_ACCOUNTS_COOKIE_SECRET="$(pass show '{{.PASS_PREFIX}}/accounts-cookie-secret' | sed -n '1p')"
+        export OMNIGENT_DEPLOY_ACCOUNTS_ADMIN_PASSWORD="$(pass show '{{.PASS_PREFIX}}/accounts-admin-password' | sed -n '1p')"
+        export OMNIGENT_DEPLOY_DEVICE_CLIENT_SECRET="$(pass show '{{.PASS_PREFIX}}/device-client-secret' | sed -n '1p')"
+        task deploy

--- a/deploy/docker/docker-compose.pass.yaml
+++ b/deploy/docker/docker-compose.pass.yaml
@@ -1,0 +1,51 @@
+# Secret-backed deployment overlay.
+#
+# The deployment task supplies these values from pass locally or from the CI
+# provider's secret store. Compose mounts them as files in the containers.
+
+services:
+  postgres:
+    environment:
+      POSTGRES_PASSWORD: !reset null
+      POSTGRES_PASSWORD_FILE: /run/secrets/postgres-password
+    secrets:
+      - postgres-password
+
+  omnigent:
+    image: ${OMNIGENT_DEPLOY_IMAGE:-omnigent-server:pass-secrets}
+    build: !reset null
+    environment:
+      DATABASE_URL: !reset null
+      DATABASE_HOST: postgres
+      DATABASE_PORT: "5432"
+      DATABASE_NAME: "${POSTGRES_DB:-omnigent}"
+      DATABASE_USER: "${POSTGRES_USER:-omnigent}"
+      DATABASE_PASSWORD_FILE: /run/secrets/postgres-password
+
+      OMNIGENT_AUTH_ENABLED: "1"
+      OMNIGENT_AUTH_PROVIDER: accounts
+      OMNIGENT_DEVICE_GRANT_ENABLED: "1"
+
+      OMNIGENT_ACCOUNTS_COOKIE_SECRET: !reset null
+      OMNIGENT_ACCOUNTS_COOKIE_SECRET_FILE: /run/secrets/accounts-cookie-secret
+      OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD: !reset null
+      OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD_FILE: /run/secrets/accounts-admin-password
+      OMNIGENT_DEVICE_CLIENT_SECRET_FILE: /run/secrets/device-client-secret
+
+      OMNIGENT_OIDC_CLIENT_SECRET: !reset null
+      OMNIGENT_OIDC_COOKIE_SECRET: !reset null
+    secrets:
+      - postgres-password
+      - accounts-cookie-secret
+      - accounts-admin-password
+      - device-client-secret
+
+secrets:
+  postgres-password:
+    environment: OMNIGENT_DEPLOY_POSTGRES_PASSWORD
+  accounts-cookie-secret:
+    environment: OMNIGENT_DEPLOY_ACCOUNTS_COOKIE_SECRET
+  accounts-admin-password:
+    environment: OMNIGENT_DEPLOY_ACCOUNTS_ADMIN_PASSWORD
+  device-client-secret:
+    environment: OMNIGENT_DEPLOY_DEVICE_CLIENT_SECRET

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -64,6 +64,9 @@ services:
       # the file survives container restarts. Empty/unset would
       # write to /root/.omnigent/ inside the ephemeral container.
       OMNIGENT_ADMIN_CREDENTIALS_PATH: /data/admin-credentials
+      # Origin allowlist for WebSocket + multipart routes behind
+      # a Tailscale (or any other) reverse proxy. Set in .env.
+      OMNIGENT_WS_ALLOWED_ORIGINS: "${OMNIGENT_WS_ALLOWED_ORIGINS:-}"
 
       # ── Auth ─────────────────────────────────────────
       # OMNIGENT_AUTH_ENABLED is the single auth switch. "1" (the

--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -40,6 +40,7 @@ import traceback
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -59,6 +60,13 @@ _DEFAULT_HOST = "0.0.0.0"
 # decoupled from the CLI's local-server default (6767 in host/local_server.py).
 _DEFAULT_PORT = "8000"
 _DEFAULT_ARTIFACT_DIR = "/data/artifacts"
+_SECRET_FILE_ENV = {
+    "OMNIGENT_ACCOUNTS_COOKIE_SECRET": "OMNIGENT_ACCOUNTS_COOKIE_SECRET_FILE",
+    "OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD": ("OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD_FILE"),
+    "OMNIGENT_DEVICE_CLIENT_SECRET": "OMNIGENT_DEVICE_CLIENT_SECRET_FILE",
+    "OMNIGENT_OIDC_CLIENT_SECRET": "OMNIGENT_OIDC_CLIENT_SECRET_FILE",
+    "OMNIGENT_OIDC_COOKIE_SECRET": "OMNIGENT_OIDC_COOKIE_SECRET_FILE",
+}
 
 
 @dataclass(frozen=True)
@@ -111,6 +119,45 @@ def run_migrations(database_url: str) -> None:
         migration_engine.dispose()
 
 
+def _read_secret_file(variable: str, file_variable: str) -> str | None:
+    """Load one allowlisted secret without putting it in container metadata."""
+
+    path_value = os.environ.get(file_variable, "").strip()
+    direct_value = os.environ.get(variable, "")
+    if not path_value:
+        return direct_value or None
+    if direct_value:
+        raise RuntimeError(f"set {variable} or {file_variable}, not both")
+    try:
+        value = Path(path_value).read_text(encoding="utf-8").rstrip("\r\n")
+    except OSError as exc:
+        raise RuntimeError(f"cannot read {file_variable}: {exc}") from exc
+    if not value:
+        raise RuntimeError(f"{file_variable} points to an empty secret")
+    return value
+
+
+def _load_secret_files() -> None:
+    for variable, file_variable in _SECRET_FILE_ENV.items():
+        value = _read_secret_file(variable, file_variable)
+        if value is not None:
+            os.environ[variable] = value
+
+
+def _database_url_from_secret_file() -> str | None:
+    password = _read_secret_file("DATABASE_PASSWORD", "DATABASE_PASSWORD_FILE")
+    if password is None:
+        return None
+    user = os.environ.get("DATABASE_USER", "omnigent")
+    host = os.environ.get("DATABASE_HOST", "postgres")
+    port = os.environ.get("DATABASE_PORT", "5432")
+    name = os.environ.get("DATABASE_NAME", "omnigent")
+    return (
+        f"postgresql+psycopg://{quote(user, safe='')}:{quote(password, safe='')}"
+        f"@{host}:{port}/{quote(name, safe='')}"
+    )
+
+
 def _resolve_config() -> _ResolvedConfig:
     """Load config and resolve startup settings before migrations run."""
 
@@ -119,6 +166,7 @@ def _resolve_config() -> _ResolvedConfig:
     from omnigent.server.server_config import load_server_config
 
     # ── Configuration ────────────────────────────────────────
+    _load_secret_files()
     # Non-secret settings come from a YAML config file (default
     # <data_dir>/config.yaml, e.g. /data/config.yaml on the volume, or
     # OMNIGENT_CONFIG) — the same experience a laptop gets from
@@ -128,7 +176,11 @@ def _resolve_config() -> _ResolvedConfig:
 
     # DATABASE_URL is env-first (compose/PaaS inject it; it's a secret),
     # with `database_uri:` in the config as a fallback for self-managed DBs.
-    database_url = os.environ.get("DATABASE_URL") or cfg.get("database_uri")
+    database_url = (
+        os.environ.get("DATABASE_URL")
+        or _database_url_from_secret_file()
+        or cfg.get("database_uri")
+    )
     if not database_url:
         raise RuntimeError(
             "DATABASE_URL is required (env), or set `database_uri:` in the server config. "

--- a/tests/deploy/test_docker_entrypoint_import.py
+++ b/tests/deploy/test_docker_entrypoint_import.py
@@ -12,6 +12,7 @@ blow up if called during import).
 from __future__ import annotations
 
 import importlib
+import os
 import sys
 from pathlib import Path
 from typing import NoReturn
@@ -129,6 +130,69 @@ def test_resolve_config_rejects_non_s3_artifact_uri(
 
     monkeypatch.setenv("OMNIGENT_ARTIFACT_URI", "gs://my-bucket")
     with pytest.raises(RuntimeError, match="s3://"):
+        _resolve_config()
+
+
+def test_resolve_config_reads_database_password_from_secret_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from deploy.docker.entrypoint import _resolve_config
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("{}\n")
+    password_file = tmp_path / "database-password"
+    password_file.write_text("p@ss/word\n")
+    monkeypatch.setenv("OMNIGENT_CONFIG", str(config_file))
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("DATABASE_HOST", "postgres")
+    monkeypatch.setenv("DATABASE_PORT", "5432")
+    monkeypatch.setenv("DATABASE_NAME", "omnigent")
+    monkeypatch.setenv("DATABASE_USER", "omnigent")
+    monkeypatch.setenv("DATABASE_PASSWORD_FILE", str(password_file))
+    monkeypatch.setenv("ARTIFACT_DIR", str(tmp_path / "artifacts"))
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "0")
+
+    resolved = _resolve_config()
+
+    assert (
+        resolved.database_url
+        == "postgresql+psycopg://omnigent:p%40ss%2Fword@postgres:5432/omnigent"
+    )
+    assert "DATABASE_PASSWORD" not in os.environ
+
+
+def test_resolve_config_loads_allowlisted_secret_file(
+    _entrypoint_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from deploy.docker.entrypoint import _resolve_config
+
+    secret_file = tmp_path / "cookie-secret"
+    secret_file.write_text("cookie-value\n")
+    monkeypatch.delenv("OMNIGENT_ACCOUNTS_COOKIE_SECRET", raising=False)
+    monkeypatch.setenv(
+        "OMNIGENT_ACCOUNTS_COOKIE_SECRET_FILE",
+        str(secret_file),
+    )
+
+    _resolve_config()
+
+    assert os.environ["OMNIGENT_ACCOUNTS_COOKIE_SECRET"] == "cookie-value"
+
+
+def test_resolve_config_rejects_ambiguous_secret_sources(
+    _entrypoint_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from deploy.docker.entrypoint import _resolve_config
+
+    secret_file = tmp_path / "cookie-secret"
+    secret_file.write_text("file-value\n")
+    monkeypatch.setenv("OMNIGENT_ACCOUNTS_COOKIE_SECRET", "environment-value")
+    monkeypatch.setenv(
+        "OMNIGENT_ACCOUNTS_COOKIE_SECRET_FILE",
+        str(secret_file),
+    )
+
+    with pytest.raises(RuntimeError, match="both"):
         _resolve_config()
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add allowlisted Docker secret-file support for PostgreSQL and OmniGent authentication credentials.
- Add one Task-based Compose pipeline shared by local `pass` deployments and self-hosted GitHub Actions deployments.
- Enable and verify accounts authentication and OAuth device grants without retaining secret values in container environment metadata.


## Test Plan

- `uv run pytest -q tests/deploy/test_docker_entrypoint_import.py`
- `uv run pre-commit run`
- `task deploy:pass`
- Confirm both Compose services become healthy.
- Confirm `/health`, `/oauth/device/authorize`, `/oauth/token`, and `/oauth/revoke`.
- Inspect the running container for four `/run/secrets` mounts and no direct secret environment values.
- Run the repository workflow misuse linter and `actionlint`.

## Demo

N/A — non-visual deployment and authentication infrastructure.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The pass-backed pipeline was exercised against the local Compose stack through its health and OAuth verification stages. Container inspection confirmed that secrets are mounted as files and absent from direct container environment values.

## Changelog

Deploy OmniGent with the same authenticated, secret-safe Compose pipeline locally and from CI.
