### PR TITLE
fix(host): refuse pytest local-server spawns against real home

### DIFF
--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -36,6 +36,11 @@ from omnigent.process_logging import (
     open_process_log_file,
 )
 
+try:
+    import pwd  # POSIX-only; absent on Windows.
+except ImportError:
+    pwd = None  # type: ignore[assignment]
+
 _LOCAL_SERVER_READY_TIMEOUT_SECONDS = 45.0
 
 # Max seconds to wait for a bind-race-doomed server child's natural
@@ -86,6 +91,86 @@ _LOCAL_SERVER_SIG_PATH = _local_data_dir() / "local_server.sig"
 # server this invocation didn't spawn. Absent for a foreground
 # ``omnigent server`` (its logs stream to the terminal, not a file).
 _LOCAL_SERVER_LOG_REF_PATH = _local_data_dir() / "local_server.logpath"
+
+
+def _real_home_dir() -> Path:
+    """Return the OS account's real home directory, ignoring ``HOME``.
+
+    :func:`_local_data_dir` (like ``Path.home()`` generally) honors the
+    ``HOME`` env var — exactly how an isolated test redirects the local
+    server's data dir into a tmp dir (see its docstring). A check for "is
+    this about to hit the REAL production home" can't just re-derive
+    ``Path.home()`` again: with ``OMNIGENT_DATA_DIR`` unset, that always
+    agrees with whatever ``HOME`` override (or lack of one) is already in
+    effect, so it can never distinguish an isolated invocation from an
+    unisolated one. Reading the passwd-database entry instead bypasses
+    ``HOME`` — and any test monkeypatch of ``Path.home`` itself — so this
+    stays pinned to the actual account's home dir no matter what the
+    process's environment or test doubles claim.
+
+    POSIX-only (``pwd`` has no Windows equivalent); on Windows, or if the
+    current uid has no passwd entry, falls back to ``Path.home()``.
+
+    :returns: The real home directory for the current OS user.
+    """
+    if pwd is not None:
+        with contextlib.suppress(KeyError, OSError):
+            return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    return Path.home()
+
+
+def _refuse_real_home_spawn_under_pytest(data_dir: Path) -> None:
+    """Refuse to spawn the local server against the real ``~/.omnigent`` under pytest.
+
+    Incident this guards against: an unisolated ``pytest`` run reached
+    this spawn path with neither ``OMNIGENT_DATA_DIR`` nor ``HOME``
+    overridden, so it resolved straight to the developer's live
+    ``~/.omnigent``. The spawned server's Alembic head was ahead of the
+    installed release, and Omnigent's startup auto-migration silently
+    carried the production DB forward by 12 migrations — two of which
+    dropped columns the installed app still read, breaking it until the
+    DB was restored by hand. Isolation for this surface is opt-in per
+    test (unlike the autouse claude/codex-native-state fixtures in
+    ``tests/conftest.py``), so a single missed test is enough to repeat
+    this. This is the fail-loud backstop for that gap.
+
+    Only checked under pytest — :data:`PYTEST_CURRENT_TEST` is set by
+    pytest for the whole setup/call/teardown of the test that reaches
+    this code, so it is visible here even though the spawn itself runs in
+    that same (parent) test process. A real user's ``omnigent run`` /
+    ``omnigent server`` never has this var set, so the guard can never
+    fire for them. A test that isolated itself — via ``OMNIGENT_DATA_DIR``,
+    via ``HOME``, or by monkeypatching ``Path.home`` directly (as the
+    spawn tests in ``tests/host/test_local_server.py`` do) — resolves
+    *data_dir* to something other than the real home, so this never fires
+    for them either.
+
+    :param data_dir: The resolved local-server data dir this spawn is
+        about to use, e.g. from :func:`_local_data_dir`.
+    :raises click.ClickException: if running under pytest and *data_dir*
+        resolves to the real OS home's ``.omnigent``.
+    """
+    if not os.environ.get("PYTEST_CURRENT_TEST"):
+        return
+    # Plain path equality, deliberately NOT ``.resolve()``: resolving symlinks
+    # would stat the real ``~/.omnigent`` to compare against, and this
+    # function must never touch that path even read-only. ``_real_home_dir``
+    # and ``_local_data_dir`` both already return absolute, expanduser'd
+    # paths, so a textual comparison is exact for the HOME/OMNIGENT_DATA_DIR
+    # overrides this guards against.
+    real_home_omnigent = _real_home_dir() / ".omnigent"
+    if data_dir.expanduser() != real_home_omnigent:
+        return
+    raise click.ClickException(
+        f"Refused to spawn the local Omnigent server against the real "
+        f"{real_home_omnigent} from a pytest run (PYTEST_CURRENT_TEST is "
+        f"set). This exact path once spawned unisolated, and the spawned "
+        f"server's startup auto-migration silently carried a live "
+        f"production DB forward, breaking the installed app.\n"
+        f"Set OMNIGENT_DATA_DIR (or HOME) to a temp directory before "
+        f"running tests, e.g. `export OMNIGENT_DATA_DIR=$(mktemp -d)`, "
+        f"then retry."
+    )
 
 
 def server_config_signature() -> str:
