### PR TITLE
fix(runner): evaluate PHASE_TOOL_CALL policy for sys_call_async background tasks

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -6172,6 +6172,10 @@ async def _evaluate_async_tool_call_policy(
     that inspect ``arguments.command``) see the same structure every in-turn
     evaluation path delivers.
 
+    An ASK verdict parks the gate server-side (up to the policy's
+    ``ask_timeout``) and blocks the background task until resolved or timed
+    out — ``sys_cancel_async`` cannot interrupt a parked evaluation.
+
     :returns: ``True`` when the tool may proceed; ``False`` to DENY.
     """
     evaluation_id = f"poleval_async_{uuid.uuid4().hex[:12]}"

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -6154,6 +6154,48 @@ async def _drain_inbox(
     return "\n\n".join(items) if items else "Inbox is empty — no completed tasks."
 
 
+async def _evaluate_async_tool_call_policy(
+    tool_name: str,
+    tool_args: str,
+    *,
+    server_client: httpx.AsyncClient,
+    conversation_id: str,
+) -> bool:
+    """
+    Evaluate PHASE_TOOL_CALL policy for an out-of-turn background dispatch.
+
+    Calls the AP server's policy-evaluate endpoint directly (no SSE
+    round-trip, since the originating turn has already ended).  ASK is
+    treated as DENY — there is no active turn to surface an approval prompt.
+
+    :returns: ``True`` when the tool may proceed; ``False`` to DENY.
+    """
+    evaluation_id = f"poleval_async_{uuid.uuid4().hex[:12]}"
+    phase = "PHASE_TOOL_CALL"
+    try:
+        resp = await server_client.post(
+            f"/v1/sessions/{conversation_id}/policies/evaluate",
+            json={"event": {"type": phase, "data": {"name": tool_name, "arguments": tool_args}}},
+            timeout=_ASK_GATE_DELIVERY_TIMEOUT,
+        )
+        if resp.status_code == 200:
+            result = resp.json()
+            action = result.get("result", "POLICY_ACTION_DENY")
+            return action == "POLICY_ACTION_ALLOW" or action == "POLICY_ACTION_UNSPECIFIED"
+        _logger.warning(
+            "async PHASE_TOOL_CALL policy evaluate returned %d for %s; denying",
+            resp.status_code,
+            evaluation_id,
+        )
+    except Exception:  # noqa: BLE001
+        _logger.warning(
+            "async PHASE_TOOL_CALL policy evaluate failed for %s; denying",
+            evaluation_id,
+            exc_info=True,
+        )
+    return False
+
+
 def _spawn_async_tool(
     args: dict[str, Any],
     *,
@@ -6216,6 +6258,29 @@ def _spawn_async_tool(
         :returns: The tool output string.
         """
         try:
