### PR TITLE
fix(pi): drain to agent_settled instead of agent_end for turn boundary

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -20,7 +20,10 @@ OpenAI Completions for others) and ``PI_CODING_AGENT_DIR`` is set so Pi
 picks it up.
 
 Requirements:
-    The ``pi`` CLI must be installed and on PATH.
+    The ``pi`` CLI must be installed and on PATH. Pi >= 0.80.4 provides
+    reliable ``agent_settled`` turn boundaries; older or undetectable
+    versions fall back to ``agent_end`` and may end early across retries,
+    compaction, or queued continuations.
 
 Environment (Databricks):
     DATABRICKS_CONFIG_PROFILE — optional Databricks profile selector
@@ -660,6 +663,14 @@ _PI_ENV_ALLOW_EXACT: frozenset[str] = frozenset(
     }
 )
 _STREAM_READ_CHUNK_SIZE = 65536
+_PI_AGENT_SETTLED_MIN_VERSION = (0, 80, 4)
+
+# Maximum silence between Pi frames; long tools and retry backoff need headroom.
+_READ_STALL_TIMEOUT_S = 120.0
+# Error-to-agent_end draining should be immediate, so cap that wait tightly.
+_POST_ERROR_READ_TIMEOUT_S = 10.0
+# Bound abort stdin.drain before force-closing a stalled session.
+_STALL_ABORT_TIMEOUT_S = 10.0
 
 # CLI flags whose values are sensitive (e.g. the full system prompt) and must
 # not be written to logs verbatim. The value following these flags is replaced
@@ -1096,11 +1107,13 @@ class _PiRpcSession:
         await self.process.stdin.drain()
 
     async def read_line(self, timeout: float = 120.0) -> str | None:
-        """Read the next JSONL line from Pi's stdout. Returns None on EOF."""
-        try:
-            return await asyncio.wait_for(self._line_queue.get(), timeout=timeout)
-        except asyncio.TimeoutError:
-            return None
+        """Read the next JSONL line from Pi's stdout.
+
+        :returns: The line, or ``None`` on EOF (the reader's sentinel).
+        :raises asyncio.TimeoutError: No line arrived within ``timeout``.
+            A stall is NOT EOF — callers must handle the two differently.
+        """
+        return await asyncio.wait_for(self._line_queue.get(), timeout=timeout)
 
     async def close(self) -> None:
         for task in (self._read_task, self._stderr_task):
@@ -1138,6 +1151,9 @@ class _PiSessionState:
     rpc: _PiRpcSession | None = None
     system_prompt: str | None = None
     model: str | None = None
+    pi_version: tuple[int, int, int] | None = None
+    supports_agent_settled: bool = False
+    _pi_version_checked: bool = False
     _has_sent_prompt: bool = False
 
 
@@ -1587,6 +1603,35 @@ def _aggregate_pi_turn_usage(
     }
 
 
+def _extract_pi_response_text(messages: list[object]) -> str:
+    """Harvest response text from an ``agent_end`` ``messages`` array.
+
+    Used only when no text deltas streamed (e.g. non-streaming models):
+    the last assistant message's text is the loop's answer.
+
+    :param messages: The ``messages`` array from an ``agent_end`` event —
+        may hold the whole conversation. Defensive against non-dict shapes.
+    :returns: The last assistant message's text, or ``""`` when none is found.
+    """
+    for m in reversed(messages):
+        if not isinstance(m, dict) or m.get("role") != "assistant":
+            continue
+        content = m.get("content", [])
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            text_parts: list[str] = []
+            for part in content:
+                if not (isinstance(part, dict) and part.get("type") == "text"):
+                    continue
+                part_text = part.get("text")
+                if isinstance(part_text, str):
+                    text_parts.append(part_text)
+            return "".join(text_parts)
+        break
+    return ""
+
+
 class PiExecutor(Executor):
     """Execute agent turns via the Pi coding agent (``pi --mode rpc``)."""
 
@@ -1666,7 +1711,8 @@ class PiExecutor(Executor):
         if not resolved_pi:
             raise ImportError(
                 "PiExecutor requires the 'pi' CLI on PATH. "
-                "Install it with: npm install -g @earendil-works/pi-coding-agent"
+                "Install it with: npm install -g "
+                "'@earendil-works/pi-coding-agent@>=0.80.4'"
             )
         self._pi_path = resolved_pi
         self._cwd = cwd
@@ -1697,10 +1743,12 @@ class PiExecutor(Executor):
         # off (they don't route through Omnigent policies / history and
         # can 400 against the Databricks Responses API), and the bridge
         # extension's tools are explicitly allowlisted.
-        from omnigent.pi_native import pi_supports_approve
+        from omnigent.pi_native import pi_version
 
         self._extra_args: list[str] = ["--no-tools"]
-        if pi_supports_approve(self._pi_path):
+        # Reuse one bounded probe for --approve and RPC boundary support.
+        self._pi_version = pi_version(self._pi_path)
+        if self._pi_version is not None and self._pi_version >= (0, 79, 0):
             # Pre-accept the project-folder trust dialog. Pi 0.79+ shows a
             # blocking TUI prompt on first launch in a directory with .pi/
             # resources. In a runner-driven session there is nobody at the
@@ -1776,6 +1824,7 @@ class PiExecutor(Executor):
         self._sandboxed = sandboxed.sandboxed
 
         self._session_states: dict[str, _PiSessionState] = {}
+        self._legacy_boundary_warning_emitted = False
         self._tool_server: _ToolServer | None = None
 
     def supports_streaming(self) -> bool:
@@ -1882,6 +1931,30 @@ class PiExecutor(Executor):
         if model is None and self._gateway_uses_databricks_profile:
             return DATABRICKS_CLAUDE_DEFAULT_MODEL
         return model
+
+    def _configure_session_turn_boundary(self, state: _PiSessionState) -> None:
+        """Cache the detected Pi version and terminal-frame capability."""
+        if state._pi_version_checked:
+            return
+        state._pi_version_checked = True
+        state.pi_version = self._pi_version
+        state.supports_agent_settled = (
+            state.pi_version is not None and state.pi_version >= _PI_AGENT_SETTLED_MIN_VERSION
+        )
+        if state.supports_agent_settled or self._legacy_boundary_warning_emitted:
+            return
+        self._legacy_boundary_warning_emitted = True
+        detected = (
+            ".".join(str(part) for part in state.pi_version)
+            if state.pi_version is not None
+            else "undetectable"
+        )
+        logger.warning(
+            "PiExecutor detected Pi version %s; using the legacy agent_end "
+            "turn boundary. Upgrade to Pi >= 0.80.4 for reliable retry, "
+            "compaction, and queued-continuation boundaries.",
+            detected,
+        )
 
     async def _ensure_tool_server(self, tools: list[ToolSpec]) -> int | None:
         """Start the TCP tool server if there are Omnigent tools to bridge."""
