### PR TITLE
fix(worktree): allow reusing an existing branch for a new session

### DIFF
--- a/omnigent/host/git_worktree.py
+++ b/omnigent/host/git_worktree.py
@@ -404,7 +404,7 @@ def create_worktree(
                 f"choose a different branch name"
             )
 
-    if base_branch is not None:
+    if base_branch is not None and not branch_exists:
         _ensure_base_resolvable(repo_root, base_branch)
     worktree_path = _resolve_worktree_path(repo_root, branch_name)
     worktree_path.parent.mkdir(parents=True, exist_ok=True)

--- a/omnigent/host/git_worktree.py
+++ b/omnigent/host/git_worktree.py
@@ -262,6 +262,20 @@ def _local_branch_exists(repo_root: str, branch_name: str) -> bool:
     )
 
 
+def _branch_checked_out_worktree(repo_root: str, branch_name: str) -> str | None:
+    """Return the worktree path where ``branch_name`` is checked out, or ``None``.
+
+    :param repo_root: Absolute repo work-tree root.
+    :param branch_name: Branch name to look up, e.g. ``"feature/login"``.
+    :returns: Worktree path string if the branch is checked out somewhere,
+        ``None`` otherwise.
+    """
+    for wt in list_worktrees(repo_path=repo_root):
+        if wt.branch == branch_name:
+            return wt.path
+    return None
+
+
 def _resolve_worktree_path(repo_root: str, branch_name: str) -> Path:
     """Compute a collision-free sibling worktree directory path.
 
@@ -377,23 +391,33 @@ def create_worktree(
     # (``…/feature-worktrees/<branch>``); resolving to the main repo keeps
     # all worktrees as siblings (``…/myrepo-worktrees/<branch>``).
     repo_root = _main_work_tree(repo_path)
-    # Friendly pre-check before git's raw "branch already exists" error.
-    # We don't reuse the existing worktree: two sessions sharing one
-    # working tree would clobber each other (designs/SESSION_GIT_WORKTREE.md).
-    if _local_branch_exists(repo_root, branch_name):
-        raise WorktreeError(
-            f"a branch named {branch_name!r} already exists; choose a different branch name"
-        )
+
+    branch_exists = _local_branch_exists(repo_root, branch_name)
+    if branch_exists:
+        # The branch exists — reuse is safe only when no worktree has it
+        # checked out; two sessions sharing one working tree would clobber
+        # each other.
+        checked_out_in = _branch_checked_out_worktree(repo_root, branch_name)
+        if checked_out_in is not None:
+            raise WorktreeError(
+                f"branch {branch_name!r} is already checked out in {checked_out_in}; "
+                f"choose a different branch name"
+            )
+
     if base_branch is not None:
         _ensure_base_resolvable(repo_root, base_branch)
     worktree_path = _resolve_worktree_path(repo_root, branch_name)
     worktree_path.parent.mkdir(parents=True, exist_ok=True)
 
-    add_args = ["worktree", "add", "-b", branch_name, str(worktree_path)]
-    if base_branch is not None:
-        # --end-of-options: treat base_branch as a rev, never a git flag, so a
-        # user-supplied value starting with '-' can't inject an option.
-        add_args += ["--end-of-options", base_branch]
+    if branch_exists:
+        # Reuse the existing branch — no -b flag.
+        add_args = ["worktree", "add", str(worktree_path), branch_name]
+    else:
+        add_args = ["worktree", "add", "-b", branch_name, str(worktree_path)]
+        if base_branch is not None:
+            # --end-of-options: treat base_branch as a rev, never a git flag,
+            # so a user-supplied value starting with '-' can't inject an option.
+            add_args += ["--end-of-options", base_branch]
     result = _run_git(add_args, cwd=repo_root)
     if result.returncode != 0:
         raise _git_error("git worktree add failed", result)

--- a/omnigent/host/git_worktree.py
+++ b/omnigent/host/git_worktree.py
@@ -276,7 +276,7 @@ def _branch_checked_out_worktree(repo_root: str, branch_name: str) -> str | None
     """
     result = _run_git(["worktree", "list", "--porcelain"], cwd=repo_root)
     if result.returncode != 0:
