### PR TITLE
feat: expose per-session context size and turn timestamps to agents

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -27,6 +27,7 @@ import mimetypes
 import os
 import re
 import tempfile
+import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -54,6 +55,10 @@ from omnigent.runtime import pending_elicitations
 from omnigent.session_lifecycle import (
     CLOSED_LABEL_KEY,
     CLOSED_LABEL_VALUE,
+    LAST_CONTEXT_AT_LABEL_KEY,
+    LAST_CONTEXT_TOKENS_LABEL_KEY,
+    LAST_CONTEXT_WINDOW_LABEL_KEY,
+    LAST_TURN_AT_LABEL_KEY,
     is_session_closed,
     title_without_closed_marker,
 )
@@ -3437,6 +3442,120 @@ async def _runner_online_or_none(
     return online if isinstance(online, bool) else None
 
 
+def _server_now_from(resp: httpx.Response) -> int:
+    """
+    Read the server's clock from a response's ``Date`` header.
+
+    Every timestamp in a session snapshot is stamped by the server, while
+    this code runs on a runner that may be a container on another machine.
+    Subtracting a local clock from a server timestamp mixes the two and can
+    report a negative age, so ages are derived from the server's own clock
+    as of the response that carried the values.
+
+    :param resp: The response whose ``Date`` header to read.
+    :returns: Server epoch seconds, falling back to local time when the
+        header is missing or unparseable.
+    """
+    raw = resp.headers.get("date")
+    if raw:
+        try:
+            from email.utils import parsedate_to_datetime
+
+            return int(parsedate_to_datetime(raw).timestamp())
+        except (TypeError, ValueError):
+            pass
+    return int(time.time())
+
+
+def _int_label(labels: Any, key: str) -> int | None:
+    """
+    Read a non-negative integer label, or ``None`` when absent or malformed.
+
+    Labels are stored as strings, so the context metrics and turn stamps
+    all arrive as digit text.
+
+    :param labels: The snapshot's ``labels`` mapping (any type — a
+        non-mapping is treated as absent).
+    :param key: Label key to read, e.g. ``"omnigent.last_turn_at"``.
+    :returns: The parsed integer, or ``None``.
+    """
+    if not isinstance(labels, dict):
+        return None
+    raw = labels.get(key)
+    return int(raw) if isinstance(raw, str) and raw.isdigit() else None
+
+
+def _seconds_since(moment: int | None, server_now: int) -> int | None:
+    """
+    Age of *moment* against the server's clock, floored at zero.
+
+    :param moment: Epoch seconds being aged, or ``None``.
+    :param server_now: Server epoch seconds to measure against.
+    :returns: Non-negative seconds elapsed, or ``None`` when *moment* is
+        ``None``. Clamped so a server clock that ticks backwards between
+        two responses reports ``0`` rather than a negative age.
+    """
+    return None if moment is None else max(0, server_now - moment)
+
+
+def _context_block(snap: dict[str, Any], server_now: int) -> dict[str, Any]:
+    """
+    Project a session's context occupancy from its snapshot.
+
+    Always returns the block, with null readings and ``stale`` set when
+    nothing has been measured — an absent key reads to a model as "this
+    tool cannot report that", where an explicit null reads as "unknown
+    right now", which is the true state.
+
+    ``stale`` is advisory and deliberately conservative: it is set when
+    there is no measurement, when a turn is in flight (the reading
+    necessarily predates the current prompt), and when the row saw
+    activity after the reading was taken. ``status`` remains the
+    authoritative answer to "is this session working".
+
+    Accepts either shape the server serves: the single-session snapshot,
+    which resolves ``last_total_tokens`` / ``context_window`` into named
+    fields, or a session-list row, which carries neither and is read from
+    its labels instead. A list row's window is therefore known only once a
+    harness has reported one — the snapshot's spec-derived fallback isn't
+    computed per row, since resolving it can hit the provider catalog.
+
+    :param snap: A session snapshot or session-list row.
+    :param server_now: Server epoch seconds, for the age.
+    :returns: The context block.
+    """
+    labels = snap.get("labels")
+    tokens = snap.get("last_total_tokens")
+    if tokens is None:
+        tokens = _int_label(labels, LAST_CONTEXT_TOKENS_LABEL_KEY)
+    window = snap.get("context_window")
+    if window is None:
+        window = _int_label(labels, LAST_CONTEXT_WINDOW_LABEL_KEY)
+    measured_at = _int_label(labels, LAST_CONTEXT_AT_LABEL_KEY)
+    updated_at = snap.get("updated_at")
+
+    used_fraction: float | None = None
+    if isinstance(tokens, int) and isinstance(window, int) and window > 0:
+        # Not clamped to 1.0: a fill above the window is real information
+        # (a lagging post-compaction reading, or a wrong window), and
+        # hiding it would mask exactly the case worth acting on.
+        used_fraction = round(tokens / window, 3)
+
+    stale = (
+        measured_at is None
+        or snap.get("status") == "running"
+        or (isinstance(updated_at, int) and updated_at > measured_at)
+    )
+    return {
+        "tokens": tokens,
+        "window": window,
+        "used_fraction": used_fraction,
+        "as_of": measured_at,
+        "age_seconds": _seconds_since(measured_at, server_now),
+        "stale": stale,
+    }
+
+
 async def _session_get_info_via_rest(
     args: dict[str, Any],
     conversation_id: str,
@@ -3455,6 +3574,12 @@ async def _session_get_info_via_rest(
     ``GET /v1/runners/{id}/status`` (``runner_online`` is ``None`` when
     the lookup fails or no runner is bound). The full transcript is
     intentionally omitted — that is what ``sys_session_get_history`` returns.
+
+    Also projects the state a caller needs to manage the session's context
+    deliberately rather than run it until something breaks: a ``context``
+    block (see :func:`_context_block`) and the turn timestamps. Ages are
+    measured against the server's clock (see :func:`_server_now_from`),
+    not the runner's.
 
     Maps a 404 to ``session_not_found`` and 401/403 to ``access_denied``
     (the server denied the read, so from the caller's vantage the target
@@ -3483,6 +3608,8 @@ async def _session_get_info_via_rest(
         return json.dumps({"error": f"sys_session_get_info returned {resp.status_code}"})
     snap: dict[str, Any] = resp.json()
     pending = snap.get("pending_elicitations") or []
+    server_now = _server_now_from(resp)
+    last_turn_completed_at = _int_label(snap.get("labels"), LAST_TURN_AT_LABEL_KEY)
     return json.dumps(
         {
             "session_id": snap.get("id"),
@@ -3513,6 +3640,16 @@ async def _session_get_info_via_rest(
             # waiting on.
             "pending_elicitations": pending,
             "pending_elicitation_count": len(pending),
+            # Context occupancy, for deciding whether to compact this session
+            # or hand its task to a fresh one before it hits the wall.
+            "context": _context_block(snap, server_now),
+            # When the session last stopped working, and how long ago. Both
+            # are needed: the caller has no clock relationship to the server,
+            # and the elapsed time is what a cache-warmth decision turns on.
+            "last_turn_completed_at": last_turn_completed_at,
+            "seconds_since_last_turn": _seconds_since(last_turn_completed_at, server_now),
+            "created_at": snap.get("created_at"),
+            "updated_at": snap.get("updated_at"),
         }
     )
 
@@ -4193,7 +4330,10 @@ async def _collect_global_sessions(
     Fetch the global session list via ``GET /v1/sessions``, with connectivity.
 
     Projects each accessible session to ``{session_id, agent_name, title,
-    status, runner_id, runner_online, parent_session_id}``.
+    status, runner_id, runner_online, parent_session_id}`` plus its
+    context state (``context_*``, flattened — see :func:`_context_block`)
+    and ``seconds_since_last_turn``, so a caller can pick which session to
+    act on without a follow-up ``sys_session_get_info`` per row.
     ``runner_online`` is resolved once per unique bound runner (see
     :func:`_resolve_runner_online_map`). An optional ``agent_name``
     filters the list server-side. Permission-bounded by the server (the
@@ -4218,6 +4358,8 @@ async def _collect_global_sessions(
     if not isinstance(rows, list):
         return []
     online = await _resolve_runner_online_map(rows, server_client)
+    server_now = _server_now_from(resp)
+    contexts = [_context_block(r, server_now) for r in rows]
     return [
         {
             "session_id": r.get("id"),
@@ -4231,8 +4373,19 @@ async def _collect_global_sessions(
             "runner_id": r.get("runner_id"),
             "runner_online": online.get(r.get("runner_id")),
             "parent_session_id": r.get("parent_session_id"),
+            # Context state, flattened rather than nested as on
+            # ``sys_session_get_info``: these rows are scanned in bulk, where
+            # a nested object per row costs far more to read than it informs.
+            "context_tokens": ctx["tokens"],
+            "context_window": ctx["window"],
+            "context_used_fraction": ctx["used_fraction"],
+            "context_as_of": ctx["as_of"],
+            "context_stale": ctx["stale"],
+            "seconds_since_last_turn": _seconds_since(
+                _int_label(r.get("labels"), LAST_TURN_AT_LABEL_KEY), server_now
+            ),
         }
-        for r in rows
+        for r, ctx in zip(rows, contexts, strict=True)
     ]
 
 

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -31,6 +31,7 @@ import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -3459,8 +3460,6 @@ def _server_now_from(resp: httpx.Response) -> int:
     raw = resp.headers.get("date")
     if raw:
         try:
-            from email.utils import parsedate_to_datetime
-
             return int(parsedate_to_datetime(raw).timestamp())
         except (TypeError, ValueError):
             pass

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -37,6 +37,12 @@ from omnigent.server.schemas import (
     ServerStreamEvent,
     SkillSummary,
 )
+from omnigent.session_lifecycle import (
+    LAST_CONTEXT_AT_LABEL_KEY,
+    LAST_CONTEXT_TOKENS_LABEL_KEY,
+    LAST_CONTEXT_WINDOW_LABEL_KEY,
+    LAST_TURN_AT_LABEL_KEY,
+)
 from omnigent.spec.types import (
     StateUpdate,
 )
@@ -178,10 +184,16 @@ _CODEX_NATIVE_COLLABORATION_MODES: frozenset[str] = frozenset({"default", "plan"
 _CODEX_NATIVE_SUBAGENT_DISPLAY_FALLBACK = "Codex"
 
 
-_LAST_CONTEXT_TOKENS_LABEL_KEY: str = "omnigent.last_context_tokens"
+_LAST_CONTEXT_TOKENS_LABEL_KEY: str = LAST_CONTEXT_TOKENS_LABEL_KEY
 
 
-_LAST_CONTEXT_WINDOW_LABEL_KEY: str = "omnigent.last_context_window"
+_LAST_CONTEXT_WINDOW_LABEL_KEY: str = LAST_CONTEXT_WINDOW_LABEL_KEY
+
+
+_LAST_CONTEXT_AT_LABEL_KEY: str = LAST_CONTEXT_AT_LABEL_KEY
+
+
+_LAST_TURN_AT_LABEL_KEY: str = LAST_TURN_AT_LABEL_KEY
 
 
 _LAST_TASK_ERROR_CODE_LABEL_KEY: str = "omnigent.last_task_error_code"
@@ -740,10 +752,12 @@ __all__ = [
     "_INTERRUPT_TYPE",
     "_KIRO_NATIVE_WRAPPER_LABEL_VALUE",
     "_LABEL_VALUE_MAX_LEN",
+    "_LAST_CONTEXT_AT_LABEL_KEY",
     "_LAST_CONTEXT_TOKENS_LABEL_KEY",
     "_LAST_CONTEXT_WINDOW_LABEL_KEY",
     "_LAST_TASK_ERROR_CODE_LABEL_KEY",
     "_LAST_TASK_ERROR_MESSAGE_LABEL_KEY",
+    "_LAST_TURN_AT_LABEL_KEY",
     "_MANAGED_RESUMABLE_TUNNEL_STALE_S",
     "_MAX_TERMINAL_LAUNCH_ARGS",
     "_MAX_TERMINAL_LAUNCH_ARG_LEN",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -3254,11 +3254,18 @@ def _publish_status(
         # snapshot to reopen a streaming bubble.
         _session_active_response_cache.pop(session_id, None)
         return
+    previous_status = _session_status_cache.get(session_id)
     _session_status_cache[session_id] = status
     # Mirror the transition onto the conversation row (best-effort,
     # deduplicated, off-loop) so replicas that don't hold this session's
     # runner tunnel serve the same sidebar status.
     session_live_state.persist_live_status(session_id, status)
+    # Stamp when the turn stopped, for callers deciding whether a session's
+    # cached prompt prefix is still warm. Only on the transition: relays
+    # re-publish a steady ``idle``, and re-stamping would keep reporting a
+    # long-quiet session as having just finished.
+    if status in ("idle", "failed") and previous_status != status:
+        session_live_state.persist_last_turn_at(session_id)
     # Event-driven scheduled-run completion. A terminal edge (idle = the turn
     # completed; failed = it errored/disconnected) flips the conversation's
     # still-``running`` scheduled_task_run to succeeded/failed. This is the

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -755,6 +755,7 @@ def _build_session_response(
         status=status,
         background_task_count=background_task_count,
         created_at=conv.created_at,
+        updated_at=conv.updated_at,
         title=title_without_closed_marker(conv.title),
         labels=labels,
         runner_id=conv.runner_id,

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -22,7 +22,7 @@ from fastapi import (
 from fastapi.responses import Response
 from pydantic import ValidationError
 
-from omnigent.db.utils import generate_agent_id, generate_task_id
+from omnigent.db.utils import generate_agent_id, generate_task_id, now_epoch
 from omnigent.entities import (
     Agent,
     CommentsFingerprint,
@@ -864,6 +864,10 @@ def _accumulate_session_usage(
     (its presence is what distinguishes a priced ``$0.00`` from
     "unpriced"; see :func:`_priced_cost_for_display`).
 
+    A reported ``usage.context_tokens`` is persisted separately via
+    :func:`_persist_context_fill` — it is a fill level, so it is set
+    rather than accumulated, and it never enters ``session_usage``.
+
     :param resp_obj: The ``response`` dict from the
         ``response.completed`` SSE event.
     :param session_id: Session/conversation identifier,
@@ -878,6 +882,21 @@ def _accumulate_session_usage(
     usage_obj = resp_obj.get("usage")
     if not isinstance(usage_obj, dict):
         return None
+    # Context fill is a LEVEL the executor reports, not one of the cumulative
+    # buckets below, so it is set rather than added — and set ahead of the
+    # counter early-out, which would otherwise drop the reading on a turn that
+    # reports fill without token deltas. Terminal-backed harnesses reach the
+    # same labels through _persist_external_session_usage; this is the relay's
+    # half of that parity. The window is left to the snapshot's spec resolver,
+    # which may block on a provider catalog fetch and must not run here.
+    raw_context_tokens = usage_obj.get("context_tokens")
+    if isinstance(raw_context_tokens, int) and raw_context_tokens >= 0:
+        _persist_context_fill(
+            session_id,
+            tokens=raw_context_tokens,
+            window=None,
+            conversation_store=conversation_store,
+        )
     input_tokens = usage_obj.get("input_tokens", 0)
     output_tokens = usage_obj.get("output_tokens", 0)
     total_tokens = usage_obj.get("total_tokens", 0)
@@ -1156,6 +1175,48 @@ def _persist_native_cumulative_usage(
     return _priced_cost_for_display(current)
 
 
+def _persist_context_fill(
+    session_id: str,
+    *,
+    tokens: int | None,
+    window: int | None,
+    conversation_store: ConversationStore,
+) -> None:
+    """
+    Persist a session's context-fill reading and when it was taken.
+
+    The single writer for the fill labels, shared by the terminal-backed
+    ``external_session_usage`` path and the relay's per-response
+    accumulation, so both harness families report the same thing.
+
+    ``tokens`` is a fill LEVEL, not a counter — it is SET, never summed.
+    Two concurrent turns each report their own post-turn fill and the
+    later commit should win, so last-write-wins is the correct semantic
+    here (unlike the cumulative usage counters, where a lost update
+    destroys information).
+
+    :param session_id: Session/conversation identifier.
+    :param tokens: Context tokens in use, or ``None`` when unreported.
+    :param window: Observed context window, or ``None`` when unreported.
+    :param conversation_store: Store used to upsert the labels.
+    """
+    updates: dict[str, str] = {}
+    stamp = now_epoch()
+    if tokens is not None:
+        updates[_LAST_CONTEXT_TOKENS_LABEL_KEY] = str(tokens)
+        # Stamped only alongside a fill reading. A window-only report carries
+        # no new measurement, so moving the timestamp would make a stale
+        # token count look freshly taken.
+        updates[_LAST_CONTEXT_AT_LABEL_KEY] = str(stamp)
+    if window is not None:
+        updates[_LAST_CONTEXT_WINDOW_LABEL_KEY] = str(window)
+    if not updates:
+        return
+    # One call, so the count and its timestamp land in the same transaction
+    # and a reader can never see a fresh stamp beside an older count.
+    conversation_store.set_labels(session_id, updates, stamp)
+
+
 async def _persist_external_session_usage(
     session_id: str,
     body: SessionEventInput,
@@ -1214,15 +1275,12 @@ async def _persist_external_session_usage(
         conversation_store,
     )
 
-    label_updates: dict[str, str] = {}
-    if raw_tokens is not None:
-        label_updates[_LAST_CONTEXT_TOKENS_LABEL_KEY] = str(raw_tokens)
-    if raw_window is not None:
-        label_updates[_LAST_CONTEXT_WINDOW_LABEL_KEY] = str(raw_window)
     await asyncio.to_thread(
-        conversation_store.set_labels,
+        _persist_context_fill,
         session_id,
-        label_updates,
+        tokens=raw_tokens,
+        window=raw_window,
+        conversation_store=conversation_store,
     )
     # The displayed cost is this session's SUBTREE total (itself + its
     # sub-agents), matching the GET snapshot. A sub-agent persists its spend on
@@ -6533,6 +6591,7 @@ __all__ = [
     "_maybe_wake_stale_resumable_managed_sandbox",
     "_native_subagent_wrapper_labels",
     "_native_terminal_runtime",
+    "_persist_context_fill",
     "_persist_external_codex_subagent_start",
     "_persist_external_conversation_item",
     "_persist_external_session_usage",

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1603,6 +1603,12 @@ class SessionResponse(BaseModel):
         still running" even though the session has settled to ``"idle"``.
         ``None`` (the default / omitted) when no shells are tracked.
     :param created_at: Unix epoch seconds of creation.
+    :param updated_at: Unix epoch seconds of the last row activity —
+        an item append, a title change, and so on. Generic activity,
+        NOT turn completion; a caller wanting the latter reads the
+        ``omnigent.last_turn_at`` label. Optional here (unlike the
+        required field on :class:`SessionListItem`) so a snapshot can
+        still be constructed without a conversation row.
     :param title: Optional human-readable title, e.g.
         ``"debugging auth flow"``. ``None`` when unset.
     :param labels: Session-scoped guardrails labels. Empty dict
@@ -1815,6 +1821,7 @@ class SessionResponse(BaseModel):
     status: Literal["idle", "running", "waiting", "failed"]
     background_task_count: int | None = None
     created_at: int
+    updated_at: int | None = None
     title: str | None = None
     labels: dict[str, str] = Field(default_factory=dict)
     runner_id: str | None = None

--- a/omnigent/server/session_live_state.py
+++ b/omnigent/server/session_live_state.py
@@ -44,6 +44,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 from omnigent.db.enum_codecs import SESSION_LIVE_STATUS
+from omnigent.session_lifecycle import LAST_TURN_AT_LABEL_KEY
 
 if TYPE_CHECKING:
     from omnigent.stores import ConversationStore
@@ -174,6 +175,34 @@ def persist_live_status(session_id: str, status: str) -> None:
             _last_status.pop(session_id, None)
 
     _submit("live_status", _store.set_session_live_status, session_id, status, on_failure=_evict)
+
+
+def persist_last_turn_at(session_id: str) -> None:
+    """
+    Persist when a session's turn reached a terminal edge.
+
+    Called from the ``idle`` / ``failed`` branches of the status publish —
+    the one place relay and terminal-backed harnesses both report a turn
+    ending, so the stamp means the same thing whichever ran it. Distinct
+    from the context-fill timestamp: forwarders report usage mid-turn, so
+    that one answers "when was the window measured", this one "when did
+    the session last stop working".
+
+    Writes a label, which leaves ``conversations.updated_at`` untouched —
+    sidebar ordering must not shift on a turn ending.
+
+    :param session_id: Session/conversation identifier.
+    """
+    if _store is None:
+        return
+    stamp = int(time.time())
+    _submit(
+        "last_turn_at",
+        _store.set_labels,
+        session_id,
+        {LAST_TURN_AT_LABEL_KEY: str(stamp)},
+        stamp,
+    )
 
 
 def persist_scheduled_run_completion(

--- a/omnigent/session_lifecycle.py
+++ b/omnigent/session_lifecycle.py
@@ -8,6 +8,18 @@ CLOSED_LABEL_KEY = "omnigent.closed"
 CLOSED_LABEL_VALUE = "true"
 CLOSED_TITLE_INFIX = ":closed:"
 
+# Context-fill metrics, written by the server whenever a harness reports usage.
+# ``_AT`` stamps when the fill was measured — a bare token count can't be told
+# apart from a stale one left behind by a turn that failed mid-flight.
+LAST_CONTEXT_TOKENS_LABEL_KEY = "omnigent.last_context_tokens"
+LAST_CONTEXT_WINDOW_LABEL_KEY = "omnigent.last_context_window"
+LAST_CONTEXT_AT_LABEL_KEY = "omnigent.last_context_at"
+
+# When the session's last turn reached a terminal edge (idle / failed). Distinct
+# from the fill timestamp: terminal-backed harnesses report usage mid-turn, so
+# the two answer different questions.
+LAST_TURN_AT_LABEL_KEY = "omnigent.last_turn_at"
+
 
 def title_without_closed_marker(title: str | None) -> str | None:
     """

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -14,6 +14,12 @@ from omnigent.entities import (
     PagedList,
 )
 from omnigent.session_import import IMPORT_PROVENANCE_LABEL_KEYS
+from omnigent.session_lifecycle import (
+    LAST_CONTEXT_AT_LABEL_KEY,
+    LAST_CONTEXT_TOKENS_LABEL_KEY,
+    LAST_CONTEXT_WINDOW_LABEL_KEY,
+    LAST_TURN_AT_LABEL_KEY,
+)
 
 # Label set on a fork of a session that had a working directory. Its
 # value is the source session id. Presence marks the (unbound) clone as
@@ -148,10 +154,11 @@ def pinned_label_key(user_id: str | None) -> str:
 #   * Runtime state bound to ONE running instance — the native bridge-id
 #     labels would route the new context's terminal + web injection to the
 #     SOURCE's claude/codex bridge (whose active-session marker isn't the
-#     clone → "session no longer active"); the context-size metrics would
-#     display the source's last usage. The bridge-id literals mirror the
-#     harness modules' ``*_BRIDGE_ID_LABEL_KEY`` constants; a store test
-#     cross-checks them so a rename in those modules fails loudly here.
+#     clone → "session no longer active"); the context-size metrics and the
+#     turn timestamps would describe the source's last activity, not the new
+#     context's. The bridge-id literals mirror the harness modules'
+#     ``*_BRIDGE_ID_LABEL_KEY`` constants; a store test cross-checks them so a
+#     rename in those modules fails loudly here.
 #
 #   * Per-context safety opt-in — the DANGEROUS codex full-bypass directive
 #     (:data:`CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY`). Letting it ride into a
@@ -164,8 +171,10 @@ _INSTANCE_SCOPED_LABEL_KEYS = frozenset(
     {
         "omnigent.claude_native.bridge_id",
         "omnigent.codex_native.bridge_id",
-        "omnigent.last_context_tokens",
-        "omnigent.last_context_window",
+        LAST_CONTEXT_TOKENS_LABEL_KEY,
+        LAST_CONTEXT_WINDOW_LABEL_KEY,
+        LAST_CONTEXT_AT_LABEL_KEY,
+        LAST_TURN_AT_LABEL_KEY,
         CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY,
     }
 )

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -473,10 +473,15 @@ class SysSessionListTool(Tool):
       ``sys_session_get_info`` / ``sys_session_close``.
     - ``sessions`` — a **global** view of every session the caller can
       access (bounded by the server's per-user permission model), each
-      with its status and runner connectivity. An optional
-      ``agent_name`` filter narrows this list. This powers
-      orchestration: discovering sessions to inspect
-      (``sys_agent_get`` / ``sys_session_get_info``) or drive
+      with its status, runner connectivity, and context state
+      (``context_tokens``, ``context_window``, ``context_used_fraction``,
+      ``context_as_of``, ``context_stale``, ``seconds_since_last_turn``)
+      so sessions can be ranked by occupancy without a
+      ``sys_session_get_info`` per row. Flattened here, where rows are
+      read in bulk; ``sys_session_get_info`` nests the same values and
+      explains their semantics. An optional ``agent_name`` filter narrows
+      this list. This powers orchestration: discovering sessions to
+      inspect (``sys_agent_get`` / ``sys_session_get_info``) or drive
       (``sys_session_send`` by ``session_id``).
 
     The global ``sessions`` view is populated only on the runner
@@ -498,8 +503,11 @@ class SysSessionListTool(Tool):
             "parent/siblings) — use their conversation_id to read "
             "history, get info, or close. 'sessions': a global list of "
             "every session "
-            "you can access, each with status + runner connectivity, "
-            "for orchestration (inspect via sys_agent_get / "
+            "you can access, each with status + runner connectivity plus "
+            "context state (context_tokens, context_window, "
+            "context_used_fraction, context_as_of, context_stale, "
+            "seconds_since_last_turn) for ranking sessions by how full "
+            "they are, for orchestration (inspect via sys_agent_get / "
             "sys_session_get_info, or drive via sys_session_send by "
             "session_id). Pass agent_name to filter the global list to "
             "sessions running that agent."
@@ -606,6 +614,22 @@ class SysSessionGetInfoTool(Tool):
     approval prompts. For the conversation transcript, use
     ``sys_session_get_history`` instead.
 
+    Also reports the state needed to manage a session's context
+    deliberately: a ``context`` block (``tokens``, ``window``,
+    ``used_fraction``, ``as_of``, ``age_seconds``, ``stale``) and
+    ``last_turn_completed_at`` / ``seconds_since_last_turn``, alongside
+    ``created_at`` / ``updated_at``.
+
+    Two distinct timestamps, because they answer different questions.
+    ``context.as_of`` is when the occupancy was measured — terminal-backed
+    harnesses report usage mid-turn, so it is not a turn boundary.
+    ``last_turn_completed_at`` is when the session last stopped working.
+
+    ``context.stale`` is advisory and deliberately conservative: set when
+    nothing has been measured, when a turn is in flight, or when the
+    session changed after the reading. ``status`` remains the
+    authoritative answer to whether a session is currently working.
+
     ``session_id`` is optional — when omitted, the caller's own
     session is described.
 
@@ -628,7 +652,14 @@ class SysSessionGetInfoTool(Tool):
             "Return a session's metadata: lifecycle status, title, "
             "agent binding (id/name), runner binding + connectivity, "
             "host, reasoning effort, model, parent session, workspace, "
-            "and outstanding approval prompts. Global read — any "
+            "and outstanding approval prompts. Also context occupancy "
+            "(context.tokens/window/used_fraction, measured at "
+            "context.as_of, context.age_seconds ago) and when the last "
+            "turn ended (last_turn_completed_at, seconds_since_last_turn) "
+            "— use these to decide whether to compact a session or start "
+            "a fresh one. context.stale means the reading may lag (never "
+            "measured, turn in flight, or activity since); status is the "
+            "authoritative in-flight signal. Global read — any "
             "session you can access. Pass session_id to target another "
             "session; omit it to describe your own. Metadata only — "
             "use sys_session_get_history for the conversation transcript."

--- a/openapi.json
+++ b/openapi.json
@@ -5209,6 +5209,18 @@
             "description": "Cumulative LLM spend for this session in USD, e.g. `0.42`. `None` when the session is **unpriced** \u2014 no turn has been priced yet (the model is absent from the pricing catalog, or no usage has been recorded) \u2014 so clients render \"\u2014\" rather than a misleading `$0.00`. Server-computed (cache-aware for relay/codex, exact billing for claude-native), the same total the cost-budget policy gates on. Lets clients seed their cost indicator on resume without waiting for the next `session.usage` SSE event.",
             "title": "Total Cost Usd"
           },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unix epoch seconds of the last row activity \u2014 an item append, a title change, and so on. Generic activity, NOT turn completion; a caller wanting the latter reads the `omnigent.last_turn_at` label. Optional here (unlike the required field on `SessionListItem`) so a snapshot can still be constructed without a conversation row.",
+            "title": "Updated At"
+          },
           "usage_by_model": {
             "anyOf": [
               {

--- a/tests/e2e/test_session_context_info_e2e.py
+++ b/tests/e2e/test_session_context_info_e2e.py
@@ -1,0 +1,150 @@
+"""E2E: context occupancy and turn recency survive a real relay turn (mock LLM).
+
+No LLM key required — an inline ``openai-agents`` agent runs one turn against
+the mock LLM server, then the real ``GET /v1/sessions/{id}`` is read back.
+
+The claim under test is **parity**. The context-fill labels were historically
+written only by the ``external_session_usage`` event that terminal-backed
+harnesses post, so a relay (SDK) session served ``last_total_tokens: null``
+forever while a native one served a real number. An orchestrator mixing both
+in one sub-agent tree has to apply a single compaction policy across them, so
+"works on native only" is indistinguishable from broken.
+
+The runner-side projection is unit-tested against a mocked transport in
+``tests/runner/test_runner_dispatch.py``; what only a live server can prove is
+that the fields those tests assume are actually the ones a real snapshot
+carries. So this drives ``_session_get_info_via_rest`` against the real
+server rather than re-asserting the projection logic.
+
+Usage::
+
+    pytest tests/e2e/test_session_context_info_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from typing import Any
+
+import httpx
+
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
+    send_user_message_to_session,
+)
+
+
+def _get_info_against(live_server: str, session_id: str) -> dict[str, Any]:
+    """
+    Run the runner's ``sys_session_get_info`` projection against a live server.
+
+    :param live_server: Base URL of the running server.
+    :param session_id: Session to describe.
+    :returns: The parsed tool output.
+    """
+    from omnigent.runner.tool_dispatch import _session_get_info_via_rest
+
+    async def _run() -> str:
+        async with httpx.AsyncClient(
+            base_url=live_server,
+            timeout=60,
+            headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+        ) as client:
+            return await _session_get_info_via_rest(
+                {"session_id": session_id},
+                session_id,
+                client,
+            )
+
+    return json.loads(asyncio.run(_run()))
+
+
+def test_relay_turn_reports_context_fill_and_turn_recency(
+    live_server: str,
+    http_client: httpx.Client,
+    live_runner_id: str,
+    mock_llm_server_url: str,
+) -> None:
+    """A relay session reports its context fill, as a native one always did.
+
+    **What breaks if wrong:**
+
+    - If the relay usage path drops ``context_tokens``, the snapshot serves
+      ``last_total_tokens: null`` and every SDK sub-agent looks unmeasured —
+      the state this whole feature exists to remove.
+    - If the fill timestamp isn't written beside the count, a caller cannot
+      tell a fresh reading from one a failed turn left behind.
+    - If the runner projection reads field names the server doesn't serve,
+      the block comes back all-null against a real server while the mocked
+      unit tests still pass.
+    """
+    model = f"mock-ctx-{uuid.uuid4().hex[:6]}"
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"ctx-info-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a helpful assistant.",
+        mock_llm_base_url=f"{mock_llm_server_url}/v1",
+    )
+    configure_mock_llm(mock_llm_server_url, [{"text": "Done."}], key=model)
+
+    session_id = create_runner_bound_session(
+        http_client,
+        agent_name=agent_name,
+        runner_id=live_runner_id,
+    )
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Say done.",
+    )
+    body = poll_session_until_terminal(
+        http_client,
+        session_id=session_id,
+        response_id=response_id,
+        timeout=60,
+    )
+    assert body["status"] == "completed", (
+        f"Expected completed, got {body['status']}. Error: {body.get('error')}."
+    )
+
+    snapshot = http_client.get(f"/v1/sessions/{session_id}").json()
+
+    # The parity claim: a relay turn's fill reaches the snapshot. This is
+    # null on a server without the relay-side persistence.
+    tokens = snapshot["last_total_tokens"]
+    assert isinstance(tokens, int) and tokens > 0, (
+        f"relay turn recorded no context fill: last_total_tokens={tokens!r}"
+    )
+    # Stamped, so staleness is decidable by the caller.
+    labels = snapshot["labels"]
+    assert labels["omnigent.last_context_at"].isdigit(), (
+        f"fill recorded without a measurement time: labels={sorted(labels)}"
+    )
+    assert isinstance(snapshot["updated_at"], int)
+
+    info = _get_info_against(live_server, session_id)
+
+    # Same numbers, reached through the tool an agent actually calls.
+    assert info["context"]["tokens"] == tokens
+    assert info["context"]["as_of"] == int(labels["omnigent.last_context_at"])
+    assert info["context"]["age_seconds"] >= 0
+    assert info["created_at"] == snapshot["created_at"]
+    assert info["updated_at"] == snapshot["updated_at"]
+
+    # The turn reached a terminal edge, so its end time is recorded and the
+    # elapsed time is derivable — the pair a cache-warmth decision needs.
+    assert info["last_turn_completed_at"] is not None, (
+        f"completed turn left no end timestamp: labels={sorted(labels)}"
+    )
+    assert info["seconds_since_last_turn"] >= 0

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -5634,6 +5634,8 @@ async def test_session_list_global_sessions_filter_and_connectivity() -> None:
     assert sessions_params.get("agent_name") == "researcher"
     # Both sessions projected with status + connectivity from the single
     # shared-runner status lookup.
+    # Rows carry no context labels here, so every context field reads null
+    # and ``context_stale`` is true — "not measured", not "measured empty".
     assert out["sessions"] == [
         {
             "session_id": "s1",
@@ -5643,6 +5645,12 @@ async def test_session_list_global_sessions_filter_and_connectivity() -> None:
             "runner_id": "r1",
             "runner_online": True,
             "parent_session_id": None,
+            "context_tokens": None,
+            "context_window": None,
+            "context_used_fraction": None,
+            "context_as_of": None,
+            "context_stale": True,
+            "seconds_since_last_turn": None,
         },
         {
             "session_id": "s2",
@@ -5652,12 +5660,85 @@ async def test_session_list_global_sessions_filter_and_connectivity() -> None:
             "runner_id": "r1",
             "runner_online": True,
             "parent_session_id": None,
+            "context_tokens": None,
+            "context_window": None,
+            "context_used_fraction": None,
+            "context_as_of": None,
+            "context_stale": True,
+            "seconds_since_last_turn": None,
         },
     ]
     # Connectivity resolved once per UNIQUE runner — two sessions share
     # r1, so exactly one status call (not one per session). A count of 2
     # would mean the dedup regressed into a per-session fan-out.
     assert runner_status_calls == ["r1"]
+
+
+@pytest.mark.asyncio
+async def test_session_list_rows_read_context_from_labels() -> None:
+    """Global ``sessions`` rows carry context state, sourced from labels.
+
+    List rows are ``SessionListItem``, which has no resolved
+    ``last_total_tokens`` / ``context_window`` fields — only ``labels``. So
+    a caller can rank sub-agents by occupancy from one list call instead of
+    a ``sys_session_get_info`` per row.
+    """
+    from email.utils import formatdate
+
+    from omnigent.runner.tool_dispatch import _execute_session_query_tool
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/v1/sessions/conv_x/child_sessions":
+            return httpx.Response(200, json={"object": "list", "data": []})
+        if path == "/v1/sessions/conv_x":
+            return httpx.Response(200, json={"id": "conv_x", "parent_session_id": None})
+        if path == "/v1/sessions":
+            return httpx.Response(
+                200,
+                json={
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "s1",
+                            "agent_name": "researcher",
+                            "title": "auth",
+                            "status": "idle",
+                            "runner_id": None,
+                            "parent_session_id": None,
+                            "updated_at": _SERVER_NOW - 700,
+                            "labels": {
+                                "omnigent.last_context_tokens": "150000",
+                                "omnigent.last_context_window": "200000",
+                                "omnigent.last_context_at": str(_SERVER_NOW - 600),
+                                "omnigent.last_turn_at": str(_SERVER_NOW - 300),
+                            },
+                        },
+                    ],
+                },
+                headers={"date": formatdate(_SERVER_NOW, usegmt=True)},
+            )
+        raise AssertionError(f"unexpected path {path}")
+
+    async with _session_query_client(handler) as client:
+        out = json.loads(
+            await _execute_session_query_tool(
+                "sys_session_list",
+                "{}",
+                conversation_id="conv_x",
+                server_client=client,
+            )
+        )
+
+    row = out["sessions"][0]
+    # Flat on rows, not the nested block get_info returns — these are read
+    # in bulk.
+    assert row["context_tokens"] == 150_000
+    assert row["context_window"] == 200_000
+    assert row["context_used_fraction"] == 0.75
+    assert row["context_as_of"] == _SERVER_NOW - 600
+    assert row["context_stale"] is False
+    assert row["seconds_since_last_turn"] == 300
 
 
 @pytest.mark.asyncio
@@ -6730,6 +6811,201 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
     assert info["pending_elicitations"] == [{"id": "el_1"}, {"id": "el_2"}]
     # Metadata-only: the full transcript is never embedded.
     assert "items" not in info
+
+
+# Fixed server clock for the context/timestamp cases, so ages are exact
+# rather than "roughly now" — a projection that silently fell back to the
+# runner's own clock would drift off these values.
+_SERVER_NOW = 1_785_000_000
+
+
+def _snapshot_with_context(
+    *,
+    status: str = "idle",
+    labels: dict[str, str] | None = None,
+    updated_at: int = _SERVER_NOW - 700,
+    last_total_tokens: int | None = 48_213,
+    context_window: int | None = 200_000,
+) -> dict[str, Any]:
+    """Build a session snapshot carrying context metrics.
+
+    :param status: Session status, e.g. ``"running"``.
+    :param labels: Session labels; defaults to a measurement 600s old and a
+        turn that ended 300s ago.
+    :param updated_at: Row activity time.
+    :param last_total_tokens: Context tokens in use, or ``None``.
+    :param context_window: Context window, or ``None``.
+    :returns: A snapshot dict for the mock ``GET /v1/sessions/{id}``.
+    """
+    return {
+        "id": "conv_target",
+        "agent_id": "ag_xyz",
+        "agent_name": "researcher",
+        "status": status,
+        "created_at": _SERVER_NOW - 10_000,
+        "updated_at": updated_at,
+        "labels": {
+            "omnigent.last_context_at": str(_SERVER_NOW - 600),
+            "omnigent.last_turn_at": str(_SERVER_NOW - 300),
+        }
+        if labels is None
+        else labels,
+        "last_total_tokens": last_total_tokens,
+        "context_window": context_window,
+        "runner_id": None,
+        "pending_elicitations": [],
+    }
+
+
+async def _get_info_with(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Run ``sys_session_get_info`` against a snapshot on a pinned server clock.
+
+    The ``Date`` header is what the projection ages timestamps against, so
+    pinning it makes the derived seconds deterministic.
+
+    :param snapshot: Snapshot the mock server returns.
+    :returns: The parsed tool output.
+    """
+    from email.utils import formatdate
+
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/conv_target":
+            return httpx.Response(
+                200,
+                json=snapshot,
+                headers={"date": formatdate(_SERVER_NOW, usegmt=True)},
+            )
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_get_info",
+            arguments=json.dumps({"session_id": "conv_target"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+        )
+    return json.loads(output)
+
+
+@pytest.mark.asyncio
+async def test_sys_session_get_info_projects_context_and_turn_timestamps() -> None:
+    """
+    ``sys_session_get_info`` reports context occupancy and turn recency.
+
+    These are what let a caller choose deliberately between compacting a
+    session and handing its task to a fresh one: how full the window is,
+    and whether the cached prefix is likely still warm. Ages are measured
+    against the server's ``Date`` header, since the runner's own clock has
+    no defined relationship to the timestamps in the snapshot.
+    """
+    info = await _get_info_with(_snapshot_with_context())
+
+    assert info["context"]["tokens"] == 48_213
+    assert info["context"]["window"] == 200_000
+    # 48213 / 200000 = 0.241065, rounded so the model isn't handed
+    # 0.24106500000000002.
+    assert info["context"]["used_fraction"] == 0.241
+    assert info["context"]["as_of"] == _SERVER_NOW - 600
+    assert info["context"]["age_seconds"] == 600
+    # Measured, not mid-turn, and no row activity since — the reading
+    # describes the session as it stands.
+    assert info["context"]["stale"] is False
+
+    assert info["last_turn_completed_at"] == _SERVER_NOW - 300
+    assert info["seconds_since_last_turn"] == 300
+    assert info["created_at"] == _SERVER_NOW - 10_000
+    assert info["updated_at"] == _SERVER_NOW - 700
+
+
+@pytest.mark.asyncio
+async def test_sys_session_get_info_context_stale_while_turn_in_flight() -> None:
+    """A running turn marks the reading stale.
+
+    The measurement necessarily predates the prompt now being processed,
+    so acting on it would size the window against the previous turn.
+    """
+    info = await _get_info_with(_snapshot_with_context(status="running"))
+
+    assert info["context"]["stale"] is True
+    # Still reported — stale means "treat as a lower bound", not "unusable".
+    assert info["context"]["tokens"] == 48_213
+
+
+@pytest.mark.asyncio
+async def test_sys_session_get_info_context_stale_when_row_changed_after_reading() -> None:
+    """Row activity after the reading marks it stale.
+
+    Items appended since the measurement are context the reading doesn't
+    account for. Writing the fill labels does not touch ``updated_at``, so
+    this compares two independent clocks rather than always tripping.
+    """
+    info = await _get_info_with(_snapshot_with_context(updated_at=_SERVER_NOW - 60))
+
+    assert info["context"]["stale"] is True
+
+
+@pytest.mark.asyncio
+async def test_sys_session_get_info_context_present_but_null_when_never_measured() -> None:
+    """An unmeasured session reports nulls, not a missing ``context`` key.
+
+    A missing key reads to a model as "this tool cannot report occupancy";
+    an explicit null with ``stale`` set reads as "not known right now",
+    which is the true state and the one worth retrying.
+    """
+    info = await _get_info_with(
+        _snapshot_with_context(labels={}, last_total_tokens=None, context_window=None)
+    )
+
+    assert info["context"] == {
+        "tokens": None,
+        "window": None,
+        "used_fraction": None,
+        "as_of": None,
+        "age_seconds": None,
+        "stale": True,
+    }
+    assert info["last_turn_completed_at"] is None
+    assert info["seconds_since_last_turn"] is None
+
+
+@pytest.mark.asyncio
+async def test_sys_session_get_info_ages_never_go_negative() -> None:
+    """A timestamp ahead of the server clock reports zero, not a negative age.
+
+    Clock skew between the write and the read must not produce a negative
+    "seconds ago", which reads as a bug rather than as freshness.
+    """
+    info = await _get_info_with(
+        _snapshot_with_context(
+            labels={
+                "omnigent.last_context_at": str(_SERVER_NOW + 120),
+                "omnigent.last_turn_at": str(_SERVER_NOW + 120),
+            }
+        )
+    )
+
+    assert info["context"]["age_seconds"] == 0
+    assert info["seconds_since_last_turn"] == 0
+
+
+@pytest.mark.asyncio
+async def test_sys_session_get_info_used_fraction_reports_overfull_window() -> None:
+    """A fill above the window is reported as-is, not clamped to 1.0.
+
+    An over-window reading means something worth acting on — a lagging
+    post-compaction measurement, or a window that isn't what was assumed.
+    Clamping would hide exactly the case that needs attention.
+    """
+    info = await _get_info_with(
+        _snapshot_with_context(last_total_tokens=220_000, context_window=200_000)
+    )
+
+    assert info["context"]["used_fraction"] == 1.1
 
 
 @pytest.mark.asyncio

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -4312,6 +4312,13 @@ async def test_post_external_session_usage_window_only_payload_persists_window(
         "omnigent.server.routes.sessions.session_stream.publish",
         lambda sid, ev: published.append((sid, ev)),
     )
+    # Distinct stamps per write, so a moved timestamp can't hide behind two
+    # posts landing in the same wall-clock second.
+    clock = iter([1_785_000_000, 1_785_000_600])
+    monkeypatch.setattr(
+        "omnigent.server.routes._sessions.orchestration.now_epoch",
+        lambda: next(clock),
+    )
     agent = await create_test_agent(client)
     session = await _create_session(client, agent["id"])
 
@@ -4332,6 +4339,10 @@ async def test_post_external_session_usage_window_only_payload_persists_window(
     snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
     assert snapshot["last_total_tokens"] == 100
     assert snapshot["context_window"] == 1_000_000
+    # The window post carried no new measurement, so the fill timestamp stays
+    # at the first post — advancing it would make the 100-token reading look
+    # freshly taken when it is 10 minutes old.
+    assert snapshot["labels"]["omnigent.last_context_at"] == "1785000000"
 
 
 async def test_post_external_session_usage_rejects_empty_payload(
@@ -4368,6 +4379,22 @@ def _read_session_usage(db_uri: str, session_id: str) -> dict[str, Any]:
     """
     conv = SqlAlchemyConversationStore(db_uri).get_conversation(session_id)
     return dict(conv.session_usage) if conv and conv.session_usage else {}
+
+
+def _read_labels(db_uri: str, session_id: str) -> dict[str, str]:
+    """
+    Read a conversation's labels directly from the DB.
+
+    The context-fill metrics land on labels, and the relay path is exercised
+    below the HTTP layer, so these tests read them through a reader store on
+    the same DB file the app writes to.
+
+    :param db_uri: The per-test SQLite URI (same one the ``client`` app uses).
+    :param session_id: Conversation id to read.
+    :returns: The conversation's labels (empty when the row is missing).
+    """
+    conv = SqlAlchemyConversationStore(db_uri).get_conversation(session_id)
+    return dict(conv.labels) if conv and conv.labels else {}
 
 
 async def test_external_session_usage_persists_cumulative_cost(
@@ -4884,6 +4911,101 @@ async def test_accumulate_session_usage_records_per_model_breakdown(
     assert by_model["model-a"]["total_cost_usd"] + by_model["model-b"][
         "total_cost_usd"
     ] == pytest.approx(usage["total_cost_usd"])
+
+
+async def test_accumulate_session_usage_persists_context_fill(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A relay turn's ``context_tokens`` reaches the snapshot, as on native harnesses.
+
+    The relay path accumulates cumulative counters and used to drop the fill
+    level entirely, so every SDK-harness session reported a null
+    ``last_total_tokens`` while terminal-backed ones reported a real number.
+    An orchestrator applying one compaction policy across a mixed tree can't
+    do that while half its children report nothing.
+    """
+    from omnigent.server.routes import sessions as sessions_routes
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    sessions_routes._accumulate_session_usage(
+        {"usage": {"input_tokens": 1000, "output_tokens": 500, "context_tokens": 48213}},
+        session["id"],
+        SqlAlchemyConversationStore(db_uri),
+    )
+
+    labels = _read_labels(db_uri, session["id"])
+    assert labels["omnigent.last_context_tokens"] == "48213"
+    # Every fill reading is stamped, so a caller can tell a fresh measurement
+    # from one left behind by a turn that died mid-flight.
+    assert labels["omnigent.last_context_at"].isdigit()
+    # The fill is a level, so it must stay out of the cumulative buckets that
+    # feed the cost badge — summing it across turns would produce nonsense.
+    assert "context_tokens" not in _read_session_usage(db_uri, session["id"])
+
+    snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+    assert snapshot["last_total_tokens"] == 48213
+
+
+async def test_accumulate_session_usage_without_context_tokens_writes_no_fill(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A turn that reports no fill leaves the fill labels absent.
+
+    Executors that make a single LLM call per turn don't emit
+    ``context_tokens``. Writing a synthesized value for them would hand the
+    caller a fabricated occupancy reading; absent is the honest answer.
+    """
+    from omnigent.server.routes import sessions as sessions_routes
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    sessions_routes._accumulate_session_usage(
+        {"usage": {"input_tokens": 1000, "output_tokens": 500}},
+        session["id"],
+        SqlAlchemyConversationStore(db_uri),
+    )
+
+    labels = _read_labels(db_uri, session["id"])
+    assert "omnigent.last_context_tokens" not in labels
+    assert "omnigent.last_context_at" not in labels
+    snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+    assert snapshot["last_total_tokens"] is None
+
+
+async def test_accumulate_session_usage_context_fill_is_set_not_summed(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Successive turns overwrite the fill rather than adding to it.
+
+    ``context_tokens`` measures how full the window is right now. Routing it
+    through the cumulative counter path would make it grow without bound and
+    read as "over budget" within a few turns.
+    """
+    from omnigent.server.routes import sessions as sessions_routes
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    store = SqlAlchemyConversationStore(db_uri)
+
+    sessions_routes._accumulate_session_usage(
+        {"usage": {"input_tokens": 1000, "output_tokens": 500, "context_tokens": 10_000}},
+        session["id"],
+        store,
+    )
+    sessions_routes._accumulate_session_usage(
+        {"usage": {"input_tokens": 1000, "output_tokens": 500, "context_tokens": 12_500}},
+        session["id"],
+        store,
+    )
+
+    # The second reading, not 22_500.
+    assert _read_labels(db_uri, session["id"])["omnigent.last_context_tokens"] == "12500"
 
 
 async def test_accumulate_session_usage_unpriced_model_has_tokens_no_cost(

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -1694,6 +1694,34 @@ async def test_session_snapshot_cost_is_own_usage_for_childless_session() -> Non
 
 
 @pytest.mark.asyncio
+async def test_session_snapshot_carries_row_activity_timestamp() -> None:
+    """The snapshot exposes ``updated_at`` alongside ``created_at``.
+
+    A caller reading one session needs to know how recently it saw any
+    activity; the list endpoint has always carried this and the single-session
+    snapshot did not, so the same question could only be answered by listing
+    every session and finding the row.
+    """
+    conv = Conversation(
+        id="3f1c9a2b4d5e6f708192a3b4c5d6e7f8",
+        created_at=1_784_990_000,
+        updated_at=1_785_000_000,
+        root_conversation_id="3f1c9a2b4d5e6f708192a3b4c5d6e7f8",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
+    )
+    conv_store = _ConversationStore(
+        [_message_item("item_1", "hi")],
+        conversations={"3f1c9a2b4d5e6f708192a3b4c5d6e7f8": conv},
+    )
+
+    snapshot = await _get_session_snapshot(conv_store, "3f1c9a2b4d5e6f708192a3b4c5d6e7f8")  # type: ignore[arg-type]
+
+    # Distinct values, so a field wired to the wrong source is visible.
+    assert snapshot.created_at == 1_784_990_000
+    assert snapshot.updated_at == 1_785_000_000
+
+
+@pytest.mark.asyncio
 async def test_session_snapshot_sums_by_model_over_subtree() -> None:
     """The snapshot's ``usage_by_model`` sums token buckets across the subtree.
 

--- a/tests/server/routes/test_sessions_turn_timestamp.py
+++ b/tests/server/routes/test_sessions_turn_timestamp.py
@@ -1,0 +1,99 @@
+"""Turn-end stamping: which status edges record ``omnigent.last_turn_at``.
+
+A caller deciding whether to continue a session or start a fresh one needs
+to know how long ago it stopped working — a recently-finished session still
+has a warm cached prefix, an hour-old one does not. ``_publish_status`` is
+the one place both relay and terminal-backed harnesses report a turn
+ending, so the stamp is written there.
+
+The edge selection is the whole substance: relays re-publish a steady
+``idle``, so stamping on every publish rather than on the transition would
+keep reporting a long-quiet session as having just finished — exactly
+inverting the decision the timestamp exists to inform.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.server import session_live_state
+from omnigent.server.routes import sessions as _sessions_mod
+from omnigent.server.routes.sessions import _publish_status
+
+_SID = "conv_turn_stamp_test"
+
+
+@pytest.fixture()
+def stamped(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record turn-end stamps instead of writing them, and isolate cache state."""
+    calls: list[str] = []
+    monkeypatch.setattr(
+        session_live_state,
+        "persist_last_turn_at",
+        lambda session_id: calls.append(session_id),
+    )
+    _sessions_mod._session_status_cache.pop(_SID, None)
+    yield calls
+    _sessions_mod._session_status_cache.pop(_SID, None)
+
+
+def test_running_to_idle_stamps_turn_end(stamped: list[str]) -> None:
+    """The ordinary turn-completion edge records the timestamp."""
+    _publish_status(_SID, "running")
+    _publish_status(_SID, "idle")
+    assert stamped == [_SID]
+
+
+def test_running_to_failed_stamps_turn_end(stamped: list[str]) -> None:
+    """A turn that errored still ended — the session stopped working."""
+    _publish_status(_SID, "running")
+    _publish_status(_SID, "failed")
+    assert stamped == [_SID]
+
+
+def test_mid_turn_edges_do_not_stamp(stamped: list[str]) -> None:
+    """``running`` / ``waiting`` are not turn ends.
+
+    ``waiting`` means blocked on an approval prompt with the turn still
+    open; stamping there would report the session as finished while it is
+    mid-flight.
+    """
+    _publish_status(_SID, "running")
+    _publish_status(_SID, "waiting")
+    assert stamped == []
+
+
+def test_repeated_idle_stamps_once(stamped: list[str]) -> None:
+    """Re-publishing a settled ``idle`` must not advance the stamp.
+
+    The PTY-activity watcher emits trailing ``idle`` edges long after the
+    turn ended; each one re-stamping would make an idle session look
+    perpetually just-finished and its cached prefix perpetually warm.
+    """
+    _publish_status(_SID, "running")
+    _publish_status(_SID, "idle")
+    _publish_status(_SID, "idle")
+    _publish_status(_SID, "idle")
+    assert stamped == [_SID]
+
+
+def test_sticky_failed_swallows_trailing_idle(stamped: list[str]) -> None:
+    """A trailing ``idle`` after ``failed`` neither clears the error nor re-stamps.
+
+    ``failed`` is terminal and already stamped; the follow-on quiescence
+    ``idle`` returns early, so the turn end keeps the time it actually
+    happened.
+    """
+    _publish_status(_SID, "running")
+    _publish_status(_SID, "failed")
+    _publish_status(_SID, "idle")
+    assert stamped == [_SID]
+
+
+def test_next_turn_stamps_again(stamped: list[str]) -> None:
+    """A new turn produces a new stamp — the value tracks the latest turn."""
+    _publish_status(_SID, "running")
+    _publish_status(_SID, "idle")
+    _publish_status(_SID, "running")
+    _publish_status(_SID, "idle")
+    assert stamped == [_SID, _SID]

--- a/tests/server/test_session_live_state.py
+++ b/tests/server/test_session_live_state.py
@@ -55,9 +55,18 @@ class _RecordingStore:
         self.pending_writes: list[tuple[str, int]] = []
         self.touches: list[list[str]] = []
         self.clears: list[str] = []
+        self.label_writes: list[tuple[str, dict[str, str], int | None]] = []
 
     def set_session_live_status(self, conversation_id: str, status: str) -> None:
         self.status_writes.append((conversation_id, status))
+
+    def set_labels(
+        self,
+        conversation_id: str,
+        updates: dict[str, str],
+        updated_at: int | None = None,
+    ) -> None:
+        self.label_writes.append((conversation_id, dict(updates), updated_at))
 
     def set_pending_elicitation_count(self, conversation_id: str, count: int) -> None:
         self.pending_writes.append((conversation_id, count))
@@ -97,6 +106,36 @@ def test_persist_live_status_dedupes_transitions(recording_store: _RecordingStor
         ("conv_1", "idle"),
         ("conv_2", "idle"),
     ]
+
+
+def test_persist_last_turn_at_writes_stamped_label(recording_store: _RecordingStore) -> None:
+    """The turn-end stamp lands as a label carrying its own timestamp.
+
+    It goes on a label rather than ``conversations.updated_at`` because the
+    latter orders the sidebar — a turn ending must not reshuffle the list.
+    The row's ``updated_at`` is passed explicitly so the stored value and
+    the row's own timestamp agree.
+    """
+    before = int(time.time())
+    session_live_state.persist_last_turn_at("conv_1")
+    _wait_until(lambda: len(recording_store.label_writes) >= 1)
+
+    conversation_id, updates, updated_at = recording_store.label_writes[0]
+    assert conversation_id == "conv_1"
+    assert set(updates) == {"omnigent.last_turn_at"}
+    stamp = int(updates["omnigent.last_turn_at"])
+    assert before <= stamp <= int(time.time())
+    assert updated_at == stamp
+
+
+def test_persist_last_turn_at_is_a_no_op_when_unconfigured() -> None:
+    """Without a store the stamp is dropped, like every other live-state write.
+
+    The runner process and unit tests never call ``configure``; a write
+    attempt there would raise on ``None``.
+    """
+    session_live_state.configure(None)
+    session_live_state.persist_last_turn_at("conv_1")
 
 
 def test_pending_count_hook_persists_publish_and_resolve(

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3439,6 +3439,8 @@ def test_fork_conversation_drops_instance_scoped_labels(
             "omnigent.codex_native.bridge_id": source.id,
             "omnigent.last_context_tokens": "39903",
             "omnigent.last_context_window": "1000000",
+            "omnigent.last_context_at": "1785000000",
+            "omnigent.last_turn_at": "1785000060",
             # The dangerous bypass opt-in must NOT ride into the fork.
             "omnigent.codex_native.bypass_sandbox": "1",
             # An ordinary, non-instance label that SHOULD carry over.
@@ -3817,12 +3819,26 @@ def test_instance_scoped_label_keys_match_harness_constants() -> None:
     """
     from omnigent.claude_native_bridge import BRIDGE_ID_LABEL_KEY
     from omnigent.codex_native_bridge import CODEX_NATIVE_BRIDGE_ID_LABEL_KEY
+    from omnigent.session_lifecycle import (
+        LAST_CONTEXT_AT_LABEL_KEY,
+        LAST_CONTEXT_TOKENS_LABEL_KEY,
+        LAST_CONTEXT_WINDOW_LABEL_KEY,
+        LAST_TURN_AT_LABEL_KEY,
+    )
     from omnigent.stores.conversation_store import _INSTANCE_SCOPED_LABEL_KEYS
 
     # Each harness's canonical bridge-id key must be in the denylist; a
     # miss means a rename slipped past the store's hard-coded literal.
     assert BRIDGE_ID_LABEL_KEY in _INSTANCE_SCOPED_LABEL_KEYS
     assert CODEX_NATIVE_BRIDGE_ID_LABEL_KEY in _INSTANCE_SCOPED_LABEL_KEYS
+
+    # The fill metrics and turn stamp describe one running instance. A key
+    # missing here leaves a fork reporting the source's measurement — worse
+    # than reporting none, since the stale value looks live.
+    assert LAST_CONTEXT_TOKENS_LABEL_KEY in _INSTANCE_SCOPED_LABEL_KEYS
+    assert LAST_CONTEXT_WINDOW_LABEL_KEY in _INSTANCE_SCOPED_LABEL_KEYS
+    assert LAST_CONTEXT_AT_LABEL_KEY in _INSTANCE_SCOPED_LABEL_KEYS
+    assert LAST_TURN_AT_LABEL_KEY in _INSTANCE_SCOPED_LABEL_KEYS
 
 
 def test_fork_conversation_copies_reasoning_effort(


### PR DESCRIPTION
## Related issue

Closes #3271

## Summary

An orchestrator driving sub-agents could not answer two questions about any session it manages: **how full is its context**, and **when did its last turn end**. `sys_session_get_info` returned neither, so `status` was the entire temporal signal — a session that finished 30 seconds ago and one that finished three hours ago were indistinguishable. The only available strategy was to keep sending turns until the window filled and the session bricked, or to compact on a blind guess.

- `sys_session_get_info` now returns a `context` block (`tokens`, `window`, `used_fraction`, `as_of`, `age_seconds`, `stale`) plus `last_turn_completed_at`, `seconds_since_last_turn`, `created_at`, `updated_at`.
- `sys_session_list` rows carry the same state flattened, so sessions can be ranked by occupancy from one call instead of a `get_info` per row.
- **Relay (SDK) sessions now persist their context fill at all** — see below.

### The issue's framing was half-right, and the other half is the actual work

The issue describes this as "a plumbing gap, not a measurement gap." That holds for terminal-backed harnesses. It does not hold for relay ones:

```
native harness  ──POST /events {external_session_usage}──►  _persist_external_session_usage  ──► labels ✓
relay / SDK     ──response.completed {usage.context_tokens}──►  _accumulate_session_usage    ──► dropped ✗
```

`_accumulate_session_usage` accumulated cumulative counters and never read `usage.context_tokens`, so **every SDK-harness session served `last_total_tokens: null`** while native ones served a real number. Since the issue calls parity "the requirement, not a nice-to-have," persisting the relay-side fill is the substance of this PR; the projection is nearly free.

Both paths now go through one writer, `_persist_context_fill`. The fill is a *level*, so it is SET rather than added — routing it through the cumulative counters would grow it without bound and corrupt the `session_usage` column that feeds the cost badge.

### Two timestamps, because they answer different questions

`context.as_of` is when occupancy was measured. Forwarders post usage on poll ticks **mid-turn**, so it is not a turn boundary. `last_turn_completed_at` is stamped from the terminal status edge in `_publish_status` — the one place relay and terminal-backed harnesses both report a turn ending, which is what makes the value mean the same thing across them.

### ELI5

Think of each session as a glass being filled. Before, you could see whether someone was currently pouring, but not how full the glass was or when they last poured. Now you can see both — so you can decide to empty the glass (compact) or fetch a fresh one (new session) *before* it overflows, instead of after.

### Deliberate omissions and judgement calls

- **`last_turn_cache` is not implemented.** The issue offers this itself: *"the lowest-confidence part of the ask — if the per-turn cache split is awkward to persist, `last_turn_completed_at` alone is enough."* It is awkward for a concrete reason: per-turn usage is not retrievably persisted (only cumulative aggregates), and the split exists on the relay path but not the native one — so shipping it would break the parity requirement. Happy to revisit if you want it.
- **`stale` is advisory and conservative** — set when nothing was measured, when a turn is in flight, or when the row changed after the reading. `status` remains authoritative for "is it working now". Worth noting `set_labels` does not bump `conversations.updated_at`, so the third rule compares two independent clocks rather than always tripping.
- **Ages are computed from the response's `Date` header**, not the runner's clock. Every timestamp involved is server-stamped, and runners are frequently remote or containerised; mixing the two clocks can report a session as finishing in the future. Values are floored at zero.
- **On prompt-cache TTL:** the issue reasons from a ~1h cache lifetime. Anthropic's default is 5 minutes, with 1h available as an opt-in the server cannot observe. So this exposes raw `seconds_since_last_turn` and leaves the threshold to the caller rather than baking in a `cache_warm` boolean.
- `used_fraction` is **not** clamped at 1.0 — an over-window reading is real information (a lagging post-compaction measurement, or a wrong window), and hiding it would mask the case most worth acting on.
- `SessionResponse.updated_at` is optional, unlike the required field on `SessionListItem`, so the model can still be constructed without a conversation row and older-server skew degrades cleanly.

## Test Plan

```bash
uv run pytest tests/runner/ tests/tools/ tests/stores/
uv run pytest tests/server/routes/ tests/server/integration/test_sessions_endpoints.py
uv run pytest tests/e2e/test_session_context_info_e2e.py    # e2e is opt-in
uv run ruff check . && uv run ruff format --check .
```

Each core claim was checked by **removing the fix and confirming the test fails**, not only by watching it pass:

- Disabling the relay persistence makes `test_accumulate_session_usage_persists_context_fill` fail with `KeyError: 'omnigent.last_context_tokens'`.
- The same removal makes the **e2e fail against a live server** with `relay turn recorded no context fill: last_total_tokens=None` — verbatim the symptom this issue reports.
- `test_openapi_drift` fails before the `openapi.json` regen and passes after; the diff is exactly one field.

**Pre-existing failures, unrelated to this PR:** `tests/server/routes/test_sessions_snapshot.py` has 5 order-dependent failures (`InvalidUuidError`). They reproduce identically on unmodified `main` — verified in a clean `git worktree` at `61fd7235` with the same command (baseline 677 passed / 5 failed; this branch 697 passed / **the same** 5 failed). Cause: `_resolve_harness_impl` (`helpers.py:1581`) reads the process-global `_agent_store`, which an earlier test's `runtime_init` leaves set. Minimal reproducer: `pytest tests/server/integration/test_sessions_endpoints.py tests/server/routes/test_sessions_snapshot.py`. Filing separately rather than bundling an unrelated fix here.

## Demo

N/A — no UI or frontend change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New tests: relay-path fill persistence and its SET-not-summed semantics (`tests/server/integration/test_sessions_endpoints.py`), the terminal-edge stamping and which status edges qualify (`tests/server/routes/test_sessions_turn_timestamp.py`), the store's instance-scoped label denylist (`tests/stores/test_conversation_store.py`), snapshot `updated_at` (`tests/server/routes/test_sessions_snapshot.py`), and the runner projection incl. staleness rules, null-when-unmeasured, and clock-skew clamping (`tests/runner/test_runner_dispatch.py`).

Manual verification: ran the keyless e2e against a live local server with a real `openai-agents` turn through the mock LLM, then read back `GET /v1/sessions/{id}` and the runner projection. Also confirmed the new fields degrade correctly against an older server (absent labels → nulls with `stale: true`) rather than erroring.

Changes are additive to tool output; no existing key changed meaning. `tests/runner/test_runner_dispatch.py` had one whole-list equality assertion on `sys_session_list` rows, updated in the same commit.

## Changelog

Agents can read a session's context occupancy and how long ago its last turn ended via `sys_session_get_info`, for deciding when to compact or start fresh
