### PR TITLE
Feat(UI): Add collapsible completed session groups

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -178,6 +178,7 @@ from omnigent.spec.types import (
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.conversation_store import (
+    COMPLETED_LABEL_KEY,
     PINNED_LABEL_KEY,
     ConversationNotFoundError,
     NameAlreadyExistsError,
@@ -7366,6 +7367,16 @@ def _reject_server_reserved_label_seed(labels: dict[str, str] | None) -> None:
             f"{PINNED_LABEL_KEY!r} key to pin for yourself",
             code=ErrorCode.INVALID_INPUT,
         )
+    suffixed_completed = next(
+        (k for k in labels if k.startswith(f"{COMPLETED_LABEL_KEY}.")),
+        None,
+    )
+    if suffixed_completed is not None:
+        raise OmnigentError(
+            f"label {suffixed_completed!r} is server-derived; set the bare "
+            f"{COMPLETED_LABEL_KEY!r} key for yourself",
+            code=ErrorCode.INVALID_INPUT,
+        )
 
 
 def _require_cost_control_label_authority(
@@ -7773,7 +7784,13 @@ def _child_session_summary_from_conversation(
     # sidebar rows only), but strip any per-user ``omnigent.pinned.<user>`` keys
     # defensively so a shared child's summary can never expose another viewer's
     # pin key. No collapse-to-canonical here: there's no pin to surface.
-    raw_labels = {k: v for k, v in conv.labels.items() if not k.startswith(f"{PINNED_LABEL_KEY}.")}
+    raw_labels = {
+        k: v
+        for k, v in conv.labels.items()
+        if not k.startswith(f"{PINNED_LABEL_KEY}.")
+        and k != COMPLETED_LABEL_KEY
+        and not k.startswith(f"{COMPLETED_LABEL_KEY}.")
+    }
     labels = labels_with_closed_status(raw_labels, conv.title)
     tool: str | None
     session_name: str | None

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -157,8 +157,10 @@ from omnigent.spec.types import (
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.conversation_store import (
+    COMPLETED_LABEL_KEY,
     PINNED_LABEL_KEY,
     ConversationNotFoundError,
+    completed_label_key,
     pinned_label_key,
 )
 from omnigent.stores.file_store import FileStore
@@ -463,11 +465,13 @@ def _labels_for_viewer(labels: dict[str, str], user_id: str | None) -> dict[str,
     reads the same bare key it writes) and stops other users' pin keys from
     bloating the payload.
 
+    Completion labels follow the same per-user collapse.
+
     :param labels: The stored conversation labels.
     :param user_id: The requesting viewer, or ``None`` in single-user mode.
     :returns: A copy with all ``omnigent.pinned.*`` keys removed and the
         canonical ``omnigent.pinned`` key added when the viewer's own pin
-        is present.
+        is present. Completion keys are handled the same way.
     """
     my_key = pinned_label_key(user_id)
     my_pin = labels.get(my_key)
@@ -478,6 +482,14 @@ def _labels_for_viewer(labels: dict[str, str], user_id: str | None) -> dict[str,
     }
     if my_pin is not None:
         cleaned[PINNED_LABEL_KEY] = my_pin
+    my_completed = labels.get(completed_label_key(user_id))
+    cleaned = {
+        k: v
+        for k, v in cleaned.items()
+        if k != COMPLETED_LABEL_KEY and not k.startswith(f"{COMPLETED_LABEL_KEY}.")
+    }
+    if my_completed is not None:
+        cleaned[COMPLETED_LABEL_KEY] = my_completed
     return cleaned
 
 

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -124,9 +124,11 @@ from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.comment_store import CommentStore
 from omnigent.stores.conversation_store import (
+    COMPLETED_LABEL_KEY,
     PINNED_LABEL_KEY,
     PROJECT_LABEL_KEY,
     ConversationNotFoundError,
+    completed_label_key,
     pinned_label_key,
 )
 from omnigent.stores.file_store import FileStore
@@ -1437,6 +1439,7 @@ def register_core_routes(
         #   session may pin it — including a read-only collaborator on a session
         #   shared with them. Only when the pinned label is the request's ONLY
         #   mutation.
+        #   Completion markers follow the same read-level rule.
         # * OWNER — archiving/unarchiving or filing into a project. Both are
         #   owner-only: projects are owner-private (an editor must not move a
         #   session between them), and archive pairs with a client-driven,
@@ -1451,7 +1454,10 @@ def register_core_routes(
         pin_only = body.model_fields_set == {"labels"} and set(body.labels or {}) == {
             PINNED_LABEL_KEY
         }
-        if pin_only:
+        completed_only = body.model_fields_set == {"labels"} and set(body.labels or {}) == {
+            COMPLETED_LABEL_KEY
+        }
+        if pin_only or completed_only:
             required_level = LEVEL_READ
         elif body.archived is not None or set_project:
             required_level = LEVEL_OWNER
@@ -1527,6 +1533,9 @@ def register_core_routes(
         # through to the delete-clear loop below under the per-user key.
         if PINNED_LABEL_KEY in labels_to_set:
             labels_to_set[pinned_label_key(user_id)] = labels_to_set.pop(PINNED_LABEL_KEY)
+        # Completion uses the same canonical-on-the-wire, per-user storage.
+        if COMPLETED_LABEL_KEY in labels_to_set:
+            labels_to_set[completed_label_key(user_id)] = labels_to_set.pop(COMPLETED_LABEL_KEY)
         if requested_codex_collaboration_mode is not None:
             labels_to_set[_CODEX_NATIVE_COLLABORATION_MODE_LABEL_KEY] = (
                 requested_codex_collaboration_mode
@@ -1761,7 +1770,12 @@ def register_core_routes(
         # so without this an empty string would linger as a stored value.
         # The pinned key was rewritten to the caller's per-user key above, so
         # clear that one (not the canonical bare key) on an empty value.
-        for _clear_key in (PROJECT_LABEL_KEY, pinned_label_key(user_id)):
+        # Completion uses the same caller-specific clear.
+        for _clear_key in (
+            PROJECT_LABEL_KEY,
+            pinned_label_key(user_id),
+            completed_label_key(user_id),
+        ):
             if labels_to_set.get(_clear_key) == "":
                 labels_to_set = {k: v for k, v in labels_to_set.items() if k != _clear_key}
                 await asyncio.to_thread(conversation_store.delete_label, session_id, _clear_key)

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -87,6 +87,7 @@ from omnigent.session_lifecycle import (
 )
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
+from omnigent.stores.conversation_store import completed_label_key
 from omnigent.stores.file_store import FileStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.telemetry import emit as _tel_emit
@@ -417,6 +418,15 @@ def register_events_routes(
             # persist or relay to the harness (which rejects
             # ``function_call`` as an unknown inbound event type).
             return {"verdict": "allow"}
+
+        if body.type == "message" and body.data.get("role") == "user":
+            completion_key = completed_label_key(user_id)
+            if completion_key in conv.labels:
+                await asyncio.to_thread(
+                    conversation_store.delete_label,
+                    session_id,
+                    completion_key,
+                )
 
         if body.type == _INTERRUPT_TYPE:
             _publish_interrupted(session_id)

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -104,6 +104,9 @@ PROJECT_LABEL_KEY = "omni_project"
 # mirrors the canonical key as ``PINNED_LABEL_KEY``.
 PINNED_LABEL_KEY = "omnigent.pinned"
 
+# Personal completion marker. The API exposes only the caller's marker.
+COMPLETED_LABEL_KEY = "omnigent.completed"
+
 # Single-user / no-auth sentinel for the per-user pin key suffix, mirroring the
 # reserved ``"local"`` identity used elsewhere (see ``RESERVED_USER_LOCAL``).
 _PINNED_LABEL_LOCAL_USER = "local"
@@ -138,6 +141,14 @@ def pinned_label_key(user_id: str | None) -> str:
         # 64 hex chars — well within the budget and collision-safe.
         suffix = "h:" + hashlib.sha256(suffix.encode("utf-8")).hexdigest()
     return f"{PINNED_LABEL_KEY}.{suffix}"
+
+
+def completed_label_key(user_id: str | None) -> str:
+    """Return the stored per-user completion key for ``user_id``."""
+    suffix = user_id if user_id is not None else "local"
+    if len(suffix) > 128 - len(COMPLETED_LABEL_KEY) - 1:
+        suffix = "h:" + hashlib.sha256(suffix.encode("utf-8")).hexdigest()
+    return f"{COMPLETED_LABEL_KEY}.{suffix}"
 
 
 # Labels that must NOT cross into a new session context — deliberately

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -79,6 +79,7 @@ from omnigent.session_import.models import (
 from omnigent.stores.conversation_store import (
     _FORK_ONLY_DROPPED_LABEL_KEYS,
     _INSTANCE_SCOPED_LABEL_KEYS,
+    COMPLETED_LABEL_KEY,
     FORK_CARRY_HISTORY_LABEL_KEY,
     FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY,
     FORK_SOURCE_LABEL_KEY,
@@ -3549,6 +3550,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 for key, value in _fetch_labels(session, source_conversation_id).items()
                 if key not in (_INSTANCE_SCOPED_LABEL_KEYS | _FORK_ONLY_DROPPED_LABEL_KEYS)
                 and not key.startswith(f"{PINNED_LABEL_KEY}.")
+                and not key.startswith(f"{COMPLETED_LABEL_KEY}.")
             }
             source_workspace = source_meta_ref.workspace if source_meta_ref else None
             source_ext_session = source_meta_ref.external_session_id if source_meta_ref else None

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -204,6 +204,58 @@ async def test_first_message_schedules_background_semantic_title(
     assert snapshot.json()["title"] == "Debug authentication timeout"
 
 
+async def test_user_message_reactivates_completed_session(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An accepted user turn clears the caller's completion marker."""
+    from omnigent.stores.conversation_store import completed_label_key
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"], title="Completed work")
+    completed = await client.patch(
+        f"/v1/sessions/{session['id']}",
+        json={"labels": {"omnigent.completed": "1721760000000"}},
+    )
+    assert completed.status_code == 200
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(202, json={"queued": True})),
+        base_url="http://runner",
+    )
+
+    async def get_runner_client(
+        _session_id: str,
+        _runner_router: object,
+    ) -> httpx.AsyncClient:
+        return fake_runner
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._get_runner_client",
+        get_runner_client,
+    )
+
+    try:
+        response = await client.post(
+            f"/v1/sessions/{session['id']}/events",
+            json={
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "One more follow-up"}],
+                },
+            },
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert response.status_code == 202, response.text
+    stored = SqlAlchemyConversationStore(db_uri).get_conversation(session["id"])
+    assert stored is not None
+    assert completed_label_key(None) not in stored.labels
+
+
 async def test_background_title_failure_does_not_break_subsequent_user_turn(
     client: httpx.AsyncClient,
     app: Any,

--- a/tests/server/routes/test_child_session_summary_labels.py
+++ b/tests/server/routes/test_child_session_summary_labels.py
@@ -14,7 +14,7 @@ from omnigent.entities import Conversation
 from omnigent.server.routes._sessions.helpers import (
     _child_session_summary_from_conversation,
 )
-from omnigent.stores.conversation_store import pinned_label_key
+from omnigent.stores.conversation_store import completed_label_key, pinned_label_key
 
 
 def _child(labels: dict[str, str]) -> Conversation:
@@ -36,11 +36,13 @@ def test_child_summary_strips_per_user_pin_keys() -> None:
         {
             pinned_label_key("alice@example.com"): "1721760000000",
             pinned_label_key("bob@example.com"): "1721760001000",
+            completed_label_key("alice@example.com"): "1721760002000",
             "omni_project": "Moonshot",
         }
     )
     summary = _child_session_summary_from_conversation(conv, "conv_parent", None)
     # No pin key of any kind survives — not the canonical one, not a per-user one.
     assert not any(k.startswith("omnigent.pinned") for k in summary.labels)
