### PR TITLE
feat(smart-routing): enable routing from config, drop OMNIGENT_SMART_ROUTING

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3409,20 +3409,19 @@ def server(
 
     server_llm = parse_server_llm(cfg.get("llm"))
 
-    # Build the routing client when the feature is enabled via
-    # OMNIGENT_SMART_ROUTING=1. Two mutually-exclusive providers, chosen
-    # by ``routing.provider``:
-    #   - ``external``: call an external ``routes:select`` service.
-    #   - ``llm`` (default): the built-in judge using the ``llm:`` block.
-    # Hidden by default — managed deployments override
+    # Build the routing client from configuration alone — no opt-in env needed.
+    # Two mutually-exclusive providers, chosen by ``routing.provider``:
+    #   - ``external``: call an external ``routes:select`` service (built when a
+    #     ``routing:`` block declares ``provider: external``).
+    #   - ``llm`` (default): the built-in judge using the ``llm:`` block (built
+    #     whenever a server ``llm:`` block is configured).
+    # Stays None when neither is configured. Managed deployments override
     # RuntimeCaps.routing_client with their own implementation.
-    routing_client = None
-    if os.environ.get("OMNIGENT_SMART_ROUTING") == "1":
-        routing_cfg = cfg.get("routing")
-        if isinstance(routing_cfg, dict) and routing_cfg.get("provider") == "external":
-            routing_client = _build_external_routing_client(routing_cfg)
-        else:
-            routing_client = _build_local_llm_routing_client(server_llm)
+    routing_cfg = cfg.get("routing")
+    if isinstance(routing_cfg, dict) and routing_cfg.get("provider") == "external":
+        routing_client = _build_external_routing_client(routing_cfg)
+    else:
+        routing_client = _build_local_llm_routing_client(server_llm)
 
     caps = RuntimeCaps(
         execution_timeout=int(effective_timeout),

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2149,9 +2149,9 @@ def create_app(
         # source as /api/version), surfaced so the web UI can show it in the
         # session info popover alongside the per-session host version.
         # smart_routing_enabled: true when the server can route — either
-        # a RoutingClient is explicitly configured (OMNIGENT_SMART_ROUTING=1
-        # + llm: config) or the managed deployment registered a
-        # policy_llm_connection_factory (which means it has LLM capability
+        # a RoutingClient is configured (a server llm: block, or a
+        # routing.provider=external block) or the managed deployment registered
+        # a policy_llm_connection_factory (which means it has LLM capability
         # and will supply its own RoutingClient).
         try:
             from omnigent.runtime._globals import _caps

--- a/omnigent/tools/builtins/advise_models.py
+++ b/omnigent/tools/builtins/advise_models.py
@@ -9,8 +9,8 @@ before the MCP proxy ever reaches the runner.
 
 The tool is registered by ``ToolManager`` when:
 - ``tools.agents`` is declared in the spec, AND
-- ``RuntimeCaps.routing_client`` is configured
-  (``OMNIGENT_SMART_ROUTING=1`` + ``llm:`` config block).
+- ``RuntimeCaps.routing_client`` is configured (a server ``llm:`` block, or a
+  ``routing.provider=external`` block).
 """
 
 from __future__ import annotations
@@ -50,7 +50,7 @@ class SysAdviseModelsTool(Tool):
             "for, plus an optional model list to constrain the pick. "
             "Returns one {agent, model, rationale} entry per agent entry. "
             "Use the returned model as args.model in sys_session_send. "
-            "Advisory only. Available when OMNIGENT_SMART_ROUTING=1."
+            "Advisory only. Available when model routing is configured."
         )
 
     def get_schema(self) -> dict[str, Any]:

--- a/web/src/lib/capabilities.ts
+++ b/web/src/lib/capabilities.ts
@@ -99,8 +99,8 @@ export interface ServerInfo {
    */
   server_version: string | null;
   /**
-   * True when the server has a routing client configured
-   * (``OMNIGENT_SMART_ROUTING=1`` + ``llm:`` config). Hidden by default.
+   * True when the server has a routing client configured — a server ``llm:``
+   * block, or a ``routing.provider=external`` block.
    */
   smart_routing_enabled: boolean;
   /**


### PR DESCRIPTION
## Related issue

N/A

## Summary

Smart routing was gated behind an `OMNIGENT_SMART_ROUTING=1` opt-in *on top of* the routing/LLM config. The env is redundant — the server can just build the routing client whenever the config supplies one:

- a server `llm:` block → the built-in judge, or
- a `routing:` block with `provider: external` → the external `routes:select` service.

This removes the env gate in `cli.py` so routing turns on from configuration alone, and refreshes the now-stale references in `app.py`, `advise_models.py`, and the web `capabilities.ts` doc comment. The `/v1/info` `smart_routing_enabled` signal already keyed on the resolved routing client, so its behavior is unchanged (it just reflects config instead of config-plus-env now).

Extracted as a standalone change from the auto-native-routing work so it can land independently.

### Behavior change

A server with an `llm:` block (or an external `routing:` block) now reports `smart_routing_enabled: true` and exposes the **Auto** harness option by default, where previously that required `OMNIGENT_SMART_ROUTING=1`. No config that lacks both a router and an `llm:` block is affected (routing stays off).

## Test Plan

- `pytest tests/cli/test_build_routing_client.py tests/server/test_smart_routing.py tests/tools/test_manager.py` → 100 passed.
- `ruff format --check` + `ruff check` clean on the changed Python.
- Grep confirms no remaining `OMNIGENT_SMART_ROUTING` references in source (excluding built web assets).

## Demo

N/A — no visual change (server config/enablement only).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No new tests: the change removes a gate rather than adding behavior. Existing routing-client builder + smart-routing tests exercise both providers and pass; manual verification confirmed no `OMNIGENT_SMART_ROUTING` references remain in source.

## Changelog

Smart routing now activates automatically when a server `llm:` block or an external `routing:` block is configured — no `OMNIGENT_SMART_ROUTING` env var needed

This pull request and its description were written by Isaac.