### PR TITLE
fix(web): use lucide files icon for Files workspace tab

### DIFF
--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -1,7 +1,7 @@
 import {
   BotIcon,
   FileIcon,
-  FilePenLineIcon,
+  FilesIcon,
   GlobeIcon,
   ListTodoIcon,
   SquareTerminalIcon,
@@ -336,7 +336,7 @@ export function WorkspacePanel({
                   aria-label={changedCount > 0 ? `Files ${changedCount} changed` : "Files"}
                   className="size-8 shrink-0 rounded-md p-0"
                 >
-                  <FilePenLineIcon className="size-4" />
+                  <FilesIcon className="size-4" />
                   <span className="sr-only">Files</span>
                   {changedCount > 0 && <span className="sr-only">{changedCount}</span>}
                 </TabsTrigger>


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The Files tab in the workspace right rail used `FilePenLineIcon` (a pen-on-page glyph), which reads more like "edit a file" than "browse files".
- Swap it to lucide's [`files`](https://lucide.dev/icons/files) icon (stacked pages), which better conveys the panel's contents.

## Test Plan

- `cd web && npm test` — 4553 passed.
- `cd web && npm run build` — clean build.
- Manual: opened a workspace and confirmed the first right-rail tab (tooltip "Files") now shows the stacked-files glyph.

## Demo

| Before | After |
| --- | --- |
| Pen-on-page (`FilePenLineIcon`) | Stacked pages (`FilesIcon`) |

<!-- UI change is a single icon swap; screenshots of before/after available on request. -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

Icon-only swap with no behavior change. Verified manually in the running app; existing WorkspacePanel tab tests (which assert on the "Files" tab label/tooltip, not the specific glyph) continue to pass.

## Changelog

The Files workspace tab now uses a stacked-files icon.

This pull request and its description were written by Isaac.
