### PR TITLE
ci+docs: harness-bench smoke + correct Layer 1 design claims

### DIFF
--- a/.github/scripts/merge-ready/required.sh
+++ b/.github/scripts/merge-ready/required.sh
@@ -26,7 +26,6 @@ REQUIRED=(
   "Pytest (stores)"
   "Pytest (misc)"
   "Pytest (databricks)"
-  "Harness bench (offline)"
   "E2E Tests (shard 0/4)"
   "E2E Tests (shard 1/4)"
   "E2E Tests (shard 2/4)"
@@ -58,7 +57,6 @@ ALLOW_SKIP=(
   "Pytest (stores)"
   "Pytest (misc)"
   "Pytest (databricks)"
-  "Harness bench (offline)"
   "E2E Tests (shard 0/4)"
   "E2E Tests (shard 1/4)"
   "E2E Tests (shard 2/4)"
@@ -82,7 +80,6 @@ workflow_for() {
   case "$1" in
     "Docker build")          echo "Docker build" ;;
     "Pytest ("*)             echo "CI" ;;
-    "Harness bench (offline)") echo "CI" ;;
     "E2E Tests (shard "*)    echo "E2E Tests" ;;
     "E2E UI Tests (shard "*) echo "E2E UI Tests" ;;
     "UI Snapshot (visual baselines)") echo "UI Snapshot" ;;

--- a/.github/scripts/merge-ready/required.sh
+++ b/.github/scripts/merge-ready/required.sh
@@ -26,6 +26,7 @@ REQUIRED=(
   "Pytest (stores)"
   "Pytest (misc)"
   "Pytest (databricks)"
+  "Harness bench (offline)"
   "E2E Tests (shard 0/4)"
   "E2E Tests (shard 1/4)"
   "E2E Tests (shard 2/4)"
@@ -57,6 +58,7 @@ ALLOW_SKIP=(
   "Pytest (stores)"
   "Pytest (misc)"
   "Pytest (databricks)"
+  "Harness bench (offline)"
   "E2E Tests (shard 0/4)"
   "E2E Tests (shard 1/4)"
   "E2E Tests (shard 2/4)"
@@ -80,6 +82,7 @@ workflow_for() {
   case "$1" in
     "Docker build")          echo "Docker build" ;;
     "Pytest ("*)             echo "CI" ;;
+    "Harness bench (offline)") echo "CI" ;;
     "E2E Tests (shard "*)    echo "E2E Tests" ;;
     "E2E UI Tests (shard "*) echo "E2E UI Tests" ;;
     "UI Snapshot (visual baselines)") echo "UI Snapshot" ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,15 +420,17 @@ jobs:
           path: artifacts/
           retention-days: 14
 
-  # Layer 1 offline harness conformance (docs/harness-bench-design.md): no
-  # network/creds. Exercises registration, capability derivation, transport
-  # resolution, and declared-matrix render for every official harness. Offline
-  # cells are SKIPPED/NOT_APPLICABLE by design, so this does NOT detect
-  # observed-vs-declared DRIFT (that is Layer 2 / --live). Pass extras through
-  # to `uv run`: a bare `uv run` re-syncs without `dev` and drops pytest, which
-  # the bench imports via tests.e2e._harness_probes.
-  harness-bench:
-    name: Harness bench (offline)
+  # Harness bench smoke (NOT a conformance / drift gate).
+  # Validates that `python -m tests.harness_bench --no-live` imports, orchestrates,
+  # and renders a non-empty declared matrix. Offline cells are SKIPPED /
+  # NOT_APPLICABLE by design (`run_harness(live=False)` → uniform SKIPPED;
+  # `reconcile` ignores non-concrete observed), so this does NOT detect
+  # observed-vs-declared DRIFT — that requires Layer 2 / --live. See
+  # docs/harness-bench-design.md. Pass extras through to `uv run`: a bare
+  # `uv run` re-syncs without `dev` and drops pytest, which the bench imports
+  # via tests.e2e._harness_probes.
+  harness-bench-smoke:
+    name: Harness bench (smoke)
     needs: gate
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
@@ -456,7 +458,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --extra all --extra dev
 
-      - name: Run offline harness conformance matrix
+      - name: Run harness bench smoke (--no-live)
         shell: bash
         run: |
           mkdir -p artifacts
@@ -466,13 +468,13 @@ jobs:
           env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u DATABRICKS_TOKEN \
             uv run --extra all --extra dev python -m tests.harness_bench \
               --no-live --no-color \
-              --report artifacts/harness-bench-offline.json
+              --report artifacts/harness-bench-smoke.json
           env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u DATABRICKS_TOKEN \
             uv run --extra all --extra dev python - <<'PY'
           import json
           from pathlib import Path
 
