### PR TITLE
fix(sessions): expose persisted activity heartbeat

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -3507,8 +3507,9 @@ async def _session_get_info_via_rest(
     caller's own ``conversation_id`` when omitted), fetches the session
     snapshot, and projects the metadata fields — status, title, agent
     binding, runner binding, host, reasoning effort, effective model,
-    parent linkage, workspace / git branch, and the outstanding approval
-    prompts (the prompts themselves plus a count). Runner connectivity
+    parent linkage, workspace / git branch, persisted last-activity time,
+    and the outstanding approval prompts (the prompts themselves plus a
+    count). Runner connectivity
     is resolved best-effort via
     ``GET /v1/runners/{id}/status`` (``runner_online`` is ``None`` when
     the lookup fails or no runner is bound). The full transcript is
@@ -3530,7 +3531,11 @@ async def _session_get_info_via_rest(
             {"error": "sys_session_get_info requires a non-empty 'session_id' string"}
         )
     try:
-        resp = await server_client.get(f"/v1/sessions/{raw_target}", timeout=30.0)
+        resp = await server_client.get(
+            f"/v1/sessions/{raw_target}",
+            params={"include_items": "false", "include_liveness": "false"},
+            timeout=30.0,
+        )
     except Exception as exc:  # noqa: BLE001
         return json.dumps({"error": f"sys_session_get_info failed: {exc}"})
     if resp.status_code == 404:
@@ -3545,6 +3550,10 @@ async def _session_get_info_via_rest(
         {
             "session_id": snap.get("id"),
             "status": snap.get("status"),
+            # Persisted conversation activity is distinct from lifecycle
+            # status: repeated polls with an unchanged value let an
+            # orchestrator detect a running session that is not advancing.
+            "last_activity_at": snap.get("updated_at"),
             "title": snap.get("title"),
             "agent_id": snap.get("agent_id"),
             # Present the public agent name: a native-UI wrapper session

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -764,6 +764,7 @@ def _build_session_response(
         status=status,
         background_task_count=background_task_count,
         created_at=conv.created_at,
+        updated_at=conv.updated_at,
         title=title_without_closed_marker(conv.title),
         labels=labels,
         runner_id=conv.runner_id,

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1813,6 +1813,9 @@ class SessionResponse(BaseModel):
         id is not re-sent on reconnect. Today only native-terminal
         forwarders (claude-native) stamp a turn id on their status
         edges; other harnesses leave this ``None``.
+    :param updated_at: Unix epoch timestamp of the last persisted session
+        activity. Advances when conversation items are appended and can be
+        compared across snapshots independently of lifecycle status.
     """
 
     id: str
@@ -1821,6 +1824,7 @@ class SessionResponse(BaseModel):
     status: Literal["idle", "running", "waiting", "failed"]
     background_task_count: int | None = None
     created_at: int
+    updated_at: int | None = None
     title: str | None = None
     labels: dict[str, str] = Field(default_factory=dict)
     runner_id: str | None = None

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1814,8 +1814,11 @@ class SessionResponse(BaseModel):
         forwarders (claude-native) stamp a turn id on their status
         edges; other harnesses leave this ``None``.
     :param updated_at: Unix epoch timestamp of the last persisted session
-        activity. Advances when conversation items are appended and can be
-        compared across snapshots independently of lifecycle status.
+        activity. Advances when conversation items are appended and on session
+        metadata edits (rename, agent switch, archive); a mid-stall rename
+        therefore resets the clock, so an orchestrator treating this as a pure
+        item-append heartbeat should account for that. Can be compared across
+        snapshots independently of lifecycle status.
     """
 
     id: str

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -602,8 +602,11 @@ class SysSessionGetInfoTool(Tool):
     model), not just the caller's spawn subtree. Reports lifecycle
     status, title, agent binding (id + name), runner binding and live
     connectivity, host, reasoning effort, effective model, parent
-    linkage, workspace / git branch, and the count of outstanding
-    approval prompts. For the conversation transcript, use
+    linkage, workspace / git branch, persisted last-activity time, and
+    the count of outstanding approval prompts. Comparing
+    ``last_activity_at`` across polls distinguishes a running session that
+    is advancing from one whose persisted output has stalled. For the
+    conversation transcript, use
     ``sys_session_get_history`` instead.
 
     ``session_id`` is optional — when omitted, the caller's own
@@ -628,7 +631,8 @@ class SysSessionGetInfoTool(Tool):
             "Return a session's metadata: lifecycle status, title, "
             "agent binding (id/name), runner binding + connectivity, "
             "host, reasoning effort, model, parent session, workspace, "
-            "and outstanding approval prompts. Global read — any "
+            "persisted last-activity time, and outstanding approval "
+            "prompts. Global read — any "
             "session you can access. Pass session_id to target another "
             "session; omit it to describe your own. Metadata only — "
             "use sys_session_get_history for the conversation transcript."

--- a/openapi.json
+++ b/openapi.json
@@ -5261,6 +5261,18 @@
             "description": "Cumulative LLM spend for this session in USD, e.g. `0.42`. `None` when the session is **unpriced** \u2014 no turn has been priced yet (the model is absent from the pricing catalog, or no usage has been recorded) \u2014 so clients render \"\u2014\" rather than a misleading `$0.00`. Server-computed (cache-aware for relay/codex, exact billing for claude-native), the same total the cost-budget policy gates on. Lets clients seed their cost indicator on resume without waiting for the next `session.usage` SSE event.",
             "title": "Total Cost Usd"
           },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unix epoch timestamp of the last persisted session activity. Advances when conversation items are appended and can be compared across snapshots independently of lifecycle status.",
+            "title": "Updated At"
+          },
           "usage_by_model": {
             "anyOf": [
               {

--- a/openapi.json
+++ b/openapi.json
@@ -5270,7 +5270,7 @@
                 "type": "null"
               }
             ],
-            "description": "Unix epoch timestamp of the last persisted session activity. Advances when conversation items are appended and can be compared across snapshots independently of lifecycle status.",
+            "description": "Unix epoch timestamp of the last persisted session activity. Advances when conversation items are appended and on session metadata edits (rename, agent switch, archive); a mid-stall rename therefore resets the clock, so an orchestrator treating this as a pure item-append heartbeat should account for that. Can be compared across snapshots independently of lifecycle status.",
             "title": "Updated At"
           },
           "usage_by_model": {

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -133,8 +133,11 @@ class Session:
         ``"running"``, or ``"failed"``.
     :param created_at: Unix epoch seconds of creation.
     :param updated_at: Unix epoch seconds of the last persisted session
-        activity. ``None`` when connected to an older server that does not
-        return the field.
+        activity. Advances when conversation items are appended and on session
+        metadata edits (rename, agent switch, archive), so a mid-stall rename
+        resets the clock — treat it as a session-write heartbeat, not a pure
+        item-append signal. ``None`` when connected to an older server that
+        does not return the field.
     :param title: Optional human-readable title, e.g.
         ``"debugging auth flow"``. ``None`` when unset.
     :param labels: Session-scoped guardrails labels. Empty dict

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -132,6 +132,9 @@ class Session:
     :param status: Session lifecycle status. One of ``"idle"``,
         ``"running"``, or ``"failed"``.
     :param created_at: Unix epoch seconds of creation.
+    :param updated_at: Unix epoch seconds of the last persisted session
+        activity. ``None`` when connected to an older server that does not
+        return the field.
     :param title: Optional human-readable title, e.g.
         ``"debugging auth flow"``. ``None`` when unset.
     :param labels: Session-scoped guardrails labels. Empty dict
@@ -179,6 +182,7 @@ class Session:
     agent_id: str
     status: str
     created_at: int
+    updated_at: int | None = None
     agent_name: str | None = None
     title: str | None = None
     labels: dict[str, str] = field(default_factory=dict)
@@ -208,11 +212,13 @@ class Session:
         labels_raw = raw.get("labels", {})
         raw_cw = raw.get("context_window")
         raw_ltt = raw.get("last_total_tokens")
+        raw_updated_at = raw.get("updated_at")
         return cls(
             id=str(raw["id"]),
             agent_id=str(raw["agent_id"]),
             status=str(raw["status"]),
             created_at=int(raw["created_at"]),
+            updated_at=int(raw_updated_at) if raw_updated_at is not None else None,
             agent_name=raw.get("agent_name"),
             title=raw.get("title"),
             labels=labels_raw if isinstance(labels_raw, dict) else {},

--- a/tests/frontends/sdk/test_sessions_namespace.py
+++ b/tests/frontends/sdk/test_sessions_namespace.py
@@ -113,6 +113,7 @@ def _session_response_body(
         "agent_id": agent_id,
         "status": status,
         "created_at": 1700000000,
+        "updated_at": 1700000042,
         "items": items if items is not None else [],
     }
 
@@ -242,6 +243,26 @@ async def test_get_returns_typed_session() -> None:
     # items round-trip as raw dicts (heterogeneous, intentionally
     # un-modeled per the namespace docstring).
     assert session.items == [{"id": "msg_1", "type": "message"}]
+    assert session.updated_at == 1700000042
+
+
+@pytest.mark.asyncio
+async def test_get_updated_at_defaults_to_none_when_omitted() -> None:
+    """Older session responses without ``updated_at`` remain parseable."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        payload = _session_response_body()
+        payload.pop("updated_at")
+        return httpx.Response(200, json=payload)
+
+    ns, client = _make_namespace(handler)
+    try:
+        session = await ns.get("conv_abc")
+    finally:
+        await client.aclose()
+
+    assert session.updated_at is None
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6405,6 +6405,7 @@ async def test_sys_session_get_info_defaults_to_caller_session() -> None:
     async def _server_handler(request: httpx.Request) -> httpx.Response:
         requested_paths.append(request.url.path)
         if request.url.path == "/v1/sessions/conv_caller":
+            assert request.url.params["include_items"] == "false"
             return httpx.Response(
                 200,
                 json={
@@ -6413,6 +6414,7 @@ async def test_sys_session_get_info_defaults_to_caller_session() -> None:
                     "agent_name": "main",
                     "status": "idle",
                     "created_at": 1,
+                    "updated_at": 42,
                     "runner_id": None,
                     "pending_elicitations": [],
                 },
@@ -6436,6 +6438,7 @@ async def test_sys_session_get_info_defaults_to_caller_session() -> None:
     # never queried (a stray /v1/runners call would mean the None-runner
     # short-circuit regressed).
     assert info["runner_online"] is None
+    assert info["last_activity_at"] == 42
     assert info["pending_elicitations"] == []
     assert info["pending_elicitation_count"] == 0
     assert not any(p.startswith("/v1/runners") for p in requested_paths)
@@ -6810,6 +6813,8 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
 
     async def _server_handler(request: httpx.Request) -> httpx.Response:
         if request.method == "GET" and request.url.path == "/v1/sessions/conv_target":
+            assert request.url.params["include_items"] == "false"
+            assert request.url.params["include_liveness"] == "false"
             return httpx.Response(
                 200,
                 json={
@@ -6818,6 +6823,7 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
                     "agent_name": "researcher",
                     "status": "running",
                     "created_at": 1,
+                    "updated_at": 84,
                     "title": "auth flow",
                     "runner_id": "runner_1",
                     "host_id": None,
@@ -6849,6 +6855,7 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
     info = json.loads(output)
     assert info["session_id"] == "conv_target"
     assert info["status"] == "running"
+    assert info["last_activity_at"] == 84
     assert info["title"] == "auth flow"
     assert info["agent_id"] == "ag_xyz"
     assert info["agent_name"] == "researcher"

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -2561,6 +2561,7 @@ async def test_get_session_includes_runner_online(
 
 async def test_get_session_slim_skips_items_and_liveness(
     client: httpx.AsyncClient,
+    db_uri: str,
 ) -> None:
     """
     ``GET /v1/sessions/{id}?include_items=false&include_liveness=false``
@@ -2579,6 +2580,8 @@ async def test_get_session_slim_skips_items_and_liveness(
     session = await _create_session(client, agent["id"], initial_message="hello")
     session_id = session["id"]
     await _wait_for_idle(client, session_id)
+    stored = SqlAlchemyConversationStore(db_uri).get_conversation(session_id)
+    assert stored is not None
 
     slim = await client.get(
         f"/v1/sessions/{session_id}",
@@ -2587,6 +2590,7 @@ async def test_get_session_slim_skips_items_and_liveness(
     assert slim.status_code == 200
     slim_body = slim.json()
     assert slim_body["id"] == session_id
+    assert slim_body["updated_at"] == stored.updated_at
     # Items read skipped — empty list, not an absent field, so clients
     # that parse `items ?? []` see the same shape either way.
     assert slim_body["items"] == []


### PR DESCRIPTION
## Related issue

Part of #3254

## Summary

- Expose each session's persisted `updated_at` timestamp on `SessionResponse` and the Python SDK.
- Project it as `last_activity_at` from `sys_session_get_info`, so orchestrators can compare polls independently of lifecycle status.
- Make the metadata poll use `include_items=false&include_liveness=false`; transcript history and liveness are handled separately.

ELI5: `running` says a worker has not stopped. `last_activity_at` says when it last produced persisted session activity. If `running` stays true while this timestamp does not move, an orchestrator now has a direct stall signal without scraping history.

```mermaid
flowchart LR
  A[Conversation item append] --> B[conversations.updated_at]
  B --> C[SessionResponse.updated_at]
  C --> D[sys_session_get_info.last_activity_at]
  D --> E[Orchestrator compares polls]
```

## Test Plan

- `.venv/bin/python -m pytest tests/runner/test_runner_dispatch.py tests/server/test_schemas.py -q`
- `.venv/bin/python -m pytest tests/server/integration/test_sessions_endpoints.py -q`
- `.venv/bin/python -m pytest tests/frontends/sdk/test_sessions_namespace.py -q`
- `.venv/bin/python scripts/dump_openapi.py --check`
- `.venv/bin/python -m pytest tests/server/test_openapi_drift.py -q`
- `.venv/bin/pre-commit run --files openapi.json sdks/python-client/omnigent_client/_sessions.py tests/frontends/sdk/test_sessions_namespace.py omnigent/runner/tool_dispatch.py omnigent/server/routes/_sessions/orchestration.py omnigent/server/schemas.py omnigent/tools/builtins/spawn.py tests/runner/test_runner_dispatch.py tests/server/integration/test_sessions_endpoints.py`

## Demo

![Two running polls with unchanged persisted activity timestamp](https://raw.githubusercontent.com/Solaris-star/omnigent/pr-assets/3279/heartbeat-demo.png)

The screenshot is produced by executing the PR branch's real `sys_session_get_info` projection twice against a deterministic session snapshot. Both polls remain `running`; the unchanged `last_activity_at` is the new direct stall signal.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The runner projection tests pin the lightweight query parameters and `last_activity_at`; the endpoint test compares the wire value to the persisted conversation row; SDK tests cover both new and old server payloads.

## Changelog

Session metadata now exposes the last persisted activity time so orchestrators can detect running sessions that have stopped advancing.

