### PR TITLE
feat: add conversation-only session revert and /revert command

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -5531,6 +5531,93 @@ async def _cmd_fork(
     )
 
 
+def _revert_user_messages(items: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Return selectable, non-meta user messages newest first."""
+    return [
+        item
+        for item in reversed(items)
+        if item.get("type") == "message"
+        and item.get("role") == "user"
+        and not item.get("is_meta")
+        and not _extract_message_text(item).lstrip().startswith("[System:")
+        and isinstance(item.get("id"), str)
+    ]
+
+
+async def _pick_revert_message(items: list[dict[str, object]]) -> str | None:
+    """Open the prompt-toolkit message picker for ``/revert``."""
+    from prompt_toolkit.application import run_in_terminal
+    from prompt_toolkit.shortcuts import radiolist_dialog
+
+    candidates = _revert_user_messages(items)
+    if not candidates:
+        return None
+
+    def choose_message() -> str | None:
+        values = []
+        for item in candidates:
+            text = " ".join(_extract_message_text(item).split()) or "(attachments only)"
+            if len(text) > 88:
+                text = text[:87].rstrip() + "…"
+            values.append((str(item["id"]), text))
+        return radiolist_dialog(
+            title="Revert conversation",
+            text="Choose the user message to return to.",
+            values=values,
+        ).run()
+
+    return await run_in_terminal(choose_message, in_executor=True)
+
+
+@_cmd("/revert", "Revert to a past user message")
+async def _cmd_revert(
+    arg: str,
+    session: Session,
+    client: OmnigentClient,
+    host: TerminalHost,
+    fmt: RichBlockFormatter,
+) -> None:
+    """Rewind this session to before a selected user message."""
+    current_id = getattr(session, "session_id", None)
+    if current_id is None:
+        host.output(Text("  /revert requires the sessions API.", style="bold red"))
+        return
+    args = arg.split()
+    if len(args) > 1 or (args and args[0].startswith("-")):
+        host.output(Text("  Usage: /revert [user-message-id]", style="bold red"))
+        return
+    try:
+        items = await _list_all_conversation_items(client, current_id)
+        if args:
+            selected = args[0]
+        elif not _revert_user_messages(items):
+            host.output(Text(f"  [{fmt.muted}]No user messages to revert to.[/{fmt.muted}]"))
+            return
+        else:
+            selected = await _pick_revert_message(items)
+        if selected is None:
+            return
+        result = await client.sessions.revert(current_id, selected)
+        await _attach_to_conversation(
+            current_id,
+            session,
+            client,
+            host,
+            fmt,
+            ui_name=_humanize_agent_name(session.model),
+            redraw_screen=True,
+        )
+    except Exception as exc:  # noqa: BLE001 — command boundary renders failures inline
+        _log.exception("Revert failed")
+        host.output(Text(f"  Revert failed: {exc}", style="bold red"))
+        return
+
+    host.output(Text.from_markup(f"  [{fmt.muted}]Reverted this session.[/{fmt.muted}]"))
+    draft = result.get("draft")
+    if isinstance(draft, str) and draft:
+        host.output(Text.from_markup(f"\n  [bold]Message to retry[/]\n  {escape(draft)}"))
+
+
 @_cmd("/history", "Show current conversation history")
 async def _cmd_history(
     arg: str,  # noqa: ARG001 — dispatch-contract params

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8996,6 +8996,8 @@ def create_runner_app(
         await _teardown_session_terminals(session_id)
         await resource_registry.cleanup_session(session_id)
         _clear_session_agent_caches(session_id, _session_agent_ids.get(session_id))
+        _session_histories.pop(session_id, None)
+        _last_server_item_id.pop(session_id, None)
         return JSONResponse(
             status_code=200,
             content={

--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -1106,6 +1106,38 @@ shape as `GET /v1/sessions/{id}` — with status `"idle"` and all
 copied items in chronological order. Clients must bind a runner
 before opening the fork's SSE stream or posting events.
 
+### Revert Session
+
+```
+POST /v1/sessions/{source_id}/revert
+Content-Type: application/json
+
+{
+  "user_message_id": "msg_abc123"
+}
+
+200 OK
+{
+  "draft": "Original prompt text"
+}
+```
+
+Deletes the selected user message and every later conversation item
+while preserving the session ID, metadata, agent binding, and earlier
+history. Native runtime state is reset so discarded native history
+cannot reappear, and the selected prompt is returned for editing.
+
+Workspace files, Git state, and files outside the workspace are never
+read or modified by this endpoint.
+
+```
+400 Bad Request — the target is not a selectable user message, the
+  session is a sub-agent, or the session has no agent binding
+404 Not Found — no session or bound agent exists
+409 Conflict — the session has an active or waiting turn
+503 Service Unavailable — a connected native runtime could not reset
+```
+
 ### Stream Session
 
 ```

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -291,6 +291,8 @@ from omnigent.server.schemas import (
     SessionResourceObject,
     SessionResourcePaginatedList,
     SessionResponse,
+    SessionRevertRequest,
+    SessionRevertResponse,
     SessionSwitchAgentRequest,
     SkillSummary,
     UpdateSessionRequest,

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -7,6 +7,7 @@ import contextlib
 import json
 import secrets
 import time
+import urllib.parse
 from collections.abc import Callable
 from typing import Any
 
@@ -34,6 +35,8 @@ from omnigent.db.utils import generate_agent_id
 from omnigent.entities import (
     CommentsFingerprint,
     Conversation,
+    ConversationItem,
+    MessageData,
     synthesize_conversation_title,
 )
 from omnigent.entities.permission import SessionPermission
@@ -114,6 +117,8 @@ from omnigent.server.schemas import (
     SessionListItem,
     SessionProjectSummary,
     SessionResponse,
+    SessionRevertRequest,
+    SessionRevertResponse,
     SessionSwitchAgentRequest,
     UpdateSessionRequest,
 )
@@ -132,6 +137,26 @@ from omnigent.stores.conversation_store import (
 from omnigent.stores.file_store import FileStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.project_store import ProjectStore
+
+
+def _list_all_items_for_revert(
+    conversation_store: ConversationStore,
+    session_id: str,
+) -> list[ConversationItem]:
+    """Read a complete transcript through the store's cursor contract."""
+    items: list[ConversationItem] = []
+    after: str | None = None
+    while True:
+        page = conversation_store.list_items(
+            session_id,
+            limit=1000,
+            after=after,
+            order="asc",
+        )
+        items.extend(page.data)
+        if not page.has_more or not page.data:
+            return items
+        after = page.data[-1].id
 
 
 def register_core_routes(
@@ -2052,6 +2077,104 @@ def register_core_routes(
             last_task_error=None,
             agent_name=base_agent.name,
         )
+
+    # ── POST /sessions/{source_id}/revert ────────────────────────
+
+    @router.post(
+        "/sessions/{source_id}/revert",
+        response_model=None,
+        responses={200: {"model": SessionRevertResponse}},
+    )
+    async def revert_session(
+        request: Request,
+        source_id: str,
+        body: SessionRevertRequest,
+    ) -> SessionRevertResponse:
+        """Rewind one session to immediately before a selected user message."""
+        user_id = _get_user_id(request, auth_provider)
+        access = await _require_access_and_level(
+            user_id,
+            source_id,
+            LEVEL_EDIT,
+            permission_store,
+            conversation_store,
+        )
+        source = access.conversation
+        if source is None:
+            source = await asyncio.to_thread(conversation_store.get_conversation, source_id)
+        if source is None:
+            raise _session_not_found()
+        if source.kind == "sub_agent":
+            raise OmnigentError(
+                "Only top-level sessions can be reverted.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        if _session_status_from_cache(source_id) in ("running", "waiting"):
+            raise OmnigentError(
+                "Wait for the current turn to finish before reverting.",
+                code=ErrorCode.CONFLICT,
+            )
+
+        items = await asyncio.to_thread(
+            _list_all_items_for_revert,
+            conversation_store,
+            source_id,
+        )
+        target = next((item for item in items if item.id == body.user_message_id), None)
+        if target is None:
+            raise OmnigentError(
+                f"User message not found: {body.user_message_id!r}",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        if (
+            target.type != "message"
+            or not isinstance(target.data, MessageData)
+            or target.data.role != "user"
+            or target.data.is_meta
+            or (_message_text(target.data.content) or "").lstrip().startswith("[System:")
+        ):
+            raise OmnigentError(
+                "The revert point must be a user message.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        if source.agent_id is None:
+            raise OmnigentError("Session has no agent binding.", code=ErrorCode.INVALID_INPUT)
+        agent = await asyncio.to_thread(agent_store.get, source.agent_id)
+        if agent is None:
+            raise OmnigentError("Session agent not found.", code=ErrorCode.NOT_FOUND)
+
+        target_is_cursor = await asyncio.to_thread(_agent_carries_cursor_fork_history, agent)
+        carry_history_into_native = target_is_cursor or await asyncio.to_thread(
+            _agent_carries_native_fork_history,
+            agent,
+        )
+        is_native = await asyncio.to_thread(_agent_is_native, agent)
+        runner_client = await _get_runner_client(source_id, runner_router) if is_native else None
+        if runner_client is not None:
+            try:
+                reset_response = await runner_client.post(
+                    f"/v1/sessions/{urllib.parse.quote(source_id, safe='')}/reset-state",
+                    timeout=15.0,
+                )
+                reset_response.raise_for_status()
+            except (httpx.HTTPError, ConnectionError) as exc:
+                raise OmnigentError(
+                    "The native session could not be reset. Please retry.",
+                    code=ErrorCode.RUNNER_UNAVAILABLE,
+                ) from exc
+
+        draft = _message_text(target.data.content) or ""
+        try:
+            await asyncio.to_thread(
+                conversation_store.rewind_conversation,
+                source_id,
+                before_item_id=target.id,
+                carry_history_into_native=carry_history_into_native,
+            )
+        except LookupError as exc:
+            raise OmnigentError(str(exc), code=ErrorCode.INVALID_INPUT) from exc
+
+        return SessionRevertResponse(draft=draft)
 
     # ── POST /sessions/{session_id}/switch-agent ─────────────────
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2123,6 +2123,20 @@ class SessionForkRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class SessionRevertRequest(BaseModel):
+    """Request to rewind a session to before a past user message."""
+
+    user_message_id: str = Field(min_length=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class SessionRevertResponse(BaseModel):
+    """Selected prompt returned to the client as an editable draft."""
+
+    draft: str
+
+
 class ReadStatePutRequest(BaseModel):
     """
     Request body for ``PUT /v1/sessions/{session_id}/read-state``.

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -39,10 +39,9 @@ FORK_SOURCE_LABEL_KEY = "omnigent.fork.source_id"
 # ``external_session_id`` is still NULL. Cleared/ignored thereafter.
 FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY = "omnigent.fork.source_external_session_id"
 
-# Fork directive: set when the fork binds a NATIVE target harness
-# (claude-native / codex-native) whose history should carry over. A native
-# CLI ignores the Omnigent transcript, so the runner rebuilds the target's
-# on-disk transcript before launch. Two rebuild paths share this directive:
+# Native-history replay directive used by forks, agent switches, and in-place
+# rewinds. A native CLI ignores the Omnigent transcript, so the runner rebuilds
+# the target's on-disk transcript before launch. Two rebuild paths share it:
 # when the source was a SAME-FAMILY native session its captured
 # ``external_session_id`` is also stamped (see
 # FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY) and the runner clones that
@@ -160,15 +159,19 @@ def pinned_label_key(user_id: str | None) -> str:
 #     typed re-confirmation and no banner, violating the "impossible to
 #     enable accidentally" contract (#657). Dropping it forces each session
 #     that runs bypass to make its own explicit opt-in.
-_INSTANCE_SCOPED_LABEL_KEYS = frozenset(
+_RUNTIME_INSTANCE_LABEL_KEYS = frozenset(
     {
+        "omnigent.antigravity_native.bridge_id",
         "omnigent.claude_native.bridge_id",
         "omnigent.codex_native.bridge_id",
+        "omnigent.opencode_native.bridge_id",
         "omnigent.last_context_tokens",
         "omnigent.last_context_window",
-        CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY,
     }
 )
+_INSTANCE_SCOPED_LABEL_KEYS = _RUNTIME_INSTANCE_LABEL_KEYS | {
+    CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY
+}
 
 # Source identity belongs only to the original imported session. Unlike runtime
 # instance labels, these survive an in-place agent switch but never a fork.
@@ -1441,6 +1444,28 @@ class ConversationStore(ABC):
             ``parent_conversation_id`` is set but no such
             conversation exists.
         :raises Exception: Backend errors propagate after rollback.
+        """
+        ...
+
+    @abstractmethod
+    def rewind_conversation(
+        self,
+        conversation_id: str,
+        *,
+        before_item_id: str,
+        carry_history_into_native: bool = False,
+    ) -> Conversation:
+        """Delete a selected item and everything after it in the same session.
+
+        Resets the native runtime identity so a supported native harness
+        rebuilds from the retained Agent Platform items on its next launch.
+
+        :param conversation_id: Session to rewind, e.g. ``"conv_abc123"``.
+        :param before_item_id: First item to delete, e.g. ``"msg_def456"``.
+        :param carry_history_into_native: Whether to mark the retained items for
+            native transcript replay.
+        :returns: The updated conversation with the same id.
+        :raises LookupError: If the conversation or cutoff item does not exist.
         """
         ...
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -79,6 +79,7 @@ from omnigent.session_import.models import (
 from omnigent.stores.conversation_store import (
     _FORK_ONLY_DROPPED_LABEL_KEYS,
     _INSTANCE_SCOPED_LABEL_KEYS,
+    _RUNTIME_INSTANCE_LABEL_KEYS,
     FORK_CARRY_HISTORY_LABEL_KEY,
     FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY,
     FORK_SOURCE_LABEL_KEY,
@@ -3248,6 +3249,96 @@ class SqlAlchemyConversationStore(ConversationStore):
             session.flush()
 
         return _created_session_from_rows(conversation_row, meta_row, agent_row, labels)
+
+    def rewind_conversation(
+        self,
+        conversation_id: str,
+        *,
+        before_item_id: str,
+        carry_history_into_native: bool = False,
+    ) -> Conversation:
+        """Delete a selected item and all later items from one conversation."""
+        now = now_epoch()
+        with self._conv_session() as session:
+            conversation = session.get(
+                SqlConversation,
+                (current_workspace_id(), conversation_id),
+            )
+            if conversation is None:
+                raise LookupError(f"conversation not found: {conversation_id!r}")
+            target_position = session.execute(
+                select(SqlConversationItem.position).where(
+                    SqlConversationItem.workspace_id == current_workspace_id(),
+                    SqlConversationItem.conversation_id == conversation_id,
+                    SqlConversationItem.id == before_item_id,
+                )
+            ).scalar_one_or_none()
+            if target_position is None:
+                raise LookupError(
+                    f"item not found in conversation {conversation_id!r}: {before_item_id!r}"
+                )
+
+            # ponytail: child sessions lack an origin item id; add that link before
+            # cascading post-rewind children instead of guessing from timestamps.
+            kept_items = (
+                session.execute(
+                    select(SqlConversationItem)
+                    .where(
+                        SqlConversationItem.workspace_id == current_workspace_id(),
+                        SqlConversationItem.conversation_id == conversation_id,
+                        SqlConversationItem.position < target_position,
+                    )
+                    .order_by(SqlConversationItem.position.asc())
+                )
+                .scalars()
+                .all()
+            )
+            delete_fts_by_conversation_ids(session, [conversation_id])
+            session.execute(
+                delete(SqlConversationItem).where(
+                    SqlConversationItem.workspace_id == current_workspace_id(),
+                    SqlConversationItem.conversation_id == conversation_id,
+                    SqlConversationItem.position >= target_position,
+                )
+            )
+            insert_fts_bulk(
+                session,
+                [(item.id, conversation_id, item.search_text or "") for item in kept_items],
+            )
+
+            conversation.next_position = target_position
+            conversation.updated_at = now
+            reset_label_keys = _RUNTIME_INSTANCE_LABEL_KEYS | {
+                FORK_CARRY_HISTORY_LABEL_KEY,
+                FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY,
+            }
+            session.execute(
+                delete(SqlConversationLabel).where(
+                    SqlConversationLabel.workspace_id == current_workspace_id(),
+                    SqlConversationLabel.conversation_id == conversation_id,
+                    SqlConversationLabel.key.in_(reset_label_keys),
+                )
+            )
+            if carry_history_into_native:
+                _upsert_labels(
+                    session,
+                    conversation_id,
+                    {FORK_CARRY_HISTORY_LABEL_KEY: "1"},
+                    now,
+                )
+
+        with self._session() as session:
+            metadata = session.get(
+                SqlConversationMetadata,
+                (current_workspace_id(), conversation_id),
+            )
+            if metadata is not None:
+                metadata.external_session_id = None
+
+        updated = self.get_conversation(conversation_id)
+        if updated is None:
+            raise LookupError(f"conversation not found: {conversation_id!r}")
+        return updated
 
     def fork_conversation(
         self,

--- a/openapi.json
+++ b/openapi.json
@@ -5246,6 +5246,36 @@
         "title": "SessionResponse",
         "type": "object"
       },
+      "SessionRevertRequest": {
+        "additionalProperties": false,
+        "description": "Request to rewind a session to before a past user message.",
+        "properties": {
+          "user_message_id": {
+            "minLength": 1,
+            "title": "User Message Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_message_id"
+        ],
+        "title": "SessionRevertRequest",
+        "type": "object"
+      },
+      "SessionRevertResponse": {
+        "description": "Selected prompt returned to the client as an editable draft.",
+        "properties": {
+          "draft": {
+            "title": "Draft",
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft"
+        ],
+        "title": "SessionRevertResponse",
+        "type": "object"
+      },
       "SessionSandboxStatusEvent": {
         "description": "Managed-sandbox launch progress for a `host_type=\"managed\"` session.\n\nA managed create returns before its sandbox exists; the Omnigent\nserver emits this event as the background launch pipeline advances\nso the Web UI can show live provisioning progress on the session\npage instead of a silent dead chat: sandbox provision \u2192 repository\nclone \u2192 host startup \u2192 runner connect \u2192 ready, or a terminal\nfailure with the reason.",
         "properties": {
@@ -12096,6 +12126,59 @@
           }
         },
         "summary": "Fork Session",
+        "tags": [
+          "sessions"
+        ]
+      }
+    },
+    "/v1/sessions/{source_id}/revert": {
+      "post": {
+        "description": "Rewind one session to immediately before a selected user message.",
+        "operationId": "revert_session_v1_sessions__source_id__revert_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "source_id",
+            "required": true,
+            "schema": {
+              "title": "Source Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionRevertRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionRevertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Revert Session",
         "tags": [
           "sessions"
         ]

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -929,6 +929,22 @@ class SessionsNamespace:
             f"POST /v1/sessions/{source_session_id}/fork",
         )
 
+    async def revert(
+        self,
+        source_session_id: str,
+        user_message_id: str,
+    ) -> dict[str, Any]:
+        """Rewind a session and return the selected prompt as a draft."""
+        resp = await self._http.post(
+            f"{self._base}/v1/sessions/{source_session_id}/revert",
+            json={"user_message_id": user_message_id},
+        )
+        raise_for_status(resp.status_code, response_body(resp))
+        return require_json_object(
+            resp,
+            f"POST /v1/sessions/{source_session_id}/revert",
+        )
+
     async def compact(self, session_id: str) -> None:
         """
         Request explicit context compaction for a session.

--- a/tests/repl/test_repl_revert_command.py
+++ b/tests/repl/test_repl_revert_command.py
@@ -1,0 +1,32 @@
+"""Tests for the REPL ``/revert`` slash command."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.repl import _repl as repl_mod
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_revert_command_registered_and_filters_system_messages() -> None:
+    """``/revert`` is discoverable and only offers real user prompts."""
+
+    def message(item_id: str, text: str, **extra: object) -> dict[str, object]:
+        return {
+            "id": item_id,
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": text}],
+            **extra,
+        }
+
+    assert "/revert" in repl_mod.COMMANDS
+    candidates = repl_mod._revert_user_messages(
+        [
+            message("msg_real", "retry me"),
+            message("msg_system", "[System: timer fired]"),
+            message("msg_meta", "hidden", is_meta=True),
+        ]
+    )
+    assert [item["id"] for item in candidates] == ["msg_real"]

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -621,7 +621,7 @@ async def test_reset_state_closes_terminals_and_publishes_deleted(tmp_path: Path
     dead terminal, and attaching to it failed with "terminal resource
     not found or not running".
     """
-    from omnigent.runner.app import _session_event_queues_ref
+    from omnigent.runner.app import _session_event_queues_ref, _session_histories_ref
 
     conv_id = "conv_switch_term_teardown"
     workspace = tmp_path / "workspace"
@@ -632,6 +632,7 @@ async def test_reset_state_closes_terminals_and_publishes_deleted(tmp_path: Path
     # Private-attr seed matches the existing resource-registry test
     # convention (no real tmux).
     _seed_registry(terminal_registry, conv_id, [_make_instance("tui", "main", tmp_path)])
+    _session_histories_ref[conv_id] = [{"type": "message", "role": "user", "content": []}]
     registry = SessionResourceRegistry(
         terminal_registry=terminal_registry,
         runner_workspace=workspace,
@@ -676,6 +677,7 @@ async def test_reset_state_closes_terminals_and_publishes_deleted(tmp_path: Path
         "reset-state must close the session's terminals; this one is "
         "still registered, so the web UI would keep listing it."
     )
+    assert conv_id not in _session_histories_ref
 
     # Exactly one session.resource.deleted for the closed terminal so
     # connected clients drop it live (the server relay also persists it).

--- a/tests/server/integration/test_sessions_revert.py
+++ b/tests/server/integration/test_sessions_revert.py
@@ -1,0 +1,103 @@
+"""Integration tests for in-place session revert."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from tests.server.helpers import create_test_agent
+from tests.server.integration.test_sessions_endpoints import (
+    _create_session,
+    _wait_for_idle,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _first_user_message(snapshot: dict[str, Any]) -> dict[str, Any]:
+    return next(
+        item
+        for item in snapshot["items"]
+        if item["type"] == "message" and item["data"]["role"] == "user"
+    )
+
+
+async def test_revert_rewinds_the_same_session_before_selected_user_message(
+    client: httpx.AsyncClient,
+) -> None:
+    """Revert mutates the source id and returns the selected prompt as a draft."""
+    agent = await create_test_agent(client)
+    source = await _create_session(client, agent["id"], initial_message="retry this prompt")
+    target = _first_user_message(await _wait_for_idle(client, source["id"]))
+
+    response = await client.post(
+        f"/v1/sessions/{source['id']}/revert",
+        json={"user_message_id": target["id"]},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"draft": "retry this prompt"}
+    snapshot = (await client.get(f"/v1/sessions/{source['id']}")).json()
+    assert snapshot["id"] == source["id"]
+    assert snapshot["items"] == []
+
+
+async def test_revert_has_no_file_restore_option(
+    client: httpx.AsyncClient,
+) -> None:
+    """The API rejects file controls instead of touching the workspace."""
+    agent = await create_test_agent(client)
+    source = await _create_session(client, agent["id"], initial_message="retry this prompt")
+    target = _first_user_message(await _wait_for_idle(client, source["id"]))
+
+    response = await client.post(
+        f"/v1/sessions/{source['id']}/revert",
+        json={"user_message_id": target["id"], "revert_files": True},
+    )
+
+    assert response.status_code == 422
+
+
+async def test_revert_resets_a_live_native_runtime_before_rewinding(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Native terminals are closed so discarded native history cannot return."""
+    from omnigent.server.routes import sessions as sessions_module
+
+    agent = await create_test_agent(client)
+    source = await _create_session(client, agent["id"], initial_message="retry native prompt")
+    target = _first_user_message(await _wait_for_idle(client, source["id"]))
+    runner_client = AsyncMock()
+    runner_client.post.return_value = httpx.Response(
+        200,
+        json={"reset": True},
+        request=httpx.Request("POST", "http://runner/reset-state"),
+    )
+
+    monkeypatch.setattr(sessions_module, "_agent_is_native", lambda _agent: True)
+    monkeypatch.setattr(
+        sessions_module,
+        "_agent_carries_native_fork_history",
+        lambda _agent: True,
+    )
+    monkeypatch.setattr(
+        sessions_module,
+        "_get_runner_client",
+        AsyncMock(return_value=runner_client),
+    )
+    response = await client.post(
+        f"/v1/sessions/{source['id']}/revert",
+        json={"user_message_id": target["id"]},
+    )
+
+    assert response.status_code == 200, response.text
+    runner_client.post.assert_awaited_once_with(
+        f"/v1/sessions/{source['id']}/reset-state",
+        timeout=15.0,
+    )
+    snapshot = (await client.get(f"/v1/sessions/{source['id']}")).json()
+    assert snapshot["labels"]["omnigent.fork.carry_history"] == "1"

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3435,8 +3435,10 @@ def test_fork_conversation_drops_instance_scoped_labels(
     conversation_store.set_labels(
         source.id,
         {
+            "omnigent.antigravity_native.bridge_id": source.id,
             "omnigent.claude_native.bridge_id": source.id,
             "omnigent.codex_native.bridge_id": source.id,
+            "omnigent.opencode_native.bridge_id": source.id,
             "omnigent.last_context_tokens": "39903",
             "omnigent.last_context_window": "1000000",
             # The dangerous bypass opt-in must NOT ride into the fork.
@@ -3589,6 +3591,54 @@ def test_fork_conversation_up_to_response_truncates_items(
     )
     # The source keeps its full 6-item history — fork must never mutate it.
     assert len(conversation_store.list_items(source.id).data) == 6
+
+
+def test_rewind_conversation_removes_selected_prompt_and_later_history(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Rewind mutates one session, resets runtime state, and keeps FTS valid."""
+    from omnigent.stores.conversation_store import (
+        CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY,
+        FORK_CARRY_HISTORY_LABEL_KEY,
+    )
+
+    source = conversation_store.create_conversation(title="Keep this title")
+    conversation_store.set_external_session_id(source.id, "native-session-old")
+    conversation_store.set_labels(
+        source.id,
+        {
+            "omnigent.claude_native.bridge_id": "bridge-old",
+            "omnigent.opencode_native.bridge_id": "opencode-old",
+            CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY: "1",
+        },
+    )
+    _append_three_responses(conversation_store, source.id)
+    source_items = conversation_store.list_items(source.id).data
+
+    rewound = conversation_store.rewind_conversation(
+        source.id,
+        before_item_id=source_items[2].id,
+        carry_history_into_native=True,
+    )
+
+    rewound_items = conversation_store.list_items(source.id).data
+    texts = [
+        block["text"]
+        for item in rewound_items
+        for block in item.data.content  # type: ignore[union-attr]
+    ]
+    assert rewound.id == source.id
+    assert rewound.title == "Keep this title"
+    assert rewound.external_session_id is None
+    assert rewound.labels[FORK_CARRY_HISTORY_LABEL_KEY] == "1"
+    assert "omnigent.claude_native.bridge_id" not in rewound.labels
+    assert "omnigent.opencode_native.bridge_id" not in rewound.labels
+    assert rewound.labels[CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY] == "1"
+    assert texts == ["Q1", "A1"]
+    assert conversation_store.search("Q2", conversation_id=source.id) == []
+    assert [item.id for item in conversation_store.search("Q1", conversation_id=source.id)] == [
+        rewound_items[0].id
+    ]
 
 
 def test_fork_conversation_truncated_drops_external_session_directive(
@@ -3815,14 +3865,18 @@ def test_instance_scoped_label_keys_match_harness_constants() -> None:
     forks would re-inherit the source's bridge. Importing the real
     constants here makes that rename fail loudly at test time.
     """
+    from omnigent.antigravity_native_bridge import ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY
     from omnigent.claude_native_bridge import BRIDGE_ID_LABEL_KEY
     from omnigent.codex_native_bridge import CODEX_NATIVE_BRIDGE_ID_LABEL_KEY
+    from omnigent.opencode_native_bridge import OPENCODE_NATIVE_BRIDGE_ID_LABEL_KEY
     from omnigent.stores.conversation_store import _INSTANCE_SCOPED_LABEL_KEYS
 
     # Each harness's canonical bridge-id key must be in the denylist; a
     # miss means a rename slipped past the store's hard-coded literal.
+    assert ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY in _INSTANCE_SCOPED_LABEL_KEYS
     assert BRIDGE_ID_LABEL_KEY in _INSTANCE_SCOPED_LABEL_KEYS
     assert CODEX_NATIVE_BRIDGE_ID_LABEL_KEY in _INSTANCE_SCOPED_LABEL_KEYS
+    assert OPENCODE_NATIVE_BRIDGE_ID_LABEL_KEY in _INSTANCE_SCOPED_LABEL_KEYS
 
 
 def test_fork_conversation_copies_reasoning_effort(

--- a/web/src/components/SlashCommandMenu.tsx
+++ b/web/src/components/SlashCommandMenu.tsx
@@ -18,6 +18,7 @@ export const BUILTIN_SLASH_COMMANDS: Record<string, string> = {
   "/context": "Show context window usage for this session",
   "/effort": "Set reasoning effort: /effort low | medium | high | default",
   "/model": "Switch the model for this session: /model <name> | default",
+  "/revert": "Return to a past user message",
   "/help": "Show available slash commands",
 };
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1118,6 +1118,26 @@
   }
 }
 
+@keyframes composer-notice {
+  0% {
+    opacity: 0;
+    transform: translateY(0.75rem);
+  }
+  10%,
+  80% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(0.75rem);
+  }
+}
+
+.composer-notice {
+  animation: composer-notice 4s ease-in-out both;
+}
+
 /* Global reduced-motion gate. The two scoped blocks above keep their
  * static-state declarations (class specificity beats * for those visible
  * properties); this universal rule collapses every other transition-* and
@@ -1131,6 +1151,9 @@
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+  .composer-notice {
+    animation: none;
   }
 }
 

--- a/web/src/lib/sessionDrafts.ts
+++ b/web/src/lib/sessionDrafts.ts
@@ -1,0 +1,49 @@
+const SESSION_DRAFTS_KEY = "omnigent.sessionDrafts";
+export const SESSION_TEXT_DRAFT_EVENT = "omnigent:session-text-draft";
+
+interface SessionDraft {
+  text: string;
+  files: File[];
+  notice?: string;
+}
+
+function loadDraftsFromStorage(): Map<string, SessionDraft> {
+  try {
+    const raw = window.sessionStorage.getItem(SESSION_DRAFTS_KEY);
+    if (!raw) return new Map();
+    const stored = JSON.parse(raw) as Record<string, string>;
+    return new Map(
+      Object.entries(stored)
+        .filter(([, text]) => Boolean(text))
+        .map(([id, text]) => [id, { text, files: [] }]),
+    );
+  } catch {
+    return new Map();
+  }
+}
+
+export const sessionDrafts = loadDraftsFromStorage();
+
+export function saveDraftsToStorage(drafts: Map<string, SessionDraft>): void {
+  try {
+    const stored = Object.fromEntries(
+      [...drafts].filter(([, draft]) => Boolean(draft.text)).map(([id, draft]) => [id, draft.text]),
+    );
+    if (Object.keys(stored).length > 0) {
+      window.sessionStorage.setItem(SESSION_DRAFTS_KEY, JSON.stringify(stored));
+    } else {
+      window.sessionStorage.removeItem(SESSION_DRAFTS_KEY);
+    }
+  } catch {
+    // In-memory drafts still work when storage is unavailable.
+  }
+}
+
+export function setSessionTextDraft(sessionId: string, text: string, notice?: string): void {
+  if (text) sessionDrafts.set(sessionId, { text, files: [], notice });
+  else sessionDrafts.delete(sessionId);
+  saveDraftsToStorage(sessionDrafts);
+  window.dispatchEvent(
+    new CustomEvent(SESSION_TEXT_DRAFT_EVENT, { detail: { sessionId, text, notice } }),
+  );
+}

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -20,6 +20,7 @@ import {
   listRunners,
   openSessionStream,
   postEvent,
+  revertSession,
   SESSION_HISTORY_PAGE_SIZE,
   stopSession,
   updateSession,
@@ -307,6 +308,19 @@ describe("forkSession", () => {
   it("surfaces a non-ok response as a thrown error (e.g. 403 no access)", async () => {
     fetchMock.mockResolvedValueOnce(mockJsonResponse({}, { ok: false, status: 403 }));
     await expect(forkSession("conv_src")).rejects.toThrow(/403/);
+  });
+});
+
+describe("revertSession", () => {
+  it("POSTs the selected user message and parses the draft", async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ draft: "retry this" }));
+
+    const result = await revertSession("conv source", "msg_1");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv%20source/revert");
+    expect(JSON.parse(init.body as string)).toEqual({ user_message_id: "msg_1" });
+    expect(result).toEqual({ draft: "retry this" });
   });
 });
 

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -533,6 +533,19 @@ export async function forkSession(
   return sessionFromWire(await readJsonOrThrow<SessionResponseWire>(res));
 }
 
+/** Rewind a session to immediately before a selected user message. */
+export async function revertSession(
+  sourceId: string,
+  userMessageId: string,
+): Promise<{ draft: string }> {
+  const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sourceId)}/revert`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-Omnigent-Client": getClientSurface() },
+    body: JSON.stringify({ user_message_id: userMessageId }),
+  });
+  return readJsonOrThrow<{ draft: string }>(res);
+}
+
 /**
  * Switch an existing session in place to a different agent/harness:
  * ``POST /v1/sessions/{id}/switch-agent``.

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -44,6 +44,7 @@ import type { ElicitationBlock } from "@/lib/blocks";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Composer, shouldQueueSend } from "./ChatPage";
 import type { QueuedMessage } from "@/store/chatStore";
+import { sessionDrafts, setSessionTextDraft } from "@/lib/sessionDrafts";
 import {
   BUILTIN_SLASH_COMMANDS,
   rankedSlashCommandNames,
@@ -104,6 +105,26 @@ function activeRow(): HTMLElement | null {
 function renderWithTooltips(ui: ReactElement) {
   return render(<TooltipProvider>{ui}</TooltipProvider>);
 }
+
+describe("Composer revert notice", () => {
+  afterEach(() => {
+    cleanup();
+    sessionDrafts.delete("conv_notice");
+    window.sessionStorage.removeItem("omnigent.sessionDrafts");
+  });
+
+  it("shows the revert confirmation immediately above the chatbox", () => {
+    useChatStore.setState({ conversationId: "conv_notice" });
+    setSessionTextDraft("conv_notice", "retry this", "Conversation reverted.");
+
+    render(<Composer {...composerProps()} />);
+
+    const notice = screen.getByRole("status");
+    expect(notice).toHaveTextContent("Conversation reverted.");
+    expect(notice).toHaveClass("composer-notice", "w-fit", "rounded-full");
+    expect(notice.nextElementSibling).toContainElement(textarea());
+  });
+});
 
 describe("Composer Claude goal control", () => {
   afterEach(() => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -30,6 +30,7 @@ import {
   SettingsIcon,
   SquareIcon,
   TerminalIcon,
+  Undo2Icon,
   WifiOffIcon,
   XIcon,
 } from "lucide-react";
@@ -188,6 +189,7 @@ import { GoalControl, GoalStatusPill, useGoalState, type Goal } from "@/componen
 import { copyText } from "@/lib/clipboard";
 import { showToast } from "@/components/ui/toast";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
+import { saveDraftsToStorage, sessionDrafts, SESSION_TEXT_DRAFT_EVENT } from "@/lib/sessionDrafts";
 
 // Matches both wordings the native executors emit: "[Attached: <path>]"
 // (claude/pi/cursor) and "[Attached file: <path>]" (codex). Capturing group
@@ -521,47 +523,6 @@ function truncateTitle(raw: string, max = 60): string {
   const cut = lastSpace > max - 10 ? lastSpace : slice.length;
   return slice.slice(0, cut).join("").trimEnd() + "…";
 }
-
-// Per-session draft storage — module-level so it survives the Composer
-// unmount/remount that happens during the loading gate between session
-// switches (ChatPage returns <HydratingPlaceholder /> while
-// loadingConversation is true, which unmounts the entire chat surface).
-// Text drafts are also persisted to sessionStorage so they survive page
-// refreshes; File objects can't be serialized, so only text round-trips.
-const SESSION_DRAFTS_KEY = "omnigent.sessionDrafts";
-
-function loadDraftsFromStorage(): Map<string, { text: string; files: File[] }> {
-  try {
-    const raw = window.sessionStorage.getItem(SESSION_DRAFTS_KEY);
-    if (!raw) return new Map();
-    const entries = JSON.parse(raw) as Record<string, string>;
-    const map = new Map<string, { text: string; files: File[] }>();
-    for (const [id, text] of Object.entries(entries)) {
-      if (text) map.set(id, { text, files: [] });
-    }
-    return map;
-  } catch {
-    return new Map();
-  }
-}
-
-function saveDraftsToStorage(drafts: Map<string, { text: string; files: File[] }>): void {
-  try {
-    const obj: Record<string, string> = {};
-    for (const [id, draft] of drafts) {
-      if (draft.text) obj[id] = draft.text;
-    }
-    if (Object.keys(obj).length === 0) {
-      window.sessionStorage.removeItem(SESSION_DRAFTS_KEY);
-    } else {
-      window.sessionStorage.setItem(SESSION_DRAFTS_KEY, JSON.stringify(obj));
-    }
-  } catch {
-    // Storage full or unavailable — drafts still work in-memory.
-  }
-}
-
-const sessionDrafts = loadDraftsFromStorage();
 
 /**
  * Single component that drives the chat surface. Streaming + history
@@ -3090,6 +3051,7 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
   const sessionId = useChatStore((s) => s.conversationId);
   // Author labels only matter once the session is shared with someone else.
   const isSessionShared = useContext(SessionSharedContext);
+  const forkDialog = useForkDialog();
   // Plain-text path is the common case.
   // - input_image: render inline <img> when the file is uploaded (file_id
   //   doesn't start with "pending:"); show a chip while the upload is
@@ -3242,11 +3204,24 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
           {text && <FilePathAwareMessageResponse breaks>{text}</FilePathAwareMessageResponse>}
         </MessageContent>
       </div>
-      {text && (
+      {(text || forkDialog?.canRevert) && (
         <MessageActions className="mt-1 ml-auto opacity-40 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100">
-          <MessageAction tooltip="Copy" onClick={handleCopy}>
-            {isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
-          </MessageAction>
+          {text && (
+            <MessageAction tooltip="Copy" onClick={handleCopy}>
+              {isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
+            </MessageAction>
+          )}
+          {forkDialog?.canRevert &&
+            !bubble.itemId.startsWith("pend_") &&
+            !bubble.itemId.startsWith("pending_") && (
+              <MessageAction
+                tooltip="Revert to here"
+                data-testid="revert-from-message"
+                onClick={() => forkDialog.openRevertDialog({ userMessageId: bubble.itemId })}
+              >
+                <Undo2Icon size={14} />
+              </MessageAction>
+            )}
         </MessageActions>
       )}
     </Message>
@@ -3858,6 +3833,8 @@ export function Composer({
   subAgentLabel = null,
 }: ComposerProps) {
   const [value, setValue] = useState("");
+  const forkDialog = useForkDialog();
+  const [composerNotice, setComposerNotice] = useState<string | null>(null);
   const dictation = useDictationInsert(setValue);
   const [files, setFiles] = useState<File[]>([]);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
@@ -4011,6 +3988,8 @@ export function Composer({
     const restored = conversationId ? sessionDrafts.get(conversationId) : undefined;
     setValue(restored?.text ?? "");
     setFiles(restored?.files ?? []);
+    setComposerNotice(restored?.notice ?? null);
+    if (restored) delete restored.notice;
     dirtyRef.current = false;
     if (!isMobileRef.current) textareaRef.current?.focus();
 
@@ -4170,6 +4149,31 @@ export function Composer({
     isMobile,
   });
 
+  useEffect(() => {
+    const applyDraft = (event: Event): void => {
+      const detail = (event as CustomEvent<{ sessionId: string; text: string; notice?: string }>)
+        .detail;
+      if (detail.sessionId !== conversationId) return;
+      const draft = sessionDrafts.get(detail.sessionId);
+      if (draft) delete draft.notice;
+      setValue(detail.text);
+      setFiles([]);
+      setMentionedItems([]);
+      setMention(null);
+      setComposerNotice(detail.notice ?? null);
+      dirtyRef.current = false;
+      if (!isMobileRef.current) textareaRef.current?.focus();
+    };
+    window.addEventListener(SESSION_TEXT_DRAFT_EVENT, applyDraft);
+    return () => window.removeEventListener(SESSION_TEXT_DRAFT_EVENT, applyDraft);
+  }, [conversationId, setMentionedItems]);
+
+  useEffect(() => {
+    if (!composerNotice) return;
+    const timeout = window.setTimeout(() => setComposerNotice(null), 4000);
+    return () => window.clearTimeout(timeout);
+  }, [composerNotice]);
+
   // Depends on mentionedItems (from the hook above), so it's computed here.
   const hasDraft = value.trim().length > 0 || files.length > 0 || mentionedItems.length > 0;
   const showInterruptButton = isWorking && !hasDraft;
@@ -4274,6 +4278,17 @@ export function Composer({
           .catch((err: unknown) => {
             setCommandError(err instanceof Error ? err.message : "Failed to set model");
           });
+        return true;
+      }
+      case "/revert": {
+        if (!forkDialog?.canRevert) {
+          setCommandError("/revert is unavailable for this session");
+          return true;
+        }
+        dirtyRef.current = true;
+        setValue("");
+        setCommandError(null);
+        forkDialog.openRevertDialog({ userMessageId: arg || undefined });
         return true;
       }
       case "/context": {
@@ -4675,6 +4690,14 @@ export function Composer({
           Truthy (not just non-null) so an empty label never peeks a
           nameless tray. */}
       {subAgentLabel ? <SubagentComposerTray label={subAgentLabel} /> : null}
+      {composerNotice && (
+        <div
+          role="status"
+          className="composer-notice mx-auto mb-2 w-fit max-w-full rounded-full border bg-popover px-4 py-2 text-center text-sm text-popover-foreground shadow-lg"
+        >
+          {composerNotice}
+        </div>
+      )}
       {/* Single rounded container — textarea on top, action row beneath.
           No top border on the surrounding form; the box itself is the
           visual container. The static neutral border carries through

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -87,6 +87,7 @@ import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
 import { CommandPalette } from "./CommandPalette";
 import { Toaster } from "@/components/ui/toast";
 import { ForkSessionDialog } from "./ForkSessionDialog";
+import { RevertSessionDialog } from "./RevertSessionDialog";
 import { ForkDialogContextProvider, type ForkDialogContextValue } from "./ForkDialogContext";
 import { InlineTerminalsSection } from "./InlineTerminalsSection";
 import { WorkspacePanel } from "./WorkspacePanel";
@@ -255,6 +256,8 @@ export function AppShell() {
   );
   const [shareOpen, setShareOpen] = useState(false);
   const [forkOpen, setForkOpen] = useState(false);
+  const [revertOpen, setRevertOpen] = useState(false);
+  const [revertUserMessageId, setRevertUserMessageId] = useState<string | null>(null);
   // Truncation point for a "fork from here" opened from a message's
   // actions (ChatPage, via ForkDialogContext). `null` = full clone —
   // the mobile menu Clone entry's behavior. Cleared whenever the dialog
@@ -404,6 +407,8 @@ export function AppShell() {
   // the per-message "Fork from here" action is the only fork entry point.
   const canClone =
     !!conversationId && isKnownTopLevel && (permissionLevel === null || permissionLevel >= 1);
+  const canRevert =
+    !!conversationId && isKnownTopLevel && (permissionLevel === null || permissionLevel >= 2);
   // Agent tools/policies exist to show.
   const hasAgentInfo = !!conversationId && agentHasInfo(boundAgent, conversationId);
   // Whether the mobile three-dot menu has any entry to offer.
@@ -1216,8 +1221,13 @@ export function AppShell() {
         setForkUpToResponseId(opts?.upToResponseId ?? null);
         setForkOpen(true);
       },
+      canRevert,
+      openRevertDialog: (opts?: { userMessageId?: string }) => {
+        setRevertUserMessageId(opts?.userMessageId ?? null);
+        setRevertOpen(true);
+      },
     }),
-    [canClone],
+    [canClone, canRevert],
   );
   const workspacePanelVisible = Boolean(
     conversationId &&
@@ -1480,6 +1490,18 @@ export function AppShell() {
               sessionId={conversationId}
               open={shareOpen}
               onOpenChange={setShareOpen}
+            />
+          )}
+          {conversationId && (
+            <RevertSessionDialog
+              key={`revert-session-dialog-${conversationId}`}
+              sourceSessionId={conversationId}
+              initialUserMessageId={revertUserMessageId}
+              open={revertOpen}
+              onOpenChange={(open) => {
+                setRevertOpen(open);
+                if (!open) setRevertUserMessageId(null);
+              }}
             />
           )}
           {conversationId && (

--- a/web/src/shell/ForkDialogContext.tsx
+++ b/web/src/shell/ForkDialogContext.tsx
@@ -20,6 +20,10 @@ export interface ForkDialogContextValue {
    * a full clone (the header button's behavior).
    */
   openForkDialog: (opts?: { upToResponseId?: string }) => void;
+  /** Whether the caller may edit and rewind the active top-level session. */
+  canRevert: boolean;
+  /** Open the shared revert picker, optionally preselecting a user message. */
+  openRevertDialog: (opts?: { userMessageId?: string }) => void;
 }
 
 const ForkDialogContext = createContext<ForkDialogContextValue | null>(null);

--- a/web/src/shell/RevertSessionDialog.test.tsx
+++ b/web/src/shell/RevertSessionDialog.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RevertSessionDialog } from "./RevertSessionDialog";
+import type { MessageItem } from "@/lib/conversationItems";
+import { fetchSessionItemsPage, revertSession } from "@/lib/sessionsApi";
+import { setSessionTextDraft } from "@/lib/sessionDrafts";
+
+const { switchToMock } = vi.hoisted(() => ({ switchToMock: vi.fn() }));
+vi.mock("@/lib/sessionsApi", () => ({
+  fetchSessionItemsPage: vi.fn(),
+  revertSession: vi.fn(),
+}));
+vi.mock("@/lib/sessionDrafts", () => ({ setSessionTextDraft: vi.fn() }));
+vi.mock("@/store/chatStore", () => ({
+  useChatStore: { getState: () => ({ switchTo: switchToMock }) },
+}));
+
+const fetchItemsMock = vi.mocked(fetchSessionItemsPage);
+const revertMock = vi.mocked(revertSession);
+const setDraftMock = vi.mocked(setSessionTextDraft);
+
+function userMessage(id: string, text: string): MessageItem {
+  return {
+    id,
+    type: "message",
+    response_id: `resp_${id}`,
+    status: "completed",
+    role: "user",
+    content: [{ type: "input_text", text }],
+  };
+}
+
+function renderDialog(initialUserMessageId: string | null = null) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const dialog = (open: boolean) => (
+    <QueryClientProvider client={client}>
+      <RevertSessionDialog
+        sourceSessionId="conv_source"
+        initialUserMessageId={initialUserMessageId}
+        open={open}
+        onOpenChange={vi.fn()}
+      />
+    </QueryClientProvider>
+  );
+  const view = render(dialog(true));
+  return { ...view, setOpen: (open: boolean) => view.rerender(dialog(open)) };
+}
+
+beforeEach(() => {
+  switchToMock.mockReset();
+  switchToMock.mockResolvedValue(undefined);
+  fetchItemsMock.mockReset();
+  revertMock.mockReset();
+  setDraftMock.mockReset();
+  fetchItemsMock.mockResolvedValue({
+    items: [userMessage("msg_1", "first prompt"), userMessage("msg_2", "second prompt")],
+    hasMore: false,
+  });
+  revertMock.mockResolvedValue({ draft: "second prompt" });
+});
+
+afterEach(cleanup);
+
+describe("RevertSessionDialog", () => {
+  it("restores the draft and reloads current messages when reopened", async () => {
+    let finishReload!: () => void;
+    switchToMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishReload = resolve;
+        }),
+    );
+    const { setOpen } = renderDialog("msg_2");
+
+    await screen.findByText("second prompt");
+    expect(screen.getByDisplayValue("msg_2")).toBeChecked();
+    expect(screen.queryByText("Revert file changes")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+
+    await waitFor(() => expect(revertMock).toHaveBeenCalledWith("conv_source", "msg_2"));
+    await waitFor(() => expect(switchToMock).toHaveBeenCalledWith("conv_source", true));
+    expect(setDraftMock).not.toHaveBeenCalled();
+
+    finishReload();
+    await waitFor(() =>
+      expect(setDraftMock).toHaveBeenCalledWith(
+        "conv_source",
+        "second prompt",
+        "Conversation reverted.",
+      ),
+    );
+
+    setOpen(false);
+    fetchItemsMock.mockResolvedValueOnce({
+      items: [userMessage("msg_1", "first prompt")],
+      hasMore: false,
+    });
+    setOpen(true);
+
+    await screen.findByText("first prompt");
+    expect(fetchItemsMock).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText("second prompt")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/shell/RevertSessionDialog.tsx
+++ b/web/src/shell/RevertSessionDialog.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from "react";
+import { HistoryIcon, Loader2Icon } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { isMessageItem, type MessageItem } from "@/lib/conversationItems";
+import { fetchSessionItemsPage, revertSession } from "@/lib/sessionsApi";
+import { setSessionTextDraft } from "@/lib/sessionDrafts";
+import { isSystemUserContent } from "@/lib/systemMessage";
+import { cn } from "@/lib/utils";
+import { useChatStore } from "@/store/chatStore";
+
+function messageText(item: MessageItem): string {
+  return item.content
+    .filter((block) => block.type === "input_text")
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+}
+
+async function loadUserMessages(sessionId: string): Promise<MessageItem[]> {
+  let items: MessageItem[] = [];
+  let olderThan: string | undefined;
+  while (true) {
+    const page = await fetchSessionItemsPage(sessionId, { olderThan, limit: 1000 });
+    items = [
+      ...page.items.filter(
+        (item): item is MessageItem =>
+          isMessageItem(item) &&
+          item.role === "user" &&
+          item.is_meta !== true &&
+          !isSystemUserContent(item.content),
+      ),
+      ...items,
+    ];
+    if (!page.hasMore || page.items.length === 0) break;
+    olderThan = page.items[0].id;
+  }
+  return items.reverse();
+}
+
+export function RevertSessionDialog({
+  sourceSessionId,
+  initialUserMessageId,
+  open,
+  onOpenChange,
+}: {
+  sourceSessionId: string;
+  initialUserMessageId?: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const {
+    data: messages = [],
+    isLoading: loading,
+    error: loadError,
+  } = useQuery({
+    queryKey: ["session", sourceSessionId, "revert-messages"],
+    queryFn: () => loadUserMessages(sourceSessionId),
+    enabled: open,
+  });
+
+  useEffect(() => {
+    if (!open || loading) return;
+    setSelectedId(
+      initialUserMessageId && messages.some((message) => message.id === initialUserMessageId)
+        ? initialUserMessageId
+        : (messages[0]?.id ?? null),
+    );
+  }, [initialUserMessageId, loading, messages, open]);
+
+  useEffect(() => {
+    if (!open) {
+      queryClient.removeQueries({
+        queryKey: ["session", sourceSessionId, "revert-messages"],
+      });
+      setError(null);
+    }
+  }, [open, queryClient, sourceSessionId]);
+
+  const errorMessage = error ?? loadError?.message ?? null;
+
+  async function handleRevert(): Promise<void> {
+    if (!selectedId || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await revertSession(sourceSessionId, selectedId);
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      await useChatStore.getState().switchTo(sourceSessionId, true);
+      setSessionTextDraft(sourceSessionId, result.draft, "Conversation reverted.");
+      onOpenChange(false);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "Couldn't revert the session.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="grid max-h-[85vh] grid-rows-[auto_minmax(0,1fr)_auto] gap-5 sm:max-w-2xl">
+        <DialogHeader className="gap-3 pr-8">
+          <DialogTitle className="flex items-center gap-2.5 text-lg leading-tight sm:text-xl">
+            <HistoryIcon className="size-5" />
+            Revert conversation
+          </DialogTitle>
+          <DialogDescription className="leading-6">
+            Choose a user message to return to. That message and everything after it will be removed
+            from this session. Files will be left unchanged.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          className="min-h-0 space-y-2 overflow-y-auto rounded-xl border p-2"
+          data-testid="revert-message-list"
+        >
+          {loading ? (
+            <div className="flex items-center justify-center gap-2 py-10 text-muted-foreground">
+              <Loader2Icon className="size-4 animate-spin" /> Loading messages…
+            </div>
+          ) : messages.length === 0 ? (
+            <p className="p-4 text-center text-muted-foreground">No user messages to revert to.</p>
+          ) : (
+            messages.map((message) => {
+              const text = messageText(message) || "(attachments only)";
+              const active = selectedId === message.id;
+              return (
+                <label
+                  key={message.id}
+                  className={cn(
+                    "flex cursor-pointer gap-3 rounded-lg px-3 py-3 hover:bg-accent",
+                    active && "bg-accent ring-1 ring-primary/30",
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="revert-message"
+                    value={message.id}
+                    checked={active}
+                    onChange={() => setSelectedId(message.id)}
+                    className="mt-1 accent-primary"
+                  />
+                  <span className="min-w-0">
+                    <span className="block text-xs font-medium text-muted-foreground">You</span>
+                    <span className="line-clamp-2 block text-sm leading-5">{text}</span>
+                  </span>
+                </label>
+              );
+            })
+          )}
+        </div>
+
+        <div>
+          {errorMessage && <p className="mb-2 text-sm text-destructive">{errorMessage}</p>}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void handleRevert()}
+              disabled={!selectedId || loading || submitting}
+            >
+              {submitting && <Loader2Icon className="animate-spin" />}
+              Revert
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -450,6 +450,32 @@ describe("chatStore — switchTo", () => {
     expect(state.conversationLoadError).toBeNull();
   });
 
+  it("reloads a rewound history without changing the active session id", async () => {
+    const original = [
+      userMessage("resp_1", "keep"),
+      assistantMessage("resp_1", "kept response"),
+      userMessage("resp_2", "discard"),
+    ];
+    seedSession("conv_rewind", original);
+    await useChatStore.getState().switchTo("conv_rewind");
+    useChatStore.setState({
+      pendingUserMessages: [
+        { tempId: "pend_stale", content: [{ type: "input_text", text: "discard" }] },
+      ],
+    });
+
+    seedSession("conv_rewind", original.slice(0, 2));
+    await useChatStore.getState().switchTo("conv_rewind", true);
+
+    const state = useChatStore.getState();
+    expect(state.conversationId).toBe("conv_rewind");
+    expect(state.blocks.map((block) => block.ctx.itemId)).toEqual(
+      original.slice(0, 2).map((item) => item.id),
+    );
+    expect(state.pendingUserMessages).toEqual([]);
+    expect(state.pendingByConversation.conv_rewind).toBeUndefined();
+  });
+
   it("hydrates pendingUserMessages from the snapshot's pending_inputs (native rebind)", async () => {
     // The core fix: a native web message that hasn't round-tripped
     // through the transcript yet is replayed by the server in

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -609,7 +609,7 @@ export interface ChatState {
     opts?: SendOptions,
   ) => Promise<void>;
   stop: () => void;
-  switchTo: (conversationId: string | null) => Promise<void>;
+  switchTo: (conversationId: string | null, forceReload?: boolean) => Promise<void>;
   submitApproval: (
     elicitationId: string,
     action: "accept" | "decline" | "cancel",
@@ -1537,8 +1537,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
     }
   },
 
-  switchTo: async (conversationId) => {
-    if (get().conversationId === conversationId) return;
+  switchTo: async (conversationId, forceReload = false) => {
+    if (!forceReload && get().conversationId === conversationId) return;
 
     // Abort the prior session's stream. The reader loop in
     // bindStream's pump unwinds via AbortError and stops applying
@@ -1557,7 +1557,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // doesn't accrete stale keys; a restored bubble is reconciled
       // against the server snapshot in bindStream.
       const pendingByConversation = { ...s.pendingByConversation };
-      if (s.conversationId !== null) {
+      if (forceReload && conversationId !== null) {
+        delete pendingByConversation[conversationId];
+      } else if (s.conversationId !== null) {
         // Stash only THIS client's own UNSETTLED bubbles — client temp
         // ids (`pend_<n>`, set by send) whose POST hasn't returned.
         // Everything else is server-owned and re-seeded by the
@@ -1595,7 +1597,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
         // (``live:*``) never bleed across.
         blocks: [],
         pendingUserMessages:
-          conversationId !== null ? (pendingByConversation[conversationId]?.messages ?? []) : [],
+          conversationId !== null && !forceReload
+            ? (pendingByConversation[conversationId]?.messages ?? [])
+            : [],
         activeResponse: null,
         interruptedResponseIds: [],
         status: "idle",


### PR DESCRIPTION
## Related issue

N/A — refactors the conversation-only portion of https://github.com/omnigent-ai/omnigent/pull/2876.

## Summary

Users need to retry an earlier prompt without branching the session or rolling back unrelated workspace work.

- Add in-place session rewind across the API, Python client, REPL, and web UI.
- Reset native runtime identity/history so discarded turns cannot reappear, while never tracking or restoring workspace/Git files.
- Reuse the existing web session-switch reset path for same-session reloads instead of maintaining a duplicate reload implementation.

**ELI5:** Pick an earlier message, remove that message and everything after it, then put the selected text back in the composer so it can be edited and retried. Files stay as they are.

```text
past user message
       |
       v
validate + rewind stored conversation
       |
       +--> reset native runtime history
       |
       +--> reload same session --> restore prompt as draft
```

## Test Plan

- `.venv/bin/python -m pytest tests/runner/test_session_resources.py::test_reset_state_closes_terminals_and_publishes_deleted tests/stores/test_conversation_store.py::test_instance_scoped_label_keys_match_harness_constants tests/stores/test_conversation_store.py::test_fork_conversation_drops_instance_scoped_labels tests/stores/test_conversation_store.py::test_rewind_conversation_removes_selected_prompt_and_later_history tests/repl/test_repl_revert_command.py tests/server/integration/test_sessions_revert.py tests/server/test_openapi_drift.py -q` — 9 passed.
- `cd web && npx vitest run src/lib/sessionsApi.test.ts src/pages/ChatPage.composer.test.tsx src/shell/RevertSessionDialog.test.tsx src/store/chatStore.test.ts` — 446 passed.
- `cd web && npm run type-check` — passed.
- `.venv/bin/pre-commit run --all-files` — passed.

## Demo

<img width="832" height="446" alt="Screenshot 2026-07-25 at 23 42 28" src="https://github.com/user-attachments/assets/2645484d-57f0-4dec-8a07-60726082d6a1" />

<img width="889" height="635" alt="Screenshot 2026-07-25 at 23 44 37" src="https://github.com/user-attachments/assets/5b6e35f7-eeee-48aa-96cd-c18e4774b5eb" />

<img width="863" height="784" alt="Screenshot 2026-07-25 at 23 56 21" src="https://github.com/user-attachments/assets/fbd8bffd-4ab1-48f0-bc3d-e4b72f7869c0" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage includes store truncation and FTS cleanup, API request validation, native runtime reset, REPL filtering, same-session web reload, draft restoration, notification placement, and OpenAPI drift.

## Changelog

Revert a session to an earlier prompt without changing workspace files.
