### PR TITLE
fix(cli): exit cleanly with a re-login hint on an expired/invalid token (#3231)

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1877,6 +1877,32 @@ def _warn_deprecated_harness_path_env_vars() -> None:
         )
 
 
+def credential_rejection_hint(exc: BaseException) -> str | None:
+    """Return a re-login hint when *exc* is the server rejecting our credentials.
+
+    An expired or invalid access token surfaces as an error carrying a
+    401/403 status (the client SDK's :class:`OmnigentError` sets
+    ``status_code``; server-side errors set ``http_status``). That is a
+    user-actionable condition — sign in again — not a bug to auto-report,
+    so ``main`` shows this hint and exits cleanly instead of rendering the
+    crash screen and prompting to file an issue.
+
+    :param exc: The exception that escaped Click dispatch.
+    :returns: The message to print, or ``None`` when *exc* is not a
+        credential rejection (any non-401/403 error falls through to the
+        normal crash handler).
+    """
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        status = getattr(exc, "http_status", None)
+    if status not in (401, 403):
+        return None
+    return (
+        f"Authentication failed: the server rejected your credentials (HTTP {status}). "
+        "Your login may have expired — run `omnigent login <server-url>` to sign in again."
+    )
+
+
 def main() -> None:
     """
     Console-script entry point for ``omnigent``.
@@ -2022,6 +2048,16 @@ def main() -> None:
         click.echo("Aborted!", err=True)
         raise SystemExit(1) from exc
     except Exception as exc:
+        # An expired/invalid access token is user-actionable (sign in
+        # again), not a crash to auto-report. Show a re-login hint and exit
+        # cleanly instead of the crash screen + bug-filing prompt, which
+        # would wrongly ask the user to file an issue for their own lapsed
+        # credentials (issue #3231).
+        auth_hint = credential_rejection_hint(exc)
+        if auth_hint is not None:
+            log_cli_exception(exc, prefix="Credential rejection")
+            click.echo(auth_hint, err=True)
+            raise SystemExit(1) from exc
         # Keep the diagnostics log line ("Details logged to …") — the
         # always-on CLI log has more context than this single crash — then
         # hand off to the friendly crash handler for the calm screen,

--- a/tests/cli/test_credential_rejection_hint.py
+++ b/tests/cli/test_credential_rejection_hint.py
@@ -1,0 +1,80 @@
+"""Tests for the credential-rejection detection that keeps an expired
+token from being auto-reported as a crash (issue #3231)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.cli import credential_rejection_hint
+
+
+class _ServerStyleError(Exception):
+    """Stand-in for a server-side error that carries ``http_status``."""
+
+    def __init__(self, http_status: int) -> None:
+        super().__init__("boom")
+        self.http_status = http_status
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_hint_for_auth_status_codes(status: int) -> None:
+    """A 401/403 client error yields a re-login hint naming ``omnigent login``."""
+    from omnigent_client import OmnigentError
+
+    hint = credential_rejection_hint(OmnigentError("Invalid access token", status))
+    assert hint is not None
+    assert "omnigent login" in hint
+    assert str(status) in hint
+
+
+def test_hint_reads_http_status_when_no_status_code() -> None:
+    """Server-side errors expose ``http_status`` rather than ``status_code``."""
+    hint = credential_rejection_hint(_ServerStyleError(403))
+    assert hint is not None
+    assert "omnigent login" in hint
+
+
+@pytest.mark.parametrize("status", [400, 404, 409, 500])
+def test_no_hint_for_non_auth_status(status: int) -> None:
+    """Non-auth HTTP errors fall through to the normal crash handler (None)."""
+    from omnigent_client import OmnigentError
+
+    assert credential_rejection_hint(OmnigentError("nope", status)) is None
+
+
+def test_no_hint_for_plain_exception() -> None:
+    """A generic exception with no status is not a credential rejection."""
+    assert credential_rejection_hint(ValueError("unrelated")) is None
+
+
+def test_no_hint_when_status_missing() -> None:
+    """An OmnigentError raised without a status is treated as a real crash."""
+    from omnigent_client import OmnigentError
+
+    assert credential_rejection_hint(OmnigentError("no status")) is None
+
+
+def test_hint_detects_the_real_3231_payload() -> None:
+    """
+    The exact error shape from issue #3231 is recognized as a credential
+    rejection.
+
+    A proxy/auth 403 whose body is not the ``{"error": {...}}`` envelope
+    makes the SDK stringify the whole body as the message while still
+    carrying ``status_code=403``. Reproduce that through the real SDK
+    ``raise_for_status`` so a change to the client's error shape can't
+    silently regress the detection.
+    """
+    from omnigent_client import OmnigentError
+    from omnigent_client._errors import raise_for_status
+
+    body = {
+        "error_code": 403,
+        "message": "Invalid access token. [ReqId: 145ae51b-da74-40a7-ac56-0ad190834faf]",
+    }
+    with pytest.raises(OmnigentError) as excinfo:
+        raise_for_status(403, body)
+
+    hint = credential_rejection_hint(excinfo.value)
+    assert hint is not None
+    assert "omnigent login" in hint


### PR DESCRIPTION
## Related issue

Closes #3231

## Summary

An expired or invalid access token crashed the CLI. On the daemon-chat path `sdk.sessions.create` raised an uncaught `OmnigentError` (the auto-reported crash was `{'error_code': 403, 'message': 'Invalid access token. [ReqId: ...]'}`). It propagated to `main`'s catch-all `except Exception`, which handed it to the friendly crash handler — so the user got the calm crash screen and a prompt to **file a GitHub issue** for what is really just their own lapsed credentials, and the crash handler auto-reported it.

A 401/403 from the server against our own credentials is user-actionable (sign in again), not a bug to report. `main` now recognizes that case, prints a re-login hint pointing at `omnigent login`, and exits 1 — without the crash screen or the bug-filing prompt. Every other error still routes to the crash handler unchanged.

Detection is a small pure helper, `credential_rejection_hint`, keyed on the error's HTTP status (the client SDK's `OmnigentError` sets `status_code`; server-side errors set `http_status`) rather than substring-matching a message. That helper fully captures the routing decision; the glue in `main` is three lines that print the hint and exit when it returns non-`None`.

