### PR TITLE
Align sidebar and project icon color

### DIFF
--- a/web/src/shell/Sidebar.projectHeaderChevron.test.tsx
+++ b/web/src/shell/Sidebar.projectHeaderChevron.test.tsx
@@ -136,6 +136,7 @@ describe("project folder header icon/chevron", () => {
 
     const folder = header.querySelector(".lucide-folder") as HTMLElement;
     expect(folder).not.toBeNull();
+    expect(folder).toHaveClass("text-muted-foreground");
 
     // The folder icon sits in a wrapper that fades out on desktop hover/focus.
     const folderWrapper = folder.parentElement as HTMLElement;

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -314,6 +314,7 @@ describe("Sidebar session list", () => {
     renderSidebar();
 
     const headerActions = screen.getByTestId("sidebar-header-actions");
+    expect(headerActions.parentElement).toHaveClass("h-8");
     const search = within(headerActions).getByTestId("sidebar-search-button");
     const settings = screen.getByTestId("settings-button");
 
@@ -336,6 +337,8 @@ describe("Sidebar session list", () => {
     const primaryNav = screen.getByTestId("sidebar-primary-nav");
     const inbox = within(primaryNav).getByTestId("inbox-button");
 
+    expect(primaryNav).toHaveClass("px-2", "pt-0", "pb-3");
+    expect(primaryNav).not.toHaveClass("-mt-0.5");
     expect(inbox).toHaveAttribute("href", "/inbox");
     expect(inbox).toHaveClass("h-7", "w-full", "justify-start");
     expect(within(inbox).getByText("Inbox")).toBeInTheDocument();

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -587,7 +587,7 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
         <SettingsSidebarBody onNavClick={onNavClick} onClose={onClose} />
       ) : (
         <>
-          <div className="mt-1 flex h-12 shrink-0 items-center justify-between px-4">
+          <div className="mt-1 flex h-8 shrink-0 items-center justify-between px-4">
             {/* Brand mark doubles as the "home" affordance: clicking it
             returns to `/`, the new-session composer. Without this there
             is no way back to the landing composer once you're inside a
@@ -664,7 +664,7 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
             </div>
           </div>
 
-          <div className="flex flex-col gap-0 px-3 py-3" data-testid="sidebar-primary-nav">
+          <div className="flex flex-col gap-0 px-2 pt-0 pb-3" data-testid="sidebar-primary-nav">
             {/* "New session" routes to the home composer ("/"), which now owns
             session creation end-to-end (host/workspace/worktree chips +
             send). Rendered as a Link so cmd/middle-click opens it in a new
@@ -969,9 +969,9 @@ function ProjectFolder({
         title={name}
         icon={
           expanded ? (
-            <FolderOpenIcon className="size-4 shrink-0" />
+            <FolderOpenIcon className="size-4 shrink-0 text-muted-foreground" />
           ) : (
-            <FolderIcon className="size-4 shrink-0" />
+            <FolderIcon className="size-4 shrink-0 text-muted-foreground" />
           )
         }
         marker={marker}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Aligns project folder icons with other sidebar section icons.
- Uses the muted foreground color for open and closed project folders.
- Adds targeted assertions for folder-icon color and header geometry.

**ELI5:** Project rows now line up visually with the rest of the sidebar instead of looking slightly offset, and project icons use the same subdued color as neighboring navigation icons.

```text
Sidebar sections
├── Pinned
├── Recent
└── Projects  ← aligned folder icon + muted color
```

## Test Plan

- `npm test -- src/shell/Sidebar.test.tsx src/shell/Sidebar.projectHeaderChevron.test.tsx` — 61 tests passed.
- `npm run type-check`
- Prettier check on all three changed files.
- `git diff --check`

## Demo
<img width="333" height="247" alt="image" src="https://github.com/user-attachments/assets/d329e4b6-4877-43c2-9078-085c011aa803" />
## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The changed classes and project-header geometry are covered by focused Sidebar tests.




## Changelog

Aligns project folder icons and color with the rest of the sidebar.