### PR TITLE
Fix Kimi harness login detection and remove broken logout

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -2383,29 +2383,30 @@ def _print_kimi_auth_help() -> None:
 def _manage_kimi_harness() -> None:
     """Run the level-2 loop for Kimi Code: install the CLI and drive ``kimi login``.
 
-    Unlike Qwen (which has no ``login`` subcommand), Kimi ships a real
-    ``kimi login`` (Moonshot OAuth or API key) and ``kimi logout``, so this
-    drill-in offers sign-in / sign-out directly. Kimi has no first-class
-    "am I logged in?" probe (its install spec sets ``status_args=None``), so
+    Kimi ships a real ``kimi login`` (Moonshot OAuth or API key), so this
+    drill-in offers sign-in directly. It has **no** ``kimi logout`` subcommand
+    (verified against kimi CLI v0.29.1), so there is no sign-out row — the user
+    clears credentials by removing kimi's own credential file. Kimi has no
+    first-class "am I logged in?" exit-code probe (its install spec sets
+    ``status_args=None``), so
     :func:`~omnigent.onboarding.harness_install.harness_cli_logged_in` always
     reports ``False`` for it — meaning ``harness_login`` runs ``kimi login``
     every time it is asked (the interactive flow lets the user cancel if
     already authenticated) and its boolean return is not a reliable success
-    signal. We therefore treat login / logout as best-effort side effects and
-    report that the flow finished rather than asserting an auth state.
+    signal. We therefore treat login as a best-effort side effect and report
+    that the flow finished rather than asserting an auth state.
 
     Like the other CLI-backed harnesses, a missing CLI gates the drill-in —
     there is nothing to configure for a harness you can't run.
 
     :returns: None. Side effects: may install the kimi CLI and run
-        ``kimi login`` / ``kimi logout`` in the foreground.
+        ``kimi login`` in the foreground.
     """
     from omnigent.onboarding.harness_install import (
         KIMI_KEY,
         harness_cli_installed,
         harness_install_spec,
         harness_login,
-        harness_logout,
     )
     from omnigent.onboarding.interactive import console, select
 
@@ -2428,7 +2429,6 @@ def _manage_kimi_harness() -> None:
     while True:
         rows: list[_HarnessMenuRow] = [
             _HarnessMenuRow("Sign in (kimi login)", action="login"),
-            _HarnessMenuRow("Sign out (kimi logout)", action="logout"),
             _HarnessMenuRow("Show auth options", action="help"),
             _HarnessMenuRow("← Back", action="back"),
         ]
@@ -2450,10 +2450,6 @@ def _manage_kimi_harness() -> None:
             console.print("  [dim]Signing in to Kimi (its login will open)…[/dim]")
             harness_login(KIMI_KEY)
             status = "kimi login flow finished — kimi stores its own credentials"
-        elif action == "logout":
-            console.print("  [dim]Signing out of Kimi…[/dim]")
-            harness_logout(KIMI_KEY)
-            status = "kimi logout flow finished"
         elif action == "help":
             _print_kimi_auth_help()
             status = None
@@ -3537,13 +3533,20 @@ def _run_configure_harnesses_interactive() -> None:
             )
             rows.append((_KIRO, "Kiro", "Not installed", "missing", _install_hint(kiro_hint)))
 
-        # Kimi Code — native CLI, own auth via `kimi login`; there is no local
-        # login status probe yet. Curl-installed (no npm package), so use its
-        # install_hint when absent and show "not configured" when present.
+        # Kimi Code — native CLI, own auth via `kimi login`. There is no CLI
+        # login-status probe, but `kimi login` writes a credential file, so a
+        # subprocess-free file check (`kimi_login_detected`) distinguishes
+        # "signed in" (green) from "installed but not configured" (yellow).
+        # Curl-installed (no npm package), so use its install_hint when absent.
         if harness_cli_installed(KIMI_KEY):
