### PR TITLE
fix(codex): expose GPT-5.6 before launch

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -55,7 +55,7 @@ CodexParams = dict[str, Any]
 _CONNECT_RETRY_DELAY_SECONDS = 0.05
 _CONNECT_TIMEOUT_SECONDS = 10.0
 _STDERR_CHUNK_LIMIT = 65536
-_DATABRICKS_CODEX_DEFAULT_MODEL = "databricks-gpt-5-5"
+_DATABRICKS_CODEX_DEFAULT_MODEL = "databricks-gpt-5-6-sol"
 _UDS_WEBSOCKET_HANDSHAKE_URI = "ws://localhost/rpc"
 _MAX_WEBSOCKET_MESSAGE_SIZE_BYTES = 128 << 20
 # hooks.json filename written into the private CODEX_HOME registering the

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1839,13 +1839,37 @@ class HostProcess:
         resolves its own catalog at launch, and the in-session picker
         re-reads that authoritative snapshot after bind.
         """
-        if canonicalize_harness(frame.harness) != "claude-native":
+        harness = canonicalize_harness(frame.harness)
+        if harness not in ("claude-native", "codex-native"):
             return HostModelOptionsResultFrame(
                 request_id=frame.request_id,
                 status="failed",
                 error=f"model options are unsupported for harness {frame.harness!r}",
             )
         try:
+            if harness == "codex-native":
+                from omnigent.model_catalog import list_models_for_worker
+                from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+                spec = AgentSpec(
+                    spec_version=1,
+                    name="model-options-preview",
+                    executor=ExecutorSpec(
+                        type="omnigent",
+                        config={"harness": "codex-native"},
+                    ),
+                )
+                listing = await asyncio.to_thread(
+                    list_models_for_worker,
+                    spec,
+                    "codex-native",
+                )
+                models = [{"id": model.id, "displayName": model.id} for model in listing.models]
+                return HostModelOptionsResultFrame(
+                    request_id=frame.request_id,
+                    status="ok",
+                    models=models,
+                )
             from omnigent.claude_native import (
                 claude_native_model_options,
                 resolve_native_claude_config,
@@ -1854,11 +1878,11 @@ class HostProcess:
             config = await asyncio.to_thread(resolve_native_claude_config, spec=None)
             models = await asyncio.to_thread(claude_native_model_options, config)
         except Exception:
-            _logger.exception("Failed to resolve pre-launch Claude model options")
+            _logger.exception("Failed to resolve pre-launch %s model options", harness)
             return HostModelOptionsResultFrame(
                 request_id=frame.request_id,
                 status="failed",
-                error="failed to resolve Claude model options",
+                error=f"failed to resolve {harness} model options",
             )
         return HostModelOptionsResultFrame(
             request_id=frame.request_id,

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -103,7 +103,7 @@ _OPENAI_CODEX_DEFAULT_MODEL = "gpt-5.4-mini"
 # generic-provider gateway path never uses this — it requires the Omnigent producer
 # to resolve a concrete model. Used only when constructing the codex config
 # from ~/.databrickscfg credentials with no spec/override model.
-_DATABRICKS_CODEX_DEFAULT_MODEL = "databricks-gpt-5-5"
+_DATABRICKS_CODEX_DEFAULT_MODEL = "databricks-gpt-5-6-sol"
 
 # Files symlinked from the real CODEX_HOME into the per-session temp home.
 # Symlinks (not copies) so credential refreshes in the real home propagate

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -89,7 +89,14 @@ _SUBSCRIPTION_STATIC_MODELS: dict[str, tuple[str, ...]] = {
         "claude-sonnet-4-6",
         "claude-haiku-4-5",
     ),
-    "codex": ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini"),
+    "codex": (
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+    ),
 }
 
 # Harness spellings -> the workflow harness whose provider resolution they

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -40,6 +40,9 @@ MODEL_LISTS: dict[str, list[str]] = {
         "databricks-gpt-5-4-mini",
         "databricks-gpt-5-4",
         "databricks-gpt-5-5",
+        "databricks-gpt-5-6-luna",
+        "databricks-gpt-5-6-terra",
+        "databricks-gpt-5-6-sol",
     ],
     # pi is multi-model: Claude and GPT both available.
     "pi": [
@@ -50,6 +53,9 @@ MODEL_LISTS: dict[str, list[str]] = {
         "databricks-gpt-5-4",
         "databricks-claude-opus-4-8",
         "databricks-gpt-5-5",
+        "databricks-gpt-5-6-luna",
+        "databricks-gpt-5-6-terra",
+        "databricks-gpt-5-6-sol",
     ],
 }
 

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -1032,11 +1032,13 @@ async def _drive_model_effort(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
-def test_start_session_select_approval_mode(seeded_session: tuple[str, str]) -> None:
-    """Picking a non-default approval preset rides along to the create call.
+def test_start_session_select_codex_model_and_approval_mode(
+    seeded_session: tuple[str, str],
+) -> None:
+    """Codex model and approval picks ride along to the create call.
 
-    Selecting "Full access" in the Codex config modal and saving must reach
-    ``POST /v1/sessions`` as
+    Selecting GPT-5.6 Sol and "Full access" in the Codex config modal must
+    reach ``POST /v1/sessions`` as a model override plus
     ``terminal_launch_args: ["--sandbox", "danger-full-access",
     "--ask-for-approval", "never"]``.
     """
