### PR TITLE
fix(native): apply routed model with the message, not a racing event

### DIFF
--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -12,8 +12,10 @@ from typing import Any
 from omnigent.claude_native_bridge import (
     BRIDGE_DIR_ENV_VAR,
     REQUEST_SESSION_ID_ENV_VAR,
+    inject_slash_command,
     inject_user_message,
     read_active_session_id,
+    read_launch_model,
 )
 from omnigent.inner.executor import (
     Executor,
@@ -60,6 +62,10 @@ class ClaudeNativeExecutor(Executor):
         # adapter caching one executor per conversation; per-turn
         # construction would regress the lock to per-turn scope.
         self._inject_lock = asyncio.Lock()
+        # The model the pane is currently on, so a routing turn only types
+        # ``/model`` when the model actually changes. Seeded lazily from the
+        # spawn ``launch_model`` on the first turn (``None`` = not yet known).
+        self._applied_model: str | None = None
 
     def supports_streaming(self) -> bool:
         """:returns: ``False`` because output is emitted by the transcript forwarder."""
@@ -115,12 +121,15 @@ class ClaudeNativeExecutor(Executor):
         :param system_prompt: System prompt from the agent spec. The
             native Claude Code terminal controls its own prompt/settings,
             so this is ignored.
-        :param config: Per-turn executor config. Unused by this
-            terminal-backed executor.
+        :param config: Per-turn executor config. Only ``config.model``
+            is used: when intelligent routing picks a model for this turn,
+            it arrives here (adapter maps ``request.model_override`` →
+            ``config.model``) and the switch is applied inline, before the
+            message — see the ``/model`` handling below.
         :yields: :class:`TurnComplete` after the input was injected,
             or :class:`ExecutorError` on bridge failure.
         """
-        del tools, system_prompt, config
+        del tools, system_prompt
         if not _session_is_active(self._bridge_dir, self._request_session_id):
             yield ExecutorError(
                 message=(
@@ -139,9 +148,35 @@ class ClaudeNativeExecutor(Executor):
         # native path. session.id is applied generically by the span processor
         # (the executor adapter binds session_scope for the turn), so there's
         # no per-call-site stamping here.
+        #
+        # Apply a routed ``/model`` switch and inject the message as ONE
+        # step under ``_inject_lock``. Intelligent routing used to switch
+        # the model with a separate server-issued ``model_change`` event
+        # that raced this inject on the same tmux pane, so the message's
+        # keystrokes could land mid-switch and be lost (the "routing drops
+        # the first message" bug). Folding the switch into the turn under
+        # the same lock removes the second writer entirely: ``/model`` fully
+        # commits, then ``inject_user_message`` (which waits for the input
+        # box and verifies its submit) delivers the message — in order,
+        # once.
+        wanted_model = config.model if config is not None else None
         try:
             with telemetry.span("claude_native.inject"):
                 async with self._inject_lock:
+                    if self._should_switch_model(wanted_model):
+                        await asyncio.to_thread(
+                            inject_slash_command,
+                            self._bridge_dir,
+                            command=f"/model {wanted_model}",
+                            # Accept the switch dialog if the CLI ever pops one,
+                            # matching the manual picker path. Runs to completion
+                            # before the message inject below (same lock), so its
+                            # confirm Enter can't race the message; a no-op on the
+                            # gateway pane, which switches inline with no dialog.
+                            auto_confirm=True,
+                        )
+                        # ``wanted_model`` is non-None here (guarded above).
+                        self._applied_model = wanted_model
                     await asyncio.to_thread(
                         inject_user_message,
                         self._bridge_dir,
@@ -151,6 +186,30 @@ class ClaudeNativeExecutor(Executor):
             yield ExecutorError(message=str(exc))
             return
         yield TurnComplete(response=None)
+
+    def _should_switch_model(self, wanted_model: str | None) -> bool:
+        """
+        Return whether this turn must type ``/model`` before the message.
+
+        Only switches when routing named a model AND it differs from the
+        model the pane is already on. The baseline is tracked per turn in
+        ``_applied_model``, seeded lazily from the spawn ``launch_model``
+        so turn 1's routed pick is compared against what Claude actually
+        booted with — not blindly re-issued.
+
+        :param wanted_model: The turn's routed model, or ``None`` when the
+            turn carries no override (routing off / already-pinned session).
+        :returns: ``True`` when a ``/model`` switch is required.
+        """
+        if not wanted_model:
+            return False
+        if self._applied_model is None:
+            # First turn: compare against the spawn model. read_launch_model
+            # is best-effort (None when no ucode profile was active); an
+            # unknown baseline means we switch to be safe — a redundant
+            # ``/model`` to the current model is a harmless no-op.
+            self._applied_model = read_launch_model(self._bridge_dir)
+        return wanted_model != self._applied_model
 
 
 def _bridge_dir_from_env() -> Path:

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -3167,6 +3167,7 @@ async def _forward_native_subagent_terminal_failure(
 def _build_native_terminal_message_event(
     conv: Conversation,
     body: SessionEventInput,
+    model_override: str | None = None,
 ) -> dict[str, Any]:
     """
     Build the runner event that delivers a web message to a native TUI.
@@ -3175,6 +3176,11 @@ def _build_native_terminal_message_event(
     :param body: Validated Sessions API message event, e.g.
         ``{"type": "message", "data": {"role": "user",
         "content": [{"type": "input_text", "text": "Hi"}]}}``.
+    :param model_override: Routed model to apply for THIS turn, e.g.
+        ``"databricks-claude-sonnet-5"``. Carried in-band on the message
+        so the claude-native executor applies ``/model`` and injects the
+        message under one lock (no separate racing ``model_change``
+        event). ``None`` when routing did not pick a model.
     :returns: Harness ``MessageEvent`` body for the runner-local
         native terminal harness, including ``agent_id`` so the runner
         can resolve the harness spec on the first message.
@@ -3187,7 +3193,7 @@ def _build_native_terminal_message_event(
             f"{display_name} terminal sessions accept only user message events",
             code=ErrorCode.INVALID_INPUT,
         )
-    return {
+    event: dict[str, Any] = {
         "type": "message",
         "role": "user",
         "content": data.content,
@@ -3202,6 +3208,13 @@ def _build_native_terminal_message_event(
         # which always includes it.
         "agent_id": conv.agent_id,
     }
+    # Ride the routed model in-band as ``model_override`` (extra field the
+    # harness MessageEvent forwards into ExecutorConfig.model). The
+    # claude-native executor applies the ``/model`` switch and the message
+    # inject as ONE locked step, so the switch can't race the message.
+    if model_override is not None:
+        event["model_override"] = model_override
+    return event
 
 
 async def _forward_native_terminal_message(
@@ -3211,6 +3224,7 @@ async def _forward_native_terminal_message(
     body: SessionEventInput,
     file_store: FileStore | None = None,
     artifact_store: ArtifactStore | None = None,
+    model_override: str | None = None,
 ) -> None:
     """
     Forward one Omnigent web-chat message to the native terminal harness.
@@ -3230,12 +3244,16 @@ async def _forward_native_terminal_message(
         content blocks.
     :param artifact_store: Optional binary content store for
         fetching file bytes during resolution.
+    :param model_override: Routed model to apply for this turn, carried
+        in-band on the message so the executor applies ``/model`` and the
+        inject under one lock (no separate racing ``model_change``).
+        ``None`` when routing did not pick a model.
     :returns: None.
     :raises HTTPException: 502 when the runner or harness rejects
         the injection request.
     """
     display_name, _, _ = _native_terminal_runtime(conv)
-    event = _build_native_terminal_message_event(conv, body)
+    event = _build_native_terminal_message_event(conv, body, model_override=model_override)
     _logger.info(
         "%s terminal message forward starting: session=%s block_types=%s",
         display_name,
@@ -3938,22 +3956,14 @@ async def _dispatch_session_event_to_runner_impl(
                             session_id,
                             exc_info=True,
                         )
-                    # For claude-native: inject /model into the running
-                    # terminal so the change takes effect immediately
-                    # (model_override alone is only applied at spawn).
-                    try:
-                        await runner_client.post(
-                            f"/v1/sessions/{session_id}/events",
-                            json={"type": "model_change", "model": _native_routed_model},
-                            timeout=5.0,
-                        )
-                    except httpx.HTTPError:
-                        _logger.debug(
-                            "smart_routing: model_change forward failed for session=%s "
-                            "(runner may not support it yet)",
-                            session_id,
-                        )
         # ────────────────────────────────────────────────────────────
+        # Forward the message, carrying any routed model in-band. The
+        # executor applies ``/model`` and injects the message as ONE step
+        # under its pane lock, so the switch can't race the message inject
+        # on the tmux pane (the earlier separate ``model_change`` POST did,
+        # dropping the first message). model_override alone is applied only
+        # at spawn, so the in-band switch is what makes routing take on an
+        # already-running pane.
         forwarded = False
         try:
             await _forward_native_terminal_message(
@@ -3963,6 +3973,7 @@ async def _dispatch_session_event_to_runner_impl(
                 body,
                 file_store=file_store,
                 artifact_store=artifact_store,
+                model_override=_native_routed_model,
             )
             forwarded = True
         finally:

--- a/tests/inner/test_claude_native_executor.py
+++ b/tests/inner/test_claude_native_executor.py
@@ -13,7 +13,7 @@ import pytest
 from omnigent.claude_native_bridge import REQUEST_SESSION_ID_ENV_VAR
 from omnigent.inner import claude_native_executor
 from omnigent.inner.claude_native_executor import ClaudeNativeExecutor
-from omnigent.inner.executor import ExecutorError, TurnComplete
+from omnigent.inner.executor import ExecutorConfig, ExecutorError, TurnComplete
 
 # Minimal valid 1x1 white PNG used for multimodal attachment tests.
 _TINY_PNG_B64 = (
@@ -815,3 +815,171 @@ async def test_run_turn_path_traversal_filename_sanitized(
     assert len(written) == 1
     assert written[0].name == ".bashrc"
     assert written[0].parent == uploads
+
+
+@pytest.mark.asyncio
+async def test_run_turn_applies_routed_model_before_message_under_one_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A routed model is switched via ``/model`` BEFORE the message, in order.
+
+    Intelligent routing delivers the picked model on the turn (adapter maps
+    ``request.model_override`` -> ``config.model``). The executor must type
+    ``/model <routed>`` and then inject the message as one sequence under
+    ``_inject_lock`` — never as a separate racing writer. This test records
+    the call order across both injectors and asserts ``/model`` lands first,
+    then the message, exactly once each. A regression that dropped the switch
+    (or ran it concurrently) would fail the ordering assertion.
+    """
+    monkeypatch.delenv(REQUEST_SESSION_ID_ENV_VAR, raising=False)
+    bridge_dir = tmp_path / "bridge"
+    calls: list[tuple[str, str]] = []
+
+    def fake_inject_slash_command(
+        bridge_dir_arg: Path,
+        *,
+        command: str,
+        timeout_s: float = 30.0,
+        auto_confirm: bool = False,
+    ) -> None:
+        """Record the ``/model`` switch keystroke and its auto_confirm flag."""
+        del bridge_dir_arg, timeout_s
+        calls.append(("slash", command, auto_confirm))
+
+    def fake_inject_user_message(
+        bridge_dir_arg: Path,
+        *,
+        content: str,
+        timeout_s: float = 30.0,
+    ) -> None:
+        """Record the message inject."""
+        del bridge_dir_arg, timeout_s
+        calls.append(("message", content))
+
+    # No ucode profile at launch -> unknown baseline -> the routed model is
+    # treated as a change and switched.
+    monkeypatch.setattr(claude_native_executor, "read_launch_model", lambda _bridge: None)
+    monkeypatch.setattr(claude_native_executor, "inject_slash_command", fake_inject_slash_command)
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fake_inject_user_message)
+
+    executor = ClaudeNativeExecutor(bridge_dir)
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "review this function"}],
+            tools=[],
+            system_prompt="",
+            config=ExecutorConfig(model="databricks-claude-sonnet-5"),
+        )
+    ]
+
+    assert calls == [
+        # auto_confirm=True mirrors the manual picker path so the switch is
+        # accepted if the CLI ever pops a confirmation dialog.
+        ("slash", "/model databricks-claude-sonnet-5", True),
+        ("message", "review this function"),
+    ], f"Expected /model (auto_confirm) then message, in order; got {calls}."
+    assert events == [TurnComplete(response=None)]
+
+
+@pytest.mark.asyncio
+async def test_run_turn_without_model_override_injects_message_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    No routed model -> no ``/model`` typed, message injected as before.
+
+    A non-routing turn (config.model None) must not touch the model at all —
+    typing ``/model`` on every turn would be wrong and noisy.
+    """
+    monkeypatch.delenv(REQUEST_SESSION_ID_ENV_VAR, raising=False)
+    bridge_dir = tmp_path / "bridge"
+    slash_calls: list[str] = []
+    msg_calls: list[str] = []
+
+    def fake_inject_slash_command(
+        bridge_dir_arg: Path, *, command: str, timeout_s: float = 30.0, auto_confirm: bool = False
+    ) -> None:
+        del bridge_dir_arg, timeout_s, auto_confirm
+        slash_calls.append(command)
+
+    def fake_inject_user_message(
+        bridge_dir_arg: Path, *, content: str, timeout_s: float = 30.0
+    ) -> None:
+        del bridge_dir_arg, timeout_s
+        msg_calls.append(content)
+
+    monkeypatch.setattr(claude_native_executor, "inject_slash_command", fake_inject_slash_command)
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fake_inject_user_message)
+
+    executor = ClaudeNativeExecutor(bridge_dir)
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            system_prompt="",
+            config=ExecutorConfig(model=None),
+        )
+    ]
+
+    assert slash_calls == [], f"No /model expected without a routed model; got {slash_calls}."
+    assert msg_calls == ["hi"]
+    assert events == [TurnComplete(response=None)]
+
+
+@pytest.mark.asyncio
+async def test_run_turn_skips_model_switch_when_already_on_that_model(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A routed model equal to the pane's launch model types no ``/model``.
+
+    ``read_launch_model`` reports what Claude booted with; if routing picks
+    that same model there is nothing to switch, so the executor must inject
+    the message only. Prevents a pointless ``/model`` (and the turn churn it
+    would add) when the pane is already correct.
+    """
+    monkeypatch.delenv(REQUEST_SESSION_ID_ENV_VAR, raising=False)
+    bridge_dir = tmp_path / "bridge"
+    slash_calls: list[str] = []
+    msg_calls: list[str] = []
+
+    def fake_inject_slash_command(
+        bridge_dir_arg: Path, *, command: str, timeout_s: float = 30.0, auto_confirm: bool = False
+    ) -> None:
+        del bridge_dir_arg, timeout_s, auto_confirm
+        slash_calls.append(command)
+
+    def fake_inject_user_message(
+        bridge_dir_arg: Path, *, content: str, timeout_s: float = 30.0
+    ) -> None:
+        del bridge_dir_arg, timeout_s
+        msg_calls.append(content)
+
+    monkeypatch.setattr(
+        claude_native_executor,
+        "read_launch_model",
+        lambda _bridge: "databricks-claude-opus-4-8",
+    )
+    monkeypatch.setattr(claude_native_executor, "inject_slash_command", fake_inject_slash_command)
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fake_inject_user_message)
+
+    executor = ClaudeNativeExecutor(bridge_dir)
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[],
+            system_prompt="",
+            config=ExecutorConfig(model="databricks-claude-opus-4-8"),
+        )
+    ]
+
+    assert slash_calls == [], f"No /model expected when already on that model; got {slash_calls}."
+    assert msg_calls == ["hello"]
+    assert events == [TurnComplete(response=None)]


### PR DESCRIPTION
## Related issue

N/A

## Summary

On a **claude-native** session with intelligent routing on, the routed model was selected but the user's **first message was silently dropped** — the model switched, no error surfaced, but no turn ran.

- The server issued **two unsynchronized writes to the same tmux pane**: a standalone `model_change` event (typing `/model <routed>` into the pane) **and**, separately, the user's message (typed via `inject_user_message`). These raced. The message keystrokes landed mid-switch, `inject_user_message` never saw its draft, hit its submit-blind fallback, and returned without error — model applied, message gone.
- Fix: **remove the second writer** by folding the switch into the message turn, mirroring how the SDK/`pi` path already applies the routed model as one operation.
  - **Executor** (`ClaudeNativeExecutor.run_turn`): the routed model already arrives in `ExecutorConfig.model` and was being discarded. It's now applied — when `config.model` differs from the pane's model, type `/model` **then** inject the message, both under the existing `_inject_lock`, in order, exactly once. `inject_user_message`'s prompt-ready gate + verified submit then guarantee delivery. `_applied_model` is seeded lazily from `read_launch_model` so turn 1's routed pick is compared against the spawn model, not blindly re-issued.
  - **Server** (`_sessions/orchestration.py`): the routed model rides **in-band** on the message (`model_override`, an extra field the harness `MessageEvent` forwards into `ExecutorConfig.model`), and the separate racing `model_change` POST is dropped. The manual composer `/model` picker path (PATCH → `model_change`) is untouched.

No polling, no retry — correct on the first turn.

## Test Plan

- `pytest tests/inner/test_claude_native_executor.py` — 17 passed (3 new + existing).
- New tests: `/model` precedes the message in order under one lock; no `/model` without a routed model; no `/model` when already on the routed model. The ordering test **fails against the prior discard-config behavior** (verified) — a real regression guard.
- Validated end-to-end on a managed claude-native session with intelligent routing enabled: routing picks a valid model (e.g. `sonnet-5`), the `/model` switch applies, and the first message runs a turn — where it was previously dropped.
- `ruff check` + `ruff format --check` clean on all three files.

## Demo
No /model command before the message is sent. 
<img width="853" height="1075" alt="Screenshot 2026-07-27 at 1 25 51 PM" src="https://github.com/user-attachments/assets/d5c7276a-a748-4268-bfd6-7580c3987b0d" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: on a managed claude-native session with intelligent routing enabled, the routed `/model` switch and the first message now inject as one ordered step under the executor's pane lock, so the message reaches the agent and a turn runs (previously the message was dropped into the racing model switch). Unit tests exercise the switch-then-message ordering deterministically with faked injectors.

## Changelog

Intelligent routing no longer drops the first message on a new claude-native session
