### PR TITLE
[polly] Launch supported child agents in goal mode

### DIFF
--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -121,6 +121,16 @@ prompt: |
       pass the diff + contract as text); the reviewer reports issues, never edits.
     - `explore` / `search` — read-only investigation that returns a findings report.
 
+  Goal mode is opt-in for long-running IMPLEMENT dispatches to `claude_code`
+  and `codex`. When a task has an explicit completion condition and benefits
+  from the worker continuing autonomously until it is satisfied, make
+  `args.input` one standalone `/goal <condition>` command. `/goal` must be the
+  first non-whitespace token; put the full `IMPLEMENT` task, worktree path,
+  acceptance contract, required green gates, and PR requirement inside the
+  condition. Do not use child goal mode for `review`, `explore`, or `search`,
+  or for `opencode`, `cursor`, `hermes`, or `pi`. Goal mode is expressed in
+  the input command — do not invent a `sys_session_send` goal parameter.
+
   Treat real investigation as delegated work. If the human asks you to
   investigate, inspect, explain, debug, audit, search, compare, summarize code
   behavior, or answer a repository-specific technical question in any depth,

--- a/examples/polly/skills/fanout/SKILL.md
+++ b/examples/polly/skills/fanout/SKILL.md
@@ -22,6 +22,11 @@ dependency).
    and opens its OWN PR for the branch. Every commit the worker authors must
    end with a blank line followed by the exact co-sign trailer as its final
    line — `Co-authored-by: omnigent <noreply@omnigent.ai>`.
+   For a long-running `claude_code` or `codex` implementation with an explicit
+   completion condition, the `input` may instead be one standalone
+   `/goal <condition>` command containing that same task, worktree, acceptance
+   contract, green gates, and PR requirement.
+   Do not use child goal mode for other workers or non-implementation purposes.
    Record each handle's `conversation_id`
    in the registry. Emit the worktree + `sys_session_send` tool calls in THIS
    turn — never end a turn having only said you will dispatch; the dispatch

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -30,6 +30,7 @@ from omnigent.spec.types import RetryPolicy
 
 from . import _proc
 from ._subprocess_lifecycle import close_subprocess_transport
+from .codex_goal_command import goal_objective_from_content as _goal_objective_from_content
 from .databricks_executor import (
     _databricks_gateway_host,
 )
