### PR TITLE
fix(windows): unblock server tunnel, workspaces, and OS tools on native Windows

### DIFF
--- a/omnigent/_platform.py
+++ b/omnigent/_platform.py
@@ -21,7 +21,8 @@ import os
 import shutil
 import sys
 from contextlib import suppress
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import TextIO
 
 _logger = logging.getLogger(__name__)
 
@@ -265,6 +266,55 @@ def stable_user_id() -> str:
     except (OSError, KeyError, ModuleNotFoundError):
         name = os.environ.get("USERNAME") or os.environ.get("USER") or "user"
     return hashlib.sha256(name.encode("utf-8"), usedforsecurity=False).hexdigest()[:12]
+
+
+def is_absolute_path(path: str) -> bool:
+    """
+    Return whether *path* is absolute on POSIX **or** Windows.
+
+    Server-side validators may run on Linux while the session host is
+    Windows (or vice versa). ``os.path.isabs`` only understands the
+    *current* OS, so a Linux server would reject ``D:\\project``. Check
+    both :class:`~pathlib.PurePosixPath` and
+    :class:`~pathlib.PureWindowsPath` so drive-letter, UNC, and
+    ``/``-rooted paths are all accepted regardless of where the server
+    process runs.
+
+    :param path: A filesystem path string, e.g. ``"/Users/a/p"`` or
+        ``"D:\\\\Users\\\\a\\\\p"``.
+    :returns: ``True`` when either pure-path flavour treats it as absolute.
+    """
+    return PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute()
+
+
+def safe_console_print(
+    message: str,
+    *,
+    file: TextIO | None = None,
+    flush: bool = False,
+) -> None:
+    """
+    Print *message* without letting :exc:`UnicodeEncodeError` escape.
+
+    Lifecycle lines in the host tunnel (``✓ Connected``, ``↑ Runner
+    started``) used to call :func:`print` directly. On a legacy Windows
+    code page (cp1252 / cp936) those glyphs raise inside the tunnel
+    handler and tear down the WebSocket — the success message itself
+    crashes the connection. Catch the encode failure and retry with
+    replacement characters so the tunnel stays up; UTF-8 consoles still
+    get the original glyphs.
+
+    :param message: Text to write (may contain non-ASCII glyphs).
+    :param file: Destination stream; defaults to ``sys.stdout``.
+    :param flush: Forwarded to :func:`print`.
+    """
+    stream = sys.stdout if file is None else file
+    try:
+        print(message, file=stream, flush=flush)
+    except UnicodeEncodeError:
+        encoding = getattr(stream, "encoding", None) or "ascii"
+        fallback = message.encode(encoding, errors="replace").decode(encoding, errors="replace")
+        print(fallback, file=stream, flush=flush)
 
 
 def resolve_repo_symlink(path: Path) -> Path:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2650,6 +2650,10 @@ def _build_host_daemon_env(
             for key, value in os.environ.items()
             if key in _RUNNER_ENV_ALLOWLIST or key.startswith(daemon_env_prefixes)
         }
+    # Force UTF-8 mode so daemon stdout never raises UnicodeEncodeError on a
+    # legacy Windows code page. Harmless on POSIX; ``setdefault`` preserves an
+    # explicit PYTHONUTF8=0 opt-out.
+    env.setdefault("PYTHONUTF8", "1")
     return env
 
 

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import websockets.asyncio.client
 from websockets.exceptions import InvalidStatus, InvalidURI
 
-from omnigent._platform import WINDOWS_ENV_PASSTHROUGH
+from omnigent._platform import WINDOWS_ENV_PASSTHROUGH, safe_console_print
 from omnigent.env_credentials import env_names_with_omnigent_prefix
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_availability import HARNESS_BINARY_MISSING, HarnessAvailability
@@ -316,6 +316,11 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         "TERMINFO",
         "TERMINFO_DIRS",
         "LANG",