+    assert not any(k.startswith("omnigent.completed") for k in summary.labels)
     # Unrelated labels are preserved.
     assert summary.labels.get("omni_project") == "Moonshot"

--- a/tests/server/routes/test_session_updates_ws.py
+++ b/tests/server/routes/test_session_updates_ws.py
@@ -591,7 +591,7 @@ def test_pin_label_collapses_to_canonical_key_on_the_wire(
     via the normal rescan-diff path: pinning a watched session out of band
     surfaces on the next ``changed`` frame (``fast_rescan`` shrinks the tick).
     """
-    from omnigent.stores.conversation_store import pinned_label_key
+    from omnigent.stores.conversation_store import completed_label_key, pinned_label_key
 
     conversation_store, _agent_store, _permission_store = stores
     s1 = _seed_session(stores, owner=ALICE, title="watched")
@@ -607,6 +607,8 @@ def test_pin_label_collapses_to_canonical_key_on_the_wire(
             {
                 pinned_label_key(ALICE): "1721760000000",
                 pinned_label_key(BOB): "1700000000000",
+                completed_label_key(ALICE): "1721760002000",
+                completed_label_key(BOB): "1700000002000",
             },
         )
         changed = _recv_until(ws, {"changed"})
@@ -615,9 +617,12 @@ def test_pin_label_collapses_to_canonical_key_on_the_wire(
         labels = items[s1]["labels"]
         # Alice's pin surfaces as the canonical bare key…
         assert labels.get("omnigent.pinned") == "1721760000000"
+        assert labels.get("omnigent.completed") == "1721760002000"
         # …and neither per-user key (hers or Bob's) leaks onto the wire.
         assert pinned_label_key(ALICE) not in labels
         assert pinned_label_key(BOB) not in labels
+        assert completed_label_key(ALICE) not in labels
+        assert completed_label_key(BOB) not in labels
 
 
 # ── comments fingerprint ──────────────────────────────────────────────

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -464,3 +464,58 @@ async def test_list_sessions_pinned_filter(
     assert plain.id not in ids
     # A pin belonging to another user must not appear for the caller.
     assert other_user_pin.id not in ids
+
+
+async def test_patch_completed_session_label(
+    client: httpx.AsyncClient,
+    session_id: str,
+    db_uri: str,
+) -> None:
+    """Completion is reversible and appears on the ordinary session list."""
+    from omnigent.stores.conversation_store import completed_label_key
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    user_key = completed_label_key(None)
+
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"labels": {"omnigent.completed": "1721760000000"}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["labels"]["omnigent.completed"] == "1721760000000"
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert conv.labels[user_key] == "1721760000000"
+
+    listed = await client.get("/v1/sessions")
+    listed_session = next(row for row in listed.json()["data"] if row["id"] == session_id)
+    assert listed_session["labels"]["omnigent.completed"] == "1721760000000"
+
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"labels": {"omnigent.completed": ""}},
+    )
+    assert resp.status_code == 200
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert user_key not in conv.labels
+
+
+async def test_patch_rejects_client_supplied_per_user_completed_key(
+    client: httpx.AsyncClient,
+    session_id: str,
+    db_uri: str,
+) -> None:
+    """Clients cannot change another user's private completion state."""
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    key = "omnigent.completed.bob@example.com"
+
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"labels": {key: "1721760000000"}},
+    )
+
+    assert resp.status_code == 400
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert key not in conv.labels

