### PR TITLE
fix(codex-native): carry hook trust across private CODEX_HOME copy

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -41,6 +41,7 @@ from omnigent.inner.codex_executor import (
     _databricks_codex_base_url,
     _databricks_codex_config_overrides,
     _find_codex_cli,
+    _merge_codex_hook_trust_back,
     _populate_codex_home_config,
     _provider_codex_config_overrides,
 )
@@ -822,6 +823,14 @@ class CodexNativeAppServer:
             except asyncio.TimeoutError:
                 _kill_process_tree(self.proc)
                 await self.proc.wait()
+        # Flush any hook-trust the user accepted this session back into the
+        # global config so the next session's copy inherits it and
+        # _retarget_codex_hook_trust_keys can carry it forward without prompting.
+        _merge_codex_hook_trust_back(
+            self.codex_home / "config.toml",
+            _codex_home_config_source_from_env(),
+            self.codex_home,
+        )
         if self.process_registry_tag is not None:
             unregister_codex_native_process(self.process_registry_tag)
         if self.process_owner_lock is not None:

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -917,6 +917,92 @@ def _retarget_codex_hook_trust_keys(
         logger.warning("could not retarget hook-trust keys in %s", config_path)
 
 
+def _merge_codex_hook_trust_back(
+    private_config: Path,
+    source_dir: Path,
+    target_dir: Path,
+) -> None:
+    """Merge ``[hooks.state]`` trust entries from a private session config back
+    into the global ``CODEX_HOME`` ``config.toml``.
+
+    When a user accepts the hook-trust prompt inside a session, Codex writes
+    ``[hooks.state.*]`` entries into the private per-session ``config.toml``
+    with path keys referencing *target_dir* (the private home). Those entries
+    are discarded when the session ends because the private home is ephemeral.
+
+    This function reads the accumulated trust state from the private copy,
+    translates the path keys back from *target_dir* → *source_dir*, and
+    upserts them into the global ``source_dir/config.toml`` so the next
+    session's copy starts with them already present — and
+    :func:`_retarget_codex_hook_trust_keys` can carry them forward again.
+
+    All writes are atomic (temp-file + rename) and best-effort: any failure
+    is logged as a warning rather than raised, since the session has already
+    ended and blocking on a trust-state flush would be unhelpful.
+
+    :param private_config: The per-session private ``config.toml``.
+    :param source_dir: Original ``CODEX_HOME``, e.g. ``Path("~/.codex")``.
+    :param target_dir: Per-session private ``CODEX_HOME`` whose path appears
+        in the private trust keys.
+    """
+    source_prefix = str(source_dir)
+    target_prefix = str(target_dir)
+    if source_prefix == target_prefix:
+        return
+    try:
+        import tomlkit
+
+        private_text = private_config.read_text(encoding="utf-8")
+        private_doc = tomlkit.parse(private_text)
+    except Exception:  # noqa: BLE001
+        logger.warning("could not read private config for hook-trust merge: %s", private_config)
+        return
+
+    private_state: dict = (
+        private_doc.get("hooks", {}).get("state", {})  # type: ignore[union-attr]
+    )
+    if not private_state:
+        return
+
+    # Translate keys: target_dir prefix → source_dir prefix.
+    translated: dict[str, object] = {}
+    for key, value in private_state.items():
+        if key.startswith(target_prefix):
+            translated[source_prefix + key[len(target_prefix) :]] = value
+        else:
+            translated[key] = value
+
+    global_config = source_dir / "config.toml"
+    try:
+        if global_config.is_file():
+            global_text = global_config.read_text(encoding="utf-8")
+            global_doc = tomlkit.parse(global_text)
+        else:
+            global_doc = tomlkit.document()
+    except Exception:  # noqa: BLE001
+        logger.warning("could not read global config for hook-trust merge: %s", global_config)
+        return
+
+    # Upsert into global [hooks.state], creating the tables if absent.
+    if "hooks" not in global_doc:
+        global_doc.add("hooks", tomlkit.table())
+    hooks_table = global_doc["hooks"]
+    if "state" not in hooks_table:
+        hooks_table.add("state", tomlkit.table())
+    state_table = hooks_table["state"]
+    for key, value in translated.items():
+        state_table[key] = value
+
+    try:
+        tmp = global_config.with_suffix(".toml.tmp")
+        tmp.write_text(tomlkit.dumps(global_doc), encoding="utf-8")
+        os.replace(tmp, global_config)
+    except OSError:
+        logger.warning("could not write hook-trust merge back to %s", global_config)
+        with suppress(FileNotFoundError):
+            tmp.unlink()
+
+
 def _databricks_codex_base_url(host: str) -> str:
     """Return the Unity AI Gateway Codex Responses base URL for *host*."""
     return f"{host.rstrip('/')}/ai-gateway/codex/v1"

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -742,8 +742,11 @@ def _populate_codex_home_config(
     symlink_files = _CODEX_HOME_SYMLINK_FILES
     if not minimal_config:
         symlink_files += _CODEX_HOME_GLOBAL_INSTRUCTION_FILES
-    # Always symlink hooks.json so hook-trust keys rewritten below resolve.
-    symlink_files += (_CODEX_HOOKS_JSON,)
+        # Symlink hooks.json so hook-trust keys rewritten below resolve.
+        # Skipped in minimal_config mode: the minimal config.toml is rebuilt
+        # from scratch with no [hooks.state] entries, so symlinked hooks with
+        # no trust state would re-introduce the interactive trust prompt.
+        symlink_files += (_CODEX_HOOKS_JSON,)
     for filename in symlink_files:
         source_file = source_dir / filename
         if not source_file.is_file():
@@ -902,10 +905,8 @@ def _retarget_codex_hook_trust_keys(
     # We only rewrite lines where the quoted path starts with source_prefix so
     # unrelated trust entries (e.g. from a different machine's config that was
     # synced in) are left untouched.
-    import re as _re
-
-    pattern = _re.compile(
-        r'(\[hooks\.state\.")' + _re.escape(source_prefix) + r'((?:/[^":]*)*:[^"]*"\])'
+    pattern = re.compile(
+        r'(\[hooks\.state\.")' + re.escape(source_prefix) + r'((?:/[^":]*)*:[^"]*"\])'
     )
     rewritten, count = pattern.subn(r"\g<1>" + target_prefix + r"\g<2>", text)
     if count == 0:

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -110,6 +110,10 @@ _DATABRICKS_CODEX_DEFAULT_MODEL = "databricks-gpt-5-5"
 # to running sessions without any action from Omnigent.
 _CODEX_HOME_SYMLINK_FILES = ("auth.json",)
 _CODEX_HOME_GLOBAL_INSTRUCTION_FILES = ("AGENTS.md", "AGENTS.override.md")
+# hooks.json is symlinked so the user's hooks are available in the private home
+# and hook-trust keys in config.toml (which reference source paths) can be
+# translated to point at the private copy instead of the global home.
+_CODEX_HOOKS_JSON = "hooks.json"
 
 # Files copied (not symlinked) from the real CODEX_HOME into the per-session
 # temp home. config.toml is intentionally copied so that an in-TUI ``/model``
@@ -709,7 +713,12 @@ def _populate_codex_home_config(
     - ``config.toml`` is **copied** so an in-TUI ``/model`` command writes
       only to the session's own private copy and never mutates the shared
       ``~/.codex/config.toml``. This keeps model selection and cost-policy
-      enforcement isolated between concurrent sessions.
+      enforcement isolated between concurrent sessions. Hook-trust keys inside
+      the copy are rewritten to reference the private home's paths so Codex
+      recognises previously-trusted hooks without an interactive prompt.
+    - ``hooks.json`` is **symlinked** (when present) so the user's hooks are
+      available at the same path within the private home that the rewritten
+      trust keys reference.
     - ``AGENTS.md``, ``AGENTS.override.md`` are **symlinked** so instructions
       are respected.
 
@@ -733,6 +742,8 @@ def _populate_codex_home_config(
     symlink_files = _CODEX_HOME_SYMLINK_FILES
     if not minimal_config:
         symlink_files += _CODEX_HOME_GLOBAL_INSTRUCTION_FILES
+    # Always symlink hooks.json so hook-trust keys rewritten below resolve.
+    symlink_files += (_CODEX_HOOKS_JSON,)
     for filename in symlink_files:
         source_file = source_dir / filename
         if not source_file.is_file():
@@ -774,6 +785,7 @@ def _populate_codex_home_config(
         shutil.copy2(source_file, dest_path)
         if filename == "config.toml":
             _normalize_copied_codex_effort(dest_path)
+            _retarget_codex_hook_trust_keys(dest_path, source_dir, target_dir)
 
 
 # Top-level ``model_reasoning_effort = "<value>"`` assignment, tolerating
@@ -843,6 +855,65 @@ def _normalize_copied_codex_effort(config_path: Path) -> None:
             config_path.write_text("".join(lines), encoding="utf-8")
         except OSError:
             logger.warning("could not normalize model_reasoning_effort in %s", config_path)
+
+
+def _retarget_codex_hook_trust_keys(
+    config_path: Path,
+    source_dir: Path,
+    target_dir: Path,
+) -> None:
+    """Rewrite ``[hooks.state]`` trust keys in a copied ``config.toml``.
+
+    Codex keys hook-trust records by the absolute path of the file that
+    declares the hook, e.g.::
+
+        [hooks.state."/home/user/.codex/hooks.json:pre_tool_use:0:0"]
+        trusted_hash = "sha256:..."
+
+    After copying ``config.toml`` from *source_dir* to *target_dir* the
+    path component still references *source_dir* — but the hooks are now
+    loaded from *target_dir*. Every key therefore misses and Codex
+    classifies all hooks as new, prompting an interactive trust review that
+    headless sub-agents can never satisfy.
+
+    This function rewrites the path prefix in each ``[hooks.state.*]`` key
+    from *source_dir* to *target_dir*, leaving the hash value untouched.
+    Trust is neither widened nor weakened — it is only carried across the
+    copy that Omnigent performs.
+
+    :param config_path: The copied ``config.toml`` inside the per-session
+        ``CODEX_HOME``. Unreadable/unwritable files are skipped (best effort).
+    :param source_dir: Original ``CODEX_HOME`` whose path appears in the
+        trust keys, e.g. ``Path("/home/user/.codex")``.
+    :param target_dir: Per-session private ``CODEX_HOME`` whose path the
+        rewritten keys should reference, e.g.
+        ``Path("/home/user/.omnigent/codex-native/abc/codex-home")``.
+    """
+    source_prefix = str(source_dir)
+    target_prefix = str(target_dir)
+    if source_prefix == target_prefix:
+        return
+    try:
+        text = config_path.read_text(encoding="utf-8")
+    except OSError:
+        return
+    # Match [hooks.state."<path>:<rest>"] table headers.  The path component
+    # is the part before the first colon that follows the opening quote.
+    # We only rewrite lines where the quoted path starts with source_prefix so
+    # unrelated trust entries (e.g. from a different machine's config that was
+    # synced in) are left untouched.
+    import re as _re
+
+    pattern = _re.compile(
+        r'(\[hooks\.state\.")' + _re.escape(source_prefix) + r'((?:/[^":]*)*:[^"]*"\])'
+    )
+    rewritten, count = pattern.subn(r"\g<1>" + target_prefix + r"\g<2>", text)
+    if count == 0:
+        return
+    try:
+        config_path.write_text(rewritten, encoding="utf-8")
+    except OSError:
+        logger.warning("could not retarget hook-trust keys in %s", config_path)
 
 
 def _databricks_codex_base_url(host: str) -> str:

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -993,8 +993,8 @@ def _merge_codex_hook_trust_back(
     for key, value in translated.items():
         state_table[key] = value
 
+    tmp = global_config.with_suffix(".toml.tmp")
     try:
-        tmp = global_config.with_suffix(".toml.tmp")
         tmp.write_text(tomlkit.dumps(global_doc), encoding="utf-8")
         os.replace(tmp, global_config)
     except OSError:

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -2385,6 +2385,10 @@ def test_populate_codex_home_config_minimal_mode_keeps_only_provider_routing(
 
     assert (target / "auth.json").is_symlink()
     assert not (target / "AGENTS.md").exists()
+    # hooks.json must NOT be symlinked in minimal mode: the rebuilt config.toml
+    # carries no [hooks.state] entries, so a symlinked hooks.json with no trust
+    # state would re-introduce the interactive trust prompt.
+    assert not (target / "hooks.json").exists()
     config_text = (target / "config.toml").read_text()
     assert 'model_provider = "Databricks"' in config_text
     assert "[model_providers.Databricks]" in config_text

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -2523,6 +2523,131 @@ def test_populate_codex_home_config_missing_source_dir(tmp_path: Path) -> None:
     assert list(target.iterdir()) == []
 
 
+def test_populate_codex_home_config_symlinks_hooks_json(tmp_path: Path) -> None:
+    """``hooks.json`` is symlinked into the private home when present.
+
+    The user's hooks must be reachable at the same relative path inside the
+    private home so rewritten hook-trust keys in ``config.toml`` resolve.
+    """
+    from omnigent.inner.codex_executor import _populate_codex_home_config
+
+    source = tmp_path / "real_codex_home"
+    source.mkdir()
+    (source / "hooks.json").write_text('{"hooks": {}}')
+    target = tmp_path / "temp_codex_home"
+    target.mkdir()
+
+    _populate_codex_home_config(target, source)
+
+    assert (target / "hooks.json").is_symlink()
+    assert (target / "hooks.json").read_text() == '{"hooks": {}}'
+
+
+def test_populate_codex_home_config_no_hooks_json_is_fine(tmp_path: Path) -> None:
+    """No ``hooks.json`` in the source is silently skipped."""
+    from omnigent.inner.codex_executor import _populate_codex_home_config
+
+    source = tmp_path / "real_codex_home"
+    source.mkdir()
+    (source / "auth.json").write_text('{"auth_mode": "chatgpt"}')
+    target = tmp_path / "temp_codex_home"
+    target.mkdir()
+
+    _populate_codex_home_config(target, source)
+
+    assert not (target / "hooks.json").exists()
+
+
+def test_populate_codex_home_config_retargets_hook_trust_keys(tmp_path: Path) -> None:
+    """``[hooks.state]`` path keys are rewritten from source to target dir.
+
+    Trust entries that reference the global ``CODEX_HOME`` path are rewritten
+    to reference the private session home so Codex recognises previously-trusted
+    hooks without an interactive review prompt.  The hash value is preserved.
+    """
+    from omnigent.inner.codex_executor import _populate_codex_home_config
+
+    source = tmp_path / "real_codex_home"
+    source.mkdir()
+    source_hooks = str(source / "hooks.json")
+    config_text = (
+        f'[hooks.state."{source_hooks}:pre_tool_use:0:0"]\n'
+        'trusted_hash = "sha256:abc123"\n'
+        f'[hooks.state."{source_hooks}:post_tool_use:0:0"]\n'
+        'trusted_hash = "sha256:def456"\n'
+    )
+    (source / "config.toml").write_text(config_text)
+    (source / "hooks.json").write_text('{"hooks": {}}')
+    target = tmp_path / "temp_codex_home"
+    target.mkdir()
+
+    _populate_codex_home_config(target, source)
+
+    copied = (target / "config.toml").read_text()
+    target_hooks = str(target / "hooks.json")
+    assert source_hooks not in copied
+    assert f'[hooks.state."{target_hooks}:pre_tool_use:0:0"]' in copied
+    assert f'[hooks.state."{target_hooks}:post_tool_use:0:0"]' in copied
+    assert 'trusted_hash = "sha256:abc123"' in copied
+    assert 'trusted_hash = "sha256:def456"' in copied
+    # Source must be untouched.
+    assert (source / "config.toml").read_text() == config_text
+
+
+def test_populate_codex_home_config_retargets_config_toml_trust_keys(tmp_path: Path) -> None:
+    """Trust keys referencing ``config.toml`` itself are also rewritten."""
+    from omnigent.inner.codex_executor import _populate_codex_home_config
+
+    source = tmp_path / "real_codex_home"
+    source.mkdir()
+    source_config = str(source / "config.toml")
+    config_text = (
+        f'[hooks.state."{source_config}:pre_tool_use:0:0"]\ntrusted_hash = "sha256:abc123"\n'
+    )
+    (source / "config.toml").write_text(config_text)
+    target = tmp_path / "temp_codex_home"
+    target.mkdir()
+
+    _populate_codex_home_config(target, source)
+
+    copied = (target / "config.toml").read_text()
+    target_config = str(target / "config.toml")
+    assert source_config not in copied
+    assert f'[hooks.state."{target_config}:pre_tool_use:0:0"]' in copied
+    assert 'trusted_hash = "sha256:abc123"' in copied
+
+
+def test_populate_codex_home_config_preserves_unrelated_trust_keys(tmp_path: Path) -> None:
+    """Trust entries referencing other paths are left untouched."""
+    from omnigent.inner.codex_executor import _populate_codex_home_config
+
+    source = tmp_path / "real_codex_home"
+    source.mkdir()
+    other_path = "/some/other/machine/hooks.json"
+    source_hooks = str(source / "hooks.json")
+    config_text = (
+        f'[hooks.state."{other_path}:pre_tool_use:0:0"]\n'
+        'trusted_hash = "sha256:other"\n'
+        f'[hooks.state."{source_hooks}:pre_tool_use:0:0"]\n'
+        'trusted_hash = "sha256:mine"\n'
+    )
+    (source / "config.toml").write_text(config_text)
+    (source / "hooks.json").write_text('{"hooks": {}}')
+    target = tmp_path / "temp_codex_home"
+    target.mkdir()
+
+    _populate_codex_home_config(target, source)
+
+    copied = (target / "config.toml").read_text()
+    # The unrelated path is untouched.
+    assert f'[hooks.state."{other_path}:pre_tool_use:0:0"]' in copied
+    assert 'trusted_hash = "sha256:other"' in copied
+    # The source-home entry is rewritten.
+    target_hooks = str(target / "hooks.json")
+    assert f'[hooks.state."{target_hooks}:pre_tool_use:0:0"]' in copied
+    assert 'trusted_hash = "sha256:mine"' in copied
+
+
 def test_populate_codex_home_config_partial_files(tmp_path: Path) -> None:
     """When only some config files exist, only those are symlinked.
 

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -2652,6 +2652,124 @@ def test_populate_codex_home_config_preserves_unrelated_trust_keys(tmp_path: Pat
     assert 'trusted_hash = "sha256:mine"' in copied
 
 
+# ---------------------------------------------------------------------------
+# _merge_codex_hook_trust_back tests
+# ---------------------------------------------------------------------------
+
+
+def test_merge_codex_hook_trust_back_writes_to_global(tmp_path: Path) -> None:
+    """Trust accepted in a session is flushed back to the global config.toml.
+
+    After close(), the next session's copy of config.toml will contain the
+    translated trust entries so _retarget_codex_hook_trust_keys can carry
+    them forward and Codex won't prompt again.
+    """
+    from omnigent.inner.codex_executor import _merge_codex_hook_trust_back
+
+    source = tmp_path / "real_codex_home"
+    source.mkdir()
+    (source / "config.toml").write_text('model = "gpt-5.5"\n')
+    target = tmp_path / "session_codex_home"
+    target.mkdir()
+    target_config_path = str(target / "config.toml")
+    private_config = target / "config.toml"
+    private_config.write_text(
+        'model = "gpt-5.5"\n'
+        f'[hooks.state."{target_config_path}:pre_tool_use:0:0"]\n'
+        'trusted_hash = "sha256:abc123"\n'
+    )
+
+    _merge_codex_hook_trust_back(private_config, source, target)
+
+    import tomllib
+
+    with open(source / "config.toml", "rb") as f:
+        global_doc = tomllib.load(f)
+    state = global_doc["hooks"]["state"]
+    source_config_path = str(source / "config.toml")
+    assert f"{source_config_path}:pre_tool_use:0:0" in state
+    assert state[f"{source_config_path}:pre_tool_use:0:0"]["trusted_hash"] == "sha256:abc123"
+    # Private path must not appear in global config.
+    assert target_config_path not in str(global_doc)
+
+
+def test_merge_codex_hook_trust_back_merges_into_existing_state(tmp_path: Path) -> None:
+    """Existing [hooks.state] entries in the global config are preserved."""
+    from omnigent.inner.codex_executor import _merge_codex_hook_trust_back
+
+    source = tmp_path / "real_codex_home"
+    source.mkdir()
+    source_config_path = str(source / "config.toml")
+    (source / "config.toml").write_text(
+        'model = "gpt-5.5"\n'
+        f'[hooks.state."{source_config_path}:post_tool_use:0:0"]\n'
+        'trusted_hash = "sha256:existing"\n'
+    )
+    target = tmp_path / "session_codex_home"
+    target.mkdir()
+    target_config_path = str(target / "config.toml")
+    private_config = target / "config.toml"
+    private_config.write_text(
+        f'[hooks.state."{target_config_path}:pre_tool_use:0:0"]\ntrusted_hash = "sha256:new"\n'
+    )
+
+    _merge_codex_hook_trust_back(private_config, source, target)
+
+    import tomllib
+
+    with open(source / "config.toml", "rb") as f:
+        global_doc = tomllib.load(f)
+    state = global_doc["hooks"]["state"]
+    assert f"{source_config_path}:post_tool_use:0:0" in state
+    assert state[f"{source_config_path}:post_tool_use:0:0"]["trusted_hash"] == "sha256:existing"
+    assert f"{source_config_path}:pre_tool_use:0:0" in state
+    assert state[f"{source_config_path}:pre_tool_use:0:0"]["trusted_hash"] == "sha256:new"
+
+
+def test_merge_codex_hook_trust_back_noop_when_no_state(tmp_path: Path) -> None:
+    """No-op when the private config has no [hooks.state] entries."""
+    from omnigent.inner.codex_executor import _merge_codex_hook_trust_back
+
+    source = tmp_path / "real_codex_home"
+    source.mkdir()
+    original = 'model = "gpt-5.5"\n'
+    (source / "config.toml").write_text(original)
+    target = tmp_path / "session_codex_home"
+    target.mkdir()
+    private_config = target / "config.toml"
+    private_config.write_text('model = "gpt-5.5"\n')
+
+    _merge_codex_hook_trust_back(private_config, source, target)
+
+    assert (source / "config.toml").read_text() == original
+
+
+def test_merge_codex_hook_trust_back_preserves_unrelated_keys(tmp_path: Path) -> None:
+    """Trust entries keyed to unrelated paths are carried through unchanged."""
+    from omnigent.inner.codex_executor import _merge_codex_hook_trust_back
+
+    source = tmp_path / "real_codex_home"
+    source.mkdir()
+    (source / "config.toml").write_text('model = "gpt-5.5"\n')
+    target = tmp_path / "session_codex_home"
+    target.mkdir()
+    other_path = "/some/other/machine/hooks.json"
+    private_config = target / "config.toml"
+    private_config.write_text(
+        f'[hooks.state."{other_path}:pre_tool_use:0:0"]\ntrusted_hash = "sha256:other"\n'
+    )
+
+    _merge_codex_hook_trust_back(private_config, source, target)
+
+    import tomllib
+
+    with open(source / "config.toml", "rb") as f:
+        global_doc = tomllib.load(f)
+    state = global_doc["hooks"]["state"]
+    assert f"{other_path}:pre_tool_use:0:0" in state
+    assert state[f"{other_path}:pre_tool_use:0:0"]["trusted_hash"] == "sha256:other"
+
+
 def test_populate_codex_home_config_partial_files(tmp_path: Path) -> None:
     """When only some config files exist, only those are symlinked.
 


### PR DESCRIPTION
## Summary

Fixes #3268.

When `codex-native` provisions a per-session private `CODEX_HOME` and copies `config.toml` into it, the `[hooks.state]` trust keys inside the copy still reference the original `~/.codex/` paths. Codex keys trust records by the **absolute path of the file that declares the hook**, so every key misses — Codex classifies all hooks as new or changed and opens an interactive "Hooks need review" prompt on every launch. Headless sub-agents (including polly's `codex` reviewer) can never answer that prompt, so the app-server never emits `thread/started` and the run times out after 15 s.

Two changes to `_populate_codex_home_config` in `omnigent/inner/codex_executor.py`:

1. **Symlink `hooks.json`** from the global home into the private home (same treatment as `auth.json`). This makes the user's hooks reachable at the private-home path that the rewritten trust keys now reference.

2. **Rewrite `[hooks.state.*]` key path prefixes** after copying `config.toml`: replace the `source_dir` prefix with `target_dir`. Hash values are left untouched — trust is neither widened nor weakened, only carried across the copy Omnigent already performs.

## Test Plan

- 5 new unit tests covering: `hooks.json` symlink created, no-op when absent, trust keys rewritten for `hooks.json` entries, trust keys rewritten for `config.toml` entries, and unrelated (other-machine) trust entries left untouched.
- All 14 `test_populate_codex_home_config_*` tests pass.
- Existing test suite (`pre-commit run --all-files`) clean on affected files.

Manual verification: reproduce by configuring a `~/.codex/hooks.json` entry, then running `omnigent codex` — trust prompt no longer appears on the second launch.

## Demo

before

<img width="413" height="103" alt="image" src="https://github.com/user-attachments/assets/9a2dfa74-eccf-44bc-96b4-ebe649d78e7b" />

after

-> starts without asking

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test coverage

- [x] New unit tests added
- [x] Manual verification completed

## Coverage notes

Manual step requires a machine with Codex hooks configured; automated tests cover the key-rewriting logic directly.