### PR TITLE
egress proxy: trust loose capath CAs, not just the cafile bundle

### DIFF
--- a/omnigent/inner/egress/ca.py
+++ b/omnigent/inner/egress/ca.py
@@ -168,21 +168,69 @@ def _is_expired(cert_path: Path) -> bool:
         return True
 
 
+def _capath_ca_bytes(capath: str | None) -> bytes:
+    """Return the concatenated PEM bytes of every cert in *capath*.
+
+    Corporate MDM / IT-managed roots are commonly installed as loose
+    files under the OpenSSL ``capath`` directory (with hashed symlinks)
+    rather than merged into the single ``cafile`` bundle. Reads each
+    regular file, keeping only those that look like PEM certificates.
+    Hashed symlinks alias the same underlying files, so duplicates are
+    dropped by resolved path; extra identical certs would be harmless
+    but this keeps the bundle tidy.
+    """
+    if not capath:
+        return b""
+    directory = Path(capath)
+    if not directory.is_dir():
+        return b""
+    parts: list[bytes] = []
+    seen: set[Path] = set()
+    for entry in sorted(directory.iterdir()):
+        try:
+            resolved = entry.resolve()
+            if resolved in seen or not resolved.is_file():
+                continue
+            data = resolved.read_bytes()
+        except OSError:
+            continue
+        if b"-----BEGIN CERTIFICATE-----" not in data:
+            continue
+        seen.add(resolved)
+        parts.append(data)
+    return b"\n".join(parts)
+
+
 def _system_ca_bundle() -> bytes:
     """Return the system CA bundle as PEM bytes.
 
-    Prefers the OS trust store (``ssl.get_default_verify_paths``) so
-    that CAs added by corporate MDM, IT policy, or the user are
-    included. Falls back to the certifi (Mozilla) bundle when the OS
-    path doesn't exist or is empty.
+    Combines the OS trust store from ``ssl.get_default_verify_paths``
+    so that CAs added by corporate MDM, IT policy, or the user are
+    included: both the consolidated ``cafile`` bundle AND the loose
+    certs under ``capath`` (where MDM roots often live). Falls back to
+    the certifi (Mozilla) bundle only when neither yields any certs.
     """
     paths = ssl.get_default_verify_paths()
+
+    cafile_bytes = b""
     for candidate in (paths.cafile, paths.openssl_cafile):
         if candidate:
             p = Path(candidate)
             if p.is_file() and p.stat().st_size > 0:
                 logger.debug("Using system CA bundle: %s", p)
-                return p.read_bytes()
+                cafile_bytes = p.read_bytes()
+                break
+
+    capath_bytes = b""
+    for candidate in (paths.capath, paths.openssl_capath):
+        capath_bytes = _capath_ca_bytes(candidate)
+        if capath_bytes:
+            logger.debug("Including loose CA certs from capath: %s", candidate)
+            break
+
+    combined = b"\n".join(part for part in (cafile_bytes, capath_bytes) if part)
+    if combined:
+        return combined
 
     import certifi
 

--- a/tests/inner/egress/test_ca.py
+++ b/tests/inner/egress/test_ca.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import datetime
+import ssl
 from pathlib import Path
 
 from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 
+from omnigent.inner.egress import ca as ca_module
 from omnigent.inner.egress.ca import ensure_ca, ensure_ca_bundle
 
 
@@ -69,3 +74,79 @@ def test_ensure_ca_key_permissions(tmp_path: Path) -> None:
     _cert_path, key_path = ensure_ca(cache_dir=tmp_path)
     mode = key_path.stat().st_mode & 0o777
     assert mode == 0o600, f"Expected key perms 0600, got {oct(mode)}"