--- a/tests/server/routes/test_sessions_input_policy_deny.py
+++ b/tests/server/routes/test_sessions_input_policy_deny.py
@@ -65,9 +65,14 @@ def route_client(db_uri: str) -> Iterator[tuple[TestClient, str]]:
 
 def test_input_policy_deny_persists_item_readable_from_items_api(
     route_client: tuple[TestClient, str],
+    db_uri: str,
 ) -> None:
     """Synchronous INPUT DENY both streams and persists the deny sentinel."""
+    from omnigent.stores.conversation_store import completed_label_key
+
     client, session_id = route_client
+    conversation_store = SqlAlchemyConversationStore(db_uri)
+    conversation_store.set_labels(session_id, {completed_label_key(None): "1721760000000"})
     spec = AgentSpec(
         spec_version=1,
         name="test-agent",
@@ -136,3 +141,6 @@ def test_input_policy_deny_persists_item_readable_from_items_api(
             "text": "[Denied by policy: Request contains BLOCK_THIS_TOKEN]",
         }
     ]
+    stored = conversation_store.get_conversation(session_id)
+    assert stored is not None
+    assert stored.labels[completed_label_key(None)] == "1721760000000"

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -55,7 +55,7 @@ def test_fork_drops_per_user_pin_labels(
     """A fork is a NEW conversation, so it must not inherit the source's pins:
     neither the forker's nor any other user's per-user pin key rides along
     (those keys have a dynamic suffix, so a prefix drop is required)."""
-    from omnigent.stores.conversation_store import pinned_label_key
+    from omnigent.stores.conversation_store import completed_label_key, pinned_label_key
 
     source = conversation_store.create_conversation()
     conversation_store.set_labels(
@@ -63,6 +63,7 @@ def test_fork_drops_per_user_pin_labels(
         {
             pinned_label_key("alice"): "1721760000000",
             pinned_label_key("bob"): "1700000000000",
+            completed_label_key("alice"): "1721760002000",
             "kept": "yes",
         },
     )
@@ -72,6 +73,7 @@ def test_fork_drops_per_user_pin_labels(
     assert fork.labels["kept"] == "yes"
     assert pinned_label_key("alice") not in fork.labels
     assert pinned_label_key("bob") not in fork.labels
+    assert completed_label_key("alice") not in fork.labels
 
 
 def test_create_and_get(conversation_store: SqlAlchemyConversationStore) -> None:
@@ -4936,6 +4938,16 @@ def test_pinned_label_key_fits_column_for_long_user_ids() -> None:
     assert key == pinned_label_key(long_id)  # deterministic
     # Distinct long ids don't collide.
     assert pinned_label_key("u" * 200) != pinned_label_key("v" * 200)
+
+
+def test_completed_label_key_fits_column_for_long_user_ids() -> None:
+    from omnigent.stores.conversation_store import COMPLETED_LABEL_KEY, completed_label_key
+
+    assert completed_label_key("alice@example.com") == f"{COMPLETED_LABEL_KEY}.alice@example.com"
+    long_id = "u" * 200
+    assert len(completed_label_key(long_id)) <= 128
+    assert completed_label_key(long_id) == completed_label_key(long_id)
+    assert completed_label_key("u" * 200) != completed_label_key("v" * 200)
 
 
 def test_list_projects_owned_by_excludes_shared_only_projects(

--- a/web/src/hooks/useToggleCompletedConversation.test.tsx
+++ b/web/src/hooks/useToggleCompletedConversation.test.tsx
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, expect, it, vi } from "vitest";
+import { type Conversation, PINNED_CONVERSATIONS_KEY } from "@/hooks/useConversations";
+import { COMPLETED_LABEL_KEY, type ConversationsInfiniteData } from "@/lib/sessionListCache";
+import { authenticatedFetch } from "@/lib/identity";
+import { useToggleCompletedConversation } from "./useToggleCompletedConversation";
+
+vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
+
+const row: Conversation = {
+  id: "conv_done",
+  object: "conversation",
+  title: "Done",
+  created_at: 1,
+  updated_at: 2,
+  labels: {},
+  permission_level: null,
+};
+
+beforeEach(() => {
+  vi.mocked(authenticatedFetch).mockReset();
+});
+
+it("patches completion into the existing list caches without a separate feed", async () => {
+  const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  const page: ConversationsInfiniteData = {
+    pages: [{ data: [row], first_id: row.id, last_id: row.id, has_more: false }],
+    pageParams: [undefined],
+  };
+  client.setQueryData(["conversations", "", true], page);
+  client.setQueryData(["project-sessions", "Project"], page);
+  client.setQueryData(PINNED_CONVERSATIONS_KEY, [row]);
+  vi.mocked(authenticatedFetch).mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      ...row,
+      labels: { [COMPLETED_LABEL_KEY]: "1721760000000" },
+    }),
+  } as Response);
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  const rendered = renderHook(() => useToggleCompletedConversation(), { wrapper });
+
+  act(() => rendered.result.current.mutate({ id: row.id, completed: true }));
+  await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+
+  for (const key of [
+    ["conversations", "", true],
+    ["project-sessions", "Project"],
+  ]) {
+    const cached = client.getQueryData<ConversationsInfiniteData>(key);
+    expect(cached?.pages[0].data[0].labels[COMPLETED_LABEL_KEY]).toBe("1721760000000");
+  }
+  expect(
+    client.getQueryData<Conversation[]>(PINNED_CONVERSATIONS_KEY)?.[0].labels[COMPLETED_LABEL_KEY],
+  ).toBe("1721760000000");
+  expect(JSON.parse(String(vi.mocked(authenticatedFetch).mock.calls[0][1]?.body))).toEqual({
+    labels: { [COMPLETED_LABEL_KEY]: expect.any(String) },
+  });
+});

