### PR TITLE
fix(sessions): strip per-user pin keys from child-session summaries

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -7769,7 +7769,12 @@ def _child_session_summary_from_conversation(
     :returns: A populated :class:`ChildSessionSummary`.
     """
     display_title = title_without_closed_marker(conv.title)
-    labels = labels_with_closed_status(conv.labels, conv.title)
+    # Child sessions aren't pinnable (the pin affordance lives on top-level
+    # sidebar rows only), but strip any per-user ``omnigent.pinned.<user>`` keys
+    # defensively so a shared child's summary can never expose another viewer's
+    # pin key. No collapse-to-canonical here: there's no pin to surface.
+    raw_labels = {k: v for k, v in conv.labels.items() if not k.startswith(f"{PINNED_LABEL_KEY}.")}
+    labels = labels_with_closed_status(raw_labels, conv.title)
     tool: str | None
     session_name: str | None
     if _is_codex_native_subagent(conv):

--- a/tests/server/routes/test_child_session_summary_labels.py
+++ b/tests/server/routes/test_child_session_summary_labels.py
@@ -1,0 +1,46 @@
+"""Unit test for pin-key stripping in child-session summaries.
+
+``_child_session_summary_from_conversation`` builds a ``ChildSessionSummary``
+for a sub-agent row. Every other serialization path collapses per-user pin keys
+via ``_labels_for_viewer``; this one must at least strip them so a shared
+child's summary can never expose another viewer's ``omnigent.pinned.<user>``
+key. Child sessions aren't pinnable, so there's nothing to surface — just the
+strip.
+"""
+
+from __future__ import annotations
+
+from omnigent.entities import Conversation
+from omnigent.server.routes._sessions.helpers import (
+    _child_session_summary_from_conversation,
+)
+from omnigent.stores.conversation_store import pinned_label_key
+
+
+def _child(labels: dict[str, str]) -> Conversation:
+    """A minimal sub-agent conversation carrying the given labels."""
+    return Conversation(
+        id="conv_child",
+        created_at=100,
+        updated_at=200,
+        root_conversation_id="conv_parent",
+        title="tool:child-task",
+        agent_id="ag_test",
+        labels=labels,
+    )
+
+
+def test_child_summary_strips_per_user_pin_keys() -> None:
+    """A per-user pin key on a child row must not leak into its summary."""
+    conv = _child(
+        {
+            pinned_label_key("alice@example.com"): "1721760000000",
+            pinned_label_key("bob@example.com"): "1721760001000",
+            "omni_project": "Moonshot",
+        }
+    )
+    summary = _child_session_summary_from_conversation(conv, "conv_parent", None)
+    # No pin key of any kind survives — not the canonical one, not a per-user one.
+    assert not any(k.startswith("omnigent.pinned") for k in summary.labels)
+    # Unrelated labels are preserved.
+    assert summary.labels.get("omni_project") == "Moonshot"

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -316,9 +316,11 @@ function showArchivedToast() {
  * legacy key so this runs at most once.
  *
  * Waits for the server pinned set to load (`pinnedLoaded`) so an id the server
- * already has isn't needlessly re-PATCHed. Runs the writes directly (not via
- * the mutation hook's cache patching) since the pinned query is invalidated by
- * each toggle anyway and this fires before any user interaction.
+ * already has isn't needlessly re-PATCHed. Runs the writes directly rather than
+ * through the mutation hook: this fires once before any user interaction, and it
+ * patches the pinned-list cache itself with the confirmed rows (below) — the
+ * same cache-patch (not invalidate) strategy `useTogglePinnedConversation` uses,
+ * since the `?pinned=true` index lags these writes.
  *
  * @param serverPinnedIds - Ids the server already reports as pinned.
  * @param pinnedLoaded - Whether the server pinned query has settled.


### PR DESCRIPTION
## Related issue

N/A — follow-up hardening on #3189 (server-side per-user pinned sessions), addressing two non-blocking notes from that PR's Polly review.

## Summary

- **Child-summary pin-key leak (defensive).** Every session serialization path collapses per-user `omnigent.pinned.<user>` keys via `_labels_for_viewer` except `_child_session_summary_from_conversation`, which passed `conv.labels` through raw. Child sessions aren't pinnable today (the pin affordance lives only on top-level sidebar rows), so this is a *latent* gap, not a live leak — but if a shared child were ever pinned, its summary would expose another viewer's pin key. Now strip any `omnigent.pinned.<user>` key from a child summary's labels. No collapse-to-canonical: there's no pin to surface, just the strip.
- **Stale docstring.** Corrected `useMigrateLocalPinsToServer`: the migration patches the pinned-list cache (like `useTogglePinnedConversation`), it does not invalidate the pinned query.

## Test Plan

- New unit test `tests/server/routes/test_child_session_summary_labels.py`: a child carrying two users' pin keys yields a summary with **no** `omnigent.pinned*` key, while unrelated labels (`omni_project`) survive.
- `pytest tests/server/routes/test_child_session_summary_labels.py` → passes.
- `ruff format` + `ruff check` clean; `prettier --check` + `tsc --noEmit` clean on the web change.

## Demo

N/A — no user-visible behaviour change (the docstring edit is a comment; the label strip closes an unreachable-today path).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — the substantive change (child-summary strip) has a dedicated unit test; the other change is a docstring correction with no runtime effect.

This pull request and its description were written by Isaac.