### PR TITLE
fix(codex): preserve host skills and terminal integrity

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -1196,20 +1196,6 @@ def _completed_agent_message_text(
     return phase, message_buffers.get(completed_item_id, completed_text)
 
 
-def _latest_buffered_agent_message(message_buffers: dict[str, str]) -> str:
-    """Return the most recent buffered assistant text from Codex deltas.
-
-    ``turn/completed`` can arrive without a terminal ``item/completed``. In
-    that case the best available response is the last accumulated delta text.
-
-    :param message_buffers: Per-item accumulated delta text keyed by item id.
-    :returns: The most recent buffered assistant text, or ``""`` when absent.
-    """
-    if not message_buffers:
-        return ""
-    return next(reversed(message_buffers.values()))
-
-
 def _sandbox_mode(spec: OSEnvSpec | None) -> str:
     if spec is None:
         return "read-only"
@@ -1498,8 +1484,9 @@ class _CodexAppServerSession:
         *,
         active_turn_id: str,
         message_buffers: dict[str, str],
-        final_response: str,
-    ) -> str:
+        final_response: str | None,
+        saw_agent_message: bool,
+    ) -> tuple[str | None, bool]:
         """Collect a trailing final-answer item that arrives after ``turn/completed``.
 
         Some Codex app-server turns emit ``turn/completed`` slightly before the
@@ -1509,18 +1496,19 @@ class _CodexAppServerSession:
 
         :param active_turn_id: The current turn id.
         :param message_buffers: Accumulated delta text keyed by item id.
-        :param final_response: The response text accumulated so far.
-        :returns: The best final response observed during the drain window.
+        :param final_response: The terminal response observed so far, if any.
+        :param saw_agent_message: Whether the turn emitted assistant text.
+        :returns: The terminal response and assistant-message observation state.
         """
         deadline = time.monotonic() + _TURN_COMPLETED_DRAIN_SECONDS
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                return final_response
+                return final_response, saw_agent_message
             try:
                 message = await asyncio.wait_for(self._events.get(), timeout=remaining)
             except asyncio.TimeoutError:
-                return final_response
+                return final_response, saw_agent_message
             self._record_event(message)
             params = message.get("params", {})
             if not isinstance(params, dict):
@@ -1538,14 +1526,14 @@ class _CodexAppServerSession:
                 if isinstance(item_id, str) and isinstance(delta, str) and delta:
                     prior = message_buffers.get(item_id, "")
                     message_buffers[item_id] = f"{prior}{delta}"
-                    if not final_response:
-                        final_response = message_buffers[item_id]
+                    saw_agent_message = True
                 continue
             if message.get("method") != "item/completed":
                 continue
             item = params.get("item", {})
             if not isinstance(item, dict) or item.get("type") != "agentMessage":
                 continue
+            saw_agent_message = True
             phase, completed_text = _completed_agent_message_text(item, message_buffers)
             if phase == "commentary":
                 item_id = item.get("id")
@@ -1554,8 +1542,7 @@ class _CodexAppServerSession:
                 continue
             if phase == "final_answer" or phase is None:
                 final_response = completed_text
-            if phase == "final_answer":
-                return final_response
+                return final_response, saw_agent_message
 
     async def run_turn(
         self,
@@ -1687,7 +1674,8 @@ class _CodexAppServerSession:
 
         message_buffers: dict[str, str] = {}
         pending_tool_results: dict[str, _PendingToolResult] = {}
-        final_response = ""
+        final_response: str | None = None
+        saw_agent_message = False
         observed_turn_id: str | None = None
 
         def _event_turn_matches(params: CodexParams) -> bool:
@@ -1842,6 +1830,7 @@ class _CodexAppServerSession:
                     delta: str = raw_delta
                     prior = message_buffers.get(item_id)
                     message_buffers[item_id] = (prior if prior is not None else "") + delta
+                    saw_agent_message = True
                     yield TextChunk(text=delta)
                     continue
 
@@ -1865,6 +1854,7 @@ class _CodexAppServerSession:
                         raw_item_type if isinstance(raw_item_type, str) else None
                     )
                     if item_type == "agentMessage":
+                        saw_agent_message = True
                         raw_completed_id = item.get("id")
                         if not isinstance(raw_completed_id, str):
                             continue
@@ -1890,12 +1880,12 @@ class _CodexAppServerSession:
                             logger.info(
                                 "Codex TurnComplete: turn_id=%s response_head=%r",
                                 active_turn_id,
-                                final_response[:120],
+                                completed_text[:120],
                             )
                             turn_usage = self._last_turn_usage
                             self._last_turn_usage = None
                             _notify_usage_from_dict(model=model, usage=turn_usage)
-                            yield TurnComplete(response=final_response, usage=turn_usage)
+                            yield TurnComplete(response=completed_text, usage=turn_usage)
                             return
                         continue
                     if item_type == "dynamicToolCall":
