### PR TITLE
fix(openai-agents): add optional tools.allowed for local model compatibility

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -793,6 +793,20 @@ def _inject_mcp_schemas(
     event_body["tools"] = list(existing) + new_schemas
 
 
+def _filter_allowed_mcp_schemas(
+    schemas: list[dict[str, Any]],
+    allowed_tools: frozenset[str] | None,
+) -> list[dict[str, Any]]:
+    """Keep only MCP schemas named by an optional tool allowlist."""
+    if allowed_tools is None:
+        return schemas
+    return [
+        schema
+        for schema in schemas
+        if (schema.get("name") or _schema_tool_name(schema)) in allowed_tools
+    ]
+
+
 def _schema_tool_name(schema: dict[str, Any]) -> str | None:
     """
     Extract a tool's function name from its OpenAI-format schema.
@@ -5874,7 +5888,11 @@ def create_runner_app(
                         for t in _session_tool_schemas.get(conv, [])
                         if not (isinstance(t, dict) and "__" in (t.get("name") or ""))
                     ]
-                    _session_tool_schemas[conv] = _builtin_tools + list(mcp_result.schemas)
+                    _allowed_tools = cached_spec.allowed_tools
+                    _mcp_tools = _filter_allowed_mcp_schemas(
+                        list(mcp_result.schemas), _allowed_tools
+                    )
+                    _session_tool_schemas[conv] = _builtin_tools + _mcp_tools
                     _session_mcp_spec_hash[conv] = _mcp_hash
                 except (
                     httpx.HTTPError,
@@ -6232,8 +6250,14 @@ def create_runner_app(
             if _eager_spec_error is None and _turn_spec is not None:
                 try:
                     _mcp = await _turn_mcp.schemas_for(_turn_spec)
-                    _mcp_schemas = _mcp.schemas
-                    _mcp_tool_names = _mcp.tool_names
+                    _mcp_schemas = _filter_allowed_mcp_schemas(
+                        _mcp.schemas, _turn_spec.allowed_tools
+                    )
+                    _mcp_tool_names = {
+                        name
+                        for schema in _mcp_schemas
+                        if (name := schema.get("name") or _schema_tool_name(schema)) is not None
+                    }
                     for _srv, _err in _mcp.failures.items():
                         _logger.warning("runner MCP %r unavailable for this turn: %s", _srv, _err)
                 except Exception:

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -93,6 +93,63 @@ _YAML_1_2_BOOL_RE = re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$")
 # string-coerced — their consumers read the nested mapping/list shape.
 _STRUCTURED_EXECUTOR_CONFIG_KEYS: frozenset[str] = frozenset()
 
+KNOWN_BUILTIN_TOOLS = frozenset(
+    [
+        "sys_add_policy",
+        "sys_policy_registry",
+        "sys_scheduled_task_create",
+        "sys_scheduled_task_list",
+        "sys_scheduled_task_update",
+        "sys_scheduled_task_delete",
+        "sys_call_async",
+        "sys_read_inbox",
+        "sys_cancel_async",
+        "sys_timer_set",
+        "sys_timer_cancel",
+        "load_skill",
+        "read_skill_file",
+        "web_search",
+        "web_fetch",
+        "upload_file",
+        "list_files",
+        "download_file",
+        "search_conversations",
+        "export_agent",
+        "hindsight_retain",
+        "hindsight_recall",
+        "hindsight_reflect",
+        "sys_session_list",
+        "sys_session_get_history",
+        "sys_session_get_info",
+        "sys_session_share",
+        "sys_session_send",
+        "sys_session_close",
+        "sys_list_models",
+        "sys_advise_models",
+        "sys_session_create",
+        "sys_session_rename",
+        "sys_agent_get",
+        "sys_agent_download",
+        "sys_agent_list",
+        "sys_cancel_task",
+        "list_comments",
+        "update_comment",
+        "browser_navigate",
+        "browser_snapshot",
+        "browser_click",
+        "browser_type",
+        "browser_screenshot",
+        "sys_os_read",
+        "sys_os_write",
+        "sys_os_edit",
+        "sys_os_shell",
+        "sys_terminal_launch",
+        "sys_terminal_send",
+        "sys_terminal_read",
+        "sys_terminal_list",
+        "sys_terminal_close",
+    ]
+)
 # Copy the resolver dict onto the subclass before mutating — it's inherited
 # from SafeLoader by reference, so in-place edits below would strip
 # SafeLoader's bool resolver process-wide.
@@ -251,6 +308,27 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
     # truthy/falsy values (``true`` / ``True`` / ``yes`` /
     # ``false`` / ``no``) consistently.
     async_enabled = bool(raw.get("async", True))
+    raw_allowed = raw_tools.get("allowed") if isinstance(raw_tools, dict) else None
+    if raw_allowed is not None:
+        from omnigent.tools.manager import ALWAYS_ON_TOOLS
+
+        if not isinstance(raw_allowed, list) or not all(
+            isinstance(item, str) for item in raw_allowed
+        ):
+            raise OmnigentError(
+                f"'tools.allowed' must be a list of strings, got: {raw_allowed!r}",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        allowed_tools: frozenset[str] | None = frozenset(raw_allowed)
+        unknown = allowed_tools - KNOWN_BUILTIN_TOOLS - ALWAYS_ON_TOOLS
+        if unknown:
+            _log.warning(
+                "tools.allowed contains unrecognized built-in names: %s — "
+                "they will be silently absent if not registered for this agent",
+                unknown,
+            )
+    else:
+        allowed_tools = None
     # Top-level ``timers:`` flag gates the LLM-callable timer
     # builtins (``sys_timer_set``, ``sys_timer_cancel``).
     # Defaults to False to match
@@ -304,6 +382,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
         local_tools=local_tools,
         sub_agents=sub_agents,
         async_enabled=async_enabled,
+        allowed_tools=allowed_tools,
         os_env=os_env,
         terminals=terminals,
         timers=timers,

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -1545,6 +1545,13 @@ class AgentSpec:  # type: ignore[explicit-any]  # params: dict[str, Any] field (
     compaction: CompactionConfig | None = None
     guardrails: GuardrailsSpec | None = None
     async_enabled: bool = True
+    # Optional tool surface restriction for local model compatibility.
+    # None = no filter (default, fully backwards-compatible).
+    # frozenset = only these tool names (plus always-on session tools) are
+    # exposed to the model via get_tool_schemas() and name lookup.
+    # Always-on tools (sys_session_list, sys_session_get_history,
+    # sys_session_get_info) are never filtered out regardless of this field.
+    allowed_tools: frozenset[str] | None = None
     os_env: OSEnvSpec | None = None
     terminals: dict[str, TerminalEnvSpec] | None = None
     timers: bool = False

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -9,12 +9,11 @@ from __future__ import annotations
 import logging
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.inner.os_env import OSEnvironment
 from omnigent.runtime import get_caps
-from omnigent.spec import AgentSpec
 from omnigent.spec.types import SharePolicy, ToolRuntime
 from omnigent.tools._srt import is_srt_available
 from omnigent.tools.base import Tool, ToolContext, is_valid_tool_name
@@ -51,9 +50,16 @@ from omnigent.tools.builtins import (
 from omnigent.tools.client_specified import ClientSideTool, ClientSideToolSpec
 from omnigent.tools.local import load_local_python_tools
 
+if TYPE_CHECKING:
+    from omnigent.spec.types import AgentSpec
+
 # MCP lifecycle moved to runner; see designs/RUNNER_MCP.md.
 
 _logger = logging.getLogger(__name__)
+
+ALWAYS_ON_TOOLS: frozenset[str] = frozenset(
+    {"sys_session_list", "sys_session_get_history", "sys_session_get_info"}
+)
 
 
 class _UCFunctionSchemaTool(Tool):
@@ -196,6 +202,11 @@ class ToolManager:
         # can drive the desktop app's browser without the spec opting in
         # (framework-owned).
         self._register_browser_tools()
+        # Apply optional tool surface filter for local model compatibility.
+        # Always-on session tools are preserved regardless of the allowlist.
+        if self._spec.allowed_tools is not None:
+            permitted = self._spec.allowed_tools | ALWAYS_ON_TOOLS
+            self._tools = {k: v for k, v in self._tools.items() if k in permitted}
 
     def _register_policy_tools(self) -> None:
         """

--- a/tests/runner/test_app_schema_injection.py
+++ b/tests/runner/test_app_schema_injection.py
@@ -12,7 +12,19 @@ from __future__ import annotations
 
 from typing import Any
 
-from omnigent.runner.app import _inject_mcp_schemas
+from omnigent.runner.app import _filter_allowed_mcp_schemas, _inject_mcp_schemas
+
+
+def test_filter_allowed_mcp_schemas_filters_flat_mcp_schemas() -> None:
+    schemas = [{"name": "read"}, {"name": "write"}]
+
+    assert _filter_allowed_mcp_schemas(schemas, frozenset({"read"})) == [{"name": "read"}]
+
+
+def test_filter_allowed_mcp_schemas_none_is_no_op() -> None:
+    schemas = [{"name": "read"}]
+
+    assert _filter_allowed_mcp_schemas(schemas, None) is schemas
 
 
 def _schema(name: str) -> dict[str, Any]:

--- a/tests/spec/test_parser_allowed_tools.py
+++ b/tests/spec/test_parser_allowed_tools.py
@@ -1,0 +1,65 @@
+"""Parser tests for the ``tools.allowed`` configuration field."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnigent.errors import OmnigentError
+from omnigent.spec.parser import parse
+
+
+def _parse_config(tmp_path: Path, tools: dict[str, object] | None = None):
+    config: dict[str, object] = {"spec_version": 1}
+    if tools is not None:
+        config["tools"] = tools
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    return parse(tmp_path)
+
+
+def test_allowed_tools_list_parses_to_frozenset(tmp_path: Path) -> None:
+    spec = _parse_config(
+        tmp_path,
+        {"allowed": ["sys_os_read", "sys_session_list"]},
+    )
+
+    assert spec.allowed_tools == frozenset({"sys_os_read", "sys_session_list"})
+
+
+@pytest.mark.parametrize("tools", [None, {}, {"allowed": None}])
+def test_allowed_tools_missing_or_null_parses_to_none(
+    tmp_path: Path,
+    tools: dict[str, object] | None,
+) -> None:
+    spec = _parse_config(tmp_path, tools)
+
+    assert spec.allowed_tools is None
+
+
+@pytest.mark.parametrize(
+    "raw_allowed",
+    ["sys_os_read", ["sys_os_read", 1], {"sys_os_read": True}],
+)
+def test_allowed_tools_rejects_non_list_of_strings(
+    tmp_path: Path,
+    raw_allowed: object,
+) -> None:
+    with pytest.raises(
+        OmnigentError,
+        match=r"'tools\.allowed' must be a list of strings",
+    ):
+        _parse_config(tmp_path, {"allowed": raw_allowed})
+
+
+def test_allowed_tools_warns_for_unrecognized_name(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="omnigent.spec.parser"):
+        spec = _parse_config(tmp_path, {"allowed": ["custom_mcp_tool"]})
+
+    assert spec.allowed_tools == frozenset({"custom_mcp_tool"})
+    assert "unrecognized built-in names" in caplog.text

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -173,6 +173,7 @@ def _make_spec(
     skills: list[SkillSpec] | None = None,
     mcp_servers: list[MCPServerConfig] | None = None,
     local_tools: list[LocalToolInfo] | None = None,
+    allowed_tools: frozenset[str] | None = None,
 ) -> AgentSpec:
     """
     Create a minimal ``AgentSpec`` with the given skills,
@@ -184,6 +185,7 @@ def _make_spec(
         no MCP servers.
     :param local_tools: Local tool infos, or ``None`` for
         no local tools.
+    :param allowed_tools: Optional tool-name allowlist.
     :returns: An ``AgentSpec`` with ``spec_version=1``.
     """
     return AgentSpec(
@@ -191,6 +193,7 @@ def _make_spec(
         skills=skills or [],
         mcp_servers=mcp_servers or [],
         local_tools=local_tools or [],
+        allowed_tools=allowed_tools,
     )
 
 
@@ -253,6 +256,46 @@ def test_registry_unknown_tool_returns_error(
 
 
 # ── get_tool_schemas ──────────────────────────────────
+
+
+def test_allowed_tools_filters_tool_surface() -> None:
+    """tools.allowed restricts schemas to listed and always-on tools."""
+    allowed = frozenset(["sys_add_policy", "sys_policy_registry"])
+    spec = _make_spec(allowed_tools=allowed)
+    manager = ToolManager(spec)
+    names = {s["function"]["name"] for s in manager.get_tool_schemas()}
+
+    expected = allowed | {
+        "sys_session_list",
+        "sys_session_get_history",
+        "sys_session_get_info",
+    }
+    assert names == expected
+
+
+def test_allowed_tools_empty_allowlist_keeps_only_always_on() -> None:
+    """An empty allowlist preserves only framework-required session tools."""
+    spec = _make_spec(allowed_tools=frozenset())
+    manager = ToolManager(spec)
+    names = {s["function"]["name"] for s in manager.get_tool_schemas()}
+
+    assert names == {
+        "sys_session_list",
+        "sys_session_get_history",
+        "sys_session_get_info",
+    }
+
+
+def test_allowed_tools_none_is_no_op() -> None:
+    """Without tools.allowed the tool surface remains unchanged."""
+    spec_with = _make_spec(allowed_tools=None)
+    spec_without = _make_spec()
+    manager_with = ToolManager(spec_with)
+    manager_without = ToolManager(spec_without)
+    names_with = {s["function"]["name"] for s in manager_with.get_tool_schemas()}
+    names_without = {s["function"]["name"] for s in manager_without.get_tool_schemas()}
+
+    assert names_with == names_without
 
 
 def test_schemas_include_load_skill_when_skills_exist(


### PR DESCRIPTION
## Related issue

N/A

## Summary

`ToolManager` currently registers all ~22 built-in tools for every agent, with no YAML-level way to reduce the model-visible tool surface. Local models through the `openai-agents` harness (Ollama, LM Studio, and similar) can fail tool calling reliably when given the full schema: with `qwen3-coder:30b` on the same task, a raw request with four tool schemas produced correct tool calls in 3/3 runs, while the Omnigent harness with the full schema failed in 3/3 runs. The same symptom has been reproduced independently in Hermes-agent, Cline, OpenCode, and Goose with Qwen2.5-coder via Ollama.

- Add an opt-in `tools.allowed` allowlist to agent YAML. The default remains `None`, preserving the existing full tool surface and making the change backwards compatible by construction.
- Validate the YAML shape, warn on unknown built-in names, and filter `ToolManager` registrations while retaining always-on coordination tools.
- Filter separately appended MCP schemas in both model-exposure runner paths; the MCP execute endpoint remains intentionally unfiltered.
- Add parser, manager, empty-allowlist, and MCP schema-injection coverage.

```yaml
tools:
  allowed:
    - sys_os_read
    - sys_os_write
    - sys_os_edit
    - sys_os_shell
```

**ELI5:** agents still receive every built-in tool by default. For local models that become unreliable when shown too many tools, an agent can now list only the tools the model should see.

```text
agent YAML tools.allowed
          |
          +--> ToolManager built-ins ----+
          |                              |
          +--> appended MCP schemas -----+--> model-visible tool schema

MCP execute endpoint (authorization path) remains unchanged
```

### Design notes

- `tools.allowed` is a model-surface filter, not an authorization boundary. It controls what the model sees in its schema, not what it is permitted to call at the auth level.
- V1 intentionally has no denylist, per-turn narrowing, or new harness file.

### Files changed

- `omnigent/spec/types.py` — add `allowed_tools: frozenset[str] | None = None`.
- `omnigent/spec/parser.py` — parse and validate YAML, define `KNOWN_BUILTIN_TOOLS`, and warn on unknown names.
- `omnigent/tools/manager.py` — add `_ALWAYS_ON_TOOLS` and apply the post-init filter.
- `omnigent/runner/app.py` — add `_filter_allowed_mcp_schemas()` and apply it to both model-exposure runner paths.
- `tests/tools/test_manager.py` — strengthen coverage and add the empty-allowlist edge case.
- `tests/spec/test_parser_allowed_tools.py` — add parser validation coverage.
- `tests/runner/test_app_schema_injection.py` — add MCP filtering coverage.

## Test Plan

- `pytest` focused suites: **62 passed, 0 failed**.
- `ruff check` clean.
- `ruff format --check` clean.
- No regressions observed.

## Demo

N/A — configuration and model-schema behavior only; no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage verifies YAML parsing and validation, default and empty-allowlist behavior, always-on tools, unknown-name warnings, and filtering of separately appended MCP schemas in both runner paths.

## Changelog

Agents using local models can limit the model-visible built-in tool schema with an optional `tools.allowed` list.
