### PR TITLE
feat(sandbox): optional runtimeClassName on the kubernetes provider

### DIFF
--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -528,6 +528,7 @@ def build_job_manifest(
     agent_name: str | None = None,
     backoff_limit: int = _JOB_BACKOFF_LIMIT,
     active_deadline_seconds: int = _JOB_ACTIVE_DEADLINE_S,
+    runtime_class: str | None = None,
 ) -> dict[str, object]:
     """
     Build the sandbox Job manifest as a plain dict.
@@ -587,6 +588,10 @@ def build_job_manifest(
       container start. Refresh is eventually consistent (kubelet sync, up to
       ~1 min), so the in-sandbox consumer must re-read the file each use — a
       value cached at start defeats the rotation.
+    - An operator *runtime_class* becomes ``spec.runtimeClassName``, scheduling
+      the Pod onto a sandboxed container runtime the cluster provides via a
+      ``RuntimeClass`` object (e.g. Kata Containers micro-VMs, gVisor). Unset
+      keeps the cluster's default runtime — today's behaviour exactly.
 
     :param job_name: DNS-label-safe Job name (see :func:`_new_pod_name`).
     :param namespace: Namespace the Job is created in.
@@ -630,6 +635,8 @@ def build_job_manifest(
     :param backoff_limit: Maximum container restart attempts before the Job
         is marked Failed.
     :param active_deadline_seconds: Hard lifetime cap for the Job.
+    :param runtime_class: ``RuntimeClass`` name set as ``spec.runtimeClassName``,
+        or ``None`` to keep the cluster's default container runtime.
     :returns: The Job manifest dict.
     """
     pod_resources = _resolve_pod_resources(resources)
@@ -788,6 +795,10 @@ def build_job_manifest(
                 _AGENT_LABEL,
                 job_name,
             )
+    if runtime_class is not None:
+        # Opt-in only: an absent key (not an explicit None/null) keeps the
+        # manifest byte-compatible with pre-runtime_class deployments.
+        pod_spec["runtimeClassName"] = runtime_class
     return {
         "apiVersion": "batch/v1",
         "kind": "Job",
@@ -1024,6 +1035,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         pvc_mounts: Sequence[Mapping[str, object]] | None = None,
         secret_mounts: Sequence[Mapping[str, object]] | None = None,
         pod_ready_timeout_s: int | None = None,
+        runtime_class: str | None = None,
     ) -> None:
         """
         Store provider config for lazy use by :meth:`start_host` / :meth:`terminate`.
@@ -1046,6 +1058,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         self._pvc_mounts = list(pvc_mounts) if pvc_mounts else None
         self._secret_mounts = list(secret_mounts) if secret_mounts else None
         self._pod_ready_timeout_s = pod_ready_timeout_s
+        self._runtime_class = runtime_class
         self._core: k8s_client.CoreV1Api | None = None
         self._batch: k8s_client.BatchV1Api | None = None
         self._api_client: k8s_client.ApiClient | None = None
@@ -1337,6 +1350,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
                     pvc_mounts=self._pvc_mounts,
                     secret_mounts=self._secret_mounts,
                     agent_name=agent_name,
+                    runtime_class=self._runtime_class,
                 )
                 # Secret before Job so the Pod's secretKeyRef resolves
                 # immediately.

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1255,6 +1255,7 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
                     "pvc_mounts",
                     "secret_mounts",
                     "pod_ready_timeout_s",
+                    "runtime_class",
                 },
                 "sandbox.kubernetes",
             )
@@ -1276,6 +1277,7 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
             pod_ready_timeout_s=_parse_provider_positive_int(
                 raw, "kubernetes", "pod_ready_timeout_s"
             ),
+            runtime_class=_parse_provider_string(raw, "kubernetes", "runtime_class"),
         )
         token_ttl_s = KUBERNETES_MANAGED_TOKEN_TTL_S
     elif provider in community:
@@ -2218,6 +2220,7 @@ def _validate_kubernetes_identifiers(
     secret_name: str | None,
     service_account: str | None,
     node_selector: dict[str, str] | None,
+    runtime_class: str | None,
 ) -> None:
     """
     Validate the YAML ``sandbox.kubernetes`` identifiers at parse time.