@@ -2048,6 +2121,7 @@ class PiExecutor(Executor):
     ) -> _PiRpcSession:
         """Get or create a Pi RPC subprocess for the given session."""
         state = self._session_states.setdefault(session_key, _PiSessionState())
+        self._configure_session_turn_boundary(state)
 
         effective_model = model
 
@@ -2130,6 +2204,9 @@ class PiExecutor(Executor):
         # context.  On subsequent turns the Pi process already has context,
         # so we only send the latest user message.
         state = self._session_states.get(session_key)
+        # _ensure_rpc always creates state; state-less test adapters model a
+        # current Pi unless they install an explicit compatibility state.
+        supports_agent_settled = state is None or state.supports_agent_settled
         is_first_turn = state is not None and not state._has_sent_prompt
 
         prompt = _build_pi_prompt(messages, is_first_turn=is_first_turn)
@@ -2167,27 +2244,76 @@ class PiExecutor(Executor):
             yield ExecutorError(message=f"Failed to send prompt to Pi: {exc}")
             return
 
-        # Read events until agent_end.
+        # Modern Pi turns end at agent_settled. agent_end closes only one
+        # internal retry/compaction/continuation loop; the compatibility
+        # branch below uses it only when the installed Pi lacks settlement.
         response_text = ""
-        streamed_any = False
+        # Response text harvested from agent_end messages, used only when
+        # nothing streamed. The LATEST agent_end supersedes earlier ones:
+        # on a retry/compaction sequence its last assistant message is the
+        # final answer, not the superseded draft.
+        fallback_response: str | None = None
         # Per-LLM-call token usage captured from each assistant message pi
         # forwards (``message_end`` is the capture site; ``agent_end`` is a
-        # fallback). Summed into a turn-level usage dict at completion so a
+        # fallback). Summed into a turn-level usage dict at settlement so a
         # multi-step (tool-loop) turn bills for every call, not just the
         # last. Empty when pi reports no usage — cost tracking is skipped.
         message_usages: list[dict[str, Any]] = []  # type: ignore[explicit-any]
-        # Error reported by a ``message_end`` (stopReason=error); surfaced at
-        # ``agent_end`` so the terminal event is consumed off the RPC stream.
+        # Error reported by a ``message_end`` (stopReason=error/aborted);
+        # surfaced at ``agent_settled`` so every terminal frame is drained
+        # off the RPC stream before the next turn reads from it.
         pending_error: str | None = None
+        # The short post-error budget applies only until that run's
+        # agent_end. Retry backoff and compaction may legitimately take the
+        # full read budget after agent_end.
+        awaiting_error_agent_end = False
+        # Usage fallback is scoped to one internal agent run. Each
+        # agent.continue() has its own newMessages/agent_end payload.
+        current_run_has_message_usage = False
+        # Recovery is determined by the outcome of the current internal run,
+        # independently of agent_end.willRetry (compaction does not set it).
+        current_run_failed = False
+        # agent_end marks an internal-run boundary; message_start (or another
+        # run event) proves that a continuation actually began.
+        internal_run_ended = False
+        supersede_response_on_next_run = False
 
         while True:
-            # After an errored message the only thing left to drain is the
-            # already-emitted agent_end, so don't wait the full idle budget.
-            line = await rpc.read_line(timeout=120.0 if pending_error is None else 10.0)
+            # Bounds silence, not total lifetime: a chatty Pi that never
+            # settles can keep this loop alive.
+            read_timeout = (
+                _POST_ERROR_READ_TIMEOUT_S if awaiting_error_agent_end else _READ_STALL_TIMEOUT_S
+            )
+            try:
+                line = await rpc.read_line(timeout=read_timeout)
+            except asyncio.TimeoutError:
+                # Silence is not settlement. Abort is best-effort and
+                # bounded because stdin.drain() can wedge along with stdout;
+                # recycling in finally is the safety boundary.
+                try:
+                    await asyncio.wait_for(
+                        rpc.send_command({"type": "abort", "id": f"abort_{cmd_id}"}),
+                        timeout=_STALL_ABORT_TIMEOUT_S,
+                    )
+                except Exception:  # noqa: BLE001 — close() below kills the process
+                    logger.debug("PiExecutor: stall abort failed", exc_info=True)
+                finally:
+                    try:
+                        await self.close_session(session_key)
+                    except Exception:  # noqa: BLE001 — state is already popped; report the stall
+                        logger.debug("PiExecutor: stalled session close failed", exc_info=True)
+                yield ExecutorError(
+                    message=(
+                        f"Pi produced no events for {read_timeout:.0f}s; "
+                        "the session was aborted and recycled."
+                    )
+                )
+                return
             if line is None:
+                # EOF: the pi process ended mid-turn (crash/kill).
                 if pending_error is not None:
                     yield ExecutorError(message=pending_error)
-                elif not streamed_any and not response_text:
+                elif not response_text and fallback_response is None:
                     stderr = "\n".join(rpc._stderr_lines) if rpc._stderr_lines else ""
                     stderr_suffix = f" Stderr: {stderr}" if stderr else ""
                     yield ExecutorError(
@@ -2196,7 +2322,9 @@ class PiExecutor(Executor):
                 else:
                     turn_usage = _aggregate_pi_turn_usage(message_usages, model)
                     _notify_usage_from_dict(model=model, usage=turn_usage)
-                    yield TurnComplete(response=response_text, usage=turn_usage)
+                    yield TurnComplete(
+                        response=response_text or fallback_response or "", usage=turn_usage
+                    )
                 return
 
             try:
@@ -2207,6 +2335,27 @@ class PiExecutor(Executor):
 
             raw_event_type = event.get("type")
             event_type: str | None = raw_event_type if isinstance(raw_event_type, str) else None
+
+            if internal_run_ended and event_type in {
+                "agent_start",
+                "message_start",
+                "message_update",
+                "message_end",
+                "tool_execution_start",
+                "tool_execution_end",
+            }:
+                # Usage fallback starts fresh for every continuation. Failed
+                # retry/overflow output is superseded; ordinary queued
+                # continuations remain part of the logical turn's response.
+                if supersede_response_on_next_run:
+                    response_text = ""
+                    fallback_response = None
+                    # Already-yielded TextChunks remain visible; only the
+                    # final aggregated response drops superseded text.
+                current_run_has_message_usage = False
+                current_run_failed = False
+                internal_run_ended = False
+                supersede_response_on_next_run = False
 
             # Skip the command-ack response.
             if event_type == "response":
@@ -2224,7 +2373,6 @@ class PiExecutor(Executor):
                     if isinstance(raw_delta, str) and raw_delta:
                         yield TextChunk(text=raw_delta)
                         response_text += raw_delta
-                        streamed_any = True
                 elif ame_type == "thinking_start":
                     # Anchors the "Thinking…" indicator before the first delta.
                     yield ReasoningChunk(delta="", event_type="reasoning_started")
@@ -2318,41 +2466,72 @@ class PiExecutor(Executor):
                 )
                 continue
 