+
+
+def _make_ca_pem(common_name: str) -> bytes:
+    """Return the PEM bytes of a throwaway self-signed CA cert."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def test_system_ca_bundle_includes_capath_loose_certs(tmp_path: Path, monkeypatch) -> None:
+    """A CA present only as a loose file under ``capath`` is included.
+
+    Corporate MDM / IT roots are often installed as loose files in the
+    OpenSSL ``capath`` directory rather than merged into the single
+    ``cafile`` bundle. Reading only ``cafile`` misses them, which breaks
+    upstream TLS verification for anything signed by such a root. The
+    bundle must pick up the loose ``capath`` certs too.
+    """
+    cafile = tmp_path / "cafile.pem"
+    capath = tmp_path / "capath"
+    capath.mkdir()
+    cafile_ca = _make_ca_pem("CAfile Root")
+    capath_ca = _make_ca_pem("Capath-only Root")
+    cafile.write_bytes(cafile_ca)
+    (capath / "corp-root.pem").write_bytes(capath_ca)
+
+    fake_paths = ssl.DefaultVerifyPaths(
+        cafile=str(cafile),
+        capath=str(capath),
+        openssl_cafile_env="",
+        openssl_cafile=str(cafile),
+        openssl_capath_env="",
+        openssl_capath=str(capath),
+    )
+    monkeypatch.setattr(ca_module.ssl, "get_default_verify_paths", lambda: fake_paths)
+
+    bundle = ca_module._system_ca_bundle()
+
+    assert capath_ca in bundle, "loose capath CA missing from the bundle"
+    assert cafile_ca in bundle, "cafile CA missing (regression)"
+
+
+def test_system_ca_bundle_skips_non_pem_in_capath(tmp_path: Path, monkeypatch) -> None:
+    """Non-PEM files in ``capath`` are skipped without error."""
+    capath = tmp_path / "capath"
+    capath.mkdir()
+    real_ca = _make_ca_pem("Real Root")
+    (capath / "root.pem").write_bytes(real_ca)
+    (capath / "README").write_bytes(b"not a certificate\n")
+
+    fake_paths = ssl.DefaultVerifyPaths(
+        cafile=None,
+        capath=str(capath),
+        openssl_cafile_env="",
+        openssl_cafile=None,
+        openssl_capath_env="",
+        openssl_capath=str(capath),
+    )
+    monkeypatch.setattr(ca_module.ssl, "get_default_verify_paths", lambda: fake_paths)
+
+    bundle = ca_module._system_ca_bundle()
+
+    assert real_ca in bundle
+    assert b"not a certificate" not in bundle


### PR DESCRIPTION
## Related issue

N/A

## Summary

Make the egress MITM proxy trust CAs installed as loose files under the OpenSSL `capath` directory, not just the consolidated `cafile` bundle.

- The proxy verifies upstream TLS against the system trust store assembled by `_system_ca_bundle()`. It read only the `cafile` (`ssl.get_default_verify_paths().cafile` / `openssl_cafile`) and ignored `capath`.
- Corporate MDM / IT-managed roots are commonly installed as loose files under `capath` (with hashed symlinks) rather than merged into the single `cafile`. Those roots were missing from the proxy's trust store, so any upstream host whose chain relies on one failed verification. In practice a corp-intercepted `github.com` returned `502` from the proxy even though the host's own git/curl trusted it, because those tools read `capath` and the proxy did not.
- Fix: also read `capath`. Concatenate the loose PEM certs from the `capath` directory onto the `cafile` bundle (dedup by resolved path so hashed-symlink aliases are not doubled, skip non-PEM entries), and keep the existing certifi fallback for when neither source yields any certs.

This grants no new trust beyond what the OS already designates as system trust roots; it just stops dropping the `capath` half of that trust store.

## Test Plan

- Added tests in `tests/inner/egress/test_ca.py`:
  - `test_system_ca_bundle_includes_capath_loose_certs`: a CA present only as a loose file under `capath` (not in `cafile`) is included in the bundle, and the `cafile` CA is still present.
  - `test_system_ca_bundle_skips_non_pem_in_capath`: non-PEM files in `capath` are skipped without error.
- Ran `tests/inner/egress/test_ca.py` locally with `uv run --no-sync pytest`: 6 passed (4 existing + 2 new).
- `ruff format --check` and `ruff check` pass on both changed files.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the capath inclusion and the non-PEM skip path; the full `test_ca.py` file passes locally (6 passed). Manually confirmed on a machine whose corp root CA lives only under `capath`: with this change the assembled bundle verifies an upstream host signed by that root, where before it did not.

## Changelog

Egress proxy now trusts corporate/MDM CA roots installed under the system `capath` directory, so TLS to hosts behind a corporate MITM works from a sandboxed agent.
