### PR TITLE
feat(automations): model + reasoning-effort selectors on automations

### DIFF
--- a/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
+++ b/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
@@ -56,8 +56,16 @@ def _create_task(
     *,
     host_id: str | None = None,
     workspace: str | None = None,
+    model_override: str | None = None,
+    reasoning_effort: str | None = None,
 ) -> str:
     """Seed one scheduled task via ``POST /v1/scheduled-tasks``.
+
+    ``model_override`` / ``reasoning_effort`` are optional so a test can seed a
+    task carrying the model/effort overrides the create/edit dialog persists —
+    used by the edit-prefill test, where the dialog must read them back onto the
+    ``task-model-trigger`` / ``task-effort-trigger`` controls. Left ``None`` they
+    are omitted from the body (the row persists null, the agent's own defaults).
 
     :returns: The created task id.
     """
@@ -72,6 +80,10 @@ def _create_task(
         body["host_id"] = host_id
     if workspace is not None:
         body["workspace"] = workspace
+    if model_override is not None:
+        body["model_override"] = model_override
+    if reasoning_effort is not None:
+        body["reasoning_effort"] = reasoning_effort
     resp = httpx.post(
         f"{base_url}/v1/scheduled-tasks",
         json=body,
@@ -371,3 +383,201 @@ def test_scheduled_task_row_run_controls(
         page.wait_for_timeout(200)
         deadline += 1
     assert _has_failed_run(), "Run now did not record a failed run within the timeout"
+
+
+# ── Model + reasoning-effort selectors (PR #3331) ──────────────────────────
+#
+# The create/edit dialog renders a Model|Effort row (ModelEffortFields) that is
+# CAPABILITY-GATED on the selected agent: shown for a native coding agent that
+# carries the model/effort surface (Claude Code — the `permissionMode`
+# capability), hidden for agents without it (Codex, plain-SDK agents). Both
+# controls default to a "Default" sentinel; on CREATE a Default control is
+# omitted from the body (agent defaults apply), and a concrete pick sends
+# `model_override` / `reasoning_effort`. On EDIT the controls prefill from the
+# loaded task. These tests are LLM-free like the sibling ones: they exercise
+# only the create/edit dialog, REST, and the rendered row — no agent turn fires.
+
+
+def _open_create_dialog(page: Page) -> None:
+    """Open the New-automation dialog and confirm Claude Code is the pick.
+
+    The picker auto-selects the first agent (Claude Code, sortRank 10) on open,
+    so the model/effort row's capability gate is satisfied without any explicit
+    selection — this just asserts that default holds before a test reads the
+    row. Mirrors the setup in ``test_scheduled_task_create_edit_modal_and_time_picker``.
+
+    :param page: Playwright page already navigated to ``/tasks``.
+    """
+    page.get_by_test_id("new-task-button").click()
+    expect(page.get_by_test_id("create-scheduled-task-dialog")).to_be_visible(timeout=30_000)
+    agent_trigger = page.get_by_test_id("task-agent-picker").get_by_test_id(
+        "new-chat-landing-agent-select"
+    )
+    expect(agent_trigger).to_contain_text("Claude Code", timeout=30_000)
+
+
+def _pick_select_option(page: Page, trigger_test_id: str, option_label: str) -> None:
+    """Open a Radix ``Select`` by its trigger test-id and click an option.
+
+    The model/effort Selects portal their listbox OUTSIDE the dialog, but the
+    dialog's dismiss guard (``handleSelectOpenChange``) keeps it open across the
+    open/pick, so this never closes the modal. Radix items expose
+    ``role="option"``; ``exact`` avoids "Sonnet 4.6" matching "Sonnet 5".
+
+    :param page: Playwright page with the create/edit dialog open.
+    :param trigger_test_id: ``"task-model-trigger"`` or ``"task-effort-trigger"``.
+    :param option_label: The exact rendered option label, e.g. ``"Opus"``.
+    """
+    page.get_by_test_id(trigger_test_id).click()
+    page.get_by_role("option", name=option_label, exact=True).click()
+
+
+def test_scheduled_task_model_effort_controls_visible_for_capable_agent(
+    page: Page,
+    live_server: str,
+) -> None:
+    """The Model/Effort row shows for Claude Code, both reading 'Default'.
+
+    Claude Code carries the ``permissionMode`` capability the dialog gates the
+    model/effort surface on, so opening the create dialog (which defaults to
+    Claude Code) renders ``task-model-effort-row`` with both the model and
+    effort triggers defaulting to the "Default" sentinel — nothing overridden.
+    """
+    page.goto(f"{live_server}/tasks")
+    _open_create_dialog(page)
+
+    expect(page.get_by_test_id("task-model-effort-row")).to_be_visible(timeout=30_000)
+    model_trigger = page.get_by_test_id("task-model-trigger")
+    effort_trigger = page.get_by_test_id("task-effort-trigger")
+    expect(model_trigger).to_be_visible()
+    expect(effort_trigger).to_be_visible()
+    expect(model_trigger).to_have_text("Default")
+    expect(effort_trigger).to_have_text("Default")
+
+
+def test_scheduled_task_model_effort_controls_hidden_for_incapable_agent(
+    page: Page,
+    live_server: str,
+) -> None:
+    """The Model/Effort row is hidden for a non-capable agent, with the hint.
+
+    The e2e server seeds the built-in ``codex-native-ui`` ("Codex") agent, which
+    carries ``approvalMode`` — NOT the ``permissionMode`` capability the
+    model/effort surface is gated on. Rather than drive the create-dialog agent
+    picker into Codex (it can fold into a hover-only "More" submenu when the host
+    reports it unconfigured, which is fragile to click), we SEED a task against
+    the Codex agent and open its EDIT dialog: edit mode gates the row on the
+    loaded task's agent, so the row must be absent and the "uses defaults" helper
+    hint shown instead. (Chosen because the e2e server does register Codex; the
+    seeded-edit path is the deterministic way to exercise the hidden branch.)
+    """
+    codex_agent_id = _builtin_agent_id(live_server, "codex-native-ui")
+    _create_task(live_server, codex_agent_id, "Codex daily", "FREQ=DAILY;BYHOUR=9;BYMINUTE=0")
+
+    page.goto(f"{live_server}/tasks")
+    row = _row_by_name(page, "Codex daily")
+    expect(row).to_be_visible(timeout=30_000)
+    row.hover()
+    row.get_by_test_id("task-row-menu").click()
+    page.get_by_test_id("task-edit").click()
+
+    dialog = page.get_by_test_id("create-scheduled-task-dialog")
+    expect(dialog).to_be_visible(timeout=30_000)
+    # Capability gate off → the row is never rendered, and the "uses defaults"
+    # helper hint stands in for it.
+    expect(page.get_by_test_id("task-model-effort-row")).to_be_hidden()
+    expect(dialog.get_by_text("Uses this agent")).to_be_visible()
+
+
+def test_scheduled_task_create_persists_model_and_effort(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Picking a concrete Model + Effort on create persists both via the API.
+
+    Opens the create dialog on Claude Code, picks Opus + High through the
+    ``task-model-trigger`` / ``task-effort-trigger`` selects, submits, then reads
+    the created row back from ``GET /v1/scheduled-tasks`` and asserts its
+    ``model_override`` / ``reasoning_effort`` are the persisted picks (asserting
+    the server-side values is more robust than re-reading the row text). Opus =
+    the ``"opus"`` model alias, High = the ``"high"`` effort — the shared option
+    vocabulary the dialog renders; a pick sends those verbatim.
+    """
+    page.goto(f"{live_server}/tasks")
+    _open_create_dialog(page)
+
+    page.get_by_test_id("task-name-input").fill("Model effort create")
+    page.get_by_test_id("task-prompt-input").fill("Summarize the day.")
+    _pick_select_option(page, "task-model-trigger", "Opus")
+    _pick_select_option(page, "task-effort-trigger", "High")
+    expect(page.get_by_test_id("task-model-trigger")).to_have_text("Opus")
+    expect(page.get_by_test_id("task-effort-trigger")).to_have_text("High")
+    page.get_by_test_id("create-scheduled-task-submit").click()
+
+    # The row renders once the create resolves; assert the persisted API values.
+    expect(_row_by_name(page, "Model effort create")).to_be_visible(timeout=30_000)
+    tasks = httpx.get(f"{live_server}/v1/scheduled-tasks", timeout=10.0).json()["scheduled_tasks"]
+    created = next(t for t in tasks if t["name"] == "Model effort create")
+    assert created["model_override"] == "opus", created
+    assert created["reasoning_effort"] == "high", created
+
+
+def test_scheduled_task_create_default_omits_model_and_effort(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Leaving both controls on 'Default' persists null model/effort.
+
+    A create that never touches the model/effort controls must omit both fields
+    so the row inherits the agent's configured model + effort. Confirms the
+    "Default" sentinel maps to a null override (not the literal sentinel string).
+    """
+    page.goto(f"{live_server}/tasks")
+    _open_create_dialog(page)
+
+    page.get_by_test_id("task-name-input").fill("Default model effort")
+    page.get_by_test_id("task-prompt-input").fill("Summarize the day.")
+    # Controls left on their default "Default" sentinel — no pick.
+    page.get_by_test_id("create-scheduled-task-submit").click()
+
+    expect(_row_by_name(page, "Default model effort")).to_be_visible(timeout=30_000)
+    tasks = httpx.get(f"{live_server}/v1/scheduled-tasks", timeout=10.0).json()["scheduled_tasks"]
+    created = next(t for t in tasks if t["name"] == "Default model effort")
+    assert created["model_override"] is None, created
+    assert created["reasoning_effort"] is None, created
+
+
+def test_scheduled_task_edit_prefills_model_and_effort(
+    page: Page,
+    live_server: str,
+) -> None:
+    """The edit dialog prefills the Model/Effort controls from the loaded task.
+
+    Seeds a Claude Code task carrying ``model_override="opus"`` +
+    ``reasoning_effort="high"``, opens its Edit dialog, and asserts the
+    ``task-model-trigger`` / ``task-effort-trigger`` render the stored picks
+    ("Opus" / "High"), not the "Default" sentinel — the round-trip the create
+    test's persistence feeds into.
+    """
+    claude_agent_id = _builtin_agent_id(live_server, "claude-native-ui")
+    _create_task(
+        live_server,
+        claude_agent_id,
+        "Prefill target",
+        "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+        model_override="opus",
+        reasoning_effort="high",
+    )
+
+    page.goto(f"{live_server}/tasks")
+    row = _row_by_name(page, "Prefill target")
+    expect(row).to_be_visible(timeout=30_000)
+    row.hover()
+    row.get_by_test_id("task-row-menu").click()
+    page.get_by_test_id("task-edit").click()
+
+    dialog = page.get_by_test_id("create-scheduled-task-dialog")
+    expect(dialog).to_be_visible(timeout=30_000)
+    expect(page.get_by_test_id("task-model-effort-row")).to_be_visible()
+    expect(page.get_by_test_id("task-model-trigger")).to_have_text("Opus")
+    expect(page.get_by_test_id("task-effort-trigger")).to_have_text("High")

--- a/web/src/components/HarnessConfigControls.tsx
+++ b/web/src/components/HarnessConfigControls.tsx
@@ -18,6 +18,21 @@ export const MODEL_SELECT_SMART = "__smart__";
 // Sentinel for the "no explicit effort" (—) choice, same reasoning.
 export const EFFORT_SELECT_NONE = "__none__";
 
+// Claude-native reasoning-effort options for the new-session / scheduled-task
+// model+effort pickers. There is deliberately no hardcoded effort default: an
+// unselected picker omits `reasoning_effort`, so Claude Code falls back to its
+// own configured effort — the same "no override" semantics the in-session
+// picker's `null` state uses. Mirrors ANTHROPIC_EFFORTS server-side. Lives here
+// (a leaf module, no heavy imports) so both NewChatDialog and the scheduled-task
+// dialog can share the single source of truth.
+export const CLAUDE_NATIVE_EFFORTS: { value: string; label: string }[] = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "xhigh", label: "xHigh" },
+  { value: "max", label: "Max" },
+];
+
 /**
  * A labeled configuration row: bold label + muted sub-description on the left,
  * the control on the right. Mirrors the "Configure …" modal layout.

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -19,7 +19,13 @@ import * as scheduledHooks from "@/hooks/useScheduledTasks";
 import type { AvailableAgent } from "@/hooks/useAvailableAgents";
 
 vi.mock("@/hooks/useAvailableAgents", () => ({ useAvailableAgents: vi.fn() }));
-vi.mock("@/hooks/useHosts", () => ({ useHosts: vi.fn() }));
+// useHostModelOptions is consumed by the ModelEffortFields sub-form (model
+// dropdown source). Returning no data makes it fall back to the static Claude
+// alias list, which is what a no-host-pinned scheduled task uses anyway.
+vi.mock("@/hooks/useHosts", () => ({
+  useHosts: vi.fn(),
+  useHostModelOptions: vi.fn(() => ({ data: undefined })),
+}));
 vi.mock("@/hooks/useScheduledTasks", () => ({
   useCreateScheduledTask: vi.fn(),
   useUpdateScheduledTask: vi.fn(),
@@ -189,11 +195,17 @@ function scheduledTask(overrides: Partial<import("@/lib/scheduledTasksApi").Sche
 }
 
 describe("agent picker readiness (needs-setup badges)", () => {
-  it("explains that scheduled tasks use the selected agent's runtime defaults", () => {
+  it("shows the model + effort controls for the default (Claude-native) agent", () => {
     renderDialog();
+    // The default effective agent is claude-native-ui (a capable native coding
+    // agent), so the model/effort pickers render and the "uses defaults" hint —
+    // shown only when the controls are hidden — is absent.
+    expect(screen.getByTestId("task-model-effort-field")).toBeInTheDocument();
+    expect(screen.getByTestId("task-model-trigger")).toBeInTheDocument();
+    expect(screen.getByTestId("task-effort-trigger")).toBeInTheDocument();
     expect(
-      screen.getByText("Uses this agent's default model, effort, and permission settings"),
-    ).toBeInTheDocument();
+      screen.queryByText("Uses this agent's default model, effort, and permission settings"),
+    ).not.toBeInTheDocument();
   });
 
   it("feeds the picker a fallback online host so 'needs setup' badges show with no host pinned", () => {
@@ -379,9 +391,9 @@ describe("CreateScheduledTaskDialog submit", () => {
     expect(arg.timezone.length).toBeGreaterThan(0);
   });
 
-  // Model/effort controls are not offered, so the create
-  // body carries agent_id and NEVER model_override / reasoning_effort, whether
-  // the pick is a bare harness (claude-native) or a plain agent (polly).
+  // With the model/effort controls left at their Default (unselected) state, the
+  // create body carries agent_id and NO model_override / reasoning_effort,
+  // whether the pick is a bare harness (claude-native) or a plain agent (polly).
   it("maps a bare-harness pick to its agent_id, never sends model/effort", async () => {
     renderDialog();
     fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "N" } });
@@ -639,6 +651,95 @@ describe("CreateScheduledTaskDialog submit", () => {
     renderDialog();
     expect(screen.queryByTestId("schedule-preview")).toBeNull();
     expect(screen.queryByText(/Reads as:/i)).toBeNull();
+  });
+});
+
+describe("CreateScheduledTaskDialog model + effort controls", () => {
+  it("renders model + effort for a capable (Claude-native) agent, hides them for a plain agent", () => {
+    renderDialog();
+    // Default effective agent is the capable claude-native harness → controls show.
+    expect(screen.getByTestId("task-model-effort-field")).toBeInTheDocument();
+
+    // Switch to Polly (claude-sdk, no permissionMode capability) → controls hide.
+    fireEvent.click(screen.getByTestId("pick-agent-polly"));
+    expect(screen.queryByTestId("task-model-effort-field")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("task-model-trigger")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("task-effort-trigger")).not.toBeInTheDocument();
+    // The "uses defaults" hint returns when the controls are hidden.
+    expect(
+      screen.getByText("Uses this agent's default model, effort, and permission settings"),
+    ).toBeInTheDocument();
+  });
+
+  it("sends the selected model + effort on create for a capable agent", async () => {
+    renderDialog();
+    fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "N" } });
+    fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
+
+    // Pick a model (keyboard is the reliable jsdom path for Radix Select).
+    fireEvent.keyDown(screen.getByTestId("task-model-trigger"), { key: "Enter" });
+    fireEvent.click(await screen.findByRole("option", { name: "Opus" }));
+    // Pick an effort.
+    fireEvent.keyDown(screen.getByTestId("task-effort-trigger"), { key: "Enter" });
+    fireEvent.click(await screen.findByRole("option", { name: "High" }));
+
+    fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    const arg = mutateAsync.mock.calls[0][0];
+    expect(arg.modelOverride).toBe("opus");
+    expect(arg.reasoningEffort).toBe("high");
+  });
+
+  it("omits model + effort on create when both are left at Default", async () => {
+    renderDialog();
+    fireEvent.change(screen.getByTestId("task-name-input"), { target: { value: "N" } });
+    fireEvent.change(screen.getByTestId("task-prompt-input"), { target: { value: "P" } });
+    fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    const arg = mutateAsync.mock.calls[0][0];
+    expect(arg).not.toHaveProperty("modelOverride");
+    expect(arg).not.toHaveProperty("reasoningEffort");
+  });
+
+  it("prefills model + effort in edit mode from the loaded task", async () => {
+    render(
+      <CreateScheduledTaskDialog
+        open
+        onOpenChange={vi.fn()}
+        editingTask={scheduledTask({
+          agentId: "ag_claude_native",
+          modelOverride: "sonnet",
+          reasoningEffort: "medium",
+        })}
+      />,
+    );
+    // Prefilled selections surface as the trigger's shown value.
+    expect(screen.getByTestId("task-model-trigger")).toHaveTextContent("Sonnet 4.6");
+    expect(screen.getByTestId("task-effort-trigger")).toHaveTextContent("Medium");
+  });
+
+  it("threads model + effort through update on edit, nulling a cleared override", async () => {
+    render(
+      <CreateScheduledTaskDialog
+        open
+        onOpenChange={vi.fn()}
+        editingTask={scheduledTask({
+          agentId: "ag_claude_native",
+          modelOverride: "opus",
+          reasoningEffort: "high",
+        })}
+      />,
+    );
+    // Reset the model back to Default; leave effort at "high".
+    fireEvent.keyDown(screen.getByTestId("task-model-trigger"), { key: "Enter" });
+    fireEvent.click(await screen.findByRole("option", { name: "Default" }));
+
+    fireEvent.click(screen.getByTestId("create-scheduled-task-submit"));
+    await waitFor(() => expect(updateMutateAsync).toHaveBeenCalledTimes(1));
+    const { input } = updateMutateAsync.mock.calls[0][0];
+    // Cleared model → null; untouched effort → the prefilled value.
+    expect(input.modelOverride).toBeNull();
+    expect(input.reasoningEffort).toBe("high");
   });
 });
 

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -23,12 +23,13 @@ import {
 } from "@/components/ui/select";
 import { Label } from "@/components/scheduled/Label";
 import { ScheduleFields } from "@/components/scheduled/ScheduleFields";
+import { ModelEffortFields } from "@/components/scheduled/ModelEffortFields";
 import { WorkspacePicker } from "@/shell/WorkspacePicker";
 import { AgentHarnessPicker } from "@/shell/NewChatDialog";
 import { useAvailableAgents, type AvailableAgent } from "@/hooks/useAvailableAgents";
 import { useHosts } from "@/hooks/useHosts";
 import { useCreateScheduledTask, useUpdateScheduledTask } from "@/hooks/useScheduledTasks";
-import { isNativeCodingAgent } from "@/lib/nativeCodingAgents";
+import { isNativeCodingAgent, nativeAgentHasCapability } from "@/lib/nativeCodingAgents";
 import { sortAgentsForDisplay } from "@/lib/agentGrouping";
 import {
   isBackdropOverlay,
@@ -80,14 +81,17 @@ export function CreateScheduledTaskDialog({
   // single `pickedAgentId` covers both cases — for a bare-harness pick it's the
   // `*-native-ui` agent's id, exactly what the interactive dialog sends.
   //
-  // Scheduled tasks currently create sessions from the selected agent. Model,
-  // effort, and permission controls are not offered here; upstream moved those into a separate
-  // gear-icon HarnessConfigModal (NewChatDialog); reusing it is disproportionate
-  // for a scheduled task (26 props, bound to smart-routing / cost-control /
-  // dynamic model loading). A scheduled task only requires `agent_id`; model_override
-  // / reasoning_effort are optional and simply omitted, so the fire path uses the
-  // agent's configured defaults. Model/effort can be a follow-up if wanted.
+  // Scheduled tasks create sessions from the selected agent. Model + effort are
+  // offered for native coding agents that support them (see `showModelEffort`
+  // below), reusing lightweight scheduled-local pickers rather than the
+  // interactive dialog's 26-prop HarnessConfigModal (bound to smart-routing /
+  // cost-control / per-turn model loading — disproportionate for a saved task).
+  // "" = unselected → `model_override` / `reasoning_effort` are omitted so the
+  // fire path uses the agent's configured defaults. Permission/approval/cursor
+  // mode is intentionally NOT offered here.
   const [pickedAgentId, setPickedAgentId] = useState<string | null>(null);
+  const [pickedModel, setPickedModel] = useState<string>("");
+  const [pickedEffort, setPickedEffort] = useState<string>("");
 
   const agentList = useMemo(
     () => sortAgentsForDisplay((agents ?? []).filter((a) => !HIDDEN_PICKER_AGENTS.has(a.name))),
@@ -112,6 +116,18 @@ export function CreateScheduledTaskDialog({
   function handleSelectAgent(agent: AvailableAgent) {
     setPickedAgentId(agent.id);
   }
+
+  // Model + effort are surfaced only for native coding agents that carry the
+  // model/effort surface — the same `permissionMode` capability the interactive
+  // dialog gates its Model/Effort/Permissions block on (Claude Code). Agents
+  // without it (plain SDK agents like Polly, or native harnesses with no
+  // model-picker surface) show no model/effort controls, exactly like
+  // interactive. In edit mode the agent is read-only, so gate on the loaded
+  // task's agent.
+  const modelEffortAgent = isEdit
+    ? agents?.find((a) => a.id === editingTask?.agentId)
+    : selectedAgent;
+  const showModelEffort = nativeAgentHasCapability(modelEffortAgent, "permissionMode");
 
   // ── Nested dropdown dismiss guard ─────────────────────────────────────────
   // The agent picker and host/schedule Selects portal dropdowns OUTSIDE DialogContent.
@@ -172,6 +188,9 @@ export function CreateScheduledTaskDialog({
         setName(editingTask.name);
         setPrompt(editingTask.prompt);
         setPickedAgentId(editingTask.agentId);
+        // Prefill the model/effort controls from the loaded task; null → "".
+        setPickedModel(editingTask.modelOverride ?? "");
+        setPickedEffort(editingTask.reasoningEffort ?? "");
         setSchedule(parsedSchedule ?? DEFAULT_SCHEDULE_MODEL);
         setScheduleUnsupported(parsedSchedule === null);
         setHostId(editingTask.hostId ?? "");
@@ -180,6 +199,8 @@ export function CreateScheduledTaskDialog({
         setName(initialName ?? "");
         setPrompt(initialPrompt ?? "");
         setPickedAgentId(null);
+        setPickedModel("");
+        setPickedEffort("");
         setSchedule(DEFAULT_SCHEDULE_MODEL);
         setScheduleUnsupported(false);
         setHostId("");
@@ -224,6 +245,8 @@ export function CreateScheduledTaskDialog({
     setName("");
     setPrompt("");
     setPickedAgentId(null);
+    setPickedModel("");
+    setPickedEffort("");
     setSchedule(DEFAULT_SCHEDULE_MODEL);
     setHostId("");
     setWorkspace("");
@@ -248,12 +271,30 @@ export function CreateScheduledTaskDialog({
         ...(hostId !== "" && workspace.trim() !== "" ? { workspace: workspace.trim() } : {}),
       };
       if (editingTask) {
-        await updateMutation.mutateAsync({ id: editingTask.id, input });
+        // Thread model/effort ONLY when the agent supports them. Each control's
+        // "" (Default) maps to `null` so an update CLEARS a previously-set
+        // override; a non-default pick sends the value. When the agent has no
+        // model/effort surface we send neither key (left untouched server-side).
+        const overrides = showModelEffort
+          ? {
+              modelOverride: pickedModel === "" ? null : pickedModel,
+              reasoningEffort: pickedEffort === "" ? null : pickedEffort,
+            }
+          : {};
+        await updateMutation.mutateAsync({
+          id: editingTask.id,
+          input: { ...input, ...overrides },
+        });
       } else {
         if (effectiveAgentId === null) return;
         await createMutation.mutateAsync({
           ...input,
           agentId: effectiveAgentId,
+          // Include an override only when the agent supports model/effort AND the
+          // user picked a non-default value; an unselected control is omitted so
+          // the create uses the agent's configured defaults.
+          ...(showModelEffort && pickedModel !== "" ? { modelOverride: pickedModel } : {}),
+          ...(showModelEffort && pickedEffort !== "" ? { reasoningEffort: pickedEffort } : {}),
         });
       }
       handleOpenChange(false);
@@ -379,10 +420,31 @@ export function CreateScheduledTaskDialog({
                 />
               </div>
             )}
-            <p className="text-[11px] text-muted-foreground">
-              Uses this agent&apos;s default model, effort, and permission settings
-            </p>
+            {!showModelEffort && (
+              <p className="text-[11px] text-muted-foreground">
+                Uses this agent&apos;s default model, effort, and permission settings
+              </p>
+            )}
           </div>
+
+          {/* Model + reasoning effort — only for native coding agents that
+              carry the model/effort surface (Claude Code). Unselected controls
+              fall back to the agent's configured defaults. */}
+          {showModelEffort && (
+            <div data-testid="task-model-effort-field">
+              <ModelEffortFields
+                model={pickedModel}
+                effort={pickedEffort}
+                hostId={hostId}
+                onModelChange={setPickedModel}
+                onEffortChange={setPickedEffort}
+                onSelectOpenChange={handleSelectOpenChange}
+              />
+              <p className="mt-1.5 text-[11px] text-muted-foreground">
+                Leave on Default to use the agent&apos;s configured model and effort.
+              </p>
+            </div>
+          )}
 
           <ScheduleFields
             model={schedule}

--- a/web/src/components/scheduled/ModelEffortFields.tsx
+++ b/web/src/components/scheduled/ModelEffortFields.tsx
@@ -1,0 +1,114 @@
+// Model + reasoning-effort sub-form for the scheduled-task dialog.
+//
+// A deliberately lightweight, scheduled-dialog-local picker rather than the
+// interactive NewChatDialog's 26-prop HarnessConfigModal (which is bound to
+// smart-routing / cost-control / per-turn dynamic model loading — all
+// disproportionate for a saved scheduled task). It reuses the SHARED source of
+// truth for the option lists: CLAUDE_NATIVE_MODELS (the version-agnostic model
+// aliases) and CLAUDE_NATIVE_EFFORTS + the MODEL_SELECT_DEFAULT /
+// EFFORT_SELECT_NONE sentinels from HarnessConfigControls, so the choices never
+// drift from the interactive dialog.
+//
+// The parent gates rendering on the selected agent's capability
+// (nativeAgentHasCapability(agent, "permissionMode") — the Claude-native flag
+// that also carries the model/effort surface), exactly like interactive. Both
+// controls default to "unselected" ("" = agent default), which the parent omits
+// from the create/update body so the fire path uses the agent's configured
+// model + effort.
+
+import { Label } from "@/components/scheduled/Label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  CLAUDE_NATIVE_EFFORTS,
+  EFFORT_SELECT_NONE,
+  MODEL_SELECT_DEFAULT,
+} from "@/components/HarnessConfigControls";
+import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
+import { useHostModelOptions } from "@/hooks/useHosts";
+
+export function ModelEffortFields({
+  model,
+  effort,
+  hostId,
+  onModelChange,
+  onEffortChange,
+  onSelectOpenChange,
+}: {
+  /** Selected model id/alias, or "" = agent default (nothing overridden). */
+  model: string;
+  /** Selected reasoning effort, or "" = agent default. */
+  effort: string;
+  /** Pinned host id, or "" when unset (task resolves a host at fire time). */
+  hostId: string;
+  onModelChange: (model: string) => void;
+  onEffortChange: (effort: string) => void;
+  /** Forwarded to each Select's onOpenChange so the parent Dialog can keep an
+   * open dropdown from dismissing the whole modal. */
+  onSelectOpenChange?: (open: boolean) => void;
+}) {
+  // When a host is pinned, use its live-resolved model options (mirrors the
+  // interactive dialog on a connected host). With no host pinned — the common
+  // case, since scheduled tasks resolve a host at fire time — fall back to the
+  // static Claude aliases so the picker is always populated.
+  const { data: hostModelOptions } = useHostModelOptions(
+    hostId === "" ? null : hostId,
+    "claude-native",
+    hostId !== "",
+  );
+  const modelOptions =
+    hostModelOptions && hostModelOptions.length > 0
+      ? hostModelOptions.map((o) => ({ id: o.id, label: o.displayName ?? o.id }))
+      : CLAUDE_NATIVE_MODELS.map((m) => ({ id: m.id, label: m.label }));
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 sm:gap-6" data-testid="task-model-effort-row">
+      <div className="flex w-full min-w-0 flex-col gap-1.5" data-testid="task-model-control">
+        <Label htmlFor="task-model">Model</Label>
+        <Select
+          value={model === "" ? MODEL_SELECT_DEFAULT : model}
+          onValueChange={(v) => onModelChange(v === MODEL_SELECT_DEFAULT ? "" : v)}
+          onOpenChange={onSelectOpenChange}
+        >
+          <SelectTrigger id="task-model" data-testid="task-model-trigger" className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent position="popper" align="start">
+            <SelectItem value={MODEL_SELECT_DEFAULT}>Default</SelectItem>
+            {modelOptions.map((m) => (
+              <SelectItem key={m.id} value={m.id}>
+                {m.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex w-full min-w-0 flex-col gap-1.5" data-testid="task-effort-control">
+        <Label htmlFor="task-effort">Effort</Label>
+        <Select
+          value={effort === "" ? EFFORT_SELECT_NONE : effort}
+          onValueChange={(v) => onEffortChange(v === EFFORT_SELECT_NONE ? "" : v)}
+          onOpenChange={onSelectOpenChange}
+        >
+          <SelectTrigger id="task-effort" data-testid="task-effort-trigger" className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent position="popper" align="start">
+            <SelectItem value={EFFORT_SELECT_NONE}>Default</SelectItem>
+            {CLAUDE_NATIVE_EFFORTS.map((e) => (
+              <SelectItem key={e.value} value={e.value}>
+                {e.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -51,6 +51,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import {
+  CLAUDE_NATIVE_EFFORTS,
   ConfigRow,
   DescribedSelect,
   EFFORT_SELECT_NONE,
@@ -207,22 +208,6 @@ const CLAUDE_NATIVE_PERMISSION_MODES: { value: string; label: string; descriptio
     label: "Bypass permissions",
     description: "Runs everything; no prompts or safety checks",
   },
-];
-
-// Claude-native reasoning-effort options for the new-session model/effort
-// picker. There is deliberately no hardcoded model/effort default: a fresh
-// session leaves both unselected and omits `model_override` / `reasoning_effort`
-// from the create, so Claude Code falls back to its own configured model — the
-// same "no override" semantics the in-session picker's `null` state and the
-// `/model default` / `/effort default` commands use. Effort levels mirror
-// CLAUDE_NATIVE_EFFORT_LEVELS in ChatPage's in-session picker (ANTHROPIC_EFFORTS
-// server-side).
-const CLAUDE_NATIVE_EFFORTS: { value: string; label: string }[] = [
-  { value: "low", label: "Low" },
-  { value: "medium", label: "Medium" },
-  { value: "high", label: "High" },
-  { value: "xhigh", label: "xHigh" },
-  { value: "max", label: "Max" },
 ];
 
 // Cursor execution modes. "default" sends no flags; other values map to CLI


### PR DESCRIPTION
## Related issue

N/A — tracked in Linear ([OMNI-1193](https://linear.app/omnigent/issue/OMNI-1193)).

## Summary

Adds **Model** and **Reasoning-effort** selectors to the Automations (scheduled tasks) create + edit dialog, so a scheduled task can pin the model/effort its runs use instead of always falling back to the agent's defaults.

- New lightweight `ModelEffortFields` component (`web/src/components/scheduled/ModelEffortFields.tsx`) — a scheduled-dialog-local picker, **not** the 26-prop `HarnessConfigModal`. It reuses the shared option lists (`CLAUDE_NATIVE_MODELS`, `CLAUDE_NATIVE_EFFORTS`, and the `Default`/`None` sentinels); `CLAUDE_NATIVE_EFFORTS` was hoisted into the shared `HarnessConfigControls` module so both dialogs share one source of truth (`NewChatDialog` now imports it — no behavior change there).
- **Capability-gated** exactly like the interactive new-chat dialog (`nativeAgentHasCapability(agent, "permissionMode")`): the controls show for Claude Code and hide for Codex / plain-SDK agents.
- **Default = omit on create** (the fire path uses the agent's configured default); on **edit**, choosing "Default" sends `null` to clear a prior override, and both controls prefill from the loaded task.
- Values are sent via the existing `scheduledTasksApi` inputs (`modelOverride`, `reasoningEffort`) — which the API client already round-trips — so this is a **pure frontend change: no API, DB, or fire-path change**. Model override + reasoning effort are already wired end-to-end server-side. Permission/approval/cursor mode is intentionally **not** included (scoped out).

**ELI5:** When you set up a recurring task, you can now pick which model it runs on and how hard it should think — or leave it on "Default" to use the agent's normal settings.

```mermaid
flowchart TD
    A[Create/Edit scheduled task dialog] --> B{Selected agent supports model/effort?}
    B -->|Claude Code| C[Show Model + Effort dropdowns]
    B -->|Codex / plain-SDK| D[Hide controls, use agent defaults]
    C --> E{Value = Default?}
    E -->|Yes, create| F[Omit field → agent default at fire time]
    E -->|Yes, edit| G[Send null → clear prior override]
    E -->|A model/effort picked| H[Send model_override / reasoning_effort]
```

## Test Plan

From `web/`:

- `npm run type-check` (tsc -b) → 0 errors
- `npm run test` (vitest) → green (full suite 4647 passed / 3 expected-fail / 1 skipped). Added 5 dialog tests (capability gating both ways; create sends chosen values; create omits when "Default"; edit prefills; edit sends null to clear an override) and updated the stale helper-text test. No tests weakened.
- `npm run lint` (oxlint) → clean on changed files (the one `NewChatDialog.tsx` no-array-index-key warning is pre-existing on `upstream/main`, outside these edits).
- `prettier --check` → clean on all changed files.
- **E2E (Playwright, `tests/e2e_ui/scheduled/test_scheduled_tasks_page.py`)** — added 5 tests (file now 9, no regressions), run via `OMNIGENT_PW_NO_SANDBOX=1 uv run pytest tests/e2e_ui/scheduled/test_scheduled_tasks_page.py --ui-skip-build` (after `uv sync --extra all --extra dev`; `uv run playwright install chromium`; `cd web && npm run build`) → **9 passed**, stable across a rerun with random ordering. Coverage: model/effort controls visible for a capable (Claude Code) agent; hidden for a non-capable (Codex, `approvalMode`-only) agent via its edit dialog; create persists `model_override`/`reasoning_effort` (asserted via `GET /v1/scheduled-tasks`); create with "Default" leaves both null; edit prefills a task's existing override.
- **Functional browser verification** (live DOM + throwaway backend): Model + Effort controls render for a Claude Code agent (both "Default", defaults hint hidden); switching to Codex hides them and restores the "uses defaults" hint; switching back restores them. Picking Opus + High and submitting created a task whose `GET /v1/scheduled-tasks` row shows `model_override: "opus"`, `reasoning_effort: "high"`; reopening it in Edit prefilled Opus + High.

## Demo

https://github.com/user-attachments/assets/2cad165b-983a-4073-84c0-e2d7f88b5b65

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit + component coverage: 5 new dialog tests (gating both ways, create sends values, create-omits-on-Default, edit prefill, edit clears override). E2E: 5 new Playwright tests exercising the controls' visibility gating and the create/edit persistence round-trip against a live backend (9 passing in the file, no regressions). The light/dark visual layout was not pixel-verified locally (Electron pane had no paintable surface) and is deferred to the UI Snapshot CI gate / a reviewer.

## Changelog

Automations: scheduled tasks can now pick a model and reasoning effort in the create/edit dialog (defaults to the agent's settings).