### PR TITLE
feat(automations): relative next-run label + card rows

### DIFF
--- a/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
+++ b/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
@@ -18,6 +18,8 @@ never exercised.
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
+
 import httpx
 from playwright.sync_api import Page, expect
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
@@ -182,6 +184,59 @@ def test_scheduled_task_rows_show_schedule_summary_and_relative_next_run(
     # (The forbidden thing was a client recompute of WHICH instant is next; a
     # delta off the server value is fine.)
     expect(daily.get_by_test_id("task-next-run")).to_contain_text("Next run in", timeout=30_000)
+
+
+def _parse_iso(ts: str) -> datetime:
+    """Parse an ISO-8601 timestamp (tolerating a trailing ``Z``) as aware UTC."""
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def test_scheduled_task_next_run_label_live_ticks_without_navigation(
+    page: Page,
+    live_server: str,
+) -> None:
+    """The relative next-run label re-renders on its own as time passes.
+
+    The label is a delta (``next_run_at − now``); ``now`` comes from the shared
+    ``useNow()`` ticker (a 30s ``setInterval`` behind ``useSyncExternalStore``),
+    so the displayed value must advance WITHOUT any navigation or reload as real
+    time passes. A regression to the frozen-at-first-render ``now`` (the bug this
+    guards) would leave the label stuck until remount.
+
+    Determinism comes from Playwright's clock mocking. We pin the browser clock a
+    known distance BEFORE the server's authoritative ``next_run_at`` (so the
+    initial label is a fixed "in 40 mins"), then fast-forward the clock past many
+    30s ticks and assert the SAME row's label changed to "in 5 mins" — no reload
+    between the two assertions. LLM-free: the row is pure UI state, no agent turn.
+    """
+    agent_id = _builtin_agent_id(live_server, "hello_world")
+    task_id = _create_task(live_server, agent_id, "Ticking task", "FREQ=DAILY;BYHOUR=9;BYMINUTE=0")
+
+    # The server armed the task; read its authoritative next fire so the delta is
+    # anchored to real server state rather than a hand-picked absolute time.
+    created = httpx.get(f"{live_server}/v1/scheduled-tasks/{task_id}", timeout=10.0).json()
+    next_run_at = created["next_run_at"]
+    assert next_run_at, "seeded active task should have an armed next_run_at"
+    fire = _parse_iso(next_run_at).replace(microsecond=0)
+
+    # Pin the browser clock to 40 minutes BEFORE the fire, so the delta the label
+    # formats is exactly 40 minutes → "Next run in 40 mins". Installed before
+    # navigation so the SPA's first `Date.now()` (and every `useNow` read) is faked.
+    page.clock.install(time=fire - timedelta(minutes=40))
+
+    page.goto(f"{live_server}/tasks")
+
+    row = _row_by_name(page, "Ticking task")
+    expect(row).to_be_visible(timeout=30_000)
+    next_run = row.get_by_test_id("task-next-run")
+    expect(next_run).to_have_text("Next run in 40 mins", timeout=30_000)
+
+    # Advance the clock 35 minutes — past 70 of the 30s ticks — WITHOUT touching
+    # navigation. The useNow() interval fires and the same element re-renders to
+    # the new delta (40 − 35 = 5 minutes). If the ticker were dead, this stays
+    # "in 40 mins" and the assertion fails.
+    page.clock.fast_forward("35:00")
+    expect(next_run).to_have_text("Next run in 5 mins", timeout=30_000)
 
 
 def test_scheduled_task_create_edit_modal_and_time_picker(

--- a/web/src/components/scheduled/ScheduledTaskRow.test.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.test.tsx
@@ -34,12 +34,18 @@ function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
   };
 }
 
