### PR TITLE
fix(seatbelt): resolve two-hop proxy symlink when detecting CPython install root

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -1364,9 +1364,12 @@ def _try_sandbox_pi(
         # Pi needs to read its own installation + node_modules.
         pi_dir = pathlib.Path(pi_path).resolve().parent.parent
         sandbox = with_additional_read_roots(sandbox, [pi_dir])
-        # Pi writes to ~/.pi and to /tmp.
+        # Pi writes to ~/.pi, /tmp, and $TMPDIR (on macOS $TMPDIR is a
+        # per-user dir under /var/folders/, not /tmp — grant both so
+        # PI_CODING_AGENT_DIR (created via tempfile.mkdtemp) is reachable.
         home_pi = pathlib.Path(os.path.expanduser("~/.pi"))
-        sandbox = with_additional_write_roots(sandbox, [home_pi, pathlib.Path("/tmp")])
+        sys_tmpdir = pathlib.Path(tempfile.gettempdir())
+        sandbox = with_additional_write_roots(sandbox, [home_pi, pathlib.Path("/tmp"), sys_tmpdir])
         sandbox = with_spawn_env_allowlist(sandbox, spawn_env_names)
         launcher = create_exec_launcher(pi_path, sandbox)
         return SandboxedPiCli(launch_path=launcher, sandboxed=True)

--- a/omnigent/inner/sandbox.py
+++ b/omnigent/inner/sandbox.py
@@ -521,10 +521,13 @@ def with_additional_read_roots(
     policy: SandboxPolicy,
     extra_roots: Sequence[Path],
 ) -> SandboxPolicy:
-    if policy.read_roots is None:
-        return policy
-
-    read_roots = list(policy.read_roots)
+    # ``read_roots=None`` means "no spec-supplied grants" for deny-default
+    # backends (darwin_seatbelt, linux_bwrap). Treat it as an empty list so
+    # caller-supplied extra roots (e.g. the pi node_modules dir granted by
+    # _try_sandbox_pi) are not silently dropped when the spec declares no
+    # read_paths. Do NOT short-circuit: the caller is explicitly widening the
+    # policy, so we must honour it even when the spec itself has no grants.
+    read_roots = list(policy.read_roots) if policy.read_roots is not None else []
     for root in extra_roots:
         resolved = root.resolve(strict=False)
         if all(existing != resolved for existing in read_roots):

--- a/omnigent/inner/seatbelt_sandbox.py
+++ b/omnigent/inner/seatbelt_sandbox.py
@@ -1280,6 +1280,16 @@ def _ensure_executable_visible(
             # ``/Users`` widening that the H1/H2/H3 hardening
             # explicitly closed.
             install_root = _interpreter_install_root(exe)
+            # Two-hop symlink case: the literal path is a tool-venv
+            # proxy (e.g. ``~/.local/share/uv/tools/<pkg>/bin/python``)
+            # whose grandparent lacks CPython layout markers, while the
+            # resolved target (``~/.local/share/uv/python/cpython-.../
+            # bin/python3.12``) does carry them.  Resolve once and retry
+            # before giving up.
+            if install_root is None:
+                exe_resolved_inner = exe.resolve(strict=False)
+                if exe_resolved_inner != exe:
+                    install_root = _interpreter_install_root(exe_resolved_inner)
             if install_root is not None and str(install_root) not in _UNSAFE_WIDEN_ANCESTORS:
                 if any(_is_within_literal(install_root, root) for root in covered_prefixes):
                     return
@@ -1309,12 +1319,12 @@ def _ensure_executable_visible(
                 f"That grants the sandboxed helper read access to every "
                 f"other user's home (or to system runtime state) and is a "
                 f"sandbox-defeating widening. Auto-detection of a narrow "
-                f"Python install root (``<root>/bin/python*`` + "
+                f"CPython install root (``<root>/bin/python*`` + "
                 f"``<root>/lib/python*`` or ``<root>/lib/libpython*``) "
-                f"did not match the layout at this path. Remediate by "
-                f"either: (1) using a Homebrew or system Python interpreter "
-                f"(``/opt/homebrew/...`` or ``/usr/bin/python3``, both "
-                f"covered by default RO subpaths); (2) placing the venv "
+                f"did not match the literal or resolved path at this location. "
+                f"Remediate by either: (1) using a Homebrew or system "
+                f"interpreter (``/opt/homebrew/...`` or ``/usr/bin/python3``, "
+                f"both covered by default RO subpaths); (2) placing the venv "
                 f"under cwd (e.g. ``./.venv/bin/python``); or "
                 f"(3) adding a narrower ``read_paths`` entry covering "
                 f"only the interpreter tree (e.g. "

--- a/tests/inner/test_seatbelt_sandbox.py
+++ b/tests/inner/test_seatbelt_sandbox.py
@@ -1150,6 +1150,77 @@ def test_helper_boots_when_interpreter_lives_under_home_uv_layout(
         _shutil.rmtree(fake_install_root, ignore_errors=True)
 
 
+def test_ensure_executable_visible_two_hop_proxy_finds_cpython_install_root(
+    tmp_path: Path,
+) -> None:
+    """
+    Regression for uv tool-install two-hop symlink layout (issue #3237).
+
+    ``uv tool install omnigent`` creates:
+      ~/.local/share/uv/tools/omnigent/bin/python  →  (proxy symlink)
+          ~/.local/share/uv/python/cpython-3.12.X-.../bin/python3.12
+
+    The LITERAL path grandparent (``tools/omnigent/``) has no CPython
+    ``lib/`` markers.  The RESOLVED target grandparent
+    (``cpython-3.12.X-.../``) does.  Pre-fix, ``_interpreter_install_root``
+    was called only on the literal path, returned ``None``, and
+    ``_add_topmost`` raised OSError.  Post-fix, the resolved path is retried
+    as a fallback, and the narrow CPython install root is returned.
+
+    This test uses ``_ensure_executable_visible`` directly (not the full
+    wrap) so we can construct a fully fake three-layer layout under
+    ``tmp_path`` without touching the real ``sys.executable``.
+    """
+    import uuid
+
+    home = Path.home()
+
+    # Layer 1 — CPython install root (the real target).  Lives under HOME
+    # so topmost ancestor is in _UNSAFE_WIDEN_ANCESTORS and the narrow-
+    # fallback path is exercised.
+    cpython_root = home / f".omnigent-test-cpython-{uuid.uuid4().hex}"
+    (cpython_root / "bin").mkdir(parents=True)
+    py_major_minor = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+    (cpython_root / "lib" / py_major_minor).mkdir(parents=True)
+
+    # Layer 2 — tool-venv proxy root (no CPython markers — this is the
+    # layout that causes the literal-path check to return None).
+    tool_root = home / f".omnigent-test-tool-{uuid.uuid4().hex}"
+    (tool_root / "bin").mkdir(parents=True)
+    # Deliberately no lib/python* here.
+
+    import shutil as _shutil
+
+    try:
+        # Fake interpreter binary in the CPython install root.
+        cpython_exe = cpython_root / "bin" / "python3"
+        cpython_exe.touch()
+
+        # Proxy symlink: tool_root/bin/python → cpython_root/bin/python3
+        tool_exe = tool_root / "bin" / "python"
+        tool_exe.symlink_to(cpython_exe)
+
+        cwd = tmp_path
+        argv = [str(tool_exe), "-c", "pass"]
+        extras = _ensure_executable_visible(argv, cwd.resolve(strict=False))
+
+        cpython_resolved = cpython_root.resolve(strict=False)
+        assert cpython_resolved in extras, (
+            f"Expected the CPython install root {cpython_resolved!r} in extras "
+            f"({extras!r}). The two-hop proxy fallback did not resolve to the "
+            "real CPython install root; without this grant the kernel EPERMs "
+            "the exec inside the sandbox."
+        )
+        for extra in extras:
+            assert str(extra) not in _UNSAFE_WIDEN_ANCESTORS, (
+                f"_ensure_executable_visible granted an unsafe broad ancestor "
+                f"{extra!r} instead of the narrow CPython install root."
+            )
+    finally:
+        _shutil.rmtree(cpython_root, ignore_errors=True)
+        _shutil.rmtree(tool_root, ignore_errors=True)
+
+
 # ---------------------------------------------------------------------------
 # Security hardening regression tests
 #
@@ -1498,7 +1569,7 @@ def test_ensure_executable_visible_still_raises_for_non_python_home_layouts(
             _ensure_executable_visible(argv, cwd)
 
     msg = str(exc.value)
-    assert "Auto-detection of a narrow Python install root" in msg, (
+    assert "Auto-detection of a narrow CPython install root" in msg, (
         f"OSError should explain that the install-root fallback was "
         f"attempted; got message: {msg!r}. Without this hint, an "
         "operator hitting a near-miss layout (e.g. they forgot to "


### PR DESCRIPTION
## Related issue

Closes #3237

## Summary

Three bugs found by reproducing the issue with \`omnigent run\` + \`darwin_seatbelt\`:

**1. Two-hop proxy symlink not resolved when detecting CPython install root**

\`uv tool install omnigent\` creates: \`tools/omnigent/bin/python\` → \`cpython-3.12.X.../bin/python3.12\`. The proxy symlink's grandparent has no \`lib/python*\` markers so \`_interpreter_install_root\` returned \`None\` on the literal path, and \`_add_topmost\` raised \`OSError\` before checking the resolved path.

Fix (\`seatbelt_sandbox.py\`): when the literal path yields no install root, resolve it and retry \`_interpreter_install_root\` on the resolved path as a fallback.

**2. \`with_additional_read_roots\` silently dropped the pi node_modules grant**

When the spec declares no \`read_paths\`, \`resolve_sandbox\` returns \`read_roots=None\`. \`with_additional_read_roots\` bailed early on \`None\`, so the pi node_modules dir granted by \`_try_sandbox_pi\` was never added to the seatbelt profile. Pi then failed with \`Cannot find package .../pi-ai/index.js\`.

Fix (\`sandbox.py\`): treat \`None\` as an empty list — the caller is explicitly widening the policy and must be honoured.

**3. \`PI_CODING_AGENT_DIR\` created under \`$TMPDIR\`, which wasn't granted**

\`_try_sandbox_pi\` granted \`/tmp\` as a write root, but on macOS \`$TMPDIR\` is \`/var/folders/.../T/\` (not \`/tmp\`). Pi creates \`PI_CODING_AGENT_DIR\` with \`tempfile.mkdtemp()\` which uses \`$TMPDIR\`, so pi got EPERM writing its extension and settings.

Fix (\`pi_executor.py\`): also grant \`tempfile.gettempdir()\` alongside \`/tmp\`.

## Test Plan

### Setup

Agent bundle:

```yaml
spec_version: 1
name: pi-sandbox-test
executor:
  type: omnigent
  config:
    harness: pi
prompt: Reply with exactly the single word PONG
os_env:
  type: caller_process
  cwd: .
  sandbox:
    type: darwin_seatbelt
```

Start a local server:

```bash
omnigent server --background
```

### Reproduce before fix (pre-fix code at parent commit 2a60e17d)

```
$ omnigent run /tmp/pi-sandbox-bundle --server http://127.0.0.1:6767 -p "Reply with PONG"

Error: inner executor error: Pi process ended without response. Stderr:
darwin_seatbelt: helper interpreter at '.../uv/python/cpython-3.12.13-macos-aarch64-none/bin/python3.12'
resolves under the unsafe ancestor '/Users'; ...
Cannot find package '.../pi-coding-agent/node_modules/@earendil-works/pi-ai/index.js'
...
```

Each fix unblocked the next error in sequence:
1. Fix 1 (two-hop symlink) → Python interpreter granted → pi starts
2. Fix 2 (\`read_roots=None\`) → node_modules granted → pi loads its packages
3. Fix 3 (\`$TMPDIR\` write) → \`PI_CODING_AGENT_DIR\` writable → pi writes its extension

### After all three fixes

```
$ omnigent run /tmp/pi-sandbox-bundle --server http://127.0.0.1:6767 -p "Reply with PONG"

omnigent: Connecting to the server…
omnigent: Preparing your agent…
omnigent: Connecting…
omnigent: Launching your agent…
PONG
```

### Unit tests

```
$ python -m pytest tests/inner/test_seatbelt_sandbox.py -q
68 passed, 1 skipped
```

New test \`test_ensure_executable_visible_two_hop_proxy_finds_cpython_install_root\` covers fix 1 directly.

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added / updated
- [x] Manual verification completed

## Coverage notes

End-to-end verified via \`omnigent run\` with \`sandbox.type: darwin_seatbelt\` — pi boots, receives a message, replies \`PONG\`. Each fix was validated individually by confirming it unblocked the next error in the failure sequence.