### PR TITLE
feat(cli): include auth override env var in non-loopback bind warning 

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1145,7 +1145,9 @@ def _apply_bind_auth_defaults(host: str) -> None:
             f"  ⚠ Binding to non-local interface {host}: enabling accounts "
             "(login) mode to prevent unauthorized access.\n"
             "    Open the server URL in a browser to create the first admin "
-            "account.",
+            "account.\n"
+            "    Set OMNIGENT_AUTH_ENABLED=0 first to override and stay in "
+            "single-user mode.",
             err=True,
         )
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- When `omnigent server` binds a non-loopback interface, it auto-enables accounts (login) mode and prints a warning.
- The warning now explicitly names `OMNIGENT_AUTH_ENABLED=0` as the override to keep single-user mode.
- Kept the warning to the canonical env var; removed any mention of the deprecated alias.
- Improved the rendered indentation so the override sentence starts on its own line.

## Test Plan

- `uv run ruff check omnigent/cli.py`
- `uv run pytest tests/cli/test_bind_auth_defaults.py -q`

Both pass.

## Demo

<img width="858" height="192" alt="image" src="https://github.com/user-attachments/assets/26f76ffe-3985-4140-b8f7-c210095ead1c" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing `tests/cli/test_bind_auth_defaults.py` already exercises the non-loopback auto-enable path and the explicit `OMNIGENT_AUTH_ENABLED=0` override. This change only updates the warning copy.

## Changelog

`omnigent server` now tells users they can set `OMNIGENT_AUTH_ENABLED=0` to override automatic multi-user mode when binding to a non-loopback interface.