-            # Agent ended — the turn is complete.
+            # agent_end closes one internal loop. Modern Pi keeps draining to
+            # its single agent_settled; older Pi must finalize here.
             if event_type == "agent_end":
+                end_messages = event.get("messages", [])
+                if isinstance(end_messages, list):
+                    if not response_text:
+                        # Response-text fallback when nothing streamed. The
+                        # LATEST agent_end wins on purpose: after a retry or
+                        # compaction, its last assistant message is the final
+                        # answer, superseding any earlier loop's draft.
+                        extracted = _extract_pi_response_text(end_messages)
+                        if extracted:
+                            fallback_response = extracted
+                    # Fallback usage capture: if no ``message_end`` carried
+                    # usage, pull it from the last assistant message in
+                    # ``messages`` (only the last — ``messages`` may hold the
+                    # whole conversation, so summing it would overcount).
+                    if not current_run_has_message_usage:
+                        for m in reversed(end_messages):
+                            captured = _extract_pi_turn_usage(m, model)
+                            if captured is not None:
+                                message_usages.append(captured)
+                                break
+                    for m in reversed(end_messages):
+                        if not isinstance(m, dict) or m.get("role") != "assistant":
+                            continue
+                        stop = m.get("stopReason")
+                        if stop in {"error", "aborted"}:
+                            current_run_failed = True
+                        elif isinstance(stop, str):
+                            current_run_failed = False
+                        if not current_run_failed:
+                            pending_error = None
+                        break
+                if not current_run_failed:
+                    # A continuation that reached agent_end without another
+                    # error recovered even if its message_end was omitted.
+                    pending_error = None
+                awaiting_error_agent_end = False
+                internal_run_ended = True
+                supersede_response_on_next_run = current_run_failed or bool(event.get("willRetry"))
+                if not supports_agent_settled:
+                    if pending_error is not None:
+                        yield ExecutorError(message=pending_error)
+                        return
+                    turn_usage = _aggregate_pi_turn_usage(message_usages, model)
+                    _notify_usage_from_dict(model=model, usage=turn_usage)
+                    yield TurnComplete(
+                        response=response_text or fallback_response or "",
+                        usage=turn_usage,
+                    )
+                    return
+                continue
+
+            # Session settled — THE turn boundary for success, error, and
+            # abort alike: every terminal frame has now been consumed, so
+            # the next turn starts against a clean stream.
+            if event_type == "agent_settled":
                 if pending_error is not None:
                     yield ExecutorError(message=pending_error)
                     return
-                end_messages = event.get("messages", [])
-                if not response_text:
-                    for m in reversed(end_messages):
-                        if m.get("role") == "assistant":
-                            content = m.get("content", [])
-                            if isinstance(content, str):
-                                response_text = content
-                            elif isinstance(content, list):
-                                text_parts: list[str] = []
-                                for part in content:
-                                    if not (isinstance(part, dict) and part.get("type") == "text"):
-                                        continue
-                                    part_text = part.get("text")
-                                    if isinstance(part_text, str):
-                                        text_parts.append(part_text)
-                                response_text = "".join(text_parts)
-                            break
-                # Fallback usage capture: if no ``message_end`` carried
-                # usage, pull it from the last assistant message in
-                # ``messages`` (only the last — ``messages`` may hold the
-                # whole conversation, so summing it would overcount).
-                if not message_usages and isinstance(end_messages, list):
-                    for m in reversed(end_messages):
-                        captured = _extract_pi_turn_usage(m, model)
-                        if captured is not None:
-                            message_usages.append(captured)
-                            break
                 turn_usage = _aggregate_pi_turn_usage(message_usages, model)
                 _notify_usage_from_dict(model=model, usage=turn_usage)
-                yield TurnComplete(response=response_text, usage=turn_usage)
+                yield TurnComplete(
+                    response=response_text or fallback_response or "", usage=turn_usage
+                )
                 return
 
             # message_end carries one completed assistant message, whose
@@ -2364,19 +2543,28 @@ class PiExecutor(Executor):
                     captured = _extract_pi_turn_usage(msg, model)
                     if captured is not None:
                         message_usages.append(captured)
+                        current_run_has_message_usage = True
                     raw_stop = msg.get("stopReason")
                     stop: str | None = raw_stop if isinstance(raw_stop, str) else None
                     if stop == "aborted":
-                        err = msg.get("errorMessage", stop)
-                        yield ExecutorError(message=str(err))
-                        return
-                    if stop == "error":
-                        # Pi emits the turn-terminal ``agent_end`` after an
-                        # errored LLM call; returning here would leave it
-                        # queued, so the next turn on this RPC session reads
-                        # the stale event as its own end. Record the error
-                        # and keep draining until ``agent_end``.
+                        # Pi still emits agent_end(stopReason=aborted) and
+                        # agent_settled after an abort; returning here would
+                        # leave them queued for the NEXT turn to misread as
+                        # its own terminal frames. Record and keep draining.
                         pending_error = str(msg.get("errorMessage", stop))
