### PR TITLE
fix(web): cache transcripts per session so switch-back skips the eager backfill (#2849)

### DIFF
--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -47,6 +47,7 @@ import { terminalsQueryKey } from "@/hooks/useTerminals";
 import { type ChildSessionInfo, childSessionsQueryKey } from "@/hooks/useChildSessions";
 import {
   consumePendingInitialPrompt,
+  __clearTranscriptCacheForTests,
   handleSessionEvent,
   initChatStore,
   pumpStreamEvents,
@@ -387,6 +388,10 @@ beforeEach(() => {
     // Restore the real send action; a prior test may have stubbed it.
     send: realSend,
   });
+  // Clear the module-level transcript switch-back cache (#2849) between
+  // cases: conversation ids are reused across tests, so a cached transcript
+  // would otherwise leak into the next test's cold load.
+  __clearTranscriptCacheForTests();
   fetchMock.mockReset();
   fetchMock.mockImplementation(defaultFetchHandler);
   vi.stubGlobal("fetch", fetchMock);
@@ -9174,5 +9179,96 @@ describe("chatStore — background cross-session flush", () => {
     await tick();
     await tick();
     expect(delivered).toEqual(["foreground", "background"]);
+  });
+});
+
+describe("chatStore — transcript switch-back cache (#2849)", () => {
+  it("restores older history on switch-back without re-running the eager backfill", async () => {
+    // Three pages: the bind window is only the newest page, older pages exist.
+    const total = SESSION_HISTORY_PAGE_SIZE * 3;
+    const items = Array.from({ length: total }, (_, i) =>
+      userMessage(`a_${i.toString().padStart(4, "0")}`, `a ${i}`),
+    );
+    seedSession("conv_a", items);
+    seedSession("conv_b", []);
+
+    // Open A and page one older window in, so state holds two pages.
+    await useChatStore.getState().switchTo("conv_a");
+    await useChatStore.getState().loadMoreHistory();
+    const loaded = useChatStore.getState();
+    const idsBefore = loaded.blocks.map((b) => b.ctx.itemId);
+    expect(idsBefore).toHaveLength(SESSION_HISTORY_PAGE_SIZE * 2);
+    const oldestBefore = loaded.oldestItemId;
+    expect(loaded.hasMoreHistory).toBe(true); // one page still older
+
+    // Leave A (stashes its transcript), then come back — counting only the
+    // item fetches the switch-back itself triggers.
+    await useChatStore.getState().switchTo("conv_b");
+    fetchMock.mockClear();
+    await useChatStore.getState().switchTo("conv_a");
+
+    const restored = useChatStore.getState();
+    // The full two-page transcript is back, in order — not just the newest
+    // page a cold bind would show.
+    expect(restored.blocks.map((b) => b.ctx.itemId)).toEqual(idsBefore);
+    expect(restored.oldestItemId).toBe(oldestBefore);
+    expect(restored.hasMoreHistory).toBe(true);
+
+    // And it cost exactly ONE item request (the bind window); the older page
+    // came from the cache, not a re-fetch. A regression to re-paging on
+    // switch-back would add an `after=` cursor fetch here.
+    const itemFetches = fetchMock.mock.calls.filter(([u]) =>
+      String(u).startsWith("/v1/sessions/conv_a/items"),
+    );
+    expect(itemFetches).toHaveLength(1);
+    expect(itemFetches.every(([u]) => !String(u).includes("after="))).toBe(true);
+
+    // Scroll-up still works off the restored cursor: the remaining older page
+    // pages in correctly, proving the restored state is internally consistent.
+    await useChatStore.getState().loadMoreHistory();
+    expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual(
+      items.map((it) => it.id),
+    );
+  });
+
+  it("falls back to a fresh reload when items arrived while away, dropping nothing", async () => {
+    const firstBatch = SESSION_HISTORY_PAGE_SIZE * 2;
+    const items = Array.from({ length: firstBatch }, (_, i) =>
+      userMessage(`a_${i.toString().padStart(4, "0")}`, `a ${i}`),
+    );
+    seedSession("conv_a", items);
+    seedSession("conv_b", []);
+
+    // Cache two pages for A.
+    await useChatStore.getState().switchTo("conv_a");
+    await useChatStore.getState().loadMoreHistory();
+    expect(useChatStore.getState().blocks).toHaveLength(SESSION_HISTORY_PAGE_SIZE * 2);
+
+    await useChatStore.getState().switchTo("conv_b");
+
+    // While away, many new items commit to A — enough that its fresh newest
+    // page shares NO id with the cached transcript. That is the gap the cache
+    // must refuse to bridge (else the missing middle items vanish).
+    const added = Array.from({ length: SESSION_HISTORY_PAGE_SIZE * 2 }, (_, i) =>
+      userMessage(`a_new_${i.toString().padStart(4, "0")}`, `a new ${i}`),
+    );
+    const grown = [...items, ...added];
+    seedSession("conv_a", grown);
+
+    await useChatStore.getState().switchTo("conv_a");
+
+    const state = useChatStore.getState();
+    // Exactly the fresh newest page (the new items) — the stale cache was NOT
+    // prepended, so nothing is scrambled and no gap is papered over.
+    expect(state.blocks.map((b) => b.ctx.itemId)).toEqual(
+      grown.slice(-SESSION_HISTORY_PAGE_SIZE).map((it) => it.id),
+    );
+    expect(state.hasMoreHistory).toBe(true);
+    // Paging up walks the real, contiguous history — including the middle
+    // items the cache never had — with no duplicates.
+    await useChatStore.getState().loadMoreHistory();
+    expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual(
+      grown.slice(-SESSION_HISTORY_PAGE_SIZE * 2).map((it) => it.id),
+    );
   });
 });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -682,6 +682,51 @@ let queryClient: QueryClient | null = null;
 const racedNativeModelOptions = new Map<string, NativeModelOption[]>();
 let pendingSeq = 0;
 let queueSeq = 0;
