### PR TITLE
feat(sandbox): bind /proc in bwrap on Lakebox hosts

### DIFF
--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -18,7 +18,9 @@ Default view inside the sandbox:
   ``/etc/ld.so.cache``, ``/etc/ld.so.conf``,
   ``/etc/ld.so.conf.d``, ``/etc/ssl``, ``/etc/ca-certificates``,
   ``/etc/pki``) bound read-only via ``--ro-bind-try``.
-- Fresh ``/proc``, ``/dev``, and ``/tmp``.
+- Fresh ``/proc`` (bind-mounted from the host on outer sandboxes that
+  forbid a fresh procfs mount, e.g. Lakebox — see
+  :func:`_should_bind_host_proc`), ``/dev``, and ``/tmp``.
 - Cwd bind-mounted read-only by default; explicit
   ``write_paths: ["."]`` flips it to read-write. Top-level
   dotfiles / dotdirs in cwd are tmpfs-masked unless their name is
@@ -176,6 +178,86 @@ _ALLOWED_SOCKET_FAMILIES = (
     2,  # AF_INET  — IPv4
     10,  # AF_INET6 — IPv6
 )
+
+
+# ---------------------------------------------------------------------------
+# Nested-sandbox /proc handling
+# ---------------------------------------------------------------------------
+
+# Outer sandbox backends whose microVM/container permits binding the
+# existing ``/proc`` but forbids mounting a FRESH procfs under
+# ``--unshare-pid`` (masked ``/proc`` overmounts make ``mount proc``
+# return EPERM). On these backends the bwrap wrap binds the host
+# ``/proc`` instead of emitting ``--proc /proc``.
+#
+# Why an explicit allow-list rather than a "fresh-proc mount failed, retry
+# with a bind" fallback: binding the existing ``/proc`` is a security
+# DOWNGRADE. It exposes the outer process list plus the world-readable
+# per-process files (``cmdline`` / ``comm`` / ``stat`` / ``status``) to the
+# sandboxed helper. It does NOT expose the ptrace-gated files (``environ``
+# / ``mem`` / ``maps`` / ``fd``): the retained user namespace keeps those
+# blocked even for same-uid targets and even as namespaced root, and
+# ``--unshare-pid`` still contains signalling. That leak is acceptable on a
+# single-tenant dev microVM (Lakebox) but not on an arbitrary host, so the
+# downgrade is only taken for vetted backends. Add entries here as more
+# backends are verified safe.
+_PROC_BIND_HOST_BACKENDS: frozenset[str] = frozenset({"lakebox"})
+
+# Env var an outer launcher may set to name the host's outer sandbox
+# backend (e.g. ``lakebox``). Authoritative when present; otherwise the
+# backend is autodetected (see ``_detect_host_sandbox_backend``). Note it
+# must survive ``SandboxPolicy.spawn_env_allowlist`` pruning to be visible
+# on the re-exec launcher path — the marker autodetect below is the
+# prune-proof fallback that lakebox relies on today.
+_HOST_SANDBOX_BACKEND_ENV = "OMNIGENT_HOST_SANDBOX_BACKEND"
+
+# Marker directory the Databricks Lakebox runtime seeds inside every
+# microVM. Used to autodetect lakebox when the launcher hasn't declared the
+# backend via ``_HOST_SANDBOX_BACKEND_ENV``.
+_LAKEBOX_MARKER = Path("/run/lakebox")
+
+
+def _detect_host_sandbox_backend() -> str | None:
+    """
+    Identify the outer sandbox backend this host process runs under.
+
+    Prefers the explicit ``OMNIGENT_HOST_SANDBOX_BACKEND`` env var (set by
+    the launcher that provisioned this host); otherwise falls back to
+    lakebox autodetection via the :data:`_LAKEBOX_MARKER` directory. Runs
+    in the host/parent process — never inside the agent's sandbox — so the
+    signals it reads cannot be forged from within the sandbox.
+
+    :returns: Lower-cased backend name (e.g. ``"lakebox"``), or ``None``
+        when the host is not running under a recognised outer sandbox.
+    """
+    declared = os.environ.get(_HOST_SANDBOX_BACKEND_ENV)
+    if declared and declared.strip():
+        return declared.strip().lower()
+    try:
+        if _LAKEBOX_MARKER.is_dir():
+            return "lakebox"
+    except OSError:
+        # A stat() failure on the marker (permissions, a racing unmount)
+        # is not fatal: fall through to "no recognised backend" and keep
+        # the fresh-proc default rather than the proc-bind downgrade.
+        _LOGGER.debug("lakebox marker probe failed for %s", _LAKEBOX_MARKER, exc_info=True)
+    return None
+
+
+def _should_bind_host_proc() -> bool:
+    """
+    Whether the bwrap wrap should bind the existing ``/proc`` instead of
+    mounting a fresh procfs.
+
+    ``True`` only when the host runs under an outer sandbox backend in
+    :data:`_PROC_BIND_HOST_BACKENDS` (lakebox today). On every other host
+    the fresh-proc mount is kept, so ordinary hosts — and their fail-closed
+    behaviour when a fresh procfs mount is denied — are unchanged.
+
+    :returns: ``True`` to emit ``--bind /proc /proc``; ``False`` to emit
+        ``--proc /proc``.
+    """
+    return _detect_host_sandbox_backend() in _PROC_BIND_HOST_BACKENDS
 
 
 # ---------------------------------------------------------------------------