@@ -1208,25 +1209,6 @@ def _extract_latest_user_content(
                 return content
             return json.dumps(content)
     return ""
-
-
-def _goal_objective_from_content(content: str | list[dict[str, Any]]) -> str | None:
-    """Return the objective from a standalone ``/goal`` user command."""
-    if isinstance(content, list):
-        text_parts: list[str] = []
-        for block in content:
-            if block.get("type") not in {"input_text", "text"}:
-                return None
-            text = block.get("text")
-            if not isinstance(text, str):
-                return None
-            text_parts.append(text)
-        content = "".join(text_parts)
-    command, separator, objective = content.strip().partition(" ")
-    if command != "/goal" or not separator:
-        return None
-    objective = objective.strip()
-    return objective or None
 
 
 def _build_initial_prompt(

--- a/omnigent/inner/codex_goal_command.py
+++ b/omnigent/inner/codex_goal_command.py
@@ -1,0 +1,28 @@
+"""Shared ``/goal`` command parsing for Codex harnesses."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def goal_objective_from_content(content: Any) -> str | None:
+    """Return the objective from a standalone, text-only ``/goal`` command."""
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                return None
+            if block.get("type") not in {"input_text", "text"}:
+                return None
+            text = block.get("text")
+            if not isinstance(text, str):
+                return None
+            text_parts.append(text)
+        content = "".join(text_parts)
+    if not isinstance(content, str):
+        return None
+    command, separator, objective = content.strip().partition(" ")
+    if command != "/goal" or not separator:
+        return None
+    objective = objective.strip()
+    return objective or None

--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -22,6 +22,7 @@ from omnigent.codex_native_bridge import (
     read_mcp_startup,
     update_active_turn_id,
 )
+from omnigent.inner.codex_goal_command import goal_objective_from_content
 from omnigent.inner.executor import (
     Executor,
     ExecutorConfig,
@@ -203,7 +204,13 @@ class CodexNativeExecutor(Executor):
         """
         del tools, system_prompt
         settings_overrides = _model_effort_overrides(config)
-        input_items = _latest_user_input_items(messages, self._bridge_dir)
+        latest_user_content = _latest_user_content(messages)
+        goal_objective = goal_objective_from_content(latest_user_content)
+        input_items = (
+            [{"type": "text", "text": goal_objective}]
+            if goal_objective is not None
+            else _content_to_input_items(latest_user_content, self._bridge_dir)
+        )
         if not input_items:
             yield ExecutorError(message="Codex native turn had no user input to send")
             return
@@ -253,6 +260,14 @@ class CodexNativeExecutor(Executor):
                 )
                 await client.connect()
                 try:
+                    if goal_objective is not None:
+                        await client.request(
+                            "thread/goal/set",
+                            {
+                                "threadId": state.thread_id,
+                                "objective": goal_objective,
+                            },
+                        )
                     if state.active_turn_id is not None:
                         response = await client.request(
                             "turn/steer",
@@ -382,20 +397,17 @@ def _session_is_active(session_id: str, request_session_id: str | None) -> bool:
     return request_session_id is None or request_session_id == session_id
 
 
-def _latest_user_input_items(messages: list[Message], bridge_dir: Path) -> list[dict[str, Any]]:
+def _latest_user_content(messages: list[Message]) -> Any:
     """
-    Build Codex app-server input items from the latest user message.
+    Return the latest user message content.
 
     :param messages: Executor message list.
-    :param bridge_dir: Bridge directory for materializing image/file
-        attachments, e.g. ``Path("/tmp/omnigent/codex-native/<digest>")``.
-    :returns: Codex ``turn/start``/``turn/steer`` input items, or ``[]``
-        when there is no user content to send.
+    :returns: The latest user content, or ``None`` when absent.
     """
     for message in reversed(messages):
         if message.get("role") == "user":
-            return _content_to_input_items(message.get("content"), bridge_dir)
-    return []
+            return message.get("content")
+    return None
 
 
 def _content_to_input_items(content: Any, bridge_dir: Path) -> list[dict[str, Any]]:

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -166,6 +166,11 @@ def test_subagent_dispatch_text_advertises_task_titles_and_purpose(
     assert "Every `sys_session_send` MUST set both" in config
     assert "Name the sub-agent session for the work it is doing" in config
     assert "Bad titles are `claude_code`, `claude-code`, `codex`" in config
+    assert "Goal mode is opt-in for long-running IMPLEMENT dispatches" in config
+    assert "one standalone `/goal <condition>` command" in config
+    assert "do not invent a `sys_session_send` goal parameter" in config
+    assert "long-running `claude_code` or `codex` implementation" in fanout
+    assert "Do not use child goal mode for other workers" in fanout
     assert 'purpose: "implement"' in fanout
     assert 'title="<task_slug>"' in fanout
     assert 'title="review-<task_slug>"' in cross_review

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -193,6 +193,51 @@ def test_web_started_codex_turn_returns_without_waiting_for_terminal_event(
     ]
 
 
+def test_goal_command_sets_goal_before_starting_objective_turn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A standalone ``/goal`` command activates the goal before work starts."""
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_123",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_123",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id=None,
+        ),
+    )
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "  /goal Finish the implementation and tests  ")
+
+    assert [type(event) for event in events] == [TurnComplete]
+    assert _FakeCodexNativeClient.requests == [
+        (
+            "thread/goal/set",
+            {
+                "threadId": "thread_123",
+                "objective": "Finish the implementation and tests",
+            },
+        ),
+        (
+            "turn/start",
+            {
+                "threadId": "thread_123",
+                "input": [{"type": "text", "text": "Finish the implementation and tests"}],
+            },
+        ),
+    ]
+
+
 def test_system_prompt_does_not_override_collaboration_mode(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Related issue

N/A

## Summary

Polly already has the transport it needs to start child goals: a standalone
`/goal` command in `sys_session_send.args.input`. Adding a server-side goal
parameter would duplicate harness-owned command semantics, so this keeps the
server and `AgentSpec` unchanged.

- Teach Polly to opt long-running `claude_code` and `codex` implementation
  dispatches into goal mode when they have an explicit completion condition.
- Give Codex native the same standalone `/goal` handling as the Codex executor:
  set the thread goal before starting a turn with the clean objective.
- Keep reviews, investigations, and unsupported workers out of child goal mode.

**ELI5:** Polly writes `/goal` at the front of a supported child's assignment.
The child harness turns that into native goal state and receives the assignment
without the slash command; Omnigent does not need a new session API parameter.

```text
Polly sys_session_send(input="/goal <task + completion condition>")
  |-- claude_code --> Claude SDK goal command
  `-- codex -------> parse command --> thread/goal/set --> turn/start objective
```

## Test Plan

- Ran 140 focused Codex executor, Codex native, and Polly bundle tests; 139
  passed together, then the one wording assertion passed after rewrapping the
  guidance.
- Ran Ruff formatting and lint checks on all changed Python files.
- Parsed `examples/polly/config.yaml` and ran every applicable pre-commit hook
  on the seven changed files.
- Ran `git diff --check`.

## Demo

N/A — this changes orchestration guidance and harness command handling, with no
new visual UI.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The Codex native unit test verifies RPC ordering and objective cleanup. The
Polly bundle test locks down the supported workers, purpose restrictions, and
standalone command contract. Existing Codex executor tests continue to cover
standalone `/goal` parsing and goal setup.

## Changelog

Polly can launch supported Claude and Codex implementation children in goal mode.