+
+/**
+ * Per-conversation transcript cache for fast session switch-back (#2849).
+ *
+ * `switchTo` resets `blocks` to `[]` and the rail then re-runs the eager
+ * backfill (up to 10 serial `/items` pages), so returning to a session just
+ * viewed pays that multi-round-trip cost again. This is a pure performance
+ * cache — deliberately module-level, NOT reactive store state, so it never
+ * triggers renders or bloats snapshots. `switchTo` stashes the loaded
+ * transcript on leave; `bindStream` restores the older history on return
+ * WITHOUT re-paging, but only when the freshly-fetched snapshot window shares
+ * an item id with the cache (proof the two are contiguous), so an item
+ * committed while the user was away can never fall into a gap. A small LRU cap
+ * bounds memory.
+ */
+interface CachedTranscript {
+  blocks: AnyBlock[];
+  oldestItemId: string | null;
+  hasMoreHistory: boolean;
+}
+const MAX_CACHED_TRANSCRIPTS = 8;
+const transcriptCache = new Map<string, CachedTranscript>();
+
+/**
+ * Stash a conversation's loaded transcript for a later switch-back.
+ *
+ * Skips a transcript with no server item id (purely optimistic/live bubbles):
+ * it can never satisfy the overlap guard and so would only waste memory.
+ * Re-inserts to mark most-recently-used and evicts the oldest past the cap.
+ */
+function stashTranscript(conversationId: string, entry: CachedTranscript): void {
+  if (!entry.blocks.some((b) => b.ctx.itemId != null)) return;
+  transcriptCache.delete(conversationId);
+  transcriptCache.set(conversationId, entry);
+  while (transcriptCache.size > MAX_CACHED_TRANSCRIPTS) {
+    const oldest = transcriptCache.keys().next().value;
+    if (oldest === undefined) break;
+    transcriptCache.delete(oldest);
+  }
+}
+
+/** Test-only: clear the module-level transcript cache between cases. */
+export function __clearTranscriptCacheForTests(): void {
+  transcriptCache.clear();
+}
 // Tail of the send chain. Each `send` waits on the previous send's network
 // work before issuing its own POST, so rapid-fire messages reach the server
 // in submission order. Concurrent `fetch` POSTs have no ordering guarantee,
@@ -1544,6 +1589,19 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // bindStream's pump unwinds via AbortError and stops applying
     // events to state.blocks.
     get().abortController?.abort();
+
+    // #2849: stash the outgoing transcript so switching back restores its
+    // older history without re-running the eager backfill. Read before the
+    // reset below wipes `blocks`. `bindStream` gates the restore on an
+    // overlap check, so a stale cache can never drop messages.
+    const outgoing = get();
+    if (outgoing.conversationId !== null) {
+      stashTranscript(outgoing.conversationId, {
+        blocks: outgoing.blocks,
+        oldestItemId: outgoing.oldestItemId,
+        hasMoreHistory: outgoing.hasMoreHistory,
+      });
+    }
 
     set((s) => {
       // Stash the OUTGOING conversation's still-in-flight optimistic
@@ -2612,6 +2670,43 @@ async function bindStream(
         }>,
       };
     });
