### PR TITLE
refactor(sandboxes): split host-launch contract from exec transport

### DIFF
--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -362,15 +362,15 @@ class RemoteProcess(ABC):
         """
 
 
-class SandboxLauncher(ABC):
+class SandboxLifecycle(ABC):
     """
-    Transport + lifecycle primitives for one sandbox provider.
+    Lifecycle + capability primitives for one sandbox provider.
 
-    Implementations exist per provider (``LakeboxLauncher``, …) and are
-    resolved by name through
-    :func:`omnigent.onboarding.sandboxes.get_launcher`. All methods
-    raise ``click.ClickException`` (with a remediation hint) on failure
-    so CLI callers surface clean errors without extra wrapping.
+    Every provider — exec-model or entrypoint-as-host — implements this
+    base. It carries the provider identity, capability flags, and the
+    provisioning / teardown / resume lifecycle. Transport (``run``, ``put``,
+    …) lives on :class:`SandboxExecTransport`; the default host launch lives
+    on :class:`ExecModelHostLauncher`.
     """
 
     # Short provider name used in CLI ``--provider`` choices and error
@@ -383,38 +383,12 @@ class SandboxLauncher(ABC):
     # Databricks corp network) override this.
     wheel_build_index_url: ClassVar[str | None] = None
 
-    # Whether this provider can bridge a local port into the sandbox
-    # (``ssh -L`` semantics). The in-sandbox App OAuth flow requires it;
-    # the bootstrap checks this flag BEFORE doing any remote work so
-    # providers without the capability (e.g. Modal) fail fast with the
-    # ``--no-auth`` hint instead of erroring mid-flow.
+    # Legacy class vars — kept for backward compat while providers migrate
+    # to explicit ``capabilities`` objects. New providers should override
+    # the ``capabilities`` property directly instead of setting these.
     supports_local_port_forward: ClassVar[bool] = False
-
-    # Whether this provider supports the CLI bootstrap flow
-    # (``omnigent sandbox create`` / ``connect``: wheel shipping via
-    # ``put`` + ``wheel_install_command``, streaming attach via
-    # ``stream_exec`` / ``exec_foreground``). Managed-only providers
-    # (e.g. Daytona) implement just the server-managed subset
-    # (``prepare`` / ``provision`` / ``run`` / ``terminate``); the CLI
-    # checks this flag up front so they fail with a pointer to
-    # ``host_type="managed"`` instead of a mid-flow capability error.
     supports_cli_bootstrap: ClassVar[bool] = True
-
-    # Whether this provider can resume a stopped sandbox IN PLACE
-    # (reattaching its persistent volume) rather than only provisioning a
-    # fresh one. The server's managed-host wake path checks this BEFORE
-    # attempting a resume: providers with a stop/resume lifecycle + a
-    # persistent volume override it to ``True``; providers whose sandboxes
-    # are ephemeral (Modal — no volume to reattach) leave it ``False``, so a
-    # dormant host there stays gone (the user starts a new session) instead
-    # of being silently revived onto an empty workspace.
     can_resume: ClassVar[bool] = False
-
-    # Whether this provider supports the server-managed host flow
-    # (``host_type="managed"`` sessions). The server checks this before
-    # launching a sandbox for a managed session. Most providers support both
-    # CLI bootstrap and managed launch; set this to ``False`` for providers
-    # that are CLI-only (e.g. Lakebox) or staged-but-not-yet-launched.
     supports_managed_launch: ClassVar[bool] = True
 
     @property
@@ -424,9 +398,9 @@ class SandboxLauncher(ABC):
 
         The returned object is derived from the provider's class vars and
         from which optional transport methods it has overridden. It is a
-        transition shim: providers will set an explicit
+        transition shim: providers override this property with an explicit
         :class:`~omnigent.onboarding.sandboxes.types.SandboxCapabilities`
-        object directly once the refactor is complete.
+        object directly.
         """
         return _sandbox_types.SandboxCapabilities(
             cli_bootstrap=self.supports_cli_bootstrap,
@@ -446,7 +420,13 @@ class SandboxLauncher(ABC):
         Used while the refactor is in transition so the capability object
         can reflect overridden methods without provider authors touching it.
         """
-        return getattr(type(self), name) is not getattr(SandboxLauncher, name)
+        self_method = getattr(type(self), name, None)
+        if self_method is None:
+            return False
+        base_method = getattr(ExecModelHostLauncher, name, None)
+        if base_method is None:
+            return False
+        return self_method is not base_method
 
     @abstractmethod
     def prepare(self) -> None:
@@ -477,181 +457,6 @@ class SandboxLauncher(ABC):
             ``"lovable-wattlebird-1530"``.
         :raises click.ClickException: If provisioning fails.
         """
-
-    def start_host(
-        self,
-        sandbox_id: str,
-        *,
-        token: str,
-        host_id: str,
-        host_name: str,
-        server_url: str,
-        repo_url: str | None = None,
-        repo_branch: str | None = None,
-        repo_name: str | None = None,
-        host_config: dict[str, object] | None = None,
-        on_stage: Callable[[str], None] | None = None,
-    ) -> str:
-        """
-        Start ``omnigent host`` in the sandbox and return the workspace path.
-
-        The default is the EXEC model: probe ``$HOME``, create
-        ``<HOME>/workspace``, optionally materialize the repository into it (via
-        :meth:`materialize_workspace`, which clones by default), merge any
-        *host_config* into ``~/.omnigent/config.yaml``, and start the host
-        detached (``setsid``-backgrounded, identity + token in the process
-        environment) — all driven through :meth:`run` / :meth:`run_background`.
-        It is shared by every provider whose sandbox is a bare box the server
-        execs into (Modal, Daytona, …); entrypoint-as-host providers (e.g.
-        Kubernetes, whose Pod boots running the host) override it. A provider
-        that only needs to change how the repository is obtained (resolve a local
-        checkout instead of cloning) overrides :meth:`materialize_workspace`
-        alone.
-
-        The launch token is registered before this call, so the host
-        authenticates the moment it dials back. The ``repo_*`` arguments arrive
-        as primitives (not the server's ``RepoWorkspace``) so this
-        onboarding-layer method carries no server dependency.
-
-        :param sandbox_id: The sandbox from :meth:`provision`.
-        :param token: The raw launch token the host authenticates with.
-        :param host_id: Server-chosen host identity, e.g. ``"host_a1b2c3d4..."``.
-        :param host_name: Server-chosen host display name, e.g.
-            ``"managed-a1b2c3d4"``.
-        :param server_url: URL of this server the host dials back to.
-        :param repo_url: Repository clone URL, or ``None`` for an empty
-            workspace.
-        :param repo_branch: Branch to clone, or ``None`` for the default branch.
-        :param repo_name: Directory the clone lands in under the workspace, or
-            ``None`` when *repo_url* is ``None``.
-        :param host_config: Deployment-supplied ``~/.omnigent/config.yaml``
-            content (the server's ``sandbox.host_config``) installed into the
-            sandbox's config BEFORE the host starts, or ``None``. On resumable
-            launchers ``None`` still runs the cleanup so entries injected by a
-            since-removed block don't outlive it — see
-            :func:`render_host_config_write_command`.
-        :param on_stage: Progress observer invoked with ``"cloning"`` before the
-            clone (when *repo_url* is set) and ``"starting"`` before the host
-            launches. Runs on this (worker) thread, so it must be thread-safe.
-            ``None`` disables progress reporting.
-        :returns: The absolute in-sandbox workspace path (the cloned repository
-            directory when *repo_url* is set).
-        :raises click.ClickException: If a sandbox command fails, the clone
-            fails, or the sandbox's ``$HOME`` cannot be resolved.
-        """
-        # The image (and the user it runs as) is operator-supplied, so the home
-        # directory isn't knowable statically — ask the sandbox.
-        home = self.run(sandbox_id, 'printf %s "$HOME"').stdout.strip()
-        if not home:
-            raise click.ClickException(
-                f"could not resolve $HOME inside sandbox '{sandbox_id}' — "
-                "the configured image must provide a usable shell environment"
-            )
-        workspace = f"{home}/workspace"
-        self.run(sandbox_id, f"mkdir -p {shlex.quote(workspace)}")
-        if repo_url is not None:
-            workspace = self.materialize_workspace(
-                sandbox_id,
-                workspace=workspace,
-                repo_url=repo_url,
-                repo_branch=repo_branch,
-                repo_name=repo_name,
-                on_stage=on_stage,
-            )
-        # "starting" covers from here through host registration — the caller's
-        # online poll resolves it.
-        if on_stage is not None:
-            on_stage("starting")
-        # Resumable sandboxes keep their filesystem, so even with no
-        # host_config the cleanup must run: an operator who removed the block
-        # expects previously injected entries gone on the next wake. Fresh
-        # sandboxes can't carry a stale marker — skip the extra exec there.
-        if host_config is not None or self.capabilities.resume_stopped:
-            self.run(sandbox_id, render_host_config_write_command(host_config or {}))
-        env_prefix = " ".join(
-            f"{key}={shlex.quote(value)}"
-            for key, value in (
-                (HOST_TOKEN_ENV_VAR, token),
-                (HOST_ID_ENV_VAR, host_id),
-                (HOST_NAME_ENV_VAR, host_name),
-            )
-        )
-        self.run_background(
-            sandbox_id,
-            f"{env_prefix} omnigent host --server {shlex.quote(server_url)}",
-        )
-        return workspace
-
-    def materialize_workspace(
-        self,
-        sandbox_id: str,
-        *,
-        workspace: str,
-        repo_url: str,
-        repo_branch: str | None,
-        repo_name: str | None,
-        on_stage: Callable[[str], None] | None = None,
-    ) -> str:
-        """
-        Materialize the requested repository into the sandbox and return the
-        working directory the host should start in.
-
-        Override point for how a repository *identity* becomes an on-disk
-        checkout. The default is the EXEC model — ``git clone`` the URL into
-        ``<workspace>/<repo_name>`` via :meth:`run` — shared by every provider
-        whose sandbox is a bare box with outbound git access (Modal, Daytona,
-        E2B, …). Providers whose sandbox already carries the repository (a
-        pre-provisioned checkout, a local mirror, a cached worktree) override
-        this to *resolve* the identity to that local path instead of cloning,
-        without having to reimplement :meth:`start_host`. Called by
-        :meth:`start_host` only when ``repo_url`` is set, after ``<workspace>``
-        has been created and before the host launches.
-
-        The ``repo_*`` arguments are the same repository identity
-        :meth:`start_host` received (the server's ``RepoWorkspace`` unpacked into
-        primitives, so this onboarding-layer method carries no server
-        dependency). An override is free to interpret ``repo_url`` as an identity
-        to map to a local checkout rather than a URL to fetch.
-
-        :param sandbox_id: The sandbox from :meth:`provision`.
-        :param workspace: The already-created workspace root, e.g.
-            ``"/root/workspace"``.
-        :param repo_url: Repository clone URL (or, for a resolving override, the
-            repository identity), e.g. ``"https://github.com/org/repo"``.
-        :param repo_branch: Branch to check out, or ``None`` for the default
-            branch.
-        :param repo_name: Directory the checkout lands in under *workspace*, or
-            ``None``.
-        :param on_stage: Progress observer; the default invokes it with
-            ``"cloning"`` before the clone. Runs on this (worker) thread, so it
-            must be thread-safe. ``None`` disables progress reporting.
-        :returns: The absolute in-sandbox path the host should start in (the
-            checkout directory).
-        :raises click.ClickException: If materialization fails (e.g. the clone
-            fails).
-        """
-        if on_stage is not None:
-            on_stage("cloning")
-        clone_dir = f"{workspace}/{repo_name}"
-        branch_args = (
-            f"--branch {shlex.quote(repo_branch)} --single-branch "
-            if repo_branch is not None
-            else ""
-        )
-        try:
-            self.run(
-                sandbox_id,
-                f"git clone {branch_args}-- {shlex.quote(repo_url)} {shlex.quote(clone_dir)}",
-            )
-        except click.ClickException as exc:
-            # Provider boundary: re-raise with the repository named so the
-            # create-session 502 says WHAT failed to clone, not just that a
-            # sandbox command exited non-zero.
-            raise click.ClickException(
-                f"failed to clone repository '{repo_url}'"
-                f"{f' (branch {repo_branch!r})' if repo_branch else ''}: {exc.message}"
-            ) from exc
-        return clone_dir
 
     def attach(self, sandbox_id: str) -> None:
         """
@@ -686,88 +491,6 @@ class SandboxLauncher(ABC):
             support keep-alive configuration.
         """
         raise self._capability_error("configure keep-alive")
-
-    @abstractmethod
-    def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
-        """
-        Run a shell command inside the sandbox and capture its output.
-
-        :param sandbox_id: Target sandbox.
-        :param command: Shell command to execute remotely, e.g.
-            ``"pip install --user /tmp/pkg.whl"``. Quote paths yourself
-            if they must survive the remote shell.
-        :param check: When ``True``, raise on non-zero exit.
-        :returns: The completed command's exit code and output.
-        :raises click.ClickException: If *check* is ``True`` and the
-            command exits non-zero.
-        """
-
-    def run_background(
-        self, sandbox_id: str, command: str, *, log_path: str = "/tmp/omnigent-host.log"
-    ) -> RemoteCommandResult:
-        """
-        Start *command* as a detached background process in the sandbox.
-
-        The default wraps the command in ``setsid nohup sh -c '…' & echo
-        launched`` so it survives the exec session ending. The ``sh -c`` wrapper
-        is load-bearing: callers pass env-prefixed commands (e.g.
-        ``"ENV=val omnigent host …"``), and ``nohup`` does NOT honor shell
-        ``VAR=val`` assignment syntax — ``nohup ENV=val cmd`` makes nohup try to
-        exec a program literally named ``ENV=val`` ("No such file or directory").
-        Re-parsing the command under ``sh -c`` lets the inner shell apply the
-        assignments before running the program. Providers where backgrounded
-        processes are reaped on exec return (e.g. OpenShell) override this
-        to hold the exec stream open instead.
-
-        :param sandbox_id: Target sandbox.
-        :param command: Shell command to background, e.g.
-            ``"ENV=val omnigent host --server https://…"``.
-        :param log_path: Where stdout/stderr of the backgrounded process
-            are redirected inside the sandbox.
-        :returns: A synthetic result with ``stdout="launched\\n"`` on success.
-        :raises click.ClickException: If the launch command fails.
-        """
-        return self.run(
-            sandbox_id,
-            f"setsid nohup sh -c {shlex.quote(command)} "
-            f"> {log_path} 2>&1 < /dev/null & echo launched",
-        )
-
-    def put(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
-        """
-        Copy a local file into the sandbox.
-
-        CLI-bootstrap capability (wheel shipping) — managed-only
-        launchers need not override the raising default.
-
-        :param sandbox_id: Target sandbox.
-        :param local_path: Path on the local machine to read from.
-        :param remote_path: Destination path on the sandbox, e.g.
-            ``"/tmp/oa-wheels.tgz"``.
-        :raises SandboxCapabilityError: When the provider does not
-            support file shipping.
-        :raises click.ClickException: If the transfer fails.
-        """
-        raise self._capability_error("ship files into the sandbox")
-
-    def stream_exec(self, sandbox_id: str, command: str, *, pty: bool = False) -> RemoteProcess:
-        """
-        Spawn a command in the sandbox and stream its output line by
-        line.
-
-        CLI-bootstrap capability (the in-sandbox OAuth login) —
-        managed-only launchers need not override the raising default.
-
-        :param sandbox_id: Target sandbox.
-        :param command: Shell command to execute remotely, e.g.
-            ``"databricks auth login --host https://… --profile oss"``.
-        :param pty: When ``True``, allocate a remote PTY. Required for
-            CLIs that suppress output when not attached to a terminal.
-        :returns: A handle streaming the process's combined output.
-        :raises SandboxCapabilityError: When the provider does not
-            support streaming execs.
-        """
-        raise self._capability_error("stream a remote process")
 
     def forward_capability_error(self) -> SandboxCapabilityError:
         """
@@ -864,6 +587,112 @@ class SandboxLauncher(ABC):
         del sandbox_id
         return None
 
+    def _capability_error(self, action: str) -> SandboxCapabilityError:
+        """
+        Build the error for an optional primitive this provider lacks.
+
+        :param action: Human phrase for the unsupported primitive,
+            e.g. ``"ship files into the sandbox"``.
+        :returns: The capability error to raise.
+        """
+        return SandboxCapabilityError(
+            f"The '{self.provider}' provider does not support the ability to {action}."
+        )
+
+
+class SandboxExecTransport(SandboxLifecycle):
+    """
+    Exec-transport primitives for providers that exec into a running sandbox.
+
+    Providers whose sandbox is a bare box the server execs into (Modal,
+    Daytona, E2B, …) inherit this via :class:`ExecModelHostLauncher`.
+    Entrypoint-as-host providers (e.g. Kubernetes, whose Pod boots running the
+    host) inherit :class:`SandboxHostLauncher` instead and need NOT implement
+    any of these methods.
+    """
+
+    @abstractmethod
+    def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
+        """
+        Run a shell command inside the sandbox and capture its output.
+
+        :param sandbox_id: Target sandbox.
+        :param command: Shell command to execute remotely, e.g.
+            ``"pip install --user /tmp/pkg.whl"``. Quote paths yourself
+            if they must survive the remote shell.
+        :param check: When ``True``, raise on non-zero exit.
+        :returns: The completed command's exit code and output.
+        :raises click.ClickException: If *check* is ``True`` and the
+            command exits non-zero.
+        """
+
+    def run_background(
+        self, sandbox_id: str, command: str, *, log_path: str = "/tmp/omnigent-host.log"
+    ) -> RemoteCommandResult:
+        """
+        Start *command* as a detached background process in the sandbox.
+
+        The default wraps the command in ``setsid nohup sh -c '…' & echo
+        launched`` so it survives the exec session ending. The ``sh -c`` wrapper
+        is load-bearing: callers pass env-prefixed commands (e.g.
+        ``"ENV=val omnigent host …"``), and ``nohup`` does NOT honor shell
+        ``VAR=val`` assignment syntax — ``nohup ENV=val cmd`` makes nohup try to
+        exec a program literally named ``ENV=val`` ("No such file or directory").
+        Re-parsing the command under ``sh -c`` lets the inner shell apply the
+        assignments before running the program. Providers where backgrounded
+        processes are reaped on exec return (e.g. OpenShell) override this
+        to hold the exec stream open instead.
+
+        :param sandbox_id: Target sandbox.
+        :param command: Shell command to background, e.g.
+            ``"ENV=val omnigent host --server https://…"``.
+        :param log_path: Where stdout/stderr of the backgrounded process
+            are redirected inside the sandbox.
+        :returns: A synthetic result with ``stdout="launched\\n"`` on success.
+        :raises click.ClickException: If the launch command fails.
+        """
+        return self.run(
+            sandbox_id,
+            f"setsid nohup sh -c {shlex.quote(command)} "
+            f"> {log_path} 2>&1 < /dev/null & echo launched",
+        )
+
+    def put(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
+        """
+        Copy a local file into the sandbox.
+
+        CLI-bootstrap capability (wheel shipping) — managed-only
+        launchers need not override the raising default.
+
+        :param sandbox_id: Target sandbox.
+        :param local_path: Path on the local machine to read from.
+        :param remote_path: Destination path on the sandbox, e.g.
+            ``"/tmp/oa-wheels.tgz"``.
+        :raises SandboxCapabilityError: When the provider does not
+            support file shipping.
+        :raises click.ClickException: If the transfer fails.
+        """
+        raise self._capability_error("ship files into the sandbox")
+
+    def stream_exec(self, sandbox_id: str, command: str, *, pty: bool = False) -> RemoteProcess:
+        """
+        Spawn a command in the sandbox and stream its output line by
+        line.
+
+        CLI-bootstrap capability (the in-sandbox OAuth login) —
+        managed-only launchers need not override the raising default.
+
+        :param sandbox_id: Target sandbox.
+        :param command: Shell command to execute remotely, e.g.
+            ``"databricks auth login --host https://… --profile oss"``.
+        :param pty: When ``True``, allocate a remote PTY. Required for
+            CLIs that suppress output when not attached to a terminal.
+        :returns: A handle streaming the process's combined output.
+        :raises SandboxCapabilityError: When the provider does not
+            support streaming execs.
+        """
+        raise self._capability_error("stream a remote process")
+
     def exec_foreground(self, sandbox_id: str, command: str) -> int:
         """
         Run a command in the sandbox with stdio inherited from the
@@ -903,14 +732,170 @@ class SandboxLauncher(ABC):
         """
         raise self._capability_error("install shipped wheels")
 
-    def _capability_error(self, action: str) -> SandboxCapabilityError:
-        """
-        Build the error for an optional primitive this provider lacks.
 
-        :param action: Human phrase for the unsupported primitive,
-            e.g. ``"ship files into the sandbox"``.
-        :returns: The capability error to raise.
+class SandboxHostLauncher(SandboxLifecycle):
+    """
+    Lifecycle + host-launch contract for a sandbox provider.
+
+    Every managed-host provider — exec-model or entrypoint-as-host — implements
+    this. :meth:`start_host` is abstract here; the exec-model default lives on
+    :class:`ExecModelHostLauncher`. Entrypoint-as-host providers (e.g.
+    Kubernetes) inherit this class directly and override :meth:`start_host`
+    without needing any exec transport.
+    """
+
+    @abstractmethod
+    def start_host(
+        self,
+        sandbox_id: str,
+        *,
+        token: str,
+        host_id: str,
+        host_name: str,
+        server_url: str,
+        repo_url: str | None = None,
+        repo_branch: str | None = None,
+        repo_name: str | None = None,
+        host_config: dict[str, object] | None = None,
+        on_stage: Callable[[str], None] | None = None,
+    ) -> str:
         """
-        return SandboxCapabilityError(
-            f"The '{self.provider}' provider does not support the ability to {action}."
+        Start ``omnigent host`` in the sandbox and return the workspace path.
+
+        :param sandbox_id: The sandbox from :meth:`provision`.
+        :param token: The raw launch token the host authenticates with.
+        :param host_id: Server-chosen host identity, e.g. ``"host_a1b2c3d4..."``.
+        :param host_name: Server-chosen host display name, e.g.
+            ``"managed-a1b2c3d4"``.
+        :param server_url: URL of this server the host dials back to.
+        :param repo_url: Repository clone URL, or ``None`` for an empty
+            workspace.
+        :param repo_branch: Branch to clone, or ``None`` for the default branch.
+        :param repo_name: Directory the clone lands in under the workspace, or
+            ``None`` when *repo_url* is ``None``.
+        :param host_config: Deployment-supplied ``~/.omnigent/config.yaml``
+            content installed into the sandbox's config BEFORE the host starts.
+        :param on_stage: Progress observer invoked with ``"cloning"`` and
+            ``"starting"``.
+        :returns: The absolute in-sandbox workspace path.
+        """
+
+
+class ExecModelHostLauncher(SandboxHostLauncher, SandboxExecTransport):
+    """
+    Default exec-model host launcher for providers that exec into a running
+    sandbox (Modal, Daytona, E2B, Islo, OpenShell, Boxlite, …).
+
+    Provides the default :meth:`start_host`, :meth:`run_background`, and
+    :meth:`materialize_workspace` that compose :meth:`run` into the full
+    managed-host bootstrap. A provider that only needs to change how the
+    repository is obtained overrides :meth:`materialize_workspace` alone.
+
+    Entrypoint-as-host providers (e.g. Kubernetes) inherit
+    :class:`SandboxHostLauncher` directly and do NOT need ``run()`` or any
+    exec transport.
+    """
+
+    def start_host(
+        self,
+        sandbox_id: str,
+        *,
+        token: str,
+        host_id: str,
+        host_name: str,
+        server_url: str,
+        repo_url: str | None = None,
+        repo_branch: str | None = None,
+        repo_name: str | None = None,
+        host_config: dict[str, object] | None = None,
+        on_stage: Callable[[str], None] | None = None,
+    ) -> str:
+        """
+        Start ``omnigent host`` in the sandbox and return the workspace path.
+
+        The default is the EXEC model: probe ``$HOME``, create
+        ``<HOME>/workspace``, optionally materialize the repository into it (via
+        :meth:`materialize_workspace`, which clones by default), merge any
+        *host_config* into ``~/.omnigent/config.yaml``, and start the host
+        detached (``setsid``-backgrounded, identity + token in the process
+        environment) — all driven through :meth:`run` / :meth:`run_background`.
+
+        :returns: The absolute in-sandbox workspace path.
+        """
+        home = self.run(sandbox_id, 'printf %s "$HOME"').stdout.strip()
+        if not home:
+            raise click.ClickException(
+                f"could not resolve $HOME inside sandbox '{sandbox_id}' — "
+                "the configured image must provide a usable shell environment"
+            )
+        workspace = f"{home}/workspace"
+        self.run(sandbox_id, f"mkdir -p {shlex.quote(workspace)}")
+        if repo_url is not None:
+            workspace = self.materialize_workspace(
+                sandbox_id,
+                workspace=workspace,
+                repo_url=repo_url,
+                repo_branch=repo_branch,
+                repo_name=repo_name,
+                on_stage=on_stage,
+            )
+        if on_stage is not None:
+            on_stage("starting")
+        if host_config is not None or self.capabilities.resume_stopped:
+            self.run(sandbox_id, render_host_config_write_command(host_config or {}))
+        env_prefix = " ".join(
+            f"{key}={shlex.quote(value)}"
+            for key, value in (
+                (HOST_TOKEN_ENV_VAR, token),
+                (HOST_ID_ENV_VAR, host_id),
+                (HOST_NAME_ENV_VAR, host_name),
+            )
         )
+        self.run_background(
+            sandbox_id,
+            f"{env_prefix} omnigent host --server {shlex.quote(server_url)}",
+        )
+        return workspace
+
+    def materialize_workspace(
+        self,
+        sandbox_id: str,
+        *,
+        workspace: str,
+        repo_url: str,
+        repo_branch: str | None,
+        repo_name: str | None,
+        on_stage: Callable[[str], None] | None = None,
+    ) -> str:
+        """
+        Materialize the requested repository into the sandbox and return the
+        working directory the host should start in.
+
+        The default is ``git clone`` into ``<workspace>/<repo_name>``. Override
+        to resolve a local checkout instead of cloning.
+        """
+        if on_stage is not None:
+            on_stage("cloning")
+        clone_dir = f"{workspace}/{repo_name}"
+        branch_args = (
+            f"--branch {shlex.quote(repo_branch)} --single-branch "
+            if repo_branch is not None
+            else ""
+        )
+        try:
+            self.run(
+                sandbox_id,
+                f"git clone {branch_args}-- {shlex.quote(repo_url)} {shlex.quote(clone_dir)}",
+            )
+        except click.ClickException as exc:
+            raise click.ClickException(
+                f"failed to clone repository '{repo_url}'"
+                f"{f' (branch {repo_branch!r})' if repo_branch else ''}: {exc.message}"
+            ) from exc
+        return clone_dir
+
+
+# Backward-compat alias: existing providers inherit ``SandboxLauncher``, which
+# is now ``ExecModelHostLauncher``. Kubernetes and future entrypoint-as-host
+# providers inherit ``SandboxHostLauncher`` directly.
+SandboxLauncher = ExecModelHostLauncher

--- a/omnigent/onboarding/sandboxes/boxlite.py
+++ b/omnigent/onboarding/sandboxes/boxlite.py
@@ -52,6 +52,7 @@ from omnigent.onboarding.sandboxes.base import (
     RemoteCommandResult,
     SandboxLauncher,
 )
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
@@ -192,6 +193,19 @@ class BoxliteSandboxLauncher(SandboxLauncher):
     # primitives (put / stream_exec / exec_foreground / wheel_install_command)
     # keep the base class's raising defaults.
     supports_cli_bootstrap: ClassVar[bool] = False
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            cli_bootstrap=False,
+            managed_launch=True,
+            local_port_forward=False,
+            resume_stopped=False,
+            programmatic_terminate=True,
+            file_copy=False,
+            streaming_exec=False,
+            foreground_exec=False,
+        )
 
     def __init__(
         self,

--- a/omnigent/onboarding/sandboxes/cwsandbox.py
+++ b/omnigent/onboarding/sandboxes/cwsandbox.py
@@ -42,6 +42,7 @@ from omnigent.onboarding.sandboxes.base import (
     foreground_record_prefix,
     host_image_wheel_install_command,
 )
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -91,6 +92,19 @@ def _ensure_sdk() -> None:
 
 class _CWRemoteProcess(RemoteProcess):
     """:class:`RemoteProcess` over a cwsandbox ``Process`` (combined output)."""
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            cli_bootstrap=True,
+            managed_launch=True,
+            local_port_forward=False,
+            resume_stopped=False,
+            programmatic_terminate=True,
+            file_copy=True,
+            streaming_exec=True,
+            foreground_exec=True,
+        )
 
     def __init__(self, process: Process) -> None:
         self._process = process

--- a/omnigent/onboarding/sandboxes/daytona.py
+++ b/omnigent/onboarding/sandboxes/daytona.py
@@ -53,6 +53,7 @@ from omnigent.onboarding.sandboxes.base import (
     SandboxLauncher,
     host_image_wheel_install_command,
 )
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -187,6 +188,19 @@ class DaytonaSandboxLauncher(SandboxLauncher):
     # Daytona preview links are sandbox→public only; there is no
     # local→sandbox path for the App OAuth callback port.
     supports_local_port_forward: ClassVar[bool] = False
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            cli_bootstrap=True,
+            managed_launch=True,
+            local_port_forward=False,
+            resume_stopped=False,
+            programmatic_terminate=True,
+            file_copy=True,
+            streaming_exec=False,
+            foreground_exec=True,
+        )
 
     def __init__(self, *, image: str | None = None, env: Sequence[str] | None = None) -> None:
         """

--- a/omnigent/onboarding/sandboxes/e2b.py
+++ b/omnigent/onboarding/sandboxes/e2b.py
@@ -56,6 +56,7 @@ from omnigent.onboarding.sandboxes.base import (
     SandboxLauncher,
     host_image_wheel_install_command,
 )
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -248,6 +249,19 @@ class _E2BRemoteProcess(RemoteProcess):
     queue — the queue is the combined-output stream the
     :class:`RemoteProcess` contract wants.
     """
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            cli_bootstrap=True,
+            managed_launch=True,
+            local_port_forward=False,
+            resume_stopped=False,
+            programmatic_terminate=True,
+            file_copy=True,
+            streaming_exec=True,
+            foreground_exec=True,
+        )
 
     def __init__(self, handle: CommandHandle) -> None:
         """

--- a/omnigent/onboarding/sandboxes/islo.py
+++ b/omnigent/onboarding/sandboxes/islo.py
@@ -45,6 +45,7 @@ from omnigent.onboarding.sandboxes.base import (
     SandboxLauncher,
     host_image_wheel_install_command,
 )
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities
 
 API_BASE_URL_ENV_VAR: str = "ISLO_BASE_URL"
 """Optional Islo API base URL override. Defaults to