@@ -460,8 +545,9 @@ def ensure_local_omnigent_server() -> LocalServerStartup:
         (stop stale + start fresh) counts as ``spawned=True`` — the fresh
         server is ours.
     :raises click.ClickException: If the server does not become healthy
-        within the startup timeout, or if port contention persists after
-        a free-port respawn.
+        within the startup timeout, if port contention persists after a
+        free-port respawn, or if running under pytest with the local data
+        dir unisolated (see :func:`_refuse_real_home_spawn_under_pytest`).
     """
     desired_sig = server_config_signature()
     reused = local_server_url_if_healthy()
@@ -593,8 +679,12 @@ def _spawn_local_server(port: int) -> _SpawnedLocalServer:
     :param port: Loopback TCP port for the child to bind, e.g. ``6767``.
     :returns: The spawned subprocess plus its log path and base URL; the
         caller awaits readiness via :func:`_wait_for_local_omnigent_server`.
+    :raises click.ClickException: if running under pytest and the
+        resolved data dir is the real OS home (see
+        :func:`_refuse_real_home_spawn_under_pytest`).
     """
     data_dir = _local_data_dir()
+    _refuse_real_home_spawn_under_pytest(data_dir)
     data_dir.mkdir(parents=True, exist_ok=True)
     (data_dir / "artifacts").mkdir(exist_ok=True)
     db_path = data_dir / "chat.db"

