### PR TITLE
fix(pi-native): surface unresolved Databricks credentials instead of a silent dead session

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -153,6 +153,11 @@ class PiProviderConfig:
         request time, used for short-lived gateway tokens).
     :param auth_header: When ``True``, Pi sends ``Authorization: Bearer
         <apiKey>`` (gateways) instead of a provider-native key header.
+    :param credential_warning: A user-facing notice set when the provider was
+        rendered but its credentials could not be resolved (e.g. an expired
+        Databricks OAuth token). Pi still launches — its ``!command`` apiKey may
+        recover at request time — but the caller surfaces this so a session that
+        would otherwise fail silently tells the user how to re-authenticate.
     """
 
     provider_id: str
@@ -161,6 +166,7 @@ class PiProviderConfig:
     model: str
     api_key: str
     auth_header: bool
+    credential_warning: str | None = None
     # Full model list for providers that expose multiple models (e.g. the
     # Databricks Anthropic gateway). Excluded from __hash__ so the frozen
     # dataclass stays hashable even though list[dict] is not hashable.
@@ -230,20 +236,35 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     # exactly the endpoints available on this workspace. Falls back to the
     # bundled static lists when credentials can't be resolved or the API call
     # fails (e.g. network blip, new workspace with no endpoints yet).
+    #
+    # Distinguish two failure modes so the caller can surface the fatal one:
+    #   * credential resolution fails (expired OAuth token) — Pi's per-request
+    #     ``!command`` apiKey will also fail, so the session dies silently. Carry
+    #     a ``credential_warning`` so the caller can tell the user to re-auth.
+    #   * model-list fetch fails after creds resolved (network blip, empty
+    #     workspace) — benign; just show the single default model.
+    credential_warning: str | None = None
+    claude_models: list[dict[str, Any]] = []
+    gpt_models: list[dict[str, Any]] = []
+    completions_models: list[dict[str, Any]] = []
     try:
         from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
 
         creds = resolve_databricks_workspace(entry.profile)
-        claude_models, gpt_models, completions_models = _fetch_pi_model_lists(
-            creds.host, creds.token
-        )
-    except Exception:  # noqa: BLE001 — credential/network failure must not break launch
+    except Exception:  # noqa: BLE001 — credential failure must not break launch
         _LOGGER.info(
             "pi-native: falling back to single-model display (could not resolve credentials)"
         )
-        claude_models = []
-        gpt_models = []
-        completions_models = []
+        credential_warning = _databricks_credential_warning(entry.profile)
+    else:
+        try:
+            claude_models, gpt_models, completions_models = _fetch_pi_model_lists(
+                creds.host, creds.token
+            )
+        except Exception:  # noqa: BLE001 — network failure must not break launch
+            _LOGGER.info(
+                "pi-native: could not fetch workspace model list; showing default model only"
+            )
     additional: dict[str, Any] = {}
     if gpt_models:
         additional[_PI_OPENAI_PROVIDER_ID] = _databricks_openai_provider(
@@ -265,6 +286,22 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         auth_header=True,
         extra_models=claude_models,
         additional_providers=additional,
+        credential_warning=credential_warning,
+    )
+
+
+def _databricks_credential_warning(profile: str | None) -> str:
+    """User-facing notice for an unresolvable Databricks profile.
+
+    :param profile: The Databricks config profile that failed to authenticate.
+    :returns: A short message naming the profile and the re-auth command.
+    """
+    profile_name = profile or "DEFAULT"
+    return (
+        f"Couldn't authenticate to the Databricks profile '{profile_name}' — "
+        "your login has likely expired, so this Pi session can't reach the model "
+        "and won't reply. Re-authenticate by running "
+        f"`databricks auth login --profile {profile_name}`, then start a new Pi session."
     )
 
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -1848,6 +1848,7 @@ async def _auto_create_pi_terminal(
     # terminal_launch_args, or when no usable provider is configured (Pi then
     # falls back to its own login). Writes a managed per-session Pi config dir,
     # never touching the user's global ``~/.pi/agent``.
+    credential_warning: str | None = None
     if not _pi_args_have_provider(launch_config.terminal_launch_args or []):
         from omnigent.pi_native_credentials import (
             pi_native_provider_launch,
@@ -1867,6 +1868,7 @@ async def _auto_create_pi_terminal(
             cred_env, cred_args = pi_native_provider_launch(bridge_dir / "pi-agent", provider)
             pi_env.update(cred_env)
             pi_args.extend(cred_args)
+            credential_warning = provider.credential_warning
     # Inherit the agent's os_env so its sandbox (e.g. ``type: none``),
     # egress_rules and env_passthrough are honoured. Without ``sandbox`` here
     # and ``parent_os_env`` below, launch_required_terminal falls back to
@@ -1904,7 +1906,63 @@ async def _auto_create_pi_terminal(
         session_id,
         pi_extension,
     )
+    # Surface an unresolved-credential warning to the session. Without it, a Pi
+    # session whose Databricks token can't be refreshed launches fine but every
+    # message silently fails to reach the model — the user sees no reply and no
+    # reason. Best-effort: a delivery failure must not fail the launch.
+    if credential_warning is not None:
+        await _post_pi_native_credential_warning(
+            session_id=session_id,
+            server_client=server_client,
+            warning=credential_warning,
+        )
     return terminal_view
+
+
+async def _post_pi_native_credential_warning(
+    *,
+    session_id: str,
+    server_client: httpx.AsyncClient | None,
+    warning: str,
+) -> None:
+    """Surface a credential warning into the session as an error banner.
+
+    Posts an ``error`` item via ``external_conversation_item`` so the notice
+    renders as the web UI's distinct destructive banner (not a misleading
+    assistant bubble), persists across reload, and — because ``error`` is a
+    non-content item type — never enters the next turn's model context. The
+    event persists without queuing an agent turn, so it's safe on a session
+    whose model is unreachable.
+
+    :param session_id: Session/conversation identifier.
+    :param server_client: Runner Omnigent server client (``None`` in tests).
+    :param warning: The user-facing warning text to surface.
+    """
+    if server_client is None:
+        return
+    try:
+        resp = await server_client.post(
+            f"/v1/sessions/{urllib.parse.quote(session_id, safe='')}/events",
+            json={
+                "type": "external_conversation_item",
+                "data": {
+                    "item_type": "error",
+                    "item_data": {
+                        "source": "execution",
+                        "code": "pi_credentials_unresolved",
+                        "message": warning,
+                    },
+                },
+            },
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPError:
+        _logger.warning(
+            "pi-native: failed to surface credential warning for session %s",
+            session_id,
+            exc_info=True,
+        )
 
 
 async def _auto_create_cursor_terminal(

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -208,6 +208,97 @@ async def test_auto_create_pi_terminal_launches_required_terminal(
 
 
 @pytest.mark.asyncio
+async def test_auto_create_pi_terminal_surfaces_credential_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider with an unresolved credential posts a visible session notice.
+
+    Without this, a Pi session whose Databricks token can't be refreshed
+    launches but every message silently fails to reach the model — no reply,
+    no reason. The warning is delivered as an ``error`` item (which the web UI
+    renders as a distinct banner) via ``external_conversation_item``.
+    """
+    import omnigent.pi_native as pi_native
+    import omnigent.pi_native_bridge as pi_native_bridge
+    import omnigent.pi_native_credentials as pi_native_credentials
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
+    monkeypatch.setattr(pi_native_bridge, "_BRIDGE_ROOT", tmp_path / "pi-bridge")
+    monkeypatch.setattr(pi_native, "resolve_pi_executable", lambda: "pi")
+
+    provider = pi_native_credentials.PiProviderConfig(
+        provider_id="omnigent",
+        base_url="https://wkspc.example.com/ai-gateway/anthropic",
+        api="anthropic-messages",
+        model="databricks-claude-sonnet-4-6",
+        api_key="!databricks auth token --profile demo-staging",
+        auth_header=True,
+        credential_warning="⚠️ Couldn't authenticate to `demo-staging`; run databricks auth login.",
+    )
+    monkeypatch.setattr(
+        pi_native_credentials, "resolve_pi_native_provider", lambda **_kwargs: provider
+    )
+    # Avoid touching the real Pi settings/models writer; the launch env is not
+    # under test here — the credential-warning surfacing is.
+    monkeypatch.setattr(
+        pi_native_credentials,
+        "pi_native_provider_launch",
+        lambda _agent_dir, _provider: ({}, []),
+    )
+
+    async def _fake_launch_config(**_kwargs: Any) -> _PiNativeLaunchConfig:
+        return _PiNativeLaunchConfig(
+            workspace=tmp_path,
+            server_url="http://127.0.0.1:8000",
+            terminal_launch_args=None,
+            external_session_id=None,
+        )
+
+    monkeypatch.setattr("omnigent.runner.app._pi_native_launch_config", _fake_launch_config)
+
+    class _FakeResourceRegistry:
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self, *, session_id: str, terminal_name: str, **_kwargs: Any
+        ) -> SessionResourceView:
+            del terminal_name, _kwargs
+            return SessionResourceView(
+                id="terminal_pi_main",
+                type="terminal",
+                session_id=session_id,
+                name="pi:main",
+                metadata={"terminal_name": "pi", "session_key": "main", "running": True},
+            )
+
+    posts: list[tuple[str, dict[str, Any]]] = []
+
+    class _RecordingServerClient(NullServerClient):
+        async def post(self, url: str, **kwargs: Any) -> NullServerClient._Response:
+            posts.append((url, kwargs.get("json") or {}))
+            return self._Response()
+
+    await _auto_create_pi_terminal(
+        "47f049b9d13df4db397c7f46859b825f",
+        _FakeResourceRegistry(),  # type: ignore[arg-type]
+        lambda _sid, _evt: None,
+        server_client=_RecordingServerClient(),  # type: ignore[arg-type]
+    )
+
+    warning_posts = [
+        body
+        for url, body in posts
+        if "/events" in url and body.get("type") == "external_conversation_item"
+    ]
+    assert len(warning_posts) == 1
+    data = warning_posts[0]["data"]
+    assert data["item_type"] == "error"
+    assert data["item_data"]["code"] == "pi_credentials_unresolved"
+    assert "databricks auth login" in data["item_data"]["message"]
+
+
+@pytest.mark.asyncio
 async def test_auto_create_kiro_terminal_launches_required_terminal_with_isolated_env(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -58,6 +58,67 @@ def test_databricks_unresolvable_host_returns_none(monkeypatch: pytest.MonkeyPat
     assert creds.resolve_pi_native_provider(config_loader=_databricks_config) is None
 
 
+def test_databricks_unresolvable_credentials_sets_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expired token → provider still resolves but carries a re-auth warning.
+
+    Pi launches fine (its ``!command`` apiKey may recover), but a silent dead
+    session is worse than a visible notice — so the resolver flags it.
+    """
+    from omnigent.inner import databricks_executor
+    from omnigent.runtime.credentials import databricks as rt_databricks
+
+    monkeypatch.setattr(
+        databricks_executor,
+        "_read_databrickscfg_host",
+        lambda profile: "https://wkspc.example.com/",
+    )
+
+    def _boom(profile: str | None):
+        raise OSError("refresh token is invalid")
+
+    monkeypatch.setattr(rt_databricks, "resolve_databricks_workspace", _boom)
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+
+    assert provider is not None
+    assert provider.credential_warning is not None
+    assert "demo-staging" in provider.credential_warning
+    assert "databricks auth login" in provider.credential_warning
+
+
+def test_databricks_model_list_failure_has_no_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Creds resolve but the model-list fetch fails → benign, no warning."""
+    from omnigent.inner import databricks_executor
+    from omnigent.runtime.credentials import databricks as rt_databricks
+
+    monkeypatch.setattr(
+        databricks_executor,
+        "_read_databrickscfg_host",
+        lambda profile: "https://wkspc.example.com/",
+    )
+    monkeypatch.setattr(
+        rt_databricks,
+        "resolve_databricks_workspace",
+        lambda profile: rt_databricks.WorkspaceCreds(
+            host="https://wkspc.example.com", token="tok"
+        ),
+    )
+
+    def _fetch_boom(host: str, token: str):
+        raise RuntimeError("network blip")
+
+    monkeypatch.setattr(creds, "_fetch_pi_model_lists", _fetch_boom)
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+
+    assert provider is not None
+    assert provider.credential_warning is None
+
+
 def test_key_provider_resolves_to_inline_family() -> None:
     """A key-kind provider with an anthropic family → inline Pi provider."""
     config = {


### PR DESCRIPTION
## Related issue

N/A

## Summary

A native Pi session routed through a Databricks gateway whose OAuth token can't be resolved (e.g. an expired refresh token) launched fine, but every message silently failed to reach the model — no reply, no error surfaced to the user. The runner log showed `pi-native: falling back to single-model display (could not resolve credentials)` and then nothing.

Root cause: `_databricks_pi_provider` caught *all* failures (credential resolution + model-list fetch) in one `try/except` and still returned a provider whose `!databricks auth token` apiKey fails again at request time. Because pi-native dispatches turns fire-and-forget (`TurnComplete` on enqueue), that request-time failure never round-trips back to Omnigent as an error — unlike codex-native, which awaits its app-server RPC and yields an `ExecutorError`.

This PR:

- Splits credential resolution from the (benign) model-list fetch in `_databricks_pi_provider`, so only a genuine auth failure carries a new `PiProviderConfig.credential_warning`.
- At Pi terminal auto-create, surfaces that warning as an `error` item via `external_conversation_item`. It renders as the web UI's distinct error banner (not a misleading assistant bubble), persists across reload, is a non-content item type so it never enters the next turn's model context, and posts without queuing an agent turn (safe on a session whose model is unreachable).

Audited the other native harnesses (claude/codex/cursor/opencode/antigravity/kiro/qwen/kimi/goose/hermes): none share this failure mode — they either surface auth failures loudly or own their auth entirely. Fix is intentionally pi-only.

## Test Plan

- `uv run --extra dev python -m pytest tests/test_pi_native_credentials.py tests/runner/test_app_sessions_native_terminals_autocreate.py` — 53 passed.
- New unit tests:
  - credential-resolution failure sets `credential_warning` (naming the profile + `databricks auth login` command); a model-list-fetch failure with resolved creds does **not**.
  - `_auto_create_pi_terminal` posts exactly one `external_conversation_item` with an `error` item (`code=pi_credentials_unresolved`) when the provider carries a warning.
- Manual: with an expired `e2e_test` profile, opening a Pi session now shows a red error banner at session start instead of a dead session.

## Demo

Before: send messages no response
After:
<img width="780" height="837" alt="image" src="https://github.com/user-attachments/assets/95ed97f0-40ca-4e49-b9fe-c2f38685c335" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover both the credential-warning resolution logic and the error-item surfacing at auto-create. Manually verified end-to-end against a live local server with an expired Databricks profile: the session now shows the credential error banner at start rather than silently accepting messages with no reply.

## Changelog

Pi sessions now show a clear error when their Databricks login has expired, instead of silently accepting messages with no reply

This pull request and its description were written by Isaac.