### PR TITLE
Add Completed session group

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -178,6 +178,7 @@ from omnigent.spec.types import (
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.conversation_store import (
+    COMPLETED_LABEL_KEY,
     PINNED_LABEL_KEY,
     ConversationNotFoundError,
     NameAlreadyExistsError,
@@ -7350,22 +7351,14 @@ def _reject_server_reserved_label_seed(labels: dict[str, str] | None) -> None:
             f"label {_TURN_ACTOR_LABEL!r} is server-internal and cannot be set by clients",
             code=ErrorCode.INVALID_INPUT,
         )
-    # Pins are per-user: the client may only write the bare canonical
-    # ``omnigent.pinned`` key (which the route rewrites to the CALLER's per-user
-    # key). A suffixed ``omnigent.pinned.<user>`` is server-derived — accepting
-    # one from a client would let a caller pin/unpin a shared session for
-    # another user, or forge arbitrary per-user pin rows, defeating the per-user
-    # isolation. Reject any suffixed form; only the bare key is client-writable.
-    suffixed_pin = next(
-        (k for k in labels if k.startswith(f"{PINNED_LABEL_KEY}.")),
-        None,
-    )
-    if suffixed_pin is not None:
-        raise OmnigentError(
-            f"label {suffixed_pin!r} is server-derived; set the bare "
-            f"{PINNED_LABEL_KEY!r} key to pin for yourself",
-            code=ErrorCode.INVALID_INPUT,
-        )
+    for canonical in (PINNED_LABEL_KEY, COMPLETED_LABEL_KEY):
+        suffixed = next((k for k in labels if k.startswith(f"{canonical}.")), None)
+        if suffixed is not None:
+            raise OmnigentError(
+                f"label {suffixed!r} is server-derived; set the bare "
+                f"{canonical!r} key for yourself",
+                code=ErrorCode.INVALID_INPUT,
+            )
 
 
 def _require_cost_control_label_authority(
@@ -7769,11 +7762,14 @@ def _child_session_summary_from_conversation(
     :returns: A populated :class:`ChildSessionSummary`.
     """
     display_title = title_without_closed_marker(conv.title)
-    # Child sessions aren't pinnable (the pin affordance lives on top-level
-    # sidebar rows only), but strip any per-user ``omnigent.pinned.<user>`` keys
-    # defensively so a shared child's summary can never expose another viewer's
-    # pin key. No collapse-to-canonical here: there's no pin to surface.
-    raw_labels = {k: v for k, v in conv.labels.items() if not k.startswith(f"{PINNED_LABEL_KEY}.")}
+    raw_labels = {
+        k: v
+        for k, v in conv.labels.items()
+        if all(
+            k != canonical and not k.startswith(f"{canonical}.")
+            for canonical in (PINNED_LABEL_KEY, COMPLETED_LABEL_KEY)
+        )
+    }
     labels = labels_with_closed_status(raw_labels, conv.title)
     tool: str | None
     session_name: str | None

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -157,8 +157,10 @@ from omnigent.spec.types import (
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.conversation_store import (
+    COMPLETED_LABEL_KEY,
     PINNED_LABEL_KEY,
     ConversationNotFoundError,
+    completed_label_key,
     pinned_label_key,
 )
 from omnigent.stores.file_store import FileStore
@@ -452,32 +454,20 @@ async def _best_effort_stop(
 
 
 def _labels_for_viewer(labels: dict[str, str], user_id: str | None) -> dict[str, str]:
-    """
-    Collapse per-user pin keys to the canonical pin label for one viewer.
-
-    Pins are stored per-user as ``omnigent.pinned.<user>`` (see
-    :func:`pinned_label_key`). On the wire we present a single canonical
-    ``omnigent.pinned`` key — set iff THIS viewer pinned the session — and drop
-    every ``omnigent.pinned.*`` key. That keeps the per-user dimension server-
-    side (a viewer never sees who else pinned a shared session, and the client
-    reads the same bare key it writes) and stops other users' pin keys from
-    bloating the payload.
-
-    :param labels: The stored conversation labels.
-    :param user_id: The requesting viewer, or ``None`` in single-user mode.
-    :returns: A copy with all ``omnigent.pinned.*`` keys removed and the
-        canonical ``omnigent.pinned`` key added when the viewer's own pin
-        is present.
-    """
-    my_key = pinned_label_key(user_id)
-    my_pin = labels.get(my_key)
+    """Expose only this viewer's canonical pin and completion labels."""
+    personal = (
+        (PINNED_LABEL_KEY, pinned_label_key(user_id)),
+        (COMPLETED_LABEL_KEY, completed_label_key(user_id)),
+    )
     cleaned = {
         k: v
         for k, v in labels.items()
-        if k != PINNED_LABEL_KEY and not k.startswith(f"{PINNED_LABEL_KEY}.")
+        if all(k != canonical and not k.startswith(f"{canonical}.") for canonical, _ in personal)
     }
-    if my_pin is not None:
-        cleaned[PINNED_LABEL_KEY] = my_pin
+    for canonical, stored in personal:
+        value = labels.get(stored)
+        if value is not None:
+            cleaned[canonical] = value
     return cleaned
 
 

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -124,9 +124,11 @@ from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.comment_store import CommentStore
 from omnigent.stores.conversation_store import (
+    COMPLETED_LABEL_KEY,
     PINNED_LABEL_KEY,
     PROJECT_LABEL_KEY,
     ConversationNotFoundError,
+    completed_label_key,
     pinned_label_key,
 )
 from omnigent.stores.file_store import FileStore
@@ -757,6 +759,7 @@ def register_core_routes(
         kind: str = Query(default="default", pattern="^(default|sub_agent|any)$"),
         project: str | None = Query(default=None),
         pinned: bool = Query(default=False),
+        completed: bool = Query(default=False),
     ) -> PaginatedList:
         """
         List sessions with cursor-based pagination.
@@ -804,6 +807,8 @@ def register_core_routes(
             has pinned (the ``omnigent.pinned`` label). Lets the
             sidebar enumerate pinned sessions that fall outside the
             loaded pagination window. ``False`` (default) disables it.
+        :param completed: When ``True``, return only sessions this user
+            marked complete.
         :returns: A :class:`PaginatedList` of
             :class:`SessionListItem`.
         """
@@ -850,6 +855,8 @@ def register_core_routes(
             pinned=pinned,
             # Pins are per-user: filter to the caller's own pin key.
             pinned_owner=user_id,
+            completed=completed,
+            completed_owner=user_id,
         )
         # list_conversations may return rows with agent_id=None for
         # legacy conversations; skip them before building the batch IDs.
@@ -1448,10 +1455,12 @@ def register_core_routes(
         # Owner implies edit, so a single check at the resolved level gates all
         # three with no redundant second permission-store read.
         set_project = "project_id" in body.model_fields_set
-        pin_only = body.model_fields_set == {"labels"} and set(body.labels or {}) == {
-            PINNED_LABEL_KEY
-        }
-        if pin_only:
+        personal_label_only = (
+            body.model_fields_set == {"labels"}
+            and bool(body.labels)
+            and set(body.labels or {}) <= {PINNED_LABEL_KEY, COMPLETED_LABEL_KEY}
+        )
+        if personal_label_only:
             required_level = LEVEL_READ
         elif body.archived is not None or set_project:
             required_level = LEVEL_OWNER
@@ -1521,12 +1530,13 @@ def register_core_routes(
                 )
             requested_codex_collaboration_mode = body.collaboration_mode
         labels_to_set = dict(body.labels or {})
-        # Pins are per-user. The client writes the canonical ``omnigent.pinned``
-        # key; rewrite it to the caller's per-user key so one user's pin doesn't
-        # pin the session for everyone with access. Empty value (unpin) carries
-        # through to the delete-clear loop below under the per-user key.
+        # Personal sidebar labels use canonical client keys and per-user
+        # storage keys so collaborators can organize the same session
+        # independently.
         if PINNED_LABEL_KEY in labels_to_set:
             labels_to_set[pinned_label_key(user_id)] = labels_to_set.pop(PINNED_LABEL_KEY)
+        if COMPLETED_LABEL_KEY in labels_to_set:
+            labels_to_set[completed_label_key(user_id)] = labels_to_set.pop(COMPLETED_LABEL_KEY)
         if requested_codex_collaboration_mode is not None:
             labels_to_set[_CODEX_NATIVE_COLLABORATION_MODE_LABEL_KEY] = (
                 requested_codex_collaboration_mode
@@ -1754,14 +1764,13 @@ def register_core_routes(
                 _codex_plan_enabled,
                 _runner_result,
             )
-        # Some labels are cleared by DELETE, not by upserting an empty value:
-        # the project membership (empty = "remove from project") and the pinned
-        # flag (empty = "unpin"). Split any empty-valued clear keys out before
-        # the bulk upsert so other labels are unaffected. Labels are upsert-only,
-        # so without this an empty string would linger as a stored value.
-        # The pinned key was rewritten to the caller's per-user key above, so
-        # clear that one (not the canonical bare key) on an empty value.
-        for _clear_key in (PROJECT_LABEL_KEY, pinned_label_key(user_id)):
+        # Project and personal labels use an empty value as a delete request.
+        # Split them out before the bulk upsert so no empty label row lingers.
+        for _clear_key in (
+            PROJECT_LABEL_KEY,
+            pinned_label_key(user_id),
+            completed_label_key(user_id),
+        ):
             if labels_to_set.get(_clear_key) == "":
                 labels_to_set = {k: v for k, v in labels_to_set.items() if k != _clear_key}
                 await asyncio.to_thread(conversation_store.delete_label, session_id, _clear_key)

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -87,6 +87,7 @@ from omnigent.session_lifecycle import (
 )
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
+from omnigent.stores.conversation_store import completed_label_key
 from omnigent.stores.file_store import FileStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.telemetry import emit as _tel_emit
@@ -417,6 +418,15 @@ def register_events_routes(
             # persist or relay to the harness (which rejects
             # ``function_call`` as an unknown inbound event type).
             return {"verdict": "allow"}
+
+        if body.type == "message" and body.data.get("role") == "user":
+            completion_key = completed_label_key(user_id)
+            if completion_key in conv.labels:
+                await asyncio.to_thread(
+                    conversation_store.delete_label,
+                    session_id,
+                    completion_key,
+                )
 
         if body.type == _INTERRUPT_TYPE:
             _publish_interrupted(session_id)

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -104,40 +104,29 @@ PROJECT_LABEL_KEY = "omni_project"
 # mirrors the canonical key as ``PINNED_LABEL_KEY``.
 PINNED_LABEL_KEY = "omnigent.pinned"
 
-# Single-user / no-auth sentinel for the per-user pin key suffix, mirroring the
-# reserved ``"local"`` identity used elsewhere (see ``RESERVED_USER_LOCAL``).
-_PINNED_LABEL_LOCAL_USER = "local"
+# Personal completion marker used by the sidebar's Completed group. The value
+# is the epoch-ms completion time; the API exposes only the caller's marker.
+COMPLETED_LABEL_KEY = "omnigent.completed"
 
-# ``conversation_labels.key`` is ``String(128)``. The prefix ``omnigent.pinned.``
-# is 16 chars, so a raw ``user_id`` suffix must stay ≤ 112 chars to fit. User ids
-# are ``String(128)`` elsewhere (SSO subject ids can be long), so a raw suffix
-# could overflow the key column — Postgres errors, MySQL silently truncates (and
-# two long ids could then collide on the truncated key). To stay safe while
-# keeping the common case (emails) human-readable in the DB, ids that don't fit
-# are replaced with a fixed-width hash suffix.
-_PINNED_LABEL_MAX_SUFFIX_LEN = 128 - len(PINNED_LABEL_KEY) - 1  # minus the "." joiner
+_PERSONAL_LABEL_LOCAL_USER = "local"
+
+
+def _personal_label_key(prefix: str, user_id: str | None) -> str:
+    """Build a per-user label key that fits the 128-character DB column."""
+    suffix = user_id if user_id is not None else _PERSONAL_LABEL_LOCAL_USER
+    if len(suffix) > 128 - len(prefix) - 1:
+        suffix = "h:" + hashlib.sha256(suffix.encode("utf-8")).hexdigest()
+    return f"{prefix}.{suffix}"
 
 
 def pinned_label_key(user_id: str | None) -> str:
-    """
-    The per-user pinned-label key for ``user_id``.
+    """Return the stored per-user pin key for ``user_id``."""
+    return _personal_label_key(PINNED_LABEL_KEY, user_id)
 
-    Deterministic in ``user_id`` (the write path and the ``pinned=True`` filter
-    derive the key the same way, so they always match). Normal ids are used
-    verbatim for DB readability; an id too long to fit the ``String(128)`` key
-    column is replaced with a fixed-width ``sha256`` suffix so it can never
-    overflow or collide via silent truncation.
 
-    :param user_id: Authenticated user id, e.g. ``"alice@example.com"``, or
-        ``None`` in single-user / no-auth mode (→ the ``local`` sentinel).
-    :returns: ``"omnigent.pinned.<suffix>"`` (suffix = the id, or its hash when
-        the id is too long).
-    """
-    suffix = user_id if user_id is not None else _PINNED_LABEL_LOCAL_USER
-    if len(suffix) > _PINNED_LABEL_MAX_SUFFIX_LEN:
-        # 64 hex chars — well within the budget and collision-safe.
-        suffix = "h:" + hashlib.sha256(suffix.encode("utf-8")).hexdigest()
-    return f"{PINNED_LABEL_KEY}.{suffix}"
+def completed_label_key(user_id: str | None) -> str:
+    """Return the stored per-user completion key for ``user_id``."""
+    return _personal_label_key(COMPLETED_LABEL_KEY, user_id)
 
 
 # Labels that must NOT cross into a new session context — deliberately
@@ -612,6 +601,8 @@ class ConversationStore(ABC):
         project: str | None = None,
         pinned: bool = False,
         pinned_owner: str | None = None,
+        completed: bool = False,
+        completed_owner: str | None = None,
         title: str | None = None,
     ) -> PagedList[Conversation]:
         """
@@ -718,6 +709,9 @@ class ConversationStore(ABC):
         :param pinned_owner: The user whose pins ``pinned=True`` filters to
             (their per-user key). ``None`` → the single-user ``local`` sentinel.
             Ignored unless ``pinned`` is ``True``.
+        :param completed: When ``True``, return only sessions the caller marked
+            complete.
+        :param completed_owner: The user whose completion marker to filter by.
         :param title: When set, only return conversations whose
             ``title`` matches exactly. ``None`` disables the filter.
             Powers the ``(agent, title)`` child-session lookup in

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -79,6 +79,7 @@ from omnigent.session_import.models import (
 from omnigent.stores.conversation_store import (
     _FORK_ONLY_DROPPED_LABEL_KEYS,
     _INSTANCE_SCOPED_LABEL_KEYS,
+    COMPLETED_LABEL_KEY,
     FORK_CARRY_HISTORY_LABEL_KEY,
     FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY,
     FORK_SOURCE_LABEL_KEY,
@@ -90,6 +91,7 @@ from omnigent.stores.conversation_store import (
     ConversationStore,
     CreatedSession,
     SessionConnectivity,
+    completed_label_key,
     pinned_label_key,
 )
 
@@ -2133,6 +2135,8 @@ class SqlAlchemyConversationStore(ConversationStore):
         project: str | None = None,
         pinned: bool = False,
         pinned_owner: str | None = None,
+        completed: bool = False,
+        completed_owner: str | None = None,
         title: str | None = None,
     ) -> PagedList[Conversation]:
         """
@@ -2193,6 +2197,9 @@ class SqlAlchemyConversationStore(ConversationStore):
             loaded pagination window.
         :param pinned_owner: The user whose pins ``pinned=True`` filters to.
             ``None`` → the single-user ``local`` sentinel.
+        :param completed: When ``True``, restrict to sessions marked complete
+            by ``completed_owner``.
+        :param completed_owner: The user whose completion marker to filter by.
         :param owned_by: When set, restrict to sessions the user owns
             (an ``owner``-level grant) — stricter than ``accessible_by``,
             which also matches sessions merely shared with them. Powers
@@ -2408,6 +2415,15 @@ class SqlAlchemyConversationStore(ConversationStore):
                         select(SqlConversationLabel.conversation_id).where(
                             SqlConversationLabel.workspace_id == current_workspace_id(),
                             SqlConversationLabel.key == pinned_label_key(pinned_owner),
+                        )
+                    )
+                )
+            if completed:
+                stmt = stmt.where(
+                    SqlConversation.id.in_(
+                        select(SqlConversationLabel.conversation_id).where(
+                            SqlConversationLabel.workspace_id == current_workspace_id(),
+                            SqlConversationLabel.key == completed_label_key(completed_owner),
                         )
                     )
                 )
@@ -3539,16 +3555,13 @@ class SqlAlchemyConversationStore(ConversationStore):
             # message instead of dropping it. Forks of chat-only sources
             # (no workspace) get no such label and resume in-process like
             # a brand-new chat session.
-            # Per-user pin keys (``omnigent.pinned.<user>``) are dynamic-suffix,
-            # so they're never in the exact-match drop sets — drop them by prefix
-            # instead. A fork is a NEW conversation; inheriting the source's pins
-            # would show the clone as pinned for the forker AND carry every other
-            # user's pin key along as dead data.
+            # Per-user sidebar labels belong to the source, not the new fork.
             fork_labels = {
                 key: value
                 for key, value in _fetch_labels(session, source_conversation_id).items()
                 if key not in (_INSTANCE_SCOPED_LABEL_KEYS | _FORK_ONLY_DROPPED_LABEL_KEYS)
                 and not key.startswith(f"{PINNED_LABEL_KEY}.")
+                and not key.startswith(f"{COMPLETED_LABEL_KEY}.")
             }
             source_workspace = source_meta_ref.workspace if source_meta_ref else None
             source_ext_session = source_meta_ref.external_session_id if source_meta_ref else None

--- a/openapi.json
+++ b/openapi.json
@@ -8562,6 +8562,17 @@
               "title": "Pinned",
               "type": "boolean"
             }
+          },
+          {
+            "description": "When `True`, return only sessions this user marked complete.",
+            "in": "query",
+            "name": "completed",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Completed",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -204,6 +204,60 @@ async def test_first_message_schedules_background_semantic_title(
     assert snapshot.json()["title"] == "Debug authentication timeout"
 
 
+async def test_user_message_reactivates_completed_session(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An accepted user turn clears only the caller's completion marker."""
+    from omnigent.stores.conversation_store import completed_label_key
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"], title="Completed work")
+    completed = await client.patch(
+        f"/v1/sessions/{session['id']}",
+        json={"labels": {"omnigent.completed": "1721760000000"}},
+    )
+    assert completed.status_code == 200
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(202, json={"queued": True})),
+        base_url="http://runner",
+    )
+
+    async def get_runner_client(
+        _session_id: str,
+        _runner_router: object,
+    ) -> httpx.AsyncClient:
+        return fake_runner
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._get_runner_client",
+        get_runner_client,
+    )
+
+    try:
+        response = await client.post(
+            f"/v1/sessions/{session['id']}/events",
+            json={
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "One more follow-up"}],
+                },
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert response.status_code == 202, response.text
+    stored = SqlAlchemyConversationStore(db_uri).get_conversation(session["id"])
+    assert stored is not None
+    assert completed_label_key(None) not in stored.labels
+    listed = await client.get("/v1/sessions?completed=true")
+    assert session["id"] not in [row["id"] for row in listed.json()["data"]]
+
+
 async def test_background_title_failure_does_not_break_subsequent_user_turn(
     client: httpx.AsyncClient,
     app: Any,

--- a/tests/server/routes/test_child_session_summary_labels.py
+++ b/tests/server/routes/test_child_session_summary_labels.py
@@ -1,11 +1,7 @@
-"""Unit test for pin-key stripping in child-session summaries.
+"""Unit test for personal-label stripping in child-session summaries.
 
 ``_child_session_summary_from_conversation`` builds a ``ChildSessionSummary``
-for a sub-agent row. Every other serialization path collapses per-user pin keys
-via ``_labels_for_viewer``; this one must at least strip them so a shared
-child's summary can never expose another viewer's ``omnigent.pinned.<user>``
-key. Child sessions aren't pinnable, so there's nothing to surface — just the
-strip.
+for a sub-agent row. Personal sidebar labels must not leak through this path.
 """
 
 from __future__ import annotations
@@ -14,7 +10,7 @@ from omnigent.entities import Conversation
 from omnigent.server.routes._sessions.helpers import (
     _child_session_summary_from_conversation,
 )
-from omnigent.stores.conversation_store import pinned_label_key
+from omnigent.stores.conversation_store import completed_label_key, pinned_label_key
 
 
 def _child(labels: dict[str, str]) -> Conversation:
@@ -30,17 +26,20 @@ def _child(labels: dict[str, str]) -> Conversation:
     )
 
 
-def test_child_summary_strips_per_user_pin_keys() -> None:
-    """A per-user pin key on a child row must not leak into its summary."""
+def test_child_summary_strips_per_user_sidebar_labels() -> None:
     conv = _child(
         {
             pinned_label_key("alice@example.com"): "1721760000000",
             pinned_label_key("bob@example.com"): "1721760001000",
+            completed_label_key("alice@example.com"): "1721760002000",
+            "omnigent.pinned": "legacy",
+            "omnigent.completed": "legacy",
             "omni_project": "Moonshot",
         }
     )
     summary = _child_session_summary_from_conversation(conv, "conv_parent", None)
-    # No pin key of any kind survives — not the canonical one, not a per-user one.
+    # No personal sidebar key survives.
     assert not any(k.startswith("omnigent.pinned") for k in summary.labels)
+    assert not any(k.startswith("omnigent.completed") for k in summary.labels)
     # Unrelated labels are preserved.
     assert summary.labels.get("omni_project") == "Moonshot"

--- a/tests/server/routes/test_session_updates_ws.py
+++ b/tests/server/routes/test_session_updates_ws.py
@@ -582,16 +582,11 @@ def test_session_added_for_inaccessible_session_is_not_pushed(
             )
 
 
-def test_pin_label_collapses_to_canonical_key_on_the_wire(
+def test_personal_labels_collapse_to_canonical_keys_on_the_wire(
     app: FastAPI, stores, fast_rescan: None
 ) -> None:
-    """Pins are stored per-user (``omnigent.pinned.<user>``), but the watch
-    stream collapses the caller's own pin key to the canonical
-    ``omnigent.pinned`` and never emits another user's per-user key. Exercised
-    via the normal rescan-diff path: pinning a watched session out of band
-    surfaces on the next ``changed`` frame (``fast_rescan`` shrinks the tick).
-    """
-    from omnigent.stores.conversation_store import pinned_label_key
+    """The watch stream exposes only the caller's canonical personal labels."""
+    from omnigent.stores.conversation_store import completed_label_key, pinned_label_key
 
     conversation_store, _agent_store, _permission_store = stores
     s1 = _seed_session(stores, owner=ALICE, title="watched")
@@ -607,6 +602,8 @@ def test_pin_label_collapses_to_canonical_key_on_the_wire(
             {
                 pinned_label_key(ALICE): "1721760000000",
                 pinned_label_key(BOB): "1700000000000",
+                completed_label_key(ALICE): "1721760002000",
+                completed_label_key(BOB): "1700000002000",
             },
         )
         changed = _recv_until(ws, {"changed"})
@@ -615,9 +612,12 @@ def test_pin_label_collapses_to_canonical_key_on_the_wire(
         labels = items[s1]["labels"]
         # Alice's pin surfaces as the canonical bare key…
         assert labels.get("omnigent.pinned") == "1721760000000"
+        assert labels.get("omnigent.completed") == "1721760002000"
         # …and neither per-user key (hers or Bob's) leaks onto the wire.
         assert pinned_label_key(ALICE) not in labels
         assert pinned_label_key(BOB) not in labels
+        assert completed_label_key(ALICE) not in labels
+        assert completed_label_key(BOB) not in labels
 
 
 # ── comments fingerprint ──────────────────────────────────────────────

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -464,3 +464,62 @@ async def test_list_sessions_pinned_filter(
     assert plain.id not in ids
     # A pin belonging to another user must not appear for the caller.
     assert other_user_pin.id not in ids
+
+
+# ── Completed session label (omnigent.completed) ────────────────────
+
+
+async def test_patch_and_list_completed_sessions(
+    client: httpx.AsyncClient,
+    session_id: str,
+    db_uri: str,
+) -> None:
+    """Completion is a reversible, per-user label exposed canonically."""
+    from omnigent.stores.conversation_store import completed_label_key
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    user_key = completed_label_key(None)
+
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"labels": {"omnigent.completed": "1721760000000"}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["labels"]["omnigent.completed"] == "1721760000000"
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert conv.labels[user_key] == "1721760000000"
+    assert "omnigent.completed" not in conv.labels
+
+    listed = await client.get("/v1/sessions?completed=true")
+    assert listed.status_code == 200
+    assert [session["id"] for session in listed.json()["data"]] == [session_id]
+
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"labels": {"omnigent.completed": ""}},
+    )
+    assert resp.status_code == 200
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert user_key not in conv.labels
+
+
+async def test_patch_rejects_client_supplied_per_user_completed_key(
+    client: httpx.AsyncClient,
+    session_id: str,
+    db_uri: str,
+) -> None:
+    """Clients cannot change another user's private completion state."""
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    key = "omnigent.completed.bob@example.com"
+
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"labels": {key: "1721760000000"}},
+    )
+
+    assert resp.status_code == 400
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert key not in conv.labels

