### PR TITLE
feat(dev): add justfile and mobile simulator lanes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,17 @@ Run the `pre-commit` hook before committing (`pre-commit run --all-files`, or
 let it run on staged files via `git commit`). Fix any issues it reports so the
 commit lands clean — CI runs the same checks.
 
+## Local development shortcuts
+
+Use `just` for common tasks; run `just --list` for grouped recipes.
+
+- `just ensure` — install/check prerequisites
+- `just run-ios` / `just run-android` — build/run mobile apps
+- `just dev` / `just dev-mobile` — start the omnigent dev pod
+- `just electron-dev` / `just electron-build` — Electron desktop shell
+- `just lint` / `just lint-all` — run pre-commit
+- `just normalize-locks` — rewrite lockfile registries to PyPI/npmjs.org
+
 ## Pull requests
 
 When you open a pull request, fill in the repo's PR template at

--- a/justfile
+++ b/justfile
@@ -1,0 +1,100 @@
+default:
+    @just --list
+
+export FASTLANE_SKIP_UPDATE_CHECK := "1"
+
+# iOS device override (default: iPhone 17 Pro)
+DEVICE := env("OMNIGENT_IOS_SIMULATOR", "iPhone 17 Pro")
+
+# --- uv Python env ---
+
+_check-uv:
+    uv run --no-sync ruff --version
+    uv run --no-sync pre-commit --version
+
+_ensure-uv:
+    uv sync --extra all --extra dev
+
+# --- iOS Ruby dependencies ---
+
+_check-ios:
+    cd web/ios && bundle check
+
+_ensure-ios:
+    cd web/ios && (bundle check || bundle install)
+
+# --- omnidev Rust dev tool ---
+
+_install-omnidev:
+    cargo install --path dev/omnidev --locked --force
+
+_check-omnidev:
+    command -v omnidev >/dev/null 2>&1
+
+_ensure-omnidev:
+    command -v omnidev >/dev/null 2>&1 || just _install-omnidev
+
+# --- Aggregate setup checks / installs ---
+
+[group('setup')]
+check: _check-uv _check-ios _check-omnidev
+
+[group('setup')]
+ensure: _ensure-uv _ensure-ios _ensure-omnidev
+
+# --- Local dev ---
+
+[group('dev')]
+dev: _ensure-omnidev
+    omnidev
+
+[group('dev')]
+dev-mobile: _ensure-omnidev
+    omnidev --vite-host 0.0.0.0 --trust-lan-origins
+
+# --- Mobile builds ---
+
+[group('mobile')]
+run-ios: _ensure-ios
+    cd web/ios && bundle exec fastlane simulator device:"{{ DEVICE }}"
+
+[group('mobile')]
+run-android:
+    cd web/android && ./gradlew installDebug runDebug
+
+[group('mobile')]
+android-reverse:
+    cd web/android && ./gradlew reverseProxy
+
+# --- Electron desktop app ---
+
+_ensure-web:
+    cd web && test -d node_modules || npm install --no-audit --no-fund
+
+_ensure-electron:
+    cd web/electron && test -d node_modules || npm install --no-audit --no-fund
+
+[group('electron')]
+electron-dev: _ensure-web _ensure-electron
+    npm --prefix web/electron run dev
+
+[group('electron')]
+electron-build: _ensure-web _ensure-electron
+    npm --prefix web/electron run build
+
+# --- Lint ---
+
+[group('lint')]
+lint: _ensure-uv
+    uv run pre-commit run
+
+[group('lint')]
+lint-all: _ensure-uv
+    uv run pre-commit run --all-files
+
+# --- Lockfile maintenance ---
+
+[group('lint')]
+normalize-locks: _ensure-uv
+    uv run scripts/normalize_package_lock_registry.py web/package-lock.json web/electron/package-lock.json editors/vscode/package-lock.json || true
+    uv run scripts/normalize_uv_lock_registry.py uv.lock || true