-          payload = json.loads(Path("artifacts/harness-bench-offline.json").read_text())
+          payload = json.loads(Path("artifacts/harness-bench-smoke.json").read_text())
           harnesses = payload["harnesses"]
           # Guard against a silently empty / truncated matrix (false confidence).
           assert len(harnesses) >= 14, f"expected >=14 harnesses, got {len(harnesses)}"
@@ -493,7 +495,7 @@ jobs:
           assert payload.get("has_drift") is False
           n_cells = sum(len(h["cells"]) for h in harnesses)
           print(
-              f"offline matrix ok: {len(harnesses)} harnesses, "
+              f"harness bench smoke ok: {len(harnesses)} harnesses, "
               f"{n_cells} cells, observed={sorted(observed)}"
           )
           PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,9 +420,13 @@ jobs:
           path: artifacts/
           retention-days: 14
 
-  # Layer 1 offline harness conformance (docs/harness-bench-design.md): declared
-  # capability matrix only — no network, no credentials, no live probes. Exits
-  # non-zero on DRIFT. Live (--live) stays nightly/on-demand, not a PR gate.
+  # Layer 1 offline harness conformance (docs/harness-bench-design.md): no
+  # network/creds. Exercises registration, capability derivation, transport
+  # resolution, and declared-matrix render for every official harness. Offline
+  # cells are SKIPPED/NOT_APPLICABLE by design, so this does NOT detect
+  # observed-vs-declared DRIFT (that is Layer 2 / --live). Pass extras through
+  # to `uv run`: a bare `uv run` re-syncs without `dev` and drops pytest, which
+  # the bench imports via tests.e2e._harness_probes.
   harness-bench:
     name: Harness bench (offline)
     needs: gate
@@ -455,8 +459,44 @@ jobs:
       - name: Run offline harness conformance matrix
         shell: bash
         run: |
+          mkdir -p artifacts
+          # --extra must match the sync step: `uv run` otherwise re-syncs the
+          # project default extras and drops pytest (dev), breaking the import
+          # chain through tests.e2e._harness_probes.
           env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u DATABRICKS_TOKEN \
-            uv run python -m tests.harness_bench --no-live --no-color
+            uv run --extra all --extra dev python -m tests.harness_bench \
+              --no-live --no-color \
+              --report artifacts/harness-bench-offline.json
+          env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u DATABRICKS_TOKEN \
+            uv run --extra all --extra dev python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("artifacts/harness-bench-offline.json").read_text())
+          harnesses = payload["harnesses"]
+          # Guard against a silently empty / truncated matrix (false confidence).
+          assert len(harnesses) >= 14, f"expected >=14 harnesses, got {len(harnesses)}"
+          observed = {
+              cell["observed"]
+              for h in harnesses
+              for cell in h["cells"]
+          }
+          # Offline layer marks every applicable cell SKIPPED; NA for inapplicable.
+          assert observed <= {"skipped", "not_applicable"}, observed
+          drifted = [
+              (h["harness"], c["dimension"])
+              for h in harnesses
+              for c in h["cells"]
+              if c.get("verdict") == "drift"
+          ]
+          assert not drifted, f"offline must not report drift: {drifted}"
+          assert payload.get("has_drift") is False
+          n_cells = sum(len(h["cells"]) for h in harnesses)
+          print(
+              f"offline matrix ok: {len(harnesses)} harnesses, "
+              f"{n_cells} cells, observed={sorted(observed)}"
+          )
+          PY
 
   coverage-report:
     name: Coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,6 +420,44 @@ jobs:
           path: artifacts/
           retention-days: 14
 
+  # Layer 1 offline harness conformance (docs/harness-bench-design.md): declared
+  # capability matrix only — no network, no credentials, no live probes. Exits
+  # non-zero on DRIFT. Live (--live) stays nightly/on-demand, not a PR gate.
+  harness-bench:
+    name: Harness bench (offline)
+    needs: gate
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v3
+        with:
+          enable-cache: true
+
+      - name: Cache virtualenv
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
+
+      - name: Install dependencies
+        run: uv sync --locked --extra all --extra dev
+
+      - name: Run offline harness conformance matrix
+        shell: bash
+        run: |
+          env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u DATABRICKS_TOKEN \
+            uv run python -m tests.harness_bench --no-live --no-color
+
   coverage-report:
     name: Coverage report
     # Combines per-shard coverage into a coverage-summary artifact. Runs in the

--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -153,15 +153,20 @@ being reimplemented under tests.
 
 - **Layer 0 — Profile / manifest.** Static facts and declared verdicts are
   derived from `harness_capabilities()` plus the existing e2e harness metadata.
-- **Layer 1 — Offline conformance.** No network or credentials. It validates
+- **Layer 1 — Offline smoke (today) / offline conformance (aspirational).**
+  `--no-live` needs no network or credentials. **Today** it only smoke-tests
   registration, profile shape, capability derivation, transport resolution,