@@ -182,6 +183,19 @@ def _load_islo_sdk() -> _IsloSDK:
 
 class _IsloClient:
     """Small synchronous adapter around the Islo Python SDK."""
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            cli_bootstrap=True,
+            managed_launch=True,
+            local_port_forward=False,
+            resume_stopped=True,
+            programmatic_terminate=True,
+            file_copy=True,
+            streaming_exec=True,
+            foreground_exec=True,
+        )
 
     def __init__(self, *, base_url: str, api_key: str) -> None:
         sdk = _load_islo_sdk()

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -66,10 +66,10 @@ from omnigent.host.identity import (
 )
 from omnigent.onboarding.sandboxes.base import (
     DEFAULT_HOST_IMAGE,
-    RemoteCommandResult,
-    SandboxLauncher,
+    SandboxHostLauncher,
     render_host_config_write_command,
 )
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -808,7 +808,7 @@ def _current_wait_reason(pod: object) -> str | None:
     return None
 
 
-class KubernetesSandboxLauncher(SandboxLauncher):
+class KubernetesSandboxLauncher(SandboxHostLauncher):
     """
     :class:`SandboxLauncher` for on-demand Kubernetes Pods.
 
@@ -822,9 +822,16 @@ class KubernetesSandboxLauncher(SandboxLauncher):
     """
 
     provider: ClassVar[str] = "kubernetes"
