### PR TITLE
refactor(server)!: remove deprecated OMNIGENT_ACCOUNTS_ENABLED env alias

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1135,10 +1135,7 @@ def _apply_bind_auth_defaults(host: str) -> None:
         os.environ.setdefault("OMNIGENT_LOCAL_SINGLE_USER", "1")
 
     # Non-loopback + no explicit auth → accounts (login) mode.
-    _raw_auth_enabled = os.environ.get("OMNIGENT_AUTH_ENABLED", "").strip()
-    _auth_enabled_explicit = bool(
-        _raw_auth_enabled or os.environ.get("OMNIGENT_ACCOUNTS_ENABLED", "").strip()
-    )
+    _auth_enabled_explicit = bool(os.environ.get("OMNIGENT_AUTH_ENABLED", "").strip())
     if not _is_loopback_bind and not _auth_provider_explicit and not _auth_enabled_explicit:
         os.environ.setdefault("OMNIGENT_AUTH_ENABLED", "1")
         click.echo(

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -371,10 +371,8 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # OMNIGENT_OIDC_* is set); =0 opts back out. Must propagate down the
         # CLI → daemon → local-server chain or `omnigent run`/`connect` would
         # spawn the wrong auth mode while the operator set the switch on the CLI.
-        # Not a secret. OMNIGENT_ACCOUNTS_ENABLED is the deprecated pre-rename
-        # alias, still propagated so existing setups keep working.
+        # Not a secret.
         "OMNIGENT_AUTH_ENABLED",
-        "OMNIGENT_ACCOUNTS_ENABLED",
         # Process logging controls. These are diagnostics knobs, not secrets.
         "OMNIGENT_LOG_LEVEL",
         "OMNIGENT_LOG_TO_STDERR",

--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -38,11 +38,8 @@ from starlette.requests import HTTPConnection
 
 logger = logging.getLogger(__name__)
 
-# Opt-in multi-user switch. ``OMNIGENT_AUTH_ENABLED`` is the current
-# name; ``OMNIGENT_ACCOUNTS_ENABLED`` is the pre-rename name, still
-# honored as a deprecated alias (see :func:`_auth_enabled`).
+# Opt-in multi-user switch.
 _AUTH_ENABLED_ENV = "OMNIGENT_AUTH_ENABLED"
-_AUTH_ENABLED_ENV_DEPRECATED = "OMNIGENT_ACCOUNTS_ENABLED"
 
 RESERVED_USER_LOCAL = "local"
 RESERVED_USER_PUBLIC = "__public__"
@@ -257,40 +254,18 @@ def resolve_auth_header_strip_prefix() -> str:
     return os.environ.get(_AUTH_HEADER_STRIP_PREFIX_ENV, "").strip()
 
 
-_auth_enabled_deprecation_warned = False
-
-
 def _auth_enabled() -> bool:
     """Whether multi-user auth is opted in via the enable switch.
 
-    Reads ``OMNIGENT_AUTH_ENABLED``. The pre-rename name
-    ``OMNIGENT_ACCOUNTS_ENABLED`` is still honored as a deprecated
-    alias: when it is set and the current name is not, its value is
-    used and a one-time deprecation warning is logged. The current name
-    always wins when both are set, so a deploy migrating to the new name
-    can leave the old one in place without surprise.
-
-    Both names share the same truthiness rules (see
-    :func:`env_var_is_truthy`) and the same explicit-falsy kill-switch
-    semantics — ``OMNIGENT_AUTH_ENABLED=0`` disables auth even though
-    the var is "set", which is how the Docker entrypoint lets an
+    Reads ``OMNIGENT_AUTH_ENABLED``. The explicit-falsy kill-switch
+    semantics mean ``OMNIGENT_AUTH_ENABLED=0`` disables auth even
+    though the var is "set", which is how the Docker entrypoint lets an
     operator opt back out of the default-on accounts mode.
 
     :returns: ``True`` when multi-user auth should be enabled.
     """
-    global _auth_enabled_deprecation_warned
     if os.environ.get(_AUTH_ENABLED_ENV, "").strip():
         return env_var_is_truthy(_AUTH_ENABLED_ENV, default=False)
-    if os.environ.get(_AUTH_ENABLED_ENV_DEPRECATED, "").strip():
-        if not _auth_enabled_deprecation_warned:
-            logger.warning(
-                "%s is deprecated; rename it to %s. The old name still "
-                "works for now but will be removed in a future release.",
-                _AUTH_ENABLED_ENV_DEPRECATED,
-                _AUTH_ENABLED_ENV,
-            )
-            _auth_enabled_deprecation_warned = True
-        return env_var_is_truthy(_AUTH_ENABLED_ENV_DEPRECATED, default=False)
     return False
 
 
@@ -308,9 +283,8 @@ def resolve_auth_source() -> str:
       wins, e.g. ``"header"`` / ``"oidc"`` / ``"accounts"``. This is the
       low-level escape hatch.
     - Otherwise ``header`` is the default, unless the opt-in switch
-      ``OMNIGENT_AUTH_ENABLED`` is truthy (see :func:`_auth_enabled`,
-      which also honors the deprecated ``OMNIGENT_ACCOUNTS_ENABLED``
-      alias). When enabled, the mode depends on whether OIDC config was
+      ``OMNIGENT_AUTH_ENABLED`` is truthy (see :func:`_auth_enabled`).
+      When enabled, the mode depends on whether OIDC config was
       supplied:
 
       - ``OMNIGENT_OIDC_ISSUER`` is set → ``"oidc"`` (the operator
@@ -677,11 +651,8 @@ def create_auth_provider() -> AuthProvider:
     ``Cf-Access-Authenticated-User-Email`` for Cloudflare Access — see
     :func:`resolve_auth_header`).
 
-    (``OMNIGENT_AUTH_ENABLED`` is the renamed opt-in gate,
-    commit ``b23e886e``, formerly ``OMNIGENT_ACCOUNTS_ENABLED``:
-    header is the shipped default, so the var is an enable switch, not
-    a kill switch. The old name is still honored as a deprecated
-    alias — see :func:`_auth_enabled`.)
+    (``OMNIGENT_AUTH_ENABLED`` is the opt-in gate: header is the
+    shipped default, so the var is an enable switch, not a kill switch.)
 
     Validates the source's required env vars at startup (fail
     loud) — OIDC fetches the discovery document, accounts decodes

