### PR TITLE
refactor(harness): normalize native launcher pass-through args (PR 1.2)

### DIFF
--- a/designs/harness-modular-registry-proposal.md
+++ b/designs/harness-modular-registry-proposal.md
@@ -362,6 +362,7 @@ shipped. **12 PRs total** (Phase 1: 1.1–1.8, Phase 2: 2.1–2.4).
 | PR | Status | Link |
 |---|---|---|
 | 1.1 Provider model + resolver | in review | #3239 |
+| 1.2 Signature normalization | in review | (stacked on 1.1) |
 
 ## Risks and open questions
 

--- a/omnigent/antigravity_native.py
+++ b/omnigent/antigravity_native.py
@@ -135,6 +135,9 @@ from omnigent.native_terminal import (
     bind_session_runner as _bind_session_runner,
 )
 from omnigent.native_terminal import (
+    normalize_extra_args as _normalize_extra_args,
+)
+from omnigent.native_terminal import (
     terminal_attach_url as _attach_url,
 )
 
@@ -198,7 +201,8 @@ def run_antigravity_native(
     *,
     server: str | None,
     session_id: str | None,
-    antigravity_args: tuple[str, ...] = (),
+    extra_args: tuple[str, ...] | None = None,
+    antigravity_args: tuple[str, ...] | None = None,
     resume_picker: bool = False,
     command: str | None = None,
     model: str | None = None,
@@ -237,6 +241,9 @@ def run_antigravity_native(
     :returns: None after the terminal attach session ends.
     :raises click.ClickException: If setup, launch, or attach fails.
     """
+    antigravity_args = _normalize_extra_args(
+        extra_args=extra_args, legacy_args=antigravity_args, legacy_param="antigravity_args"
+    )
     resolved_command = (command or agy_binary_path()).strip()
     if not resolved_command:
         raise click.ClickException("Antigravity command must not be empty.")

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -1162,7 +1162,7 @@ def _run_claude_native_resume_redirect(
     run_claude_native(
         server=base_url,
         session_id=conversation_id,
-        claude_args=(),
+        extra_args=(),
         auto_open_conversation=auto_open_conversation,
     )
 
@@ -1196,7 +1196,7 @@ def _run_codex_native_resume_redirect(
     run_codex_native(
         server=base_url,
         session_id=conversation_id,
-        codex_args=(),
+        extra_args=(),
         auto_open_conversation=auto_open_conversation,
     )
 
@@ -1228,7 +1228,7 @@ def _run_pi_native_resume_redirect(
     run_pi_native(
         server=base_url,
         session_id=conversation_id,
-        pi_args=(),
+        extra_args=(),
         auto_open_conversation=auto_open_conversation,
     )
 
@@ -1252,7 +1252,7 @@ def _run_kiro_native_resume_redirect(
     run_kiro_native(
         server=base_url,
         session_id=conversation_id,
-        kiro_args=(),
+        extra_args=(),
         auto_open_conversation=auto_open_conversation,
     )
 
@@ -1292,7 +1292,7 @@ def _run_cursor_native_resume_redirect(
     run_cursor_native(
         server=base_url,
         session_id=conversation_id,
-        cursor_args=(),
+        extra_args=(),
         auto_open_conversation=auto_open_conversation,
     )
 
@@ -1330,7 +1330,7 @@ def _run_kimi_native_resume_redirect(
     run_kimi_native(
         server=base_url,
         session_id=conversation_id,
-        kimi_args=(),
+        extra_args=(),
         auto_open_conversation=auto_open_conversation,
     )
 

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -104,6 +104,9 @@ from omnigent.native_terminal import (
     bind_session_runner as _bind_session_runner,
 )
 from omnigent.native_terminal import (
+    normalize_extra_args as _normalize_extra_args,
+)
+from omnigent.native_terminal import (
     terminal_attach_url as _attach_url,
 )
 from omnigent.terminals.ws_bridge import (
@@ -545,7 +548,8 @@ def run_claude_native(
     *,
     server: str | None,
     session_id: str | None,
-    claude_args: tuple[str, ...],
+    extra_args: tuple[str, ...] | None = None,
+    claude_args: tuple[str, ...] | None = None,
     resume_picker: bool = False,
     command: str = _DEFAULT_CLAUDE_COMMAND,
     use_claude_config: bool = False,
@@ -580,6 +584,9 @@ def run_claude_native(
     :returns: None after the attach session ends.
     :raises click.ClickException: If setup, launch, or attach fails.
     """
+    claude_args = _normalize_extra_args(
+        extra_args=extra_args, legacy_args=claude_args, legacy_param="claude_args"
+    )
     startup_profiler = startup_profiler or StartupProfiler.from_env(
         name="omnigent claude",
         env_var=_CLAUDE_STARTUP_PROFILE_ENV_VAR,

--- a/omnigent/cli_native.py
+++ b/omnigent/cli_native.py
@@ -244,7 +244,7 @@ def register_native_commands(cli: click.Group) -> None:
             server=server,
             session_id=resolved_session_id,
             resume_picker=choice.picker,
-            claude_args=_resolve_harness_startup_args(cfg, "claude-native", claude_args),
+            extra_args=_resolve_harness_startup_args(cfg, "claude-native", claude_args),
             use_claude_config=use_claude_config,
             auto_open_conversation=auto_open_conversation,
             startup_profiler=startup_profiler,
@@ -358,7 +358,7 @@ def register_native_commands(cli: click.Group) -> None:
             server=server,
             session_id=resolved_session_id,
             resume_picker=choice.picker,
-            codex_args=_resolve_harness_startup_args(cfg, "codex-native", codex_args),
+            extra_args=_resolve_harness_startup_args(cfg, "codex-native", codex_args),
             model=model,
             prompt=prompt,
             auto_open_conversation=auto_open_conversation,
@@ -463,7 +463,7 @@ def register_native_commands(cli: click.Group) -> None:
             server=server,
             session_id=resolved_session_id,
             resume_picker=choice.picker,
-            opencode_args=_resolve_harness_startup_args(cfg, "opencode-native", opencode_args),
+            extra_args=_resolve_harness_startup_args(cfg, "opencode-native", opencode_args),
             model=model,
             auto_open_conversation=auto_open_conversation,
         )
@@ -553,7 +553,7 @@ def register_native_commands(cli: click.Group) -> None:
             server=server,
             session_id=resolved_session_id,
             resume_picker=choice.picker,
-            pi_args=_resolve_harness_startup_args(cfg, "pi-native", pi_args),
+            extra_args=_resolve_harness_startup_args(cfg, "pi-native", pi_args),
             auto_open_conversation=auto_open_conversation,
         )
 
@@ -668,7 +668,7 @@ def register_native_commands(cli: click.Group) -> None:
             server=server,
             session_id=resolved_session_id,
             resume_picker=choice.picker,
-            cursor_args=_resolve_harness_startup_args(cfg, "cursor-native", cursor_args),
+            extra_args=_resolve_harness_startup_args(cfg, "cursor-native", cursor_args),
             model=model,
             auto_open_conversation=auto_open_conversation,
             mode=mode,
@@ -798,7 +798,7 @@ def register_native_commands(cli: click.Group) -> None:
             server=server,
             session_id=resolved_session_id,
             resume_picker=choice.picker,
-            kiro_args=launch_args,
+            extra_args=launch_args,
             model=model,
             prompt=prompt,
             auto_open_conversation=auto_open_conversation,
@@ -887,7 +887,7 @@ def register_native_commands(cli: click.Group) -> None:
             server=server,
             session_id=resolved_session_id,
             resume_picker=choice.picker,
-            goose_args=_resolve_harness_startup_args(cfg, "goose-native", goose_args),
+            extra_args=_resolve_harness_startup_args(cfg, "goose-native", goose_args),
             auto_open_conversation=auto_open_conversation,
         )
 