+                        current_run_failed = True
+                        awaiting_error_agent_end = True
+                    elif stop == "error":
+                        # Same drain discipline: agent_end (then
+                        # agent_settled) always follows an errored LLM call.
+                        pending_error = str(msg.get("errorMessage", stop))
+                        current_run_failed = True
+                        awaiting_error_agent_end = True
+                    else:
+                        # Pi emits agent_end immediately after an error, so a
+                        # later message_end (even without stopReason) proves recovery.
+                        pending_error = None
+                        current_run_failed = False
                 continue
 
             logger.debug("PiExecutor: ignoring event type=%s", event_type)

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -32,6 +32,7 @@ from omnigent.inner.pi_executor import (
     _generate_extension_js,
     _pi_provider_for_model,
     _PiRpcSession,
+    _PiSessionState,
     _redact_argv_for_log,
     _safe_dumps,
     _sanitize_schema,
@@ -1300,8 +1301,19 @@ class TestPiExecutorConstructor(unittest.TestCase):
 
     def test_constructor_raises_when_pi_not_found(self):
         with patch("omnigent.inner.pi_executor._find_pi_cli", return_value=None):
-            with self.assertRaises(ImportError):
+            with self.assertRaisesRegex(ImportError, r">=0\.80\.4"):
                 PiExecutor()
+
+    def test_constructor_reuses_one_version_probe(self):
+        with (
+            patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"),
+            patch("omnigent.pi_native.pi_version", return_value=(0, 80, 4)) as version_probe,
+        ):
+            executor = PiExecutor()
+
+        version_probe.assert_called_once_with("/usr/bin/pi")
+        self.assertEqual(executor._pi_version, (0, 80, 4))
+        self.assertIn("--approve", executor._extra_args)
 
     def test_constructor_databricks_with_env(self):
         with (
@@ -1796,6 +1808,7 @@ class TestRunTurn(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
             for line in lines:
                 fake_rpc._line_queue.put_nowait(line)
@@ -1857,6 +1870,7 @@ class TestRunTurn(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
             for line in lines:
                 fake_rpc._line_queue.put_nowait(line)
@@ -1983,6 +1997,7 @@ class TestRunTurn(unittest.TestCase):
                         ],
                     }
                 ),
+                json.dumps({"type": "agent_settled"}),
             ]
             for line in lines:
                 fake_rpc._line_queue.put_nowait(line)
@@ -2029,6 +2044,7 @@ class TestRunTurn(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
             for line in lines:
                 fake_rpc._line_queue.put_nowait(line)
@@ -2076,6 +2092,7 @@ class TestRunTurn(unittest.TestCase):
                 json.dumps({"type": "message_end", "message": errored}),
                 # Pi's agent loop always emits agent_end after an errored call.
                 json.dumps({"type": "agent_end", "messages": [errored]}),
+                json.dumps({"type": "agent_settled"}),
             ]
             for line in lines:
                 fake_rpc._line_queue.put_nowait(line)
@@ -2154,11 +2171,11 @@ class TestRunTurn(unittest.TestCase):
 
         _run(_test())
 
-    def test_post_tool_error_drains_agent_end_before_failing(self):
+    def test_post_tool_error_drains_to_settlement_before_failing(self):
         """A message_end error after a successful tool call fails the turn
-        with pi's error message, but only after consuming the trailing
-        ``agent_end`` — leaving it queued would make the next turn on the
-        same RPC session read the stale terminal event as its own end.
+        with pi's error message, but only after consuming ``agent_end`` and
+        ``agent_settled``. Leaving either queued would contaminate the next
+        turn on the same RPC session.
         """
 
         async def _test():
@@ -2197,6 +2214,7 @@ class TestRunTurn(unittest.TestCase):
                 # Pi always emits agent_end after the errored LLM call ends
                 # the agent loop; it carries the errored message.
                 json.dumps({"type": "agent_end", "messages": [errored_assistant]}),
+                json.dumps({"type": "agent_settled"}),
             ]
             for line in lines:
                 fake_rpc._line_queue.put_nowait(line)
@@ -2224,8 +2242,7 @@ class TestRunTurn(unittest.TestCase):
             self.assertEqual([e.message for e in errors], [parse_error])
             self.assertFalse(any(isinstance(e, TurnComplete) for e in events))
             self.assertFalse(any(isinstance(e, TextChunk) for e in events))
-            # The trailing agent_end was consumed: nothing stale is left for
-            # the next turn on this RPC session.
+            # Both terminal frames were consumed.
             self.assertTrue(fake_rpc._line_queue.empty())
 
         _run(_test())
@@ -2339,6 +2356,7 @@ def test_pi_thinking_deltas_stream_as_reasoning_chunks() -> None:
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -2403,6 +2421,7 @@ def test_pi_thinking_and_text_delta_ordering_preserved() -> None:
                 _update({"type": "thinking_delta", "contentIndex": 2, "delta": "revise"}),
                 _update({"type": "text_delta", "contentIndex": 3, "delta": " step two"}),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -2638,6 +2657,7 @@ class TestBlockedToolDetection(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
         tool_completes = [e for e in events if isinstance(e, ToolCallComplete)]
@@ -2660,6 +2680,7 @@ class TestBlockedToolDetection(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
         tool_completes = [e for e in events if isinstance(e, ToolCallComplete)]
@@ -2681,6 +2702,7 @@ class TestBlockedToolDetection(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
         tool_completes = [e for e in events if isinstance(e, ToolCallComplete)]
@@ -2706,6 +2728,7 @@ class TestBlockedToolDetection(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
         tool_completes = [e for e in events if isinstance(e, ToolCallComplete)]
@@ -2727,6 +2750,7 @@ class TestBlockedToolDetection(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
         tool_completes = [e for e in events if isinstance(e, ToolCallComplete)]
@@ -3344,6 +3368,7 @@ def test_run_turn_spawn_log_redacts_system_prompt_end_to_end(monkeypatch, caplog
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ],
             stderr_lines=[],
         )
@@ -3416,6 +3441,7 @@ def test_run_turn_spawn_env_has_no_host_secrets(monkeypatch) -> None:
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ],
             stderr_lines=[],
         )
@@ -3475,6 +3501,7 @@ def test_run_turn_spawn_env_honors_spec_env_passthrough(monkeypatch) -> None:
             stdout_lines=[
                 json.dumps({"type": "response", "success": True}),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ],
             stderr_lines=[],
         )
@@ -3606,6 +3633,7 @@ def test_run_turn_bridge_extension_carries_live_server_token(monkeypatch) -> Non
             stdout_lines=[
                 json.dumps({"type": "response", "success": True}),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ],
             stderr_lines=[],
         )
