### PR TITLE
feat(runner): let sys_session_create set a per-session reasoning_effort (#2080)

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -2241,15 +2241,16 @@ def _build_session_create_body(
     title: object,
     message: object,
     model: object = None,
+    reasoning_effort: object = None,
 ) -> _JsonObject:
     """
     Build the JSON ``POST /v1/sessions`` body for ``sys_session_create``.
 
     ``parent_session_id`` is hard-forced to ``conversation_id`` — this is
     what makes the write child-only (an orchestrator cannot create a
-    top-level or sibling session). A non-empty ``title``, ``message``, and
-    ``model`` are included when provided; the message becomes the child's
-    first queued user turn via ``initial_items``.
+    top-level or sibling session). A non-empty ``title``, ``message``,
+    ``model``, and ``reasoning_effort`` are included when provided; the
+    message becomes the child's first queued user turn via ``initial_items``.
 
     :param agent_id: The existing agent to launch, e.g. ``"ag_abc123"``.
     :param conversation_id: The caller's session id — the forced parent.
@@ -2259,6 +2260,8 @@ def _build_session_create_body(
         non-empty string.
     :param model: Optional model override, e.g. ``"databricks-glm-5-2"``;
         written as ``model_override`` on the session.
+    :param reasoning_effort: Optional per-session reasoning effort, e.g.
+        ``"high"``; written as ``reasoning_effort`` on the session.
     :returns: The JSON request body.
     """
     body: _JsonObject = {
@@ -2269,6 +2272,8 @@ def _build_session_create_body(
         body["title"] = title
     if isinstance(model, str) and model:
         body["model_override"] = model
+    if isinstance(reasoning_effort, str) and reasoning_effort:
+        body["reasoning_effort"] = reasoning_effort
     if isinstance(message, str) and message:
         body["initial_items"] = [
             {
@@ -2423,6 +2428,7 @@ async def _execute_session_create(
         args.get("title"),
         args.get("message"),
         model=args.get("model"),
+        reasoning_effort=args.get("reasoning_effort"),
     )
     try:
         resp = await server_client.post("/v1/sessions", json=body, timeout=30.0)

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -936,6 +936,15 @@ class SysSessionCreateTool(Tool):
                                 "agent's default."
                             ),
                         },
+                        "reasoning_effort": {
+                            "type": "string",
+                            "description": (
+                                "Optional reasoning-effort override for "
+                                "the child session, e.g. 'low', 'medium', "
+                                "or 'high'. Set at session creation; omit "
+                                "to use the agent's default."
+                            ),
+                        },
                     },
                     # Only the always-optional fields are listed in
                     # ``required`` (none): the agent_id-vs-config_path

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6176,6 +6176,81 @@ async def test_sys_session_create_spawns_child_under_caller() -> None:
 
 
 @pytest.mark.asyncio
+async def test_sys_session_create_threads_model_and_reasoning_effort() -> None:
+    """
+    ``sys_session_create(agent_id=...)`` forwards a caller-supplied
+    ``model`` and ``reasoning_effort`` into the create body as
+    ``model_override`` / ``reasoning_effort``.
+
+    The server persists both on the child row for spawn/model resolution.
+    Without this a parent that launches an existing agent by id is pinned
+    to that agent's default model and effort, so cheap fan-out probes
+    cannot be routed to a smaller/cheaper tier (issue #2080).
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    captured: dict[str, Any] = {}
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/sessions":
+            captured.update(json.loads(request.content))
+            return httpx.Response(201, json={"id": "conv_child", "agent_id": "ag_x"})
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        await execute_tool(
+            tool_name="sys_session_create",
+            arguments=json.dumps(
+                {
+                    "agent_id": "ag_x",
+                    "model": "databricks-claude-haiku-4-5",
+                    "reasoning_effort": "low",
+                }
+            ),
+            server_client=server_client,
+            conversation_id="conv_caller",
+        )
+
+    assert captured["model_override"] == "databricks-claude-haiku-4-5"
+    assert captured["reasoning_effort"] == "low"
+
+
+@pytest.mark.asyncio
+async def test_sys_session_create_omits_reasoning_effort_when_absent() -> None:
+    """
+    An unset ``reasoning_effort`` is left out of the create body entirely,
+    so the server applies the agent default rather than persisting an
+    empty override.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    captured: dict[str, Any] = {}
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/sessions":
+            captured.update(json.loads(request.content))
+            return httpx.Response(201, json={"id": "conv_child", "agent_id": "ag_x"})
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        await execute_tool(
+            tool_name="sys_session_create",
+            arguments=json.dumps({"agent_id": "ag_x"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+        )
+
+    assert "reasoning_effort" not in captured
+    assert "model_override" not in captured
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "arguments",
     [


### PR DESCRIPTION
## Related issue

Closes #2080

## Summary

`sys_session_create(agent_id=...)` already forwards a caller-supplied `model` into the `POST /v1/sessions` body as `model_override` (shipped since the issue was filed), but there was no matching knob for reasoning effort — so a parent that launches an existing agent by id was pinned to that agent's default effort. `SessionCreateRequest.reasoning_effort` is already a first-class field on the create endpoint; only the tool surface didn't expose it.

This adds an optional `reasoning_effort` parameter to `sys_session_create`, threaded through `_build_session_create_body` into the create body next to `model_override`. It is included only when a non-empty string, so an unset value leaves the server on the agent default rather than persisting an empty override. That completes the per-session override surface the issue asks for (cost / tier routing of fan-out children: cheap throwaway probes on a small/haiku-class model + low effort, distinct from the orchestrator's own default).

## Test Plan

Added to `tests/runner/test_runner_dispatch.py`:

- `test_sys_session_create_threads_model_and_reasoning_effort` — both `model_override` and `reasoning_effort` land in the create body
- `test_sys_session_create_omits_reasoning_effort_when_absent` — an unset value (and model) is omitted entirely

```
OMNIGENT_SKIP_WEB_UI=true uv run pytest tests/runner/test_runner_dispatch.py -q -k sys_session_create
```

The reasoning_effort thread-through fails against `main` (the key is dropped from the create body) and passes with the change. `ruff check` + `ruff format --check` clean.

## Demo

N/A. Runner tool-surface change with no visual surface. Before: `sys_session_create` had `model` but no `reasoning_effort`, so a by-id child always ran the agent's default effort. After: passing `reasoning_effort: "low"` persists it on the child session (omitted when unset).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The thread-through is asserted end to end through `execute_tool` (schema → dispatch → create body) for both the present and absent cases. The `model` half of the issue was already shipped and covered; this PR closes the remaining `reasoning_effort` gap.

## Changelog

`sys_session_create` now accepts an optional `reasoning_effort`, so an orchestrator can launch an existing agent on a non-default reasoning effort (matching the existing `model` override) for cost/tier routing.