@@ -974,7 +974,7 @@ def register_native_commands(cli: click.Group) -> None:
             server=server,
             session_id=resolved_session_id,
             resume_picker=choice.picker,
-            hermes_args=_resolve_harness_startup_args(cfg, "hermes-native", hermes_args),
+            extra_args=_resolve_harness_startup_args(cfg, "hermes-native", hermes_args),
             auto_open_conversation=auto_open_conversation,
         )
 
@@ -1073,9 +1073,7 @@ def register_native_commands(cli: click.Group) -> None:
             server=server,
             session_id=resolved_session_id,
             resume_picker=choice.picker,
-            antigravity_args=_resolve_harness_startup_args(
-                cfg, "antigravity-native", antigravity_args
-            ),
+            extra_args=_resolve_harness_startup_args(cfg, "antigravity-native", antigravity_args),
             model=model,
             auto_open_conversation=auto_open_conversation,
             command=resolved_command or None,
@@ -1164,7 +1162,7 @@ def register_native_commands(cli: click.Group) -> None:
             server=server,
             session_id=resolved_session_id,
             resume_picker=choice.picker,
-            qwen_args=_resolve_harness_startup_args(cfg, "qwen-native", qwen_args),
+            extra_args=_resolve_harness_startup_args(cfg, "qwen-native", qwen_args),
             auto_open_conversation=auto_open_conversation,
         )
 
@@ -1260,6 +1258,6 @@ def register_native_commands(cli: click.Group) -> None:
             server=server,
             session_id=resolved_session_id,
             resume_picker=choice.picker,
