### PR TITLE
fix(web): stop refetching terminals on every chat↔terminal switch

### DIFF
--- a/web/src/hooks/useTerminals.test.ts
+++ b/web/src/hooks/useTerminals.test.ts
@@ -20,6 +20,7 @@ import {
   terminalsReconcileInterval,
   terminalTabKey,
   useTerminals,
+  useTerminalsLivenessSync,
   type TerminalInfo,
 } from "./useTerminals";
 
@@ -376,6 +377,13 @@ describe("useTerminals — SSE-primary list, poll corrects on edges", () => {
     return { client, wrapper };
   }
 
+  // Mirror the shell: `useTerminals` reads the shared cache, and a single
+  // `useTerminalsLivenessSync` applies the runner-liveness edge corrections.
+  const useTerminalsWithSync = (conversationId: string) => {
+    useTerminalsLivenessSync(conversationId);
+    return useTerminals(conversationId);
+  };
+
   const TERMINAL = { id: "terminal_claude_main", name: "claude", session: "main", running: true };
   const emptyList = () => mockResponse({ object: "list", data: [] });
   const oneTerminal = () =>
@@ -402,7 +410,7 @@ describe("useTerminals — SSE-primary list, poll corrects on edges", () => {
     fetchMock.mockResolvedValue(oneTerminal());
     runnerOnlineMock.mockReturnValue(false);
 
-    const { result } = renderHook(() => useTerminals("conv_abc"), {
+    const { result } = renderHook(() => useTerminalsWithSync("conv_abc"), {
       wrapper: makeClientWrapper().wrapper,
     });
     await act(async () => void (await vi.advanceTimersByTimeAsync(0)));
@@ -420,7 +428,7 @@ describe("useTerminals — SSE-primary list, poll corrects on edges", () => {
     fetchMock.mockResolvedValue(oneTerminal());
     runnerOnlineMock.mockReturnValue(true);
 
-    const { result, rerender } = renderHook(() => useTerminals("conv_abc"), {
+    const { result, rerender } = renderHook(() => useTerminalsWithSync("conv_abc"), {
       wrapper: makeClientWrapper().wrapper,
     });
     await act(async () => void (await vi.advanceTimersByTimeAsync(0)));
@@ -446,7 +454,7 @@ describe("useTerminals — SSE-primary list, poll corrects on edges", () => {
     fetchMock.mockResolvedValue(emptyList());
     runnerOnlineMock.mockReturnValue(undefined);
 
-    const { result, rerender } = renderHook(() => useTerminals("conv_abc"), {
+    const { result, rerender } = renderHook(() => useTerminalsWithSync("conv_abc"), {
       wrapper: makeClientWrapper().wrapper,
     });
     await act(async () => void (await vi.advanceTimersByTimeAsync(0)));
@@ -464,6 +472,29 @@ describe("useTerminals — SSE-primary list, poll corrects on edges", () => {
     });
     await act(async () => void rerender());
     expect(result.current.terminals).toEqual([TERMINAL]);
+  });
+
+  it("mounting an extra useTerminals consumer while online does not refetch", async () => {
+    // The chat↔terminal switch: with a terminal already seeded and the runner
+    // online, opening a second `useTerminals` consumer must serve the shared
+    // cache without a network round-trip. The liveness edge memory lives in a
+    // single `useTerminalsLivenessSync`, so a fresh consumer can't read a
+    // spurious `undefined → true` "came online" edge and invalidate the cache.
+    fetchMock.mockResolvedValue(oneTerminal());
+    runnerOnlineMock.mockReturnValue(true);
+    const { wrapper } = makeClientWrapper();
+
+    const first = renderHook(() => useTerminalsWithSync("conv_abc"), { wrapper });
+    await act(async () => void (await vi.advanceTimersByTimeAsync(0)));
+    expect(first.result.current.terminals).toEqual([TERMINAL]);
+    const callsAfterFirst = fetchMock.mock.calls.length;
+
+    // A plain consumer (no liveness sync — the shell owns that one) mounts on
+    // the tab switch. It shares the cache and must not trigger any fetch.
+    const second = renderHook(() => useTerminals("conv_abc"), { wrapper });
+    await act(async () => void (await vi.advanceTimersByTimeAsync(0)));
+    expect(second.result.current.terminals).toEqual([TERMINAL]);
+    expect(fetchMock.mock.calls.length).toBe(callsAfterFirst);
   });
 });
 

--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -394,13 +394,10 @@ export function useTerminals(
   // The terminal list is SSE-primary: live `session.resource.{created,deleted}`
   // deltas (plus the mount seed) ARE the list, so a terminal becomes openable
   // the instant its `created` event lands — no waiting on the runner-liveness
-  // poll. The `/health` poll (`runnerOnline`) is only a *corrector* for the
-  // statuses the SSE stream can't deliver, applied on its liveness edges in the
-  // effect below — it never continuously masks the SSE-driven list. Runner
-  // liveness is poll-driven (the real-time push was removed upstream), so a
-  // continuous mask would read stale-`false` during a cold/relaunch boot and
-  // wrongly hide a terminal the SSE just delivered.
-  const runnerOnline = useSessionRunnerOnline(conversationId ?? undefined);
+  // poll. The runner-liveness corrections that the SSE stream can't deliver
+  // live in `useTerminalsLivenessSync`, mounted once per session in the shell —
+  // NOT here, so mounting an extra consumer (e.g. opening the terminal view)
+  // never re-fires the "came online" refetch on this shared cache.
   const { data, isLoading, error } = useQuery({
     queryKey:
       conversationId === null
@@ -429,20 +426,48 @@ export function useTerminals(
     refetchInterval: (query) =>
       terminalsReconcileInterval(reconcileWhilePending, query.state.data?.length ?? 0),
   });
-  // The poll corrects the SSE-driven list ONLY on runner-liveness edges — it
-  // never masks continuously. Two corrections, both keyed off the edge so a
-  // stale-`false` read during boot (before the runner has ever been seen up)
-  // can't wipe a terminal the SSE just delivered:
-  //
-  //   - `→ true` (came online): re-read the authoritative endpoint to pick up
-  //     a `session.resource.created` the SSE may have dropped. The queryFn
-  //     unions, so a live SSE entry is never lost — this is purely additive.
-  //   - `true → false` (confirmed stop): the runner's PTYs are gone, but a
-  //     stop emits no `session.resource.deleted`, so the SSE list would keep
-  //     showing dead terminals. Clear them. Gated on the *was-online* edge so
-  //     it fires for a real stop, not for the cold-boot `undefined → false`
-  //     window (where the runner is on its way up and a terminal may already
-  //     have arrived via SSE).
+  return {
+    // SSE-primary: the list is whatever the cache holds (seed + live deltas,
+    // corrected on the runner-liveness edges in `useTerminalsLivenessSync`).
+    // No continuous runner-online mask.
+    terminals: data ?? [],
+    isLoading,
+    error: (error as Error | null) ?? null,
+  };
+}
+
+/**
+ * Correct the SSE-driven terminals cache on runner-liveness edges.
+ *
+ * Mount this EXACTLY ONCE per session, from a component that stays mounted
+ * for the session's whole lifetime (the shell), not from a
+ * :func:`useTerminals` consumer — the edge memory below is per-instance, so
+ * a fresh mount observing an already-online runner would read a spurious
+ * ``undefined → true`` "came online" edge and refetch the shared cache. That
+ * is exactly the cost a chat↔terminal tab switch used to pay on every toggle.
+ *
+ * The runner-liveness ``/health`` poll (``runnerOnline``) corrects the
+ * SSE-driven list ONLY on its edges — it never masks continuously. Two
+ * corrections, both keyed off the edge so a stale-``false`` read during boot
+ * (before the runner has ever been seen up) can't wipe a terminal the SSE
+ * just delivered:
+ *
+ *   - ``→ true`` (came online): re-read the authoritative endpoint to pick up
+ *     a ``session.resource.created`` the SSE may have dropped. The queryFn
+ *     unions, so a live SSE entry is never lost — this is purely additive.
+ *   - ``true → false`` (confirmed stop): the runner's PTYs are gone, but a
+ *     stop emits no ``session.resource.deleted``, so the SSE list would keep
+ *     showing dead terminals. Clear them. Gated on the *was-online* edge so
+ *     it fires for a real stop, not for the cold-boot ``undefined → false``
+ *     window (where the runner is on its way up and a terminal may already
+ *     have arrived via SSE).
+ *
+ * :param conversationId: Session/conversation identifier, or ``null`` when
+ *     no session is open (the effect is inert).
+ */
+export function useTerminalsLivenessSync(conversationId: string | null): void {
+  const queryClient = useQueryClient();
+  const runnerOnline = useSessionRunnerOnline(conversationId ?? undefined);
   const wasRunnerOnline = useRef<boolean | undefined>(undefined);
   useEffect(() => {
     if (conversationId !== null) {
@@ -454,11 +479,4 @@ export function useTerminals(
     }
     wasRunnerOnline.current = runnerOnline;
   }, [conversationId, runnerOnline, queryClient]);
-  return {
-    // SSE-primary: the list is whatever the cache holds (seed + live deltas,
-    // corrected on poll edges above). No continuous runner-online mask.
-    terminals: data ?? [],
-    isLoading,
-    error: (error as Error | null) ?? null,
-  };
 }

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -51,6 +51,7 @@ import {
   PANEL_NO_TERMINAL_KEY,
   terminalTabKey,
   useTerminals,
+  useTerminalsLivenessSync,
 } from "@/hooks/useTerminals";
 import {
   useWorkspaceChangedFiles,
@@ -280,6 +281,11 @@ export function AppShell() {
   const { terminals } = useTerminals(conversationId ?? null, {
     reconcileWhilePending: terminalPending,
   });
+  // Owns the runner-liveness corrections to the shared terminals cache. Mounted
+  // once here — the shell outlives chat↔terminal switches — so extra
+  // `useTerminals` consumers (the terminal view, the rail) don't re-fire the
+  // "came online" refetch each time they mount.
+  useTerminalsLivenessSync(conversationId ?? null);
 
   const debugMode = useDebugMode();
   const { data: conversationsData } = useConversations("", true);


### PR DESCRIPTION
## Related issue

N/A

## Summary

Switching to the terminals tab fired a fresh `GET /v1/sessions/<id>/resources/terminals?order=asc&limit=1000` on **every** chat↔terminal toggle — even though `AppShell` already seeds that query, it uses `staleTime: Infinity`, and every consumer shares the same query key. A plain remount should have served the cache.

The refetch came from the runner-liveness correction effect that lived *inside* `useTerminals`. Its `wasRunnerOnline` ref resets to `undefined` on every fresh mount, so a consumer mounting while the runner is already online (the terminal view, on a tab switch) read `undefined → true` as a "came online" edge and invalidated the shared cache for every consumer.

The fix lifts that effect into a standalone `useTerminalsLivenessSync` hook mounted **once** in `AppShell`, which outlives chat↔terminal switches. The edge memory now survives across toggles: the came-online invalidation fires once at session open (unchanged), never again per switch. Other `useTerminals` consumers now only read the shared cache.

The real liveness corrections are unchanged:
- `→ true` (runner comes online) — re-read to recover a dropped `session.resource.created`.
- `true → false` (confirmed stop) — clear dead terminals after a runner stop.

## Test Plan

- `npx vitest run src/hooks/useTerminals.test.ts` — **34/34** pass, including a new regression test (`mounting an extra useTerminals consumer while online does not refetch`) that mounts a second consumer against the shared QueryClient and asserts zero additional fetches.
- `npx vitest run src/shell src/store/chatStore.test.ts` — **1821 passed** across 80 files (2 expected-fail, unchanged).
- `tsc -b` clean; `oxlint` clean on the changed files.
- Manual: open a terminal-first session with DevTools → Network filtered to `resources/terminals`, then toggle Chat ↔ Terminal via the connection pill. Before: one list request per switch. After: none.

## Demo

N/A — no visual change; the fix removes a redundant network request. (Verify via the Network tab as described in the Test Plan.)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a unit regression test that reproduces the exact tab-switch scenario (a second `useTerminals` consumer mounting while the runner is online) and asserts no refetch. The existing "poll corrects on edges" tests were updated to mount `useTerminalsLivenessSync` alongside `useTerminals`, mirroring how the shell composes them, so the liveness-edge behavior stays covered. Manual verification: confirmed via the browser Network tab that toggling Chat ↔ Terminal no longer issues a `resources/terminals` request.

## Changelog

Switching between Chat and Terminal no longer refetches the terminal list on every toggle

This pull request and its description were written by Isaac.
