### PR TITLE
🐛 fix(usage): attribute native per-model cost by delta, not cumulative total

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -977,8 +977,11 @@ def _persist_native_cumulative_usage(
 
     Unlike the Omnigent relay path (:func:`_accumulate_session_usage`), which adds
     per-response *deltas*, native harnesses (claude-native / codex-native)
-    report *cumulative* session usage — so this writes with SET semantics, not
-    add. The two paths never run for the same session, so they don't conflict.
+    report *cumulative* session usage — so the flat session fields are written
+    with SET semantics. The per-model ``by_model`` buckets are the exception:
+    they accumulate each report's growth (new - old) attributed to the active
+    model, so they stay correct across mid-session model switches (see below).
+    The two paths never run for the same session, so they don't conflict.
 
     Reads explicit cumulative fields from the ``external_session_usage`` event's
     ``data`` (all optional; a no-op when none are present):
@@ -1048,6 +1051,9 @@ def _persist_native_cumulative_usage(
     # label writes — usage was the missing half.)
     old_cost = float(current.get("total_cost_usd", 0.0) or 0.0)
     old_policy_cost = float(current.get("policy_cost_usd", 0.0) or 0.0)
+    # Old cumulative token totals, captured before the overwrites below so
+    # per-model attribution can add only this report's growth (new - old).
+    old_tokens = {key: int(current.get(key, 0) or 0) for key in _MODEL_TOKEN_KEYS}
     if cin is not None:
         # The reported input total is INCLUSIVE of cached tokens (codex's
         # ``inputTokens`` counts cache reads). Split the cached portion into
@@ -1115,23 +1121,19 @@ def _persist_native_cumulative_usage(
                 # priced cost below the persisted figure.
                 current["total_cost_usd"] = max(old_cost, compute_llm_cost(current, pricing))
 
-    # Per-model attribution (SET). Native harnesses report cumulative SESSION
-    # totals, not per-model splits, so attribute the running cumulative buckets
-    # to the current model. For the usual single-model native session this
-    # makes the per-model view equal the flat totals; on a mid-session model
-    # switch the current model absorbs the cumulative (splitting deferred —
-    # keyed on the raw harness model id). Cost mirrors the flat
-    # ``total_cost_usd`` so the per-model cost key is present iff priced.
-    # ``model_name`` is set on token-bearing AND cost-bearing broadcasts, so a
-    # claude-native cost-only broadcast attributes its cumulative cost here too
-    # (token buckets stay absent — claude-native reports no token counts).
+    # ADD this report's growth (new - old) to the active model, not the whole
+    # cumulative total, so per-model buckets sum to the flat total across model
+    # switches. Clamp >= 0 so a lowered report never claws a bucket back (flat
+    # tokens are SET not clamped, so buckets can exceed them then — fail-safe).
     if isinstance(model_name, str) and model_name:
         bucket = _model_usage_bucket(current, model_name)
         for key in _MODEL_TOKEN_KEYS:
             if key in current:
-                bucket[key] = current[key]
+                bucket[key] = int(bucket.get(key, 0)) + max(0, int(current[key]) - old_tokens[key])
         if "total_cost_usd" in current:
-            bucket["total_cost_usd"] = current["total_cost_usd"]
+            bucket["total_cost_usd"] = float(bucket.get("total_cost_usd", 0.0)) + max(
+                0.0, float(current["total_cost_usd"]) - old_cost
+            )
 
     # Enforcement value (claude-native display/policy split). Stored
     # separately from the displayed ``total_cost_usd`` so the gate can read

--- a/tests/server/routes/test_native_usage_attribution.py
+++ b/tests/server/routes/test_native_usage_attribution.py
@@ -1,0 +1,218 @@
+"""Per-model cost/token attribution for the native cumulative usage path.
+
+``_persist_native_cumulative_usage`` receives *cumulative* session totals from
+native harnesses (claude-native / codex-native). It must attribute each
+report's growth to the currently-active model so per-model buckets hold each
+model's own spend and sum to the flat session total across mid-session model
+switches — rather than SETting every bucket to the whole running total (which
+double-counted the shared baseline once the active model changed).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.server.routes._sessions.orchestration import (
+    _persist_native_cumulative_usage,
+)
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+
+# Agent ids are stored as 16-byte uuids, so tests use a valid 32-char hex id.
+_AGENT_ID = "0123456789abcdef0123456789abcdef"
+
+
+def _usage(store: SqlAlchemyConversationStore, conv_id: str) -> dict:
+    conv = store.get_conversation(conv_id)
+    assert conv is not None
+    return dict(conv.session_usage)
+
+
+def test_per_model_cost_sums_across_model_switch(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    conv = store.create_conversation(title="switch", agent_id=_AGENT_ID)
+
+    # Cumulative session cost climbs on opus, then keeps climbing after a
+    # /model switch to sonnet (native /cost is a running session total).
+    _persist_native_cumulative_usage(
+        conv.id, {"cumulative_cost_usd": 3.0, "model": "claude-opus-4-8"}, store
+    )
+    _persist_native_cumulative_usage(
+        conv.id, {"cumulative_cost_usd": 10.80, "model": "claude-opus-4-8"}, store
+    )
+    _persist_native_cumulative_usage(
+        conv.id, {"cumulative_cost_usd": 11.91, "model": "claude-sonnet-4-5"}, store
+    )
+
+    usage = _usage(store, conv.id)
+    by_model = usage["by_model"]
+    # Each model holds only its own spend (opus's growth 0->10.80, sonnet's
+    # 10.80->11.91), and the buckets sum to the flat total — the bug fixed here.
+    assert usage["total_cost_usd"] == pytest.approx(11.91)
+    assert by_model["claude-opus-4-8"]["total_cost_usd"] == pytest.approx(10.80)
+    assert by_model["claude-sonnet-4-5"]["total_cost_usd"] == pytest.approx(1.11)
+    assert sum(m["total_cost_usd"] for m in by_model.values()) == pytest.approx(11.91)
+
+
+def test_per_model_cost_accumulates_when_switching_back(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    conv = store.create_conversation(title="switch-back", agent_id=_AGENT_ID)
+
+    # A -> B -> A: model A's bucket must accumulate across its two separate
+    # active spans (not be overwritten on the second visit), so the returning
+    # model's growth adds onto its earlier spend.
+    _persist_native_cumulative_usage(
+        conv.id, {"cumulative_cost_usd": 10.0, "model": "model-a"}, store
+    )
+    _persist_native_cumulative_usage(
+        conv.id, {"cumulative_cost_usd": 12.50, "model": "model-b"}, store
+    )
+    _persist_native_cumulative_usage(
+        conv.id, {"cumulative_cost_usd": 15.0, "model": "model-a"}, store
+    )
+
+    usage = _usage(store, conv.id)
+    by_model = usage["by_model"]
+    # A = 10.0 (first span) + 2.50 (15.0 - 12.50 on return); B = 12.50 - 10.0.
+    assert usage["total_cost_usd"] == pytest.approx(15.0)
+    assert by_model["model-a"]["total_cost_usd"] == pytest.approx(12.50)
+    assert by_model["model-b"]["total_cost_usd"] == pytest.approx(2.50)
+    assert sum(m["total_cost_usd"] for m in by_model.values()) == pytest.approx(15.0)
+
+
+def test_single_model_bucket_equals_flat_total(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    conv = store.create_conversation(title="single", agent_id=_AGENT_ID)
+
+    _persist_native_cumulative_usage(
+        conv.id, {"cumulative_cost_usd": 2.0, "model": "claude-opus-4-8"}, store
+    )
+    _persist_native_cumulative_usage(
+        conv.id, {"cumulative_cost_usd": 5.5, "model": "claude-opus-4-8"}, store
+    )
+
+    usage = _usage(store, conv.id)
+    assert usage["total_cost_usd"] == pytest.approx(5.5)
+    assert usage["by_model"]["claude-opus-4-8"]["total_cost_usd"] == pytest.approx(5.5)
+
+
+def test_lowered_report_does_not_claw_back_bucket(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    conv = store.create_conversation(title="rebased", agent_id=_AGENT_ID)
+
+    _persist_native_cumulative_usage(conv.id, {"cumulative_cost_usd": 10.0, "model": "m1"}, store)
+    # A forged / rebased lower report: the flat total is monotonic-clamped, and
+    # the per-model delta is clamped >= 0, so neither is clawed back.
+    _persist_native_cumulative_usage(conv.id, {"cumulative_cost_usd": 2.0, "model": "m1"}, store)
+
+    usage = _usage(store, conv.id)
+    assert usage["total_cost_usd"] == pytest.approx(10.0)
+    assert usage["by_model"]["m1"]["total_cost_usd"] == pytest.approx(10.0)
+
+
+def test_per_model_tokens_accumulate_from_cumulative(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    conv = store.create_conversation(title="tokens", agent_id=_AGENT_ID)
+
+    # codex-native style: cumulative token totals plus an explicit cost.
+    _persist_native_cumulative_usage(
+        conv.id,
+        {
+            "cumulative_input_tokens": 100,
+            "cumulative_output_tokens": 20,
+            "cumulative_cost_usd": 1.0,
+            "model": "gpt-5.6",
+        },
+        store,
+    )
+    _persist_native_cumulative_usage(
+        conv.id,
+        {
+            "cumulative_input_tokens": 300,
+            "cumulative_output_tokens": 50,
+            "cumulative_cost_usd": 3.0,
+            "model": "gpt-5.6",
+        },
+        store,
+    )
+
+    usage = _usage(store, conv.id)
+    bucket = usage["by_model"]["gpt-5.6"]
+    # The bucket accumulates deltas to match the flat cumulative session totals.
+    assert bucket["input_tokens"] == usage["input_tokens"] == 300
+    assert bucket["output_tokens"] == usage["output_tokens"] == 50
+    assert bucket["total_tokens"] == usage["total_tokens"] == 350
+    assert bucket["total_cost_usd"] == pytest.approx(3.0)
+
+
+def test_per_model_tokens_sum_across_model_switch(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    conv = store.create_conversation(title="switch-tokens", agent_id=_AGENT_ID)
+
+    # codex-style: cumulative tokens (with explicit cost to avoid the catalog)
+    # climb on opus, then keep climbing after a /model switch to sonnet.
+    _persist_native_cumulative_usage(
+        conv.id,
+        {
+            "cumulative_input_tokens": 100,
+            "cumulative_output_tokens": 20,
+            "cumulative_cost_usd": 3.0,
+            "model": "claude-opus-4-8",
+        },
+        store,
+    )
+    _persist_native_cumulative_usage(
+        conv.id,
+        {
+            "cumulative_input_tokens": 300,
+            "cumulative_output_tokens": 60,
+            "cumulative_cost_usd": 11.91,
+            "model": "claude-sonnet-4-5",
+        },
+        store,
+    )
+
+    usage = _usage(store, conv.id)
+    opus = usage["by_model"]["claude-opus-4-8"]
+    sonnet = usage["by_model"]["claude-sonnet-4-5"]
+    # Each model holds only its own token growth, and the per-model token +
+    # cost buckets sum to the flat session totals across the switch.
+    assert opus["input_tokens"] == 100
+    assert sonnet["input_tokens"] == 200
+    assert opus["input_tokens"] + sonnet["input_tokens"] == usage["input_tokens"] == 300
+    assert opus["output_tokens"] + sonnet["output_tokens"] == usage["output_tokens"] == 60
+    assert opus["total_tokens"] + sonnet["total_tokens"] == usage["total_tokens"] == 360
+    assert opus["total_cost_usd"] + sonnet["total_cost_usd"] == pytest.approx(11.91)
+
+
+def test_token_priced_bucket_matches_flat_cost(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    conv = store.create_conversation(title="codex-priced", agent_id=_AGENT_ID)
+
+    # codex-native reports cumulative tokens but NO explicit cost, so cost is
+    # computed from the running token totals. Stub pricing so the test does not
+    # depend on the live catalog; assert the per-model cost bucket still tracks
+    # the flat token-priced total (the elif-has_tokens branch feeds by_model).
+    monkeypatch.setattr(
+        "omnigent.llms.context_window.fetch_model_pricing",
+        lambda model: {"stub": True},
+    )
+    monkeypatch.setattr(
+        "omnigent.llms.context_window.compute_llm_cost",
+        lambda usage, pricing: float(usage.get("total_tokens", 0)) * 0.01,
+    )
+
+    _persist_native_cumulative_usage(
+        conv.id,
+        {"cumulative_input_tokens": 200, "cumulative_output_tokens": 50, "model": "gpt-5.6"},
+        store,
+    )
+
+    usage = _usage(store, conv.id)
+    # total_tokens = 200 (input) + 0 (cache) + 50 (output) = 250; cost = 2.50.
+    assert usage["total_cost_usd"] == pytest.approx(2.50)
+    assert usage["by_model"]["gpt-5.6"]["total_cost_usd"] == pytest.approx(2.50)


### PR DESCRIPTION
## Related issue

N/A

## Summary

Native harnesses (claude-native / codex-native) report a **cumulative** session
cost, not a per-model split. `_persist_native_cumulative_usage` SET each active
model's `by_model` bucket to the whole running session total, so a session that
switched models mid-run double-counted the shared baseline — the previous model
kept its last cumulative snapshot while the new model got the full total, and
summing the per-model buckets exceeded the real session total (e.g. a $11.91
session showing opus $10.80 + sonnet $11.91).

This attributes only each report's **growth (new − old)** to the currently-active
model, mirroring the relay path's per-model delta accumulation. Per-model token
and cost buckets now hold each model's own usage and sum to the flat session
total across model switches. Deltas are clamped `>= 0` so a lowered / rebased
report never claws usage back out of a bucket (the flat totals keep their
existing monotonic clamp).

Read-only consumers (`omni usage`, the web session sidebar) read `by_model`
verbatim, so no reader change is needed. Existing sessions keep their stored
buckets — this corrects attribution for turns recorded after it ships.

## Test Plan

- New `tests/server/routes/test_native_usage_attribution.py` (6 tests): per-model
  cost + token summing across a model switch, single-model bucket equals the flat
  total, no claw-back on a lowered report, token accumulation, and the
  token-priced (compute-from-tokens) path.
- Existing native-path suites pass unchanged — `test_sessions_snapshot.py`
  (`by_model` subtree sums), `test_session_updates_ws.py` (`external_session_usage`),
  and `test_sessions_endpoints.py` (session usage endpoints).

## Demo

N/A — server-side usage accounting, no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests exercise the model-switch double-count directly and assert the
per-model buckets sum to the flat total; existing native-path suites guard
against regressions in single-report and subtree behaviour.

## Changelog

Fixed per-model cost attribution for native harnesses so a session's per-model
costs sum to its total after a mid-session model switch
