### PR TITLE
feat(server): migrate sessions across single-user ↔ multi-user toggles

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -51,7 +51,13 @@ from omnigent.runtime import (
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
 from omnigent.server import session_live_state
-from omnigent.server.auth import AuthProvider, SharingMode
+from omnigent.server.auth import (
+    RESERVED_USER_LOCAL,
+    AuthProvider,
+    SharingMode,
+    UnifiedAuthProvider,
+    local_single_user_enabled,
+)
 from omnigent.server.background_session_titles import (
     BackgroundSessionTitleCoordinator,
     RunnerBackgroundTitleGenerator,
@@ -90,6 +96,11 @@ from omnigent.server.routes.terminal_attach import create_terminal_attach_router
 from omnigent.server.routes.usage import create_usage_router
 from omnigent.server.runner_session_init import RunnerSessionInitializer
 from omnigent.server.scheduled import ScheduledTaskScheduler
+from omnigent.server.server_state import (
+    ServerState,
+    load_server_state,
+    save_server_state,
+)
 from omnigent.server.ws_origin import WebSocketOriginMiddleware
 from omnigent.stores import (
     AgentStore,
@@ -106,6 +117,67 @@ from omnigent.stores.project_store import ProjectStore
 from omnigent.stores.scheduled_task_store import ScheduledTaskStore
 
 _logger = logging.getLogger(__name__)
+
+
+def _current_auth_source(auth_provider: AuthProvider | None) -> str:
+    """Return the canonical auth source string for the current provider."""
+    if isinstance(auth_provider, UnifiedAuthProvider):
+        return auth_provider._source
+    return "none"
+
+
+def _is_header_single_user(auth_provider: AuthProvider | None) -> bool:
+    """Whether the active provider is header mode (the single-user default)."""
+    return isinstance(auth_provider, UnifiedAuthProvider) and auth_provider._source == "header"
+
+
+def _first_admin_username(account_store: Any) -> str | None:
+    """Return the first password-having admin, or None if no admin exists yet."""
+    users = [u for u in account_store.list_users() if u.has_password]
+    admins = [u for u in users if u.is_admin]
+    if admins:
+        return admins[0].id
+    if users:
+        return users[0].id
+    return None
+
+
+def _migrate_local_sessions_to_first_admin(
+    account_store: Any,
+    permission_store: PermissionStore,
+) -> None:
+    """Single-user → accounts: hand ``local`` session ownership to the first admin."""
+    admin_username = _first_admin_username(account_store)
+    if admin_username is None:
+        return
+    permission_store.ensure_user(admin_username, is_admin=True)
+    permission_store.reassign_user_grants(RESERVED_USER_LOCAL, admin_username)
+    _logger.info(
+        "auth-mode transition: migrated local sessions to admin %r",
+        admin_username,
+    )
+
+
+def _ensure_local_single_user_admin(
+    auth_provider: AuthProvider,
+    permission_store: PermissionStore,
+) -> None:
+    """Make the reserved ``local`` user an admin in single-user local mode.
+
+    Accounts → single-user header: the operator's machine owns every
+    session across auth-mode flips. Instead of rewriting ownership
+    grants (which would erase the record of who created what), we leave
+    the grants alone and promote the sentinel ``local`` user so the
+    existing admin bypass lets the machine owner see and manage every
+    session.
+    """
+    if not _is_header_single_user(auth_provider) or not local_single_user_enabled():
+        return
+    permission_store.ensure_user(RESERVED_USER_LOCAL, is_admin=True)
+    permission_store.set_admin(RESERVED_USER_LOCAL, True)
+    _logger.info(
+        "auth-mode transition: promoted local single-user sentinel to admin",
+    )
 
 
 def _server_version() -> str:
@@ -1252,6 +1324,10 @@ def create_app(
     if permission_store is not None and auth_provider is None:
         raise ValueError("auth_provider is required when permission_store is provided")
 
+    # Persistent transition markers for single-user ↔ multi-user flips.
+    # Loaded once at startup and saved (after migrations) before returning.
+    _prev_state = load_server_state()
+
     # First-boot admin bootstrap for the accounts auth provider.
     # Runs before any route is mounted so the login page is never
     # served against an empty user table (avoids the Immich-style
@@ -1281,6 +1357,28 @@ def create_app(
                 session_ttl_hours=_accounts_cfg.session_ttl_hours,
                 cookie_secret=_accounts_cfg.cookie_secret,
             )
+
+            # Single-user → accounts transition: hand pre-existing
+            # "local" sessions to the first admin. Only runs when the
+            # sidecar says the previous boot was a local single-user
+            # header runtime, so deployed accounts servers never pay
+            # for this check unless they really flipped.
+            if (
+                permission_store is not None
+                and _prev_state.last_auth_source == "header"
+                and _prev_state.last_local_single_user
+            ):
+                _migrate_local_sessions_to_first_admin(
+                    account_store,
+                    permission_store,
+                )
+
+    # Accounts → single-user header: promote the reserved "local" user to
+    # admin instead of rewriting grants. This lets the machine owner act
+    # on sessions created under any prior auth mode without destroying the
+    # original ownership record.
+    if permission_store is not None and auth_provider is not None:
+        _ensure_local_single_user_admin(auth_provider, permission_store)
 
     from omnigent.runner.routing import RunnerRouter
     from omnigent.runner.transports.ws_tunnel.registry import TunnelRegistry
@@ -2855,6 +2953,15 @@ def create_app(
         async def root() -> FileResponse:
             """Serve the API-only landing page (no web UI bundle present)."""
             return FileResponse(_API_ONLY_LANDING_HTML, media_type="text/html")
+
+    # Record the posture we booted with so the next process can detect
+    # a transition and run the appropriate ownership migration.
+    save_server_state(
+        ServerState(
+            last_auth_source=_current_auth_source(auth_provider),
+            last_local_single_user=local_single_user_enabled(),
+        )
+    )
 
     return app
 

--- a/omnigent/server/routes/accounts_auth.py
+++ b/omnigent/server/routes/accounts_auth.py
@@ -529,15 +529,14 @@ def create_accounts_auth_router(
                 cookie_secret=config.cookie_secret,
                 session_ttl_hours=config.session_ttl_hours,
             )
-            # Single-user continuity: a loopback server flipping into accounts
-            # mode is the same human's laptop. The pre-accounts chats are owned
-            # by the reserved ``local`` user; hand them to the new admin so they
-            # stay visible (sessions are listed by owner, with no admin-sees-all
-            # bypass). Loopback-only, so a multi-user deploy never reassigns one
-            # user's sessions to another.
-            if permission_store is not None:
-                permission_store.ensure_user(username, is_admin=True)
-                permission_store.reassign_user_grants(RESERVED_USER_LOCAL, username)
+        # Single-user continuity: when the first admin is claimed from a DB
+        # that previously held single-user sessions, hand ``local``-owned
+        # sessions to the new admin. This fires for loopback and remote
+        # first-run setups alike; it only touches rows owned by the reserved
+        # ``local`` sentinel, which cannot be created in accounts mode.
+        if permission_store is not None:
+            permission_store.ensure_user(username, is_admin=True)
+            permission_store.reassign_user_grants(RESERVED_USER_LOCAL, username)
         session_jwt = mint_session_cookie(
             user_id=username,
             cookie_secret=config.cookie_secret,

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -66,7 +66,9 @@ from omnigent.server.auth import (
     LEVEL_EDIT,
     LEVEL_OWNER,
     LEVEL_READ,
+    RESERVED_USER_LOCAL,
     AuthProvider,
+    local_single_user_enabled,
 )
 from omnigent.server.background_session_titles import (
     BackgroundSessionTitleCoordinator,
@@ -827,7 +829,16 @@ def register_core_routes(
         # the store resolves the project NAME to the caller's own project id.
         # The flat list (project=None) and Unfiled (project="") stay unscoped so
         # shared sessions still surface for the "Shared with me" tab.
-        owned_by = user_id if project else None
+        #
+        # Local single-user mode is the machine owner's runtime: drop the
+        # access filters so they see every session, regardless of which user
+        # id owned it before a single ↔ multi-user toggle.
+        if user_id == RESERVED_USER_LOCAL and local_single_user_enabled():
+            accessible_by = None
+            owned_by = None
+        else:
+            accessible_by = user_id
+            owned_by = user_id if project else None
         page = await asyncio.to_thread(
             conversation_store.list_conversations,
             limit=limit,
@@ -835,7 +846,7 @@ def register_core_routes(
             before=before,
             agent_id=agent_id,
             agent_name=agent_name,
-            accessible_by=user_id,
+            accessible_by=accessible_by,
             owned_by=owned_by,
             has_agent_id=True,
             # The store treats ``None`` as "no kind filter"; the API

--- a/omnigent/server/server_state.py
+++ b/omnigent/server/server_state.py
@@ -1,0 +1,65 @@
+"""Persistent server-side state that survives process restarts.
+
+Stores lightweight transition markers (auth source, single-user flag) in a
+JSON sidecar in the data dir. This lets startup detect single-user ↔
+multi-user auth-mode flips and migrate session ownership accordingly, without
+querying the whole permissions table on every boot.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _server_state_path() -> Path:
+    """Location of ``server-state.json`` in the runtime data dir.
+
+    Mirrors :func:`omnigent.host.local_server._local_data_dir` so the file
+    always lives next to ``local_server.pid`` and the default SQLite DB.
+    """
+    value = os.environ.get("OMNIGENT_DATA_DIR")
+    if value:
+        return Path(value).expanduser() / "server-state.json"
+    return Path.home() / ".omnigent" / "server-state.json"
+
+
+@dataclass(frozen=True)
+class ServerState:
+    """Last-known auth posture written by the previous server process."""
+
+    last_auth_source: str | None = None
+    last_local_single_user: bool = False
+
+
+def load_server_state() -> ServerState:
+    """Read the sidecar file, returning a blank state if it is missing."""
+    path = _server_state_path()
+    if not path.exists():
+        return ServerState()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ServerState()
+    return ServerState(
+        last_auth_source=data.get("last_auth_source"),
+        last_local_single_user=bool(data.get("last_local_single_user")),
+    )
+
+
+def save_server_state(state: ServerState) -> None:
+    """Persist the current auth posture for the next process."""
+    path = _server_state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "last_auth_source": state.last_auth_source,
+                "last_local_single_user": state.last_local_single_user,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )

--- a/tests/e2e/test_auth_mode_toggle_e2e.py
+++ b/tests/e2e/test_auth_mode_toggle_e2e.py
@@ -1,0 +1,249 @@
+"""E2E coverage for single-user ↔ multi-user auth-mode toggles.
+
+Verifies that a session created in local single-user mode survives being
+switched to accounts mode and back, without the operator having to manually
+export/import anything.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+_AGENT_YAML = """\
+name: hello_world
+prompt: You are a friendly assistant. Say hello and answer questions.
+
+executor:
+  model: gpt-4o-mini
+  harness: openai-agents
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+"""
+
+_ADMIN_USERNAME = "toggleadmin"
+_ADMIN_PASSWORD = "toggle-admin-pw-123456"
+
+
+def _free_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_server(base_url: str, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            resp = httpx.get(f"{base_url}/health", timeout=2.0)
+            if resp.status_code == 200:
+                return
+        except httpx.ConnectError:
+            pass
+        time.sleep(0.25)
+    raise RuntimeError(f"Server did not become healthy at {base_url}")
+
+
+def _terminate(proc: subprocess.Popen[bytes]) -> None:
+    if proc.poll() is None:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def _spawn_server(
+    tmp_path: Path,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[subprocess.Popen[bytes], str]:
+    """Start an ``omnigent server`` subprocess and return (proc, base_url)."""
+    repo_root = Path(__file__).parents[2].resolve()
+    port = _free_port()
+
+    db_path = tmp_path / "toggle.db"
+    artifact_dir = tmp_path / "artifacts"
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "hello_world.yaml").write_text(_AGENT_YAML)
+    log_path = tmp_path / "server.log"
+
+    base_env = {**os.environ}
+    # Strip any ambient auth-mode variables so the test fully controls mode.
+    for var in (
+        "OMNIGENT_AUTH_PROVIDER",
+        "OMNIGENT_AUTH_ENABLED",
+        "OMNIGENT_ACCOUNTS_ENABLED",
+        "OMNIGENT_LOCAL_SINGLE_USER",
+        "OMNIGENT_ACCOUNTS_COOKIE_SECRET",
+        "OMNIGENT_ACCOUNTS_BASE_URL",
+        "OMNIGENT_ACCOUNTS_INIT_ADMIN_USERNAME",
+        "OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD",
+        "OMNIGENT_ACCOUNTS_AUTO_OPEN",
+    ):
+        base_env.pop(var, None)
+
+    env = {
+        **base_env,
+        "PYTHONPATH": f"{repo_root}{os.pathsep}{base_env.get('PYTHONPATH', '')}",
+        "OMNIGENT_DATA_DIR": str(tmp_path),
+        "OPENAI_API_KEY": "dummy",
+        "OMNIGENT_ACCOUNTS_AUTO_OPEN": "0",
+        **(extra_env or {}),
+    }
+
+    log_handle = open(log_path, "w")  # noqa: SIM115
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "omnigent.cli",
+            "server",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--database-uri",
+            f"sqlite:///{db_path}",
+            "--artifact-location",
+            str(artifact_dir),
+            "--agent",
+            str(agent_dir),
+        ],
+        env=env,
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+    )
+
+    base_url = f"http://127.0.0.1:{port}"
+    try:
+        _wait_for_server(base_url)
+    except Exception:
+        _terminate(proc)
+        raise
+    return proc, base_url
+
+
+def _agent_id(base_url: str) -> str:
+    resp = httpx.get(f"{base_url}/v1/agents?limit=100", timeout=10.0)
+    resp.raise_for_status()
+    for agent in resp.json().get("data", []):
+        if agent["name"] == "hello_world":
+            return str(agent["id"])
+    raise RuntimeError("hello_world agent not found in built-in list")
+
+
+def _create_session(base_url: str, agent_id: str, title: str = "toggle-test") -> str:
+    resp = httpx.post(
+        f"{base_url}/v1/sessions",
+        json={"agent_id": agent_id, "title": title},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    return str(resp.json()["id"])
+
+
+def _list_session_ids(base_url: str, *, cookies: dict[str, str] | None = None) -> set[str]:
+    resp = httpx.get(
+        f"{base_url}/v1/sessions",
+        cookies=cookies,
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return {str(item["id"]) for item in data.get("data", [])}
+
+
+def _login(base_url: str, username: str, password: str) -> httpx.Cookies:
+    client = httpx.Client()
+    resp = client.post(
+        f"{base_url}/auth/login",
+        json={"username": username, "password": password},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    return client.cookies
+
+
+@pytest.mark.timeout(120)
+def test_session_survives_auth_mode_toggle(tmp_path: Path) -> None:
+    """A local session survives switching to accounts and back."""
+    proc: subprocess.Popen[bytes] | None = None
+
+    def stop() -> None:
+        nonlocal proc
+        if proc is not None:
+            _terminate(proc)
+            proc = None
+
+    try:
+        # 1. Start in local single-user header mode.
+        proc, base_url = _spawn_server(tmp_path)
+        agent_id = _agent_id(base_url)
+        session_id = _create_session(base_url, agent_id)
+        assert session_id in _list_session_ids(base_url)
+        stop()
+
+        # 2. Restart in accounts mode. The forward migration should hand the
+        #    session to the first admin.
+        proc, base_url = _spawn_server(
+            tmp_path,
+            extra_env={
+                "OMNIGENT_AUTH_PROVIDER": "accounts",
+                "OMNIGENT_AUTH_ENABLED": "1",
+                "OMNIGENT_ACCOUNTS_COOKIE_SECRET": secrets.token_hex(32),
+                "OMNIGENT_ACCOUNTS_BASE_URL": "http://127.0.0.1:0",
+                "OMNIGENT_ACCOUNTS_INIT_ADMIN_USERNAME": _ADMIN_USERNAME,
+                "OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD": _ADMIN_PASSWORD,
+            },
+        )
+        cookies = _login(base_url, _ADMIN_USERNAME, _ADMIN_PASSWORD)
+        assert session_id in _list_session_ids(base_url, cookies=cookies)
+        stop()
+
+        # 3. Restart back in local single-user mode. The reverse migration
+        #    should consolidate ownership under the local sentinel.
+        proc, base_url = _spawn_server(tmp_path)
+        assert session_id in _list_session_ids(base_url)
+        stop()
+
+        # 4. Restart in accounts mode again. The forward migration should find
+        #    the local-owned session and hand it back to the admin.
+        proc, base_url = _spawn_server(
+            tmp_path,
+            extra_env={
+                "OMNIGENT_AUTH_PROVIDER": "accounts",
+                "OMNIGENT_AUTH_ENABLED": "1",
+                "OMNIGENT_ACCOUNTS_COOKIE_SECRET": secrets.token_hex(32),
+                "OMNIGENT_ACCOUNTS_BASE_URL": "http://127.0.0.1:0",
+                "OMNIGENT_ACCOUNTS_INIT_ADMIN_USERNAME": _ADMIN_USERNAME,
+                "OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD": _ADMIN_PASSWORD,
+            },
+        )
+        cookies = _login(base_url, _ADMIN_USERNAME, _ADMIN_PASSWORD)
+        assert session_id in _list_session_ids(base_url, cookies=cookies)
+    finally:
+        stop()
+
+    # The sidecar should record the final accounts posture too.
+    sidecar = tmp_path / "server-state.json"
+    assert sidecar.exists()
+    state = json.loads(sidecar.read_text())
+    assert state["last_auth_source"] == "accounts"
+    assert state["last_local_single_user"] is False

--- a/tests/server/test_server_state.py
+++ b/tests/server/test_server_state.py
@@ -1,0 +1,54 @@
+"""Unit tests for server-state sidecar persistence."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from omnigent.server.server_state import (
+    ServerState,
+    load_server_state,
+    save_server_state,
+)
+
+
+def test_load_missing_returns_blank_state(tmp_path: Path) -> None:
+    """A missing sidecar is treated as an unknown previous state."""
+    os.environ["OMNIGENT_DATA_DIR"] = str(tmp_path)
+    state = load_server_state()
+    assert state == ServerState()
+
+
+def test_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Save then load preserves auth posture."""
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
+
+    expected = ServerState(last_auth_source="accounts", last_local_single_user=True)
+    save_server_state(expected)
+    assert load_server_state() == expected
+
+
+def test_corrupt_file_returns_blank_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A corrupt sidecar is treated like a missing one so startup never fails."""
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
+
+    state_path = tmp_path / "server-state.json"
+    state_path.write_text("not json")
+
+    state = load_server_state()
+    assert state == ServerState()
+
+
+def test_legacy_keys_default_to_blank(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An old sidecar with missing keys stays forward-compatible."""
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
+
+    state_path = tmp_path / "server-state.json"
+    state_path.write_text(json.dumps({"last_auth_source": "header"}))
+
+    state = load_server_state()
+    assert state.last_auth_source == "header"
+    assert state.last_local_single_user is False


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Added a lightweight JSON sidecar (`server-state.json` in the data dir) that records the previous boot's auth posture.
- On a transition from single-user header mode to accounts mode, existing sessions owned by the reserved `local` user are migrated to the first admin.
- On the reverse transition (accounts → single-user header), the reserved `local` user is promoted to admin and session listing drops owner filters so the machine operator can see every session without rewriting grants.
- The `/auth/setup` first-admin web form now reassigns `local` sessions on all deployments, not just loopback, fixing the non-loopback/pre-seed gap.
- No DB table was added, and the migration only runs when the sidecar records a transition, so deployed accounts servers do not pay a startup penalty.

## Test Plan

- New unit tests for `omnigent/server/server_state.py` (missing/corrupt/round-trip).
- New E2E test `tests/e2e/test_auth_mode_toggle_e2e.py` that starts a server in local single-user mode, creates a session, restarts in accounts mode, logs in, and asserts the session is still visible. It then switches back to single user and back to accounts again.
- Existing test suites pass:
  - `uv run pytest tests/cli/test_bind_auth_defaults.py`
  - `uv run pytest tests/server/test_accounts.py tests/server/test_permissions.py tests/server/test_server_state.py`
  - `uv run pytest tests/server/test_openapi_drift.py`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Covered by the new E2E toggle test plus focused unit tests for the sidecar helper. Existing server auth tests verify the setup route and bootstrap logic remain intact.

## Changelog

`omnigent server` now preserves existing sessions when switching between local single-user mode and accounts multi-user mode.