+            # Evaluate PHASE_TOOL_CALL policy before executing. The originating
+            # turn has already ended, so we call the AP server directly instead
+            # of going through the SSE round-trip. ASK is treated as DENY —
+            # there is no active turn to surface an approval prompt.
+            if server_client is not None and conversation_id is not None:
+                allowed = await _evaluate_async_tool_call_policy(
+                    target_tool,
+                    target_args,
+                    server_client=server_client,
+                    conversation_id=conversation_id,
+                )
+                if not allowed:
+                    result = "[Result suppressed by policy: PHASE_TOOL_CALL denied]"
+                    session_inbox.put_nowait(
+                        {
+                            "handle_id": handle_id,
+                            "tool_name": target_tool,
+                            "status": "failed",
+                            "output": result,
+                        }
+                    )
+                    return result
+
             # Race the tool execution against the cancel event.
             exec_coro = execute_tool(
                 tool_name=target_tool,

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -6165,17 +6165,29 @@ async def _evaluate_async_tool_call_policy(
     Evaluate PHASE_TOOL_CALL policy for an out-of-turn background dispatch.
 
     Calls the AP server's policy-evaluate endpoint directly (no SSE
-    round-trip, since the originating turn has already ended).  ASK is
-    treated as DENY — there is no active turn to surface an approval prompt.
+    round-trip, since the originating turn has already ended).
+
+    ``arguments`` is sent as a dict (not a JSON string) so the server's policy
+    context builder and argument-aware built-in policies (e.g. safety rules
+    that inspect ``arguments.command``) see the same structure every in-turn
+    evaluation path delivers.
 
     :returns: ``True`` when the tool may proceed; ``False`` to DENY.
     """
     evaluation_id = f"poleval_async_{uuid.uuid4().hex[:12]}"
     phase = "PHASE_TOOL_CALL"
     try:
+        try:
+            arguments_dict: dict[str, Any] = json.loads(tool_args)
+            if not isinstance(arguments_dict, dict):
+                arguments_dict = {}
+        except (json.JSONDecodeError, ValueError):
+            arguments_dict = {}
         resp = await server_client.post(
             f"/v1/sessions/{conversation_id}/policies/evaluate",
-            json={"event": {"type": phase, "data": {"name": tool_name, "arguments": tool_args}}},
+            json={
+                "event": {"type": phase, "data": {"name": tool_name, "arguments": arguments_dict}}
+            },
             timeout=_ASK_GATE_DELIVERY_TIMEOUT,
         )
         if resp.status_code == 200:

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -7382,6 +7382,13 @@ async def test_spawn_async_tool_phase_tool_call_policy_deny(
     event = policy_requests[0]["event"]
     assert event["type"] == "PHASE_TOOL_CALL"
     assert event["data"]["name"] == "sys_os_shell"
+    # arguments must arrive as a dict so argument-aware policies (e.g. safety
+    # rules that inspect arguments.command) see the same structure every
+    # in-turn evaluation path delivers — not a raw JSON string.
+    assert isinstance(event["data"]["arguments"], dict), (
+        "arguments must be a dict, not a JSON string"
+    )
+    assert event["data"]["arguments"] == {"command": "echo hi"}
 
     item = inbox.get_nowait()
     assert item["status"] == "failed"

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -7320,3 +7320,123 @@ async def test_spawn_async_tool_cancels_losing_future_no_leak(
     await asyncio.sleep(0)
     assert inbox.get_nowait()["status"] == "cancelled"
     assert _leaked(before) == []
+
+
+@pytest.mark.asyncio
+async def test_spawn_async_tool_phase_tool_call_policy_deny(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``_spawn_async_tool`` evaluates PHASE_TOOL_CALL policy via the AP server
+    before dispatching.  A DENY verdict must suppress execution and push a
+    failed item to the inbox — the tool must never run.
+    """
+    from omnigent.runner import tool_dispatch
+
+    executed: list[str] = []
+
+    async def _should_not_run(**_kw: Any) -> str:
+        executed.append("ran")
+        return "should not reach"
+
+    monkeypatch.setattr(tool_dispatch, "execute_tool", _should_not_run)
+
+    policy_requests: list[dict[str, Any]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and "/policies/evaluate" in request.url.path:
+            policy_requests.append(json.loads(request.content))
+            return httpx.Response(
+                200, json={"result": "POLICY_ACTION_DENY", "reason": "test deny"}
+            )
+        return httpx.Response(404)
+
+    inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    tasks: dict[str, tuple[asyncio.Task[str], asyncio.Event]] = {}
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        tool_dispatch._spawn_async_tool(
+            {"tool": "sys_os_shell", "args": '{"command": "echo hi"}'},
+            session_inbox=inbox,
+            session_async_tasks=tasks,
+            server_client=server_client,
+            terminal_registry=None,
+            resource_registry=None,
+            agent_spec=None,
+            conversation_id="conv_policy_deny",
+            task_id=None,
+            agent_id=None,
+            agent_name=None,
+            runner_workspace=None,
+            mcp_manager=None,
+            filesystem_registry=None,
+        )
+        bg_task, _evt = next(iter(tasks.values()))
+        await bg_task
+
+    assert executed == [], "Tool must not execute when PHASE_TOOL_CALL is denied"
+    assert len(policy_requests) == 1
+    event = policy_requests[0]["event"]
+    assert event["type"] == "PHASE_TOOL_CALL"
+    assert event["data"]["name"] == "sys_os_shell"
+
+    item = inbox.get_nowait()
+    assert item["status"] == "failed"
+    assert "policy" in item["output"].lower()
+
+
+@pytest.mark.asyncio
+async def test_spawn_async_tool_phase_tool_call_policy_allow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A PHASE_TOOL_CALL ALLOW verdict must let the tool execute normally.
+    """
+    from omnigent.runner import tool_dispatch
+
+    executed: list[str] = []
+
+    async def _fast(**_kw: Any) -> str:
+        executed.append("ran")
+        return "ok"
+
+    monkeypatch.setattr(tool_dispatch, "execute_tool", _fast)
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if "/policies/evaluate" in request.url.path:
+            return httpx.Response(200, json={"result": "POLICY_ACTION_ALLOW"})
+        return httpx.Response(404)
+
+    inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    tasks: dict[str, tuple[asyncio.Task[str], asyncio.Event]] = {}
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        tool_dispatch._spawn_async_tool(
+            {"tool": "sys_os_shell", "args": '{"command": "echo hi"}'},
+            session_inbox=inbox,
+            session_async_tasks=tasks,
+            server_client=server_client,
+            terminal_registry=None,
+            resource_registry=None,
+            agent_spec=None,
+            conversation_id="conv_policy_allow",
+            task_id=None,
+            agent_id=None,
+            agent_name=None,
+            runner_workspace=None,
+            mcp_manager=None,
+            filesystem_registry=None,
+        )
+        bg_task, _evt = next(iter(tasks.values()))
+        await bg_task
+
+    assert executed == ["ran"], "Tool must execute when PHASE_TOOL_CALL is allowed"
+    item = inbox.get_nowait()
+    assert item["status"] == "completed"
+    assert item["output"] == "ok"


### PR DESCRIPTION
## Summary

- \`sys_call_async\` dispatches tools in a detached \`asyncio.Task\` (\`_bg()\` inside \`_spawn_async_tool\`). By the time \`_bg()\` executes, \`run_turn\`'s \`finally\` block has already cleared \`_current_ctx = None\` on the \`ExecutorAdapter\`.
- \`_stable_policy_evaluator\` reads \`_current_ctx\` and fails closed to DENY when it's \`None\` — so a \`PHASE_TOOL_CALL\` policy configured as ASK or ALLOW was never evaluated; it always DENY'd.
- Fix: add \`_evaluate_async_tool_call_policy()\` that calls \`POST /sessions/{id}/policies/evaluate\` directly (no SSE round-trip, which requires a live turn stream). Called at the top of \`_bg()\` before \`execute_tool\`. ASK parks server-side as normal — the background task blocks until the user approves or rejects, honoring the policy's \`ask_timeout\`.

Fixes #3233. Distinct from #522 (async completion delivery) and #1077 (turn-context desync recovery).

## Test Plan

- New \`test_spawn_async_tool_phase_tool_call_policy_deny\`: DENY verdict suppresses execution, pushes \`status: failed\` to inbox, tool never runs.
- New \`test_spawn_async_tool_phase_tool_call_policy_allow\`: ALLOW verdict lets tool execute normally, \`status: completed\` in inbox.
- Existing \`test_spawn_handle_round_trips_to_sys_cancel_async\` and \`test_spawn_async_tool_cancels_losing_future_no_leak\` continue to pass (pass \`server_client=None\`, skipping policy evaluation).

```
pytest tests/runner/test_runner_dispatch.py::test_spawn_async_tool_phase_tool_call_policy_deny \
       tests/runner/test_runner_dispatch.py::test_spawn_async_tool_phase_tool_call_policy_allow \
       tests/runner/test_runner_dispatch.py::test_spawn_handle_round_trips_to_sys_cancel_async \
       tests/runner/test_runner_dispatch.py::test_spawn_async_tool_cancels_losing_future_no_leak
# 4 passed
```

## Demo

N/A — no UI change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test coverage

- [x] New tests added