-    # Managed-only: no CLI bootstrap, no local→sandbox port forward.
-    supports_cli_bootstrap: ClassVar[bool] = False
-    supports_local_port_forward: ClassVar[bool] = False
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            cli_bootstrap=False,
+            managed_launch=True,
+            local_port_forward=False,
+            resume_stopped=False,
+            programmatic_terminate=True,
+        )
 
     def __init__(
         self,
@@ -1532,20 +1539,4 @@ class KubernetesSandboxLauncher(SandboxLauncher):
             f"{_POD_DELETE_MAX_ATTEMPTS} attempts ({reason}); it may still exist "
             "and carries the omnigent managed-by/role labels for GC.",
             err=True,
-        )
-
-    # ── unsupported: no exec transport (the host is the Pod entrypoint) ──
-
-    def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
-        """
-        Unsupported: the host runs as the Pod's entrypoint, so there is no
-        exec-in transport.
-
-        :param sandbox_id: Unused.
-        :param command: Unused.
-        :param check: Unused.
-        :raises SandboxCapabilityError: Always.
-        """
-        raise self._capability_error(
-            "run a command via exec — the host runs as the Pod entrypoint"
         )

--- a/omnigent/onboarding/sandboxes/modal.py
+++ b/omnigent/onboarding/sandboxes/modal.py
@@ -44,6 +44,7 @@ from omnigent.onboarding.sandboxes.base import (
     foreground_record_prefix,
     host_image_wheel_install_command,
 )
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -207,6 +208,19 @@ class _ModalRemoteProcess(RemoteProcess):
     The handle's stdout stream carries the combined output (the spawn
     site merges stderr in-shell or via a PTY).
     """
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            cli_bootstrap=True,
+            managed_launch=True,
+            local_port_forward=False,
+            resume_stopped=False,
+            programmatic_terminate=True,
+            file_copy=True,
+            streaming_exec=True,
+            foreground_exec=True,
+        )
 
     def __init__(self, process: modal.container_process.ContainerProcess[str]) -> None:
         """

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -55,6 +55,7 @@ from omnigent.onboarding.sandboxes.base import (
     foreground_record_prefix,
     host_image_wheel_install_command,
 )
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -117,6 +118,19 @@ class _OpenShellClient:
     and translates SDK / gRPC errors into ``click.ClickException`` so
     the launcher surface stays clean.
     """
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            cli_bootstrap=True,
+            managed_launch=True,
+            local_port_forward=False,
+            resume_stopped=False,
+            programmatic_terminate=True,
+            file_copy=True,
+            streaming_exec=False,
+            foreground_exec=True,
+        )
 
     def __init__(self, *, cluster: str | None = None) -> None:
         _ensure_sdk()

--- a/omnigent/onboarding/sandboxes/registry.py
+++ b/omnigent/onboarding/sandboxes/registry.py
@@ -19,7 +19,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from omnigent.onboarding.sandboxes.base import SandboxLauncher
+from omnigent.onboarding.sandboxes.base import SandboxLifecycle
 
 if TYPE_CHECKING:
     pass
@@ -298,10 +298,10 @@ def instantiate(
         raise SandboxRegistryError(
             f"could not load sandbox provider '{name}' from {meta.launcher_class!r}: {exc}"
         ) from exc
-    if not isinstance(launcher_cls, type) or not issubclass(launcher_cls, SandboxLauncher):
+    if not isinstance(launcher_cls, type) or not issubclass(launcher_cls, SandboxLifecycle):
         raise SandboxRegistryError(
             f"sandbox provider '{name}' resolved to {launcher_cls!r}, "
-            f"which is not a SandboxLauncher subclass"
+            f"which is not a SandboxLifecycle subclass"
         )
     if name == "lakebox" and workspace_host is not None:
         return launcher_cls(workspace_host=workspace_host)

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -24,7 +24,6 @@ from omnigent.host.identity import (
     HOST_TOKEN_ENV_VAR,
 )
 from omnigent.onboarding.sandboxes.base import (
-    SandboxCapabilityError,
     render_host_config_write_command,
 )
 from omnigent.onboarding.sandboxes.kubernetes import (
@@ -684,12 +683,15 @@ def test_terminate_retries_transient_then_gives_up_best_effort(
     assert fake_core.deleted_secrets == ["omnigent-pod-8-token"]
 
 
-def test_provision_reserves_pod_name_and_run_is_unsupported() -> None:
-    """provision reserves a Pod name (no Pod created); run has no exec transport."""
+def test_provision_reserves_pod_name_and_no_exec_transport() -> None:
+    """provision reserves a Pod name (no Pod created); no exec transport."""
     launcher = _launcher()
     # provision reserves the id — it does NOT create a Pod and does NOT raise.
     name = launcher.provision("managed-abc")
     assert name.startswith("omnigent-managed-abc-")
-    # run is unsupported: the host is the Pod entrypoint, there is no exec-in.
-    with pytest.raises(SandboxCapabilityError):
-        launcher.run("sb", "echo hi")
+    # Kubernetes is an entrypoint-as-host provider: it has no ``run()`` method
+    # at all (no exec transport), unlike exec-model providers that inherit
+    # ``ExecModelHostLauncher``.
+    assert not hasattr(launcher, "run")
+    # CLI bootstrap is not supported.
+    assert launcher.capabilities.cli_bootstrap is False

--- a/tests/onboarding/sandboxes/test_registry.py
+++ b/tests/onboarding/sandboxes/test_registry.py
@@ -309,5 +309,5 @@ def test_instantiate_rejects_non_launcher_class(
         lambda _: _NotALauncher,
     )
 
-    with pytest.raises(SandboxRegistryError, match="not a SandboxLauncher subclass"):
+    with pytest.raises(SandboxRegistryError, match="not a SandboxLifecycle subclass"):
         instantiate("not-a-launcher")


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Split `SandboxLauncher` into a layered hierarchy: `SandboxLifecycle`
  (lifecycle + capabilities), `SandboxExecTransport` (run/put/stream/exec),
  `SandboxHostLauncher` (abstract start_host), and `ExecModelHostLauncher`
  (default start_host + run_background + materialize_workspace).
- `SandboxLauncher` is now a backward-compat alias for `ExecModelHostLauncher`.
- Migrated Kubernetes to inherit `SandboxHostLauncher` directly — it no
  longer needs a fake `run()` that raises; the entrypoint-as-host model
  (Pod boots running the host) has no exec transport at all.
- All 8 providers now declare an explicit `capabilities` property instead
  of relying on class-var derivation.
- Updated the registry's `isinstance` guard to check `SandboxLifecycle`
  (the common base) so both exec-model and entrypoint-as-host providers pass.
- Updated the Kubernetes test that asserted `run()` raises to assert the
  method does not exist instead.

### Class hierarchy

```mermaid
classDiagram
    class SandboxLifecycle {
        <<abstract>>
        +provider: str
        +capabilities: SandboxCapabilities
        +prepare()*
        +provision(name)*
        +attach(sandbox_id)
        +keep_alive(sandbox_id)
        +terminate(sandbox_id)
        +resume(sandbox_id)
        +is_running(sandbox_id)
    }

    class SandboxExecTransport {
        <<abstract>>
        +run(sandbox_id, command)*
        +run_background(sandbox_id, command)
        +put(sandbox_id, local, remote)
        +stream_exec(sandbox_id, command)
        +exec_foreground(sandbox_id, command)
        +wheel_install_command(path)
    }

    class SandboxHostLauncher {
        <<abstract>>
        +start_host(sandbox_id, ...)*
    }

    class ExecModelHostLauncher {
        +start_host(sandbox_id, ...)
        +materialize_workspace(...)
    }

    class KubernetesSandboxLauncher {
        +start_host(sandbox_id, ...)
    }

    SandboxExecTransport --|> SandboxLifecycle
    SandboxHostLauncher --|> SandboxLifecycle
    ExecModelHostLauncher --|> SandboxHostLauncher
    ExecModelHostLauncher --|> SandboxExecTransport
    KubernetesSandboxLauncher --|> SandboxHostLauncher
    ModalSandboxLauncher --|> ExecModelHostLauncher
    DaytonaSandboxLauncher --|> ExecModelHostLauncher
    CWSandboxLauncher --|> ExecModelHostLauncher
    E2BSandboxLauncher --|> ExecModelHostLauncher
    IsloSandboxLauncher --|> ExecModelHostLauncher
    OpenShellSandboxLauncher --|> ExecModelHostLauncher
    BoxliteSandboxLauncher --|> ExecModelHostLauncher
```

**Exec-model providers** (Modal, Daytona, CWSandbox, E2B, Islo, OpenShell, Boxlite)
inherit `ExecModelHostLauncher` and get the default `start_host` +
`run_background` + `materialize_workspace` for free — they only implement
`run()`, `put()`, `terminate()`, etc.

**Entrypoint-as-host providers** (Kubernetes) inherit `SandboxHostLauncher`
directly and have NO exec transport at all — the Pod's container command IS
`omnigent host`, so `start_host` builds the Pod manifest instead of exec-ing
into a running sandbox.

### Sandbox lifecycle

The state diagram below traces a sandbox from provisioning through host
registration, idle/resume cycles, and teardown — showing which launcher
methods fire at each transition:

```mermaid
stateDiagram-v2
    [*] --> Provisioning

    Provisioning --> Online: prepare() + provision() + start_host()
    note right of Provisioning
        CLI: build_wheels() + ship_wheels()
        + login_app_oauth_in_sandbox()
        Managed: start_host() builds Pod /
        execs `omnigent host` in background
    end note

    Online --> Idle: provider auto-stop / pause
    Idle --> Online: resume() + start_host()
    note right of Idle
        Only for providers with
        capabilities.resume_stopped = True
        (e.g. Islo). Others relaunch
        a fresh sandbox instead.
    end note

    Online --> HostDead: host process crash / tunnel drop
    note right of HostDead
        Sandbox may still be alive.
        Resumable providers: resume() +
        start_host() (same sandbox id).
        Non-resumable: relaunch fresh.
    end note
    HostDead --> Online: resume() + start_host()
    HostDead --> Dead: relaunch failed / not resumable

    Online --> Dead: provider lifetime cap (e.g. Modal 24h)
    Idle --> Dead: lifetime expires

    Dead --> Online: relaunch (new sandbox id)
    note right of Dead
        Sandbox is gone. Managed-host flow
        detects dead host, provisions a fresh
        sandbox, re-registers under same
        host_id.
    end note

    Online --> [*]: terminate()
    Idle --> [*]: terminate()
    HostDead --> [*]: terminate()
    Dead --> [*]: terminate() (best-effort)
```

### CLI bootstrap flow (exec-model only)

```mermaid
stateDiagram-v2
    [*] --> Prepared: prepare()
    Prepared --> Provisioned: provision(name)
    Provisioned --> WheelsShipped: put() + run(wheel_install_command())
    WheelsShipped --> Authed: login_app_oauth_in_sandbox()
    note right of Authed
        Requires capabilities.local_port_forward.
        Providers without it (Modal, Daytona, ...)
        skip this step automatically (--no-auth).
    end note
    Authed --> Connected: exec_foreground("omnigent host")
    Connected --> [*]: Ctrl-C / disconnect
```

## Test Plan

```bash
uv run pytest tests/onboarding/sandboxes tests/sandbox tests/cli/test_cli.py tests/server -k managed -q
pre-commit run --files <all changed files>
```

All 780 selected tests pass and pre-commit is clean.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing provider and CLI tests pass unchanged, confirming backward
compatibility. The Kubernetes test was updated to reflect that `run()` no
longer exists on the launcher. The registry test was updated for the
`SandboxLifecycle` guard message.