--- a/tests/cli/test_bind_auth_defaults.py
+++ b/tests/cli/test_bind_auth_defaults.py
@@ -21,7 +21,6 @@ from omnigent.cli import _apply_bind_auth_defaults
 _AUTH_ENVS = (
     "OMNIGENT_AUTH_PROVIDER",
     "OMNIGENT_AUTH_ENABLED",
-    "OMNIGENT_ACCOUNTS_ENABLED",
     "OMNIGENT_LOCAL_SINGLE_USER",
     "OMNIGENT_OIDC_ISSUER",
 )
@@ -124,20 +123,6 @@ def test_non_loopback_respects_explicit_auth_enabled_zero(
 
     # Stays "0", not overwritten by setdefault.
     assert os.environ.get("OMNIGENT_AUTH_ENABLED") == "0"
-    assert _stderr(capsys) == ""
-
-
-def test_non_loopback_respects_deprecated_accounts_enabled(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """The deprecated OMNIGENT_ACCOUNTS_ENABLED alias also counts as explicit.
-
-    An operator who set the old var name should not be auto-overridden.
-    """
-    monkeypatch.setenv("OMNIGENT_ACCOUNTS_ENABLED", "0")
-    _apply_bind_auth_defaults("0.0.0.0")
-
-    assert os.environ.get("OMNIGENT_AUTH_ENABLED") is None
     assert _stderr(capsys) == ""
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,7 @@ os.environ.setdefault("OMNIGENT_DISABLE_CATALOG_LOOKUP", "1")
 
 # Pin header mode for the whole suite. Header is the env-unset default,
 # but a developer's shell often has OMNIGENT_AUTH_ENABLED=1 set (the
-# multi-user opt-in they use to test the login flow locally; the
-# pre-rename OMNIGENT_ACCOUNTS_ENABLED is still honored too) — and that
+# multi-user opt-in they use to test the login flow locally) — and that
 # enable switch would flip the env-unset default to accounts (or oidc, if
 # the shell also exports OMNIGENT_OIDC_ISSUER), booting every server in
 # multi-user mode and failing loud with "Missing required environment

--- a/tests/e2e/test_local_server_lifecycle_e2e.py
+++ b/tests/e2e/test_local_server_lifecycle_e2e.py
@@ -65,9 +65,6 @@ _ENV_TO_CLEAR = (
     "OMNIGENT_DATA_DIR",
     "OMNIGENT_CONFIG_HOME",
     "OMNIGENT_AUTH_ENABLED",
-    # Pre-rename alias for OMNIGENT_AUTH_ENABLED — still honored, so strip
-    # it too or a dev shell that exports it flips the server into accounts mode.
-    "OMNIGENT_ACCOUNTS_ENABLED",
     # An ambient issuer would select oidc once auth is (accidentally) enabled.
     "OMNIGENT_OIDC_ISSUER",
     "OMNIGENT_AUTH_PROVIDER",

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -437,7 +437,6 @@ def test_resolve_auth_source_defaults_to_header(
     """
     monkeypatch.delenv("OMNIGENT_AUTH_PROVIDER", raising=False)
     monkeypatch.delenv("OMNIGENT_AUTH_ENABLED", raising=False)
-    monkeypatch.delenv("OMNIGENT_ACCOUNTS_ENABLED", raising=False)
     assert resolve_auth_source() == "header"
 
 
@@ -483,40 +482,7 @@ def test_resolve_auth_source_oidc_issuer_ignored_when_auth_disabled(
     """
     monkeypatch.delenv("OMNIGENT_AUTH_PROVIDER", raising=False)
     monkeypatch.delenv("OMNIGENT_AUTH_ENABLED", raising=False)
-    monkeypatch.delenv("OMNIGENT_ACCOUNTS_ENABLED", raising=False)
     monkeypatch.setenv("OMNIGENT_OIDC_ISSUER", "https://accounts.google.com")
-    assert resolve_auth_source() == "header"
-
-
-def test_resolve_auth_source_deprecated_alias_still_selects_accounts(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The pre-rename ``OMNIGENT_ACCOUNTS_ENABLED`` alias still works.
-
-    Existing deploys that set the old name must keep booting in accounts
-    mode after the rename. If this regressed, an upgrade would silently
-    drop those deploys back to single-user header mode (no login).
-    """
-    monkeypatch.delenv("OMNIGENT_AUTH_PROVIDER", raising=False)
-    monkeypatch.delenv("OMNIGENT_AUTH_ENABLED", raising=False)
-    monkeypatch.setenv("OMNIGENT_ACCOUNTS_ENABLED", "1")
-    assert resolve_auth_source() == "accounts"
-
-
-def test_resolve_auth_source_new_var_wins_over_deprecated_alias(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The current name wins when both names are set.
-
-    A deploy migrating to ``OMNIGENT_AUTH_ENABLED`` can leave the old
-    ``OMNIGENT_ACCOUNTS_ENABLED`` in place: an explicit ``=0`` on the
-    new name disables auth even though the old name is truthy. If the
-    alias took precedence the new value would be unsettable while the
-    old one lingered.
-    """
-    monkeypatch.delenv("OMNIGENT_AUTH_PROVIDER", raising=False)
-    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "0")
-    monkeypatch.setenv("OMNIGENT_ACCOUNTS_ENABLED", "1")
     assert resolve_auth_source() == "header"
 
 
@@ -551,7 +517,6 @@ def test_factory_defaults_to_header_when_env_unset(
     """
     monkeypatch.delenv("OMNIGENT_AUTH_PROVIDER", raising=False)
     monkeypatch.delenv("OMNIGENT_AUTH_ENABLED", raising=False)
-    monkeypatch.delenv("OMNIGENT_ACCOUNTS_ENABLED", raising=False)
 
     provider = create_auth_provider()
 


### PR DESCRIPTION
refactor(server)!: remove deprecated OMNIGENT_ACCOUNTS_ENABLED env alias

## Related issue

N/A

## Summary

- Remove the long-deprecated `OMNIGENT_ACCOUNTS_ENABLED` environment-variable alias for the multi-user auth enable switch. The canonical name `OMNIGENT_AUTH_ENABLED` has existed since the repository was open-sourced.
- Strip the alias logic from `omnigent/server/auth.py::_auth_enabled()`, the explicit-auth check in `omnigent/cli.py::_apply_bind_auth_defaults()`, and the runner env-propagation allowlist in `omnigent/host/connect.py`.
- Delete the tests that exercised the alias and the obsolete comment in `tests/conftest.py`.

## Test Plan

- `uv run ruff check omnigent/server/auth.py omnigent/cli.py omnigent/host/connect.py tests/conftest.py tests/cli/test_bind_auth_defaults.py tests/server/test_accounts.py tests/e2e/test_local_server_lifecycle_e2e.py` passed.
- `uv run pytest tests/cli/test_bind_auth_defaults.py tests/server/test_accounts.py -q --no-header` passed (95 items).
- `uv run pytest tests/server/test_accounts.py::test_resolve_auth_source_defaults_to_header tests/server/test_accounts.py::test_resolve_auth_source_opt_in_selects_accounts tests/server/test_accounts.py::test_factory_defaults_to_header_when_env_unset tests/cli/test_bind_auth_defaults.py -q --no-header` passed (15 items).
- Verified no remaining references with `grep -R "OMNIGENT_ACCOUNTS_ENABLED" . --exclude-dir=.git --exclude-dir=.venv`.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [x] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Removed the tests that specifically covered the deprecated alias; remaining tests continue to validate `OMNIGENT_AUTH_ENABLED` behavior. The refactor does not change the `OMNIGENT_AUTH_ENABLED=1 | =0` semantics.

## Changelog

[Breaking] The deprecated `OMNIGENT_ACCOUNTS_ENABLED` environment variable has been removed; use `OMNIGENT_AUTH_ENABLED` instead.

BREAKING CHANGE: Users and deploys still setting `OMNIGENT_ACCOUNTS_ENABLED` must rename the variable to `OMNIGENT_AUTH_ENABLED` before upgrading; the old name is no longer read or propagated.