-  rendering, and orchestration behavior in normal CI.
+  rendering, and orchestration: every applicable cell is observed as
+  `SKIPPED`, so `reconcile` can never emit `DRIFT`. It is **not** a
+  capability-conformance gate. Making Layer 1 real requires concrete offline
+  observations (see [Making Layer 1 real](#making-layer-1-real) below).
 - **Layer 2 — Live probes.** Drivers execute behavioral probes through the
   wrap boundary or the real server/runner session API. Missing credentials,
-  vendor binaries, or vendor login produce capability-neutral skips.
+  vendor binaries, or vendor login produce capability-neutral skips. This is
+  where `DRIFT` is detectable today.
 - **Report.** The CLI renders the declared matrix offline or reconciles live
   observations into terminal, Markdown, and JSON reports. `DRIFT` produces a
-  non-zero exit status.
+  non-zero exit status (live only, with the current offline path).
 
 ### Build on `HarnessProbe`, don't reinvent it
 
@@ -309,10 +314,63 @@ The bench on `main` includes:
 
 ## CI integration
 
-- **Every PR:** Layer 1 offline conformance (fast, no network, no creds).
-- **Nightly / on-demand:** Layer 2 live probes (real API cost + flake surface),
-  gated on CLI + creds, P0 blocking, P1 report-only. Follows the existing
-  nightly/flake-stress pattern rather than blocking every PR on live turns.
+- **Every PR (smoke only):** `Harness bench (smoke)` runs
+  `python -m tests.harness_bench --no-live`. It asserts the CLI imports,
+  orchestrates, and renders a non-empty declared matrix. It is **not** in
+  merge-ready `REQUIRED` and does **not** detect capability drift (see below).
+  Substantive Layer 0/1 shape checks (e.g. every P0 dimension declared) live in
+  `tests/harness_bench/` and already run under the Pytest (misc) shard.
+- **Nightly / on-demand (not yet wired as a dedicated job):** Layer 2 live
+  probes (real API cost + flake surface), gated on CLI + creds, P0 blocking,
+  P1 report-only. Follows the existing nightly/flake-stress pattern rather than
+  blocking every PR on live turns.
+
+### What `--no-live` actually does today
+
+As of the CI wiring, a full offline run covers **14 harnesses × 12 dimensions =
+168 cells**. Observed breakdown: **164 `SKIPPED`**, **4 `NOT_APPLICABLE`**,
+**0 concrete** (`SUPPORTED` / `UNSUPPORTED` / `PARTIAL`). `has_drift` is always
+false. The table glyphs you see are the *declared* values painted for display
+(`declared=True` in the renderer), not probe results.
+
+Root cause (structural, not a bug in `reconcile`):
+
+1. `run_harness(..., live=False)` short-circuits before any driver or probe
+   runs and builds a uniform report with
+   `ProbeResult.skipped("offline (declared shown)")`
+   (`tests/harness_bench/bench.py`).
+2. `reconcile(observed, declared)` only returns `DRIFT` when **both** sides are
+   concrete (`SUPPORTED` / `UNSUPPORTED` / `PARTIAL` / `NOT_APPLICABLE`).
+   `SKIPPED` and `UNKNOWN` are excluded by design
+   (`tests/harness_bench/verdict.py`: "Unknown or skipped results cannot
+   establish drift").
+3. Therefore `reconcile(SKIPPED, SUPPORTED) → SKIPPED`. Flipping a declared
+   capability (e.g. `cursor-native` `streaming=False→True`) changes the
+   rendered glyph and still exits 0.
+
+Do not treat a green `--no-live` run as evidence that declarations match
+reality. That signal only exists under `--live` (Layer 2) today.
+
+### Making Layer 1 real
+
+To make offline mode a true every-PR conformance gate, offline runs must
+produce **concrete** observed verdicts without credentials or vendor CLIs.
+What would need to change (record only — not designed here):
+
+- **Seam that yields SKIPPED today:** `run_harness` when `live=False` never
+  enters a driver; it returns `_uniform_report(..., ProbeResult.skipped(...))`.
+  That short-circuit is the origin of every offline `SKIPPED` cell.
+- **What has to replace it:** offline (or fake) drivers / probe doubles that
+  return concrete `SUPPORTED` / `UNSUPPORTED` / `PARTIAL` for each P0
+  dimension without spawning a gateway turn — e.g. replaying recorded event
+  streams, or a deterministic in-process fake that exercises the same probe
+  assertions the live drivers do.
+- **What can stay:** `reconcile` itself is already correct for gating once
+  observations are concrete; the CLI exit-on-`has_drift` path is already wired.
+  The gap is upstream of reconcile, in the offline orchestration/driver layer.
+- **Until that exists:** keep `--no-live` as a smoke, keep shape/invariant
+  coverage in pytest, and treat Layer 2 live (or a future offline-concrete
+  path) as the only drift detector.
 
 ## Running the bench and reading the result
 
@@ -335,10 +393,12 @@ missing credentials select the offline declared matrix. Native harnesses also
 need their vendor CLI installed and logged in; the bench cannot provision those
 accounts, so unavailable harnesses skip without aborting the run.
 
-Offline conformance covers every registered harness in CI. Live runs are
-spot-checks of observed behavior and can vary with model behavior and timing;
-re-run an isolated timeout or skip before treating it as a regression. The
-signals that matter most are `DRIFT` and repeatable unexpected
+`--no-live` renders the declared matrix for every registered harness (CI smoke).
+It does **not** reconcile observations against declarations — offline cells are
+`SKIPPED`, so `DRIFT` cannot fire (see [CI integration](#ci-integration)). Live
+runs are the spot-checks of observed behavior and can vary with model behavior
+and timing; re-run an isolated timeout or skip before treating it as a
+regression. The signals that matter most are `DRIFT` and repeatable unexpected
 `UNSUPPORTED`/`PARTIAL` verdicts on a runnable harness.
 
 ## Streaming is a binary declared capability


### PR DESCRIPTION
## Related issue

N/A

## Summary

Corrects a false design claim and wires an honestly named CI smoke — without creating a false-confidence merge gate.

- **Doc (durable):** `docs/harness-bench-design.md` no longer presents `--no-live` as an every-PR Layer 1 *conformance* gate. It records what offline mode actually does today, why drift is structurally undetectable, and what would be required to make Layer 1 real (concrete offline observations upstream of `reconcile`).
- **CI smoke:** Job renamed to **`Harness bench (smoke)`**. Comment states plainly: validates import / orchestrate / render of a non-empty matrix; does **not** detect capability drift. Not in merge-ready `REQUIRED`.
- **uv extras fix:** `uv run --extra all --extra dev` so the run env keeps pytest (imported via `tests.e2e._harness_probes`). Bare `uv run` re-syncs without `dev` and fails.

### Evidence (most useful artifact)

Full offline run: **14 harnesses × 12 dimensions = 168 cells**.
Observed: **164 `SKIPPED`**, **4 `NOT_APPLICABLE`**, **0 concrete**. `has_drift=false`.

Capability-flip experiment: changed `cursor-native` `streaming=False→True` in `harness_plugins.py`.
- Offline exit **0**; rendered glyph `✗→✓`; still no drift.
- `reconcile(UNSUPPORTED, SUPPORTED) → DRIFT` (live path).
- `reconcile(SKIPPED, SUPPORTED) → SKIPPED` (offline path — structural).
- Reverted.

Root seam: `run_harness(live=False)` short-circuits to uniform `ProbeResult.skipped(...)` before any driver/probe; `reconcile` correctly ignores non-concrete observed. Gap is the offline driver layer, not `reconcile`.

### ALLOW_SKIP note (for whoever revisits)

If this check were ever added to `REQUIRED`, it would also need `ALLOW_SKIP` + `workflow_for → CI`: the CI *workflow* has `paths-ignore` even though the job does not, so a path-ignored PR would otherwise fail merge-ready on a missing check. `workflow_for` is what prevents “missing while CI in flight” from silently passing. Moot while it stays non-required.

### Merge recommendation

**Merge this PR as-is (doc + smoke job).**

The doc correction is mandatory — it is what caused the mistaken “wire as conformance gate” plan. The smoke job is worth keeping: ~0.5s of matrix work after deps, runs in parallel with other CI jobs, and exercises the exact `uv run --extra … python -m tests.harness_bench` path humans and CI share (the path that broke without extras). Named `Harness bench (smoke)`, it should not be misread as conformance.

I would **not** reduce to doc-only: the marginal runner cost is small in a fan-out CI matrix, and an honestly named canary for the CLI entrypoint is useful. I would **not** add it to merge-ready `REQUIRED` until Layer 1 can produce concrete observations (or until live Layer 2 is a dedicated gate).

## Test Plan

- [x] Reproduced bare `uv run` → `ModuleNotFoundError: pytest`; fixed with `--extra all --extra dev`.
- [x] Clean-env matrix ~0.43–0.51s; JSON assert ≥14 harnesses / only skipped|NA.
- [x] 14×12=168 / 164 skipped / 4 NA; capability-flip exits 0; reconcile proof above.
- [x] Job name is `Harness bench (smoke)`; design doc Layer 1 / CI sections updated.
- [x] YAML parses; `uv.lock` not modified; pre-commit on touched files passed.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual: footgun repro, clean-env timings, full-matrix cell counts, capability-flip + reconcile proof. Pytest meta-tests under `tests/harness_bench/` (already in Pytest misc) remain the shape/invariant coverage; this PR does not claim drift detection offline.