-        return None
+        raise _git_error("git worktree list failed", result)
     ref_suffix = f"refs/heads/{branch_name}"
     path: str | None = None
     for line in result.stdout.splitlines():

--- a/omnigent/host/git_worktree.py
+++ b/omnigent/host/git_worktree.py
@@ -265,14 +265,28 @@ def _local_branch_exists(repo_root: str, branch_name: str) -> bool:
 def _branch_checked_out_worktree(repo_root: str, branch_name: str) -> str | None:
     """Return the worktree path where ``branch_name`` is checked out, or ``None``.
 
+    Parses ``git worktree list --porcelain`` directly against *repo_root*
+    (which is already the main work tree) to avoid the redundant
+    ``_main_work_tree`` resolution that :func:`list_worktrees` performs.
+
     :param repo_root: Absolute repo work-tree root.
     :param branch_name: Branch name to look up, e.g. ``"feature/login"``.
     :returns: Worktree path string if the branch is checked out somewhere,
         ``None`` otherwise.
     """
-    for wt in list_worktrees(repo_path=repo_root):
-        if wt.branch == branch_name:
-            return wt.path
+    result = _run_git(["worktree", "list", "--porcelain"], cwd=repo_root)
+    if result.returncode != 0:
+        return None
+    ref_suffix = f"refs/heads/{branch_name}"
+    path: str | None = None
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            path = line[len("worktree ") :].strip()
+        elif line.startswith("branch ") and path is not None:
+            if line[len("branch ") :].strip() == ref_suffix:
+                return path
+        elif line == "":
+            path = None
     return None
 
 
@@ -366,22 +380,25 @@ def create_worktree(
     branch_name: str,
     base_branch: str | None = None,
 ) -> CreatedWorktree:
-    """Create a git worktree with a new branch checked out.
+    """Create a git worktree, reusing an existing branch when possible.
 