--- a/web/src/hooks/useToggleCompletedConversation.ts
+++ b/web/src/hooks/useToggleCompletedConversation.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { type Conversation, PINNED_CONVERSATIONS_KEY } from "@/hooks/useConversations";
+import { authenticatedFetch } from "@/lib/identity";
+import { COMPLETED_LABEL_KEY, type ConversationsInfiniteData } from "@/lib/sessionListCache";
+
+export async function setConversationCompleted(
+  id: string,
+  completed: boolean,
+): Promise<Conversation> {
+  const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      labels: { [COMPLETED_LABEL_KEY]: completed ? String(Date.now()) : "" },
+    }),
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as Conversation;
+}
+
+export function useToggleCompletedConversation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, completed }: { id: string; completed: boolean }) =>
+      setConversationCompleted(id, completed),
+    onSuccess: (updated) => {
+      const patchPages = (data: ConversationsInfiniteData | undefined) =>
+        data
+          ? {
+              ...data,
+              pages: data.pages.map((page) => ({
+                ...page,
+                data: page.data.map((conversation) =>
+                  conversation.id === updated.id
+                    ? { ...conversation, labels: updated.labels }
+                    : conversation,
+                ),
+              })),
+            }
+          : data;
+      for (const queryKey of [["conversations"], ["project-sessions"]]) {
+        queryClient.setQueriesData<ConversationsInfiniteData>({ queryKey }, patchPages);
+      }
+      queryClient.setQueryData<Conversation[]>(PINNED_CONVERSATIONS_KEY, (old) =>
+        old?.map((conversation) =>
+          conversation.id === updated.id
+            ? { ...conversation, labels: updated.labels }
+            : conversation,
+        ),
+      );
+    },
+  });
+}

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -35,6 +35,9 @@ export const PROJECT_LABEL_KEY = "omni_project";
  */
 export const PINNED_LABEL_KEY = "omnigent.pinned";
 