+        # Python stdio / UTF-8 mode knobs — not secrets. Without them the host
+        # strips a user-set PYTHONUTF8=1, and a legacy Windows code page raises
+        # UnicodeEncodeError on the ✓ / ↑ lifecycle glyphs, killing the tunnel.
+        "PYTHONUTF8",
+        "PYTHONIOENCODING",
         "SSL_CERT_FILE",
         "SSL_CERT_DIR",
         "REQUESTS_CA_BUNDLE",
@@ -590,6 +595,10 @@ def _build_runner_env(
         or key.startswith(_RUNNER_ENV_ALLOWLIST_PREFIXES)
         or key in forwarded
     }
+    # Force UTF-8 mode so runner stdout/stderr never raise UnicodeEncodeError
+    # on legacy Windows code pages when printing lifecycle glyphs. Harmless
+    # on POSIX (already UTF-8); process-essential config, not a secret.
+    env.setdefault("PYTHONUTF8", "1")
     env["RUNNER_SERVER_URL"] = server_url
     env[RUNNER_ID_ENV_VAR] = runner_id
     env[RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR] = binding_token
@@ -1028,7 +1037,9 @@ class HostProcess:
                 # terminal — print once per redirect streak so a foreground
                 # `omnigent host` shows the auth problem and its fix instead
                 # of sitting silent while it retries.