-    Resolves the repo root, picks a collision-free sibling directory,
-    and runs ``git worktree add -b`` (fetching once if ``base_branch``
-    isn't locally resolvable).
+    If ``branch_name`` already exists and is not checked out in another
+    worktree, the branch is reused as-is (``base_branch`` is ignored).
+    Otherwise a new branch is created with ``git worktree add -b``
+    (fetching once if ``base_branch`` isn't locally resolvable).
 
     :param repo_path: Absolute path inside the source repo — the
         directory the user picked, e.g. ``"/Users/alice/myrepo"``.
-    :param branch_name: New branch to create and check out, e.g.
-        ``"feature/login"``.
-    :param base_branch: Optional base ref, e.g. ``"main"``. ``None``
-        branches from the repo's current ``HEAD``.
+    :param branch_name: Branch to check out. Created if it does not
+        exist; reused if it exists and is not checked out elsewhere.
+    :param base_branch: Optional base ref for new branches, e.g.
+        ``"main"``. ``None`` branches from the repo's current ``HEAD``.
+        Ignored when reusing an existing branch.
     :returns: The created worktree's path and branch.
     :raises WorktreeError: If the branch name is invalid, the path is
-        not a git repo, the base ref can't be resolved, or
-        ``git worktree add`` fails (e.g. the branch already exists).
+        not a git repo, the base ref can't be resolved, the branch is
+        already checked out in another worktree, or
+        ``git worktree add`` fails.
     """
     validate_branch_name(branch_name)
     # Always create the worktree off the MAIN work tree, even when

--- a/omnigent/host/git_worktree.py
+++ b/omnigent/host/git_worktree.py
@@ -428,7 +428,7 @@ def create_worktree(
 
     if branch_exists:
         # Reuse the existing branch — no -b flag.
-        add_args = ["worktree", "add", str(worktree_path), branch_name]
+        add_args = ["worktree", "add", str(worktree_path), f"refs/heads/{branch_name}"]
     else:
         add_args = ["worktree", "add", "-b", branch_name, str(worktree_path)]
         if base_branch is not None:

--- a/tests/host/test_git_worktree.py
+++ b/tests/host/test_git_worktree.py
@@ -248,28 +248,34 @@ def test_create_worktree_option_like_base_branch_not_executed(
     assert _worktree_count(git_repo) == 1
 
 
-def test_create_worktree_duplicate_branch_fails(git_repo: Path) -> None:
-    """Creating two worktrees for the same branch name fails loud with the friendly error."""
+def test_create_worktree_duplicate_branch_checked_out_fails(git_repo: Path) -> None:
+    """Creating a second worktree for a branch already checked out fails loud."""
     create_worktree(repo_path=str(git_repo), branch_name="dup")
     with pytest.raises(WorktreeError) as exc:
         create_worktree(repo_path=str(git_repo), branch_name="dup")
-    # The pre-check catches the existing branch before git's raw error;
-    # we must NOT silently reuse the existing worktree.
-    assert "already exists" in exc.value.message
+    assert "already checked out" in exc.value.message
 
 
-def test_create_worktree_existing_branch_no_worktree_fails(git_repo: Path) -> None:
-    """A branch that exists WITHOUT a worktree is still rejected by the pre-check.
+def test_create_worktree_existing_branch_no_worktree_reuses(git_repo: Path) -> None:
+    """A branch that exists WITHOUT an active worktree is reused, not rejected.
 
-    Proves the pre-check keys off branch existence, not directory
-    occupancy — creating a worktree for a plain pre-existing branch
-    would otherwise hit git's raw error.
+    This is the common case when a previous session ended and the user
+    starts a new session on the same branch.
     """
     _git(git_repo, "branch", "preexisting")
-    with pytest.raises(WorktreeError) as exc:
-        create_worktree(repo_path=str(git_repo), branch_name="preexisting")
-    assert "already exists" in exc.value.message
-    assert "preexisting" in exc.value.message
+    created = create_worktree(repo_path=str(git_repo), branch_name="preexisting")
+    assert Path(created.worktree_path).is_dir()
+    assert _current_branch(Path(created.worktree_path)) == "preexisting"
+
+
+def test_create_worktree_reuses_after_worktree_removed(git_repo: Path) -> None:
+    """A branch whose worktree was removed can be reused for a new session."""
+    first = create_worktree(repo_path=str(git_repo), branch_name="reuse-me")
+    remove_worktree(worktree_path=first.worktree_path, branch="reuse-me", delete_branch=False)
+    assert _branch_exists(git_repo, "reuse-me")
+    second = create_worktree(repo_path=str(git_repo), branch_name="reuse-me")
+    assert Path(second.worktree_path).is_dir()
+    assert _current_branch(Path(second.worktree_path)) == "reuse-me"
 
 
 def test_create_worktree_non_repo_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

The worktree pre-check in `create_worktree()` rejected any branch that already existed, even when no worktree had it checked out. This blocked users from starting a new session on a branch from a previous (ended) session — they had to pick a different name every time.

This narrows the check: only reject when the branch is actively checked out in another worktree (which would cause two sessions to clobber each other). When the branch exists but isn't checked out anywhere, reuse it with `git worktree add <path> <branch>` (no `-b`).

## Test Plan

- `python -m pytest tests/host/test_git_worktree.py -v` — all 35 tests pass.
- Key new/updated tests:
  - `test_create_worktree_duplicate_branch_checked_out_fails` — still rejects when branch is checked out in another worktree.
  - `test_create_worktree_existing_branch_no_worktree_reuses` — a branch with no worktree is reused successfully.
  - `test_create_worktree_reuses_after_worktree_removed` — covers the exact user scenario (create → remove worktree keeping branch → create again on same branch).

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

Starting a new session on a branch from a previous session no longer fails with "branch already exists"