### PR TITLE
fix(kimi-native): bridge Kimi 1.49 approvals

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -357,6 +357,11 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # cli._ensure_host_daemon), never to a (possibly hosted) runner.
         "OMNIGENT_CONFIG_HOME",
         "OMNIGENT_DATA_DIR",
+        # Native Kimi executable selector. This is a filesystem path, not a
+        # credential, and must survive the host→runner environment boundary so
+        # wrappers can pin the current Kimi Code install when a legacy
+        # ``kimi-cli`` executable is also present on PATH.
+        "OMNIGENT_KIMI_PATH",
         # Auth provider selection. The env-unset default was flipped
         # to "accounts", so the whole CLI → daemon → local-server chain has
         # to agree on the mode. Without this, the daemon strips

--- a/omnigent/kimi_native.py
+++ b/omnigent/kimi_native.py
@@ -110,10 +110,16 @@ class PreparedKimiTerminal:
     cold_resumed: bool = False
 
 
-def _configured_kimi_command(env: Mapping[str, str]) -> str:
-    """Return the configured kimi executable name/path from *env*."""
-    value = env.get(_KIMI_PATH_ENV, "").strip()
-    return value or _DEFAULT_KIMI_COMMAND
+def _kimi_command_candidates(env: Mapping[str, str]) -> tuple[str, ...]:
+    """Return kimi executable candidates in preference order."""
+    configured = env.get(_KIMI_PATH_ENV, "").strip()
+    if configured:
+        return (configured,)
+
+    home = env.get("HOME", "").strip()
+    official_home = Path(home) if home else Path.home()
+    official = official_home / ".kimi-code" / "bin" / "kimi"
+    return (str(official), _DEFAULT_KIMI_COMMAND)
 
 
 def resolve_kimi_executable(
@@ -131,15 +137,15 @@ def resolve_kimi_executable(
     """
     env = os.environ if env is None else env
     which = shutil.which if which is None else which
-    command = _configured_kimi_command(env)
-    resolved = which(command)
-    if resolved is None:
-        raise click.ClickException(
-            "Native Kimi requires the 'kimi' CLI on PATH. Install it with: "
-            "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash, then "
-            f"run 'kimi login'. You can also set {_KIMI_PATH_ENV}=/path/to/kimi."
-        )
-    return resolved
+    for command in _kimi_command_candidates(env):
+        resolved = which(command)
+        if resolved is not None:
+            return resolved
+    raise click.ClickException(
+        "Native Kimi requires the official Kimi Code install or a 'kimi' CLI on PATH. "
+        "Install it with: curl -fsSL https://code.kimi.com/kimi-code/install.sh | "
+        f"bash, then run 'kimi login'. You can also set {_KIMI_PATH_ENV}=/path/to/kimi."
+    )
 
 
 def build_kimi_launch(

--- a/omnigent/kimi_native_approval_bridge.py
+++ b/omnigent/kimi_native_approval_bridge.py
@@ -1,0 +1,357 @@
+"""Bridge Kimi 1.49 approval-runtime events to Omnigent.
+
+This file is also loaded as ``sitecustomize`` inside the Kimi process. Keep its
+imports limited to the standard library until the guarded Kimi import at the
+bottom of the module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import functools
+import importlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Coroutine
+from pathlib import Path
+from typing import Protocol, cast
+
+ENABLED_ENV_VAR = "OMNIGENT_KIMI_APPROVAL_BRIDGE"
+BRIDGE_DIR_ENV_VAR = "OMNIGENT_KIMI_APPROVAL_BRIDGE_DIR"
+
+_CONFIG_FILE = "hook_config.json"
+_STARTUP_DIR = "kimi-python-startup"
+_SITE_CUSTOMIZE_FILE = "sitecustomize.py"
+_WEB_TIMEOUT_S = 3600.0
+_RESOLUTION_TIMEOUT_S = 10.0
+_PATCHED_ATTR = "_omnigent_approval_bridge_patched"
+_TASKS_ATTR = "_omnigent_approval_bridge_tasks"
+_IN_PROGRESS_ATTR = "_omnigent_approval_bridge_in_progress"
+_WEB_RESOLVING_ATTR = "_omnigent_approval_bridge_web_resolving"
+
+
+class _ApprovalRequest(Protocol):
+    id: str
+    tool_call_id: str
+    sender: str
+    action: str
+    description: str
+    display: list[object]
+    status: str
+
+
+class _ApprovalRuntime(Protocol):
+    def subscribe(self, callback: Callable[[object], None]) -> str: ...
+
+    def resolve(
+        self,
+        request_id: str,
+        response: str,
+        feedback: str = "",
+    ) -> bool: ...
+
+
+class _Initializer(Protocol):
+    def __call__(
+        self,
+        instance: object,
+        *args: object,
+        **kwargs: object,
+    ) -> None: ...
+
+
+def materialize_kimi_approval_bridge(bridge_dir: Path) -> dict[str, str]:
+    """Expose this module to Kimi as a launch-scoped ``sitecustomize``."""
+    bridge_dir.mkdir(parents=True, exist_ok=True)
+    startup_dir = bridge_dir / _STARTUP_DIR
+    startup_dir.mkdir(parents=True, exist_ok=True)
+    for path in (bridge_dir, startup_dir):
+        with contextlib.suppress(OSError):
+            os.chmod(path, 0o700)
+
+    startup_file = startup_dir / _SITE_CUSTOMIZE_FILE
+    target = Path(__file__).resolve()
+    if startup_file.is_symlink():
+        if startup_file.resolve() != target:
+            raise RuntimeError(f"unexpected Kimi sitecustomize target: {startup_file}")
+    elif startup_file.exists():
+        raise RuntimeError(f"refusing to replace Kimi sitecustomize file: {startup_file}")
+    else:
+        startup_file.symlink_to(target)
+
+    return {
+        "PYTHONPATH": str(startup_dir),
+        ENABLED_ENV_VAR: "1",
+        BRIDGE_DIR_ENV_VAR: str(bridge_dir),
+    }
+
+
+def _jsonable_display(block: object) -> object:
+    model_dump = getattr(block, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return model_dump(mode="json")
+        except TypeError:
+            return model_dump()
+    if isinstance(block, (dict, list, str, int, float, bool)) or block is None:
+        return block
+    return str(block)
+
+
+def approval_elicitation_id(request_id: str) -> str:
+    """Return the stable Omnigent elicitation id for one Kimi request."""
+    return f"elicit_kimi_{request_id}"
+
+
+def approval_payload(request: _ApprovalRequest) -> dict[str, object]:
+    """Convert Kimi's approval record to the generic native card payload."""
+    request_id = str(request.id)
+    tool_call_id = str(getattr(request, "tool_call_id", ""))
+    sender = str(getattr(request, "sender", "Kimi"))
+    action = str(getattr(request, "action", "tool"))
+    description = str(getattr(request, "description", "") or "Kimi wants approval to run a tool")
+    display = getattr(request, "display", [])
+    display_items = (
+        [_jsonable_display(item) for item in display] if isinstance(display, list) else []
+    )
+    preview = json.dumps(
+        {
+            "tool_call_id": tool_call_id,
+            "sender": sender,
+            "display": display_items,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )[:1024]
+    return {
+        "elicitation_id": approval_elicitation_id(request_id),
+        "agent": "Kimi",
+        "policy_name": "kimi_native_permission",
+        "operation_type": action,
+        "message": description,
+        "content_preview": preview,
+    }
+
+
+def _read_config(bridge_dir: Path) -> dict[str, object]:
+    try:
+        data = json.loads((bridge_dir / _CONFIG_FILE).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _request_details(bridge_dir: Path, suffix: str) -> tuple[str, dict[str, str]] | None:
+    config = _read_config(bridge_dir)
+    base_url = config.get("ap_server_url")
+    session_id = config.get("session_id")
+    if not isinstance(base_url, str) or not base_url:
+        return None
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    raw_headers = config.get("ap_auth_headers")
+    headers = (
+        {str(key): str(value) for key, value in raw_headers.items()}
+        if isinstance(raw_headers, dict)
+        else {}
+    )
+    quoted_session = urllib.parse.quote(session_id, safe="")
+    url = f"{base_url.rstrip('/')}/v1/sessions/{quoted_session}/{suffix.lstrip('/')}"
+    return url, headers
+
+
+def _post_json(
+    url: str,
+    headers: dict[str, str],
+    payload: dict[str, object],
+    *,
+    timeout_s: float,
+) -> bytes | None:
+    request_headers = {"Content-Type": "application/json", **headers}
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=request_headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_s) as response:
+            return cast(bytes, response.read())
+    except (OSError, urllib.error.URLError, ValueError):
+        return None
+
+
+def request_web_verdict(bridge_dir: Path, request: _ApprovalRequest) -> str | None:
+    """Park one Kimi approval in Omnigent and return a concrete web action."""
+    details = _request_details(bridge_dir, "hooks/native-permission-request")
+    if details is None:
+        return None
+    raw = _post_json(
+        details[0],
+        details[1],
+        approval_payload(request),
+        timeout_s=_WEB_TIMEOUT_S,
+    )
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    action = data.get("action") if isinstance(data, dict) else None
+    return action if action in {"accept", "decline", "cancel"} else None
+
+
+def post_external_resolution(bridge_dir: Path, request_id: str) -> None:
+    """Release an Omnigent card answered through Kimi's native modal."""
+    details = _request_details(bridge_dir, "events")
+    if details is None:
+        return
+    _post_json(
+        details[0],
+        details[1],
+        {
+            "type": "external_elicitation_resolved",
+            "data": {"elicitation_id": approval_elicitation_id(request_id)},
+        },
+        timeout_s=_RESOLUTION_TIMEOUT_S,
+    )
+
+
+def _runtime_string_set(runtime: object, name: str) -> set[str]:
+    value = getattr(runtime, name, None)
+    if isinstance(value, set):
+        return cast(set[str], value)
+    strings: set[str] = set()
+    setattr(runtime, name, strings)
+    return strings
+
+
+def _runtime_tasks(runtime: object) -> set[asyncio.Task[None]]:
+    value = getattr(runtime, _TASKS_ATTR, None)
+    if isinstance(value, set):
+        return cast(set[asyncio.Task[None]], value)
+    tasks: set[asyncio.Task[None]] = set()
+    setattr(runtime, _TASKS_ATTR, tasks)
+    return tasks
+
+
+def _start_task(
+    runtime: object,
+    coroutine: Coroutine[object, object, None],
+) -> None:
+    try:
+        task = asyncio.get_running_loop().create_task(coroutine)
+    except RuntimeError:
+        coroutine.close()
+        return
+    tasks = _runtime_tasks(runtime)
+    tasks.add(task)
+
+    def _done(completed: asyncio.Task[None]) -> None:
+        tasks.discard(completed)
+        if completed.cancelled():
+            return
+        exc = completed.exception()
+        if exc is not None:
+            print(f"Omnigent Kimi approval bridge failed: {exc}", file=sys.stderr)
+
+    task.add_done_callback(_done)
+
+
+async def _bridge_created_request(
+    runtime: _ApprovalRuntime,
+    bridge_dir: Path,
+    request: _ApprovalRequest,
+) -> None:
+    request_id = str(request.id)
+    try:
+        verdict = await asyncio.to_thread(request_web_verdict, bridge_dir, request)
+        if request.status != "pending":
+            return
+        response = "approve" if verdict == "accept" else "reject"
+        if verdict not in {"accept", "decline", "cancel"}:
+            return
+        web_resolving = _runtime_string_set(runtime, _WEB_RESOLVING_ATTR)
+        web_resolving.add(request_id)
+        try:
+            runtime.resolve(request_id, response, feedback="Resolved in Omnigent")
+        finally:
+            web_resolving.discard(request_id)
+    finally:
+        _runtime_string_set(runtime, _IN_PROGRESS_ATTR).discard(request_id)
+
+
+def _handle_runtime_event(
+    runtime: _ApprovalRuntime,
+    bridge_dir: Path,
+    event: object,
+) -> None:
+    raw_request = getattr(event, "request", None)
+    request_id = getattr(raw_request, "id", None)
+    if raw_request is None or not isinstance(request_id, str) or not request_id:
+        return
+    request = cast(_ApprovalRequest, raw_request)
+    kind = getattr(event, "kind", None)
+    if kind == "request_created":
+        in_progress = _runtime_string_set(runtime, _IN_PROGRESS_ATTR)
+        if request_id in in_progress:
+            return
+        in_progress.add(request_id)
+        _start_task(runtime, _bridge_created_request(runtime, bridge_dir, request))
+        return
+    if kind == "request_resolved":
+        if request_id in _runtime_string_set(runtime, _WEB_RESOLVING_ATTR):
+            return
+        _start_task(
+            runtime,
+            asyncio.to_thread(post_external_resolution, bridge_dir, request_id),
+        )
+
+
+def patch_approval_runtime(runtime_type: type[object], bridge_dir: Path) -> None:
+    """Subscribe every Kimi ApprovalRuntime instance to the Omnigent bridge."""
+    if getattr(runtime_type, _PATCHED_ATTR, False):
+        return
+    original_init = cast(_Initializer, runtime_type.__init__)
+
+    @functools.wraps(original_init)
+    def _bridged_init(self: object, *args: object, **kwargs: object) -> None:
+        original_init(self, *args, **kwargs)
+        runtime = cast(_ApprovalRuntime, self)
+        runtime.subscribe(lambda event: _handle_runtime_event(runtime, bridge_dir, event))
+
+    # The Kimi class is imported dynamically in sitecustomize, so assignment
+    # through setattr is the intentional runtime patch boundary.
+    setattr(runtime_type, "__init__", _bridged_init)  # noqa: B010
+    setattr(runtime_type, _PATCHED_ATTR, True)
+
+
+async def wait_for_bridge_tasks(runtime: object) -> None:
+    """Wait until the bridge's current background tasks settle (test helper)."""
+    while True:
+        tasks = list(_runtime_tasks(runtime))
+        if not tasks:
+            return
+        await asyncio.gather(*tasks)
+
+
+def _install_from_environment() -> None:
+    bridge_value = os.environ.get(BRIDGE_DIR_ENV_VAR, "")
+    if not bridge_value:
+        return
+    try:
+        approval_module = importlib.import_module("kimi_cli.approval_runtime")
+    except ImportError:
+        return
+    runtime_type = cast(type[object], approval_module.ApprovalRuntime)
+    patch_approval_runtime(runtime_type, Path(bridge_value))
+
+
+if os.environ.get(ENABLED_ENV_VAR) == "1":
+    _install_from_environment()

--- a/omnigent/kimi_native_bridge.py
+++ b/omnigent/kimi_native_bridge.py
@@ -31,8 +31,8 @@ _TMUX_FILE = "tmux.json"
 # Omnigent routing details the kimi hook subprocess reads to reach the server.
 # Mirrors claude-native's ``permission_hook.json`` (server URL + auth headers +
 # the active Omnigent session). Written by the runner at terminal-create time;
-# read by :mod:`omnigent.kimi_native_hook` (PreToolUse deny-gate + the
-# PermissionRequest read-only surface).
+# read by :mod:`omnigent.kimi_native_hook` (PreToolUse deny-gate) and
+# :mod:`omnigent.kimi_native_approval_bridge` (Kimi 1.49 approval runtime).
 _HOOK_CONFIG_FILE = "hook_config.json"
 _TMUX_READY_TIMEOUT_S = 30.0
 _TMUX_SEND_TIMEOUT_S = 5.0

--- a/omnigent/kimi_native_credentials.py
+++ b/omnigent/kimi_native_credentials.py
@@ -21,13 +21,38 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 import shlex
 import sys
+import tomllib
 from pathlib import Path
 
+#: Env var Kimi CLI 1.49+ reads for config, auth, and session state.
+KIMI_SHARE_DIR_ENV_VAR = "KIMI_SHARE_DIR"
 #: Env var Kimi Code reads to locate its data dir (config.toml + oauth + …).
 KIMI_CODE_HOME_ENV_VAR = "KIMI_CODE_HOME"
 _CONFIG_FILE = "config.toml"
+_CURRENT_ISOLATED_ENTRIES = frozenset(
+    {_CONFIG_FILE, "imported_sessions", "kimi.json", "logs", "sessions", "telemetry"}
+)
+_LEGACY_ISOLATED_ENTRIES = frozenset(
+    {_CONFIG_FILE, "logs", "session_index.jsonl", "sessions"}
+)
+_EMPTY_TOP_LEVEL_HOOKS = re.compile(
+    r"^[ \t]*hooks[ \t]*=[ \t]*\[[ \t]*\][ \t]*(?:#.*)?(?:\r?\n)?$"
+)
+
+
+class KimiConfigError(RuntimeError):
+    """Raised when launch-scoped hooks cannot be merged safely."""
+
+
+def resolve_user_kimi_share_dir() -> Path:
+    """Return Kimi CLI 1.49+'s global share directory."""
+    env = os.environ.get(KIMI_SHARE_DIR_ENV_VAR)
+    if env:
+        return Path(env)
+    return Path.home() / ".kimi"
 
 
 def resolve_user_kimi_home() -> Path:
@@ -44,7 +69,12 @@ def resolve_user_kimi_home() -> Path:
     return Path.home() / ".kimi-code"
 
 
-def render_kimi_hooks_toml(*, bridge_dir: Path, python_executable: str | None = None) -> str:
+def render_kimi_hooks_toml(
+    *,
+    bridge_dir: Path,
+    python_executable: str | None = None,
+    include_permission_request: bool = True,
+) -> str:
     """Render the two Omnigent ``[[hooks]]`` entries as TOML text.
 
     Both hooks dispatch to :mod:`omnigent.kimi_native_hook` with the bridge
@@ -68,7 +98,6 @@ def render_kimi_hooks_toml(*, bridge_dir: Path, python_executable: str | None = 
     base = f"{shlex.quote(python)} -I -m omnigent.kimi_native_hook"
     bridge = shlex.quote(str(bridge_dir))
     pre = f"{base} evaluate-policy --bridge-dir {bridge}"
-    perm = f"{base} permission-request --bridge-dir {bridge}"
     # No ``matcher`` → matches every tool. Commands are TOML basic strings;
     # shlex.quote yields single-quoted POSIX tokens, which contain no double
     # quotes or backslashes, so they embed in a "..." TOML string verbatim.
@@ -78,19 +107,100 @@ def render_kimi_hooks_toml(*, bridge_dir: Path, python_executable: str | None = 
     # injected Approve/Deny keystroke never lands) and could sever a slow policy
     # evaluate. Pin both to kimi's 600s ceiling — the longest the human may take
     # to answer the card — after which kimi's own TUI prompt stands.
-    return (
+    rendered = (
         "\n"
         "# --- Omnigent native hooks (auto-generated; do not edit) ---\n"
         "[[hooks]]\n"
         'event = "PreToolUse"\n'
         f'command = "{pre}"\n'
         "timeout = 600\n"
-        "\n"
-        "[[hooks]]\n"
-        'event = "PermissionRequest"\n'
-        f'command = "{perm}"\n'
-        "timeout = 600\n"
     )
+    if not include_permission_request:
+        return rendered
+    perm = f"{base} permission-request --bridge-dir {bridge}"
+    return (
+        rendered
+        + "\n"
+        + "[[hooks]]\n"
+        + 'event = "PermissionRequest"\n'
+        + f'command = "{perm}"\n'
+        + "timeout = 600\n"
+    )
+
+
+def _merge_config_and_hooks(base_config: str, hooks: str) -> str:
+    """Append hook tables without rewriting compatible user configuration."""
+    try:
+        parsed = tomllib.loads(base_config) if base_config.strip() else {}
+    except tomllib.TOMLDecodeError as exc:
+        raise KimiConfigError("user Kimi config is invalid TOML") from exc
+    configured_hooks = parsed.get("hooks")
+    if configured_hooks is not None and not isinstance(configured_hooks, list):
+        raise KimiConfigError("user Kimi hooks value is not a list")
+
+    prepared = base_config
+    if configured_hooks == []:
+        lines = prepared.splitlines(keepends=True)
+        kept: list[str] = []
+        at_top_level = True
+        removed = False
+        for line in lines:
+            stripped = line.lstrip()
+            if at_top_level and _EMPTY_TOP_LEVEL_HOOKS.fullmatch(line):
+                removed = True
+                continue
+            if stripped.startswith("[") and not stripped.startswith("#"):
+                at_top_level = False
+            kept.append(line)
+        if not removed:
+            raise KimiConfigError(
+                "empty Kimi hooks declaration is not a supported top-level assignment"
+            )
+        prepared = "".join(kept)
+    elif configured_hooks:
+        raise KimiConfigError(
+            "non-empty inline Kimi hooks cannot be extended without rewriting user config"
+        )
+
+    if prepared and not prepared.endswith("\n"):
+        prepared += "\n"
+    merged = prepared + hooks
+    try:
+        tomllib.loads(merged)
+    except tomllib.TOMLDecodeError as exc:
+        raise KimiConfigError("generated Kimi hook config is invalid TOML") from exc
+    return merged
+
+
+def _materialize_scoped_home(
+    scoped_home: Path,
+    *,
+    user_home: Path,
+    isolated_entries: frozenset[str],
+    hooks: str,
+) -> None:
+    """Copy config and link immutable support files into one scoped home."""
+    scoped_home.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError):
+        os.chmod(scoped_home, 0o700)
+
+    base_config = ""
+    if user_home.is_dir():
+        for entry in user_home.iterdir():
+            if entry.name in isolated_entries:
+                continue
+            link = scoped_home / entry.name
+            if link.exists() or link.is_symlink():
+                continue
+            with contextlib.suppress(OSError):
+                link.symlink_to(entry)
+        with contextlib.suppress(OSError):
+            base_config = (user_home / _CONFIG_FILE).read_text(encoding="utf-8")
+
+    config_file = scoped_home / _CONFIG_FILE
+    config_file.write_text(_merge_config_and_hooks(base_config, hooks), encoding="utf-8")
+    with contextlib.suppress(OSError):
+        os.chmod(config_file, 0o600)
 
 
 def build_kimi_session_home(
@@ -98,6 +208,7 @@ def build_kimi_session_home(
     *,
     bridge_dir: Path,
     python_executable: str | None = None,
+    include_current: bool = False,
 ) -> dict[str, str]:
     """Materialize a session-scoped ``KIMI_CODE_HOME`` with Omnigent hooks.
 
@@ -113,29 +224,33 @@ def build_kimi_session_home(
     :returns: ``{"KIMI_CODE_HOME": str(session_home)}`` to merge into the
         launched kimi process env.
     """
-    session_home.mkdir(parents=True, exist_ok=True)
-    with contextlib.suppress(OSError):
-        os.chmod(session_home, 0o700)
+    legacy_hooks = render_kimi_hooks_toml(
+        bridge_dir=bridge_dir,
+        python_executable=python_executable,
+        include_permission_request=True,
+    )
+    _materialize_scoped_home(
+        session_home,
+        user_home=resolve_user_kimi_home(),
+        isolated_entries=(
+            _LEGACY_ISOLATED_ENTRIES if include_current else frozenset({_CONFIG_FILE})
+        ),
+        hooks=legacy_hooks,
+    )
+    env = {KIMI_CODE_HOME_ENV_VAR: str(session_home)}
+    if not include_current:
+        return env
 
-    user_home = resolve_user_kimi_home()
-    base_config = ""
-    if user_home.is_dir():
-        for entry in user_home.iterdir():
-            if entry.name == _CONFIG_FILE:
-                # config.toml is materialized fresh below (user content + hooks).
-                continue
-            link = session_home / entry.name
-            if link.exists() or link.is_symlink():
-                continue
-            with contextlib.suppress(OSError):
-                link.symlink_to(entry)
-        with contextlib.suppress(OSError):
-            base_config = (user_home / _CONFIG_FILE).read_text(encoding="utf-8")
-
-    hooks = render_kimi_hooks_toml(bridge_dir=bridge_dir, python_executable=python_executable)
-    # Ensure a clean separation if the user's config has no trailing newline.
-    if base_config and not base_config.endswith("\n"):
-        base_config += "\n"
-    (session_home / _CONFIG_FILE).write_text(base_config + hooks, encoding="utf-8")
-
-    return {KIMI_CODE_HOME_ENV_VAR: str(session_home)}
+    current_share_dir = session_home.parent / "kimi-share"
+    current_hooks = render_kimi_hooks_toml(
+        bridge_dir=bridge_dir,
+        python_executable=python_executable,
+        include_permission_request=False,
+    )
+    _materialize_scoped_home(
+        current_share_dir,
+        user_home=resolve_user_kimi_share_dir(),
+        isolated_entries=_CURRENT_ISOLATED_ENTRIES,
+        hooks=current_hooks,
+    )
+    return {KIMI_SHARE_DIR_ENV_VAR: str(current_share_dir), **env}

--- a/omnigent/kimi_native_credentials.py
+++ b/omnigent/kimi_native_credentials.py
@@ -1,16 +1,13 @@
-"""Per-session ``KIMI_CODE_HOME`` builder that injects Omnigent hooks.
+"""Build isolated current and legacy Kimi homes with Omnigent policy hooks.
 
-Kimi Code reads a single ``config.toml`` at ``$KIMI_CODE_HOME/config.toml``
-(default ``~/.kimi-code``) and stores its auth (``oauth/`` + ``credentials/``)
-relative to the same home — there is no project-level merge for the ``hooks``
-array. To gate a session's tools without mutating the user's global config, the
-runner points the launched ``kimi`` process at a session-scoped home that:
+Kimi 1.49 reads ``$KIMI_SHARE_DIR`` (default ``~/.kimi``); legacy Kimi reads
+``$KIMI_CODE_HOME`` (default ``~/.kimi-code``). Each has one ``config.toml``
+and no project-level hook merge. To apply policy without mutating either global
+home, the runner creates session-scoped equivalents that:
 
-- symlinks every entry of the user's global home (oauth, credentials,
-  sessions, …) so login / providers / history keep working, and
-- carries a ``config.toml`` that is the user's config text with two Omnigent
-  ``[[hooks]]`` appended — a ``PreToolUse`` deny-gate and a ``PermissionRequest``
-  read-only surface, both dispatched to :mod:`omnigent.kimi_native_hook`.
+- link reusable login/provider files while isolating config, logs, and sessions;
+- append a ``PreToolUse`` policy hook to both layouts; and
+- retain the legacy ``PermissionRequest`` hook only where that event exists.
 
 Appending as text (rather than parsing + re-emitting TOML) keeps the user's
 config byte-for-byte and needs no TOML writer: a trailing ``[[hooks]]`` table
@@ -24,8 +21,9 @@ import os
 import re
 import shlex
 import sys
-import tomllib
 from pathlib import Path
+
+import tomllib
 
 #: Env var Kimi CLI 1.49+ reads for config, auth, and session state.
 KIMI_SHARE_DIR_ENV_VAR = "KIMI_SHARE_DIR"
@@ -35,9 +33,7 @@ _CONFIG_FILE = "config.toml"
 _CURRENT_ISOLATED_ENTRIES = frozenset(
     {_CONFIG_FILE, "imported_sessions", "kimi.json", "logs", "sessions", "telemetry"}
 )
-_LEGACY_ISOLATED_ENTRIES = frozenset(
-    {_CONFIG_FILE, "logs", "session_index.jsonl", "sessions"}
-)
+_LEGACY_ISOLATED_ENTRIES = frozenset({_CONFIG_FILE, "logs", "session_index.jsonl", "sessions"})
 _EMPTY_TOP_LEVEL_HOOKS = re.compile(
     r"^[ \t]*hooks[ \t]*=[ \t]*\[[ \t]*\][ \t]*(?:#.*)?(?:\r?\n)?$"
 )
@@ -210,19 +206,18 @@ def build_kimi_session_home(
     python_executable: str | None = None,
     include_current: bool = False,
 ) -> dict[str, str]:
-    """Materialize a session-scoped ``KIMI_CODE_HOME`` with Omnigent hooks.
+    """Materialize session-scoped Kimi homes with Omnigent policy hooks.
 
-    Symlinks every entry of the user's global kimi home (except
-    ``config.toml``) into *session_home*, then writes a ``config.toml`` that is
-    the user's config plus the Omnigent hooks. Best-effort and idempotent:
-    re-running rewrites ``config.toml`` and leaves existing symlinks in place.
+    The legacy home is always built. With ``include_current=True``, a sibling
+    ``kimi-share`` directory is also built for Kimi 1.49+. Best-effort and
+    idempotent: re-running rewrites config and keeps existing support links.
 
     :param session_home: Directory to use as the session's ``KIMI_CODE_HOME``.
     :param bridge_dir: The kimi-native bridge dir the hook commands read.
     :param python_executable: Interpreter for the hook commands (see
         :func:`render_kimi_hooks_toml`).
-    :returns: ``{"KIMI_CODE_HOME": str(session_home)}`` to merge into the
-        launched kimi process env.
+    :param include_current: Also build and export Kimi 1.49's share directory.
+    :returns: Environment variables to merge into the launched process.
     """
     legacy_hooks = render_kimi_hooks_toml(
         bridge_dir=bridge_dir,

--- a/omnigent/kimi_native_forwarder.py
+++ b/omnigent/kimi_native_forwarder.py
@@ -7,12 +7,10 @@ reply renders live in the embedded terminal, but — unlike the SDK ``KimiExecut
 transcript (the chat bubbles). This module closes that gap, the kimi analog of
 :mod:`omnigent.cursor_native_forwarder`.
 
-Data source: kimi persists each session to an append-only JSONL "wire" log at
-``$KIMI_CODE_HOME/sessions/<wd_…>/<session_…>/agents/main/wire.jsonl``. The
-native harness points ``KIMI_CODE_HOME`` at ``<bridge_dir>/kimi-code-home`` whose
-``sessions/`` is symlinked to the user's global store, so several workspaces'
-sessions share the tree; we disambiguate by ``workDir`` (via ``session_index.jsonl``)
-and recency. Relevant wire events:
+Data source: Kimi persists each session to an append-only ``wire.jsonl``.
+Kimi 1.49 writes below the launch-scoped ``$KIMI_SHARE_DIR``; legacy Kimi writes
+below ``$KIMI_CODE_HOME``. Discovery checks both layouts and selects only a
+launch-scoped session for the requested workspace. Relevant wire events include:
 
 - ``{"type": "turn.prompt", "input": [{"type":"text","text":…}], "origin": {"kind":"user"}}``
   → a user message.
@@ -23,9 +21,8 @@ and recency. Relevant wire events:
   ``tool.result`` events are still skipped — the embedded terminal shows them.)
 
 Each mirrored turn is POSTed as an ``external_conversation_item`` to
-``/v1/sessions/{id}/events`` (the same shape :mod:`omnigent.kimi_native_hook`
-uses for its read-only approval surface). A per-session line offset is persisted
-in ``<bridge_dir>/kimi_forwarder.json`` so restarts resume without double-posting.
+``/v1/sessions/{id}/events``. A per-session line offset is persisted in
+``<bridge_dir>/kimi_forwarder.json`` so restarts resume without double-posting.
 """
 
 from __future__ import annotations

--- a/omnigent/kimi_native_forwarder.py
+++ b/omnigent/kimi_native_forwarder.py
@@ -35,6 +35,7 @@ import contextlib
 import json
 import logging
 from dataclasses import dataclass
+from hashlib import md5
 from pathlib import Path
 
 import httpx
@@ -178,6 +179,57 @@ def _discover_wire(kimi_home: Path, workspace: str, launch_epoch_ms: int) -> Pat
     return best[1] if best is not None else None
 
 
+def _discover_current_wire(
+    kimi_share_dir: Path, workspace: str, launch_epoch_ms: int
+) -> Path | None:
+    """Locate Kimi 1.49's newest launch-scoped wire for *workspace*."""
+    workspace_dir = md5(workspace.encode("utf-8")).hexdigest()
+    sessions_root = kimi_share_dir / "sessions" / workspace_dir
+    if not sessions_root.exists():
+        return None
+    floor_s = (launch_epoch_ms - _DISCOVER_SKEW_MS) / 1000.0
+    best: tuple[float, Path] | None = None
+    for wire in sessions_root.glob("*/wire.jsonl"):
+        try:
+            mtime = wire.stat().st_mtime
+        except OSError:
+            continue
+        if mtime < floor_s:
+            continue
+        if best is None or mtime > best[0]:
+            best = (mtime, wire)
+    return best[1] if best is not None else None
+
+
+def discover_kimi_wire(
+    *,
+    kimi_share_dir: Path | None,
+    legacy_kimi_home: Path | None,
+    workspace: str,
+    launch_epoch_ms: int,
+) -> Path | None:
+    """Choose the newest matching wire from Kimi 1.49 or Kimi 0.27."""
+    candidates = [
+        candidate
+        for candidate in (
+            (
+                _discover_current_wire(kimi_share_dir, workspace, launch_epoch_ms)
+                if kimi_share_dir is not None
+                else None
+            ),
+            (
+                _discover_wire(legacy_kimi_home, workspace, launch_epoch_ms)
+                if legacy_kimi_home is not None
+                else None
+            ),
+        )
+        if candidate is not None
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda path: path.stat().st_mtime)
+
+
 def _input_text(blocks: object) -> str:
     """Concatenate the ``text`` of an ``input`` / ``content`` block list."""
     if not isinstance(blocks, list):
@@ -191,8 +243,8 @@ def _input_text(blocks: object) -> str:
     return "".join(parts)
 
 
-def _row_to_item(line_no: int, row: dict[str, object]) -> KimiWireItem | None:
-    """Map one wire-log row to a conversation item, or ``None`` to skip it."""
+def _legacy_row_to_item(line_no: int, row: dict[str, object]) -> KimiWireItem | None:
+    """Map one Kimi 0.27 wire row to a conversation item."""
     row_type = row.get("type")
     if row_type == "turn.prompt":
         origin = row.get("origin")
@@ -243,6 +295,67 @@ def _row_to_item(line_no: int, row: dict[str, object]) -> KimiWireItem | None:
             )
         return None
     return None
+
+
+def _current_input_text(value: object) -> str:
+    """Normalize Kimi 1.49's string-or-block-list user input."""
+    if isinstance(value, str):
+        return value
+    return _input_text(value)
+
+
+def _current_row_to_item(line_no: int, row: dict[str, object]) -> KimiWireItem | None:
+    """Map one Kimi 1.49 typed-envelope row to a conversation item."""
+    message = row.get("message")
+    if not isinstance(message, dict):
+        return None
+    message_type = message.get("type")
+    payload = message.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    response_id = f"kimi:current:line:{line_no}"
+    if message_type in {"TurnBegin", "SteerInput"}:
+        text = _current_input_text(payload.get("user_input"))
+        if not text:
+            return None
+        return KimiWireItem(
+            line_no=line_no,
+            role="user",
+            text=text,
+            response_id=response_id,
+        )
+    if message_type != "ContentPart":
+        return None
+    part_type = payload.get("type")
+    if part_type == "text":
+        text = payload.get("text")
+        if not isinstance(text, str) or not text:
+            return None
+        return KimiWireItem(
+            line_no=line_no,
+            role="assistant",
+            text=text,
+            response_id=response_id,
+        )
+    if part_type == "think":
+        think = payload.get("think")
+        if not isinstance(think, str) or not think:
+            return None
+        return KimiWireItem(
+            line_no=line_no,
+            role="assistant",
+            text=think,
+            response_id=response_id,
+            kind="reasoning",
+        )
+    return None
+
+
+def _row_to_item(line_no: int, row: dict[str, object]) -> KimiWireItem | None:
+    """Map one current or legacy wire row to a conversation item."""
+    if isinstance(row.get("message"), dict):
+        return _current_row_to_item(line_no, row)
+    return _legacy_row_to_item(line_no, row)
 
 
 def read_kimi_wire_items(wire_path: Path, last_line: int) -> list[KimiWireItem]:
@@ -334,9 +447,11 @@ async def forward_kimi_wire_to_session(
     headers: dict[str, str],
     session_id: str,
     bridge_dir: Path,
-    kimi_home: Path,
     workspace: str,
     launch_epoch_ms: int,
+    kimi_home: Path | None = None,
+    kimi_share_dir: Path | None = None,
+    legacy_kimi_home: Path | None = None,
     agent_name: str = "kimi-native-ui",
 ) -> None:
     """Poll the kimi session wire log and mirror new turns into the chat.
@@ -345,6 +460,7 @@ async def forward_kimi_wire_to_session(
     first turn), then tails it, POSTing each new user/assistant turn and
     persisting the line offset after every post.
     """
+    legacy_home = legacy_kimi_home or kimi_home
     state = _read_state(bridge_dir)
     wire_path = Path(state.wire_path) if state is not None else None
     last_line = state.last_line if state is not None else 0
@@ -352,7 +468,11 @@ async def forward_kimi_wire_to_session(
         while True:
             if wire_path is None or not wire_path.exists():
                 discovered = await asyncio.to_thread(
-                    _discover_wire, kimi_home, workspace, launch_epoch_ms
+                    discover_kimi_wire,
+                    kimi_share_dir=kimi_share_dir,
+                    legacy_kimi_home=legacy_home,
+                    workspace=workspace,
+                    launch_epoch_ms=launch_epoch_ms,
                 )
                 if discovered is not None and discovered != wire_path:
                     wire_path = discovered
@@ -393,9 +513,11 @@ async def supervise_kimi_forwarder(
     headers: dict[str, str],
     session_id: str,
     bridge_dir: Path,
-    kimi_home: Path,
     workspace: str,
     launch_epoch_ms: int,
+    kimi_home: Path | None = None,
+    kimi_share_dir: Path | None = None,
+    legacy_kimi_home: Path | None = None,
     agent_name: str = "kimi-native-ui",
 ) -> None:
     """Run :func:`forward_kimi_wire_to_session` with restart-on-crash backoff.
@@ -412,9 +534,11 @@ async def supervise_kimi_forwarder(
                 headers=headers,
                 session_id=session_id,
                 bridge_dir=bridge_dir,
-                kimi_home=kimi_home,
                 workspace=workspace,
                 launch_epoch_ms=launch_epoch_ms,
+                kimi_home=kimi_home,
+                kimi_share_dir=kimi_share_dir,
+                legacy_kimi_home=legacy_kimi_home,
                 agent_name=agent_name,
             )
         except asyncio.CancelledError:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -6809,6 +6809,59 @@ def create_runner_app(
                     _ingest_now_serving[conversation_id] = _seq + 1
                     _cond.notify_all()
 
+        if body_type == "approval_wait":
+            data = body.get("data") if isinstance(body, dict) else None
+            if not isinstance(data, dict):
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error": "invalid_request",
+                        "detail": "approval_wait requires a data object",
+                    },
+                )
+            state = data.get("state")
+            elicitation_id = data.get("elicitation_id")
+            if (
+                state not in {"started", "ended"}
+                or not isinstance(elicitation_id, str)
+                or not elicitation_id
+            ):
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error": "invalid_request",
+                        "detail": (
+                            "approval_wait requires state started/ended and a "
+                            "non-empty elicitation_id"
+                        ),
+                    },
+                )
+            if state == "started":
+                ttl_s = data.get("ttl_s")
+                if (
+                    isinstance(ttl_s, bool)
+                    or not isinstance(ttl_s, (int, float))
+                    or not 1.0 <= float(ttl_s) <= 172_800.0
+                ):
+                    return JSONResponse(
+                        status_code=400,
+                        content={
+                            "error": "invalid_request",
+                            "detail": "approval_wait ttl_s must be between 1 and 172800",
+                        },
+                    )
+                process_manager.mark_approval_pending(
+                    conversation_id,
+                    elicitation_id,
+                    ttl_s=float(ttl_s),
+                )
+            else:
+                process_manager.clear_approval_pending(
+                    conversation_id,
+                    elicitation_id,
+                )
+            return Response(status_code=204)
+
         if body_type == "interrupt":
             _harness = _session_harness_name(conversation_id)
             if _harness == "claude-native":

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3186,13 +3186,14 @@ async def _auto_create_kimi_terminal(
     then advertises the pane's tmux socket+target so the kimi-native harness
     executor can inject web-UI turns into the same pane (tmux paste).
 
-    The pane runs with a session-scoped ``KIMI_CODE_HOME`` (built by
+    The pane runs with session-scoped current and legacy Kimi homes (built by
     :func:`omnigent.kimi_native_credentials.build_kimi_session_home`) that
     mirrors the user's global ``kimi login`` (symlinked ``oauth`` / providers)
-    and adds the Omnigent tool-policy hooks — a ``PreToolUse`` deny-gate and a
-    ``PermissionRequest`` read-only surface dispatched to
-    :mod:`omnigent.kimi_native_hook`. The hook subprocess reads its routing
-    from ``hook_config.json`` in the bridge dir.
+    and adds the Omnigent ``PreToolUse`` policy hook. Kimi 1.49's in-process
+    approval runtime is subscribed through
+    :mod:`omnigent.kimi_native_approval_bridge`; its web request is only
+    resolved on a concrete user verdict, leaving Kimi's native modal
+    authoritative when the bridge is unavailable.
 
     A background forwarder (:func:`omnigent.kimi_native_forwarder.
     supervise_kimi_forwarder`) tails kimi's per-session ``wire.jsonl`` transcript
@@ -3216,6 +3217,7 @@ async def _auto_create_kimi_terminal(
     del ensure_comment_relay, agent_spec
     from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
     from omnigent.kimi_native import resolve_kimi_executable
+    from omnigent.kimi_native_approval_bridge import materialize_kimi_approval_bridge
     from omnigent.kimi_native_bridge import (
         bridge_dir_for_session_id,
         write_hook_config,
@@ -3246,15 +3248,9 @@ async def _auto_create_kimi_terminal(
     # snapshot and threaded here.
     kimi_args = list(launch_config.terminal_launch_args or [])
 
-    # Wire the Omnigent tool-policy hooks: kimi reads a single
-    # ``$KIMI_CODE_HOME/config.toml``, so point it at a session-scoped home that
-    # mirrors the user's global kimi config (symlinked auth) plus a PreToolUse
-    # deny-gate and a PermissionRequest read-only surface, both dispatched to
-    # ``omnigent.kimi_native_hook``. The hook subprocess reads the server URL +
-    # auth + session id from ``hook_config.json`` in the bridge dir, so persist
-    # those first. The hook gets a one-shot token snapshot (a quick
-    # request/reply, like claude-native's permission hook); ``None`` factory is
-    # a safe no-op for local unauthenticated runs.
+    # Isolate both state layouts and add policy. Current Kimi uses the in-process
+    # approval bridge; legacy Kimi keeps its PermissionRequest hook. Both read
+    # routing from ``hook_config.json``; missing auth is safe for local runs.
     server_url = os.environ.get("RUNNER_SERVER_URL", "http://localhost:6767").rstrip("/")
     _auth_factory = _make_auth_token_factory()
     _auth_token = _auth_factory() if _auth_factory is not None else None
@@ -3270,10 +3266,14 @@ async def _auto_create_kimi_terminal(
         headers=_runner_headers,
         session_id=session_id,
     )
-    kimi_env = build_kimi_session_home(
-        bridge_dir / "kimi-code-home",
-        bridge_dir=bridge_dir,
-    )
+    kimi_env = {
+        **build_kimi_session_home(
+            bridge_dir / "kimi-code-home",
+            bridge_dir=bridge_dir,
+            include_current=True,
+        ),
+        **materialize_kimi_approval_bridge(bridge_dir),
+    }
     terminal_view = await resource_registry.launch_required_terminal(
         session_id=session_id,
         terminal_name="kimi",
@@ -3318,7 +3318,8 @@ async def _auto_create_kimi_terminal(
             headers=_runner_headers,
             session_id=session_id,
             bridge_dir=bridge_dir,
-            kimi_home=bridge_dir / "kimi-code-home",
+            kimi_share_dir=bridge_dir / "kimi-share",
+            legacy_kimi_home=bridge_dir / "kimi-code-home",
             workspace=workspace,
             launch_epoch_ms=launch_epoch_ms,
         ),

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -568,6 +568,10 @@ class HarnessProcessManager:
         # and the idle reaper skips any conversation present here so an
         # actively-streaming turn is never reaped mid-flight.
         self._in_flight_response_ids: dict[str, str] = {}
+        # Native approvals outlive the injection request. A bounded lease keeps
+        # the runner and pane busy while the user decides, without leaking
+        # forever when a completion event is lost.
+        self._pending_approval_deadlines: dict[str, dict[str, float]] = {}
         # Per-conversation spawn lock — see §Process management:
         # Spawn lock. The lock guards the lazy-init window in
         # ``get_client``; uncontested after the first spawn for a
@@ -901,15 +905,57 @@ class HarnessProcessManager:
 
     def has_active_turn(self, conversation_id: str) -> bool:
         """
-        Check whether the given conversation has an in-flight
-        harness response (i.e. a turn is currently streaming).
+        Check whether the conversation has an in-flight response or approval.
 
         :param conversation_id: AP-allocated conversation id,
             e.g. ``"conv_abc123"``.
-        :returns: ``True`` if an in-flight response id is
+        :returns: ``True`` if a response id or unexpired approval lease is
             registered.
         """
-        return conversation_id in self._in_flight_response_ids
+        return conversation_id in self._in_flight_response_ids or self._has_pending_approval(
+            conversation_id
+        )
+
+    def _has_pending_approval(self, conversation_id: str) -> bool:
+        approvals = self._pending_approval_deadlines.get(conversation_id)
+        if not approvals:
+            return False
+        now = time.monotonic()
+        expired = [
+            elicitation_id for elicitation_id, deadline in approvals.items() if deadline <= now
+        ]
+        for elicitation_id in expired:
+            approvals.pop(elicitation_id, None)
+        if approvals:
+            return True
+        self._pending_approval_deadlines.pop(conversation_id, None)
+        return False
+
+    def mark_approval_pending(
+        self,
+        conversation_id: str,
+        elicitation_id: str,
+        *,
+        ttl_s: float,
+    ) -> None:
+        """Lease one native approval so idle cleanup cannot reap its session."""
+        if ttl_s <= 0:
+            raise ValueError("approval lease ttl_s must be positive")
+        approvals = self._pending_approval_deadlines.setdefault(conversation_id, {})
+        approvals[elicitation_id] = time.monotonic() + ttl_s
+
+    def clear_approval_pending(
+        self,
+        conversation_id: str,
+        elicitation_id: str,
+    ) -> None:
+        """Release one native approval lease, if present."""
+        approvals = self._pending_approval_deadlines.get(conversation_id)
+        if approvals is None:
+            return
+        approvals.pop(elicitation_id, None)
+        if not approvals:
+            self._pending_approval_deadlines.pop(conversation_id, None)
 
     def mark_in_flight(self, conversation_id: str, response_id: str) -> None:
         """
@@ -998,6 +1044,7 @@ class HarnessProcessManager:
                         current is None
                         or current.last_used_at > only_if_idle_cutoff
                         or conversation_id in self._in_flight_response_ids
+                        or self._has_pending_approval(conversation_id)
                     ):
                         _logger.info(
                             "skipping idle reap for conversation %s: entry became "
@@ -1009,6 +1056,7 @@ class HarnessProcessManager:
                     self._release_generations.get(conversation_id, 0) + 1
                 )
                 entry = self._entries.pop(conversation_id, None)
+                self._pending_approval_deadlines.pop(conversation_id, None)
                 # NOTE: ``_spawn_locks[conversation_id]`` intentionally
                 # NOT popped — see this method's docstring for the
                 # per-conv lock-identity invariant rationale.
@@ -1251,15 +1299,15 @@ class HarnessProcessManager:
         Background task: periodically reap idle subprocesses.
 
         Iterates the registry, releasing any entry whose
-        ``last_used_at`` is older than ``idle_timeout_s`` AND
-        has no in-flight response on the harness. Sleeps for
+        ``last_used_at`` is older than ``idle_timeout_s`` AND has neither an
+        in-flight response nor a pending native approval. Sleeps for
         ``reaper_interval_s`` between passes. Terminates on
         :class:`asyncio.CancelledError` from :meth:`shutdown`. A
         non-positive ``idle_timeout_s`` (e.g.
         ``OMNIGENT_HARNESS_IDLE_TIMEOUT_S=0``) disables reaping — each
         pass is a no-op.
 
-        Two safety guards beyond raw ``last_used_at`` checks:
+        Three safety guards beyond raw ``last_used_at`` checks:
 
         1. **In-flight skip** — entries with an active
            harness ``response_id`` (set when the harness
@@ -1285,6 +1333,10 @@ class HarnessProcessManager:
            different clock sources; ``time.monotonic()`` is
            the single process-wide source both ends of the
            comparison agree on.
+
+        3. **Approval lease skip** — native terminal approvals can remain
+           pending after their injection request finishes. A bounded lease
+           keeps the harness and terminal pane alive while the user decides.
         """
         while True:
             try:
@@ -1306,6 +1358,8 @@ class HarnessProcessManager:
                     if entry.last_used_at > cutoff:
                         continue
                     if conv_id in self._in_flight_response_ids:
+                        continue
+                    if self._has_pending_approval(conv_id):
                         continue
                     stale.append(conv_id)
             for conv_id in stale:

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -1114,15 +1114,40 @@ def register_hooks_routes(
         )
         from omnigent.server.routes import sessions as _sf
 
-        result = await _publish_and_wait_for_harness_elicitation(
-            request,
-            session_id=session_id,
-            params=params,
-            timeout_s=_sf._NATIVE_PERMISSION_HOOK_TIMEOUT_S,
-            conversation_store=conversation_store,
-            elicitation_id=elicitation_id,
-            tool_name=f"{agent}({operation_type})",
+        await _forward_session_change_to_runner(
+            session_id,
+            get_server_runner_router(),
+            {
+                "type": "approval_wait",
+                "data": {
+                    "state": "started",
+                    "elicitation_id": elicitation_id,
+                    "ttl_s": _sf._NATIVE_PERMISSION_HOOK_TIMEOUT_S + 60.0,
+                },
+            },
         )
+        try:
+            result = await _publish_and_wait_for_harness_elicitation(
+                request,
+                session_id=session_id,
+                params=params,
+                timeout_s=_sf._NATIVE_PERMISSION_HOOK_TIMEOUT_S,
+                conversation_store=conversation_store,
+                elicitation_id=elicitation_id,
+                tool_name=f"{agent}({operation_type})",
+            )
+        finally:
+            await _forward_session_change_to_runner(
+                session_id,
+                get_server_runner_router(),
+                {
+                    "type": "approval_wait",
+                    "data": {
+                        "state": "ended",
+                        "elicitation_id": elicitation_id,
+                    },
+                },
+            )
         if result is None:
             return Response(status_code=status.HTTP_200_OK)
         if result.action == "decline":

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1519,6 +1519,7 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
         "OMNIGENT_LOG_LEVEL": "DEBUG",
         "OMNIGENT_LOG_TO_STDERR": "1",
         "OMNIGENT_LOG_TTY_FD": "9",
+        "OMNIGENT_KIMI_PATH": "/home/alice/.kimi-code/bin/kimi",
     }
 
     env = _build_runner_env(
@@ -1536,6 +1537,7 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     assert env["HOME"] == "/home/alice"
     assert env["LANG"] == "en_US.UTF-8"
     assert env["LC_CTYPE"] == "UTF-8"
+    assert env["OMNIGENT_KIMI_PATH"] == "/home/alice/.kimi-code/bin/kimi"
     # Databricks config selectors are allowlisted ambient passthrough —
     # the ambient value reaches the runner unmodified (no flag override).
     assert env["DATABRICKS_CONFIG_PROFILE"] == "ambient"

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -110,6 +110,81 @@ class _RecordingCodexAppServerClient:
 
 
 @pytest.mark.asyncio
+async def test_approval_wait_event_leases_and_releases_runner_lifecycle() -> None:
+    """The server can protect a native approval without starting a new turn."""
+
+    class _ApprovalTrackingProcessManager(_FakeProcessManager):
+        def __init__(self) -> None:
+            super().__init__(_ScriptedHarnessClient([]))
+            self.approval_events: list[tuple[str, str, str, float | None]] = []
+
+        def mark_approval_pending(
+            self,
+            conversation_id: str,
+            elicitation_id: str,
+            *,
+            ttl_s: float,
+        ) -> None:
+            self.approval_events.append(("started", conversation_id, elicitation_id, ttl_s))
+
+        def clear_approval_pending(
+            self,
+            conversation_id: str,
+            elicitation_id: str,
+        ) -> None:
+            self.approval_events.append(("ended", conversation_id, elicitation_id, None))
+
+    conversation_id = "conv_kimi_approval_wait"
+    process_manager = _ApprovalTrackingProcessManager()
+    app = create_runner_app(
+        process_manager=process_manager,  # type: ignore[arg-type]
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        started = await client.post(
+            f"/v1/sessions/{conversation_id}/events",
+            json={
+                "type": "approval_wait",
+                "data": {
+                    "state": "started",
+                    "elicitation_id": "approval-1",
+                    "ttl_s": 120.0,
+                },
+            },
+        )
+        ended = await client.post(
+            f"/v1/sessions/{conversation_id}/events",
+            json={
+                "type": "approval_wait",
+                "data": {
+                    "state": "ended",
+                    "elicitation_id": "approval-1",
+                },
+            },
+        )
+        invalid = await client.post(
+            f"/v1/sessions/{conversation_id}/events",
+            json={
+                "type": "approval_wait",
+                "data": {
+                    "state": "started",
+                    "elicitation_id": "approval-2",
+                    "ttl_s": 0,
+                },
+            },
+        )
+
+    assert started.status_code == 204
+    assert ended.status_code == 204
+    assert invalid.status_code == 400
+    assert process_manager.approval_events == [
+        ("started", conversation_id, "approval-1", 120.0),
+        ("ended", conversation_id, "approval-1", None),
+    ]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "event_payload,expected_params",
     [

--- a/tests/runner/test_kimi_native_terminal_launch.py
+++ b/tests/runner/test_kimi_native_terminal_launch.py
@@ -22,6 +22,79 @@ from omnigent.runner.resource_registry import KIMI_NATIVE_TERMINAL_ROLE
 from tests.runner.helpers import NullServerClient
 
 
+def test_kimi_executable_prefers_official_install_over_legacy_path(
+    tmp_path: Path,
+) -> None:
+    """The current Kimi Code install wins when PATH still exposes kimi-cli."""
+    import omnigent.kimi_native as kimi_native
+
+    official = tmp_path / ".kimi-code" / "bin" / "kimi"
+    legacy = "/Users/test/.local/bin/kimi"
+    resolutions = {
+        str(official): str(official),
+        "kimi": legacy,
+    }
+    looked_up: list[str] = []
+
+    def _which(command: str) -> str | None:
+        looked_up.append(command)
+        return resolutions.get(command)
+
+    resolved = kimi_native.resolve_kimi_executable(
+        env={"HOME": str(tmp_path)},
+        which=_which,
+    )
+
+    assert resolved == str(official)
+    assert looked_up == [str(official)]
+
+
+def test_kimi_executable_falls_back_to_path_when_official_install_is_absent(
+    tmp_path: Path,
+) -> None:
+    """PATH remains compatible for hosts without the current Kimi install."""
+    import omnigent.kimi_native as kimi_native
+
+    official = tmp_path / ".kimi-code" / "bin" / "kimi"
+    looked_up: list[str] = []
+
+    def _which(command: str) -> str | None:
+        looked_up.append(command)
+        return "/opt/bin/kimi" if command == "kimi" else None
+
+    resolved = kimi_native.resolve_kimi_executable(
+        env={"HOME": str(tmp_path)},
+        which=_which,
+    )
+
+    assert resolved == "/opt/bin/kimi"
+    assert looked_up == [str(official), "kimi"]
+
+
+def test_kimi_executable_honors_explicit_override_before_official_install(
+    tmp_path: Path,
+) -> None:
+    """An explicit operator path remains authoritative."""
+    import omnigent.kimi_native as kimi_native
+
+    looked_up: list[str] = []
+
+    def _which(command: str) -> str | None:
+        looked_up.append(command)
+        return command
+
+    resolved = kimi_native.resolve_kimi_executable(
+        env={
+            "HOME": str(tmp_path),
+            "OMNIGENT_KIMI_PATH": "/opt/custom/kimi",
+        },
+        which=_which,
+    )
+
+    assert resolved == "/opt/custom/kimi"
+    assert looked_up == ["/opt/custom/kimi"]
+
+
 @pytest.mark.asyncio
 async def test_kimi_launch_wires_current_state_and_approval_runtime(
     tmp_path: Path,

--- a/tests/runner/test_kimi_native_terminal_launch.py
+++ b/tests/runner/test_kimi_native_terminal_launch.py
@@ -1,0 +1,124 @@
+"""Regression tests for the runner-owned Kimi terminal launch."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from omnigent.entities.session_resources import SessionResourceView
+from omnigent.kimi_native_approval_bridge import (
+    BRIDGE_DIR_ENV_VAR,
+    ENABLED_ENV_VAR,
+)
+from omnigent.kimi_native_credentials import (
+    KIMI_CODE_HOME_ENV_VAR,
+    KIMI_SHARE_DIR_ENV_VAR,
+)
+from omnigent.runner.native import orchestration
+from omnigent.runner.resource_registry import KIMI_NATIVE_TERMINAL_ROLE
+from tests.runner.helpers import NullServerClient
+
+
+@pytest.mark.asyncio
+async def test_kimi_launch_wires_current_state_and_approval_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Kimi 1.49 receives its isolated state, web approval bridge, and forwarder."""
+    import omnigent.kimi_native as kimi_native
+    import omnigent.kimi_native_bridge as kimi_native_bridge
+    import omnigent.kimi_native_forwarder as kimi_native_forwarder
+
+    session_id = "kimi-approval-runtime-session"
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:6767")
+    monkeypatch.setattr(kimi_native_bridge, "_BRIDGE_ROOT", tmp_path / "bridges")
+    monkeypatch.setattr(kimi_native, "resolve_kimi_executable", lambda: "/usr/bin/kimi")
+
+    async def _launch_config(
+        **_kwargs: Any,
+    ) -> orchestration._PiNativeLaunchConfig:
+        return orchestration._PiNativeLaunchConfig(
+            workspace=tmp_path,
+            server_url="http://127.0.0.1:6767",
+            terminal_launch_args=None,
+            external_session_id=None,
+        )
+
+    monkeypatch.setattr(orchestration, "_pi_native_launch_config", _launch_config)
+    forwarder_calls: list[dict[str, Any]] = []
+
+    async def _forwarder(**kwargs: Any) -> None:
+        forwarder_calls.append(kwargs)
+
+    monkeypatch.setattr(kimi_native_forwarder, "supervise_kimi_forwarder", _forwarder)
+    captured: dict[str, Any] = {}
+
+    class _FakeResourceRegistry:
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            resource_role: str,
+            spec: Any,
+        ) -> SessionResourceView:
+            captured["terminal_name"] = terminal_name
+            captured["session_key"] = session_key
+            captured["resource_role"] = resource_role
+            captured["spec"] = spec
+            return SessionResourceView(
+                id="terminal_kimi_main",
+                type="terminal",
+                session_id=session_id,
+                name="kimi:main",
+                metadata={
+                    "terminal_name": "kimi",
+                    "session_key": "main",
+                    "running": True,
+                },
+            )
+
+    try:
+        await orchestration._auto_create_kimi_terminal(
+            session_id,
+            _FakeResourceRegistry(),  # type: ignore[arg-type]
+            lambda _session_id, _event: None,
+            server_client=NullServerClient(),  # type: ignore[arg-type]
+        )
+        for _ in range(20):
+            if forwarder_calls:
+                break
+            await asyncio.sleep(0)
+    finally:
+        await orchestration._cancel_auto_forwarder_task(session_id)
+
+    bridge_dir = kimi_native_bridge.bridge_dir_for_session_id(session_id)
+    spec = captured["spec"]
+    assert captured["terminal_name"] == "kimi"
+    assert captured["session_key"] == "main"
+    assert captured["resource_role"] == KIMI_NATIVE_TERMINAL_ROLE
+    assert spec.command == "/usr/bin/kimi"
+    assert spec.env[KIMI_SHARE_DIR_ENV_VAR] == str(bridge_dir / "kimi-share")
+    assert spec.env[KIMI_CODE_HOME_ENV_VAR] == str(bridge_dir / "kimi-code-home")
+    assert spec.env[ENABLED_ENV_VAR] == "1"
+    assert spec.env[BRIDGE_DIR_ENV_VAR] == str(bridge_dir)
+    assert Path(spec.env["PYTHONPATH"], "sitecustomize.py").is_symlink()
+    assert forwarder_calls == [
+        {
+            "base_url": "http://127.0.0.1:6767",
+            "headers": {},
+            "session_id": session_id,
+            "bridge_dir": bridge_dir,
+            "kimi_share_dir": bridge_dir / "kimi-share",
+            "legacy_kimi_home": bridge_dir / "kimi-code-home",
+            "workspace": str(tmp_path),
+            "launch_epoch_ms": forwarder_calls[0]["launch_epoch_ms"],
+        }
+    ]

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -839,6 +839,55 @@ async def test_idle_reaper_spares_turn_started_during_pass(tmp_path: Path) -> No
             await reaper
 
 
+async def test_approval_lease_spares_then_releases_stale_entry(tmp_path: Path) -> None:
+    """A pending native approval keeps both harness and pane lifecycle busy."""
+    mgr = HarnessProcessManager(
+        idle_timeout_s=0.5,
+        reaper_interval_s=0.2,
+        tmp_parent=tmp_path,
+    )
+    entry = _SubprocessEntry(
+        _FakeReapProc(),
+        _SlowCloseClient(0.0),
+        _FakeEndpoint(),
+        "h",
+    )  # type: ignore[arg-type]
+    entry.last_used_at = time.monotonic() - 100.0
+    mgr._entries = {"conv": entry}
+    cutoff = time.monotonic() - 0.5
+
+    mgr.mark_approval_pending("conv", "approval-1", ttl_s=60.0)
+    assert mgr.has_active_turn("conv")
+    await mgr.release("conv", only_if_idle_cutoff=cutoff)
+    assert "conv" in mgr._entries
+    assert not entry.process.killed
+
+    mgr.clear_approval_pending("conv", "approval-1")
+    assert not mgr.has_active_turn("conv")
+    await mgr.release("conv", only_if_idle_cutoff=cutoff)
+    assert "conv" not in mgr._entries
+    assert entry.process.killed
+
+
+def test_expired_approval_lease_fails_closed_without_lifecycle_leak(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lost completion events expire instead of keeping a process forever."""
+    clock = {"now": 100.0}
+    monkeypatch.setattr(
+        "omnigent.runtime.harnesses.process_manager.time.monotonic",
+        lambda: clock["now"],
+    )
+    mgr = HarnessProcessManager(tmp_parent=tmp_path)
+
+    mgr.mark_approval_pending("conv", "approval-1", ttl_s=5.0)
+    assert mgr.has_active_turn("conv")
+
+    clock["now"] = 106.0
+    assert not mgr.has_active_turn("conv")
+
+
 async def test_idle_reaper_disabled_when_timeout_zero(
     register_test_harness: None,
     short_tmp_parent: Path,

--- a/tests/server/integration/test_sessions_permission_request_hook.py
+++ b/tests/server/integration/test_sessions_permission_request_hook.py
@@ -289,6 +289,7 @@ async def test_cursor_permission_request_hook_allow_round_trip(
 
 async def test_qwen_permission_request_hook_allow_round_trip(
     client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
     qwen-native TUI ``can_use_tool`` → web ApprovalCard → accept → verdict.
@@ -315,6 +316,21 @@ async def test_qwen_permission_request_hook_allow_round_trip(
         "message": "qwen wants to run run_shell_command",
         "content_preview": "echo hi > out.txt",
     }
+    lifecycle_events: list[dict[str, Any]] = []
+
+    async def _capture_lifecycle(
+        forwarded_session_id: str,
+        _runner_router: object,
+        event: dict[str, Any],
+    ) -> None:
+        assert forwarded_session_id == session_id
+        lifecycle_events.append(event)
+
+    monkeypatch.setattr(
+        sessions_route,
+        "_forward_session_change_to_runner",
+        _capture_lifecycle,
+    )
 
     drain_task = asyncio.create_task(_drain_until_elicitation(session_id))
     await asyncio.sleep(0.05)
@@ -339,6 +355,23 @@ async def test_qwen_permission_request_hook_allow_round_trip(
     resp = await hook_task
     assert resp.status_code == 200, resp.text
     assert resp.json() == {"action": "accept"}
+    assert lifecycle_events == [
+        {
+            "type": "approval_wait",
+            "data": {
+                "state": "started",
+                "elicitation_id": elicitation_id,
+                "ttl_s": sessions_route._NATIVE_PERMISSION_HOOK_TIMEOUT_S + 60.0,
+            },
+        },
+        {
+            "type": "approval_wait",
+            "data": {
+                "state": "ended",
+                "elicitation_id": elicitation_id,
+            },
+        },
+    ]
 
 
 async def test_cursor_permission_request_hook_stamps_ask_user_question_extra(

--- a/tests/test_kimi_native_approval_bridge.py
+++ b/tests/test_kimi_native_approval_bridge.py
@@ -1,0 +1,167 @@
+"""Tests for the Kimi 1.49 in-process approval bridge."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import omnigent.kimi_native_approval_bridge as bridge
+
+
+class _FakeRuntime:
+    """Small ApprovalRuntime stand-in exposing Kimi's public seams."""
+
+    def __init__(self) -> None:
+        self.subscribers: list[Any] = []
+        self.resolutions: list[tuple[str, str, str]] = []
+
+    def subscribe(self, callback: Any) -> str:
+        self.subscribers.append(callback)
+        return "subscription"
+
+    def resolve(self, request_id: str, response: str, feedback: str = "") -> bool:
+        self.resolutions.append((request_id, response, feedback))
+        return True
+
+    def publish(self, event: object) -> None:
+        for callback in self.subscribers:
+            callback(event)
+
+
+def _request(*, status: str = "pending") -> SimpleNamespace:
+    display = SimpleNamespace(
+        model_dump=lambda **_kwargs: {"type": "shell", "command": "touch should-not-exist"}
+    )
+    return SimpleNamespace(
+        id="approval-123",
+        tool_call_id="tool-456",
+        sender="Shell",
+        action="execute",
+        description="Run a shell command",
+        display=[display],
+        status=status,
+        feedback="",
+    )
+
+
+def test_materialize_sitecustomize_uses_owner_scoped_bridge(tmp_path: Path) -> None:
+    env = bridge.materialize_kimi_approval_bridge(tmp_path / "bridge")
+
+    startup_dir = Path(env["PYTHONPATH"])
+    startup_file = startup_dir / "sitecustomize.py"
+    assert startup_file.is_symlink()
+    assert startup_file.resolve() == Path(bridge.__file__).resolve()
+    assert env[bridge.ENABLED_ENV_VAR] == "1"
+    assert env[bridge.BRIDGE_DIR_ENV_VAR] == str(tmp_path / "bridge")
+    assert startup_dir.stat().st_mode & 0o077 == 0
+
+
+def test_web_payload_preserves_kimi_request_identity_and_display() -> None:
+    payload = bridge.approval_payload(_request())
+
+    assert payload == {
+        "elicitation_id": "elicit_kimi_approval-123",
+        "agent": "Kimi",
+        "policy_name": "kimi_native_permission",
+        "operation_type": "execute",
+        "message": "Run a shell command",
+        "content_preview": json.dumps(
+            {
+                "tool_call_id": "tool-456",
+                "sender": "Shell",
+                "display": [{"type": "shell", "command": "touch should-not-exist"}],
+            },
+            sort_keys=True,
+        ),
+    }
+
+
+def test_web_payload_bounds_tool_preview() -> None:
+    request = _request()
+    request.display[0].model_dump = lambda **_kwargs: {
+        "type": "shell",
+        "command": "x" * 4_096,
+    }
+
+    payload = bridge.approval_payload(request)
+
+    assert len(str(payload["content_preview"])) == 1024
+
+
+@pytest.mark.parametrize(
+    ("web_verdict", "expected_response"),
+    [
+        pytest.param("accept", "approve", id="web-accept"),
+        pytest.param("decline", "reject", id="web-decline"),
+        pytest.param("cancel", "reject", id="web-cancel"),
+        pytest.param(None, None, id="unresolved-keeps-native-modal"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_runtime_request_is_resolved_only_from_concrete_web_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    web_verdict: str | None,
+    expected_response: str | None,
+) -> None:
+    monkeypatch.setattr(
+        bridge,
+        "request_web_verdict",
+        lambda _bridge_dir, _request: web_verdict,
+    )
+    runtime_type = type(f"Runtime_{web_verdict}", (_FakeRuntime,), {})
+    bridge.patch_approval_runtime(runtime_type, tmp_path)
+    runtime = runtime_type()
+    request = _request()
+
+    runtime.publish(SimpleNamespace(kind="request_created", request=request))
+    await bridge.wait_for_bridge_tasks(runtime)
+
+    if expected_response is None:
+        assert runtime.resolutions == []
+    else:
+        assert runtime.resolutions == [("approval-123", expected_response, "Resolved in Omnigent")]
+
+
+@pytest.mark.asyncio
+async def test_terminal_resolution_releases_pending_web_card(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    released: list[tuple[Path, str]] = []
+    monkeypatch.setattr(
+        bridge,
+        "post_external_resolution",
+        lambda bridge_dir, request_id: released.append((bridge_dir, request_id)),
+    )
+    runtime_type = type("Runtime_terminal_resolution", (_FakeRuntime,), {})
+    bridge.patch_approval_runtime(runtime_type, tmp_path)
+    runtime = runtime_type()
+
+    runtime.publish(SimpleNamespace(kind="request_resolved", request=_request(status="resolved")))
+    await bridge.wait_for_bridge_tasks(runtime)
+
+    assert released == [(tmp_path, "approval-123")]
+
+
+def test_web_transport_failure_returns_no_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = {
+        "ap_server_url": "http://127.0.0.1:6767",
+        "ap_auth_headers": {},
+        "session_id": "session-1",
+    }
+    (tmp_path / "hook_config.json").write_text(json.dumps(config), encoding="utf-8")
+
+    def _unreachable(*_args: object, **_kwargs: object) -> object:
+        raise OSError("offline")
+
+    monkeypatch.setattr(bridge.urllib.request, "urlopen", _unreachable)
+
+    assert bridge.request_web_verdict(tmp_path, _request()) is None

--- a/tests/test_kimi_native_credentials.py
+++ b/tests/test_kimi_native_credentials.py
@@ -9,6 +9,7 @@ import tomllib
 
 from omnigent.kimi_native_credentials import (
     KIMI_CODE_HOME_ENV_VAR,
+    KIMI_SHARE_DIR_ENV_VAR,
     build_kimi_session_home,
     render_kimi_hooks_toml,
 )
@@ -95,3 +96,60 @@ def test_build_session_home_without_user_home_writes_hooks_only(
 
     parsed = tomllib.loads((session_home / "config.toml").read_text(encoding="utf-8"))
     assert {h["event"] for h in parsed["hooks"]} == {"PreToolUse", "PermissionRequest"}
+
+
+def test_build_dual_session_homes_renders_generation_specific_hooks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Kimi 1.49 gets only its supported hook while Kimi 0.27 stays compatible."""
+    current_user_home = tmp_path / "user-kimi"
+    legacy_user_home = tmp_path / "user-kimi-code"
+    current_user_home.mkdir()
+    legacy_user_home.mkdir()
+    (current_user_home / "config.toml").write_text(
+        'default_model = "kimi"\nhooks = []\n', encoding="utf-8"
+    )
+    (legacy_user_home / "config.toml").write_text(
+        'default_model = "kimi-legacy"\nhooks = []\n', encoding="utf-8"
+    )
+    for entry in ("credentials", "sessions", "logs"):
+        (current_user_home / entry).mkdir()
+    (current_user_home / "device_id").write_text("device", encoding="utf-8")
+    (current_user_home / "kimi.json").write_text("{}", encoding="utf-8")
+    (current_user_home / "mcp.json").write_text("{}", encoding="utf-8")
+    for entry in ("oauth", "sessions"):
+        (legacy_user_home / entry).mkdir()
+    (legacy_user_home / "session_index.jsonl").write_text("", encoding="utf-8")
+    monkeypatch.setenv(KIMI_SHARE_DIR_ENV_VAR, str(current_user_home))
+    monkeypatch.setenv(KIMI_CODE_HOME_ENV_VAR, str(legacy_user_home))
+
+    legacy_session_home = tmp_path / "runtime" / "kimi-code-home"
+    env = build_kimi_session_home(
+        legacy_session_home,
+        bridge_dir=tmp_path / "bridge",
+        python_executable="/opt/omnigent/python",
+        include_current=True,
+    )
+    current_session_home = tmp_path / "runtime" / "kimi-share"
+
+    assert env == {
+        KIMI_SHARE_DIR_ENV_VAR: str(current_session_home),
+        KIMI_CODE_HOME_ENV_VAR: str(legacy_session_home),
+    }
+    current_config = (current_session_home / "config.toml").read_text(encoding="utf-8")
+    legacy_config = (legacy_session_home / "config.toml").read_text(encoding="utf-8")
+    current_parsed = tomllib.loads(current_config)
+    legacy_parsed = tomllib.loads(legacy_config)
+    assert [hook["event"] for hook in current_parsed["hooks"]] == ["PreToolUse"]
+    assert [hook["event"] for hook in legacy_parsed["hooks"]] == [
+        "PreToolUse",
+        "PermissionRequest",
+    ]
+    assert (current_session_home / "credentials").is_symlink()
+    assert (current_session_home / "device_id").is_symlink()
+    assert (current_session_home / "mcp.json").is_symlink()
+    assert not (current_session_home / "sessions").exists()
+    assert not (current_session_home / "kimi.json").exists()
+    assert not (current_session_home / "logs").exists()
+    assert (legacy_session_home / "oauth").is_symlink()
+    assert not (legacy_session_home / "sessions").exists()

--- a/tests/test_kimi_native_forwarder.py
+++ b/tests/test_kimi_native_forwarder.py
@@ -9,6 +9,8 @@ by the e2e gate, not here.
 from __future__ import annotations
 
 import json
+import os
+from hashlib import md5
 from pathlib import Path
 
 from omnigent.kimi_native_forwarder import (
@@ -18,11 +20,67 @@ from omnigent.kimi_native_forwarder import (
     _row_to_item,
     _write_state,
     clear_kimi_bridge_state,
+    discover_kimi_wire,
     read_kimi_wire_items,
 )
 
 
 class TestRowToItem:
+    def test_current_turn_begin_is_user(self) -> None:
+        row = {
+            "timestamp": 1784854258.07757,
+            "message": {
+                "type": "TurnBegin",
+                "payload": {"user_input": [{"type": "text", "text": "hi"}]},
+            },
+        }
+        item = _row_to_item(1, row)
+        assert item is not None
+        assert item.role == "user"
+        assert item.text == "hi"
+        assert item.response_id == "kimi:current:line:1"
+
+    def test_current_content_parts_keep_reasoning_and_answer(self) -> None:
+        reasoning = _row_to_item(
+            2,
+            {
+                "message": {
+                    "type": "ContentPart",
+                    "payload": {"type": "think", "think": "Reason carefully."},
+                }
+            },
+        )
+        answer = _row_to_item(
+            3,
+            {
+                "message": {
+                    "type": "ContentPart",
+                    "payload": {"type": "text", "text": "Done."},
+                }
+            },
+        )
+        assert reasoning is not None
+        assert (reasoning.role, reasoning.text, reasoning.kind) == (
+            "assistant",
+            "Reason carefully.",
+            "reasoning",
+        )
+        assert answer is not None
+        assert (answer.role, answer.text, answer.kind) == ("assistant", "Done.", "message")
+
+    def test_current_steer_input_string_is_user(self) -> None:
+        item = _row_to_item(
+            4,
+            {
+                "message": {
+                    "type": "SteerInput",
+                    "payload": {"user_input": "one more thing"},
+                }
+            },
+        )
+        assert item is not None
+        assert (item.role, item.text, item.kind) == ("user", "one more thing", "message")
+
     def test_turn_prompt_is_user(self) -> None:
         row = {
             "type": "turn.prompt",
@@ -176,3 +234,55 @@ class TestDiscoverWire:
         self._make_session(home, "session_stale", "/ws", mtime=1000.0)
         # launch far in the future (ms) → the 1000s-mtime session is below the floor.
         assert _discover_wire(home, "/ws", launch_epoch_ms=9_000_000_000_000) is None
+
+    def test_selects_newest_current_or_legacy_launch_scoped_wire(
+        self, tmp_path: Path
+    ) -> None:
+        workspace = "/tmp/Andrew Project"
+        current_share = tmp_path / "kimi-share"
+        legacy_home = tmp_path / "kimi-code-home"
+        current_wire = (
+            current_share
+            / "sessions"
+            / md5(workspace.encode("utf-8")).hexdigest()
+            / "149-session"
+            / "wire.jsonl"
+        )
+        wrong_workspace_wire = (
+            current_share
+            / "sessions"
+            / md5(b"/tmp/Other Project").hexdigest()
+            / "other-session"
+            / "wire.jsonl"
+        )
+        legacy_wire = self._make_session(
+            legacy_home, "session_027", workspace, mtime=1005.0
+        )
+        for wire, mtime in (
+            (current_wire, 1010.0),
+            (wrong_workspace_wire, 1030.0),
+        ):
+            wire.parent.mkdir(parents=True, exist_ok=True)
+            wire.write_text("{}\n", encoding="utf-8")
+            os.utime(wire, (mtime, mtime))
+
+        assert (
+            discover_kimi_wire(
+                kimi_share_dir=current_share,
+                legacy_kimi_home=legacy_home,
+                workspace=workspace,
+                launch_epoch_ms=1_000_000,
+            )
+            == current_wire
+        )
+
+        os.utime(legacy_wire, (1020.0, 1020.0))
+        assert (
+            discover_kimi_wire(
+                kimi_share_dir=current_share,
+                legacy_kimi_home=legacy_home,
+                workspace=workspace,
+                launch_epoch_ms=1_000_000,
+            )
+            == legacy_wire
+        )

--- a/tests/test_kimi_native_forwarder.py
+++ b/tests/test_kimi_native_forwarder.py
@@ -235,9 +235,7 @@ class TestDiscoverWire:
         # launch far in the future (ms) → the 1000s-mtime session is below the floor.
         assert _discover_wire(home, "/ws", launch_epoch_ms=9_000_000_000_000) is None
 
-    def test_selects_newest_current_or_legacy_launch_scoped_wire(
-        self, tmp_path: Path
-    ) -> None:
+    def test_selects_newest_current_or_legacy_launch_scoped_wire(self, tmp_path: Path) -> None:
         workspace = "/tmp/Andrew Project"
         current_share = tmp_path / "kimi-share"
         legacy_home = tmp_path / "kimi-code-home"
@@ -255,9 +253,7 @@ class TestDiscoverWire:
             / "other-session"
             / "wire.jsonl"
         )
-        legacy_wire = self._make_session(
-            legacy_home, "session_027", workspace, mtime=1005.0
-        )
+        legacy_wire = self._make_session(legacy_home, "session_027", workspace, mtime=1005.0)
         for wire, mtime in (
             (current_wire, 1010.0),
             (wrong_workspace_wire, 1030.0),


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Fix Kimi 1.49 sessions that appeared to work forever without producing chat output when a tool approval was waiting only in the terminal.
- Support Kimi 1.49's current `KIMI_SHARE_DIR` state/wire format while retaining the legacy Kimi layout.
- Subscribe to Kimi's supported in-process `ApprovalRuntime`, mirror requests through Omnigent's existing approval card, and resolve Kimi only after an explicit web verdict. If the bridge is unavailable, Kimi's native modal remains authoritative.
- Add a bounded approval-wait lease so idle cleanup cannot reap the harness or terminal pane while a user is deciding.

ELI5: Kimi moved its permission doorbell. Omnigent was still listening at the old door, so Kimi waited silently. This teaches Omnigent where the new doorbell is and keeps the session alive until the user answers.

```text
Kimi ApprovalRuntime
        │
        ▼
launch-scoped subscriber ──► Omnigent approval card ──► explicit verdict
        │                                                   │
        └── bridge unavailable: native modal stays open ◄───┘
```

## Test Plan

- `uv run pre-commit run --all-files`
- `OMNIGENT_DATA_DIR=/tmp/omnigent-kimi-approval-runtime-tests uv run pytest -q <Kimi, permission-route, lifecycle, and process-manager test files>` — 270 passed.
- `uv run mypy omnigent/kimi_native_approval_bridge.py`
- Loaded the launch shim inside the installed Kimi CLI 1.49 Python environment and confirmed the real `ApprovalRuntime` class was patched with exactly one subscriber (`True 1`).

## Demo

N/A — this repairs an existing approval-card flow without changing frontend code.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used the locally installed Kimi CLI 1.49 runtime to prove that Python startup loads the bridge and subscribes the real approval runtime. Automated coverage exercises accept, decline, cancel, transport failure, native-modal resolution, current/legacy wire discovery, launch environment wiring, server-to-runner leases, expiry, and idle reaping.

## Changelog

Kimi tool approvals now appear in chat and no longer leave sessions silently stuck.
