### PR TITLE
fix(web): remove "Create new project" from the project picker menu

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_pinned_project_flyout.py
+++ b/tests/e2e_ui/sessions/test_sidebar_pinned_project_flyout.py
@@ -46,16 +46,27 @@ def _row(page: Page, session_id: str) -> Locator:
     return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
 
 
+def _create_project(page: Page, name: str) -> None:
+    """Create an empty project via the "Projects" group header's "New project"
+    (+) button, typing *name* into the dialog and confirming."""
+    page.get_by_test_id("new-project").click()
+    dialog_input = page.get_by_placeholder("Project name…")
+    dialog_input.fill(name)
+    page.get_by_test_id("new-project-confirm").click()
+
+
 def _move_to_new_project(page: Page, row: Locator, name: str) -> None:
-    """Drive the row kebab → "Add to project" → "Create new project" flow,
-    typing *name* and committing with Enter."""
+    """File *row*'s session into a fresh project *name*.
+
+    Projects are created from the "Projects" group header's + button (the
+    picker no longer offers an inline "Create new project"), so this first
+    creates the empty project, then drives the row kebab → "Add to project" →
+    picking that project from the list."""
+    _create_project(page, name)
     row.hover()
     row.get_by_test_id("conversation-actions").click()
     page.get_by_test_id("move-to-project").click()
-    page.get_by_role("menuitem", name="Create new project").click()
-    new_input = page.get_by_placeholder("Project name…")
-    new_input.fill(name)
-    new_input.press("Enter")
+    page.get_by_role("menuitem", name=name, exact=True).click()
 
 
 def test_pinned_project_row_hover_shows_project_name(

--- a/tests/e2e_ui/sessions/test_sidebar_projects.py
+++ b/tests/e2e_ui/sessions/test_sidebar_projects.py
@@ -52,28 +52,40 @@ def _row(page: Page, session_id: str) -> Locator:
     return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
 
 
+def _create_project(page: Page, name: str) -> None:
+    """Create an empty project via the "Projects" group header's "New project"
+    (+) button, typing *name* into the dialog and confirming."""
+    page.get_by_test_id("new-project").click()
+    dialog_input = page.get_by_placeholder("Project name…")
+    dialog_input.fill(name)
+    page.get_by_test_id("new-project-confirm").click()
+
+
 def _move_to_new_project(page: Page, row: Locator, name: str) -> None:
-    """Drive the row kebab → "Add to project" → "Create new project" flow,
-    typing *name* and committing with Enter."""
+    """File *row*'s session into a fresh project *name*.
+
+    Projects are created from the "Projects" group header's + button (the
+    picker no longer offers an inline "Create new project"), so this first
+    creates the empty project, then drives the row kebab → "Add to project" →
+    picking that project from the list."""
+    _create_project(page, name)
     row.hover()
     row.get_by_test_id("conversation-actions").click()
-    # Open the submenu flyout, then start the inline new-project input.
+    # Open the submenu flyout, then pick the just-created project by name.
     page.get_by_test_id("move-to-project").click()
-    page.get_by_role("menuitem", name="Create new project").click()
-    new_input = page.get_by_placeholder("Project name…")
-    new_input.fill(name)
-    new_input.press("Enter")
+    page.get_by_role("menuitem", name=name, exact=True).click()
 
 
 def test_move_session_into_new_project(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Creating a project from the kebab moves the row into it.
+    """Filing a session into a freshly-created project moves the row into it.
 
-    The session starts under "Sessions"; after "Add to project → Create new
-    project", a project folder with that name appears under the "Projects" group and the
-    row lives under it (once expanded) and no longer under "Sessions".
+    The session starts under "Sessions"; after creating the project (+ button)
+    and picking it from "Add to project", a project folder with that name
+    appears under the "Projects" group and the row lives under it (once
+    expanded) and no longer under "Sessions".
     """
     base_url, session_id = seeded_session
     title = f"e2e-proj-{uuid.uuid4().hex[:8]}"

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -479,8 +479,8 @@ describe("mobile in-place project picker", () => {
   // Desktop opens the "Add to project" item as a side-flyout submenu, but a
   // side flyout has no room on mobile. There the item instead swaps the kebab
   // body in place: the main actions are replaced by the project picker (search
-  // + list + Create new project) plus a Back control that returns to the main
-  // menu — no submenu, no close/reopen. Desktop keeps the flyout untouched.
+  // + list) plus a Back control that returns to the main menu — no submenu, no
+  // close/reopen. Desktop keeps the flyout untouched.
 
   it("swaps the kebab body to the project picker in place, and Back returns", () => {
     mocks.isMobile = true;
@@ -499,12 +499,11 @@ describe("mobile in-place project picker", () => {
     expect(moveItem).not.toHaveAttribute("aria-haspopup", "menu");
 
     // Tapping it swaps the body in place to the project picker — the main
-    // actions are gone, and the picker (search + project + Create new project)
-    // plus a Back control are shown.
+    // actions are gone, and the picker (search + project list) plus a Back
+    // control are shown.
     fireEvent.click(moveItem);
     expect(screen.getByPlaceholderText("Search projects")).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /Sprint 42/ })).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: /Create new project/ })).toBeInTheDocument();
     expect(screen.getByTestId("project-picker-back")).toBeInTheDocument();
     // The main actions are no longer rendered — the body was replaced, not
     // stacked beside a flyout.

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -40,7 +40,6 @@ import {
   PencilIcon,
   PinIcon,
   PinOffIcon,
-  PlusIcon,
   SearchIcon,
   SettingsIcon,
   ShareIcon,
@@ -3518,26 +3517,10 @@ function ProjectPickerMenu({
 }) {
   const { data: projects = [] } = useProjects();
   const [search, setSearch] = useState("");
-  const [creatingNew, setCreatingNew] = useState(false);
-  const [newProjectName, setNewProjectName] = useState("");
-  const newInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (creatingNew) {
-      newInputRef.current?.focus();
-    }
-  }, [creatingNew]);
 
   const filtered = search
     ? projects.filter((p) => p.name.toLowerCase().includes(search.toLowerCase()))
     : projects;
-
-  function handleNewProjectCommit() {
-    const name = newProjectName.trim();
-    setCreatingNew(false);
-    setNewProjectName("");
-    if (name) onSelect(name);
-  }
 
   // Keep keystrokes inside the inputs from reaching the menu's typeahead /
   // navigation handlers (which would otherwise steal letters and arrows).
@@ -3566,54 +3549,20 @@ function ProjectPickerMenu({
             )}
           </C.Item>
         ))}
