### PR TITLE
refactor(theme): drive shell night mode from selected theme source

### DIFF
--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -22,9 +22,9 @@ import android.webkit.WebView
 import android.widget.FrameLayout
 import android.widget.PopupMenu
 import android.widget.TextView
-import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.graphics.Insets
@@ -45,7 +45,7 @@ import androidx.webkit.WebViewFeature
  * Server URL comes from [ServerStore]; when none is set yet, launch routes to
  * [ConnectActivity] first. Sidebar edge-swipe is intentionally absent (README).
  */
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     private lateinit var webView: WebView
     private lateinit var notifications: NativeNotificationManager
     private lateinit var blobSaver: BlobSaver
@@ -139,9 +139,6 @@ class MainActivity : ComponentActivity() {
                 webViewClient =
                     OmnigentWebViewClient(
                         pinnedOrigin = { pinnedOrigin },
-                        // Full page loads briefly use OS-derived bar polarity until the SPA
-                        // reports its resolved scheme; capable SPAs override it immediately.
-                        onTopLevelNavigation = ::resetColorSchemeToSystem,
                         shouldInjectBridgeAtPageReady = {
                             bridgeTransportInstalled && bridgeScriptHandler == null
                         },
@@ -189,6 +186,7 @@ class MainActivity : ComponentActivity() {
                 }
         container.addView(switchButton)
         setContentView(container)
+        applySystemBarContrast()
         installBridge()
 
         // Measure the OS safe area and push it into the page as CSS custom
@@ -284,6 +282,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
+        applySystemBarContrast()
         if (::webView.isInitialized) {
             // Notify matchMedia listeners without reloading the SPA.
             webView.dispatchConfigurationChanged(newConfig)
@@ -309,7 +308,6 @@ class MainActivity : ComponentActivity() {
                 OmnigentBridgeListener(
                     notifications = notifications,
                     blobSaver = blobSaver,
-                    onColorScheme = ::applyColorScheme,
                 ),
             )
         } catch (_: IllegalArgumentException) {
@@ -331,19 +329,14 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun applyColorScheme(scheme: ResolvedColorScheme) {
-        val useDarkIcons = scheme == ResolvedColorScheme.LIGHT
-        WindowInsetsControllerCompat(window, window.decorView).apply {
-            isAppearanceLightStatusBars = useDarkIcons
-            isAppearanceLightNavigationBars = useDarkIcons
-        }
-    }
-
-    private fun resetColorSchemeToSystem() {
+    private fun applySystemBarContrast() {
         val isLightMode =
             resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK !=
                 Configuration.UI_MODE_NIGHT_YES
-        applyColorScheme(if (isLightMode) ResolvedColorScheme.LIGHT else ResolvedColorScheme.DARK)
+        WindowInsetsControllerCompat(window, window.decorView).apply {
+            isAppearanceLightStatusBars = isLightMode
+            isAppearanceLightNavigationBars = isLightMode
+        }
     }
 
     /**

--- a/web/android/app/src/main/java/ai/omnigent/android/NativeBridgeScript.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/NativeBridgeScript.kt
@@ -13,8 +13,6 @@ package ai.omnigent.android
  * frames on the pinned origin. `notify()` resolves `true` optimistically (as on
  * iOS) since the post is fire-and-forget. native -> web is driven by
  * `evaluateJavascript` into the `window.__omnigentNativeEmit*` functions here.
- * Once installed, the facade emits `omnigent-native-ready` so a SPA whose
- * first color-scheme report raced the injection can replay it.
  */
 object NativeBridgeScript {
     val source: String =
@@ -90,29 +88,6 @@ object NativeBridgeScript {
               if (bridge) bridge.postMessage(JSON.stringify(payload));
             } catch (_) {}
           };
-
-          // The SPA owns its resolved theme via the root class. Watch it here so
-          // native bars stay correct even when the server cannot report changes.
-          const resolvePageColorScheme = () => {
-            const root = document.documentElement;
-            if (root?.classList.contains("dark")) return "dark";
-            if (root?.classList.contains("light")) return "light";
-            return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-          };
-          let lastPageColorScheme = null;
-          const syncPageColorScheme = () => {
-            const scheme = resolvePageColorScheme();
-            if (scheme === lastPageColorScheme) return;
-            lastPageColorScheme = scheme;
-            post({ method: "setColorScheme", scheme });
-          };
-          const colorSchemeRoot = document.documentElement;
-          const colorSchemeObserver = colorSchemeRoot ? new MutationObserver(syncPageColorScheme) : null;
-          colorSchemeObserver?.observe(colorSchemeRoot, {
-            attributes: true,
-            attributeFilter: ["class"],
-          });
-          syncPageColorScheme();
 
           const notificationCallbacks = new Set();
           // An activation is a fire-once event, but the native side may emit it
@@ -229,7 +204,7 @@ object NativeBridgeScript {
           window.omnigentNative = Object.freeze({
             kind: "android",
             setColorScheme(scheme) {
-              if (scheme !== "light" && scheme !== "dark") return;
+              if (scheme !== "light" && scheme !== "dark" && scheme !== "system") return;
               post({ method: "setColorScheme", scheme });
             },
             setBadgeCount(count, options) {
@@ -276,7 +251,6 @@ object NativeBridgeScript {
               return () => insetCallbacks.delete(callback);
             },
           });
-          window.dispatchEvent(new Event("omnigent-native-ready"));
         })();
         """.trimIndent()
 }

--- a/web/android/app/src/main/java/ai/omnigent/android/OmnigentBridgeListener.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OmnigentBridgeListener.kt
@@ -1,9 +1,8 @@
 package ai.omnigent.android
 
 import android.net.Uri
-import android.os.Handler
-import android.os.Looper
 import android.webkit.WebView
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.WebMessageCompat
 import androidx.webkit.WebViewCompat
@@ -19,16 +18,12 @@ import org.json.JSONObject
  * structural equivalent of the iOS `isMainFrame` + frame-origin check that a
  * raw `addJavascriptInterface` bridge cannot express.
  *
- * Color-scheme updates are posted to the main looper; [BlobSaver] offloads
- * writes to its own worker.
+ * [BlobSaver] offloads writes to its own worker.
  */
 class OmnigentBridgeListener(
     private val notifications: NativeNotificationManager,
     private val blobSaver: BlobSaver,
-    private val onColorScheme: (ResolvedColorScheme) -> Unit,
 ) : WebViewCompat.WebMessageListener {
-    private val mainHandler = Handler(Looper.getMainLooper())
-
     override fun onPostMessage(
         view: WebView,
         message: WebMessageCompat,
@@ -52,13 +47,25 @@ class OmnigentBridgeListener(
 
         when (json.optString("method")) {
             "setColorScheme" -> {
-                val scheme =
-                    when (json.optString("scheme")) {
-                        "light" -> ResolvedColorScheme.LIGHT
-                        "dark" -> ResolvedColorScheme.DARK
-                        else -> return
+                when (json.optString("scheme")) {
+                    "light" -> {
+                        AppCompatDelegate.setDefaultNightMode(
+                            AppCompatDelegate.MODE_NIGHT_NO,
+                        )
                     }
-                mainHandler.post { onColorScheme(scheme) }
+
+                    "dark" -> {
+                        AppCompatDelegate.setDefaultNightMode(
+                            AppCompatDelegate.MODE_NIGHT_YES,
+                        )
+                    }
+
+                    "system" -> {
+                        AppCompatDelegate.setDefaultNightMode(
+                            AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM,
+                        )
+                    }
+                }
             }
 
             "setBadgeCount" -> {

--- a/web/android/app/src/main/java/ai/omnigent/android/OmnigentWebViewClient.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OmnigentWebViewClient.kt
@@ -13,12 +13,10 @@ import android.webkit.WebViewClient
  *
  * The facade is normally registered with `addDocumentStartJavaScript` in
  * `MainActivity`. Older WebViews that support the message listener but not
- * document-start scripts inject it after the pinned page finishes; the facade's
- * ready event then replays any color scheme the SPA reported before injection.
+ * document-start scripts inject it after the pinned page finishes.
  */
 class OmnigentWebViewClient(
     private val pinnedOrigin: () -> String?,
-    private val onTopLevelNavigation: () -> Unit,
     private val shouldInjectBridgeAtPageReady: () -> Boolean,
     private val onPageReady: (url: String?) -> Unit,
     private val onLoginRequired: () -> Unit,
@@ -29,7 +27,6 @@ class OmnigentWebViewClient(
         favicon: Bitmap?,
     ) {
         super.onPageStarted(view, url, favicon)
-        onTopLevelNavigation()
 
         val origin = originOf(url)
         val scheme = url?.let { Uri.parse(it).scheme?.lowercase() }

--- a/web/android/app/src/main/java/ai/omnigent/android/ResolvedColorScheme.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/ResolvedColorScheme.kt
@@ -1,6 +1,0 @@
-package ai.omnigent.android
-
-enum class ResolvedColorScheme {
-    LIGHT,
-    DARK,
-}

--- a/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
@@ -25,16 +25,35 @@ class MainActivityTest {
     }
 
     @Test
-    fun `configuration change preserves SPA-applied system bar polarity`() {
-        // Skip onCreate to isolate the bare config-change path from WebView dispatch.
-        val activity = Robolectric.buildActivity(MainActivity::class.java).get()
-        activity.applyColorScheme(ResolvedColorScheme.LIGHT)
+    @Config(qualifiers = "notnight")
+    fun `light configuration uses dark status bar icons`() {
+        ServerStore(ApplicationProvider.getApplicationContext()).connect("https://example.com")
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
         val insetsController =
             WindowInsetsControllerCompat(activity.window, activity.window.decorView)
-        val statusBarsWereLight = insetsController.isAppearanceLightStatusBars
-        val navigationBarsWereLight = insetsController.isAppearanceLightNavigationBars
-        assertTrue(statusBarsWereLight)
-        assertTrue(navigationBarsWereLight)
+
+        assertTrue(insetsController.isAppearanceLightStatusBars)
+        assertTrue(insetsController.isAppearanceLightNavigationBars)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `dark configuration uses light status bar icons`() {
+        ServerStore(ApplicationProvider.getApplicationContext()).connect("https://example.com")
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
+        val insetsController =
+            WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+
+        assertFalse(insetsController.isAppearanceLightStatusBars)
+        assertFalse(insetsController.isAppearanceLightNavigationBars)
+    }
+
+    @Test
+    fun `configuration change updates system bar icon polarity`() {
+        ServerStore(ApplicationProvider.getApplicationContext()).connect("https://example.com")
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
+        val insetsController =
+            WindowInsetsControllerCompat(activity.window, activity.window.decorView)
 
         val darkConfiguration =
             Configuration(activity.resources.configuration).apply {
@@ -43,56 +62,18 @@ class MainActivityTest {
                     Configuration.UI_MODE_NIGHT_YES
             }
         activity.onConfigurationChanged(darkConfiguration)
-
-        // The SPA owns resolved polarity; config changes must not re-derive it from uiMode.
-        assertEquals(statusBarsWereLight, insetsController.isAppearanceLightStatusBars)
-        assertEquals(navigationBarsWereLight, insetsController.isAppearanceLightNavigationBars)
-    }
-
-    @Test
-    fun `resolved page scheme drives both system bar icon polarities`() {
-        val activity = Robolectric.buildActivity(MainActivity::class.java).get()
-        val insetsController =
-            WindowInsetsControllerCompat(activity.window, activity.window.decorView)
-
-        activity.applyColorScheme(ResolvedColorScheme.DARK)
         assertFalse(insetsController.isAppearanceLightStatusBars)
         assertFalse(insetsController.isAppearanceLightNavigationBars)
 
-        activity.applyColorScheme(ResolvedColorScheme.LIGHT)
+        val lightConfiguration =
+            Configuration(activity.resources.configuration).apply {
+                uiMode =
+                    (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or
+                    Configuration.UI_MODE_NIGHT_NO
+            }
+        activity.onConfigurationChanged(lightConfiguration)
         assertTrue(insetsController.isAppearanceLightStatusBars)
         assertTrue(insetsController.isAppearanceLightNavigationBars)
-    }
-
-    @Test
-    @Config(sdk = [35], qualifiers = "night")
-    fun `top level navigation resets system bars to the OS fallback`() {
-        ServerStore(ApplicationProvider.getApplicationContext()).connect("https://example.com")
-        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
-        val webView = activity.webView()
-        val insetsController =
-            WindowInsetsControllerCompat(activity.window, activity.window.decorView)
-        assertEquals(
-            Configuration.UI_MODE_NIGHT_YES,
-            activity.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK,
-        )
-
-        activity.applyColorScheme(ResolvedColorScheme.LIGHT)
-        assertTrue(insetsController.isAppearanceLightStatusBars)
-        assertTrue(insetsController.isAppearanceLightNavigationBars)
-
-        webView.webViewClient.onPageStarted(webView, "https://example.com/next", null)
-
-        assertFalse(insetsController.isAppearanceLightStatusBars)
-        assertFalse(insetsController.isAppearanceLightNavigationBars)
-    }
-
-    private fun MainActivity.applyColorScheme(scheme: ResolvedColorScheme) {
-        MainActivity::class
-            .java
-            .getDeclaredMethod("applyColorScheme", ResolvedColorScheme::class.java)
-            .apply { isAccessible = true }
-            .invoke(this, scheme)
     }
 
     private fun MainActivity.webView(): WebView =

--- a/web/android/app/src/test/java/ai/omnigent/android/OmnigentBridgeListenerTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/OmnigentBridgeListenerTest.kt
@@ -3,7 +3,7 @@ package ai.omnigent.android
 import android.app.Application
 import android.app.NotificationManager
 import android.content.Context
-import android.os.Looper
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -25,18 +25,17 @@ class OmnigentBridgeListenerTest {
     private lateinit var context: Application
     private lateinit var listener: OmnigentBridgeListener
     private lateinit var shadow: ShadowNotificationManager
-    private val appliedSchemes = mutableListOf<ResolvedColorScheme>()
 
     private val badgeId = 1
 
     @Before
     fun setUp() {
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
         context = ApplicationProvider.getApplicationContext()
         listener =
             OmnigentBridgeListener(
                 notifications = NativeNotificationManager(context),
                 blobSaver = BlobSaver(context),
-                onColorScheme = appliedSchemes::add,
             )
         shadow =
             shadowOf(
@@ -45,33 +44,35 @@ class OmnigentBridgeListenerTest {
     }
 
     @Test
-    fun `setColorScheme applies concrete schemes`() {
+    fun `setColorScheme light sets night mode no`() {
         listener.handle("""{"method":"setColorScheme","scheme":"light"}""")
-        listener.handle("""{"method":"setColorScheme","scheme":"dark"}""")
-        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(AppCompatDelegate.MODE_NIGHT_NO, AppCompatDelegate.getDefaultNightMode())
+    }
 
+    @Test
+    fun `setColorScheme dark sets night mode yes`() {
+        listener.handle("""{"method":"setColorScheme","scheme":"dark"}""")
+        assertEquals(AppCompatDelegate.MODE_NIGHT_YES, AppCompatDelegate.getDefaultNightMode())
+    }
+
+    @Test
+    fun `setColorScheme system follows system`() {
+        listener.handle("""{"method":"setColorScheme","scheme":"system"}""")
         assertEquals(
-            listOf(ResolvedColorScheme.LIGHT, ResolvedColorScheme.DARK),
-            appliedSchemes,
+            AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM,
+            AppCompatDelegate.getDefaultNightMode(),
         )
     }
 
     @Test
     fun `setColorScheme rejects missing and unsupported schemes`() {
-        listener.handle("""{"method":"setColorScheme","scheme":"system"}""")
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+
         listener.handle("""{"method":"setColorScheme"}""")
-        shadowOf(Looper.getMainLooper()).idle()
-
-        assertEquals(emptyList<ResolvedColorScheme>(), appliedSchemes)
-    }
-
-    @Test
-    fun `setColorScheme rejects non-string schemes`() {
+        listener.handle("""{"method":"setColorScheme","scheme":"auto"}""")
         listener.handle("""{"method":"setColorScheme","scheme":123}""")
-        listener.handle("""{"method":"setColorScheme","scheme":{"value":"light"}}""")
-        shadowOf(Looper.getMainLooper()).idle()
 
-        assertEquals(emptyList<ResolvedColorScheme>(), appliedSchemes)
+        assertEquals(AppCompatDelegate.MODE_NIGHT_NO, AppCompatDelegate.getDefaultNightMode())
     }
 
     @Test

--- a/web/android/app/src/test/java/ai/omnigent/android/OmnigentWebViewClientTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/OmnigentWebViewClientTest.kt
@@ -45,7 +45,6 @@ class OmnigentWebViewClientTest {
         onPageReady: (String?) -> Unit = {},
     ) = OmnigentWebViewClient(
         pinnedOrigin = { PINNED_ORIGIN },
-        onTopLevelNavigation = {},
         shouldInjectBridgeAtPageReady = { shouldInjectBridgeAtPageReady },
         onPageReady = onPageReady,
         onLoginRequired = {},

--- a/web/ios/Omnigent/AppRootView.swift
+++ b/web/ios/Omnigent/AppRootView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct AppRootView: View {
   @EnvironmentObject private var settings: SettingsStore
   @EnvironmentObject private var router: AppRouter
+  @StateObject private var theme = ThemeController.shared
   @State private var mode: Mode
 
   /// A deep link to a server the user has never connected to, awaiting the
@@ -47,6 +48,8 @@ struct AppRootView: View {
         )
       }
     }
+    .environmentObject(theme)
+    .preferredColorScheme(theme.source.colorScheme)
     .task {
       guard shouldAutoOpenSavedServer else { return }
       // A deep link that arrived before this task ran already moved us off the

--- a/web/ios/Omnigent/OmnigentWebView.swift
+++ b/web/ios/Omnigent/OmnigentWebView.swift
@@ -184,6 +184,13 @@ struct OmnigentWebView: UIViewRepresentable {
       });
       window.omnigentNative = Object.freeze({
         kind: "ios",
+        setColorScheme(scheme) {
+          if (scheme !== "light" && scheme !== "dark" && scheme !== "system") return;
+          window.webkit.messageHandlers.omnigentNative.postMessage({
+            method: "setColorScheme",
+            scheme,
+          });
+        },
         setBadgeCount(count) {
           window.webkit.messageHandlers.omnigentNative.postMessage({
             method: "setBadgeCount",
@@ -335,6 +342,11 @@ struct OmnigentWebView: UIViewRepresentable {
       else { return }
 
       switch method {
+      case "setColorScheme":
+        guard let scheme = body["scheme"] as? String,
+          let source = ThemeSource(rawValue: scheme)
+        else { return }
+        ThemeController.shared.apply(source)
       case "setBadgeCount":
         let count = (body["count"] as? NSNumber)?.intValue ?? 0
         NativeNotificationManager.shared.setBadgeCount(count)
@@ -600,5 +612,57 @@ extension UIViewController {
       return selected.omnigentTopViewController
     }
     return self
+  }
+}
+
+/// The user-selected theme source. Mirrors the value space the web app sends
+/// through the bridge via `setColorScheme`.
+enum ThemeSource: String, Equatable, CaseIterable {
+  case system
+  case light
+  case dark
+
+  /// UIKit interface style override used for windows and WKWebView.
+  var userInterfaceStyle: UIUserInterfaceStyle {
+    switch self {
+    case .system:
+      return .unspecified
+    case .light:
+      return .light
+    case .dark:
+      return .dark
+    }
+  }
+
+  /// SwiftUI's equivalent for `.preferredColorScheme`. `nil` means "follow the system".
+  var colorScheme: ColorScheme? {
+    switch self {
+    case .system:
+      return nil
+    case .light:
+      return .light
+    case .dark:
+      return .dark
+    }
+  }
+}
+
+/// App-wide theme override. The web layer drives this through the bridge so
+/// native chrome and the WebView track the in-app theme switcher.
+@MainActor
+final class ThemeController: ObservableObject {
+  static let shared = ThemeController()
+
+  @Published private(set) var source: ThemeSource = .system
+
+  private init() {}
+
+  func apply(_ source: ThemeSource) {
+    self.source = source
+    for scene in UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }) {
+      for window in scene.windows {
+        window.overrideUserInterfaceStyle = source.userInterfaceStyle
+      }
+    }
   }
 }

--- a/web/ios/OmnigentTests/DeepLinkTests.swift
+++ b/web/ios/OmnigentTests/DeepLinkTests.swift
@@ -153,5 +153,25 @@ final class DeepLinkTests: XCTestCase {
     // 33rd char not hex
     XCTAssertNotNil(DeepLink.parse(URL(string: "omnigent://localhost:8000/c/host_\(hex)")!))
     // wrong legacy prefix
+    XCTAssertNotNil(DeepLink.parse(URL(string: "omnigent://localhost:8000/c/conv_\(hex)")!))
+  }
+
+  func testThemeSourceMapsToUserInterfaceStyle() {
+    XCTAssertEqual(ThemeSource.system.userInterfaceStyle, .unspecified)
+    XCTAssertEqual(ThemeSource.light.userInterfaceStyle, .light)
+    XCTAssertEqual(ThemeSource.dark.userInterfaceStyle, .dark)
+  }
+
+  func testThemeSourceMapsToColorScheme() {
+    XCTAssertNil(ThemeSource.system.colorScheme)
+    XCTAssertEqual(ThemeSource.light.colorScheme, .light)
+    XCTAssertEqual(ThemeSource.dark.colorScheme, .dark)
+  }
+
+  func testThemeSourceParsesFromRawString() {
+    XCTAssertEqual(ThemeSource(rawValue: "system"), .system)
+    XCTAssertEqual(ThemeSource(rawValue: "light"), .light)
+    XCTAssertEqual(ThemeSource(rawValue: "dark"), .dark)
+    XCTAssertNil(ThemeSource(rawValue: "invalid"))
   }
 }

--- a/web/src/components/theme/ThemeProvider.test.tsx
+++ b/web/src/components/theme/ThemeProvider.test.tsx
@@ -5,59 +5,39 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeProvider } from "./ThemeProvider";
 
 const themeState = vi.hoisted(() => ({
-  reportColorScheme: vi.fn(),
+  setThemeSource: vi.fn(),
   theme: "system" as string | undefined,
-  resolvedTheme: "light" as string | undefined,
 }));
 
 vi.mock("@/lib/nativeBridge", () => ({
-  reportColorScheme: themeState.reportColorScheme,
+  setThemeSource: themeState.setThemeSource,
 }));
 
 vi.mock("next-themes", () => ({
   ThemeProvider: ({ children }: { children: ReactNode }) => children,
-  useTheme: () => ({ theme: themeState.theme, resolvedTheme: themeState.resolvedTheme }),
+  useTheme: () => ({ theme: themeState.theme }),
 }));
 
 beforeEach(() => {
-  themeState.reportColorScheme.mockClear();
+  themeState.setThemeSource.mockClear();
   themeState.theme = "system";
-  themeState.resolvedTheme = "light";
 });
 
 afterEach(cleanup);
 
 describe("ThemeProvider native theme sync", () => {
-  it("reports the resolved Android scheme and selected Electron system theme", () => {
+  it("tells the native shell to follow the system theme by default", () => {
     render(<ThemeProvider>content</ThemeProvider>);
-    expect(themeState.reportColorScheme).toHaveBeenCalledWith("light", "system");
+    expect(themeState.setThemeSource).toHaveBeenCalledWith("system");
   });
 
-  it("updates Android while Electron remains on system when the OS scheme changes", () => {
+  it("updates the native shell when the user selects an explicit theme", () => {
     const { rerender } = render(<ThemeProvider>content</ThemeProvider>);
-    themeState.reportColorScheme.mockClear();
-
-    themeState.resolvedTheme = "dark";
-    rerender(<ThemeProvider>content</ThemeProvider>);
-
-    expect(themeState.reportColorScheme).toHaveBeenCalledWith("dark", "system");
-  });
-
-  it("reports an explicit Electron theme when system is deselected without a resolved change", () => {
-    const { rerender } = render(<ThemeProvider>content</ThemeProvider>);
-    themeState.reportColorScheme.mockClear();
+    themeState.setThemeSource.mockClear();
 
     themeState.theme = "light";
     rerender(<ThemeProvider>content</ThemeProvider>);
 
-    expect(themeState.reportColorScheme).toHaveBeenCalledWith("light", "light");
-  });
-
-  it("keeps the resolved Android scheme separate from the explicit Electron theme", () => {
-    themeState.theme = "dark";
-    themeState.resolvedTheme = "light";
-    render(<ThemeProvider>content</ThemeProvider>);
-
-    expect(themeState.reportColorScheme).toHaveBeenCalledWith("light", "dark");
+    expect(themeState.setThemeSource).toHaveBeenCalledWith("light");
   });
 });

--- a/web/src/components/theme/ThemeProvider.tsx
+++ b/web/src/components/theme/ThemeProvider.tsx
@@ -1,19 +1,17 @@
 import { type ReactNode, useEffect } from "react";
 import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
-import { reportColorScheme } from "@/lib/nativeBridge";
+import { setThemeSource } from "@/lib/nativeBridge";
 
 /**
- * Mirrors the in-app theme onto native shell chrome. Renders nothing.
+ * Mirrors the in-app theme selection onto native shell chrome. Renders nothing.
  */
 function NativeThemeSync() {
-  const { theme, resolvedTheme } = useTheme();
+  const { theme } = useTheme();
   useEffect(() => {
-    if (resolvedTheme === "light" || resolvedTheme === "dark") {
-      const selectedTheme =
-        theme === "light" || theme === "dark" || theme === "system" ? theme : resolvedTheme;
-      reportColorScheme(resolvedTheme, selectedTheme);
+    if (theme === "light" || theme === "dark" || theme === "system") {
+      setThemeSource(theme);
     }
-  }, [theme, resolvedTheme]);
+  }, [theme]);
   return null;
 }
 

--- a/web/src/lib/nativeBridge.test.ts
+++ b/web/src/lib/nativeBridge.test.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -10,9 +8,9 @@ import {
   nativeNotify,
   onNativeNotificationActivated,
   onNativeSidebarDrag,
-  reportColorScheme,
   setBadgeCount as bridgeSetBadge,
   setNativeServerSwitcherHidden,
+  setThemeSource,
   supportsBrowser,
 } from "./nativeBridge";
 
@@ -41,19 +39,6 @@ const androidNotify = vi.fn().mockResolvedValue(true);
 const androidUnsubscribe = vi.fn();
 const androidOnNotificationActivated = vi.fn().mockReturnValue(androidUnsubscribe);
 const androidSetColorScheme = vi.fn();
-
-const androidBridgeScriptSource = readFileSync(
-  resolve("android/app/src/main/java/ai/omnigent/android/NativeBridgeScript.kt"),
-  "utf8",
-);
-
-function androidColorSchemeSyncSource(): string {
-  const match = androidBridgeScriptSource.match(
-    /          const resolvePageColorScheme = \(\) => \{[\s\S]*?          syncPageColorScheme\(\);/,
-  );
-  if (!match) throw new Error("Android color-scheme sync script not found");
-  return match[0].replace(/^ {10}/gm, "");
-}
 
 /**
  * Simulate running inside / outside the Electron shell via the preload key.
@@ -134,8 +119,6 @@ beforeEach(() => {
 afterEach(() => {
   setElectron(false);
   setIOS(false);
-  setAndroid(true);
-  window.dispatchEvent(new Event("omnigent-native-ready"));
   setAndroid(false);
 });
 
@@ -219,67 +202,32 @@ describe("supportsBrowser", () => {
   });
 });
 
-describe("reportColorScheme", () => {
+describe("setThemeSource", () => {
   it("routes the selected system theme through the Electron bridge", () => {
     setElectron(true);
-    reportColorScheme("dark", "system");
+    setThemeSource("system");
     expect(electronSetColorScheme).toHaveBeenCalledWith("system");
   });
 
   it("routes an explicit selected theme through the Electron bridge", () => {
     setElectron(true);
-    reportColorScheme("light", "light");
-    expect(electronSetColorScheme).toHaveBeenCalledWith("light");
+    setThemeSource("dark");
+    expect(electronSetColorScheme).toHaveBeenCalledWith("dark");
   });
 
-  it("routes only resolved concrete schemes through the Android bridge", () => {
+  it("routes the selected theme through the Android bridge", () => {
     setAndroid(true);
-    reportColorScheme("light", "system");
-    reportColorScheme("dark", "system");
-    expect(androidSetColorScheme).toHaveBeenNthCalledWith(1, "light");
-    expect(androidSetColorScheme).toHaveBeenNthCalledWith(2, "dark");
-  });
-
-  it("replays an explicit scheme when Android installs after the first report", () => {
-    setAndroid(false);
-    reportColorScheme("light", "light");
-    expect(androidSetColorScheme).not.toHaveBeenCalled();
-
-    setAndroid(true);
-    window.dispatchEvent(new Event("omnigent-native-ready"));
-
-    expect(androidSetColorScheme).toHaveBeenCalledOnce();
+    setThemeSource("light");
     expect(androidSetColorScheme).toHaveBeenCalledWith("light");
   });
-});
 
-describe("Android injected color scheme sync", () => {
-  it("re-pushes concrete schemes after live root theme changes", async () => {
-    document.documentElement.className = "light";
-    const post = vi.fn();
-    const disconnect = new Function(
-      "post",
-      `${androidColorSchemeSyncSource()}\nreturn () => colorSchemeObserver?.disconnect();`,
-    )(post) as () => void;
-
-    try {
-      expect(post).toHaveBeenLastCalledWith({ method: "setColorScheme", scheme: "light" });
-      post.mockClear();
-
-      document.documentElement.className = "dark";
-      await vi.waitFor(() => {
-        expect(post).toHaveBeenLastCalledWith({ method: "setColorScheme", scheme: "dark" });
-      });
-
-      post.mockClear();
-      document.documentElement.className = "light";
-      await vi.waitFor(() => {
-        expect(post).toHaveBeenLastCalledWith({ method: "setColorScheme", scheme: "light" });
-      });
-    } finally {
-      disconnect();
-      document.documentElement.className = "";
-    }
+  it("routes the selected theme through the Android bridge over Electron legacy", () => {
+    setElectron(true);
+    (
+      window as unknown as { omnigentNative?: { kind: string; setColorScheme?: unknown } }
+    ).omnigentNative = undefined;
+    setThemeSource("system");
+    expect(electronSetColorScheme).toHaveBeenCalledWith("system");
   });
 });
 

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -59,7 +59,7 @@ interface NativeShellApi {
    * ignore it.
    */
   setBadgeCount: (count: number, activation?: BadgeActivation) => void;
-  /** Electron receives the selected theme; Android receives resolved light/dark, never "system". */
+  /** Tell the shell which theme source the user selected. */
   setColorScheme?: (scheme: "light" | "dark" | "system") => void;
   /** Fire an OS notification; resolves true when it was shown. */
   notify: (params: NativeNotifyParams) => Promise<boolean>;
@@ -117,9 +117,7 @@ interface NativeShellApi {
   onNativeInsets?: (callback: (insets: NativeInsets) => void) => () => void;
 }
 
-const ANDROID_BRIDGE_READY_EVENT = "omnigent-native-ready";
-let pendingAndroidColorScheme: "light" | "dark" | undefined;
-let waitingForAndroidBridge = false;
+export type ThemeSource = "light" | "dark" | "system";
 
 /** Footprints (CSS px) of the native floating bars, reported by the shell. */
 export interface NativeInsets {
@@ -287,33 +285,16 @@ function nativeApi(): NativeShellApi | undefined {
   return electronApi();
 }
 
-function applyAndroidColorScheme(scheme: "light" | "dark"): boolean {
-  const android = nativeApi();
-  if (android?.kind !== "android" || !android.setColorScheme) return false;
+function callSetColorScheme(scheme: ThemeSource): boolean {
+  const native = nativeApi();
+  if (!native?.setColorScheme) return false;
   try {
-    android.setColorScheme(scheme);
+    native.setColorScheme(scheme);
   } catch (err) {
     console.warn("[nativeBridge] setColorScheme failed:", err);
+    return false;
   }
   return true;
-}
-
-function queueAndroidColorScheme(scheme: "light" | "dark"): void {
-  pendingAndroidColorScheme = scheme;
-  if (typeof window === "undefined" || waitingForAndroidBridge) return;
-
-  waitingForAndroidBridge = true;
-  window.addEventListener(
-    ANDROID_BRIDGE_READY_EVENT,
-    () => {
-      waitingForAndroidBridge = false;
-      const pendingScheme = pendingAndroidColorScheme;
-      if (!pendingScheme) return;
-      if (applyAndroidColorScheme(pendingScheme)) pendingAndroidColorScheme = undefined;
-      else queueAndroidColorScheme(pendingScheme);
-    },
-    { once: true },
-  );
 }
 
 /** True when running inside the Electron desktop shell. */
@@ -496,30 +477,12 @@ export function onNativeSidebarDrag(
  * descriptive text. Electron/iOS have a real icon badge and ignore it.
  */
 /**
- * Tell native shell chrome the web app's color scheme. Electron receives the
- * selected theme so system mode keeps following the OS; Android receives the
- * resolved scheme for system-bar icon contrast.
+ * Tell the native shell which theme source the user selected. The shell drives
+ * its own OS-level night mode so that native chrome and the WebView agree.
  * No-op outside supported shells. Fire-and-forget.
  */
-export function reportColorScheme(
-  resolvedScheme: "light" | "dark",
-  selectedScheme: "light" | "dark" | "system",
-): void {
-  const electron = electronApi();
-  if (electron?.setColorScheme) {
-    try {
-      electron.setColorScheme(selectedScheme);
-    } catch (err) {
-      console.warn("[nativeBridge] setColorScheme failed:", err);
-    }
-    return;
-  }
-
-  if (applyAndroidColorScheme(resolvedScheme)) {
-    pendingAndroidColorScheme = undefined;
-    return;
-  }
-  queueAndroidColorScheme(resolvedScheme);
+export function setThemeSource(themeSource: ThemeSource): void {
+  callSetColorScheme(themeSource);
 }
 
 export async function setBadgeCount(count: number, activation?: BadgeActivation): Promise<void> {


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace the web-resolved-theme bridge with a single cross-shell contract, `setThemeSource(theme)`, so the web app only reports the user's chosen theme source and each shell drives its own OS-level dark mode.
- Android: `MainActivity` now extends `AppCompatActivity`; `OmnigentBridgeListener` maps `setColorScheme` to `AppCompatDelegate.setDefaultNightMode`; system-bar icon contrast is derived from `resources.configuration.uiMode`. Removes `ResolvedColorScheme.kt`, the root-class MutationObserver, and the top-level navigation reset on init.
- iOS: Add a `ThemeSource` enum and `ThemeController` singleton inside the existing `OmnigentWebView.swift` target file to avoid `.pbxproj` edits; wire `setColorScheme` through the JS bridge and apply it via `.preferredColorScheme(...)` and `window.overrideUserInterfaceStyle`.
- Web: Update `nativeBridge.setThemeSource`, remove the `omnigent-native-ready` queue, and update `ThemeProvider`/`nativeBridge` unit tests.
- Android and web unit tests are updated to match the new contract.

## Architecture

```mermaid
flowchart LR
    subgraph Web
        TP["ThemeProvider"]
        NB["nativeBridge.setThemeSource(source)"]
    end

    subgraph Android
        AW["WebView JS bridge"]
        BL["OmnigentBridgeListener"]
        AD["AppCompatDelegate.setDefaultNightMode"]
        CSC["system bar contrast"]
    end

    subgraph iOS
        IW["WKWebView JS bridge"]
        TC["ThemeController"]
        OUI["window.overrideUserInterfaceStyle"]
        PCS[".preferredColorScheme"]
    end

    TP -->|selected theme source| NB
    NB -->|postMessage / evaluateJavaScript| AW
    NB -->|postMessage / evaluateJavaScript| IW
    AW --> BL
    BL --> AD
    AD -->|sets OS night mode| CSC
    AD -->|inherited by WebView| TP
    IW --> TC
    TC --> OUI
    TC --> PCS
    OUI -->|inherited by WebView| TP
    PCS -->|SwiftUI chrome| AppRootView
```

## Test Plan

- iOS: `cd web/ios && xcodebuild -project Omnigent.xcodeproj -scheme Omnigent -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug -only-testing:OmnigentTests test`
- Android: `cd web/android && ./gradlew :app:testDebugUnitTest`
- Web: `cd web && npm install && npm run type-check && npm run test -- ThemeProvider.test.tsx nativeBridge.test.ts`

## Demo

https://github.com/user-attachments/assets/ba5fb523-48b6-444d-ab78-09e382e37faf


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification completed for iOS: the app builds and `OmnigentTests` passes in the iPhone 17 Pro simulator. Android and web test suites were not run end-to-end in this session, but the affected unit tests were updated in the same change.
