### PR TITLE
fix(sessions): don't wipe local pins when UI upgrades before server

### DIFF
--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -26,8 +26,10 @@ import {
   useStopAndDeleteConversation,
   useStopSession,
   useTogglePinnedConversation,
+  fetchPinnedConversations,
   PINNED_CONVERSATIONS_KEY,
   type Conversation,
+  type PinnedConversationsResult,
 } from "./useConversations";
 import { PINNED_LABEL_KEY } from "@/lib/sessionListCache";
 
@@ -875,8 +877,8 @@ describe("useTogglePinnedConversation cache patching", () => {
     rendered.result.current.mutate({ id: "conv_x", pinned: true });
     await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
 
-    const pinned = queryClient.getQueryData<Conversation[]>(PINNED_CONVERSATIONS_KEY);
-    const row = pinned!.find((c) => c.id === "conv_x")!;
+    const pinned = queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY);
+    const row = pinned!.conversations.find((c) => c.id === "conv_x")!;
     // The row is present immediately AND has a real timestamp — the bug was a
     // blank time field until the pinned query refetched.
     expect(row.updated_at).toBe(150);
@@ -885,14 +887,17 @@ describe("useTogglePinnedConversation cache patching", () => {
 
   it("removes the row from the pinned cache on unpin", async () => {
     const { queryClient, rendered } = seed(false);
-    queryClient.setQueryData<Conversation[]>(PINNED_CONVERSATIONS_KEY, [
-      conversation({ id: "conv_x", updated_at: 150 }),
-    ]);
+    queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, {
+      conversations: [conversation({ id: "conv_x", updated_at: 150 })],
+      filterHonored: true,
+    });
 
     rendered.result.current.mutate({ id: "conv_x", pinned: false });
     await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
 
-    expect(queryClient.getQueryData<Conversation[]>(PINNED_CONVERSATIONS_KEY)).toEqual([]);
+    expect(
+      queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY)?.conversations,
+    ).toEqual([]);
   });
 
   it("does not blank an existing list row's updated_at (labels-only overlay)", async () => {
@@ -919,6 +924,70 @@ describe("useTogglePinnedConversation cache patching", () => {
     expect(invalidateSpy).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect((fetchMock.mock.calls[0] as [string, RequestInit])[1].method).toBe("PATCH");
+  });
+});
+
+describe("fetchPinnedConversations filter-honored detection", () => {
+  // A pre-upgrade server ignores the unknown `?pinned=true` param and returns
+  // an ordinary session page. Detecting that (filterHonored=false) is what
+  // stops the sidebar's one-time migration from wiping local pins against an
+  // old server. The new server returns only rows carrying `omnigent.pinned`.
+  function pinnedRow(id: string): unknown {
+    return {
+      id,
+      object: "conversation",
+      title: id,
+      created_at: 0,
+      updated_at: 1,
+      labels: { [PINNED_LABEL_KEY]: "1721760000000" },
+    };
+  }
+  function plainRow(id: string): unknown {
+    return { id, object: "conversation", title: id, created_at: 0, updated_at: 1, labels: {} };
+  }
+
+  it("reports honored when every returned row is actually pinned", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ data: [pinnedRow("conv_a"), pinnedRow("conv_b")] }),
+    );
+
+    const result = await fetchPinnedConversations();
+
+    expect(result.filterHonored).toBe(true);
+    expect(result.conversations.map((c) => c.id)).toEqual(["conv_a", "conv_b"]);
+  });
+
+  it("reports honored for an empty page (a user with no pins)", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ data: [] }));
+
+    const result = await fetchPinnedConversations();
+
+    expect(result.filterHonored).toBe(true);
+    expect(result.conversations).toEqual([]);
+  });
+
+  it("reports NOT honored and drops unpinned rows when an old server ignores the filter", async () => {
+    // Old server: returns the normal first page — none carry the pin label.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ data: [plainRow("conv_a"), plainRow("conv_b")] }),
+    );
+
+    const result = await fetchPinnedConversations();
+
+    expect(result.filterHonored).toBe(false);
+    // Never surface unpinned rows as pinned.
+    expect(result.conversations).toEqual([]);
+  });
+
+  it("reports NOT honored on a mixed page (some rows lack the pin label)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ data: [pinnedRow("conv_a"), plainRow("conv_b")] }),
+    );
+
+    const result = await fetchPinnedConversations();
+
+    expect(result.filterHonored).toBe(false);
+    expect(result.conversations.map((c) => c.id)).toEqual(["conv_a"]);
   });
 });
 

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -825,6 +825,17 @@ export async function fetchPinnedConversations(): Promise<PinnedConversationsRes
   // Honored iff the server returned nothing, or everything it returned is
   // actually pinned. An old server returns unfiltered rows (none pinned), so a
   // non-empty raw page with fewer pinned rows means the filter was ignored.
