### PR TITLE
fix(web): allow session switching from empty editables

### DIFF
--- a/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
+++ b/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
@@ -26,8 +26,11 @@ sidebar's "Sessions" group, so both are in the hotkey's ordered list.
 
 from __future__ import annotations
 
+from urllib.parse import urlsplit
+
 import httpx
 from playwright.sync_api import Page, expect
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 _COMPOSER = "Ask the agent anything…"
 
@@ -40,6 +43,29 @@ def _set_title(base_url: str, session_id: str, title: str) -> None:
         timeout=10.0,
     )
     resp.raise_for_status()
+
+
+def _press_down_and_expect_session_change(page: Page) -> None:
+    """Press the traversal chord and require a different session URL."""
+    previous_url = page.url
+    previous_path = urlsplit(previous_url).path
+    assert previous_path.startswith("/c/") and previous_path.count("/") == 2
+
+    page.keyboard.press("ControlOrMeta+ArrowDown")
+    try:
+        page.wait_for_function(
+            """previousPath => {
+                const current = new URL(window.location.href);
+                return current.pathname !== previousPath
+                    && /^\\/c\\/[^/]+$/.test(current.pathname);
+            }""",
+            arg=previous_path,
+            timeout=10_000,
+        )
+    except PlaywrightTimeoutError:
+        raise AssertionError(
+            f"expected a different /c/<id> after session traversal from {previous_url}"
+        ) from None
 
 
 def test_ctrl_arrow_does_not_switch_session_from_focused_composer(
@@ -100,11 +126,9 @@ def test_empty_focused_composer_does_not_block_session_switching(
     expect(composer).to_have_value("")
     composer.focus()
 
-    page.keyboard.press("ControlOrMeta+ArrowDown")
-    expect(page).to_have_url(f"{base_url}/c/{session_b}", timeout=10_000)
-
-    page.keyboard.press("ControlOrMeta+ArrowDown")
-    expect(page).to_have_url(f"{base_url}/c/{session_a}", timeout=10_000)
-
-    page.keyboard.press("ControlOrMeta+ArrowDown")
-    expect(page).to_have_url(f"{base_url}/c/{session_b}", timeout=10_000)
+    # Assert only the traversal invariant. Other sessions may exist in the
+    # sidebar, so seeded sessions are not guaranteed to be adjacent.
+    for _ in range(3):
+        expect(composer).to_have_value("")
+        _press_down_and_expect_session_change(page)
+        expect(composer).to_have_value("")

--- a/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
+++ b/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
@@ -1,11 +1,11 @@
-"""E2E: Cmd/Ctrl+Arrow switches sessions from the page body, but not the composer.
+"""E2E: Cmd/Ctrl+Arrow traverses from empty, but not drafted, composers.
 
 ``useSessionSwitchHotkey`` (window keydown) steps the sidebar's ordered
 sessions on Cmd/Ctrl+Up/Down. It bails when the keydown target is inside an
-editable field (``textarea``, ``input``, ``[contenteditable="true"]``) so
-typing in the composer keeps its native caret-to-start/end and the user isn't
-yanked to another session mid-edit. The chord still navigates when focus is
-outside an editable field.
+non-empty editable field (``textarea``, ``input``, or
+``[contenteditable="true"]``) so typing in the composer keeps its native
+caret-to-start/end and the user isn't yanked to another session mid-edit. An
+empty focused editable still allows session traversal.
 
 This exercises both halves of that contract through the real chain the unit
 tests mock out: live session list -> sidebar render order -> window keydown
@@ -14,9 +14,9 @@ handler -> client-side navigation to ``/c/{id}``.
 - ``test_ctrl_arrow_does_not_switch_session_from_focused_composer``: focus the
   composer, leave a draft, press Ctrl+Down, and assert the route stays put.
   A regression that drops the editable-field guard would route away here.
-- ``test_ctrl_arrow_still_switches_session_from_body_focus``: blur the
-  composer so the keydown targets the body, press Ctrl+Down, and assert the
-  route leaves the current session — the happy path the guard must preserve.
+- ``test_empty_focused_composer_does_not_block_session_switching``: focus the
+  empty composer once, press Ctrl+Down three times with no intervening focus
+  changes, and assert every press navigates.
 
 No LLM turn is needed — pure client-side keyboard + routing — so this skips the
 nightly/real-agent markers the approval suites carry. Two runner-bound
@@ -78,11 +78,11 @@ def test_ctrl_arrow_does_not_switch_session_from_focused_composer(
     expect(page).to_have_url(f"{base_url}/c/{session_a}")
 
 
-def test_ctrl_arrow_still_switches_session_from_body_focus(
+def test_empty_focused_composer_does_not_block_session_switching(
     page: Page,
     seeded_session_pair: tuple[str, str, str],
 ) -> None:
-    """With focus outside the composer, Ctrl+↓ still steps to a neighbor."""
+    """An empty focused composer must not block repeated Ctrl+↓ traversal."""
     base_url, session_a, session_b = seeded_session_pair
     _set_title(base_url, session_a, "e2e-switch-a")
     _set_title(base_url, session_b, "e2e-switch-b")
@@ -92,22 +92,19 @@ def test_ctrl_arrow_still_switches_session_from_body_focus(
     expect(page.locator(f'a[href="/c/{session_a}"]')).to_be_visible(timeout=30_000)
     expect(page.locator(f'a[href="/c/{session_b}"]')).to_be_visible()
 
-    # Move focus off the composer so the editable-field guard doesn't swallow
-    # the chord (the session page autofocuses the composer on load).
-    page.evaluate(
-        "() => { const el = document.activeElement; "
-        "if (el && typeof el.blur === 'function') el.blur(); }"
-    )
+    # Headless Chromium does not retain ChatPage's autofocus after navigation,
+    # so it cannot reproduce the full autofocus interaction chain. Focus the
+    # empty composer once to test the guard invariant directly; the headed
+    # product demo covers the natural flow.
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_have_value("")
+    composer.focus()
 
-    # Dispatch the chord at the body; the keydown bubbles to the window hook,
-    # the guard sees a non-editable target, and we navigate to a neighbor.
-    page.locator("body").press("ControlOrMeta+ArrowDown")
+    page.keyboard.press("ControlOrMeta+ArrowDown")
+    expect(page).to_have_url(f"{base_url}/c/{session_b}", timeout=10_000)
 
-    # Assert we left session_a for another /c/ route. We check "switched away"
-    # rather than a hard-coded target id: the suite shares one server across
-    # tests, so the sidebar may hold sessions beyond this pair — but
-    # navigating at all from body focus is the behavior the guard preserves.
-    expect(page).not_to_have_url(f"{base_url}/c/{session_a}", timeout=10_000)
-    assert "/c/" in page.url and session_a not in page.url, (
-        f"expected to switch to another session, still at {page.url}"
-    )
+    page.keyboard.press("ControlOrMeta+ArrowDown")
+    expect(page).to_have_url(f"{base_url}/c/{session_a}", timeout=10_000)
+
+    page.keyboard.press("ControlOrMeta+ArrowDown")
+    expect(page).to_have_url(f"{base_url}/c/{session_b}", timeout=10_000)

--- a/web/src/hooks/useSessionSwitchHotkey.test.tsx
+++ b/web/src/hooks/useSessionSwitchHotkey.test.tsx
@@ -101,6 +101,22 @@ describe("useSessionSwitchHotkey", () => {
     expect(navigate).toHaveBeenCalledWith("/c/b");
   });
 
+  it("protects unpersisted mentions carried by an empty editable", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    const composer = document.createElement("div");
+    composer.dataset.unpersistedMentions = "true";
+    const ta = document.createElement("textarea");
+    composer.appendChild(ta);
+    document.body.appendChild(composer);
+
+    press("ArrowDown", { metaKey: true }, ta);
+    expect(navigate).not.toHaveBeenCalled();
+
+    delete composer.dataset.unpersistedMentions;
+    press("ArrowDown", { metaKey: true }, ta);
+    expect(navigate).toHaveBeenCalledWith("/c/b");
+  });
+
   it("does not switch while a textarea contains a draft", () => {
     renderHook(() => useSessionSwitchHotkey(ids, "a"));
     const ta = document.createElement("textarea");

--- a/web/src/hooks/useSessionSwitchHotkey.test.tsx
+++ b/web/src/hooks/useSessionSwitchHotkey.test.tsx
@@ -1,6 +1,6 @@
 // Cmd/Ctrl+↓/↑ steps next/prev with wrap; off-list ↓ enters at top, ↑ at
-// bottom; suppressed inside editable fields; ignores Alt/Shift/bare arrows; a
-// no-op step (same id) doesn't navigate.
+// bottom; suppressed inside non-empty editable fields; ignores
+// Alt/Shift/bare arrows; a no-op step (same id) doesn't navigate.
 
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -93,19 +93,56 @@ describe("useSessionSwitchHotkey", () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
-  it("does not switch while a textarea is focused (composer editing)", () => {
+  it("switches while an empty textarea is focused", () => {
     renderHook(() => useSessionSwitchHotkey(ids, "a"));
     const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    press("ArrowDown", { metaKey: true }, ta);
+    expect(navigate).toHaveBeenCalledWith("/c/b");
+  });
+
+  it("does not switch while a textarea contains a draft", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    const ta = document.createElement("textarea");
+    ta.value = "unsent draft";
     document.body.appendChild(ta);
     press("ArrowDown", { metaKey: true }, ta);
     expect(navigate).not.toHaveBeenCalled();
   });
 
-  it("does not switch while an input is focused", () => {
+  it("switches while an empty input is focused", () => {
     renderHook(() => useSessionSwitchHotkey(ids, "a"));
     const input = document.createElement("input");
     document.body.appendChild(input);
     press("ArrowDown", { metaKey: true }, input);
+    expect(navigate).toHaveBeenCalledWith("/c/b");
+  });
+
+  it("does not switch while an input contains text", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    const input = document.createElement("input");
+    input.value = "query";
+    document.body.appendChild(input);
+    press("ArrowDown", { metaKey: true }, input);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("switches while an empty contenteditable is focused", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    const editor = document.createElement("div");
+    editor.setAttribute("contenteditable", "true");
+    document.body.appendChild(editor);
+    press("ArrowDown", { metaKey: true }, editor);
+    expect(navigate).toHaveBeenCalledWith("/c/b");
+  });
+
+  it("does not switch while a contenteditable contains text", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    const editor = document.createElement("div");
+    editor.setAttribute("contenteditable", "true");
+    editor.textContent = "draft";
+    document.body.appendChild(editor);
+    press("ArrowDown", { metaKey: true }, editor);
     expect(navigate).not.toHaveBeenCalled();
   });
 

--- a/web/src/hooks/useSessionSwitchHotkey.ts
+++ b/web/src/hooks/useSessionSwitchHotkey.ts
@@ -1,7 +1,8 @@
 // Cmd+↑/↓ (Ctrl+↑/↓ on Win/Linux) opens the previous / next sidebar session,
 // wrapping at the ends. Sibling to ChatPage's Cmd+Alt+↑/↓ message nav; they
 // don't collide (that one requires Alt, this one requires Alt up). Suppressed
-// inside editable fields so typing in the composer isn't interrupted. Bind ONCE.
+// inside non-empty editable fields so typing in the composer isn't interrupted.
+// Bind ONCE.
 
 import { useEffect, useRef } from "react";
 import { useNavigate } from "@/lib/routing";
@@ -27,14 +28,24 @@ export function useSessionSwitchHotkey(
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
 
-      // Leave the chord alone while editing so the composer keeps its native
-      // caret-to-start/end and the user isn't yanked to another session.
+      // Leave the chord alone when an editable has content so native
+      // caret-to-start/end movement and in-progress text stay uninterrupted.
       const target = e.target;
-      if (
-        target instanceof HTMLElement &&
-        target.closest('textarea, input, [contenteditable="true"]')
-      ) {
-        return;
+      if (target instanceof HTMLElement) {
+        const editable = target.closest('textarea, input, [contenteditable="true"]');
+        if (
+          (editable instanceof HTMLTextAreaElement || editable instanceof HTMLInputElement) &&
+          editable.value.length > 0
+        ) {
+          return;
+        }
+        if (
+          editable instanceof HTMLElement &&
+          editable.matches('[contenteditable="true"]') &&
+          (editable.textContent?.length ?? 0) > 0
+        ) {
+          return;
+        }
       }
 
       const { orderedIds: ids, activeId: active } = latest.current;

--- a/web/src/hooks/useSessionSwitchHotkey.ts
+++ b/web/src/hooks/useSessionSwitchHotkey.ts
@@ -1,8 +1,7 @@
 // Cmd+↑/↓ (Ctrl+↑/↓ on Win/Linux) opens the previous / next sidebar session,
 // wrapping at the ends. Sibling to ChatPage's Cmd+Alt+↑/↓ message nav; they
 // don't collide (that one requires Alt, this one requires Alt up). Suppressed
-// inside non-empty editable fields so typing in the composer isn't interrupted.
-// Bind ONCE.
+// inside editables with text or unpersisted draft state. Bind ONCE.
 
 import { useEffect, useRef } from "react";
 import { useNavigate } from "@/lib/routing";
@@ -28,11 +27,17 @@ export function useSessionSwitchHotkey(
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
 
-      // Leave the chord alone when an editable has content so native
-      // caret-to-start/end movement and in-progress text stay uninterrupted.
+      // Leave the chord alone when an editable has content or carries draft
+      // state outside its value, preserving native movement and unsent work.
       const target = e.target;
       if (target instanceof HTMLElement) {
         const editable = target.closest('textarea, input, [contenteditable="true"]');
+        if (
+          editable instanceof HTMLElement &&
+          editable.closest('[data-unpersisted-mentions="true"]')
+        ) {
+          return;
+        }
         if (
           (editable instanceof HTMLTextAreaElement || editable instanceof HTMLInputElement) &&
           editable.value.length > 0

--- a/web/src/pages/ChatPage.mention.test.tsx
+++ b/web/src/pages/ChatPage.mention.test.tsx
@@ -380,8 +380,10 @@ describe("Composer @-file-mention browser (native sessions)", () => {
     type("@");
     fireEvent.click(screen.getByTitle("Attach readme.md"));
     expect(screen.getByText("@readme.md")).toBeInTheDocument();
+    expect(textarea()).toHaveAttribute("data-unpersisted-mentions", "true");
     fireEvent.click(screen.getByLabelText("Remove readme.md"));
     expect(screen.queryByText("@readme.md")).not.toBeInTheDocument();
+    expect(textarea()).not.toHaveAttribute("data-unpersisted-mentions");
   });
 
   it("dedups re-attaching the same file via '@' to a single chip", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4755,6 +4755,9 @@ export function Composer({
           <textarea
             ref={textareaRef}
             value={value}
+            // Session drafts persist text and files, but not mention chips.
+            // Remove this marker and its hotkey guard once mentions persist.
+            data-unpersisted-mentions={mentionedItems.length > 0 ? "true" : undefined}
             onChange={(e) => {
               setValue(e.target.value);
               dirtyRef.current = true;


### PR DESCRIPTION
## Related issue

Closes #3219

## Summary

`useSessionSwitchHotkey` treated every focused editable as an active draft, so an empty composer
swallowed Cmd/Ctrl+Up/Down and stopped session traversal. The guard now returns only when the
editable contains text or carries unpersisted mention chips. This keeps native caret movement,
text drafts, and mention-only drafts protected while allowing the shortcut to traverse from an
otherwise empty focused `textarea`, `input`, or contenteditable element.

The selector remains generic. No composer identity, route-specific focus handling, or shortcut
remapping was added.

## Test Plan

- `npm test -- --run src/hooks/useSessionSwitchHotkey.test.tsx src/pages/ChatPage.mention.test.tsx`
  under Node 20.20.2: 51 passed.
- Baseline regression probe on `db110815`: the empty-textarea case failed with zero navigation
  calls; the same case passes after the change.
- Live mention-only draft reproduction on `d5f7480a`: the empty focused textarea allowed
  navigation and the mention chip was absent on return. On `13a1dd76`, the chord was blocked and
  the chip remained present.
- `PLAYWRIGHT_BROWSERS_PATH="$HOME/Library/Caches/ms-playwright" .venv/bin/python -m pytest tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py -q`:
  2 passed. After CI exposed a seeded-session adjacency assumption, the E2E now focuses an empty
  composer once and asserts that each of three chords reaches a `/c/<id>` different from the URL
  before that press, without assuming sidebar ordering. The non-empty-draft guard remains covered.
- Changed-file Oxlint and Prettier checks: passed, with existing unrelated warnings in
  `ChatPage.tsx`.
- `npm run type-check` and the production build exercised by the live reproduction: passed.

## Demo

Before and after recordings use the real web application, a Playwright-recorded headed Chromium
window, and three synthetic sessions. Both start at `/inbox`. The operator physically presses
Command+Down three times; Playwright sends no keys. An injected display-only HUD renders the
keydown events received by the page.

Before (`db110815`) - the three chords produce Session A -> Session B -> Session B:

![Before](https://raw.githubusercontent.com/dosenr/omnigent/e8208ebba264d99adce6fc22de55962cb9c8fac6/before-db110815.gif)
After (`d5f7480a`) - the same procedure produces Session A -> Session B -> Session C:

![After](https://raw.githubusercontent.com/dosenr/omnigent/e8208ebba264d99adce6fc22de55962cb9c8fac6/after-d5f7480a.gif)

The baseline was repeated and produced the same two-transition freeze. Playwright's injected
`page.keyboard.press()` did not retain composer focus after navigation on this MacBook, in either
headless or headed mode. The committed E2E therefore tests the empty-focused-composer invariant
directly, while the physical-input recordings prove the natural product flow.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The headed before and after captures exercise the real sidebar, router, session pages, composer
focus, and keyboard handler. The headless E2E covers the guard invariant because the natural
autofocus chain is not stable in that browser mode.

## Changelog

Cmd/Ctrl+Up/Down keeps traversing sessions when the focused composer is empty.