@@ -3722,6 +3750,7 @@ def test_pi_usage_captured_from_message_end() -> None:
                 ),
                 json.dumps({"type": "message_end", "message": _pi_assistant_message_with_usage()}),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -3783,6 +3812,7 @@ def test_pi_usage_fallback_from_agent_end() -> None:
                         ],
                     }
                 ),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -3831,6 +3861,7 @@ def test_pi_usage_model_falls_back_to_configured_model() -> None:
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ],
             model="databricks-claude-sonnet-4-6",
         )
@@ -3901,6 +3932,7 @@ def test_pi_usage_sums_across_multiple_message_end() -> None:
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -3952,6 +3984,7 @@ def test_pi_turn_without_usage_leaves_usage_none() -> None:
                 # message_end with no usage object, then a usage-less agent_end.
                 json.dumps({"type": "message_end", "message": {"stopReason": "stop"}}),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -3972,3 +4005,669 @@ def test_pi_turn_without_usage_leaves_usage_none() -> None:
         assert turn_complete[0].response == "Hi there"
 
     _run(_test())
+
+
+# ---------------------------------------------------------------------------
+# PiExecutor turn-boundary tests: agent_settled, not agent_end, ends a turn.
+#
+# Pi wraps one logical turn (prompt + retry + compaction + queued
+# continuation) in a single agent session that can emit SEVERAL agent_end
+# frames — one per internal agent loop — followed by exactly one
+# agent_settled. run_turn must drain to agent_settled; returning at the
+# first agent_end drops the rest of the turn and leaves its late frames
+# queued for the NEXT run_turn to misread as its own terminal frames.
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSettledTurnBoundary(unittest.TestCase):
+    def _make_executor(self):
+        with patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"):
+            return PiExecutor()
+
+    def _make_fake_rpc(self, lines: list[str]) -> _PiRpcSession:
+        fake_rpc = _PiRpcSession()
+        fake_rpc._line_queue = asyncio.Queue()
+        fake_rpc.process = _FakeProcess()
+        fake_rpc._stderr_lines = []
+        for line in lines:
+            fake_rpc._line_queue.put_nowait(line)
+        return fake_rpc
+
+    def _attach(
+        self,
+        executor,
+        fake_rpc,
+        version: tuple[int, int, int] | None = (0, 80, 4),
+    ) -> None:
+        executor._pi_version = version
+        state = _PiSessionState(rpc=fake_rpc)
+        executor._session_states["__default__"] = state
+
+        async def fake_ensure_rpc(*args, **kwargs):
+            executor._configure_session_turn_boundary(state)
+            return fake_rpc
+
+        executor._ensure_rpc = fake_ensure_rpc
+
+    def _usage_message(self, text: str, input_tokens: int, output_tokens: int) -> dict:
+        """Assistant message carrying a pi ``usage`` object."""
+        return {
+            "role": "assistant",
+            "content": [{"type": "text", "text": text}],
+            "stopReason": "stop",
+            "model": "claude-sonnet-4-6",
+            "usage": {
+                "input": input_tokens,
+                "output": output_tokens,
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "totalTokens": input_tokens + output_tokens,
+            },
+        }
+
+    def test_supported_version_waits_for_agent_settled(self):
+        """Pi 0.80.4+ must not finalize at the first agent_end."""
+
+        async def _test():
+            executor = self._make_executor()
+            lines = [
+                json.dumps({"type": "response", "success": True}),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {"type": "text_delta", "delta": "first "},
+                    }
+                ),
+                json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {"type": "text_delta", "delta": "second"},
+                    }
+                ),
+                json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
+            ]
+            fake_rpc = self._make_fake_rpc(lines)
+            self._attach(executor, fake_rpc, version=(0, 80, 4))
+
+            events = [
+                event
+                async for event in executor.run_turn(
+                    [{"role": "user", "content": "hello"}],
+                    [],
+                    "system",
+                )
+            ]
+
+            completed = [event for event in events if isinstance(event, TurnComplete)]
+            self.assertEqual([event.response for event in completed], ["first second"])
+            self.assertTrue(fake_rpc._line_queue.empty())
+
+        _run(_test())
+
+    def test_older_version_uses_legacy_agent_end_boundary(self):
+        """Pi before 0.80.4 completes at agent_end instead of stalling."""
+
+        async def _test():
+            executor = self._make_executor()
+            lines = [
+                json.dumps({"type": "response", "success": True}),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {"type": "text_delta", "delta": "legacy"},
+                    }
+                ),
+                json.dumps({"type": "agent_end", "messages": []}),
+            ]
+            fake_rpc = self._make_fake_rpc(lines)
+            self._attach(executor, fake_rpc, version=(0, 80, 3))
+
+            with patch("omnigent.inner.pi_executor.logger.warning"):
+                events = [
+                    event
+                    async for event in executor.run_turn(
+                        [{"role": "user", "content": "hello"}],
+                        [],
+                        "system",
+                    )
+                ]
+
+            completed = [event for event in events if isinstance(event, TurnComplete)]
+            self.assertEqual([event.response for event in completed], ["legacy"])
+            state = executor._session_states["__default__"]
+            self.assertEqual(state.pi_version, (0, 80, 3))
+            self.assertFalse(state.supports_agent_settled)
+
+        _run(_test())
+
+    def test_undetectable_version_uses_legacy_agent_end_boundary(self):
+        """An unknown version fails safe to the non-hanging boundary."""
+
+        async def _test():
+            executor = self._make_executor()
+            lines = [
+                json.dumps({"type": "response", "success": True}),
+                json.dumps({"type": "agent_end", "messages": []}),
+            ]
+            fake_rpc = self._make_fake_rpc(lines)
+            self._attach(executor, fake_rpc, version=None)
+
+            with patch("omnigent.inner.pi_executor.logger.warning"):
+                events = [
+                    event
+                    async for event in executor.run_turn(
+                        [{"role": "user", "content": "hello"}],
+                        [],
+                        "system",
+                    )
+                ]
+
+            self.assertEqual(len([e for e in events if isinstance(e, TurnComplete)]), 1)
+            self.assertFalse(any(isinstance(e, ExecutorError) for e in events))
+
+        _run(_test())
+
+    def test_legacy_boundary_warning_is_emitted_once(self):
+        """Multiple old-version sessions emit one actionable warning."""
+        executor = self._make_executor()
+        executor._pi_version = (0, 80, 3)
+
+        with patch("omnigent.inner.pi_executor.logger.warning") as warning:
+            executor._configure_session_turn_boundary(_PiSessionState())
+            executor._configure_session_turn_boundary(_PiSessionState())
+
+        warning.assert_called_once()
+        args = warning.call_args.args
+        self.assertIn("0.80.3", args)
+        self.assertIn("Pi >= 0.80.4", args[0])
+
+    def test_multiple_agent_ends_settle_to_one_turn_complete(self):
+        """A retried turn emits message_end(error) + agent_end(willRetry)
+        for the failed loop, then streams the real answer and ends the
+        second loop with agent_end + agent_settled. Exactly ONE TurnComplete
+        must surface, carrying the retry's answer — not the failed loop's
+        error, and not a completion at the first agent_end.
+        """
+
+        async def _test():
+            executor = self._make_executor()
+            errored = {
+                "role": "assistant",
+                "content": [],
+                "stopReason": "error",
+                "errorMessage": "Rate limited",
+            }
+            lines = [
+                json.dumps({"type": "response", "success": True}),
+                # First internal loop: retryable LLM failure.
+                json.dumps({"type": "message_end", "message": errored}),
+                json.dumps({"type": "agent_end", "willRetry": True, "messages": [errored]}),
+                # Second internal loop (the retry) streams the real answer.
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {"type": "text_delta", "delta": "Final "},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {"type": "text_delta", "delta": "answer"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "message_end",
+                        "message": self._usage_message("Final answer", 100, 20),
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "agent_end",
+                        "messages": [self._usage_message("Final answer", 100, 20)],
+                    }
+                ),
+                json.dumps({"type": "agent_settled"}),
+            ]
+            fake_rpc = self._make_fake_rpc(lines)
+            self._attach(executor, fake_rpc)
+
+            events = [
+                e
+                async for e in executor.run_turn(
+                    [{"role": "user", "content": "hello"}],
+                    [],
+                    "system",
+                )
+            ]
+
+            errors = [e for e in events if isinstance(e, ExecutorError)]
+            self.assertEqual(errors, [])
+            turn_complete = [e for e in events if isinstance(e, TurnComplete)]
+            self.assertEqual(len(turn_complete), 1)
+            # The completion carries the retry's streamed answer, and it is
+            # the LAST event — emitted at settlement, not mid-turn.
+            self.assertIsInstance(events[-1], TurnComplete)
+            self.assertEqual(turn_complete[0].response, "Final answer")
+            usage = turn_complete[0].usage
+            self.assertIsNotNone(usage)
+            self.assertEqual(usage["input_tokens"], 100)
+            self.assertEqual(usage["output_tokens"], 20)
+            # Every terminal frame was drained: nothing stale is left for
+            # the next turn on this RPC session.
+            self.assertTrue(fake_rpc._line_queue.empty())
+
+        _run(_test())
+
+    def test_abort_drains_to_agent_settled(self):
+        """message_end(stopReason=aborted) must NOT end the read loop:
+        agent_end(stopReason=aborted) and agent_settled follow it on the
+        wire, and leaving them queued poisons the next turn.
+        """
+
+        async def _test():
+            executor = self._make_executor()
+            aborted = {
+                "role": "assistant",
+                "content": [],
+                "stopReason": "aborted",
+                "errorMessage": "Request was aborted",
+            }
+            lines = [
+                json.dumps({"type": "response", "success": True}),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {"type": "text_delta", "delta": "working"},
+                    }
+                ),
+                json.dumps({"type": "message_end", "message": aborted}),
+                json.dumps({"type": "agent_end", "messages": [aborted]}),
+                json.dumps({"type": "agent_settled"}),
+            ]
+            fake_rpc = self._make_fake_rpc(lines)
+            self._attach(executor, fake_rpc)
+
+            events = [
+                e
+                async for e in executor.run_turn(
+                    [{"role": "user", "content": "hello"}],
+                    [],
+                    "system",
+                )
+            ]
+
+            errors = [e for e in events if isinstance(e, ExecutorError)]
+            self.assertEqual([e.message for e in errors], ["Request was aborted"])
+            self.assertFalse(any(isinstance(e, TurnComplete) for e in events))
+            # agent_end + agent_settled were consumed, not left queued.
+            self.assertTrue(fake_rpc._line_queue.empty())
+
+        _run(_test())
+
+    def test_error_drains_to_agent_settled(self):
+        """A non-retried LLM error surfaces as ExecutorError only after
+        agent_end AND agent_settled are drained off the stream.
+        """
+
+        async def _test():
+            executor = self._make_executor()
+            errored = {
+                "role": "assistant",
+                "content": [],
+                "stopReason": "error",
+                "errorMessage": "401 Unauthorized",
+            }
+            lines = [
+                json.dumps({"type": "response", "success": True}),
+                json.dumps({"type": "message_end", "message": errored}),
+                json.dumps({"type": "agent_end", "messages": [errored]}),
+                json.dumps({"type": "agent_settled"}),
+            ]
+            fake_rpc = self._make_fake_rpc(lines)
+            self._attach(executor, fake_rpc)
+
+            events = [
+                e
+                async for e in executor.run_turn(
+                    [{"role": "user", "content": "hello"}],
+                    [],
+                    "system",
+                )
+            ]
+
+            errors = [e for e in events if isinstance(e, ExecutorError)]
+            self.assertEqual([e.message for e in errors], ["401 Unauthorized"])
+            self.assertFalse(any(isinstance(e, TurnComplete) for e in events))
+            self.assertTrue(fake_rpc._line_queue.empty())
+
+        _run(_test())
+
+    def test_context_overflow_compaction_returns_recovered_answer(self):
+        """Context overflow is not auto-retryable, so willRetry is false.
+        Pi compacts and continues anyway; the successful continuation must
+        supersede the overflow error and its partial output.
+        """
+
+        async def _test():
+            executor = self._make_executor()
+            overflow = {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "discarded"}],
+                "stopReason": "error",
+                "errorMessage": "context window exceeded",
+            }
+            lines = [
+                json.dumps({"type": "response", "success": True}),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {"type": "text_delta", "delta": "discarded"},
+                    }
+                ),
+                json.dumps({"type": "message_end", "message": overflow}),
+                json.dumps({"type": "agent_end", "willRetry": False, "messages": [overflow]}),
+                json.dumps({"type": "compaction_start"}),
+                json.dumps({"type": "compaction_end"}),
+                json.dumps({"type": "agent_start"}),
+                json.dumps({"type": "message_start", "message": {"role": "assistant"}}),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {
+                            "type": "text_delta",
+                            "delta": "Post-compaction answer",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "message_end",
+                        "message": self._usage_message("Post-compaction answer", 80, 12),
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "agent_end",
+                        "messages": [self._usage_message("Post-compaction answer", 80, 12)],
+                    }
+                ),
+                json.dumps({"type": "agent_settled"}),
+            ]
+            fake_rpc = self._make_fake_rpc(lines)
+            self._attach(executor, fake_rpc)
+            read_timeouts: list[float] = []
+            real_read = fake_rpc.read_line
+
+            async def read_spy(timeout=120.0):
+                read_timeouts.append(timeout)
+                return await real_read(timeout)
+
+            fake_rpc.read_line = read_spy
+
+            events = [
+                e
+                async for e in executor.run_turn(
+                    [{"role": "user", "content": "hello"}],
+                    [],
+                    "system",
+                )
+            ]
+
+            self.assertFalse(any(isinstance(e, ExecutorError) for e in events))
+            completed = [e for e in events if isinstance(e, TurnComplete)]
+            self.assertEqual(len(completed), 1)
+            self.assertEqual(completed[0].response, "Post-compaction answer")
+            # The error-to-agent_end read uses the short drain budget; after
+            # agent_end, compaction gets the normal budget again.
+            self.assertEqual(read_timeouts[3], 10.0)
+            self.assertEqual(read_timeouts[4], 120.0)
+            self.assertTrue(fake_rpc._line_queue.empty())
+
+        _run(_test())
+
+    def test_partial_retry_output_is_not_retained(self):
+        """A failed retry attempt may stream text before erroring. Its text
+        must not prefix the successful attempt's TurnComplete response.
+        """
+
+        async def _test():
+            executor = self._make_executor()
+            errored = {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "partial"}],
+                "stopReason": "error",
+                "errorMessage": "retry me",
+            }
+            final = self._usage_message("Final answer", 30, 5)
+            lines = [
+                json.dumps({"type": "response", "success": True}),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {"type": "text_delta", "delta": "partial"},
+                    }
+                ),
+                json.dumps({"type": "message_end", "message": errored}),
+                json.dumps({"type": "agent_end", "willRetry": True, "messages": [errored]}),
+                json.dumps({"type": "message_start", "message": {"role": "assistant"}}),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {
+                            "type": "text_delta",
+                            "delta": "Final answer",
+                        },
+                    }
+                ),
+                json.dumps({"type": "message_end", "message": final}),
+                json.dumps({"type": "agent_end", "messages": [final]}),
+                json.dumps({"type": "agent_settled"}),
+            ]
+            fake_rpc = self._make_fake_rpc(lines)
+            self._attach(executor, fake_rpc)
+
+            events = [
+                e
+                async for e in executor.run_turn(
+                    [{"role": "user", "content": "hello"}],
+                    [],
+                    "system",
+                )
+            ]
+
+            completed = [e for e in events if isinstance(e, TurnComplete)]
+            self.assertEqual(len(completed), 1)
+            self.assertEqual(completed[0].response, "Final answer")
+
+        _run(_test())
+
+    def test_later_internal_run_uses_agent_end_usage_fallback(self):
+        """Usage fallback is per internal run, not per logical turn."""
+
+        async def _test():
+            executor = self._make_executor()
+            first = self._usage_message("First", 10, 2)
+            second_with_usage = self._usage_message("Second", 20, 3)
+            second_without_usage = {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Second"}],
+                "stopReason": "stop",
+            }
+            lines = [
+                json.dumps({"type": "response", "success": True}),
+                json.dumps({"type": "message_end", "message": first}),
+                json.dumps({"type": "agent_end", "messages": [first]}),
+                json.dumps({"type": "agent_start"}),
+                json.dumps({"type": "message_start", "message": {"role": "assistant"}}),
+                json.dumps({"type": "message_end", "message": second_without_usage}),
+                json.dumps({"type": "agent_end", "messages": [second_with_usage]}),
+                json.dumps({"type": "agent_settled"}),
+            ]
+            fake_rpc = self._make_fake_rpc(lines)
+            self._attach(executor, fake_rpc)
+
+            events = [
+                e
+                async for e in executor.run_turn(
+                    [{"role": "user", "content": "hello"}],
+                    [],
+                    "system",
+                )
+            ]
+
+            completed = [e for e in events if isinstance(e, TurnComplete)]
+            self.assertEqual(len(completed), 1)
+            usage = completed[0].usage
+            self.assertIsNotNone(usage)
+            self.assertEqual(usage["input_tokens"], 30)
+            self.assertEqual(usage["output_tokens"], 5)
+
+        _run(_test())
+
+    def test_interleaved_state_response_does_not_discard_stream_frames(self):
+        """A stale get_state response is just another command response.
+        Stream frames around it still pass through the normal state machine.
+        """
+
+        async def _test():
+            executor = self._make_executor()
+            lines = [
+                json.dumps({"type": "response", "success": True}),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {"type": "text_delta", "delta": "before "},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "id": "stale_probe",
+                        "type": "response",
+                        "command": "get_state",
+                        "success": True,
+                        "data": {"isStreaming": True},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {"type": "text_delta", "delta": "after"},
+                    }
+                ),
+                json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
+            ]
+            fake_rpc = self._make_fake_rpc(lines)
+            self._attach(executor, fake_rpc)
+
+            events = [
+                e
+                async for e in executor.run_turn(
+                    [{"role": "user", "content": "hello"}],
+                    [],
+                    "system",
+                )
+            ]
+
+            completed = [e for e in events if isinstance(e, TurnComplete)]
+            self.assertEqual([e.response for e in completed], ["before after"])
+            self.assertTrue(fake_rpc._line_queue.empty())
+
+        _run(_test())
+
+    def test_idle_response_before_settlement_does_not_end_turn(self):
+        """Pi can report idle before its settlement handler writes the
+        agent_settled frame. Only the latter is the turn boundary.
+        """
+
+        async def _test():
+            executor = self._make_executor()
+            lines = [
+                json.dumps({"type": "response", "success": True}),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {"type": "text_delta", "delta": "done"},
+                    }
+                ),
+                json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps(
+                    {
+                        "id": "stale_probe",
+                        "type": "response",
+                        "command": "get_state",
+                        "success": True,
+                        "data": {"isStreaming": False},
+                    }
+                ),
+                json.dumps({"type": "agent_settled"}),
+            ]
+            fake_rpc = self._make_fake_rpc(lines)
+            self._attach(executor, fake_rpc)
+
+            events = [
+                e
+                async for e in executor.run_turn(
+                    [{"role": "user", "content": "hello"}],
+                    [],
+                    "system",
+                )
+            ]
+
+            completed = [e for e in events if isinstance(e, TurnComplete)]
+            self.assertEqual([e.response for e in completed], ["done"])
+            self.assertTrue(fake_rpc._line_queue.empty())
+
+        _run(_test())
+
+    def test_stall_abort_send_is_bounded_and_rpc_is_recycled(self):
+        """A wedged abort drain cannot outlive the stall watchdog, and the
+        active RPC is closed even when the abort command times out.
+        """
+
+        async def _test():
+            executor = self._make_executor()
+            fake_rpc = self._make_fake_rpc([json.dumps({"type": "response", "success": True})])
+            fake_process = fake_rpc.process
+            self._attach(executor, fake_rpc)
+            abort_started = asyncio.Event()
+            real_send = fake_rpc.send_command
+            sent_types: list[str] = []
+
+            async def send_with_wedged_abort(command):
+                sent_types.append(command.get("type", ""))
+                if command.get("type") != "abort":
+                    await real_send(command)
+                    return
+                abort_started.set()
+                await asyncio.Event().wait()
+
+            fake_rpc.send_command = send_with_wedged_abort
+
+            with (
+                patch("omnigent.inner.pi_executor._READ_STALL_TIMEOUT_S", 0.01),
+                patch("omnigent.inner.pi_executor._STALL_ABORT_TIMEOUT_S", 0.01),
+            ):
+                events = [
+                    e
+                    async for e in executor.run_turn(
+                        [{"role": "user", "content": "hello"}],
+                        [],
+                        "system",
+                    )
+                ]
+
+            self.assertTrue(abort_started.is_set())
+            self.assertEqual(sent_types, ["prompt", "abort"])
+            errors = [e for e in events if isinstance(e, ExecutorError)]
+            self.assertEqual(len(errors), 1)
+            self.assertIn("aborted and recycled", errors[0].message)
+            self.assertEqual(executor._session_states, {})
+            self.assertIsNone(fake_rpc.process)
+            self.assertIsNotNone(fake_process)
+            self.assertEqual(fake_process.returncode, 0)
+
+        _run(_test())