-        {filtered.length === 0 && !creatingNew && (
+        {filtered.length === 0 && (
           <p className="px-2 py-1.5 text-xs text-muted-foreground">No projects yet.</p>
         )}
       </div>
-      <div className="border-t pt-1">
-        {creatingNew ? (
-          <div className="flex items-center gap-1 px-2 py-1">
-            <input
-              ref={newInputRef}
-              className="flex-1 bg-transparent text-xs outline-none"
-              placeholder="Project name…"
-              value={newProjectName}
-              onChange={(e) => setNewProjectName(e.target.value)}
-              onKeyDown={(e) => {
-                e.stopPropagation();
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  handleNewProjectCommit();
-                }
-                if (e.key === "Escape") {
-                  setCreatingNew(false);
-                  setNewProjectName("");
-                }
-              }}
-            />
-          </div>
-        ) : (
-          <C.Item
-            className="px-2 py-1"
-            // Keep the menu open so the inline input can take over in place.
-            onSelect={(e) => {
-              e.preventDefault();
-              setCreatingNew(true);
-            }}
-          >
-            <PlusIcon className="size-3.5 shrink-0" />
-            Create new project
-          </C.Item>
-        )}
-        {currentProject && (
+      {currentProject && (
+        <div className="border-t pt-1">
           <C.Item className="px-2 py-1" onSelect={() => onSelect("")}>
             Remove from{" "}
             <span className="rounded bg-muted px-1 py-0.5 font-mono text-[0.95em]">
               {currentProject}
             </span>
           </C.Item>
-        )}
-      </div>
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The sidebar project picker menu had a "Create new project" row (with an inline name input) that duplicated the existing entry point — the **+** icon next to the "Projects" header.
- This removes that redundant row from `ProjectPickerMenu`, along with the inline new-project input it toggled and its now-unused state/handlers. The picker now shows: search → project list → "Remove from \<project\>".

## Test Plan

- `cd web && npm test` — all pass (updated the mobile in-place project picker test that asserted the "Create new project" menuitem).
- `cd web && npm run build` — passes.
- Manual: open the sidebar kebab → project picker; confirmed the "Create new project" row is gone while search, selection checkmark, and "Remove from …" still work, and project creation is still reachable from the + icon.

## Demo

N/A — removes a menu row; behaviour otherwise unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Updated `Sidebar.rowActions.test.tsx` to drop the assertion for the removed "Create new project" menuitem. Manually verified the picker in the running app: search, project selection, and "Remove from …" still work; new projects are created via the + icon next to Projects.

## Changelog

Removed the redundant "Create new project" option from the sidebar project picker — create projects with the + icon next to Projects

This pull request and its description were written by Isaac.