### PR TITLE
fix(codex): attribute per-model usage for turns with no pinned model

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -126,7 +126,7 @@ _CODEX_MINIMAL_CONFIG_ENV = "HARNESS_CODEX_MINIMAL_CONFIG"
 _CODEX_ENV_DENY_EXACT: frozenset[str] = frozenset({"OPENAI_API_KEY"})
 
 
-def _extract_codex_last_turn_usage(params: object) -> dict[str, int] | None:
+def _extract_codex_last_turn_usage(params: object, model: str) -> dict[str, Any] | None:
     """Map a ``thread/tokenUsage/updated`` payload's ``last`` breakdown
     onto the wire shape that :class:`TurnComplete` consumes.
 
@@ -137,6 +137,16 @@ def _extract_codex_last_turn_usage(params: object) -> dict[str, int] | None:
     out into ``cache_read_input_tokens`` and keep only the remainder in
     ``input_tokens`` — otherwise cached tokens are billed at the full input
     rate. Mirrors the codex-native forwarder split.
+
+    :param model: The resolved model this turn ran with, e.g.
+        ``"gpt-5.4-mini"`` — the ``run_turn`` argument, which carries the
+        harness/provider's resolved default even when the agent spec pins
+        none. Stamped into the returned usage as ``"model"`` so the
+        server's per-model cost/token attribution (``session_usage.by_model``)
+        can key on it instead of silently falling back to an unresolvable
+        spec model and dropping the turn from the per-model breakdown
+        (mirrors ``claude_sdk_executor``'s ``observed_model`` and every
+        other relay executor, all of which already report ``usage.model``).
     """
     if not isinstance(params, dict):
         return None
@@ -149,13 +159,15 @@ def _extract_codex_last_turn_usage(params: object) -> dict[str, int] | None:
     input_total = int(last.get("inputTokens") or 0)
     # Clamp so a malformed cached > total never makes input_tokens negative.
     cached = min(int(last.get("cachedInputTokens") or 0), input_total)
-    usage = {
+    usage: dict[str, Any] = {
         "input_tokens": input_total - cached,  # non-cached portion
         "output_tokens": int(last.get("outputTokens") or 0),
         "total_tokens": int(last.get("totalTokens") or 0),
     }
     if cached:
         usage["cache_read_input_tokens"] = cached
+    if model:
+        usage["model"] = model
     return usage
 
 
@@ -1906,7 +1918,7 @@ class _CodexAppServerSession:
                         continue
 
                 if method == "thread/tokenUsage/updated":
-                    self._last_turn_usage = _extract_codex_last_turn_usage(params)
+                    self._last_turn_usage = _extract_codex_last_turn_usage(params, model)
                     continue
 
                 if method == "turn/completed":

--- a/tests/codex_parity/test_codex_executor_parity.py
+++ b/tests/codex_parity/test_codex_executor_parity.py
@@ -144,6 +144,7 @@ async def test_real_codex_usage_and_model_override_cross_boundary(
         "output_tokens": 7,
         "total_tokens": 18,
         "cache_read_input_tokens": 3,
+        "model": "mock-model-override",
     }
     assert sidecar.requests(min_count=1)[0]["body"]["model"] == "mock-model-override"
 

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -1403,7 +1403,12 @@ class TestCodexExecutor(unittest.TestCase):
             self.assertIsInstance(events[0], TurnComplete)
             self.assertEqual(
                 events[0].usage,
-                {"input_tokens": 100, "output_tokens": 25, "total_tokens": 125},
+                {
+                    "input_tokens": 100,
+                    "output_tokens": 25,
+                    "total_tokens": 125,
+                    "model": "gpt-5.4-mini",
+                },
             )
             # The cached usage must be cleared after consumption so the next
             # turn doesn't inherit stale numbers.
@@ -2143,11 +2148,12 @@ def test_extract_codex_last_turn_usage_splits_cached_out_of_input() -> None:
             "total": {"inputTokens": 100, "outputTokens": 50, "totalTokens": 150},
         },
     }