+  //
+  // Ambiguity: an EMPTY page is treated as honored, but "new server, no pins"
+  // and "old server, zero sessions" are indistinguishable here — we infer
+  // honored-ness from row contents rather than an explicit capability marker.
+  // This is safe in practice: an old server returns an empty page only when the
+  // account has no sessions at all, so any leftover localStorage pin ids point
+  // at sessions that no longer exist. The migration's PATCH to those ids 404s,
+  // the write is recorded as failed, and the id is RETAINED in localStorage
+  // (not cleared) — so no pin is lost even in this corner. Closing the window
+  // fully would need a server capability flag; deferred since pins haven't
+  // shipped yet.
   const filterHonored = rows.length === 0 || conversations.length === rows.length;
   return { conversations, filterHonored };
 }

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -779,14 +779,39 @@ export { PINNED_LABEL_KEY };
 export const PINNED_CONVERSATIONS_KEY = ["pinned-conversations"] as const;
 
 /**
+ * Result of the pinned-session query. `conversations` is the viewer's pinned
+ * sessions; `filterHonored` says whether the server actually applied the
+ * `?pinned=true` filter (see {@link fetchPinnedConversations}).
+ */
+export interface PinnedConversationsResult {
+  conversations: Conversation[];
+  /**
+   * False when the server ignored the `pinned` query param — i.e. a
+   * pre-upgrade server that predates server-side pins. Such a server returns
+   * an ordinary (unfiltered) session page whose rows carry no `omnigent.pinned`
+   * label. The sidebar reads this to keep the one-time localStorage→server pin
+   * migration inert until the server can actually store pins, so a
+   * UI-before-server upgrade can't wipe local pins.
+   */
+  filterHonored: boolean;
+}
+
+/**
  * Fetch every pinned session (the `omnigent.pinned` label) via
  * `GET /v1/sessions?pinned=true`, independent of the sidebar's paginated
  * window. Pins now live on the server (a session label) so they follow the
  * user across devices; this query is the source of truth for which sessions
  * are pinned and supplies the rows for any pin that sits outside the loaded
  * list. A generous single page (100) covers realistic pin counts.
+ *
+ * A pre-upgrade server doesn't know the `pinned` param and silently ignores
+ * it (FastAPI drops unknown query params), returning an ordinary session page.
+ * We defend against that by keeping only rows that actually carry the
+ * `omnigent.pinned` label and reporting `filterHonored: false` whenever the
+ * server handed back rows that aren't pinned — the signal the sidebar uses to
+ * skip the destructive localStorage migration against an old server.
  */