+/** Personal completion timestamp returned for the current viewer. */
+export const COMPLETED_LABEL_KEY = "omnigent.completed";
+
 /** Filter dimensions encoded by a `["conversations", ...]` query key. */
 export interface ConversationListFilters {
   searchQuery: string;

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -45,6 +45,7 @@ const mocks = vi.hoisted(() => {
   };
   return {
     rename: { mutate: vi.fn() },
+    complete: { mutate: vi.fn() },
     isMobile: false,
     // Projects surfaced by the picker + the move-to-project mutation, so the
     // mobile in-place project view test can assert both the list and the pick.
@@ -60,6 +61,10 @@ const mocks = vi.hoisted(() => {
 // flips `mocks.isMobile` for the duration of that case.
 vi.mock("@/hooks/useIsMobileViewport", () => ({
   useIsMobileViewport: () => mocks.isMobile,
+}));
+
+vi.mock("@/hooks/useToggleCompletedConversation", () => ({
+  useToggleCompletedConversation: () => mocks.complete,
 }));
 
 vi.mock("@/hooks/useConversations", () => ({
@@ -218,6 +223,7 @@ function renderSidebar(activeId?: string, info?: ServerInfo) {
 
 beforeEach(() => {
   mocks.rename.mutate.mockReset();
+  mocks.complete.mutate.mockReset();
   mocks.moveToProject.mutate.mockReset();
   mocks.projects = [];
   // Default every test to the desktop viewport; the mobile flyout test opts in.
@@ -233,6 +239,50 @@ beforeEach(() => {
 });
 
 afterEach(cleanup);
+
+describe("completed session actions", () => {
+  it("marks an idle session completed", () => {
+    renderSidebar();
+
+    fireEvent.contextMenu(screen.getByRole("link", { name: /My Session/ }));
+    fireEvent.click(screen.getByTestId("complete-conversation"));
+
+    expect(mocks.complete.mutate).toHaveBeenCalledWith({
+      id: "conv_1",
+      completed: true,
+    });
+  });
+
+  it("marks a completed session active", () => {
+    mockConversations([
+      {
+        ...CONV,
+        labels: { "omnigent.completed": "1721760000000" },
+      },
+    ]);
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Completed" }));
+    fireEvent.contextMenu(screen.getByRole("link", { name: /My Session/ }));
+    const action = screen.getByTestId("complete-conversation");
+    expect(action).toHaveTextContent("Mark active");
+    fireEvent.click(action);
+
+    expect(mocks.complete.mutate).toHaveBeenCalledWith({
+      id: "conv_1",
+      completed: false,
+    });
+  });
+
+  it("disables completion while a session is running", () => {
+    mockConversations([{ ...CONV, status: "running" }]);
+    renderSidebar();
+
+    fireEvent.contextMenu(screen.getByRole("link", { name: /My Session/ }));
+
+    expect(screen.getByTestId("complete-conversation")).toHaveAttribute("data-disabled");
+  });
+});
 
 describe("quick pin/unpin hover button", () => {
   it("keeps the row full-width and the trailing controls inset from the right edge", () => {

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -676,6 +676,51 @@ describe("Sidebar sections", () => {
     expect(screen.getByText("No sessions shared with you")).toBeInTheDocument();
     expect(screen.queryByText("conv_only_mine")).toBeNull();
   });
+
+  it("nests completed ungrouped sessions under Sessions", () => {
+    mockConversations([
+      conv("conv_active", "Claude Code"),
+      conv("conv_done", "Claude Code", {
+        labels: { "omnigent.completed": "1721760000000" },
+      }),
+    ]);
+    renderSidebar();
+
+    expect(screen.getByText("conv_active")).toBeInTheDocument();
+    expect(screen.queryByText("conv_done")).toBeNull();
+    const completed = screen.getByRole("button", { name: "Completed" });
+    expect(completed).toHaveAttribute("aria-expanded", "false");
+    expect(completed.firstElementChild).toHaveClass("lucide-chevron-right");
+    expect(completed.closest("section")?.parentElement).toHaveClass("mt-1");
+
+    fireEvent.click(completed);
+
+    expect(screen.getByText("conv_done")).toHaveClass("opacity-70");
+  });
+
+  it("keeps completed project sessions inside their project", () => {
+    projectsMock.push("Customer X");
+    seedPins(["conv_done"]);
+    mockConversations([
+      conv("conv_done", "Claude Code", {
+        labels: {
+          omni_project: "Customer X",
+          "omnigent.completed": "1721760000000",
+        },
+      }),
+    ]);
+    renderSidebar();
+
+    expect(screen.queryByText("Pinned")).toBeNull();
+    expect(screen.queryByText("conv_done")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /^Customer X/ }));
+    const completed = screen.getByRole("button", { name: "Completed" });
+    expect(completed).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(completed);
+
+    expect(screen.getByText("conv_done")).toBeInTheDocument();
+  });
 });
 
 // The sidebar splits sessions across two tabs: "My sessions" (owned, with the

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -116,6 +116,7 @@ import {
   useStopAndDeleteConversation,
   useStopSession,
 } from "@/hooks/useConversations";
+import { useToggleCompletedConversation } from "@/hooks/useToggleCompletedConversation";
 import { useHosts, type Host } from "@/hooks/useHosts";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -140,6 +141,7 @@ import {
   useUnseenTick,
 } from "@/hooks/useUnseenConversations";
 import { cn } from "@/lib/utils";
+import { COMPLETED_LABEL_KEY } from "@/lib/sessionListCache";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
@@ -178,6 +180,13 @@ const SIDEBAR_HOVER_HIGHLIGHT =
 const SIDEBAR_ACTIVE_HIGHLIGHT =
   "bg-[var(--sidebar-active)] text-[var(--sidebar-active-foreground)]";
 const DROP_TARGET_HIGHLIGHT = SIDEBAR_ACTIVE_HIGHLIGHT;
+
+function sortByCompletedAtDesc(conversations: readonly Conversation[]): Conversation[] {
+  return [...conversations].sort(
+    (a, b) =>
+      Number(b.labels?.[COMPLETED_LABEL_KEY] ?? 0) - Number(a.labels?.[COMPLETED_LABEL_KEY] ?? 0),
+  );
+}
 
 // Maps a first-class project id → its name, provided once at the list level so
 // each row resolves its ``project_id`` to a folder name without its own
@@ -904,6 +913,8 @@ function ProjectFolder({
   onToggleSelected,
   onProjectAssigned,
   projectRenderedIdsRef,
+  completedExpanded,
+  onToggleCompleted,
 }: {
   name: string;
   /** First-class project id, or null for a label-only folder. */
@@ -921,23 +932,35 @@ function ProjectFolder({
   onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
   onProjectAssigned?: (projectName: string) => void;
   projectRenderedIdsRef?: RefObject<Map<string, string[]>>;
+  completedExpanded: boolean;
+  onToggleCompleted: () => void;
 }) {
   const query = useProjectSessions(name, expanded);
   const pinnedSet = useMemo(() => new Set(pinnedConversationIds), [pinnedConversationIds]);
-  const conversations = useMemo(() => {
+  const { conversations, completed } = useMemo(() => {
     const loaded = query.data?.pages.flatMap((page) => page.data) ?? [];
+    const completedRows = sortByCompletedAtDesc(
+      loaded.filter((c) => c.labels?.[COMPLETED_LABEL_KEY] != null),
+    );
     // Pinned sessions live in the global Pinned section, not their folder.
-    return sortByUpdatedAtDesc(
-      loaded.filter((c) => !pinnedSet.has(c.id)),
+    const activeRows = sortByUpdatedAtDesc(
+      loaded.filter((c) => c.labels?.[COMPLETED_LABEL_KEY] == null && !pinnedSet.has(c.id)),
       activeOverride,
     );
+    return { conversations: activeRows, completed: completedRows };
   }, [query.data, pinnedSet, activeOverride]);
 
   // Register this folder's rendered IDs synchronously during render so the
   // shift-select range uses the real per-project data, not the global list.
   const renderedIds = useMemo(
-    () => (expanded ? conversations.map((c) => c.id) : []),
-    [expanded, conversations],
+    () =>
+      expanded
+        ? [
+            ...conversations.map((c) => c.id),
+            ...(completedExpanded ? completed.map((c) => c.id) : []),
+          ]
+        : [],
+    [expanded, conversations, completed, completedExpanded],
   );
   if (projectRenderedIdsRef) {
     projectRenderedIdsRef.current.set(name, renderedIds);
@@ -986,23 +1009,44 @@ function ProjectFolder({
         selectedIds={selectedIds}
         onToggleSelected={onToggleSelected}
         onProjectAssigned={onProjectAssigned}
-        emptyMessage={loadingFirstPage ? undefined : "No sessions"}
+        emptyMessage={loadingFirstPage || completed.length > 0 ? undefined : "No sessions"}
         indentRows
         headerAction={
           <ProjectFolderActions projectName={name} projectId={projectId} onNavigate={onRowClick} />
         }
         footer={
-          loadingFirstPage ? (
-            <p className="px-2 py-1 pl-5 text-muted-foreground text-xs">Loading…</p>
-          ) : (
-            <InfiniteScrollSentinel
-              hasMore={query.hasNextPage}
-              isFetching={query.isFetchingNextPage}
-              fetchMore={query.fetchNextPage}
-              scrollRoot={scrollRoot}
-              indent
-            />
-          )
+          <>
+            {completed.length > 0 && (
+              <div className="mt-1 pl-6">
+                <ConversationSection
+                  title="Completed"
+                  chevronBeforeTitle
+                  marker={projectMarkerState(completed)}
+                  conversations={completed}
+                  pinnedConversationIds={pinnedConversationIds}
+                  collapsed={!completedExpanded}
+                  onToggleCollapsed={onToggleCompleted}
+                  onRowClick={onRowClick}
+                  onTogglePinned={onTogglePinned}
+                  selectionMode={selectionMode}
+                  selectedIds={selectedIds}
+                  onToggleSelected={onToggleSelected}
+                  onProjectAssigned={onProjectAssigned}
+                />
+              </div>
+            )}
+            {loadingFirstPage ? (
+              <p className="px-2 py-1 pl-5 text-muted-foreground text-xs">Loading…</p>
+            ) : (
+              <InfiniteScrollSentinel
+                hasMore={query.hasNextPage}
+                isFetching={query.isFetchingNextPage}
+                fetchMore={query.fetchNextPage}
+                scrollRoot={scrollRoot}
+                indent
+              />
+            )}
+          </>
         }
       />
     </div>
@@ -1155,6 +1199,8 @@ function ConversationList({
       activeTab === "shared"
         ? notArchived.filter((c) => !isOwnedByViewer(c, viewerId))
         : notArchived.filter((c) => isOwnedByViewer(c, viewerId));
+    const completed = tabScoped.filter((c) => c.labels?.[COMPLETED_LABEL_KEY] != null);
+    const active = tabScoped.filter((c) => c.labels?.[COMPLETED_LABEL_KEY] == null);
 
     // Pinned takes precedence over Project: pinning a session moves it OUT of
     // its project into the flat global Pinned section (no nested pins). Ordered
@@ -1163,7 +1209,7 @@ function ConversationList({
     // pinned session holds its slot when a new message bumps its `updated_at`.
     // Pins are ownership-agnostic, so a pinned shared session floats to Pinned
     // on the Shared tab just like an owned one on My sessions.
-    const pinned = orderByPinnedTimestamp(tabScoped.filter((c) => pinnedSet.has(c.id)));
+    const pinned = orderByPinnedTimestamp(active.filter((c) => pinnedSet.has(c.id)));
     const pinnedIdSet = new Set(pinned.map((c) => c.id));
 
     // Projects are a "My sessions"-only tool (filing into a project is
@@ -1172,19 +1218,29 @@ function ConversationList({
     // (it lives under Pinned), so pinning a project's last session leaves the
     // folder showing "No sessions".
     const filedIds = new Set<string>();
-    const projectGroups: { id: string | null; name: string; conversations: Conversation[] }[] =
+    const projectGroups: {
+      id: string | null;
+      name: string;
+      conversations: Conversation[];
+      completed: Conversation[];
+    }[] =
       activeTab === "shared"
         ? []
         : projects.map(({ id, name }) => {
+            const belongsToProject = (conversation: Conversation) =>
+              (id !== null && conversation.project_id === id) ||
+              conversation.labels?.[PROJECT_LABEL_KEY] === name;
             // Dual-read membership: a session belongs to this folder if it has
             // the first-class id OR the legacy omni_project label of this name.
-            const inProject = tabScoped.filter(
-              (c) =>
-                ((id !== null && c.project_id === id) || c.labels?.[PROJECT_LABEL_KEY] === name) &&
-                !pinnedIdSet.has(c.id),
-            );
-            inProject.forEach((c) => filedIds.add(c.id));
-            return { id, name, conversations: sortByUpdatedAtDesc(inProject, activeOverride) };
+            const inProject = active.filter((c) => belongsToProject(c) && !pinnedIdSet.has(c.id));
+            const completedInProject = completed.filter(belongsToProject);
+            [...inProject, ...completedInProject].forEach((c) => filedIds.add(c.id));
+            return {
+              id,
+              name,
+              conversations: sortByUpdatedAtDesc(inProject, activeOverride),
+              completed: sortByCompletedAtDesc(completedInProject),
+            };
           });
     // NOTE: empty projects are intentionally NOT filtered out. A project comes
     // from the server project list (useProjects), so it can have zero *loaded*
@@ -1194,14 +1250,15 @@ function ConversationList({
 
     // Sessions: the remainder of the tab's slice — not pinned, not filed.
     const sessions = sortByUpdatedAtDesc(
-      tabScoped.filter((c) => !pinnedIdSet.has(c.id) && !filedIds.has(c.id)),
+      active.filter((c) => !pinnedIdSet.has(c.id) && !filedIds.has(c.id)),
       activeOverride,
     );
+    const completedSessions = sortByCompletedAtDesc(completed.filter((c) => !filedIds.has(c.id)));
     const archived = sortByUpdatedAtDesc(
       allWithPinned.filter((c) => c.archived === true),
       activeOverride,
     );
-    return { pinned, sessions, archived, projectGroups };
+    return { pinned, sessions, completedSessions, archived, projectGroups };
   }, [
     allConversations,
     pinnedConversations,
@@ -1218,6 +1275,12 @@ function ConversationList({
   const [collapsedSections, setCollapsedSections] = useState<string[]>(
     readCollapsedSidebarSections,
   );
+  const [expandedCompletedSections, setExpandedCompletedSections] = useState<string[]>([]);
+  const toggleCompletedSection = useCallback((scope: string) => {
+    setExpandedCompletedSections((expanded) =>
+      expanded.includes(scope) ? expanded.filter((item) => item !== scope) : [...expanded, scope],
+    );
+  }, []);
   const toggleSectionCollapsed = useCallback((sectionTitle: string) => {
     setCollapsedSections((prev) => {
       const next = prev.includes(sectionTitle)
@@ -1432,16 +1495,27 @@ function ConversationList({
     // expanded AND that individual project folder is expanded (folders are
     // collapsed unless explicitly opened — inverse of the fixed sections).
     const projectsCollapsed = effectiveCollapsedSections.includes("Projects");
-    const projectVisible = (name: string, list: readonly Conversation[]) =>
-      !projectsCollapsed && expandedProjects.includes(name) ? list : [];
+    const projectVisible = (group: (typeof sections.projectGroups)[number]) =>
+      !projectsCollapsed && expandedProjects.includes(group.name)
+        ? [
+            ...group.conversations,
+            ...(expandedCompletedSections.includes(`project:${group.id ?? group.name}`)
+              ? group.completed
+              : []),
+          ]
+        : [];
     // `sections` is already scoped to the active tab, so the same Pinned /
     // Projects / Sessions walk covers both tabs (Projects is empty on shared).
     return [
       ...visible("Pinned", sections.pinned),
-      ...sections.projectGroups.flatMap((g) => projectVisible(g.name, g.conversations)),
+      ...sections.projectGroups.flatMap(projectVisible),
       ...visible("Chats", sections.sessions),
+      ...(effectiveCollapsedSections.includes("Chats") ||
+      !expandedCompletedSections.includes("sessions")
+        ? []
+        : sections.completedSessions),
     ].map((c) => c.id);
-  }, [sections, effectiveCollapsedSections, expandedProjects]);
+  }, [sections, effectiveCollapsedSections, expandedProjects, expandedCompletedSections]);
   useEffect(() => {
     onVisibleCountChange(orderedConversationIds.length);
   }, [orderedConversationIds.length, onVisibleCountChange]);
@@ -1449,12 +1523,23 @@ function ConversationList({
     const visible = (title: string, list: readonly Conversation[]) =>
       effectiveCollapsedSections.includes(title) ? [] : [...list];
     const projectsCollapsed = effectiveCollapsedSections.includes("Projects");
-    const projectVisible = (name: string, list: readonly Conversation[]) =>
-      !projectsCollapsed && expandedProjects.includes(name) ? [...list] : [];
+    const projectVisible = (group: (typeof sections.projectGroups)[number]) =>
+      !projectsCollapsed && expandedProjects.includes(group.name)
+        ? [
+            ...group.conversations,
+            ...(expandedCompletedSections.includes(`project:${group.id ?? group.name}`)
+              ? group.completed
+              : []),
+          ]
+        : [];
     return [
       ...visible("Pinned", sections.pinned),
-      ...sections.projectGroups.flatMap((g) => projectVisible(g.name, g.conversations)),
+      ...sections.projectGroups.flatMap(projectVisible),
       ...visible("Chats", sections.sessions),
+      ...(effectiveCollapsedSections.includes("Chats") ||
+      !expandedCompletedSections.includes("sessions")
+        ? []
+        : sections.completedSessions),
     ];
   };
   // Getter that builds the shift-select visible order on demand (at click
@@ -1472,6 +1557,10 @@ function ConversationList({
         ? []
         : sections.projectGroups.flatMap((g) => projectRenderedIdsRef.current.get(g.name) ?? [])),
       ...vis("Chats", sections.sessions),
+      ...(effectiveCollapsedSections.includes("Chats") ||
+      !expandedCompletedSections.includes("sessions")
+        ? []
+        : sections.completedSessions.map((c) => c.id)),
     ];
   };
   useSessionSwitchHotkey(orderedConversationIds, activeId);
@@ -1518,8 +1607,9 @@ function ConversationList({
   const totalVisible =
     sections.pinned.length +
     sections.sessions.length +
+    sections.completedSessions.length +
     sections.projectGroups.length +
-    sections.projectGroups.reduce((sum, g) => sum + g.conversations.length, 0);
+    sections.projectGroups.reduce((sum, g) => sum + g.conversations.length + g.completed.length, 0);
 
   // Section structure comes from the muted micro-headers + whitespace
   // alone (Linear-style) — no icons or counts in the headers, no divider
@@ -1542,9 +1632,10 @@ function ConversationList({
             ungroup target (wrapped below). This top strip is only a FALLBACK
             for when there are no ungrouped chats yet, so the Chats section
             isn't rendered and there'd otherwise be nowhere to drop. */}
-          {!showShared && activeDrag?.project != null && sections.sessions.length === 0 && (
-            <UngroupDropZone />
-          )}
+          {!showShared &&
+            activeDrag?.project != null &&
+            sections.sessions.length === 0 &&
+            sections.completedSessions.length === 0 && <UngroupDropZone />}
           {totalVisible === 0 ? (
             <>
               <p className="px-2 py-1 text-muted-foreground text-xs">{emptyMessage}</p>
@@ -1665,7 +1756,7 @@ function ConversationList({
                       expanded={expandedProjects.includes(group.name)}
                       // Best-effort marker from the globally-loaded window: a
                       // collapsed folder hasn't fetched its own sessions yet.
-                      marker={projectMarkerState(group.conversations)}
+                      marker={projectMarkerState([...group.conversations, ...group.completed])}
                       onToggleCollapsed={() => toggleProjectExpanded(group.name)}
                       pinnedConversationIds={pinnedConversationIds}
                       activeOverride={activeOverride}
@@ -1677,6 +1768,12 @@ function ConversationList({
                       onToggleSelected={onToggleSelected}
                       onProjectAssigned={expandProject}
                       projectRenderedIdsRef={projectRenderedIdsRef}
+                      completedExpanded={expandedCompletedSections.includes(
+                        `project:${group.id ?? group.name}`,
+                      )}
+                      onToggleCompleted={() =>
+                        toggleCompletedSection(`project:${group.id ?? group.name}`)
+                      }
                     />
                   ))}
                   {sections.projectGroups.length === 0 &&
@@ -1687,7 +1784,7 @@ function ConversationList({
                     )}
                 </SectionGroup>
               )}
-              {sections.sessions.length > 0 && (
+              {(sections.sessions.length > 0 || sections.completedSessions.length > 0) && (
                 // Drop a session here to send it to the flat "Chats" list — where
                 // unfiled, unpinned sessions live. Active while dragging a filed
                 // session (removes it from its project) or a pinned one (unpins
@@ -1707,6 +1804,27 @@ function ConversationList({
                     selectedIds={selectedIds}
                     onToggleSelected={onToggleSelected}
                     onProjectAssigned={expandProject}
+                    footer={
+                      sections.completedSessions.length > 0 ? (
+                        <div className="mt-1 pl-4">
+                          <ConversationSection
+                            title="Completed"
+                            chevronBeforeTitle
+                            marker={projectMarkerState(sections.completedSessions)}
+                            conversations={sections.completedSessions}
+                            pinnedConversationIds={pinnedConversationIds}
+                            collapsed={!expandedCompletedSections.includes("sessions")}
+                            onToggleCollapsed={() => toggleCompletedSection("sessions")}
+                            onRowClick={onRowClick}
+                            onTogglePinned={onTogglePinned}
+                            selectionMode={selectionMode}
+                            selectedIds={selectedIds}
+                            onToggleSelected={onToggleSelected}
+                            onProjectAssigned={expandProject}
+                          />
+                        </div>
+                      ) : undefined
+                    }
                     headerAction={
                       !selectionMode ? (
                         <Tooltip>
@@ -1872,6 +1990,7 @@ function projectMarkerState(conversations: Conversation[]): SessionState | null 
 function SectionHeader({
   title,
   icon,
+  chevronBeforeTitle,
   marker,
   hasAction,
   collapsed,
@@ -1879,6 +1998,7 @@ function SectionHeader({
 }: {
   title: string;
   icon?: ReactNode;
+  chevronBeforeTitle?: boolean;
   marker?: SessionState | null;
   /** Whether the section also renders a hover-revealed header action (the
       project-folder kebab), which shares the header's right edge with the
@@ -1920,19 +2040,26 @@ function SectionHeader({
             />
           </span>
         ) : null}
+        {chevronBeforeTitle && (
+          <ChevronRightIcon
+            className={cn("size-3.5 shrink-0 transition-transform", !collapsed && "rotate-90")}
+          />
+        )}
         <span className="min-w-0 truncate">{title}</span>
         {/* Trailing chevron, rotating on expand. Headers without a leading icon
             reveal it on desktop hover/focus; icon headers show it only on mobile
             (no hover) since desktop swaps the folder for the chevron above. */}
-        <ChevronRightIcon
-          className={cn(
-            "size-3.5 shrink-0 transition-[transform,opacity]",
-            !collapsed && "rotate-90",
-            icon
-              ? "md:hidden"
-              : "md:opacity-0 md:group-hover:opacity-100 md:group-focus-visible:opacity-100",
-          )}
-        />
+        {!chevronBeforeTitle && (
+          <ChevronRightIcon
+            className={cn(
+              "size-3.5 shrink-0 transition-[transform,opacity]",
+              !collapsed && "rotate-90",
+              icon
+                ? "md:hidden"
+                : "md:opacity-0 md:group-hover:opacity-100 md:group-focus-visible:opacity-100",
+            )}
+          />
+        )}
         {/* A hidden row inside this collapsed section carries a marker — surface
             the exact same badge a row would show, pinned to the right edge. */}
         {collapsed && marker && (
@@ -2003,6 +2130,7 @@ function SectionGroup({
 function ConversationSection({
   title,
   icon,
+  chevronBeforeTitle,
   marker,
   conversations,
   pinnedConversationIds,
@@ -2022,6 +2150,8 @@ function ConversationSection({
   title?: string;
   /** Optional icon rendered before the title (e.g. project folder icon). */
   icon?: ReactNode;
+  /** Keep the disclosure chevron before the title instead of trailing it. */
+  chevronBeforeTitle?: boolean;
   /** When collapsed, the aggregate marker of hidden rows (same badge as a row). */
   marker?: SessionState | null;
   conversations: Conversation[];
@@ -2060,6 +2190,7 @@ function ConversationSection({
           <SectionHeader
             title={title}
             icon={icon}
+            chevronBeforeTitle={chevronBeforeTitle}
             marker={marker}
             hasAction={headerAction != null}
             collapsed={isCollapsed}
@@ -2163,13 +2294,16 @@ function ConversationMenuItems({
   conversation,
   isPinned,
   isArchived,
+  isCompleted,
   isOwner,
   sharingOff,
   isSingleUser,
   canStop,
   canMarkUnread,
+  canComplete,
   currentProject,
   onTogglePinned,
+  onToggleCompleted,
   onMarkUnread,
   onProjectAssigned,
   moveToProject,
@@ -2185,6 +2319,7 @@ function ConversationMenuItems({
   conversation: Conversation;
   isPinned: boolean;
   isArchived: boolean;
+  isCompleted: boolean;
   isOwner: boolean;
   // Server-wide sharing kill switch (OMNIGENT_SHARING_MODE=off): disables the
   // Share item for everyone, independent of the per-user ownership check.
@@ -2196,8 +2331,10 @@ function ConversationMenuItems({
   // Whether "Mark as unread" applies: any row not already showing the
   // unread dot (the active thread and running sessions included).
   canMarkUnread: boolean;
+  canComplete: boolean;
   currentProject: string | null;
   onTogglePinned: (conversationId: string) => void;
+  onToggleCompleted: () => void;
   onMarkUnread: () => void;
   onProjectAssigned?: (projectName: string) => void;
   moveToProject: ReturnType<typeof useMoveToProject>;
@@ -2271,7 +2408,7 @@ function ConversationMenuItems({
       {/* Pin/Unpin — mobile-only (md:hidden); desktop uses the
           hover-revealed quick-pin button. Archived rows omit it (archive
           outranks pin). */}
-      {!isArchived && (
+      {!isArchived && !isCompleted && (
         <C.Item
           data-testid="pin-conversation"
           className="md:hidden"
@@ -2342,6 +2479,31 @@ function ConversationMenuItems({
           <MailIcon className="size-3.5" />
           Mark as unread
         </C.Item>
+      )}
+      {isCompleted ? (
+        <C.Item data-testid="complete-conversation" onSelect={onToggleCompleted}>
+          <SquareIcon className="size-3.5" />
+          Mark active
+        </C.Item>
+      ) : canComplete ? (
+        <C.Item data-testid="complete-conversation" onSelect={onToggleCompleted}>
+          <SquareCheckIcon className="size-3.5" />
+          Mark as completed
+        </C.Item>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div>
+              <C.Item data-testid="complete-conversation" disabled>
+                <SquareCheckIcon className="size-3.5" />
+                Mark as completed
+              </C.Item>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            Wait for the session and pending approvals to finish
+          </TooltipContent>
+        </Tooltip>
       )}
       {/* Projects are a My-sessions-only tool, so filing is owner-only — a
           shared session shows no project affordance. */}
@@ -2584,6 +2746,7 @@ function ConversationRow({
   const rename = useRenameConversation();
   const del = useStopAndDeleteConversation();
   const archive = useArchiveConversation();
+  const complete = useToggleCompletedConversation();
   const moveToProject = useMoveToProject();
   // Archive stops the runner first (resource hygiene): a hidden session
   // shouldn't keep a runner alive. This is NOT the user-facing Stop action
@@ -2595,6 +2758,7 @@ function ConversationRow({
   // instance so its pending/error state can't bleed into archiving's.
   const stopSession = useStopSession();
   const isArchived = conversation.archived === true;
+  const isCompleted = conversation.labels?.[COMPLETED_LABEL_KEY] != null;
   const [isEditing, setIsEditing] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [stopOpen, setStopOpen] = useState(false);
@@ -2633,6 +2797,8 @@ function ConversationRow({
       hostId: conversation.host_id,
       runnerId: conversation.runner_id,
     }) && runnerOnline !== false;
+  const canComplete =
+    conversation.status !== "running" && (conversation.pending_elicitations_count ?? 0) === 0;
 
   // The session's current project NAME, or null when unfiled — drives the
   // kebab submenu label ("Add to project" vs "Move session") and the pinned
@@ -2651,7 +2817,7 @@ function ConversationRow({
   // and leave it overlaying the chat after navigation. Forcing null there
   // routes the row through the plain ContextMenu/link path and restores the
   // native `title` tooltip.
-  const projectFlyoutName = !isMobile && isPinned ? currentProject : null;
+  const projectFlyoutName = !isMobile && isPinned && !isCompleted ? currentProject : null;
 
   const label = conversationDisplayLabel(conversation);
   // Recompute unseen state the moment the last-seen map changes (e.g. the
@@ -2695,7 +2861,7 @@ function ConversationRow({
   } = useDraggable({
     id: conversation.id,
     data: { type: "session", label, project: currentProject, isPinned },
-    disabled: !isOwner || selectionMode || isArchived || isEditing,
+    disabled: !isOwner || selectionMode || isArchived || isCompleted || isEditing,
   });
   // A drag ends with a synthetic click on the row's <Link> (mousedown + mouseup
   // on the same anchor still fires a click); swallow that one click so a drag
@@ -2827,6 +2993,10 @@ function ConversationRow({
     });
   }
 
+  function runToggleCompleted() {
+    complete.mutate({ id: conversation.id, completed: !isCompleted });
+  }
+
   // Shared by the kebab dropdown and the right-click context menu so the two
   // menus render identical items. `setMenuOpen` is supplied per-call (the
   // controlled kebab passes the real setter; the uncontrolled context menu a
@@ -2835,13 +3005,16 @@ function ConversationRow({
     conversation,
     isPinned,
     isArchived,
+    isCompleted,
     isOwner,
     sharingOff,
     isSingleUser,
     canStop,
     canMarkUnread,
+    canComplete,
     currentProject,
     onTogglePinned,
+    onToggleCompleted: runToggleCompleted,
     onMarkUnread: () => markConversationUnread(conversation.id, conversation.updated_at),
     onProjectAssigned,
     moveToProject,
@@ -2903,7 +3076,14 @@ function ConversationRow({
           here. Leading icons (agent type, pin, shared) were removed to keep
           rows text-clean; pinned rows still group under "Pinned". */}
       <div className="flex w-full items-center gap-1.5">
-        <span className="relative min-w-0 truncate">
+        <span
+          className={cn(
+            "relative min-w-0 truncate",
+            isCompleted &&
+              "opacity-70 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100",
+            isActive && "opacity-100",
+          )}
+        >
           {label}
           {hasUnseenMessages && <span className="sr-only"> (unread)</span>}
         </span>
@@ -3019,7 +3199,7 @@ function ConversationRow({
         <div className="-translate-y-1/2 absolute top-1/2 right-1 flex items-center gap-0.5">
           {/* Archived rows omit the pin entirely: pinning is meaningless there
               (archive outranks pin), so there's no pin action even on hover. */}
-          {!isArchived && (
+          {!isArchived && !isCompleted && (
             <Button
               type="button"
               variant="ghost"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a per-user completed state that can be toggled from a session's menu and is cleared when new user input is accepted.
- Idea is to mark clearly which sessions are completed so that the user doesn't have to think about them anymore
- Keep completed sessions in their existing project or Sessions parent, grouped under a collapsed `Completed` disclosure with muted titles.
- Preserve project and pin membership while completed, and restore the normal grouping when marked active.

ELI5: completing a session moves it into a small drawer inside its current folder instead of sending it to a separate global list.

```mermaid
flowchart LR
    A[Active session] -->|Mark as completed| C[Completed group in the same parent]
    C -->|Mark active| A
```

## Test Plan

- `pre-commit run`
- `node web/node_modules/vitest/vitest.mjs run --root web src/hooks/useToggleCompletedConversation.test.tsx src/shell/Sidebar.test.tsx src/shell/Sidebar.rowActions.test.tsx` — 91 passed
- `python -m pytest` for the eight focused completion, label-isolation, websocket, input-policy, and store cases — 8 passed
- `node web/node_modules/typescript/bin/tsc -b web/tsconfig.json`
- Manually verified marking sessions completed and active in both project and ungrouped sidebar sections.

## Demo

Screenshots will be added by @anthonyivn2 before this draft is marked ready for review.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the collapsed and expanded `Completed` groups, their spacing and chevrons, muted completed-session titles, and restoring a session with `Mark active`.

## Changelog

Completed sessions can now be tucked into collapsible groups within their existing project or Sessions section.