+// A fixed `now` so the relative next-run label is deterministic (the real hook
+// supplies a ticking clock; the row just formats the delta against whatever it's
+// given).
+const NOW = new Date("2026-03-10T12:00:00Z");
+
 function renderRow(
   t: ScheduledTask,
   handlers: Partial<Parameters<typeof ScheduledTaskRow>[0]> = {},
 ) {
   const props = {
     task: t,
+    now: NOW,
     onEdit: vi.fn(),
     onPauseToggle: vi.fn(),
     onRunNow: vi.fn(),
@@ -55,10 +61,10 @@ afterEach(cleanup);
 
 describe("next-run text (server-sourced, relative delta)", () => {
   it("renders the relative next-run with a 'Next run' prefix when nextRunAt is set", () => {
-    // A near-future instant → a relative "in N hours" label. Relative
-    // formatting is covered in scheduleText.test.ts; here we assert the row
-    // surfaces it with the prefix.
-    const future = new Date(Date.now() + 2 * 60 * 60 * 1000 + 60_000).toISOString();
+    // A near-future instant (2h1m past the fixed NOW) → a relative "in 2 hours"
+    // label. Relative formatting is covered in scheduleText.test.ts; here we
+    // assert the row surfaces it with the prefix, using the injected `now`.
+    const future = new Date(NOW.getTime() + 2 * 60 * 60 * 1000 + 60_000).toISOString();
     renderRow(task({ nextRunAt: future }));
     const nextRun = screen.getByTestId("task-next-run");
     expect(nextRun.textContent).toBe("Next run in 2 hours");

--- a/web/src/components/scheduled/ScheduledTaskRow.test.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.test.tsx
@@ -53,14 +53,15 @@ function renderRow(
 
 afterEach(cleanup);
 
-describe("next-run text (server-sourced, relative)", () => {
-  it("renders the relative next-run with a 'Next run' prefix when nextRunAt is set", () => {
-    // ~2h in the future → "in 2h". Delta formatting is covered in
+describe("next-run text (server-sourced, absolute wall-clock)", () => {
+  it("renders the absolute next-run with a 'Next run' prefix when nextRunAt is set", () => {
+    // A near-future instant → an absolute "Today/Tomorrow at H:MM AM/PM" or
+    // "Mon D, H:MM AM/PM" label. Absolute formatting is covered in
     // scheduleText.test.ts; here we assert the row surfaces it with the prefix.
     const future = new Date(Date.now() + 2 * 60 * 60 * 1000 + 60_000).toISOString();
     renderRow(task({ nextRunAt: future }));
     const nextRun = screen.getByTestId("task-next-run");
-    expect(nextRun.textContent).toMatch(/^Next run in \d+h$/);
+    expect(nextRun.textContent).toMatch(/^Next run .*\d{1,2}:\d{2}\s?(AM|PM)$/);
   });
 
   it("renders NO next-run text when nextRunAt is null (paused / unarmed)", () => {

--- a/web/src/components/scheduled/ScheduledTaskRow.test.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.test.tsx
@@ -53,15 +53,15 @@ function renderRow(
 
 afterEach(cleanup);
 
-describe("next-run text (server-sourced, absolute wall-clock)", () => {
-  it("renders the absolute next-run with a 'Next run' prefix when nextRunAt is set", () => {
-    // A near-future instant → an absolute "Today/Tomorrow at H:MM AM/PM" or
-    // "Mon D, H:MM AM/PM" label. Absolute formatting is covered in
-    // scheduleText.test.ts; here we assert the row surfaces it with the prefix.
+describe("next-run text (server-sourced, relative delta)", () => {
+  it("renders the relative next-run with a 'Next run' prefix when nextRunAt is set", () => {
+    // A near-future instant → a relative "in N hours" label. Relative
+    // formatting is covered in scheduleText.test.ts; here we assert the row
+    // surfaces it with the prefix.
     const future = new Date(Date.now() + 2 * 60 * 60 * 1000 + 60_000).toISOString();
     renderRow(task({ nextRunAt: future }));
     const nextRun = screen.getByTestId("task-next-run");
-    expect(nextRun.textContent).toMatch(/^Next run .*\d{1,2}:\d{2}\s?(AM|PM)$/);
+    expect(nextRun.textContent).toBe("Next run in 2 hours");
   });
 
   it("renders NO next-run text when nextRunAt is null (paused / unarmed)", () => {

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -36,6 +36,7 @@ import type { ScheduledTask } from "@/lib/scheduledTasksApi";
 
 export function ScheduledTaskRow({
   task,
+  now,
   onEdit,
   onPauseToggle,
   onRunNow,
@@ -43,6 +44,11 @@ export function ScheduledTaskRow({
   busy,
 }: {
   task: ScheduledTask;
+  // The current wall-clock time, supplied by the parent's shared `useNow` ticker
+  // so the relative next-run label ("in 3 hours") re-renders and stays fresh as
+  // time passes. Passed in (not read here) to keep the row a pure function of
+  // props — one ticker for the whole list, and deterministic in tests.
+  now: Date;
   onEdit: (task: ScheduledTask) => void;
   onPauseToggle: (task: ScheduledTask) => void;
   onRunNow: (task: ScheduledTask) => void;
@@ -53,9 +59,10 @@ export function ScheduledTaskRow({
   const paused = task.state === "paused";
   // Subtitle: the schedule summary, plus the SERVER's next-run time when armed
   // (active tasks only — a paused task has null nextRunAt). We only format the
-  // server value; we never recompute next-run on the client.
+  // delta from the server value against the ticking `now`; we never recompute
+  // WHICH instant is next on the client.
   const scheduleSummary = useMemo(() => describeSchedule(task.rrule), [task.rrule]);
-  const nextRun = useMemo(() => formatNextRunAt(task.nextRunAt), [task.nextRunAt]);
+  const nextRun = useMemo(() => formatNextRunAt(task.nextRunAt, now), [task.nextRunAt, now]);
 
   return (
     <div

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -2,17 +2,17 @@
 // rounded corners + internal padding; the list stacks these with a gap). Layout:
 // bold task title on line 1 (+ a small "Paused" pill when paused), a single
 // muted subline on line 2 with the human-readable schedule summary ("Weekdays
-// at 8:00 AM") followed by the next-run time ("· Next run Tomorrow at 8:00 AM")
-// when armed.
+// at 8:00 AM") followed by the next-run time ("· Next run in 3 hours") when
+// armed.
 //
 // The next-run time is derived from the scheduler's authoritative `nextRunAt`
-// (an ISO string the server computes): we only FORMAT that instant as an
-// absolute wall-clock time, never recompute WHICH instant is next on the client
-// — so the "no client countdown" rule (a client-recomputed instant can't match
-// the server anchor for INTERVAL>1 rules) is not violated. Paused rows are NOT
-// dimmed — the title stays fully legible and the pill is the sole paused
-// signal. A hover-revealed ellipsis (⋯) action menu (Run now / Pause /
-// Resume / Edit / Delete) sits on the right.
+// (an ISO string the server computes): we only FORMAT the delta from that
+// instant (a full-words "in N hours / days" label), never recompute WHICH
+// instant is next on the client — so the "no client countdown" rule (a
+// client-recomputed instant can't match the server anchor for INTERVAL>1 rules)
+// is not violated. Paused rows are NOT dimmed — the title stays fully legible
+// and the pill is the sole paused signal. A hover-revealed ellipsis (⋯) action
+// menu (Run now / Pause / Resume / Edit / Delete) sits on the right.
 
 import { useMemo, useState } from "react";
 import {
@@ -31,7 +31,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
-import { describeSchedule, formatNextRunAtAbsolute } from "@/lib/scheduleText";
+import { describeSchedule, formatNextRunAt } from "@/lib/scheduleText";
 import type { ScheduledTask } from "@/lib/scheduledTasksApi";
 
 export function ScheduledTaskRow({
@@ -55,10 +55,7 @@ export function ScheduledTaskRow({
   // (active tasks only — a paused task has null nextRunAt). We only format the
   // server value; we never recompute next-run on the client.
   const scheduleSummary = useMemo(() => describeSchedule(task.rrule), [task.rrule]);
-  const nextRun = useMemo(
-    () => formatNextRunAtAbsolute(task.nextRunAt, task.timezone),
-    [task.nextRunAt, task.timezone],
-  );
+  const nextRun = useMemo(() => formatNextRunAt(task.nextRunAt), [task.nextRunAt]);
 
   return (
     <div

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -1,13 +1,14 @@
-// One row in the Tasks list, rendered as a FLAT list row (no card chrome — no
-// border/background/shadow box, no per-row divider). Layout: bold task title on
-// line 1 (+ a small "Paused" pill when paused), a single muted subline on line 2
-// with the human-readable schedule summary ("Weekdays at 8:00 AM") followed by
-// the next-run delta ("· Next run in 15h") when armed.
+// One row in the Tasks list, rendered as a CARD (border + subtle background +
+// rounded corners + internal padding; the list stacks these with a gap). Layout:
+// bold task title on line 1 (+ a small "Paused" pill when paused), a single
+// muted subline on line 2 with the human-readable schedule summary ("Weekdays
+// at 8:00 AM") followed by the next-run time ("· Next run Tomorrow at 8:00 AM")
+// when armed.
 //
-// The next-run delta is derived from the scheduler's authoritative `nextRunAt`
-// (an ISO string the server computes): we format only how far away it is
-// (nextRunAt − now), never recompute WHICH instant is next on the client — so
-// the old "no client countdown" rule (a client-recomputed instant can't match
+// The next-run time is derived from the scheduler's authoritative `nextRunAt`
+// (an ISO string the server computes): we only FORMAT that instant as an
+// absolute wall-clock time, never recompute WHICH instant is next on the client
+// — so the "no client countdown" rule (a client-recomputed instant can't match
 // the server anchor for INTERVAL>1 rules) is not violated. Paused rows are NOT
 // dimmed — the title stays fully legible and the pill is the sole paused
 // signal. A hover-revealed ellipsis (⋯) action menu (Run now / Pause /
@@ -30,7 +31,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
-import { describeSchedule, formatNextRunAt } from "@/lib/scheduleText";
+import { describeSchedule, formatNextRunAtAbsolute } from "@/lib/scheduleText";
 import type { ScheduledTask } from "@/lib/scheduledTasksApi";
 
 export function ScheduledTaskRow({
@@ -54,24 +55,27 @@ export function ScheduledTaskRow({
   // (active tasks only — a paused task has null nextRunAt). We only format the
   // server value; we never recompute next-run on the client.
   const scheduleSummary = useMemo(() => describeSchedule(task.rrule), [task.rrule]);
-  const nextRun = useMemo(() => formatNextRunAt(task.nextRunAt), [task.nextRunAt]);
+  const nextRun = useMemo(
+    () => formatNextRunAtAbsolute(task.nextRunAt, task.timezone),
+    [task.nextRunAt, task.timezone],
+  );
 
   return (
     <div
       data-testid="scheduled-task-row"
       data-state={task.state}
       className={cn(
-        // Flat row — NO card chrome (no border/bg/shadow box) and no per-row
-        // divider. `group relative` so the absolutely-positioned ⋯ trigger can
-        // hover-reveal; vertical padding gives the flat-list spacing.
-        // `-mx-2 rounded-lg` + `hover:bg-muted/70` gives a subtle FULL-ROW hover
-        // highlight (like the sidebar conversation rows) that extends past the
-        // content while keeping the title aligned with the page. `pl-2` (left
-        // content inset) is mirrored by the ⋯ button's `right-2` inset so the
-        // two edges are symmetric within the highlight; `pr-10` keeps the text
-        // clear of the inset button. Paused rows are NOT dimmed — the title must
-        // stay legible (AA); the "Paused" pill is the sole signal.
-        "group relative -mx-2 flex items-center gap-3 rounded-lg py-[11px] pr-10 pl-2 transition-colors hover:bg-muted/70",
+        // Card chrome — matching the app's card vocabulary (`rounded-xl border
+        // border-border bg-card`, see InboxPage rows / the Card component): a
+        // visible border, subtle card background, rounded corners, and internal
+        // padding. The list container (TasksPage) stacks these with a `gap` so
+        // there is vertical spacing between cards. `group relative` lets the
+        // absolutely-positioned ⋯ trigger hover-reveal; `pr-12` keeps the text
+        // clear of the inset button, whose `right-3` matches the card's `px-4`
+        // inset so the two edges are symmetric. A subtle `hover:bg-muted/40`
+        // keeps the full-card hover affordance. Paused rows are NOT dimmed — the
+        // title must stay legible (AA); the "Paused" pill is the sole signal.
+        "group relative flex items-center gap-3 rounded-xl border border-border bg-card py-3 pr-12 pl-4 transition-colors hover:bg-muted/40",
       )}
     >
       <div className="flex min-w-0 flex-1 flex-col">
@@ -114,7 +118,7 @@ export function ScheduledTaskRow({
             data-testid="task-row-menu"
             disabled={busy}
             className={cn(
-              "-translate-y-1/2 absolute top-1/2 right-2 transition-opacity",
+              "-translate-y-1/2 absolute top-1/2 right-3 transition-opacity",
               "md:opacity-0 md:group-hover:opacity-100 md:group-has-[:focus-visible]:opacity-100",
               "md:aria-expanded:opacity-100",
             )}

--- a/web/src/hooks/useNow.test.ts
+++ b/web/src/hooks/useNow.test.ts
@@ -1,0 +1,85 @@
+// Unit tests for useNow — the shared, slowly-ticking wall clock that keeps
+// relative time labels ("Next run in 3 hours") fresh. Exercised with fake timers
+// so the ticking is deterministic. Each assertion is chosen so that removing the
+// interval (a frozen clock) or the unmount cleanup (a leaked timer) turns it red.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TICK_MS, useNow } from "./useNow";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useNow", () => {
+  it("advances `now` after each tick interval", () => {
+    const { result } = renderHook(() => useNow());
+    const first = result.current.getTime();
+
+    act(() => {
+      vi.advanceTimersByTime(TICK_MS);
+    });
+    const second = result.current.getTime();
+    // Without the interval firing setNow, `now` would be frozen at `first` and
+    // the relative label would never count down.
+    expect(second).toBeGreaterThanOrEqual(first + TICK_MS);
+
+    act(() => {
+      vi.advanceTimersByTime(TICK_MS);
+    });
+    expect(result.current.getTime()).toBeGreaterThanOrEqual(second + TICK_MS);
+  });
+
+  it("does not advance before a full interval has elapsed", () => {
+    const { result } = renderHook(() => useNow());
+    const first = result.current;
+
+    act(() => {
+      vi.advanceTimersByTime(TICK_MS - 1);
+    });
+    // Same Date reference between ticks — the snapshot is stable so React does
+    // not re-render on every timer granularity, only once per TICK_MS.
+    expect(result.current).toBe(first);
+  });
+
+  it("shares ONE timer across multiple subscribers", () => {
+    const setSpy = vi.spyOn(globalThis, "setInterval");
+    const a = renderHook(() => useNow());
+    const b = renderHook(() => useNow());
+    const c = renderHook(() => useNow());
+    // A single module-level interval drives every subscriber — not one per row.
+    expect(setSpy).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(TICK_MS);
+    });
+    // All subscribers observe the same advanced instant.
+    expect(a.result.current.getTime()).toBe(b.result.current.getTime());
+    expect(b.result.current.getTime()).toBe(c.result.current.getTime());
+
+    a.unmount();
+    b.unmount();
+    c.unmount();
+    setSpy.mockRestore();
+  });
+
+  it("clears the shared timer once the last subscriber unmounts", () => {
+    const clearSpy = vi.spyOn(globalThis, "clearInterval");
+    const a = renderHook(() => useNow());
+    const b = renderHook(() => useNow());
+
+    // First unmount still leaves a live subscriber → timer must stay running.
+    a.unmount();
+    expect(clearSpy).not.toHaveBeenCalled();
+
+    // Last subscriber leaves → the interval is torn down (no leak, no
+    // state-update-after-unmount).
+    b.unmount();
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    clearSpy.mockRestore();
+  });
+});

--- a/web/src/hooks/useNow.ts
+++ b/web/src/hooks/useNow.ts
@@ -1,0 +1,60 @@
+// Shared, slowly-ticking wall clock for relative time labels ("Next run in 3
+// hours"). A relative delta goes stale as real time passes, so any component
+// that renders one needs a periodic re-render to keep it fresh — otherwise the
+// label freezes at its first-render value until something else re-renders.
+//
+// One MODULE-LEVEL `setInterval` drives every subscriber (same pattern as
+// `useWorkingLabelTick` / `useIsMobileViewport`): a single timer regardless of
+// how many rows are on screen, rather than one interval per row. Subscribers
+// read the shared `now` via `useSyncExternalStore`; `getSnapshot` returns the
+// SAME Date reference between ticks so React doesn't loop, and the timer swaps
+// in a fresh Date (and notifies) once per `TICK_MS`. The timer starts lazily on
+// the first subscriber and is torn down when the last one leaves — no leaks.
+
+import { useSyncExternalStore } from "react";
+
+// How often the shared clock advances. Deliberately coarse: the next-run label
+// is minute-granular, so a 30s cadence keeps it at most ~30s stale while
+// costing one cheap timer wakeup — far cheaper than a 1s countdown for a value
+// that rarely changes wording.
+export const TICK_MS = 30_000;
+
+let currentNow = new Date();
+let intervalId: ReturnType<typeof setInterval> | null = null;
+const listeners = new Set<() => void>();
+
+function subscribe(callback: () => void): () => void {
+  listeners.add(callback);
+  // Lazily start the one shared timer on the first subscriber. Refresh `now`
+  // right away so a freshly-mounted subscriber doesn't briefly show a value
+  // left over from a previous mount (the timer only advanced it while mounted).
+  if (intervalId === null) {
+    currentNow = new Date();
+    intervalId = setInterval(() => {
+      currentNow = new Date();
+      for (const listener of listeners) listener();
+    }, TICK_MS);
+  }
+  return () => {
+    listeners.delete(callback);
+    // Tear the timer down once nothing is listening.
+    if (listeners.size === 0 && intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  };
+}
+
+function getSnapshot(): Date {
+  return currentNow;
+}
+
+/**
+ * The current wall-clock time, refreshed every {@link TICK_MS} so relative time
+ * labels re-render and stay fresh. Feed it as the `now` argument to
+ * `formatNextRunAt` (or any relative formatter). All subscribers share a single
+ * timer and the same `now` instant. SSR-safe (returns the module's `now`).
+ */
+export function useNow(): Date {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/web/src/lib/scheduleText.test.ts
+++ b/web/src/lib/scheduleText.test.ts
@@ -368,29 +368,45 @@ describe("formatNextRunAt (relative delta from the server's next-run, full words
     expect(formatNextRunAt("not-a-date", NOW)).toBeNull();
   });
 
-  it("formats a sub-hour delta in minutes (floor), pluralizing", () => {
+  it("formats a sub-hour delta in minutes, pluralizing", () => {
     expect(formatNextRunAt(iso(8 * MIN), NOW)).toBe("in 8 mins");
     expect(formatNextRunAt(iso(30 * MIN), NOW)).toBe("in 30 mins");
-    // Floor: 59m59s → "in 59 mins".
-    expect(formatNextRunAt(iso(59 * MIN + 59_000), NOW)).toBe("in 59 mins");
     // Minimum bucket is 1 min (just over the 'soon' threshold), singular.
     expect(formatNextRunAt(iso(MIN), NOW)).toBe("in 1 min");
   });
 
-  it("formats a sub-day delta in hours (floor), pluralizing", () => {
+  it("formats a sub-day delta in hours, pluralizing", () => {
     expect(formatNextRunAt(iso(HR), NOW)).toBe("in 1 hour");
     expect(formatNextRunAt(iso(3 * HR), NOW)).toBe("in 3 hours");
     expect(formatNextRunAt(iso(15 * HR), NOW)).toBe("in 15 hours");
-    // Floor: 23h59m → "in 23 hours".
-    expect(formatNextRunAt(iso(23 * HR + 59 * MIN), NOW)).toBe("in 23 hours");
   });
 
-  it("formats a multi-day delta in days (floor), pluralizing", () => {
+  it("formats a multi-day delta in days, pluralizing", () => {
     expect(formatNextRunAt(iso(DAY), NOW)).toBe("in 1 day");
     expect(formatNextRunAt(iso(2 * DAY), NOW)).toBe("in 2 days");
     expect(formatNextRunAt(iso(6 * DAY), NOW)).toBe("in 6 days");
-    // Floor: 6d23h → "in 6 days".
-    expect(formatNextRunAt(iso(6 * DAY + 23 * HR), NOW)).toBe("in 6 days");
+  });
+
+  it("rounds to the nearest unit (not floor)", () => {
+    // The user's exact case: 1h49m away reads "in 2 hours", not "in 1 hour".
+    expect(formatNextRunAt(iso(HR + 49 * MIN), NOW)).toBe("in 2 hours");
+    expect(formatNextRunAt(iso(HR + 20 * MIN), NOW)).toBe("in 1 hour"); // rounds down
+    expect(formatNextRunAt(iso(HR + 30 * MIN), NOW)).toBe("in 2 hours"); // half rounds up
+    expect(formatNextRunAt(iso(8 * MIN + 30_000), NOW)).toBe("in 9 mins");
+    expect(formatNextRunAt(iso(8 * MIN + 29_000), NOW)).toBe("in 8 mins");
+    expect(formatNextRunAt(iso(2 * DAY + 12 * HR), NOW)).toBe("in 3 days");
+    expect(formatNextRunAt(iso(2 * DAY + 11 * HR), NOW)).toBe("in 2 days");
+  });
+
+  it("promotes to the next unit when rounding carries (no 'in 60 mins' / 'in 24 hours')", () => {
+    // Rounds to 60 min → promote to hours as "in 1 hour".
+    expect(formatNextRunAt(iso(59 * MIN + 40_000), NOW)).toBe("in 1 hour");
+    expect(formatNextRunAt(iso(59 * MIN + 59_000), NOW)).toBe("in 1 hour");
+    // Rounds to 24 h → promote to days as "in 1 day".
+    expect(formatNextRunAt(iso(23 * HR + 40 * MIN), NOW)).toBe("in 1 day");
+    expect(formatNextRunAt(iso(23 * HR + 59 * MIN), NOW)).toBe("in 1 day");
+    // Rounds up within the day bucket (6d23h → 7 days).
+    expect(formatNextRunAt(iso(6 * DAY + 23 * HR), NOW)).toBe("in 7 days");
   });
 
   it("returns 'soon' for an imminent or just-passed delta (< 1 minute)", () => {

--- a/web/src/lib/scheduleText.test.ts
+++ b/web/src/lib/scheduleText.test.ts
@@ -6,7 +6,13 @@
 
 import { describe, expect, it } from "vitest";
 import { RRule, rrulestr } from "rrule";
-import { describeSchedule, formatClockTime, formatNextRunAt, nextRunAtMs } from "./scheduleText";
+import {
+  describeSchedule,
+  formatClockTime,
+  formatNextRunAt,
+  formatNextRunAtAbsolute,
+  nextRunAtMs,
+} from "./scheduleText";
 import {
   buildRRule,
   DEFAULT_SCHEDULE_MODEL,
@@ -399,5 +405,52 @@ describe("formatNextRunAt (compact relative delta from the server's next-run)", 
   it("bucket boundaries: 60m → hours, 24h → days", () => {
     expect(formatNextRunAt(iso(60 * MIN), NOW)).toBe("in 1h");
     expect(formatNextRunAt(iso(24 * HR), NOW)).toBe("in 1d");
+  });
+});
+
+describe("formatNextRunAtAbsolute (absolute wall-clock from the server's next-run)", () => {
+  // A fixed "now" so the Today/Tomorrow bucketing is deterministic. We pin the
+  // task timezone to UTC so the rendered clock time equals the ISO wall time.
+  const NOW = new Date("2026-03-10T12:00:00Z"); // Tue 2026-03-10, 12:00 UTC
+  const TZ = "UTC";
+
+  it("returns null for null / empty / unparseable input", () => {
+    expect(formatNextRunAtAbsolute(null, TZ, NOW)).toBeNull();
+    expect(formatNextRunAtAbsolute(undefined, TZ, NOW)).toBeNull();
+    expect(formatNextRunAtAbsolute("", TZ, NOW)).toBeNull();
+    expect(formatNextRunAtAbsolute("not-a-date", TZ, NOW)).toBeNull();
+  });
+
+  it("formats an instant later TODAY as 'Today at H:MM AM/PM'", () => {
+    expect(formatNextRunAtAbsolute("2026-03-10T14:30:00Z", TZ, NOW)).toBe("Today at 2:30 PM");
+    // Earlier same calendar day (before `now`) is still labelled Today.
+    expect(formatNextRunAtAbsolute("2026-03-10T08:00:00Z", TZ, NOW)).toBe("Today at 8:00 AM");
+  });
+
+  it("formats an instant on the NEXT calendar day as 'Tomorrow at H:MM AM/PM'", () => {
+    expect(formatNextRunAtAbsolute("2026-03-11T08:00:00Z", TZ, NOW)).toBe("Tomorrow at 8:00 AM");
+    // Just after midnight the next day is still Tomorrow (calendar-day based,
+    // not a 24h delta).
+    expect(formatNextRunAtAbsolute("2026-03-11T00:15:00Z", TZ, NOW)).toBe("Tomorrow at 12:15 AM");
+  });
+
+  it("formats an instant further out as 'Mon D, H:MM AM/PM'", () => {
+    expect(formatNextRunAtAbsolute("2026-03-15T08:00:00Z", TZ, NOW)).toBe("Mar 15, 8:00 AM");
+    expect(formatNextRunAtAbsolute("2026-07-26T20:00:00Z", TZ, NOW)).toBe("Jul 26, 8:00 PM");
+  });
+
+  it("renders in the task timezone, not the viewer's", () => {
+    // Mar 11 2026 is EDT (UTC-4, DST began Mar 8), so 8:00 AM America/New_York
+    // is 12:00 UTC. Formatted in the task's NY zone it reads 8:00 AM; the
+    // Tomorrow bucket is computed in that zone too.
+    expect(formatNextRunAtAbsolute("2026-03-11T12:00:00Z", "America/New_York", NOW)).toBe(
+      "Tomorrow at 8:00 AM",
+    );
+  });
+
+  it("falls back to a legal render when timezone is omitted or invalid", () => {
+    // No throw; produces a non-null label using the viewer's local zone.
+    expect(formatNextRunAtAbsolute("2026-03-11T08:00:00Z", undefined, NOW)).not.toBeNull();
+    expect(formatNextRunAtAbsolute("2026-03-11T08:00:00Z", "Not/AZone", NOW)).not.toBeNull();
   });
 });

--- a/web/src/lib/scheduleText.test.ts
+++ b/web/src/lib/scheduleText.test.ts
@@ -6,13 +6,7 @@
 
 import { describe, expect, it } from "vitest";
 import { RRule, rrulestr } from "rrule";
-import {
-  describeSchedule,
-  formatClockTime,
-  formatNextRunAt,
-  formatNextRunAtAbsolute,
-  nextRunAtMs,
-} from "./scheduleText";
+import { describeSchedule, formatClockTime, formatNextRunAt, nextRunAtMs } from "./scheduleText";
 import {
   buildRRule,
   DEFAULT_SCHEDULE_MODEL,
@@ -359,7 +353,7 @@ describe("nextRunAtMs", () => {
   });
 });
 
-describe("formatNextRunAt (compact relative delta from the server's next-run)", () => {
+describe("formatNextRunAt (relative delta from the server's next-run, full words)", () => {
   // A fixed "now" so the delta buckets are deterministic.
   const NOW = new Date("2026-03-10T12:00:00Z"); // Tue 2026-03-10, 12:00 UTC
   const iso = (ms: number) => new Date(NOW.getTime() + ms).toISOString();
@@ -374,26 +368,29 @@ describe("formatNextRunAt (compact relative delta from the server's next-run)", 
     expect(formatNextRunAt("not-a-date", NOW)).toBeNull();
   });
 
-  it("formats a sub-hour delta in minutes (floor)", () => {
-    expect(formatNextRunAt(iso(30 * MIN), NOW)).toBe("in 30m");
-    // Floor: 59m59s → "in 59m".
-    expect(formatNextRunAt(iso(59 * MIN + 59_000), NOW)).toBe("in 59m");
-    // Minimum bucket is 1m (just over the 'soon' threshold).
-    expect(formatNextRunAt(iso(MIN), NOW)).toBe("in 1m");
+  it("formats a sub-hour delta in minutes (floor), pluralizing", () => {
+    expect(formatNextRunAt(iso(8 * MIN), NOW)).toBe("in 8 mins");
+    expect(formatNextRunAt(iso(30 * MIN), NOW)).toBe("in 30 mins");
+    // Floor: 59m59s → "in 59 mins".
+    expect(formatNextRunAt(iso(59 * MIN + 59_000), NOW)).toBe("in 59 mins");
+    // Minimum bucket is 1 min (just over the 'soon' threshold), singular.
+    expect(formatNextRunAt(iso(MIN), NOW)).toBe("in 1 min");
   });
 
-  it("formats a sub-day delta in hours (floor)", () => {
-    expect(formatNextRunAt(iso(HR), NOW)).toBe("in 1h");
-    expect(formatNextRunAt(iso(15 * HR), NOW)).toBe("in 15h");
-    // Floor: 23h59m → "in 23h".
-    expect(formatNextRunAt(iso(23 * HR + 59 * MIN), NOW)).toBe("in 23h");
+  it("formats a sub-day delta in hours (floor), pluralizing", () => {
+    expect(formatNextRunAt(iso(HR), NOW)).toBe("in 1 hour");
+    expect(formatNextRunAt(iso(3 * HR), NOW)).toBe("in 3 hours");
+    expect(formatNextRunAt(iso(15 * HR), NOW)).toBe("in 15 hours");
+    // Floor: 23h59m → "in 23 hours".
+    expect(formatNextRunAt(iso(23 * HR + 59 * MIN), NOW)).toBe("in 23 hours");
   });
 
-  it("formats a multi-day delta in days (floor)", () => {
-    expect(formatNextRunAt(iso(DAY), NOW)).toBe("in 1d");
-    expect(formatNextRunAt(iso(6 * DAY), NOW)).toBe("in 6d");
-    // Floor: 6d23h → "in 6d".
-    expect(formatNextRunAt(iso(6 * DAY + 23 * HR), NOW)).toBe("in 6d");
+  it("formats a multi-day delta in days (floor), pluralizing", () => {
+    expect(formatNextRunAt(iso(DAY), NOW)).toBe("in 1 day");
+    expect(formatNextRunAt(iso(2 * DAY), NOW)).toBe("in 2 days");
+    expect(formatNextRunAt(iso(6 * DAY), NOW)).toBe("in 6 days");
+    // Floor: 6d23h → "in 6 days".
+    expect(formatNextRunAt(iso(6 * DAY + 23 * HR), NOW)).toBe("in 6 days");
   });
 
   it("returns 'soon' for an imminent or just-passed delta (< 1 minute)", () => {
@@ -403,54 +400,7 @@ describe("formatNextRunAt (compact relative delta from the server's next-run)", 
   });
 
   it("bucket boundaries: 60m → hours, 24h → days", () => {
-    expect(formatNextRunAt(iso(60 * MIN), NOW)).toBe("in 1h");
-    expect(formatNextRunAt(iso(24 * HR), NOW)).toBe("in 1d");
-  });
-});
-
-describe("formatNextRunAtAbsolute (absolute wall-clock from the server's next-run)", () => {
-  // A fixed "now" so the Today/Tomorrow bucketing is deterministic. We pin the
-  // task timezone to UTC so the rendered clock time equals the ISO wall time.
-  const NOW = new Date("2026-03-10T12:00:00Z"); // Tue 2026-03-10, 12:00 UTC
-  const TZ = "UTC";
-
-  it("returns null for null / empty / unparseable input", () => {
-    expect(formatNextRunAtAbsolute(null, TZ, NOW)).toBeNull();
-    expect(formatNextRunAtAbsolute(undefined, TZ, NOW)).toBeNull();
-    expect(formatNextRunAtAbsolute("", TZ, NOW)).toBeNull();
-    expect(formatNextRunAtAbsolute("not-a-date", TZ, NOW)).toBeNull();
-  });
-
-  it("formats an instant later TODAY as 'Today at H:MM AM/PM'", () => {
-    expect(formatNextRunAtAbsolute("2026-03-10T14:30:00Z", TZ, NOW)).toBe("Today at 2:30 PM");
-    // Earlier same calendar day (before `now`) is still labelled Today.
-    expect(formatNextRunAtAbsolute("2026-03-10T08:00:00Z", TZ, NOW)).toBe("Today at 8:00 AM");
-  });
-
-  it("formats an instant on the NEXT calendar day as 'Tomorrow at H:MM AM/PM'", () => {
-    expect(formatNextRunAtAbsolute("2026-03-11T08:00:00Z", TZ, NOW)).toBe("Tomorrow at 8:00 AM");
-    // Just after midnight the next day is still Tomorrow (calendar-day based,
-    // not a 24h delta).
-    expect(formatNextRunAtAbsolute("2026-03-11T00:15:00Z", TZ, NOW)).toBe("Tomorrow at 12:15 AM");
-  });
-
-  it("formats an instant further out as 'Mon D, H:MM AM/PM'", () => {
-    expect(formatNextRunAtAbsolute("2026-03-15T08:00:00Z", TZ, NOW)).toBe("Mar 15, 8:00 AM");
-    expect(formatNextRunAtAbsolute("2026-07-26T20:00:00Z", TZ, NOW)).toBe("Jul 26, 8:00 PM");
-  });
-
-  it("renders in the task timezone, not the viewer's", () => {
-    // Mar 11 2026 is EDT (UTC-4, DST began Mar 8), so 8:00 AM America/New_York
-    // is 12:00 UTC. Formatted in the task's NY zone it reads 8:00 AM; the
-    // Tomorrow bucket is computed in that zone too.
-    expect(formatNextRunAtAbsolute("2026-03-11T12:00:00Z", "America/New_York", NOW)).toBe(
-      "Tomorrow at 8:00 AM",
-    );
-  });
-
-  it("falls back to a legal render when timezone is omitted or invalid", () => {
-    // No throw; produces a non-null label using the viewer's local zone.
-    expect(formatNextRunAtAbsolute("2026-03-11T08:00:00Z", undefined, NOW)).not.toBeNull();
-    expect(formatNextRunAtAbsolute("2026-03-11T08:00:00Z", "Not/AZone", NOW)).not.toBeNull();
+    expect(formatNextRunAt(iso(60 * MIN), NOW)).toBe("in 1 hour");
+    expect(formatNextRunAt(iso(24 * HR), NOW)).toBe("in 1 day");
   });
 });

--- a/web/src/lib/scheduleText.ts
+++ b/web/src/lib/scheduleText.ts
@@ -75,10 +75,12 @@ export function formatClockTime(hour: number, minute: number): string {
  * INTERVAL>1 rules); here the instant comes from the server and only the
  * "how far away" is derived, so the removal rule is not violated.
  *
- * Buckets (floor of the chosen unit — standard time-remaining convention),
- * with a singular noun when the value is exactly 1:
+ * Buckets (rounded to the nearest of the chosen unit — the closest "about how
+ * long" reading), with a singular noun when the value is exactly 1:
  *   < 60 min → `in N min(s)` (minimum `in 1 min`), < 24 h → `in N hour(s)`,
- *   else `in N day(s)`.
+ *   else `in N day(s)`. Each threshold uses the already-rounded value so a delta
+ *   that rounds up to a full unit promotes to the next unit (never `in 60 mins`
+ *   or `in 24 hours`).
  * A delta at or below ~0 (imminent / just passed due to clock skew) → `soon`.
  * Returns `null` for a null / unparseable `iso` so the caller renders nothing.
  *
@@ -96,9 +98,17 @@ export function formatNextRunAt(
   const deltaMs = instant.getTime() - now.getTime();
   // Imminent or just-passed (timing skew): don't render a "0 mins" / negative delta.
   if (deltaMs < MIN_MS) return "soon";
-  if (deltaMs < HOUR_MS) return `in ${pluralize(Math.floor(deltaMs / MIN_MS), "min")}`;
-  if (deltaMs < DAY_MS) return `in ${pluralize(Math.floor(deltaMs / HOUR_MS), "hour")}`;
-  return `in ${pluralize(Math.floor(deltaMs / DAY_MS), "day")}`;
+  // Round to nearest — the closest approximation of "about how long" (a 1h49m
+  // delta reads "in 2 hours", not the floored "in 1 hour"). Each guard tests the
+  // ALREADY-ROUNDED value so a delta that rounds up to a full unit PROMOTES to
+  // the next unit rather than printing "in 60 mins" / "in 24 hours" (e.g. 59m40s
+  // → "in 1 hour", 23h40m → "in 1 day").
+  const mins = Math.round(deltaMs / MIN_MS);
+  if (mins < 60) return `in ${pluralize(mins, "min")}`;
+  const hours = Math.round(deltaMs / HOUR_MS);
+  if (hours < 24) return `in ${pluralize(hours, "hour")}`;
+  const days = Math.round(deltaMs / DAY_MS);
+  return `in ${pluralize(days, "day")}`;
 }
 
 /** `1 min` / `8 mins` — singular noun only when the count is exactly 1. */

--- a/web/src/lib/scheduleText.ts
+++ b/web/src/lib/scheduleText.ts
@@ -64,7 +64,8 @@ export function formatClockTime(hour: number, minute: number): string {
 
 /**
  * Format the time until the SERVER's authoritative next-run instant as a
- * compact relative delta, e.g. `in 30m`, `in 15h`, `in 6d`, or `soon`.
+ * relative delta in full words, e.g. `in 8 mins`, `in 3 hours`, `in 2 days`,
+ * or `soon`. This is the user-facing next-run label in the Tasks list.
  *
  * `iso` is the server's `next_run_at` (the live scheduler's authoritative next
  * fire). We compute ONLY the delta (`nextRunAt − now`) and format how far away
@@ -74,8 +75,10 @@ export function formatClockTime(hour: number, minute: number): string {
  * INTERVAL>1 rules); here the instant comes from the server and only the
  * "how far away" is derived, so the removal rule is not violated.
  *
- * Buckets (floor of the chosen unit — standard time-remaining convention):
- *   < 60 min → `in Xm` (minimum `in 1m`), < 24 h → `in Xh`, else `in Xd`.
+ * Buckets (floor of the chosen unit — standard time-remaining convention),
+ * with a singular noun when the value is exactly 1:
+ *   < 60 min → `in N min(s)` (minimum `in 1 min`), < 24 h → `in N hour(s)`,
+ *   else `in N day(s)`.
  * A delta at or below ~0 (imminent / just passed due to clock skew) → `soon`.
  * Returns `null` for a null / unparseable `iso` so the caller renders nothing.
  *
@@ -91,104 +94,16 @@ export function formatNextRunAt(
   if (Number.isNaN(instant.getTime())) return null;
 
   const deltaMs = instant.getTime() - now.getTime();
-  // Imminent or just-passed (timing skew): don't render a "0m" / negative delta.
+  // Imminent or just-passed (timing skew): don't render a "0 mins" / negative delta.
   if (deltaMs < MIN_MS) return "soon";
-  if (deltaMs < HOUR_MS) return `in ${Math.floor(deltaMs / MIN_MS)}m`;
-  if (deltaMs < DAY_MS) return `in ${Math.floor(deltaMs / HOUR_MS)}h`;
-  return `in ${Math.floor(deltaMs / DAY_MS)}d`;
+  if (deltaMs < HOUR_MS) return `in ${pluralize(Math.floor(deltaMs / MIN_MS), "min")}`;
+  if (deltaMs < DAY_MS) return `in ${pluralize(Math.floor(deltaMs / HOUR_MS), "hour")}`;
+  return `in ${pluralize(Math.floor(deltaMs / DAY_MS), "day")}`;
 }
 
-/**
- * Format the SERVER's authoritative next-run instant as an ABSOLUTE wall-clock
- * time, e.g. `Today at 2:30 PM`, `Tomorrow at 8:00 AM`, or `Jul 26, 8:00 AM`
- * for anything further out. This is the user-facing next-run label (replacing
- * the relative `formatNextRunAt` delta in the Tasks list).
- *
- * Like `formatNextRunAt`, this only FORMATS the server value (`next_run_at`) —
- * it never recomputes WHICH instant is next on the client (a client-recomputed
- * instant can't match the server anchor for INTERVAL>1 rules). The instant is
- * server-authoritative; we only choose how to render it.
- *
- * The instant is rendered in the task's IANA `timezone` when supplied (so
- * "8:00 AM America/New_York" reads as 8:00 AM regardless of the viewer's zone),
- * falling back to the viewer's local zone when `timezone` is undefined. The
- * Today/Tomorrow bucketing is likewise computed in that same zone, so the
- * calendar-day label agrees with the rendered time.
- *
- * Returns `null` for a null / unparseable `iso` so the caller renders nothing
- * (paused / unarmed tasks have a null `next_run_at`).
- *
- * @param iso The server's `next_run_at` ISO string, or `null`.
- * @param timezone The task's IANA timezone; falls back to local when omitted.
- * @param now Injectable clock for deterministic tests; defaults to `new Date()`.
- */
-export function formatNextRunAtAbsolute(
-  iso: string | null | undefined,
-  timezone?: string,
-  now: Date = new Date(),
-): string | null {
-  if (!iso) return null;
-  const instant = new Date(iso);
-  if (Number.isNaN(instant.getTime())) return null;
-
-  const timeStr = safeFormat(instant, timezone, {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
-
-  const dayDelta = civilDayInZone(instant, timezone) - civilDayInZone(now, timezone);
-  if (dayDelta === 0) return `Today at ${timeStr}`;
-  if (dayDelta === 1) return `Tomorrow at ${timeStr}`;
-
-  const dateStr = safeFormat(instant, timezone, { month: "short", day: "numeric" });
-  return `${dateStr}, ${timeStr}`;
-}
-
-/** `Intl.DateTimeFormat` in en-US, tolerating an invalid `timeZone` by
- * falling back to the viewer's local zone rather than throwing. */
-function safeFormat(
-  date: Date,
-  timezone: string | undefined,
-  options: Intl.DateTimeFormatOptions,
-): string {
-  try {
-    return new Intl.DateTimeFormat("en-US", { timeZone: timezone, ...options }).format(date);
-  } catch {
-    return new Intl.DateTimeFormat("en-US", options).format(date);
-  }
-}
-
-/**
- * The calendar day `date` falls on in `timezone` (local when omitted), as a
- * whole day-number since the epoch. Subtracting two of these gives the count of
- * calendar days between them in that zone, which drives the Today/Tomorrow
- * bucketing independent of the instant's absolute delta.
- */
-function civilDayInZone(date: Date, timezone: string | undefined): number {
-  let y: number;
-  let m: number;
-  let d: number;
-  try {
-    const parts = new Intl.DateTimeFormat("en-CA", {
-      timeZone: timezone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    }).formatToParts(date);
-    const map: Record<string, number> = {};
-    for (const p of parts) {
-      if (p.type !== "literal") map[p.type] = Number(p.value);
-    }
-    y = map.year!;
-    m = map.month!;
-    d = map.day!;
-  } catch {
-    y = date.getFullYear();
-    m = date.getMonth() + 1;
-    d = date.getDate();
-  }
-  return Math.floor(Date.UTC(y, m - 1, d) / DAY_MS);
+/** `1 min` / `8 mins` — singular noun only when the count is exactly 1. */
+function pluralize(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
 /** Parse an RRULE string into an `RRule`, or `null` if it can't be parsed. */

--- a/web/src/lib/scheduleText.ts
+++ b/web/src/lib/scheduleText.ts
@@ -98,6 +98,99 @@ export function formatNextRunAt(
   return `in ${Math.floor(deltaMs / DAY_MS)}d`;
 }
 
+/**
+ * Format the SERVER's authoritative next-run instant as an ABSOLUTE wall-clock
+ * time, e.g. `Today at 2:30 PM`, `Tomorrow at 8:00 AM`, or `Jul 26, 8:00 AM`
+ * for anything further out. This is the user-facing next-run label (replacing
+ * the relative `formatNextRunAt` delta in the Tasks list).
+ *
+ * Like `formatNextRunAt`, this only FORMATS the server value (`next_run_at`) —
+ * it never recomputes WHICH instant is next on the client (a client-recomputed
+ * instant can't match the server anchor for INTERVAL>1 rules). The instant is
+ * server-authoritative; we only choose how to render it.
+ *
+ * The instant is rendered in the task's IANA `timezone` when supplied (so
+ * "8:00 AM America/New_York" reads as 8:00 AM regardless of the viewer's zone),
+ * falling back to the viewer's local zone when `timezone` is undefined. The
+ * Today/Tomorrow bucketing is likewise computed in that same zone, so the
+ * calendar-day label agrees with the rendered time.
+ *
+ * Returns `null` for a null / unparseable `iso` so the caller renders nothing
+ * (paused / unarmed tasks have a null `next_run_at`).
+ *
+ * @param iso The server's `next_run_at` ISO string, or `null`.
+ * @param timezone The task's IANA timezone; falls back to local when omitted.
+ * @param now Injectable clock for deterministic tests; defaults to `new Date()`.
+ */
+export function formatNextRunAtAbsolute(
+  iso: string | null | undefined,
+  timezone?: string,
+  now: Date = new Date(),
+): string | null {
+  if (!iso) return null;
+  const instant = new Date(iso);
+  if (Number.isNaN(instant.getTime())) return null;
+
+  const timeStr = safeFormat(instant, timezone, {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+
+  const dayDelta = civilDayInZone(instant, timezone) - civilDayInZone(now, timezone);
+  if (dayDelta === 0) return `Today at ${timeStr}`;
+  if (dayDelta === 1) return `Tomorrow at ${timeStr}`;
+
+  const dateStr = safeFormat(instant, timezone, { month: "short", day: "numeric" });
+  return `${dateStr}, ${timeStr}`;
+}
+
+/** `Intl.DateTimeFormat` in en-US, tolerating an invalid `timeZone` by
+ * falling back to the viewer's local zone rather than throwing. */
+function safeFormat(
+  date: Date,
+  timezone: string | undefined,
+  options: Intl.DateTimeFormatOptions,
+): string {
+  try {
+    return new Intl.DateTimeFormat("en-US", { timeZone: timezone, ...options }).format(date);
+  } catch {
+    return new Intl.DateTimeFormat("en-US", options).format(date);
+  }
+}
+
+/**
+ * The calendar day `date` falls on in `timezone` (local when omitted), as a
+ * whole day-number since the epoch. Subtracting two of these gives the count of
+ * calendar days between them in that zone, which drives the Today/Tomorrow
+ * bucketing independent of the instant's absolute delta.
+ */
+function civilDayInZone(date: Date, timezone: string | undefined): number {
+  let y: number;
+  let m: number;
+  let d: number;
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(date);
+    const map: Record<string, number> = {};
+    for (const p of parts) {
+      if (p.type !== "literal") map[p.type] = Number(p.value);
+    }
+    y = map.year!;
+    m = map.month!;
+    d = map.day!;
+  } catch {
+    y = date.getFullYear();
+    m = date.getMonth() + 1;
+    d = date.getDate();
+  }
+  return Math.floor(Date.UTC(y, m - 1, d) / DAY_MS);
+}
+
 /** Parse an RRULE string into an `RRule`, or `null` if it can't be parsed. */
 function tryParse(rrule: string): RRule | null {
   try {

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -27,6 +27,7 @@ import {
   useScheduledTasks,
   useUpdateScheduledTask,
 } from "@/hooks/useScheduledTasks";
+import { useNow } from "@/hooks/useNow";
 import type { ScheduledTask } from "@/lib/scheduledTasksApi";
 import { nextRunAtMs } from "@/lib/scheduleText";
 import { cn } from "@/lib/utils";
@@ -41,6 +42,10 @@ const FILTER_TABS: { value: FilterTab; label: string }[] = [
 
 export function TasksPage() {
   const { data: tasks, isLoading, isError, refetch } = useScheduledTasks();
+  // A single shared, slowly-ticking clock for the whole list. Passing it down to
+  // each row (rather than each row owning a timer) keeps the relative next-run
+  // labels fresh with ONE interval regardless of how many rows are on screen.
+  const now = useNow();
   const updateMutation = useUpdateScheduledTask();
   const deleteMutation = useDeleteScheduledTask();
   const runNowMutation = useRunScheduledTaskNow();
@@ -224,6 +229,7 @@ export function TasksPage() {
             <ScheduledTaskRow
               key={task.id}
               task={task}
+              now={now}
               busy={busyId === task.id}
               onEdit={handleEdit}
               onPauseToggle={handlePauseToggle}

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -216,10 +216,10 @@ export function TasksPage() {
           onPickSuggestion={openFromSuggestion}
         />
       ) : (
-        // Flat list — no boxed cards, and NO per-row hairline dividers (the row
-        // padding alone gives the spacing). The only divider on the page is the
-        // one before the Suggestions section (see SuggestionsSection).
-        <div className="flex flex-col" data-testid="tasks-list">
+        // Card list — each row is a bordered card (see ScheduledTaskRow), stacked
+        // with a gap so there's vertical spacing between cards. The only divider
+        // on the page is the one before the Suggestions section.
+        <div className="flex flex-col gap-2" data-testid="tasks-list">
           {filtered.map((task) => (
             <ScheduledTaskRow
               key={task.id}


### PR DESCRIPTION
## Related issue

N/A — tracked in Linear ([OMNI-1193](https://linear.app/omnigent/issue/OMNI-1193)).

## Summary

Two UI improvements to the Automations (scheduled tasks) list, plus a fix to keep the new label live:

- **Card-style rows.** Each `ScheduledTaskRow` now renders as a card (border, `bg-card`, rounded corners, internal padding, matching the app's `ui/card.tsx` / InboxPage vocabulary); the list stacks with `gap-2`. The ⋯ action menu, "Paused" pill, title truncation, and every `data-testid` are preserved; paused rows are not dimmed.
- **Relative next-run label.** The next-run line shows how long from now the task fires — "Next run in 8 mins" / "in 3 hours" / "in 2 days" (full words, singular/plural correct, "soon" when imminent) — via `formatNextRunAt`. It only formats the delta against the server-authoritative `next_run_at`; it never recomputes which instant is next on the client (that would drift from the server anchor for `INTERVAL > 1` RRULEs).
- **Live-ticking countdown.** The relative label was frozen at first-render `now` and only refreshed on remount (navigating away and back). A shared 30s `useNow()` clock — one module-level `setInterval` exposed via `useSyncExternalStore`, matching the codebase's `useWorkingLabelTick` precedent — now drives live re-renders, so the countdown updates on its own with one timer for the whole list.

**ELI5:** The schedule list rows are now tidy cards, each showing how soon the task runs next ("in 3 hours") instead of a clock time — and that countdown now ticks down on its own while you watch, instead of getting stuck until you leave and come back.

```mermaid
flowchart TD
    A[Server computes next_run_at] --> B[Row receives task.nextRunAt]
    C[useNow: one shared 30s timer] --> D[now advances every 30s]
    B --> E["formatNextRunAt(nextRunAt, now)"]
    D --> E
    E --> F["'Next run in 8 mins' — re-renders as now ticks"]
```

## Test Plan

From `web/`:

- `npm run type-check` (tsc -b) → 0 errors
- `npm run test` (vitest) → green; added 4 `useNow` tests (advances after each 30s tick; stable ref between ticks so React doesn't loop; one shared timer across N subscribers; `clearInterval` after the last unmount) and extended `formatNextRunAt` cases for full-word singular/plural + "soon". `formatNextRunAt` unit tests inject `now` and stay deterministic.
- `npm run lint` (oxlint) → 0 findings in the changed files.
- `prettier --check` → clean on all touched paths.
- **Browser (light + dark):** verified on a local dev stack with seeded automations across hourly/daily/weekly RRULEs. Rows render as cards with correct borders/spacing/alignment and `bg-card` contrast in both themes; the label reads "Next run in <relative>"; and it was observed ticking from "9 mins" → "8 mins" with the page left open (no navigation), confirming the live-tick fix.

Note: repo-wide `npm run lint` exits non-zero on 5 pre-existing errors in untouched files (`lastAssistantText.ts`, `agentBundle.test.ts`), which are byte-identical to `upstream/main` — not introduced here.

## Demo

https://github.com/user-attachments/assets/86600048-899b-4e29-b89f-d80f9082873f



## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage described in the Test Plan (new `useNow` tests + extended `formatNextRunAt` phrasing tests; `ScheduledTaskRow` tests pass a fixed `now` for determinism). The card styling and the live-ticking behavior over wall-clock time were verified manually in the browser (light + dark), since visual fidelity and the "does the label actually tick" behavior aren't caught by type-check or the hermetic test suite.

## Changelog

Automations list: tasks now render as cards and show a live-updating relative next-run time ("Next run in 3 hours").