-export async function fetchPinnedConversations(): Promise<Conversation[]> {
+export async function fetchPinnedConversations(): Promise<PinnedConversationsResult> {
   const params = new URLSearchParams({
     order: "desc",
     sort_by: "updated_at",
@@ -795,12 +820,18 @@ export async function fetchPinnedConversations(): Promise<Conversation[]> {
   });
   const res = await authenticatedFetch(`/v1/sessions?${params.toString()}`);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  return ((await res.json()) as ConversationsPage).data;
+  const rows = ((await res.json()) as ConversationsPage).data;
+  const conversations = rows.filter((c) => c.labels?.[PINNED_LABEL_KEY] != null);
+  // Honored iff the server returned nothing, or everything it returned is
+  // actually pinned. An old server returns unfiltered rows (none pinned), so a
+  // non-empty raw page with fewer pinned rows means the filter was ignored.
+  const filterHonored = rows.length === 0 || conversations.length === rows.length;
+  return { conversations, filterHonored };
 }
 
 /** Server-authoritative list of the viewer's pinned sessions. */
 export function usePinnedConversations() {
-  return useQuery<Conversation[]>({
+  return useQuery<PinnedConversationsResult>({
     queryKey: PINNED_CONVERSATIONS_KEY,
     queryFn: fetchPinnedConversations,
     staleTime: 30_000,
@@ -858,7 +889,9 @@ export function useTogglePinnedConversation() {
   // window, so that cache is searched too — otherwise its pinned row would be
   // built from the timestamp-less snapshot.
   const findRow = (id: string): Conversation | undefined =>
-    queryClient.getQueryData<Conversation[]>(PINNED_CONVERSATIONS_KEY)?.find((c) => c.id === id) ??
+    queryClient
+      .getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY)
+      ?.conversations.find((c) => c.id === id) ??
     queryClient
       .getQueriesData<ConversationsInfiniteData>({ queryKey: ["conversations"] })
       .flatMap(([, data]) => data?.pages.flatMap((p) => p.data) ?? [])
@@ -894,9 +927,13 @@ export function useTogglePinnedConversation() {
     queryClient.setQueryData<Session>(["session", id], (old) => (old ? { ...old, labels } : old));
     // Add the row on pin (its label carries the pin timestamp the sidebar sorts
     // by) built from the existing row + labels; drop it on unpin.
-    queryClient.setQueryData<Conversation[]>(PINNED_CONVERSATIONS_KEY, (old) => {
-      const rest = (old ?? []).filter((c) => c.id !== id);
-      if (!pinned) return rest;
+    queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, (old) => {
+      // Preserve the query's `filterHonored` flag; the toggle only mutates the
+      // list. If the query hasn't loaded yet, an optimistic patch implies the
+      // server can store pins, so treat it as honored.
+      const prev = old ?? { conversations: [], filterHonored: true };
+      const rest = prev.conversations.filter((c) => c.id !== id);
+      if (!pinned) return { ...prev, conversations: rest };
       // Prefer the full cached row (keeps title/updated_at); fall back to a
       // minimal row when the session isn't in any loaded cache (rare — the pin
       // affordance lives on a visible row). The pinned query refetch fills the
@@ -904,7 +941,7 @@ export function useTogglePinnedConversation() {
       const row: Conversation = existing
         ? { ...existing, labels }
         : ({ id, object: "conversation", labels } as Conversation);
-      return [...rest, row];
+      return { ...prev, conversations: [...rest, row] };
     });
   };
 
@@ -916,7 +953,8 @@ export function useTogglePinnedConversation() {
     // network resolves, which reads as lag. Snapshot the pinned cache so a
     // failed PATCH rolls back.
     onMutate: ({ id, pinned }) => {
-      const prevPinned = queryClient.getQueryData<Conversation[]>(PINNED_CONVERSATIONS_KEY);
+      const prevPinned =
+        queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY);
       const base = findRow(id)?.labels ?? {};
       const labels: Record<string, string> = pinned
         ? { ...base, [PINNED_LABEL_KEY]: String(Date.now()) }

--- a/web/src/shell/Sidebar.archive.test.tsx
+++ b/web/src/shell/Sidebar.archive.test.tsx
@@ -32,7 +32,10 @@ vi.mock("@/hooks/useConversations", () => ({
     isPending: false,
     isError: false,
   }),
-  usePinnedConversations: () => ({ data: [], isSuccess: true }),
+  usePinnedConversations: () => ({
+    data: { conversations: [], filterHonored: true },
+    isSuccess: true,
+  }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],

--- a/web/src/shell/Sidebar.bulkActionLayout.test.tsx
+++ b/web/src/shell/Sidebar.bulkActionLayout.test.tsx
@@ -28,7 +28,10 @@ vi.mock("@/hooks/useConversations", () => ({
     isPending: false,
     isError: false,
   }),
-  usePinnedConversations: () => ({ data: [], isSuccess: true }),
+  usePinnedConversations: () => ({
+    data: { conversations: [], filterHonored: true },
+    isSuccess: true,
+  }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],

--- a/web/src/shell/Sidebar.delete.test.tsx
+++ b/web/src/shell/Sidebar.delete.test.tsx
@@ -28,7 +28,10 @@ vi.mock("@/hooks/useConversations", () => ({
   useConversations: vi.fn(),
   useConnectedConversations: () => [],
   useStopAndDeleteConversation: () => mocks.del,
-  usePinnedConversations: () => ({ data: [], isSuccess: true }),
+  usePinnedConversations: () => ({
+    data: { conversations: [], filterHonored: true },
+    isSuccess: true,
+  }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],

--- a/web/src/shell/Sidebar.pinBackwardsCompat.test.tsx
+++ b/web/src/shell/Sidebar.pinBackwardsCompat.test.tsx
@@ -1,0 +1,176 @@
+// End-to-end backwards-compatibility test for the server-side pin migration.
+//
+// Scenario (the reported failure): a user pins a session on the OLD build
+// (localStorage-only), then the UI is upgraded BEFORE the server, then the
+// server is upgraded. The pin must survive every step — it must never be wiped
+// during the UI-before-server window.
+//
+// Unlike Sidebar.pinMigration.test.tsx (which mocks the query), this drives the
+// REAL `usePinnedConversations` + `useMigrateLocalPinsToServer` +
+// `setConversationPinned` against a fake `/v1/sessions` server that flips from
+// old (ignores `?pinned=true`) to new (honors it + stores a per-user pin), with
+// a fresh QueryClient per stage to model a page reload.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePinnedConversations } from "@/hooks/useConversations";
+import { PINNED_LABEL_KEY } from "@/lib/sessionListCache";
+import { useMigrateLocalPinsToServer } from "./Sidebar";
+import { PINNED_CONVERSATION_IDS_STORAGE_KEY } from "./sidebarNav";
+
+vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
+
+// ── Fake server ───────────────────────────────────────────────────────────
+//
+// Models the only two behaviours that matter for this scenario:
+//   old → ignores the `pinned` param, returns the full (unfiltered) page, and
+//         no row carries the `omnigent.pinned` label (pre-feature server).
+//   new → honors `?pinned=true`, returns only the caller's pinned rows with the
+//         label collapsed to the bare `omnigent.pinned` key, and PATCH stores /
+//         clears the per-user pin.
+const server = {
+  mode: "old" as "old" | "new",
+  // ids the server currently reports as pinned (new mode only).
+  pins: new Set<string>(),
+  // every session that exists (what an old server returns unfiltered).
+  allSessions: ["chat_1", "chat_2"],
+  patchCount: 0,
+};
+
+function row(id: string, pinned: boolean) {
+  return {
+    id,
+    object: "conversation",
+    title: id,
+    created_at: 0,
+    updated_at: 1,
+    labels: pinned ? { [PINNED_LABEL_KEY]: "1721760000000" } : {},
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, status: 200, statusText: "OK", json: async () => body } as unknown as Response;
+}
+
+const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+  const url = input.toString();
+  // PATCH /v1/sessions/{id} — pin/unpin.
+  if (init?.method === "PATCH") {
+    server.patchCount += 1;
+    const id = decodeURIComponent(url.split("/v1/sessions/")[1]);
+    const body = JSON.parse(init.body as string) as { labels?: Record<string, string> };
+    const val = body.labels?.[PINNED_LABEL_KEY];
+    // An old server never gets here: the migration is gated off against it.
+    if (val === "" || val == null) server.pins.delete(id);
+    else server.pins.add(id);
+    return Promise.resolve(jsonResponse(row(id, server.pins.has(id))));
+  }
+  // GET /v1/sessions?...&pinned=true — the pinned list.
+  if (server.mode === "old") {
+    // Old server drops the unknown `pinned` param and returns everything.
+    return Promise.resolve(jsonResponse({ data: server.allSessions.map((id) => row(id, false)) }));
+  }
+  return Promise.resolve(jsonResponse({ data: [...server.pins].map((id) => row(id, true)) }));
+});
+
+// The union the sidebar renders: server pins ∪ leftover localStorage pins.
+function readLegacyPins(): string[] {
+  const raw = localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY);
+  return raw ? (JSON.parse(raw) as string[]) : [];
+}
+
+// Minimal harness wiring the real hooks exactly as the Sidebar does, exposing
+// the union pinned set so assertions read "what the user sees as pinned".
+function Harness() {
+  const { data, isSuccess } = usePinnedConversations();
+  const serverIds = (data?.conversations ?? []).map((c) => c.id);
+  useMigrateLocalPinsToServer(new Set(serverIds), isSuccess, data?.filterHonored ?? false);
+  const union = new Set(serverIds);
+  for (const id of readLegacyPins()) union.add(id);
+  return createElement("div", { "data-testid": "pinned" }, [...union].sort().join(","));
+}
+
+function loadPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return render(createElement(Harness), { wrapper });
+}
+
+beforeEach(() => {
+  server.mode = "old";
+  server.pins = new Set();
+  server.patchCount = 0;
+  vi.stubGlobal("fetch", fetchMock);
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("pin survives a UI-before-server upgrade", () => {
+  it("keeps a pin pinned across old→new server without ever losing it", async () => {
+    // Pre-state: the user pinned `chat_1` on the OLD build (localStorage only).
+    localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(["chat_1"]));
+
+    // ── Stage 1: UI upgraded, server still OLD ────────────────────────────
+    const stage1 = loadPage();
+    // The pin shows immediately (union with localStorage).
+    await waitFor(() => expect(stage1.getByTestId("pinned").textContent).toBe("chat_1"));
+    // Migration stayed inert: no writes, legacy key intact — so the eventual
+    // server upgrade still has the pin to migrate instead of finding it gone.
+    expect(server.patchCount).toBe(0);
+    expect(readLegacyPins()).toEqual(["chat_1"]);
+    stage1.unmount();
+
+    // ── Stage 2: server upgraded, page reloaded ───────────────────────────
+    server.mode = "new"; // now honors ?pinned=true (currently no server pins)
+    const stage2 = loadPage();
+    // Migration fires and pushes the local pin to the server.
+    await waitFor(() => expect(server.pins.has("chat_1")).toBe(true));
+    expect(server.patchCount).toBe(1);
+    // Legacy key is cleared once the write is confirmed.
+    await waitFor(() =>
+      expect(localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY)).toBeNull(),
+    );
+    // Still pinned throughout (server cache patch keeps it in the union).
+    await waitFor(() => expect(stage2.getByTestId("pinned").textContent).toBe("chat_1"));
+    stage2.unmount();
+
+    // ── Stage 3: subsequent reload on the NEW server ──────────────────────
+    const stage3 = loadPage();
+    // Pin is now server-authoritative; it persists with nothing left in
+    // localStorage and no further migration writes.
+    await waitFor(() => expect(stage3.getByTestId("pinned").textContent).toBe("chat_1"));
+    expect(server.patchCount).toBe(1);
+    expect(readLegacyPins()).toEqual([]);
+  });
+
+  it("does not lose the pin even if the server is upgraded much later (repeated old-server loads)", async () => {
+    localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(["chat_1"]));
+
+    // Several reloads while the server is still old — each must be a no-op that
+    // preserves the pin (the failure report was the pin vanishing here). The
+    // reloads are inherently sequential (each models a fresh page load).
+    for (let i = 0; i < 3; i++) {
+      const r = loadPage();
+      // eslint-disable-next-line no-await-in-loop
+      await waitFor(() => expect(r.getByTestId("pinned").textContent).toBe("chat_1"));
+      expect(server.patchCount).toBe(0);
+      expect(readLegacyPins()).toEqual(["chat_1"]);
+      r.unmount();
+    }
+
+    // Finally the server catches up.
+    server.mode = "new";
+    const final = loadPage();
+    await waitFor(() => expect(server.pins.has("chat_1")).toBe(true));
+    await waitFor(() => expect(final.getByTestId("pinned").textContent).toBe("chat_1"));
+  });
+});

--- a/web/src/shell/Sidebar.pinMigration.test.tsx
+++ b/web/src/shell/Sidebar.pinMigration.test.tsx
@@ -199,4 +199,28 @@ describe("localStorage → server pin migration gate", () => {
       expect(localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY)).toBeNull(),
     );
   });
+
+  it("retains the legacy pin when its migration write fails (e.g. a 404 for a deleted session)", async () => {
+    // Guards the empty-page ambiguity in `filterHonored`: an old server with
+    // zero sessions returns an empty page (read as honored), so migration may
+    // fire — but its PATCH to a now-deleted session 404s. The failed write must
+    // leave the id in localStorage so no pin is silently lost.
+    filterHonoredRef.current = true;
+    pinnedRef.current = [];
+    setPinnedSpy.mockRejectedValueOnce(new Error("404 Not Found"));
+    localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(["chat_gone"]));
+    mockConversations([]);
+
+    renderSidebar();
+
+    await waitFor(() =>
+      expect(setPinnedSpy).toHaveBeenCalledWith("chat_gone", true, expect.any(Number)),
+    );
+    // The write failed, so the id is kept for a later retry — not cleared.
+    await waitFor(() =>
+      expect(localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY)).toBe(
+        JSON.stringify(["chat_gone"]),
+      ),
+    );
+  });
 });

--- a/web/src/shell/Sidebar.pinMigration.test.tsx
+++ b/web/src/shell/Sidebar.pinMigration.test.tsx
@@ -1,0 +1,202 @@
+// Regression tests for the UI-before-server pin-migration data loss.
+//
+// Pins moved from localStorage to a server-side `omnigent.pinned` label. The
+// one-time migration must NOT run against a pre-upgrade server that ignores
+// the `?pinned=true` filter — doing so PATCHes pins the old server can't
+// per-user-scope AND clears the legacy key, so after the server upgrade every
+// pin reads as unpinned. `usePinnedConversations` reports `filterHonored`;
+// migration is gated on it. Meanwhile a still-local pin keeps rendering via the
+// union of the server set and the legacy localStorage key.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { Conversation } from "@/hooks/useConversations";
+import { PINNED_CONVERSATION_IDS_STORAGE_KEY } from "@/shell/sidebarNav";
+
+// Controls for the mocked pinned query and the migration write spy.
+const { pinnedRef, filterHonoredRef, setPinnedSpy } = vi.hoisted(() => ({
+  pinnedRef: { current: [] as unknown[] },
+  filterHonoredRef: { current: true },
+  // Resolves with a minimal confirmed row so a successful migration write
+  // clears the legacy id.
+  setPinnedSpy: vi.fn((id: string) =>
+    Promise.resolve({ id, object: "conversation", labels: { "omnigent.pinned": "1" } }),
+  ),
+}));
+
+vi.mock("@/hooks/useConversations", () => ({
+  useConversations: vi.fn(),
+  useArchiveConversation: () => ({ mutate: vi.fn() }),
+  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useConnectedConversations: () => [],
+  useStopAndDeleteConversation: () => ({ mutate: vi.fn() }),
+  usePinnedConversations: () => ({
+    data: { conversations: pinnedRef.current, filterHonored: filterHonoredRef.current },
+    isSuccess: true,
+  }),
+  useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
+  setConversationPinned: setPinnedSpy,
+  PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
+  useRenameConversation: () => ({ mutate: vi.fn() }),
+  useStopSession: () => ({ mutate: vi.fn() }),
+  useProjects: () => ({ data: [] }),
+  useProjectSessions: vi.fn(),
+  useMoveToProject: () => ({ mutate: vi.fn() }),
+  useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  fetchProjectSessionIds: () => Promise.resolve([]),
+  PROJECT_LABEL_KEY: "omni_project",
+}));
+vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
+
+import { useConversations, useProjectSessions } from "@/hooks/useConversations";
+import { Sidebar } from "./Sidebar";
+
+const useConvMock = vi.mocked(useConversations);
+const useProjectSessionsMock = vi.mocked(useProjectSessions);
+
+function conv(id: string): Conversation {
+  return {
+    id,
+    object: "conversation",
+    title: id,
+    created_at: 0,
+    updated_at: 0,
+    labels: {},
+    permission_level: null,
+    agent_name: null,
+  } as unknown as Conversation;
+}
+
+function mockConversations(convs: Conversation[]) {
+  useConvMock.mockReturnValue({
+    data: {
+      pages: [{ data: convs, first_id: null, last_id: null, has_more: false }],
+      pageParams: [undefined],
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  } as unknown as ReturnType<typeof useConversations>);
+}
+
+function renderSidebar() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={["/"]}>
+          <Routes>
+            <Route path="/" element={<Sidebar open onClose={vi.fn()} />} />
+          </Routes>
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  useConvMock.mockReset();
+  useProjectSessionsMock.mockReset();
+  useProjectSessionsMock.mockReturnValue({
+    data: {
+      pages: [{ data: [], first_id: null, last_id: null, has_more: false }],
+      pageParams: [undefined],
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  } as unknown as ReturnType<typeof useProjectSessions>);
+  pinnedRef.current = [];
+  filterHonoredRef.current = true;
+  setPinnedSpy.mockClear();
+  localStorage.clear();
+});
+
+afterEach(cleanup);
+
+describe("localStorage → server pin migration gate", () => {
+  it("does NOT migrate (and preserves the legacy key) against an old server that ignores the filter", async () => {
+    // Old server: filter not honored, so it reports no server pins.
+    filterHonoredRef.current = false;
+    pinnedRef.current = [];
+    localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(["chat_1"]));
+    mockConversations([conv("chat_1")]);
+
+    renderSidebar();
+
+    // Give any (erroneous) async migration a chance to fire.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // No pins were pushed to the server, and the legacy key is intact — so the
+    // eventual server upgrade can migrate them instead of finding them gone.
+    expect(setPinnedSpy).not.toHaveBeenCalled();
+    expect(localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY)).toBe(
+      JSON.stringify(["chat_1"]),
+    );
+  });
+
+  it("still renders a legacy-only pin in the Pinned section against an old server", () => {
+    // The pin must stay visible while migration is inert — union of the (empty)
+    // server set and the legacy localStorage key.
+    filterHonoredRef.current = false;
+    pinnedRef.current = [];
+    localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(["chat_1"]));
+    mockConversations([conv("chat_1")]);
+
+    renderSidebar();
+
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /chat_1/ })).toBeInTheDocument();
+  });
+
+  it("migrates legacy pins and clears the legacy key against a new server", async () => {
+    // New server honors the filter but doesn't yet know this pin.
+    filterHonoredRef.current = true;
+    pinnedRef.current = [];
+    localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(["chat_1"]));
+    mockConversations([conv("chat_1")]);
+
+    renderSidebar();
+
+    await waitFor(() =>
+      expect(setPinnedSpy).toHaveBeenCalledWith("chat_1", true, expect.any(Number)),
+    );
+    // The confirmed write drops the id from the legacy key (nothing left to retry).
+    await waitFor(() =>
+      expect(localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY)).toBeNull(),
+    );
+  });
+
+  it("does not re-PATCH a pin the new server already owns", async () => {
+    filterHonoredRef.current = true;
+    // Server already reports chat_1 as pinned.
+    pinnedRef.current = [conv("chat_1")];
+    localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(["chat_1"]));
+    mockConversations([conv("chat_1")]);
+
+    renderSidebar();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(setPinnedSpy).not.toHaveBeenCalled();
+    // Legacy key cleared: the server owns everything it listed.
+    await waitFor(() =>
+      expect(localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY)).toBeNull(),
+    );
+  });
+});

