### PR TITLE
fix(codex-native): keep task plans out of chat

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -3088,13 +3088,12 @@ async def _handle_turn_plan_updated(
     params: dict[str, Any],
 ) -> None:
     """
-    Mirror a Codex plan update in both the transcript and the todo panel.
+    Mirror a Codex plan update in the todo panel.
 
     Codex emits plan changes as app-server notifications rather than
     ordinary assistant text. The forwarder posts the structured plan as an
     ``external_session_todos`` event so the web ``TodoPanel`` renders it like
-    Claude's todo list, and also mirrors it as a compact assistant message so
-    the plan stays visible inline in the transcript.
+    Claude's todo list without duplicating it in the chat transcript.
 
     :param client: HTTP client for Omnigent event posts.
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
@@ -3108,20 +3107,6 @@ async def _handle_turn_plan_updated(
             session_id=session_id,
             todos=todos,
         )
-    text = _plan_text_from_update(params)
-    if not text:
-        return
-    await _post_external_item(
-        client,
-        session_id,
-        item_type="message",
-        item_data={
-            "role": "assistant",
-            "agent": _AGENT_NAME,
-            "content": [{"type": "output_text", "text": text}],
-        },
-        response_id=_response_id(params),
-    )
 
 
 def _handle_turn_diff_updated(
@@ -5288,11 +5273,10 @@ async def _post_review_mode_marker(
     Codex ``/review`` brackets a turn with ``enteredReviewMode`` /
     ``exitedReviewMode`` thread items. The web UI has no dedicated review
     affordance, and a review transition is session *state*, not user input —
-    so it is surfaced as a short assistant-message marker (the same visible
-    rail used for plan updates in :func:`_handle_turn_plan_updated`). A
-    user-role ``[System: …]`` note was rejected here because a non-meta
-    user item drains the pending-input FIFO server-side, which would
-    swallow the web user's next real message.
+    so it is surfaced as a short assistant-message marker. A user-role
+    ``[System: …]`` note was rejected here because a non-meta user item drains
+    the pending-input FIFO server-side, which would swallow the web user's next
+    real message.
 
     :param client: HTTP client for Omnigent event posts.
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
@@ -6885,37 +6869,6 @@ def _json_string(value: dict[str, Any]) -> str | None:
         return None
 
 
-def _plan_text_from_update(params: dict[str, Any]) -> str | None:
-    """
-    Render a Codex ``turn/plan/updated`` payload as Markdown text.
-
-    :param params: Codex plan update params.
-    :returns: Markdown plan text, or ``None`` when no valid plan steps
-        are present.
-    """
-    plan = params.get("plan")
-    if not isinstance(plan, list) or not plan:
-        return None
-    lines: list[str] = []
-    explanation = params.get("explanation")
-    if isinstance(explanation, str) and explanation:
-        lines.append(explanation)
-        lines.append("")
-    lines.append("Plan:")
-    for entry in plan:
-        if not isinstance(entry, dict):
-            continue
-        step = entry.get("step")
-        if not isinstance(step, str) or not step:
-            continue
-        status = entry.get("status")
-        marker = _plan_status_marker(status)
-        lines.append(f"{marker} {step}")
-    if len(lines) == 1 or (len(lines) == 3 and lines[-1] == "Plan:"):
-        return None
-    return "\n".join(lines)
-
-
 def _plan_todos_from_update(params: dict[str, Any]) -> list[dict[str, Any]] | None:
     """
     Map a Codex ``turn/plan/updated`` payload to the todo-list schema.
@@ -6960,20 +6913,6 @@ def _plan_todo_status(status: Any) -> str:
     if status in {"inProgress", "in_progress"}:
         return "in_progress"
     return "pending"
-
-
-def _plan_status_marker(status: Any) -> str:
-    """
-    Return a readable Markdown marker for a Codex plan step status.
-
-    :param status: Codex step status value.
-    :returns: Markdown list marker.
-    """
-    return {
-        "completed": "- [x]",
-        "in_progress": "- [~]",
-        "pending": "- [ ]",
-    }[_plan_todo_status(status)]
 
 
 def _response_id(params: dict[str, Any]) -> str:

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -5207,15 +5207,8 @@ def test_forwarder_skips_user_recovery_when_user_seen_live(tmp_path: Path) -> No
     assert fake_client.requests == []
 
 
