### PR TITLE
fix(sessions): fall back to localStorage when pinning against an old server

### DIFF
--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -1009,6 +1009,32 @@ describe("useTogglePinnedConversation old-server fallback", () => {
     expect((fetchMock.mock.calls[0] as [string, RequestInit])[1].method).toBe("PATCH");
     expect(localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY)).toBeNull();
   });
+
+  it("rolls back the optimistic pin when the local write fails (e.g. storage full)", async () => {
+    // The fallback's localStorage write is the pin's ONLY persistence, so a
+    // swallowed failure would report success while the pin vanishes on reload.
+    // It must throw → reject the mutation → roll back the optimistic patch.
+    const { queryClient, rendered } = seedOldServer();
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+
+    try {
+      rendered.result.current.mutate({ id: "conv_x", pinned: true });
+      await waitFor(() => expect(rendered.result.current.isError).toBe(true));
+
+      // No network write, nothing persisted locally, and the optimistic row was
+      // rolled back — the pinned section is empty again, honestly reflecting
+      // that the pin didn't take.
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(
+        queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY)
+          ?.conversations,
+      ).toEqual([]);
+    } finally {
+      setItemSpy.mockRestore();
+    }
+  });
 });
 
 describe("fetchPinnedConversations filter-honored detection", () => {

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -33,6 +33,7 @@ import {
   type PinnedConversationsResult,
 } from "./useConversations";
 import { PINNED_LABEL_KEY } from "@/lib/sessionListCache";
+import { PINNED_CONVERSATION_IDS_STORAGE_KEY } from "@/shell/sidebarNav";
 
 vi.mock("./useSessionUpdatesConnected", () => ({ useSessionUpdatesConnected: vi.fn() }));
 
@@ -925,6 +926,88 @@ describe("useTogglePinnedConversation cache patching", () => {
     expect(invalidateSpy).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect((fetchMock.mock.calls[0] as [string, RequestInit])[1].method).toBe("PATCH");
+  });
+});
+
+describe("useTogglePinnedConversation old-server fallback", () => {
+  // When the server can't store pins (`filterHonored` is false — a pre-upgrade
+  // server that ignores `?pinned=true`), a PATCH would persist a bare
+  // `omnigent.pinned` key the upgraded server discards on read. So the toggle
+  // must write localStorage instead, so the pin survives to migrate later.
+  function seedOldServer(existingPinnedListItems: Conversation[] = []) {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, {
+      conversations: existingPinnedListItems,
+      filterHonored: false,
+    });
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([conversation({ id: "conv_x", updated_at: 150 })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const rendered = renderHook(() => useTogglePinnedConversation(), { wrapper });
+    return { queryClient, rendered };
+  }
+
+  beforeEach(() => localStorage.clear());
+
+  it("pins to localStorage and does NOT PATCH the server", async () => {
+    const { queryClient, rendered } = seedOldServer();
+
+    rendered.result.current.mutate({ id: "conv_x", pinned: true });
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+
+    // No network write — a PATCH would be stored under a bare key the upgraded
+    // server drops.
+    expect(fetchMock).not.toHaveBeenCalled();
+    // Persisted to the legacy localStorage key so the migration picks it up.
+    expect(JSON.parse(localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY) ?? "[]")).toEqual([
+      "conv_x",
+    ]);
+    // Optimistic cache patch still moved the row into the Pinned section.
+    const pinned = queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY);
+    expect(pinned!.conversations.map((c) => c.id)).toContain("conv_x");
+    // The fallback must not flip the flag — the server still can't store pins.
+    expect(pinned!.filterHonored).toBe(false);
+  });
+
+  it("unpins by removing the id from localStorage", async () => {
+    localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(["conv_x"]));
+    const { queryClient, rendered } = seedOldServer([
+      conversation({ id: "conv_x", updated_at: 150 }),
+    ]);
+
+    rendered.result.current.mutate({ id: "conv_x", pinned: false });
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY)).toBeNull();
+    expect(
+      queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY)?.conversations,
+    ).toEqual([]);
+  });
+
+  it("PATCHes the server (no localStorage write) once the server can store pins", async () => {
+    // filterHonored true → normal server path, localStorage untouched.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "conv_x", object: "conversation", labels: { [PINNED_LABEL_KEY]: "1" } }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, {
+      conversations: [],
+      filterHonored: true,
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const rendered = renderHook(() => useTogglePinnedConversation(), { wrapper });
+
+    rendered.result.current.mutate({ id: "conv_x", pinned: true });
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0] as [string, RequestInit])[1].method).toBe("PATCH");
+    expect(localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY)).toBeNull();
   });
 });
 

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -28,6 +28,7 @@ import {
   type ConversationsInfiniteData,
   type SessionListWireItem,
 } from "@/lib/sessionListCache";