-                print(
+                # ``safe_console_print``: a legacy Windows code page must not
+                # UnicodeEncodeError-out of the reconnect loop on the ⚠ glyph.
+                safe_console_print(
                     f"⚠ {cause} Retrying — this also happens briefly while "
                     f"the server restarts. {self._credentials_fix_hint()}",
                     file=sys.stderr,
@@ -1204,7 +1215,9 @@ class HostProcess:
         # host's own terminal shows lifecycle lines, but the runner's real
         # output — the agent turn, tracebacks — lands only in this file.
         session_line = f"\n    session: {frame.session_id}" if frame.session_id else ""
-        print(
+        # ``safe_console_print``: a cp1252 console must not raise on ↑ and tear
+        # down the tunnel after the runner is already tracked.
+        safe_console_print(
             f"  ↑ Runner started: {runner_id} (pid={proc.pid})\n"
             f"    log: {_display_log_path(log_path)}"
             f"{session_line}",
@@ -1242,7 +1255,7 @@ class HostProcess:
                 handle.proc.kill()
                 handle.proc.wait()
         _logger.info("Stopped runner %s", frame.runner_id)
-        print(
+        safe_console_print(
             f"  ↓ Runner stopped: {frame.runner_id}",
             flush=True,
         )
@@ -2319,11 +2332,10 @@ class HostProcess:
         for runner_id, error in list(self._unreported_exits.items()):
             del self._unreported_exits[runner_id]
             await self._report_runner_exit(runner_id, error)
-        # ``print`` (not ``_logger.warning``) so the user always sees the
-        # success line after the noisy ``databricks.sdk`` warnings —
-        # otherwise the terminal goes silent after auth and there's no
-        # signal the WS handshake actually completed.
-        print(
+        # ``safe_console_print`` (not ``_logger.warning``) so the success line
+        # survives the noisy ``databricks.sdk`` warnings — and so a legacy code
+        # page can't UnicodeEncodeError on ✓ and tear the tunnel down here.
+        safe_console_print(
             f"✓ Connected as {self._identity.name!r} "
             f"({self._identity.host_id}), {len(hello.runners)} live runner(s). "
             "Listening for sessions — Ctrl-C to disconnect.",
@@ -2498,20 +2510,20 @@ def run_host_process(
     path = config_path or CONFIG_PATH
     identity = load_or_create_host_identity(path)
     if not path.exists():
-        print(f"Auto-generated {path} ({identity.host_id}, name: {identity.name})")
-    print(f"Connecting to {server_url} as {identity.name!r} ({identity.host_id})")
+        safe_console_print(f"Auto-generated {path} ({identity.host_id}, name: {identity.name})")
+    safe_console_print(f"Connecting to {server_url} as {identity.name!r} ({identity.host_id})")
     # Tell the user where logs land up front — `omnigent host` used to run
     # silently, so a stuck/quiet host gave no hint where to look. Session
     # work goes to per-runner files under the runner dir (the exact
     # file is printed when each runner launches). The host process's
     # own diagnostics go to the host destination.
-    print(f"Session logs: {_display_log_path(_runner_log_dir())}/")
-    print(f"This host's log: {_display_log_path(host_log_path)}")
+    safe_console_print(f"Session logs: {_display_log_path(_runner_log_dir())}/")
+    safe_console_print(f"This host's log: {_display_log_path(host_log_path)}")
     from omnigent.cli_diagnostics import current_cli_log_path
 
     _cli_log = current_cli_log_path()
     if _cli_log is not None and _cli_log != host_log_path:
-        print(f"CLI diagnostics: {_display_log_path(_cli_log)}")
+        safe_console_print(f"CLI diagnostics: {_display_log_path(_cli_log)}")
 
     host = HostProcess(identity, server_url)
     try:
@@ -2520,5 +2532,9 @@ def run_host_process(
         # Fail loud: a permanent connection failure must not look like the
         # process is still working. Print the cause + fix, then exit non-zero
         # instead of the old behavior of reconnecting silently forever.
-        print(f"\n✗ Could not connect to {server_url}.\n{exc}", file=sys.stderr, flush=True)
+        safe_console_print(
+            f"\n✗ Could not connect to {server_url}.\n{exc}",
+            file=sys.stderr,
+            flush=True,
+        )
         raise SystemExit(1) from exc

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -123,6 +123,7 @@ _DEFAULT_ENV_PASSTHROUGH: tuple[str, ...] = (
     # Python interpreter knobs that don't change security posture.
     "PYTHONHASHSEED",
     "PYTHONIOENCODING",
+    "PYTHONUTF8",
     "PYTHONUNBUFFERED",
     "PYTHONDONTWRITEBYTECODE",
     "PYTHONFAULTHANDLER",
@@ -495,7 +496,12 @@ class _HelperProcessClient:
         # paths/booleans — but we still keep the file private and ephemeral.
         r_fd: int | None = None
         if IS_WINDOWS:
-            assert self._tmpdir is not None
+            # The config-file fallback needs a private dir even when the
+            # sandbox is inactive — Job Object containment creates no scratch
+            # tmpdir the way bwrap/seatbelt do, so make one lazily here.
+            if self._tmpdir is None:
+                self._tmpdir = create_private_tmpdir()
+                set_temp_env(env, self._tmpdir)
             config_file = self._tmpdir / "helper-config.json"
             config_file.write_bytes(config_bytes)
             config_arg = ["--config-file", str(config_file)]

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -35,6 +35,7 @@ import httpx
 from fastapi import FastAPI, HTTPException, Query, Request, WebSocket
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
+from omnigent._platform import IS_WINDOWS
 from omnigent.entities.session_resources import (
     DEFAULT_ENVIRONMENT_ID,
     resolve_terminal_entry_by_resource_id,
@@ -3349,8 +3350,12 @@ def create_runner_app(
                     finally:
                         _publish_terminal_pending(_publish_event, session_id, False)
 
+        # The convenience REPL terminal is tmux/PTY-backed, which Windows has
+        # no implementation for — attempting it there only logs a traceback and
+        # flickers the UI's terminal-pending state on and back off.
         if (
             spec is not None
+            and not IS_WINDOWS
             and not is_native_harness(harness_name)
             and not _sa_name
             and resource_registry.terminal_registry is not None

--- a/omnigent/server/routes/_session_create_validation.py
+++ b/omnigent/server/routes/_session_create_validation.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 from typing import Any
 
+from omnigent._platform import is_absolute_path
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.model_override import validate_model_override
 from omnigent.reasoning_effort import EFFORT_VALUES, validate_effort
@@ -114,9 +115,9 @@ async def validate_existing_host_workspace(
             "workspace required when host_id is set",
             code=ErrorCode.INVALID_INPUT,
         )
-    if not workspace.startswith("/"):
+    if not is_absolute_path(workspace):
         raise OmnigentError(
-            "workspace must be an absolute path starting with /",
+            "workspace must be an absolute path",
             code=ErrorCode.INVALID_INPUT,
         )
     if agent_cache is None:

--- a/omnigent/server/routes/_workspace_validation.py
+++ b/omnigent/server/routes/_workspace_validation.py
@@ -29,6 +29,7 @@ import logging
 import secrets
 from typing import Any
 
+from omnigent._platform import is_absolute_path
 from omnigent.host.frames import HostStatFrame, encode_host_frame
 from omnigent.server.host_registry import HostConnection, HostRegistry
 
@@ -214,11 +215,13 @@ async def validate_workspace(
         The exception message is suitable for surfacing to the
         API caller verbatim.
     """
-    if not workspace.startswith("/"):
+    if not is_absolute_path(workspace):
         # Belt-and-suspenders. The Pydantic schema layer also
         # rejects this; pin it here so direct callers (tests,
-        # other server-internal paths) can't bypass.
-        raise WorkspaceValidationError("workspace must be an absolute path starting with /")
+        # other server-internal paths) can't bypass. Accepts POSIX
+        # and Windows (``D:\\...``, UNC) forms so a Linux server can
+        # validate a Windows host's workspace.
+        raise WorkspaceValidationError("workspace must be an absolute path")
 
     display_host = host_name_for_errors or host_id
 

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -272,6 +272,37 @@ def test_build_host_daemon_env_remote_strips_provider_credentials(
     assert env["DATABRICKS_TOKEN"] == "test-databricks-token"
 
 
+def test_build_host_daemon_env_forces_pythonutf8(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Daemon env always sets PYTHONUTF8 so cp1252 consoles cannot crash.
+
+    Without this, a user-exported PYTHONUTF8=1 is stripped by the allowlist
+    and lifecycle glyphs (✓ / ↑) raise UnicodeEncodeError inside the tunnel
+    handler, tearing down the connection after a successful handshake.
+    """
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.delenv("PYTHONUTF8", raising=False)
+
+    local_env = _build_host_daemon_env(server_url=None)
+    remote_env = _build_host_daemon_env(server_url="https://example.databricksapps.com")
+
+    assert local_env["PYTHONUTF8"] == "1"
+    assert remote_env["PYTHONUTF8"] == "1"
+
+
+def test_build_host_daemon_env_preserves_explicit_pythonutf8(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit PYTHONUTF8 from the parent shell survives setdefault."""
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("PYTHONUTF8", "0")
+
+    env = _build_host_daemon_env(server_url=None)
+
+    assert env["PYTHONUTF8"] == "0"
+
+
 def test_ensure_host_daemon_reuses_same_target(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1536,6 +1536,8 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     assert env["HOME"] == "/home/alice"
     assert env["LANG"] == "en_US.UTF-8"
     assert env["LC_CTYPE"] == "UTF-8"
+    # Forced so lifecycle glyphs cannot crash runners on cp1252.
+    assert env["PYTHONUTF8"] == "1"
     # Databricks config selectors are allowlisted ambient passthrough —
     # the ambient value reaches the runner unmodified (no flag override).
     assert env["DATABRICKS_CONFIG_PROFILE"] == "ambient"

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -401,3 +401,69 @@ def test_shell_command_does_not_see_omnigent_project_root(
     out = result.get("stdout", "")
     assert project_entry in out
     assert str(_project_root()) not in out
+
+
+def test_windows_inactive_sandbox_creates_tmpdir_for_config_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Windows config-file delivery must create a tmpdir when sandbox is inactive.
+
+    On Windows the helper config cannot ride an inherited pipe fd, so
+    ``_start_locked`` writes ``helper-config.json`` into ``self._tmpdir``.
+    That tmpdir used to be created only when ``sandbox.active`` — but
+    Windows Job Object containment never activates a filesystem sandbox,
+    so the assert fired and every OS tool returned an empty error.
+    """
+    import json
+    from unittest.mock import MagicMock
+
+    import omnigent.inner.os_env as os_env_mod
+    from omnigent.inner.os_env import _HelperProcessClient
+
+    monkeypatch.setattr(os_env_mod, "IS_WINDOWS", True)
+    created: list[Path] = []
+
+    def _fake_tmpdir() -> Path:
+        d = tmp_path / f"osenv-{len(created)}"
+        d.mkdir()
+        created.append(d)
+        return d
+
+    monkeypatch.setattr(os_env_mod, "create_private_tmpdir", _fake_tmpdir)
+
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = None
+    fake_proc.stdin = MagicMock()
+    fake_proc.stdout = MagicMock()
+    fake_proc.stderr = MagicMock()
+    captured: dict[str, object] = {}
+
+    def _fake_popen(argv, **kwargs):
+        captured["argv"] = list(argv)
+        captured["env"] = dict(kwargs.get("env") or {})
+        return fake_proc
+
+    monkeypatch.setattr(os_env_mod.subprocess, "Popen", _fake_popen)
+
+    client = _HelperProcessClient(
+        cwd=tmp_path,
+        shell_path="cmd.exe",
+        sandbox=_inactive_policy(),
+    )
+    try:
+        client._start_locked()
+    finally:
+        client._tmpdir = None  # avoid rmtree of our tmp_path child in close
+        client._proc = None
+        client.close()
+
+    assert created, "Windows inactive sandbox must create a private tmpdir"
+    assert "--config-file" in captured["argv"]
+    config_path = Path(captured["argv"][captured["argv"].index("--config-file") + 1])
+    assert config_path.parent == created[0]
+    assert config_path.is_file()
+    payload = json.loads(config_path.read_bytes())
+    assert payload["cwd"] == str(tmp_path)
+    # Temp env vars point at the private dir so helper scratch stays contained.
+    assert captured["env"]["TMP"] == str(created[0])

--- a/tests/inner/test_proc_and_platform.py
+++ b/tests/inner/test_proc_and_platform.py
@@ -453,3 +453,39 @@ def test_cli_fallback_dirs_no_nvm_dir_is_safe(monkeypatch, tmp_path):
     monkeypatch.setattr(_platform.Path, "home", staticmethod(lambda: tmp_path))
     dirs = _platform._cli_fallback_dirs()
     assert tmp_path / ".local" / "bin" in dirs
+
+
+def test_is_absolute_path_accepts_posix_and_windows_forms() -> None:
+    """Cross-OS absolute check accepts drive-letter paths on a POSIX server.
+
+    ``os.path.isabs(r"D:\\proj")`` is False on Linux, which is how a Linux
+    server used to reject every Windows workspace. Either pure-path flavour
+    treating it as absolute is enough for a path to pass.
+    """
+    assert _platform.is_absolute_path("/Users/alice/proj") is True
+    assert _platform.is_absolute_path(r"D:\Users\alice\proj") is True
+    assert _platform.is_absolute_path(r"D:/Users/alice/proj") is True
+    assert _platform.is_absolute_path(r"\\server\share\proj") is True
+    assert _platform.is_absolute_path("some/relative") is False
+    assert _platform.is_absolute_path("~/projects") is False
+    assert _platform.is_absolute_path("") is False
+
+
+def test_safe_console_print_survives_legacy_code_page() -> None:
+    """Lifecycle glyphs must not raise on a cp1252 stream."""
+    import io
+
+    class _Cp1252Stream(io.TextIOWrapper):
+        def write(self, s: str) -> int:
+            encoded = s.encode("cp1252")  # raises on ✓ / ↑
+            return self.buffer.write(encoded)
+
+    buf = io.BytesIO()
+    stream = _Cp1252Stream(buf, encoding="cp1252", errors="strict")
+    # Must not raise — replacement characters land instead of the glyphs.
+    _platform.safe_console_print("✓ Connected as 'host'", file=stream, flush=True)
+    _platform.safe_console_print("  ↑ Runner started", file=stream, flush=True)
+    out = buf.getvalue()
+    assert out  # something was written
+    # Round-trip through cp1252 must succeed (no undecodable leftovers).
+    out.decode("cp1252")

--- a/tests/runner/test_app_sessions_native_terminal_routing.py
+++ b/tests/runner/test_app_sessions_native_terminal_routing.py
@@ -836,22 +836,26 @@ async def test_auto_create_repl_terminal_inherits_agent_sandbox(
 
 
 @pytest.mark.parametrize(
-    ("harness", "sub_agent_name", "expect_created"),
+    ("harness", "sub_agent_name", "is_windows", "expect_created"),
     [
         # SDK harness, top-level → REPL terminal auto-creates.
-        ("openai-agents", None, True),
+        ("openai-agents", None, False, True),
         # Sub-agent sessions surface through the parent transcript — no
         # REPL pane of their own.
-        ("openai-agents", "worker", False),
+        ("openai-agents", "worker", False, False),
         # Native harnesses own a dedicated terminal (the vendor TUI); the
         # REPL pane must not double up next to it.
-        ("codex-native", None, False),
+        ("codex-native", None, False, False),
+        # The REPL pane is tmux/PTY-backed, which Windows cannot launch —
+        # skip it there instead of logging a traceback every session.
+        ("openai-agents", None, True, False),
     ],
 )
 @pytest.mark.asyncio
 async def test_create_session_repl_terminal_dispatch(
     harness: str,
     sub_agent_name: str | None,
+    is_windows: bool,
     expect_created: bool,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -860,20 +864,23 @@ async def test_create_session_repl_terminal_dispatch(
     ``POST /v1/sessions`` auto-creates the REPL terminal for SDK sessions only.
 
     Exercises the route-level dispatch condition: non-native harness AND
-    top-level session AND a terminal registry present. If the condition
-    regresses, either SDK sessions lose their embedded web TUI (no
-    create) or native / sub-agent sessions grow a spurious second
-    terminal (over-create).
+    top-level session AND a terminal registry present AND not Windows. If
+    the condition regresses, either SDK sessions lose their embedded web
+    TUI (no create) or native / sub-agent / Windows sessions grow a
+    spurious second terminal (over-create).
 
     :param harness: Harness id resolved from the agent spec,
         e.g. ``"openai-agents"``.
     :param sub_agent_name: ``sub_agent_name`` in the POST body, or
         ``None`` for a top-level session.
+    :param is_windows: Platform the dispatch gate sees. Pinned so the
+        matrix behaves identically on every host OS.
     :param expect_created: Whether the REPL auto-create must fire.
     :param tmp_path: Temporary directory isolating bridge state.
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
+    monkeypatch.setattr("omnigent.runner.app.IS_WINDOWS", is_windows)
     # Keep the codex-native branch's bridge writes inside tmp_path.
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
 

--- a/tests/server/integration/test_scheduled_tasks_routes.py
+++ b/tests/server/integration/test_scheduled_tasks_routes.py
@@ -41,7 +41,7 @@ def _stub_host_workspace_validation(monkeypatch: pytest.MonkeyPatch) -> None:
             from omnigent.errors import ErrorCode, OmnigentError
 
             raise OmnigentError(
-                "workspace must be an absolute path starting with /",
+                "workspace must be an absolute path",
                 code=ErrorCode.INVALID_INPUT,
             )
         return workspace

--- a/tests/server/routes/test_workspace_validation.py
+++ b/tests/server/routes/test_workspace_validation.py
@@ -606,3 +606,31 @@ async def test_tilde_boundary_passed_through_to_host(
         spec_cwd="~/universe",
     )
     assert canonical == "/Users/corey/universe/src/foo"
+
+
+async def test_windows_drive_workspace_accepted(
+    host_setup: tuple[HostRegistry, _FakeWebSocket, asyncio.Task[None]],
+) -> None:
+    """
+    A Windows drive-letter workspace must pass the absolute-path guard.
+
+    The validator may run on a Linux server while the host is Windows.
+    ``os.path.isabs(r"D:\\proj")`` is False on Linux, so the old
+    ``startswith("/")`` check (and a naive ``os.path.isabs`` swap) both
+    reject valid Windows workspaces with HTTP 400.
+    """
+    registry, _, _ = host_setup
+    win_workspace = r"D:\Users\alice\proj"
+    _set_stat(
+        registry,
+        win_workspace,
+        canonical=win_workspace,
+    )
+
+    canonical = await validate_workspace(
+        host_registry=registry,
+        host_id=_HOST_ID,
+        workspace=win_workspace,
+        spec_cwd=".",
+    )
+    assert canonical == win_workspace


### PR DESCRIPTION
## Related issue

Refs #2422 — intentionally **not** a closing keyword, because the older community PR #2424 already says "Fixes #2422". See the overlap note below.

## Summary

**ELI5:** On a native Windows box, you could install Omnigent and start the server, but you could not actually get an agent to do anything. Four separate bugs sat in a row: the host printed a checkmark that crashed its own connection, you couldn't turn that off, the server rejected `C:\...` as "not an absolute path", and once past all that every shell command came back empty. Each bug hid the next one.

#2422 documents five chained defects inside the subset the README promises works on Windows (`omnigent server`, the web UI, SDK harnesses). This PR fixes the four that are still outstanding.

```
omnigent server ──► omnigent host ──► create session ──► agent runs a shell command
       │                  │                  │                      │
  (1) os.getuid()    (2) cp1252 glyph   (3) "C:\proj" is      (5) tmpdir assert
      at import          tears down          not absolute          fires
      ALREADY FIXED      the tunnel          → HTTP 400        → {"error": ""}
      on main                 │
                        (4) PYTHONUTF8 stripped from the daemon env
                            → you can't even work around (2) from your shell
```

- **(2) Host tunnel** — the success line printed right after the WS handshake raised `UnicodeEncodeError` on a legacy code page, tearing the tunnel down from inside its own handler. The `↑` in the runner-started line did the same one step later, surfacing as a misleading 504 even though the runner had started. `safe_console_print()` falls back to replacement characters; UTF-8 consoles still get the real glyphs.
- **(4) Env allowlist** — `PYTHONUTF8` / `PYTHONIOENCODING` were filtered out of the daemon and runner env, so setting them in your shell could not work around (2). Both now pass through, and `PYTHONUTF8` defaults to `1` (an explicit `PYTHONUTF8=0` still wins).
- **(3) Workspace validation** — `workspace.startswith("/")` rejected every Windows path with HTTP 400. `is_absolute_path()` also accepts drive-letter and UNC forms, so a **Linux** server can validate a **Windows** host's workspace.
- **(5) OS tools** — the Windows config-file fallback asserted a tmpdir that only the active-sandbox path created, but Job Object containment never activates a filesystem sandbox. Every `sys_os_*` call returned `{"error": ""}`. That branch now creates the tmpdir lazily.

Plus one adjacent wart: the tmux-backed REPL terminal auto-create is now skipped on Windows. It could never succeed there, and it logged a traceback and flickered the UI's terminal-pending state on **every** session start.

### Overlap with #2424

| # | Defect | Where it stands |
|---|--------|-----------------|
| 1 | `os.getuid()` at import in 4 native bridges | **Already on `main`** — the bridges use `tempfile.gettempdir()` / `stable_user_id()` today, so #2424's half of this is now redundant |
| 2 | cp1252 glyph tears down the tunnel | **This PR** — no open PR covers it |
| 3 | POSIX-only workspace validation | **This PR.** #2424 also fixes this, but edits `omnigent/server/routes/sessions.py`, which no longer exists (refactored into `server/routes/sessions/` + `_session_create_validation.py`) |
| 4 | env allowlist strips `PYTHONUTF8` | **This PR** — no open PR covers it |
| 5 | `os_env` tmpdir assert | **This PR** — no open PR covers it |

Happy to rebase if #2424 lands first, or to have this supersede it — maintainer's call. I did not want to file a competing `Closes` and have one of them auto-closed.

## Test Plan

Verified end-to-end on **Windows 11 native (no WSL), Python 3.12.13**, against a live local server + host.

**(2) cp1252 tunnel** — ran the host on a forced legacy code page:

```powershell
$env:PYTHONIOENCODING = "cp1252"; $env:PYTHONUTF8 = "0"; omnigent host
```

```
? Connected as 'ELD1' (8d6709dc...), 0 live runner(s). Listening for sessions ? Ctrl-C to disconnect.
```

The glyph degrades to `?` and **the tunnel stays up** — `GET /v1/hosts` reported `status=online` continuously for several minutes. Confirmed a bare `print()` of the same line on an identical stream still raises `UnicodeEncodeError: 'charmap' codec can't encode character '\u2713'`.

**(3) Workspace** — `POST /v1/sessions` with `workspace: "C:\Users\...\Omnigent"` returns 201 with the path stored verbatim and `runner_online: true`; the runner's git probe then ran in that directory. Pre-fix this was a 400.

**(5) OS tools** — drove the real helper process with the sandbox inactive:

```
sandbox        active=False backend='none'
sys_os_shell   error=None  {'stdout': 'hello-from-windows-helper\n', 'exit_code': 0}
sys_os_write   error=None  {'bytes_written': 18, 'created': True}
sys_os_read    error=None  'line one\nline two'
```

**REPL terminal** — a fresh session's runner log now contains zero `ERROR` / `Traceback` lines; previously every Windows session start logged the tmux `RuntimeError`.

**Suite:** `188 passed, 3 failed` across the touched files. All three failures reproduce identically without this change (verified individually against a no-change baseline) and are pre-existing Windows gaps: a hardcoded `/opt/venvs/...` POSIX assertion, `omnigent claude` native tmux being unsupported on Windows by design, and a native-Claude error-string difference. `ruff check` and `ruff format --check` are clean.

Two of the new tests land in `windows.yml`'s **hard** (must-pass) step via `tests/inner/test_proc_and_platform.py`; the rest are platform-independent (they monkeypatch `IS_WINDOWS`) so Linux CI covers them.

## Demo

`omnigent host` on a legacy Windows code page (cp1252), before and after this PR.
Windows 11 native, no WSL, Python 3.12.13.

<img width="741" height="683" alt="Screenshot 2026-07-24 190415" src="https://github.com/user-attachments/assets/f5c16d99-6efb-4def-ba27-70d5f3a9fbb5" />


**Top** — on `main`, the success line raises `UnicodeEncodeError: 'charmap' codec
can't encode character '\u2713'` *inside the tunnel handler*, so the connection
tears itself down and the host retries forever without ever coming online. The
run prints nothing; the failure is only visible in the host log.

**Bottom** — with the fix, the glyph degrades to `?` and the tunnel stays up:
`Connected as 'ELD1' ... Listening for sessions`.

Note this reproduces whenever stdout is not a console — piped, redirected, or
running as the background daemon. An interactive run in Windows Terminal writes
UTF-16 directly and looks healthy, which is why the daemon path fails while
`omnigent host` by hand appears fine.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Six new unit tests cover the four fixes: `is_absolute_path` across POSIX/drive-letter/UNC forms, `safe_console_print` against a cp1252 stream, `PYTHONUTF8` forced in the daemon env (and the `PYTHONUTF8=0` opt-out preserved), the lazy tmpdir on an inactive Windows sandbox, and a Windows drive workspace passing `validate_workspace`. The REPL-terminal skip is covered by adding a Windows case to the existing `test_create_session_repl_terminal_dispatch` matrix; its three original cases now pin `IS_WINDOWS=False`, which also fixes a latent Windows-only failure in that test.

The tunnel-survives-a-real-handshake behaviour and the live `sys_os_*` round trip are manual only — both need a real host process and a real helper subprocess, which the unit layer stubs out.

## Changelog

Omnigent now runs on native Windows: the host tunnel survives legacy console code pages, `C:\...` workspaces are accepted, and agent shell/file tools work.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