@@ -347,9 +429,18 @@ class BwrapSandboxBackend(SandboxBackend):
         # /proc, /dev (filtered by bwrap to a safe minimal device set),
         # and a private /tmp so the agent's writes there don't pollute
         # the host.
+        #
+        # ``--proc`` mounts a FRESH procfs tied to the new PID namespace so
+        # the helper sees only its own processes. Some nested outer
+        # sandboxes (Lakebox) forbid that mount under ``--unshare-pid``
+        # (masked ``/proc`` overmounts -> ``mount proc: EPERM``), so there
+        # we bind the host ``/proc`` instead. See ``_should_bind_host_proc``
+        # for the gate and the security trade-off.
+        if _should_bind_host_proc():
+            bwrap_args += ["--bind", "/proc", "/proc"]
+        else:
+            bwrap_args += ["--proc", "/proc"]
         bwrap_args += [
-            "--proc",
-            "/proc",
             "--dev",
             "/dev",
             "--tmpfs",

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -36,12 +36,17 @@ from unittest.mock import patch
 
 import pytest
 
+from omnigent.inner import bwrap_sandbox
 from omnigent.inner.bwrap_sandbox import (
     _ALLOWED_SOCKET_FAMILIES,
     _CLONE_NEW_FLAG_BITS,
     _DEFAULT_CWD_ALLOW_HIDDEN,
+    _HOST_SANDBOX_BACKEND_ENV,
+    _PROC_BIND_HOST_BACKENDS,
     BwrapSandboxBackend,
     _bwrap_extra_seccomp_rules,
+    _detect_host_sandbox_backend,
+    _should_bind_host_proc,
 )
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.sandbox import SandboxPolicy, with_denied_unix_sockets
@@ -899,6 +904,124 @@ def test_wrap_launcher_argv_reexposes_interpreter_under_masked_dotdir(
     assert not _has_pair(argv, "--ro-bind-try", local_dir, local_dir), (
         ".local was re-bound wholesale, defeating the dotfile mask."
     )
+
+
+# ---------------------------------------------------------------------------
+# Nested-sandbox /proc handling (lakebox proc bind)
+# ---------------------------------------------------------------------------
+
+
+def _clear_host_backend_signals(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """
+    Neutralise every host-backend signal so detection returns ``None``.
+
+    Removes the declaration env var and repoints the lakebox marker at a
+    path that does not exist, isolating the test from the machine it runs
+    on — which must not be assumed to be (or not to be) a lakebox microVM.
+    """
+    monkeypatch.delenv(_HOST_SANDBOX_BACKEND_ENV, raising=False)
+    monkeypatch.setattr(bwrap_sandbox, "_LAKEBOX_MARKER", tmp_path / "no-such-marker")
+
+
+def test_detect_host_backend_none_without_signals(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    With no env declaration and no marker, no outer backend is detected,
+    so the proc bind stays off (fresh procfs is kept everywhere by
+    default).
+    """
+    _clear_host_backend_signals(monkeypatch, tmp_path)
+    assert _detect_host_sandbox_backend() is None
+    assert _should_bind_host_proc() is False
+
+
+def test_detect_host_backend_env_declaration_is_normalised(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    ``OMNIGENT_HOST_SANDBOX_BACKEND`` is the explicit, authoritative
+    signal; it is trimmed and lower-cased so callers don't have to match
+    an exact casing, and ``lakebox`` is on the proc-bind allow-list.
+    """
+    _clear_host_backend_signals(monkeypatch, tmp_path)
+    monkeypatch.setenv(_HOST_SANDBOX_BACKEND_ENV, "  LakeBox  ")
+    assert _detect_host_sandbox_backend() == "lakebox"
+    assert _should_bind_host_proc() is True
+
+
+def test_detect_host_backend_env_non_lakebox_keeps_fresh_proc(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    A declared backend that is NOT on :data:`_PROC_BIND_HOST_BACKENDS`
+    must not trigger the proc downgrade — even if the lakebox marker
+    happens to exist — because the explicit declaration is authoritative.
+    """
+    marker = tmp_path / "run-lakebox"
+    marker.mkdir()
+    monkeypatch.setattr(bwrap_sandbox, "_LAKEBOX_MARKER", marker)
+    monkeypatch.setenv(_HOST_SANDBOX_BACKEND_ENV, "modal")
+    assert _detect_host_sandbox_backend() == "modal"
+    assert "modal" not in _PROC_BIND_HOST_BACKENDS
+    assert _should_bind_host_proc() is False
+
+
+def test_detect_host_backend_marker_autodetects_lakebox(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    When no env var is set, the ``/run/lakebox`` marker directory
+    autodetects lakebox. This is the prune-proof fallback the re-exec
+    launcher path relies on (the env var may be stripped by the spawn
+    allow-list, but the filesystem marker survives).
+    """
+    marker = tmp_path / "run-lakebox"
+    marker.mkdir()
+    monkeypatch.delenv(_HOST_SANDBOX_BACKEND_ENV, raising=False)
+    monkeypatch.setattr(bwrap_sandbox, "_LAKEBOX_MARKER", marker)
+    assert _detect_host_sandbox_backend() == "lakebox"
+    assert _should_bind_host_proc() is True
+
+
+def test_wrap_launcher_argv_fresh_proc_by_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    On an ordinary host the wrap emits ``--proc /proc`` (a fresh procfs
+    tied to the new PID namespace) and never binds the host ``/proc``.
+    """
+    _clear_host_backend_signals(monkeypatch, tmp_path)
+    backend = _make_backend()
+    policy = _make_policy(tmp_path)
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, tmp_path)
+    assert _has_pair_single_dest(argv, "--proc", "/proc")
+    assert not _has_pair(argv, "--bind", "/proc", "/proc")
+
+
+def test_wrap_launcher_argv_binds_proc_on_lakebox(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    On a lakebox host the wrap binds the existing ``/proc`` instead of
+    mounting a fresh procfs (lakebox's masked ``/proc`` overmounts make
+    the fresh mount fail under ``--unshare-pid``). ``/dev`` and ``/tmp``
+    are unaffected.
+    """
+    _clear_host_backend_signals(monkeypatch, tmp_path)
+    monkeypatch.setenv(_HOST_SANDBOX_BACKEND_ENV, "lakebox")
+    backend = _make_backend()
+    policy = _make_policy(tmp_path)
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, tmp_path)
+    assert _has_pair(argv, "--bind", "/proc", "/proc"), (
+        "lakebox host must bind the existing /proc; got no `--bind /proc /proc`."
+    )
+    assert not _has_pair_single_dest(argv, "--proc", "/proc"), (
+        "lakebox host must NOT also mount a fresh procfs — the two would "
+        "conflict at the same mountpoint."
+    )
+    assert _has_pair_single_dest(argv, "--dev", "/dev")
+    assert "--tmpfs" in argv
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

N/A

## Summary

The `linux_bwrap` sandbox mounts a fresh procfs under `--unshare-pid`. A
Databricks Lakebox microVM masks `/proc`, so that mount is rejected with
`bwrap: Can't mount proc on /newroot/proc: Operation not permitted` and the
sandbox never starts. That blocked `linux_bwrap` — and the L7 egress
management built on top of it — on the Lakebox backend.

- **Bind the existing `/proc` instead of mounting a fresh one, but only on
  outer sandbox backends known to be safe** (allow-list: `lakebox`).
  `wrap_launcher_argv` emits `--bind /proc /proc` in that case and
  `--proc /proc` everywhere else.
- Resolve the outer backend from `OMNIGENT_HOST_SANDBOX_BACKEND` when a
  launcher sets it, otherwise autodetect Lakebox via the `/run/lakebox`
  marker. Detection runs in the host process, never inside the sandboxed
  agent, so it cannot be forged from within the sandbox.
- **Impact on non-Lakebox hosts: none.** They keep the fresh-proc mount and
  its fail-closed behavior. Adding a backend later is one entry in
  `_PROC_BIND_HOST_BACKENDS`.

**ELI5.** bwrap normally gives the agent a brand-new `/proc` that shows only
its own processes. Lakebox does not allow creating that new `/proc`, so the
agent could not start at all. On Lakebox we hand the agent the existing
`/proc` instead. That reveals the list of other process names on the box,
but the user namespace still hides the sensitive parts (each process's
environment, memory, and open files), so it is a safe trade on a
single-tenant dev VM.

```mermaid
flowchart TD
    A[bwrap builds sandbox argv] --> B{host backend on the<br/>proc-bind allow-list?}
    B -- "lakebox (env var or /run/lakebox)" --> C["--bind /proc /proc<br/>reuse host proc"]
    B -- "anything else" --> D["--proc /proc<br/>fresh procfs, fail-closed"]
```

**Security trade-off** (documented inline in `bwrap_sandbox.py`): binding
`/proc` exposes the outer process list and the world-readable per-process
files (`cmdline` / `comm` / `stat` / `status`). It does not expose the
ptrace-gated files (`environ` / `mem` / `maps` / `fd`): the retained user
namespace keeps those blocked even for same-uid targets and even as
namespaced root, and `--unshare-pid` still contains signalling. Because the
bind is a security downgrade, it is gated to an explicit allow-list rather
than a blind "fresh-proc failed, retry with a bind" fallback.

## Test Plan

Unit tests and lint (local):

- `uv run pytest tests/inner/test_bwrap_sandbox.py -q -k "proc or host_backend"` → **7 passed**.
- `uv run ruff check` and `ruff format --check` on both files → clean;
  `pre-commit` on both files → all hooks passed.

Live end-to-end on a Lakebox microVM (`e2-dogfood`, `omnigent-egress-test`):

- Detection inside the VM (no env var set): `detect = lakebox | should_bind_proc = True`.
- `linux_bwrap` shell now starts and runs: `id` and `uname -a` return
  `rc=0`; `cat /proc/1/cmdline` returns the host `sandbox-daemon`, proving
  `/proc` is the bound host proc (a fresh procfs would show the helper as
  PID 1).
- Negative control `OMNIGENT_HOST_SANDBOX_BACKEND=bare` → `should_bind_proc = False`
  → reproduces the original failure `bwrap: Can't mount proc on /newroot/proc:
  Operation not permitted`, confirming the gate is precisely scoped.
- `linux_bwrap` + `egress_rules: ["* pypi.org/**"]` (default-deny): allowed
  `pypi.org` → `HTTP=200 exit=0`; denied `example.com` → `HTTP=000 exit=56`
  (blocked by the egress proxy).

New coverage (unit):

- `_detect_host_sandbox_backend` — none without signals, env declaration
  normalised and authoritative, non-lakebox env keeps fresh proc even with
  the marker present, `/run/lakebox` marker autodetects lakebox.
- `wrap_launcher_argv` — emits `--proc /proc` by default and
  `--bind /proc /proc` on lakebox (with `/dev` and `/tmp` unchanged).

Pre-existing, unrelated: the four `resolve()` tests in
`tests/inner/test_bwrap_sandbox.py` fail on macOS with "only available on
Linux". I confirmed via `git stash` that they fail identically without this
change (the Linux gate is in the base file), so they are not a regression;
they pass on Linux/CI.

## Demo

N/A (non-visual change).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was run on a live Lakebox microVM on `e2-dogfood`: the
branch's `bwrap_sandbox.py` was loaded in the VM and exercised via
`create_os_environment().shell()` for the positive (`linux_bwrap` starts,
`/proc` bound), negative-control (forced non-lakebox backend reproduces the
mount `EPERM`), and egress (`pypi.org` allowed, `example.com` denied) cases.
The VM's file was restored to its original state afterward. The proc-mode
selection logic itself is covered by the new unit tests above.

## Changelog

`linux_bwrap` sandboxes and their egress rules now run on the Databricks Lakebox backend.
