### PR TITLE
fix(pi-native): web model-switch resolves to keyless provider variant, failing with false "no API key"

### DIFF
--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -847,19 +847,26 @@ async function applyModelChange(pi, config, ctx, modelId) {
   const id = typeof modelId === "string" ? modelId.trim() : "";
   if (!id) return false;
   const registry = ctx ? ctx.modelRegistry : undefined;
-  // Resolve against whichever listing method exists. Accept EITHER getAll or
-  // getAvailable so the resolve path can never be narrower than the picker's:
-  // postModelOptions lists from getAvailable(), so gating apply on getAll alone
-  // would fail every switch on a hypothetical Pi build exposing only
-  // getAvailable. getAll (the full catalog) is a superset of getAvailable, so
-  // prefer it to resolve; fall back to getAvailable when getAll is absent.
-  const listModels =
+  // Resolve the picked id to a concrete model. A bare id (e.g. "claude-opus-5")
+  // can exist under MULTIPLE providers at once: a keyless built-in vendor entry
+  // AND an authed provider (e.g. the kiro extension provider). getAll() spans the
+  // entire catalog including keyless duplicates, so resolving against it can pick
+  // the keyless variant, whose setModel() then fails with "no API key" even though
+  // an authed variant of the same id exists. The picker (postModelOptions) lists
+  // from getAvailable() -- only models with configured auth -- so resolve against
+  // getAvailable() FIRST to select the authed variant the user actually saw, and
+  // fall back to getAll() only when getAvailable is absent or the id is not there
+  // (keeps the resolve path from being narrower than the picker on Pi builds that
+  // only expose getAll).
+  const getAvailable =
+    registry && typeof registry.getAvailable === "function"
+      ? () => registry.getAvailable()
+      : null;
+  const getAll =
     registry && typeof registry.getAll === "function"
       ? () => registry.getAll()
-      : registry && typeof registry.getAvailable === "function"
-        ? () => registry.getAvailable()
-        : null;
-  if (!pi || typeof pi.setModel !== "function" || !listModels) {
+      : null;
+  if (!pi || typeof pi.setModel !== "function" || (!getAvailable && !getAll)) {
     await postModelChangeError(
       config,
       `Omnigent: could not switch to model "${id}" — this Pi session exposes ` +
@@ -869,7 +876,9 @@ async function applyModelChange(pi, config, ctx, modelId) {
   }
   let model;
   try {
-    model = listModels().find((m) => m && m.id === id);
+    model =
+      (getAvailable ? getAvailable().find((m) => m && m.id === id) : undefined) ||
+      (getAll ? getAll().find((m) => m && m.id === id) : undefined);
   } catch (_err) {
     model = undefined;
   }


### PR DESCRIPTION
## Summary

A model picked in the Omnigent Web UI for a native **Pi** session fails with
`pi_model_change_failed — Omnigent: could not switch to model "<id>" — no API
key is configured for it`, even though the model is offered in the picker and
switches fine from Pi's own in-terminal `/model`.

## Root cause

`applyModelChange` in `omnigent/resources/pi_native/omnigent_pi_native_extension.js`
resolves the picked bare id against **`getAll()`** (Pi's entire catalog):

```js
const listModels = registry.getAll ? () => registry.getAll() : ... getAvailable ...;
model = listModels().find((m) => m && m.id === id);
const applied = await pi.setModel(model); // -> false -> "no API key configured"
```

A bare id (e.g. `claude-opus-5`) can exist under **multiple providers at once** —
a keyless built-in vendor entry **and** an authed provider (e.g. the
`@arvoretech/pi-kiro-provider` kiro extension). `getAll()` spans every vendor
including the keyless duplicates, so `.find(m.id === id)` can return the
**keyless** variant; `pi.setModel()` then returns `false` → the "no API key"
error — while an authed variant of the same id was available all along.

Meanwhile the picker (`postModelOptions`) lists from **`getAvailable()`** (only
models with configured auth), so it *offers* `claude-opus-5` (the kiro variant).
That mismatch — offer from `getAvailable()`, resolve from `getAll()` — is the bug.
Pi's own `/model` works because it hands `setModel` the concrete authed model
object.

## Reproduction (confirmed)

- Pi session with the kiro provider extension installed and `/login kiro` done.
- Pi terminal status line shows `(kiro) claude-opus-5` and switching works.
- In the Omnigent Web UI composer, pick `Claude Opus 5` (or `Claude Sonnet 5`,
  `Claude Opus 4-8`) → `pi_model_change_failed … no API key is configured for it`.

## Fix

Resolve the switch against **`getAvailable()` first** (the same authed set the
picker used), falling back to `getAll()` only when `getAvailable` is absent or the
id isn't there (so the resolve path is never narrower than the picker on Pi builds
that only expose `getAll`). This selects the authed variant the user actually saw:

```js
model =
  (getAvailable ? getAvailable().find((m) => m && m.id === id) : undefined) ||
  (getAll ? getAll().find((m) => m && m.id === id) : undefined);
```

Behavior change is limited to the duplicate-id case: previously a bare id that
existed under both a keyless and an authed provider resolved to the keyless one
(hard failure); now it resolves to the authed one (success). Single-provider ids
are unaffected.

## Suggested regression test

The existing `omnigent_pi_native_extension.test.js` drives the extension through
its inbox-poller surface. A case for this bug: mock `ctx.modelRegistry` so
`getAll()` returns `[{id:"claude-opus-5",provider:"anthropic"}, {id:"claude-opus-5",provider:"kiro"}]`
(keyless first) and `getAvailable()` returns `[{id:"claude-opus-5",provider:"kiro"}]`;
mock `pi.setModel(m)` to return `m.provider === "kiro"`; deliver a model-change for
`"claude-opus-5"` via the inbox and assert `setModel` was called with the kiro
model and no `pi_model_change_failed` error was posted. (Pre-fix this fails.)

## Environment

omnigent 0.6.0 server, Pi 0.82.1, `@arvoretech/pi-kiro-provider@0.8.5`, kiro via
IAM Identity Center.