+    // #2849: on a cold load, restore the older transcript from the
+    // switch-away cache instead of re-running the eager backfill — but only
+    // when the fresh snapshot window shares an item id with the cache. A
+    // shared id proves the cache is contiguous with the window, so items
+    // committed while the user was away cannot fall into a gap. No shared id
+    // (a long-idle switch-back, or heavy activity while away) leaves the
+    // normal backfill to run. Runs synchronously right after the bind set()
+    // — no `await` between them — so the rail's eager-load effect sees the
+    // restored history and skips its serial paging.
+    if (hydratePending && get().conversationId === id) {
+      const cached = transcriptCache.get(id);
+      if (cached !== undefined) {
+        set((state) => {
+          const windowIds = new Set(
+            state.blocks.map((b) => b.ctx.itemId).filter((iid): iid is string => Boolean(iid)),
+          );
+          const overlaps = cached.blocks.some(
+            (b) => b.ctx.itemId != null && windowIds.has(b.ctx.itemId),
+          );
+          if (!overlaps) return {};
+          // Prepend only the strictly-older committed cached blocks (those the
+          // fresh window doesn't already hold), preserving their order, and
+          // restore the paging cursor so scroll-up and the rail see the full
+          // loaded range. Optimistic/live bubbles (no item id) are never
+          // carried over — the pending logic above owns those.
+          const olderFromCache = cached.blocks.filter(
+            (b) => b.ctx.itemId != null && !windowIds.has(b.ctx.itemId),
+          );
+          if (olderFromCache.length === 0) return {};
+          return {
+            blocks: [...olderFromCache, ...state.blocks],
+            oldestItemId: cached.oldestItemId ?? state.oldestItemId,
+            hasMoreHistory: cached.hasMoreHistory,
+          };
+        });
+      }
+    }
     racedNativeModelOptions.delete(id);
   } catch (err) {
     if (get().conversationId !== id) return;


### PR DESCRIPTION
## Related issue

Closes #2849

## Summary

Switching sessions in the web/desktop UI — including switching **back** to a session just viewed — took ~5-10s. `switchTo` resets `blocks` to `[]`, and the turn rail then re-runs the eager backfill (up to `MAX_EAGER_PAGES=10` × `EAGER_PAGE_LIMIT=200` **serial** `/items` pages) to surface its ticks. With no per-session cache, returning to a prior session pays that full multi-round-trip cost again, and it scales with session length: tool-heavy autonomous sessions have sparse user turns, so the loop hits its 10-page cap on essentially every open.

This adds a small **module-level (non-reactive) transcript cache**. `switchTo` stashes the loaded transcript on leave; on switch-back `bindStream` restores the older history from it instead of re-paging, so the rail already has enough turns and skips the backfill entirely (the "and back again" case becomes a single bind request).

### Why it can't drop messages

The restore preserves `bindStream`'s existing no-drop invariant. `bindStream` still fetches the fresh snapshot window as usual (never a stale snapshot), and the cache is bridged **only when that window shares an item id with it** — proof the two are contiguous. If items committed while the user was away pushed the window past the cache (no shared id), the cache is ignored and the normal load runs. So a stale cache can never drop a message into a gap or scramble order. Only strictly-older *committed* blocks are prepended; optimistic/live bubbles (no item id) are never carried over — the pending logic still owns those. An LRU cap bounds memory.

Scope: this is the primary transcript-backfill cost (fires on every open). The issue's secondary Files-panel probing is independent and left for a follow-up.

## Test Plan

Added to `web/src/store/chatStore.test.ts`:

- **restore path** — after loading two pages of a session, leaving, and returning, the full two-page transcript is back in order, `oldestItemId`/`hasMoreHistory` are restored, and it cost **exactly one** item request (the bind window) with **no `after=` re-paging**; a subsequent scroll-up still pages correctly.
- **gap-guard path** — a session that grew past the cache while away (fresh window shares no id) falls back to a clean reload: exactly the fresh page, then scroll-up walks the real contiguous history with nothing dropped or duplicated.

```
cd web && npx vitest run src/store/chatStore.test.ts
# 292 passed
```

The restore test fails with the seed logic disabled (blocks would be just the newest page); the gap-guard test holds either way. `tsc -b` and `oxlint` clean (the only warning is the established `__…ForTests` test-export convention, matching `__resetReadStateForTests`).

## Demo

No visual change — this is a latency fix, so the observable effect is request volume, which the tests assert directly. Before: a switch-back to a tool-heavy session re-runs the eager backfill (the issue measured ~14× `/items` per open, 10 of them the serial backfill). After: a switch-back to a cached session issues a **single** `/items` bind request and restores the rest from cache (asserted: exactly one request, no `after=` cursor fetch).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Both the restore and the gap-guard branches are covered end to end through `switchTo`/`bindStream` against the faithful `/items` mock (real keyset pagination), including the request-count assertion that proves the backfill is skipped and the scroll-up-after assertions that prove the restored/fallback state is internally consistent.

## Changelog

Switching back to a recently-viewed session in the web UI is now near-instant: the transcript is restored from an in-memory per-session cache instead of re-running the multi-request history backfill (guarded so no message is ever dropped when a session changed while you were away).