### PR DESCRIPTION
## Related issue

N/A

## Summary

### Symptom

Pi workers intermittently failed with `inner executor error: Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message.` This was observed across `xiaomi/mimo-v2.5-pro`, `moonshotai/kimi-k3`, and `z-ai/glm-5.2`, but never on the Codex or Claude harnesses. Some Pi sessions also remained permanently unusable after a turn appeared to end.

### Root cause

`PiExecutor.run_turn` returned at the first `agent_end`, but `agent_end` is not session settlement. Pi's `AgentSession` may call `agent.continue()` repeatedly inside one logical run.

### A second, quieter bug

This path needs no request race: any turn that hit an automatic retry or context-overflow compaction could return early with truncated output, while later output leaked into the next request. That produces short or missing responses with no error at all, so it does not appear in error logs.

### Why `streamingBehavior: "followUp"` is not the fix

Adding `streamingBehavior: "followUp"` to the prompt command does not start a fresh run. It merges the prompt into the in-flight run, which still emits exactly one `agent_end` and one `agent_settled` regardless of queue depth. Empirical RPC traces confirmed this; the one-liner would turn a loud rejection into silently dropped output.

### Fix

`agent_settled` is now the turn boundary. `agent_end` still drives usage accounting, response aggregation, retry/compaction recovery, and per-run fallback state. A stalled read performs a bounded best-effort abort followed by unconditional session recycling.

