### PR TITLE
feat(Policy): Make dangerous shell command gating configurable, fix UI-created global policies getting skipped by default

### DIFF
--- a/omnigent/policies/builtins/orchestration.py
+++ b/omnigent/policies/builtins/orchestration.py
@@ -649,28 +649,33 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
         "handler": "omnigent.policies.builtins.orchestration.blast_radius",
         "kind": "factory",
         "name": "Block Dangerous Shell Commands",
-        "description": "Classifies shell commands across Omnigent, Claude/Codex, Cursor, "
-        "Pi, Hermes, and Goose as safe, risky (configurable ASK or DENY), or "
-        "catastrophic (DENY) to prevent destructive operations like force-push or rm -rf /",
+        "description": "Allows safe shell commands, applies a configurable ASK or DENY action "
+        "to recoverable risky commands, and always denies catastrophic commands such as "
+        "force-push or rm -rf /. Supports Omnigent, Claude/Codex, Cursor, Pi, Hermes, and Goose.",
         "params_schema": {
             "type": "object",
             "properties": {
                 "gate_pushes": {
                     "type": "boolean",
-                    "description": "Gate ordinary pushes and other recoverable "
-                    "high-blast-radius commands.",
+                    "description": "Controls recoverable risky commands such as ordinary pushes, "
+                    "scoped recursive deletes, PR merges, and deployments. True applies "
+                    "risky_action; false allows them without prompting. Catastrophic commands "
+                    "are always denied.",
                     "default": True,
                 },
                 "risky_action": {
                     "type": "string",
                     "enum": ["ASK", "DENY"],
-                    "description": "Verdict for ordinary git push and other recoverable "
-                    "high-blast-radius commands.",
+                    "description": "Action when gate_pushes is true: ASK prompts the user before "
+                    "running the command; DENY blocks it immediately. This setting never "
+                    "weakens catastrophic-command denial.",
                     "default": "ASK",
                 },
                 "deny_reason": {
                     "type": "string",
-                    "description": "Reason shown when the policy denies a command.",
+                    "description": "Message shown when the policy returns DENY, including "
+                    "catastrophic commands and recoverable commands blocked by "
+                    "risky_action=DENY.",
                     "default": "Blocked by the blast-radius policy.",
                 },
             },

--- a/omnigent/policies/builtins/orchestration.py
+++ b/omnigent/policies/builtins/orchestration.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import os
 import re
 import shlex
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from typing import Any, TypeAlias
 
 # Heterogeneous JSON-shaped maps — the V0 policy event + decision payloads.
@@ -36,7 +36,7 @@ def _decision(result: str, reason: str) -> _Json:
     return {"result": result, "reason": reason}
 
 
-def _tool_call(event: _Json, tool_names: set[str]) -> _Json | None:
+def _tool_call(event: _Json, tool_names: Collection[str]) -> _Json | None:
     """
     Return the args dict of a matching ``tool_call`` event, else ``None``.
 
@@ -129,6 +129,9 @@ _GIT_GLOBAL_VALUE_OPTS: frozenset[str] = frozenset(
 )
 _PUSH_SHORT_VALUE_OPTS: frozenset[str] = frozenset({"o"})
 _ENV_ASSIGNMENT_RE: re.Pattern[str] = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=.*")
+_SHELL_TOOLS: frozenset[str] = frozenset(
+    {"sys_os_shell", "Bash", "bash", "Shell", "terminal", "developer__shell"}
+)
 
 
 def _shell_statements(command: str) -> list[list[str]]:
@@ -346,6 +349,7 @@ def _push_severity(argv: list[str]) -> str | None:
 def blast_radius(
     *,
     gate_pushes: bool = True,
+    risky_action: str = "ASK",
     deny_reason: str = "Blocked by the blast-radius policy.",
 ) -> Callable[[_Json, _Json], _Json]:
     """
@@ -354,16 +358,25 @@ def blast_radius(
     Catastrophic, irreversible commands (force-push, ``rm -rf /``,
     hard-reset to a remote ref) are DENIED. Outward or destructive but
     recoverable commands (``git push``, ``gh pr merge``, ``rm -rf`` of a
-    path, infra deploy/destroy) return ASK so the human approves before
-    they run. Everything else — reads, tests, edits, and local git
-    (commit / merge / worktree) — is ALLOWED.
+    path, infra deploy/destroy) return ``risky_action``. Everything else
+    — reads, tests, edits, and local git (commit / merge / worktree) — is
+    ALLOWED.
 
     :param gate_pushes: When ``True`` (default), recoverable-but-outward
-        commands return ASK. When ``False`` only the catastrophic DENY
-        set is enforced — use only for trusted unattended batch runs.
+        commands return ``risky_action``. When ``False`` only the
+        catastrophic DENY set is enforced — use only for trusted
+        unattended batch runs.
+    :param risky_action: Verdict for recoverable-but-outward commands:
+        ``"ASK"`` (default) or ``"DENY"``.
     :param deny_reason: Reason text surfaced on a DENY decision.
     :returns: An evaluator ``fn(event, config)`` returning a V0 decision.
+    :raises ValueError: If ``risky_action`` is not ``"ASK"`` or ``"DENY"``.
     """
+    normalized_risky_action = risky_action.strip().upper()
+    if normalized_risky_action not in {"ASK", "DENY"}:
+        raise ValueError(
+            f"blast_radius: risky_action must be 'ASK' or 'DENY', got {risky_action!r}"
+        )
 
     def _evaluate(event: _Json, config: _Json) -> _Json:  # noqa: ARG001
         """
@@ -374,13 +387,9 @@ def blast_radius(
             factory params).
         :returns: ALLOW / ASK / DENY decision dict.
         """
-        # Match the Omnigent built-in OS shell, the Claude/Codex native
-        # Bash tool, and Pi's native lowercase ``bash``. The PreToolUse hook
-        # reports BOTH CLI harnesses' shell tool as ``Bash`` with a string
-        # ``command`` (codex normalizes to this shape); Pi's ``tool_call``
-        # hook reports ``bash`` with the same ``command`` key — so one match
-        # set covers all three.
-        args = _tool_call(event, {"sys_os_shell", "Bash", "bash"})
+        # Native harnesses use different names for the same command-shaped
+        # shell tool; all are normalized to a ``command`` argument.
+        args = _tool_call(event, _SHELL_TOOLS)
         if args is None:
             return _ALLOW
         command = args.get("command")
@@ -399,7 +408,12 @@ def blast_radius(
         if "DENY" in severities or any(p.search(command) for p in _DENY_PATTERNS):
             return _decision("DENY", f"{deny_reason} (irreversible: {command!r})")
         if gate_pushes and ("ASK" in severities or any(p.search(command) for p in _ASK_PATTERNS)):
-            return _decision("ASK", f"High-blast-radius command needs approval: {command!r}")
+            reason = (
+                "High-blast-radius command needs approval"
+                if normalized_risky_action == "ASK"
+                else deny_reason
+            )
+            return _decision(normalized_risky_action, f"{reason}: {command!r}")
         return _ALLOW
 
     return _evaluate
@@ -635,9 +649,32 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
         "handler": "omnigent.policies.builtins.orchestration.blast_radius",
         "kind": "factory",
         "name": "Block Dangerous Shell Commands",
-        "description": "Classifies shell commands (sys_os_shell, Claude/Codex native Bash, "
-        "and Pi native bash) as safe, risky (ASK), or catastrophic (DENY) to prevent "
-        "destructive operations like force-push or rm -rf /",
+        "description": "Classifies shell commands across Omnigent, Claude/Codex, Cursor, "
+        "Pi, Hermes, and Goose as safe, risky (configurable ASK or DENY), or "
+        "catastrophic (DENY) to prevent destructive operations like force-push or rm -rf /",
+        "params_schema": {
+            "type": "object",
+            "properties": {
+                "gate_pushes": {
+                    "type": "boolean",
+                    "description": "Gate ordinary pushes and other recoverable "
+                    "high-blast-radius commands.",
+                    "default": True,
+                },
+                "risky_action": {
+                    "type": "string",
+                    "enum": ["ASK", "DENY"],
+                    "description": "Verdict for ordinary git push and other recoverable "
+                    "high-blast-radius commands.",
+                    "default": "ASK",
+                },
+                "deny_reason": {
+                    "type": "string",
+                    "description": "Reason shown when the policy denies a command.",
+                    "default": "Blocked by the blast-radius policy.",
+                },
+            },
+        },
     },
     {
         "handler": "omnigent.policies.builtins.orchestration.spawn_bounds",

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -272,6 +272,8 @@ def any_policies_apply(
         return True
     if default_policies:
         return True
+    if _load_default_policy_specs(policy_store):
+        return True
     # Session policies are LRU-cached per (workspace_id, conversation_id) —
     # this is a cache hit on any call after the first for this session.
     if _load_session_policy_specs(conversation_id, policy_store):

--- a/tests/inner/nessie/test_policies.py
+++ b/tests/inner/nessie/test_policies.py
@@ -112,11 +112,21 @@ def test_blast_radius_gates_pi_native_bash_tool() -> None:
     assert _result(evaluate(_tool_call("bash", command="git status"), {})) == "ALLOW"
 
 
+@pytest.mark.parametrize("tool", ["Shell", "terminal", "developer__shell"])
+def test_blast_radius_gates_other_native_shell_tools(tool: str) -> None:
+    """Cursor, Hermes, and Goose shell calls receive the same push gate."""
+    evaluate = blast_radius()
+
+    assert _result(evaluate(_tool_call(tool, command="git push origin main"), {})) == "ASK"
+    assert (
+        _result(evaluate(_tool_call(tool, command="git push --force origin main"), {})) == "DENY"
+    )
+
+
 def test_blast_radius_ignores_non_shell_tools() -> None:
     """
-    Non-shell tool calls pass through ALLOW — blast_radius only inspects
-    ``sys_os_shell`` and ``Bash``. A failure here means the guard is matching
-    on the wrong tool and would corrupt unrelated tool dispatch.
+    Non-shell tool calls pass through ALLOW. A failure means the guard is
+    matching the wrong tool and would corrupt unrelated tool dispatch.
     """
     evaluate = blast_radius()
     assert _result(evaluate(_tool_call("sys_session_send", agent="impl_claude"), {})) == "ALLOW"
@@ -135,6 +145,21 @@ def test_blast_radius_gate_pushes_false_allows_recoverable_not_catastrophic() ->
         == "ALLOW"
     )
     assert _result(evaluate(_tool_call("sys_os_shell", command="rm -rf /"), {})) == "DENY"
+
+
+def test_blast_radius_risky_action_can_deny() -> None:
+    """``risky_action=DENY`` blocks ordinary pushes and other risky commands."""
+    evaluate = blast_radius(risky_action="DENY")
+
+    assert _result(evaluate(_tool_call("Bash", command="git push origin main"), {})) == "DENY"
+    assert _result(evaluate(_tool_call("Bash", command="terraform apply"), {})) == "DENY"
+    assert _result(evaluate(_tool_call("Bash", command="git status"), {})) == "ALLOW"
+
+
+def test_blast_radius_rejects_unknown_risky_action() -> None:
+    """Invalid actions fail at policy construction instead of silently allowing."""
+    with pytest.raises(ValueError, match="risky_action must be 'ASK' or 'DENY'"):
+        blast_radius(risky_action="ALLOW")
 
 
 # Catastrophic commands that the previous single-regex DENY set MISSED — each
@@ -195,6 +220,7 @@ def test_blast_radius_denies_destructive_variants(command: str) -> None:
         "rm -r node_modules",  # recursive, no force, relative
         "rm -rf /home/u/proj/build",  # scoped path under /home, not a system dir
         "git push origin main",  # ordinary outward push (also asserts the gate=False ALLOW)
+        "git push --dry-run origin HEAD",  # dry-run still exercises the push gate
         "git push -u origin main",  # set-upstream is outward, not force/delete
         "git push -o ci.skip origin main",  # push-option value is not a destructive flag
         "git push -o=fast origin main",  # attached push-option value must not over-match `f`

--- a/tests/policies/test_registry.py
+++ b/tests/policies/test_registry.py
@@ -66,20 +66,30 @@ def test_get_params_schema_returns_schema() -> None:
     assert schema["properties"]["limit"]["type"] == "integer"
 
 
-def test_blast_radius_schema_exposes_risky_action() -> None:
-    """The UI can configure risky shell operations as ASK or DENY."""
+def test_blast_radius_schema_explains_configuration() -> None:
+    """The UI explains how the three blast-radius settings interact."""
     load_registry()
     schema = get_params_schema("omnigent.policies.builtins.orchestration.blast_radius")
 
     assert schema is not None
+    assert schema["properties"]["gate_pushes"]["description"] == (
+        "Controls recoverable risky commands such as ordinary pushes, scoped recursive deletes, "
+        "PR merges, and deployments. True applies risky_action; false allows them without "
+        "prompting. Catastrophic commands are always denied."
+    )
     assert schema["properties"]["risky_action"] == {
         "type": "string",
         "enum": ["ASK", "DENY"],
         "description": (
-            "Verdict for ordinary git push and other recoverable high-blast-radius commands."
+            "Action when gate_pushes is true: ASK prompts the user before running the command; "
+            "DENY blocks it immediately. This setting never weakens catastrophic-command denial."
         ),
         "default": "ASK",
     }
+    assert schema["properties"]["deny_reason"]["description"] == (
+        "Message shown when the policy returns DENY, including catastrophic commands and "
+        "recoverable commands blocked by risky_action=DENY."
+    )
 
 
 def test_get_params_schema_none_for_direct_callable() -> None:

--- a/tests/policies/test_registry.py
+++ b/tests/policies/test_registry.py
@@ -66,6 +66,22 @@ def test_get_params_schema_returns_schema() -> None:
     assert schema["properties"]["limit"]["type"] == "integer"
 
 
+def test_blast_radius_schema_exposes_risky_action() -> None:
+    """The UI can configure risky shell operations as ASK or DENY."""
+    load_registry()
+    schema = get_params_schema("omnigent.policies.builtins.orchestration.blast_radius")
+
+    assert schema is not None
+    assert schema["properties"]["risky_action"] == {
+        "type": "string",
+        "enum": ["ASK", "DENY"],
+        "description": (
+            "Verdict for ordinary git push and other recoverable high-blast-radius commands."
+        ),
+        "default": "ASK",
+    }
+
+
 def test_get_params_schema_none_for_direct_callable() -> None:
     """``get_params_schema`` returns ``None`` for a direct (non-factory) callable."""
     load_registry()

--- a/tests/server/integration/test_policy_ask_lifecycle_e2e.py
+++ b/tests/server/integration/test_policy_ask_lifecycle_e2e.py
@@ -35,6 +35,7 @@ from fastapi import FastAPI
 
 from omnigent.runtime import pending_elicitations, session_stream
 from omnigent.runtime.agent_cache import AgentCache
+from omnigent.runtime.policies.builder import invalidate_default_policy_specs_cache
 from omnigent.server.app import create_app
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.artifact_store.local import LocalArtifactStore
@@ -173,6 +174,20 @@ async def _attach_ask_policy(
     return body["id"]
 
 
+async def _attach_global_ask_policy(client: httpx.AsyncClient) -> str:
+    """Create the same ASK policy as a UI-managed global policy."""
+    resp = await client.post(
+        "/v1/policies",
+        json={
+            "name": "test_global_ask_policy",
+            "type": "python",
+            "handler": "omnigent.policies.builtins.safety.ask_on_os_tools",
+        },
+    )
+    assert resp.status_code == 200, f"attach policy failed: {resp.status_code} {resp.text}"
+    return resp.json()["id"]
+
+
 def _tool_call_request(
     tool_name: str = "Bash",
     arguments: dict[str, Any] | None = None,
@@ -222,22 +237,27 @@ async def _drain_elicitation_id(
 # ── Tests ───────────────────────────────────────────────────
 
 
+@pytest.mark.parametrize("scope", ["session", "global"])
 async def test_ask_policy_approve_flow(
     client: httpx.AsyncClient,
+    scope: str,
 ) -> None:
     """
-    Attach ASK policy, evaluate, approve → ALLOW.
+    Attach a session or global ASK policy, evaluate, approve → ALLOW.
 
     Full journey: create session → attach ``ask_on_os_tools`` policy
     → trigger evaluate with a Bash tool call → observe pending
     elicitation in the session snapshot → resolve with accept →
-    evaluate returns ``POLICY_ACTION_ALLOW``. Proves the session-
-    attached policy fires, parks a real server-side Future, and the
+    evaluate returns ``POLICY_ACTION_ALLOW``. Proves both policy scopes
+    survive the native-evaluation fast path, park a real server-side Future, and the
     URL-based resolve wakes it with the correct verdict.
     """
     agent = await create_test_agent(client, "test-ask-approve")
     session_id = await _create_session(client, agent["id"])
-    await _attach_ask_policy(client, session_id)
+    if scope == "global":
+        await _attach_global_ask_policy(client)
+    else:
+        await _attach_ask_policy(client, session_id)
 
     drain = asyncio.create_task(_drain_elicitation_id(session_id))
     evaluate = None
@@ -281,6 +301,8 @@ async def test_ask_policy_approve_flow(
                 task.cancel()
                 await asyncio.gather(task, return_exceptions=True)
         pending_elicitations.reset_for_tests()
+        if scope == "global":
+            invalidate_default_policy_specs_cache()
 
 
 async def test_ask_policy_refuse_flow(

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -379,7 +379,7 @@ function AddPolicyDialog({
         onOpenChange(next);
       }}
     >
-      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-md">
+      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Add Policy</DialogTitle>
           <DialogDescription>Choose a policy to apply to this session.</DialogDescription>
@@ -487,7 +487,7 @@ function AddPolicyDialog({
                       )}
                     </label>
                     {prop?.description && (
-                      <p className="break-all text-[11px] text-muted-foreground">
+                      <p className="break-words text-[11px] text-muted-foreground">
                         {prop.description}
                       </p>
                     )}

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -148,7 +148,7 @@ function AddDefaultPolicyDialog({
         onOpenChange(next);
       }}
     >
-      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-md">
+      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Add Global Policy</DialogTitle>
           <DialogDescription>Choose a policy to apply globally to all sessions.</DialogDescription>
@@ -256,7 +256,7 @@ function AddDefaultPolicyDialog({
                       )}
                     </label>
                     {prop?.description && (
-                      <p className="break-all text-[11px] text-muted-foreground">
+                      <p className="break-words text-[11px] text-muted-foreground">
                         {prop.description}
                       </p>
                     )}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Make recoverable high-blast-radius shell operations configurable as `ASK` or `DENY`, while keeping force-pushes, remote deletions, catastrophic recursive deletes, and destructive resets unconditionally denied.
- This change also fixes the native evaluation fast path so UI-created global policies are not skipped, across all policies
- Apply the shell-command policy consistently across native harness shell tool names
- Widen the policy configuration dialogs and wrap descriptions at word boundaries.

ELI5: safe commands pass, recoverable risky commands follow the administrator's `ASK`/`DENY` choice, and catastrophic commands are always blocked.

```text
shell command
├─ safe ────────────────────────────────> ALLOW
├─ recoverable ─> gate disabled ───────> ALLOW
│                 gate enabled ────────> ASK or DENY
└─ catastrophic ────────────────────────> DENY
```

## Test Plan

- `pre-commit run --all-files`
- `.venv/bin/python -m pytest tests/server/integration/test_policy_ask_lifecycle_e2e.py tests/runtime/policies/test_builder_session_policies.py tests/inner/nessie/test_policies.py tests/policies/test_registry.py -q` — 145 passed
- From `web/` with Node 24: `npm test -- --run src/pages/PoliciesPage.test.tsx src/components/AgentInfo.test.tsx` — 63 passed
- In omnidev, enabled the global policy with `gate_pushes=true` and `risky_action=ASK`, then verified `git push --dry-run origin HEAD` showed an approval prompt before execution.

## Demo

Policy working:
<img width="919" height="1017" alt="Screenshot 2026-07-26 at 20 54 29" src="https://github.com/user-attachments/assets/bcfe1480-a6d2-4aca-9fca-d9f08f3a9eba" />
<img width="868" height="1003" alt="Screenshot 2026-07-26 at 20 53 38" src="https://github.com/user-attachments/assets/8499d5ed-a64e-4bb0-89b0-f53cde7c3b48" />

User can set ASK or DENY for recoverable operations:
<img width="626" height="728" alt="Screenshot 2026-07-26 at 21 18 30" src="https://github.com/user-attachments/assets/b4a7516e-80f3-4baf-9a37-c136456c3b0c" />
<img width="668" height="755" alt="Screenshot 2026-07-26 at 21 18 27" src="https://github.com/user-attachments/assets/a5d38bc8-cfc6-4c1a-9d90-797318585095" />



## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the global-policy flow in omnidev: the configured ASK gate appears before an ordinary dry-run push executes. Automated coverage exercises command classification, registry schema exposure, global-policy fast-path inclusion, and the approval lifecycle.

## Changelog

Configure recoverable dangerous shell commands to ask for approval or deny execution, while always blocking catastrophic operations.