-def test_forwarder_posts_codex_turn_plan_update(tmp_path: Path) -> None:
-    """
-    Codex ``turn/plan/updated`` notifications are visible in Omnigent web.
-
-    Plan mode emits plan state through a dedicated app-server
-    notification rather than assistant text. If the forwarder ignores
-    it, the terminal shows the plan while the web transcript appears to
-    skip straight to the final prompt.
-    """
+def test_forwarder_posts_codex_turn_plan_update_only_to_tasks(tmp_path: Path) -> None:
+    """Codex ``turn/plan/updated`` notifications update only the Tasks tab."""
     posted: list[dict[str, Any]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -5250,57 +5243,14 @@ def test_forwarder_posts_codex_turn_plan_update(tmp_path: Path) -> None:
                         "threadId": "thread_123",
                         "turnId": "turn_123",
                         "explanation": None,
-                        "plan": [
-                            {"step": "Inspect Codex plan events", "status": "completed"},
-                            {"step": "Mirror plans to web", "status": "inProgress"},
-                            {"step": "Run checks", "status": "pending"},
-                        ],
+                        "plan": [{"step": "Inspect Codex plan events", "status": "pending"}],
                     },
                 },
             )
 
     asyncio.run(run())
 
-    # The plan is mirrored to the todo panel and inline in the transcript.
-    assert len(posted) == 2
-    todos_post = next(p for p in posted if p["type"] == "external_session_todos")
-    assert todos_post["data"]["todos"] == [
-        {
-            "content": "Inspect Codex plan events",
-            "status": "completed",
-            "activeForm": "Inspect Codex plan events",
-        },
-        {
-            "content": "Mirror plans to web",
-            "status": "in_progress",
-            "activeForm": "Mirror plans to web",
-        },
-        {
-            "content": "Run checks",
-            "status": "pending",
-            "activeForm": "Run checks",
-        },
-    ]
-
-    message_post = next(p for p in posted if p["type"] == "external_conversation_item")
-    data = message_post["data"]
-    assert data["item_type"] == "message"
-    assert data["response_id"] == "codex_turn_123"
-    assert data["item_data"] == {
-        "role": "assistant",
-        "agent": "codex-native-ui",
-        "content": [
-            {
-                "type": "output_text",
-                "text": (
-                    "Plan:\n"
-                    "- [x] Inspect Codex plan events\n"
-                    "- [~] Mirror plans to web\n"
-                    "- [ ] Run checks"
-                ),
-            }
-        ],
-    }
+    assert [event["type"] for event in posted] == ["external_session_todos"]
 
 
 def test_plan_todos_from_update_maps_steps_and_statuses() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Stop mirroring Codex `turn/plan/updated` events as assistant messages, so task progress no longer appears in chat history.
- Keep the existing `external_session_todos` path intact for the Tasks tab and remove the now-unused Markdown formatters.

## Test Plan

- `uv run --extra dev pre-commit run --all-files`
- `uv run --extra dev pytest tests/test_codex_native.py -k 'turn_plan_update or plan_todos_from_update or completed_codex_plan_item'`
- In Omnigent Desktop, connect to a server running this branch, create a new Codex-native session in Default mode, ask Codex to use `update_plan`, and verify the steps appear under Tasks without a generated `Plan:` checklist in chat.

## Demo

Before:
<img width="1399" height="1055" alt="Screenshot 2026-07-25 at 00 29 40" src="https://github.com/user-attachments/assets/d7d8a668-b819-4fe7-bec9-54141ba7a0d8" />

After:
<img width="900" height="472" alt="Screenshot 2026-07-25 at 00 35 21" src="https://github.com/user-attachments/assets/1ae26c78-e443-4d9a-b042-ae7ee618da2c" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified in Omnigent Desktop with a new Codex-native Default-mode session: `update_plan` steps appeared and updated in Tasks, while no plan checklist was added to chat history.

## Changelog

Codex task plans now stay in Tasks instead of being duplicated in chat.
