### PR TITLE
fix(accounts): enforce the last-admin invariant atomically on delete

### DIFF
--- a/omnigent/server/accounts_store.py
+++ b/omnigent/server/accounts_store.py
@@ -32,6 +32,7 @@ import time
 
 from sqlalchemy import and_, delete, exists, select, update
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
 from omnigent.db.db_models import (
     SqlAccountToken,
@@ -93,6 +94,15 @@ class SqlAlchemyAccountStore:
         self.storage_location = storage_location
         self._engine = get_or_create_engine(storage_location)
         self._session = make_managed_session_maker(self._engine)
+        # Immediate session: for the last-admin invariant in delete_user,
+        # which must lock the current admin set before counting it. On
+        # SQLite, ``BEGIN IMMEDIATE`` acquires the write lock before the
+        # first read, so a second concurrent delete/demote blocks instead
+        # of reading the same stale admin count. On other dialects this is
+        # a no-op — those paths lock explicitly with ``SELECT ... FOR
+        # UPDATE`` instead (see ``_supports_for_update``).
+        self._session_immediate = make_managed_session_maker(self._engine, immediate=True)
+        self._supports_for_update = self._engine.dialect.name != "sqlite"
 
     # ── User credentials (extends rows in the `users` table) ──────
 
@@ -213,28 +223,67 @@ class SqlAlchemyAccountStore:
             )
             return [_to_account(r) for r in rows if r.id not in _HIDDEN_LIST_USERS]
 
-    def delete_user(self, user_id: str) -> bool:
-        """Delete a user row and their permission grants.
+    def _locked_admin_ids(self, session: Session) -> list[str]:
+        """Return every admin's user id, locked against concurrent change.
+
+        Must be called on a session opened via ``self._session_immediate``
+        (SQLite) or ``self._session`` with ``_supports_for_update`` True
+        (other dialects) — see callers. On Postgres this issues
+        ``SELECT ... FOR UPDATE`` on the admin rows, so a second
+        transaction doing the same read blocks until this one commits
+        instead of observing the same stale count. On SQLite the
+        immediate session already holds the write lock, so no per-row
+        clause is needed.
+
+        Excludes ``_HIDDEN_LIST_USERS`` (``"local"``, ``"__public__"``)
+        the same way :meth:`list_users` does — the legacy ``"local"``
+        row can carry ``is_admin=True`` from the pre-accounts backfill,
+        but it's reserved and can't authenticate in accounts mode, so
+        counting it as a real admin would let the actual last admin
+        get deleted believing a usable admin remains.
+        """
+        query = select(SqlUser.id).where(
+            SqlUser.workspace_id == current_workspace_id(),
+            SqlUser.is_admin.is_(True),
+            SqlUser.id.not_in(_HIDDEN_LIST_USERS),
+        )
+        if self._supports_for_update:
+            query = query.with_for_update()
+        return list(session.execute(query).scalars().all())
+
+    def delete_user(self, user_id: str) -> bool | None:
+        """Delete a user row and their permission grants, refusing to
+        remove the last admin.
 
         Explicitly deletes all ``session_permissions`` rows for the user
         before removing the user row — the DB no longer cascades this.
+        The admin-invariant check and the delete run in the same locked
+        transaction (see :meth:`_locked_admin_ids`), so this is atomic
+        against a concurrent delete of a different admin — unlike a
+        plain read-then-delete, the two can't both observe "an admin
+        remains" and both apply.
 
-        :returns: ``True`` if a user row was deleted, ``False`` otherwise.
+        :returns: ``True`` if deleted, ``False`` if refused because
+            ``user_id`` is the last remaining admin, ``None`` if no such
+            user exists.
         """
-        with self._session() as session:
+        session_maker = self._session if self._supports_for_update else self._session_immediate
+        with session_maker() as session:
+            target = session.get(SqlUser, (current_workspace_id(), user_id))
+            if target is None:
+                return None
+            if target.is_admin:
+                other_admins = [uid for uid in self._locked_admin_ids(session) if uid != user_id]
+                if not other_admins:
+                    return False
             session.execute(
                 delete(SqlSessionPermission).where(
                     SqlSessionPermission.workspace_id == current_workspace_id(),
                     SqlSessionPermission.user_id == user_id,
                 )
             )
-            result = session.execute(
-                delete(SqlUser).where(
-                    SqlUser.workspace_id == current_workspace_id(),
-                    SqlUser.id == user_id,
-                )
-            )
-            return result.rowcount > 0
+            session.delete(target)
+            return True
 
     def get_password_hash(self, user_id: str) -> str | None:
         """Fetch a user's password hash for verification.