@@ -1088,6 +1090,7 @@ async def _drive_agent_picker_pagination_dedupe(base_url: str, session_id: str) 
 
             await page.route("**/v1/agents?after=ag_codex_fork_2", handle_agents_page_2)
             await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
             await page.add_init_script(
                 f"""window.localStorage.setItem(
                     "omnigent:recent-workspaces",
@@ -1149,6 +1152,28 @@ async def _drive_approval_mode(base_url: str, session_id: str) -> None:
 
             await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
 
+            async def handle_model_options(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps(
+                        {
+                            "models": [
+                                {
+                                    "id": "databricks-gpt-5-6-sol",
+                                    "displayName": "GPT-5.6 Sol",
+                                },
+                                {"id": "databricks-gpt-5-5", "displayName": "GPT-5.5"},
+                            ]
+                        }
+                    ),
+                )
+
+            await page.route(
+                f"**/v1/hosts/{_HOST_ID}/harnesses/codex-native/model-options",
+                handle_model_options,
+            )
+
             await page.add_init_script(
                 f"""window.localStorage.setItem(
                     "omnigent:recent-workspaces",
@@ -1160,9 +1185,14 @@ async def _drive_approval_mode(base_url: str, session_id: str) -> None:
             await page.get_by_test_id("new-chat-landing-input").wait_for(
                 state="visible", timeout=30_000
             )
-            # Codex auto-selects (only built-in); its approval presets live in
-            # the gear-icon config modal.
+            # Codex auto-selects (only built-in); model and approval choices
+            # share the gear-icon config modal.
             await _open_entry_config(page, "ag_codex_e2e")
+            await _pick_config_select(
+                page,
+                "new-chat-landing-config-model",
+                "GPT-5.6 Sol",
+            )
             approval = page.get_by_test_id("new-chat-landing-config-approval")
             await expect(approval).to_be_visible()
             await approval.click()
@@ -1179,6 +1209,7 @@ async def _drive_approval_mode(base_url: str, session_id: str) -> None:
             assert body["agent_id"] == "ag_codex_e2e", body
             assert body["host_id"] == _HOST_ID, body
             assert body["workspace"] == "/work/repo", body
+            assert body.get("model_override") == "databricks-gpt-5-6-sol", body
             assert body.get("terminal_launch_args") == [
                 "--sandbox",
                 "danger-full-access",

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -99,6 +99,45 @@ async def test_handle_model_options_uses_host_claude_configuration(
     )
 
 
+async def test_handle_model_options_uses_host_codex_provider_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Codex launch picker previews the host's resolved provider models."""
+    from omnigent import model_catalog
+    from omnigent.model_catalog import ModelEntry, ModelListing
+
+    monkeypatch.setattr(
+        model_catalog,
+        "list_models_for_worker",
+        lambda spec, harness: ModelListing(
+            source="gateway",
+            verified=True,
+            models=(
+                ModelEntry(id="databricks-gpt-5-6-sol", family="openai"),
+                ModelEntry(id="databricks-gpt-5-5", family="openai"),
+            ),
+            note="test catalog",
+        ),
+    )
+    host = _make_host_process()
+
+    result = await host._handle_model_options(
+        HostModelOptionsFrame(request_id="req_models", harness="codex-native"),
+    )
+
+    assert result == HostModelOptionsResultFrame(
+        request_id="req_models",
+        status="ok",
+        models=[
+            {
+                "id": "databricks-gpt-5-6-sol",
+                "displayName": "databricks-gpt-5-6-sol",
+            },
+            {"id": "databricks-gpt-5-5", "displayName": "databricks-gpt-5-5"},
+        ],
+    )
+
+
 def _make_host_process() -> HostProcess:
     """Create a HostProcess with a test identity.
 

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -441,7 +441,7 @@ class TestCodexExecutor(unittest.TestCase):
             ]
 
             self.assertEqual(events[-1].response, "done")
-            self.assertEqual(fake_session.calls[0]["model"], "databricks-gpt-5-5")
+            self.assertEqual(fake_session.calls[0]["model"], "databricks-gpt-5-6-sol")
 
         _run(_t())
 

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -96,6 +96,11 @@ def test_infer_models_codex() -> None:
     models = infer_models("codex")
     assert models is not None
     assert any("gpt" in m for m in models)
+    assert models[-3:] == [
+        "databricks-gpt-5-6-luna",
+        "databricks-gpt-5-6-terra",
+        "databricks-gpt-5-6-sol",
+    ]
 
 
 def test_infer_models_openai_agents() -> None:

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -805,7 +805,14 @@ def test_cli_config_listing_is_static_and_unverified(
     listing = list_models_for_worker(_worker_spec("codex-native"), "codex-native")
     assert listing.source == "static"
     assert listing.verified is False
-    assert [m.id for m in listing.models] == ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"]
+    assert [m.id for m in listing.models] == [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+    ]
     # The note must say the CLI resolves the credential itself — this row
     # is a working worker, not a credentials preflight failure.
     assert "resolved by the CLI at launch" in listing.note

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1069,6 +1069,45 @@ describe("NewChatLandingScreen", () => {
     expect(screen.getByText("Read only")).toBeTruthy();
   });
 
+  it("offers host Codex models before launch and sends the selected override", async () => {
+    useHostModelOptionsMock.mockImplementation(
+      (_hostId, harness) =>
+        ({
+          data:
+            harness === "codex-native"
+              ? [
+                  {
+                    id: "databricks-gpt-5-6-sol",
+                    displayName: "GPT-5.6 Sol",
+                  },
+                  { id: "databricks-gpt-5-5", displayName: "GPT-5.5" },
+                ]
+              : [],
+          isLoading: false,
+          isError: false,
+        }) as unknown as ReturnType<typeof useHostModelOptions>,
+    );
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    renderLanding();
+
+    openAgentConfig("a2");
+    expect(screen.getByTestId("new-chat-landing-config-model")).toBeTruthy();
+    pickSelectOption("new-chat-landing-config-model", "GPT-5.6 Sol");
+    saveConfig();
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "upgrade the project" },
+    });
+    fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
+
+    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = authenticatedFetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
+    expect(body.model_override).toBe("databricks-gpt-5-6-sol");
+  });
+
   it("arms codex full bypass via the Approval dropdown and shows the warning banner", () => {
     renderLanding();
     // Open Codex's (a2) config modal; bypass is the most-permissive Approval option.

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1220,8 +1220,8 @@ function HarnessConfigModal({
   cursorExecMode,
   bypassSandbox,
   pickedModel,
-  claudeModelOptions,
-  claudeModelsLoading,
+  modelOptions,
+  modelsLoading,
   pickedEffort,
   pickedHarness,
   costControlMode,
@@ -1246,8 +1246,8 @@ function HarnessConfigModal({
   cursorExecMode: string;
   bypassSandbox: boolean;
   pickedModel: string;
-  claudeModelOptions: readonly { id: string; displayName: string }[];
-  claudeModelsLoading: boolean;
+  modelOptions: readonly { id: string; displayName: string }[];
+  modelsLoading: boolean;
   pickedEffort: string;
   pickedHarness: string | null;
   costControlMode: CostControlMode;
@@ -1335,9 +1335,11 @@ function HarnessConfigModal({
           mode: draftPermission,
         });
     } else if (hasApproval) {
+      setPickedModel(draftModel);
       setApprovalMode(draftApproval);
       setBypassSandbox(draftBypass);
-      if (entryHarness) writeHarnessOption(entryHarness, { mode: draftApproval });
+      if (entryHarness)
+        writeHarnessOption(entryHarness, { model: draftModel, mode: draftApproval });
     } else if (hasCursor) {
       setCursorExecMode(draftCursor);
       if (entryHarness) writeHarnessOption(entryHarness, { mode: draftCursor });
@@ -1372,10 +1374,8 @@ function HarnessConfigModal({
         </DialogHeader>
 
         <div className="flex flex-col gap-5 py-1">
-          {/* Smart Routing as a standalone toggle, first, for routable agents
-          that have no Model dropdown to fold it into (Codex, bundle agents, …).
-          Claude offers it as a Model option instead, so it's excluded here. */}
-          {smartRoutingEligible && !hasPermission && (
+          {/* Agents with a model picker expose Smart Routing in that picker. */}
+          {smartRoutingEligible && !hasPermission && !isCodex && (
             <ConfigRow label="Smart Routing" description="Auto-pick the model per turn by task">
               <div className="flex h-8 items-center justify-end">
                 <Switch
@@ -1388,45 +1388,45 @@ function HarnessConfigModal({
               </div>
             </ConfigRow>
           )}
+          {(hasPermission || isCodex) && (
+            <ConfigRow label="Model" description="Underlying LLM">
+              <Select value={modelValue} onValueChange={onModelChange}>
+                <SelectTrigger
+                  className="w-full"
+                  data-testid="new-chat-landing-config-model"
+                  aria-label="Model"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent
+                  position="popper"
+                  align="start"
+                  className="[&_[data-slot=select-item]]:pl-2.5"
+                >
+                  {smartRoutingEligible && (
+                    <SelectItem value={MODEL_SELECT_SMART}>Smart Routing</SelectItem>
+                  )}
+                  <SelectItem value={MODEL_SELECT_DEFAULT}>Default</SelectItem>
+                  {modelOptions.map((m) => (
+                    <SelectItem key={m.id} value={m.id}>
+                      {m.displayName}
+                    </SelectItem>
+                  ))}
+                  {modelsLoading && (
+                    <div className="px-2.5 py-1 text-xs text-muted-foreground">Loading models…</div>
+                  )}
+                  {!modelsLoading && modelOptions.length === 0 && (
+                    <div className="px-2.5 py-1 text-xs text-muted-foreground">
+                      Models unavailable
+                    </div>
+                  )}
+                </SelectContent>
+              </Select>
+            </ConfigRow>
+          )}
+
           {hasPermission && (
             <>
-              <ConfigRow label="Model" description="Underlying LLM">
-                <Select value={modelValue} onValueChange={onModelChange}>
-                  <SelectTrigger
-                    className="w-full"
-                    data-testid="new-chat-landing-config-model"
-                    aria-label="Model"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent
-                    position="popper"
-                    align="start"
-                    className="[&_[data-slot=select-item]]:pl-2.5"
-                  >
-                    {smartRoutingEligible && (
-                      <SelectItem value={MODEL_SELECT_SMART}>Smart Routing</SelectItem>
-                    )}
-                    <SelectItem value={MODEL_SELECT_DEFAULT}>Default</SelectItem>
-                    {claudeModelOptions.map((m) => (
-                      <SelectItem key={m.id} value={m.id}>
-                        {m.displayName}
-                      </SelectItem>
-                    ))}
-                    {claudeModelsLoading && (
-                      <div className="px-2.5 py-1 text-xs text-muted-foreground">
-                        Loading models…
-                      </div>
-                    )}
-                    {!claudeModelsLoading && claudeModelOptions.length === 0 && (
-                      <div className="px-2.5 py-1 text-xs text-muted-foreground">
-                        Models unavailable
-                      </div>
-                    )}
-                  </SelectContent>
-                </Select>
-              </ConfigRow>
-
               <ConfigRow label="Effort" description="Reasoning depth vs. speed">
                 <Select
                   value={draftEffort || EFFORT_SELECT_NONE}
@@ -1757,24 +1757,6 @@ export function NewChatLandingScreen() {
   // (host_type: "managed"), so no host_id or workspace is sent.
   const [sandboxSelected, setSandboxSelected] = useState(
     () => landingDraft?.sandboxSelected ?? false,
-  );
-  const { data: hostClaudeModelOptions, isLoading: hostClaudeModelsLoading } = useHostModelOptions(
-    selectedHostId,
-    "claude-native",
-    !sandboxSelected,
-  );
-  const claudeModelOptions = useMemo(
-    () =>
-      sandboxSelected
-        ? CLAUDE_NATIVE_MODELS.map((model) => ({
-            id: model.id,
-            displayName: model.label,
-          }))
-        : (hostClaudeModelOptions ?? []).map((option) => ({
-            id: option.id,
-            displayName: option.displayName ?? option.id,
-          })),
-    [hostClaudeModelOptions, sandboxSelected],
   );
   // Desktop-shell host status for THIS machine (null outside Electron), so the
   // picker can tag the current machine and offer to auto-connect it.
@@ -2154,6 +2136,30 @@ export function NewChatLandingScreen() {
         : agentList.find((a) => a.id === effectiveAgentId),
     [agentList, effectiveAgentId, pendingAgent],
   );
+  const selectedNativeHarness = nativeCodingAgentForAvailableAgent(selectedAgent)?.harness ?? null;
+  const previewHarness =
+    selectedNativeHarness === "claude-native" || selectedNativeHarness === "codex-native"
+      ? selectedNativeHarness
+      : "claude-native";
+  const { data: hostModelOptions, isLoading: hostModelsLoading } = useHostModelOptions(
+    selectedHostId,
+    previewHarness,
+    !sandboxSelected &&
+      (selectedNativeHarness === "claude-native" || selectedNativeHarness === "codex-native"),
+  );
+  const nativeModelOptions = useMemo(
+    () =>
+      sandboxSelected && selectedNativeHarness === "claude-native"
+        ? CLAUDE_NATIVE_MODELS.map((model) => ({
+            id: model.id,
+            displayName: model.label,
+          }))
+        : (hostModelOptions ?? []).map((option) => ({
+            id: option.id,
+            displayName: option.displayName ?? option.id,
+          })),
+    [hostModelOptions, sandboxSelected, selectedNativeHarness],
+  );
   const supportsPermissionMode = nativeAgentHasCapability(selectedAgent, "permissionMode");
   const supportsApprovalMode = nativeAgentHasCapability(selectedAgent, "approvalMode");
   const supportsCursorMode = nativeAgentHasCapability(selectedAgent, "cursorMode");
@@ -2183,7 +2189,7 @@ export function NewChatLandingScreen() {
     if (supportsPermissionMode) {
       const modelValue = routingOn
         ? "Smart Routing"
-        : (claudeModelOptions.find((m) => m.id === pickedModel)?.displayName ?? "Default");
+        : (nativeModelOptions.find((m) => m.id === pickedModel)?.displayName ?? "Default");
       // Smart Routing freezes effort to the default (the router picks per turn),
       // so mirror the modal: show "Default" whenever routing is on or effort is
       // unset, else the picked level.
@@ -2215,7 +2221,13 @@ export function NewChatLandingScreen() {
           ? CODEX_NATIVE_BYPASS_APPROVAL_OPTION.label
           : (CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === approvalMode)?.label ??
             approvalMode);
-      return [{ label: "Approval", value: approvalValue }, ...routingRow];
+      const modelValue =
+        nativeModelOptions.find((m) => m.id === pickedModel)?.displayName ?? "Default";
+      return [
+        ...(isCodex ? [{ label: "Model", value: modelValue }] : []),
+        { label: "Approval", value: approvalValue },
+        ...routingRow,
+      ];
     }
     if (supportsCursorMode) {
       const modeValue =
@@ -2239,7 +2251,7 @@ export function NewChatLandingScreen() {
     brainHarnessLabels,
     routingOn,
     pickedModel,
-    claudeModelOptions,
+    nativeModelOptions,
     pickedEffort,
     permissionMode,
     approvalMode,
@@ -2268,7 +2280,6 @@ export function NewChatLandingScreen() {
   // The selected native harness, used to persist/seed its option knobs (mode /
   // model / effort), which are harness-specific. null for non-native agents,
   // which have no knobs to remember.
-  const selectedNativeHarness = nativeCodingAgentForAvailableAgent(selectedAgent)?.harness ?? null;
   // Seed the harness's knobs from the user's last picks when the selected
   // harness changes (including the first mount), so a returning user starts a
   // new session on the options they used last for that harness instead of the
@@ -2295,7 +2306,7 @@ export function NewChatLandingScreen() {
       // nothing stored (or a retired id) it resolves to "" — unselected, so the
       // create omits the override and Claude Code uses its own configured model.
       setPickedModel(
-        stored.model != null && claudeModelOptions.some((m) => m.id === stored.model)
+        stored.model != null && nativeModelOptions.some((m) => m.id === stored.model)
           ? stored.model
           : "",
       );
@@ -2306,13 +2317,18 @@ export function NewChatLandingScreen() {
       );
     } else if (supportsApprovalMode) {
       setApprovalMode(resolve(CODEX_NATIVE_APPROVAL_MODES, CODEX_NATIVE_DEFAULT_APPROVAL_MODE));
+      setPickedModel(
+        stored.model != null && nativeModelOptions.some((m) => m.id === stored.model)
+          ? stored.model
+          : "",
+      );
     } else if (supportsCursorMode) {
       setCursorExecMode(resolve(CURSOR_NATIVE_EXEC_MODES, CURSOR_NATIVE_DEFAULT_EXEC_MODE));
     }
     // Reseed on harness changes and when the selected host's catalog resolves;
     // capability flags are derived from the same harness and stay omitted.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedNativeHarness, claudeModelOptions]);
+  }, [selectedNativeHarness, nativeModelOptions]);
   // Native-terminal agents interpret slash commands inside their own CLI
   // (the runner injects the text verbatim), so the landing composer must
   // not intercept them — no skills menu, no slash_command routing.
@@ -2808,6 +2824,7 @@ export function NewChatLandingScreen() {
       const agentSupportsPermissionMode = nativeAgentHasCapability(agent, "permissionMode");
       const agentSupportsApprovalMode = nativeAgentHasCapability(agent, "approvalMode");
       const agentSupportsCursorMode = nativeAgentHasCapability(agent, "cursorMode");
+      const agentIsCodex = nativeCodingAgentForAvailableAgent(agent)?.harness === "codex-native";
 
       let data: { id: string };
 
@@ -2887,12 +2904,12 @@ export function NewChatLandingScreen() {
                   : agentSupportsCursorMode && cursorExecMode !== CURSOR_NATIVE_DEFAULT_EXEC_MODE
                     ? (CURSOR_NATIVE_EXEC_MODES.find((m) => m.value === cursorExecMode)?.args ?? [])
                     : undefined,
-            // Model + reasoning effort, persisted on the session row before
-            // the runner launches. Only claude-native surfaces the picker, so
-            // only its agents carry the choice; the runner reads them as
-            // `--model` / `--effort` at terminal launch. An unselected ("")
-            // knob is omitted so Claude Code keeps its own configured model.
-            model_override: agentSupportsPermissionMode && pickedModel ? pickedModel : undefined,
+            // Model + reasoning effort are persisted before the runner launches.
+            // An unselected knob is omitted so the native CLI keeps its default.
+            model_override:
+              (agentSupportsPermissionMode || agentIsCodex) && pickedModel
+                ? pickedModel
+                : undefined,
             reasoning_effort:
               agentSupportsPermissionMode && pickedEffort ? pickedEffort : undefined,
             // Smart routing toggle — server-side. The "Auto" harness always
@@ -3367,10 +3384,8 @@ export function NewChatLandingScreen() {
                     cursorExecMode={cursorExecMode}
                     bypassSandbox={bypassSandbox}
                     pickedModel={pickedModel}
-                    claudeModelOptions={claudeModelOptions}
-                    claudeModelsLoading={
-                      !sandboxSelected && selectedHostId !== null && hostClaudeModelsLoading
-                    }
+                    modelOptions={nativeModelOptions}
+                    modelsLoading={!sandboxSelected && selectedHostId !== null && hostModelsLoading}
                     pickedEffort={pickedEffort}
                     pickedHarness={pickedHarness}
                     costControlMode={costControlMode}


### PR DESCRIPTION
## Related issue

Closes #3366

## Summary

- Add a host-resolved Codex model catalog to the New Chat configuration modal, persist the choice per harness, and send it as the session's launch-time `model_override`.
- Add GPT-5.6 Luna, Terra, and Sol to Codex's static and Smart Routing catalogs.
- Move the Databricks Codex fallback from GPT-5.5 to GPT-5.6 Sol while preserving explicitly configured provider defaults.

ELI5: Codex previously learned its model choices only after a chat started. The selected host can now report those choices before launch, so users can start directly on GPT-5.6.

```text
Selected host -> pre-launch model catalog -> New Chat picker
                                              |
                                              v
                                     session model_override
                                              |
                                              v
                                          Codex launch
```

## Test Plan

- `npm test -- --run src/shell/NewChatDialog.test.tsx` — 153 passed
- `npm run type-check`
- `uv run pytest -q -p no:rerunfailures tests/host/test_connect.py tests/test_model_catalog.py tests/server/test_smart_routing.py` — 185 passed
- `uv run python -m unittest tests.inner.test_codex_executor` — 46 passed
- `uv run pytest -q tests/e2e_ui/start_session/test_start_session.py::test_start_session_select_codex_model_and_approval_mode` — 1 passed
- `.venv/bin/pre-commit run --all-files`

The regressions verify host-side Codex provider discovery, New Chat selection and submission, Smart Routing's GPT-5.6 series, the Databricks Sol fallback, and the complete Playwright picker-to-create flow.

## Demo

The Playwright E2E opens Codex configuration before launch, chooses “GPT-5.6 Sol” and “Full access,” creates the session, and verifies `model_override: databricks-gpt-5-6-sol` plus the expected launch arguments.

<img width="1280" height="720" alt="pr-3367-codex-picker" src="https://github.com/user-attachments/assets/49bded0f-0bb5-4316-9c97-1684072c9ffe" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The component test covers picker state and payload construction, the host test covers provider resolution, and Playwright verifies the production UI flow through session creation.

## Changelog

Choose a GPT-5.6 Codex model before starting a chat, with GPT-5.6 Sol as the updated Databricks fallback.