--- a/web/src/shell/Sidebar.pinnedAutoExpand.test.tsx
+++ b/web/src/shell/Sidebar.pinnedAutoExpand.test.tsx
@@ -23,7 +23,10 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useConnectedConversations: () => [],
   useStopAndDeleteConversation: () => ({ mutate: vi.fn() }),
-  usePinnedConversations: () => ({ data: pinnedRef.current, isSuccess: true }),
+  usePinnedConversations: () => ({
+    data: { conversations: pinnedRef.current, filterHonored: true },
+    isSuccess: true,
+  }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],

--- a/web/src/shell/Sidebar.projectHeaderChevron.test.tsx
+++ b/web/src/shell/Sidebar.projectHeaderChevron.test.tsx
@@ -27,7 +27,10 @@ vi.mock("@/hooks/useConversations", () => ({
     isPending: false,
     isError: false,
   }),
-  usePinnedConversations: () => ({ data: [], isSuccess: true }),
+  usePinnedConversations: () => ({
+    data: { conversations: [], filterHonored: true },
+    isSuccess: true,
+  }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -78,7 +78,10 @@ vi.mock("@/hooks/useConversations", () => ({
     const ids = useSyncExternalStore(mocks.pinnedStore.subscribe, () => mocks.pinnedStore.ids);
     const idSet = new Set(ids);
     return {
-      data: (mocks.conversations as { id: string }[]).filter((c) => idSet.has(c.id)),
+      data: {
+        conversations: (mocks.conversations as { id: string }[]).filter((c) => idSet.has(c.id)),
+        filterHonored: true,
+      },
       isSuccess: true,
     };
   },

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -59,7 +59,10 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useConnectedConversations: () => [],
   useStopAndDeleteConversation: () => ({ mutate: vi.fn() }),
-  usePinnedConversations: () => ({ data: [], isSuccess: true }),
+  usePinnedConversations: () => ({
+    data: { conversations: [], filterHonored: true },
+    isSuccess: true,
+  }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],

--- a/web/src/shell/Sidebar.stop.test.tsx
+++ b/web/src/shell/Sidebar.stop.test.tsx
@@ -29,7 +29,10 @@ vi.mock("@/hooks/useConversations", () => ({
     isPending: false,
     isError: false,
   }),
-  usePinnedConversations: () => ({ data: [], isSuccess: true }),
+  usePinnedConversations: () => ({
+    data: { conversations: [], filterHonored: true },
+    isSuccess: true,
+  }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],

--- a/web/src/shell/Sidebar.subagentHighlight.test.tsx
+++ b/web/src/shell/Sidebar.subagentHighlight.test.tsx
@@ -30,7 +30,10 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useConnectedConversations: () => [],
   useStopAndDeleteConversation: () => ({ mutate: vi.fn() }),
-  usePinnedConversations: () => ({ data: [], isSuccess: true }),
+  usePinnedConversations: () => ({
+    data: { conversations: [], filterHonored: true },
+    isSuccess: true,
+  }),
   useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
   setConversationPinned: vi.fn(() => Promise.resolve({})),
   PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -72,7 +72,13 @@ vi.mock("@/hooks/useConversations", () => ({
   // `seedPins` exercise the Pinned section without a separate fixture.
   usePinnedConversations: () => {
     const idSet = new Set(pinnedIdsRef.current);
-    return { data: conversationsRef.current.filter((c) => idSet.has(c.id)), isSuccess: true };
+    return {
+      data: {
+        conversations: conversationsRef.current.filter((c) => idSet.has(c.id)),
+        filterHonored: true,
+      },
+      isSuccess: true,
+    };
   },
   // Reflect the toggle into the seeded ref so a test that clicks quick-pin then
   // re-renders sees the updated Pinned set.

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -529,6 +529,12 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
   // migration clears the legacy key. Ordering/rows still come from
   // `pinnedConversations` where available; a legacy-only id renders from the
   // loaded list rows the grouping already has.
+  //
+  // Caveat: a legacy-only id whose session is OUTSIDE the currently-loaded
+  // paginated window has no backing row, so the id is in the pinned set but may
+  // not render a row until it's loaded. This is window-scoped and transient —
+  // against a new server the migration promotes the id to a real server pinned
+  // row (which carries its own row) on the same or next load.
   const pinnedConversationIds = useMemo(() => {
     const ids = pinnedConversations.map((c) => c.id);
     const seen = new Set(ids);

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -98,6 +98,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import {
   type Conversation,
+  type PinnedConversationsResult,
   useArchiveConversation,
   useBulkArchiveConversations,
   useBulkDeleteConversations,
@@ -305,6 +306,10 @@ function showArchivedToast() {
   showToast(<ArchivedToast />);
 }
 
+/** Stable empty array for the pinned-conversations fallback (referential
+    equality keeps dependent memos from re-firing while the query loads). */
+const EMPTY_CONVERSATIONS: Conversation[] = [];
+
 /**
  * One-time migration of localStorage pins to server-side labels.
  *
@@ -312,24 +317,44 @@ function showArchivedToast() {
  * `PINNED_CONVERSATION_IDS_STORAGE_KEY`. Now they're an `omnigent.pinned`
  * session label so they follow the user across devices. On the first mount
  * after this ships, push any still-local pins the server doesn't already know
- * about (as the label) so no one loses their existing pins, then clear the
- * legacy key so this runs at most once.
+ * about (as the label) so no one loses their existing pins.
  *
- * Waits for the server pinned set to load (`pinnedLoaded`) so an id the server
- * already has isn't needlessly re-PATCHed. Runs the writes directly rather than
- * through the mutation hook: this fires once before any user interaction, and it
- * patches the pinned-list cache itself with the confirmed rows (below) — the
- * same cache-patch (not invalidate) strategy `useTogglePinnedConversation` uses,
- * since the `?pinned=true` index lags these writes.
+ * Runs only when `filterHonored` is true — i.e. the server actually applied
+ * `?pinned=true`, so it can store server-side pins. A pre-upgrade server that
+ * predates this feature ignores the param and returns an unfiltered page;
+ * migrating against it would PATCH pins under a key that server can't
+ * per-user-scope AND clear the legacy key, so after the eventual server upgrade
+ * every pin would read as unpinned. Gating on `filterHonored` keeps the
+ * migration inert (localStorage untouched, pins still render via the union in
+ * the caller) until the server can honor it — so a UI-before-server upgrade is
+ * safe.
+ *
+ * A legacy id is only dropped from localStorage once its server write is
+ * confirmed; anything unwritten (failed, offline, or not-yet-run because the
+ * server can't store pins) stays so the next load retries. Runs the writes
+ * directly rather than through the mutation hook: this fires once before any
+ * user interaction, and it patches the pinned-list cache itself with the
+ * confirmed rows — the same cache-patch (not invalidate) strategy
+ * `useTogglePinnedConversation` uses, since the `?pinned=true` index lags these
+ * writes.
  *
  * @param serverPinnedIds - Ids the server already reports as pinned.
  * @param pinnedLoaded - Whether the server pinned query has settled.
+ * @param filterHonored - Whether the server applied the `?pinned=true` filter.
  */
-function useMigrateLocalPinsToServer(serverPinnedIds: Set<string>, pinnedLoaded: boolean): void {
+export function useMigrateLocalPinsToServer(
+  serverPinnedIds: Set<string>,
+  pinnedLoaded: boolean,
+  filterHonored: boolean,
+): void {
   const queryClient = useQueryClient();
   const migratedRef = useRef(false);
   useEffect(() => {
-    if (!pinnedLoaded || migratedRef.current) return;
+    // Don't migrate until the query settled AND the server proved it honors the
+    // pinned filter — an old server ignores it, and migrating there wipes local
+    // pins. Leave `migratedRef` false so a later load (post server upgrade)
+    // still runs the migration.
+    if (!pinnedLoaded || !filterHonored || migratedRef.current) return;
     migratedRef.current = true;
     const legacyIds = readPinnedConversationIds();
     const toMigrate = legacyIds.filter((id) => !serverPinnedIds.has(id));
@@ -363,16 +388,20 @@ function useMigrateLocalPinsToServer(serverPinnedIds: Set<string>, pinnedLoaded:
       // here would momentarily drop the just-migrated pins.
       const rows = results.map((r) => r.conv).filter((c): c is Conversation => c != null);
       if (rows.length > 0) {
-        queryClient.setQueryData<Conversation[]>(PINNED_CONVERSATIONS_KEY, (old) => {
+        queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, (old) => {
           const ids = new Set(rows.map((c) => c.id));
-          return [...(old ?? []).filter((c) => !ids.has(c.id)), ...rows];
+          const prev = old ?? { conversations: [], filterHonored: true };
+          return {
+            ...prev,
+            conversations: [...prev.conversations.filter((c) => !ids.has(c.id)), ...rows],
+          };
         });
       }
     })();
-    // Run once after the pinned set loads; serverPinnedIds is captured at that
-    // point and the ref guard prevents re-entry.
+    // Re-run when the query settles or the filter starts being honored (post
+    // server upgrade); the ref guard prevents re-entry once it actually runs.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pinnedLoaded]);
+  }, [pinnedLoaded, filterHonored]);
 }
 
 export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: SidebarProps) {
@@ -485,13 +514,38 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
   // they follow the user across devices. `usePinnedConversations` is the
   // authoritative pinned set (independent of the paginated window); the toggle
   // mutation flips the label and refreshes that query.
-  const { data: pinnedConversations = [], isSuccess: pinnedLoaded } = usePinnedConversations();
-  const pinnedConversationIds = useMemo(
-    () => pinnedConversations.map((c) => c.id),
-    [pinnedConversations],
+  const { data: pinnedData, isSuccess: pinnedLoaded } = usePinnedConversations();
+  // Stable empty fallback so downstream memos don't re-fire on every render
+  // while the query is still loading (`pinnedData` undefined).
+  const pinnedConversations = useMemo(
+    () => pinnedData?.conversations ?? EMPTY_CONVERSATIONS,
+    [pinnedData],
   );
+  const pinnedFilterHonored = pinnedData?.filterHonored ?? false;
+  // Membership is the union of the server's pinned rows and any pins still in
+  // the legacy localStorage key — so a not-yet-migrated pin (server too old, or
+  // a migration write that hasn't landed) keeps showing in the Pinned section
+  // instead of vanishing. The union collapses to just the server set once the
+  // migration clears the legacy key. Ordering/rows still come from
+  // `pinnedConversations` where available; a legacy-only id renders from the
+  // loaded list rows the grouping already has.
+  const pinnedConversationIds = useMemo(() => {
+    const ids = pinnedConversations.map((c) => c.id);
+    const seen = new Set(ids);
+    for (const id of readPinnedConversationIds()) if (!seen.has(id)) ids.push(id);
+    return ids;
+    // `pinnedLoaded` isn't read but is a dep on purpose: it re-reads the legacy
+    // key after the migration (gated on the query settling) mutates it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pinnedConversations, pinnedLoaded]);
   const togglePinnedMutation = useTogglePinnedConversation();
   const pinnedIdSet = useMemo(() => new Set(pinnedConversationIds), [pinnedConversationIds]);
+  // The migration compares the legacy key against what the SERVER already owns
+  // (not the union — a legacy-only id must still count as "to migrate").
+  const serverPinnedIdSet = useMemo(
+    () => new Set(pinnedConversations.map((c) => c.id)),
+    [pinnedConversations],
+  );
   const togglePinnedConversation = useCallback(
     (conversationId: string) => {
       togglePinnedMutation.mutate({
@@ -506,7 +560,7 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
   // still-local pins up to the server (as the `omnigent.pinned` label) the
   // first time this build runs, so no one loses their existing pins, then
   // clear the legacy key so this runs at most once.
-  useMigrateLocalPinsToServer(pinnedIdSet, pinnedLoaded);
+  useMigrateLocalPinsToServer(serverPinnedIdSet, pinnedLoaded, pinnedFilterHonored);
 
   // Desktop-only drag-to-resize, mirroring the right rail. The width is
   // exposed as a CSS variable consumed by the ``md:w-[var(--sidebar-width)]``


### PR DESCRIPTION
## Related issue

Follow-up to #3189 (server-side pinned sessions) — fixes a data-loss bug reported when the UI is upgraded before the server.

## Summary

Pinning moved from client-only localStorage to a server-side per-user label in #3189, with a one-time localStorage→server migration. That migration trusted an ambiguous success signal, so an **upgrade order of UI-first, then server** wiped all existing pins:

- A pre-upgrade server doesn't know the `?pinned=true` query param and silently ignores it (FastAPI drops unknown params), returning the normal **unfiltered** session page.
- The UI treated those ~100 arbitrary rows as "already-pinned on the server", computed an empty to-migrate set, and cleared localStorage **without ever writing a pin**.
- After the server was upgraded, its per-user key filter (`omnigent.pinned.<user>`) found nothing, so every previously-pinned session read as unpinned.

This is fixed **entirely client-side** (no server/API change — appropriate for a one-time upgrade-window issue that hasn't shipped):

- **Detect whether the server honored the filter** — `fetchPinnedConversations` now returns `{ conversations, filterHonored }`. It keeps only rows that actually carry the `omnigent.pinned` label, and reports `filterHonored: false` when the server returned unpinned rows (the tell-tale of an old server ignoring the filter). `filterHonored = rows.length === 0 || everyReturnedRowIsPinned`.
- **Gate the migration on `filterHonored`** — it stays inert (localStorage untouched, `migratedRef` left false) against an old server and re-runs after the eventual server upgrade. A legacy id is dropped from localStorage only once its server write is confirmed.
- **Render the union while a legacy pin still exists** — pinned membership is `server pins ∪ leftover localStorage pins`, so a not-yet-migrated pin keeps showing in the Pinned section during the UI-before-server window instead of vanishing.

### Deploy-order behaviour after the fix

| Deploy order | Behaviour |
|---|---|
| Server-first, then UI | migrates cleanly |
| **UI-first, then server** | migration inert, localStorage preserved, pins still render; migrates once the server upgrade is detected |
| Server stays old | pins keep working from localStorage indefinitely |

> Note: this stops *further* loss but can't recover pins already wiped by the buggy build (their localStorage source is gone). Since #3189 hasn't been released, no backfill is needed.

## Test Plan

- `cd web && npm test` — 4563 pass (+2 for the new backwards-compat file); `tsc -b` + `oxlint` clean; `prettier` clean.
- New coverage:
  - `useConversations.test.ts` — `fetchPinnedConversations` filter-honored detection (honored / empty page / old-server-ignored / mixed page) + updated toggle cache-shape assertions.
  - `Sidebar.pinMigration.test.tsx` — migration gate: no-migrate + key-preserved vs old server, legacy pin still renders, migrate + clear vs new server, no re-PATCH of already-owned pins.
  - `Sidebar.pinBackwardsCompat.test.tsx` — **end-to-end**: drives the real `usePinnedConversations` + `useMigrateLocalPinsToServer` + `setConversationPinned` against a fake server that flips old→new across simulated reloads, asserting the pin is never lost (stage-1 `patchCount === 0` + intact legacy key is what would fail against the buggy code).
- Updated the 9 existing Sidebar test mocks to the new `{ conversations, filterHonored }` return shape.

## Demo

N/A — no visible UI change; the fix is in migration/persistence logic. The Pinned section renders identically.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: pin a session on the old build, deploy this UI against a server without #3189's backend, reload → pin stays and `omnigent:pinned-conversation-ids` in localStorage remains intact; then upgrade the server and reload → the pin migrates server-side and the legacy key clears. The automated `Sidebar.pinBackwardsCompat.test.tsx` encodes this same old→new sequence end-to-end.

## Changelog

Fixed pinned sessions being lost when the web UI was updated before the server.

This pull request and its description were written by Isaac.