--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -152,14 +152,11 @@ def _refuse_real_home_spawn_under_pytest(data_dir: Path) -> None:
     """
     if not os.environ.get("PYTEST_CURRENT_TEST"):
         return
-    # Plain path equality, deliberately NOT ``.resolve()``: resolving symlinks
-    # would stat the real ``~/.omnigent`` to compare against, and this
-    # function must never touch that path even read-only. ``_real_home_dir``
-    # and ``_local_data_dir`` both already return absolute, expanduser'd
-    # paths, so a textual comparison is exact for the HOME/OMNIGENT_DATA_DIR
-    # overrides this guards against.
+    # Canonicalize both paths so an OMNIGENT_DATA_DIR symlink cannot bypass the
+    # guard. Resolution is read-only and happens before any target directory is
+    # created or opened.
     real_home_omnigent = _real_home_dir() / ".omnigent"
-    if data_dir.expanduser() != real_home_omnigent:
+    if data_dir.expanduser().resolve(strict=False) != real_home_omnigent.resolve(strict=False):
         return
     raise click.ClickException(
         f"Refused to spawn the local Omnigent server against the real "

--- a/tests/host/test_local_server.py
+++ b/tests/host/test_local_server.py
@@ -504,6 +504,22 @@ def test_refuse_real_home_spawn_under_pytest_allows_omnigent_data_dir(
     local_server._refuse_real_home_spawn_under_pytest(local_server._local_data_dir())
 
 
+def test_refuse_real_home_spawn_under_pytest_rejects_real_home_symlink(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A symlink to the real data directory is still unisolated."""
+    real_home = tmp_path / "real-home"
+    real_data_dir = real_home / ".omnigent"
+    real_data_dir.mkdir(parents=True)
+    alias = tmp_path / "claimed-isolated"
+    alias.symlink_to(real_data_dir, target_is_directory=True)
+    monkeypatch.setattr(local_server, "_real_home_dir", lambda: real_home)
+
+    with pytest.raises(click.ClickException, match="Refused to spawn"):
+        local_server._refuse_real_home_spawn_under_pytest(alias)
+
+
 def test_refuse_real_home_spawn_under_pytest_allows_home_override(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/host/test_local_server.py
+++ b/tests/host/test_local_server.py
@@ -460,6 +460,110 @@ def test_local_data_dir_honors_data_dir_not_config_home(
     assert local_server._local_data_dir() == tmp_path / "data"
 
 
+# ---------------------------------------------------------------------------
+# _refuse_real_home_spawn_under_pytest — the real-~/.omnigent spawn guard
+# ---------------------------------------------------------------------------
+
+
+def test_refuse_real_home_spawn_under_pytest_fires_on_real_home(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard raises when the resolved data dir is the real home under pytest.
+
+    Regression test for the incident: an unisolated pytest run reached the
+    spawn path with neither ``OMNIGENT_DATA_DIR`` nor ``HOME`` overridden,
+    resolving straight to the developer's real ``~/.omnigent`` — whose
+    startup auto-migration then broke the installed app. This test
+    simulates the same miss (``OMNIGENT_DATA_DIR`` unset, ``HOME``
+    untouched); ``PYTEST_CURRENT_TEST`` is already set by pytest for the
+    duration of this test, so the guard must raise.
+    """
+    monkeypatch.delenv("OMNIGENT_DATA_DIR", raising=False)
+
+    with pytest.raises(click.ClickException) as excinfo:
+        local_server._refuse_real_home_spawn_under_pytest(local_server._local_data_dir())
+
+    message = str(excinfo.value)
+    expected_path = local_server._real_home_dir() / ".omnigent"
+    assert str(expected_path) in message
+    assert "OMNIGENT_DATA_DIR" in message
+
+
+def test_refuse_real_home_spawn_under_pytest_allows_omnigent_data_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Setting ``OMNIGENT_DATA_DIR`` isolates the spawn — the guard stays quiet.
+
+    This is the purpose-built data-isolation knob (:func:`_local_data_dir`);
+    once it points somewhere other than the real home, the guard must let
+    the resolved dir through unmodified.
+    """
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+
+    local_server._refuse_real_home_spawn_under_pytest(local_server._local_data_dir())
+
+
+def test_refuse_real_home_spawn_under_pytest_allows_home_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Overriding ``Path.home`` (not just ``OMNIGENT_DATA_DIR``) also stays quiet.
+
+    The resumption e2e tests isolate by setting ``HOME`` rather than
+    ``OMNIGENT_DATA_DIR`` (see :func:`_local_data_dir`'s docstring), and
+    the spawn tests in this file simulate that by monkeypatching
+    ``Path.home`` directly. A guard that just re-derived
+    ``Path.home() / ".omnigent"`` to decide "is this the real home" would
+    trivially agree with itself here (``OMNIGENT_DATA_DIR`` is unset in
+    both cases) and fire on every one of those tests; comparing against
+    :func:`_real_home_dir` (a ``Path.home``-independent lookup) instead
+    proves it does not.
+    """
+    monkeypatch.delenv("OMNIGENT_DATA_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+
+    local_server._refuse_real_home_spawn_under_pytest(local_server._local_data_dir())
+
+
+def test_refuse_real_home_spawn_under_pytest_noop_outside_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without ``PYTEST_CURRENT_TEST`` set, the guard never fires.
+
+    A real user's ``omnigent run`` / ``omnigent server`` never has this
+    var set, so the guard must be a complete no-op for them — even when
+    handed the real home's data dir, as here.
+    """
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+    local_server._refuse_real_home_spawn_under_pytest(local_server._real_home_dir() / ".omnigent")
+
+
+def test_spawn_local_server_refuses_real_home_under_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_spawn_local_server`` itself refuses before touching anything.
+
+    Proves the guard is actually wired into the real spawn path and not
+    just unit-tested in isolation: with ``OMNIGENT_DATA_DIR`` unset and
+    ``HOME`` untouched, calling the real entry point must raise before
+    ``subprocess.Popen`` is ever reached (the stub below fails the test
+    if it is).
+    """
+    monkeypatch.delenv("OMNIGENT_DATA_DIR", raising=False)
+
+    def _must_not_popen(*_args: object, **_kwargs: object) -> Any:
+        raise AssertionError("spawned a subprocess despite targeting the real home")
+
+    monkeypatch.setattr(local_server.subprocess, "Popen", _must_not_popen)
+
+    with pytest.raises(click.ClickException) as excinfo:
+        local_server._spawn_local_server(8765)
+
+    assert "pytest" in str(excinfo.value).lower()
+
+
 def test_pick_local_port_returns_preferred_when_free() -> None:
     """``pick_local_port`` returns the preferred port when it's bindable.
 

--- a/tests/host/test_local_server.py
+++ b/tests/host/test_local_server.py
@@ -730,6 +730,12 @@ def test_ensure_local_omnigent_server_spawn_records_and_returns_log_path(
     monkeypatch.setattr(local_server, "_LOCAL_SERVER_SIG_PATH", sig_file)
     monkeypatch.setattr(local_server, "_LOCAL_SERVER_LOG_REF_PATH", log_ref)
     # Point the persistent data dir at tmp so logs/server lands under tmp.
+    # ``_local_data_dir`` consults OMNIGENT_DATA_DIR *before* falling back to
+    # ``Path.home()``, so the patch below only takes effect once that env var
+    # is out of the way. Without this delenv the test silently resolves to the
+    # ambient OMNIGENT_DATA_DIR and fails — which is exactly what happens to
+    # anyone following the isolation advice in the spawn guard's error message.
+    monkeypatch.delenv("OMNIGENT_DATA_DIR", raising=False)
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
 
     class _Proc:


### PR DESCRIPTION
## Related issue

N/A — production-safety regression discovered after an unisolated pytest run migrated the local database.

## Summary

- Refuse local-server spawning under pytest when the resolved data directory is the OS user's real `~/.omnigent`.
- Canonicalize paths so an `OMNIGENT_DATA_DIR` symlink cannot bypass the guard.

## Test Plan

- `OMNIGENT_DATA_DIR=<temporary> OMNIGENT_CONFIG_HOME=<temporary> uv run --extra dev pytest tests/host/test_local_server.py -q` (35 passed)
- `uv run --extra dev ruff check omnigent/host/local_server.py tests/host/test_local_server.py`
- `uvx pre-commit run --files omnigent/host/local_server.py tests/host/test_local_server.py`

## Demo

N/A — non-visual safety guard.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test update

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual verification only

## Coverage notes

The new regression asserts that a symlink resolving to the real data directory is refused before spawn.

## Changelog

Prevent test-spawned local servers from writing to the real OmniGent home.