**ELI5:** Pi can say “this attempt ended” several times before saying “the whole turn is finished.” Omnigent now waits for the second signal.

```text
prompt
  -> agent_end (retry / compaction / queued continuation)
  -> agent.continue()
  -> agent_end
  -> agent_settled
  -> TurnComplete
```

### Compatibility

`agent_settled` was added in Pi 0.80.4 on 2026-07-09. The installed version is detected once per executor through the existing bounded version probe and cached on session state:

- Pi >= 0.80.4 uses the settlement boundary.
- Older or undetectable versions keep the legacy `agent_end` boundary and receive a one-time warning recommending an upgrade, so existing users do not regress into a deterministic 120-second failure.
- The install hint now requires `@earendil-works/pi-coding-agent@>=0.80.4`.

### Known limitations

- The watchdog bounds **silence**, not liveness. A Pi process that emits frames more often than every 120 seconds but never settles would not terminate; the old implementation was immune to this.
- During a retry, superseded partial text may already have streamed to the UI as `TextChunk` events before it is excluded from the final response, so streamed and final output can diverge.
- A wedged-but-alive session is recycled rather than salvaged. This is deliberate and fails in the safe direction.

## Test Plan

Added 14 regression tests in `tests/inner/test_pi_executor.py`; each was individually verified to fail against the unmodified executor. Important cases cover:

