### PR TITLE
fix(openai-agents): honor explicit Databricks profiles

### DIFF
--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -434,11 +434,10 @@ def _get_openai_async_client(
     :param databricks_auth_command: Shell command from ucode state that
         prints a bearer token, e.g.
         ``"databricks auth token --host https://example.databricks.com ..."``.
-    :param model: The model name that will be used. When set to a
-        non-Databricks model (i.e. does not start with ``"databricks-"``),
-        both the explicit ``profile`` block and the ambient Databricks
-        credential fallback are skipped — the caller must supply
-        ``OPENAI_API_KEY`` (and optionally ``OPENAI_BASE_URL``) instead.
+    :param model: The model or model-service name that will be used. An
+        explicit ``profile`` selects Databricks regardless of this value.
+        Without a profile, only legacy ``"databricks-"`` names enable
+        ambient Databricks credential fallback.
     :raises DatabricksAuthError: When an explicit ``profile`` is given,
         authentication fails, and no ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY``
         env-var fallbacks are available.
@@ -498,11 +497,11 @@ def _get_openai_async_client(
             **retry_kwargs,
         )
 
-    is_databricks_model = model is None or model.startswith("databricks-")
+    allow_ambient_databricks = model is None or model.startswith("databricks-")
 
-    # Databricks profile auth only applies when the model is Databricks-hosted.
-    # An explicit spec/provider profile wins over ambient env vars.
-    if is_databricks_model and profile:
+    # An explicit Databricks profile is authoritative; model-service names
+    # are opaque Unity Catalog identifiers such as catalog.schema.service.
+    if profile:
         from .databricks_executor import DatabricksAuthError, _resolve_databricks_auth
 
         try:
@@ -547,17 +546,17 @@ def _get_openai_async_client(
     if api_key:
         return AsyncOpenAI(api_key=api_key, **retry_kwargs)
 
-    # Non-Databricks model with no OpenAI credentials — fail loudly rather
-    # than silently routing to the Databricks AI Gateway, which will 404.
-    if not is_databricks_model:
+    # Without an explicit profile, only legacy Databricks model names opt in
+    # to ambient Databricks credentials.
+    if not profile and not allow_ambient_databricks:
         raise ValueError(
-            f"Model {model!r} is not a Databricks-hosted model but no OpenAI "
-            "credentials were found. Set OPENAI_API_KEY (and optionally "
-            "OPENAI_BASE_URL) to use this model, or use a 'databricks-' "
-            "prefixed model name to route through Databricks."
+            f"No provider credentials were configured for model {model!r}. "
+            "Set OPENAI_API_KEY (and optionally OPENAI_BASE_URL), configure a "
+            "Databricks profile, or use a 'databricks-' prefixed model name "
+            "for legacy automatic Databricks routing."
         )
 
-    # No profile, no env — final fallback via ambient Databricks credentials.
+    # No env client: use the explicit profile or legacy ambient Databricks auth.
     try:
         from .databricks_executor import _resolve_databricks_auth
 

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -1489,8 +1489,9 @@ class TestOpenAIAgentsSDKExecutor(unittest.TestCase):
 def test_get_openai_client_profile_uses_callback_auth(monkeypatch):
     """Explicit ``profile`` uses httpx callback auth, not a static ``api_key``.
 
-    Verifies that when a Databricks profile is provided, the client
-    is constructed with an ``http_client`` carrying a
+    Verifies that a Unity Catalog model-service name does not override an
+    explicit Databricks profile. The client is constructed with an
+    ``http_client`` carrying a
     ``_DatabricksBearerAuth`` that refreshes tokens per-request,
     and that the ``api_key`` is a placeholder (not the real token).
 
@@ -1521,7 +1522,10 @@ def test_get_openai_client_profile_uses_callback_auth(monkeypatch):
     import openai as _openai_mod
 
     with patch.object(_openai_mod, "AsyncOpenAI", _StubAsyncOpenAI, create=True):
-        _get_openai_async_client(profile="dev")
+        _get_openai_async_client(
+            profile="dev",
+            model="production.agents.support_assistant",
+        )
 
     assert captured["base_url"] == "https://profile-host.example.com/ai-gateway/openai/v1"
     assert captured["api_key"] != "should-not-be-used"
@@ -1723,6 +1727,20 @@ def test_get_openai_client_no_profile_honors_env_vars(monkeypatch):
     assert captured["base_url"] == "https://env-host.example.com/v1"
     assert captured["api_key"] == "env-key"
     assert "http_client" not in captured
+
+
+def test_get_openai_client_model_service_without_provider_fails_loudly(monkeypatch):
+    """A model-service name alone does not imply ambient Databricks routing.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    from omnigent.inner.openai_agents_sdk_executor import _get_openai_async_client
+
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="No provider credentials"):
+        _get_openai_async_client(model="production.agents.support_assistant")
 
 
 def test_get_openai_client_invalid_profile_raises_auth_error(monkeypatch):


### PR DESCRIPTION
## Related issue

N/A

## Summary

Unity AI Gateway Model Services are addressed by fully qualified Unity Catalog names such as `<catalog>.<schema>.<model_service>` (for example, `system.ai.gpt-5-5`). These valid identifiers do not necessarily start with `databricks-`; see the [Databricks query documentation](https://docs.databricks.com/aws/en/ai-gateway/query-model-services).

The OpenAI Agents SDK client resolver previously inferred routing twice:

1. The workflow resolved the configured Databricks provider and passed its profile to the harness.
2. The harness then ignored that explicit profile unless the model name started with `databricks-`.

As a result, an agent configured with a Databricks provider and a model service such as `production.agents.support_assistant` could fall through to ambient OpenAI credentials or fail before contacting the selected Databricks workspace.

This change makes an explicit Databricks profile authoritative and treats the model identifier as opaque. It keeps the legacy `databricks-*` and `databricks/` checks only for profile-less automatic Databricks routing.

### ELI5

The profile is the address on the envelope; the model name is the recipient. Once the user has supplied a Databricks address, the harness should not discard it because the recipient's new Unity Catalog name has a different spelling.

```text
explicit API key/base URL?
  yes -> use that explicit OpenAI-compatible target
  no
   |
explicit Databricks profile?
  yes -> use that workspace; pass the model-service name through unchanged
  no
   |
OPENAI_BASE_URL / OPENAI_API_KEY?
  yes -> use the configured OpenAI-compatible target
  no
   |
legacy databricks-* / databricks/ model?
  yes -> use ambient/default Databricks credentials (backward compatibility)
  no  -> fail loudly instead of guessing a provider
```

### Compatibility

| Profile | Model identifier | Result |
|---|---|---|
| `dev` | `production.agents.support_assistant` | Databricks workspace from `dev` |
| `dev` | `databricks-gpt-5-4` | Databricks workspace from `dev` |
| none | `databricks-gpt-5-4` | Legacy ambient/default Databricks routing |
| none | `databricks/databricks-gpt-5-4` | Legacy ambient/default Databricks routing |
| none | `production.agents.support_assistant` | OpenAI env credentials, or a clear configuration error |

### Harness impact

- **Directly affected:** `openai-agents-sdk` (`openai-agents`) only. Its `_get_openai_async_client` resolver no longer lets model-name inference veto an explicit Databricks profile.
- **Not changed:** Claude SDK/native, Codex/native, Pi, Qwen, Cursor, Copilot, Antigravity, Kimi, and other harnesses. No shared provider resolver or their executor code changed.

## Test Plan

- Ran the complete OpenAI Agents executor unit suite:

  ```bash
  uv run --extra dev --extra all pytest tests/inner/test_openai_agents_sdk_executor.py
  ```

  Result: `71 passed`.

- Updated the profile-precedence test to use the Unity Catalog model-service name `production.agents.support_assistant` while an ambient `OPENAI_API_KEY=should-not-be-used` is present. It verifies that the explicit profile still selects the Databricks workspace and callback authentication.
- Added a regression test proving that a fully qualified model-service name without a provider/profile does not silently opt into ambient Databricks credentials.
- Existing legacy-prefix tests continue to cover profile-less `databricks-gpt-*` routing.
- Ran the repository-wide hooks:

  ```bash
  pre-commit run --all-files
  ```

  All hooks passed.

## Demo

N/A — no visual UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused regressions cover both sides of the routing boundary: an explicit Databricks profile accepts a fully qualified Unity Catalog model-service name, while the same name without any configured provider still fails loudly. The existing tests retain coverage for legacy `databricks-*` ambient routing.

## Changelog

Custom OpenAI Agents can use Unity AI Gateway Model Services with fully qualified model names when a Databricks provider or profile is configured.