@@ -2228,6 +2231,7 @@ def _validate_kubernetes_identifiers(
     _validate_dns1123_label(namespace, "namespace")
     _validate_dns1123_subdomain(secret_name, "secret_name")
     _validate_dns1123_subdomain(service_account, "service_account")
+    _validate_dns1123_subdomain(runtime_class, "runtime_class")
     for key, value in (node_selector or {}).items():
         if not _validate_label_key(key):
             raise ValueError(
@@ -2544,6 +2548,7 @@ def _kubernetes_launcher_factory(
     pvc_mounts: list[dict[str, object]] | None,
     secret_mounts: list[dict[str, object]] | None,
     pod_ready_timeout_s: int | None,
+    runtime_class: str | None,
 ) -> Callable[[], SandboxHostLauncher]:
     """
     Build the launcher factory for the YAML ``provider: kubernetes`` path.
@@ -2571,10 +2576,15 @@ def _kubernetes_launcher_factory(
         runner Pod (rotation-friendly credential volumes), or ``None``.
     :param pod_ready_timeout_s: Pod-start wait budget in seconds, or ``None``
         for the launcher's built-in default.
+    :param runtime_class: ``RuntimeClass`` name every runner Pod is scheduled
+        under as ``spec.runtimeClassName`` (e.g. ``kata`` for micro-VM
+        isolation), or ``None`` for the cluster's default runtime.
     :returns: A factory producing parameterized Kubernetes launchers.
     :raises ValueError: When a name or node-selector label is malformed.
     """
-    _validate_kubernetes_identifiers(namespace, secret_name, service_account, node_selector)
+    _validate_kubernetes_identifiers(
+        namespace, secret_name, service_account, node_selector, runtime_class
+    )
 
     def _build() -> SandboxHostLauncher:
         """Construct the Kubernetes launcher (lazy SDK import inside)."""
@@ -2593,6 +2603,7 @@ def _kubernetes_launcher_factory(
             pvc_mounts=pvc_mounts,
             secret_mounts=secret_mounts,
             pod_ready_timeout_s=pod_ready_timeout_s,
+            runtime_class=runtime_class,
         )
 
     return _build

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -273,6 +273,18 @@ def test_build_job_manifest_node_selector_can_override_arch() -> None:
     assert selector["disktype"] == "ssd"
 
 
+def test_build_job_manifest_omits_runtime_class_by_default() -> None:
+    """No runtime_class → no runtimeClassName key: the cluster default runtime."""
+    manifest = build_job_manifest(**_MANIFEST_KW)
+    assert "runtimeClassName" not in _pod_spec(manifest)
+
+
+def test_build_job_manifest_runtime_class_sets_runtime_class_name() -> None:
+    """An operator runtime_class lands verbatim as spec.runtimeClassName."""
+    manifest = build_job_manifest(**{**_MANIFEST_KW, "runtime_class": "kata"})
+    assert _pod_spec(manifest)["runtimeClassName"] == "kata"
+
+
 def test_build_job_manifest_pvc_mounts_land_on_host_container_only() -> None:
     """Each pvc_mounts entry becomes a persistentVolumeClaim volume mounted on host only."""
     manifest = build_job_manifest(

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -218,6 +218,7 @@ class FakeSandboxLauncher(SandboxLauncher):
         self.pvc_mounts: list[dict[str, object]] | None = None
         self.secret_mounts: list[dict[str, object]] | None = None
         self.pod_ready_timeout_s: int | None = None
+        self.runtime_class: str | None = None
         self.prepared = False
         self.provisioned_names: list[str] = []
         self.commands: list[str] = []
@@ -555,7 +556,7 @@ def install_fake_kubernetes_launcher(
     The managed flow constructs ``KubernetesSandboxLauncher(image=…, env=…,
     namespace=…, secret_name=…, service_account=…, node_selector=…,
     kubeconfig=…, in_cluster=…, resources=…, pvc_mounts=…, secret_mounts=…,
-    pod_ready_timeout_s=…)``; the shim records those constructor args on the
+    pod_ready_timeout_s=…, runtime_class=…)``; the shim records those constructor args on the
     fake and hands it back, so production code runs unmodified against it.
 
     :param monkeypatch: The test's ``pytest.MonkeyPatch``.
@@ -577,6 +578,7 @@ def install_fake_kubernetes_launcher(
         pvc_mounts: list[dict[str, object]] | None = None,
         secret_mounts: list[dict[str, object]] | None = None,
         pod_ready_timeout_s: int | None = None,
+        runtime_class: str | None = None,
     ) -> FakeSandboxLauncher:
         """Stand-in constructor recording the construction wiring."""
         fake.image = image
@@ -591,6 +593,7 @@ def install_fake_kubernetes_launcher(
         fake.pvc_mounts = pvc_mounts
         fake.secret_mounts = secret_mounts
         fake.pod_ready_timeout_s = pod_ready_timeout_s
+        fake.runtime_class = runtime_class
         return fake
 
     monkeypatch.setattr(kubernetes_mod, "KubernetesSandboxLauncher", _ctor)

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -683,6 +683,7 @@ def test_parse_valid_kubernetes_config_builds_parameterized_factory(
                 "secret_name": "omnigent-creds",
                 "service_account": "omnigent-runner",
                 "node_selector": {"omnigent.ai/runner-ready": "true"},
+                "runtime_class": "kata",
                 "in_cluster": True,
                 "resources": {"requests": {"cpu": "500m"}, "limits": {"memory": "8Gi"}},
                 "pod_ready_timeout_s": 300,
@@ -704,6 +705,7 @@ def test_parse_valid_kubernetes_config_builds_parameterized_factory(
     assert fake.secret_name == "omnigent-creds"
     assert fake.service_account == "omnigent-runner"
     assert fake.node_selector == {"omnigent.ai/runner-ready": "true"}
+    assert fake.runtime_class == "kata"
     assert fake.in_cluster is True
     assert fake.resources == {"requests": {"cpu": "500m"}, "limits": {"memory": "8Gi"}}
     assert fake.pod_ready_timeout_s == 300
@@ -857,6 +859,7 @@ def test_parse_host_config_lossy_json_key_collision_fails_loud() -> None:
     [
         ({"namespace": "Bad_NS"}, "sandbox.kubernetes.namespace"),
         ({"node_selector": {"omnigent.ai/x": "Bad Value"}}, "node_selector"),
+        ({"runtime_class": "Not_A_DNS_Name"}, "sandbox.kubernetes.runtime_class"),
         ({"resources": {"requests": {"cpu": "not a quantity!"}}}, "valid Kubernetes quantity"),
         ({"resources": {"requests": {"disk": "1Gi"}}}, "unknown key"),
         ({"in_cluster": "yes"}, "must be a boolean"),


### PR DESCRIPTION
Implements #3164: an opt-in `runtime_class` key on the `sandbox.kubernetes` config, threaded through `KubernetesSandboxLauncher` into `build_pod_manifest()` as `spec.runtimeClassName` — so operators with a RuntimeClass-enabled cluster (Kata Containers, gVisor) can schedule agent Pods onto a sandboxed container runtime for VM-grade per-session isolation, with no runtime-specific code in Omnigent.

## Shape (mirrors the existing `node_selector` pattern)

```yaml
sandbox:
  provider: kubernetes
  kubernetes:
    runtime_class: kata   # optional; unset = cluster default runtime, today's behaviour exactly
```

- **Default-off:** when unset, the key is *absent* from the manifest (not `null`) — byte-compatible with existing deployments.
- **Parse-time validation:** the name must be an RFC 1123 DNS subdomain (RuntimeClass names are object names), validated in `_validate_kubernetes_identifiers` alongside namespace/secret/SA so an operator typo fails server startup, not the first launch; the `_reject_unknown_keys` allowlist covers key misspellings.
- **No new dependency**; Kata/gVisor are installed cluster-side by the operator via a standard `RuntimeClass` object.

## Tests

- `test_build_pod_manifest_omits_runtime_class_by_default` — unset ⇒ no `runtimeClassName` key.
- `test_build_pod_manifest_runtime_class_sets_runtime_class_name` — set ⇒ lands verbatim.
- Valid-config parse test extended (`runtime_class: kata` reaches the launcher ctor); invalid-name case added to the fail-loud parametrize.
- `tests/onboarding/sandboxes/test_kubernetes.py` 46 passed; `tests/server/test_managed_hosts.py` 170 passed; ruff check + format clean.

## Field report

We validated the target runtime today on our own cluster (Talos v1.13.7, Kata via the `kata-containers` system extension, nested KVM on Proxmox): a `runtimeClassName: kata` pod reaches Ready in ~8s on cloud-hypervisor with ~156 MB hypervisor RSS, guest kernel distinct from the node kernel. This patch is the remaining piece that lets the omnigent server schedule its sandbox Pods there.

On the open design point in #3164 (Kata vs the "restricted" securityContext): no change proposed here — the restricted securityContext applies inside the guest and worked as-is in our testing; happy to follow up if maintainers want an escape hatch.
