### PR TITLE
[ci] Clear waiting labels after missed author activity

### DIFF
--- a/.github/scripts/waiting_on_author.py
+++ b/.github/scripts/waiting_on_author.py
@@ -119,6 +119,18 @@ class GitHubAPI:
     def list_timeline(self, issue_number: int) -> list[dict[str, Any]]:
         return self.paginated(f"/repos/{self.repo}/issues/{issue_number}/timeline?per_page=100")
 
+    def list_issue_comments(self, issue_number: int) -> list[dict[str, Any]]:
+        return self.paginated(f"/repos/{self.repo}/issues/{issue_number}/comments?per_page=100")
+
+    def list_review_comments(self, pull_number: int) -> list[dict[str, Any]]:
+        return self.paginated(f"/repos/{self.repo}/pulls/{pull_number}/comments?per_page=100")
+
+    def list_reviews(self, pull_number: int) -> list[dict[str, Any]]:
+        return self.paginated(f"/repos/{self.repo}/pulls/{pull_number}/reviews?per_page=100")
+
+    def list_commits(self, pull_number: int) -> list[dict[str, Any]]:
+        return self.paginated(f"/repos/{self.repo}/pulls/{pull_number}/commits?per_page=100")
+
     def close_pull(self, pull_number: int) -> None:
         self.request("PATCH", f"/repos/{self.repo}/pulls/{pull_number}", {"state": "closed"})
 
@@ -144,6 +156,46 @@ def remove_waiting_label(api: GitHubAPI, issue_number: int, reason: str) -> bool
     else:
         print(f"#{issue_number} no longer has {LABEL}; nothing to remove.")
     return removed
+
+
+def user_login(item: dict[str, Any]) -> str | None:
+    login = item.get("user", {}).get("login")
+    return login.lower() if login else None
+
+
+def is_after(timestamp: str | None, since: str) -> bool:
+    return bool(timestamp and parse_time(timestamp) > parse_time(since))
+
+
+def authored_after(items: list[dict[str, Any]], author: str, since: str, key: str) -> bool:
+    return any(user_login(item) == author and is_after(item.get(key), since) for item in items)
+
+
+def commit_after(commits: list[dict[str, Any]], since: str) -> bool:
+    for commit in commits:
+        authored_at = commit.get("commit", {}).get("author", {}).get("date")
+        committed_at = commit.get("commit", {}).get("committer", {}).get("date")
+        if is_after(authored_at, since) or is_after(committed_at, since):
+            return True
+    return False
+
+
+def author_activity_since_label(api: GitHubAPI, pull: dict[str, Any], since: str) -> str | None:
+    author = pull.get("user", {}).get("login")
+    if not author:
+        return None
+    author = author.lower()
+    pull_number = pull["number"]
+
+    if authored_after(api.list_issue_comments(pull_number), author, since, "created_at"):
+        return "the author commented"
+    if authored_after(api.list_review_comments(pull_number), author, since, "created_at"):
+        return "the author replied to a review comment"
+    if authored_after(api.list_reviews(pull_number), author, since, "submitted_at"):
+        return "the author submitted a review response"
+    if commit_after(api.list_commits(pull_number), since):
+        return "new commits were pushed"
+    return None
 
 
 def clear_on_author_activity(event_name: str, payload: dict[str, Any], api: GitHubAPI) -> bool:
@@ -205,6 +257,13 @@ def close_stale_waiting_prs(api: GitHubAPI, now: datetime | None = None) -> int:
                     "in the timeline; skipping."
                 )
                 continue
+
+            pull = api.get_pull(issue["number"])
+            reason = author_activity_since_label(api, pull, label_applied_at)
+            if reason:
+                remove_waiting_label(api, issue["number"], reason)
+                continue
+
             if days_between(label_applied_at, now) < WAITING_DAYS:
                 continue
 

--- a/.github/scripts/waiting_on_author_test.py
+++ b/.github/scripts/waiting_on_author_test.py
@@ -51,10 +51,18 @@ class FakeAPI:
         pull: dict[str, Any] | None = None,
         issues: list[dict[str, Any]] | None = None,
         timeline_by_issue: dict[int, list[dict[str, Any]]] | None = None,
+        issue_comments: dict[int, list[dict[str, Any]]] | None = None,
+        review_comments: dict[int, list[dict[str, Any]]] | None = None,
+        reviews: dict[int, list[dict[str, Any]]] | None = None,
+        commits: dict[int, list[dict[str, Any]]] | None = None,
     ):
         self.pull = pull or pr()
         self.issues = issues or []
         self.timeline_by_issue = timeline_by_issue or {}
+        self.issue_comments = issue_comments or {}
+        self.review_comments = review_comments or {}
+        self.reviews = reviews or {}
+        self.commits = commits or {}
         self.removed: list[tuple[int, str]] = []
         self.closed: list[int] = []
         self.comments: list[tuple[int, str]] = []
@@ -71,6 +79,18 @@ class FakeAPI:
 
     def list_timeline(self, issue_number: int) -> list[dict[str, Any]]:
         return self.timeline_by_issue.get(issue_number, [])