-            kimi_args=_resolve_harness_startup_args(cfg, "kimi-native", kimi_args),
+            extra_args=_resolve_harness_startup_args(cfg, "kimi-native", kimi_args),
             auto_open_conversation=auto_open_conversation,
         )

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -88,6 +88,9 @@ from omnigent.native_terminal import (
     bind_session_runner as _bind_session_runner,
 )
 from omnigent.native_terminal import (
+    normalize_extra_args as _normalize_extra_args,
+)
+from omnigent.native_terminal import (
     terminal_attach_url as _attach_url,
 )
 
@@ -348,7 +351,8 @@ def run_codex_native(
     *,
     server: str | None,
     session_id: str | None,
-    codex_args: tuple[str, ...],
+    extra_args: tuple[str, ...] | None = None,
+    codex_args: tuple[str, ...] | None = None,
     resume_picker: bool = False,
     command: str = _DEFAULT_CODEX_COMMAND,
     model: str | None = None,
@@ -372,6 +376,9 @@ def run_codex_native(
     :returns: None after the terminal attach session ends.
     :raises click.ClickException: If setup fails.
     """
+    codex_args = _normalize_extra_args(
+        extra_args=extra_args, legacy_args=codex_args, legacy_param="codex_args"
+    )
     resolved_command = command.strip()
     if not resolved_command:
         raise click.ClickException("Codex command must not be empty.")

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -52,6 +52,9 @@ from omnigent.native_terminal import (
     DAEMON_TERMINAL_READY_TIMEOUT_S as _DAEMON_TERMINAL_READY_TIMEOUT_S,
 )
 from omnigent.native_terminal import bind_session_runner as _bind_session_runner
+from omnigent.native_terminal import (
+    normalize_extra_args as _normalize_extra_args,
+)
 from omnigent.native_terminal import url_component
 
 _DEFAULT_CURSOR_COMMAND = "cursor-agent"
@@ -272,7 +275,8 @@ def run_cursor_native(
     *,
     server: str | None,
     session_id: str | None,
-    cursor_args: tuple[str, ...],
+    extra_args: tuple[str, ...] | None = None,
+    cursor_args: tuple[str, ...] | None = None,
     resume_picker: bool = False,
     model: str | None = None,
     auto_open_conversation: bool = False,
@@ -294,6 +298,9 @@ def run_cursor_native(
         Injected as ``--mode <mode>`` unless already present in *cursor_args*.
     :returns: None after the terminal attach session ends.
     """
+    cursor_args = _normalize_extra_args(
+        extra_args=extra_args, legacy_args=cursor_args, legacy_param="cursor_args"
+    )
     _preflight_local_tools()
     if server is None:
         raise click.ClickException(

--- a/omnigent/goose_native.py
+++ b/omnigent/goose_native.py
@@ -54,6 +54,9 @@ from omnigent.native_terminal import (
     DAEMON_TERMINAL_READY_TIMEOUT_S as _DAEMON_TERMINAL_READY_TIMEOUT_S,
 )
 from omnigent.native_terminal import bind_session_runner as _bind_session_runner
+from omnigent.native_terminal import (
+    normalize_extra_args as _normalize_extra_args,
+)
 from omnigent.native_terminal import url_component
 
 _DEFAULT_GOOSE_COMMAND = "goose"
@@ -153,7 +156,8 @@ def run_goose_native(
     *,
     server: str | None,
     session_id: str | None,
-    goose_args: tuple[str, ...],
+    extra_args: tuple[str, ...] | None = None,
+    goose_args: tuple[str, ...] | None = None,
     resume_picker: bool = False,
     auto_open_conversation: bool = False,
 ) -> None:
@@ -168,6 +172,9 @@ def run_goose_native(
         URL after launch.
     :returns: None after the terminal attach session ends.
     """
+    goose_args = _normalize_extra_args(
+        extra_args=extra_args, legacy_args=goose_args, legacy_param="goose_args"
+    )
     _preflight_local_tools()
     if server is None:
         raise click.ClickException(

--- a/omnigent/hermes_native.py
+++ b/omnigent/hermes_native.py
@@ -53,6 +53,9 @@ from omnigent.native_terminal import (
     DAEMON_TERMINAL_READY_TIMEOUT_S as _DAEMON_TERMINAL_READY_TIMEOUT_S,
 )
 from omnigent.native_terminal import bind_session_runner as _bind_session_runner
+from omnigent.native_terminal import (
+    normalize_extra_args as _normalize_extra_args,
+)
 from omnigent.native_terminal import url_component
 
 _DEFAULT_HERMES_COMMAND = "hermes"
@@ -152,7 +155,8 @@ def run_hermes_native(
     *,
     server: str | None,
     session_id: str | None,
-    hermes_args: tuple[str, ...],
+    extra_args: tuple[str, ...] | None = None,
+    hermes_args: tuple[str, ...] | None = None,
     resume_picker: bool = False,
     auto_open_conversation: bool = False,
 ) -> None:
@@ -167,6 +171,9 @@ def run_hermes_native(
         URL after launch.
     :returns: None after the terminal attach session ends.
     """
+    hermes_args = _normalize_extra_args(
+        extra_args=extra_args, legacy_args=hermes_args, legacy_param="hermes_args"
+    )
     _preflight_local_tools()
     if server is None:
         raise click.ClickException(

--- a/omnigent/kimi_native.py
+++ b/omnigent/kimi_native.py
@@ -51,6 +51,9 @@ from omnigent.native_terminal import (
     DAEMON_TERMINAL_READY_TIMEOUT_S as _DAEMON_TERMINAL_READY_TIMEOUT_S,
 )
 from omnigent.native_terminal import bind_session_runner as _bind_session_runner
+from omnigent.native_terminal import (
+    normalize_extra_args as _normalize_extra_args,
+)
 from omnigent.native_terminal import url_component
 
 _DEFAULT_KIMI_COMMAND = "kimi"
@@ -157,7 +160,8 @@ def run_kimi_native(
     *,
     server: str | None,
     session_id: str | None,
-    kimi_args: tuple[str, ...],
+    extra_args: tuple[str, ...] | None = None,
+    kimi_args: tuple[str, ...] | None = None,
     resume_picker: bool = False,
     auto_open_conversation: bool = False,
 ) -> None:
@@ -172,6 +176,9 @@ def run_kimi_native(
         conversation URL after launch.
     :returns: None after the terminal attach session ends.
     """
+    kimi_args = _normalize_extra_args(
+        extra_args=extra_args, legacy_args=kimi_args, legacy_param="kimi_args"
+    )
     _preflight_local_tools()
     if server is None:
         raise click.ClickException(

--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -39,6 +39,9 @@ from omnigent.native_terminal import (
     DAEMON_TERMINAL_READY_TIMEOUT_S as _DAEMON_TERMINAL_READY_TIMEOUT_S,
 )
 from omnigent.native_terminal import bind_session_runner as _bind_session_runner
+from omnigent.native_terminal import (
+    normalize_extra_args as _normalize_extra_args,
+)
 from omnigent.native_terminal import url_component
 
 _DEFAULT_KIRO_COMMAND = "kiro-cli"
@@ -186,13 +189,17 @@ def run_kiro_native(
     *,
     server: str | None,
     session_id: str | None,
-    kiro_args: tuple[str, ...],
+    extra_args: tuple[str, ...] | None = None,
+    kiro_args: tuple[str, ...] | None = None,
     resume_picker: bool = False,
     model: str | None = None,
     prompt: str | None = None,
     auto_open_conversation: bool = False,
 ) -> None:
     """Launch the Kiro TUI in an Omnigent terminal."""
+    kiro_args = _normalize_extra_args(
+        extra_args=extra_args, legacy_args=kiro_args, legacy_param="kiro_args"
+    )
     _preflight_local_tools()
     if server is None:
         raise click.ClickException(

--- a/omnigent/native_terminal.py
+++ b/omnigent/native_terminal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import urllib.parse
+import warnings
 
 import click
 import httpx
@@ -12,6 +13,38 @@ from omnigent.host.daemon_launch import error_text
 DAEMON_HOST_ONLINE_TIMEOUT_S = 30.0
 DAEMON_RUNNER_ONLINE_TIMEOUT_S = 60.0
 DAEMON_TERMINAL_READY_TIMEOUT_S = 60.0
+
+
+def normalize_extra_args(
+    *,
+    extra_args: tuple[str, ...] | None,
+    legacy_args: tuple[str, ...] | None,
+    legacy_param: str,
+) -> tuple[str, ...]:
+    """Reconcile a native launcher's pass-through args from both spellings.
+
+    Every ``run_<x>_native`` entry point accepts a uniform keyword-only
+    ``extra_args`` (the spelling the provider seam calls with) plus its legacy
+    ``<x>_args`` alias. This collapses the two into one tuple:
+
+    - only ``extra_args`` set → use it;
+    - only the legacy alias set → use it, emitting a ``DeprecationWarning``;
+    - both set → ``extra_args`` wins (the legacy alias is ignored) with a warning;
+    - neither set → empty tuple.
+
+    The ``<x>_args`` alias is deprecated and slated for removal in 0.9.0; callers
+    should pass ``extra_args``.
+    """
+    if legacy_args is not None:
+        warnings.warn(
+            f"{legacy_param!r} is deprecated; pass extra_args instead "
+            "(the alias is removed in 0.9.0)",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        if extra_args is None:
+            return tuple(legacy_args)
+    return tuple(extra_args or ())
 
 
 def url_component(value: str) -> str:

--- a/omnigent/opencode_native.py
+++ b/omnigent/opencode_native.py
@@ -55,6 +55,9 @@ from omnigent.native_terminal import (
     DAEMON_TERMINAL_READY_TIMEOUT_S as _DAEMON_TERMINAL_READY_TIMEOUT_S,
 )
 from omnigent.native_terminal import bind_session_runner as _bind_session_runner
+from omnigent.native_terminal import (
+    normalize_extra_args as _normalize_extra_args,
+)
 from omnigent.native_terminal import url_component
 from omnigent.opencode_native_state import read_launch_state, write_launch_state
 
@@ -155,7 +158,8 @@ def run_opencode_native(  # pragma: no cover
     *,
     server: str | None,
     session_id: str | None,
-    opencode_args: tuple[str, ...],
+    extra_args: tuple[str, ...] | None = None,
+    opencode_args: tuple[str, ...] | None = None,
     resume_picker: bool = False,
     model: str | None = None,
     auto_open_conversation: bool = False,
@@ -177,6 +181,9 @@ def run_opencode_native(  # pragma: no cover
     :param auto_open_conversation: Open the browser conversation URL on launch.
     :returns: None after the terminal attach session ends.
     """
+    opencode_args = _normalize_extra_args(
+        extra_args=extra_args, legacy_args=opencode_args, legacy_param="opencode_args"
+    )
     _preflight_local_tools()
     if server is None:
         raise click.ClickException(

--- a/omnigent/pi_native.py
+++ b/omnigent/pi_native.py
@@ -40,6 +40,9 @@ from omnigent.native_terminal import (
     DAEMON_TERMINAL_READY_TIMEOUT_S as _DAEMON_TERMINAL_READY_TIMEOUT_S,
 )
 from omnigent.native_terminal import bind_session_runner as _bind_session_runner
+from omnigent.native_terminal import (
+    normalize_extra_args as _normalize_extra_args,
+)
 from omnigent.native_terminal import url_component
 from omnigent.pi_native_bridge import bridge_dir_for_session_id
 
@@ -198,7 +201,8 @@ def run_pi_native(
     *,
     server: str | None,
     session_id: str | None,
-    pi_args: tuple[str, ...],
+    extra_args: tuple[str, ...] | None = None,
+    pi_args: tuple[str, ...] | None = None,
     resume_picker: bool = False,
     auto_open_conversation: bool = False,
 ) -> None:
@@ -213,6 +217,9 @@ def run_pi_native(
         conversation URL after launch.
     :returns: None after the terminal attach session ends.
     """
+    pi_args = _normalize_extra_args(
+        extra_args=extra_args, legacy_args=pi_args, legacy_param="pi_args"
+    )
     _preflight_local_tools()
     if server is None:
         raise click.ClickException(

--- a/omnigent/qwen_native.py
+++ b/omnigent/qwen_native.py
@@ -54,6 +54,9 @@ from omnigent.native_terminal import (
     DAEMON_TERMINAL_READY_TIMEOUT_S as _DAEMON_TERMINAL_READY_TIMEOUT_S,
 )
 from omnigent.native_terminal import bind_session_runner as _bind_session_runner
+from omnigent.native_terminal import (
+    normalize_extra_args as _normalize_extra_args,
+)
 from omnigent.native_terminal import url_component
 
 _DEFAULT_QWEN_COMMAND = "qwen"
@@ -152,7 +155,8 @@ def run_qwen_native(
     *,
     server: str | None,
     session_id: str | None,
-    qwen_args: tuple[str, ...],
+    extra_args: tuple[str, ...] | None = None,
+    qwen_args: tuple[str, ...] | None = None,
     resume_picker: bool = False,
     auto_open_conversation: bool = False,
 ) -> None:
@@ -167,6 +171,9 @@ def run_qwen_native(
         URL after launch.
     :returns: None after the terminal attach session ends.
     """
+    qwen_args = _normalize_extra_args(
+        extra_args=extra_args, legacy_args=qwen_args, legacy_param="qwen_args"
+    )
     _preflight_local_tools()
     if server is None:
         raise click.ClickException(

--- a/omnigent/resume_dispatch.py
+++ b/omnigent/resume_dispatch.py
@@ -241,7 +241,7 @@ def _dispatch_wrapper(
         run_claude_native(
             server=server,
             session_id=session_id,
-            claude_args=(),
+            extra_args=(),
         )
         return True
     if native_agent.key == "codex":
@@ -250,7 +250,7 @@ def _dispatch_wrapper(
         run_codex_native(
             server=server,
             session_id=session_id,
-            codex_args=(),
+            extra_args=(),
         )
         return True
     if native_agent.key == "pi":
@@ -259,7 +259,7 @@ def _dispatch_wrapper(
         run_pi_native(
             server=server,
             session_id=session_id,
-            pi_args=(),
+            extra_args=(),
         )
         return True
     if native_agent.key == "cursor":
@@ -268,7 +268,7 @@ def _dispatch_wrapper(
         run_cursor_native(
             server=server,
             session_id=session_id,
-            cursor_args=(),
+            extra_args=(),
         )
         return True
     if native_agent.key == "kiro":
@@ -277,7 +277,7 @@ def _dispatch_wrapper(
         run_kiro_native(
             server=server,
             session_id=session_id,
-            kiro_args=(),
+            extra_args=(),
         )
         return True
     if native_agent.key == "goose":
@@ -286,7 +286,7 @@ def _dispatch_wrapper(
         run_goose_native(
             server=server,
             session_id=session_id,
-            goose_args=(),
+            extra_args=(),
         )
         return True
     if native_agent.key == "antigravity":
@@ -295,7 +295,7 @@ def _dispatch_wrapper(
         run_antigravity_native(
             server=server,
             session_id=session_id,
-            antigravity_args=(),
+            extra_args=(),
         )
         return True
     if native_agent.key == "qwen":
@@ -304,7 +304,7 @@ def _dispatch_wrapper(
         run_qwen_native(
             server=server,
             session_id=session_id,
-            qwen_args=(),
+            extra_args=(),
         )
         return True
     if native_agent.key == "kimi":
@@ -313,7 +313,7 @@ def _dispatch_wrapper(
         run_kimi_native(
             server=server,
             session_id=session_id,
-            kimi_args=(),
+            extra_args=(),
         )
         return True
     if native_agent.key == "hermes":
@@ -322,7 +322,7 @@ def _dispatch_wrapper(
         run_hermes_native(
             server=server,
             session_id=session_id,
-            hermes_args=(),
+            extra_args=(),
         )
         return True
     return False

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -97,7 +97,7 @@ def test_redirect_native_resume_routes_kiro_wrapper(monkeypatch: pytest.MonkeyPa
     assert captured == {
         "server": "https://example.com",
         "session_id": "conv_kiro",
-        "kiro_args": (),
+        "extra_args": (),
         "auto_open_conversation": True,
     }
 
@@ -3814,7 +3814,7 @@ def test_redirect_native_resume_handles_cursor(monkeypatch: pytest.MonkeyPatch) 
     assert captured == {
         "server": "https://example.com",
         "session_id": "conv_abc123",
-        "cursor_args": (),
+        "extra_args": (),
         "auto_open_conversation": True,
     }
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -432,7 +432,7 @@ def test_claude_command_resume_binds_session_and_passes_unknown_args(
     # there).
     assert captured["server"] == "https://example.com"
     assert captured["session_id"] == "conv_abc"
-    assert captured["claude_args"] == ("--resume", "claude-session", "-p", "say hi")
+    assert captured["extra_args"] == ("--resume", "claude-session", "-p", "say hi")
     # No picker requested when ``--resume`` carries a value.
     assert captured["resume_picker"] is False
     # Default: Databricks auth is active (``--use-native-config`` not set) —
@@ -465,7 +465,7 @@ def test_claude_command_short_r_binds_omnigent_session(
     assert result.exit_code == 0, result.output
     assert captured["session_id"] == "conv_abc"
     # ``-r <conv_id>`` consumes both tokens; no leftover claude args.
-    assert captured["claude_args"] == ()
+    assert captured["extra_args"] == ()
     assert captured["resume_picker"] is False
 
 
@@ -662,7 +662,7 @@ def test_codex_command_resume_binds_session_and_passes_unknown_args(
     assert result.exit_code == 0, result.output
     assert captured["server"] == "https://example.com"
     assert captured["session_id"] == "conv_abc"
-    assert captured["codex_args"] == ("-c", "approval_policy=on-request")
+    assert captured["extra_args"] == ("-c", "approval_policy=on-request")
     assert captured["model"] == "gpt-test"
     assert captured["prompt"] == "say hi"
     assert captured["resume_picker"] is False
@@ -876,7 +876,7 @@ def test_codex_config_args_form_base_cli_args_append(
     result = CliRunner().invoke(cli, ["codex", "--dangerously-skip-permissions"])
 
     assert result.exit_code == 0, result.output
-    assert captured["codex_args"] == (
+    assert captured["extra_args"] == (
         "--config",
         "k=v",
         "--dangerously-skip-permissions",
@@ -901,7 +901,7 @@ def test_codex_config_args_only_when_no_cli_args(
     result = CliRunner().invoke(cli, ["codex"])
 
     assert result.exit_code == 0, result.output
-    assert captured["codex_args"] == ("--verbose",)
+    assert captured["extra_args"] == ("--verbose",)
 
 
 def test_codex_args_no_config_is_cli_args_only(
@@ -919,7 +919,7 @@ def test_codex_args_no_config_is_cli_args_only(
     result = CliRunner().invoke(cli, ["codex", "--flag"])
 
     assert result.exit_code == 0, result.output
-    assert captured["codex_args"] == ("--flag",)
+    assert captured["extra_args"] == ("--flag",)
 
 
 def test_pi_config_args_form_base_cli_args_append(
@@ -940,7 +940,7 @@ def test_pi_config_args_form_base_cli_args_append(
     result = CliRunner().invoke(cli, ["pi", "--cli-flag"])
 
     assert result.exit_code == 0, result.output
-    assert captured["pi_args"] == ("--base", "--cli-flag")
+    assert captured["extra_args"] == ("--base", "--cli-flag")
 
 
 def test_kiro_command_is_registered_in_click_help() -> None:
@@ -988,7 +988,7 @@ def test_kiro_command_parses_native_options_and_prompt(
     assert captured["resume_picker"] is False
     assert captured["model"] == "auto"
     assert captured["prompt"] == "hi"
-    assert captured["kiro_args"] == (
+    assert captured["extra_args"] == (
         "--effort",
         "high",
         "--agent",

--- a/tests/test_native_terminal.py
+++ b/tests/test_native_terminal.py
@@ -177,3 +177,34 @@ def test_terminal_attach_url_encodes_path_components_and_switches_scheme() -> No
         url == "wss://example.databricks.com/base/v1/sessions/conv%2Fa%20b"
         "/resources/terminals/terminal%2Fmain/attach"
     )
+
+
+def test_normalize_extra_args_prefers_extra_args() -> None:
+    assert native_terminal.normalize_extra_args(
+        extra_args=("--a",), legacy_args=None, legacy_param="pi_args"
+    ) == ("--a",)
+
+
+def test_normalize_extra_args_empty_when_neither_set() -> None:
+    assert (
+        native_terminal.normalize_extra_args(
+            extra_args=None, legacy_args=None, legacy_param="pi_args"
+        )
+        == ()
+    )
+
+
+def test_normalize_extra_args_legacy_alias_warns_and_is_used() -> None:
+    with pytest.warns(DeprecationWarning, match="pi_args"):
+        result = native_terminal.normalize_extra_args(
+            extra_args=None, legacy_args=("--legacy",), legacy_param="pi_args"
+        )
+    assert result == ("--legacy",)
+
+
+def test_normalize_extra_args_extra_args_wins_over_legacy_with_warning() -> None:
+    with pytest.warns(DeprecationWarning):
+        result = native_terminal.normalize_extra_args(
+            extra_args=("--new",), legacy_args=("--old",), legacy_param="pi_args"
+        )
+    assert result == ("--new",)

--- a/tests/test_resume_dispatch.py
+++ b/tests/test_resume_dispatch.py
@@ -121,7 +121,7 @@ def test_dispatch_by_runtime_claude_native_remote_routes_to_wrapper(
     # Trailing slash stripped — the wrapper expects a bare base URL.
     assert captured["server"] == "https://example.com"
     # No leaking claude args; the wrapper builds its own.
-    assert captured["claude_args"] == ()
+    assert captured["extra_args"] == ()
 
 
 def test_dispatch_by_runtime_codex_native_remote_routes_to_wrapper(
@@ -158,7 +158,7 @@ def test_dispatch_by_runtime_codex_native_remote_routes_to_wrapper(
 
     assert captured["session_id"] == "4e92b5a0c0ee6db3f874f9c4a3f855a5"
     assert captured["server"] == "https://example.com"
-    assert captured["codex_args"] == ()
+    assert captured["extra_args"] == ()
 
 
 def test_dispatch_by_runtime_codex_native_local_routes_to_wrapper(
@@ -195,7 +195,7 @@ def test_dispatch_by_runtime_codex_native_local_routes_to_wrapper(
 
     assert captured["session_id"] == "415c9954e2fe4b9276083a4d2c66f689"
     assert captured["server"] is None
-    assert captured["codex_args"] == ()
+    assert captured["extra_args"] == ()
 
 
 def test_dispatch_by_runtime_kiro_native_remote_routes_to_wrapper(
@@ -221,7 +221,7 @@ def test_dispatch_by_runtime_kiro_native_remote_routes_to_wrapper(
 
     assert captured["session_id"] == "823dbd1aab969b5a813fac59bb977a77"
     assert captured["server"] == "https://example.com"
-    assert captured["kiro_args"] == ()
+    assert captured["extra_args"] == ()
 
 
 def test_dispatch_by_runtime_antigravity_native_remote_routes_to_wrapper(
@@ -262,7 +262,7 @@ def test_dispatch_by_runtime_antigravity_native_remote_routes_to_wrapper(
 
     assert captured["session_id"] == "a8bcbee631c58ddb98fb5e3f54a1592a"
     assert captured["server"] == "https://example.com"
-    assert captured["antigravity_args"] == ()
+    assert captured["extra_args"] == ()
 
 
 def test_dispatch_by_runtime_antigravity_native_local_routes_to_wrapper(
@@ -299,7 +299,7 @@ def test_dispatch_by_runtime_antigravity_native_local_routes_to_wrapper(
 
     assert captured["session_id"] == "e85224ee39457def1d20bcce5b74ed8c"
     assert captured["server"] is None
-    assert captured["antigravity_args"] == ()
+    assert captured["extra_args"] == ()
 
 
 def test_dispatch_by_runtime_claude_native_local_still_routes_to_wrapper(
@@ -336,7 +336,7 @@ def test_dispatch_by_runtime_claude_native_local_still_routes_to_wrapper(
 
     assert captured["session_id"] == "64a784c3aa907d1774f44313546947c6"
     assert captured["server"] is None
-    assert captured["claude_args"] == ()
+    assert captured["extra_args"] == ()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
> **Stacked on #3239 (PR 1.1).** Base branch is `harness-seam-1-1-pr`, so this diff shows only 1.2's changes. Merge #3239 first; GitHub will retarget this to `main` automatically.

## Workstream progress

Modular native-harness registry (`designs/harness-modular-registry-proposal.md`). **12 PRs total** — Phase 1 (internal seam, core-only): 1.1–1.8; Phase 2 (community + web): 2.1–2.4.

- ✅ Phase 0 — file splits (#3047, #3097, #3148, #3149) + costed plan (#3212, #3217).
- ✅ 1.1 Provider model + resolver — #3239 (in review).
- 🔄 **1.2 Signature normalization — this PR.**
- ⏳ 1.3 Resume hubs → 1.4 CLI subcommands → 1.5 Runner launch/terminal-route *(risk center)* → 1.6 Runner interrupt/stop → 1.7 Seeding loop → 1.8 Derive enumerations.
- ⏳ Phase 2: 2.1 Validator flip → 2.2 `/v1/harnesses` native rows → 2.3 Web off the endpoint → 2.4 Docs + example plugin.

Critical path: 1.1 → 1.2 → 1.5 → 2.2 → 2.3.

## Related issue

N/A — Phase 1, PR 1.2 of the modular native-harness registry.

## Summary

The 11 `run_<x>_native` launchers each spelled their pass-through arg differently (`claude_args`, `pi_args`, …). The provider seam (1.1) needs one uniform spelling to call them generically. This introduces `extra_args` as that spelling and keeps `<x>_args` as a back-compat alias. **No behavior change** — every native harness launches identically.

- Add `native_terminal.normalize_extra_args()`: reconciles `extra_args` vs the legacy `<x>_args` alias — `extra_args` wins, the legacy alias emits a `DeprecationWarning` (**removal targeted for 0.9.0**; we're on 0.7.0.dev0, so the deprecate-and-remove-in-different-releases rule holds), neither yields `()`.
- Give all 11 `run_<x>_native` entry points a keyword-only `extra_args` and make `<x>_args` an optional deprecated alias, normalizing at the top of each body so the deep internals keep using the existing local variable unchanged.
- Migrate the internal callers (`resume_dispatch` ×10, `chat` resume-redirect ×6, `cli_native` ×11) to `extra_args` so nothing in core trips the new warning; the alias exists purely for external back-compat. (Exploration found **zero external callers**, so the alias is belt-and-suspenders.)

## Test Plan

```
python -m pytest tests/test_native_terminal.py tests/test_resume_dispatch.py \
  tests/cli/test_cli.py tests/cli/test_chat.py -q          # 378 passed
python -m ruff check omnigent/ tests/  # clean
```

- New unit tests cover the four `normalize_extra_args` branches (extra-only, legacy-only+warns, both→extra-wins+warns, neither→`()`).
- Internal-caller tests updated to assert the `extra_args` spelling. Existing native tests that still call `<x>_args=` now double as back-compat coverage for the alias.
- With default warning filters the full native + hub suite is green; the handful of unrelated reds on this machine are pre-existing gateway-env artifacts, byte-identical to the clean tree.

## Demo

N/A — no user-facing behavior change (keyword-arg normalization).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [x] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The `<x>_args` alias is a soft deprecation, not a hard break today — but I checked the **Breaking change** box because the parameter is on a one-release deprecation clock (removal in **0.9.0**). Tests cover both spellings; the existing native suites (unchanged) cover launch behavior.

## Changelog

The `run_<x>_native` launchers accept a uniform `extra_args`; the per-harness `<x>_args` keyword is deprecated and will be removed in 0.9.0.

This pull request and its description were written by Isaac.
