### PR TITLE
feat(automations): automations detail page

### DIFF
--- a/omnigent/server/routes/scheduled_tasks.py
+++ b/omnigent/server/routes/scheduled_tasks.py
@@ -27,6 +27,7 @@ from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.server.auth import RESERVED_USER_LOCAL, AuthProvider
 from omnigent.server.routes._auth_helpers import require_user
 from omnigent.server.routes._host_launch import resolve_host_owner
+from omnigent.server.routes._sessions.helpers import _read_state_entry
 from omnigent.server.routes._session_create_validation import (
     validate_existing_host_workspace,
     validate_session_agent,
@@ -132,11 +133,28 @@ def _to_response(
     }
 
 
-def _run_to_response(run: ScheduledTaskRun) -> dict[str, Any]:
+def _run_to_response(
+    run: ScheduledTaskRun,
+    *,
+    conversation_updated_at: int | None = None,
+    conversation_status: str | None = None,
+    viewer_unread: bool | None = None,
+) -> dict[str, Any]:
     """Serialize a :class:`ScheduledTaskRun` to a JSON-safe dict.
 
     Excludes the free-text ``error`` blob (never SQL-queried, potentially
     large); ``error_code`` carries the queryable failure classification.
+
+    :param conversation_updated_at: The conversation's ``updated_at`` epoch
+        seconds, or ``None`` for runs without a conversation. Embedded so the
+        frontend can call ``isConversationUnseen`` with no per-row fetch.
+    :param conversation_status: The conversation's ``live_status`` (``"idle"``,
+        ``"running"``, etc.), or ``None`` for runs without a conversation. Same
+        semantics as the ``status`` field in ``GET /v1/sessions``.
+    :param viewer_unread: The caller's ``viewer_unread`` flag for the
+        conversation (in-memory read-state explicit-unread), or ``None`` for
+        runs without a conversation. Hydrates ``useUnseenConversations`` on load
+        so the frontend never needs a separate session fetch.
     """
     return {
         "id": run.id,
@@ -147,6 +165,9 @@ def _run_to_response(run: ScheduledTaskRun) -> dict[str, Any]:
         "fired_at": run.fired_at,
         "finished_at": run.finished_at,
         "error_code": run.error_code,
+        "conversation_updated_at": conversation_updated_at,
+        "conversation_status": conversation_status,
+        "viewer_unread": viewer_unread,
     }
 
 
@@ -410,8 +431,28 @@ def create_scheduled_tasks_router(
         _require_owned(scheduled_task_id, owner_id)
         runs, next_cursor = store.list_runs(scheduled_task_id, limit=limit, after_id=after)
         runs = force_fail_stale_runs(store, runs)
+        # Batch-fetch conversation metadata for runs that produced a session so
+        # the frontend can compute unread dots without per-row session GETs.
+        # Runs without a conversation_id (skipped/failed) contribute null fields.
+        conv_ids = [r.conversation_id for r in runs if r.conversation_id is not None]
+        convs = conversation_store.get_conversations(conv_ids) if conv_ids else {}
+        run_rows = []
+        for r in runs:
+            if r.conversation_id is not None and r.conversation_id in convs:
+                conv = convs[r.conversation_id]
+                last_seen, explicit_unread = _read_state_entry(owner_id, r.conversation_id)
+                run_rows.append(
+                    _run_to_response(
+                        r,
+                        conversation_updated_at=conv.updated_at,
+                        conversation_status=conv.live_status,
+                        viewer_unread=explicit_unread,
+                    )
+                )
+            else:
+                run_rows.append(_run_to_response(r))
         return {
-            "runs": [_run_to_response(r) for r in runs],
+            "runs": run_rows,
             "next_cursor": next_cursor,
         }
 

--- a/omnigent/server/routes/scheduled_tasks.py
+++ b/omnigent/server/routes/scheduled_tasks.py
@@ -27,12 +27,12 @@ from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.server.auth import RESERVED_USER_LOCAL, AuthProvider
 from omnigent.server.routes._auth_helpers import require_user
 from omnigent.server.routes._host_launch import resolve_host_owner
-from omnigent.server.routes._sessions.helpers import _read_state_entry
 from omnigent.server.routes._session_create_validation import (
     validate_existing_host_workspace,
     validate_session_agent,
     validate_session_model_metadata,
 )
+from omnigent.server.routes._sessions.helpers import _read_state_entry
 from omnigent.server.scheduled.rrule import RRuleValidationError, validate_rrule
 from omnigent.server.scheduled.run_reconciler import force_fail_stale_runs
 from omnigent.stores import AgentStore, ConversationStore, PermissionStore
@@ -440,7 +440,7 @@ def create_scheduled_tasks_router(
         for r in runs:
             if r.conversation_id is not None and r.conversation_id in convs:
                 conv = convs[r.conversation_id]
-                last_seen, explicit_unread = _read_state_entry(owner_id, r.conversation_id)
+                _last_seen, explicit_unread = _read_state_entry(owner_id, r.conversation_id)
                 run_rows.append(
                     _run_to_response(
                         r,

--- a/omnigent/server/scheduled/fire.py
+++ b/omnigent/server/scheduled/fire.py
@@ -355,6 +355,11 @@ async def _run_fire_for_task(
             )
             return
 
+        # Missing host_id / workspace after resolution is a PERMANENT misconfig,
+        # not a host-availability miss: this task's stored spec can never launch
+        # a connected-host run, and it will re-hit this gate on every occurrence.
+        # Record a "failed" run (not "skipped") so the user gets a signal to fix
+        # the task's configuration rather than a silent, forever-skipped task.
         input_error = _validate_connected_host_inputs(effective)
         if input_error is not None:
             error, error_code = input_error
@@ -364,7 +369,7 @@ async def _run_fire_for_task(
                 task,
                 None,
                 scheduled_at,
-                status="skipped",
+                status="failed",
                 error=error,
                 error_code=error_code,
             )
@@ -393,6 +398,12 @@ async def _run_fire_for_task(
         # enforced even for a defaulted workspace, exactly as ``POST /v1/sessions``
         # does — an agent that pins an absolute cwd outside HOME records a failed
         # run instead of silently launching outside its declared boundary.
+        #
+        # A validation failure here (bad model_override, workspace outside the
+        # agent boundary, non-absolute path, missing execution input) is a
+        # PERMANENT misconfig, not a host-availability miss — the stored spec
+        # will fail this gate on every occurrence. Record a "failed" run (not
+        # "skipped") so the user gets a signal to fix the task's configuration.
         validate_workspace = preflight is not None and effective.workspace is not None
         validation_error = await _validate_fire_session_inputs(
             deps, effective, validate_workspace=validate_workspace
@@ -405,7 +416,7 @@ async def _run_fire_for_task(
                 task,
                 None,
                 scheduled_at,
-                status="skipped",
+                status="failed",
                 error=error,
                 error_code=error_code,
             )

--- a/omnigent/server/scheduled/fire.py
+++ b/omnigent/server/scheduled/fire.py
@@ -12,7 +12,7 @@ firing:
    ``host_id`` resolves the owner's most-recently-active live host at fire time;
    a task that pinned no ``workspace`` (research / summaries / chat-only) starts
    the runner in the host's home directory. A pinned host that is missing or
-   offline — and an owner with no live host at all — records a failed/skipped
+   offline — and an owner with no live host at all — records a skipped
    run instead of a running run.
 #. **Creates a session** bound to the task's agent, carrying the resolved
    ``workspace`` / ``host_id`` and the stored ``model_override`` /
@@ -333,7 +333,8 @@ async def _run_fire_for_task(
         # host at fire time. An unset ``workspace`` (research / summaries /
         # chat-only) defaults to the host's home directory so the runner still
         # has a real cwd. If no live host can be resolved, this records a
-        # failed run — the same honest behavior as a pinned host that is offline.
+        # skipped run — the host being offline at fire time means the occurrence
+        # didn't run, not that something broke.
         #
         # ``task`` stays the source of truth for the persisted row; ``effective``
         # carries the resolved host_id / defaulted workspace through preflight,
@@ -348,7 +349,7 @@ async def _run_fire_for_task(
                 task,
                 None,
                 scheduled_at,
-                status="failed",
+                status="skipped",
                 error=str(exc),
                 error_code=exc.error_code,
             )
@@ -363,7 +364,7 @@ async def _run_fire_for_task(
                 task,
                 None,
                 scheduled_at,
-                status="failed",
+                status="skipped",
                 error=error,
                 error_code=error_code,
             )
@@ -379,7 +380,7 @@ async def _run_fire_for_task(
                     task,
                     None,
                     scheduled_at,
-                    status="failed",
+                    status="skipped",
                     error=str(exc),
                     error_code=exc.error_code,
                 )
@@ -404,7 +405,7 @@ async def _run_fire_for_task(
                 task,
                 None,
                 scheduled_at,
-                status="failed",
+                status="skipped",
                 error=error,
                 error_code=error_code,
             )
@@ -480,7 +481,7 @@ async def _resolve_effective_task(deps: FireDeps, task: ScheduledTask) -> Schedu
 
     * ``host_id`` unset → the owner's most-recently-active ONLINE host. No live
       host (or no host store/registry) raises :class:`_CannotLaunchScheduledFire`
-      so the caller records a failed run instead of silently no-oping.
+      so the caller records a skipped run instead of silently no-oping.
     * ``workspace`` unset → the launch host's home directory, canonicalized to an
       absolute realpath via a ``host.stat`` round-trip, so the runner launches
       with a real cwd and the stored row never holds a literal ``~``. This HOME
@@ -545,7 +546,7 @@ async def _resolve_default_workspace(deps: FireDeps, host_id: str) -> str:
     host — the host expands the tilde against its own ``HOME`` and returns the
     absolute ``canonical_path``, the same value the normal session-create path
     stores. Raises :class:`_CannotLaunchScheduledFire` if the host is gone or
-    can't resolve its home dir, so the caller records an honest failed run.
+    can't resolve its home dir, so the caller records a skipped run.
     """
     from omnigent.server.routes._workspace_validation import (
         WorkspaceValidationError,

--- a/tests/e2e_ui/scheduled/test_scheduled_task_detail_page.py
+++ b/tests/e2e_ui/scheduled/test_scheduled_task_detail_page.py
@@ -1,0 +1,156 @@
+"""UI journey: the Scheduled Task DETAIL page (``/tasks/:taskId``).
+
+Covers the core detail-page render + interaction path for a scheduled task:
+
+* The detail page renders the task's name, prompt, Configuration block
+  (agent + host), and the status line (pause toggle + Active/Paused pill +
+  human-readable schedule).
+* Clicking the task card on ``/tasks`` navigates to ``/tasks/:taskId``.
+* Triggering **Run now** from the detail header fires
+  ``POST /v1/scheduled-tasks/{id}/run``, records a run in the background,
+  and the run-history section renders a run row.
+
+The seeded task pins no host, so a manual Run now with no online host records
+a ``skipped`` run (post the unresolved-host reclassification on this branch).
+This exercises the end-to-end render path without needing a live host or an
+agent turn, exactly like ``test_scheduled_task_row_run_controls`` in the sibling
+test file.
+
+**Icon / tooltip semantics are NOT re-tested here.** The CalendarOff-for-skipped
+icon, the amber triangle for failed runs, the unread blue dot, and all tooltip
+text are already covered by:
+
+* 20 RTL unit tests in ``web/src/pages/TaskDetailPage.test.tsx``
+* 31 backend unit tests in ``tests/server/scheduled/test_fire.py``
+
+This E2E test focuses on the render + navigation + run-now → run-row journey
+that only the live server path can exercise.
+"""
+
+from __future__ import annotations
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.scheduled.test_scheduled_tasks_page import (
+    _builtin_agent_id,
+    _create_task,
+    _row_by_name,
+)
+
+
+def test_scheduled_task_detail_page_renders_header_and_sections(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Navigating to a task card lands on the detail page with all key sections.
+
+    Asserts the title, prompt, Configuration block (agent + host), and the
+    status line (Active pill + pause toggle + schedule summary) all render.
+    """
+    agent_id = _builtin_agent_id(live_server, "hello_world")
+    _create_task(
+        live_server,
+        agent_id,
+        "Detail render test",
+        "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+    )
+
+    page.goto(f"{live_server}/tasks")
+    row = _row_by_name(page, "Detail render test")
+    expect(row).to_be_visible(timeout=30_000)
+
+    # Click the card body to navigate to the detail page.
+    row.get_by_test_id("task-row-open").click()
+
+    # URL must change to /tasks/:id.
+    page.wait_for_url("**/tasks/**", timeout=15_000)
+
+    # Header: task name.
+    expect(page.get_by_test_id("task-detail-title")).to_have_text(
+        "Detail render test", timeout=30_000
+    )
+
+    # Status line: Active pill, pause toggle, schedule summary.
+    expect(page.get_by_test_id("task-detail-state-pill")).to_contain_text("Active")
+    expect(page.get_by_test_id("task-detail-pause-toggle")).to_be_visible()
+    # The schedule summary is derived client-side from the stored RRULE.
+    expect(page.get_by_test_id("task-detail-schedule")).to_contain_text(
+        "Every day at 9:00 AM", timeout=15_000
+    )
+
+    # Prompt section.
+    expect(page.get_by_test_id("task-detail-prompt")).to_be_visible()
+
+    # Configuration block: the agent label resolves; the host defaults to
+    # "Auto (connected host)" when no host_id is pinned.
+    expect(page.get_by_test_id("task-detail-agent")).to_be_visible()
+    expect(page.get_by_test_id("task-detail-host")).to_contain_text("Auto (connected host)")
+
+    # Back link navigates back to the list.
+    expect(page.get_by_test_id("task-detail-back")).to_be_visible()
+
+
+def test_scheduled_task_detail_page_run_now_records_run_row(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Run now from the detail header fires the task and a run row appears.
+
+    The seeded task has no host, so the fire resolves to a ``skipped`` run
+    (no online host at fire time). This exercises the real
+    ``POST /v1/scheduled-tasks/{id}/run`` path from the detail page and
+    confirms the run-history section renders a row — a status icon + timestamp
+    — once the background fire lands.
+
+    Icon / tooltip semantics (CalendarOff for skipped, amber triangle for
+    failed, etc.) are covered by the RTL unit tests; this test only asserts
+    that A run row is rendered, not which icon it carries.
+    """
+    agent_id = _builtin_agent_id(live_server, "hello_world")
+    task_id = _create_task(
+        live_server,
+        agent_id,
+        "Detail run-now test",
+        "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+    )
+
+    page.goto(f"{live_server}/tasks")
+    row = _row_by_name(page, "Detail run-now test")
+    expect(row).to_be_visible(timeout=30_000)
+    row.get_by_test_id("task-row-open").click()
+    page.wait_for_url("**/tasks/**", timeout=15_000)
+
+    # Confirm the detail page loaded.
+    expect(page.get_by_test_id("task-detail-title")).to_have_text(
+        "Detail run-now test", timeout=30_000
+    )
+
+    # No run has fired yet.
+    pre = httpx.get(f"{live_server}/v1/scheduled-tasks/{task_id}/runs", timeout=10.0)
+    assert pre.json()["runs"] == [], "expected empty run history before Run now"
+
+    # Trigger Run now from the detail-page header button.
+    page.get_by_test_id("task-detail-run-now").click()
+
+    # The POST returns 202; the actual run is written by a background task.
+    # Poll the API until the run is recorded (mirrors the sibling list-page test).
+    def _has_run() -> bool:
+        runs = httpx.get(
+            f"{live_server}/v1/scheduled-tasks/{task_id}/runs", timeout=10.0
+        ).json()["runs"]
+        return len(runs) >= 1
+
+    deadline = 0
+    while not _has_run() and deadline < 100:
+        page.wait_for_timeout(200)
+        deadline += 1
+    assert _has_run(), "Run now did not record a run within the timeout"
+
+    # After the run is written the page's polling query (useScheduledTaskRuns)
+    # re-fetches and the run-history section renders at least one row.
+    # The exact status (skipped/failed/running) depends on host availability;
+    # we only assert a row rendered — the status icon is unit-tested.
+    expect(page.get_by_test_id("task-detail-runs")).to_be_visible(timeout=30_000)
+    runs_section = page.get_by_test_id("task-detail-runs")
+    expect(runs_section.get_by_test_id("task-detail-run").first).to_be_visible(timeout=30_000)

--- a/tests/e2e_ui/scheduled/test_scheduled_task_detail_page.py
+++ b/tests/e2e_ui/scheduled/test_scheduled_task_detail_page.py
@@ -136,9 +136,9 @@ def test_scheduled_task_detail_page_run_now_records_run_row(
     # The POST returns 202; the actual run is written by a background task.
     # Poll the API until the run is recorded (mirrors the sibling list-page test).
     def _has_run() -> bool:
-        runs = httpx.get(
-            f"{live_server}/v1/scheduled-tasks/{task_id}/runs", timeout=10.0
-        ).json()["runs"]
+        runs = httpx.get(f"{live_server}/v1/scheduled-tasks/{task_id}/runs", timeout=10.0).json()[
+            "runs"
+        ]
         return len(runs) >= 1
 
     deadline = 0

--- a/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
+++ b/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
@@ -341,7 +341,7 @@ def test_scheduled_task_row_run_controls(
     """Run controls: relative next-run label, and Run now → a run is recorded.
 
     LLM-free. The seeded task pins no host, so a manual Run now resolves no online
-    host and records a ``failed`` run. This exercises the real
+    host and records a ``skipped`` run. This exercises the real
     POST /v1/scheduled-tasks/{id}/run path (the ⋯-menu action) end-to-end and
     confirms the run row is written, without ever dispatching an agent turn. The
     completion pill was removed from the row UI, so completion is asserted via the
@@ -370,19 +370,19 @@ def test_scheduled_task_row_run_controls(
     page.get_by_test_id("task-run-now").click()
 
     # The manual fire runs through the shared fire path and records a run row.
-    # With no online host it resolves to a ``failed`` run. Poll the history until
+    # With no online host it resolves to a ``skipped`` run. Poll the history until
     # the background fire lands (the POST returns 202 before the run is written).
-    def _has_failed_run() -> bool:
+    def _has_skipped_run() -> bool:
         runs = httpx.get(f"{live_server}/v1/scheduled-tasks/{task_id}/runs", timeout=10.0).json()[
             "runs"
         ]
-        return len(runs) == 1 and runs[0]["status"] == "failed"
+        return len(runs) == 1 and runs[0]["status"] == "skipped"
 
     deadline = 0
-    while not _has_failed_run() and deadline < 100:
+    while not _has_skipped_run() and deadline < 100:
         page.wait_for_timeout(200)
         deadline += 1
-    assert _has_failed_run(), "Run now did not record a failed run within the timeout"
+    assert _has_skipped_run(), "Run now did not record a skipped run within the timeout"
 
 
 # ── Model + reasoning-effort selectors (PR #3331) ──────────────────────────

--- a/tests/server/integration/test_scheduled_tasks_routes.py
+++ b/tests/server/integration/test_scheduled_tasks_routes.py
@@ -574,6 +574,67 @@ async def test_list_runs_returns_history_for_owned_task(
     assert "error" not in newest
 
 
+async def test_list_runs_includes_conversation_read_state_fields(
+    auth_client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """Run rows include batched conversation read-state fields; skipped runs get nulls.
+
+    The ``/runs`` endpoint enriches each run that has a ``conversation_id`` with
+    ``conversation_updated_at``, ``conversation_status``, and ``viewer_unread``
+    so the frontend can compute the unread dot without per-row session GETs.
+    Runs with no conversation (skipped/failed host-less) get null for all three.
+    """
+    import uuid
+
+    from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+    _make_user(db_uri)
+    created = (
+        await auth_client.post("/v1/scheduled-tasks", json=_create_body(), headers=_headers())
+    ).json()
+    task_id = created["id"]
+
+    # Create a real conversation in the store so the batch-fetch can hydrate it.
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    conv = conv_store.create_conversation(conversation_id=uuid.uuid4().hex)
+
+    succeeded_id = uuid.uuid4().hex
+    skipped_id = uuid.uuid4().hex
+    _seed_run(
+        db_uri,
+        task_id,
+        succeeded_id,
+        scheduled_at=1000,
+        status="succeeded",
+        conversation_id=conv.id,
+    )
+    _seed_run(
+        db_uri,
+        task_id,
+        skipped_id,
+        scheduled_at=2000,
+        status="skipped",
+        error_code="no_online_host",
+        conversation_id=None,
+    )
+
+    resp = await auth_client.get(f"/v1/scheduled-tasks/{task_id}/runs", headers=_headers())
+    assert resp.status_code == 200, resp.text
+    runs = {r["id"]: r for r in resp.json()["runs"]}
+
+    # The succeeded run with a real conversation gets enriched fields.
+    succ = runs[succeeded_id]
+    assert succ["conversation_updated_at"] == conv.updated_at
+    assert succ["conversation_status"] is None  # live_status is None until first turn
+    assert succ["viewer_unread"] is False  # no explicit-unread set for this viewer
+
+    # The skipped run (no conversation_id) gets null for all three fields.
+    skip = runs[skipped_id]
+    assert skip["conversation_updated_at"] is None
+    assert skip["conversation_status"] is None
+    assert skip["viewer_unread"] is None
+
+
 async def test_list_runs_empty_for_task_with_no_runs(
     auth_client: httpx.AsyncClient, db_uri: str
 ) -> None:

--- a/tests/server/scheduled/test_fire.py
+++ b/tests/server/scheduled/test_fire.py
@@ -498,7 +498,7 @@ async def test_launch_failure_is_swallowed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_validation_failure_records_failed_without_session() -> None:
+async def test_validation_failure_records_skipped_without_session() -> None:
     conv_store = FakeConversationStore()
     store = FakeScheduledTaskStore(rows={"task_1": _task(model_override="--danger")})
 
@@ -514,7 +514,7 @@ async def test_validation_failure_records_failed_without_session() -> None:
 
     assert conv_store.created == []
     assert len(store.runs) == 1
-    assert store.runs[0]["status"] == "failed"
+    assert store.runs[0]["status"] == "skipped"
     assert store.runs[0]["error_code"] == "invalid_input"
     assert store.runs[0]["conversation_id"] is None
 
@@ -599,9 +599,9 @@ async def test_unset_host_resolves_owner_online_host_and_runs() -> None:
 
 
 @pytest.mark.asyncio
-async def test_unset_host_no_online_host_records_failed() -> None:
-    """An unset host_id with no live host is an honest failure, not a no-op: it
-    records a failed run with the no_online_host code and creates no session."""
+async def test_unset_host_no_online_host_records_skipped() -> None:
+    """An unset host_id with no live host records a skipped run (the occurrence
+    didn't run because no host was available), not a failure."""
     conv_store = FakeConversationStore()
     store = FakeScheduledTaskStore(
         rows={"task_1": _task(user_id="alice@example.com", host_id=None, workspace=None)}
@@ -627,7 +627,7 @@ async def test_unset_host_no_online_host_records_failed() -> None:
     assert launched == []
     assert conv_store.created == []
     assert len(store.runs) == 1
-    assert store.runs[0]["status"] == "failed"
+    assert store.runs[0]["status"] == "skipped"
     assert store.runs[0]["error_code"] == "no_online_host"
     assert store.runs[0]["conversation_id"] is None
 
@@ -762,17 +762,17 @@ async def test_pinned_nonowned_host_no_workspace_rejected_before_stat(
     assert resolve_calls == []
     assert conv_store.created == []
     assert len(store.runs) == 1
-    assert store.runs[0]["status"] == "failed"
+    assert store.runs[0]["status"] == "skipped"
     assert store.runs[0]["error_code"] == "host_not_owned"
     assert store.runs[0]["conversation_id"] is None
 
 
 @pytest.mark.asyncio
-async def test_no_workspace_unresolvable_home_records_failed(
+async def test_no_workspace_unresolvable_home_records_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """If the host can't resolve its home dir, the fire records an honest failed
-    run rather than launching with a bogus workspace."""
+    """If the host can't resolve its home dir, the fire records a skipped run
+    rather than launching with a bogus workspace."""
     conv_store = FakeConversationStore()
     store = FakeScheduledTaskStore(
         rows={"task_1": _task(user_id="alice@example.com", host_id=None, workspace=None)}
@@ -798,7 +798,7 @@ async def test_no_workspace_unresolvable_home_records_failed(
 
     assert conv_store.created == []
     assert len(store.runs) == 1
-    assert store.runs[0]["status"] == "failed"
+    assert store.runs[0]["status"] == "skipped"
     assert store.runs[0]["error_code"] == "default_workspace_unresolved"
 
 
@@ -846,16 +846,16 @@ async def test_defaulted_workspace_is_boundary_validated(
     # The boundary check ran against the resolved absolute workspace.
     assert seen["validate_workspace"] is True
     assert seen["workspace"] == "/home/alice"
-    # The boundary failure was recorded honestly; no session was created.
+    # The boundary failure records a skipped run; no session was created.
     assert conv_store.created == []
     assert len(store.runs) == 1
-    assert store.runs[0]["status"] == "failed"
+    assert store.runs[0]["status"] == "skipped"
     assert store.runs[0]["error_code"] == "invalid_input"
 
 
 @pytest.mark.asyncio
-async def test_no_host_store_records_failed_when_host_unset() -> None:
-    """No host store/registry configured + an unset host is an honest failure."""
+async def test_no_host_store_records_skipped_when_host_unset() -> None:
+    """No host store/registry configured + an unset host records a skipped run."""
     conv_store = FakeConversationStore()
     store = FakeScheduledTaskStore(rows={"task_1": _task(host_id=None, workspace=None)})
 
@@ -867,7 +867,7 @@ async def test_no_host_store_records_failed_when_host_unset() -> None:
 
     assert conv_store.created == []
     assert len(store.runs) == 1
-    assert store.runs[0]["status"] == "failed"
+    assert store.runs[0]["status"] == "skipped"
     assert store.runs[0]["error_code"] == "host_registry_unavailable"
     assert store.runs[0]["conversation_id"] is None
 
@@ -922,7 +922,7 @@ async def test_resolve_default_workspace_raises_when_home_missing(
 
 
 @pytest.mark.asyncio
-async def test_no_host_registry_records_failed_without_session() -> None:
+async def test_no_host_registry_records_skipped_without_session() -> None:
     conv_store = FakeConversationStore()
     store = FakeScheduledTaskStore(rows={"task_1": _task()})
 
@@ -934,13 +934,13 @@ async def test_no_host_registry_records_failed_without_session() -> None:
 
     assert conv_store.created == []
     assert len(store.runs) == 1
-    assert store.runs[0]["status"] == "failed"
+    assert store.runs[0]["status"] == "skipped"
     assert store.runs[0]["error_code"] == "host_registry_unavailable"
     assert store.runs[0]["conversation_id"] is None
 
 
 @pytest.mark.asyncio
-async def test_offline_connected_host_records_failed_without_session() -> None:
+async def test_offline_connected_host_records_skipped_without_session() -> None:
     conv_store = FakeConversationStore()
     store = FakeScheduledTaskStore(rows={"task_1": _task(user_id="alice@example.com")})
 
@@ -957,7 +957,7 @@ async def test_offline_connected_host_records_failed_without_session() -> None:
 
     assert conv_store.created == []
     assert len(store.runs) == 1
-    assert store.runs[0]["status"] == "failed"
+    assert store.runs[0]["status"] == "skipped"
     assert store.runs[0]["error_code"] == "host_offline"
     assert store.runs[0]["conversation_id"] is None
 

--- a/tests/server/scheduled/test_fire.py
+++ b/tests/server/scheduled/test_fire.py
@@ -498,7 +498,9 @@ async def test_launch_failure_is_swallowed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_validation_failure_records_skipped_without_session() -> None:
+async def test_validation_failure_records_failed_without_session() -> None:
+    """A bad model_override is a PERMANENT misconfig (fails every occurrence), so
+    it records a FAILED run — not skipped — signalling the user to fix the task."""
     conv_store = FakeConversationStore()
     store = FakeScheduledTaskStore(rows={"task_1": _task(model_override="--danger")})
 
@@ -514,8 +516,35 @@ async def test_validation_failure_records_skipped_without_session() -> None:
 
     assert conv_store.created == []
     assert len(store.runs) == 1
-    assert store.runs[0]["status"] == "skipped"
+    assert store.runs[0]["status"] == "failed"
     assert store.runs[0]["error_code"] == "invalid_input"
+    assert store.runs[0]["conversation_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_missing_connected_host_input_records_failed_without_session() -> None:
+    """A blank pinned host_id is a PERMANENT misconfig — the stored spec can never
+    launch a connected-host run — so gate (c) records a FAILED run (not skipped),
+    unlike the host-availability misses which stay skipped."""
+    conv_store = FakeConversationStore()
+    # host_id="" (not None) is left untouched by _resolve_effective_task but is
+    # rejected by _validate_connected_host_inputs as missing_host_id.
+    store = FakeScheduledTaskStore(rows={"task_1": _task(host_id="", workspace="/repo")})
+
+    async def _launch(conv: Any, task: Any) -> None:
+        return None
+
+    on_fire = build_on_fire(
+        _deps(store, conversation_store=conv_store),
+        launch_dispatch=_launch,
+    )
+    await on_fire(0, "task_1")
+    await _drain()
+
+    assert conv_store.created == []
+    assert len(store.runs) == 1
+    assert store.runs[0]["status"] == "failed"
+    assert store.runs[0]["error_code"] == "missing_host_id"
     assert store.runs[0]["conversation_id"] is None
 
 
@@ -808,8 +837,8 @@ async def test_defaulted_workspace_is_boundary_validated(
 ) -> None:
     """The resolved default HOME workspace is validated against the agent's
     os_env.cwd boundary, exactly like a caller-supplied one — the check is gated
-    on the RESOLVED workspace, not the (null) stored value. A boundary failure
-    records a failed run and creates no session."""
+    on the RESOLVED workspace, not the (null) stored value. A boundary failure is
+    a permanent misconfig, so it records a FAILED run and creates no session."""
     conv_store = FakeConversationStore()
     store = FakeScheduledTaskStore(
         rows={"task_1": _task(user_id="alice@example.com", host_id=None, workspace=None)}
@@ -846,10 +875,10 @@ async def test_defaulted_workspace_is_boundary_validated(
     # The boundary check ran against the resolved absolute workspace.
     assert seen["validate_workspace"] is True
     assert seen["workspace"] == "/home/alice"
-    # The boundary failure records a skipped run; no session was created.
+    # The boundary failure records a failed run; no session was created.
     assert conv_store.created == []
     assert len(store.runs) == 1
-    assert store.runs[0]["status"] == "skipped"
+    assert store.runs[0]["status"] == "failed"
     assert store.runs[0]["error_code"] == "invalid_input"
 
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,6 +23,9 @@ const ApprovePage = lazy(() =>
 );
 const InboxPage = lazy(() => import("@/pages/InboxPage").then((m) => ({ default: m.InboxPage })));
 const TasksPage = lazy(() => import("@/pages/TasksPage").then((m) => ({ default: m.TasksPage })));
+const TaskDetailPage = lazy(() =>
+  import("@/pages/TaskDetailPage").then((m) => ({ default: m.TaskDetailPage })),
+);
 const SettingsPage = lazy(() =>
   import("@/pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
 );
@@ -121,6 +124,7 @@ function App({ basename }: AppProps = {}) {
           <Route path={`${prefix}/c/:conversationId`} element={<ChatPage />} />
           <Route path={`${prefix}/inbox`} element={<InboxPage />} />
           <Route path={`${prefix}/tasks`} element={<TasksPage />} />
+          <Route path={`${prefix}/tasks/:taskId`} element={<TaskDetailPage />} />
           {/* Settings renders into the chat outlet so the conversations
               sidebar stays put — entering settings only swaps the card's
               content (the section nav) and the main area. The active section

--- a/web/src/components/scheduled/ScheduledTaskRow.test.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.test.tsx
@@ -6,9 +6,19 @@
 // uses pointerDown on the trigger (matching the TasksPage tests).
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ScheduledTaskRow } from "./ScheduledTaskRow";
 import type { ScheduledTask } from "@/lib/scheduledTasksApi";
+
+// Capture navigate() calls; the row uses `@/lib/routing`'s useNavigate, which
+// falls back to react-router-dom. Mocking it lets us assert the target without
+// a full router history.
+const navigate = vi.fn();
+vi.mock("@/lib/routing", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/routing")>();
+  return { ...actual, useNavigate: () => navigate };
+});
 
 function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
   return {
@@ -53,11 +63,18 @@ function renderRow(
     busy: false,
     ...handlers,
   };
-  render(<ScheduledTaskRow {...props} />);
+  render(
+    <MemoryRouter>
+      <ScheduledTaskRow {...props} />
+    </MemoryRouter>,
+  );
   return props;
 }
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  navigate.mockReset();
+});
 
 describe("next-run text (server-sourced, relative delta)", () => {
   it("renders the relative next-run with a 'Next run' prefix when nextRunAt is set", () => {
@@ -100,5 +117,33 @@ describe("⋯ menu actions", () => {
   it("disables the menu trigger while the row is busy", () => {
     renderRow(task(), { busy: true });
     expect(screen.getByTestId("task-row-menu")).toBeDisabled();
+  });
+});
+
+describe("card-body navigation", () => {
+  it("navigates to the task's detail page when the card body is clicked", () => {
+    const t = task({ id: "st_42" });
+    renderRow(t);
+    fireEvent.click(screen.getByTestId("task-row-open"));
+    expect(navigate).toHaveBeenCalledWith("/tasks/st_42");
+  });
+
+  it("opening the ⋯ menu does NOT navigate", () => {
+    renderRow(task({ id: "st_42" }));
+    // Radix opens on pointerdown; the trigger stops propagation so the
+    // card-body navigation never fires.
+    fireEvent.pointerDown(screen.getByTestId("task-row-menu"), { button: 0 });
+    expect(screen.getByTestId("task-run-now")).toBeInTheDocument();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("selecting a menu item dispatches its callback without navigating", () => {
+    const onRunNow = vi.fn();
+    const t = task({ id: "st_42" });
+    renderRow(t, { onRunNow });
+    fireEvent.pointerDown(screen.getByTestId("task-row-menu"), { button: 0 });
+    fireEvent.click(screen.getByTestId("task-run-now"));
+    expect(onRunNow).toHaveBeenCalledWith(t);
+    expect(navigate).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -105,7 +105,7 @@ export function ScheduledTaskRow({
         data-testid="task-row-open"
         onClick={handleNavigate}
         aria-label={`Open ${task.name}`}
-        className="flex min-w-0 flex-1 flex-col text-left after:absolute after:inset-0 after:content-['']"
+        className="flex min-w-0 flex-1 cursor-pointer flex-col text-left after:absolute after:inset-0 after:content-['']"
       >
         <span className="flex min-w-0 items-center gap-2">
           <span className="truncate text-[15px] font-semibold">{task.name}</span>

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -23,6 +23,7 @@ import {
   Trash2Icon,
   ZapIcon,
 } from "lucide-react";
+import { useNavigate } from "@/lib/routing";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -55,6 +56,7 @@ export function ScheduledTaskRow({
   onDelete: (task: ScheduledTask) => void;
   busy: boolean;
 }) {
+  const navigate = useNavigate();
   const [menuOpen, setMenuOpen] = useState(false);
   const paused = task.state === "paused";
   // Subtitle: the schedule summary, plus the SERVER's next-run time when armed
@@ -63,6 +65,15 @@ export function ScheduledTaskRow({
   // WHICH instant is next on the client.
   const scheduleSummary = useMemo(() => describeSchedule(task.rrule), [task.rrule]);
   const nextRun = useMemo(() => formatNextRunAt(task.nextRunAt, now), [task.nextRunAt, now]);
+
+  // Navigate to the task's detail page from the card BODY. The ⋯ menu (trigger
+  // + portalled content) stops propagation so opening / using it never also
+  // navigates. Rendered as a real <button> so keyboard (Enter/Space) and focus
+  // come for free; the ⋯ trigger is a sibling, not a descendant, so there's no
+  // nested-interactive-element (button-in-button) violation.
+  function handleNavigate() {
+    navigate(`/tasks/${task.id}`);
+  }
 
   return (
     <div
@@ -82,7 +93,20 @@ export function ScheduledTaskRow({
         "group relative flex items-center gap-3 rounded-xl border border-border bg-card py-3 pr-12 pl-4 transition-colors hover:bg-muted/40",
       )}
     >
-      <div className="flex min-w-0 flex-1 flex-col">
+      {/* The card BODY is the navigation affordance. `after:absolute
+          after:inset-0` stretches its hit area over the whole card (behind the
+          ⋯ trigger, which sits above via its own stacking) so a click anywhere
+          on the row except the menu opens the detail page — while keeping ONE
+          real interactive element for a11y (no wrapping the ⋯ button inside
+          it). `text-left` + `min-w-0` keep the truncation behavior identical to
+          the old div. */}
+      <button
+        type="button"
+        data-testid="task-row-open"
+        onClick={handleNavigate}
+        aria-label={`Open ${task.name}`}
+        className="flex min-w-0 flex-1 flex-col text-left after:absolute after:inset-0 after:content-['']"
+      >
         <span className="flex min-w-0 items-center gap-2">
           <span className="truncate text-[15px] font-semibold">{task.name}</span>
           {paused && (
@@ -106,7 +130,7 @@ export function ScheduledTaskRow({
             </>
           )}
         </span>
-      </div>
+      </button>
 
       {/* Hover-revealed ellipsis menu, mirroring the sidebar conversation-row
           action button: absolute-positioned on the right, hidden until the row
@@ -121,8 +145,15 @@ export function ScheduledTaskRow({
             aria-label={`Actions for ${task.name}`}
             data-testid="task-row-menu"
             disabled={busy}
+            // `relative z-10` lifts the trigger above the body button's
+            // stretched `after` hit area; `onClick`/`onPointerDown`
+            // stopPropagation so opening the menu never bubbles to the
+            // card-body navigation. (Radix opens on pointerdown, so both are
+            // guarded.)
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
             className={cn(
-              "-translate-y-1/2 absolute top-1/2 right-3 transition-opacity",
+              "-translate-y-1/2 absolute top-1/2 right-3 z-10 transition-opacity",
               "md:opacity-0 md:group-hover:opacity-100 md:group-has-[:focus-visible]:opacity-100",
               "md:aria-expanded:opacity-100",
             )}
@@ -130,7 +161,14 @@ export function ScheduledTaskRow({
             <MoreHorizontalIcon className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
+        {/* The menu content portals to the body, so a click inside it can't
+            bubble to the card; guard anyway for the rare non-portalled path and
+            to keep item selection from triggering navigation. */}
+        <DropdownMenuContent
+          align="end"
+          onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
           <DropdownMenuItem onSelect={() => onRunNow(task)} data-testid="task-run-now">
             <ZapIcon className="size-4" />
             Run now

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -15,7 +15,14 @@
 // menu (Run now / Pause / Resume / Edit / Delete) sits on the right.
 
 import { useMemo, useState } from "react";
-import { MoreHorizontalIcon, PauseIcon, PencilIcon, PlayIcon, Trash2Icon } from "lucide-react";
+import {
+  CirclePlayIcon,
+  MoreHorizontalIcon,
+  PauseIcon,
+  PencilIcon,
+  PlayIcon,
+  Trash2Icon,
+} from "lucide-react";
 import { useNavigate } from "@/lib/routing";
 import { Button } from "@/components/ui/button";
 import {
@@ -173,7 +180,7 @@ export function ScheduledTaskRow({
           <DropdownMenuItem onSelect={() => onPauseToggle(task)} data-testid="task-pause-toggle">
             {paused ? (
               <>
-                <PlayIcon className="size-4" />
+                <CirclePlayIcon className="size-4" />
                 Resume
               </>
             ) : (

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -15,14 +15,7 @@
 // menu (Run now / Pause / Resume / Edit / Delete) sits on the right.
 
 import { useMemo, useState } from "react";
-import {
-  MoreHorizontalIcon,
-  PauseIcon,
-  PencilIcon,
-  PlayIcon,
-  Trash2Icon,
-  ZapIcon,
-} from "lucide-react";
+import { MoreHorizontalIcon, PauseIcon, PencilIcon, PlayIcon, Trash2Icon } from "lucide-react";
 import { useNavigate } from "@/lib/routing";
 import { Button } from "@/components/ui/button";
 import {
@@ -170,7 +163,7 @@ export function ScheduledTaskRow({
           onPointerDown={(e) => e.stopPropagation()}
         >
           <DropdownMenuItem onSelect={() => onRunNow(task)} data-testid="task-run-now">
-            <ZapIcon className="size-4" />
+            <PlayIcon className="size-4" />
             Run now
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => onEdit(task)} data-testid="task-edit">

--- a/web/src/hooks/useScheduledTasks.test.tsx
+++ b/web/src/hooks/useScheduledTasks.test.tsx
@@ -1,6 +1,7 @@
 // Tests for the scheduled-tasks React-Query hooks: the list query shape, the
-// invalidate-on-success contract of the create / update / delete mutations,
-// and the accelerated post-run-now run-history poll.
+// invalidate-on-success contract of the create / update / delete mutations, and
+// the status-aware run-history refetchInterval that drives a run row to its
+// terminal state live (replacing the old accelerated post-run-now poll).
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
@@ -8,12 +9,14 @@ import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "@/lib/scheduledTasksApi";
 import {
-  cancelRunNowPoll,
+  hasUnsettledRun,
   SCHEDULED_TASKS_KEY,
+  scheduledTaskKey,
   scheduledTaskRunsKey,
   useCreateScheduledTask,
   useDeleteScheduledTask,
   useRunScheduledTaskNow,
+  useScheduledTaskRuns,
   useScheduledTasks,
   useUpdateScheduledTask,
 } from "./useScheduledTasks";
@@ -123,7 +126,7 @@ describe("mutations invalidate the list", () => {
     expect(spy).toHaveBeenCalledWith({ queryKey: SCHEDULED_TASKS_KEY });
   });
 
-  it("run-now calls the API and invalidates the list + that task's runs", async () => {
+  it("run-now calls the API and immediately invalidates the list, detail + runs", async () => {
     const { queryClient, wrapper } = makeWrapper();
     const spy = vi.spyOn(queryClient, "invalidateQueries");
     const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
@@ -131,8 +134,33 @@ describe("mutations invalidate the list", () => {
     expect(api.runScheduledTaskNow).toHaveBeenCalledWith("st_1");
     // Refreshes the list (so the completion badge updates)…
     expect(spy).toHaveBeenCalledWith({ queryKey: SCHEDULED_TASKS_KEY });
-    // …and the fired task's run history (via the final invalidate after polling).
+    // …the detail query…
+    expect(spy).toHaveBeenCalledWith({ queryKey: scheduledTaskKey("st_1") });
+    // …and the fired task's run history, so the new "running" row appears at
+    // once. Driving it to terminal is the refetchInterval's job, not this
+    // mutation's — it must NOT start a poll of its own.
     expect(spy).toHaveBeenCalledWith({ queryKey: scheduledTaskRunsKey("st_1") });
+  });
+
+  it("run-now does NOT schedule its own follow-up refetches (no accelerated poll)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    try {
+      const { queryClient, wrapper } = makeWrapper();
+      const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
+      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync("st_1");
+      });
+      // Well past the old ~20s poll budget: nothing self-scheduled fires.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+      });
+
+      expect(countRunRefetches(refetchSpy)).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -143,7 +171,7 @@ const RUNNING_RUN: api.ScheduledTaskRun = {
   conversationStatus: "running",
 };
 // Run row terminal but the CONVERSATION is still running — the intermediate
-// state the old poll stopped on too early (BUG 1). The poll must keep going.
+// state a run-status-only check would treat as settled one step too early.
 const SUCCEEDED_CONV_RUNNING_RUN: api.ScheduledTaskRun = {
   ...RUN,
   status: "succeeded",
@@ -170,216 +198,191 @@ function countRunRefetches(spy: { mock: { calls: unknown[][] } }) {
   ).length;
 }
 
-// Capture the run-now poll's own setTimeout delays (isolate from react-query's
-// internal timers by filtering to the poll's interval band, ~0.7s–4s).
-function pollDelays(spy: { mock: { calls: unknown[][] } }): number[] {
-  return spy.mock.calls
-    .map((args) => args[1])
-    .filter((d): d is number => typeof d === "number" && d >= 700 && d <= 4_000);
-}
-
-describe("run-now fast-poll after 202", () => {
-  it("keeps polling while the CONVERSATION is still running even though the run row is terminal, and stops once it settles (BUG 1)", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: false });
-    try {
-      const { queryClient, wrapper } = makeWrapper();
-      // Register a queryFn so the poll's refetchQueries actually calls the mocked
-      // API (consuming the mock sequence) and writes each transition into the
-      // cache that the stop condition reads back.
-      queryClient.setQueryDefaults(scheduledTaskRunsKey("st_1"), {
-        queryFn: () => api.listScheduledTaskRuns("st_1"),
-      });
-      queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
-
-      // Tick 1: run running. Tick 2: run terminal but conversation STILL running
-      // (the intermediate state the old poll stopped on too early). Tick 3+:
-      // conversation settled to idle — only now may the poll stop.
-      vi.mocked(api.listScheduledTaskRuns)
-        .mockResolvedValueOnce([RUNNING_RUN])
-        .mockResolvedValueOnce([SUCCEEDED_CONV_RUNNING_RUN])
-        .mockResolvedValue([SUCCEEDED_RUN]);
-
-      const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
-      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
-
-      await act(async () => {
-        void result.current.mutateAsync("st_1");
-        await Promise.resolve();
-      });
-
-      // Tick 1 (~750ms): run running — keep going.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(800);
-      });
-      expect(countRunRefetches(refetchSpy)).toBe(1);
-
-      // Tick 2 (~1275ms later): run terminal but conversation running — MUST NOT
-      // stop (the old bug). Poll continues.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(1_300);
-      });
-      expect(countRunRefetches(refetchSpy)).toBe(2);
-
-      // Tick 3 (~2168ms later): conversation now idle — poll stops.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(2_200);
-      });
-      const countAfterStop = countRunRefetches(refetchSpy);
-      expect(countAfterStop).toBe(3);
-
-      // No further refetches once settled, even well past the ceiling.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(20_000);
-      });
-      expect(countRunRefetches(refetchSpy)).toBe(countAfterStop);
-    } finally {
-      vi.useRealTimers();
-    }
+describe("hasUnsettledRun (the refetchInterval stop condition)", () => {
+  it("is true while a run row is still running or scheduled", () => {
+    expect(hasUnsettledRun([RUNNING_RUN])).toBe(true);
+    expect(hasUnsettledRun([{ ...RUN, status: "scheduled", conversationStatus: null }])).toBe(true);
   });
 
-  it("stops immediately when a terminal run has NO conversation (host-less skip)", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: false });
-    try {
-      const { queryClient, wrapper } = makeWrapper();
-      queryClient.setQueryDefaults(scheduledTaskRunsKey("st_1"), {
-        queryFn: () => api.listScheduledTaskRuns("st_1"),
-      });
-      queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
-
-      // First (and every) tick returns a terminal skipped run with no conversation
-      // — there is nothing to wait for, so the poll stops after one tick.
-      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([SKIPPED_NO_CONV_RUN]);
-
-      const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
-      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
-
-      await act(async () => {
-        void result.current.mutateAsync("st_1");
-        await Promise.resolve();
-      });
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(800);
-      });
-      expect(countRunRefetches(refetchSpy)).toBe(1);
-
-      // Poll stopped — no more refetches over the next 20s.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(20_000);
-      });
-      expect(countRunRefetches(refetchSpy)).toBe(1);
-    } finally {
-      vi.useRealTimers();
-    }
+  it("stays true while the run row is terminal but its CONVERSATION still runs", () => {
+    // The unread dot keys off the conversation, not the row — stopping here
+    // would leave the dot grey until a remount refetched the idle conversation.
+    expect(hasUnsettledRun([SUCCEEDED_CONV_RUNNING_RUN])).toBe(true);
   });
 
-  it("uses EXPONENTIAL BACKOFF for the poll interval (BUG 2)", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: false });
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-    try {
-      const { queryClient, wrapper } = makeWrapper();
-      queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
+  it("is false once everything is terminal", () => {
+    expect(hasUnsettledRun([SUCCEEDED_RUN])).toBe(false);
+    expect(hasUnsettledRun([{ ...RUN, status: "failed", conversationStatus: "idle" }])).toBe(false);
+  });
 
-      // Never settles — always running — so we observe several backoff intervals.
+  it("is false for a terminal run with NO conversation (host-less skip)", () => {
+    expect(hasUnsettledRun([SKIPPED_NO_CONV_RUN])).toBe(false);
+  });
+
+  it("is false for no-data / empty history rather than polling forever", () => {
+    expect(hasUnsettledRun(undefined)).toBe(false);
+    expect(hasUnsettledRun([])).toBe(false);
+  });
+
+  it("treats an unrecognised status as settled so polling can never strand", () => {
+    // `incomplete` is an END state (the server's stale-run force-fail backstop).
+    // Any status this client doesn't know must not keep the interval alive.
+    expect(hasUnsettledRun([{ ...RUN, status: "incomplete", conversationStatus: "idle" }])).toBe(
+      false,
+    );
+  });
+
+  it("is true when ANY run in the history is unsettled, not just the newest", () => {
+    expect(hasUnsettledRun([SUCCEEDED_RUN, { ...RUNNING_RUN, id: "run_old" }])).toBe(true);
+  });
+});
+
+describe("useScheduledTaskRuns live refresh", () => {
+  it("keeps refetching a >20s run until it settles, WITHOUT a remount", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    try {
+      const { wrapper } = makeWrapper();
+      // A realistically SLOW run: still running well past the old 20s poll
+      // budget (which is exactly why the row used to spin forever), settling
+      // only at ~60s. Each phase must be observed live by the same mount.
       vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([RUNNING_RUN]);
 
-      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
+      const { result } = renderHook(() => useScheduledTaskRuns("st_1"), { wrapper });
       await act(async () => {
-        void result.current.mutateAsync("st_1");
-        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(0);
       });
+      expect(result.current.isSuccess).toBe(true);
 
-      // Let several ticks fire.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(15_000);
-      });
+      const callsAtStart = vi.mocked(api.listScheduledTaskRuns).mock.calls.length;
 
-      const delays = pollDelays(setTimeoutSpy);
-      // At least three intervals observed, each strictly larger than the last
-      // until the per-tick cap (~4s) is hit.
-      expect(delays.length).toBeGreaterThanOrEqual(3);
-      expect(delays[0]).toBeLessThan(delays[1]!);
-      expect(delays[1]).toBeLessThan(delays[2]!);
-      // First interval is the fast initial tick (< 1s), and none exceed the cap.
-      expect(delays[0]).toBeLessThan(1_000);
-      expect(Math.max(...delays)).toBeLessThanOrEqual(4_000);
-    } finally {
-      setTimeoutSpy.mockRestore();
-      vi.useRealTimers();
-    }
-  });
-
-  it("run-now stops polling after the bound even without a settled run", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: false });
-    try {
-      const { queryClient, wrapper } = makeWrapper();
-      queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
-
-      // Runs never settle — always returns running row (simulates stuck run).
-      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([RUNNING_RUN]);
-
-      const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
-      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
-
-      await act(async () => {
-        void result.current.mutateAsync("st_1");
-        await Promise.resolve();
-      });
-
-      // Advance well past the ~20s time budget.
+      // Past the OLD 20s budget the run is still going — the interval must not
+      // have given up.
       await act(async () => {
         await vi.advanceTimersByTimeAsync(30_000);
       });
+      const callsAt30s = vi.mocked(api.listScheduledTaskRuns).mock.calls.length;
+      expect(callsAt30s).toBeGreaterThan(callsAtStart);
+      // Still spinning on-screen, which is correct — the run really is running.
+      expect(result.current.data).toEqual([RUNNING_RUN]);
 
-      // Bounded — far fewer than the old ~20 fixed-interval ticks thanks to backoff.
-      const countAfterBound = countRunRefetches(refetchSpy);
-      expect(countAfterBound).toBeLessThanOrEqual(12);
+      // The row goes terminal while its conversation is still running: keep going.
+      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([SUCCEEDED_CONV_RUNNING_RUN]);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(12_000);
+      });
+      const callsAfterRowTerminal = vi.mocked(api.listScheduledTaskRuns).mock.calls.length;
+      expect(callsAfterRowTerminal).toBeGreaterThan(callsAt30s);
 
-      // No more refetches after another 10s — poller has stopped.
+      // Conversation settles too — the row is now fully terminal on-screen, with
+      // no navigation away and back (the bug being fixed).
+      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([SUCCEEDED_RUN]);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(12_000);
+      });
+      expect(result.current.data).toEqual([SUCCEEDED_RUN]);
+
+      // …and polling STOPS: no further requests over a long quiet window.
+      const callsAfterSettled = vi.mocked(api.listScheduledTaskRuns).mock.calls.length;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(vi.mocked(api.listScheduledTaskRuns).mock.calls.length).toBe(callsAfterSettled);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("never starts polling when the history is already all-terminal", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    try {
+      const { wrapper } = makeWrapper();
+      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([SUCCEEDED_RUN]);
+
+      const { result } = renderHook(() => useScheduledTaskRuns("st_1"), { wrapper });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.isSuccess).toBe(true);
+
+      const callsAfterFirstFetch = vi.mocked(api.listScheduledTaskRuns).mock.calls.length;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(vi.mocked(api.listScheduledTaskRuns).mock.calls.length).toBe(callsAfterFirstFetch);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops refetching once the page unmounts", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    try {
+      const { wrapper } = makeWrapper();
+      // Never settles — only the unmount can stop this.
+      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([RUNNING_RUN]);
+
+      const { result, unmount } = renderHook(() => useScheduledTaskRuns("st_1"), { wrapper });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.isSuccess).toBe(true);
       await act(async () => {
         await vi.advanceTimersByTimeAsync(10_000);
       });
-      expect(countRunRefetches(refetchSpy)).toBe(countAfterBound);
+
+      unmount();
+      const callsAtUnmount = vi.mocked(api.listScheduledTaskRuns).mock.calls.length;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(vi.mocked(api.listScheduledTaskRuns).mock.calls.length).toBe(callsAtUnmount);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("cancelRunNowPoll stops the poller (no further refetches after unmount cancel)", async () => {
+  it("keeps polling while awaitingRun even though the history is all-terminal", async () => {
+    // REGRESSION: `POST /run` returns 202 and the server writes the run row a few
+    // seconds LATER, so the invalidate right after a fire sees a history that is
+    // still entirely terminal. Keying the interval on run status alone made it
+    // evaluate to `false` at that moment and never restart — the new row never
+    // appeared at all.
     vi.useFakeTimers({ shouldAdvanceTime: false });
     try {
       const { queryClient, wrapper } = makeWrapper();
-      queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
+      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([SUCCEEDED_RUN]);
 
-      // Never settles — the poll would otherwise keep going until the bound.
-      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([RUNNING_RUN]);
-
-      const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
-      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
-
+      const { result } = renderHook(() => useScheduledTaskRuns("st_1", true, true), { wrapper });
       await act(async () => {
-        void result.current.mutateAsync("st_1");
-        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(0);
       });
+      expect(result.current.isSuccess).toBe(true);
 
-      // One poll happens, then the page "unmounts" and cancels the poller.
+      const callsAtStart = vi.mocked(api.listScheduledTaskRuns).mock.calls.length;
+      // The fired row lands a few seconds in; polling must still be running.
+      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([
+        { ...RUNNING_RUN, id: "run_new" },
+        SUCCEEDED_RUN,
+      ]);
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(800);
-      });
-      const countBeforeCancel = countRunRefetches(refetchSpy);
-      expect(countBeforeCancel).toBeGreaterThanOrEqual(1);
-
-      act(() => {
-        cancelRunNowPoll("st_1");
+        await vi.advanceTimersByTimeAsync(10_000);
       });
 
-      // No further poll refetches once cancelled, even well past the bound window.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(30_000);
-      });
-      expect(countRunRefetches(refetchSpy)).toBe(countBeforeCancel);
+      // Polling kept going despite the all-terminal history, and picked the new
+      // row up. Asserted on the cache the poll writes rather than the rendered
+      // value, which lags it by a tick under fake timers.
+      expect(vi.mocked(api.listScheduledTaskRuns).mock.calls.length).toBeGreaterThan(callsAtStart);
+      const cached = queryClient.getQueryData<api.ScheduledTaskRun[]>(scheduledTaskRunsKey("st_1"));
+      expect(cached?.[0]?.id).toBe("run_new");
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("does not fetch at all while disabled", async () => {
+    const { wrapper } = makeWrapper();
+    vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([RUNNING_RUN]);
+    renderHook(() => useScheduledTaskRuns("st_1", false), { wrapper });
+    expect(api.listScheduledTaskRuns).not.toHaveBeenCalled();
   });
 });

--- a/web/src/hooks/useScheduledTasks.test.tsx
+++ b/web/src/hooks/useScheduledTasks.test.tsx
@@ -132,98 +132,119 @@ describe("mutations invalidate the list", () => {
   });
 });
 
+const RUNNING_RUN: api.ScheduledTaskRun = { ...RUN, status: "running" };
+const SUCCEEDED_RUN: api.ScheduledTaskRun = { ...RUN, status: "succeeded" };
+
+function countRunRefetches(spy: { mock: { calls: unknown[][] } }) {
+  return spy.mock.calls.filter(
+    (args) =>
+      JSON.stringify(args[0]) === JSON.stringify({ queryKey: scheduledTaskRunsKey("st_1") }),
+  ).length;
+}
+
 describe("run-now fast-poll after 202", () => {
-  it("starts polling runs after run-now and stops once a new row appears", async () => {
+  it("keeps polling while the newest run is 'running' and stops once it reaches a terminal status", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: false });
+    try {
+      const { queryClient, wrapper } = makeWrapper();
+      queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
 
-    const { queryClient, wrapper } = makeWrapper();
+      // First refetch returns running; second returns succeeded (terminal).
+      vi.mocked(api.listScheduledTaskRuns)
+        .mockResolvedValueOnce([RUNNING_RUN])
+        .mockResolvedValue([SUCCEEDED_RUN]);
 
-    // Seed the runs query directly so there is no async waitFor needed.
-    queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
+      const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
+      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
 
-    // First refetch still returns empty; subsequent return [RUN] (new row appeared).
-    vi.mocked(api.listScheduledTaskRuns).mockResolvedValueOnce([]).mockResolvedValue([RUN]);
+      await act(async () => {
+        void result.current.mutateAsync("st_1");
+        await Promise.resolve();
+      });
 
-    const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
+      // 1s: first poll — sees RUNNING_RUN (non-terminal), keeps going.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+      expect(countRunRefetches(refetchSpy)).toBeGreaterThanOrEqual(1);
 
-    const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
+      // 1s: second poll — sees SUCCEEDED_RUN (terminal), stops.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+      const countAfterStop = countRunRefetches(refetchSpy);
+      expect(countAfterStop).toBeGreaterThanOrEqual(2);
 
-    // Fire the mutation (202 response resolves, onSuccess runs synchronously in fake-timer mode).
-    await act(async () => {
-      void result.current.mutateAsync("st_1");
-      // Drain microtasks so onSuccess fires.
-      await Promise.resolve();
-    });
-
-    // Advance 1s → first poll fires and resolves.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1_000);
-    });
-
-    // Advance 1s → second poll fires (run now visible, poller should stop after this).
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1_000);
-    });
-
-    // At least 2 refetches of the runs query (poll started and ran).
-    const runRefetches = refetchSpy.mock.calls.filter(
-      (args) =>
-        JSON.stringify(args[0]) === JSON.stringify({ queryKey: scheduledTaskRunsKey("st_1") }),
-    );
-    expect(runRefetches.length).toBeGreaterThanOrEqual(2);
-
-    // The poll is bounded: even after a further 5s, total refetches stay <= the cap.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_000);
-    });
-    const totalRunRefetches = refetchSpy.mock.calls.filter(
-      (args) =>
-        JSON.stringify(args[0]) === JSON.stringify({ queryKey: scheduledTaskRunsKey("st_1") }),
-    );
-    expect(totalRunRefetches.length).toBeLessThanOrEqual(10);
-
-    vi.useRealTimers();
+      // No more refetches in the next 5s — poller has stopped.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      expect(countRunRefetches(refetchSpy)).toBeLessThanOrEqual(20);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  it("run-now stops polling after the attempt cap even without a new row", async () => {
+  it("does NOT stop early when the new row is still running (non-terminal)", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: false });
+    try {
+      const { queryClient, wrapper } = makeWrapper();
+      queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
 
-    const { queryClient, wrapper } = makeWrapper();
+      // Runs always return the running row — never transitions to terminal.
+      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([RUNNING_RUN]);
 
-    // Seed empty runs directly — no async fetch needed.
-    queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
+      const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
+      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
 
-    // Runs never appear — always empty.
-    vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([]);
+      await act(async () => {
+        void result.current.mutateAsync("st_1");
+        await Promise.resolve();
+      });
 
-    const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
+      // After 3 polls (3s) the poller is still going (run still running).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3_000);
+      });
+      expect(countRunRefetches(refetchSpy)).toBeGreaterThanOrEqual(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
-    const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
+  it("run-now stops polling after the attempt cap even without a terminal run", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    try {
+      const { queryClient, wrapper } = makeWrapper();
+      queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
 
-    await act(async () => {
-      void result.current.mutateAsync("st_1");
-      await Promise.resolve();
-    });
+      // Runs never terminal — always returns running row (simulates stuck run).
+      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([RUNNING_RUN]);
 
-    // Advance past the 10-attempt cap (10 × 1s + 1s buffer).
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(11_000);
-    });
+      const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
+      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
 
-    const runRefetches = refetchSpy.mock.calls.filter(
-      (args) =>
-        JSON.stringify(args[0]) === JSON.stringify({ queryKey: scheduledTaskRunsKey("st_1") }),
-    );
-    // At most _RUN_NOW_POLL_MAX (10) poll refetches.
-    expect(runRefetches.length).toBeLessThanOrEqual(10);
+      await act(async () => {
+        void result.current.mutateAsync("st_1");
+        await Promise.resolve();
+      });
 
-    // No more refetches after another 5s.
-    const countAfterCap = refetchSpy.mock.calls.length;
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_000);
-    });
-    expect(refetchSpy.mock.calls.length).toBe(countAfterCap);
+      // Advance past the 20-attempt cap (20 × 1s + 1s buffer).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(21_000);
+      });
 
-    vi.useRealTimers();
+      // At most RUN_NOW_POLL_MAX (20) poll refetches.
+      expect(countRunRefetches(refetchSpy)).toBeLessThanOrEqual(20);
+
+      // No more refetches after another 5s.
+      const countAfterCap = refetchSpy.mock.calls.length;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      expect(refetchSpy.mock.calls.length).toBe(countAfterCap);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/web/src/hooks/useScheduledTasks.test.tsx
+++ b/web/src/hooks/useScheduledTasks.test.tsx
@@ -65,6 +65,9 @@ const RUN: api.ScheduledTaskRun = {
   firedAt: 1_700_000_000,
   finishedAt: null,
   errorCode: null,
+  conversationUpdatedAt: 1_700_000_500,
+  conversationStatus: "running",
+  viewerUnread: false,
 };
 
 beforeEach(() => {

--- a/web/src/hooks/useScheduledTasks.test.tsx
+++ b/web/src/hooks/useScheduledTasks.test.tsx
@@ -8,6 +8,7 @@ import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "@/lib/scheduledTasksApi";
 import {
+  cancelRunNowPoll,
   SCHEDULED_TASKS_KEY,
   scheduledTaskRunsKey,
   useCreateScheduledTask,
@@ -246,6 +247,44 @@ describe("run-now fast-poll after 202", () => {
         await vi.advanceTimersByTimeAsync(5_000);
       });
       expect(refetchSpy.mock.calls.length).toBe(countAfterCap);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancelRunNowPoll stops the poller (no further refetches after unmount cancel)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    try {
+      const { queryClient, wrapper } = makeWrapper();
+      queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
+
+      // Never terminal — the poll would otherwise keep going until the cap.
+      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([RUNNING_RUN]);
+
+      const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
+      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
+
+      await act(async () => {
+        void result.current.mutateAsync("st_1");
+        await Promise.resolve();
+      });
+
+      // One poll happens, then the page "unmounts" and cancels the poller.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+      const countBeforeCancel = countRunRefetches(refetchSpy);
+      expect(countBeforeCancel).toBeGreaterThanOrEqual(1);
+
+      act(() => {
+        cancelRunNowPoll("st_1");
+      });
+
+      // No further poll refetches once cancelled, even well past the cap window.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(25_000);
+      });
+      expect(countRunRefetches(refetchSpy)).toBe(countBeforeCancel);
     } finally {
       vi.useRealTimers();
     }

--- a/web/src/hooks/useScheduledTasks.test.tsx
+++ b/web/src/hooks/useScheduledTasks.test.tsx
@@ -1,9 +1,9 @@
-// Tests for the scheduled-tasks React-Query hooks: the list query shape and the
-// invalidate-on-success contract of the create / update / delete mutations.
-// The API client is mocked so we assert on hook wiring, not HTTP.
+// Tests for the scheduled-tasks React-Query hooks: the list query shape, the
+// invalidate-on-success contract of the create / update / delete mutations,
+// and the accelerated post-run-now run-history poll.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "@/lib/scheduledTasksApi";
@@ -19,6 +19,7 @@ import {
 
 vi.mock("@/lib/scheduledTasksApi", () => ({
   listScheduledTasks: vi.fn(),
+  listScheduledTaskRuns: vi.fn(),
   createScheduledTask: vi.fn(),
   updateScheduledTask: vi.fn(),
   deleteScheduledTask: vi.fn(),
@@ -55,8 +56,20 @@ function makeWrapper() {
   return { queryClient, wrapper };
 }
 
+const RUN: api.ScheduledTaskRun = {
+  id: "run_1",
+  scheduledTaskId: "st_1",
+  status: "running",
+  scheduledAt: 1_700_000_000,
+  conversationId: "c_1",
+  firedAt: 1_700_000_000,
+  finishedAt: null,
+  errorCode: null,
+};
+
 beforeEach(() => {
   vi.mocked(api.listScheduledTasks).mockResolvedValue([TASK]);
+  vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([]);
   vi.mocked(api.createScheduledTask).mockResolvedValue(TASK);
   vi.mocked(api.updateScheduledTask).mockResolvedValue({ ...TASK, state: "paused" });
   vi.mocked(api.deleteScheduledTask).mockResolvedValue(undefined);
@@ -114,7 +127,103 @@ describe("mutations invalidate the list", () => {
     expect(api.runScheduledTaskNow).toHaveBeenCalledWith("st_1");
     // Refreshes the list (so the completion badge updates)…
     expect(spy).toHaveBeenCalledWith({ queryKey: SCHEDULED_TASKS_KEY });
-    // …and the fired task's run history.
+    // …and the fired task's run history (via the final invalidate after polling).
     expect(spy).toHaveBeenCalledWith({ queryKey: scheduledTaskRunsKey("st_1") });
+  });
+});
+
+describe("run-now fast-poll after 202", () => {
+  it("starts polling runs after run-now and stops once a new row appears", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+
+    const { queryClient, wrapper } = makeWrapper();
+
+    // Seed the runs query directly so there is no async waitFor needed.
+    queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
+
+    // First refetch still returns empty; subsequent return [RUN] (new row appeared).
+    vi.mocked(api.listScheduledTaskRuns).mockResolvedValueOnce([]).mockResolvedValue([RUN]);
+
+    const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
+
+    const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
+
+    // Fire the mutation (202 response resolves, onSuccess runs synchronously in fake-timer mode).
+    await act(async () => {
+      void result.current.mutateAsync("st_1");
+      // Drain microtasks so onSuccess fires.
+      await Promise.resolve();
+    });
+
+    // Advance 1s → first poll fires and resolves.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    // Advance 1s → second poll fires (run now visible, poller should stop after this).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    // At least 2 refetches of the runs query (poll started and ran).
+    const runRefetches = refetchSpy.mock.calls.filter(
+      (args) =>
+        JSON.stringify(args[0]) === JSON.stringify({ queryKey: scheduledTaskRunsKey("st_1") }),
+    );
+    expect(runRefetches.length).toBeGreaterThanOrEqual(2);
+
+    // The poll is bounded: even after a further 5s, total refetches stay <= the cap.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    const totalRunRefetches = refetchSpy.mock.calls.filter(
+      (args) =>
+        JSON.stringify(args[0]) === JSON.stringify({ queryKey: scheduledTaskRunsKey("st_1") }),
+    );
+    expect(totalRunRefetches.length).toBeLessThanOrEqual(10);
+
+    vi.useRealTimers();
+  });
+
+  it("run-now stops polling after the attempt cap even without a new row", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+
+    const { queryClient, wrapper } = makeWrapper();
+
+    // Seed empty runs directly — no async fetch needed.
+    queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
+
+    // Runs never appear — always empty.
+    vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([]);
+
+    const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
+
+    const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
+
+    await act(async () => {
+      void result.current.mutateAsync("st_1");
+      await Promise.resolve();
+    });
+
+    // Advance past the 10-attempt cap (10 × 1s + 1s buffer).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(11_000);
+    });
+
+    const runRefetches = refetchSpy.mock.calls.filter(
+      (args) =>
+        JSON.stringify(args[0]) === JSON.stringify({ queryKey: scheduledTaskRunsKey("st_1") }),
+    );
+    // At most _RUN_NOW_POLL_MAX (10) poll refetches.
+    expect(runRefetches.length).toBeLessThanOrEqual(10);
+
+    // No more refetches after another 5s.
+    const countAfterCap = refetchSpy.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(refetchSpy.mock.calls.length).toBe(countAfterCap);
+
+    vi.useRealTimers();
   });
 });

--- a/web/src/hooks/useScheduledTasks.test.tsx
+++ b/web/src/hooks/useScheduledTasks.test.tsx
@@ -136,8 +136,32 @@ describe("mutations invalidate the list", () => {
   });
 });
 
-const RUNNING_RUN: api.ScheduledTaskRun = { ...RUN, status: "running" };
-const SUCCEEDED_RUN: api.ScheduledTaskRun = { ...RUN, status: "succeeded" };
+// Run row running, conversation running (fresh fire, nothing settled yet).
+const RUNNING_RUN: api.ScheduledTaskRun = {
+  ...RUN,
+  status: "running",
+  conversationStatus: "running",
+};
+// Run row terminal but the CONVERSATION is still running — the intermediate
+// state the old poll stopped on too early (BUG 1). The poll must keep going.
+const SUCCEEDED_CONV_RUNNING_RUN: api.ScheduledTaskRun = {
+  ...RUN,
+  status: "succeeded",
+  conversationStatus: "running",
+};
+// Fully settled: run terminal AND conversation left "running".
+const SUCCEEDED_RUN: api.ScheduledTaskRun = {
+  ...RUN,
+  status: "succeeded",
+  conversationStatus: "idle",
+};
+// Host-less skipped run: terminal with no conversation — nothing to wait for.
+const SKIPPED_NO_CONV_RUN: api.ScheduledTaskRun = {
+  ...RUN,
+  status: "skipped",
+  conversationId: null,
+  conversationStatus: null,
+};
 
 function countRunRefetches(spy: { mock: { calls: unknown[][] } }) {
   return spy.mock.calls.filter(
@@ -146,16 +170,33 @@ function countRunRefetches(spy: { mock: { calls: unknown[][] } }) {
   ).length;
 }
 
+// Capture the run-now poll's own setTimeout delays (isolate from react-query's
+// internal timers by filtering to the poll's interval band, ~0.7s–4s).
+function pollDelays(spy: { mock: { calls: unknown[][] } }): number[] {
+  return spy.mock.calls
+    .map((args) => args[1])
+    .filter((d): d is number => typeof d === "number" && d >= 700 && d <= 4_000);
+}
+
 describe("run-now fast-poll after 202", () => {
-  it("keeps polling while the newest run is 'running' and stops once it reaches a terminal status", async () => {
+  it("keeps polling while the CONVERSATION is still running even though the run row is terminal, and stops once it settles (BUG 1)", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: false });
     try {
       const { queryClient, wrapper } = makeWrapper();
+      // Register a queryFn so the poll's refetchQueries actually calls the mocked
+      // API (consuming the mock sequence) and writes each transition into the
+      // cache that the stop condition reads back.
+      queryClient.setQueryDefaults(scheduledTaskRunsKey("st_1"), {
+        queryFn: () => api.listScheduledTaskRuns("st_1"),
+      });
       queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
 
-      // First refetch returns running; second returns succeeded (terminal).
+      // Tick 1: run running. Tick 2: run terminal but conversation STILL running
+      // (the intermediate state the old poll stopped on too early). Tick 3+:
+      // conversation settled to idle — only now may the poll stop.
       vi.mocked(api.listScheduledTaskRuns)
         .mockResolvedValueOnce([RUNNING_RUN])
+        .mockResolvedValueOnce([SUCCEEDED_CONV_RUNNING_RUN])
         .mockResolvedValue([SUCCEEDED_RUN]);
 
       const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
@@ -166,36 +207,115 @@ describe("run-now fast-poll after 202", () => {
         await Promise.resolve();
       });
 
-      // 1s: first poll — sees RUNNING_RUN (non-terminal), keeps going.
+      // Tick 1 (~750ms): run running — keep going.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(1_000);
+        await vi.advanceTimersByTimeAsync(800);
       });
-      expect(countRunRefetches(refetchSpy)).toBeGreaterThanOrEqual(1);
+      expect(countRunRefetches(refetchSpy)).toBe(1);
 
-      // 1s: second poll — sees SUCCEEDED_RUN (terminal), stops.
+      // Tick 2 (~1275ms later): run terminal but conversation running — MUST NOT
+      // stop (the old bug). Poll continues.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(1_000);
+        await vi.advanceTimersByTimeAsync(1_300);
+      });
+      expect(countRunRefetches(refetchSpy)).toBe(2);
+
+      // Tick 3 (~2168ms later): conversation now idle — poll stops.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_200);
       });
       const countAfterStop = countRunRefetches(refetchSpy);
-      expect(countAfterStop).toBeGreaterThanOrEqual(2);
+      expect(countAfterStop).toBe(3);
 
-      // No more refetches in the next 5s — poller has stopped.
+      // No further refetches once settled, even well past the ceiling.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(5_000);
+        await vi.advanceTimersByTimeAsync(20_000);
       });
-      expect(countRunRefetches(refetchSpy)).toBeLessThanOrEqual(20);
+      expect(countRunRefetches(refetchSpy)).toBe(countAfterStop);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("does NOT stop early when the new row is still running (non-terminal)", async () => {
+  it("stops immediately when a terminal run has NO conversation (host-less skip)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    try {
+      const { queryClient, wrapper } = makeWrapper();
+      queryClient.setQueryDefaults(scheduledTaskRunsKey("st_1"), {
+        queryFn: () => api.listScheduledTaskRuns("st_1"),
+      });
+      queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
+
+      // First (and every) tick returns a terminal skipped run with no conversation
+      // — there is nothing to wait for, so the poll stops after one tick.
+      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([SKIPPED_NO_CONV_RUN]);
+
+      const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
+      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
+
+      await act(async () => {
+        void result.current.mutateAsync("st_1");
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(800);
+      });
+      expect(countRunRefetches(refetchSpy)).toBe(1);
+
+      // Poll stopped — no more refetches over the next 20s.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      });
+      expect(countRunRefetches(refetchSpy)).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses EXPONENTIAL BACKOFF for the poll interval (BUG 2)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const { queryClient, wrapper } = makeWrapper();
+      queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
+
+      // Never settles — always running — so we observe several backoff intervals.
+      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([RUNNING_RUN]);
+
+      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
+      await act(async () => {
+        void result.current.mutateAsync("st_1");
+        await Promise.resolve();
+      });
+
+      // Let several ticks fire.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15_000);
+      });
+
+      const delays = pollDelays(setTimeoutSpy);
+      // At least three intervals observed, each strictly larger than the last
+      // until the per-tick cap (~4s) is hit.
+      expect(delays.length).toBeGreaterThanOrEqual(3);
+      expect(delays[0]).toBeLessThan(delays[1]!);
+      expect(delays[1]).toBeLessThan(delays[2]!);
+      // First interval is the fast initial tick (< 1s), and none exceed the cap.
+      expect(delays[0]).toBeLessThan(1_000);
+      expect(Math.max(...delays)).toBeLessThanOrEqual(4_000);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("run-now stops polling after the bound even without a settled run", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: false });
     try {
       const { queryClient, wrapper } = makeWrapper();
       queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
 
-      // Runs always return the running row — never transitions to terminal.
+      // Runs never settle — always returns running row (simulates stuck run).
       vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([RUNNING_RUN]);
 
       const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
@@ -206,47 +326,20 @@ describe("run-now fast-poll after 202", () => {
         await Promise.resolve();
       });
 
-      // After 3 polls (3s) the poller is still going (run still running).
+      // Advance well past the ~20s time budget.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(3_000);
-      });
-      expect(countRunRefetches(refetchSpy)).toBeGreaterThanOrEqual(3);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("run-now stops polling after the attempt cap even without a terminal run", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: false });
-    try {
-      const { queryClient, wrapper } = makeWrapper();
-      queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
-
-      // Runs never terminal — always returns running row (simulates stuck run).
-      vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([RUNNING_RUN]);
-
-      const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
-      const { result } = renderHook(() => useRunScheduledTaskNow(), { wrapper });
-
-      await act(async () => {
-        void result.current.mutateAsync("st_1");
-        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(30_000);
       });
 
-      // Advance past the 20-attempt cap (20 × 1s + 1s buffer).
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(21_000);
-      });
+      // Bounded — far fewer than the old ~20 fixed-interval ticks thanks to backoff.
+      const countAfterBound = countRunRefetches(refetchSpy);
+      expect(countAfterBound).toBeLessThanOrEqual(12);
 
-      // At most RUN_NOW_POLL_MAX (20) poll refetches.
-      expect(countRunRefetches(refetchSpy)).toBeLessThanOrEqual(20);
-
-      // No more refetches after another 5s.
-      const countAfterCap = refetchSpy.mock.calls.length;
+      // No more refetches after another 10s — poller has stopped.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(5_000);
+        await vi.advanceTimersByTimeAsync(10_000);
       });
-      expect(refetchSpy.mock.calls.length).toBe(countAfterCap);
+      expect(countRunRefetches(refetchSpy)).toBe(countAfterBound);
     } finally {
       vi.useRealTimers();
     }
@@ -258,7 +351,7 @@ describe("run-now fast-poll after 202", () => {
       const { queryClient, wrapper } = makeWrapper();
       queryClient.setQueryData(scheduledTaskRunsKey("st_1"), [] as api.ScheduledTaskRun[]);
 
-      // Never terminal — the poll would otherwise keep going until the cap.
+      // Never settles — the poll would otherwise keep going until the bound.
       vi.mocked(api.listScheduledTaskRuns).mockResolvedValue([RUNNING_RUN]);
 
       const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
@@ -271,7 +364,7 @@ describe("run-now fast-poll after 202", () => {
 
       // One poll happens, then the page "unmounts" and cancels the poller.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(1_000);
+        await vi.advanceTimersByTimeAsync(800);
       });
       const countBeforeCancel = countRunRefetches(refetchSpy);
       expect(countBeforeCancel).toBeGreaterThanOrEqual(1);
@@ -280,9 +373,9 @@ describe("run-now fast-poll after 202", () => {
         cancelRunNowPoll("st_1");
       });
 
-      // No further poll refetches once cancelled, even well past the cap window.
+      // No further poll refetches once cancelled, even well past the bound window.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(25_000);
+        await vi.advanceTimersByTimeAsync(30_000);
       });
       expect(countRunRefetches(refetchSpy)).toBe(countBeforeCancel);
     } finally {

--- a/web/src/hooks/useScheduledTasks.ts
+++ b/web/src/hooks/useScheduledTasks.ts
@@ -10,6 +10,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   createScheduledTask,
   deleteScheduledTask,
+  getScheduledTask,
   listScheduledTaskRuns,
   listScheduledTasks,
   runScheduledTaskNow,
@@ -22,6 +23,11 @@ import {
 
 /** Query key for the caller's scheduled-tasks list. */
 export const SCHEDULED_TASKS_KEY = ["scheduled-tasks"] as const;
+
+/** Query key for one task's detail. */
+export function scheduledTaskKey(id: string): readonly unknown[] {
+  return ["scheduled-task", id];
+}
 
 /** Query key for one task's run history. */
 export function scheduledTaskRunsKey(id: string): readonly unknown[] {
@@ -51,6 +57,27 @@ export function useScheduledTasks() {
     // persistent scheduled-tasks indicator, add a SEPARATE lightweight query
     // (no short refetchInterval, or a much longer one) — don't reuse this one.
     refetchInterval: 60_000,
+  });
+}
+
+/**
+ * One task's detail (the `/tasks/:taskId` page). Seeds initial data from the
+ * already-cached list so navigating from the list paints instantly, then
+ * refetches to pick up any fields the list row didn't carry / staleness. The
+ * seed is `placeholderData` (not `initialData`) so the query is still
+ * considered stale and refetches immediately — a task edited elsewhere won't
+ * show a frozen list snapshot. `enabled` gates the fetch (e.g. a missing id).
+ */
+export function useScheduledTask(id: string, enabled: boolean = true) {
+  const queryClient = useQueryClient();
+  return useQuery<ScheduledTask>({
+    queryKey: scheduledTaskKey(id),
+    queryFn: () => getScheduledTask(id),
+    enabled: enabled && id !== "",
+    staleTime: 30_000,
+    // Paint from the list cache while the detail fetch is in flight.
+    placeholderData: () =>
+      queryClient.getQueryData<ScheduledTask[]>(SCHEDULED_TASKS_KEY)?.find((t) => t.id === id),
   });
 }
 
@@ -86,6 +113,8 @@ export function useUpdateScheduledTask() {
       updateScheduledTask(id, input),
     onSuccess: (updated) => {
       void queryClient.invalidateQueries({ queryKey: SCHEDULED_TASKS_KEY });
+      // Refresh the detail query so the /tasks/:id page reflects the edit.
+      void queryClient.invalidateQueries({ queryKey: scheduledTaskKey(updated.id) });
       // A schedule/state change can shift the run history too (e.g. a
       // just-reactivated task), so refresh that task's runs if they're loaded.
       void queryClient.invalidateQueries({ queryKey: scheduledTaskRunsKey(updated.id) });
@@ -116,6 +145,7 @@ export function useRunScheduledTaskNow() {
     mutationFn: (id: string) => runScheduledTaskNow(id),
     onSuccess: (_data, id) => {
       void queryClient.invalidateQueries({ queryKey: SCHEDULED_TASKS_KEY });
+      void queryClient.invalidateQueries({ queryKey: scheduledTaskKey(id) });
       void queryClient.invalidateQueries({ queryKey: scheduledTaskRunsKey(id) });
     },
   });

--- a/web/src/hooks/useScheduledTasks.ts
+++ b/web/src/hooks/useScheduledTasks.ts
@@ -81,16 +81,82 @@ export function useScheduledTask(id: string, enabled: boolean = true) {
   });
 }
 
+// Statuses a run can still move OUT of. Everything else (succeeded / failed /
+// skipped, plus any status this client doesn't know) is treated as settled, so
+// an unrecognised value can never strand the poll below in an infinite loop.
+const ACTIVE_RUN_STATUSES = new Set(["running", "scheduled"]);
+
+/** Live-refresh cadence for a task's run history while anything is in flight. */
+const RUNS_REFETCH_INTERVAL_MS = 4_000;
+
+/**
+ * Whether a run list still has work in flight, i.e. a value the server is
+ * expected to change on its own.
+ *
+ * TWO-PART, because a run row and its conversation settle at different times.
+ * The row flips to a terminal status a beat BEFORE its conversation leaves
+ * "running" and bumps `updated_at`, and the unread dot (`isConversationUnseen`)
+ * keys off the CONVERSATION, not the row. Stopping on run-terminal alone would
+ * end the refresh one step too early — the last fetch would still observe a
+ * "running" conversation, leaving the dot grey until a remount refetched the
+ * now-idle conversation. A run with no conversation (host-less skip/fail) never
+ * gets one, so there is nothing to wait for.
+ *
+ * @param runs Run history as returned by the server (most-recent-first).
+ * @returns `true` while any run — or any run's conversation — is unsettled.
+ */
+export function hasUnsettledRun(runs: ScheduledTaskRun[] | undefined): boolean {
+  if (runs == null) return false;
+  return runs.some(
+    (run) =>
+      ACTIVE_RUN_STATUSES.has(run.status) ||
+      (run.conversationId != null && run.conversationStatus === "running"),
+  );
+}
+
 /**
  * One task's run history (most-recent-first). `enabled` gates the fetch so an
  * unexpanded row costs nothing.
+ *
+ * POLLING CONTRACT — status-aware, and the ONLY thing that drives a run row to
+ * its terminal state on-screen. Real runs take MINUTES (multi-minute agent turns
+ * are routine), so a one-shot invalidate after "Run now" cannot settle the row:
+ * the refresh has to outlive the run. While any run is unsettled
+ * (`hasUnsettledRun`) we refetch every few seconds; once everything is terminal
+ * the interval returns `false` and polling STOPS — no steady-state traffic.
+ *
+ * Reads the stop condition from the query's OWN cached data, so it never feeds
+ * back through the caller (same shape as `terminalsReconcileInterval` in
+ * `useTerminals.ts`). Like every `refetchInterval`, it only runs while a
+ * component mounting this hook is mounted — TanStack Query tears the interval
+ * down on unmount, so navigating away ends it with no manual cleanup.
+ *
+ * A run stuck in `running` (host died mid-turn) keeps the interval alive while
+ * the page stays open. That is deliberate and self-limiting: each poll is a READ
+ * of the runs endpoint, which is exactly what triggers the server's
+ * lazy-on-read stale-run backstop (`force_fail_stale_runs`) that force-fails the
+ * row and lets polling stop.
+ *
+ * @param awaitingRun Whether a "Run now" was just fired and its row has not
+ *     appeared yet. Load-bearing: `POST /run` returns 202 and writes the row a
+ *     few seconds LATER, so the invalidate that follows it observes a history
+ *     that is still entirely terminal. Without this the interval would evaluate
+ *     to `false` right after a fire and never restart, so the new row would not
+ *     appear at all. The caller is responsible for clearing the flag (on row
+ *     arrival, or a safety timeout), which bounds this side of the condition.
  */
-export function useScheduledTaskRuns(id: string, enabled: boolean = true) {
+export function useScheduledTaskRuns(
+  id: string,
+  enabled: boolean = true,
+  awaitingRun: boolean = false,
+) {
   return useQuery<ScheduledTaskRun[]>({
     queryKey: scheduledTaskRunsKey(id),
     queryFn: () => listScheduledTaskRuns(id),
     enabled,
     staleTime: 30_000,
+    refetchInterval: (query) =>
+      awaitingRun || hasUnsettledRun(query.state.data) ? RUNS_REFETCH_INTERVAL_MS : false,
   });
 }
 
@@ -133,71 +199,24 @@ export function useDeleteScheduledTask() {
   });
 }
 
-// Post-run-now accelerated poll tuning. The poll uses EXPONENTIAL BACKOFF rather
-// than a fixed interval: it starts fast (to resolve the common ~5-8s run quickly)
-// and slows down, so a slow run still settles without spamming the server. The
-// interval starts at ~750ms, multiplies by ~1.7 each tick, and is capped per-tick
-// at ~4s; a total time budget of ~20s (plus an attempt safety cap) bounds it,
-// roughly matching the old fixed-1s/20-attempt ceiling but with far fewer
-// requests in the common case (~4 ticks vs ~8).
-const RUN_NOW_POLL_INITIAL_MS = 750;
-const RUN_NOW_POLL_BACKOFF_FACTOR = 1.7;
-const RUN_NOW_POLL_MAX_INTERVAL_MS = 4_000;
-const RUN_NOW_POLL_CEILING_MS = 20_000;
-// Hard safety cap on attempts, independent of the time budget (which is the
-// primary bound). With backoff the budget is reached in well under this many
-// ticks; this only guards against a degenerate timing schedule.
-const RUN_NOW_POLL_MAX = 12;
-
-const TERMINAL_STATUSES = new Set(["succeeded", "failed", "skipped"]);
-
-// Guard against stacking pollers when Run now is clicked rapidly. One active
-// poller per task id at a time — the timer id is stored here and cleared when
-// the poll finishes or yields to a newer one.
-const runNowPollers: Map<string, ReturnType<typeof setTimeout>> = new Map();
-
-/**
- * Cancel the accelerated run-now poller for a task id, if one is active: clears
- * its pending timer and drops it from the module-global map. Idempotent (a no-op
- * when there is no poller for the id). Call it from an unmount effect in any
- * component that fired a run-now so the self-scheduling `setTimeout` chain stops
- * issuing `refetchQueries` after the user navigates away — mirroring how
- * TaskDetailPage cancels its own awaiting-run timer on unmount. The poll is
- * already self-bounded (RUN_NOW_POLL_MAX / terminal status) and only touches the
- * unmount-safe queryClient, so this just avoids the wasted background refetches.
- */
-export function cancelRunNowPoll(id: string): void {
-  const timer = runNowPollers.get(id);
-  if (timer != null) clearTimeout(timer);
-  runNowPollers.delete(id);
-}
-
 /**
  * Trigger an immediate ("run now") fire of a task, then refresh the list and
- * that task's run history. The server returns 202 (fire-and-forget) and writes
- * the run row in the background as status "running", then transitions it to a
- * terminal status ("succeeded"/"failed"/"skipped") a few seconds later. A
- * single invalidate would miss both transitions. We kick off a bounded
- * accelerated poll and stop only once the fired run is fully settled.
+ * that task's run history.
  *
- * STOP CONDITION — two-part, because the run row and its conversation settle at
- * different times. The run row flips to a terminal status (succeeded/failed/
- * skipped) a beat BEFORE its conversation leaves "running" and bumps
- * updated_at. The unread dot (`isConversationUnseen`) keys off the CONVERSATION,
- * not the run row, and stays grey while the conversation is still "running". So
- * stopping on run-terminal alone would end the poll one step too early — the
- * final /runs fetch would still observe a "running" conversation, leaving the
- * dot grey until a remount refetched the now-idle conversation. We therefore
- * keep polling until BOTH (a) the fired run row is terminal AND (b) its
- * conversation has left "running" (or the run has no conversation at all — a
- * host-less skipped/failed run never gets one, so there is nothing to wait for).
- * That way the last fetch happens while the page is mounted and the dot flips to
- * pink WITHOUT navigating away.
+ * The server returns 202 (fire-and-forget) and writes the run row in the
+ * background as status "running", then transitions it to a terminal status
+ * ("succeeded"/"failed"/"skipped") once the agent turn finishes — which for a
+ * real run is MINUTES later. This mutation deliberately only invalidates: it
+ * makes the new "running" row appear promptly and does NOT try to chase the
+ * run to completion.
  *
- * INTERVAL — exponential backoff (see the RUN_NOW_POLL_* constants) rather than
- * a fixed 1s: fast first ticks resolve the common ~5-8s run quickly, then the
- * interval grows so a slow run still settles without spamming GET /runs. A total
- * time budget (~20s) plus an attempt cap bound it.
+ * Driving the row to its terminal state is `useScheduledTaskRuns`'s
+ * status-aware `refetchInterval`, which keeps refreshing for as long as the run
+ * is unsettled and stops when it isn't. That replaced an accelerated poll that
+ * lived here: a mutation-scoped poll has to guess a time budget up front, and
+ * any budget short enough to avoid hammering the server was far too short for a
+ * multi-minute run — it gave up mid-run and left the row spinning until a
+ * remount refetched it. The query-level interval has no budget to exhaust.
  */
 export function useRunScheduledTaskNow() {
   const queryClient = useQueryClient();
@@ -206,64 +225,9 @@ export function useRunScheduledTaskNow() {
     onSuccess: (_data, id) => {
       void queryClient.invalidateQueries({ queryKey: SCHEDULED_TASKS_KEY });
       void queryClient.invalidateQueries({ queryKey: scheduledTaskKey(id) });
-
-      // Immediate invalidate so callers not on the detail page still see a fast
-      // refresh (mirrors the old behaviour; the poll below is additive).
+      // Surfaces the new "running" row immediately; the run-history
+      // refetchInterval takes it from there.
       void queryClient.invalidateQueries({ queryKey: scheduledTaskRunsKey(id) });
-
-      // Snapshot the pre-fire newest-run id so we can identify the new row.
-      const pre = queryClient.getQueryData<ScheduledTaskRun[]>(scheduledTaskRunsKey(id));
-      const preNewestId = pre?.[0]?.id ?? null;
-
-      // Cancel any in-flight poller for this task (double-click guard).
-      const existing = runNowPollers.get(id);
-      if (existing != null) clearTimeout(existing);
-
-      let attempts = 0;
-      const startedAt = Date.now();
-
-      // The next backoff interval for the given (1-indexed) attempt number,
-      // capped per-tick. attempt 1 → ~750ms, 2 → ~1275ms, 3 → ~2168ms, …
-      function nextIntervalMs(attemptNumber: number): number {
-        const raw = RUN_NOW_POLL_INITIAL_MS * RUN_NOW_POLL_BACKOFF_FACTOR ** (attemptNumber - 1);
-        return Math.min(raw, RUN_NOW_POLL_MAX_INTERVAL_MS);
-      }
-
-      function poll() {
-        attempts += 1;
-        void queryClient.refetchQueries({ queryKey: scheduledTaskRunsKey(id) }).then(() => {
-          const current = queryClient.getQueryData<ScheduledTaskRun[]>(scheduledTaskRunsKey(id));
-          // The newest run is index 0 (most-recent-first). Only the run we JUST
-          // fired counts — a new row still "running"/"scheduled" keeps polling.
-          const newestRun = current?.[0];
-          const isNewRun = newestRun != null && newestRun.id !== preNewestId;
-          const isRunTerminal = isNewRun && TERMINAL_STATUSES.has(newestRun.status);
-          // Conversation-settled: a run with no conversation (host-less skip/fail)
-          // has nothing to wait for; a run WITH a conversation must have left
-          // "running" so the final fetch observes the idle conversation and the
-          // unread dot flips to pink on-page (BUG 1).
-          const hasConversation = isNewRun && newestRun.conversationId != null;
-          const conversationSettled =
-            isRunTerminal &&
-            (!hasConversation ||
-              (newestRun.conversationStatus != null && newestRun.conversationStatus !== "running"));
-
-          const budgetExhausted =
-            attempts >= RUN_NOW_POLL_MAX || Date.now() - startedAt >= RUN_NOW_POLL_CEILING_MS;
-
-          if (conversationSettled || budgetExhausted) {
-            // Fully settled (or bound reached) — final invalidate and stop.
-            runNowPollers.delete(id);
-            void queryClient.invalidateQueries({ queryKey: scheduledTaskRunsKey(id) });
-          } else {
-            const timer = setTimeout(poll, nextIntervalMs(attempts + 1));
-            runNowPollers.set(id, timer);
-          }
-        });
-      }
-
-      const timer = setTimeout(poll, nextIntervalMs(1));
-      runNowPollers.set(id, timer);
     },
   });
 }

--- a/web/src/hooks/useScheduledTasks.ts
+++ b/web/src/hooks/useScheduledTasks.ts
@@ -133,11 +133,24 @@ export function useDeleteScheduledTask() {
   });
 }
 
+// Max attempts and interval for the post-run-now accelerated poll. The poll
+// stops as soon as a new run row appears, or after the cap (~10s ceiling).
+const RUN_NOW_POLL_MAX = 10;
+const RUN_NOW_POLL_INTERVAL_MS = 1_000;
+
+// Guard against stacking pollers when Run now is clicked rapidly. One active
+// poller per task id at a time — the timer id is stored here and cleared when
+// the poll finishes or yields to a newer one.
+const runNowPollers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+
 /**
  * Trigger an immediate ("run now") fire of a task, then refresh the list and
- * that task's run history so the completion badge (last-run status) reflects
- * the new run. The server launches the run in the background (202), so the
- * badge lands on the next list poll / invalidation rather than synchronously.
+ * that task's run history. The server returns 202 (fire-and-forget) and writes
+ * the run row in the background, so a single invalidate would miss it until the
+ * 60s background poll. To make the new run appear within ~1-2s, we kick off a
+ * bounded accelerated poll of the runs query after success: refetch every 1s
+ * until a new run row lands or after 10 attempts (~10s ceiling), then do a
+ * final invalidate and stop.
  */
 export function useRunScheduledTaskNow() {
   const queryClient = useQueryClient();
@@ -146,7 +159,39 @@ export function useRunScheduledTaskNow() {
     onSuccess: (_data, id) => {
       void queryClient.invalidateQueries({ queryKey: SCHEDULED_TASKS_KEY });
       void queryClient.invalidateQueries({ queryKey: scheduledTaskKey(id) });
+
+      // Immediate invalidate so callers not on the detail page still see a fast
+      // refresh (mirrors the old behaviour; the poll below is additive).
       void queryClient.invalidateQueries({ queryKey: scheduledTaskRunsKey(id) });
+
+      // Snapshot the pre-fire run count so we know when a new row has landed.
+      const pre = queryClient.getQueryData<ScheduledTaskRun[]>(scheduledTaskRunsKey(id));
+      const preCount = pre?.length ?? 0;
+
+      // Cancel any in-flight poller for this task (double-click guard).
+      const existing = runNowPollers.get(id);
+      if (existing != null) clearTimeout(existing);
+
+      let attempts = 0;
+
+      function poll() {
+        attempts += 1;
+        void queryClient.refetchQueries({ queryKey: scheduledTaskRunsKey(id) }).then(() => {
+          const current = queryClient.getQueryData<ScheduledTaskRun[]>(scheduledTaskRunsKey(id));
+          const currentCount = current?.length ?? 0;
+          if (currentCount > preCount || attempts >= RUN_NOW_POLL_MAX) {
+            // New row appeared (or cap reached) — do a final broad invalidate and stop.
+            runNowPollers.delete(id);
+            void queryClient.invalidateQueries({ queryKey: scheduledTaskRunsKey(id) });
+          } else {
+            const timer = setTimeout(poll, RUN_NOW_POLL_INTERVAL_MS);
+            runNowPollers.set(id, timer);
+          }
+        });
+      }
+
+      const timer = setTimeout(poll, RUN_NOW_POLL_INTERVAL_MS);
+      runNowPollers.set(id, timer);
     },
   });
 }

--- a/web/src/hooks/useScheduledTasks.ts
+++ b/web/src/hooks/useScheduledTasks.ts
@@ -133,11 +133,21 @@ export function useDeleteScheduledTask() {
   });
 }
 
-// Max attempts and interval for the post-run-now accelerated poll. The poll
-// stops when the newest run reaches a terminal status, or after the cap (~20s
-// ceiling — enough to cover the typical ~5s running→succeeded transition).
-const RUN_NOW_POLL_MAX = 20;
-const RUN_NOW_POLL_INTERVAL_MS = 1_000;
+// Post-run-now accelerated poll tuning. The poll uses EXPONENTIAL BACKOFF rather
+// than a fixed interval: it starts fast (to resolve the common ~5-8s run quickly)
+// and slows down, so a slow run still settles without spamming the server. The
+// interval starts at ~750ms, multiplies by ~1.7 each tick, and is capped per-tick
+// at ~4s; a total time budget of ~20s (plus an attempt safety cap) bounds it,
+// roughly matching the old fixed-1s/20-attempt ceiling but with far fewer
+// requests in the common case (~4 ticks vs ~8).
+const RUN_NOW_POLL_INITIAL_MS = 750;
+const RUN_NOW_POLL_BACKOFF_FACTOR = 1.7;
+const RUN_NOW_POLL_MAX_INTERVAL_MS = 4_000;
+const RUN_NOW_POLL_CEILING_MS = 20_000;
+// Hard safety cap on attempts, independent of the time budget (which is the
+// primary bound). With backoff the budget is reached in well under this many
+// ticks; this only guards against a degenerate timing schedule.
+const RUN_NOW_POLL_MAX = 12;
 
 const TERMINAL_STATUSES = new Set(["succeeded", "failed", "skipped"]);
 
@@ -168,10 +178,26 @@ export function cancelRunNowPoll(id: string): void {
  * the run row in the background as status "running", then transitions it to a
  * terminal status ("succeeded"/"failed"/"skipped") a few seconds later. A
  * single invalidate would miss both transitions. We kick off a bounded
- * accelerated poll: refetch every 1s until the newest run reaches a terminal
- * status, or after the 20-attempt cap (~20s ceiling), then final-invalidate and
- * stop. This ensures the spinner resolves and the unread dot appears once the
- * run completes.
+ * accelerated poll and stop only once the fired run is fully settled.
+ *
+ * STOP CONDITION — two-part, because the run row and its conversation settle at
+ * different times. The run row flips to a terminal status (succeeded/failed/
+ * skipped) a beat BEFORE its conversation leaves "running" and bumps
+ * updated_at. The unread dot (`isConversationUnseen`) keys off the CONVERSATION,
+ * not the run row, and stays grey while the conversation is still "running". So
+ * stopping on run-terminal alone would end the poll one step too early — the
+ * final /runs fetch would still observe a "running" conversation, leaving the
+ * dot grey until a remount refetched the now-idle conversation. We therefore
+ * keep polling until BOTH (a) the fired run row is terminal AND (b) its
+ * conversation has left "running" (or the run has no conversation at all — a
+ * host-less skipped/failed run never gets one, so there is nothing to wait for).
+ * That way the last fetch happens while the page is mounted and the dot flips to
+ * pink WITHOUT navigating away.
+ *
+ * INTERVAL — exponential backoff (see the RUN_NOW_POLL_* constants) rather than
+ * a fixed 1s: fast first ticks resolve the common ~5-8s run quickly, then the
+ * interval grows so a slow run still settles without spamming GET /runs. A total
+ * time budget (~20s) plus an attempt cap bound it.
  */
 export function useRunScheduledTaskNow() {
   const queryClient = useQueryClient();
@@ -194,29 +220,49 @@ export function useRunScheduledTaskNow() {
       if (existing != null) clearTimeout(existing);
 
       let attempts = 0;
+      const startedAt = Date.now();
+
+      // The next backoff interval for the given (1-indexed) attempt number,
+      // capped per-tick. attempt 1 → ~750ms, 2 → ~1275ms, 3 → ~2168ms, …
+      function nextIntervalMs(attemptNumber: number): number {
+        const raw = RUN_NOW_POLL_INITIAL_MS * RUN_NOW_POLL_BACKOFF_FACTOR ** (attemptNumber - 1);
+        return Math.min(raw, RUN_NOW_POLL_MAX_INTERVAL_MS);
+      }
 
       function poll() {
         attempts += 1;
         void queryClient.refetchQueries({ queryKey: scheduledTaskRunsKey(id) }).then(() => {
           const current = queryClient.getQueryData<ScheduledTaskRun[]>(scheduledTaskRunsKey(id));
-          // The newest run is index 0 (most-recent-first). We only stop once the
-          // RUN WE JUST FIRED has reached a terminal status — a new row that is
-          // still "running"/"scheduled" keeps the poll going.
+          // The newest run is index 0 (most-recent-first). Only the run we JUST
+          // fired counts — a new row still "running"/"scheduled" keeps polling.
           const newestRun = current?.[0];
           const isNewRun = newestRun != null && newestRun.id !== preNewestId;
-          const isTerminal = isNewRun && TERMINAL_STATUSES.has(newestRun.status);
-          if (isTerminal || attempts >= RUN_NOW_POLL_MAX) {
-            // Terminal (or cap reached) — final invalidate and stop.
+          const isRunTerminal = isNewRun && TERMINAL_STATUSES.has(newestRun.status);
+          // Conversation-settled: a run with no conversation (host-less skip/fail)
+          // has nothing to wait for; a run WITH a conversation must have left
+          // "running" so the final fetch observes the idle conversation and the
+          // unread dot flips to pink on-page (BUG 1).
+          const hasConversation = isNewRun && newestRun.conversationId != null;
+          const conversationSettled =
+            isRunTerminal &&
+            (!hasConversation ||
+              (newestRun.conversationStatus != null && newestRun.conversationStatus !== "running"));
+
+          const budgetExhausted =
+            attempts >= RUN_NOW_POLL_MAX || Date.now() - startedAt >= RUN_NOW_POLL_CEILING_MS;
+
+          if (conversationSettled || budgetExhausted) {
+            // Fully settled (or bound reached) — final invalidate and stop.
             runNowPollers.delete(id);
             void queryClient.invalidateQueries({ queryKey: scheduledTaskRunsKey(id) });
           } else {
-            const timer = setTimeout(poll, RUN_NOW_POLL_INTERVAL_MS);
+            const timer = setTimeout(poll, nextIntervalMs(attempts + 1));
             runNowPollers.set(id, timer);
           }
         });
       }
 
-      const timer = setTimeout(poll, RUN_NOW_POLL_INTERVAL_MS);
+      const timer = setTimeout(poll, nextIntervalMs(1));
       runNowPollers.set(id, timer);
     },
   });

--- a/web/src/hooks/useScheduledTasks.ts
+++ b/web/src/hooks/useScheduledTasks.ts
@@ -147,6 +147,22 @@ const TERMINAL_STATUSES = new Set(["succeeded", "failed", "skipped"]);
 const runNowPollers: Map<string, ReturnType<typeof setTimeout>> = new Map();
 
 /**
+ * Cancel the accelerated run-now poller for a task id, if one is active: clears
+ * its pending timer and drops it from the module-global map. Idempotent (a no-op
+ * when there is no poller for the id). Call it from an unmount effect in any
+ * component that fired a run-now so the self-scheduling `setTimeout` chain stops
+ * issuing `refetchQueries` after the user navigates away — mirroring how
+ * TaskDetailPage cancels its own awaiting-run timer on unmount. The poll is
+ * already self-bounded (RUN_NOW_POLL_MAX / terminal status) and only touches the
+ * unmount-safe queryClient, so this just avoids the wasted background refetches.
+ */
+export function cancelRunNowPoll(id: string): void {
+  const timer = runNowPollers.get(id);
+  if (timer != null) clearTimeout(timer);
+  runNowPollers.delete(id);
+}
+
+/**
  * Trigger an immediate ("run now") fire of a task, then refresh the list and
  * that task's run history. The server returns 202 (fire-and-forget) and writes
  * the run row in the background as status "running", then transitions it to a

--- a/web/src/hooks/useScheduledTasks.ts
+++ b/web/src/hooks/useScheduledTasks.ts
@@ -134,9 +134,12 @@ export function useDeleteScheduledTask() {
 }
 
 // Max attempts and interval for the post-run-now accelerated poll. The poll
-// stops as soon as a new run row appears, or after the cap (~10s ceiling).
-const RUN_NOW_POLL_MAX = 10;
+// stops when the newest run reaches a terminal status, or after the cap (~20s
+// ceiling — enough to cover the typical ~5s running→succeeded transition).
+const RUN_NOW_POLL_MAX = 20;
 const RUN_NOW_POLL_INTERVAL_MS = 1_000;
+
+const TERMINAL_STATUSES = new Set(["succeeded", "failed", "skipped"]);
 
 // Guard against stacking pollers when Run now is clicked rapidly. One active
 // poller per task id at a time — the timer id is stored here and cleared when
@@ -146,11 +149,13 @@ const runNowPollers: Map<string, ReturnType<typeof setTimeout>> = new Map();
 /**
  * Trigger an immediate ("run now") fire of a task, then refresh the list and
  * that task's run history. The server returns 202 (fire-and-forget) and writes
- * the run row in the background, so a single invalidate would miss it until the
- * 60s background poll. To make the new run appear within ~1-2s, we kick off a
- * bounded accelerated poll of the runs query after success: refetch every 1s
- * until a new run row lands or after 10 attempts (~10s ceiling), then do a
- * final invalidate and stop.
+ * the run row in the background as status "running", then transitions it to a
+ * terminal status ("succeeded"/"failed"/"skipped") a few seconds later. A
+ * single invalidate would miss both transitions. We kick off a bounded
+ * accelerated poll: refetch every 1s until the newest run reaches a terminal
+ * status, or after the 20-attempt cap (~20s ceiling), then final-invalidate and
+ * stop. This ensures the spinner resolves and the unread dot appears once the
+ * run completes.
  */
 export function useRunScheduledTaskNow() {
   const queryClient = useQueryClient();
@@ -164,9 +169,9 @@ export function useRunScheduledTaskNow() {
       // refresh (mirrors the old behaviour; the poll below is additive).
       void queryClient.invalidateQueries({ queryKey: scheduledTaskRunsKey(id) });
 
-      // Snapshot the pre-fire run count so we know when a new row has landed.
+      // Snapshot the pre-fire newest-run id so we can identify the new row.
       const pre = queryClient.getQueryData<ScheduledTaskRun[]>(scheduledTaskRunsKey(id));
-      const preCount = pre?.length ?? 0;
+      const preNewestId = pre?.[0]?.id ?? null;
 
       // Cancel any in-flight poller for this task (double-click guard).
       const existing = runNowPollers.get(id);
@@ -178,9 +183,14 @@ export function useRunScheduledTaskNow() {
         attempts += 1;
         void queryClient.refetchQueries({ queryKey: scheduledTaskRunsKey(id) }).then(() => {
           const current = queryClient.getQueryData<ScheduledTaskRun[]>(scheduledTaskRunsKey(id));
-          const currentCount = current?.length ?? 0;
-          if (currentCount > preCount || attempts >= RUN_NOW_POLL_MAX) {
-            // New row appeared (or cap reached) — do a final broad invalidate and stop.
+          // The newest run is index 0 (most-recent-first). We only stop once the
+          // RUN WE JUST FIRED has reached a terminal status — a new row that is
+          // still "running"/"scheduled" keeps the poll going.
+          const newestRun = current?.[0];
+          const isNewRun = newestRun != null && newestRun.id !== preNewestId;
+          const isTerminal = isNewRun && TERMINAL_STATUSES.has(newestRun.status);
+          if (isTerminal || attempts >= RUN_NOW_POLL_MAX) {
+            // Terminal (or cap reached) — final invalidate and stop.
             runNowPollers.delete(id);
             void queryClient.invalidateQueries({ queryKey: scheduledTaskRunsKey(id) });
           } else {

--- a/web/src/hooks/useUnseenConversations.test.ts
+++ b/web/src/hooks/useUnseenConversations.test.ts
@@ -156,6 +156,36 @@ describe("markConversationSeen", () => {
   });
 });
 
+describe("seedRunUnreadBaseline", () => {
+  it("pins the baseline just below updatedAt and makes the dot show via isConversationUnseen", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([]);
+    authFetch.mockClear();
+
+    mod.seedRunUnreadBaseline("conv-1", 5_000);
+
+    expect(mod.isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
+    // Crucially: no explicitlyUnread override — markConversationSeen is not blocked.
+    expect(mod.isExplicitlyUnread("conv-1")).toBe(false);
+  });
+
+  it("does NOT block markConversationSeen — opening the conversation clears the dot", async () => {
+    // Regression: markConversationUnread set explicitlyUnread, blocking markConversationSeen
+    // (useMarkConversationSeen's initial-mount guard skips clearUnreadOverride on a fresh
+    // ChatPage mount). seedRunUnreadBaseline omits the override so the dot clears on open.
+    const mod = await loadFresh();
+    mod.seedReadState([]);
+    vi.useFakeTimers({ now: 6_000_000 });
+    setWindowFocused(true);
+
+    mod.seedRunUnreadBaseline("conv-1", 5_000);
+    expect(mod.isConversationUnseen("conv-1", 5_000, "idle")).toBe(true); // dot shows
+
+    mod.markConversationSeen("conv-1"); // simulates ChatPage opening the conversation
+    expect(mod.isConversationUnseen("conv-1", 5_000, "idle")).toBe(false); // dot clears
+  });
+});
+
 describe("markConversationUnread", () => {
   it("pins the baseline just below updated_at and flags + PUTs unread", async () => {
     const mod = await loadFresh();

--- a/web/src/hooks/useUnseenConversations.ts
+++ b/web/src/hooks/useUnseenConversations.ts
@@ -262,6 +262,26 @@ export function markConversationSeen(conversationId: string, atSeconds?: number)
 }
 
 /**
+ * Seeds a run-history unread dot for a freshly-completed scheduled-task run
+ * without setting the {@link explicitlyUnread} override. The dot condition
+ * (`updated_at > stored`) is satisfied by pinning the baseline just below
+ * `updatedAt`, exactly like {@link markConversationUnread}, but omitting the
+ * override means {@link markConversationSeen} is NOT blocked when the user
+ * clicks through from the detail page — so the dot clears on open as expected.
+ *
+ * The override is deliberately withheld because the run's conversation is never
+ * the "active thread" while the user is on `/tasks/:taskId`, so the suppression
+ * that `explicitlyUnread` provides (keeping the dot alive while you're looking
+ * at the thread) is not needed here and would instead prevent the dot from
+ * clearing on click-through.
+ */
+export function seedRunUnreadBaseline(conversationId: string, updatedAt: number): void {
+  lastSeenMap[conversationId] = updatedAt - 1;
+  persistToStorage();
+  notifySubscribers();
+}
+
+/**
  * Forces a conversation back to "unseen" — the inverse of
  * {@link markConversationSeen}, backing the kebab's "Mark as unread".
  * The dot's condition is `updated_at > stored`, so the baseline is

--- a/web/src/lib/scheduleText.test.ts
+++ b/web/src/lib/scheduleText.test.ts
@@ -504,10 +504,10 @@ describe("formatRunTimestamp", () => {
 describe("describeRunError", () => {
   it("maps known fire-path error codes to human copy", () => {
     expect(describeRunError("no_online_host", "skipped")).toBe(
-      "Host was offline at fire time — run skipped",
+      "Host was offline at fire time. Run skipped.",
     );
     expect(describeRunError("incomplete", "failed")).toBe(
-      "The host went away mid-run — run left incomplete",
+      "The host went away mid-run. Run left incomplete.",
     );
     expect(describeRunError("launch_failed", "failed")).toBe("The agent session failed to launch");
   });

--- a/web/src/lib/scheduleText.test.ts
+++ b/web/src/lib/scheduleText.test.ts
@@ -512,6 +512,25 @@ describe("describeRunError", () => {
     expect(describeRunError("launch_failed", "failed")).toBe("The agent session failed to launch");
   });
 
+  it("maps permanent-misconfig codes to config-fixing copy (now recorded as failed)", () => {
+    expect(describeRunError("invalid_input", "failed")).toBe(
+      "This task's model or workspace is invalid. Edit the task to fix it.",
+    );
+    const missingCopy = "This task is missing its host or workspace. Edit the task to fix it.";
+    expect(describeRunError("missing_workspace", "failed")).toBe(missingCopy);
+    expect(describeRunError("missing_host_id", "failed")).toBe(missingCopy);
+    expect(describeRunError("missing_execution_input", "failed")).toBe(missingCopy);
+  });
+
+  it("keeps host-availability codes as skipped copy", () => {
+    expect(describeRunError("host_offline", "skipped")).toBe(
+      "The pinned host was offline. Run skipped.",
+    );
+    expect(describeRunError("default_workspace_unresolved", "skipped")).toBe(
+      "Couldn't resolve a workspace on the host. Run skipped.",
+    );
+  });
+
   it("falls back to a status-keyed generic for an unknown / null code", () => {
     expect(describeRunError("some_new_code", "skipped")).toBe("Run skipped");
     expect(describeRunError(null, "failed")).toBe("Run failed");

--- a/web/src/lib/scheduleText.test.ts
+++ b/web/src/lib/scheduleText.test.ts
@@ -6,7 +6,15 @@
 
 import { describe, expect, it } from "vitest";
 import { RRule, rrulestr } from "rrule";
-import { describeSchedule, formatClockTime, formatNextRunAt, nextRunAtMs } from "./scheduleText";
+import {
+  describeRunError,
+  describeSchedule,
+  formatClockTime,
+  formatNextRunAt,
+  formatRunDuration,
+  formatRunTimestamp,
+  nextRunAtMs,
+} from "./scheduleText";
 import {
   buildRRule,
   DEFAULT_SCHEDULE_MODEL,
@@ -418,5 +426,95 @@ describe("formatNextRunAt (relative delta from the server's next-run, full words
   it("bucket boundaries: 60m → hours, 24h → days", () => {
     expect(formatNextRunAt(iso(60 * MIN), NOW)).toBe("in 1 hour");
     expect(formatNextRunAt(iso(24 * HR), NOW)).toBe("in 1 day");
+  });
+});
+
+describe("formatRunDuration", () => {
+  it("formats sub-minute runs in bare seconds", () => {
+    expect(formatRunDuration(1000, 1003)).toBe("3s");
+    expect(formatRunDuration(1000, 1059)).toBe("59s");
+  });
+
+  it("formats minute-scale runs as 'Nm Ss', dropping a zero seconds", () => {
+    // 1m 42s.
+    expect(formatRunDuration(1000, 1000 + 102)).toBe("1m 42s");
+    // Exactly 2 minutes → no trailing seconds.
+    expect(formatRunDuration(1000, 1000 + 120)).toBe("2m");
+  });
+
+  it("formats hour-scale runs as 'Nh Mm', dropping a zero minutes", () => {
+    expect(formatRunDuration(0, 3600 + 5 * 60)).toBe("1h 5m"); // 1h 5m 0s
+    expect(formatRunDuration(0, 2 * 3600)).toBe("2h"); // exactly 2h
+  });
+
+  it("rounds a sub-second (but non-zero) run up to 1s", () => {
+    expect(formatRunDuration(1000, 1000.4)).toBe("1s");
+  });
+
+  it("returns null when the run hasn't finished or never fired", () => {
+    expect(formatRunDuration(1000, null)).toBeNull();
+    expect(formatRunDuration(null, 1000)).toBeNull();
+    expect(formatRunDuration(undefined, undefined)).toBeNull();
+  });
+
+  it("returns null for a negative or non-finite span", () => {
+    expect(formatRunDuration(2000, 1000)).toBeNull();
+    expect(formatRunDuration(Number.NaN, 1000)).toBeNull();
+  });
+});
+
+describe("formatRunTimestamp", () => {
+  // A fixed viewer-local reference. formatRunTimestamp works in local time, so
+  // build the run instants relative to NOW's local midnight to stay
+  // zone-independent.
+  const NOW = new Date("2026-07-27T15:30:00");
+
+  function atLocal(daysAgo: number, hour: number, minute: number): number {
+    const d = new Date(NOW.getFullYear(), NOW.getMonth(), NOW.getDate() - daysAgo, hour, minute, 0);
+    return Math.floor(d.getTime() / 1000);
+  }
+
+  it("labels a same-day run 'Today, <time>'", () => {
+    expect(formatRunTimestamp(atLocal(0, 8, 0), NOW)).toBe("Today, 8:00 AM");
+  });
+
+  it("labels a previous-calendar-day run 'Yesterday, <time>'", () => {
+    expect(formatRunTimestamp(atLocal(1, 14, 30), NOW)).toBe("Yesterday, 2:30 PM");
+  });
+
+  it("labels an older same-year run 'Mon D, <time>' without a year", () => {
+    const label = formatRunTimestamp(atLocal(10, 8, 0), NOW)!;
+    expect(label).toMatch(/^Jul \d{1,2}, 8:00 AM$/);
+    expect(label).not.toContain("2026");
+  });
+
+  it("includes the year for a run from a different year", () => {
+    const priorYear = Math.floor(new Date(2025, 11, 25, 9, 0, 0).getTime() / 1000);
+    const label = formatRunTimestamp(priorYear, NOW)!;
+    expect(label).toContain("2025");
+  });
+
+  it("returns null for a null / non-finite timestamp", () => {
+    expect(formatRunTimestamp(null, NOW)).toBeNull();
+    expect(formatRunTimestamp(undefined, NOW)).toBeNull();
+    expect(formatRunTimestamp(Number.NaN, NOW)).toBeNull();
+  });
+});
+
+describe("describeRunError", () => {
+  it("maps known fire-path error codes to human copy", () => {
+    expect(describeRunError("no_online_host", "skipped")).toBe(
+      "Host was offline at fire time — run skipped",
+    );
+    expect(describeRunError("incomplete", "failed")).toBe(
+      "The host went away mid-run — run left incomplete",
+    );
+    expect(describeRunError("launch_failed", "failed")).toBe("The agent session failed to launch");
+  });
+
+  it("falls back to a status-keyed generic for an unknown / null code", () => {
+    expect(describeRunError("some_new_code", "skipped")).toBe("Run skipped");
+    expect(describeRunError(null, "failed")).toBe("Run failed");
+    expect(describeRunError(undefined, "skipped")).toBe("Run skipped");
   });
 });

--- a/web/src/lib/scheduleText.ts
+++ b/web/src/lib/scheduleText.ts
@@ -214,17 +214,17 @@ export function describeRunError(
 ): string {
   switch (errorCode) {
     case "no_online_host":
-      return "Host was offline at fire time — run skipped";
+      return "Host was offline at fire time. Run skipped.";
     case "host_offline":
-      return "The pinned host was offline — run skipped";
+      return "The pinned host was offline. Run skipped.";
     case "host_not_found":
-      return "The pinned host no longer exists — run skipped";
+      return "The pinned host no longer exists. Run skipped.";
     case "host_not_owned":
-      return "The pinned host isn't available to you — run skipped";
+      return "The pinned host isn't available to you. Run skipped.";
     case "host_registry_unavailable":
-      return "No host was reachable at fire time — run skipped";
+      return "No host was reachable at fire time. Run skipped.";
     case "default_workspace_unresolved":
-      return "Couldn't resolve a workspace on the host — run skipped";
+      return "Couldn't resolve a workspace on the host. Run skipped.";
     case "unsupported_target":
       return "This task's target can't be run automatically";
     case "session_create_failed":
@@ -234,7 +234,7 @@ export function describeRunError(
     case "launch_failed":
       return "The agent session failed to launch";
     case "incomplete":
-      return "The host went away mid-run — run left incomplete";
+      return "The host went away mid-run. Run left incomplete.";
     default:
       return status === "skipped" ? "Run skipped" : "Run failed";
   }

--- a/web/src/lib/scheduleText.ts
+++ b/web/src/lib/scheduleText.ts
@@ -116,6 +116,130 @@ function pluralize(count: number, noun: string): string {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
+/**
+ * Format the wall-clock time a run FIRED (or was scheduled) as a short absolute
+ * label for the run-history list, e.g. `Today, 8:00 AM`, `Yesterday, 2:30 PM`,
+ * or `Jul 26, 8:00 AM` for anything older. The date is relative to `now` by
+ * calendar day (viewer-local), so "Today"/"Yesterday" track midnight rather than
+ * a rolling 24h window.
+ *
+ * @param epochSeconds The run's `firedAt ?? scheduledAt` (epoch SECONDS, matching
+ *   the server's `_run_to_response`), or `null`.
+ * @param now Injectable clock for deterministic tests; defaults to `new Date()`.
+ * @returns The label, or `null` for a null / non-finite input so the caller
+ *   renders nothing.
+ */
+export function formatRunTimestamp(
+  epochSeconds: number | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (epochSeconds == null || !Number.isFinite(epochSeconds)) return null;
+  const date = new Date(epochSeconds * 1000);
+  if (Number.isNaN(date.getTime())) return null;
+
+  const time = date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  const dayDelta = calendarDayDelta(date, now);
+  if (dayDelta === 0) return `Today, ${time}`;
+  if (dayDelta === 1) return `Yesterday, ${time}`;
+  // Older (or a future-dated run, e.g. a scheduled-but-not-fired row): show an
+  // absolute month/day. Include the year only when it differs from `now`'s so a
+  // run from a prior year isn't ambiguous.
+  const sameYear = date.getFullYear() === now.getFullYear();
+  const datePart = date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  });
+  return `${datePart}, ${time}`;
+}
+
+/**
+ * Whole-calendar-day difference (viewer-local) between `date` and `now`:
+ * `0` = same day, `1` = `date` was yesterday, negative = `date` is in the
+ * future. Compares local midnights so it ignores time-of-day.
+ */
+function calendarDayDelta(date: Date, now: Date): number {
+  const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  return Math.round((startOfDay(now) - startOfDay(date)) / DAY_MS);
+}
+
+/**
+ * Format a run's elapsed wall-clock duration (`finishedAt − firedAt`) as a
+ * compact `1m 42s` / `3s` / `2h 5m` label for the run-history list.
+ *
+ * Both inputs are epoch SECONDS (server `_run_to_response`). Returns `null` when
+ * either bound is missing (the run hasn't finished, or never fired) or the
+ * arithmetic is nonsensical (finished before fired / non-finite), so the caller
+ * simply omits the duration rather than showing `0s` or a negative value.
+ *
+ * Units: shows the two most-significant non-zero units, largest first — `h`+`m`
+ * for hour-scale runs, `m`+`s` for minute-scale, bare `s` under a minute. A
+ * sub-second run rounds up to `1s` (a run that fired and finished always took
+ * *some* time; `0s` reads as "didn't run").
+ */
+export function formatRunDuration(
+  firedAt: number | null | undefined,
+  finishedAt: number | null | undefined,
+): string | null {
+  if (firedAt == null || finishedAt == null) return null;
+  if (!Number.isFinite(firedAt) || !Number.isFinite(finishedAt)) return null;
+  const seconds = finishedAt - firedAt;
+  if (seconds < 0) return null;
+  const total = Math.max(1, Math.round(seconds));
+
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  if (m > 0) return s > 0 ? `${m}m ${s}s` : `${m}m`;
+  return `${s}s`;
+}
+
+/**
+ * Human-readable, one-line explanation for a run that did not succeed, derived
+ * from the server's machine-readable `errorCode` (see the fire path's
+ * `_CannotLaunchScheduledFire` codes in `omnigent/server/scheduled/fire.py` and
+ * the reconciler's `incomplete`). Used as the run's detail line for
+ * `skipped` / `failed` runs — never fabricated summary text.
+ *
+ * Unknown / null codes fall back to a generic message keyed on the run status
+ * so a new server-side code still renders something honest rather than blank.
+ *
+ * @param errorCode The run's `errorCode`, or `null`.
+ * @param status The run's status, used only for the fallback wording.
+ */
+export function describeRunError(
+  errorCode: string | null | undefined,
+  status: "skipped" | "failed" | (string & {}),
+): string {
+  switch (errorCode) {
+    case "no_online_host":
+      return "Host was offline at fire time — run skipped";
+    case "host_offline":
+      return "The pinned host was offline — run skipped";
+    case "host_not_found":
+      return "The pinned host no longer exists — run skipped";
+    case "host_not_owned":
+      return "The pinned host isn't available to you — run skipped";
+    case "host_registry_unavailable":
+      return "No host was reachable at fire time — run skipped";
+    case "default_workspace_unresolved":
+      return "Couldn't resolve a workspace on the host — run skipped";
+    case "unsupported_target":
+      return "This task's target can't be run automatically";
+    case "session_create_failed":
+      return "Couldn't start the agent session";
+    case "owner_grant_failed":
+      return "Couldn't authorize the agent session";
+    case "launch_failed":
+      return "The agent session failed to launch";
+    case "incomplete":
+      return "The host went away mid-run — run left incomplete";
+    default:
+      return status === "skipped" ? "Run skipped" : "Run failed";
+  }
+}
+
 /** Parse an RRULE string into an `RRule`, or `null` if it can't be parsed. */
 function tryParse(rrule: string): RRule | null {
   try {

--- a/web/src/lib/scheduleText.ts
+++ b/web/src/lib/scheduleText.ts
@@ -225,6 +225,15 @@ export function describeRunError(
       return "No host was reachable at fire time. Run skipped.";
     case "default_workspace_unresolved":
       return "Couldn't resolve a workspace on the host. Run skipped.";
+    // Permanent misconfiguration codes — the stored task spec fails every
+    // occurrence (recorded as "failed", not "skipped"). Copy points the user at
+    // fixing the task's configuration rather than waiting for a host.
+    case "invalid_input":
+      return "This task's model or workspace is invalid. Edit the task to fix it.";
+    case "missing_workspace":
+    case "missing_host_id":
+    case "missing_execution_input":
+      return "This task is missing its host or workspace. Edit the task to fix it.";
     case "unsupported_target":
       return "This task's target can't be run automatically";
     case "session_create_failed":

--- a/web/src/lib/scheduledTasksApi.ts
+++ b/web/src/lib/scheduledTasksApi.ts
@@ -78,6 +78,19 @@ export interface ScheduledTaskRun {
   finishedAt: number | null;
   /** Queryable failure classification, e.g. `no_online_host`; `null` on success. */
   errorCode: string | null;
+  /** Epoch seconds of the conversation's last update; `null` for runs without a conversation. */
+  conversationUpdatedAt: number | null;
+  /**
+   * The conversation's live status (e.g. `"idle"`, `"running"`); `null` for runs without a
+   * conversation. Same semantics as the `status` field in `GET /v1/sessions` list items.
+   */
+  conversationStatus: string | null;
+  /**
+   * Whether the caller has explicitly marked this conversation unread (server-side
+   * `viewer_unread`); `null` for runs without a conversation. Hydrates
+   * `useUnseenConversations` on load so the dot can be computed without per-row fetches.
+   */
+  viewerUnread: boolean | null;
 }
 
 /** Body for `POST /v1/scheduled-tasks`. */
@@ -144,6 +157,9 @@ interface ScheduledTaskRunWire {
   fired_at: number | null;
   finished_at: number | null;
   error_code: string | null;
+  conversation_updated_at: number | null;
+  conversation_status: string | null;
+  viewer_unread: boolean | null;
 }
 
 /**
@@ -219,6 +235,9 @@ function runFromWire(wire: ScheduledTaskRunWire): ScheduledTaskRun {
     firedAt: wire.fired_at,
     finishedAt: wire.finished_at,
     errorCode: wire.error_code,
+    conversationUpdatedAt: wire.conversation_updated_at ?? null,
+    conversationStatus: wire.conversation_status ?? null,
+    viewerUnread: wire.viewer_unread ?? null,
   };
 }
 

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@/hooks/useScheduledTasks", () => ({
   useUpdateScheduledTask: vi.fn(),
   useDeleteScheduledTask: vi.fn(),
   useRunScheduledTaskNow: vi.fn(),
+  cancelRunNowPoll: vi.fn(),
 }));
 
 const showToast = vi.fn();

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -1,8 +1,8 @@
 // Tests for the scheduled-task DETAIL page (`/tasks/:taskId`): header + prompt
 // + configuration + run-history rendering from mocked hooks, the header actions
-// (Run now fires the mutation, delete navigates back, edit opens the dialog),
+// (Run now fires the mutation + shows a toast, delete navigates back, edit opens the dialog),
 // and the run-row rendering rules: the LEFT status-icon column (failed triangle
-// > skipped calendar-off > succeeded-unread blue dot > succeeded-read grey dot),
+// > skipped calendar-off > running pulsing dot > succeeded-unread blue dot > succeeded-read grey dot),
 // duration, errorCode messages, and the whole-row click affordance (a run with a
 // conversation is a link; a skipped run is not) — never a fabricated summary.
 //
@@ -35,6 +35,9 @@ vi.mock("@/hooks/useScheduledTasks", () => ({
   useDeleteScheduledTask: vi.fn(),
   useRunScheduledTaskNow: vi.fn(),
 }));
+
+const showToast = vi.fn();
+vi.mock("@/components/ui/toast", () => ({ showToast: (...args: unknown[]) => showToast(...args) }));
 
 // Agent / host catalogs — return simple lists so labels resolve.
 vi.mock("@/hooks/useAvailableAgents", () => ({
@@ -152,6 +155,7 @@ beforeEach(() => {
   updateMutate.mockReset();
   deleteMutate.mockReset();
   runNowMutate.mockReset();
+  showToast.mockReset();
   fetchConversationById.mockClear();
   fetchConversationById.mockResolvedValue({
     id: "c_9",
@@ -267,11 +271,37 @@ describe("loading / not-found states", () => {
 });
 
 describe("header actions", () => {
-  it("Run now fires the run mutation", () => {
+  it("Run now fires the run mutation with toast callbacks", () => {
     setTask(task());
     renderPage();
     fireEvent.click(screen.getByTestId("task-detail-run-now"));
-    expect(runNowMutate).toHaveBeenCalledWith("st_1");
+    expect(runNowMutate).toHaveBeenCalledWith(
+      "st_1",
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+  });
+
+  it("Run now shows 'Run started' toast on success", () => {
+    runNowMutate.mockImplementation(
+      (_id: string, opts?: { onSuccess?: () => void; onError?: () => void }) => opts?.onSuccess?.(),
+    );
+    setTask(task());
+    renderPage();
+    fireEvent.click(screen.getByTestId("task-detail-run-now"));
+    expect(showToast).toHaveBeenCalledWith("Run started");
+  });
+
+  it("Run now shows error toast on failure", () => {
+    runNowMutate.mockImplementation(
+      (_id: string, opts?: { onSuccess?: () => void; onError?: () => void }) => opts?.onError?.(),
+    );
+    setTask(task());
+    renderPage();
+    fireEvent.click(screen.getByTestId("task-detail-run-now"));
+    expect(showToast).toHaveBeenCalledWith("Couldn't start the run");
   });
 
   it("toggling the Switch off pauses an active task (update to paused)", () => {
@@ -440,6 +470,30 @@ describe("run history", () => {
     // no finished timestamps → no duration.
     expect(within(row).queryByTestId("run-open")).toBeNull();
     expect(within(row).queryByTestId("run-duration")).toBeNull();
+  });
+
+  it("renders a RUNNING run with a pulsing grey dot and a 'Running' tooltip", async () => {
+    setTask(task());
+    setRuns([
+      run({
+        id: "run_running",
+        status: "running",
+        conversationId: null,
+        firedAt: 1_700_000_000,
+        finishedAt: null,
+      }),
+    ]);
+    renderPage();
+    const row = screen.getByTestId("task-detail-run");
+    const dot = within(row).getByTestId("run-status-dot");
+    expect(dot).toHaveAttribute("data-run-icon", "running");
+    expect(dot.className).toContain("animate-pulse");
+    expect(dot.className).toContain("bg-muted-foreground/40");
+    // No status ICON — running uses the dot slot, not an svg icon.
+    expect(within(row).queryByTestId("run-status-icon")).toBeNull();
+    // Tooltip reads "Running".
+    fireEvent.focus(dot);
+    await waitFor(() => expect(screen.getAllByText("Running").length).toBeGreaterThan(0));
   });
 
   it("renders an error message when run history fails to load", () => {

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -67,10 +67,12 @@ vi.mock("@/hooks/useConversations", () => ({
 // Read-state mirror: control unread verdicts deterministically. Default read.
 const isConversationUnseen = vi.fn(() => false);
 const isExplicitlyUnread = vi.fn(() => false);
+const markConversationUnread = vi.fn();
 vi.mock("@/hooks/useUnseenConversations", () => ({
   useUnseenTick: () => 0,
   isConversationUnseen: (...args: unknown[]) => isConversationUnseen(...(args as [])),
   isExplicitlyUnread: (...args: unknown[]) => isExplicitlyUnread(...(args as [])),
+  markConversationUnread: (...args: unknown[]) => markConversationUnread(...args),
 }));
 
 // Freeze the ticking clock so relative next-run text is deterministic.
@@ -168,6 +170,7 @@ beforeEach(() => {
   isConversationUnseen.mockReturnValue(false);
   isExplicitlyUnread.mockReset();
   isExplicitlyUnread.mockReturnValue(false);
+  markConversationUnread.mockReset();
   vi.mocked(hooks.useUpdateScheduledTask).mockReturnValue({
     mutate: updateMutate,
     isPending: false,
@@ -560,5 +563,100 @@ describe("run history", () => {
     setRuns([], { isError: true });
     renderPage();
     expect(screen.getByTestId("task-detail-runs-error")).toBeInTheDocument();
+  });
+});
+
+describe("auto-mark runs unread", () => {
+  it("marks a newly-completed run unread when it transitions running→succeeded", () => {
+    setTask(task());
+    // First render: one running run (sets baseline — NOT marked).
+    setRuns([
+      run({
+        id: "run_new",
+        status: "running",
+        conversationId: "c_new",
+        firedAt: 1_700_000_000,
+        finishedAt: null,
+      }),
+    ]);
+    const { rerender } = renderPage();
+    // Baseline seeded with the running run (not terminal → not in autoMarked set).
+    // markConversationUnread should NOT have been called yet.
+    expect(markConversationUnread).not.toHaveBeenCalled();
+
+    // Simulate the run completing: update the mock to return succeeded.
+    setRuns([
+      run({
+        id: "run_new",
+        status: "succeeded",
+        conversationId: "c_new",
+        firedAt: 1_700_000_000,
+        finishedAt: 1_700_000_042,
+      }),
+    ]);
+    rerender(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })}
+      >
+        <TooltipProvider>
+          <MemoryRouter>
+            <TaskDetailPage />
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(markConversationUnread).toHaveBeenCalledWith("c_new", 1_700_000_042);
+  });
+
+  it("does NOT re-mark a run that was already opened (resurrection guard)", () => {
+    setTask(task());
+    // First render: empty runs (baseline seeded as empty).
+    setRuns([]);
+    const { rerender } = renderPage();
+    expect(markConversationUnread).not.toHaveBeenCalled();
+
+    // Run completes — gets marked once.
+    setRuns([run({ id: "run_1", status: "succeeded", conversationId: "c_opened" })]);
+    rerender(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })}
+      >
+        <TooltipProvider>
+          <MemoryRouter>
+            <TaskDetailPage />
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+    expect(markConversationUnread).toHaveBeenCalledTimes(1);
+
+    // Simulate user opening the conversation (would call clearUnreadOverride /
+    // markConversationSeen externally). Now poll re-fetches the same runs list.
+    rerender(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })}
+      >
+        <TooltipProvider>
+          <MemoryRouter>
+            <TaskDetailPage />
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+    // markConversationUnread must NOT be called again — the id is in the ref.
+    expect(markConversationUnread).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT auto-mark pre-existing terminal runs on first page load (no-retroactive guard)", () => {
+    setTask(task());
+    // First render: two already-succeeded runs (pre-existing history).
+    setRuns([
+      run({ id: "run_old_1", status: "succeeded", conversationId: "c_old_1" }),
+      run({ id: "run_old_2", status: "succeeded", conversationId: "c_old_2" }),
+    ]);
+    renderPage();
+    // Baseline seeds both ids as already-seen → markConversationUnread never called.
+    expect(markConversationUnread).not.toHaveBeenCalled();
   });
 });

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -9,13 +9,14 @@
 // All data hooks are mocked at their seam; the edit dialog is stubbed so we
 // only assert it opened. useParams/useNavigate come from `@/lib/routing`.
 
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TaskDetailPage } from "./TaskDetailPage";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import * as hooks from "@/hooks/useScheduledTasks";
+import { ScheduledTaskApiError } from "@/lib/scheduledTasksApi";
 import type { ScheduledTask, ScheduledTaskRun } from "@/lib/scheduledTasksApi";
 
 const navigate = vi.fn();
@@ -294,14 +295,53 @@ describe("header actions", () => {
     expect(showToast).toHaveBeenCalledWith("Run started");
   });
 
-  it("Run now shows error toast on failure", () => {
+  it("Run now shows error toast on a generic (non-409) failure", () => {
     runNowMutate.mockImplementation(
-      (_id: string, opts?: { onSuccess?: () => void; onError?: () => void }) => opts?.onError?.(),
+      (_id: string, opts?: { onSuccess?: () => void; onError?: (err: unknown) => void }) =>
+        opts?.onError?.(new ScheduledTaskApiError("server error", 503, null)),
     );
     setTask(task());
     renderPage();
     fireEvent.click(screen.getByTestId("task-detail-run-now"));
     expect(showToast).toHaveBeenCalledWith("Couldn't start the run");
+  });
+
+  it("Run now shows 'already in progress' toast for a 409 (overlap guard hit)", () => {
+    runNowMutate.mockImplementation(
+      (_id: string, opts?: { onSuccess?: () => void; onError?: (err: unknown) => void }) =>
+        opts?.onError?.(new ScheduledTaskApiError("conflict", 409, "CONFLICT")),
+    );
+    setTask(task());
+    renderPage();
+    fireEvent.click(screen.getByTestId("task-detail-run-now"));
+    expect(showToast).toHaveBeenCalledWith("This run is already in progress");
+  });
+
+  it("Run now button stays disabled through the 10s justFired window after success", async () => {
+    vi.useFakeTimers();
+    try {
+      runNowMutate.mockImplementation(
+        (_id: string, opts?: { onSuccess?: () => void; onError?: (err: unknown) => void }) =>
+          opts?.onSuccess?.(),
+      );
+      setTask(task());
+      renderPage();
+      const btn = screen.getByTestId("task-detail-run-now");
+      expect(btn).not.toBeDisabled();
+      // Wrap in act so the synchronous onSuccess → setJustFired(true) state update flushes.
+      await act(async () => {
+        fireEvent.click(btn);
+      });
+      // After success the button should be disabled (justFired=true).
+      expect(btn).toBeDisabled();
+      // Advance past the 10s window so the timer fires and setJustFired(false) runs.
+      await act(async () => {
+        vi.advanceTimersByTime(10_001);
+      });
+      expect(btn).not.toBeDisabled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("toggling the Switch off pauses an active task (update to paused)", () => {

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -1,0 +1,288 @@
+// Tests for the scheduled-task DETAIL page (`/tasks/:taskId`): header + prompt
+// + configuration + run-history rendering from mocked hooks, the header actions
+// (Run now fires the mutation, delete navigates back, edit opens the dialog),
+// and the run-row rendering rules (status dots, duration, errorCode messages,
+// and the "Open conversation" link — never a fabricated summary).
+//
+// All data hooks are mocked at their seam; the edit dialog is stubbed so we
+// only assert it opened. useParams/useNavigate come from `@/lib/routing`.
+
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TaskDetailPage } from "./TaskDetailPage";
+import * as hooks from "@/hooks/useScheduledTasks";
+import type { ScheduledTask, ScheduledTaskRun } from "@/lib/scheduledTasksApi";
+
+const navigate = vi.fn();
+vi.mock("@/lib/routing", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/routing")>();
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+    useParams: () => ({ taskId: "st_1" }),
+  };
+});
+
+vi.mock("@/hooks/useScheduledTasks", () => ({
+  useScheduledTask: vi.fn(),
+  useScheduledTaskRuns: vi.fn(),
+  useUpdateScheduledTask: vi.fn(),
+  useDeleteScheduledTask: vi.fn(),
+  useRunScheduledTaskNow: vi.fn(),
+}));
+
+// Agent / host catalogs — return simple lists so labels resolve.
+vi.mock("@/hooks/useAvailableAgents", () => ({
+  useAvailableAgents: () => ({
+    data: [{ id: "ag_1", name: "polly", display_name: "Polly" }],
+  }),
+}));
+vi.mock("@/hooks/useHosts", () => ({
+  useHosts: () => ({ data: [{ host_id: "h_1", name: "My Laptop" }] }),
+}));
+
+// Freeze the ticking clock so relative next-run text is deterministic.
+vi.mock("@/hooks/useNow", () => ({
+  useNow: () => new Date("2026-07-27T12:00:00Z"),
+}));
+
+// Stub the edit dialog to a marker that reports open + the task it edits.
+vi.mock("@/components/scheduled/CreateScheduledTaskDialog", () => ({
+  CreateScheduledTaskDialog: ({
+    open,
+    editingTask,
+  }: {
+    open: boolean;
+    editingTask?: ScheduledTask | null;
+  }) =>
+    open ? <div data-testid="edit-dialog-open" data-editing-id={editingTask?.id ?? ""} /> : null,
+}));
+
+function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: "st_1",
+    name: "Nightly triage",
+    prompt: "Triage the inbox and summarize.",
+    rrule: "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=8;BYMINUTE=0",
+    ownerUserId: null,
+    agentId: "ag_1",
+    timezone: "UTC",
+    createdAt: 1,
+    updatedAt: 2,
+    modelOverride: null,
+    reasoningEffort: null,
+    workspace: null,
+    hostId: null,
+    state: "active",
+    lastRunAt: null,
+    lastRunStatus: null,
+    lastRunConversationId: null,
+    nextRunAt: null,
+    ...overrides,
+  };
+}
+
+function run(overrides: Partial<ScheduledTaskRun> = {}): ScheduledTaskRun {
+  return {
+    id: "run_1",
+    scheduledTaskId: "st_1",
+    status: "succeeded",
+    scheduledAt: 1_700_000_000,
+    conversationId: null,
+    firedAt: 1_700_000_000,
+    finishedAt: 1_700_000_102,
+    errorCode: null,
+    ...overrides,
+  };
+}
+
+const updateMutate = vi.fn();
+const deleteMutate = vi.fn();
+const runNowMutate = vi.fn();
+
+function setTask(
+  data: ScheduledTask | undefined,
+  state: { isLoading?: boolean; isError?: boolean } = {},
+) {
+  vi.mocked(hooks.useScheduledTask).mockReturnValue({
+    data,
+    isLoading: state.isLoading ?? false,
+    isError: state.isError ?? false,
+  } as unknown as ReturnType<typeof hooks.useScheduledTask>);
+}
+
+function setRuns(runs: ScheduledTaskRun[], state: { isLoading?: boolean; isError?: boolean } = {}) {
+  vi.mocked(hooks.useScheduledTaskRuns).mockReturnValue({
+    data: runs,
+    isLoading: state.isLoading ?? false,
+    isError: state.isError ?? false,
+  } as unknown as ReturnType<typeof hooks.useScheduledTaskRuns>);
+}
+
+beforeEach(() => {
+  navigate.mockReset();
+  updateMutate.mockReset();
+  deleteMutate.mockReset();
+  runNowMutate.mockReset();
+  vi.mocked(hooks.useUpdateScheduledTask).mockReturnValue({
+    mutate: updateMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof hooks.useUpdateScheduledTask>);
+  vi.mocked(hooks.useDeleteScheduledTask).mockReturnValue({
+    mutate: deleteMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof hooks.useDeleteScheduledTask>);
+  vi.mocked(hooks.useRunScheduledTaskNow).mockReturnValue({
+    mutate: runNowMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof hooks.useRunScheduledTaskNow>);
+  setRuns([]);
+});
+
+afterEach(cleanup);
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <TaskDetailPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("header, prompt, configuration", () => {
+  it("renders the title, prompt, schedule, and agent/host config", () => {
+    setTask(task());
+    renderPage();
+    expect(screen.getByTestId("task-detail-title")).toHaveTextContent("Nightly triage");
+    expect(screen.getByTestId("task-detail-prompt")).toHaveTextContent(
+      "Triage the inbox and summarize.",
+    );
+    expect(screen.getByTestId("task-detail-schedule").textContent).toContain("Weekdays at 8:00 AM");
+    expect(screen.getByTestId("task-detail-agent")).toHaveTextContent("Polly");
+    // Null hostId → resolve-at-fire label, not blank.
+    expect(screen.getByTestId("task-detail-host")).toHaveTextContent("Auto (connected host)");
+    expect(screen.getByTestId("task-detail-state-pill")).toHaveTextContent("Active");
+  });
+
+  it("resolves a pinned host id to its name", () => {
+    setTask(task({ hostId: "h_1" }));
+    renderPage();
+    expect(screen.getByTestId("task-detail-host")).toHaveTextContent("My Laptop");
+  });
+
+  it("shows a Paused pill and a resume affordance for a paused task", () => {
+    setTask(task({ state: "paused" }));
+    renderPage();
+    expect(screen.getByTestId("task-detail-state-pill")).toHaveTextContent("Paused");
+    expect(screen.getByTestId("task-detail-pause-toggle")).toHaveAttribute(
+      "aria-label",
+      "Resume automation",
+    );
+  });
+});
+
+describe("loading / not-found states", () => {
+  it("renders a spinner while loading", () => {
+    setTask(undefined, { isLoading: true });
+    renderPage();
+    expect(screen.getByTestId("task-detail-loading")).toBeInTheDocument();
+  });
+
+  it("renders a friendly not-found with a back link on error", () => {
+    setTask(undefined, { isError: true });
+    renderPage();
+    expect(screen.getByTestId("task-detail-not-found")).toBeInTheDocument();
+    expect(screen.getByTestId("task-detail-back")).toBeInTheDocument();
+  });
+});
+
+describe("header actions", () => {
+  it("Run now fires the run mutation", () => {
+    setTask(task());
+    renderPage();
+    fireEvent.click(screen.getByTestId("task-detail-run-now"));
+    expect(runNowMutate).toHaveBeenCalledWith("st_1");
+  });
+
+  it("pause toggle fires the update mutation with the flipped state", () => {
+    setTask(task({ state: "active" }));
+    renderPage();
+    fireEvent.click(screen.getByTestId("task-detail-pause-toggle"));
+    expect(updateMutate).toHaveBeenCalledWith({ id: "st_1", input: { state: "paused" } });
+  });
+
+  it("delete fires the mutation and navigates back to the list on success", () => {
+    setTask(task());
+    // Make the delete mutation invoke its onSuccess callback synchronously.
+    deleteMutate.mockImplementation((_id: string, opts?: { onSuccess?: () => void }) =>
+      opts?.onSuccess?.(),
+    );
+    renderPage();
+    fireEvent.click(screen.getByTestId("task-detail-delete"));
+    expect(deleteMutate).toHaveBeenCalledWith(
+      "st_1",
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+    expect(navigate).toHaveBeenCalledWith("/tasks");
+  });
+
+  it("edit opens the reused create dialog in edit mode", () => {
+    setTask(task());
+    renderPage();
+    expect(screen.queryByTestId("edit-dialog-open")).toBeNull();
+    fireEvent.click(screen.getByTestId("task-detail-edit"));
+    expect(screen.getByTestId("edit-dialog-open")).toHaveAttribute("data-editing-id", "st_1");
+  });
+});
+
+describe("run history", () => {
+  it("renders the empty state when there are no runs", () => {
+    setTask(task());
+    setRuns([]);
+    renderPage();
+    expect(screen.getByTestId("task-detail-runs-empty")).toHaveTextContent("No runs yet.");
+  });
+
+  it("renders a succeeded run with a duration and an Open conversation link", () => {
+    setTask(task());
+    setRuns([run({ status: "succeeded", conversationId: "c_9" })]);
+    renderPage();
+    const row = screen.getByTestId("task-detail-run");
+    expect(row).toHaveAttribute("data-run-status", "succeeded");
+    expect(within(row).getByTestId("run-duration")).toHaveTextContent("1m 42s");
+    const link = within(row).getByTestId("run-open-conversation");
+    expect(link).toHaveAttribute("href", "/c/c_9");
+    // Never a fabricated summary line.
+    expect(within(row).queryByTestId("run-error-detail")).toBeNull();
+  });
+
+  it("renders a skipped run's errorCode-derived message, not a conversation link", () => {
+    setTask(task());
+    setRuns([
+      run({
+        id: "run_skip",
+        status: "skipped",
+        errorCode: "no_online_host",
+        firedAt: null,
+        finishedAt: null,
+        conversationId: null,
+      }),
+    ]);
+    renderPage();
+    const row = screen.getByTestId("task-detail-run");
+    expect(within(row).getByTestId("run-error-detail")).toHaveTextContent(
+      "Host was offline at fire time — run skipped",
+    );
+    expect(within(row).queryByTestId("run-open-conversation")).toBeNull();
+    // No finished timestamps → no duration shown.
+    expect(within(row).queryByTestId("run-duration")).toBeNull();
+  });
+
+  it("renders an error message when run history fails to load", () => {
+    setTask(task());
+    setRuns([], { isError: true });
+    renderPage();
+    expect(screen.getByTestId("task-detail-runs-error")).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -2,7 +2,7 @@
 // + configuration + run-history rendering from mocked hooks, the header actions
 // (Run now fires the mutation + shows a toast, delete navigates back, edit opens the dialog),
 // and the run-row rendering rules: the LEFT status-icon column (failed triangle
-// > skipped calendar-off > running pulsing dot > succeeded-unread blue dot > succeeded-read grey dot),
+// > skipped calendar-off > running spinner > succeeded-unread brand-accent dot > succeeded-read grey dot),
 // duration, errorCode messages, and the whole-row click affordance (a run with a
 // conversation is a link; a skipped run is not) — never a fabricated summary.
 //
@@ -427,17 +427,18 @@ describe("run history", () => {
     expect(link.className).toContain("hover:bg-muted");
   });
 
-  it("renders a BLUE unread dot with an 'Unread' tooltip for an unread success", async () => {
+  it("renders an unread dot (brand-accent) with an 'Unread' tooltip for an unread success", async () => {
     isConversationUnseen.mockReturnValue(true);
     setTask(task());
     setRuns([run({ status: "succeeded", conversationId: "c_9" })]);
     renderPage();
     const row = screen.getByTestId("task-detail-run");
-    // The dot flips to blue once the unread query resolves.
+    // The dot flips to the unread state once the unread query resolves.
     await waitFor(() => expect(row).toHaveAttribute("data-run-unread", "true"));
     const dot = within(row).getByTestId("run-status-dot");
     expect(dot).toHaveAttribute("data-run-icon", "unread");
-    expect(dot.className).toContain("bg-blue-500");
+    // Color matches the sidebar's unread indicator (brand-accent, not blue-500).
+    expect(dot.className).toContain("bg-brand-accent");
     // No status ICON (that leading slot only holds fail/skip icons).
     expect(within(row).queryByTestId("run-status-icon")).toBeNull();
     // Focusing the tooltip trigger (Radix opens on focus in jsdom) → "Unread".

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -67,12 +67,12 @@ vi.mock("@/hooks/useConversations", () => ({
 // Read-state mirror: control unread verdicts deterministically. Default read.
 const isConversationUnseen = vi.fn(() => false);
 const isExplicitlyUnread = vi.fn(() => false);
-const markConversationUnread = vi.fn();
+const seedRunUnreadBaseline = vi.fn();
 vi.mock("@/hooks/useUnseenConversations", () => ({
   useUnseenTick: () => 0,
   isConversationUnseen: (...args: unknown[]) => isConversationUnseen(...(args as [])),
   isExplicitlyUnread: (...args: unknown[]) => isExplicitlyUnread(...(args as [])),
-  markConversationUnread: (...args: unknown[]) => markConversationUnread(...args),
+  seedRunUnreadBaseline: (...args: unknown[]) => seedRunUnreadBaseline(...args),
 }));
 
 // Freeze the ticking clock so relative next-run text is deterministic.
@@ -170,7 +170,7 @@ beforeEach(() => {
   isConversationUnseen.mockReturnValue(false);
   isExplicitlyUnread.mockReset();
   isExplicitlyUnread.mockReturnValue(false);
-  markConversationUnread.mockReset();
+  seedRunUnreadBaseline.mockReset();
   vi.mocked(hooks.useUpdateScheduledTask).mockReturnValue({
     mutate: updateMutate,
     isPending: false,
@@ -649,8 +649,8 @@ describe("auto-mark runs unread", () => {
     ]);
     const { rerender } = renderPage();
     // Baseline seeded with the running run (not terminal → not in autoMarked set).
-    // markConversationUnread should NOT have been called yet.
-    expect(markConversationUnread).not.toHaveBeenCalled();
+    // seedRunUnreadBaseline should NOT have been called yet.
+    expect(seedRunUnreadBaseline).not.toHaveBeenCalled();
 
     // Simulate the run completing: update the mock to return succeeded.
     setRuns([
@@ -674,7 +674,7 @@ describe("auto-mark runs unread", () => {
       </QueryClientProvider>,
     );
 
-    expect(markConversationUnread).toHaveBeenCalledWith("c_new", 1_700_000_042);
+    expect(seedRunUnreadBaseline).toHaveBeenCalledWith("c_new", 1_700_000_042);
   });
 
   it("does NOT re-mark a run that was already opened (resurrection guard)", () => {
@@ -682,7 +682,7 @@ describe("auto-mark runs unread", () => {
     // First render: empty runs (baseline seeded as empty).
     setRuns([]);
     const { rerender } = renderPage();
-    expect(markConversationUnread).not.toHaveBeenCalled();
+    expect(seedRunUnreadBaseline).not.toHaveBeenCalled();
 
     // Run completes — gets marked once.
     setRuns([run({ id: "run_1", status: "succeeded", conversationId: "c_opened" })]);
@@ -697,7 +697,7 @@ describe("auto-mark runs unread", () => {
         </TooltipProvider>
       </QueryClientProvider>,
     );
-    expect(markConversationUnread).toHaveBeenCalledTimes(1);
+    expect(seedRunUnreadBaseline).toHaveBeenCalledTimes(1);
 
     // Simulate user opening the conversation (would call clearUnreadOverride /
     // markConversationSeen externally). Now poll re-fetches the same runs list.
@@ -712,8 +712,8 @@ describe("auto-mark runs unread", () => {
         </TooltipProvider>
       </QueryClientProvider>,
     );
-    // markConversationUnread must NOT be called again — the id is in the ref.
-    expect(markConversationUnread).toHaveBeenCalledTimes(1);
+    // seedRunUnreadBaseline must NOT be called again — the id is in the ref.
+    expect(seedRunUnreadBaseline).toHaveBeenCalledTimes(1);
   });
 
   it("does NOT auto-mark pre-existing terminal runs on first page load (no-retroactive guard)", () => {
@@ -724,7 +724,43 @@ describe("auto-mark runs unread", () => {
       run({ id: "run_old_2", status: "succeeded", conversationId: "c_old_2" }),
     ]);
     renderPage();
-    // Baseline seeds both ids as already-seen → markConversationUnread never called.
-    expect(markConversationUnread).not.toHaveBeenCalled();
+    // Baseline seeds both ids as already-seen → seedRunUnreadBaseline never called.
+    expect(seedRunUnreadBaseline).not.toHaveBeenCalled();
+  });
+
+  it("uses seedRunUnreadBaseline (not markConversationUnread) so the dot clears when the conversation is opened", () => {
+    // Regression: previously markConversationUnread set the explicitlyUnread
+    // override, which blocked markConversationSeen in ChatPage (the initial-mount
+    // guard skips clearUnreadOverride on a fresh mount). The dot would therefore
+    // stick after the user clicked through. seedRunUnreadBaseline omits the
+    // override so markConversationSeen isn't blocked.
+    //
+    // Verify: auto-mark calls seedRunUnreadBaseline (no override), NOT
+    // markConversationUnread. The absence of markConversationUnread in the mock
+    // confirms the dot is driven by the baseline alone — openable via
+    // markConversationSeen without any guard blocking it.
+    setTask(task());
+    setRuns([]);
+    const { rerender } = renderPage();
+
+    setRuns([run({ id: "run_1", status: "succeeded", conversationId: "c_run" })]);
+    rerender(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })}
+      >
+        <TooltipProvider>
+          <MemoryRouter>
+            <TaskDetailPage />
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+
+    // seedRunUnreadBaseline was called — not markConversationUnread.
+    expect(seedRunUnreadBaseline).toHaveBeenCalledWith("c_run", expect.any(Number));
+    // isExplicitlyUnread is never set by seedRunUnreadBaseline, so opening the
+    // conversation (markConversationSeen) is not blocked. The dot is driven
+    // purely by isConversationUnseen, which clears normally on open.
+    expect(isExplicitlyUnread).not.toHaveBeenCalledWith("c_run");
   });
 });

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -9,7 +9,7 @@
 // All data hooks are mocked at their seam; the edit dialog is stubbed so we
 // only assert it opened. useParams/useNavigate come from `@/lib/routing`.
 
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -346,6 +346,74 @@ describe("header actions", () => {
     expect(idleBtn).not.toBeDisabled();
     expect(idleBtn).toHaveTextContent("Run now");
     expect(idleBtn.querySelector(".animate-spin")).toBeNull();
+  });
+
+  it("Run now button stays 'In progress' after 202 until a new run row appears", async () => {
+    // Start with empty runs so preFireNewestId = null.
+    setTask(task());
+    setRuns([]);
+    runNowMutate.mockImplementation(
+      (_id: string, opts?: { onSuccess?: () => void; onError?: (err: unknown) => void }) =>
+        opts?.onSuccess?.(),
+    );
+    const { rerender } = renderPage();
+
+    const btn = screen.getByTestId("task-detail-run-now");
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    // After onSuccess fires, button is in "In progress" state (awaitingRunRow=true).
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent("In progress");
+
+    // Simulate the accelerated poll delivering a new run row.
+    setRuns([run({ id: "run_new", status: "running", conversationId: "c_new" })]);
+    await act(async () => {
+      rerender(
+        <QueryClientProvider
+          client={new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })}
+        >
+          <TooltipProvider>
+            <MemoryRouter>
+              <TaskDetailPage />
+            </MemoryRouter>
+          </TooltipProvider>
+        </QueryClientProvider>,
+      );
+    });
+
+    // New row appeared (id changed) → flag cleared → button re-enables.
+    expect(btn).not.toBeDisabled();
+    expect(btn).toHaveTextContent("Run now");
+  });
+
+  it("Run now button re-enables after 20s safety cap if no row arrives", async () => {
+    vi.useFakeTimers();
+    try {
+      setTask(task());
+      setRuns([]);
+      runNowMutate.mockImplementation(
+        (_id: string, opts?: { onSuccess?: () => void; onError?: (err: unknown) => void }) =>
+          opts?.onSuccess?.(),
+      );
+      renderPage();
+      const btn = screen.getByTestId("task-detail-run-now");
+      await act(async () => {
+        fireEvent.click(btn);
+      });
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveTextContent("In progress");
+
+      // Advance past the 20s safety cap.
+      await act(async () => {
+        vi.advanceTimersByTime(20_001);
+      });
+      expect(btn).not.toBeDisabled();
+      expect(btn).toHaveTextContent("Run now");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("toggling the Switch off pauses an active task (update to paused)", () => {

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -472,7 +472,7 @@ describe("run history", () => {
     expect(within(row).queryByTestId("run-duration")).toBeNull();
   });
 
-  it("renders a RUNNING run with a pulsing grey dot and a 'Running' tooltip", async () => {
+  it("renders a RUNNING run with a spinning loader icon and a 'Running' tooltip", async () => {
     setTask(task());
     setRuns([
       run({
@@ -485,15 +485,32 @@ describe("run history", () => {
     ]);
     renderPage();
     const row = screen.getByTestId("task-detail-run");
-    const dot = within(row).getByTestId("run-status-dot");
-    expect(dot).toHaveAttribute("data-run-icon", "running");
-    expect(dot.className).toContain("animate-pulse");
-    expect(dot.className).toContain("bg-muted-foreground/40");
-    // No status ICON — running uses the dot slot, not an svg icon.
-    expect(within(row).queryByTestId("run-status-icon")).toBeNull();
+    const icon = within(row).getByTestId("run-status-icon");
+    expect(icon).toHaveAttribute("data-run-icon", "running");
+    expect(icon.getAttribute("class") ?? "").toContain("animate-spin");
+    // It is an svg icon, not the dot span.
+    expect(within(row).queryByTestId("run-status-dot")).toBeNull();
     // Tooltip reads "Running".
-    fireEvent.focus(dot);
+    fireEvent.focus(icon);
     await waitFor(() => expect(screen.getAllByText("Running").length).toBeGreaterThan(0));
+  });
+
+  it("a RUNNING run with a conversationId renders a clickable link", () => {
+    setTask(task());
+    setRuns([
+      run({
+        id: "run_running_linked",
+        status: "running",
+        conversationId: "c_run",
+        firedAt: 1_700_000_000,
+        finishedAt: null,
+      }),
+    ]);
+    renderPage();
+    const row = screen.getByTestId("task-detail-run");
+    const link = within(row).getByTestId("run-open");
+    expect(link).toHaveAttribute("href", "/c/c_run");
+    expect(link.tagName).toBe("A");
   });
 
   it("renders an error message when run history fails to load", () => {

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -1,16 +1,20 @@
 // Tests for the scheduled-task DETAIL page (`/tasks/:taskId`): header + prompt
 // + configuration + run-history rendering from mocked hooks, the header actions
 // (Run now fires the mutation, delete navigates back, edit opens the dialog),
-// and the run-row rendering rules (status dots, duration, errorCode messages,
-// and the "Open conversation" link — never a fabricated summary).
+// and the run-row rendering rules: the LEFT status-icon column (failed triangle
+// > skipped circle-slash > succeeded-unread blue dot > succeeded-read grey dot),
+// duration, errorCode messages, and the whole-row click affordance (a run with a
+// conversation is a link; a skipped run is not) — never a fabricated summary.
 //
 // All data hooks are mocked at their seam; the edit dialog is stubbed so we
 // only assert it opened. useParams/useNavigate come from `@/lib/routing`.
 
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TaskDetailPage } from "./TaskDetailPage";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import * as hooks from "@/hooks/useScheduledTasks";
 import type { ScheduledTask, ScheduledTaskRun } from "@/lib/scheduledTasksApi";
 
@@ -40,6 +44,29 @@ vi.mock("@/hooks/useAvailableAgents", () => ({
 }));
 vi.mock("@/hooks/useHosts", () => ({
   useHosts: () => ({ data: [{ host_id: "h_1", name: "My Laptop" }] }),
+}));
+
+// Conversation fetch backing the per-run unread query. Default: a live
+// conversation exists (idle) so unread is driven purely by the read-state
+// mirror mock below. Individual tests override the resolved value (e.g. null
+// for a deleted conversation).
+const fetchConversationById = vi.fn(async (id: string) => ({
+  id,
+  object: "conversation" as const,
+  updated_at: 1_700_000_500,
+  status: "idle",
+}));
+vi.mock("@/hooks/useConversations", () => ({
+  fetchConversationById: (id: string) => fetchConversationById(id),
+}));
+
+// Read-state mirror: control unread verdicts deterministically. Default read.
+const isConversationUnseen = vi.fn(() => false);
+const isExplicitlyUnread = vi.fn(() => false);
+vi.mock("@/hooks/useUnseenConversations", () => ({
+  useUnseenTick: () => 0,
+  isConversationUnseen: (...args: unknown[]) => isConversationUnseen(...(args as [])),
+  isExplicitlyUnread: (...args: unknown[]) => isExplicitlyUnread(...(args as [])),
 }));
 
 // Freeze the ticking clock so relative next-run text is deterministic.
@@ -125,6 +152,17 @@ beforeEach(() => {
   updateMutate.mockReset();
   deleteMutate.mockReset();
   runNowMutate.mockReset();
+  fetchConversationById.mockClear();
+  fetchConversationById.mockResolvedValue({
+    id: "c_9",
+    object: "conversation",
+    updated_at: 1_700_000_500,
+    status: "idle",
+  } as never);
+  isConversationUnseen.mockReset();
+  isConversationUnseen.mockReturnValue(false);
+  isExplicitlyUnread.mockReset();
+  isExplicitlyUnread.mockReturnValue(false);
   vi.mocked(hooks.useUpdateScheduledTask).mockReturnValue({
     mutate: updateMutate,
     isPending: false,
@@ -143,10 +181,18 @@ beforeEach(() => {
 afterEach(cleanup);
 
 function renderPage() {
+  // A real QueryClient backs the per-run unread useQuery in useRunUnread.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
   return render(
-    <MemoryRouter>
-      <TaskDetailPage />
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <MemoryRouter>
+          <TaskDetailPage />
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>,
   );
 }
 
@@ -275,20 +321,96 @@ describe("run history", () => {
     expect(screen.getByTestId("task-detail-runs-empty")).toHaveTextContent("No runs yet.");
   });
 
-  it("renders a succeeded run with a duration and an Open conversation link", () => {
+  it("renders a READ succeeded run with a grey dot ('Completed' tooltip) and a clickable row", async () => {
+    // Default mocks resolve read (isConversationUnseen → false).
     setTask(task());
     setRuns([run({ status: "succeeded", conversationId: "c_9" })]);
     renderPage();
     const row = screen.getByTestId("task-detail-run");
     expect(row).toHaveAttribute("data-run-status", "succeeded");
     expect(within(row).getByTestId("run-duration")).toHaveTextContent("1m 42s");
-    const link = within(row).getByTestId("run-open-conversation");
-    expect(link).toHaveAttribute("href", "/c/c_9");
-    // Never a fabricated summary line.
+    // No "Open conversation" link text — the whole row is the affordance now.
+    expect(within(row).queryByTestId("run-open-conversation")).toBeNull();
+    // No detail line below the timestamp (removed in FIX 1).
     expect(within(row).queryByTestId("run-error-detail")).toBeNull();
+    // Read success → a muted grey dot (left column), not the blue unread one.
+    await waitFor(() => expect(row).toHaveAttribute("data-run-unread", "false"));
+    const dot = within(row).getByTestId("run-status-dot");
+    expect(dot).toHaveAttribute("data-run-icon", "read");
+    expect(dot.className).toContain("bg-muted-foreground/40");
+    // Tooltip reads "Completed".
+    fireEvent.focus(dot);
+    await waitFor(() => expect(screen.getAllByText("Completed").length).toBeGreaterThan(0));
   });
 
-  it("renders a skipped run's errorCode-derived message, not a conversation link", () => {
+  it("makes a succeeded run's whole row a link to its conversation", () => {
+    setTask(task());
+    setRuns([run({ status: "succeeded", conversationId: "c_9" })]);
+    renderPage();
+    const row = screen.getByTestId("task-detail-run");
+    const link = within(row).getByTestId("run-open");
+    // The row itself is the anchor to /c/:conversationId (keyboard-focusable,
+    // Enter/Space activate natively).
+    expect(link).toHaveAttribute("href", "/c/c_9");
+    expect(link.tagName).toBe("A");
+    expect(link.className).toContain("cursor-pointer");
+    expect(link.className).toContain("hover:bg-muted");
+  });
+
+  it("renders a BLUE unread dot with an 'Unread' tooltip for an unread success", async () => {
+    isConversationUnseen.mockReturnValue(true);
+    setTask(task());
+    setRuns([run({ status: "succeeded", conversationId: "c_9" })]);
+    renderPage();
+    const row = screen.getByTestId("task-detail-run");
+    // The dot flips to blue once the unread query resolves.
+    await waitFor(() => expect(row).toHaveAttribute("data-run-unread", "true"));
+    const dot = within(row).getByTestId("run-status-dot");
+    expect(dot).toHaveAttribute("data-run-icon", "unread");
+    expect(dot.className).toContain("bg-blue-500");
+    // No status ICON (that leading slot only holds fail/skip icons).
+    expect(within(row).queryByTestId("run-status-icon")).toBeNull();
+    // Focusing the tooltip trigger (Radix opens on focus in jsdom) → "Unread".
+    fireEvent.focus(dot);
+    await waitFor(() => expect(screen.getAllByText("Unread").length).toBeGreaterThan(0));
+  });
+
+  it("treats a deleted conversation (fetch → null) as read: grey dot, still clickable", async () => {
+    isConversationUnseen.mockReturnValue(true); // would be unread IF it existed
+    fetchConversationById.mockResolvedValue(null as never);
+    setTask(task());
+    setRuns([run({ status: "succeeded", conversationId: "c_gone" })]);
+    renderPage();
+    const row = screen.getByTestId("task-detail-run");
+    await waitFor(() => expect(row).toHaveAttribute("data-run-unread", "false"));
+    const dot = within(row).getByTestId("run-status-dot");
+    expect(dot).toHaveAttribute("data-run-icon", "read");
+    expect(dot.className).toContain("bg-muted-foreground/40");
+  });
+
+  it("renders a FAILED run with an amber warning-triangle icon whose tooltip carries the error", async () => {
+    setTask(task());
+    setRuns([
+      run({
+        id: "run_fail",
+        status: "failed",
+        errorCode: "agent_error",
+        conversationId: null,
+      }),
+    ]);
+    renderPage();
+    const row = screen.getByTestId("task-detail-run");
+    const icon = within(row).getByTestId("run-status-icon");
+    expect(icon).toHaveAttribute("data-run-icon", "failed");
+    expect(icon.getAttribute("class") ?? "").toContain("text-amber-500");
+    // No inline detail line — the error message lives only in the icon tooltip.
+    expect(within(row).queryByTestId("run-error-detail")).toBeNull();
+    // The errorCode message is the icon's tooltip (Radix opens on focus).
+    fireEvent.focus(icon);
+    await waitFor(() => expect(screen.getAllByText("Run failed").length).toBeGreaterThan(0));
+  });
+
+  it("renders a skipped run with a muted circle-slash icon and is NOT clickable", async () => {
     setTask(task());
     setRuns([
       run({
@@ -302,11 +424,21 @@ describe("run history", () => {
     ]);
     renderPage();
     const row = screen.getByTestId("task-detail-run");
-    expect(within(row).getByTestId("run-error-detail")).toHaveTextContent(
-      "Host was offline at fire time — run skipped",
+    const icon = within(row).getByTestId("run-status-icon");
+    expect(icon).toHaveAttribute("data-run-icon", "skipped");
+    expect(icon.getAttribute("class") ?? "").toContain("text-muted-foreground");
+    // No inline detail line — skip reason lives only in the icon tooltip.
+    expect(within(row).queryByTestId("run-error-detail")).toBeNull();
+    // The skip reason is the icon's tooltip (Radix opens on focus).
+    fireEvent.focus(icon);
+    await waitFor(() =>
+      expect(
+        screen.getAllByText("Host was offline at fire time — run skipped").length,
+      ).toBeGreaterThan(0),
     );
-    expect(within(row).queryByTestId("run-open-conversation")).toBeNull();
-    // No finished timestamps → no duration shown.
+    // No conversation → NOT a clickable row (no anchor, no hover/pointer), and
+    // no finished timestamps → no duration.
+    expect(within(row).queryByTestId("run-open")).toBeNull();
     expect(within(row).queryByTestId("run-duration")).toBeNull();
   });
 

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -9,7 +9,7 @@
 // All data hooks are mocked at their seam; the edit dialog is stubbed so we
 // only assert it opened. useParams/useNavigate come from `@/lib/routing`.
 
-import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -317,31 +317,34 @@ describe("header actions", () => {
     expect(showToast).toHaveBeenCalledWith("This run is already in progress");
   });
 
-  it("Run now button stays disabled through the 10s justFired window after success", async () => {
-    vi.useFakeTimers();
-    try {
-      runNowMutate.mockImplementation(
-        (_id: string, opts?: { onSuccess?: () => void; onError?: (err: unknown) => void }) =>
-          opts?.onSuccess?.(),
-      );
-      setTask(task());
-      renderPage();
-      const btn = screen.getByTestId("task-detail-run-now");
-      expect(btn).not.toBeDisabled();
-      // Wrap in act so the synchronous onSuccess → setJustFired(true) state update flushes.
-      await act(async () => {
-        fireEvent.click(btn);
-      });
-      // After success the button should be disabled (justFired=true).
-      expect(btn).toBeDisabled();
-      // Advance past the 10s window so the timer fires and setJustFired(false) runs.
-      await act(async () => {
-        vi.advanceTimersByTime(10_001);
-      });
-      expect(btn).not.toBeDisabled();
-    } finally {
-      vi.useRealTimers();
-    }
+  it("Run now button shows spinner + 'In progress' while pending and re-enables after", () => {
+    // Simulate a pending mutation (isPending=true while it hasn't resolved).
+    vi.mocked(hooks.useRunScheduledTaskNow).mockReturnValue({
+      mutate: runNowMutate,
+      isPending: true,
+    } as unknown as ReturnType<typeof hooks.useRunScheduledTaskNow>);
+    setTask(task());
+    renderPage();
+    const btn = screen.getByTestId("task-detail-run-now");
+    // Button is disabled while pending (busy includes runNowMutation.isPending).
+    expect(btn).toBeDisabled();
+    // Shows "In progress" text (not "Run now").
+    expect(btn).toHaveTextContent("In progress");
+    expect(btn.querySelector(".animate-spin")).not.toBeNull();
+
+    // Once the mutation resolves (isPending=false), button re-enables with "Run now".
+    vi.mocked(hooks.useRunScheduledTaskNow).mockReturnValue({
+      mutate: runNowMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof hooks.useRunScheduledTaskNow>);
+    // Re-render by re-calling renderPage on a fresh DOM is awkward; just check the
+    // idle state in a separate render.
+    cleanup();
+    renderPage();
+    const idleBtn = screen.getByTestId("task-detail-run-now");
+    expect(idleBtn).not.toBeDisabled();
+    expect(idleBtn).toHaveTextContent("Run now");
+    expect(idleBtn.querySelector(".animate-spin")).toBeNull();
   });
 
   it("toggling the Switch off pauses an active task (update to paused)", () => {

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -175,10 +175,33 @@ describe("header, prompt, configuration", () => {
     setTask(task({ state: "paused" }));
     renderPage();
     expect(screen.getByTestId("task-detail-state-pill")).toHaveTextContent("Paused");
-    expect(screen.getByTestId("task-detail-pause-toggle")).toHaveAttribute(
-      "aria-label",
-      "Resume automation",
-    );
+    const toggle = screen.getByTestId("task-detail-pause-toggle");
+    // The toggle is a Switch (role="switch"), OFF (unchecked) when paused.
+    expect(toggle).toHaveAttribute("role", "switch");
+    expect(toggle).toHaveAttribute("aria-label", "Resume automation");
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("the active-state toggle Switch is ON for an active task", () => {
+    setTask(task({ state: "active" }));
+    renderPage();
+    const toggle = screen.getByTestId("task-detail-pause-toggle");
+    expect(toggle).toHaveAttribute("role", "switch");
+    expect(toggle).toHaveAttribute("aria-label", "Pause automation");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("renders the status line as [state pill] [toggle] [schedule], in that order", () => {
+    setTask(task({ state: "active" }));
+    renderPage();
+    const pill = screen.getByTestId("task-detail-state-pill");
+    const toggle = screen.getByTestId("task-detail-pause-toggle");
+    const schedule = screen.getByTestId("task-detail-schedule");
+    // Document order: pill before toggle before schedule.
+    expect(pill.compareDocumentPosition(toggle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(
+      toggle.compareDocumentPosition(schedule) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });
 
@@ -205,11 +228,19 @@ describe("header actions", () => {
     expect(runNowMutate).toHaveBeenCalledWith("st_1");
   });
 
-  it("pause toggle fires the update mutation with the flipped state", () => {
+  it("toggling the Switch off pauses an active task (update to paused)", () => {
     setTask(task({ state: "active" }));
     renderPage();
+    // Clicking the Switch fires onCheckedChange → handlePauseToggle.
     fireEvent.click(screen.getByTestId("task-detail-pause-toggle"));
     expect(updateMutate).toHaveBeenCalledWith({ id: "st_1", input: { state: "paused" } });
+  });
+
+  it("toggling the Switch on resumes a paused task (update to active)", () => {
+    setTask(task({ state: "paused" }));
+    renderPage();
+    fireEvent.click(screen.getByTestId("task-detail-pause-toggle"));
+    expect(updateMutate).toHaveBeenCalledWith({ id: "st_1", input: { state: "active" } });
   });
 
   it("delete fires the mutation and navigates back to the list on success", () => {

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -50,20 +50,6 @@ vi.mock("@/hooks/useHosts", () => ({
   useHosts: () => ({ data: [{ host_id: "h_1", name: "My Laptop" }] }),
 }));
 
-// Conversation fetch backing the per-run unread query. Default: a live
-// conversation exists (idle) so unread is driven purely by the read-state
-// mirror mock below. Individual tests override the resolved value (e.g. null
-// for a deleted conversation).
-const fetchConversationById = vi.fn(async (id: string) => ({
-  id,
-  object: "conversation" as const,
-  updated_at: 1_700_000_500,
-  status: "idle",
-}));
-vi.mock("@/hooks/useConversations", () => ({
-  fetchConversationById: (id: string) => fetchConversationById(id),
-}));
-
 // Read-state mirror: control unread verdicts deterministically. Default read.
 const isConversationUnseen = vi.fn(() => false);
 const isExplicitlyUnread = vi.fn(() => false);
@@ -126,6 +112,9 @@ function run(overrides: Partial<ScheduledTaskRun> = {}): ScheduledTaskRun {
     firedAt: 1_700_000_000,
     finishedAt: 1_700_000_102,
     errorCode: null,
+    conversationUpdatedAt: 1_700_000_500,
+    conversationStatus: "idle",
+    viewerUnread: null,
     ...overrides,
   };
 }
@@ -159,13 +148,6 @@ beforeEach(() => {
   deleteMutate.mockReset();
   runNowMutate.mockReset();
   showToast.mockReset();
-  fetchConversationById.mockClear();
-  fetchConversationById.mockResolvedValue({
-    id: "c_9",
-    object: "conversation",
-    updated_at: 1_700_000_500,
-    status: "idle",
-  } as never);
   isConversationUnseen.mockReset();
   isConversationUnseen.mockReturnValue(false);
   isExplicitlyUnread.mockReset();
@@ -189,7 +171,7 @@ beforeEach(() => {
 afterEach(cleanup);
 
 function renderPage() {
-  // A real QueryClient backs the per-run unread useQuery in useRunUnread.
+  // QueryClient required by other hooks in the tree (useScheduledTask, etc.).
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
@@ -518,11 +500,41 @@ describe("run history", () => {
     await waitFor(() => expect(screen.getAllByText("Unread").length).toBeGreaterThan(0));
   });
 
-  it("treats a deleted conversation (fetch → null) as read: grey dot, still clickable", async () => {
-    isConversationUnseen.mockReturnValue(true); // would be unread IF it existed
-    fetchConversationById.mockResolvedValue(null as never);
+  it("shows unread dot from server viewerUnread=true with no per-row fetchConversationById call", async () => {
+    // isConversationUnseen stays false (local mirror has no baseline yet, as on
+    // a fresh page load). The server-side viewerUnread flag drives the dot.
+    isConversationUnseen.mockReturnValue(false);
     setTask(task());
-    setRuns([run({ status: "succeeded", conversationId: "c_gone" })]);
+    setRuns([
+      run({
+        status: "succeeded",
+        conversationId: "c_server_unread",
+        conversationUpdatedAt: 1_700_000_500,
+        conversationStatus: "idle",
+        viewerUnread: true,
+      }),
+    ]);
+    renderPage();
+    const row = screen.getByTestId("task-detail-run");
+    await waitFor(() => expect(row).toHaveAttribute("data-run-unread", "true"));
+    const dot = within(row).getByTestId("run-status-dot");
+    expect(dot).toHaveAttribute("data-run-icon", "unread");
+  });
+
+  it("treats a deleted/missing conversation (no payload) as read: grey dot, still clickable", async () => {
+    isConversationUnseen.mockReturnValue(true); // would be unread IF it existed
+    setTask(task());
+    // A run whose conversation was deleted: the backend returns null for the
+    // enriched fields (no conversation found in the store).
+    setRuns([
+      run({
+        status: "succeeded",
+        conversationId: "c_gone",
+        conversationUpdatedAt: null,
+        conversationStatus: null,
+        viewerUnread: null,
+      }),
+    ]);
     renderPage();
     const row = screen.getByTestId("task-detail-run");
     await waitFor(() => expect(row).toHaveAttribute("data-run-unread", "false"));
@@ -758,9 +770,7 @@ describe("auto-mark runs unread", () => {
 
     // seedRunUnreadBaseline was called — not markConversationUnread.
     expect(seedRunUnreadBaseline).toHaveBeenCalledWith("c_run", expect.any(Number));
-    // isExplicitlyUnread is never set by seedRunUnreadBaseline, so opening the
-    // conversation (markConversationSeen) is not blocked. The dot is driven
-    // purely by isConversationUnseen, which clears normally on open.
-    expect(isExplicitlyUnread).not.toHaveBeenCalledWith("c_run");
+    // seedRunUnreadBaseline does NOT set the explicitlyUnread override, so
+    // markConversationSeen is never blocked by it when the user clicks through.
   });
 });

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -2,7 +2,7 @@
 // + configuration + run-history rendering from mocked hooks, the header actions
 // (Run now fires the mutation, delete navigates back, edit opens the dialog),
 // and the run-row rendering rules: the LEFT status-icon column (failed triangle
-// > skipped circle-slash > succeeded-unread blue dot > succeeded-read grey dot),
+// > skipped calendar-off > succeeded-unread blue dot > succeeded-read grey dot),
 // duration, errorCode messages, and the whole-row click affordance (a run with a
 // conversation is a link; a skipped run is not) — never a fabricated summary.
 //
@@ -410,7 +410,7 @@ describe("run history", () => {
     await waitFor(() => expect(screen.getAllByText("Run failed").length).toBeGreaterThan(0));
   });
 
-  it("renders a skipped run with a muted circle-slash icon and is NOT clickable", async () => {
+  it("renders a skipped run with a muted calendar-off icon and is NOT clickable", async () => {
     setTask(task());
     setRuns([
       run({

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -433,7 +433,7 @@ describe("run history", () => {
     fireEvent.focus(icon);
     await waitFor(() =>
       expect(
-        screen.getAllByText("Host was offline at fire time — run skipped").length,
+        screen.getAllByText("Host was offline at fire time. Run skipped.").length,
       ).toBeGreaterThan(0),
     );
     // No conversation → NOT a clickable row (no anchor, no hover/pointer), and

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -35,7 +35,6 @@ vi.mock("@/hooks/useScheduledTasks", () => ({
   useUpdateScheduledTask: vi.fn(),
   useDeleteScheduledTask: vi.fn(),
   useRunScheduledTaskNow: vi.fn(),
-  cancelRunNowPoll: vi.fn(),
 }));
 
 const showToast = vi.fn();

--- a/web/src/pages/TaskDetailPage.test.tsx
+++ b/web/src/pages/TaskDetailPage.test.tsx
@@ -242,17 +242,15 @@ describe("header, prompt, configuration", () => {
     expect(toggle).toHaveAttribute("aria-checked", "true");
   });
 
-  it("renders the status line as [state pill] [toggle] [schedule], in that order", () => {
+  it("renders the status line as [toggle] [state pill] [schedule], in that order", () => {
     setTask(task({ state: "active" }));
     renderPage();
     const pill = screen.getByTestId("task-detail-state-pill");
     const toggle = screen.getByTestId("task-detail-pause-toggle");
     const schedule = screen.getByTestId("task-detail-schedule");
-    // Document order: pill before toggle before schedule.
-    expect(pill.compareDocumentPosition(toggle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(
-      toggle.compareDocumentPosition(schedule) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
+    // Document order: toggle before pill before schedule.
+    expect(toggle.compareDocumentPosition(pill) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(pill.compareDocumentPosition(schedule) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });
 

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -13,7 +13,6 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import {
   CalendarOffIcon,
   ChevronLeftIcon,
@@ -37,7 +36,6 @@ import {
   useScheduledTaskRuns,
   useUpdateScheduledTask,
 } from "@/hooks/useScheduledTasks";
-import { fetchConversationById } from "@/hooks/useConversations";
 import {
   isConversationUnseen,
   isExplicitlyUnread,
@@ -412,32 +410,38 @@ function ConfigField({ label, value, testId }: { label: string; value: string; t
 }
 
 /**
- * Resolve whether a succeeded run's conversation is genuinely UNREAD, using the
- * SAME read-state signal as the sidebar's "new messages" dot.
+ * Resolve whether a run's conversation is genuinely UNREAD from the enriched
+ * run payload — with zero per-row session GETs.
  *
- * IMPORTANT: the run row carries only `conversationId`; unread lives on the
- * conversation. The single-session `GET /v1/sessions/{id}` (what
- * `fetchConversationById` calls) does NOT return `viewer_unread` — that field
- * is only on the LIST items (`SessionListItem`), verified against the schema
- * and the live backend. So we don't read a `viewer_unread` off the fetch.
- * Instead we fetch the conversation for its authoritative `updated_at` +
- * `status`, then feed those to the app's `isConversationUnseen` (the read-state
- * mirror in `useUnseenConversations`), OR honor an explicit "mark unread".
- * `useUnseenTick()` makes this recompute the instant the user opens the thread
- * (marking it read) without a refetch. A deleted conversation → `null` → read.
+ * The runs endpoint returns `conversationUpdatedAt`, `conversationStatus`, and
+ * `viewerUnread` (batched server-side). Priority:
+ *   1. Local explicit-unread override (app-level "mark unread", a628dc12 path).
+ *   2. Local `isConversationUnseen` — fires once `lastSeenMap` has a baseline
+ *      for this conversation (set by `seedRunUnreadBaseline` on new completions,
+ *      or by the sidebar's `seedReadState` on load).
+ *   3. Server `viewerUnread` — the server-side explicit-unread flag, covering
+ *      runs that were completed before this page was ever opened (no local
+ *      baseline yet).
+ * `useUnseenTick()` re-renders the instant the user opens the thread (marking
+ * it read in the local mirror) so the dot clears without a refetch.
  */
-function useRunUnread(conversationId: string | null, enabled: boolean): boolean {
+function useRunUnread(run: ScheduledTaskRun): boolean {
   // Re-render when the read-state mirror changes (open thread → mark read).
   useUnseenTick();
-  const { data: conversation } = useQuery({
-    queryKey: ["conversation-unread", conversationId],
-    queryFn: () => fetchConversationById(conversationId as string),
-    enabled: enabled && conversationId !== null,
-    staleTime: 30_000,
-  });
-  if (!conversationId || !conversation) return false;
-  if (isExplicitlyUnread(conversationId)) return true;
-  return isConversationUnseen(conversationId, conversation.updated_at, conversation.status);
+  if (run.conversationId === null || run.conversationUpdatedAt === null) return false;
+  if (isExplicitlyUnread(run.conversationId)) return true;
+  if (
+    isConversationUnseen(
+      run.conversationId,
+      run.conversationUpdatedAt,
+      run.conversationStatus ?? undefined,
+    )
+  ) {
+    return true;
+  }
+  // Fall back to the server's explicit-unread flag for runs the local mirror
+  // hasn't seeded yet (no lastSeenMap entry from this client session).
+  return run.viewerUnread === true;
 }
 
 /**
@@ -458,10 +462,7 @@ function RunRow({ run, now }: { run: ScheduledTaskRun; now: Date }) {
   const timestamp = formatRunTimestamp(run.firedAt ?? run.scheduledAt, now);
   const duration = formatRunDuration(run.firedAt, run.finishedAt);
   // Unread only applies to a succeeded run that produced a conversation.
-  const unread = useRunUnread(
-    run.conversationId,
-    run.status === "succeeded" && run.conversationId !== null,
-  );
+  const unread = useRunUnread(run);
 
   const body = (
     <>

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -17,7 +17,6 @@ import {
   ArrowRightIcon,
   ChevronLeftIcon,
   Loader2Icon,
-  PauseIcon,
   PencilIcon,
   PlayIcon,
   Trash2Icon,
@@ -25,6 +24,7 @@ import {
 import { Link, useNavigate, useParams } from "@/lib/routing";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import { CreateScheduledTaskDialog } from "@/components/scheduled/CreateScheduledTaskDialog";
 import {
   useDeleteScheduledTask,
@@ -175,18 +175,9 @@ export function TaskDetailPage() {
         </div>
       </div>
 
-      {/* Status line: pause/resume toggle + state pill + schedule + next-run. */}
+      {/* Status line: state pill + active toggle (Switch, ON = active) +
+          schedule + next-run. The Switch sits to the RIGHT of the pill. */}
       <div className="mt-3 flex flex-wrap items-center gap-2 text-sm">
-        <Button
-          variant="outline"
-          size="icon-sm"
-          aria-label={paused ? "Resume automation" : "Pause automation"}
-          data-testid="task-detail-pause-toggle"
-          disabled={busy}
-          onClick={handlePauseToggle}
-        >
-          {paused ? <PlayIcon className="size-4" /> : <PauseIcon className="size-4" />}
-        </Button>
         <span
           data-testid="task-detail-state-pill"
           className={cn(
@@ -198,6 +189,16 @@ export function TaskDetailPage() {
         >
           {paused ? "Paused" : "Active"}
         </span>
+        {/* A scheduled task is ON when active. onCheckedChange passes a boolean,
+            but handlePauseToggle derives the next state from `paused` and
+            ignores its args, so no rewiring is needed. */}
+        <Switch
+          aria-label={paused ? "Resume automation" : "Pause automation"}
+          data-testid="task-detail-pause-toggle"
+          checked={!paused}
+          disabled={busy}
+          onCheckedChange={handlePauseToggle}
+        />
         <span className="text-muted-foreground" data-testid="task-detail-schedule">
           {scheduleSummary}
           {nextRun && ` · Next run ${nextRun}`}

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -12,7 +12,7 @@
  * open-conversation link) — never an invented summary line.
  */
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   CalendarOffIcon,
@@ -53,6 +53,7 @@ import {
   formatRunDuration,
   formatRunTimestamp,
 } from "@/lib/scheduleText";
+import { ScheduledTaskApiError } from "@/lib/scheduledTasksApi";
 import type { ScheduledTaskRun } from "@/lib/scheduledTasksApi";
 import { cn } from "@/lib/utils";
 
@@ -74,6 +75,16 @@ export function TaskDetailPage() {
   const runNowMutation = useRunScheduledTaskNow();
 
   const [editOpen, setEditOpen] = useState(false);
+  // Keeps the Run now button disabled through the ~10s post-fire poll window so
+  // a quick second click can't trigger a 409 "already in flight" from the server.
+  const [justFired, setJustFired] = useState(false);
+  const justFiredTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (justFiredTimerRef.current != null) clearTimeout(justFiredTimerRef.current);
+    };
+  }, []);
 
   // Resolve the agent + host display labels from their catalogs. Both are
   // best-effort: an unknown id falls back to the raw id (agent) or a friendly
@@ -134,8 +145,23 @@ export function TaskDetailPage() {
 
   function handleRunNow() {
     runNowMutation.mutate(task!.id, {
-      onSuccess: () => showToast("Run started"),
-      onError: () => showToast("Couldn't start the run"),
+      onSuccess: () => {
+        showToast("Run started");
+        // Disable Run now for ~10s while the background fire is in flight so a
+        // quick second click doesn't hit the server's overlap guard (409).
+        setJustFired(true);
+        if (justFiredTimerRef.current != null) clearTimeout(justFiredTimerRef.current);
+        justFiredTimerRef.current = setTimeout(() => setJustFired(false), 10_000);
+      },
+      onError: (err) => {
+        // A 409 (CONFLICT) means a run for this task is already in flight — the
+        // run is fine. Show a truthful, non-alarming message.
+        if (err instanceof ScheduledTaskApiError && err.status === 409) {
+          showToast("This run is already in progress");
+        } else {
+          showToast("Couldn't start the run");
+        }
+      },
     });
   }
 
@@ -177,7 +203,11 @@ export function TaskDetailPage() {
           >
             <Trash2Icon className="size-4" />
           </Button>
-          <Button data-testid="task-detail-run-now" disabled={busy} onClick={handleRunNow}>
+          <Button
+            data-testid="task-detail-run-now"
+            disabled={busy || justFired}
+            onClick={handleRunNow}
+          >
             {runNowMutation.isPending ? (
               <Loader2Icon className="size-4 animate-spin" />
             ) : (

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -21,7 +21,6 @@ import {
   PencilIcon,
   PlayIcon,
   Trash2Icon,
-  ZapIcon,
 } from "lucide-react";
 import { Link, useNavigate, useParams } from "@/lib/routing";
 import { PageScroll } from "@/components/PageScroll";
@@ -169,7 +168,7 @@ export function TaskDetailPage() {
             {runNowMutation.isPending ? (
               <Loader2Icon className="size-4 animate-spin" />
             ) : (
-              <ZapIcon className="size-4" />
+              <PlayIcon className="size-4" />
             )}
             Run now
           </Button>

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -12,7 +12,7 @@
  * open-conversation link) — never an invented summary line.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   CalendarOffIcon,
@@ -75,16 +75,6 @@ export function TaskDetailPage() {
   const runNowMutation = useRunScheduledTaskNow();
 
   const [editOpen, setEditOpen] = useState(false);
-  // Keeps the Run now button disabled through the ~10s post-fire poll window so
-  // a quick second click can't trigger a 409 "already in flight" from the server.
-  const [justFired, setJustFired] = useState(false);
-  const justFiredTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (justFiredTimerRef.current != null) clearTimeout(justFiredTimerRef.current);
-    };
-  }, []);
 
   // Resolve the agent + host display labels from their catalogs. Both are
   // best-effort: an unknown id falls back to the raw id (agent) or a friendly
@@ -145,14 +135,7 @@ export function TaskDetailPage() {
 
   function handleRunNow() {
     runNowMutation.mutate(task!.id, {
-      onSuccess: () => {
-        showToast("Run started");
-        // Disable Run now for ~10s while the background fire is in flight so a
-        // quick second click doesn't hit the server's overlap guard (409).
-        setJustFired(true);
-        if (justFiredTimerRef.current != null) clearTimeout(justFiredTimerRef.current);
-        justFiredTimerRef.current = setTimeout(() => setJustFired(false), 10_000);
-      },
+      onSuccess: () => showToast("Run started"),
       onError: (err) => {
         // A 409 (CONFLICT) means a run for this task is already in flight — the
         // run is fine. Show a truthful, non-alarming message.
@@ -203,17 +186,18 @@ export function TaskDetailPage() {
           >
             <Trash2Icon className="size-4" />
           </Button>
-          <Button
-            data-testid="task-detail-run-now"
-            disabled={busy || justFired}
-            onClick={handleRunNow}
-          >
+          <Button data-testid="task-detail-run-now" disabled={busy} onClick={handleRunNow}>
             {runNowMutation.isPending ? (
-              <Loader2Icon className="size-4 animate-spin" />
+              <>
+                <Loader2Icon className="size-4 animate-spin" />
+                In progress
+              </>
             ) : (
-              <PlayIcon className="size-4" />
+              <>
+                <PlayIcon className="size-4" />
+                Run now
+              </>
             )}
-            Run now
           </Button>
         </div>
       </div>
@@ -487,7 +471,7 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
           data-testid="run-status-dot"
           data-run-icon="unread"
           data-run-unread={true}
-          className="size-2.5 shrink-0 rounded-full bg-brand-accent"
+          className="size-2 shrink-0 rounded-full bg-brand-accent"
         />
       </IndicatorWithTooltip>
     );
@@ -500,7 +484,7 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
       data-testid="run-status-dot"
       data-run-icon={run.status === "succeeded" ? "read" : "pending"}
       data-run-unread={run.status === "succeeded" ? false : undefined}
-      className="size-2.5 shrink-0 rounded-full bg-muted-foreground/40"
+      className="size-2 shrink-0 rounded-full bg-muted-foreground/40"
     />
   );
   if (run.status === "succeeded") {

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -1,0 +1,369 @@
+/**
+ * Scheduled-task DETAIL page (`/tasks/:taskId`) — opened by clicking a task
+ * card on the `/tasks` list. Shows the task's header (title + edit / delete /
+ * Run now), a status line (pause-resume toggle + Active/Paused pill + the
+ * human-readable schedule + relative next-run), the Prompt, a Configuration
+ * block (agent + host), and the run history.
+ *
+ * All data + mutations come from the existing scheduled-tasks hooks; editing
+ * reuses `CreateScheduledTaskDialog` in its edit mode. Nothing here is
+ * fabricated: each run renders only the fields the server actually returns
+ * (status, timestamp, duration, an errorCode-derived message, and an
+ * open-conversation link) — never an invented summary line.
+ */
+
+import { useMemo, useState } from "react";
+import {
+  ArrowRightIcon,
+  ChevronLeftIcon,
+  Loader2Icon,
+  PauseIcon,
+  PencilIcon,
+  PlayIcon,
+  Trash2Icon,
+  ZapIcon,
+} from "lucide-react";
+import { Link, useNavigate, useParams } from "@/lib/routing";
+import { PageScroll } from "@/components/PageScroll";
+import { Button } from "@/components/ui/button";
+import { CreateScheduledTaskDialog } from "@/components/scheduled/CreateScheduledTaskDialog";
+import {
+  useDeleteScheduledTask,
+  useRunScheduledTaskNow,
+  useScheduledTask,
+  useScheduledTaskRuns,
+  useUpdateScheduledTask,
+} from "@/hooks/useScheduledTasks";
+import { useNow } from "@/hooks/useNow";
+import { useAvailableAgents } from "@/hooks/useAvailableAgents";
+import { useHosts } from "@/hooks/useHosts";
+import {
+  describeRunError,
+  describeSchedule,
+  formatNextRunAt,
+  formatRunDuration,
+  formatRunTimestamp,
+} from "@/lib/scheduleText";
+import type { ScheduledTaskRun, ScheduledTaskRunStatus } from "@/lib/scheduledTasksApi";
+import { cn } from "@/lib/utils";
+
+export function TaskDetailPage() {
+  const { taskId = "" } = useParams<{ taskId: string }>();
+  const navigate = useNavigate();
+  const now = useNow();
+
+  const { data: task, isLoading, isError } = useScheduledTask(taskId);
+  // Run history only fetches once we have a real id.
+  const {
+    data: runs,
+    isLoading: runsLoading,
+    isError: runsError,
+  } = useScheduledTaskRuns(taskId, taskId !== "");
+
+  const updateMutation = useUpdateScheduledTask();
+  const deleteMutation = useDeleteScheduledTask();
+  const runNowMutation = useRunScheduledTaskNow();
+
+  const [editOpen, setEditOpen] = useState(false);
+
+  // Resolve the agent + host display labels from their catalogs. Both are
+  // best-effort: an unknown id falls back to the raw id (agent) or a friendly
+  // default (host) rather than blanking the field.
+  const { data: agents } = useAvailableAgents();
+  const { data: hosts } = useHosts();
+  const agentLabel = useMemo(() => {
+    if (!task) return "";
+    return agents?.find((a) => a.id === task.agentId)?.display_name ?? task.agentId;
+  }, [agents, task]);
+  const hostLabel = useMemo(() => {
+    if (!task) return "";
+    // Null hostId = the server resolves the connected host at fire time.
+    if (task.hostId == null) return "Auto (connected host)";
+    return hosts?.find((h) => h.host_id === task.hostId)?.name ?? task.hostId;
+  }, [hosts, task]);
+
+  if (isLoading) {
+    return (
+      <PageScroll contentClassName="px-6" data-testid="task-detail-loading">
+        <div className="flex items-center gap-2 py-12 text-sm text-muted-foreground">
+          <Loader2Icon className="size-4 animate-spin" />
+          Loading task…
+        </div>
+      </PageScroll>
+    );
+  }
+
+  // Not found (bad / deleted id → 404) or any load error: a friendly message
+  // plus a way back to the list.
+  if (isError || !task) {
+    return (
+      <PageScroll contentClassName="px-6" data-testid="task-detail-not-found">
+        <BackLink />
+        <div className="flex flex-col items-start gap-2 py-12">
+          <p className="text-sm font-medium">This automation couldn’t be found.</p>
+          <p className="text-sm text-muted-foreground">
+            It may have been deleted, or the link is out of date.
+          </p>
+        </div>
+      </PageScroll>
+    );
+  }
+
+  const paused = task.state === "paused";
+  const scheduleSummary = describeSchedule(task.rrule);
+  const nextRun = formatNextRunAt(task.nextRunAt, now);
+  // A single per-task busy flag: the header actions disable while any of this
+  // task's mutations are in flight.
+  const busy = updateMutation.isPending || deleteMutation.isPending || runNowMutation.isPending;
+
+  function handlePauseToggle() {
+    updateMutation.mutate({
+      id: task!.id,
+      input: { state: paused ? "active" : "paused" },
+    });
+  }
+
+  function handleRunNow() {
+    runNowMutation.mutate(task!.id);
+  }
+
+  function handleDelete() {
+    // Optimistic navigation: on success return to the list (the row is already
+    // gone from the invalidated list cache).
+    deleteMutation.mutate(task!.id, {
+      onSuccess: () => navigate("/tasks"),
+    });
+  }
+
+  return (
+    <PageScroll contentClassName="px-6" data-testid="task-detail-page">
+      <BackLink />
+
+      {/* Header: title + right-aligned actions. */}
+      <div className="mt-4 flex items-start justify-between gap-4">
+        <h1 className="min-w-0 break-words text-2xl font-semibold" data-testid="task-detail-title">
+          {task.name}
+        </h1>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Edit automation"
+            data-testid="task-detail-edit"
+            disabled={busy}
+            onClick={() => setEditOpen(true)}
+          >
+            <PencilIcon className="size-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Delete automation"
+            data-testid="task-detail-delete"
+            disabled={busy}
+            onClick={handleDelete}
+          >
+            <Trash2Icon className="size-4" />
+          </Button>
+          <Button data-testid="task-detail-run-now" disabled={busy} onClick={handleRunNow}>
+            {runNowMutation.isPending ? (
+              <Loader2Icon className="size-4 animate-spin" />
+            ) : (
+              <ZapIcon className="size-4" />
+            )}
+            Run now
+          </Button>
+        </div>
+      </div>
+
+      {/* Status line: pause/resume toggle + state pill + schedule + next-run. */}
+      <div className="mt-3 flex flex-wrap items-center gap-2 text-sm">
+        <Button
+          variant="outline"
+          size="icon-sm"
+          aria-label={paused ? "Resume automation" : "Pause automation"}
+          data-testid="task-detail-pause-toggle"
+          disabled={busy}
+          onClick={handlePauseToggle}
+        >
+          {paused ? <PlayIcon className="size-4" /> : <PauseIcon className="size-4" />}
+        </Button>
+        <span
+          data-testid="task-detail-state-pill"
+          className={cn(
+            "rounded-full px-2 py-0.5 text-xs font-medium",
+            paused
+              ? "bg-muted text-muted-foreground"
+              : "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+          )}
+        >
+          {paused ? "Paused" : "Active"}
+        </span>
+        <span className="text-muted-foreground" data-testid="task-detail-schedule">
+          {scheduleSummary}
+          {nextRun && ` · Next run ${nextRun}`}
+        </span>
+      </div>
+
+      {/* Prompt. */}
+      <Section title="Prompt">
+        <p
+          className="whitespace-pre-wrap text-sm text-foreground/90"
+          data-testid="task-detail-prompt"
+        >
+          {task.prompt}
+        </p>
+      </Section>
+
+      {/* Configuration: agent + host columns. */}
+      <Section title="Configuration">
+        <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <ConfigField label="Agent" value={agentLabel} testId="task-detail-agent" />
+          <ConfigField label="Host" value={hostLabel} testId="task-detail-host" />
+        </dl>
+      </Section>
+
+      <hr className="my-6 border-border" />
+
+      {/* Run history. */}
+      <h2 className="mb-3 text-sm font-medium text-muted-foreground">Run history</h2>
+      {runsLoading ? (
+        <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+          <Loader2Icon className="size-4 animate-spin" />
+          Loading runs…
+        </div>
+      ) : runsError ? (
+        <p className="py-6 text-sm text-muted-foreground" data-testid="task-detail-runs-error">
+          Couldn’t load run history.
+        </p>
+      ) : (runs ?? []).length === 0 ? (
+        <p className="py-6 text-sm text-muted-foreground" data-testid="task-detail-runs-empty">
+          No runs yet.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1" data-testid="task-detail-runs">
+          {(runs ?? []).map((run) => (
+            <RunRow key={run.id} run={run} now={now} />
+          ))}
+        </ul>
+      )}
+
+      <CreateScheduledTaskDialog open={editOpen} onOpenChange={setEditOpen} editingTask={task} />
+    </PageScroll>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      to="/tasks"
+      data-testid="task-detail-back"
+      className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <ChevronLeftIcon className="size-4" />
+      Scheduled tasks
+    </Link>
+  );
+}
+
+/** A titled block with a small muted-caps label above its content. */
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-6">
+      <h2 className="mb-2 text-sm font-medium text-muted-foreground">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function ConfigField({ label, value, testId }: { label: string; value: string; testId: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-xs text-muted-foreground uppercase tracking-wide">{label}</dt>
+      <dd className="truncate text-sm text-foreground" data-testid={testId}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+/**
+ * One run in the history list: a status dot, the fire timestamp (bold), the
+ * duration (muted), and a detail line — an errorCode-derived message for
+ * skipped/failed runs, or an "Open conversation →" link when the run produced
+ * a conversation. No fabricated per-run summary.
+ */
+function RunRow({ run, now }: { run: ScheduledTaskRun; now: Date }) {
+  const timestamp = formatRunTimestamp(run.firedAt ?? run.scheduledAt, now);
+  const duration = formatRunDuration(run.firedAt, run.finishedAt);
+  const detail = runDetail(run);
+
+  return (
+    <li
+      data-testid="task-detail-run"
+      data-run-status={run.status}
+      className="flex items-start gap-3 rounded-lg px-2 py-2"
+    >
+      <span
+        aria-hidden
+        data-testid="run-status-dot"
+        className={cn("mt-1.5 size-2 shrink-0 rounded-full", statusDotClass(run.status))}
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm font-semibold">{timestamp ?? "—"}</span>
+          {duration && (
+            <span className="text-xs text-muted-foreground" data-testid="run-duration">
+              {duration}
+            </span>
+          )}
+        </div>
+        {detail}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * The run's detail line. Skipped/failed → a human message from the errorCode;
+ * otherwise, if the run produced a conversation, an "Open conversation →" link.
+ * Returns null when there's nothing honest to show (e.g. a scheduled/running
+ * run with no conversation yet).
+ */
+function runDetail(run: ScheduledTaskRun): React.ReactNode {
+  if (run.status === "skipped" || run.status === "failed") {
+    return (
+      <span className="text-xs text-muted-foreground" data-testid="run-error-detail">
+        {describeRunError(run.errorCode, run.status)}
+      </span>
+    );
+  }
+  if (run.conversationId) {
+    return (
+      <Link
+        to={`/c/${run.conversationId}`}
+        data-testid="run-open-conversation"
+        className="inline-flex w-fit items-center gap-1 text-xs text-primary transition-colors hover:underline"
+      >
+        Open conversation
+        <ArrowRightIcon className="size-3" />
+      </Link>
+    );
+  }
+  return null;
+}
+
+/** Status → colored dot. Mirrors the list's completion-badge color semantics. */
+function statusDotClass(status: ScheduledTaskRunStatus): string {
+  switch (status) {
+    case "succeeded":
+      return "bg-emerald-500";
+    case "failed":
+      return "bg-destructive";
+    case "skipped":
+      return "bg-amber-500";
+    default:
+      // scheduled / running / incomplete — not yet a terminal signal.
+      return "bg-muted-foreground/40";
+  }
+}

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -471,7 +471,7 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
           data-testid="run-status-dot"
           data-run-icon="unread"
           data-run-unread={true}
-          className="size-2 shrink-0 rounded-full bg-brand-accent"
+          className="size-1.5 shrink-0 rounded-full bg-brand-accent"
         />
       </IndicatorWithTooltip>
     );
@@ -484,7 +484,7 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
       data-testid="run-status-dot"
       data-run-icon={run.status === "succeeded" ? "read" : "pending"}
       data-run-unread={run.status === "succeeded" ? false : undefined}
-      className="size-2 shrink-0 rounded-full bg-muted-foreground/40"
+      className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40"
     />
   );
   if (run.status === "succeeded") {

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -571,7 +571,7 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
           data-testid="run-status-dot"
           data-run-icon="unread"
           data-run-unread={true}
-          className="size-1.5 shrink-0 rounded-full bg-brand-accent"
+          className="size-2 shrink-0 rounded-full bg-brand-accent"
         />
       </IndicatorWithTooltip>
     );
@@ -584,7 +584,7 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
       data-testid="run-status-dot"
       data-run-icon={run.status === "succeeded" ? "read" : "pending"}
       data-run-unread={run.status === "succeeded" ? false : undefined}
-      className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40"
+      className="size-2 shrink-0 rounded-full bg-muted-foreground/40"
     />
   );
   if (run.status === "succeeded") {

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -41,7 +41,7 @@ import { fetchConversationById } from "@/hooks/useConversations";
 import {
   isConversationUnseen,
   isExplicitlyUnread,
-  markConversationUnread,
+  seedRunUnreadBaseline,
   useUnseenTick,
 } from "@/hooks/useUnseenConversations";
 import { useNow } from "@/hooks/useNow";
@@ -150,7 +150,7 @@ export function TaskDetailPage() {
         !autoMarkedRef.current.has(run.conversationId)
       ) {
         autoMarkedRef.current.add(run.conversationId);
-        markConversationUnread(
+        seedRunUnreadBaseline(
           run.conversationId,
           run.finishedAt ?? run.firedAt ?? Math.floor(Date.now() / 1000),
         );

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -30,7 +30,6 @@ import { showToast } from "@/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { CreateScheduledTaskDialog } from "@/components/scheduled/CreateScheduledTaskDialog";
 import {
-  cancelRunNowPoll,
   useDeleteScheduledTask,
   useRunScheduledTaskNow,
   useScheduledTask,
@@ -62,26 +61,28 @@ export function TaskDetailPage() {
   const navigate = useNavigate();
   const now = useNow();
 
+  // "Awaiting new run row" loading state for the Run now button. The button
+  // stays in its loading state after the POST returns 202 until a new run row
+  // arrives (newest id changes) or the safety cap fires. Declared BEFORE the
+  // runs query because it also keeps that query's refetchInterval alive across
+  // the gap between the 202 and the server writing the row.
+  const [awaitingRunRow, setAwaitingRunRow] = useState(false);
+  const preFireNewestIdRef = useRef<string | null>(null);
+  const awaitingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const { data: task, isLoading, isError } = useScheduledTask(taskId);
   // Run history only fetches once we have a real id.
   const {
     data: runs,
     isLoading: runsLoading,
     isError: runsError,
-  } = useScheduledTaskRuns(taskId, taskId !== "");
+  } = useScheduledTaskRuns(taskId, taskId !== "", awaitingRunRow);
 
   const updateMutation = useUpdateScheduledTask();
   const deleteMutation = useDeleteScheduledTask();
   const runNowMutation = useRunScheduledTaskNow();
 
   const [editOpen, setEditOpen] = useState(false);
-
-  // "Awaiting new run row" loading state for the Run now button. The button
-  // stays in its loading state after the POST returns 202 until the accelerated
-  // poll delivers a new run row (newest id changes) or the 20s safety cap fires.
-  const [awaitingRunRow, setAwaitingRunRow] = useState(false);
-  const preFireNewestIdRef = useRef<string | null>(null);
-  const awaitingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Clear the awaiting flag and its safety timer (shared by the effect and
   // the timer callback so neither leaks).
@@ -103,14 +104,13 @@ export function TaskDetailPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runs, awaitingRunRow]);
 
-  // Unmount cleanup so neither the local safety timer nor the module-global
-  // run-now poller fires into / refetches for an unmounted page.
+  // Unmount cleanup for the local safety timer so it can't fire into an
+  // unmounted page. The run-history refresh needs no cleanup here: it's a
+  // `refetchInterval` on `useScheduledTaskRuns`, which TanStack Query tears
+  // down automatically when this page unmounts.
   useEffect(() => {
     return () => {
       if (awaitingTimerRef.current != null) clearTimeout(awaitingTimerRef.current);
-      // Stop the accelerated run-now poll this page kicked off (self-scheduling
-      // setTimeout chain in useRunScheduledTaskNow) once we navigate away.
-      if (taskId !== "") cancelRunNowPoll(taskId);
     };
   }, [taskId]);
 
@@ -225,9 +225,13 @@ export function TaskDetailPage() {
     runNowMutation.mutate(task!.id, {
       onSuccess: () => {
         showToast("Run started");
-        // Keep the button in loading state until the new run row appears (~1s).
+        // Keep the button in loading state until the new run row appears, and —
+        // because the row is written a few seconds AFTER this 202 — keep the run
+        // history polling across that gap so the row is picked up at all.
         setAwaitingRunRow(true);
-        // Safety cap: clear after 20s even if no row ever shows up.
+        // Safety cap: clear after 20s even if no row ever shows up. Generous
+        // next to the observed few-second write, and only this window is
+        // unconditional — once the row lands, run status drives the polling.
         if (awaitingTimerRef.current != null) clearTimeout(awaitingTimerRef.current);
         awaitingTimerRef.current = setTimeout(clearAwaitingRunRow, 20_000);
       },

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -487,7 +487,7 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
           data-testid="run-status-dot"
           data-run-icon="unread"
           data-run-unread={true}
-          className="size-2.5 shrink-0 rounded-full bg-blue-500"
+          className="size-2.5 shrink-0 rounded-full bg-brand-accent"
         />
       </IndicatorWithTooltip>
     );

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -13,18 +13,21 @@
  */
 
 import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import {
-  ArrowRightIcon,
   ChevronLeftIcon,
+  CircleSlashIcon,
   Loader2Icon,
   PencilIcon,
   PlayIcon,
   Trash2Icon,
+  TriangleAlertIcon,
 } from "lucide-react";
 import { Link, useNavigate, useParams } from "@/lib/routing";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { CreateScheduledTaskDialog } from "@/components/scheduled/CreateScheduledTaskDialog";
 import {
   useDeleteScheduledTask,
@@ -33,6 +36,12 @@ import {
   useScheduledTaskRuns,
   useUpdateScheduledTask,
 } from "@/hooks/useScheduledTasks";
+import { fetchConversationById } from "@/hooks/useConversations";
+import {
+  isConversationUnseen,
+  isExplicitlyUnread,
+  useUnseenTick,
+} from "@/hooks/useUnseenConversations";
 import { useNow } from "@/hooks/useNow";
 import { useAvailableAgents } from "@/hooks/useAvailableAgents";
 import { useHosts } from "@/hooks/useHosts";
@@ -43,7 +52,7 @@ import {
   formatRunDuration,
   formatRunTimestamp,
 } from "@/lib/scheduleText";
-import type { ScheduledTaskRun, ScheduledTaskRunStatus } from "@/lib/scheduledTasksApi";
+import type { ScheduledTaskRun } from "@/lib/scheduledTasksApi";
 import { cn } from "@/lib/utils";
 
 export function TaskDetailPage() {
@@ -288,82 +297,191 @@ function ConfigField({ label, value, testId }: { label: string; value: string; t
 }
 
 /**
- * One run in the history list: a status dot, the fire timestamp (bold), the
- * duration (muted), and a detail line — an errorCode-derived message for
- * skipped/failed runs, or an "Open conversation →" link when the run produced
- * a conversation. No fabricated per-run summary.
+ * Resolve whether a succeeded run's conversation is genuinely UNREAD, using the
+ * SAME read-state signal as the sidebar's "new messages" dot.
+ *
+ * IMPORTANT: the run row carries only `conversationId`; unread lives on the
+ * conversation. The single-session `GET /v1/sessions/{id}` (what
+ * `fetchConversationById` calls) does NOT return `viewer_unread` — that field
+ * is only on the LIST items (`SessionListItem`), verified against the schema
+ * and the live backend. So we don't read a `viewer_unread` off the fetch.
+ * Instead we fetch the conversation for its authoritative `updated_at` +
+ * `status`, then feed those to the app's `isConversationUnseen` (the read-state
+ * mirror in `useUnseenConversations`), OR honor an explicit "mark unread".
+ * `useUnseenTick()` makes this recompute the instant the user opens the thread
+ * (marking it read) without a refetch. A deleted conversation → `null` → read.
+ */
+function useRunUnread(conversationId: string | null, enabled: boolean): boolean {
+  // Re-render when the read-state mirror changes (open thread → mark read).
+  useUnseenTick();
+  const { data: conversation } = useQuery({
+    queryKey: ["conversation-unread", conversationId],
+    queryFn: () => fetchConversationById(conversationId as string),
+    enabled: enabled && conversationId !== null,
+    staleTime: 30_000,
+  });
+  if (!conversationId || !conversation) return false;
+  if (isExplicitlyUnread(conversationId)) return true;
+  return isConversationUnseen(conversationId, conversation.updated_at, conversation.status);
+}
+
+/**
+ * One run in the history list. Layout (LEFT status column + whole-row click):
+ * - LEADING: a single status icon chosen by priority (see `RunStatusIcon`) —
+ *   failed triangle > skipped circle-slash > succeeded-unread blue dot >
+ *   succeeded-read grey dot — each with an explanatory tooltip.
+ * - BODY: the fire timestamp (bold), the duration (muted), and — for
+ *   skipped/failed — an errorCode-derived message. No fabricated summary.
+ *
+ * When the run produced a conversation the ENTIRE row is the click target
+ * (a real `<Link>`: keyboard-focusable, Enter/Space activate natively) that
+ * navigates to `/c/:conversationId`, with a hover highlight + pointer cursor.
+ * Runs without a conversation (e.g. skipped) render as a plain, non-interactive
+ * row: no highlight, no pointer, not focusable.
  */
 function RunRow({ run, now }: { run: ScheduledTaskRun; now: Date }) {
   const timestamp = formatRunTimestamp(run.firedAt ?? run.scheduledAt, now);
   const duration = formatRunDuration(run.firedAt, run.finishedAt);
-  const detail = runDetail(run);
+  // Unread only applies to a succeeded run that produced a conversation.
+  const unread = useRunUnread(
+    run.conversationId,
+    run.status === "succeeded" && run.conversationId !== null,
+  );
 
-  return (
-    <li
-      data-testid="task-detail-run"
-      data-run-status={run.status}
-      className="flex items-start gap-3 rounded-lg px-2 py-2"
-    >
-      <span
-        aria-hidden
-        data-testid="run-status-dot"
-        className={cn("mt-1.5 size-2 shrink-0 rounded-full", statusDotClass(run.status))}
-      />
-      <div className="flex min-w-0 flex-1 flex-col">
-        <div className="flex items-baseline gap-2">
+  const body = (
+    <>
+      <span className="flex size-4 shrink-0 items-center justify-center">
+        <RunStatusIcon run={run} unread={unread} />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="flex items-baseline gap-2">
           <span className="text-sm font-semibold">{timestamp ?? "—"}</span>
           {duration && (
             <span className="text-xs text-muted-foreground" data-testid="run-duration">
               {duration}
             </span>
           )}
-        </div>
-        {detail}
-      </div>
+        </span>
+      </span>
+    </>
+  );
+
+  const commonClassName = "flex items-center gap-3 rounded-lg px-2 py-2";
+
+  // Clickable when the run has a conversation to open. A real <Link> (anchor)
+  // is focusable and Enter/Space-activatable for free; the hover highlight +
+  // pointer cursor signal clickability without any explicit link text.
+  if (run.conversationId) {
+    return (
+      <li data-testid="task-detail-run" data-run-status={run.status} data-run-unread={unread}>
+        <Link
+          to={`/c/${run.conversationId}`}
+          data-testid="run-open"
+          aria-label="Open conversation"
+          className={cn(
+            commonClassName,
+            "cursor-pointer transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-none",
+          )}
+        >
+          {body}
+        </Link>
+      </li>
+    );
+  }
+
+  // No conversation → not clickable, no hover highlight, not focusable.
+  return (
+    <li
+      data-testid="task-detail-run"
+      data-run-status={run.status}
+      data-run-unread={run.status === "succeeded" ? unread : undefined}
+      className={commonClassName}
+    >
+      {body}
     </li>
   );
 }
 
 /**
- * The run's detail line. Skipped/failed → a human message from the errorCode;
- * otherwise, if the run produced a conversation, an "Open conversation →" link.
- * Returns null when there's nothing honest to show (e.g. a scheduled/running
- * run with no conversation yet).
+ * The leading LEFT status icon for a run. Exactly one renders, by priority:
+ *   1. failed              → amber warning triangle, tooltip = errorCode message.
+ *   2. skipped             → muted circle-slash, tooltip = skip reason.
+ *   3. succeeded + UNREAD  → blue filled dot, tooltip = "Unread".
+ *   4. succeeded + READ / no conversation → muted grey dot, tooltip = "Completed".
+ *   5. scheduled/running/incomplete → muted grey dot, no tooltip (not terminal).
  */
-function runDetail(run: ScheduledTaskRun): React.ReactNode {
-  if (run.status === "skipped" || run.status === "failed") {
+function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean }) {
+  if (run.status === "failed") {
     return (
-      <span className="text-xs text-muted-foreground" data-testid="run-error-detail">
-        {describeRunError(run.errorCode, run.status)}
-      </span>
+      <IndicatorWithTooltip tooltip={describeRunError(run.errorCode, "failed")}>
+        <TriangleAlertIcon
+          data-testid="run-status-icon"
+          data-run-icon="failed"
+          className="size-4 shrink-0 text-amber-500"
+        />
+      </IndicatorWithTooltip>
     );
   }
-  if (run.conversationId) {
+  if (run.status === "skipped") {
     return (
-      <Link
-        to={`/c/${run.conversationId}`}
-        data-testid="run-open-conversation"
-        className="inline-flex w-fit items-center gap-1 text-xs text-primary transition-colors hover:underline"
-      >
-        Open conversation
-        <ArrowRightIcon className="size-3" />
-      </Link>
+      <IndicatorWithTooltip tooltip={describeRunError(run.errorCode, "skipped")}>
+        <CircleSlashIcon
+          data-testid="run-status-icon"
+          data-run-icon="skipped"
+          className="size-4 shrink-0 text-muted-foreground"
+        />
+      </IndicatorWithTooltip>
     );
   }
-  return null;
+  if (run.status === "succeeded" && unread) {
+    return (
+      <IndicatorWithTooltip tooltip="Unread">
+        <span
+          aria-hidden
+          data-testid="run-status-dot"
+          data-run-icon="unread"
+          data-run-unread={true}
+          className="size-2.5 shrink-0 rounded-full bg-blue-500"
+        />
+      </IndicatorWithTooltip>
+    );
+  }
+  // Succeeded+read gets a tooltip ("Completed"); non-terminal statuses share the
+  // same muted dot but with no tooltip (nothing meaningful to say yet).
+  const dot = (
+    <span
+      aria-hidden
+      data-testid="run-status-dot"
+      data-run-icon={run.status === "succeeded" ? "read" : "pending"}
+      data-run-unread={run.status === "succeeded" ? false : undefined}
+      className="size-2.5 shrink-0 rounded-full bg-muted-foreground/40"
+    />
+  );
+  if (run.status === "succeeded") {
+    return <IndicatorWithTooltip tooltip="Completed">{dot}</IndicatorWithTooltip>;
+  }
+  return dot;
 }
 
-/** Status → colored dot. Mirrors the list's completion-badge color semantics. */
-function statusDotClass(status: ScheduledTaskRunStatus): string {
-  switch (status) {
-    case "succeeded":
-      return "bg-emerald-500";
-    case "failed":
-      return "bg-destructive";
-    case "skipped":
-      return "bg-amber-500";
-    default:
-      // scheduled / running / incomplete — not yet a terminal signal.
-      return "bg-muted-foreground/40";
-  }
+/** Wrap a status indicator in the shared Tooltip (app already provides the
+ * TooltipProvider). The trigger uses `asChild` so it renders the child element
+ * directly (icon/dot) rather than a nested button. */
+function IndicatorWithTooltip({
+  tooltip,
+  children,
+}: {
+  tooltip: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {/* A span wrapper keeps the trigger focusable/hoverable for both the
+            svg icon and the pure-CSS dot span. Vertical alignment to the
+            timestamp baseline is set per-child (icons vs. the smaller dot). */}
+        <span className="inline-flex shrink-0">{children}</span>
+      </TooltipTrigger>
+      <TooltipContent data-testid="run-status-tooltip">{tooltip}</TooltipContent>
+    </Tooltip>
+  );
 }

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -12,7 +12,7 @@
  * open-conversation link) — never an invented summary line.
  */
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   CalendarOffIcon,
@@ -41,6 +41,7 @@ import { fetchConversationById } from "@/hooks/useConversations";
 import {
   isConversationUnseen,
   isExplicitlyUnread,
+  markConversationUnread,
   useUnseenTick,
 } from "@/hooks/useUnseenConversations";
 import { useNow } from "@/hooks/useNow";
@@ -75,6 +76,53 @@ export function TaskDetailPage() {
   const runNowMutation = useRunScheduledTaskNow();
 
   const [editOpen, setEditOpen] = useState(false);
+
+  // Auto-mark newly-completed (succeeded) runs as unread so the pink dot
+  // appears until the user opens the conversation.
+  //
+  // Two guards prevent incorrect behaviour:
+  //   1. ONCE-PER-SESSION: `autoMarkedRef` tracks every conversationId this
+  //      component has already auto-marked. Re-marking on a subsequent poll
+  //      would resurrect the dot for a run the user already opened.
+  //   2. NO-RETROACTIVE: the ref is seeded on the FIRST non-empty runs response
+  //      with all currently-terminal ids, so pre-existing history is never
+  //      mass-marked pink on page load. Only runs that appear as terminal AFTER
+  //      the baseline is established trigger a mark.
+  const autoMarkedRef = useRef<Set<string>>(new Set());
+  const baselineSeededRef = useRef(false);
+  useEffect(() => {
+    if (!runs) return;
+
+    if (!baselineSeededRef.current) {
+      // Seed the baseline from the initial run list — skip all currently-terminal
+      // ids so existing history stays read. Seed even when empty so a subsequent
+      // update with a new completed run is correctly treated as "new", not as a
+      // second baseline seed.
+      for (const run of runs) {
+        if (run.conversationId && run.status === "succeeded") {
+          autoMarkedRef.current.add(run.conversationId);
+        }
+      }
+      baselineSeededRef.current = true;
+      return;
+    }
+
+    // On subsequent updates, mark any succeeded run whose conversationId hasn't
+    // been auto-marked yet (new completion observed by this client).
+    for (const run of runs) {
+      if (
+        run.status === "succeeded" &&
+        run.conversationId &&
+        !autoMarkedRef.current.has(run.conversationId)
+      ) {
+        autoMarkedRef.current.add(run.conversationId);
+        markConversationUnread(
+          run.conversationId,
+          run.finishedAt ?? run.firedAt ?? Math.floor(Date.now() / 1000),
+        );
+      }
+    }
+  }, [runs]);
 
   // Resolve the agent + host display labels from their catalogs. Both are
   // best-effort: an unknown id falls back to the raw id (agent) or a friendly

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -202,9 +202,19 @@ export function TaskDetailPage() {
         </div>
       </div>
 
-      {/* Status line: state pill + active toggle (Switch, ON = active) +
-          schedule + next-run. The Switch sits to the RIGHT of the pill. */}
+      {/* Status line: active toggle (Switch, ON = active) + state pill +
+          schedule + next-run. The Switch sits to the LEFT of the pill. */}
       <div className="mt-3 flex flex-wrap items-center gap-2 text-sm">
+        {/* A scheduled task is ON when active. onCheckedChange passes a boolean,
+            but handlePauseToggle derives the next state from `paused` and
+            ignores its args, so no rewiring is needed. */}
+        <Switch
+          aria-label={paused ? "Resume automation" : "Pause automation"}
+          data-testid="task-detail-pause-toggle"
+          checked={!paused}
+          disabled={busy}
+          onCheckedChange={handlePauseToggle}
+        />
         <span
           data-testid="task-detail-state-pill"
           className={cn(
@@ -216,16 +226,6 @@ export function TaskDetailPage() {
         >
           {paused ? "Paused" : "Active"}
         </span>
-        {/* A scheduled task is ON when active. onCheckedChange passes a boolean,
-            but handlePauseToggle derives the next state from `paused` and
-            ignores its args, so no rewiring is needed. */}
-        <Switch
-          aria-label={paused ? "Resume automation" : "Pause automation"}
-          data-testid="task-detail-pause-toggle"
-          checked={!paused}
-          disabled={busy}
-          onCheckedChange={handlePauseToggle}
-        />
         <span className="text-muted-foreground" data-testid="task-detail-schedule">
           {scheduleSummary}
           {nextRun && ` · Next run ${nextRun}`}

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -15,8 +15,8 @@
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
+  CalendarOffIcon,
   ChevronLeftIcon,
-  CircleSlashIcon,
   Loader2Icon,
   PencilIcon,
   PlayIcon,
@@ -425,7 +425,7 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
   if (run.status === "skipped") {
     return (
       <IndicatorWithTooltip tooltip={describeRunError(run.errorCode, "skipped")}>
-        <CircleSlashIcon
+        <CalendarOffIcon
           data-testid="run-status-icon"
           data-run-icon="skipped"
           className="size-4 shrink-0 text-muted-foreground"

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -359,7 +359,7 @@ function RunRow({ run, now }: { run: ScheduledTaskRun; now: Date }) {
       </span>
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="flex items-baseline gap-2">
-          <span className="text-sm font-semibold">{timestamp ?? "—"}</span>
+          <span className="text-sm font-normal">{timestamp ?? "—"}</span>
           {duration && (
             <span className="text-xs text-muted-foreground" data-testid="run-duration">
               {duration}
@@ -410,7 +410,7 @@ function RunRow({ run, now }: { run: ScheduledTaskRun; now: Date }) {
  * The leading LEFT status icon for a run. Exactly one renders, by priority:
  *   1. failed              → amber warning triangle, tooltip = errorCode message.
  *   2. skipped             → muted calendar-off icon, tooltip = skip reason.
- *   3. running             → pulsing grey dot, tooltip = "Running".
+ *   3. running             → spinning loader icon, tooltip = "Running".
  *   4. succeeded + UNREAD  → blue filled dot, tooltip = "Unread".
  *   5. succeeded + READ / no conversation → muted grey dot, tooltip = "Completed".
  *   6. scheduled/incomplete → muted grey dot, no tooltip (not terminal).
@@ -441,11 +441,10 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
   if (run.status === "running") {
     return (
       <IndicatorWithTooltip tooltip="Running">
-        <span
-          aria-hidden
-          data-testid="run-status-dot"
+        <Loader2Icon
+          data-testid="run-status-icon"
           data-run-icon="running"
-          className="size-2.5 shrink-0 animate-pulse rounded-full bg-muted-foreground/40"
+          className="size-3 shrink-0 animate-spin text-muted-foreground"
         />
       </IndicatorWithTooltip>
     );

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -30,6 +30,7 @@ import { showToast } from "@/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { CreateScheduledTaskDialog } from "@/components/scheduled/CreateScheduledTaskDialog";
 import {
+  cancelRunNowPoll,
   useDeleteScheduledTask,
   useRunScheduledTaskNow,
   useScheduledTask,
@@ -102,12 +103,16 @@ export function TaskDetailPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runs, awaitingRunRow]);
 
-  // Unmount cleanup so the safety timer doesn't fire into an unmounted component.
+  // Unmount cleanup so neither the local safety timer nor the module-global
+  // run-now poller fires into / refetches for an unmounted page.
   useEffect(() => {
     return () => {
       if (awaitingTimerRef.current != null) clearTimeout(awaitingTimerRef.current);
+      // Stop the accelerated run-now poll this page kicked off (self-scheduling
+      // setTimeout chain in useRunScheduledTaskNow) once we navigate away.
+      if (taskId !== "") cancelRunNowPoll(taskId);
     };
-  }, []);
+  }, [taskId]);
 
   // Auto-mark newly-completed (succeeded) runs as unread so the pink dot
   // appears until the user opens the conversation.

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -466,7 +466,7 @@ function RunRow({ run, now }: { run: ScheduledTaskRun; now: Date }) {
 
   const body = (
     <>
-      <span className="flex size-4 shrink-0 items-center justify-center">
+      <span className="flex size-5 shrink-0 items-center justify-center">
         <RunStatusIcon run={run} unread={unread} />
       </span>
       <span className="flex min-w-0 flex-1 flex-col">
@@ -534,7 +534,8 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
         <TriangleAlertIcon
           data-testid="run-status-icon"
           data-run-icon="failed"
-          className="size-3.5 shrink-0 text-amber-500"
+          className="size-4 shrink-0 text-amber-500"
+          strokeWidth={1.75}
         />
       </IndicatorWithTooltip>
     );
@@ -545,7 +546,8 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
         <CalendarOffIcon
           data-testid="run-status-icon"
           data-run-icon="skipped"
-          className="size-3.5 shrink-0 text-muted-foreground"
+          className="size-4 shrink-0 text-muted-foreground"
+          strokeWidth={1.75}
         />
       </IndicatorWithTooltip>
     );
@@ -556,7 +558,7 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
         <Loader2Icon
           data-testid="run-status-icon"
           data-run-icon="running"
-          className="size-3 shrink-0 animate-spin text-muted-foreground"
+          className="size-3.5 shrink-0 animate-spin text-muted-foreground"
         />
       </IndicatorWithTooltip>
     );

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -436,7 +436,7 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
         <TriangleAlertIcon
           data-testid="run-status-icon"
           data-run-icon="failed"
-          className="size-3 shrink-0 text-amber-500"
+          className="size-3.5 shrink-0 text-amber-500"
         />
       </IndicatorWithTooltip>
     );
@@ -447,7 +447,7 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
         <CalendarOffIcon
           data-testid="run-status-icon"
           data-run-icon="skipped"
-          className="size-3 shrink-0 text-muted-foreground"
+          className="size-3.5 shrink-0 text-muted-foreground"
         />
       </IndicatorWithTooltip>
     );

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -350,7 +350,7 @@ export function TaskDetailPage() {
       <hr className="my-6 border-border" />
 
       {/* Run history. */}
-      <h2 className="mb-3 text-sm font-medium text-muted-foreground">Run history</h2>
+      <h2 className="mb-2 text-sm font-medium text-muted-foreground">Run history</h2>
       {runsLoading ? (
         <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
           <Loader2Icon className="size-4 animate-spin" />

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -27,6 +27,7 @@ import { Link, useNavigate, useParams } from "@/lib/routing";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { showToast } from "@/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { CreateScheduledTaskDialog } from "@/components/scheduled/CreateScheduledTaskDialog";
 import {
@@ -132,7 +133,10 @@ export function TaskDetailPage() {
   }
 
   function handleRunNow() {
-    runNowMutation.mutate(task!.id);
+    runNowMutation.mutate(task!.id, {
+      onSuccess: () => showToast("Run started"),
+      onError: () => showToast("Couldn't start the run"),
+    });
   }
 
   function handleDelete() {
@@ -405,10 +409,11 @@ function RunRow({ run, now }: { run: ScheduledTaskRun; now: Date }) {
 /**
  * The leading LEFT status icon for a run. Exactly one renders, by priority:
  *   1. failed              → amber warning triangle, tooltip = errorCode message.
- *   2. skipped             → muted circle-slash, tooltip = skip reason.
- *   3. succeeded + UNREAD  → blue filled dot, tooltip = "Unread".
- *   4. succeeded + READ / no conversation → muted grey dot, tooltip = "Completed".
- *   5. scheduled/running/incomplete → muted grey dot, no tooltip (not terminal).
+ *   2. skipped             → muted calendar-off icon, tooltip = skip reason.
+ *   3. running             → pulsing grey dot, tooltip = "Running".
+ *   4. succeeded + UNREAD  → blue filled dot, tooltip = "Unread".
+ *   5. succeeded + READ / no conversation → muted grey dot, tooltip = "Completed".
+ *   6. scheduled/incomplete → muted grey dot, no tooltip (not terminal).
  */
 function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean }) {
   if (run.status === "failed") {
@@ -417,7 +422,7 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
         <TriangleAlertIcon
           data-testid="run-status-icon"
           data-run-icon="failed"
-          className="size-4 shrink-0 text-amber-500"
+          className="size-3 shrink-0 text-amber-500"
         />
       </IndicatorWithTooltip>
     );
@@ -428,7 +433,19 @@ function RunStatusIcon({ run, unread }: { run: ScheduledTaskRun; unread: boolean
         <CalendarOffIcon
           data-testid="run-status-icon"
           data-run-icon="skipped"
-          className="size-4 shrink-0 text-muted-foreground"
+          className="size-3 shrink-0 text-muted-foreground"
+        />
+      </IndicatorWithTooltip>
+    );
+  }
+  if (run.status === "running") {
+    return (
+      <IndicatorWithTooltip tooltip="Running">
+        <span
+          aria-hidden
+          data-testid="run-status-dot"
+          data-run-icon="running"
+          className="size-2.5 shrink-0 animate-pulse rounded-full bg-muted-foreground/40"
         />
       </IndicatorWithTooltip>
     );

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -357,11 +357,11 @@ export function TaskDetailPage() {
           Loading runs…
         </div>
       ) : runsError ? (
-        <p className="py-6 text-sm text-muted-foreground" data-testid="task-detail-runs-error">
+        <p className="pb-2 text-sm text-muted-foreground" data-testid="task-detail-runs-error">
           Couldn’t load run history.
         </p>
       ) : (runs ?? []).length === 0 ? (
-        <p className="py-6 text-sm text-muted-foreground" data-testid="task-detail-runs-empty">
+        <p className="pb-2 text-sm text-muted-foreground" data-testid="task-detail-runs-empty">
           No runs yet.
         </p>
       ) : (

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -77,6 +77,40 @@ export function TaskDetailPage() {
 
   const [editOpen, setEditOpen] = useState(false);
 
+  // "Awaiting new run row" loading state for the Run now button. The button
+  // stays in its loading state after the POST returns 202 until the accelerated
+  // poll delivers a new run row (newest id changes) or the 20s safety cap fires.
+  const [awaitingRunRow, setAwaitingRunRow] = useState(false);
+  const preFireNewestIdRef = useRef<string | null>(null);
+  const awaitingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the awaiting flag and its safety timer (shared by the effect and
+  // the timer callback so neither leaks).
+  function clearAwaitingRunRow() {
+    setAwaitingRunRow(false);
+    if (awaitingTimerRef.current != null) {
+      clearTimeout(awaitingTimerRef.current);
+      awaitingTimerRef.current = null;
+    }
+  }
+
+  // Clear the flag when a new run row appears (newestId changed from snapshot).
+  useEffect(() => {
+    if (!awaitingRunRow) return;
+    const newestId = runs?.[0]?.id ?? null;
+    if (newestId != null && newestId !== preFireNewestIdRef.current) {
+      clearAwaitingRunRow();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runs, awaitingRunRow]);
+
+  // Unmount cleanup so the safety timer doesn't fire into an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (awaitingTimerRef.current != null) clearTimeout(awaitingTimerRef.current);
+    };
+  }, []);
+
   // Auto-mark newly-completed (succeeded) runs as unread so the pink dot
   // appears until the user opens the conversation.
   //
@@ -182,9 +216,20 @@ export function TaskDetailPage() {
   }
 
   function handleRunNow() {
+    // Snapshot the pre-fire newest run id so the awaiting effect knows what
+    // "a new row appeared" means.
+    preFireNewestIdRef.current = runs?.[0]?.id ?? null;
     runNowMutation.mutate(task!.id, {
-      onSuccess: () => showToast("Run started"),
+      onSuccess: () => {
+        showToast("Run started");
+        // Keep the button in loading state until the new run row appears (~1s).
+        setAwaitingRunRow(true);
+        // Safety cap: clear after 20s even if no row ever shows up.
+        if (awaitingTimerRef.current != null) clearTimeout(awaitingTimerRef.current);
+        awaitingTimerRef.current = setTimeout(clearAwaitingRunRow, 20_000);
+      },
       onError: (err) => {
+        clearAwaitingRunRow();
         // A 409 (CONFLICT) means a run for this task is already in flight — the
         // run is fine. Show a truthful, non-alarming message.
         if (err instanceof ScheduledTaskApiError && err.status === 409) {
@@ -234,8 +279,12 @@ export function TaskDetailPage() {
           >
             <Trash2Icon className="size-4" />
           </Button>
-          <Button data-testid="task-detail-run-now" disabled={busy} onClick={handleRunNow}>
-            {runNowMutation.isPending ? (
+          <Button
+            data-testid="task-detail-run-now"
+            disabled={busy || awaitingRunRow}
+            onClick={handleRunNow}
+          >
+            {runNowMutation.isPending || awaitingRunRow ? (
               <>
                 <Loader2Icon className="size-4 animate-spin" />
                 In progress

--- a/web/src/pages/TasksPage.test.tsx
+++ b/web/src/pages/TasksPage.test.tsx
@@ -19,7 +19,6 @@ vi.mock("@/hooks/useScheduledTasks", () => ({
   useUpdateScheduledTask: vi.fn(),
   useDeleteScheduledTask: vi.fn(),
   useRunScheduledTaskNow: vi.fn(),
-  cancelRunNowPoll: vi.fn(),
 }));
 
 // Stub the create dialog — its internals are covered separately; here we only

--- a/web/src/pages/TasksPage.test.tsx
+++ b/web/src/pages/TasksPage.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@/hooks/useScheduledTasks", () => ({
   useUpdateScheduledTask: vi.fn(),
   useDeleteScheduledTask: vi.fn(),
   useRunScheduledTaskNow: vi.fn(),
+  cancelRunNowPoll: vi.fn(),
 }));
 
 // Stub the create dialog — its internals are covered separately; here we only

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -10,7 +10,7 @@
  * endpoint.
  */
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ClockIcon, Loader2Icon, SearchIcon, TriangleAlertIcon } from "lucide-react";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
@@ -22,6 +22,7 @@ import {
   type ScheduledTaskSuggestion,
 } from "@/components/scheduled/suggestions";
 import {
+  cancelRunNowPoll,
   useDeleteScheduledTask,
   useRunScheduledTaskNow,
   useScheduledTasks,
@@ -134,9 +135,22 @@ export function TasksPage() {
     deleteMutation.mutate(task.id);
   }
 
+  // Task ids this page fired a run-now for, so their module-global pollers can be
+  // cancelled on unmount (the poll's self-scheduling setTimeout chain in
+  // useRunScheduledTaskNow would otherwise keep refetching after we leave /tasks).
+  const firedRunNowIdsRef = useRef<Set<string>>(new Set());
+
   function handleRunNow(task: ScheduledTask) {
+    firedRunNowIdsRef.current.add(task.id);
     runNowMutation.mutate(task.id);
   }
+
+  useEffect(() => {
+    const firedIds = firedRunNowIdsRef.current;
+    return () => {
+      for (const id of firedIds) cancelRunNowPoll(id);
+    };
+  }, []);
 
   function handleEdit(task: ScheduledTask) {
     setPrefill(null);

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -10,7 +10,7 @@
  * endpoint.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { ClockIcon, Loader2Icon, SearchIcon, TriangleAlertIcon } from "lucide-react";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
@@ -22,7 +22,6 @@ import {
   type ScheduledTaskSuggestion,
 } from "@/components/scheduled/suggestions";
 import {
-  cancelRunNowPoll,
   useDeleteScheduledTask,
   useRunScheduledTaskNow,
   useScheduledTasks,
@@ -135,22 +134,9 @@ export function TasksPage() {
     deleteMutation.mutate(task.id);
   }
 
-  // Task ids this page fired a run-now for, so their module-global pollers can be
-  // cancelled on unmount (the poll's self-scheduling setTimeout chain in
-  // useRunScheduledTaskNow would otherwise keep refetching after we leave /tasks).
-  const firedRunNowIdsRef = useRef<Set<string>>(new Set());
-
   function handleRunNow(task: ScheduledTask) {
-    firedRunNowIdsRef.current.add(task.id);
     runNowMutation.mutate(task.id);
   }
-
-  useEffect(() => {
-    const firedIds = firedRunNowIdsRef.current;
-    return () => {
-      for (const id of firedIds) cancelRunNowPoll(id);
-    };
-  }, []);
 
   function handleEdit(task: ScheduledTask) {
     setPrefill(null);

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -415,6 +415,20 @@ describe("Sidebar session list", () => {
     );
   });
 
+  it("marks Automations active (not New session) on /tasks/:taskId (detail route)", () => {
+    mockConversations(THREE_TYPE_CONVERSATIONS);
+    renderSidebar(true, "/tasks/task_abc123");
+
+    // Automations is highlighted on the detail route — same pill as the list page.
+    expect(screen.getByTestId("scheduled-tasks-nav").className).toContain(
+      "bg-[var(--sidebar-active)]",
+    );
+    // New session must NOT be highlighted — it was wrongly lit before this fix.
+    expect(screen.getByTestId("new-chat-button").className).not.toContain(
+      "bg-[var(--sidebar-active)]",
+    );
+  });
+
   it("does NOT close the sidebar when the footer Settings is tapped", () => {
     // No onNavClick on the footer Settings link: on mobile the overlay stays
     // open and swaps to the settings section list rather than collapsing onto

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -237,15 +237,18 @@ interface SidebarProps {
 }
 
 /**
- * Which top-level nav button (New session / Inbox) is active for the current
- * route.
+ * Which top-level nav button (New session / Inbox / Automations) is active for
+ * the current route.
  *
- * The inbox route has no param to key off, and the sidebar is basename-agnostic
- * (in embedded mode the routing seam rebases `to="/inbox"` → `${basename}/inbox`
- * behind its back), so `useMatch` / `NavLink` can't be used without knowing the
- * mount path. Instead compare the active route's last non-empty path segment,
- * which is `inbox` in both standalone and embedded modes. Conversation ids are
- * `conv_…`-prefixed, so a chat route's leaf can never collide with `inbox`.
+ * The inbox/tasks routes have no `:conversationId` param to key off, and the
+ * sidebar is basename-agnostic (in embedded mode the routing seam rebases
+ * `to="/inbox"` → `${basename}/inbox` behind its back), so `useMatch` /
+ * `NavLink` can't be used without knowing the mount path. Instead compare path
+ * segments from the end:
+ *   - `/tasks` (leaf === "tasks")
+ *   - `/tasks/:taskId` (second-to-last segment === "tasks") — the detail route.
+ * Conversation ids are `conv_…`-prefixed, so a chat route's leaf can never
+ * collide with "inbox" or "tasks".
  */
 function useActiveNavItem(): {
   isNewChatPage: boolean;
@@ -253,9 +256,12 @@ function useActiveNavItem(): {
   isTasksPage: boolean;
 } {
   const { conversationId: activeConversationId } = useParams<{ conversationId: string }>();
-  const leaf = useLocation().pathname.split("/").filter(Boolean).at(-1);
+  const segments = useLocation().pathname.split("/").filter(Boolean);
+  const leaf = segments.at(-1);
   const isInboxPage = leaf === "inbox";
-  const isTasksPage = leaf === "tasks";
+  // True for both /tasks (list) and /tasks/:taskId (detail). Basename-agnostic:
+  // match the "tasks" segment by position from the end, not an absolute path.
+  const isTasksPage = leaf === "tasks" || segments.at(-2) === "tasks";
   // Exclude inbox/tasks: they also have no `:conversationId`, so they would
   // otherwise light up the "New session" button.
   const isNewChatPage = activeConversationId == null && !isInboxPage && !isTasksPage;


### PR DESCRIPTION
## Related issue

N/A — tracked in Linear ([OMNI-1193](https://linear.app/omnigent/issue/OMNI-1193)).

## Summary

Adds a **detail page for scheduled tasks (automations)**, opened by clicking a task card on `/tasks`. The page shows the task's header with edit / delete / **Run now** actions, a status line (active toggle + Active/Paused pill + human-readable schedule + relative next-run), the Prompt, a Configuration block (agent + host), and the task's **Run history**.

This PR is **mostly frontend**, but it also makes two deliberate **backend changes** (see below) — the original "frontend-only, no backend change" framing was inaccurate.

### Frontend

- New `/tasks/:taskId` route + `TaskDetailPage`, reached by clicking a task card on `/tasks`.
- Each run in the history renders only server-returned fields — a status dot/icon, the fire timestamp, the run duration, and either an `errorCode`-derived message (skipped/failed) or an "Open conversation →" link. No fabricated per-run summary text.
- The task card body on the list is the navigation affordance (a real button, for keyboard/focus a11y); the hover ⋯ menu is a sibling that stops propagation so opening it never navigates.
- **Run-history unread dots are computed with zero per-row fetches.** `useRunUnread` derives the dot from the run payload's read-state fields via `isConversationUnseen` + `isExplicitlyUnread` — the previous implementation issued one `GET /v1/sessions/{id}` per succeeded run (an N+1, up to ~100 requests on load); that per-row fetch is removed.
- Status-indicator normalization: the failed triangle, skipped calendar-off, and read/unread dot share a fixed 20px slot with consistent optical weight; the dot is intentionally smaller (8px) than the 16px glyph icons.

### Backend (contract + semantics changes — reflect in review + release notes)

1. **`GET /v1/scheduled-tasks/{id}/runs` response contract changed.** Each run object gains three fields — `conversation_updated_at`, `conversation_status`, and `viewer_unread` — populated for runs that produced a conversation and `null` otherwise. `list_scheduled_task_runs` now batch-fetches all run conversations in one `get_conversations(conv_ids)` call and reads per-viewer read-state (`_read_state_entry`) for each, so the frontend can compute unread state without per-row session fetches.
2. **`scheduled/fire.py` run-status semantics changed.** A fire that cannot resolve a live host at fire time (unset/offline host, unresolvable home dir) now records a **`skipped`** run instead of a **`failed`** run — an offline host means the occurrence didn't run, not that something broke. Backend unit tests and the sibling e2e run-controls test were updated to assert `skipped`.

### How it fits together

```mermaid
flowchart LR
    A["/tasks list<br/>(ScheduledTaskRow)"] -- "click card body" --> B["/tasks/:taskId<br/>(TaskDetailPage)"]
    B --> C["useScheduledTask(id)<br/>GET /scheduled-tasks/{id}"]
    B --> D["useScheduledTaskRuns(id)<br/>GET /scheduled-tasks/{id}/runs<br/>(now returns per-run read-state)"]
    B -- "Run now / edit / delete / pause" --> E["existing mutations"]
    D --> F["Run history rows<br/>status icon · time · duration ·<br/>errorCode msg | Open conversation →"]
    F --> G["useRunUnread<br/>isConversationUnseen (no per-row fetch)"]
```

## Test Plan

- `npm run type-check`, `oxlint`, `prettier --check` — clean.
- `npm run test` — full web suite green (detail page renders header/prompt/config/run-history from mocked hooks; card body navigates while the ⋯ menu does not; `viewerUnread=true` renders the dot; delete navigates back; Run now fires the mutation; active toggle flips state; indicator sizing assertions updated).
- Backend `pytest`:
  - `tests/server/integration/test_scheduled_tasks_routes.py` — a succeeded run returns the enriched read-state fields; a skipped run returns nulls.
  - `tests/server/scheduled/test_fire.py` — unresolved/offline host records a `skipped` run (updated from `failed`).
  - `tests/e2e_ui/scheduled/` — detail-page journey + the list-page run-controls test (now asserts `skipped`).
- **Manual (dev server, light + dark themes):** detail page renders and matches the reference; Run now fires a run that appears in history; edit/delete/pause work; run history shows status indicators, durations, skip/fail reasons, and "Open conversation →" links; the ⋯ menu opens without navigating; verified no per-row `GET /v1/sessions/{id}` fires when the run history loads; status indicators are optically consistent and vertically centered in both themes.

## Demo

See the detail-page screenshots (light + dark) below. <!-- attach the PNGs -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [x] Backend / API change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the new page, the card-body-vs-menu navigation split, the date/duration/error helpers, and the read-state-driven unread dot. A backend integration test covers the new `/runs` response fields (populated vs. null), and backend unit tests cover the `failed`→`skipped` fire reclassification. Manual verification in the running app (both themes) covered the visual layout, the interactive actions, and the no-per-row-fetch behavior.

## Changelog

Scheduled tasks now have a detail page — click a task to see its schedule, configuration, and full run history, and run / edit / pause / delete it from there. The `GET /v1/scheduled-tasks/{id}/runs` response now includes per-run conversation read-state (`conversation_updated_at`, `conversation_status`, `viewer_unread`) so run-history unread indicators load without extra requests. A scheduled fire that finds no live host at fire time is now recorded as `skipped` (previously `failed`).