--- a/omnigent/server/routes/accounts_auth.py
+++ b/omnigent/server/routes/accounts_auth.py
@@ -682,6 +682,9 @@ def create_accounts_auth_router(
           bootstrap admin's name now defaults to the OS user
           (e.g. ``dhruv.gupta``), so the check generalizes to
           "would this leave zero admins". Same invariant, name-agnostic.
+          Checked and applied atomically (see
+          ``AccountStore.delete_user``) so two concurrent deletes of
+          two different admins can't both slip past the check.
         """
         admin_id = auth_provider.get_user_id(request)
         if admin_id is None or not account_store.is_admin(admin_id):
@@ -689,23 +692,17 @@ def create_accounts_auth_router(
         if user_id == admin_id:
             return JSONResponse(status_code=400, content={"error": "cannot delete self"})
 
-        target = account_store.get_user(user_id)
-        if target is None:
+        result = account_store.delete_user(user_id)
+        if result is None:
             return JSONResponse(status_code=404, content={"error": "not found"})
-        if target.is_admin:
-            other_admins = [
-                u for u in account_store.list_users() if u.is_admin and u.id != user_id
-            ]
-            if not other_admins:
-                return JSONResponse(
-                    status_code=400,
-                    content={
-                        "error": "cannot delete the last admin — promote another "
-                        "user first or the deploy would have no recovery path"
-                    },
-                )
-
-        account_store.delete_user(user_id)
+        if result is False:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": "cannot delete the last admin — promote another "
+                    "user first or the deploy would have no recovery path"
+                },
+            )
         return Response(status_code=204)
 
     @router.post("/users/{user_id}/reset")

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -1585,6 +1585,52 @@ def test_admin_cannot_delete_last_admin(accounts_app: TestClient) -> None:
     assert "self" in resp.json()["error"].lower() or "last admin" in resp.json()["error"].lower()
 
 
+def test_concurrent_deletes_cannot_leave_zero_admins(tmp_path: Path) -> None:
+    """Two concurrent deletes of two *different* admins can't both apply.
+
+    Regression test for a TOCTOU race: a naive read-then-delete
+    ("are there other admins? if so, delete") checks and writes in
+    two separate transactions. If two admins are deleted at once,
+    each request's read can see the *other* as the remaining admin,
+    both checks pass, and the deploy ends up with zero admins and no
+    recovery path. ``AccountStore.delete_user`` closes this by
+    locking the admin set before counting it (``BEGIN IMMEDIATE`` on
+    SQLite), so the second writer blocks and re-observes the
+    up-to-date count instead of the stale one.
+
+    Runs the two deletes as real concurrent threads against the same
+    on-disk SQLite database — not a simulated interleave — so it
+    actually exercises the locking, not just the application logic.
+    """
+    import threading
+
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    store = SqlAlchemyAccountStore(db_url)
+    store.create_user_with_password("alice", hash_password("alice-pw-1234"), is_admin=True)
+    store.create_user_with_password("bob", hash_password("bob-pw-1234"), is_admin=True)
+
+    results: dict[str, bool | None] = {}
+    barrier = threading.Barrier(2)
+
+    def delete(user_id: str) -> None:
+        barrier.wait()  # maximize the chance both threads race the same window
+        results[user_id] = store.delete_user(user_id)
+
+    threads = [threading.Thread(target=delete, args=(uid,)) for uid in ("alice", "bob")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    remaining_admins = {u.id for u in store.list_users() if u.is_admin}
+    assert remaining_admins, (
+        f"last-admin invariant violated: {remaining_admins=} results={results}"
+    )
+    # Exactly one delete should have been refused (whichever ran second
+    # relative to the DB lock); the other applied.
+    assert sorted(results.values()) == [False, True]
+
+
 def test_admin_reset_returns_new_plaintext_once(
     accounts_app: TestClient,
 ) -> None:


### PR DESCRIPTION
## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #3303

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->
- `DELETE /auth/users/{user_id}` enforced the "never leave zero admins" invariant with a check-then-act pattern split across two unlocked transactions (`list_users()` read, then `delete_user()` write). Two concurrent deletes of two different admins could each pass the check and both apply, leaving zero admins with no in-app recovery path.
- Added `AccountStore._locked_admin_ids()`, which locks the current admin set (`BEGIN IMMEDIATE` on SQLite, `SELECT ... FOR UPDATE` on other dialects) before counting it, and rewrote `delete_user()` to run the check and the delete in that same locked transaction.

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->
- Reproduced the bug directly against the unpatched `SqlAlchemyAccountStore` by interleaving two admins' check-then-delete calls in the exact order two concurrent requests would produce; confirmed it leaves zero admins.
- Applied the fix and re-ran the same reproduction with real concurrent OS threads (not a simulated interleave) against the same on-disk SQLite database; confirmed exactly one delete is refused and one admin always remains.
- Ran the full `tests/server/test_accounts.py`, `tests/stores/test_permission_store.py`, and `tests/server/test_admin_list.py` suites; all pass with no regressions.
- `pre-commit run` (ruff format, ruff check, all repo hooks) clean.

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->
`N/A`, this is a backend change.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [X] Manual verification completed
- [X] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `test_concurrent_deletes_cannot_leave_zero_admins`, which spins up two real threads deleting two different admins at once against the same on-disk SQLite database and asserts at least one admin always survives. Manual verification: confirmed the bug reproduces on unpatched code and is resolved on patched code, both via direct interleaved store calls and via real concurrent threads (see Test Plan).

## Changelog

Fixed a race condition where deleting two admins at nearly the same time could leave a deployment with zero admins and no way to recover through the API.