--- a/web/android/app/build.gradle.kts
+++ b/web/android/app/build.gradle.kts
@@ -106,3 +106,35 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)
 }
+
+// Local development helpers — these delegate to adb so they work with physical
+// devices or any running emulator.
+tasks.register<Exec>("listDevices") {
+    description = "List attached Android devices/emulators"
+    group = "install"
+    commandLine("adb", "devices", "-l")
+}
+
+tasks.register("runDebug") {
+    description = "Install and launch the debug APK on a device/emulator"
+    group = "install"
+    dependsOn("installDebug")
+    doLast {
+        exec {
+            commandLine(
+                "adb",
+                "shell",
+                "am",
+                "start",
+                "-n",
+                "ai.omnigent.android/.MainActivity",
+            )
+        }
+    }
+}
+
+tasks.register<Exec>("reverseProxy") {
+    description = "Forward local port 8000 to the Android device/emulator (adb reverse)"
+    group = "install"
+    commandLine("adb", "reverse", "tcp:8000", "tcp:8000")
+}

--- a/web/ios/fastlane/Fastfile
+++ b/web/ios/fastlane/Fastfile
@@ -120,6 +120,33 @@ platform :ios do
     )
   end
 
+  desc "Build and run the Omnigent app in the iOS Simulator"
+  lane :simulator do |options|
+    device = options[:device] || ENV.fetch("OMNIGENT_IOS_SIMULATOR", "iPhone 17 Pro")
+    build_dir = File.expand_path("build", __dir__)
+
+    # Build the .app for simulator
+    xcodebuild(
+      project: "Omnigent.xcodeproj",
+      scheme: "Omnigent",
+      configuration: "Debug",
+      destination: "platform=iOS Simulator,name=#{device}",
+      derivedDataPath: build_dir,
+      build_settings: {
+        "CODE_SIGNING_ALLOWED" => "NO",
+      }
+    )
+
+    app_path = File.join(build_dir, "Build/Products/Debug-iphonesimulator/Omnigent.app")
+
+    # Boot, install, and launch
+    sh("xcrun simctl boot '#{device}' || true") # || true so already-booted is fine
+    sh("xcrun simctl install booted '#{app_path}'")
+    sh("xcrun simctl launch booted ai.omnigent.ios")
+
+    UI.success("Launched on #{device}")
+  end
+
   desc "Generate App Store screenshots with fastlane snapshot"
   lane :screenshots do
     repo_root = File.expand_path("../../..", __dir__)


### PR DESCRIPTION
feat(dev): add justfile and mobile simulator lanes

## Related issue

N/A

## Summary

- Add a top-level `justfile` that groups common local dev tasks (`run-ios`, `run-android`, `dev`, `electron-dev`, `lint`, `normalize-locks`, etc.) with hidden `_ensure-*` / `_check-*` prerequisites.
- Add an iOS `simulator` Fastlane lane that builds the Debug .app, installs it on an already-created iOS Simulator, and launches it.
- Add Android Gradle tasks (`runDebug`, `reverseProxy`) for launching the debug APK and running `adb reverse`.
- Fix the Fastlane `xcodebuild` invocation to use camel-case `derivedDataPath` so the built `.app` is written where the lane expects it.
- Export `FASTLANE_SKIP_UPDATE_CHECK=1` in the justfile.
- Document the new `justfile` recipes concisely in `AGENTS.md`.

## Test Plan

- `just --list` shows grouped recipes.
- `just run-ios` built/launched the iOS app in the iPhone 17 Pro Simulator.
- `pre-commit` passes on the touched files.

## Demo

N/A

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually by running `just run-ios` and watching the Omnigent app launch in the iOS Simulator.

## Changelog

Add a top-level `justfile` with recipes for launching the iOS Simulator, running the Android debug build, starting the omnigent dev pod, and running pre-commit/lockfile normalization.
