### PR TITLE
bwrap sandbox: bind /etc/alternatives so update-alternatives tools resolve

### DIFF
--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -128,14 +128,17 @@ _DEFAULT_ETC_FILES = (
 )
 
 # Read-only directory binds for the multi-file /etc subtrees — linker
-# search paths and TLS trust stores. Bound as directories so adding /
-# updating cert bundles on the host stays transparent inside the
-# sandbox.
+# search paths, TLS trust stores, and the update-alternatives symlink
+# hub (so generic names like awk/python3/editor resolve through
+# /etc/alternatives to their real binaries under the mounted /usr).
+# Bound as directories so host-side changes stay transparent inside
+# the sandbox.
 _DEFAULT_ETC_DIRS = (
     "/etc/ld.so.conf.d",
     "/etc/ssl",
     "/etc/ca-certificates",
     "/etc/pki",
+    "/etc/alternatives",
 )
 
 # Linux ``CLONE_NEW*`` flag bits. Any of these set in arg 0 of

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -412,6 +412,28 @@ def test_wrap_launcher_argv_includes_required_mounts_and_chdir(
     assert argv[chdir_idx + 1] == str(tmp_path.resolve(strict=False))
 
 
+def test_wrap_launcher_argv_binds_etc_alternatives(tmp_path: Path) -> None:
+    """
+    ``/etc/alternatives`` is bound read-only by default.
+
+    Tools invoked by generic name (awk, python3, editor, ...) resolve
+    through ``/usr/bin/<name> -> /etc/alternatives/<name> -> real
+    binary``. Without the ``/etc/alternatives`` dir bind the middle
+    symlink node is missing inside the jail and the lookup fails with
+    "command not found", even though the real binary under ``/usr`` is
+    mounted.
+    """
+    backend = _make_backend()
+    policy = _make_policy(tmp_path)
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, tmp_path)
+    assert "/etc/alternatives" in argv
+    # Emitted as ``--ro-bind-try <src> <dest>`` with src == dest, like the
+    # other default /etc dir binds; never read-write.
+    idx = argv.index("/etc/alternatives")
+    assert argv[idx - 1] == "--ro-bind-try"
+    assert argv[idx + 1] == "/etc/alternatives"
+
+
 @pytest.mark.parametrize(
     "allow_network,should_unshare",
     [(True, False), (False, True)],


### PR DESCRIPTION
## Related issue

N/A

## Summary

Bind `/etc/alternatives` read-only into the bwrap sandbox by default so tools invoked by their generic name resolve inside the jail.

- On Debian/Ubuntu, `/usr/bin/awk`, `/usr/bin/python3`, `/usr/bin/editor`, etc. are symlinks that resolve through `/usr/bin/<name>` to `/etc/alternatives/<name>` to the real binary (managed by `update-alternatives`).
- The real binaries already live under the mounted `/usr`, but `/etc/alternatives` was not bound, so the intermediate symlink node was missing inside the jail. Running `awk` (for example from a build wrapper) failed with `command not found` even though `gawk` was present.
- Fix: add `/etc/alternatives` to the default `_DEFAULT_ETC_DIRS` list, alongside the existing `/etc/ssl` and `/etc/ca-certificates` dir binds. It is a directory of symlinks (no secrets); bound read-only so the mapping cannot be repointed, and every target is a binary already exposed under `/usr`, so it grants no new capability. It only restores standard name resolution.

Scope: Linux (`linux_bwrap`) backend only. `darwin_seatbelt` does not use `/etc/alternatives` and is unaffected.

## Test Plan

- Added `test_wrap_launcher_argv_binds_etc_alternatives` in `tests/inner/test_bwrap_sandbox.py`, asserting `/etc/alternatives` is emitted as a read-only (`--ro-bind-try`) mount, mirroring the existing `test_wrap_launcher_argv_includes_required_mounts_and_chdir`.
- Ran the full bwrap suite locally with `uv run --no-sync pytest tests/inner/test_bwrap_sandbox.py`: 35 passed, including the new test.
- `ruff format --check` and `ruff check` pass on both changed files.
- Verified the mechanism directly with a standalone bwrap invocation: a jail with `/usr` mounted and `/etc` as tmpfs fails `awk` with `command not found`; adding `--ro-bind /etc/alternatives /etc/alternatives` makes `awk` and `python3` resolve. Binding the directory recreates the symlink nodes only (it does not bind their targets), so entries pointing outside the jail simply dangle and cause no error.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit test asserts the mount is emitted read-only, and the full bwrap test file passes locally (35 passed). Also manually verified via a standalone bwrap invocation that binding `/etc/alternatives` makes update-alternatives-managed tools (awk, python3) resolve inside the jail.

## Changelog

Sandboxed agents can now run tools managed by update-alternatives (awk, python3, editor, and similar) on Linux.