-    assert _extract_codex_last_turn_usage(params) == {
+    assert _extract_codex_last_turn_usage(params, "gpt-5.4-mini") == {
         "input_tokens": 6,  # 7 total input - 1 cached
         "output_tokens": 3,
         "total_tokens": 10,
         "cache_read_input_tokens": 1,
+        "model": "gpt-5.4-mini",
     }
 
 
@@ -2160,7 +2166,35 @@ def test_extract_codex_last_turn_usage_no_cache_key_when_uncached() -> None:
     from omnigent.inner.codex_executor import _extract_codex_last_turn_usage
 
     params = {"tokenUsage": {"last": {"inputTokens": 7, "outputTokens": 3, "totalTokens": 10}}}
-    assert _extract_codex_last_turn_usage(params) == {
+    assert _extract_codex_last_turn_usage(params, "gpt-5.4-mini") == {
+        "input_tokens": 7,
+        "output_tokens": 3,
+        "total_tokens": 10,
+        "model": "gpt-5.4-mini",
+    }
+
+
+def test_extract_codex_last_turn_usage_stamps_resolved_model() -> None:
+    """The turn's resolved model is stamped into the usage dict as ``model``.
+
+    Without this, an agent spec that pins no ``llm.model`` (e.g. Debby's
+    ``gpt`` head, which deliberately runs on whatever model the codex
+    harness/provider resolves by default) has no signal the server can use to
+    attribute this turn's usage to a model — the flat session total still
+    accumulates, but ``session_usage.by_model`` silently never gets an entry
+    for it (see ``_extract_codex_last_turn_usage``'s docstring).
+    """
+    from omnigent.inner.codex_executor import _extract_codex_last_turn_usage
+
+    params = {"tokenUsage": {"last": {"inputTokens": 7, "outputTokens": 3, "totalTokens": 10}}}
+    assert _extract_codex_last_turn_usage(params, "databricks-gpt-5-5") == {
+        "input_tokens": 7,
+        "output_tokens": 3,
+        "total_tokens": 10,
+        "model": "databricks-gpt-5-5",
+    }
+    # A falsy/empty resolved model must not synthesize a misleading key.
+    assert _extract_codex_last_turn_usage(params, "") == {
         "input_tokens": 7,
         "output_tokens": 3,
         "total_tokens": 10,
@@ -2171,11 +2205,11 @@ def test_extract_codex_last_turn_usage_handles_missing_or_malformed() -> None:
     """Missing or non-dict shapes return None rather than raising."""
     from omnigent.inner.codex_executor import _extract_codex_last_turn_usage
 
-    assert _extract_codex_last_turn_usage(None) is None
-    assert _extract_codex_last_turn_usage("not a dict") is None
-    assert _extract_codex_last_turn_usage({}) is None
-    assert _extract_codex_last_turn_usage({"tokenUsage": None}) is None
-    assert _extract_codex_last_turn_usage({"tokenUsage": {"total": {}}}) is None
+    assert _extract_codex_last_turn_usage(None, "gpt-5.4-mini") is None
+    assert _extract_codex_last_turn_usage("not a dict", "gpt-5.4-mini") is None
+    assert _extract_codex_last_turn_usage({}, "gpt-5.4-mini") is None
+    assert _extract_codex_last_turn_usage({"tokenUsage": None}, "gpt-5.4-mini") is None
+    assert _extract_codex_last_turn_usage({"tokenUsage": {"total": {}}}, "gpt-5.4-mini") is None
 
 
 def _make_skill_dir(root: Path, name: str) -> Path:

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -4832,6 +4832,69 @@ async def test_accumulate_session_usage_unpriced_without_usage_model(
     assert "total_cost_usd" not in usage
 
 
+async def test_accumulate_session_usage_codex_unpinned_model_gets_by_model_entry(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Regression test for the Debby/Polly per-model-breakdown bug.
+
+    A codex-harness agent that pins no ``llm.model`` (the exact shape of
+    Debby's ``gpt`` head, ``examples/debby/agents/gpt/config.yaml``) has no
+    ``model_override`` and no spec ``llm.model``, so ``_resolve_llm_model``
+    falls back to ``None`` unless the turn's own ``usage.model`` supplies it.
+    Before ``codex_executor.py``'s ``_extract_codex_last_turn_usage`` stamped
+    the resolved model onto the usage dict, codex turns never carried
+    ``usage.model`` — so the flat token total still accumulated (first call
+    below) but ``by_model`` was silently never written for it. The second
+    call reproduces the fixed shape (``model`` present, exactly what
+    ``_extract_codex_last_turn_usage`` now returns) and must get an entry —
+    surfaced through the real ``GET /v1/sessions/{id}`` API the web UI reads.
+    """
+    from omnigent.server.routes import sessions as sessions_routes
+
+    agent = await create_test_agent(
+        client,
+        executor={"type": "omnigent", "config": {"harness": "codex"}},
+        include_llm=False,  # mirrors examples/debby/agents/gpt/config.yaml
+    )
+    session = await _create_session(client, agent["id"])
+    store = SqlAlchemyConversationStore(db_uri)
+
+    # BEFORE (the bug): no "model" in usage — the old codex_executor shape.
+    sessions_routes._accumulate_session_usage(
+        {"usage": {"input_tokens": 1000, "output_tokens": 500, "total_tokens": 1500}},
+        session["id"],
+        store,
+    )
+    before = _read_session_usage(db_uri, session["id"])
+    assert before.get("input_tokens") == 1000  # flat total still accumulates...
+    assert "by_model" not in before  # ...but no per-model entry is ever written.
+
+    # AFTER (the fix): usage carries "model", as _extract_codex_last_turn_usage
+    # now stamps it.
+    sessions_routes._accumulate_session_usage(
+        {
+            "usage": {
+                "input_tokens": 200,
+                "output_tokens": 100,
+                "total_tokens": 300,
+                "model": "gpt-5.4-mini",
+            }
+        },
+        session["id"],
+        store,
+    )
+    after = _read_session_usage(db_uri, session["id"])
+    assert after["input_tokens"] == 1200  # flat total keeps accumulating
+    assert after["by_model"]["gpt-5.4-mini"]["input_tokens"] == 200
+    assert after["by_model"]["gpt-5.4-mini"]["output_tokens"] == 100
+
+    # And the real HTTP read API — the same one the web UI's cost panel
+    # reads on load — projects the per-model entry too.
+    snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+    assert snapshot["usage_by_model"]["gpt-5.4-mini"]["input_tokens"] == 200
+
+
 async def test_accumulate_session_usage_records_per_model_breakdown(
     client: httpx.AsyncClient,
     db_uri: str,


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #3283 

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->
- `codex_executor.py`'s `TurnComplete.usage` never carried a `"model"` field, unlike every other relay executor (`claude-sdk`, `cursor`, `copilot`, `openai-agents`, `pi`), all of which already report the resolved model on `usage`.
- For a codex-harness agent that pins no `llm.model` in its spec (e.g. Debby's `gpt` head, which deliberately defers to the harness/provider default), `_accumulate_session_usage`'s model-resolution fallback chain (`usage.model` → `model_override` → spec `llm.model`) had nothing to resolve to. The turn's flat token/cost totals still accumulated, but `session_usage.by_model` silently never got an entry for that model.
- User-visible symptom: multi-head/orchestrated agents (Debby, Polly) show a cost panel whose total includes every model's spend, but whose per-model breakdown only ever shows the session's starting model.
- Fix: stamp the turn's already-resolved model (`run_turn`'s `model` argument) onto the usage dict extracted from `thread/tokenUsage/updated`, mirroring `claude_sdk_executor`'s `observed_model` pattern.

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

1. `tests/inner/test_codex_executor.py -k usage` — unit-level: `_extract_codex_last_turn_usage` now stamps `model` onto the returned usage dict; `TurnComplete.usage` carries it end-to-end.
2. `tests/server/integration/test_sessions_endpoints.py -k codex_unpinned_model_gets_by_model_entry` — API-level: an agent shaped exactly like Debby's `gpt` head (codex harness, no pinned model) is created via the real app, a usage delta with no `model` key reproduces the bug (flat total accumulates, `by_model` stays empty), and a delta carrying `model` (the fixed shape) gets a `by_model` entry that also surfaces through the real `GET /v1/sessions/{id}` response the web UI's cost panel reads.
3. Verified the fix actually flips: temporarily reverted `codex_executor.py` alone (test files untouched) and re-ran (1) — got a clean, expected failure (`TypeError: _extract_codex_last_turn_usage() takes 1 positional argument but 2 were given`); restored the fix and both (1) and (2) passed again.
4. Re-ran full adjacent suites for regressions: `tests/inner/test_codex_executor.py`, `tests/codex_parity/`, `tests/server/integration/test_sessions_endpoints.py` (usage subset), `tests/server/routes/test_usage_report.py`, `tests/runtime/policies/test_builder.py` — all green (a handful of pre-existing, unrelated Windows-symlink-privilege failures in `test_codex_executor.py` reproduce identically on `main`, confirmed via `git stash`).

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

N/A — backend-only change, no UI/frontend modification.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->
Live end-to-end verification through the actual Debby/Polly web UI with real `codex`/`claude` credentials was **not** performed — this sandbox has no `node`/`npm` (so no web UI build) and no configured LLM credentials or CLI binaries. In its place, the fix was verified against the real production code path (`_accumulate_session_usage`, the real `GET /v1/sessions/{id}` API) using a synthetic usage payload shaped exactly like what `codex_executor.py` now produces, plus a before/after flip by temporarily reverting only the fixed file. A maintainer with a live environment (node/npm + Anthropic/OpenAI credentials) can confirm end-to-end via `examples/debby`'s `/debate` skill and the `AgentInfo` cost panel.

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->
Session cost panel now shows a per-model breakdown for sub-agents/second heads (e.g. Debby's GPT head, Polly's codex sub-agents) running on an unpinned codex model, instead of folding their usage into the total with no per-model entry.

<Add a line to describe the change, else delete this section>
