### PR TITLE
docs(contributing): add Developer Certificate of Origin language and DCO file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,10 +177,27 @@ Frontend changes follow the same expectation with a different toolchain:
 - Styling/formatting-only changes, copy tweaks with no flow change, and
   refactors with no behaviour change are exempt, same as the backend.
 
+## Developer Certificate of Origin
+
+To contribute to this repository, you must sign off your commits to certify
+that you have the right to contribute the code and that it complies with the
+open source license. If you can certify the contents of the [DCO](DCO), add a
+`Signed-off-by` line to each commit message:
+
+```
+Signed-off-by: Joe Smith <joe.smith@email.com>
+```
+
+Please use your real name — pseudonymous/anonymous contributions are not
+accepted. If your `user.name` and `user.email` git configs are set, `git
+commit -s` adds the sign-off automatically. The DCO check on every pull
+request enforces this, so unsigned commits will block merging.
+
 ## Pull requests
 
 - Branch from `main`, keep changes focused, and include tests or docs when relevant.
-- Sign off your commits with `git commit -s` (Developer Certificate of Origin).
+- Sign off your commits with `git commit -s` (see
+  [Developer Certificate of Origin](#developer-certificate-of-origin) above).
 - Fill in the PR template. For **UI / frontend changes**, check the
   "UI / frontend change" box and attach a **video or images** in the `Demo`
   section showing the new behaviour, so reviewers can see it without checking

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
## Related issue

N/A — contributor-docs gap raised by legal review.

## Summary

- The DCO check (probot `dco` app, required by merge-ready) has been enforced on every PR since the repo went public, but `CONTRIBUTING.md` only carried a one-line "sign off your commits" bullet with no explanation of what the sign-off actually certifies.
- Add the standard [Developer Certificate of Origin 1.1](https://developercertificate.org/) text as a root `DCO` file, and a **Developer Certificate of Origin** section to `CONTRIBUTING.md` covering what the sign-off certifies, the `Signed-off-by` line format, the real-name requirement, and `git commit -s`.
- Follows the same pattern as [databricks/zerobus-sdk](https://github.com/databricks/zerobus-sdk?tab=contributing-ov-file), the reference our OSS legal team pointed to for DCO-based contribution language.

## Test Plan

- `pre-commit run --files CONTRIBUTING.md DCO` passes.
- Docs-only change; verified the new section's anchor link (`#developer-certificate-of-origin`) matches the heading, and the `DCO` file matches the canonical DCO 1.1 text verbatim.
- This PR's own commit is signed off, so the DCO check on this PR exercises the documented flow.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only change (Markdown + a verbatim license text file); no code paths to test. The DCO status check that enforces the documented behaviour already runs on every PR, including this one.

This pull request and its description were written by Isaac.
