### PR TITLE
feat(scheduled tasks): Run now, relative next-run, and Tasks-list row polish

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1453,23 +1453,27 @@ def create_app(
         # the run — all fire-and-forget so the timer re-arms immediately.
         scheduled_task_scheduler: ScheduledTaskScheduler | None = None
         if scheduled_task_store is not None:
-            from omnigent.server.scheduled.fire import FireDeps, build_on_fire
+            from omnigent.server.scheduled.fire import FireDeps, build_on_fire, build_run_now
 
-            on_fire = build_on_fire(
-                FireDeps(
-                    scheduled_task_store=scheduled_task_store,
-                    agent_store=agent_store,
-                    conversation_store=conversation_store,
-                    permission_store=permission_store,
-                    host_store=host_store,
-                    host_registry=host_registry,
-                    agent_cache=agent_cache,
-                    runner_router=runner_router,
-                    tunnel_registry=tunnel_registry,
-                    file_store=file_store,
-                    artifact_store=artifact_store,
-                )
+            fire_deps = FireDeps(
+                scheduled_task_store=scheduled_task_store,
+                agent_store=agent_store,
+                conversation_store=conversation_store,
+                permission_store=permission_store,
+                host_store=host_store,
+                host_registry=host_registry,
+                agent_cache=agent_cache,
+                runner_router=runner_router,
+                tunnel_registry=tunnel_registry,
+                file_store=file_store,
+                artifact_store=artifact_store,
             )
+            on_fire = build_on_fire(fire_deps)
+            # The manual "run now" trigger reuses the same fire path (dispatch /
+            # preflight / in-flight guard) as the scheduler; it only differs in
+            # allowing a paused task to fire. Exposed on app.state for the
+            # POST /v1/scheduled-tasks/{id}/run route.
+            app_inst.state.scheduled_task_run_now = build_run_now(fire_deps)
             scheduled_task_scheduler = ScheduledTaskScheduler(
                 store=scheduled_task_store,
                 on_fire=on_fire,

--- a/omnigent/server/routes/scheduled_tasks.py
+++ b/omnigent/server/routes/scheduled_tasks.py
@@ -90,8 +90,24 @@ class UpdateScheduledTaskRequest(BaseModel):
         return self
 
 
-def _to_response(task: ScheduledTask) -> dict[str, Any]:
-    """Serialize a :class:`ScheduledTask` to a JSON-safe dict."""
+def _to_response(
+    task: ScheduledTask,
+    *,
+    last_run_status: str | None = None,
+    next_run_at: str | None = None,
+) -> dict[str, Any]:
+    """Serialize a :class:`ScheduledTask` to a JSON-safe dict.
+
+    :param last_run_status: The status of the task's most recent run
+        (``succeeded`` / ``failed`` / ``skipped`` / ``running`` / ``scheduled``),
+        or ``None`` when the task has never run. Surfaced so the Tasks list can
+        render a completion badge without an extra per-row ``/runs`` fetch.
+    :param next_run_at: ISO-8601 timestamp of the task's next scheduled fire as
+        computed by the live scheduler (the server's authoritative anchor), or
+        ``None`` when the task is paused / not armed. Deliberately server-sourced
+        — the client must never recompute next-run (it can't match the server
+        anchor for INTERVAL>1 rules).
+    """
     return {
         "id": task.id,
         "name": task.name,
@@ -109,7 +125,9 @@ def _to_response(task: ScheduledTask) -> dict[str, Any]:
         "host_id": task.host_id,
         "state": task.state,
         "last_run_at": task.last_run_at,
+        "last_run_status": last_run_status,
         "last_run_conversation_id": task.last_run_conversation_id,
+        "next_run_at": next_run_at,
         "updated_at": task.updated_at,
     }
 
@@ -299,7 +317,12 @@ def create_scheduled_tasks_router(
         scheduler = _scheduler(request)
         if scheduler is not None:
             scheduler.add(task)
-        return _to_response(task)
+        # A freshly created task has no runs (last_run_status is None); its
+        # next_run_at is available now that the scheduler armed it above.
+        return _to_response(
+            task,
+            next_run_at=scheduler.next_run_at(task.id) if scheduler is not None else None,
+        )
 
     @router.get("/scheduled-tasks")
     async def list_scheduled_tasks(request: Request) -> dict[str, list[dict[str, Any]]]:
@@ -317,9 +340,23 @@ def create_scheduled_tasks_router(
         owner = _owner(request)
         owner_id = None if owner == RESERVED_USER_LOCAL else owner
         tasks = store.list(owner_user_id=owner_id)
-        running = store.list_running_runs_for_tasks([t.id for t in tasks])
+        task_ids = [t.id for t in tasks]
+        running = store.list_running_runs_for_tasks(task_ids)
+        # Force-fail stale orphans FIRST so the completion badge below reports a
+        # dead run as ``failed`` rather than a stuck ``running``.
         force_fail_stale_runs(store, running)
-        return {"scheduled_tasks": [_to_response(t) for t in tasks]}
+        latest_status = store.list_latest_run_status_for_tasks(task_ids)
+        scheduler = _scheduler(request)
+        return {
+            "scheduled_tasks": [
+                _to_response(
+                    t,
+                    last_run_status=latest_status.get(t.id),
+                    next_run_at=scheduler.next_run_at(t.id) if scheduler is not None else None,
+                )
+                for t in tasks
+            ]
+        }
 
     @router.get("/scheduled-tasks/{scheduled_task_id}")
     async def get_scheduled_task(
@@ -330,7 +367,15 @@ def create_scheduled_tasks_router(
         owner = _owner(request)
         owner_id = None if owner == RESERVED_USER_LOCAL else owner
         task = _require_owned(scheduled_task_id, owner_id)
-        return _to_response(task)
+        running = store.list_running_runs_for_tasks([task.id])
+        force_fail_stale_runs(store, running)
+        latest_status = store.list_latest_run_status_for_tasks([task.id])
+        scheduler = _scheduler(request)
+        return _to_response(
+            task,
+            last_run_status=latest_status.get(task.id),
+            next_run_at=scheduler.next_run_at(task.id) if scheduler is not None else None,
+        )
 
     @router.get("/scheduled-tasks/{scheduled_task_id}/runs")
     async def list_scheduled_task_runs(
@@ -369,6 +414,49 @@ def create_scheduled_tasks_router(
             "runs": [_run_to_response(r) for r in runs],
             "next_cursor": next_cursor,
         }
+
+    @router.post("/scheduled-tasks/{scheduled_task_id}/run", status_code=202)
+    async def run_scheduled_task_now(
+        request: Request,
+        scheduled_task_id: str,
+    ) -> dict[str, Any]:
+        """Trigger an immediate fire of one of the caller's scheduled tasks.
+
+        A manual override that reuses the SHARED scheduled-fire path (the same
+        ``on_fire`` machinery — session create, owner grant, runner launch,
+        prompt dispatch, run recording) via ``app.state.scheduled_task_run_now``.
+        It does NOT re-implement the fire logic and cannot collide with a
+        scheduled fire of the same task (both share the in-flight overlap guard).
+
+        Paused tasks ARE runnable here — run-now is an explicit manual override,
+        so it does not require the ``active`` state the scheduler enforces.
+
+        Fire-and-forget: like the scheduler, the session create + launch runs in
+        the background, so this returns ``202 Accepted`` with the task id rather
+        than the finished run. The new run row (status ``running`` / ``failed`` /
+        ``skipped``) appears in the task's ``/runs`` history and in the LIST
+        endpoint's ``last_run_status`` once recorded. Returns ``409`` when a fire
+        for this task is already in flight, and ``503`` when the scheduler
+        subsystem is not running (no trigger wired).
+        """
+        owner = _owner(request)
+        owner_id = None if owner == RESERVED_USER_LOCAL else owner
+        task = _require_owned(scheduled_task_id, owner_id)
+        run_now = getattr(request.app.state, "scheduled_task_run_now", None)
+        if run_now is None:
+            raise OmnigentError(
+                "scheduled task scheduler is not running",
+                code=ErrorCode.RUNNER_UNAVAILABLE,
+            )
+        started = await run_now(task.workspace_id, task.id)
+        if not started:
+            # The row exists (we just loaded it) and paused is allowed, so the
+            # only skip reason is an already-in-flight fire for this task.
+            raise OmnigentError(
+                "a run for this scheduled task is already in flight",
+                code=ErrorCode.CONFLICT,
+            )
+        return {"triggered": True, "id": task.id}
 
     @router.patch("/scheduled-tasks/{scheduled_task_id}")
     async def update_scheduled_task(
@@ -412,7 +500,12 @@ def create_scheduled_tasks_router(
         scheduler = _scheduler(request)
         if scheduler is not None:
             scheduler.update(updated)
-        return _to_response(updated)
+        latest_status = store.list_latest_run_status_for_tasks([updated.id])
+        return _to_response(
+            updated,
+            last_run_status=latest_status.get(updated.id),
+            next_run_at=scheduler.next_run_at(updated.id) if scheduler is not None else None,
+        )
 
     @router.delete("/scheduled-tasks/{scheduled_task_id}")
     async def delete_scheduled_task(

--- a/omnigent/server/scheduled/fire.py
+++ b/omnigent/server/scheduled/fire.py
@@ -157,40 +157,114 @@ def build_on_fire(
         dispatch = launch_dispatch
 
     async def on_fire(workspace_id: int, scheduled_task_id: str) -> None:
-        # Re-read the row: never trust the armed timer. A deleted or
-        # non-active row is a logged no-op done synchronously.
-        with workspace_scope(workspace_id):
-            task = await asyncio.to_thread(deps.scheduled_task_store.get, scheduled_task_id)
-            if task is None:
-                _logger.info(
-                    "scheduled fire: task %s no longer exists — skipping", scheduled_task_id
-                )
-                return
-            if task.state != "active":
-                _logger.info(
-                    "scheduled fire: task %s is %s (not active) — skipping",
-                    scheduled_task_id,
-                    task.state,
-                )
-                return
-
-        key = (workspace_id, scheduled_task_id)
-        if key in _IN_FLIGHT_TASKS:
-            _logger.info("scheduled fire: task %s already in flight — skipping", scheduled_task_id)
-            return
-        _IN_FLIGHT_TASKS.add(key)
-
-        # Fire-and-forget: the session create + launch runs in the background so
-        # on_fire returns immediately and the scheduler re-arms the timer now.
-        fire_task = asyncio.create_task(
-            _run_fire(deps, workspace_id, scheduled_task_id, dispatch, preflight),
-            name=f"scheduled-fire-{scheduled_task_id}",
+        await _trigger_fire(
+            deps,
+            workspace_id,
+            scheduled_task_id,
+            dispatch,
+            preflight,
+            require_active=True,
         )
-        _PENDING_FIRES.add(fire_task)
-        fire_task.add_done_callback(_PENDING_FIRES.discard)
-        fire_task.add_done_callback(lambda _task: _IN_FLIGHT_TASKS.discard(key))
 
     return on_fire
+
+
+def build_run_now(
+    deps: FireDeps,
+    *,
+    launch_dispatch: LaunchDispatch | None = None,
+) -> Callable[[int, str], Awaitable[bool]]:
+    """Build the manual "run now" trigger — an immediate fire of a task.
+
+    Reuses the exact scheduled-fire machinery (the same
+    :func:`_run_fire_for_task` body, dispatch/preflight seams, and the shared
+    ``_IN_FLIGHT_TASKS`` overlap guard) so a manual run cannot duplicate the fire
+    logic and cannot collide with a scheduled fire of the same task. It differs
+    from :func:`build_on_fire` in ONE way: a **paused** task is still runnable
+    (``require_active=False``), because run-now is an explicit manual override.
+    A deleted / missing row is still a no-op.
+
+    Fire-and-forget like the scheduler path: the session create + launch runs in
+    the background and the returned callback resolves as soon as the fire is
+    accepted. The caller (the ``POST /run`` route) therefore returns ``202
+    Accepted`` rather than the finished run.
+
+    :returns: ``async run_now(workspace_id, scheduled_task_id) -> bool`` that
+        returns ``True`` if a fire was started, ``False`` if it was skipped
+        (row gone, or a fire for that task is already in flight).
+    """
+    preflight: ConnectedHostPreflight | None = None
+    if launch_dispatch is None:
+        dispatch = _make_connected_host_dispatch(deps)
+        preflight = _make_connected_host_preflight(deps)
+    else:
+        dispatch = launch_dispatch
+
+    async def run_now(workspace_id: int, scheduled_task_id: str) -> bool:
+        return await _trigger_fire(
+            deps,
+            workspace_id,
+            scheduled_task_id,
+            dispatch,
+            preflight,
+            require_active=False,
+        )
+
+    return run_now
+
+
+async def _trigger_fire(
+    deps: FireDeps,
+    workspace_id: int,
+    scheduled_task_id: str,
+    dispatch: LaunchDispatch,
+    preflight: ConnectedHostPreflight | None,
+    *,
+    require_active: bool,
+) -> bool:
+    """Synchronously guard a fire, then dispatch the run in the background.
+
+    Shared by the scheduled fire path (``require_active=True``) and the manual
+    run-now trigger (``require_active=False``). The re-read + guard run
+    synchronously so an obviously dead fire costs nothing; the create/launch is
+    fire-and-forget so the caller (scheduler timer or ``POST /run`` route)
+    returns immediately.
+
+    :returns: ``True`` if a background fire was started, ``False`` if skipped
+        (row gone / not active when required / already in flight).
+    """
+    # Re-read the row: never trust the caller. A deleted (or, for the scheduled
+    # path, non-active) row is a logged no-op done synchronously.
+    with workspace_scope(workspace_id):
+        task = await asyncio.to_thread(deps.scheduled_task_store.get, scheduled_task_id)
+        if task is None:
+            _logger.info("scheduled fire: task %s no longer exists — skipping", scheduled_task_id)
+            return False
+        if require_active and task.state != "active":
+            _logger.info(
+                "scheduled fire: task %s is %s (not active) — skipping",
+                scheduled_task_id,
+                task.state,
+            )
+            return False
+
+    key = (workspace_id, scheduled_task_id)
+    if key in _IN_FLIGHT_TASKS:
+        _logger.info("scheduled fire: task %s already in flight — skipping", scheduled_task_id)
+        return False
+    _IN_FLIGHT_TASKS.add(key)
+
+    # Fire-and-forget: the session create + launch runs in the background so the
+    # caller returns immediately (the scheduler re-arms the timer now; the route
+    # returns 202).
+    fire_task = asyncio.create_task(
+        _run_fire(deps, workspace_id, scheduled_task_id, dispatch, preflight, require_active),
+        name=f"scheduled-fire-{scheduled_task_id}",
+    )
+    _PENDING_FIRES.add(fire_task)
+    fire_task.add_done_callback(_PENDING_FIRES.discard)
+    fire_task.add_done_callback(lambda _task: _IN_FLIGHT_TASKS.discard(key))
+    return True
 
 
 async def _run_fire(
@@ -199,18 +273,20 @@ async def _run_fire(
     scheduled_task_id: str,
     dispatch: LaunchDispatch,
     preflight: ConnectedHostPreflight | None,
+    require_active: bool = True,
 ) -> None:
     """Background body of a firing: create session, grant, launch, record run.
 
     Wrapped so any failure is logged rather than propagated — a failed fire must
-    not crash the scheduler.
+    not crash the scheduler. ``require_active`` mirrors the synchronous guard:
+    the scheduled path requires an active row, run-now allows a paused row.
     """
     with workspace_scope(workspace_id):
         task = await asyncio.to_thread(deps.scheduled_task_store.get, scheduled_task_id)
         if task is None:
             _logger.info("scheduled fire: task %s no longer exists — skipping", scheduled_task_id)
             return
-        if task.state != "active":
+        if require_active and task.state != "active":
             _logger.info(
                 "scheduled fire: task %s is %s (not active) — skipping",
                 scheduled_task_id,

--- a/omnigent/stores/scheduled_task_store/__init__.py
+++ b/omnigent/stores/scheduled_task_store/__init__.py
@@ -295,3 +295,31 @@ class ScheduledTaskStore(ABC):
             tasks, ordered ``scheduled_at DESC, id DESC``.
         """
         ...
+
+    @abstractmethod
+    def list_latest_run_status_for_tasks(self, scheduled_task_ids: list[str]) -> dict[str, str]:
+        """
+        Return each task's MOST RECENT run status in one windowed query.
+
+        Powers the Tasks-list completion badge: the route resolves the owner's
+        tasks, then this returns ``{task_id: status}`` for the single latest run
+        per task, so a page of N tasks costs ONE query instead of N per-row
+        ``/runs`` fetches. A task with no runs is simply absent from the map (the
+        caller renders "never run").
+
+        "Latest" uses the same ``(scheduled_at DESC, id DESC)`` ordering as
+        :meth:`list_runs`, so the reported status matches the run that would head
+        that task's history — and, crucially, a run-now firing (which creates a
+        new run with a ``scheduled_at`` at/after the last scheduled fire) becomes
+        the reported status as soon as it is recorded. Callers should force-fail
+        stale ``running`` runs BEFORE calling this so a dead orphan reports
+        ``failed`` rather than a stuck ``running``.
+
+        Workspace-scoped (filters on ``current_workspace_id()``) like every other
+        read; an empty id list returns an empty map without a query.
+
+        :param scheduled_task_ids: Task ids (already owner-scoped by the caller).
+        :returns: ``{scheduled_task_id: latest_run_status}`` for tasks that have
+            at least one run.
+        """
+        ...

--- a/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
+++ b/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import and_, asc, delete, desc, or_, select, tuple_
+from sqlalchemy import and_, asc, delete, desc, func, or_, select, tuple_
 
 from omnigent.db.db_models import (
     DEFAULT_WORKSPACE_ID,
@@ -475,3 +475,38 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
             )
             rows = session.execute(stmt).scalars().all()
             return [_run_to_entity(r) for r in rows]
+
+    def list_latest_run_status_for_tasks(self, scheduled_task_ids: list[str]) -> dict[str, str]:
+        """Return ``{task_id: latest_run_status}`` for the given tasks.
+
+        One windowed query: ``row_number()`` partitioned by ``scheduled_task_id``
+        and ordered ``scheduled_at DESC, id DESC`` (the same order as
+        :meth:`list_runs`) picks each task's single most-recent run, decoded to
+        its status name. Tasks with no runs are absent from the map. Both SQLite
+        (>= 3.25) and PostgreSQL support window functions, matching the
+        conversation store's ``row_number()`` usage.
+        """
+        if not scheduled_task_ids:
+            return {}
+        with self._session() as session:
+            ranked = (
+                select(
+                    SqlScheduledTaskRun.scheduled_task_id.label("task_id"),
+                    SqlScheduledTaskRun.status.label("status"),
+                    func.row_number()
+                    .over(
+                        partition_by=SqlScheduledTaskRun.scheduled_task_id,
+                        order_by=(
+                            desc(SqlScheduledTaskRun.scheduled_at),
+                            desc(SqlScheduledTaskRun.id),
+                        ),
+                    )
+                    .label("row_num"),
+                )
+                .where(SqlScheduledTaskRun.workspace_id == current_workspace_id())
+                .where(SqlScheduledTaskRun.scheduled_task_id.in_(scheduled_task_ids))
+                .subquery()
+            )
+            stmt = select(ranked.c.task_id, ranked.c.status).where(ranked.c.row_num == 1)
+            rows = session.execute(stmt).all()
+            return {task_id: decode_scheduled_task_run_status(status) for task_id, status in rows}

--- a/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
+++ b/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
@@ -2,10 +2,12 @@
 
 Covers the Scheduled Tasks page row behavior: a task row renders the
 human-readable schedule SUMMARY derived client-side from the stored RRULE
-(``describeSchedule``), and it does NOT render a "Next run in Xh"
-countdown — that was deliberately removed because a client-computed
-next-run can't be guaranteed to match the server's anchor for
-INTERVAL>1 rules, so only the always-correct summary is shown.
+(``describeSchedule``). It does NOT render the old CLIENT-computed "Next run
+in Xh" countdown — that was deliberately removed because a client-computed
+next-run can't be guaranteed to match the server's anchor for INTERVAL>1
+rules. It DOES render the SERVER's authoritative next-run ("Next: …") plus a
+last-run completion pill and a Run-now action (see
+``test_scheduled_task_row_run_controls``).
 
 Tasks are seeded through the same REST API the page consumes
 (``POST /v1/scheduled-tasks``), so this asserts the real render path
@@ -112,23 +114,27 @@ def test_scheduled_task_rows_show_schedule_summary_without_countdown(
     rows = page.locator('[data-testid="scheduled-task-row"]')
     expect(rows).to_have_count(3, timeout=30_000)
 
-    # Each row's schedule line shows the client-derived summary text.
+    # Each row's schedule line shows the client-derived summary text. The line
+    # may also carry the SERVER's next-run suffix ("· Next: …") for an armed
+    # active task, so assert the summary is CONTAINED rather than the exact line.
     daily = _row_by_name(page, "Daily digest")
-    expect(daily.get_by_test_id("task-schedule-line")).to_have_text(
+    expect(daily.get_by_test_id("task-schedule-line")).to_contain_text(
         "Every day at 9:00 AM", timeout=30_000
     )
 
     weekday = _row_by_name(page, "Weekday triage")
-    expect(weekday.get_by_test_id("task-schedule-line")).to_have_text("Weekdays at 8:00 AM")
+    expect(weekday.get_by_test_id("task-schedule-line")).to_contain_text("Weekdays at 8:00 AM")
 
     # The hourly-minute fix: interval-1 hourly with a non-zero BYMINUTE shows
     # the minute rather than a bare "Hourly".
     hourly = _row_by_name(page, "Half-past sweep")
-    expect(hourly.get_by_test_id("task-schedule-line")).to_have_text("Hourly at :30")
+    expect(hourly.get_by_test_id("task-schedule-line")).to_contain_text("Hourly at :30")
 
-    # The "Next run in Xh" countdown was removed — it must not appear anywhere
-    # on the page (this pins the decision so it can't silently regress).
-    expect(page.get_by_text("Next run", exact=False)).to_have_count(0)
+    # The old CLIENT-computed "Next run in Xh" countdown stays removed — it must
+    # not appear anywhere (this pins that decision). The new server-authoritative
+    # value renders as "Next: <time>" (a different string, and a different source),
+    # so this guard still holds.
+    expect(page.get_by_text("Next run in", exact=False)).to_have_count(0)
 
 
 def test_scheduled_task_create_edit_modal_and_time_picker(
@@ -176,7 +182,8 @@ def test_scheduled_task_create_edit_modal_and_time_picker(
 
     created_row = _row_by_name(page, "Typed time daily")
     expect(created_row).to_be_visible(timeout=30_000)
-    expect(created_row.get_by_test_id("task-schedule-line")).to_have_text(
+    # `to_contain_text`: the line may also carry the server next-run suffix.
+    expect(created_row.get_by_test_id("task-schedule-line")).to_contain_text(
         "Every day at 9:37 AM",
         timeout=30_000,
     )
@@ -214,7 +221,51 @@ def test_scheduled_task_create_edit_modal_and_time_picker(
     expect(time_input).to_have_value("10:37 AM")
     submit.click()
 
-    expect(edit_row.get_by_test_id("task-schedule-line")).to_have_text(
+    expect(edit_row.get_by_test_id("task-schedule-line")).to_contain_text(
         "Every day at 10:37 AM",
         timeout=30_000,
     )
+
+
+def test_scheduled_task_row_run_controls(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Run controls: next-run text, and Run now → a run is recorded + the badge updates.
+
+    LLM-free. The seeded task pins no host, so a manual Run now resolves no online
+    host and records a ``failed`` run — which is exactly what we assert flips the
+    row's completion pill from empty (never run) to "Failed". This exercises the
+    real POST /v1/scheduled-tasks/{id}/run path and the list invalidation that
+    surfaces ``last_run_status`` on the row, without ever dispatching an agent turn.
+    """
+    agent_id = _builtin_agent_id(live_server, "hello_world")
+    task_id = _create_task(
+        live_server, agent_id, "Run-now target", "FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
+    )
+
+    page.goto(f"{live_server}/tasks")
+    row = _row_by_name(page, "Run-now target")
+    expect(row).to_be_visible(timeout=30_000)
+
+    # Server-authoritative next-run renders (armed active task). We assert the
+    # label prefix, not an exact time (the scheduler anchors it to the real now).
+    expect(row.get_by_test_id("task-next-run")).to_contain_text("Next:", timeout=30_000)
+
+    # Never run yet → no completion pill.
+    expect(row.get_by_test_id("task-run-status-pill")).to_have_count(0)
+
+    # Trigger Run now from the ⋯ menu.
+    row.hover()
+    row.get_by_test_id("task-row-menu").click()
+    page.get_by_test_id("task-run-now").click()
+
+    # The manual fire resolves no online host and records a failed run; the list
+    # invalidation refetches and the row now shows the "Failed" completion pill.
+    expect(row.get_by_test_id("task-run-status-pill")).to_have_text("Failed", timeout=30_000)
+
+    # And the run is recorded server-side (the shared fire path wrote a run row).
+    resp = httpx.get(f"{live_server}/v1/scheduled-tasks/{task_id}/runs", timeout=10.0)
+    runs = resp.json()["runs"]
+    assert len(runs) == 1
+    assert runs[0]["status"] == "failed"

--- a/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
+++ b/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
@@ -2,12 +2,12 @@
 
 Covers the Scheduled Tasks page row behavior: a task row renders the
 human-readable schedule SUMMARY derived client-side from the stored RRULE
-(``describeSchedule``). It does NOT render the old CLIENT-computed "Next run
-in Xh" countdown — that was deliberately removed because a client-computed
-next-run can't be guaranteed to match the server's anchor for INTERVAL>1
-rules. It DOES render the SERVER's authoritative next-run ("Next: …") plus a
-last-run completion pill and a Run-now action (see
-``test_scheduled_task_row_run_controls``).
+(``describeSchedule``), plus a Run-now action and a relative next-run label
+("Next run in Xh"). That label is a DELTA formatted from the server's
+authoritative ``next_run_at`` (nextRunAt − now) — the client never recomputes
+WHICH instant is next (which couldn't match the server anchor for INTERVAL>1
+rules), so the old "no client-recomputed countdown" rule still holds. See
+``test_scheduled_task_row_run_controls``.
 
 Tasks are seeded through the same REST API the page consumes
 (``POST /v1/scheduled-tasks``), so this asserts the real render path
@@ -83,16 +83,17 @@ def _row_by_name(page: Page, name: str):
     return page.locator('[data-testid="scheduled-task-row"]').filter(has_text=name)
 
 
-def test_scheduled_task_rows_show_schedule_summary_without_countdown(
+def test_scheduled_task_rows_show_schedule_summary_and_relative_next_run(
     page: Page,
     live_server: str,
 ) -> None:
-    """Rows render the RRULE-derived schedule summary and no next-run countdown.
+    """Rows render the RRULE-derived schedule summary + the relative next-run label.
 
     Seeds three tasks whose summaries exercise the daily, weekdays, and
-    hourly-with-minute (the ``describeSchedule`` hourly fix) cases, then
-    asserts each row's schedule line shows the expected text and that the
-    countdown ("Next run") is absent anywhere on the page.
+    hourly-with-minute (the ``describeSchedule`` hourly fix) cases, then asserts
+    each row's schedule line shows the expected summary and that the armed rows
+    carry the server-derived relative "Next run in …" label (a delta from the
+    server's next_run_at, NOT a client-recomputed instant).
     """
     agent_id = _builtin_agent_id(live_server, "hello_world")
 
@@ -115,7 +116,7 @@ def test_scheduled_task_rows_show_schedule_summary_without_countdown(
     expect(rows).to_have_count(3, timeout=30_000)
 
     # Each row's schedule line shows the client-derived summary text. The line
-    # may also carry the SERVER's next-run suffix ("· Next: …") for an armed
+    # also carries the relative next-run suffix ("· Next run in …") for an armed
     # active task, so assert the summary is CONTAINED rather than the exact line.
     daily = _row_by_name(page, "Daily digest")
     expect(daily.get_by_test_id("task-schedule-line")).to_contain_text(
@@ -130,11 +131,12 @@ def test_scheduled_task_rows_show_schedule_summary_without_countdown(
     hourly = _row_by_name(page, "Half-past sweep")
     expect(hourly.get_by_test_id("task-schedule-line")).to_contain_text("Hourly at :30")
 
-    # The old CLIENT-computed "Next run in Xh" countdown stays removed — it must
-    # not appear anywhere (this pins that decision). The new server-authoritative
-    # value renders as "Next: <time>" (a different string, and a different source),
-    # so this guard still holds.
-    expect(page.get_by_text("Next run in", exact=False)).to_have_count(0)
+    # The next-run label IS shown now — but as a DELTA from the server's
+    # next_run_at ("Next run in Xh/Xd"), not a client-recomputed instant. An
+    # armed daily task is always <24h out, so its label is "Next run in …".
+    # (The forbidden thing was a client recompute of WHICH instant is next; a
+    # delta off the server value is fine.)
+    expect(daily.get_by_test_id("task-next-run")).to_contain_text("Next run in", timeout=30_000)
 
 
 def test_scheduled_task_create_edit_modal_and_time_picker(
@@ -231,13 +233,14 @@ def test_scheduled_task_row_run_controls(
     page: Page,
     live_server: str,
 ) -> None:
-    """Run controls: next-run text, and Run now → a run is recorded + the badge updates.
+    """Run controls: relative next-run label, and Run now → a run is recorded.
 
     LLM-free. The seeded task pins no host, so a manual Run now resolves no online
-    host and records a ``failed`` run — which is exactly what we assert flips the
-    row's completion pill from empty (never run) to "Failed". This exercises the
-    real POST /v1/scheduled-tasks/{id}/run path and the list invalidation that
-    surfaces ``last_run_status`` on the row, without ever dispatching an agent turn.
+    host and records a ``failed`` run. This exercises the real
+    POST /v1/scheduled-tasks/{id}/run path (the ⋯-menu action) end-to-end and
+    confirms the run row is written, without ever dispatching an agent turn. The
+    completion pill was removed from the row UI, so completion is asserted via the
+    server-side run record rather than a visible badge.
     """
     agent_id = _builtin_agent_id(live_server, "hello_world")
     task_id = _create_task(
@@ -248,24 +251,30 @@ def test_scheduled_task_row_run_controls(
     row = _row_by_name(page, "Run-now target")
     expect(row).to_be_visible(timeout=30_000)
 
-    # Server-authoritative next-run renders (armed active task). We assert the
-    # label prefix, not an exact time (the scheduler anchors it to the real now).
-    expect(row.get_by_test_id("task-next-run")).to_contain_text("Next:", timeout=30_000)
+    # Relative next-run renders for an armed active task — a delta off the
+    # server's next_run_at ("Next run in …"), not a client-recomputed instant.
+    expect(row.get_by_test_id("task-next-run")).to_contain_text("Next run in", timeout=30_000)
 
-    # Never run yet → no completion pill.
-    expect(row.get_by_test_id("task-run-status-pill")).to_have_count(0)
+    # No run has fired yet → the run history is empty.
+    empty = httpx.get(f"{live_server}/v1/scheduled-tasks/{task_id}/runs", timeout=10.0)
+    assert empty.json()["runs"] == []
 
     # Trigger Run now from the ⋯ menu.
     row.hover()
     row.get_by_test_id("task-row-menu").click()
     page.get_by_test_id("task-run-now").click()
 
-    # The manual fire resolves no online host and records a failed run; the list
-    # invalidation refetches and the row now shows the "Failed" completion pill.
-    expect(row.get_by_test_id("task-run-status-pill")).to_have_text("Failed", timeout=30_000)
+    # The manual fire runs through the shared fire path and records a run row.
+    # With no online host it resolves to a ``failed`` run. Poll the history until
+    # the background fire lands (the POST returns 202 before the run is written).
+    def _has_failed_run() -> bool:
+        runs = httpx.get(f"{live_server}/v1/scheduled-tasks/{task_id}/runs", timeout=10.0).json()[
+            "runs"
+        ]
+        return len(runs) == 1 and runs[0]["status"] == "failed"
 
-    # And the run is recorded server-side (the shared fire path wrote a run row).
-    resp = httpx.get(f"{live_server}/v1/scheduled-tasks/{task_id}/runs", timeout=10.0)
-    runs = resp.json()["runs"]
-    assert len(runs) == 1
-    assert runs[0]["status"] == "failed"
+    deadline = 0
+    while not _has_failed_run() and deadline < 100:
+        page.wait_for_timeout(200)
+        deadline += 1
+    assert _has_failed_run(), "Run now did not record a failed run within the timeout"

--- a/tests/server/integration/test_scheduled_tasks_routes.py
+++ b/tests/server/integration/test_scheduled_tasks_routes.py
@@ -974,3 +974,214 @@ async def test_publish_status_failed_edge_transitions_scheduled_run_to_failed(
     assert row.status == "failed"
     assert row.finished_at is not None
     assert row.error_code == "runner_disconnected"
+
+
+# ── serializer fields: last_run_status + next_run_at ─────────────────────────
+
+
+async def test_list_and_get_carry_last_run_status_and_next_run_at(
+    auth_client: httpx.AsyncClient, auth_app: FastAPI, db_uri: str
+) -> None:
+    """LIST + GET surface the latest run's status and the scheduler's next fire.
+
+    ``last_run_status`` comes from the windowed store query (the most-recent run
+    by scheduled_at DESC); ``next_run_at`` comes from the live scheduler, so an
+    armed active task reports a non-null ISO timestamp.
+    """
+    import uuid
+
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    task_id = created["id"]
+    # A freshly created task has never run.
+    assert created["last_run_status"] is None
+    # It is armed on the scheduler, so next_run_at is a non-null ISO string.
+    assert isinstance(created["next_run_at"], str)
+
+    # Seed two runs; the newer (failed) one is the reported status.
+    _seed_run(
+        db_uri,
+        task_id,
+        uuid.uuid4().hex,
+        scheduled_at=1000,
+        status="succeeded",
+        conversation_id=uuid.uuid4().hex,
+    )
+    _seed_run(
+        db_uri,
+        task_id,
+        uuid.uuid4().hex,
+        scheduled_at=2000,
+        status="failed",
+        finished_at=2002,
+        conversation_id=uuid.uuid4().hex,
+    )
+
+    list_body = (await auth_client.get("/v1/scheduled-tasks", headers=_headers())).json()
+    row = next(t for t in list_body["scheduled_tasks"] if t["id"] == task_id)
+    assert row["last_run_status"] == "failed"
+    assert isinstance(row["next_run_at"], str)
+
+    get_body = (await auth_client.get(f"/v1/scheduled-tasks/{task_id}", headers=_headers())).json()
+    assert get_body["last_run_status"] == "failed"
+    assert isinstance(get_body["next_run_at"], str)
+
+
+async def test_paused_task_has_null_next_run_at(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """A paused task is not armed, so next_run_at is null."""
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    task_id = created["id"]
+    patched = (
+        await auth_client.patch(
+            f"/v1/scheduled-tasks/{task_id}", json={"state": "paused"}, headers=_headers()
+        )
+    ).json()
+    assert patched["state"] == "paused"
+    assert patched["next_run_at"] is None
+
+
+# ── POST /v1/scheduled-tasks/{id}/run (run now) ──────────────────────────────
+
+
+async def test_run_now_triggers_and_records_a_run(
+    auth_client: httpx.AsyncClient, auth_app: FastAPI, db_uri: str
+) -> None:
+    """POST /run returns 202 and drives the wired run-now trigger for the task.
+
+    The route delegates to ``app.state.scheduled_task_run_now`` (built over the
+    shared fire path). Here we stub that trigger with a recorder that writes a
+    ``running`` run row, then assert the row appears in the task's history and as
+    ``last_run_status`` — the integration contract the real trigger fulfills.
+    """
+    import time
+    import uuid
+
+    from omnigent.stores.scheduled_task_store.sqlalchemy_store import (
+        SqlAlchemyScheduledTaskStore,
+    )
+
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    task_id = created["id"]
+
+    calls: list[tuple[int, str]] = []
+    now = int(time.time())
+
+    async def _fake_run_now(workspace_id: int, scheduled_task_id: str) -> bool:
+        calls.append((workspace_id, scheduled_task_id))
+        # Use a current-time fire so the LIST endpoint's stale backstop (6h age
+        # from fired_at) does NOT reap this fresh in-flight run to ``failed``.
+        SqlAlchemyScheduledTaskStore(db_uri).create_run(
+            run_id=uuid.uuid4().hex,
+            scheduled_task_id=scheduled_task_id,
+            status="running",
+            scheduled_at=now,
+            conversation_id=uuid.uuid4().hex,
+            fired_at=now,
+        )
+        return True
+
+    auth_app.state.scheduled_task_run_now = _fake_run_now
+
+    resp = await auth_client.post(f"/v1/scheduled-tasks/{task_id}/run", headers=_headers())
+    assert resp.status_code == 202, resp.text
+    assert resp.json() == {"triggered": True, "id": task_id}
+    # The trigger was invoked with the task's workspace + id.
+    assert calls == [(0, task_id)]
+
+    runs = (
+        await auth_client.get(f"/v1/scheduled-tasks/{task_id}/runs", headers=_headers())
+    ).json()["runs"]
+    assert len(runs) == 1
+    assert runs[0]["status"] == "running"
+    # And the completion badge source now reports it.
+    list_body = (await auth_client.get("/v1/scheduled-tasks", headers=_headers())).json()
+    row = next(t for t in list_body["scheduled_tasks"] if t["id"] == task_id)
+    assert row["last_run_status"] == "running"
+
+
+async def test_run_now_allows_paused_task(
+    auth_client: httpx.AsyncClient, auth_app: FastAPI, db_uri: str
+) -> None:
+    """Run-now is a manual override — a paused task is still triggerable (202)."""
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    task_id = created["id"]
+    await auth_client.patch(
+        f"/v1/scheduled-tasks/{task_id}", json={"state": "paused"}, headers=_headers()
+    )
+
+    triggered: list[str] = []
+
+    async def _fake_run_now(workspace_id: int, scheduled_task_id: str) -> bool:
+        triggered.append(scheduled_task_id)
+        return True
+
+    auth_app.state.scheduled_task_run_now = _fake_run_now
+    resp = await auth_client.post(f"/v1/scheduled-tasks/{task_id}/run", headers=_headers())
+    assert resp.status_code == 202, resp.text
+    assert triggered == [task_id]
+
+
+async def test_run_now_conflict_when_already_in_flight(
+    auth_client: httpx.AsyncClient, auth_app: FastAPI, db_uri: str
+) -> None:
+    """A trigger that reports it was skipped (already in flight) surfaces as 409."""
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    task_id = created["id"]
+
+    async def _fake_run_now(workspace_id: int, scheduled_task_id: str) -> bool:
+        return False  # already in flight
+
+    auth_app.state.scheduled_task_run_now = _fake_run_now
+    resp = await auth_client.post(f"/v1/scheduled-tasks/{task_id}/run", headers=_headers())
+    assert resp.status_code == 409, resp.text
+
+
+async def test_run_now_404_for_nonowned_task(
+    auth_client: httpx.AsyncClient, auth_app: FastAPI, db_uri: str
+) -> None:
+    """Running another user's task 404s (not enumerable across users)."""
+    _make_user(db_uri, "alice@example.com")
+    _make_user(db_uri, "bob@example.com")
+    created = (
+        await auth_client.post(
+            "/v1/scheduled-tasks", json=_create_body(), headers=_headers("alice@example.com")
+        )
+    ).json()
+
+    async def _fake_run_now(workspace_id: int, scheduled_task_id: str) -> bool:
+        raise AssertionError("run_now must not be reached for a non-owned task")
+
+    auth_app.state.scheduled_task_run_now = _fake_run_now
+    resp = await auth_client.post(
+        f"/v1/scheduled-tasks/{created['id']}/run", headers=_headers("bob@example.com")
+    )
+    assert resp.status_code == 404, resp.text
+
+
+async def test_run_now_503_when_scheduler_not_running(
+    auth_client: httpx.AsyncClient, auth_app: FastAPI, db_uri: str
+) -> None:
+    """With no run-now trigger wired, the endpoint reports the subsystem is down."""
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    auth_app.state.scheduled_task_run_now = None
+    resp = await auth_client.post(f"/v1/scheduled-tasks/{created['id']}/run", headers=_headers())
+    assert resp.status_code == 503, resp.text

--- a/tests/server/scheduled/test_fire.py
+++ b/tests/server/scheduled/test_fire.py
@@ -28,7 +28,7 @@ from omnigent.db.db_models import current_workspace_id
 from omnigent.entities import ScheduledTask
 from omnigent.server.auth import LEVEL_OWNER, RESERVED_USER_LOCAL
 from omnigent.server.scheduled import fire as fire_mod
-from omnigent.server.scheduled.fire import FireDeps, build_on_fire
+from omnigent.server.scheduled.fire import FireDeps, build_on_fire, build_run_now
 
 # ── Fakes ──────────────────────────────────────────────────────────────────
 
@@ -978,3 +978,107 @@ async def test_managed_sandbox_is_skipped_and_recorded() -> None:
     assert launched == []
     assert len(store.runs) == 1
     assert store.runs[0]["status"] == "skipped"
+
+
+# ── build_run_now (manual "run now" trigger) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_now_active_creates_session_grant_and_run() -> None:
+    """Run-now fires an active task through the same create/grant/record path."""
+    perm = FakePermissionStore()
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task()})
+    launched: list[Any] = []
+
+    async def _launch(conv: Any, task: Any) -> None:
+        launched.append((conv, task))
+
+    run_now = build_run_now(
+        _deps(store, permission_store=perm, conversation_store=conv_store),
+        launch_dispatch=_launch,
+    )
+    started = await run_now(0, "task_1")
+    await _drain()
+
+    assert started is True
+    assert len(conv_store.created) == 1
+    assert perm.grants and perm.grants[0][2] == LEVEL_OWNER
+    assert len(launched) == 1
+    assert len(store.runs) == 1
+    assert store.runs[0]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_run_now_fires_paused_task() -> None:
+    """Run-now is a manual override: a PAUSED task still fires (unlike the scheduler)."""
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task(state="paused")})
+    launched: list[Any] = []
+
+    async def _launch(conv: Any, task: Any) -> None:
+        launched.append(conv)
+
+    run_now = build_run_now(
+        _deps(store, conversation_store=conv_store),
+        launch_dispatch=_launch,
+    )
+    started = await run_now(0, "task_1")
+    await _drain()
+
+    assert started is True
+    assert len(conv_store.created) == 1
+    assert len(launched) == 1
+    assert len(store.runs) == 1
+    assert store.runs[0]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_run_now_missing_row_is_noop() -> None:
+    """Run-now on a deleted/missing task starts nothing and records no run."""
+    store = FakeScheduledTaskStore(rows={})
+    launched: list[Any] = []
+
+    async def _launch(conv: Any, task: Any) -> None:
+        launched.append(conv)
+
+    run_now = build_run_now(_deps(store), launch_dispatch=_launch)
+    started = await run_now(0, "task_1")
+    await _drain()
+
+    assert started is False
+    assert launched == []
+    assert store.runs == []
+
+
+@pytest.mark.asyncio
+async def test_run_now_skips_when_already_in_flight() -> None:
+    """A second run-now for the same task is skipped while the first is in flight.
+
+    Shares the ``_IN_FLIGHT_TASKS`` overlap guard with the scheduled path, so a
+    manual run cannot double-launch (or collide with a scheduled fire).
+    """
+    conv_store = FakeConversationStore()
+    store = FakeScheduledTaskStore(rows={"task_1": _task()})
+    release = asyncio.Event()
+
+    async def _slow_launch(conv: Any, task: Any) -> None:
+        await release.wait()
+
+    run_now = build_run_now(
+        _deps(store, conversation_store=conv_store),
+        launch_dispatch=_slow_launch,
+    )
+    first = await run_now(0, "task_1")
+    second = await run_now(0, "task_1")
+
+    for _ in range(100):
+        if conv_store.created:
+            break
+        await asyncio.sleep(0.01)
+    assert first is True
+    assert second is False
+    assert len(conv_store.created) == 1
+    release.set()
+    await _drain()
+    assert len(store.runs) == 1

--- a/tests/stores/test_scheduled_task_store.py
+++ b/tests/stores/test_scheduled_task_store.py
@@ -917,6 +917,143 @@ def test_list_running_runs_for_tasks_is_workspace_scoped(
         assert [r.id for r in got] == [_uid("run_w11")]
 
 
+# ── list_latest_run_status_for_tasks (Tasks-list completion badge source) ─────
+
+
+def test_list_latest_run_status_for_tasks_returns_most_recent_status(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """Returns each task's single most-recent run status by scheduled_at DESC.
+
+    Powers the Tasks-list completion badge in one windowed query. A task with a
+    terminal run followed by a newer run reports the NEWER run's status (so a
+    run-now firing becomes the badge as soon as it is recorded).
+    """
+    for seed in ("a", "b"):
+        store.create(
+            scheduled_task_id=_uid(f"lst_{seed}"),
+            name=seed,
+            prompt="p",
+            rrule="FREQ=MINUTELY",
+            user_id="u",
+            agent_id=_uid("ag"),
+            timezone="UTC",
+        )
+    # task_a: an older succeeded run, then a newer failed run — failed wins.
+    store.create_run(
+        run_id=_uid("lst_a_old"),
+        scheduled_task_id=_uid("lst_a"),
+        status="succeeded",
+        scheduled_at=100,
+        finished_at=105,
+    )
+    store.create_run(
+        run_id=_uid("lst_a_new"),
+        scheduled_task_id=_uid("lst_a"),
+        status="failed",
+        scheduled_at=200,
+        finished_at=205,
+    )
+    # task_b: a single running run.
+    store.create_run(
+        run_id=_uid("lst_b_run"),
+        scheduled_task_id=_uid("lst_b"),
+        status="running",
+        scheduled_at=150,
+    )
+
+    got = store.list_latest_run_status_for_tasks([_uid("lst_a"), _uid("lst_b")])
+    assert got == {_uid("lst_a"): "failed", _uid("lst_b"): "running"}
+
+
+def test_list_latest_run_status_tiebreaks_on_id_desc(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """Two runs at the SAME scheduled_at break the tie on id DESC.
+
+    Mirrors ``list_runs``' compound ``(scheduled_at DESC, id DESC)`` order so the
+    reported status matches the run that heads that task's history.
+    """
+    store.create(
+        scheduled_task_id=_uid("lst_tie"),
+        name="tie",
+        prompt="p",
+        rrule="FREQ=MINUTELY",
+        user_id="u",
+        agent_id=_uid("ag"),
+        timezone="UTC",
+    )
+    # Same scheduled_at; the store orders id DESC, so whichever id sorts higher
+    # is "latest". Compute that deterministically and assert its status wins.
+    low_id, high_id = sorted([_uid("tie_x"), _uid("tie_y")])
+    store.create_run(
+        run_id=low_id,
+        scheduled_task_id=_uid("lst_tie"),
+        status="succeeded",
+        scheduled_at=300,
+        finished_at=305,
+    )
+    store.create_run(
+        run_id=high_id,
+        scheduled_task_id=_uid("lst_tie"),
+        status="skipped",
+        scheduled_at=300,
+    )
+    got = store.list_latest_run_status_for_tasks([_uid("lst_tie")])
+    assert got == {_uid("lst_tie"): "skipped"}
+
+
+def test_list_latest_run_status_omits_tasks_with_no_runs(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """A task that has never run is absent from the map (badge → never run)."""
+    store.create(
+        scheduled_task_id=_uid("lst_norun"),
+        name="norun",
+        prompt="p",
+        rrule="FREQ=MINUTELY",
+        user_id="u",
+        agent_id=_uid("ag"),
+        timezone="UTC",
+    )
+    assert store.list_latest_run_status_for_tasks([_uid("lst_norun")]) == {}
+
+
+def test_list_latest_run_status_empty_ids_returns_empty(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """An empty task-id list short-circuits to an empty map (no query)."""
+    assert store.list_latest_run_status_for_tasks([]) == {}
+
+
+def test_list_latest_run_status_is_workspace_scoped(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """A task's runs are invisible to the latest-status query from another workspace."""
+    with workspace_scope(11):
+        store.create(
+            scheduled_task_id=_uid("lst_w11"),
+            name="w11",
+            prompt="p",
+            rrule="FREQ=MINUTELY",
+            user_id="a",
+            agent_id=_uid("ag"),
+            timezone="UTC",
+        )
+        store.create_run(
+            run_id=_uid("lst_w11_run"),
+            scheduled_task_id=_uid("lst_w11"),
+            status="succeeded",
+            scheduled_at=100,
+            finished_at=105,
+        )
+    assert store.list_latest_run_status_for_tasks([_uid("lst_w11")]) == {}
+    with workspace_scope(11):
+        assert store.list_latest_run_status_for_tasks([_uid("lst_w11")]) == {
+            _uid("lst_w11"): "succeeded"
+        }
+
+
 # ── get_running_run_by_conversation (event-hook reverse lookup) ───────────────
 
 

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -181,7 +181,9 @@ function scheduledTask(overrides: Partial<import("@/lib/scheduledTasksApi").Sche
     hostId: null,
     state: "active",
     lastRunAt: null,
+    lastRunStatus: null,
     lastRunConversationId: null,
+    nextRunAt: null,
     ...overrides,
   } satisfies import("@/lib/scheduledTasksApi").ScheduledTask;
 }

--- a/web/src/components/scheduled/ScheduledTaskRow.test.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.test.tsx
@@ -1,0 +1,151 @@
+// Tests for ScheduledTaskRow: the last-run completion pill (one per status,
+// plus the no-pill cases), the server-sourced next-run text, and the ⋯ menu
+// actions (Run now / Pause-Resume / Edit / Delete) dispatching their callbacks.
+//
+// The row is fully props-driven, so these render it directly with a built task
+// object — no hook mocking needed. The ⋯ menu is a Radix dropdown; opening it
+// uses pointerDown on the trigger (matching the TasksPage tests).
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ScheduledTaskRow } from "./ScheduledTaskRow";
+import type { ScheduledTask, ScheduledTaskRunStatus } from "@/lib/scheduledTasksApi";
+
+function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: "st_1",
+    name: "Nightly triage",
+    prompt: "Triage",
+    rrule: "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=8;BYMINUTE=0",
+    ownerUserId: null,
+    agentId: "ag_1",
+    timezone: "UTC",
+    createdAt: 1,
+    updatedAt: 2,
+    modelOverride: null,
+    reasoningEffort: null,
+    workspace: null,
+    hostId: null,
+    state: "active",
+    lastRunAt: null,
+    lastRunStatus: null,
+    lastRunConversationId: null,
+    nextRunAt: null,
+    ...overrides,
+  };
+}
+
+function renderRow(
+  t: ScheduledTask,
+  handlers: Partial<Parameters<typeof ScheduledTaskRow>[0]> = {},
+) {
+  const props = {
+    task: t,
+    onEdit: vi.fn(),
+    onPauseToggle: vi.fn(),
+    onRunNow: vi.fn(),
+    onDelete: vi.fn(),
+    busy: false,
+    ...handlers,
+  };
+  render(<ScheduledTaskRow {...props} />);
+  return props;
+}
+
+afterEach(cleanup);
+
+describe("last-run status pill", () => {
+  it.each<[ScheduledTaskRunStatus, string]>([
+    ["failed", "Failed"],
+    ["incomplete", "Failed"],
+    ["skipped", "Skipped"],
+    ["running", "Running"],
+    ["scheduled", "Queued"],
+  ])("renders the %s status as a '%s' pill", (status, label) => {
+    renderRow(task({ lastRunStatus: status }));
+    const pill = screen.getByTestId("task-run-status-pill");
+    expect(pill).toHaveTextContent(label);
+    expect(pill).toHaveAttribute("data-status", status);
+  });
+
+  it("renders NO status pill when the task has never run (null status)", () => {
+    renderRow(task({ lastRunStatus: null }));
+    expect(screen.queryByTestId("task-run-status-pill")).toBeNull();
+  });
+
+  it("renders NO status pill for a succeeded run (success is not noise)", () => {
+    renderRow(task({ lastRunStatus: "succeeded" }));
+    expect(screen.queryByTestId("task-run-status-pill")).toBeNull();
+  });
+
+  it("marks failed distinctly from skipped (destructive vs muted)", () => {
+    const { rerender } = render(
+      <ScheduledTaskRow
+        task={task({ lastRunStatus: "failed" })}
+        onEdit={vi.fn()}
+        onPauseToggle={vi.fn()}
+        onRunNow={vi.fn()}
+        onDelete={vi.fn()}
+        busy={false}
+      />,
+    );
+    expect(screen.getByTestId("task-run-status-pill").className).toContain("text-destructive");
+    rerender(
+      <ScheduledTaskRow
+        task={task({ lastRunStatus: "skipped" })}
+        onEdit={vi.fn()}
+        onPauseToggle={vi.fn()}
+        onRunNow={vi.fn()}
+        onDelete={vi.fn()}
+        busy={false}
+      />,
+    );
+    const skipped = screen.getByTestId("task-run-status-pill");
+    expect(skipped.className).toContain("text-muted-foreground");
+    expect(skipped.className).not.toContain("text-destructive");
+  });
+});
+
+describe("next-run text (server-sourced)", () => {
+  it("renders the formatted next-run when nextRunAt is set", () => {
+    // A fixed future instant so the formatter produces stable text.
+    renderRow(task({ nextRunAt: "2999-01-02T09:00:00Z", timezone: "UTC" }));
+    const nextRun = screen.getByTestId("task-next-run");
+    expect(nextRun.textContent).toMatch(/Next:/);
+    // The date/time formatting is exercised in scheduleText.test.ts; here we
+    // just assert the row surfaces the server value.
+    expect(nextRun.textContent).toMatch(/9:00 AM|9:00 AM/);
+  });
+
+  it("renders NO next-run text when nextRunAt is null (paused / unarmed)", () => {
+    renderRow(task({ nextRunAt: null }));
+    expect(screen.queryByTestId("task-next-run")).toBeNull();
+  });
+});
+
+describe("⋯ menu actions", () => {
+  it("dispatches onRunNow when 'Run now' is selected", () => {
+    const onRunNow = vi.fn();
+    const t = task();
+    renderRow(t, { onRunNow });
+    fireEvent.pointerDown(screen.getByTestId("task-row-menu"), { button: 0 });
+    fireEvent.click(screen.getByTestId("task-run-now"));
+    expect(onRunNow).toHaveBeenCalledWith(t);
+  });
+
+  it("offers Run now even for a paused task (manual override)", () => {
+    const onRunNow = vi.fn();
+    const t = task({ state: "paused" });
+    renderRow(t, { onRunNow });
+    fireEvent.pointerDown(screen.getByTestId("task-row-menu"), { button: 0 });
+    const runNow = screen.getByTestId("task-run-now");
+    expect(runNow).toBeInTheDocument();
+    fireEvent.click(runNow);
+    expect(onRunNow).toHaveBeenCalledWith(t);
+  });
+
+  it("disables the menu trigger while the row is busy", () => {
+    renderRow(task(), { busy: true });
+    expect(screen.getByTestId("task-row-menu")).toBeDisabled();
+  });
+});

--- a/web/src/components/scheduled/ScheduledTaskRow.test.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.test.tsx
@@ -1,5 +1,4 @@
-// Tests for ScheduledTaskRow: the last-run completion pill (one per status,
-// plus the no-pill cases), the server-sourced next-run text, and the ⋯ menu
+// Tests for ScheduledTaskRow: the server-sourced next-run text and the ⋯ menu
 // actions (Run now / Pause-Resume / Edit / Delete) dispatching their callbacks.
 //
 // The row is fully props-driven, so these render it directly with a built task
@@ -9,7 +8,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ScheduledTaskRow } from "./ScheduledTaskRow";
-import type { ScheduledTask, ScheduledTaskRunStatus } from "@/lib/scheduledTasksApi";
+import type { ScheduledTask } from "@/lib/scheduledTasksApi";
 
 function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
   return {
@@ -53,58 +52,6 @@ function renderRow(
 }
 
 afterEach(cleanup);
-
-describe("last-run status pill", () => {
-  it.each<[ScheduledTaskRunStatus, string]>([
-    ["failed", "Failed"],
-    ["incomplete", "Failed"],
-    ["skipped", "Skipped"],
-    ["running", "Running"],
-    ["scheduled", "Queued"],
-  ])("renders the %s status as a '%s' pill", (status, label) => {
-    renderRow(task({ lastRunStatus: status }));
-    const pill = screen.getByTestId("task-run-status-pill");
-    expect(pill).toHaveTextContent(label);
-    expect(pill).toHaveAttribute("data-status", status);
-  });
-
-  it("renders NO status pill when the task has never run (null status)", () => {
-    renderRow(task({ lastRunStatus: null }));
-    expect(screen.queryByTestId("task-run-status-pill")).toBeNull();
-  });
-
-  it("renders NO status pill for a succeeded run (success is not noise)", () => {
-    renderRow(task({ lastRunStatus: "succeeded" }));
-    expect(screen.queryByTestId("task-run-status-pill")).toBeNull();
-  });
-
-  it("marks failed distinctly from skipped (destructive vs muted)", () => {
-    const { rerender } = render(
-      <ScheduledTaskRow
-        task={task({ lastRunStatus: "failed" })}
-        onEdit={vi.fn()}
-        onPauseToggle={vi.fn()}
-        onRunNow={vi.fn()}
-        onDelete={vi.fn()}
-        busy={false}
-      />,
-    );
-    expect(screen.getByTestId("task-run-status-pill").className).toContain("text-destructive");
-    rerender(
-      <ScheduledTaskRow
-        task={task({ lastRunStatus: "skipped" })}
-        onEdit={vi.fn()}
-        onPauseToggle={vi.fn()}
-        onRunNow={vi.fn()}
-        onDelete={vi.fn()}
-        busy={false}
-      />,
-    );
-    const skipped = screen.getByTestId("task-run-status-pill");
-    expect(skipped.className).toContain("text-muted-foreground");
-    expect(skipped.className).not.toContain("text-destructive");
-  });
-});
 
 describe("next-run text (server-sourced)", () => {
   it("renders the formatted next-run when nextRunAt is set", () => {

--- a/web/src/components/scheduled/ScheduledTaskRow.test.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.test.tsx
@@ -53,15 +53,14 @@ function renderRow(
 
 afterEach(cleanup);
 
-describe("next-run text (server-sourced)", () => {
-  it("renders the formatted next-run when nextRunAt is set", () => {
-    // A fixed future instant so the formatter produces stable text.
-    renderRow(task({ nextRunAt: "2999-01-02T09:00:00Z", timezone: "UTC" }));
+describe("next-run text (server-sourced, relative)", () => {
+  it("renders the relative next-run with a 'Next run' prefix when nextRunAt is set", () => {
+    // ~2h in the future → "in 2h". Delta formatting is covered in
+    // scheduleText.test.ts; here we assert the row surfaces it with the prefix.
+    const future = new Date(Date.now() + 2 * 60 * 60 * 1000 + 60_000).toISOString();
+    renderRow(task({ nextRunAt: future }));
     const nextRun = screen.getByTestId("task-next-run");
-    expect(nextRun.textContent).toMatch(/Next:/);
-    // The date/time formatting is exercised in scheduleText.test.ts; here we
-    // just assert the row surfaces the server value.
-    expect(nextRun.textContent).toMatch(/9:00 AM|9:00 AM/);
+    expect(nextRun.textContent).toMatch(/^Next run in \d+h$/);
   });
 
   it("renders NO next-run text when nextRunAt is null (paused / unarmed)", () => {

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -2,14 +2,15 @@
 // border/background/shadow box, no per-row divider). Layout: bold task title on
 // line 1 (+ a small "Paused" pill when paused), a single muted subline on line 2
 // with the human-readable schedule summary ("Weekdays at 8:00 AM") followed by
-// the SERVER's next-run time ("· Next: Tomorrow 9:00 AM") when armed.
+// the next-run delta ("· Next run in 15h") when armed.
 //
-// The next-run time is the scheduler's authoritative `nextRunAt` (an ISO string
-// the server computes) — we only FORMAT it, never recompute it on the client,
-// because a client-computed next-run can't match the server anchor for
-// INTERVAL>1 rules (the original reason a client countdown was removed). Paused
-// rows are NOT dimmed — the title stays fully legible and the pill is the sole
-// paused signal. A hover-revealed ellipsis (⋯) action menu (Run now / Pause /
+// The next-run delta is derived from the scheduler's authoritative `nextRunAt`
+// (an ISO string the server computes): we format only how far away it is
+// (nextRunAt − now), never recompute WHICH instant is next on the client — so
+// the old "no client countdown" rule (a client-recomputed instant can't match
+// the server anchor for INTERVAL>1 rules) is not violated. Paused rows are NOT
+// dimmed — the title stays fully legible and the pill is the sole paused
+// signal. A hover-revealed ellipsis (⋯) action menu (Run now / Pause /
 // Resume / Edit / Delete) sits on the right.
 
 import { useMemo, useState } from "react";
@@ -53,10 +54,7 @@ export function ScheduledTaskRow({
   // (active tasks only — a paused task has null nextRunAt). We only format the
   // server value; we never recompute next-run on the client.
   const scheduleSummary = useMemo(() => describeSchedule(task.rrule), [task.rrule]);
-  const nextRun = useMemo(
-    () => formatNextRunAt(task.nextRunAt, task.timezone),
-    [task.nextRunAt, task.timezone],
-  );
+  const nextRun = useMemo(() => formatNextRunAt(task.nextRunAt), [task.nextRunAt]);
 
   return (
     <div
@@ -96,7 +94,7 @@ export function ScheduledTaskRow({
           {nextRun && (
             <>
               {" · "}
-              <span data-testid="task-next-run">Next: {nextRun}</span>
+              <span data-testid="task-next-run">Next run {nextRun}</span>
             </>
           )}
         </span>

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -1,16 +1,27 @@
 // One row in the Tasks list, rendered as a FLAT list row (no card chrome — no
 // border/background/shadow box, no per-row divider). Layout: bold task title on
-// line 1 (+ a small "Paused" pill when paused), a single muted subline on line 2
-// with the human-readable schedule summary ("Weekdays at 8:00 AM"). We show ONLY
-// the schedule — no "Next run in Xh" countdown — because a client-computed
-// next-run can't be guaranteed to match the server's anchor for INTERVAL>1
-// rules; the schedule summary is always correct. Paused rows are NOT dimmed —
-// the title stays fully legible and the pill is the sole paused signal. A
-// hover-revealed ellipsis (⋯) action menu (Pause/Resume + Delete) sits on the
-// right. No leading or trailing status circles — the ⋯ menu is the only affordance.
+// line 1 (+ a small "Paused" pill when paused, + a completion-status pill for
+// the last run), a single muted subline on line 2 with the human-readable
+// schedule summary ("Weekdays at 8:00 AM") followed by the SERVER's next-run
+// time ("· Next: Tomorrow 9:00 AM") when armed.
+//
+// The next-run time is the scheduler's authoritative `nextRunAt` (an ISO string
+// the server computes) — we only FORMAT it, never recompute it on the client,
+// because a client-computed next-run can't match the server anchor for
+// INTERVAL>1 rules (the original reason a client countdown was removed). Paused
+// rows are NOT dimmed — the title stays fully legible and the pill is the sole
+// paused signal. A hover-revealed ellipsis (⋯) action menu (Run now / Pause /
+// Resume / Edit / Delete) sits on the right.
 
 import { useMemo, useState } from "react";
-import { MoreHorizontalIcon, PauseIcon, PencilIcon, PlayIcon, Trash2Icon } from "lucide-react";
+import {
+  MoreHorizontalIcon,
+  PauseIcon,
+  PencilIcon,
+  PlayIcon,
+  Trash2Icon,
+  ZapIcon,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -19,28 +30,52 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
-import { describeSchedule } from "@/lib/scheduleText";
-import type { ScheduledTask } from "@/lib/scheduledTasksApi";
+import { describeSchedule, formatNextRunAt } from "@/lib/scheduleText";
+import type { ScheduledTask, ScheduledTaskRunStatus } from "@/lib/scheduledTasksApi";
+
+/**
+ * Display config for each last-run status pill. `succeeded` deliberately renders
+ * NOTHING (a green "Succeeded" pill on every healthy row is visual noise — the
+ * signal is failure/skip/in-flight); the others are distinct: destructive for
+ * `failed`, muted for `skipped`, accent for the in-flight `running`/`scheduled`.
+ * `incomplete` (a stale run force-failed by the server) reads as a failure.
+ */
+const RUN_STATUS_PILL: Partial<
+  Record<ScheduledTaskRunStatus, { label: string; className: string }>
+> = {
+  failed: { label: "Failed", className: "bg-destructive/10 text-destructive" },
+  incomplete: { label: "Failed", className: "bg-destructive/10 text-destructive" },
+  skipped: { label: "Skipped", className: "bg-muted text-muted-foreground" },
+  running: { label: "Running", className: "bg-primary/10 text-primary" },
+  scheduled: { label: "Queued", className: "bg-primary/10 text-primary" },
+};
 
 export function ScheduledTaskRow({
   task,
   onEdit,
   onPauseToggle,
+  onRunNow,
   onDelete,
   busy,
 }: {
   task: ScheduledTask;
   onEdit: (task: ScheduledTask) => void;
   onPauseToggle: (task: ScheduledTask) => void;
+  onRunNow: (task: ScheduledTask) => void;
   onDelete: (task: ScheduledTask) => void;
   busy: boolean;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const paused = task.state === "paused";
-  // The subtitle is just the schedule summary for both active and paused rows
-  // (no next-run countdown). The paused signal is the pill next to the title,
-  // NOT a "· Paused" suffix and NOT row-wide dimming.
-  const secondaryLine = useMemo(() => describeSchedule(task.rrule), [task.rrule]);
+  const statusPill = task.lastRunStatus ? RUN_STATUS_PILL[task.lastRunStatus] : undefined;
+  // Subtitle: the schedule summary, plus the SERVER's next-run time when armed
+  // (active tasks only — a paused task has null nextRunAt). We only format the
+  // server value; we never recompute next-run on the client.
+  const scheduleSummary = useMemo(() => describeSchedule(task.rrule), [task.rrule]);
+  const nextRun = useMemo(
+    () => formatNextRunAt(task.nextRunAt, task.timezone),
+    [task.nextRunAt, task.timezone],
+  );
 
   return (
     <div
@@ -71,9 +106,27 @@ export function ScheduledTaskRow({
               Paused
             </span>
           )}
+          {statusPill && (
+            <span
+              data-testid="task-run-status-pill"
+              data-status={task.lastRunStatus}
+              className={cn(
+                "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium",
+                statusPill.className,
+              )}
+            >
+              {statusPill.label}
+            </span>
+          )}
         </span>
         <span className="truncate text-xs text-muted-foreground" data-testid="task-schedule-line">
-          {secondaryLine}
+          {scheduleSummary}
+          {nextRun && (
+            <>
+              {" · "}
+              <span data-testid="task-next-run">Next: {nextRun}</span>
+            </>
+          )}
         </span>
       </div>
 
@@ -100,6 +153,10 @@ export function ScheduledTaskRow({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={() => onRunNow(task)} data-testid="task-run-now">
+            <ZapIcon className="size-4" />
+            Run now
+          </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => onEdit(task)} data-testid="task-edit">
             <PencilIcon className="size-4" />
             Edit

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -97,7 +97,7 @@ export function ScheduledTaskRow({
     >
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="flex min-w-0 items-center gap-2">
-          <span className="truncate text-sm font-semibold">{task.name}</span>
+          <span className="truncate text-base font-bold">{task.name}</span>
           {paused && (
             <span
               data-testid="task-paused-pill"

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -120,7 +120,7 @@ export function ScheduledTaskRow({
           )}
         </span>
         <span
-          className="truncate text-[13px] text-muted-foreground"
+          className="truncate text-[13px] text-muted-foreground/80"
           data-testid="task-schedule-line"
         >
           {scheduleSummary}

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -97,7 +97,7 @@ export function ScheduledTaskRow({
     >
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="flex min-w-0 items-center gap-2">
-          <span className="truncate text-sm font-semibold">{task.name}</span>
+          <span className="truncate text-[15px] font-semibold">{task.name}</span>
           {paused && (
             <span
               data-testid="task-paused-pill"
@@ -119,7 +119,10 @@ export function ScheduledTaskRow({
             </span>
           )}
         </span>
-        <span className="truncate text-xs text-muted-foreground" data-testid="task-schedule-line">
+        <span
+          className="truncate text-[13px] text-muted-foreground"
+          data-testid="task-schedule-line"
+        >
           {scheduleSummary}
           {nextRun && (
             <>

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -1,9 +1,8 @@
 // One row in the Tasks list, rendered as a FLAT list row (no card chrome — no
 // border/background/shadow box, no per-row divider). Layout: bold task title on
-// line 1 (+ a small "Paused" pill when paused, + a completion-status pill for
-// the last run), a single muted subline on line 2 with the human-readable
-// schedule summary ("Weekdays at 8:00 AM") followed by the SERVER's next-run
-// time ("· Next: Tomorrow 9:00 AM") when armed.
+// line 1 (+ a small "Paused" pill when paused), a single muted subline on line 2
+// with the human-readable schedule summary ("Weekdays at 8:00 AM") followed by
+// the SERVER's next-run time ("· Next: Tomorrow 9:00 AM") when armed.
 //
 // The next-run time is the scheduler's authoritative `nextRunAt` (an ISO string
 // the server computes) — we only FORMAT it, never recompute it on the client,
@@ -31,24 +30,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { describeSchedule, formatNextRunAt } from "@/lib/scheduleText";
-import type { ScheduledTask, ScheduledTaskRunStatus } from "@/lib/scheduledTasksApi";
-
-/**
- * Display config for each last-run status pill. `succeeded` deliberately renders
- * NOTHING (a green "Succeeded" pill on every healthy row is visual noise — the
- * signal is failure/skip/in-flight); the others are distinct: destructive for
- * `failed`, muted for `skipped`, accent for the in-flight `running`/`scheduled`.
- * `incomplete` (a stale run force-failed by the server) reads as a failure.
- */
-const RUN_STATUS_PILL: Partial<
-  Record<ScheduledTaskRunStatus, { label: string; className: string }>
-> = {
-  failed: { label: "Failed", className: "bg-destructive/10 text-destructive" },
-  incomplete: { label: "Failed", className: "bg-destructive/10 text-destructive" },
-  skipped: { label: "Skipped", className: "bg-muted text-muted-foreground" },
-  running: { label: "Running", className: "bg-primary/10 text-primary" },
-  scheduled: { label: "Queued", className: "bg-primary/10 text-primary" },
-};
+import type { ScheduledTask } from "@/lib/scheduledTasksApi";
 
 export function ScheduledTaskRow({
   task,
@@ -67,7 +49,6 @@ export function ScheduledTaskRow({
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const paused = task.state === "paused";
-  const statusPill = task.lastRunStatus ? RUN_STATUS_PILL[task.lastRunStatus] : undefined;
   // Subtitle: the schedule summary, plus the SERVER's next-run time when armed
   // (active tasks only — a paused task has null nextRunAt). We only format the
   // server value; we never recompute next-run on the client.
@@ -92,7 +73,7 @@ export function ScheduledTaskRow({
         // two edges are symmetric within the highlight; `pr-10` keeps the text
         // clear of the inset button. Paused rows are NOT dimmed — the title must
         // stay legible (AA); the "Paused" pill is the sole signal.
-        "group relative -mx-2 flex items-center gap-3 rounded-lg py-3 pr-10 pl-2 transition-colors hover:bg-muted/50",
+        "group relative -mx-2 flex items-center gap-3 rounded-lg py-[11px] pr-10 pl-2 transition-colors hover:bg-muted/50",
       )}
     >
       <div className="flex min-w-0 flex-1 flex-col">
@@ -104,18 +85,6 @@ export function ScheduledTaskRow({
               className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
             >
               Paused
-            </span>
-          )}
-          {statusPill && (
-            <span
-              data-testid="task-run-status-pill"
-              data-status={task.lastRunStatus}
-              className={cn(
-                "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium",
-                statusPill.className,
-              )}
-            >
-              {statusPill.label}
             </span>
           )}
         </span>

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -64,14 +64,14 @@ export function ScheduledTaskRow({
         // Flat row — NO card chrome (no border/bg/shadow box) and no per-row
         // divider. `group relative` so the absolutely-positioned ⋯ trigger can
         // hover-reveal; vertical padding gives the flat-list spacing.
-        // `-mx-2 rounded-lg` + `hover:bg-muted/50` gives a subtle FULL-ROW hover
+        // `-mx-2 rounded-lg` + `hover:bg-muted/70` gives a subtle FULL-ROW hover
         // highlight (like the sidebar conversation rows) that extends past the
         // content while keeping the title aligned with the page. `pl-2` (left
         // content inset) is mirrored by the ⋯ button's `right-2` inset so the
         // two edges are symmetric within the highlight; `pr-10` keeps the text
         // clear of the inset button. Paused rows are NOT dimmed — the title must
         // stay legible (AA); the "Paused" pill is the sole signal.
-        "group relative -mx-2 flex items-center gap-3 rounded-lg py-[11px] pr-10 pl-2 transition-colors hover:bg-muted/50",
+        "group relative -mx-2 flex items-center gap-3 rounded-lg py-[11px] pr-10 pl-2 transition-colors hover:bg-muted/70",
       )}
     >
       <div className="flex min-w-0 flex-1 flex-col">

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -97,7 +97,7 @@ export function ScheduledTaskRow({
     >
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="flex min-w-0 items-center gap-2">
-          <span className="truncate text-base font-bold">{task.name}</span>
+          <span className="truncate text-sm font-semibold">{task.name}</span>
           {paused && (
             <span
               data-testid="task-paused-pill"

--- a/web/src/hooks/useScheduledTasks.test.tsx
+++ b/web/src/hooks/useScheduledTasks.test.tsx
@@ -9,8 +9,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "@/lib/scheduledTasksApi";
 import {
   SCHEDULED_TASKS_KEY,
+  scheduledTaskRunsKey,
   useCreateScheduledTask,
   useDeleteScheduledTask,
+  useRunScheduledTaskNow,
   useScheduledTasks,
   useUpdateScheduledTask,
 } from "./useScheduledTasks";
@@ -20,6 +22,7 @@ vi.mock("@/lib/scheduledTasksApi", () => ({
   createScheduledTask: vi.fn(),
   updateScheduledTask: vi.fn(),
   deleteScheduledTask: vi.fn(),
+  runScheduledTaskNow: vi.fn(),
 }));
 
 const TASK: api.ScheduledTask = {
@@ -38,7 +41,9 @@ const TASK: api.ScheduledTask = {
   hostId: null,
   state: "active",
   lastRunAt: null,
+  lastRunStatus: null,
   lastRunConversationId: null,
+  nextRunAt: null,
 };
 
 function makeWrapper() {
@@ -55,6 +60,7 @@ beforeEach(() => {
   vi.mocked(api.createScheduledTask).mockResolvedValue(TASK);
   vi.mocked(api.updateScheduledTask).mockResolvedValue({ ...TASK, state: "paused" });
   vi.mocked(api.deleteScheduledTask).mockResolvedValue(undefined);
+  vi.mocked(api.runScheduledTaskNow).mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -98,5 +104,17 @@ describe("mutations invalidate the list", () => {
     const { result } = renderHook(() => useDeleteScheduledTask(), { wrapper });
     await result.current.mutateAsync("st_1");
     expect(spy).toHaveBeenCalledWith({ queryKey: SCHEDULED_TASKS_KEY });
+  });
+
+  it("run-now calls the API and invalidates the list + that task's runs", async () => {
+    const { queryClient, wrapper } = makeWrapper();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
+    await result.current.mutateAsync("st_1");
+    expect(api.runScheduledTaskNow).toHaveBeenCalledWith("st_1");
+    // Refreshes the list (so the completion badge updates)…
+    expect(spy).toHaveBeenCalledWith({ queryKey: SCHEDULED_TASKS_KEY });
+    // …and the fired task's run history.
+    expect(spy).toHaveBeenCalledWith({ queryKey: scheduledTaskRunsKey("st_1") });
   });
 });

--- a/web/src/hooks/useScheduledTasks.ts
+++ b/web/src/hooks/useScheduledTasks.ts
@@ -12,6 +12,7 @@ import {
   deleteScheduledTask,
   listScheduledTaskRuns,
   listScheduledTasks,
+  runScheduledTaskNow,
   updateScheduledTask,
   type CreateScheduledTaskInput,
   type ScheduledTask,
@@ -99,6 +100,23 @@ export function useDeleteScheduledTask() {
     mutationFn: (id: string) => deleteScheduledTask(id),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: SCHEDULED_TASKS_KEY });
+    },
+  });
+}
+
+/**
+ * Trigger an immediate ("run now") fire of a task, then refresh the list and
+ * that task's run history so the completion badge (last-run status) reflects
+ * the new run. The server launches the run in the background (202), so the
+ * badge lands on the next list poll / invalidation rather than synchronously.
+ */
+export function useRunScheduledTaskNow() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => runScheduledTaskNow(id),
+    onSuccess: (_data, id) => {
+      void queryClient.invalidateQueries({ queryKey: SCHEDULED_TASKS_KEY });
+      void queryClient.invalidateQueries({ queryKey: scheduledTaskRunsKey(id) });
     },
   });
 }

--- a/web/src/lib/scheduleText.test.ts
+++ b/web/src/lib/scheduleText.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from "vitest";
 import { RRule, rrulestr } from "rrule";
-import { describeSchedule, formatClockTime, nextRunAtMs } from "./scheduleText";
+import { describeSchedule, formatClockTime, formatNextRunAt, nextRunAtMs } from "./scheduleText";
 import {
   buildRRule,
   DEFAULT_SCHEDULE_MODEL,
@@ -350,5 +350,50 @@ describe("nextRunAtMs", () => {
 
     expect(next).not.toBeNull();
     expect(elapsedMs).toBeLessThan(30);
+  });
+});
+
+describe("formatNextRunAt (formats the SERVER's next-run instant)", () => {
+  // A fixed "now" so Today/Tomorrow/weekday buckets are deterministic.
+  const NOW = new Date("2026-03-10T12:00:00Z"); // Tue 2026-03-10, 12:00 UTC
+
+  it("returns null for null / empty / unparseable input", () => {
+    expect(formatNextRunAt(null, "UTC", NOW)).toBeNull();
+    expect(formatNextRunAt(undefined, "UTC", NOW)).toBeNull();
+    expect(formatNextRunAt("", "UTC", NOW)).toBeNull();
+    expect(formatNextRunAt("not-a-date", "UTC", NOW)).toBeNull();
+  });
+
+  it("labels a same-day fire as 'Today <time>'", () => {
+    expect(formatNextRunAt("2026-03-10T18:30:00Z", "UTC", NOW)).toBe("Today 6:30 PM");
+  });
+
+  it("labels the next calendar day as 'Tomorrow <time>'", () => {
+    expect(formatNextRunAt("2026-03-11T09:00:00Z", "UTC", NOW)).toBe("Tomorrow 9:00 AM");
+  });
+
+  it("names the weekday for a fire later in the coming week", () => {
+    // 2026-03-13 is a Friday.
+    expect(formatNextRunAt("2026-03-13T08:00:00Z", "UTC", NOW)).toBe("Fri 8:00 AM");
+  });
+
+  it("uses a short date for a fire a week or more out", () => {
+    // 2026-03-20 is >7 days from NOW.
+    expect(formatNextRunAt("2026-03-20T06:00:00Z", "UTC", NOW)).toBe("Mar 20, 6:00 AM");
+  });
+
+  it("renders in the TASK's timezone, not the viewer's", () => {
+    // 2026-03-11T04:00Z is still 2026-03-10 in America/Los_Angeles (PDT, UTC-7
+    // in March → 9:00 PM), so it reads 'Today' in LA even though it's already
+    // tomorrow in UTC.
+    expect(formatNextRunAt("2026-03-11T04:00:00Z", "America/Los_Angeles", NOW)).toBe(
+      "Today 9:00 PM",
+    );
+  });
+
+  it("crosses the calendar boundary by wall-clock date, not a 24h delta", () => {
+    // NOW is noon Tue; a fire at 1am Wed is <24h away but a DIFFERENT calendar
+    // day, so it must read 'Tomorrow', not 'Today'.
+    expect(formatNextRunAt("2026-03-11T01:00:00Z", "UTC", NOW)).toBe("Tomorrow 1:00 AM");
   });
 });

--- a/web/src/lib/scheduleText.test.ts
+++ b/web/src/lib/scheduleText.test.ts
@@ -353,47 +353,51 @@ describe("nextRunAtMs", () => {
   });
 });
 
-describe("formatNextRunAt (formats the SERVER's next-run instant)", () => {
-  // A fixed "now" so Today/Tomorrow/weekday buckets are deterministic.
+describe("formatNextRunAt (compact relative delta from the server's next-run)", () => {
+  // A fixed "now" so the delta buckets are deterministic.
   const NOW = new Date("2026-03-10T12:00:00Z"); // Tue 2026-03-10, 12:00 UTC
+  const iso = (ms: number) => new Date(NOW.getTime() + ms).toISOString();
+  const MIN = 60_000;
+  const HR = 60 * MIN;
+  const DAY = 24 * HR;
 
   it("returns null for null / empty / unparseable input", () => {
-    expect(formatNextRunAt(null, "UTC", NOW)).toBeNull();
-    expect(formatNextRunAt(undefined, "UTC", NOW)).toBeNull();
-    expect(formatNextRunAt("", "UTC", NOW)).toBeNull();
-    expect(formatNextRunAt("not-a-date", "UTC", NOW)).toBeNull();
+    expect(formatNextRunAt(null, NOW)).toBeNull();
+    expect(formatNextRunAt(undefined, NOW)).toBeNull();
+    expect(formatNextRunAt("", NOW)).toBeNull();
+    expect(formatNextRunAt("not-a-date", NOW)).toBeNull();
   });
 
-  it("labels a same-day fire as 'Today <time>'", () => {
-    expect(formatNextRunAt("2026-03-10T18:30:00Z", "UTC", NOW)).toBe("Today 6:30 PM");
+  it("formats a sub-hour delta in minutes (floor)", () => {
+    expect(formatNextRunAt(iso(30 * MIN), NOW)).toBe("in 30m");
+    // Floor: 59m59s → "in 59m".
+    expect(formatNextRunAt(iso(59 * MIN + 59_000), NOW)).toBe("in 59m");
+    // Minimum bucket is 1m (just over the 'soon' threshold).
+    expect(formatNextRunAt(iso(MIN), NOW)).toBe("in 1m");
   });
 
-  it("labels the next calendar day as 'Tomorrow <time>'", () => {
-    expect(formatNextRunAt("2026-03-11T09:00:00Z", "UTC", NOW)).toBe("Tomorrow 9:00 AM");
+  it("formats a sub-day delta in hours (floor)", () => {
+    expect(formatNextRunAt(iso(HR), NOW)).toBe("in 1h");
+    expect(formatNextRunAt(iso(15 * HR), NOW)).toBe("in 15h");
+    // Floor: 23h59m → "in 23h".
+    expect(formatNextRunAt(iso(23 * HR + 59 * MIN), NOW)).toBe("in 23h");
   });
 
-  it("names the weekday for a fire later in the coming week", () => {
-    // 2026-03-13 is a Friday.
-    expect(formatNextRunAt("2026-03-13T08:00:00Z", "UTC", NOW)).toBe("Fri 8:00 AM");
+  it("formats a multi-day delta in days (floor)", () => {
+    expect(formatNextRunAt(iso(DAY), NOW)).toBe("in 1d");
+    expect(formatNextRunAt(iso(6 * DAY), NOW)).toBe("in 6d");
+    // Floor: 6d23h → "in 6d".
+    expect(formatNextRunAt(iso(6 * DAY + 23 * HR), NOW)).toBe("in 6d");
   });
 
-  it("uses a short date for a fire a week or more out", () => {
-    // 2026-03-20 is >7 days from NOW.
-    expect(formatNextRunAt("2026-03-20T06:00:00Z", "UTC", NOW)).toBe("Mar 20, 6:00 AM");
+  it("returns 'soon' for an imminent or just-passed delta (< 1 minute)", () => {
+    expect(formatNextRunAt(iso(20_000), NOW)).toBe("soon"); // 20s out
+    expect(formatNextRunAt(iso(0), NOW)).toBe("soon"); // exactly now
+    expect(formatNextRunAt(iso(-5 * MIN), NOW)).toBe("soon"); // 5m in the past (skew)
   });
 
-  it("renders in the TASK's timezone, not the viewer's", () => {
-    // 2026-03-11T04:00Z is still 2026-03-10 in America/Los_Angeles (PDT, UTC-7
-    // in March → 9:00 PM), so it reads 'Today' in LA even though it's already
-    // tomorrow in UTC.
-    expect(formatNextRunAt("2026-03-11T04:00:00Z", "America/Los_Angeles", NOW)).toBe(
-      "Today 9:00 PM",
-    );
-  });
-
-  it("crosses the calendar boundary by wall-clock date, not a 24h delta", () => {
-    // NOW is noon Tue; a fire at 1am Wed is <24h away but a DIFFERENT calendar
-    // day, so it must read 'Tomorrow', not 'Today'.
-    expect(formatNextRunAt("2026-03-11T01:00:00Z", "UTC", NOW)).toBe("Tomorrow 1:00 AM");
+  it("bucket boundaries: 60m → hours, 24h → days", () => {
+    expect(formatNextRunAt(iso(60 * MIN), NOW)).toBe("in 1h");
+    expect(formatNextRunAt(iso(24 * HR), NOW)).toBe("in 1d");
   });
 });

--- a/web/src/lib/scheduleText.ts
+++ b/web/src/lib/scheduleText.ts
@@ -57,6 +57,102 @@ export function formatClockTime(hour: number, minute: number): string {
   return `${h12}:${mm} ${period}`;
 }
 
+/**
+ * Format the SERVER's authoritative next-run instant (an ISO-8601 string from
+ * the live scheduler) as a short human label in the task's timezone, e.g.
+ * `Today 9:00 AM`, `Tomorrow 8:30 AM`, `Mon 6:00 AM`, `Mar 3, 9:00 AM`.
+ *
+ * This formats a value the SERVER computed — it does NOT recompute next-run on
+ * the client (which can't match the server anchor for INTERVAL>1 rules). Pass
+ * the task's `nextRunAt` straight through. Returns `null` for a null/unparseable
+ * input so the caller renders nothing.
+ *
+ * "Today" / "Tomorrow" are decided by calendar-day difference in `timezone`
+ * (not a 24h delta), so an 11pm-now / 1am-tomorrow fire still reads "Tomorrow".
+ *
+ * @param iso The server's `next_run_at` ISO string, or `null`.
+ * @param timezone IANA timezone the label is rendered in (the task timezone).
+ * @param now Injectable clock for deterministic tests; defaults to `new Date()`.
+ */
+export function formatNextRunAt(
+  iso: string | null | undefined,
+  timezone: string,
+  now: Date = new Date(),
+): string | null {
+  if (!iso) return null;
+  const instant = new Date(iso);
+  if (Number.isNaN(instant.getTime())) return null;
+
+  const dayDelta = calendarDayDeltaInTz(now, instant, timezone);
+  const time = formatInstantClock(instant, timezone);
+  if (dayDelta === 0) return `Today ${time}`;
+  if (dayDelta === 1) return `Tomorrow ${time}`;
+  // Within the coming week, name the weekday ("Mon"); otherwise a short date.
+  if (dayDelta > 1 && dayDelta < 7) {
+    return `${formatInstantPart(instant, timezone, { weekday: "short" })} ${time}`;
+  }
+  const date = formatInstantPart(instant, timezone, { month: "short", day: "numeric" });
+  return `${date}, ${time}`;
+}
+
+/** 12-hour clock (`9:00 AM`) for an absolute instant, rendered in `timezone`. */
+function formatInstantClock(instant: Date, timezone: string): string {
+  return formatInstantPart(instant, timezone, {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+/** Render an absolute instant in `timezone` with the given Intl options. */
+function formatInstantPart(
+  instant: Date,
+  timezone: string,
+  options: Intl.DateTimeFormatOptions,
+): string {
+  try {
+    return new Intl.DateTimeFormat("en-US", { timeZone: timezone, ...options }).format(instant);
+  } catch {
+    // Unknown timezone → fall back to the viewer's local zone rather than throw.
+    return new Intl.DateTimeFormat("en-US", options).format(instant);
+  }
+}
+
+/**
+ * Whole-calendar-day difference (`b` − `a`) as counted in `timezone`, so
+ * "today"/"tomorrow" reflect the wall-clock date boundary rather than a 24h
+ * span. Returns e.g. 0 (same day), 1 (next day), or a negative number for a
+ * past instant.
+ */
+function calendarDayDeltaInTz(a: Date, b: Date, timezone: string): number {
+  const dayA = civilDayNumber(a, timezone);
+  const dayB = civilDayNumber(b, timezone);
+  if (dayA == null || dayB == null) return Math.round((b.getTime() - a.getTime()) / 86_400_000);
+  return dayB - dayA;
+}
+
+/** The instant's civil date in `timezone` as a day count (days since epoch). */
+function civilDayNumber(instant: Date, timezone: string): number | null {
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(instant);
+    const map: Record<string, number> = {};
+    for (const p of parts) {
+      if (p.type !== "literal") map[p.type] = Number(p.value);
+    }
+    if (map.year == null || map.month == null || map.day == null) return null;
+    // Days since the Unix epoch for that civil date (UTC math on the tz-local
+    // Y/M/D — a pure day index, so DST never shifts the count).
+    return Math.floor(Date.UTC(map.year, map.month - 1, map.day) / 86_400_000);
+  } catch {
+    return null;
+  }
+}
+
 /** Parse an RRULE string into an `RRule`, or `null` if it can't be parsed. */
 function tryParse(rrule: string): RRule | null {
   try {

--- a/web/src/lib/scheduleText.ts
+++ b/web/src/lib/scheduleText.ts
@@ -29,6 +29,11 @@ import { RRule, rrulestr } from "rrule";
 const OCCURRENCE_ANCHOR = new Date(Date.UTC(2000, 0, 1, 0, 0, 0));
 const FIXED_PERIOD_SAFETY_MARGIN = 2;
 
+// Millisecond units for the compact relative next-run delta (formatNextRunAt).
+const MIN_MS = 60_000;
+const HOUR_MS = 60 * MIN_MS;
+const DAY_MS = 24 * HOUR_MS;
+
 /** Days-of-week bit set helpers. RRule weekday order is MO..SU (0..6). */
 const WEEKDAYS = [RRule.MO, RRule.TU, RRule.WE, RRule.TH, RRule.FR].map((d) => d.weekday);
 const ALL_DAYS = [RRule.MO, RRule.TU, RRule.WE, RRule.TH, RRule.FR, RRule.SA, RRule.SU].map(
@@ -58,99 +63,39 @@ export function formatClockTime(hour: number, minute: number): string {
 }
 
 /**
- * Format the SERVER's authoritative next-run instant (an ISO-8601 string from
- * the live scheduler) as a short human label in the task's timezone, e.g.
- * `Today 9:00 AM`, `Tomorrow 8:30 AM`, `Mon 6:00 AM`, `Mar 3, 9:00 AM`.
+ * Format the time until the SERVER's authoritative next-run instant as a
+ * compact relative delta, e.g. `in 30m`, `in 15h`, `in 6d`, or `soon`.
  *
- * This formats a value the SERVER computed — it does NOT recompute next-run on
- * the client (which can't match the server anchor for INTERVAL>1 rules). Pass
- * the task's `nextRunAt` straight through. Returns `null` for a null/unparseable
- * input so the caller renders nothing.
+ * `iso` is the server's `next_run_at` (the live scheduler's authoritative next
+ * fire). We compute ONLY the delta (`nextRunAt − now`) and format how far away
+ * it is — the instant itself stays server-authoritative. This is NOT the old
+ * client-recomputed countdown that was removed: that one recomputed WHICH
+ * instant is next on the client (and couldn't match the server anchor for
+ * INTERVAL>1 rules); here the instant comes from the server and only the
+ * "how far away" is derived, so the removal rule is not violated.
  *
- * "Today" / "Tomorrow" are decided by calendar-day difference in `timezone`
- * (not a 24h delta), so an 11pm-now / 1am-tomorrow fire still reads "Tomorrow".
+ * Buckets (floor of the chosen unit — standard time-remaining convention):
+ *   < 60 min → `in Xm` (minimum `in 1m`), < 24 h → `in Xh`, else `in Xd`.
+ * A delta at or below ~0 (imminent / just passed due to clock skew) → `soon`.
+ * Returns `null` for a null / unparseable `iso` so the caller renders nothing.
  *
  * @param iso The server's `next_run_at` ISO string, or `null`.
- * @param timezone IANA timezone the label is rendered in (the task timezone).
  * @param now Injectable clock for deterministic tests; defaults to `new Date()`.
  */
 export function formatNextRunAt(
   iso: string | null | undefined,
-  timezone: string,
   now: Date = new Date(),
 ): string | null {
   if (!iso) return null;
   const instant = new Date(iso);
   if (Number.isNaN(instant.getTime())) return null;
 
-  const dayDelta = calendarDayDeltaInTz(now, instant, timezone);
-  const time = formatInstantClock(instant, timezone);
-  if (dayDelta === 0) return `Today ${time}`;
-  if (dayDelta === 1) return `Tomorrow ${time}`;
-  // Within the coming week, name the weekday ("Mon"); otherwise a short date.
-  if (dayDelta > 1 && dayDelta < 7) {
-    return `${formatInstantPart(instant, timezone, { weekday: "short" })} ${time}`;
-  }
-  const date = formatInstantPart(instant, timezone, { month: "short", day: "numeric" });
-  return `${date}, ${time}`;
-}
-
-/** 12-hour clock (`9:00 AM`) for an absolute instant, rendered in `timezone`. */
-function formatInstantClock(instant: Date, timezone: string): string {
-  return formatInstantPart(instant, timezone, {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
-}
-
-/** Render an absolute instant in `timezone` with the given Intl options. */
-function formatInstantPart(
-  instant: Date,
-  timezone: string,
-  options: Intl.DateTimeFormatOptions,
-): string {
-  try {
-    return new Intl.DateTimeFormat("en-US", { timeZone: timezone, ...options }).format(instant);
-  } catch {
-    // Unknown timezone → fall back to the viewer's local zone rather than throw.
-    return new Intl.DateTimeFormat("en-US", options).format(instant);
-  }
-}
-
-/**
- * Whole-calendar-day difference (`b` − `a`) as counted in `timezone`, so
- * "today"/"tomorrow" reflect the wall-clock date boundary rather than a 24h
- * span. Returns e.g. 0 (same day), 1 (next day), or a negative number for a
- * past instant.
- */
-function calendarDayDeltaInTz(a: Date, b: Date, timezone: string): number {
-  const dayA = civilDayNumber(a, timezone);
-  const dayB = civilDayNumber(b, timezone);
-  if (dayA == null || dayB == null) return Math.round((b.getTime() - a.getTime()) / 86_400_000);
-  return dayB - dayA;
-}
-
-/** The instant's civil date in `timezone` as a day count (days since epoch). */
-function civilDayNumber(instant: Date, timezone: string): number | null {
-  try {
-    const parts = new Intl.DateTimeFormat("en-CA", {
-      timeZone: timezone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    }).formatToParts(instant);
-    const map: Record<string, number> = {};
-    for (const p of parts) {
-      if (p.type !== "literal") map[p.type] = Number(p.value);
-    }
-    if (map.year == null || map.month == null || map.day == null) return null;
-    // Days since the Unix epoch for that civil date (UTC math on the tz-local
-    // Y/M/D — a pure day index, so DST never shifts the count).
-    return Math.floor(Date.UTC(map.year, map.month - 1, map.day) / 86_400_000);
-  } catch {
-    return null;
-  }
+  const deltaMs = instant.getTime() - now.getTime();
+  // Imminent or just-passed (timing skew): don't render a "0m" / negative delta.
+  if (deltaMs < MIN_MS) return "soon";
+  if (deltaMs < HOUR_MS) return `in ${Math.floor(deltaMs / MIN_MS)}m`;
+  if (deltaMs < DAY_MS) return `in ${Math.floor(deltaMs / HOUR_MS)}h`;
+  return `in ${Math.floor(deltaMs / DAY_MS)}d`;
 }
 
 /** Parse an RRULE string into an `RRule`, or `null` if it can't be parsed. */

--- a/web/src/lib/scheduledTasksApi.ts
+++ b/web/src/lib/scheduledTasksApi.ts
@@ -50,7 +50,21 @@ export interface ScheduledTask {
   state: ScheduledTaskState;
   /** Epoch seconds of the last fire, or `null` if it has never fired. */
   lastRunAt: number | null;
+  /**
+   * Status of the task's MOST RECENT run (`succeeded` / `failed` / `skipped` /
+   * `running` / `scheduled` / `incomplete`), or `null` when the task has never
+   * run. Server-computed from the latest run row so the list can show a
+   * completion badge without a per-row `/runs` fetch.
+   */
+  lastRunStatus: ScheduledTaskRunStatus | null;
   lastRunConversationId: string | null;
+  /**
+   * ISO-8601 timestamp of the next scheduled fire, computed by the SERVER's
+   * live scheduler (its authoritative anchor), or `null` when the task is
+   * paused / not armed. Never recompute this on the client — a client-computed
+   * next-run can't match the server anchor for INTERVAL>1 rules.
+   */
+  nextRunAt: string | null;
 }
 
 /** One run of a scheduled task, camelCased from `_run_to_response`. */
@@ -115,7 +129,9 @@ interface ScheduledTaskWire {
   host_id: string | null;
   state: ScheduledTaskState;
   last_run_at: number | null;
+  last_run_status: ScheduledTaskRunStatus | null;
   last_run_conversation_id: string | null;
+  next_run_at: string | null;
 }
 
 /** Wire shape of a run row (snake_case), matching `_run_to_response`. */
@@ -187,7 +203,9 @@ function taskFromWire(wire: ScheduledTaskWire): ScheduledTask {
     hostId: wire.host_id,
     state: wire.state,
     lastRunAt: wire.last_run_at,
+    lastRunStatus: wire.last_run_status,
     lastRunConversationId: wire.last_run_conversation_id,
+    nextRunAt: wire.next_run_at,
   };
 }
 
@@ -281,6 +299,20 @@ export async function updateScheduledTask(
 export async function deleteScheduledTask(id: string): Promise<void> {
   const res = await authenticatedFetch(`/v1/scheduled-tasks/${encodeURIComponent(id)}`, {
     method: "DELETE",
+  });
+  if (!res.ok) throw await errorFromResponse(res);
+}
+
+/**
+ * Trigger an immediate ("run now") fire of a task. A manual override that
+ * reuses the server's shared fire path; paused tasks are runnable. The server
+ * responds `202 Accepted` (the run launches in the background), so this returns
+ * `void` — callers invalidate the list + runs queries to pick up the new run's
+ * status. A `409` (already in flight) surfaces as a {@link ScheduledTaskApiError}.
+ */
+export async function runScheduledTaskNow(id: string): Promise<void> {
+  const res = await authenticatedFetch(`/v1/scheduled-tasks/${encodeURIComponent(id)}/run`, {
+    method: "POST",
   });
   if (!res.ok) throw await errorFromResponse(res);
 }

--- a/web/src/pages/TasksPage.test.tsx
+++ b/web/src/pages/TasksPage.test.tsx
@@ -18,6 +18,7 @@ vi.mock("@/hooks/useScheduledTasks", () => ({
   useScheduledTasks: vi.fn(),
   useUpdateScheduledTask: vi.fn(),
   useDeleteScheduledTask: vi.fn(),
+  useRunScheduledTaskNow: vi.fn(),
 }));
 
 // Stub the create dialog — its internals are covered separately; here we only
@@ -63,13 +64,16 @@ function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     hostId: null,
     state: "active",
     lastRunAt: null,
+    lastRunStatus: null,
     lastRunConversationId: null,
+    nextRunAt: null,
     ...overrides,
   };
 }
 
 const mutate = vi.fn();
 const deleteMutate = vi.fn();
+const runNowMutate = vi.fn();
 
 function setTasks(tasks: ScheduledTask[], state: { isLoading?: boolean; isError?: boolean } = {}) {
   vi.mocked(hooks.useScheduledTasks).mockReturnValue({
@@ -83,6 +87,7 @@ function setTasks(tasks: ScheduledTask[], state: { isLoading?: boolean; isError?
 beforeEach(() => {
   mutate.mockReset();
   deleteMutate.mockReset();
+  runNowMutate.mockReset();
   vi.mocked(hooks.useUpdateScheduledTask).mockReturnValue({
     mutate,
     isPending: false,
@@ -93,6 +98,11 @@ beforeEach(() => {
     isPending: false,
     variables: undefined,
   } as unknown as ReturnType<typeof hooks.useDeleteScheduledTask>);
+  vi.mocked(hooks.useRunScheduledTaskNow).mockReturnValue({
+    mutate: runNowMutate,
+    isPending: false,
+    variables: undefined,
+  } as unknown as ReturnType<typeof hooks.useRunScheduledTaskNow>);
 });
 
 afterEach(() => cleanup());

--- a/web/src/pages/TasksPage.test.tsx
+++ b/web/src/pages/TasksPage.test.tsx
@@ -244,7 +244,7 @@ describe("sort order", () => {
       renderPage();
       const names = screen
         .getAllByTestId("scheduled-task-row")
-        .map((r) => r.querySelector(".font-semibold")?.textContent);
+        .map((r) => r.querySelector(".font-bold")?.textContent);
       expect(names).toEqual(["Active soon", "Active late", "Paused early"]);
     } finally {
       vi.useRealTimers();

--- a/web/src/pages/TasksPage.test.tsx
+++ b/web/src/pages/TasksPage.test.tsx
@@ -244,7 +244,7 @@ describe("sort order", () => {
       renderPage();
       const names = screen
         .getAllByTestId("scheduled-task-row")
-        .map((r) => r.querySelector(".font-bold")?.textContent);
+        .map((r) => r.querySelector(".font-semibold")?.textContent);
       expect(names).toEqual(["Active soon", "Active late", "Paused early"]);
     } finally {
       vi.useRealTimers();

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/scheduled/suggestions";
 import {
   useDeleteScheduledTask,
+  useRunScheduledTaskNow,
   useScheduledTasks,
   useUpdateScheduledTask,
 } from "@/hooks/useScheduledTasks";
@@ -42,6 +43,7 @@ export function TasksPage() {
   const { data: tasks, isLoading, isError, refetch } = useScheduledTasks();
   const updateMutation = useUpdateScheduledTask();
   const deleteMutation = useDeleteScheduledTask();
+  const runNowMutation = useRunScheduledTaskNow();
 
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<FilterTab>("all");
@@ -105,12 +107,16 @@ export function TasksPage() {
   }, [tasks, search, filter]);
 
   // A per-task busy flag so a row's menu disables while its own mutation runs.
+  // Covers pause/resume (update), delete, and run-now so the ⋯ menu can't be
+  // re-triggered mid-flight for the task whose mutation is pending.
   const busyId =
     updateMutation.isPending && updateMutation.variables
       ? updateMutation.variables.id
       : deleteMutation.isPending
         ? (deleteMutation.variables as string | undefined)
-        : undefined;
+        : runNowMutation.isPending
+          ? (runNowMutation.variables as string | undefined)
+          : undefined;
 
   function handlePauseToggle(task: ScheduledTask) {
     updateMutation.mutate({
@@ -121,6 +127,10 @@ export function TasksPage() {
 
   function handleDelete(task: ScheduledTask) {
     deleteMutation.mutate(task.id);
+  }
+
+  function handleRunNow(task: ScheduledTask) {
+    runNowMutation.mutate(task.id);
   }
 
   function handleEdit(task: ScheduledTask) {
@@ -217,6 +227,7 @@ export function TasksPage() {
               busy={busyId === task.id}
               onEdit={handleEdit}
               onPauseToggle={handlePauseToggle}
+              onRunNow={handleRunNow}
               onDelete={handleDelete}
             />
           ))}


### PR DESCRIPTION
## Related issue

<!-- One issue per PR; closing keyword auto-links + closes on merge. -->
N/A — tracked in Linear ([OMNI-1193](https://linear.app/omnigent/issue/OMNI-1193)). UI/UX follow-up on the merged Scheduled Tasks backend (#2720) and run-completion tracking (#3014).

## Summary

Adds two user-facing capabilities to the Scheduled Tasks list and polishes the row presentation:

- **Run now** — new `POST /v1/scheduled-tasks/{id}/run` (202) that triggers an immediate fire by **reusing the existing scheduler fire path** (`build_run_now` shares the same dispatch/preflight/in-flight guard as `on_fire`; no duplicated logic). Paused tasks are runnable (manual override). Surfaced as a "Run now" item in each row's ⋯ menu, wired through a `useRunScheduledTaskNow` mutation that invalidates the list on success.
- **Next run** — the row now shows a **relative** "Next run in 15h / in 6d" label. This is a delta formatted from the scheduler's **server-authoritative** `next_run_at` (added to the list/GET serializer), **not** a client recompute of the next instant — so it does not reintroduce the client-countdown problem for INTERVAL>1 rules. Paused/unarmed tasks (null `next_run_at`) render nothing.
- **Row styling** — title 15px / weight 600; metadata subline 13px, lightened (`text-muted-foreground/80`); inter-row spacing tightened 2px; row hover background darkened (`bg-muted/70`); the "Paused" pill retained.
- **Serializer note:** `last_run_status` is also added to the task response (via a single windowed `list_latest_run_status_for_tasks` store query — no N per-row `/runs` fetches). The per-row status **pill was intentionally removed from the UI** during review, but the field is left in the API/store as harmless, ready data if a status treatment returns later.

**ELI5:** Each scheduled task row now tells you *when it'll run next* ("in 15h") and lets you *run it right now* from the ⋯ menu — and the "run now" button reuses the exact same machinery the scheduler already uses to fire tasks, so there's no second code path to keep in sync. The rest is visual tidying of the row.

```mermaid
flowchart TD
    A[User clicks 'Run now' in ⋯ menu] --> B[POST /v1/scheduled-tasks/id/run]
    B --> C[build_run_now — same shared trigger as scheduler on_fire]
    C --> D[in-flight guard + preflight + dispatch]
    D --> E[run row recorded; 202 returned]
    E --> F[mutation invalidates list query → row refreshes]
    G[list/GET serializer] --> H[next_run_at from scheduler.next_run_at — server-authoritative]
    H --> I[row formats delta → 'Next run in 15h']
```

## Test Plan

- **Backend:** `pytest` scheduled + routes + store suites green (**172 passed**). New coverage: the `/run` endpoint (happy 202, records a run, paused runnable, 404 not-owned, 409 in-flight, 503 no-scheduler), the windowed `list_latest_run_status_for_tasks` store query, and the `next_run_at` / `last_run_status` serializer fields.
- **Frontend:** `npx tsc -b` exit 0; `npx vitest run` green (full suite ~4539 passed at feature completion; the targeted `ScheduledTaskRow` / `TasksPage` / `scheduleText` suites stayed green through the styling iterations). New unit tests: run-now mutation wiring, relative next-run formatting (each bucket + "soon" + null boundary), and row rendering.
- **E2E:** `tests/e2e_ui/scheduled` **3/3** (ran locally after a fresh `vite build`), including a Run-now journey (⋯ → Run now records a run) and the reconciled next-run-label guard.
- **Browser:** `/tasks` verified in **light and dark** themes via DOM measurement (screenshots come back empty in this harness per a known embed-root quirk) — Run now triggers a real fire and the list refreshes, relative next-run renders on armed rows and nothing on paused rows, and the row type sizes/weights/hover match the targets.

## Demo

https://github.com/user-attachments/assets/9ff9ff92-7573-4c11-bf0f-8d1c977824a3



## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated unit + integration + e2e coverage is described in the Test Plan. Manual verification covered the live Run-now → fire → list-refresh loop and the per-theme visual check, done via DOM measurement because the embedded browser returns empty screenshots in this harness — the pixel capture (not the behavior) is what's unreproducible.

## Changelog

Scheduled task rows now show when each task will next run ("Next run in 15h") and a "Run now" action in the ⋯ menu to fire a task immediately, with refreshed row styling.

---
This pull request and its description were written by Isaac.