- multiple `agent_end` events settling to one `TurnComplete`;
- context-overflow compaction returning the recovered answer instead of the overflow error;
- superseded partial retry output being discarded from the final response;
- usage fallback scoped per internal run;
- idle-response-before-settlement ordering;
- bounded stall abort with actual RPC recycling;
- supported, older, and undetectable Pi version gates plus one-time warning behavior.

Verification:

```bash
unset PYTHONPATH
uv run --no-sync pytest tests/inner/test_pi_executor.py  # 151 passed
uv run --no-sync pre-commit run --all-files             # passed
git diff --check                                         # passed
```

### E2E coverage

`.github/copilot-instructions.md` exempts bug fixes with no observable behavior change; this fix does shift observable turn boundaries. The bug is nevertheless covered at the unit level because it lives entirely in deterministic RPC frame ordering. The regressions script the exact retry, compaction, settlement, error, abort, and stall sequences, whereas a provider-backed e2e would need induced timing/errors and would be gateway-dependent and flaky.

## Demo

N/A — backend RPC lifecycle fix with no visual UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually compared all 14 new regressions against `origin/main`, where each failed individually, then restored the implementation and reran the complete Pi executor file. Full `tests/inner` results were also compared with a clean baseline; the same 12 pre-existing platform/environment failures remained byte-identical.

## Changelog

Pi turns now wait for session settlement, preventing truncated responses, leaked output, and stuck-session errors during retries, compaction, and queued continuations.