--- a/tests/server/routes/test_sessions_input_policy_deny.py
+++ b/tests/server/routes/test_sessions_input_policy_deny.py
@@ -65,9 +65,14 @@ def route_client(db_uri: str) -> Iterator[tuple[TestClient, str]]:
 
 def test_input_policy_deny_persists_item_readable_from_items_api(
     route_client: tuple[TestClient, str],
+    db_uri: str,
 ) -> None:
     """Synchronous INPUT DENY both streams and persists the deny sentinel."""
+    from omnigent.stores.conversation_store import completed_label_key
+
     client, session_id = route_client
+    conversation_store = SqlAlchemyConversationStore(db_uri)
+    conversation_store.set_labels(session_id, {completed_label_key(None): "1721760000000"})
     spec = AgentSpec(
         spec_version=1,
         name="test-agent",
@@ -136,3 +141,6 @@ def test_input_policy_deny_persists_item_readable_from_items_api(
             "text": "[Denied by policy: Request contains BLOCK_THIS_TOKEN]",
         }
     ]
+    stored = conversation_store.get_conversation(session_id)
+    assert stored is not None
+    assert stored.labels[completed_label_key(None)] == "1721760000000"

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -49,13 +49,11 @@ def test_fork_drops_import_provenance_labels(
     assert IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY not in fork.labels
 
 
-def test_fork_drops_per_user_pin_labels(
+def test_fork_drops_per_user_sidebar_labels(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """A fork is a NEW conversation, so it must not inherit the source's pins:
-    neither the forker's nor any other user's per-user pin key rides along
-    (those keys have a dynamic suffix, so a prefix drop is required)."""
-    from omnigent.stores.conversation_store import pinned_label_key
+    """A fork must not inherit the source's personal sidebar organization."""
+    from omnigent.stores.conversation_store import completed_label_key, pinned_label_key
 
     source = conversation_store.create_conversation()
     conversation_store.set_labels(
@@ -63,6 +61,7 @@ def test_fork_drops_per_user_pin_labels(
         {
             pinned_label_key("alice"): "1721760000000",
             pinned_label_key("bob"): "1700000000000",
+            completed_label_key("alice"): "1721760002000",
             "kept": "yes",
         },
     )
@@ -72,6 +71,7 @@ def test_fork_drops_per_user_pin_labels(
     assert fork.labels["kept"] == "yes"
     assert pinned_label_key("alice") not in fork.labels
     assert pinned_label_key("bob") not in fork.labels
+    assert completed_label_key("alice") not in fork.labels
 
 
 def test_create_and_get(conversation_store: SqlAlchemyConversationStore) -> None:
@@ -4936,6 +4936,22 @@ def test_pinned_label_key_fits_column_for_long_user_ids() -> None:
     assert key == pinned_label_key(long_id)  # deterministic
     # Distinct long ids don't collide.
     assert pinned_label_key("u" * 200) != pinned_label_key("v" * 200)
+
+
+def test_list_conversations_filters_by_completed_label(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """The completed filter matches only the requesting user's marker."""
+    from omnigent.stores.conversation_store import completed_label_key
+
+    completed = conversation_store.create_conversation(title="completed")
+    other_user = conversation_store.create_conversation(title="other user's completed")
+    conversation_store.set_labels(completed.id, {completed_label_key("alice"): "1721760000000"})
+    conversation_store.set_labels(other_user.id, {completed_label_key("bob"): "1721760000000"})
+
+    page = conversation_store.list_conversations(completed=True, completed_owner="alice")
+
+    assert [conversation.id for conversation in page.data] == [completed.id]
 
 
 def test_list_projects_owned_by_excludes_shared_only_projects(

--- a/web/src/hooks/SessionUpdatesProvider.test.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.test.tsx
@@ -10,7 +10,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useNavigate } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
+import {
+  COMPLETED_CONVERSATIONS_KEY,
+  type Conversation,
+  type ConversationsPage,
+} from "@/hooks/useConversations";
 import type { ConversationsInfiniteData } from "@/lib/sessionListCache";
 
 // Mock the socket transport so setWatched is observable and start/stop are
@@ -116,6 +120,16 @@ describe("SessionUpdatesProvider watch-set", () => {
     seedConversations(client, ["conv_open", "conv_b"]);
     renderProvider(client, ["/c/conv_open"]);
     expect(lastWatched()).toEqual(["conv_b", "conv_open"]);
+  });
+
+  it("watches completed rows outside the loaded sidebar page", () => {
+    const client = new QueryClient();
+    seedConversations(client, ["conv_a"]);
+    client.setQueryData(COMPLETED_CONVERSATIONS_KEY, [conv("conv_completed")]);
+
+    renderProvider(client, ["/"]);
+
+    expect(lastWatched()).toEqual(["conv_a", "conv_completed"]);
   });
 
   it("re-pushes the watch-set with the new open id on navigation", () => {
@@ -306,6 +320,24 @@ describe("SessionUpdatesProvider fingerprint pruning", () => {
 });
 
 describe("SessionUpdatesProvider list invalidation", () => {
+  it("removes a reactivated row from the completed cache", () => {
+    const client = new QueryClient();
+    seedConversations(client, ["conv_a"]);
+    client.setQueryData(COMPLETED_CONVERSATIONS_KEY, [
+      { ...conv("conv_a"), labels: { "omnigent.completed": "1721760000000" } },
+    ]);
+    renderProvider(client, ["/"]);
+
+    act(() =>
+      frameHandler()({
+        type: "changed",
+        items: [{ ...conv("conv_a"), labels: {} }],
+      }),
+    );
+
+    expect(client.getQueryData(COMPLETED_CONVERSATIONS_KEY)).toEqual([]);
+  });
+
   it("invalidates the archived-project-names scan on a remote removal", () => {
     // Another client archiving/relabeling/deleting must refresh the Archived
     // view's project picker — only local mutations invalidate it otherwise.

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -20,6 +20,13 @@ import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { useActiveConversationId } from "@/hooks/useActiveConversationId";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
 import {
+  COMPLETED_CONVERSATIONS_KEY,
+  PINNED_CONVERSATIONS_KEY,
+  type Conversation,
+} from "@/hooks/useConversations";
+import {
+  COMPLETED_LABEL_KEY,
+  PINNED_LABEL_KEY,
   type ConversationsInfiniteData,
   type SessionListWireItem,
   collectConversationIds,
@@ -40,6 +47,10 @@ const DEBOUNCE_MS = 250;
 // Live frames overlay those caches with these fixed filters so archived rows
 // drop out the same way they do from the default sidebar list.
 const PROJECT_FOLDER_FILTERS = { searchQuery: "", includeArchived: false } as const;
+const PERSONAL_LISTS = [
+  { queryKey: PINNED_CONVERSATIONS_KEY, labelKey: PINNED_LABEL_KEY },
+  { queryKey: COMPLETED_CONVERSATIONS_KEY, labelKey: COMPLETED_LABEL_KEY },
+] as const;
 
 /**
  * Overlay wire items onto every cached `["conversations", ...]` variant.
@@ -93,6 +104,28 @@ function applyItemsToCache(
     if (queryNeedsRefetch) needsRefetch = true;
     if (next !== data) queryClient.setQueryData(key, next);
   }
+  for (const { queryKey, labelKey } of PERSONAL_LISTS) {
+    queryClient.setQueryData<Conversation[]>(queryKey, (old) => {
+      if (!old) return old;
+      let next = old;
+      for (const item of itemsById.values()) {
+        if (item.labels === undefined) continue;
+        const index = next.findIndex((conversation) => conversation.id === item.id);
+        if (index >= 0) foundAnywhere.add(item.id);
+        const belongs = labelKey in item.labels;
+        if (!belongs && index >= 0) {
+          next = next.filter((conversation) => conversation.id !== item.id);
+        } else if (belongs && index >= 0) {
+          next = next.map((conversation, i) =>
+            i === index ? { ...conversation, ...item } : conversation,
+          );
+        } else if (belongs) {
+          next = [...next, item as Conversation];
+        }
+      }
+      return next;
+    });
+  }
   return {
     missingIds: [...itemsById.keys()].filter((id) => !foundAnywhere.has(id)),
     needsRefetch,
@@ -119,6 +152,14 @@ function removeIdsFromCache(queryClient: QueryClient, ids: string[]): boolean {
         removedAny = true;
       }
     }
+  }
+  for (const { queryKey } of PERSONAL_LISTS) {
+    queryClient.setQueryData<Conversation[]>(queryKey, (old) => {
+      if (!old) return old;
+      const next = old.filter((conversation) => !idSet.has(conversation.id));
+      if (next.length !== old.length) removedAny = true;
+      return next;
+    });
   }
   return removedAny;
 }
@@ -168,6 +209,11 @@ export function SessionUpdatesProvider({ children }: { children: ReactNode }) {
       queryKey: ["project-sessions"],
     });
     const ids = collectConversationIds([...entries, ...projectEntries].map(([, data]) => data));
+    for (const { queryKey } of PERSONAL_LISTS) {
+      for (const conversation of queryClient.getQueryData<Conversation[]>(queryKey) ?? []) {
+        if (!ids.includes(conversation.id)) ids.push(conversation.id);
+      }
+    }
     // Union in the open session. A directly-opened child / sub-agent
     // session is filtered out of the sidebar list, so it's absent from
     // every cached conversations page and wouldn't otherwise be watched —

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -11,6 +11,7 @@ import { useSessionUpdatesConnected } from "./useSessionUpdatesConnected";
 import {
   deleteConversation,
   fetchAllArchivedProjectNames,
+  fetchCompletedConversations,
   renameConversation,
   useArchiveConversation,
   useBulkArchiveConversations,
@@ -25,11 +26,13 @@ import {
   useRenameConversation,
   useStopAndDeleteConversation,
   useStopSession,
+  useToggleCompletedConversation,
   useTogglePinnedConversation,
+  COMPLETED_CONVERSATIONS_KEY,
   PINNED_CONVERSATIONS_KEY,
   type Conversation,
 } from "./useConversations";
-import { PINNED_LABEL_KEY } from "@/lib/sessionListCache";
+import { COMPLETED_LABEL_KEY, PINNED_LABEL_KEY } from "@/lib/sessionListCache";
 
 vi.mock("./useSessionUpdatesConnected", () => ({ useSessionUpdatesConnected: vi.fn() }));
 
@@ -95,6 +98,34 @@ describe("renameConversation", () => {
   it("throws on non-2xx", async () => {
     fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 404 }));
     await expect(renameConversation("missing", "x")).rejects.toThrow(/404/);
+  });
+});
+
+describe("fetchCompletedConversations", () => {
+  it("follows cursors so older completed sessions are not truncated", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({
+          data: [conversation({ id: "conv_new" })],
+          first_id: "conv_new",
+          last_id: "conv_new",
+          has_more: true,
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          data: [conversation({ id: "conv_old" })],
+          first_id: "conv_old",
+          last_id: "conv_old",
+          has_more: false,
+        }),
+      );
+
+    const rows = await fetchCompletedConversations();
+
+    expect(rows.map((row) => row.id)).toEqual(["conv_new", "conv_old"]);
+    expect(fetchMock.mock.calls[0][0]).toContain("completed=true");
+    expect(fetchMock.mock.calls[1][0]).toContain("after=conv_new");
   });
 });
 
@@ -919,6 +950,61 @@ describe("useTogglePinnedConversation cache patching", () => {
     expect(invalidateSpy).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect((fetchMock.mock.calls[0] as [string, RequestInit])[1].method).toBe("PATCH");
+  });
+});
+
+describe("useToggleCompletedConversation cache patching", () => {
+  function seed(completed: boolean) {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        id: "conv_x",
+        object: "conversation",
+        title: "Session X",
+        created_at: 0,
+        labels: completed ? { [COMPLETED_LABEL_KEY]: "1721760000000" } : {},
+      }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([conversation({ id: "conv_x", updated_at: 150 })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const rendered = renderHook(() => useToggleCompletedConversation(), { wrapper });
+    return { queryClient, rendered };
+  }
+
+  it("moves a completed row immediately and PATCHes the canonical label", async () => {
+    const { queryClient, rendered } = seed(true);
+
+    rendered.result.current.mutate({ id: "conv_x", completed: true });
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+
+    const completed = queryClient.getQueryData<Conversation[]>(COMPLETED_CONVERSATIONS_KEY);
+    expect(completed?.[0].updated_at).toBe(150);
+    expect(completed?.[0].labels?.[COMPLETED_LABEL_KEY]).toBe("1721760000000");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv_x");
+    expect(JSON.parse(init.body as string)).toEqual({
+      labels: { [COMPLETED_LABEL_KEY]: expect.any(String) },
+    });
+  });
+
+  it("removes a row from Completed when marked active", async () => {
+    const { queryClient, rendered } = seed(false);
+    queryClient.setQueryData<Conversation[]>(COMPLETED_CONVERSATIONS_KEY, [
+      conversation({
+        id: "conv_x",
+        updated_at: 150,
+        labels: { [COMPLETED_LABEL_KEY]: "1721760000000" },
+      }),
+    ]);
+
+    rendered.result.current.mutate({ id: "conv_x", completed: false });
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+
+    expect(queryClient.getQueryData<Conversation[]>(COMPLETED_CONVERSATIONS_KEY)).toEqual([]);
   });
 });
 

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -20,6 +20,7 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
 import {
+  COMPLETED_LABEL_KEY,
   filtersFromConversationQueryKey,
   mergeItemsIntoPages,
   PINNED_LABEL_KEY,
@@ -660,6 +661,24 @@ export function useBulkArchiveConversations() {
   });
 }
 
+export function useBulkCompleteConversations() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ ids, completed }: { ids: string[]; completed: boolean }) => {
+      const results = await Promise.allSettled(
+        ids.map((id) => setConversationCompleted(id, completed)),
+      );
+      const failed = ids.filter((_, index) => results[index].status === "rejected");
+      if (failed.length > 0) throw { failed, total: ids.length };
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
+      void queryClient.invalidateQueries({ queryKey: COMPLETED_CONVERSATIONS_KEY });
+    },
+  });
+}
+
 /**
  * Delete multiple conversations in parallel (stop + delete each).
  *
@@ -768,6 +787,7 @@ export function useBulkStopSessions() {
 // (see sessionListCache) so membership checks can read it without a value
 // import cycle; re-exported here for the existing consumers.
 export { PINNED_LABEL_KEY };
+export { COMPLETED_LABEL_KEY };
 
 // TanStack Query key for the server-authoritative pinned-session list.
 // Deliberately NOT under the ["conversations"] prefix: the list mutations do
@@ -777,6 +797,7 @@ export { PINNED_LABEL_KEY };
 // would be swept into those loops — the throw aborted the toggle's cache patch,
 // so a pinned row didn't move until a refetch. A sibling key keeps it isolated.
 export const PINNED_CONVERSATIONS_KEY = ["pinned-conversations"] as const;
+export const COMPLETED_CONVERSATIONS_KEY = ["completed-conversations"] as const;
 
 /**
  * Fetch every pinned session (the `omnigent.pinned` label) via
@@ -807,6 +828,36 @@ export function usePinnedConversations() {
   });
 }
 
+export async function fetchCompletedConversations(): Promise<Conversation[]> {
+  const conversations: Conversation[] = [];
+  let after: string | undefined;
+  for (;;) {
+    const params = new URLSearchParams({
+      order: "desc",
+      sort_by: "updated_at",
+      limit: "100",
+      completed: "true",
+    });
+    if (after) params.set("after", after);
+    // eslint-disable-next-line no-await-in-loop
+    const res = await authenticatedFetch(`/v1/sessions?${params.toString()}`);
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    // eslint-disable-next-line no-await-in-loop
+    const page = (await res.json()) as ConversationsPage;
+    conversations.push(...page.data);
+    if (!page.has_more || !page.last_id) return conversations;
+    after = page.last_id;
+  }
+}
+
+export function useCompletedConversations() {
+  return useQuery<Conversation[]>({
+    queryKey: COMPLETED_CONVERSATIONS_KEY,
+    queryFn: fetchCompletedConversations,
+    staleTime: 30_000,
+  });
+}
+
 /**
  * PATCH the pinned label on a session. Pinning stores the epoch-ms pin time as
  * the value (so the Pinned section can order by pin recency); an empty string
@@ -830,35 +881,31 @@ export async function setConversationPinned(
   return (await res.json()) as Conversation;
 }
 
-/**
- * Pin / unpin a session via `PATCH /v1/sessions/{id}` (the `omnigent.pinned`
- * label). Overlays only the `labels` field onto cached rows and patches the
- * pinned-list query directly (adding the row on pin, removing it on unpin)
- * rather than invalidating it. `GET /v1/sessions?pinned=true` is served from a
- * label index that catches up to the write asynchronously (same reindex lag the
- * rename / delete hooks document), so an immediate refetch races it and would
- * return the pre-toggle set — the Pinned section would flip back until a manual
- * refresh. The query's `staleTime` converges it later.
- *
- * The PATCH returns a `SessionResponse` snapshot, which carries `labels` but
- * NOT `updated_at` (only the list endpoint's `SessionListItem` has it). So the
- * row inserted into the pinned cache is built from the existing cached row (for
- * its `updated_at`, `title`, etc.) with the server-confirmed `labels` overlaid
- * — never from the raw PATCH response, which would leave the row without a
- * timestamp until the pinned query refetched (a blank time field on the new
- * row). For the same reason the list overlay carries only `labels`, so pinning
- * can't blank an existing row's timestamp.
- */
-export function useTogglePinnedConversation() {
+export async function setConversationCompleted(
+  id: string,
+  completed: boolean,
+): Promise<Conversation> {
+  const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      labels: { [COMPLETED_LABEL_KEY]: completed ? String(Date.now()) : "" },
+    }),
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as Conversation;
+}
+
+function useTogglePersonalLabelConversation<Variables extends { id: string }>(
+  listKey: readonly [string],
+  labelKey: string,
+  enabledFor: (variables: Variables) => boolean,
+  save: (id: string, enabled: boolean) => Promise<Conversation>,
+) {
   const queryClient = useQueryClient();
 
-  // Locate the fullest cached row for an id, so the pinned insert keeps a real
-  // `updated_at` (the PATCH snapshot lacks it). A project session lives only in
-  // its folder's ["project-sessions", name] cache when it's outside the main
-  // window, so that cache is searched too — otherwise its pinned row would be
-  // built from the timestamp-less snapshot.
   const findRow = (id: string): Conversation | undefined =>
-    queryClient.getQueryData<Conversation[]>(PINNED_CONVERSATIONS_KEY)?.find((c) => c.id === id) ??
+    queryClient.getQueryData<Conversation[]>(listKey)?.find((c) => c.id === id) ??
     queryClient
       .getQueriesData<ConversationsInfiniteData>({ queryKey: ["conversations"] })
       .flatMap(([, data]) => data?.pages.flatMap((p) => p.data) ?? [])
@@ -868,39 +915,28 @@ export function useTogglePinnedConversation() {
       .flatMap(([, data]) => data?.pages.flatMap((p) => p.data) ?? [])
       .find((c) => c.id === id);
 
-  // Apply a pin/unpin to every cache that renders the row. `labels` is the
-  // authoritative label map to write; membership in the Pinned section is
-  // driven by the PINNED_CONVERSATIONS_KEY cache, so that patch is what makes
-  // the row visibly move.
-  const patch = (id: string, labels: Record<string, string>, pinned: boolean) => {
+  const patch = (id: string, labels: Record<string, string>, enabled: boolean) => {
     const existing = findRow(id);
-    // The pin toggle only changes `labels`; overlay just that so it can't
-    // clobber other fields (e.g. blank `updated_at`) on the list rows.
     const itemsById = new Map([[id, { id, labels } satisfies SessionListWireItem]]);
-    for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
-      queryKey: ["conversations"],
-    })) {
-      const { data: next } = mergeItemsIntoPages(
-        data,
-        itemsById,
-        filtersFromConversationQueryKey(key),
-        undefined,
-      );
-      if (next !== data) queryClient.setQueryData(key, next);
+    for (const queryKey of [["conversations"], ["project-sessions"]]) {
+      for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+        queryKey,
+      })) {
+        const filters =
+          key[0] === "conversations"
+            ? filtersFromConversationQueryKey(key)
+            : PROJECT_FOLDER_FILTERS;
+        const { data: next } = mergeItemsIntoPages(data, itemsById, filters, undefined);
+        if (next !== data) queryClient.setQueryData(key, next);
+      }
     }
     queryClient.setQueryData<Conversation | null>(["conversation-backfill", id], (old) =>
       old ? { ...old, labels } : old,
     );
     queryClient.setQueryData<Session>(["session", id], (old) => (old ? { ...old, labels } : old));
-    // Add the row on pin (its label carries the pin timestamp the sidebar sorts
-    // by) built from the existing row + labels; drop it on unpin.
-    queryClient.setQueryData<Conversation[]>(PINNED_CONVERSATIONS_KEY, (old) => {
+    queryClient.setQueryData<Conversation[]>(listKey, (old) => {
       const rest = (old ?? []).filter((c) => c.id !== id);
-      if (!pinned) return rest;
-      // Prefer the full cached row (keeps title/updated_at); fall back to a
-      // minimal row when the session isn't in any loaded cache (rare — the pin
-      // affordance lives on a visible row). The pinned query refetch fills the
-      // rest in later.
+      if (!enabled) return rest;
       const row: Conversation = existing
         ? { ...existing, labels }
         : ({ id, object: "conversation", labels } as Conversation);
@@ -909,41 +945,47 @@ export function useTogglePinnedConversation() {
   };
 
   return useMutation({
-    mutationFn: ({ id, pinned }: { id: string; pinned: boolean }) =>
-      setConversationPinned(id, pinned),
-    // Move the row immediately — don't wait for the PATCH round-trip. Without
-    // this the row lingers in its project folder (or the flat list) until the
-    // network resolves, which reads as lag. Snapshot the pinned cache so a
-    // failed PATCH rolls back.
-    onMutate: ({ id, pinned }) => {
-      const prevPinned = queryClient.getQueryData<Conversation[]>(PINNED_CONVERSATIONS_KEY);
+    mutationFn: (variables: Variables) => save(variables.id, enabledFor(variables)),
+    onMutate: (variables) => {
+      const enabled = enabledFor(variables);
+      const previous = queryClient.getQueryData<Conversation[]>(listKey);
+      const { id } = variables;
       const base = findRow(id)?.labels ?? {};
-      const labels: Record<string, string> = pinned
-        ? { ...base, [PINNED_LABEL_KEY]: String(Date.now()) }
-        : Object.fromEntries(Object.entries(base).filter(([k]) => k !== PINNED_LABEL_KEY));
-      patch(id, labels, pinned);
-      return { prevPinned };
+      const wasEnabled = previous?.some((conversation) => conversation.id === id) ?? false;
+      const labels: Record<string, string> = enabled
+        ? { ...base, [labelKey]: String(Date.now()) }
+        : Object.fromEntries(Object.entries(base).filter(([key]) => key !== labelKey));
+      patch(id, labels, enabled);
+      return { previous, base, wasEnabled };
     },
-    onError: (_err, _vars, ctx) => {
-      // Restore the pinned section; the label overlays on the other caches are
-      // cosmetic and self-heal on the next reconcile.
-      if (ctx?.prevPinned !== undefined) {
-        queryClient.setQueryData(PINNED_CONVERSATIONS_KEY, ctx.prevPinned);
+    onError: (_error, { id }, context) => {
+      if (context) patch(id, context.base, context.wasEnabled);
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(listKey, context.previous);
       }
     },
-    onSuccess: (updated, { pinned }) => {
-      // No `markConversationSeen` here: a pin PATCH writes only the label row,
-      // never conversations.updated_at (unlike rename/archive/move, which bump
-      // it and need the anchor to suppress that self-bump). Anchoring here would
-      // instead mark a session with genuine unread activity as read on pin.
-      //
-      // Reconcile with the server-confirmed labels (authoritative pin
-      // timestamp). Don't invalidate the pinned query — the `?pinned=true` label
-      // index lags the write, so a refetch would momentarily revert the toggle;
-      // the query's `staleTime` converges it later.
-      patch(updated.id, updated.labels, pinned);
+    onSuccess: (updated, variables) => {
+      patch(updated.id, updated.labels, enabledFor(variables));
     },
   });
+}
+
+export function useTogglePinnedConversation() {
+  return useTogglePersonalLabelConversation(
+    PINNED_CONVERSATIONS_KEY,
+    PINNED_LABEL_KEY,
+    ({ pinned }: { id: string; pinned: boolean }) => pinned,
+    setConversationPinned,
+  );
+}
+
+export function useToggleCompletedConversation() {
+  return useTogglePersonalLabelConversation(
+    COMPLETED_CONVERSATIONS_KEY,
+    COMPLETED_LABEL_KEY,
+    ({ completed }: { id: string; completed: boolean }) => completed,
+    setConversationCompleted,
+  );
 }
 
 // ── Project hooks ─────────────────────────────────────────────────────────────

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -35,6 +35,9 @@ export const PROJECT_LABEL_KEY = "omni_project";
  */
 export const PINNED_LABEL_KEY = "omnigent.pinned";
 
+/** Personal completion timestamp used by the sidebar's Completed group. */
+export const COMPLETED_LABEL_KEY = "omnigent.completed";
+
 /** Filter dimensions encoded by a `["conversations", ...]` query key. */
 export interface ConversationListFilters {
   searchQuery: string;

--- a/web/src/shell/Sidebar.archive.test.tsx
+++ b/web/src/shell/Sidebar.archive.test.tsx
@@ -34,11 +34,14 @@ vi.mock("@/hooks/useConversations", () => ({
   }),
   usePinnedConversations: () => ({ data: [], isSuccess: true }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
+  useCompletedConversations: () => ({ data: [], isSuccess: true }),
+  useToggleCompletedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useArchiveConversation: () => mocks.archive,
   useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkCompleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => mocks.stop,
@@ -49,6 +52,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
+  COMPLETED_LABEL_KEY: "omnigent.completed",
 }));
 
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));

--- a/web/src/shell/Sidebar.bulkActionLayout.test.tsx
+++ b/web/src/shell/Sidebar.bulkActionLayout.test.tsx
@@ -30,11 +30,14 @@ vi.mock("@/hooks/useConversations", () => ({
   }),
   usePinnedConversations: () => ({ data: [], isSuccess: true }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
+  useCompletedConversations: () => ({ data: [], isSuccess: true }),
+  useToggleCompletedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useArchiveConversation: () => ({ mutate: vi.fn() }),
   useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkCompleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
@@ -55,6 +58,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
+  COMPLETED_LABEL_KEY: "omnigent.completed",
 }));
 
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));

--- a/web/src/shell/Sidebar.delete.test.tsx
+++ b/web/src/shell/Sidebar.delete.test.tsx
@@ -30,6 +30,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useStopAndDeleteConversation: () => mocks.del,
   usePinnedConversations: () => ({ data: [], isSuccess: true }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
+  useCompletedConversations: () => ({ data: [], isSuccess: true }),
+  useToggleCompletedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
   // Rename/archive are wired on the row but not exercised here; minimal
@@ -37,6 +39,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useArchiveConversation: () => ({ mutate: vi.fn() }),
   useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkCompleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
@@ -47,6 +50,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
+  COMPLETED_LABEL_KEY: "omnigent.completed",
 }));
 
 // Heavy sibling widgets in the sidebar pull their own hooks/providers;

--- a/web/src/shell/Sidebar.pinnedAutoExpand.test.tsx
+++ b/web/src/shell/Sidebar.pinnedAutoExpand.test.tsx
@@ -19,12 +19,15 @@ vi.mock("@/hooks/useConversations", () => ({
   useConversations: vi.fn(),
   useArchiveConversation: () => ({ mutate: vi.fn() }),
   useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkCompleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useConnectedConversations: () => [],
   useStopAndDeleteConversation: () => ({ mutate: vi.fn() }),
   usePinnedConversations: () => ({ data: pinnedRef.current, isSuccess: true }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
+  useCompletedConversations: () => ({ data: [], isSuccess: true }),
+  useToggleCompletedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
   useRenameConversation: () => ({ mutate: vi.fn() }),
@@ -37,6 +40,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
+  COMPLETED_LABEL_KEY: "omnigent.completed",
 }));
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
 

--- a/web/src/shell/Sidebar.projectHeaderChevron.test.tsx
+++ b/web/src/shell/Sidebar.projectHeaderChevron.test.tsx
@@ -29,11 +29,14 @@ vi.mock("@/hooks/useConversations", () => ({
   }),
   usePinnedConversations: () => ({ data: [], isSuccess: true }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
+  useCompletedConversations: () => ({ data: [], isSuccess: true }),
+  useToggleCompletedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useArchiveConversation: () => ({ mutate: vi.fn() }),
   useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkCompleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
@@ -53,6 +56,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
+  COMPLETED_LABEL_KEY: "omnigent.completed",
 }));
 
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -50,6 +50,7 @@ const mocks = vi.hoisted(() => {
     // mobile in-place project view test can assert both the list and the pick.
     projects: [] as string[],
     moveToProject: { mutate: vi.fn() },
+    complete: { mutate: vi.fn() },
     conversations: [] as unknown[],
     pinnedStore,
   };
@@ -86,11 +87,14 @@ vi.mock("@/hooks/useConversations", () => ({
     mutate: ({ id, pinned }: { id: string; pinned: boolean }) =>
       mocks.pinnedStore.toggle(id, pinned),
   }),
+  useCompletedConversations: () => ({ data: [], isSuccess: true }),
+  useToggleCompletedConversation: () => mocks.complete,
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
   useRenameConversation: () => mocks.rename,
   useArchiveConversation: () => ({ mutate: vi.fn() }),
   useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkCompleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
@@ -113,6 +117,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
+  COMPLETED_LABEL_KEY: "omnigent.completed",
 }));
 
 // Heavy sibling widgets pull their own hooks/providers; stub them so this
@@ -219,6 +224,7 @@ function renderSidebar(activeId?: string, info?: ServerInfo) {
 beforeEach(() => {
   mocks.rename.mutate.mockReset();
   mocks.moveToProject.mutate.mockReset();
+  mocks.complete.mutate.mockReset();
   mocks.projects = [];
   // Default every test to the desktop viewport; the mobile flyout test opts in.
   mocks.isMobile = false;
@@ -233,6 +239,54 @@ beforeEach(() => {
 });
 
 afterEach(cleanup);
+
+describe("completed session actions", () => {
+  it("marks an idle session complete from the row menu", () => {
+    renderSidebar();
+
+    fireEvent.contextMenu(screen.getByRole("link", { name: /My Session/ }));
+    const item = screen.getByTestId("complete-conversation");
+    expect(item).toHaveTextContent("Mark as completed");
+
+    fireEvent.click(item);
+
+    expect(mocks.complete.mutate).toHaveBeenCalledWith({
+      id: "conv_1",
+      completed: true,
+    });
+  });
+
+  it("offers Mark active for a session in the Completed group", () => {
+    mockConversations([
+      {
+        ...CONV,
+        labels: { "omnigent.completed": "1700000000000" },
+      },
+    ]);
+    renderSidebar();
+
+    fireEvent.click(screen.getByText("Completed"));
+    fireEvent.contextMenu(screen.getByRole("link", { name: /My Session/ }));
+    const item = screen.getByTestId("complete-conversation");
+    expect(item).toHaveTextContent("Mark active");
+
+    fireEvent.click(item);
+
+    expect(mocks.complete.mutate).toHaveBeenCalledWith({
+      id: "conv_1",
+      completed: false,
+    });
+  });
+
+  it("disables completion while a session is running", () => {
+    mockConversations([{ ...CONV, status: "running" }]);
+    renderSidebar();
+
+    fireEvent.contextMenu(screen.getByRole("link", { name: /My Session/ }));
+
+    expect(screen.getByTestId("complete-conversation")).toHaveAttribute("data-disabled");
+  });
+});
 
 describe("quick pin/unpin hover button", () => {
   it("keeps the row full-width and the trailing controls inset from the right edge", () => {

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -55,12 +55,15 @@ vi.mock("@/hooks/useConversations", () => ({
   useConversations: vi.fn(),
   useArchiveConversation: () => ({ mutate: vi.fn() }),
   useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkCompleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useConnectedConversations: () => [],
   useStopAndDeleteConversation: () => ({ mutate: vi.fn() }),
   usePinnedConversations: () => ({ data: [], isSuccess: true }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
+  useCompletedConversations: () => ({ data: [], isSuccess: true }),
+  useToggleCompletedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
   useRenameConversation: () => ({ mutate: vi.fn() }),
@@ -95,6 +98,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: vi.fn(() => Promise.resolve([] as string[])),
   PROJECT_LABEL_KEY: "omni_project",
+  COMPLETED_LABEL_KEY: "omnigent.completed",
 }));
 
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));

--- a/web/src/shell/Sidebar.stop.test.tsx
+++ b/web/src/shell/Sidebar.stop.test.tsx
@@ -31,11 +31,14 @@ vi.mock("@/hooks/useConversations", () => ({
   }),
   usePinnedConversations: () => ({ data: [], isSuccess: true }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
+  useCompletedConversations: () => ({ data: [], isSuccess: true }),
+  useToggleCompletedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useArchiveConversation: () => ({ mutate: vi.fn() }),
   useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkCompleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => mocks.stop,
@@ -46,6 +49,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
+  COMPLETED_LABEL_KEY: "omnigent.completed",
 }));
 
 vi.mock("@/hooks/RunnerHealthProvider", async (importOriginal) => ({

--- a/web/src/shell/Sidebar.subagentHighlight.test.tsx
+++ b/web/src/shell/Sidebar.subagentHighlight.test.tsx
@@ -26,12 +26,15 @@ vi.mock("@/hooks/useConversations", () => ({
   useConversations: vi.fn(),
   useArchiveConversation: () => ({ mutate: vi.fn() }),
   useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkCompleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useConnectedConversations: () => [],
   useStopAndDeleteConversation: () => ({ mutate: vi.fn() }),
   usePinnedConversations: () => ({ data: [], isSuccess: true }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
+  useCompletedConversations: () => ({ data: [], isSuccess: true }),
+  useToggleCompletedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
   useRenameConversation: () => ({ mutate: vi.fn() }),
@@ -44,6 +47,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
+  COMPLETED_LABEL_KEY: "omnigent.completed",
 }));
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
 

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -63,6 +63,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useConversations: vi.fn(),
   useArchiveConversation: () => ({ mutate: vi.fn() }),
   useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkCompleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useConnectedConversations: () => [],
@@ -84,6 +85,13 @@ vi.mock("@/hooks/useConversations", () => ({
         : ids.filter((x) => x !== id);
     },
   }),
+  useCompletedConversations: () => ({
+    data: conversationsRef.current.filter((conversation) =>
+      Boolean(conversation.labels?.["omnigent.completed"]),
+    ),
+    isSuccess: true,
+  }),
+  useToggleCompletedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
   useRenameConversation: () => ({ mutate: vi.fn() }),
@@ -128,6 +136,7 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: createProjectSpy, isPending: false, isError: false }),
   fetchProjectSessionIds: fetchProjectSessionIdsMock,
   PROJECT_LABEL_KEY: "omni_project",
+  COMPLETED_LABEL_KEY: "omnigent.completed",
 }));
 // Header / dialog children that pull their own context — stub to keep the
 // test scoped to the conversation list + funnel.
@@ -675,6 +684,33 @@ describe("Sidebar sections", () => {
     showSharedTab();
     expect(screen.getByText("No sessions shared with you")).toBeInTheDocument();
     expect(screen.queryByText("conv_only_mine")).toBeNull();
+  });
+
+  it("moves completed sessions into their own group ahead of pins and projects", () => {
+    projectsMock.push("Customer X");
+    seedPins(["conv_done"]);
+    mockConversations([
+      conv("conv_done", "Claude Code", {
+        labels: {
+          omni_project: "Customer X",
+          "omnigent.completed": "1700000000000",
+        },
+      }),
+      conv("conv_active", "Claude Code"),
+    ]);
+    renderSidebar();
+
+    expect(screen.queryByText("Pinned")).toBeNull();
+    expect(
+      within(screen.getByText("Sessions").closest("section")!).getByText("conv_active"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("conv_done")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Completed" }));
+
+    expect(
+      within(screen.getByText("Completed").closest("section")!).getByText("conv_done"),
+    ).toBeInTheDocument();
   });
 });
 
@@ -1277,18 +1313,28 @@ describe("Sidebar collapsed project marker", () => {
   });
 });
 
-// Every section is expanded by default, but a collapse the user makes
-// persists across reloads.
+// Completed starts tucked away; the everyday sections start expanded. A
+// collapse the user makes persists across reloads.
 describe("Sidebar default section collapse", () => {
-  it("expands Pinned and Sessions by default when there is no stored preference", () => {
+  it("expands Pinned and Sessions but collapses Completed by default", () => {
     seedPins(["conv_pin"]);
-    mockConversations([conv("conv_pin", "Claude Code"), conv("conv_recent", "Claude Code")]);
+    mockConversations([
+      conv("conv_pin", "Claude Code"),
+      conv("conv_recent", "Claude Code"),
+      conv("conv_done", "Claude Code", {
+        labels: { "omnigent.completed": "1700000000000" },
+      }),
+    ]);
     renderSidebar();
 
     expect(screen.getByRole("button", { name: /Pinned/ })).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("button", { name: /Sessions/ })).toHaveAttribute(
       "aria-expanded",
       "true",
+    );
+    expect(screen.getByRole("button", { name: /Completed/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
     );
   });
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -100,16 +100,20 @@ import {
   type Conversation,
   useArchiveConversation,
   useBulkArchiveConversations,
+  useBulkCompleteConversations,
   useBulkDeleteConversations,
+  useCompletedConversations,
   useProjects,
   useProjectSessions,
   useConversations,
   useMoveToProject,
   useDeleteProject,
   useRenameProject,
+  COMPLETED_LABEL_KEY,
   PROJECT_LABEL_KEY,
   PINNED_CONVERSATIONS_KEY,
   usePinnedConversations,
+  useToggleCompletedConversation,
   useTogglePinnedConversation,
   setConversationPinned,
   useRenameConversation,
@@ -501,6 +505,8 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
     },
     [togglePinnedMutation, pinnedIdSet],
   );
+  const { data: completedConversations = [], isSuccess: completedLoaded } =
+    useCompletedConversations();
 
   // One-time migration: pins used to live only in localStorage. Push any
   // still-local pins up to the server (as the `omnigent.pinned` label) the
@@ -718,7 +724,11 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
             {selectionMode ? (
               <BulkActionBar
                 selectedIds={selectedIds}
-                allConversations={loadedRows}
+                allConversations={dedupeConversationsById([
+                  ...loadedRows,
+                  ...pinnedConversations,
+                  ...completedConversations,
+                ])}
                 visibleCount={visibleConversationCount}
                 onSelectAll={() => selectAll(getVisibleConversationsRef.current())}
                 onDeselectAll={deselectAll}
@@ -804,6 +814,8 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
               activeTab={multiUser ? activeTab : "mine"}
               pinnedConversationIds={pinnedConversationIds}
               pinnedConversations={pinnedConversations}
+              completedConversations={completedConversations}
+              completedLoaded={completedLoaded}
               onTogglePinned={togglePinnedConversation}
               onEnterSelectionMode={() => setSelectionMode(true)}
               selectionMode={selectionMode}
@@ -928,7 +940,7 @@ function ProjectFolder({
     const loaded = query.data?.pages.flatMap((page) => page.data) ?? [];
     // Pinned sessions live in the global Pinned section, not their folder.
     return sortByUpdatedAtDesc(
-      loaded.filter((c) => !pinnedSet.has(c.id)),
+      loaded.filter((c) => !pinnedSet.has(c.id) && c.labels?.[COMPLETED_LABEL_KEY] == null),
       activeOverride,
     );
   }, [query.data, pinnedSet, activeOverride]);
@@ -1020,6 +1032,8 @@ interface ConversationListProps {
   // The server-authoritative pinned sessions, so a pinned session that sits
   // outside the loaded pagination window still renders in the Pinned section.
   pinnedConversations: Conversation[];
+  completedConversations: Conversation[];
+  completedLoaded: boolean;
   onTogglePinned: (conversationId: string) => void;
   onEnterSelectionMode: () => void;
   selectionMode: boolean;
@@ -1082,6 +1096,8 @@ function ConversationList({
   activeTab,
   pinnedConversationIds,
   pinnedConversations,
+  completedConversations,
+  completedLoaded,
   onTogglePinned,
   onEnterSelectionMode,
   selectionMode,
@@ -1105,6 +1121,10 @@ function ConversationList({
   const allConversations = useMemo(
     () => conversationsQuery.data?.pages.flatMap((page) => page.data) ?? [],
     [conversationsQuery.data],
+  );
+  const completedConversationIds = useMemo(
+    () => completedConversations.map((conversation) => conversation.id),
+    [completedConversations],
   );
 
   // Project folders ({ id, name }) for grouping sessions — first-class id
@@ -1136,17 +1156,16 @@ function ConversationList({
     setActiveOverride((prev) => computeNextActiveOverride(activeId, allConversations, prev));
   }, [activeId, allConversations]);
 
-  // Build sections: Pinned and Archived are peeled off; the rest splits into
-  // the viewer's own sessions (Chats) and ones shared with them. Archived
-  // sessions render in their own group at the bottom (below "Shared with
-  // me"); a pinned-then-archived session shows under Archived, not Pinned.
+  // Completed takes precedence over Pinned and Projects while preserving both
+  // labels, so marking active returns the row to its previous group.
   const pinnedSet = useMemo(() => new Set(pinnedConversationIds), [pinnedConversationIds]);
   const sections = useMemo(() => {
-    // Merge the server pinned set in, so a pinned session outside the loaded
-    // paginated window still renders. Dedupe by id: a pinned session is usually
-    // also present in the paginated list, and merging both would render it twice.
-    const allWithPinned = dedupeConversationsById([...allConversations, ...pinnedConversations]);
-    const notArchived = allWithPinned.filter((c) => c.archived !== true);
+    const allWithPersonal = dedupeConversationsById([
+      ...allConversations,
+      ...pinnedConversations,
+      ...completedConversations,
+    ]);
+    const notArchived = allWithPersonal.filter((c) => c.archived !== true);
     // Each tab shows a disjoint slice — "mine" is the sessions the viewer owns,
     // "shared" is the ones others shared with them. The Pinned / Projects /
     // Sessions structure is then built from that slice, so both tabs reuse the
@@ -1155,6 +1174,12 @@ function ConversationList({
       activeTab === "shared"
         ? notArchived.filter((c) => !isOwnedByViewer(c, viewerId))
         : notArchived.filter((c) => isOwnedByViewer(c, viewerId));
+    const completed = tabScoped
+      .filter((c) => c.labels?.[COMPLETED_LABEL_KEY] != null)
+      .sort(
+        (a, b) => Number(b.labels?.[COMPLETED_LABEL_KEY]) - Number(a.labels?.[COMPLETED_LABEL_KEY]),
+      );
+    const active = tabScoped.filter((c) => c.labels?.[COMPLETED_LABEL_KEY] == null);
 
     // Pinned takes precedence over Project: pinning a session moves it OUT of
     // its project into the flat global Pinned section (no nested pins). Ordered
@@ -1163,7 +1188,7 @@ function ConversationList({
     // pinned session holds its slot when a new message bumps its `updated_at`.
     // Pins are ownership-agnostic, so a pinned shared session floats to Pinned
     // on the Shared tab just like an owned one on My sessions.
-    const pinned = orderByPinnedTimestamp(tabScoped.filter((c) => pinnedSet.has(c.id)));
+    const pinned = orderByPinnedTimestamp(active.filter((c) => pinnedSet.has(c.id)));
     const pinnedIdSet = new Set(pinned.map((c) => c.id));
 
     // Projects are a "My sessions"-only tool (filing into a project is
@@ -1178,7 +1203,7 @@ function ConversationList({
         : projects.map(({ id, name }) => {
             // Dual-read membership: a session belongs to this folder if it has
             // the first-class id OR the legacy omni_project label of this name.
-            const inProject = tabScoped.filter(
+            const inProject = active.filter(
               (c) =>
                 ((id !== null && c.project_id === id) || c.labels?.[PROJECT_LABEL_KEY] === name) &&
                 !pinnedIdSet.has(c.id),
@@ -1194,17 +1219,14 @@ function ConversationList({
 
     // Sessions: the remainder of the tab's slice — not pinned, not filed.
     const sessions = sortByUpdatedAtDesc(
-      tabScoped.filter((c) => !pinnedIdSet.has(c.id) && !filedIds.has(c.id)),
+      active.filter((c) => !pinnedIdSet.has(c.id) && !filedIds.has(c.id)),
       activeOverride,
     );
-    const archived = sortByUpdatedAtDesc(
-      allWithPinned.filter((c) => c.archived === true),
-      activeOverride,
-    );
-    return { pinned, sessions, archived, projectGroups };
+    return { pinned, sessions, completed, projectGroups };
   }, [
     allConversations,
     pinnedConversations,
+    completedConversations,
     pinnedSet,
     activeOverride,
     projects,
@@ -1246,6 +1268,48 @@ function ConversationList({
       });
     }
   }, [pinnedConversationIds]);
+
+  const selectSessionsAction = !selectionMode ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Select sessions"
+          data-testid="toggle-selection-mode"
+          onClick={(event) => {
+            event.stopPropagation();
+            onEnterSelectionMode();
+          }}
+        >
+          <ListChecksIcon className="size-3.5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Select sessions</TooltipContent>
+    </Tooltip>
+  ) : undefined;
+
+  const prevCompletedIds = useRef(completedConversationIds);
+  const completedInitialized = useRef(false);
+  useEffect(() => {
+    if (!completedLoaded) return;
+    if (!completedInitialized.current) {
+      completedInitialized.current = true;
+      prevCompletedIds.current = completedConversationIds;
+      return;
+    }
+    const previous = new Set(prevCompletedIds.current);
+    const newlyCompleted = completedConversationIds.some((id) => !previous.has(id));
+    prevCompletedIds.current = completedConversationIds;
+    if (!newlyCompleted) return;
+    setCollapsedSections((collapsed) => {
+      if (!collapsed.includes("Completed")) return collapsed;
+      const next = collapsed.filter((title) => title !== "Completed");
+      writeCollapsedSidebarSections(next);
+      return next;
+    });
+  }, [completedConversationIds, completedLoaded]);
 
   // When a search query appears, auto-expand all sections so results
   // in collapsed groups are visible. The user can still manually collapse
@@ -1420,8 +1484,9 @@ function ConversationList({
   useEffect(() => {
     if (!activeId || !activeProjectName) return;
     if (pinnedSet.has(activeId)) return;
+    if (completedConversationIds.includes(activeId)) return;
     expandProject(activeProjectName);
-  }, [activeId, activeProjectName, pinnedSet, expandProject]);
+  }, [activeId, activeProjectName, pinnedSet, completedConversationIds, expandProject]);
 
   // Visible rows in render order (collapsed sections excluded) for the Cmd+↑/↓
   // session hotkey. Titles must match the <ConversationSection> props below.
@@ -1440,6 +1505,7 @@ function ConversationList({
       ...visible("Pinned", sections.pinned),
       ...sections.projectGroups.flatMap((g) => projectVisible(g.name, g.conversations)),
       ...visible("Chats", sections.sessions),
+      ...visible("Completed", sections.completed),
     ].map((c) => c.id);
   }, [sections, effectiveCollapsedSections, expandedProjects]);
   useEffect(() => {
@@ -1455,6 +1521,7 @@ function ConversationList({
       ...visible("Pinned", sections.pinned),
       ...sections.projectGroups.flatMap((g) => projectVisible(g.name, g.conversations)),
       ...visible("Chats", sections.sessions),
+      ...visible("Completed", sections.completed),
     ];
   };
   // Getter that builds the shift-select visible order on demand (at click
@@ -1472,6 +1539,7 @@ function ConversationList({
         ? []
         : sections.projectGroups.flatMap((g) => projectRenderedIdsRef.current.get(g.name) ?? [])),
       ...vis("Chats", sections.sessions),
+      ...vis("Completed", sections.completed),
     ];
   };
   useSessionSwitchHotkey(orderedConversationIds, activeId);
@@ -1518,6 +1586,7 @@ function ConversationList({
   const totalVisible =
     sections.pinned.length +
     sections.sessions.length +
+    sections.completed.length +
     sections.projectGroups.length +
     sections.projectGroups.reduce((sum, g) => sum + g.conversations.length, 0);
 
@@ -1707,30 +1776,25 @@ function ConversationList({
                     selectedIds={selectedIds}
                     onToggleSelected={onToggleSelected}
                     onProjectAssigned={expandProject}
-                    headerAction={
-                      !selectionMode ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon-xs"
-                              aria-label="Select sessions"
-                              data-testid="toggle-selection-mode"
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                onEnterSelectionMode();
-                              }}
-                            >
-                              <ListChecksIcon className="size-3.5" />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">Select sessions</TooltipContent>
-                        </Tooltip>
-                      ) : undefined
-                    }
+                    headerAction={selectSessionsAction}
                   />
                 </ChatsDropZone>
+              )}
+              {sections.completed.length > 0 && (
+                <ConversationSection
+                  title="Completed"
+                  conversations={sections.completed}
+                  pinnedConversationIds={pinnedConversationIds}
+                  collapsed={effectiveCollapsedSections.includes("Completed")}
+                  onToggleCollapsed={() => effectiveToggleSectionCollapsed("Completed")}
+                  onRowClick={onRowClick}
+                  onTogglePinned={onTogglePinned}
+                  selectionMode={selectionMode}
+                  selectedIds={selectedIds}
+                  onToggleSelected={onToggleSelected}
+                  onProjectAssigned={expandProject}
+                  headerAction={sections.sessions.length === 0 ? selectSessionsAction : undefined}
+                />
               )}
               {/* Both tabs render this same Pinned / Projects / Sessions tree;
               `sections` is scoped to the active tab's conversations (owned vs.
@@ -2163,13 +2227,16 @@ function ConversationMenuItems({
   conversation,
   isPinned,
   isArchived,
+  isCompleted,
   isOwner,
   sharingOff,
   isSingleUser,
   canStop,
   canMarkUnread,
+  canComplete,
   currentProject,
   onTogglePinned,
+  runToggleCompleted,
   onMarkUnread,
   onProjectAssigned,
   moveToProject,
@@ -2185,6 +2252,7 @@ function ConversationMenuItems({
   conversation: Conversation;
   isPinned: boolean;
   isArchived: boolean;
+  isCompleted: boolean;
   isOwner: boolean;
   // Server-wide sharing kill switch (OMNIGENT_SHARING_MODE=off): disables the
   // Share item for everyone, independent of the per-user ownership check.
@@ -2196,8 +2264,10 @@ function ConversationMenuItems({
   // Whether "Mark as unread" applies: any row not already showing the
   // unread dot (the active thread and running sessions included).
   canMarkUnread: boolean;
+  canComplete: boolean;
   currentProject: string | null;
   onTogglePinned: (conversationId: string) => void;
+  runToggleCompleted: () => void;
   onMarkUnread: () => void;
   onProjectAssigned?: (projectName: string) => void;
   moveToProject: ReturnType<typeof useMoveToProject>;
@@ -2271,7 +2341,7 @@ function ConversationMenuItems({
       {/* Pin/Unpin — mobile-only (md:hidden); desktop uses the
           hover-revealed quick-pin button. Archived rows omit it (archive
           outranks pin). */}
-      {!isArchived && (
+      {!isArchived && !isCompleted && (
         <C.Item
           data-testid="pin-conversation"
           className="md:hidden"
@@ -2342,6 +2412,31 @@ function ConversationMenuItems({
           <MailIcon className="size-3.5" />
           Mark as unread
         </C.Item>
+      )}
+      {isCompleted ? (
+        <C.Item data-testid="complete-conversation" onSelect={runToggleCompleted}>
+          <SquareIcon className="size-3.5" />
+          Mark active
+        </C.Item>
+      ) : canComplete ? (
+        <C.Item data-testid="complete-conversation" onSelect={runToggleCompleted}>
+          <SquareCheckIcon className="size-3.5" />
+          Mark as completed
+        </C.Item>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div>
+              <C.Item data-testid="complete-conversation" disabled>
+                <SquareCheckIcon className="size-3.5" />
+                Mark as completed
+              </C.Item>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            Wait for the session and pending approvals to finish
+          </TooltipContent>
+        </Tooltip>
       )}
       {/* Projects are a My-sessions-only tool, so filing is owner-only — a
           shared session shows no project affordance. */}
@@ -2584,6 +2679,7 @@ function ConversationRow({
   const rename = useRenameConversation();
   const del = useStopAndDeleteConversation();
   const archive = useArchiveConversation();
+  const complete = useToggleCompletedConversation();
   const moveToProject = useMoveToProject();
   // Archive stops the runner first (resource hygiene): a hidden session
   // shouldn't keep a runner alive. This is NOT the user-facing Stop action
@@ -2595,6 +2691,7 @@ function ConversationRow({
   // instance so its pending/error state can't bleed into archiving's.
   const stopSession = useStopSession();
   const isArchived = conversation.archived === true;
+  const isCompleted = conversation.labels?.[COMPLETED_LABEL_KEY] != null;
   const [isEditing, setIsEditing] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [stopOpen, setStopOpen] = useState(false);
@@ -2633,6 +2730,8 @@ function ConversationRow({
       hostId: conversation.host_id,
       runnerId: conversation.runner_id,
     }) && runnerOnline !== false;
+  const canComplete =
+    conversation.status !== "running" && (conversation.pending_elicitations_count ?? 0) === 0;
 
   // The session's current project NAME, or null when unfiled — drives the
   // kebab submenu label ("Add to project" vs "Move session") and the pinned
@@ -2695,7 +2794,7 @@ function ConversationRow({
   } = useDraggable({
     id: conversation.id,
     data: { type: "session", label, project: currentProject, isPinned },
-    disabled: !isOwner || selectionMode || isArchived || isEditing,
+    disabled: !isOwner || selectionMode || isArchived || isCompleted || isEditing,
   });
   // A drag ends with a synthetic click on the row's <Link> (mousedown + mouseup
   // on the same anchor still fires a click); swallow that one click so a drag
@@ -2827,6 +2926,10 @@ function ConversationRow({
     });
   }
 
+  function runToggleCompleted() {
+    complete.mutate({ id: conversation.id, completed: !isCompleted });
+  }
+
   // Shared by the kebab dropdown and the right-click context menu so the two
   // menus render identical items. `setMenuOpen` is supplied per-call (the
   // controlled kebab passes the real setter; the uncontrolled context menu a
@@ -2835,13 +2938,16 @@ function ConversationRow({
     conversation,
     isPinned,
     isArchived,
+    isCompleted,
     isOwner,
     sharingOff,
     isSingleUser,
     canStop,
     canMarkUnread,
+    canComplete,
     currentProject,
     onTogglePinned,
+    runToggleCompleted,
     onMarkUnread: () => markConversationUnread(conversation.id, conversation.updated_at),
     onProjectAssigned,
     moveToProject,
@@ -3017,9 +3123,8 @@ function ConversationRow({
           row controls). */}
       {!selectionMode && (
         <div className="-translate-y-1/2 absolute top-1/2 right-1 flex items-center gap-0.5">
-          {/* Archived rows omit the pin entirely: pinning is meaningless there
-              (archive outranks pin), so there's no pin action even on hover. */}
-          {!isArchived && (
+          {/* Lifecycle groups take precedence over pinning. */}
+          {!isArchived && !isCompleted && (
             <Button
               type="button"
               variant="ghost"
@@ -3784,6 +3889,7 @@ function BulkActionBar({
   const navigate = useNavigate();
   const { conversationId: activeId } = useParams<{ conversationId: string }>();
   const bulkArchive = useBulkArchiveConversations();
+  const bulkComplete = useBulkCompleteConversations();
   const bulkDelete = useBulkDeleteConversations();
   const viewerId = useViewerId();
 
@@ -3809,10 +3915,28 @@ function BulkActionBar({
 
   const allSelectedSameArchiveGroup =
     ownedSelected.length > 0 && (archivedSelected.length === 0 || nonArchivedSelected.length === 0);
+  const completedSelected = useMemo(
+    () => selectedConversations.filter((c) => c.labels?.[COMPLETED_LABEL_KEY] != null),
+    [selectedConversations],
+  );
+  const activeSelected = useMemo(
+    () => selectedConversations.filter((c) => c.labels?.[COMPLETED_LABEL_KEY] == null),
+    [selectedConversations],
+  );
+  const allSelectedSameCompletionGroup =
+    selectedConversations.length > 0 &&
+    (completedSelected.length === 0 || activeSelected.length === 0);
+  const canCompleteAll = activeSelected.every(
+    (conversation) =>
+      conversation.status !== "running" && (conversation.pending_elicitations_count ?? 0) === 0,
+  );
+  const completingSelection = activeSelected.length > 0;
+  const showCompletionAction =
+    allSelectedSameCompletionGroup && (completingSelection || completedSelected.length > 0);
 
   const count = selectedIds.size;
   const allSelected = count > 0 && count === visibleCount;
-  const isBusy = bulkArchive.isPending || bulkDelete.isPending;
+  const isBusy = bulkArchive.isPending || bulkComplete.isPending || bulkDelete.isPending;
 
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
@@ -3837,6 +3961,15 @@ function BulkActionBar({
           onDeselectAll();
         },
       },
+    );
+  }
+
+  function handleComplete(completed: boolean) {
+    const rows = completed ? activeSelected : completedSelected;
+    if (rows.length === 0) return;
+    bulkComplete.mutate(
+      { ids: rows.map((conversation) => conversation.id), completed },
+      { onSuccess: onDeselectAll },
     );
   }
 
@@ -3900,6 +4033,26 @@ function BulkActionBar({
         </div>
 
         <div className="flex items-center gap-1.5 px-2">
+          {showCompletionAction && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1.5 text-xs"
+              disabled={isBusy || (completingSelection && !canCompleteAll)}
+              onClick={() => handleComplete(completingSelection)}
+              data-testid={completingSelection ? "bulk-complete" : "bulk-mark-active"}
+            >
+              {bulkComplete.isPending ? (
+                <Loader2Icon className="size-3 animate-spin" />
+              ) : completingSelection ? (
+                <SquareCheckIcon className="size-3" />
+              ) : (
+                <SquareIcon className="size-3" />
+              )}
+              {completingSelection ? "Complete" : "Mark active"}
+            </Button>
+          )}
           {allSelectedSameArchiveGroup && nonArchivedSelected.length > 0 && (
             <Button
               type="button"
@@ -3954,7 +4107,7 @@ function BulkActionBar({
           </Button>
         </div>
 
-        {(bulkArchive.isError || bulkDelete.isError) && (
+        {(bulkArchive.isError || bulkComplete.isError || bulkDelete.isError) && (
           <p className="text-xs text-destructive" role="alert">
             Some actions failed. Retry or dismiss.
           </p>
@@ -4058,11 +4211,9 @@ function writeLegacyPinnedConversationIds(ids: string[]) {
   }
 }
 
-// Default collapse state: every section (Pinned / Projects / Chats / Shared)
-// starts expanded. Archived no longer lives in the sidebar (it's on the
-// Settings page). Once the user toggles any header, the stored array (even an
-// empty one) becomes the preference and persists across reloads.
-const DEFAULT_COLLAPSED_SIDEBAR_SECTIONS: string[] = [];
+// Completed starts collapsed to keep finished work from replacing active
+// clutter with different clutter. User choices persist across reloads.
+const DEFAULT_COLLAPSED_SIDEBAR_SECTIONS: string[] = ["Completed"];
 
 function readCollapsedSidebarSections(): string[] {
   if (typeof window === "undefined") return DEFAULT_COLLAPSED_SIDEBAR_SECTIONS;


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a personal **Completed** sidebar group for finished sessions that should remain easy to reference without being archived.
- Preserve pin and project labels while Completed takes display precedence; **Mark active** returns a session to its previous grouping, and sending a new user message reactivates it automatically.
- Keep completion state per-user and synchronized across pagination, project folders, optimistic cache updates, and live session updates.

### ELI5

Completed works like a reversible “done” shelf. A session moves out of the active sidebar groups, keeps its existing organization underneath, and can be put back by marking it active or continuing the conversation.

```mermaid
flowchart LR
    Active["Pinned / Projects / Sessions"] -->|"Mark as completed"| Completed
    Completed -->|"Mark active"| Active
    Completed -->|"Send a user message"| Active
```

## Test Plan

- `pre-commit run --all-files`
- `npm run type-check`
- Focused Vitest coverage for conversation caches, live updates, sidebar grouping, row actions, bulk actions, and sidebar ordering: 208 tests passed.
- Focused pytest coverage for per-user completion labels, filtering, canonical wire labels, policy denial, forking, and message-based reactivation: 7 tests passed.
- Verify in the desktop/web UI:
  1. Mark an idle session as completed from its row menu.
  2. Confirm it moves to the default-collapsed Completed group and retains its pin/project assignment.
  3. Mark it active and confirm it returns to the prior group.
  4. Mark it completed again, send a user message, and confirm it becomes active automatically.

## Demo

How sessions are marked as completed, and how they can be returned to active:
<img width="323" height="553" alt="Screenshot 2026-07-26 at 11 12 26" src="https://github.com/user-attachments/assets/d749e980-bb1e-4f96-8d9a-b3d0cc830a2a" />

<img width="320" height="459" alt="Screenshot 2026-07-26 at 11 12 42" src="https://github.com/user-attachments/assets/1a870787-4da7-4ccc-8df3-38304eb5f45f" />

<img width="326" height="602" alt="Screenshot 2026-07-26 at 11 26 06" src="https://github.com/user-attachments/assets/7ce8f05d-adbb-4c64-8968-cee99d2c739b" />

<img width="322" height="431" alt="Screenshot 2026-07-26 at 11 26 18" src="https://github.com/user-attachments/assets/fc2bc4c8-322c-47c4-a52d-9550e49743ba" />

Completed sessions can still be returned as active:
<img width="326" height="741" alt="Screenshot 2026-07-26 at 12 35 51" src="https://github.com/user-attachments/assets/f131e9a8-72e0-408d-b1ee-d4dc6ade2e52" />


Completed sessions can still be marked as unread:
<img width="324" height="544" alt="Screenshot 2026-07-26 at 12 41 06" src="https://github.com/user-attachments/assets/865717e3-67ec-47d4-ad41-b05ede612e1e" />

<img width="352" height="600" alt="Screenshot 2026-07-26 at 12 41 16" src="https://github.com/user-attachments/assets/88bffb94-0b63-4f14-a52a-93c704587316" />

Pinned sessions remains at the top:
<img width="314" height="557" alt="Screenshot 2026-07-26 at 12 36 07" src="https://github.com/user-attachments/assets/76d6c27f-7dcd-4a11-a73b-7027b3edd418" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage exercises the backend label lifecycle and the frontend cache, grouping, action, and live-update paths. The draft still needs a visual demo before review.

## Changelog

You can mark finished sessions as completed and keep them in a dedicated, reversible sidebar group.
