### PR TITLE
feat(catalog): add claude-opus-5 to curated claude subscription models

### DIFF
--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -83,6 +83,7 @@ _LLM_TASK_TOKENS = ("chat", "completion")
 _SUBSCRIPTION_STATIC_MODELS: dict[str, tuple[str, ...]] = {
     "claude": (
         "claude-fable-5",
+        "claude-opus-5",
         "claude-opus-4-8",
         "claude-sonnet-5",
         "claude-sonnet-4-6",

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -3699,6 +3699,7 @@ async def test_sys_list_models_dispatches_locally_with_static_provider(
     # exact ids an orchestrator may pass back as args.model.
     assert [m["id"] for m in worker["models"]] == [
         "claude-fable-5",
+        "claude-opus-5",
         "claude-opus-4-8",
         "claude-sonnet-5",
         "claude-sonnet-4-6",

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -772,6 +772,7 @@ def test_subscription_listing_is_static_and_unverified(
     # Exactly the curated claude tiers — these are aliases, not a live list.
     assert [m.id for m in listing.models] == [
         "claude-fable-5",
+        "claude-opus-5",
         "claude-opus-4-8",
         "claude-sonnet-5",
         "claude-sonnet-4-6",


### PR DESCRIPTION
## What

Adds `claude-opus-5` (Claude Opus 5, released 2026-07-24) to `_SUBSCRIPTION_STATIC_MODELS["claude"]` in `omnigent/model_catalog.py`, plus the two tests that assert the exact curated tuple.

**Placement:** the list is ordered by capability tier descending (fable → opus → sonnet → haiku) with the newest version first within a family (cf. `claude-sonnet-5` ahead of `claude-sonnet-4-6`), so `claude-opus-5` slots between `claude-fable-5` and `claude-opus-4-8`.

## Empirical verification (Claude Code 2.1.220)

Each id tested with `claude --model <id> -p 'Reply with exactly: OK' --output-format json`:

| id | is_error | action |
|---|---|---|
| `claude-opus-5` | **false** (`result: "OK"`, canonicalModel `claude-opus-5`) | added |
| `claude-opus-5-fast` | **true** (404, model does not exist; "fast mode" is a CLI feature flag, not a model id) | not added |
| `claude-opus-5-20260724` | **true** (dated form invalid) | not added |
| `opus` | **false** (version-agnostic alias, already resolves to latest Opus) | n/a |

## Web mirror

`web/src/lib/claudeNativeModels.ts` intentionally lists **version-agnostic aliases** (`opus` → latest installed Opus; header comment: "the list never drifts when a version retires"), not pinned ids — so no change needed there. The `sonnet_5` row exists only because the default `sonnet` alias is pinned to 4.6; there is no analogous Opus pin.

## Diff summary

```
omnigent/model_catalog.py            | 1 +
tests/runner/test_runner_dispatch.py | 1 +
tests/test_model_catalog.py          | 1 +
3 files changed, 3 insertions(+)
```

## Verification (run in an isolated worktree venv, uv 0.11.32)

- `pytest tests/test_model_catalog.py -q` → **46 passed**
- `pytest tests/runner/test_runner_dispatch.py -q` → **140 passed, 1 skipped**
- `pytest tests/test_claude_native.py tests/test_claude_native_bridge.py tests/test_claude_native_forwarder.py tests/policies/builtins/test_cost.py tests/inner/test_claude_gateway_shim.py tests/inner/test_claude_sdk_executor.py -q` → **639 passed**
- `ruff check` + `ruff format --check` on the 3 touched files → **all checks passed, 3 files already formatted**

Targeted subset only — the full suite was not run.