-            rows.append(
-                (_KIMI, "Kimi Code", "Not configured", "warn", "Sign in with `kimi login`.")
-            )
+            from omnigent.onboarding.kimi_auth import kimi_login_detected
+
+            if kimi_login_detected():
+                rows.append((_KIMI, "Kimi Code", "Signed in", "ready", ""))
+            else:
+                rows.append(
+                    (_KIMI, "Kimi Code", "Not configured", "warn", "Sign in with `kimi login`.")
+                )
         else:
             kimi_spec = harness_install_spec(KIMI_KEY)
             kimi_hint = (kimi_spec.install_hint if kimi_spec else None) or "see Kimi Code docs"

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -151,15 +151,17 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
     # npm). ``kimi login`` is the interactive provider login (OAuth or a
     # Moonshot API key). ``status_args`` is intentionally ``None``: kimi has
     # no first-class "am I logged in?" exit-code probe — login state is
-    # only inspected interactively. With ``None`` the login path runs every
-    # time the operator asks for it (interactive, so they can cancel if
-    # already authenticated).
+    # inspected file-based via ``kimi_auth.kimi_login_detected`` instead. With
+    # ``None`` the login path runs every time the operator asks for it
+    # (interactive, so they can cancel if already authenticated).
+    # ``logout_args`` is ``None`` because kimi has no ``kimi logout`` subcommand
+    # (verified against kimi CLI v0.29.1 — ``kimi logout`` errors "unknown
+    # command"), so ``harness_logout`` is a no-op for it (same as Qwen / agy).
     KIMI_KEY: HarnessInstallSpec(
         "Kimi",
         "kimi",
         package=None,
         login_args=("login",),
-        logout_args=("logout",),
         install_hint="curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
     ),
     KIRO_KEY: HarnessInstallSpec(

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -29,6 +29,7 @@ import os
 from collections.abc import Callable
 
 import omnigent.onboarding.gemini_auth as _gemini_auth
+import omnigent.onboarding.kimi_auth as _kimi_auth
 from omnigent._platform import resolve_cli_binary
 from omnigent.harness_aliases import HARNESS_ALIASES, canonicalize_harness
 from omnigent.harness_availability import (
@@ -74,16 +75,20 @@ _SDK_HARNESSES: frozenset[str] = frozenset(
     {"claude-sdk", "openai-agents", "openai-agents-sdk", "antigravity"}
 )
 
-# Families whose CLIs authenticate via file-based credentials rather than a CLI
-# login command. For these, ``harness_is_configured`` checks BOTH the binary
-# (via ``harness_cli_installed``) AND the credential (via the callable here).
-# The ``anthropic`` / ``openai`` families authenticate via subscription provider
-# config and do not appear here. The lambda resolves through the module at call
-# time so a test can monkeypatch
-# ``omnigent.onboarding.gemini_auth.gemini_login_detected`` and have the patch
-# take effect without this dict caching the old function object.
+# Families/harnesses whose CLIs authenticate via file-based credentials rather
+# than a CLI login-status command. For these, ``harness_is_configured`` checks
+# BOTH the binary (via ``harness_cli_installed``) AND the credential (via the
+# callable here). ``agy`` writes an OAuth token on its first interactive run;
+# ``kimi login`` writes ``~/.kimi-code/credentials/kimi-code.json`` (kimi has no
+# login-status probe). The ``anthropic`` / ``openai`` families authenticate via
+# subscription provider config and do not appear here. Each lambda resolves
+# through its module at call time so a test can monkeypatch
+# ``…gemini_auth.gemini_login_detected`` / ``…kimi_auth.kimi_login_detected``
+# and have the patch take effect without this dict caching the old function
+# object.
 _FAMILY_CREDENTIAL_CHECK: dict[str, Callable[[], bool]] = {
     GEMINI_FAMILY: lambda: _gemini_auth.gemini_login_detected(),
+    KIMI_KEY: lambda: _kimi_auth.kimi_login_detected(),
 }
 
 # CLI-wrapping pi harnesses. Both the bare ``pi`` surface and the native

--- a/omnigent/onboarding/kimi_auth.py
+++ b/omnigent/onboarding/kimi_auth.py
@@ -1,0 +1,53 @@
+"""Detect a Kimi Code (``kimi``) login for the ``kimi`` harness.
+
+The ``kimi`` CLI authenticates against Moonshot AI's backend via ``kimi login``
+(an interactive OAuth flow or a Moonshot API key). It has **no** ``kimi logout``
+subcommand and no first-class "am I logged in?" exit-code probe, so login state
+can only be inspected from the credential file the login flow writes (verified
+live against kimi CLI v0.29.1):
+
+- ``kimi login`` writes ``~/.kimi-code/credentials/kimi-code.json`` — the file is
+  present exactly when a login has completed and absent (or empty) otherwise.
+
+Detection is file-based and subprocess-free: a non-empty credential file counts
+as a completed login. Like
+:func:`omnigent.onboarding.gemini_auth.gemini_login_detected`, it cannot detect
+server-side revocation — its only job is to reject the "no-credential /
+file-empty" case so the readiness layer can distinguish a signed-in kimi from an
+installed-but-unconfigured one without spawning a subprocess.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Where ``kimi login`` writes its credential after a completed sign-in
+# (verified against kimi CLI v0.29.1). Present and non-empty exactly when the
+# user is logged in.
+KIMI_CREDENTIALS_PATH: Path = (
+    Path(os.path.expanduser("~")) / ".kimi-code" / "credentials" / "kimi-code.json"
+)
+
+
+def kimi_login_detected(creds_path: Path | None = None) -> bool:
+    """Return whether ``kimi`` has a completed login on this machine.
+
+    Subprocess-free file check: ``kimi login`` writes its credential to
+    :data:`KIMI_CREDENTIALS_PATH`, so a present, non-empty file is treated as a
+    completed sign-in. This cannot detect server-side revocation — it only
+    rejects the "no-credential / file-empty" case. Used by the readiness layer
+    to distinguish a signed-in kimi from an installed-but-unconfigured one.
+
+    :param creds_path: A specific credential file to check; ``None`` uses
+        :data:`KIMI_CREDENTIALS_PATH`.
+    :returns: ``True`` when the credential file exists and is non-empty;
+        ``False`` when it is missing, empty, or unreadable.
+    """
+    path = creds_path if creds_path is not None else KIMI_CREDENTIALS_PATH
+    try:
+        return path.is_file() and path.stat().st_size > 0
+    except OSError:
+        # A stat/permission error on the credential path is treated as "no
+        # usable credential" rather than crashing the readiness refresh.
+        return False

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -5909,7 +5909,7 @@ def test_manage_kimi_harness_not_installed_shows_hint_returns(
 
     Kimi is curl-installed (no npm ``package``), so the drill-in can't
     auto-install it — it must surface the install_hint and bail without
-    touching login / logout.
+    touching login.
     """
     import omnigent.onboarding.harness_install as hi
     import omnigent.onboarding.interactive as it
@@ -5918,16 +5918,13 @@ def test_manage_kimi_harness_not_installed_shows_hint_returns(
     console = Mock()
     monkeypatch.setattr(it, "console", console)
     login = Mock()
-    logout = Mock()
     monkeypatch.setattr(hi, "harness_login", login)
-    monkeypatch.setattr(hi, "harness_logout", logout)
     # If the drill-in wrongly reached the menu loop, this select would drive it.
     monkeypatch.setattr(it, "select", lambda *a, **k: 0)
 
     _manage_kimi_harness()
 
     login.assert_not_called()
-    logout.assert_not_called()
     # The curl install command was surfaced to the user.
     printed = " ".join(str(c.args[0]) for c in console.print.call_args_list if c.args)
     assert "code.kimi.com/kimi-code/install.sh" in printed
@@ -5943,16 +5940,44 @@ def test_manage_kimi_harness_back_does_not_login(
     monkeypatch.setattr(hi, "harness_cli_installed", lambda key: True)
     monkeypatch.setattr(it, "console", Mock())
     login = Mock()
-    logout = Mock()
     monkeypatch.setattr(hi, "harness_login", login)
-    monkeypatch.setattr(hi, "harness_logout", logout)
-    # rows = [Sign in, Sign out, Show auth options, ← Back]; pick Back (3).
-    monkeypatch.setattr(it, "select", lambda *a, **k: 3)
+    # rows = [Sign in, Show auth options, ← Back]; pick Back (2). There is no
+    # "Sign out" row — kimi has no ``kimi logout`` subcommand.
+    monkeypatch.setattr(it, "select", lambda *a, **k: 2)
 
     _manage_kimi_harness()
 
     login.assert_not_called()
-    logout.assert_not_called()
+
+
+def test_manage_kimi_harness_has_no_sign_out_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Kimi drill-in offers no sign-out — kimi has no ``kimi logout``.
+
+    Capture the menu labels passed to ``select`` and assert none mention a
+    logout/sign-out action, so a regression re-adding the broken row is caught.
+    """
+    import omnigent.onboarding.harness_install as hi
+    import omnigent.onboarding.interactive as it
+
+    monkeypatch.setattr(hi, "harness_cli_installed", lambda key: True)
+    monkeypatch.setattr(it, "console", Mock())
+    monkeypatch.setattr(hi, "harness_login", Mock())
+    captured: list[str] = []
+
+    def _select(_title: str, labels: list[str], *a, **k) -> int:
+        captured.extend(labels)
+        return len(labels) - 1  # pick "← Back" to exit
+
+    monkeypatch.setattr(it, "select", _select)
+
+    _manage_kimi_harness()
+
+    joined = " ".join(captured).lower()
+    assert "sign out" not in joined
+    assert "logout" not in joined
+    assert any("sign in" in label.lower() for label in captured)
 
 
 def test_manage_kimi_harness_login_runs_kimi_login(
@@ -5965,14 +5990,11 @@ def test_manage_kimi_harness_login_runs_kimi_login(
     monkeypatch.setattr(hi, "harness_cli_installed", lambda key: True)
     monkeypatch.setattr(it, "console", Mock())
     login = Mock(return_value=False)  # kimi has no status probe; return is ignored
-    logout = Mock()
     monkeypatch.setattr(hi, "harness_login", login)
-    monkeypatch.setattr(hi, "harness_logout", logout)
-    # First iteration: Sign in (0); second: ← Back (3) to exit the loop.
-    choices = iter([0, 3])
+    # First iteration: Sign in (0); second: ← Back (2) to exit the loop.
+    choices = iter([0, 2])
     monkeypatch.setattr(it, "select", lambda *a, **k: next(choices))
 
     _manage_kimi_harness()
 
     login.assert_called_once_with(hi.KIMI_KEY)
-    logout.assert_not_called()

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1973,11 +1973,17 @@ def test_installed_native_cli_auth_unknown_rows_are_not_configured(
     not a green ``Installed`` row that implies the harness is ready to use.
     (Hermes, like Goose, *does* have a config probe now — its ``model`` is read
     from ``~/.hermes/config.yaml`` — so its ready/unconfigured split is covered
-    by ``test_overview_hermes_row_reflects_configured_model`` instead.)
+    by ``test_overview_hermes_row_reflects_configured_model`` instead. Kimi now
+    has a file-based login probe too, so its signed-in split is covered by
+    ``test_overview_kimi_row_reflects_detected_login`` — here we pin the
+    not-signed-in case, so ``kimi_login_detected`` is forced ``False``.)
     """
     monkeypatch.setattr(
         "omnigent.onboarding.harness_install.harness_cli_installed", lambda family: True
     )
+    # Kimi's row now consults a file-based login probe; force "no login" so the
+    # not-configured assertion is deterministic regardless of the dev machine.
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_login_detected", lambda: False)
     options, selectable, descriptions, _compact, _max_visible = _capture_setup_overview(
         monkeypatch
     )
@@ -1985,6 +1991,28 @@ def test_installed_native_cli_auth_unknown_rows_are_not_configured(
     assert "[yellow]✗ Not configured[/]" in options[row_index]
     assert "[green]✓ Installed[/]" not in options[row_index]
     assert descriptions[row_index]
+
+
+def test_overview_kimi_row_reflects_detected_login(isolated_config, monkeypatch) -> None:
+    """An installed kimi with a detected ``kimi login`` renders green "Signed in".
+
+    Bug fix: the kimi row was hardcoded to yellow "Not configured" whenever the
+    CLI was installed, so a successful ``kimi login`` never showed. It now
+    consults the subprocess-free file probe ``kimi_login_detected`` and renders
+    a green ready row when a credential is present.
+    """
+    monkeypatch.setattr(
+        "omnigent.onboarding.harness_install.harness_cli_installed", lambda family: True
+    )
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_login_detected", lambda: True)
+    options, selectable, descriptions, _compact, _max_visible = _capture_setup_overview(
+        monkeypatch
+    )
+    row_index = _overview_row_names(options, selectable).index("Kimi Code")
+    assert "[green]✓ Signed in[/]" in options[row_index]
+    assert "[yellow]✗ Not configured[/]" not in options[row_index]
+    # A ready row carries no next-step hint.
+    assert descriptions[row_index] == ""
 
 
 def test_overview_descriptions_map_to_their_rows(isolated_config, monkeypatch) -> None:
@@ -2007,6 +2035,9 @@ def test_overview_descriptions_map_to_their_rows(isolated_config, monkeypatch) -
         "omnigent.onboarding.antigravity_auth.antigravity_sdk_installed", lambda: True
     )
     monkeypatch.setattr("omnigent.onboarding.copilot_auth.copilot_sdk_installed", lambda: True)
+    # Kimi's row consults a file-based login probe; force "no login" so the
+    # "Sign in with `kimi login`" hint is asserted deterministically.
+    monkeypatch.setattr("omnigent.onboarding.kimi_auth.kimi_login_detected", lambda: False)
     monkeypatch.setattr(
         "omnigent.onboarding.opencode_auth.opencode_auth_summary",
         lambda: OpenCodeAuthSummary(installed=True, stored_providers=(), env_providers=()),

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -54,7 +54,9 @@ def test_kimi_install_spec_is_login_only_no_npm() -> None:
     """Kimi ships via a curl installer (no npm package) and authenticates
     through its own ``kimi login`` (OAuth or Moonshot API key), so it carries
     an ``install_hint`` instead of a ``package`` and intentionally has no
-    ``status_args`` (no exit-code "am I logged in?" probe to read).
+    ``status_args`` (no exit-code "am I logged in?" probe to read). It has no
+    ``kimi logout`` subcommand (verified against kimi CLI v0.29.1), so
+    ``logout_args`` is ``None`` and ``harness_logout`` is a no-op for it.
     """
     spec = hi.harness_install_spec(hi.KIMI_KEY)
     assert spec is not None
@@ -62,7 +64,7 @@ def test_kimi_install_spec_is_login_only_no_npm() -> None:
     assert spec.package is None
     assert spec.install_hint is not None and "code.kimi.com" in spec.install_hint
     assert spec.login_args == ("login",)
-    assert spec.logout_args == ("logout",)
+    assert spec.logout_args is None
     assert spec.status_args is None
 
 

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -390,10 +390,12 @@ def test_configured_harness_map_all_true_with_clis(
     The CLI harnesses pass their binary check, the SDK harnesses are ungated,
     cursor (key-gated) is satisfied by a ``CURSOR_API_KEY``, copilot
     (token-gated) by a ``GH_TOKEN``, antigravity-native (binary + credential
-    gated) by a detected Gemini OAuth credential, and the generic ACP harness
+    gated) by a detected Gemini OAuth credential, kimi (binary + credential
+    gated) by a detected ``kimi login`` credential, and the generic ACP harness
     (config-gated) by a registered agent — so nothing is reported unconfigured.
     """
     import omnigent.onboarding.gemini_auth as _ga
+    import omnigent.onboarding.kimi_auth as _ka
 
     _all_clis_installed(monkeypatch)
     monkeypatch.setattr(
@@ -403,6 +405,8 @@ def test_configured_harness_map_all_true_with_clis(
     monkeypatch.setenv("CURSOR_API_KEY", "crsr_ready")
     # antigravity-native also needs a credential (not just the ``agy`` binary).
     monkeypatch.setattr(_ga, "gemini_login_detected", lambda: True)
+    # kimi also needs a credential (not just the ``kimi`` binary).
+    monkeypatch.setattr(_ka, "kimi_login_detected", lambda: True)
     monkeypatch.setenv("GH_TOKEN", "gho_ready")
     # claude / pi are auth-aware on the credential axis now: satisfy the provider
     # check deterministically (don't depend on the dev machine's real config).
@@ -440,21 +444,33 @@ def test_configured_harness_map_probes_codex_readiness_once(
     assert result["native-codex"] == "needs-auth"
 
 
-def test_kimi_readiness_keys_off_binary(
+def test_kimi_readiness_keys_off_binary_and_credential(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Kimi is configured iff the ``kimi`` binary is on PATH.
+    """Kimi is configured iff the ``kimi`` binary is on PATH AND a login exists.
 
     Kimi authenticates against Moonshot AI's backend via ``kimi login`` (OAuth
-    or a Moonshot API key), which the daemon cannot inspect — so readiness
-    keys off binary presence, and the alias ``kimi-code`` resolves to the
-    same verdict via canonicalization.
+    or a Moonshot API key), which writes a credential file. Like agy, the
+    daemon has no CLI login-status probe, so readiness is binary presence PLUS
+    a subprocess-free credential check (``kimi_login_detected``). The alias
+    ``kimi-code`` resolves to the same verdict via canonicalization.
     """
+    import omnigent.onboarding.kimi_auth as _ka
+
+    # No binary → not configured regardless of credential.
     _no_clis_installed(monkeypatch)
+    monkeypatch.setattr(_ka, "kimi_login_detected", lambda: True)
     assert harness_is_configured("kimi") is False
     assert harness_is_configured("kimi-code") is False
 
+    # Binary present but no login → still not configured.
     _all_clis_installed(monkeypatch)
+    monkeypatch.setattr(_ka, "kimi_login_detected", lambda: False)
+    assert harness_is_configured("kimi") is False
+    assert harness_is_configured("kimi-code") is False
+
+    # Binary present and login detected → configured.
+    monkeypatch.setattr(_ka, "kimi_login_detected", lambda: True)
     assert harness_is_configured("kimi") is True
     assert harness_is_configured("kimi-code") is True
 

--- a/tests/onboarding/test_kimi_auth.py
+++ b/tests/onboarding/test_kimi_auth.py
@@ -1,0 +1,54 @@
+"""Tests for :mod:`omnigent.onboarding.kimi_auth`.
+
+``kimi login`` writes ``~/.kimi-code/credentials/kimi-code.json`` (verified
+against kimi CLI v0.29.1). Detection is a subprocess-free file check: a present,
+non-empty file is a completed login; a missing or empty file is not.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnigent.onboarding import kimi_auth as ka
+
+
+def test_credential_present_and_nonempty_detected(tmp_path: Path) -> None:
+    """A present, non-empty credential file reads as a completed login."""
+    creds = tmp_path / "kimi-code.json"
+    creds.write_text('{"access_token": "sk-abc"}', encoding="utf-8")
+    assert ka.kimi_login_detected(creds) is True
+
+
+def test_credential_absent_not_detected(tmp_path: Path) -> None:
+    """A missing credential file reads as not-logged-in."""
+    assert ka.kimi_login_detected(tmp_path / "kimi-code.json") is False
+
+
+def test_credential_empty_not_detected(tmp_path: Path) -> None:
+    """An empty (zero-byte) credential file is not a completed login."""
+    creds = tmp_path / "kimi-code.json"
+    creds.write_text("", encoding="utf-8")
+    assert ka.kimi_login_detected(creds) is False
+
+
+def test_credential_directory_not_detected(tmp_path: Path) -> None:
+    """A path that is a directory (not a regular file) is not a login."""
+    creds = tmp_path / "kimi-code.json"
+    creds.mkdir()
+    assert ka.kimi_login_detected(creds) is False
+
+
+def test_default_path_uses_home_credentials(monkeypatch, tmp_path: Path) -> None:
+    """With no argument, detection checks the real ``~/.kimi-code`` location.
+
+    Point ``HOME`` at a tmp dir and recompute the module default so the check is
+    deterministic and never depends on the developer's real credential file.
+    """
+    fake_creds = tmp_path / ".kimi-code" / "credentials" / "kimi-code.json"
+    fake_creds.parent.mkdir(parents=True, exist_ok=True)
+    fake_creds.write_text('{"access_token": "sk-xyz"}', encoding="utf-8")
+    monkeypatch.setattr(ka, "KIMI_CREDENTIALS_PATH", fake_creds)
+    assert ka.kimi_login_detected() is True
+
+    fake_creds.unlink()
+    assert ka.kimi_login_detected() is False


### PR DESCRIPTION
## Summary

Fixes two bugs in the Kimi Code (`kimi`) harness integration: Omnigent could never detect a completed `kimi login`, and the "sign out" path was wired to a subcommand that does not exist.

All commands verified live on kimi CLI **v0.29.1**:
- `kimi --help` subcommands are: `export, provider, acp, web, server, login, doctor, vis, migrate, upgrade` — there is **no** `logout`.
- `kimi logout` errors with `unknown command 'logout'`.
- `kimi login` works; a successful login writes `~/.kimi-code/credentials/kimi-code.json` (present ⇔ logged in).
- The runnable binary is `kimi` (not `kimi-code`).

## Bug 1 — Omnigent cannot detect a kimi login

The `KIMI_KEY` install spec had `status_args=None` and there was no file-based login detector, and the setup-overview readiness row was hardcoded to `"Not configured"` / `warn` whenever the CLI was installed. So even after a successful `kimi login` the overview always showed **"Not configured"**, making it look like login never works.

**Fix**
- New `omnigent/onboarding/kimi_auth.py` with a subprocess-free `kimi_login_detected()` that returns `True` when `~/.kimi-code/credentials/kimi-code.json` exists and is non-empty — mirroring `gemini_auth.gemini_login_detected()`.
- Wired into `harness_readiness._FAMILY_CREDENTIAL_CHECK` (`KIMI_KEY: lambda: _kimi_auth.kimi_login_detected()`), so `harness_is_configured("kimi")` now gates on **binary + credential**, exactly like `agy`.
- The setup-overview kimi row now renders a green `✓ Signed in` (`"ready"`) when the detector is `True`, and keeps the yellow `✗ Not configured` / "Sign in with `kimi login`." state otherwise.

## Bug 2 — Sign-out is broken

The `KIMI_KEY` spec declared `logout_args=("logout",)`, but kimi has no `logout` subcommand, so the "Sign out (kimi logout)" menu action shelled out to a command that errors.

**Fix**
- `logout_args=None` in the `KIMI_KEY` spec (makes `harness_logout` a no-op for kimi, same as Qwen / agy), with the surrounding comment corrected.
- Removed the `_HarnessMenuRow("Sign out (kimi logout)", ...)` row and its `elif action == "logout"` branch from `_manage_kimi_harness()`.
- Corrected the function docstring (it falsely claimed kimi ships `kimi logout`).

Sign-in is untouched — `kimi login` / `kimi provider add` and the `~/.kimi-code/config.toml` help text are unchanged.

## Tests + gates

- **New** `tests/onboarding/test_kimi_auth.py`: `kimi_login_detected()` for present / absent / empty / directory / default-home credential cases (tmp-path + monkeypatched path).
- Updated `tests/onboarding/test_harness_install.py` (asserts `logout_args is None`), `tests/onboarding/test_harness_readiness.py` (binary + credential gating), `tests/cli/test_cli.py` (drill-in has no sign-out row; menu indices), `tests/cli/test_configure_models.py` (signed-in vs not-configured overview row).

Gates run under WSL2 Ubuntu (matching CI), on the branch:

| Gate | Command | Result |
| --- | --- | --- |
| ruff lint | `uv run ruff check <9 changed files>` | **All checks passed** |
| ruff format | `uv run ruff format --check <9 changed files>` | **9 files already formatted** |
| mypy | `uv run mypy` on the 3 changed source modules | **clean** (kimi_auth / harness_readiness / harness_install); no new errors in cli_config.py vs upstream baseline |
| onboarding tests | `uv run pytest tests/onboarding/` | **821 passed** |
| CLI tests | `uv run pytest tests/cli/test_cli.py -k kimi` + `tests/cli/test_configure_models.py` | **6 passed, 112 passed** |

## Files changed

- `omnigent/onboarding/kimi_auth.py` (new)
- `omnigent/onboarding/harness_readiness.py`
- `omnigent/onboarding/harness_install.py`
- `omnigent/cli_config.py`
- `tests/onboarding/test_kimi_auth.py` (new)
- `tests/onboarding/test_harness_install.py`
- `tests/onboarding/test_harness_readiness.py`
- `tests/cli/test_cli.py`
- `tests/cli/test_configure_models.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