+import { setLegacyPinnedConversationId } from "@/shell/sidebarNav";
 import { stopSession } from "@/lib/sessionsApi";
 import {
   createProject as apiCreateProject,
@@ -883,9 +884,27 @@ export async function setConversationPinned(
  * timestamp until the pinned query refetched (a blank time field on the new
  * row). For the same reason the list overlay carries only `labels`, so pinning
  * can't blank an existing row's timestamp.
+ *
+ * Old-server fallback: when the server can't store pins (`filterHonored` is
+ * false — a pre-upgrade server that ignores `?pinned=true`), a PATCH would
+ * persist a bare `omnigent.pinned` key that the upgraded server discards on
+ * read (it only surfaces the caller's per-user `omnigent.pinned.<user>` key),
+ * so the pin would silently vanish on the server upgrade. Instead we write the
+ * pin to localStorage — the same store the pre-upgrade UI used — so it survives
+ * and later migrates through `useMigrateLocalPinsToServer` like any other
+ * pre-upgrade pin. The optimistic cache patch still runs, and the sidebar
+ * unions localStorage pins into the Pinned section, so it shows immediately.
  */
 export function useTogglePinnedConversation() {
   const queryClient = useQueryClient();
+
+  // Whether the server can store pins. Sourced from the pinned query's
+  // `filterHonored`; defaults to true when the query hasn't loaded (a manual
+  // toggle implies a reachable, working server — the same assumption the cache
+  // patch below makes).
+  const serverCanStorePins = (): boolean =>
+    queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY)?.filterHonored ??
+    true;
 
   // Locate the fullest cached row for an id, so the pinned insert keeps a real
   // `updated_at` (the PATCH snapshot lacks it). A project session lives only in
@@ -950,8 +969,18 @@ export function useTogglePinnedConversation() {
   };
 
   return useMutation({
-    mutationFn: ({ id, pinned }: { id: string; pinned: boolean }) =>
-      setConversationPinned(id, pinned),
+    mutationFn: ({ id, pinned }: { id: string; pinned: boolean }) => {
+      // Against an old server, persist the pin locally instead of PATCHing a
+      // bare key it would store but the upgraded server would drop on read.
+      if (!serverCanStorePins()) {
+        setLegacyPinnedConversationId(id, pinned);
+        // Resolve with a minimal snapshot; the optimistic patch already moved
+        // the row and there's no server row to reconcile.
+        const labels = pinned ? { [PINNED_LABEL_KEY]: String(Date.now()) } : {};
+        return Promise.resolve({ id, object: "conversation", labels } as Conversation);
+      }
+      return setConversationPinned(id, pinned);
+    },
     // Move the row immediately — don't wait for the PATCH round-trip. Without
     // this the row lingers in its project folder (or the flat list) until the
     // network resolves, which reads as lag. Snapshot the pinned cache so a

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -973,6 +973,9 @@ export function useTogglePinnedConversation() {
       // Against an old server, persist the pin locally instead of PATCHing a
       // bare key it would store but the upgraded server would drop on read.
       if (!serverCanStorePins()) {
+        // Throws if the local write fails (e.g. storage full) — a sync throw
+        // here rejects the mutation, so `onError` rolls back the optimistic
+        // patch rather than reporting a success that won't survive a reload.
         setLegacyPinnedConversationId(id, pinned);
         // Resolve with a minimal snapshot; the optimistic patch already moved
         // the row and there's no server row to reconcile.

--- a/web/src/shell/Sidebar.pinBackwardsCompat.test.tsx
+++ b/web/src/shell/Sidebar.pinBackwardsCompat.test.tsx
@@ -15,7 +15,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { usePinnedConversations } from "@/hooks/useConversations";
+import { usePinnedConversations, useTogglePinnedConversation } from "@/hooks/useConversations";
 import { PINNED_LABEL_KEY } from "@/lib/sessionListCache";
 import { useMigrateLocalPinsToServer } from "./Sidebar";
 import { PINNED_CONVERSATION_IDS_STORAGE_KEY } from "./sidebarNav";
@@ -32,8 +32,12 @@ vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }
 //         clears the per-user pin.
 const server = {
   mode: "old" as "old" | "new",
-  // ids the server currently reports as pinned (new mode only).
-  pins: new Set<string>(),
+  // Per-user pins the NEW server stores + surfaces (omnigent.pinned.<user>).
+  perUserPins: new Set<string>(),
+  // Bare-key pins an OLD server stores from a PATCH. Faithful to the bug: the
+  // new server drops any bare `omnigent.pinned` key on read (only its per-user
+  // key is surfaced), so a bare-key pin written pre-upgrade is LOST on upgrade.
+  barePins: new Set<string>(),
   // every session that exists (what an old server returns unfiltered).
   allSessions: ["chat_1", "chat_2"],
   patchCount: 0,
@@ -56,23 +60,29 @@ function jsonResponse(body: unknown): Response {
 
 const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
   const url = input.toString();
-  // PATCH /v1/sessions/{id} — pin/unpin.
+  // PATCH /v1/sessions/{id} — pin/unpin. Both servers accept it; they differ in
+  // how they store it (per-user on new, bare on old).
   if (init?.method === "PATCH") {
     server.patchCount += 1;
     const id = decodeURIComponent(url.split("/v1/sessions/")[1]);
     const body = JSON.parse(init.body as string) as { labels?: Record<string, string> };
     const val = body.labels?.[PINNED_LABEL_KEY];
-    // An old server never gets here: the migration is gated off against it.
-    if (val === "" || val == null) server.pins.delete(id);
-    else server.pins.add(id);
-    return Promise.resolve(jsonResponse(row(id, server.pins.has(id))));
+    const store = server.mode === "new" ? server.perUserPins : server.barePins;
+    if (val === "" || val == null) store.delete(id);
+    else store.add(id);
+    return Promise.resolve(jsonResponse(row(id, store.has(id))));
   }
   // GET /v1/sessions?...&pinned=true — the pinned list.
   if (server.mode === "old") {
-    // Old server drops the unknown `pinned` param and returns everything.
+    // Old server drops the unknown `pinned` param and returns everything,
+    // WITHOUT any pin label (a bare-key pin isn't surfaced as omnigent.pinned
+    // on the pre-feature read path).
     return Promise.resolve(jsonResponse({ data: server.allSessions.map((id) => row(id, false)) }));
   }
-  return Promise.resolve(jsonResponse({ data: [...server.pins].map((id) => row(id, true)) }));
+  // New server: only per-user pins are surfaced (bare pins are dropped on read).
+  return Promise.resolve(
+    jsonResponse({ data: [...server.perUserPins].map((id) => row(id, true)) }),
+  );
 });
 
 // The union the sidebar renders: server pins ∪ leftover localStorage pins.
@@ -81,12 +91,19 @@ function readLegacyPins(): string[] {
   return raw ? (JSON.parse(raw) as string[]) : [];
 }
 
+// Captures the live toggle mutation so a test can pin/unpin through the REAL
+// `useTogglePinnedConversation` (including its old-server localStorage fallback)
+// while the harness is mounted.
+let toggle: ((args: { id: string; pinned: boolean }) => void) | null = null;
+
 // Minimal harness wiring the real hooks exactly as the Sidebar does, exposing
 // the union pinned set so assertions read "what the user sees as pinned".
 function Harness() {
   const { data, isSuccess } = usePinnedConversations();
   const serverIds = (data?.conversations ?? []).map((c) => c.id);
   useMigrateLocalPinsToServer(new Set(serverIds), isSuccess, data?.filterHonored ?? false);
+  const toggleMutation = useTogglePinnedConversation();
+  toggle = toggleMutation.mutate;
   const union = new Set(serverIds);
   for (const id of readLegacyPins()) union.add(id);
   return createElement("div", { "data-testid": "pinned" }, [...union].sort().join(","));
@@ -103,8 +120,10 @@ function loadPage() {
 
 beforeEach(() => {
   server.mode = "old";
-  server.pins = new Set();
+  server.perUserPins = new Set();
+  server.barePins = new Set();
   server.patchCount = 0;
+  toggle = null;
   vi.stubGlobal("fetch", fetchMock);
   localStorage.clear();
 });
@@ -133,7 +152,7 @@ describe("pin survives a UI-before-server upgrade", () => {
     server.mode = "new"; // now honors ?pinned=true (currently no server pins)
     const stage2 = loadPage();
     // Migration fires and pushes the local pin to the server.
-    await waitFor(() => expect(server.pins.has("chat_1")).toBe(true));
+    await waitFor(() => expect(server.perUserPins.has("chat_1")).toBe(true));
     expect(server.patchCount).toBe(1);
     // Legacy key is cleared once the write is confirmed.
     await waitFor(() =>
@@ -170,7 +189,41 @@ describe("pin survives a UI-before-server upgrade", () => {
     // Finally the server catches up.
     server.mode = "new";
     const final = loadPage();
-    await waitFor(() => expect(server.pins.has("chat_1")).toBe(true));
+    await waitFor(() => expect(server.perUserPins.has("chat_1")).toBe(true));
     await waitFor(() => expect(final.getByTestId("pinned").textContent).toBe("chat_1"));
+  });
+
+  it("keeps a pin created DURING the UI-before-server window (toggle falls back to localStorage)", async () => {
+    // No pre-existing pin. The user pins a session in the NEW UI while the
+    // server is still OLD — the reported failure: the pin was PATCHed as a bare
+    // key the upgraded server dropped, so it vanished on the server upgrade.
+
+    // ── Stage 1: pin in the new UI, old server ────────────────────────────
+    const stage1 = loadPage();
+    await waitFor(() => expect(stage1.getByTestId("pinned").textContent).toBe(""));
+    toggle!({ id: "chat_2", pinned: true });
+    // The pin shows immediately (optimistic patch + localStorage union)...
+    await waitFor(() => expect(stage1.getByTestId("pinned").textContent).toBe("chat_2"));
+    // ...and crucially was NOT PATCHed to the old server (which would store a
+    // bare key the upgraded server discards). It went to localStorage instead.
+    expect(server.patchCount).toBe(0);
+    expect(server.barePins.has("chat_2")).toBe(false);
+    await waitFor(() => expect(readLegacyPins()).toEqual(["chat_2"]));
+    stage1.unmount();
+
+    // ── Stage 2: reload, still old server — pin persists ──────────────────
+    const stage2 = loadPage();
+    await waitFor(() => expect(stage2.getByTestId("pinned").textContent).toBe("chat_2"));
+    expect(readLegacyPins()).toEqual(["chat_2"]);
+    stage2.unmount();
+
+    // ── Stage 3: server upgraded — the pin migrates instead of vanishing ──
+    server.mode = "new";
+    const stage3 = loadPage();
+    await waitFor(() => expect(server.perUserPins.has("chat_2")).toBe(true));
+    await waitFor(() =>
+      expect(localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY)).toBeNull(),
+    );
+    await waitFor(() => expect(stage3.getByTestId("pinned").textContent).toBe("chat_2"));
   });
 });

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -152,17 +152,18 @@ import { NewProjectButton } from "./NewProjectButton";
 import { SettingsSidebarBody, useSettingsRoute, useTrackSettingsReturn } from "./settingsNav";
 import {
   type ActiveChatOverride,
+  clearLegacyPinnedConversationIds,
   COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY,
   computeNextActiveOverride,
   conversationDisplayLabel,
   dedupeConversationsById,
   EXPANDED_PROJECT_SECTIONS_STORAGE_KEY,
-  migratePinnedConversationIds,
   orderByPinnedTimestamp,
-  PINNED_CONVERSATION_IDS_STORAGE_KEY,
+  readPinnedConversationIds,
   resolveSidebarDrop,
   type SidebarDropTarget,
   sortByUpdatedAtDesc,
+  writeLegacyPinnedConversationIds,
 } from "./sidebarNav";
 
 // Positioning for a row's trailing session-state badge. On desktop the badge
@@ -4088,52 +4089,6 @@ function BulkActionBar({
 export function isMobileViewport(): boolean {
   if (typeof window === "undefined") return false;
   return !window.matchMedia("(min-width: 768px)").matches;
-}
-
-function readPinnedConversationIds(): string[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = window.localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY);
-    if (!raw) return [];
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    // Migrate legacy prefixed ids (``conv_<hex>``) to the bare-hex form the API
-    // returns post id-to-binary migration; the write-back effect re-persists
-    // the migrated ids, so this one-time rewrite is durable across reloads.
-    return migratePinnedConversationIds(
-      parsed.filter((value): value is string => typeof value === "string"),
-    );
-  } catch {
-    // Browser storage is user-editable and can contain stale/corrupt values.
-    // Treat bad pin state as "no pins" instead of breaking navigation.
-    return [];
-  }
-}
-
-function clearLegacyPinnedConversationIds() {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.removeItem(PINNED_CONVERSATION_IDS_STORAGE_KEY);
-  } catch {
-    // Best-effort cleanup — leaving the stale key is harmless (the migration
-    // guard skips already-pinned ids), so a failure here needn't surface.
-  }
-}
-
-// Overwrite the legacy key with exactly `ids` (empty ⇒ remove). Used by the
-// migration to retain only the pins whose server write failed, so a transient
-// failure retries on the next load instead of dropping the pin.
-function writeLegacyPinnedConversationIds(ids: string[]) {
-  if (typeof window === "undefined") return;
-  try {
-    if (ids.length === 0) {
-      window.localStorage.removeItem(PINNED_CONVERSATION_IDS_STORAGE_KEY);
-    } else {
-      window.localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(ids));
-    }
-  } catch {
-    // Best-effort — a write failure just means the migration retries next load.
-  }
 }
 
 // Default collapse state: every section (Pinned / Projects / Chats / Shared)

--- a/web/src/shell/sidebarNav.ts
+++ b/web/src/shell/sidebarNav.ts
@@ -4,6 +4,75 @@ import { PINNED_LABEL_KEY } from "@/lib/sessionListCache";
 
 export const PINNED_CONVERSATION_IDS_STORAGE_KEY = "omnigent:pinned-conversation-ids";
 
+// ── Legacy localStorage pin helpers ───────────────────────────────────────
+//
+// Pins are server-authoritative now, but two paths still touch the legacy
+// localStorage key: the one-time server migration, and the pin toggle's
+// fallback when the server can't yet store pins (`filterHonored === false` — a
+// pre-upgrade server that ignores `?pinned=true`). Kept in this leaf module so
+// both the Sidebar and the `useConversations` toggle hook can use them without
+// an import cycle.
+
+/** Read the legacy pin ids, migrated to bare-hex form. Corrupt/absent ⇒ []. */
+export function readPinnedConversationIds(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(PINNED_CONVERSATION_IDS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Migrate legacy prefixed ids (``conv_<hex>``) to the bare-hex form the API
+    // returns post id-to-binary migration; callers re-persist so the one-time
+    // rewrite is durable across reloads.
+    return migratePinnedConversationIds(
+      parsed.filter((value): value is string => typeof value === "string"),
+    );
+  } catch {
+    // Browser storage is user-editable and can contain stale/corrupt values.
+    // Treat bad pin state as "no pins" instead of breaking navigation.
+    return [];
+  }
+}
+
+/** Remove the legacy pin key entirely (migration complete). */
+export function clearLegacyPinnedConversationIds(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(PINNED_CONVERSATION_IDS_STORAGE_KEY);
+  } catch {
+    // Best-effort cleanup — a stale key is harmless (dedup + migration guard
+    // skip already-known ids), so a failure here needn't surface.
+  }
+}
+
+// Overwrite the legacy key with exactly `ids` (empty ⇒ remove). Used by the
+// migration to retain only the pins whose server write failed, and by the
+// old-server toggle fallback to add/remove a single pin.
+export function writeLegacyPinnedConversationIds(ids: readonly string[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (ids.length === 0) {
+      window.localStorage.removeItem(PINNED_CONVERSATION_IDS_STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(ids));
+    }
+  } catch {
+    // Best-effort — a write failure just means the pin isn't persisted locally.
+  }
+}
+
+/**
+ * Add or remove a single id in the legacy localStorage pin list, most-recently-
+ * pinned-first (matching the pre-server ordering the migration relies on).
+ * Used by the pin toggle's old-server fallback so a pin created before the
+ * server upgrade survives in localStorage and later migrates like any other
+ * pre-upgrade pin.
+ */
+export function setLegacyPinnedConversationId(id: string, pinned: boolean): void {
+  const rest = readPinnedConversationIds().filter((x) => x !== id);
+  writeLegacyPinnedConversationIds(pinned ? [id, ...rest] : rest);
+}
+
 // Titles of sidebar sections the user has collapsed, e.g. ["Archived"].
 // Keyed by display title — stable identifiers for these fixed groups.
 export const COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY = "omnigent:collapsed-sidebar-sections";

--- a/web/src/shell/sidebarNav.ts
+++ b/web/src/shell/sidebarNav.ts
@@ -45,19 +45,26 @@ export function clearLegacyPinnedConversationIds(): void {
   }
 }
 
-// Overwrite the legacy key with exactly `ids` (empty ⇒ remove). Used by the
-// migration to retain only the pins whose server write failed, and by the
-// old-server toggle fallback to add/remove a single pin.
-export function writeLegacyPinnedConversationIds(ids: readonly string[]): void {
+// Overwrite the legacy key with exactly `ids` (empty ⇒ remove). Throws if the
+// browser rejects the write (e.g. storage quota exceeded); no window ⇒ no-op.
+function writeLegacyPinnedConversationIdsOrThrow(ids: readonly string[]): void {
   if (typeof window === "undefined") return;
+  if (ids.length === 0) {
+    window.localStorage.removeItem(PINNED_CONVERSATION_IDS_STORAGE_KEY);
+  } else {
+    window.localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(ids));
+  }
+}
+
+// Overwrite the legacy key with exactly `ids` (empty ⇒ remove). Best-effort:
+// swallows write errors. Used by the migration to retain only the pins whose
+// server write failed — a failure here just means the migration retries on the
+// next load, so it must not surface.
+export function writeLegacyPinnedConversationIds(ids: readonly string[]): void {
   try {
-    if (ids.length === 0) {
-      window.localStorage.removeItem(PINNED_CONVERSATION_IDS_STORAGE_KEY);
-    } else {
-      window.localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(ids));
-    }
+    writeLegacyPinnedConversationIdsOrThrow(ids);
   } catch {
-    // Best-effort — a write failure just means the pin isn't persisted locally.
+    // Best-effort — a failed write is retried on the next load.
   }
 }
 
@@ -67,10 +74,16 @@ export function writeLegacyPinnedConversationIds(ids: readonly string[]): void {
  * Used by the pin toggle's old-server fallback so a pin created before the
  * server upgrade survives in localStorage and later migrates like any other
  * pre-upgrade pin.
+ *
+ * Throws if the write fails (unlike the migration's best-effort write): this is
+ * the fallback's ONLY persistence, so a swallowed failure would let the toggle
+ * report success while the pin silently vanishes on reload. Throwing rejects
+ * the mutation instead, so its optimistic patch rolls back and the UI honestly
+ * shows the pin didn't take — matching the server PATCH path's failure handling.
  */
 export function setLegacyPinnedConversationId(id: string, pinned: boolean): void {
   const rest = readPinnedConversationIds().filter((x) => x !== id);
-  writeLegacyPinnedConversationIds(pinned ? [id, ...rest] : rest);
+  writeLegacyPinnedConversationIdsOrThrow(pinned ? [id, ...rest] : rest);
 }
 
 // Titles of sidebar sections the user has collapsed, e.g. ["Archived"].


### PR DESCRIPTION
## Related issue

Follow-up to #3189 (server-side pinned sessions) and #3323 (migration-gate fix). Fixes a second data-loss path in the same UI-before-server upgrade window.

## Summary

#3323 stopped the localStorage→server migration from wiping pins made **before** the UI upgrade. But a pin created **after** the UI upgrade, while the server was still old, was still lost on the server upgrade. Manual testing confirmed: *"the session I pinned after upgrading the UI is not pinned anymore after I upgrade the server; the one I pinned before is still pinned."*

**Mechanism.** The new UI's pin toggle (`useTogglePinnedConversation` → `setConversationPinned`) is server-only — it PATCHes `/v1/sessions/{id}` with `labels: {omnigent.pinned: <ts>}` and never touches localStorage. Against a **pre-upgrade server** (no per-user pin concept) that PATCH is stored verbatim as the **bare** `omnigent.pinned` key. When the server upgrades, its read path (`_labels_for_viewer`) **drops every bare / `omnigent.pinned.*` key** and only re-surfaces the caller's own `omnigent.pinned.<user_id>` key — so the bare-key pin silently vanishes. The migration can't recover it either, since that pin was never in localStorage.

**Fix (client-only, consistent with #3323).** The toggle now checks the pinned query's `filterHonored`:

- **Server can't store pins (`filterHonored === false`)** → write the pin to **localStorage** (the same store the pre-upgrade UI used) instead of PATCHing a doomed bare key. The optimistic cache patch still runs and the sidebar already unions localStorage pins into the Pinned section, so the pin shows immediately — and it later migrates through `useMigrateLocalPinsToServer` like any pre-upgrade pin.
- **Server can store pins** → unchanged; PATCH as before.

Also moves the legacy-pin localStorage helpers (`readPinnedConversationIds`, `writeLegacyPinnedConversationIds`, `clearLegacyPinnedConversationIds`, + a new single-id `setLegacyPinnedConversationId`) from `Sidebar.tsx` into the leaf `sidebarNav` module so the toggle hook can use them without an import cycle.

### Pin durability across the upgrade window (after this fix)

| Pin created… | Behaviour |
|---|---|
| Before UI upgrade (localStorage) | ✅ survives (was #3323) |
| **After UI upgrade, old server** | ✅ localStorage → migrates on server upgrade (this PR) |
| Both upgraded | ✅ server-side, unchanged |

## Test Plan

- `cd web && npm test` — 4657 pass (+ new cases); `tsc -b` + `oxlint` clean; `prettier` clean.
- New coverage:
  - `useConversations.test.ts` — toggle old-server fallback: pins/unpins to localStorage with **no** PATCH when `filterHonored` is false; still PATCHes (no localStorage) once honored.
  - `Sidebar.pinBackwardsCompat.test.tsx` — extended the end-to-end suite: the fake server now models an old server that *accepts* a PATCH into a bare key which the upgraded server drops on read (faithful to the bug). New case drives the **real** toggle to pin a session **during** the UI-before-server window and asserts it (a) never PATCHes the old server, (b) persists in localStorage, and (c) migrates to a server pin — surviving — on the server upgrade. Verified this case fails against the pre-fix toggle.
- Manual: on the new UI + old server, pin a session → reload (still old server): still pinned, present in `omnigent:pinned-conversation-ids`. Upgrade server → reload: pin migrates server-side and persists.

## Demo

N/A — no visible UI change; the fix is in pin persistence logic. The Pinned section renders identically.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covers the cross-upgrade persistence (pinning during the UI-before-server window), which the extended `Sidebar.pinBackwardsCompat.test.tsx` also encodes end-to-end against a fake server that reproduces the bare-key-dropped-on-read behaviour.

## Changelog

Fixed sessions pinned in the updated web UI being lost after the server was updated.

This pull request and its description were written by Isaac.
