### PR TITLE
feat(UI): copy worktree and working folder paths

### DIFF
--- a/web/src/pages/ChatPage.statusLine.test.tsx
+++ b/web/src/pages/ChatPage.statusLine.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useChatStore } from "@/store/chatStore";
@@ -20,11 +20,13 @@ vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
 // renders deterministically without a QueryClient / RunnerHealth provider. The
 // default is "not host-bound", so the badge self-hides and the existing branch/
 // ring/harness assertions are unchanged; host-aware tests override per case.
-const { useSessionMock, useHostsMock, useSessionHostOnlineMock } = vi.hoisted(() => ({
+const { copyTextMock, useSessionMock, useHostsMock, useSessionHostOnlineMock } = vi.hoisted(() => ({
+  copyTextMock: vi.fn(),
   useSessionMock: vi.fn(),
   useHostsMock: vi.fn(),
   useSessionHostOnlineMock: vi.fn(),
 }));
+vi.mock("@/lib/clipboard", () => ({ copyText: copyTextMock }));
 vi.mock("@/hooks/useSession", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/hooks/useSession")>()),
   useSession: (id: string | null | undefined) => useSessionMock(id),
@@ -113,6 +115,7 @@ function bindHost(name: string) {
 
 describe("Composer status line (branch + context ring)", () => {
   beforeEach(() => {
+    copyTextMock.mockReset().mockResolvedValue(undefined);
     // Default: no host bound, so HostBadge renders nothing.
     useSessionMock.mockReset().mockReturnValue({
       session: { hostId: null },
@@ -247,6 +250,26 @@ describe("Composer status line (branch + context ring)", () => {
     // `truncate` (overflow-hidden + ellipsis + nowrap) is the guard that
     // keeps a long branch from wrapping the tray onto a second line.
     expect(branch).toHaveClass("truncate");
+  });
+
+  it("copies the worktree path beside the branch name", async () => {
+    useSessionMock.mockReturnValue({
+      session: {
+        hostId: "host_a1b2",
+        workspace: "/Users/corey/repo-worktrees/feature-login",
+      },
+      isLoading: false,
+      error: null,
+    });
+    useChatStore.setState({ gitBranch: "feature/login" });
+    renderComposer();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy worktree path" }));
+
+    await waitFor(() =>
+      expect(copyTextMock).toHaveBeenCalledWith("/Users/corey/repo-worktrees/feature-login"),
+    );
+    expect(screen.getByRole("button", { name: "Copied worktree path" })).toBeInTheDocument();
   });
 
   it("renders the tray with a branch even when the ring is absent", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3041,7 +3041,7 @@ export const BubbleView = memo(
 );
 
 /**
- * Copy-to-clipboard handler for a message bubble's "Copy" action.
+ * Copy-to-clipboard handler with inline success feedback.
  *
  * Uses the shared {@link copyText} helper (async Clipboard API with an
  * `execCommand` fallback) rather than `navigator.clipboard.writeText`
@@ -3052,9 +3052,9 @@ export const BubbleView = memo(
  * copy is confirmed.
  *
  * @param getText - Produces the text to copy at click time.
- * @returns `{ isCopied, handleCopy }` for the action button.
+ * @returns `{ isCopied, handleCopy }` for a copy action button.
  */
-function useCopyMessage(getText: () => string): {
+function useCopyText(getText: () => string): {
   isCopied: boolean;
   handleCopy: () => void;
 } {
@@ -3078,7 +3078,7 @@ function useCopyMessage(getText: () => string): {
         }
       },
       (error) => {
-        console.warn("Failed to copy message", error);
+        console.warn("Failed to copy text", error);
       },
     );
   }, [getText, isCopied, isMobile]);
@@ -3121,7 +3121,7 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
   const showAuthorBadge = shouldShowAuthorBadge(author, getCurrentAuthorId(), isSessionShared);
   // Equality selector so Zustand only re-renders the matching bubble.
   const flashing = useChatStore((s) => s.flashItemId === bubble.itemId);
-  const { isCopied, handleCopy } = useCopyMessage(() => text);
+  const { isCopied, handleCopy } = useCopyText(() => text);
 
   return (
     <Message
@@ -3262,7 +3262,7 @@ function AssistantBubble({ bubble }: { bubble: Extract<Bubble, { kind: "assistan
   // Getter computes the markdown lazily at click time — the hook must run
   // before the early return below (rules of hooks), but `markdownText` is
   // derived after it.
-  const { isCopied, handleCopy } = useCopyMessage(() => collectBubbleMarkdown(bubble.items));
+  const { isCopied, handleCopy } = useCopyText(() => collectBubbleMarkdown(bubble.items));
   // null outside AppShell's provider (isolated tests) → hide the action.
   const forkDialog = useForkDialog();
 
@@ -3671,6 +3671,9 @@ function ComposerStatusLine({
   // from the same source the badge does so the tray's render guard matches.
   const { session } = useSession(conversationId);
   const isHostBound = !!session?.hostId;
+  const { isCopied: isWorktreePathCopied, handleCopy: copyWorktreePath } = useCopyText(
+    () => session?.workspace ?? "",
+  );
 
   const showBranch = !!conversationId && !!gitBranch;
   // Host indicator (green/red dot + host name), left of the worktree branch.
@@ -3727,6 +3730,23 @@ function ComposerStatusLine({
             <span data-testid="composer-git-branch" className="min-w-0 truncate" title={gitBranch}>
               {gitBranch}
             </span>
+            {session?.workspace && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label={isWorktreePathCopied ? "Copied worktree path" : "Copy worktree path"}
+                title={isWorktreePathCopied ? "Copied worktree path" : "Copy worktree path"}
+                onClick={copyWorktreePath}
+                className="-my-1 size-5"
+              >
+                {isWorktreePathCopied ? (
+                  <CheckIcon className="size-3" />
+                ) : (
+                  <CopyIcon className="size-3" />
+                )}
+              </Button>
+            )}
           </span>
         )}
       </div>

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { useState } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -16,6 +16,8 @@ import { FilesPanel } from "./FilesPanel";
 import { FilesPanelDrawer } from "./FilesPanelDrawer";
 import { FolderTree } from "./FolderTree";
 
+const { copyTextMock } = vi.hoisted(() => ({ copyTextMock: vi.fn() }));
+vi.mock("@/lib/clipboard", () => ({ copyText: copyTextMock }));
 vi.mock("@/hooks/useWorkspaceChangedFiles", () => ({
   useWorkspaceAllFiles: vi.fn(),
   useWorkspaceChangedFiles: vi.fn(),
@@ -157,6 +159,7 @@ function renderPanel({
 }
 
 beforeEach(() => {
+  copyTextMock.mockReset().mockResolvedValue(undefined);
   useAllFilesMock.mockReset();
   useChangedFilesMock.mockReset();
   useDirectoryMock.mockReset();
@@ -198,6 +201,19 @@ describe("FilesPanel working folder directory", () => {
     expect(screen.getByText("my-project")).toBeInTheDocument();
   });
 
+  it("copies the full working folder path", async () => {
+    renderPanel({
+      conversationId: "conv_wdir_copy",
+      files: [],
+      workingDir: "/home/user/my-project",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy working folder path" }));
+
+    await waitFor(() => expect(copyTextMock).toHaveBeenCalledWith("/home/user/my-project"));
+    expect(screen.getByRole("button", { name: "Copied working folder path" })).toBeInTheDocument();
+  });
+
   it("does not render a directory label when workingDir is null", () => {
     renderPanel({ conversationId: "conv_wdir_null", files: [] });
     // "Working folder" label is present but no directory name span
@@ -214,7 +230,7 @@ describe("FilesPanel working folder header role", () => {
   // always visible and the header never carries aria-expanded.
   it("renders the header as a static label (no toggle button) in the standalone card", () => {
     renderPanel({ conversationId: "conv_header_card", files: [] });
-    expect(screen.queryByRole("button", { name: /working folder/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^working folder$/i })).toBeNull();
     expect(screen.getByText("Working folder")).toBeInTheDocument();
     // Content is always shown — the scope switch is part of it.
     expect(screen.getByRole("radiogroup", { name: "File scope" })).toBeInTheDocument();
@@ -249,7 +265,7 @@ describe("FilesPanel working folder header role", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.queryByRole("button", { name: /working folder/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^working folder$/i })).toBeNull();
     expect(screen.getByText("Working folder")).toBeInTheDocument();
     expect(screen.getByRole("radiogroup", { name: "File scope" })).toBeInTheDocument();
   });
@@ -257,7 +273,7 @@ describe("FilesPanel working folder header role", () => {
   it("renders a static label header with a Close button in the drawer", () => {
     renderPanel({ conversationId: "conv_header_drawer", files: [], onClose: vi.fn() });
     // The drawer adds an X close button; the title is a plain label everywhere.
-    expect(screen.queryByRole("button", { name: /working folder/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^working folder$/i })).toBeNull();
     expect(screen.getByText("Working folder")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Close files" })).toBeInTheDocument();
   });

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -1,6 +1,8 @@
 import {
   ArrowDownAZIcon,
   ArrowDownWideNarrowIcon,
+  CheckIcon,
+  CopyIcon,
   EyeIcon,
   EyeOffIcon,
   FileClockIcon,
@@ -23,6 +25,7 @@ import {
   useWorkspaceFileSearch,
 } from "@/hooks/useWorkspaceChangedFiles";
 import { cn } from "@/lib/utils";
+import { copyText } from "@/lib/clipboard";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   DropdownMenu,
@@ -542,19 +545,50 @@ export function FilesPanel({
 // ---------------------------------------------------------------------------
 
 function WorkingDirLabel({ dir }: { dir: string }) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = window.setTimeout(() => setCopied(false), 2000);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  function copyWorkingDir() {
+    if (copied) return;
+    copyText(dir).then(
+      () => setCopied(true),
+      (error) => console.warn("Failed to copy working folder path", error),
+    );
+  }
+
   // Outer span participates in the flex row as flex-1 for layout/truncation.
   // Inner span is the actual tooltip trigger so Radix anchors the popup to
   // the text's bounding rect (not the full flex-1 width).
   return (
-    <span className="min-w-0 flex-1 flex items-center overflow-hidden">
+    <span className="flex min-w-0 flex-1 items-center gap-1">
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <span className="inline-block max-w-full truncate font-mono text-[11px] text-muted-foreground cursor-default">
+            <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground cursor-default">
               {dirBasename(dir)}
             </span>
           </TooltipTrigger>
           <TooltipContent side="bottom">{dir}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={copied ? "Copied working folder path" : "Copy working folder path"}
+              className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              onClick={copyWorkingDir}
+            >
+              {copied ? <CheckIcon className="size-3.5" /> : <CopyIcon className="size-3.5" />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {copied ? "Copied working folder path" : "Copy working folder path"}
+          </TooltipContent>
         </Tooltip>
       </TooltipProvider>
     </span>


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a small copy action beside the active session worktree branch in the composer status tray.
- Add a copy action beside the Working folder name in the Files panel, available for both regular project folders and git worktrees.
- Copy the full absolute path using the existing clipboard fallback and show temporary checkmark feedback.
- Cover both interactions with focused unit tests.

## Test Plan

- cd web && npm test -- src/pages/ChatPage.statusLine.test.tsx src/shell/FilesPanel.test.tsx
- cd web && npm run type-check
- Run targeted oxlint and Prettier checks for the four changed source and test files
- uvx pre-commit run
- Manually verified in Omnigent Desktop that the Files-panel button copies the complete working-folder path and changes to a checkmark

## Demo

Copy worktree path:
<img width="768" height="189" alt="Screenshot 2026-07-25 at 20 43 33" src="https://github.com/user-attachments/assets/27ff6389-3939-4a7c-be0b-e6d1565f416d" />

Copy working folder path:
<img width="306" height="148" alt="Screenshot 2026-07-25 at 22 21 54" src="https://github.com/user-attachments/assets/1a0e51d6-e30b-4e61-8011-2d7a3b1929f2" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused tests verify that each button copies the full absolute path and exposes its copied state. Manual verification confirmed the Working folder action in the desktop Files panel for a real local session.

## Changelog

Copy worktree and working-folder paths directly from the session UI.