@@ -1925,18 +1915,25 @@ class _CodexAppServerSession:
                             active_turn_id,
                         )
                         continue
-                    if not final_response:
-                        final_response = _latest_buffered_agent_message(message_buffers)
-                    if not final_response:
-                        final_response = await self._drain_turn_completed_tail(
+                    if final_response is None:
+                        final_response, saw_agent_message = await self._drain_turn_completed_tail(
                             active_turn_id=active_turn_id,
                             message_buffers=message_buffers,
                             final_response=final_response,
+                            saw_agent_message=saw_agent_message,
                         )
                     turn_usage = self._last_turn_usage
                     self._last_turn_usage = None
                     _notify_usage_from_dict(model=model, usage=turn_usage)
-                    yield TurnComplete(response=final_response, usage=turn_usage)
+                    if final_response is None and saw_agent_message:
+                        yield ExecutorError(
+                            message=(
+                                "Codex App Server turn completed after assistant text "
+                                "without a terminal final-answer item"
+                            )
+                        )
+                    else:
+                        yield TurnComplete(response=final_response or "", usage=turn_usage)
                     return
 
                 if method == "turn/failed":

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -6587,14 +6587,12 @@ def _execute_skill_tool(
     # agent's own bundle to ship a skills/ directory.
     bundled_skills = _inject_orchestrator_skills(bundled_skills, agent_spec)
 
-    if tool_name == "load_skill":
-        tool = LoadSkillTool(
-            bundled_skills,
-            agent_root=runner_workspace,
-            skills_filter=skills_filter,
-        )
-    else:
-        tool = ReadSkillFileTool(bundled_skills)
+    loader = LoadSkillTool(
+        bundled_skills,
+        agent_root=runner_workspace,
+        skills_filter=skills_filter,
+    )
+    tool = loader if tool_name == "load_skill" else ReadSkillFileTool(loader.skills)
 
     arguments_json = json.dumps(args)
     from omnigent.tools.base import ToolContext

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -1538,11 +1538,14 @@ class TestCodexExecutor(unittest.TestCase):
 
             self.assertEqual(len(events), 1)
             self.assertIsInstance(events[0], TurnComplete)
+            self.assertEqual(events[0].response, "")
             self.assertIsNone(events[0].usage)
 
         _run(_t())
 
-    def test_app_server_run_turn_drains_final_answer_after_turn_completed(self):
+    def test_app_server_run_turn_drains_final_answer_after_turn_completed_with_buffered_delta(
+        self,
+    ):
         async def _t():
             session = _CodexAppServerSession(
                 codex_path="/bin/echo",
@@ -1557,6 +1560,16 @@ class TestCodexExecutor(unittest.TestCase):
 
             async def _inject_trailing_final_answer() -> None:
                 await asyncio.sleep(0.01)
+                session._events.put_nowait(
+                    {
+                        "method": "item/agentMessage/delta",
+                        "params": {
+                            "turnId": "turn-1",
+                            "itemId": "msg-progress",
+                            "delta": "working...",
+                        },
+                    }
+                )
                 session._events.put_nowait(
                     {
                         "method": "turn/completed",
@@ -1595,13 +1608,15 @@ class TestCodexExecutor(unittest.TestCase):
             ]
             await inject_task
 
-            self.assertEqual(len(events), 1)
-            self.assertIsInstance(events[0], TurnComplete)
-            self.assertEqual(events[0].response, "done")
+            self.assertEqual(len(events), 2, events)
+            self.assertIsInstance(events[0], TextChunk)
+            self.assertEqual(events[0].text, "working...")
+            self.assertIsInstance(events[1], TurnComplete)
+            self.assertEqual(events[1].response, "done")
 
         _run(_t())
 
-    def test_app_server_run_turn_uses_buffered_delta_when_completed_item_is_missing(self):
+    def test_app_server_run_turn_rejects_buffered_delta_without_terminal_item(self):
         async def _t():
             session = _CodexAppServerSession(
                 codex_path="/bin/echo",
@@ -1614,40 +1629,48 @@ class TestCodexExecutor(unittest.TestCase):
             session.thread_id = "thread-1"
             session._request = AsyncMock(return_value={"result": {"turn": {"id": "turn-1"}}})
 
-            await session._events.put(
-                {
-                    "method": "item/agentMessage/delta",
-                    "params": {
-                        "turnId": "turn-1",
-                        "itemId": "msg-1",
-                        "delta": "done",
-                    },
-                }
-            )
-            await session._events.put(
-                {
-                    "method": "turn/completed",
-                    "params": {
-                        "turn": {"id": "turn-1"},
-                    },
-                }
-            )
-
-            events = [
-                event
-                async for event in session.run_turn(
-                    messages=[{"role": "user", "content": "hi"}],
-                    tools=[],
-                    system_prompt="",
-                    model="gpt-5.4-mini",
-                    cwd=".",
-                    sandbox="workspace-write",
+            async def _inject_completed_without_final_answer() -> None:
+                await asyncio.sleep(0.01)
+                session._events.put_nowait(
+                    {
+                        "method": "item/agentMessage/delta",
+                        "params": {
+                            "turnId": "turn-1",
+                            "itemId": "msg-1",
+                            "delta": "done",
+                        },
+                    }
                 )
-            ]
+                session._events.put_nowait(
+                    {
+                        "method": "turn/completed",
+                        "params": {
+                            "turn": {"id": "turn-1"},
+                        },
+                    }
+                )
 
-            self.assertEqual(len(events), 1)
-            self.assertIsInstance(events[0], TurnComplete)
-            self.assertEqual(events[0].response, "done")
+            inject_task = asyncio.create_task(_inject_completed_without_final_answer())
+            with patch("omnigent.inner.codex_executor._TURN_COMPLETED_DRAIN_SECONDS", 0.001):
+                events = [
+                    event
+                    async for event in session.run_turn(
+                        messages=[{"role": "user", "content": "hi"}],
+                        tools=[],
+                        system_prompt="",
+                        model="gpt-5.4-mini",
+                        cwd=".",
+                        sandbox="workspace-write",
+                    )
+                ]
+            await inject_task
+
+            self.assertEqual(len(events), 2, events)
+            self.assertIsInstance(events[0], TextChunk)
+            self.assertEqual(events[0].text, "done")
+            self.assertIsInstance(events[1], ExecutorError)
+            self.assertFalse(events[1].retryable)
+            self.assertIn("terminal final-answer", events[1].message)
 
         _run(_t())
 

--- a/tests/runner/test_skill_tool_dispatch.py
+++ b/tests/runner/test_skill_tool_dispatch.py
@@ -1,0 +1,60 @@
+"""Regression tests for runner-local skill-tool dispatch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from omnigent.runner.tool_dispatch import _execute_skill_tool
+
+
+def test_host_skill_resource_read_uses_the_loader_catalog_and_keeps_confinement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host skill loaded by the runner can read its advertised resource."""
+    home = tmp_path / "home"
+    (home / ".claude" / "skills").mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    workspace = tmp_path / "workspace"
+    skill_dir = workspace / ".agents" / "skills" / "host-research"
+    references = skill_dir / "references"
+    references.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: host-research\n"
+        "description: Read local research guidance.\n"
+        "---\n\n"
+        "Use the local resource.\n"
+    )
+    (references / "guide.md").write_text("# Host guidance\n\nRead this first.\n")
+    agent_spec = SimpleNamespace(skills=[], skills_filter="all")
+
+    loaded = _execute_skill_tool(
+        "load_skill",
+        {"name": "host-research"},
+        agent_spec=agent_spec,
+        runner_workspace=workspace,
+    )
+    resource = _execute_skill_tool(
+        "read_skill_file",
+        {"skill_name": "host-research", "path": "references/guide.md"},
+        agent_spec=agent_spec,
+        runner_workspace=workspace,
+    )
+    outside = tmp_path / "outside.md"
+    outside.write_text("must stay outside the skill root\n")
+    (references / "escape.md").symlink_to(outside)
+    escaped = _execute_skill_tool(
+        "read_skill_file",
+        {"skill_name": "host-research", "path": "references/escape.md"},
+        agent_spec=agent_spec,
+        runner_workspace=workspace,
+    )
+
+    assert "references/guide.md" in loaded
+    assert "# Host guidance" in resource
+    assert "path traversal not allowed" in escaped


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Make `read_skill_file` use the same discovered catalog as `load_skill`, so host-scope skill resources remain readable.
- Require a terminal completed final-answer item before emitting `TurnComplete`; progress-only turns now surface a typed executor error.
- Add focused regressions for host-skill resource reads, symlink confinement, delayed final answers, and progress-only completion.

ELI5: the runner was showing an agent a skill, then handing its file reader a different list that did not contain it. Separately, it was treating a work-in-progress message as a finished answer. Both paths now preserve the right contract.

```text
load_skill ──> discovered catalog ──> read_skill_file
progress delta ──> TextChunk ──> final_answer ──> TurnComplete
                                 no final_answer ──> ExecutorError
```

## Test Plan

- Ran `TestCodexExecutor`: 44 passed in isolated OmniGent state.
- Ran adjacent load-skill/read-skill-file/runner suites: 37 passed in isolated state.
- Ran Ruff format/check, project test-quality linters, and `git diff --check`.
- The clean worktree lacks its expected `.venv`, so the pre-commit wrapper could not launch its first four Python hooks; the equivalent checks ran from a disposable synced environment.

## Demo

N/A — backend reliability fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused unit coverage exercises the runner dispatch boundary and Codex event ordering; no UI or live-provider test is needed for this deterministic repair.

## Changelog

Codex child results now require a terminal answer instead of treating progress updates as completed work.