### PR TITLE
fix(web): stop short links collapsing table columns in chat markdown

### DIFF
--- a/tests/e2e_ui/messages/test_markdown_table_link_column_width.py
+++ b/tests/e2e_ui/messages/test_markdown_table_link_column_width.py
@@ -1,0 +1,150 @@
+"""E2E: a link-only markdown table column keeps its natural width.
+
+Regression guard for the "PR # column is two characters wide" bug. Streamdown
+styles links with ``wrap-anywhere``, which also drops the element's min-content
+width to a single character. Its table is ``table-layout: auto``, so a column
+holding only a link reported ~1ch and got squeezed to ~2ch — a short link like
+``#3090`` stacked one or two characters per line while the prose columns took
+the width. ``web/src/index.css`` narrows links inside table cells back to
+``overflow-wrap: break-word``, which still wraps overlong URLs but keeps
+min-content at the longest unbreakable run.
+
+A deterministic assistant message (seeded via ``external_assistant_message`` —
+no LLM run) carries the table shape that triggered the bug: a link-only ``#``
+column, wide prose columns, and a full-URL column. Asserted:
+
+  - The short link renders on **one line box** instead of stacking.
+  - Its cell is at least as wide as the link, so the column was not squeezed
+    below its content.
+  - A long URL still **wraps** and does not overflow its cell — the narrowed
+    rule must not regress long-URL handling into overflow.
+
+Line-box counts and widths (rather than a computed ``overflow-wrap`` value)
+keep the test tied to what the user actually sees.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_AGENT_NAME = "hello_world"
+_TABLE = '[data-streamdown="table"]'
+_LINK = '[data-streamdown="link"]'
+
+# The short link whose column used to collapse.
+_SHORT_LINK_TEXT = "#3090"
+
+# Rendered as its own link text, and too long to fit one line in a cell.
+_LONG_URL = (
+    "https://github.com/omnigent-ai/omnigent/pull/3350/files#diff-markdown-table-link-column"
+)
+
+
+def _row(num: str, title: str, author: str, waiting: str) -> str:
+    """Build one markdown row: link-only `#`, prose title, then a full URL.
+
+    :param num: PR number rendered as the whole `#` cell, e.g. ``#3090``.
+    :param title: prose wide enough to win the auto-layout width fight.
+    :param author: author cell.
+    :param waiting: age cell.
+    :returns: the pipe-delimited markdown row.
+    """
+    href = f"https://github.com/omnigent-ai/omnigent/pull/{num.lstrip('#')}"
+    cells = (f"[{num}]({href})", title, author, waiting, f"[{_LONG_URL}]({_LONG_URL})")
+    return f"| {' | '.join(cells)} |"
+
+
+# The table that reproduced the bug: a link-only `#` column beside prose
+# columns, plus a full-URL column that must still soft-wrap.
+_MESSAGE_TEXT = "\n".join(
+    [
+        "Here are the pull requests still waiting on review:",
+        "",
+        "| # | PR | Author | Waiting | Link |",
+        "| --- | --- | --- | --- | --- |",
+        _row(
+            _SHORT_LINK_TEXT,
+            "Fix table link column collapsing to two characters",
+            "alex",
+            "3 days",
+        ),
+        _row("#3351", "Add e2e coverage for markdown table link wrapping", "robin", "1 day"),
+        "",
+    ]
+)
+
+# A collapsed column stacks the link across several line boxes.
+_LINE_BOXES = "el => el.getClientRects().length"
+
+# Widest line box vs. the cell's content box — catches a link painting outside
+# its cell, the failure mode an over-aggressive fix would introduce.
+_OVERFLOWS_CELL = """el => {
+  const cell = el.closest('[data-streamdown="table-cell"]');
+  if (!cell) return true;
+  const style = getComputedStyle(cell);
+  const inner =
+    cell.clientWidth -
+    parseFloat(style.paddingLeft) -
+    parseFloat(style.paddingRight);
+  const widest = Math.max(...[...el.getClientRects()].map((r) => r.width));
+  return widest - inner > 1;  // 1px subpixel tolerance
+}"""
+
+
+@pytest.fixture
+def table_session(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    """Seed a runner-bound session with an assistant reply containing the table.
+
+    :param seeded_session: ``(base_url, session_id)`` for a runner-bound session.
+    :returns: the same ``(base_url, session_id)`` after the reply is seeded.
+    """
+    base_url, session_id = seeded_session
+    event_resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_assistant_message",
+            "data": {"agent": _AGENT_NAME, "text": _MESSAGE_TEXT},
+        },
+        timeout=10.0,
+    )
+    event_resp.raise_for_status()
+    yield (base_url, session_id)
+
+
+def test_table_link_column_keeps_its_natural_width(
+    page: Page,
+    table_session: tuple[str, str],
+) -> None:
+    """A short link in a table cell stays on one line; long URLs still wrap."""
+    base_url, session_id = table_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    table = page.locator(_TABLE).first
+    expect(table).to_be_visible(timeout=30_000)
+
+    short_link = page.locator(_LINK, has_text=_SHORT_LINK_TEXT).first
+    expect(short_link).to_be_visible(timeout=30_000)
+
+    # The bug: the column collapsed to ~2ch, so "#3090" stacked across boxes.
+    boxes = short_link.evaluate(_LINE_BOXES)
+    assert boxes == 1, f"short table link should occupy one line box, got {boxes}"
+
+    # The column got at least its content's min-content width.
+    cell_width = short_link.evaluate(
+        'el => el.closest("[data-streamdown=\\"table-cell\\"]").clientWidth'
+    )
+    link_width = short_link.evaluate("el => el.getBoundingClientRect().width")
+    assert cell_width >= link_width, (
+        f"link column ({cell_width}px) is narrower than its link ({link_width}px)"
+    )
+
+    # The counterpart: a full URL soft-wraps inside its cell.
+    long_link = page.locator(_LINK, has_text=_LONG_URL).first
+    expect(long_link).to_be_visible(timeout=30_000)
+    long_boxes = long_link.evaluate(_LINE_BOXES)
+    assert long_boxes > 1, f"long URL should wrap across multiple lines, got {long_boxes}"
+    assert not long_link.evaluate(_OVERFLOWS_CELL), "long URL overflows its table cell"

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -881,6 +881,18 @@
   cursor: pointer;
 }
 
+/* Streamdown renders links with `wrap-anywhere` (overflow-wrap: anywhere),
+ * which also shrinks the element's min-content width to a single character.
+ * In an auto-layout table that lets a link-only column collapse to ~2ch, so
+ * a short link like "#3090" stacks one or two characters per line while the
+ * prose columns hog the width. `break-word` still wraps overlong URLs, but
+ * keeps min-content at the longest unbreakable run so the column can't be
+ * squeezed below it. */
+:is([data-streamdown="table-cell"], [data-streamdown="table-header-cell"])
+  [data-streamdown="link"] {
+  overflow-wrap: break-word;
+}
+
 /* Flatten Streamdown's loud heading ramp (text-3xl..xl) to em sizes proportional to body. */
 [data-streamdown="heading-1"] {
   font-size: 1.4em;

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -130,3 +130,55 @@ describe("index.css bg-card glass rule selector", () => {
     aside.remove();
   });
 });
+
+/* Regression test for the "table link column collapses to ~2ch" bug.
+ *
+ * Streamdown styles links with `wrap-anywhere`, which also drops the
+ * element's min-content width to one character. Inside its auto-layout
+ * table that let a link-only column ("#3090") be squeezed to ~2ch and
+ * stack one character per line. index.css narrows links in table cells
+ * back to `break-word`; this pins the selector so the override keeps
+ * applying to cells only, and never leaks into prose links.
+ */
+describe("index.css table link wrapping rule", () => {
+  const rule = (cssSource.match(/[^{}]+\{[^{}]*\}/g) ?? []).find(
+    (block) => block.includes('[data-streamdown="table-cell"]') && /overflow-wrap\s*:/.test(block),
+  );
+
+  // Derived lazily: a missing rule must fail the assertions below with a
+  // readable message, not crash at collection time.
+  const selector = (rule ?? "")
+    .slice(0, rule ? rule.indexOf("{") : 0)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .trim();
+
+  it("has the rule this test exists to protect", () => {
+    expect(rule, "the table-cell link wrapping rule is gone from index.css").toBeDefined();
+    expect(rule).toMatch(/overflow-wrap\s*:\s*break-word/);
+  });
+
+  function makeLink(cellAttr: string | null): HTMLElement {
+    const host = document.createElement("div");
+    if (cellAttr) host.setAttribute("data-streamdown", cellAttr);
+    const link = document.createElement("a");
+    link.setAttribute("data-streamdown", "link");
+    link.className = "wrap-anywhere";
+    host.appendChild(link);
+    document.body.appendChild(host);
+    return link;
+  }
+
+  it.each(["table-cell", "table-header-cell"])("targets links inside a %s", (cellAttr) => {
+    const link = makeLink(cellAttr);
+    expect(link.matches(selector)).toBe(true);
+    link.parentElement?.remove();
+  });
+
+  it("leaves links outside table cells on Streamdown's wrap-anywhere", () => {
+    // Prose links must keep `anywhere` so a bare overlong URL in a
+    // paragraph still breaks mid-token instead of overflowing.
+    const link = makeLink(null);
+    expect(link.matches(selector)).toBe(false);
+    link.parentElement?.remove();
+  });
+});


### PR DESCRIPTION
## Related issue

N/A

## Summary

A markdown table with a short-link column rendered the links one or two
characters per line — `#3090` stacked as `#3` / `09` / `0` — while the prose
columns took all the width.

Streamdown styles every link with `wrap-anywhere` (`overflow-wrap: anywhere`).
Unlike `break-word`, `anywhere` also shrinks the element's **min-content width
to a single character**. Streamdown's table is `table-layout: auto` + `w-full`,
so the browser hands each column the width its min-content demands — and a
link-only column truthfully reported ~1ch, so it got squeezed to ~2ch.

This narrows links **inside table cells** to `overflow-wrap: break-word`.
Overlong URLs still soft-wrap (that's what `anywhere` was there for), but
min-content stays at the longest unbreakable run, so the column can no longer
be squeezed below its content. Links in ordinary prose are untouched.

```
 auto table layout asks each column: "how narrow can you go?"

 wrap-anywhere  →  "1 character"   →  column gets ~2ch  →  #3 / 09 / 0
 break-word     →  "as wide as #3090"  →  column gets 42px  →  #3090
```

## Test Plan

- Reproduced the bug in headless Chrome with the exact table from the report,
  using Streamdown's own DOM/classes, and measured the link's client rects:
  - `wrap-anywhere`: **3 line boxes, 17px wide** (the reported stacking)
  - `break-word`: **1 line box, 42px wide** (fixed)
- Verified the cascade: the unlayered `index.css` rule beats Tailwind's
  `@layer utilities { .wrap-anywhere }` — computed `overflow-wrap` resolves to
  `break-word` with no `!important` needed.
- Regression check for the behaviour `anywhere` existed to provide: a long
  unbreakable URL in a narrow cell still soft-wraps and does **not** overflow
  (link 388px inside a 457px cell; the table stays at its 520px container).
- Added 4 unit tests to `web/src/index.css.test.ts` that run the real selector
  from `index.css` against a DOM: it must match links in `table-cell` and
  `table-header-cell`, and must **not** match prose links. Mutation-checked —
  deleting the rule from `index.css` fails all 4.
- `cd web && npx vitest run src/index.css.test.ts` → 12 passed.
- Added a Playwright e2e test,
  `tests/e2e_ui/messages/test_markdown_table_link_column_width.py`, which is the
  half jsdom can't do: it seeds a deterministic assistant message (no LLM run)
  containing the table shape that triggered the bug — a link-only `#` column,
  wide prose columns, and a **full-URL** column — and asserts in a real browser
  that the short link occupies **one line box**, that its cell is at least as
  wide as the link, and that a long URL still soft-wraps without overflowing its
  cell.
- Mutation-checked against the pre-fix stylesheet: with `web/src/index.css`
  reverted to `origin/main` and the SPA rebuilt, `#3090` stacks across **5 line
  boxes** and the test fails; with the fix restored it passes.
- `uv run pytest tests/e2e_ui/messages/test_markdown_table_link_column_width.py`
  → 1 passed.
- `pre-commit run --files ...` → clean on all three files.

## Demo

Before / after, same markdown, same width:

```
BEFORE                             AFTER
┌────┬──────────┬─────────┐        ┌───────┬──────────┬─────────┐
│ #  │ Author   │ Note    │        │ #     │ Author   │ Note    │
├────┼──────────┼─────────┤        ├───────┼──────────┼─────────┤
│ #3 │ alice    │ waiting │        │ #3090 │ alice    │ waiting │
│ 09 │          │ on CI   │        │ #3088 │ bob      │ on CI   │
│ 0  │          │         │        └───────┴──────────┴─────────┘
└────┴──────────┴─────────┘
```

Before:
<img width="1241" height="566" alt="image" src="https://github.com/user-attachments/assets/83e6c946-ec70-4015-9fbf-e5e924f7f371" />


After:
<img width="1241" height="566" alt="image" src="https://github.com/user-attachments/assets/b96233c7-3036-43d7-b635-8cb0f136dca3" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two layers, because neither alone is enough. The vitest tests pin the
selector's contract (cells yes, prose no) but can't assert layout — jsdom has no
layout engine. The Playwright test covers the layout itself in a real browser
and is the one that actually fails if the rule regresses (5 stacked line boxes
vs. 1). The manual headless-Chrome measurements in the Test Plan were how the
root cause was found.

Note this locally overrides an upstream Streamdown styling choice; `wrap-anywhere`
on links is arguably wrong inside a `table-layout: auto` table, so it may be
worth filing upstream too. The local rule is still the right fix to carry.

## Changelog

Short links like `#3090` in chat markdown tables no longer stack one character per line

