### PR TITLE
fix(projects): guard settings inputs during config load; correct worktree doc

### DIFF
--- a/designs/PROJECTS_PRD.md
+++ b/designs/PROJECTS_PRD.md
@@ -565,12 +565,15 @@ folder), carrying the first-class `id` when one exists.
     can't win the race. An opt-in worktree (`use_worktree: true`) generates a
     fresh `worktree-<hex>` branch once the workspace is in place and confirmed a
     git repo — including for empty projects, where the workspace comes from the
-    config or the home-fallback. Still deferred (backend hardening, once the
-    config key vocabulary firms up — from the #3108 review): (a) bound the
-    serialized `config` size on create/update — the value is persisted verbatim
-    and reflected back, so an unbounded blob is a mild storage/response-size
-    amplifier; (b) make `_decode_config` defensive — coerce a non-dict blob
-    (future writer / manual DB edit) back to `{}` rather than returning it raw.
+    config or the home-fallback.
+  - ✅ **Backend `config` hardening (from the #3108 review).** Both landed in
+    `stores/project_store/sqlalchemy_store.py`: (a) `_encode_config` bounds the
+    serialized `config` at 64 KiB (`_CONFIG_MAX_SERIALIZED_LEN`) and raises
+    `INVALID_INPUT` past it — the value is persisted verbatim and reflected back,
+    so an unbounded blob is a mild storage/response-size amplifier; (b)
+    `_decode_config` coerces a non-dict blob (future writer / manual DB edit) back
+    to `{}` rather than returning it raw, so callers can always treat config as a
+    mapping.
   - ✅ **Replaced the inference-based prefill (PR #2133).** That merged PR
     prefilled the composer by *inferring* defaults from the project's newest
     session (host/agent/repo + a fresh worktree branch) — an explicit non-goal

--- a/web/src/lib/projectsApi.ts
+++ b/web/src/lib/projectsApi.ts
@@ -26,11 +26,12 @@ export interface ProjectConfig {
   /** Default agent id for new sessions. */
   agent_id?: string;
   /**
-   * When `true` (the default posture new sessions take today), a new session in
-   * a git workspace defaults to a fresh randomly-named worktree;
-   * when `false`, it starts directly in the workspace. Unset = leave the
-   * composer's own default behavior. The base branch a worktree forks from
-   * stays a global preference (Settings › Git), not a project default.
+   * Opt-in worktree default: only `true` is meaningful. When `true`, a new
+   * session in a git workspace starts in a fresh randomly-named worktree; unset
+   * (the only other value the dialog stores) starts directly in the workspace.
+   * `false` is never written and is treated the same as unset. The base branch a
+   * worktree forks from stays a global preference (Settings › Git), not a
+   * project default.
    */
   use_worktree?: boolean;
 }

--- a/web/src/shell/ProjectSettingsDialog.tsx
+++ b/web/src/shell/ProjectSettingsDialog.tsx
@@ -305,7 +305,8 @@ export function ProjectSettingsDialog({
                   type="button"
                   onClick={() => setWorkspaceOpen((v) => !v)}
                   aria-expanded={workspaceOpen}
-                  className="flex h-8 w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 text-sm outline-none"
+                  disabled={isLoading}
+                  className="flex h-8 w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   <span className={workspace ? "truncate" : "truncate text-muted-foreground"}>
                     {workspace || "Browse…"}
@@ -343,10 +344,11 @@ export function ProjectSettingsDialog({
               <input
                 id="project-settings-workspace"
                 data-testid="project-settings-workspace"
-                className="w-full rounded-md border bg-transparent px-3 py-2 text-sm outline-none"
+                className="w-full rounded-md border bg-transparent px-3 py-2 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
                 placeholder="/path/to/repo"
                 value={workspace}
                 onChange={(e) => setWorkspace(e.target.value)}
+                disabled={isLoading}
               />
             )}
           </Field>
@@ -360,6 +362,7 @@ export function ProjectSettingsDialog({
                 data-testid="project-settings-worktree"
                 checked={useWorktree}
                 onCheckedChange={setUseWorktree}
+                disabled={isLoading}
               />
             </div>
           </Field>


### PR DESCRIPTION
## Related issue

N/A — follow-up to the non-blocking review notes on #3221.

## Summary

Two non-blocking follow-ups from the #3221 review:

- **Guard inputs during load.** The host `<Select>` was already disabled while
  the project config fetch was in flight, but the worktree toggle, the workspace
  Browse trigger, and the path input were not. An edit made in that window would
  be clobbered by the seeding effect once the fetch settled. All three now share
  `disabled={isLoading}` (with matching disabled styling).
- **Doc fix.** Rewrite the `use_worktree` docstring to match the opt-in
  implementation — only `true` is ever written; `false` is never stored and is
  treated the same as unset.

## Test Plan

- `npx tsc --noEmit` — clean.
- `npx vitest run src/shell/ProjectSettingsDialog.test.tsx` — 8/8 pass.
- `pre-commit run` (web prettier + hygiene) — clean.

## Demo

N/A — the only visible effect is the settings fields briefly showing a disabled
state during the config fetch (sub-second), matching the already-disabled host
dropdown.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Existing dialog tests exercise the load/seed/save flow and still pass; the change
is a purely additive `disabled` guard during the load window plus a doc-comment
edit, so no new test is warranted.

This pull request and its description were written by Isaac.