## Test Plan

`tests/cli/test_credential_rejection_hint.py` (new):

- 401 and 403 → a hint naming `omnigent login`
- server-style error exposing `http_status` (not `status_code`) → hint
- 400 / 404 / 409 / 500 → `None` (falls through to the crash handler)
- a plain exception / an error with no status → `None`
- the exact #3231 payload, reconstructed through the SDK's own `raise_for_status`, → recognized as a credential rejection

```
OMNIGENT_SKIP_WEB_UI=true uv run pytest tests/cli/test_credential_rejection_hint.py -q
# 10 passed
```

Without the change the suite errors at import (the helper does not exist); with it, all 10 pass. `ruff check` + `ruff format --check` clean.

## Demo

N/A. CLI error-handling change with no visual surface of its own. Before: an expired token renders the crash screen and prompts the user to file a GitHub issue (and auto-reports it). After: `Authentication failed: the server rejected your credentials (HTTP 403). Your login may have expired — run \`omnigent login <server-url>\` to sign in again.` and a clean exit 1.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The helper is pure and covers the full routing decision (which statuses are treated as credential rejections vs. handed to the crash handler), including the real-world #3231 body shape reconstructed via the SDK. The three-line glue in `main` (print hint + `SystemExit(1)` when the helper returns a message) is verified by reading; a full `main()` invocation is intentionally not driven since it installs the crash handler, migrates state, and sets up logging.

## Changelog

An expired or invalid login now exits with a clear "run `omnigent login`" hint instead of showing the crash screen and prompting to file a bug report.