+
+    def list_issue_comments(self, issue_number: int) -> list[dict[str, Any]]:
+        return self.issue_comments.get(issue_number, [])
+
+    def list_review_comments(self, pull_number: int) -> list[dict[str, Any]]:
+        return self.review_comments.get(pull_number, [])
+
+    def list_reviews(self, pull_number: int) -> list[dict[str, Any]]:
+        return self.reviews.get(pull_number, [])
+
+    def list_commits(self, pull_number: int) -> list[dict[str, Any]]:
+        return self.commits.get(pull_number, [])
 
     def close_pull(self, pull_number: int) -> None:
         self.closed.append(pull_number)
@@ -139,6 +159,56 @@ class WaitingOnAuthorTest(unittest.TestCase):
         self.assertEqual(api.closed, [20])
         self.assertEqual(len(api.comments), 1)
         self.assertIn(waiting_on_author.LABEL, api.comments[0][1])
+
+    def test_scheduled_sweep_removes_label_after_author_comment(self) -> None:
+        api = FakeAPI(
+            pull=pr(number=23, author="alice"),
+            issues=[issue(23)],
+            timeline_by_issue={23: [labeled_at("2026-07-01T00:00:00Z")]},
+            issue_comments={
+                23: [{"user": {"login": "alice"}, "created_at": "2026-07-20T00:00:00Z"}]
+            },
+        )
+        waiting_on_author.close_stale_waiting_prs(api, now=datetime(2026, 7, 24, tzinfo=UTC))
+        self.assertEqual(api.removed, [(23, waiting_on_author.LABEL)])
+        self.assertEqual(api.closed, [])
+
+    def test_scheduled_sweep_keeps_label_after_maintainer_comment(self) -> None:
+        api = FakeAPI(
+            pull=pr(number=24, author="alice"),
+            issues=[issue(24)],
+            timeline_by_issue={24: [labeled_at("2026-07-18T00:00:00Z")]},
+            issue_comments={
+                24: [{"user": {"login": "maintainer"}, "created_at": "2026-07-20T00:00:00Z"}]
+            },
+        )
+        waiting_on_author.close_stale_waiting_prs(api, now=datetime(2026, 7, 24, tzinfo=UTC))
+        self.assertEqual(api.removed, [])
+        self.assertEqual(api.closed, [])
+
+    def test_scheduled_sweep_removes_label_after_new_commit(self) -> None:
+        api = FakeAPI(
+            pull=pr(number=25, author="alice"),
+            issues=[issue(25)],
+            timeline_by_issue={25: [labeled_at("2026-07-01T00:00:00Z")]},
+            commits={25: [{"commit": {"author": {"date": "2026-07-20T00:00:00Z"}}}]},
+        )
+        waiting_on_author.close_stale_waiting_prs(api, now=datetime(2026, 7, 24, tzinfo=UTC))
+        self.assertEqual(api.removed, [(25, waiting_on_author.LABEL)])
+        self.assertEqual(api.closed, [])
+
+    def test_scheduled_sweep_ignores_author_comment_before_label(self) -> None:
+        api = FakeAPI(
+            pull=pr(number=26, author="alice"),
+            issues=[issue(26)],
+            timeline_by_issue={26: [labeled_at("2026-07-17T00:00:00Z")]},
+            issue_comments={
+                26: [{"user": {"login": "alice"}, "created_at": "2026-07-10T00:00:00Z"}]
+            },
+        )
+        waiting_on_author.close_stale_waiting_prs(api, now=datetime(2026, 7, 24, tzinfo=UTC))
+        self.assertEqual(api.removed, [])
+        self.assertEqual(api.closed, [26])
 
     def test_scheduled_sweep_leaves_6_day_pr_open(self) -> None:
         api = FakeAPI(


### PR DESCRIPTION
## Related issue

N/A

## Summary

The first `waiting-on-author` sweep closed PRs that had carried the label for 7 days even when the author had already replied or pushed commits before this new workflow existed. The event-triggered cleanup only works for future activity, so the scheduled sweep also needs to backfill missed author activity before it decides to close anything.

- Before closing a labeled PR, fetch the PR author activity since the latest `waiting-on-author` label event
- Remove the label and skip closure when the author has commented, replied to review comments, submitted a review response, or pushed commits after the label
- Add regression tests for old labels with later author comments/commits, maintainer comments, and comments that happened before the label

ELI5: if someone already answered after we marked their PR as waiting, the sweep now notices that answer, removes the waiting label, and does not close the PR.

```mermaid
flowchart TD
  A[waiting-on-author label] --> B[Find latest label time]
  B --> C{Author activity after label?}
  C -- Yes --> D[Remove label]
  C -- No --> E{7 days old?}
  E -- No --> F[Keep open]
  E -- Yes --> G[Close PR]
```

## Test Plan

- `/Users/pat.sukprasert/git/omnigent/.venv/bin/python .github/scripts/waiting_on_author_test.py`
- `git diff --check`
- `/Users/pat.sukprasert/git/omnigent/.venv/bin/python -m ruff format --check --no-cache --force-exclude .github/scripts/waiting_on_author.py .github/scripts/waiting_on_author_test.py`
- `/Users/pat.sukprasert/git/omnigent/.venv/bin/python -m ruff check --no-cache --force-exclude .github/scripts/waiting_on_author.py .github/scripts/waiting_on_author_test.py`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added mocked unit coverage for scheduled sweeps that encounter older labels with later author activity. Manual verification used the commands above; ruff ran with cache disabled because this sandbox cannot write `.ruff_cache`.
