### PR TITLE
fix(native): escalate forwarder/pane death to durable failed status

### DIFF
--- a/omnigent/_native_forwarder_liveness.py
+++ b/omnigent/_native_forwarder_liveness.py
@@ -1,0 +1,260 @@
+"""Escalate native-forwarder poll / supervisor failures to durable session status.
+
+Native forwarders historically caught poll-loop exceptions, logged them, slept,
+and continued. The UI only reacts to durable ``session.status`` writes, so a
+hung TUI or repeatedly-crashing forwarder left the chat frozen with no failed
+card. This module is the single escalation path every forwarder must use.
+
+Policy:
+- After ``POLL_FAILURE_THRESHOLD`` consecutive poll failures, POST
+  ``external_session_status: failed``.
+- Permanent error classes escalate on the first failure.
+- After ``RESTART_FAILURE_THRESHOLD`` supervisor restarts within
+  ``RESTART_FAILURE_WINDOW_S``, POST the same durable failure.
+- A successful poll / healthy supervisor uptime resets the counters so
+  transient blips do not accumulate into a false failure card.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+
+import httpx
+
+from omnigent._native_post_delivery import post_external_session_status
+
+_logger = logging.getLogger(__name__)
+
+# Consecutive poll-loop exceptions before a durable failed status.
+POLL_FAILURE_THRESHOLD = 5
+# Supervisor crashes within the window before escalating.
+RESTART_FAILURE_THRESHOLD = 3
+RESTART_FAILURE_WINDOW_S = 300.0
+
+# Errors that will not recover by sleeping and retrying the same poll.
+PERMANENT_POLL_ERROR_TYPES: tuple[type[BaseException], ...] = (
+    PermissionError,
+    NotADirectoryError,
+)
+
+
+PostStatusFn = Callable[..., Awaitable[None]]
+
+
+@dataclass
+class PollFailureTracker:
+    """Consecutive poll-failure counter for one forwarder run.
+
+    :param consecutive_failures: Failures since the last successful poll.
+    :param failed_status_emitted: Whether a durable ``failed`` was already
+        posted for this streak (avoids spamming the server every poll).
+    """
+
+    consecutive_failures: int = 0
+    failed_status_emitted: bool = False
+
+
+@dataclass
+class RestartFailureTracker:
+    """Sliding-window supervisor-restart tracker for one session.
+
+    :param restart_at: Monotonic timestamps of recent crashes / unexpected
+        returns, oldest first.
+    :param failed_status_emitted: Whether a durable ``failed`` was already
+        posted for the current outage window.
+    """
+
+    restart_at: list[float] = field(default_factory=list)
+    failed_status_emitted: bool = False
+
+
+def is_permanent_poll_error(
+    error: BaseException,
+    *,
+    permanent_types: Sequence[type[BaseException]] = PERMANENT_POLL_ERROR_TYPES,
+) -> bool:
+    """
+    Return whether ``error`` should fail the session on the first poll miss.
+
+    :param error: Exception raised by a forwarder poll iteration.
+    :param permanent_types: Exception types treated as non-recoverable.
+    :returns: ``True`` when the error should escalate immediately.
+    """
+    return isinstance(error, tuple(permanent_types))
+
+
+def note_poll_success(tracker: PollFailureTracker) -> None:
+    """
+    Clear the poll-failure streak after a successful iteration.
+
+    :param tracker: Per-forwarder poll failure tracker.
+    :returns: None.
+    """
+    tracker.consecutive_failures = 0
+    tracker.failed_status_emitted = False
+
+
+def note_supervisor_healthy(tracker: RestartFailureTracker) -> None:
+    """
+    Clear restart escalation after a healthy forwarder uptime window.
+
+    :param tracker: Per-session supervisor restart tracker.
+    :returns: None.
+    """
+    tracker.restart_at.clear()
+    tracker.failed_status_emitted = False
+
+
+async def handle_poll_failure(
+    *,
+    client: httpx.AsyncClient,
+    session_id: str,
+    tracker: PollFailureTracker,
+    error: BaseException,
+    harness: str,
+    threshold: int = POLL_FAILURE_THRESHOLD,
+    permanent_types: Sequence[type[BaseException]] = PERMANENT_POLL_ERROR_TYPES,
+    post_status: PostStatusFn | None = None,
+    logger: logging.Logger | None = None,
+) -> bool:
+    """
+    Record a poll-loop exception and POST ``failed`` when the policy trips.
+
+    :param client: Omnigent HTTP client used for the status POST.
+    :param session_id: Omnigent session/conversation id.
+    :param tracker: Per-forwarder poll failure tracker.
+    :param error: Exception raised by the poll iteration.
+    :param harness: Short harness label for the failure message, e.g.
+        ``"claude-native"``.
+    :param threshold: Consecutive failures required for a transient error.
+    :param permanent_types: Exception types that escalate immediately.
+    :param post_status: Optional override for :func:`post_external_session_status`
+        (tests inject a recorder).
+    :param logger: Optional logger; defaults to this module's logger.
+    :returns: ``True`` when a durable ``failed`` status was posted this call.
+    """
+    log = logger or _logger
+    tracker.consecutive_failures += 1
+    permanent = is_permanent_poll_error(error, permanent_types=permanent_types)
+    should_fail = permanent or tracker.consecutive_failures >= threshold
+    if not should_fail or tracker.failed_status_emitted:
+        return False
+
+    reason = (
+        f"{harness} forwarder permanent poll failure: {error!r}"
+        if permanent
+        else (
+            f"{harness} forwarder failed {tracker.consecutive_failures} "
+            f"consecutive polls: {error!r}"
+        )
+    )
+    posted = await _post_failed_status(
+        client=client,
+        session_id=session_id,
+        reason=reason,
+        post_status=post_status,
+        logger=log,
+    )
+    if posted:
+        tracker.failed_status_emitted = True
+    return posted
+
+
+async def handle_supervisor_restart(
+    *,
+    client: httpx.AsyncClient | None,
+    session_id: str,
+    tracker: RestartFailureTracker,
+    error: BaseException | None,
+    harness: str,
+    threshold: int = RESTART_FAILURE_THRESHOLD,
+    window_s: float = RESTART_FAILURE_WINDOW_S,
+    now: float | None = None,
+    post_status: PostStatusFn | None = None,
+    logger: logging.Logger | None = None,
+) -> bool:
+    """
+    Record a supervisor restart and POST ``failed`` when the window trips.
+
+    :param client: Omnigent HTTP client, or ``None`` when the crash happened
+        before a client existed (escalation is skipped until a client is
+        available; the restart is still counted).
+    :param session_id: Omnigent session/conversation id.
+    :param tracker: Per-session supervisor restart tracker.
+    :param error: Crash exception, or ``None`` for an unexpected normal return.
+    :param harness: Short harness label for the failure message.
+    :param threshold: Restarts within ``window_s`` that trigger escalation.
+    :param window_s: Sliding window length in seconds.
+    :param now: Optional monotonic timestamp (tests inject a clock).
+    :param post_status: Optional override for the status POST.
+    :param logger: Optional logger; defaults to this module's logger.
+    :returns: ``True`` when a durable ``failed`` status was posted this call.
+    """
+    log = logger or _logger
+    stamp = time.monotonic() if now is None else now
+    tracker.restart_at.append(stamp)
+    cutoff = stamp - window_s
+    tracker.restart_at = [t for t in tracker.restart_at if t >= cutoff]
+    if len(tracker.restart_at) < threshold or tracker.failed_status_emitted:
+        return False
+    if client is None:
+        log.warning(
+            "%s forwarder supervisor exceeded restart budget but has no HTTP "
+            "client to publish failed status; session=%s restarts=%d",
+            harness,
+            session_id,
+            len(tracker.restart_at),
+        )
+        return False
+
+    detail = f"{error!r}" if error is not None else "unexpected return"
+    reason = (
+        f"{harness} forwarder restarted {len(tracker.restart_at)} times within "
+        f"{window_s:.0f}s: {detail}"
+    )
+    posted = await _post_failed_status(
+        client=client,
+        session_id=session_id,
+        reason=reason,
+        post_status=post_status,
+        logger=log,
+    )
+    if posted:
+        tracker.failed_status_emitted = True
+    return posted
+
+
+async def _post_failed_status(
+    *,
+    client: httpx.AsyncClient,
+    session_id: str,
+    reason: str,
+    post_status: PostStatusFn | None,
+    logger: logging.Logger,
+) -> bool:
+    """
+    Best-effort POST of ``external_session_status: failed``.
+
+    :returns: ``True`` when the POST succeeded.
+    """
+    poster = post_status or post_external_session_status
+    try:
+        await poster(
+            client,
+            session_id=session_id,
+            status="failed",
+            output=reason,
+        )
+    except Exception as exc:  # noqa: BLE001 — status POST must not kill the loop
+        logger.warning(
+            "Failed to publish forwarder failure status; session=%s reason=%s error=%r",
+            session_id,
+            reason,
+            exc,
+            exc_info=True,
+        )
+        return False
+    return True

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -16,6 +16,14 @@ from pathlib import Path
 
 import httpx
 
+from omnigent._native_forwarder_liveness import (
+    PollFailureTracker,
+    RestartFailureTracker,
+    handle_poll_failure,
+    handle_supervisor_restart,
+    note_poll_success,
+    note_supervisor_healthy,
+)
 from omnigent._native_post_delivery import (
     append_dead_letter,
     post_external_session_status,
@@ -794,6 +802,7 @@ async def forward_claude_transcript_to_session(
     task_statuses: dict[str, str] = {}
     task_order: list[str] = []
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
+    poll_failures = PollFailureTracker()
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
@@ -994,9 +1003,10 @@ async def forward_claude_transcript_to_session(
                             bridge_dir=bridge_dir,
                             dedupe=dedupe,
                         )
+                    note_poll_success(poll_failures)
             except asyncio.CancelledError:
                 raise
-            except TimeoutError:
+            except TimeoutError as exc:
                 # The deadline cancelled a stalled await mid-iteration; the
                 # traceback names it. Cursor state advances only after
                 # successful posts, so resuming retries the interrupted step.
@@ -1009,11 +1019,27 @@ async def forward_claude_transcript_to_session(
                     bridge_dir,
                     exc_info=True,
                 )
-            except Exception:
+                await handle_poll_failure(
+                    client=client,
+                    session_id=session_id,
+                    tracker=poll_failures,
+                    error=exc,
+                    harness="claude-native",
+                    logger=_logger,
+                )
+            except Exception as exc:
                 _logger.exception(
                     "Claude transcript forwarder loop failed; session=%s bridge_dir=%s",
                     session_id,
                     bridge_dir,
+                )
+                await handle_poll_failure(
+                    client=client,
+                    session_id=session_id,
+                    tracker=poll_failures,
+                    error=exc,
+                    harness="claude-native",
+                    logger=_logger,
                 )
             await asyncio.sleep(poll_interval_s)
 
@@ -1975,6 +2001,7 @@ async def supervise_forwarder(
     :returns: Never normally returns; cancel the task to stop it.
     """
     backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+    restart_failures = RestartFailureTracker()
     while True:
         run_started_at = _supervisor_monotonic()
         crash_exc: Exception | None = None
@@ -2007,6 +2034,7 @@ async def supervise_forwarder(
         run_duration_s = _supervisor_monotonic() - run_started_at
         if run_duration_s >= _SUPERVISOR_HEALTHY_UPTIME_S:
             backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+            note_supervisor_healthy(restart_failures)
         if crash_exc is not None:
             # Log AFTER the healthy-uptime reset so the reported delay
             # matches the sleep that actually follows.
@@ -2017,6 +2045,18 @@ async def supervise_forwarder(
                 session_id,
                 bridge_dir,
                 exc_info=crash_exc,
+            )
+        timeout = httpx.Timeout(_POST_TIMEOUT_S)
+        async with httpx.AsyncClient(
+            base_url=base_url, headers=headers, auth=auth, timeout=timeout
+        ) as client:
+            await handle_supervisor_restart(
+                client=client,
+                session_id=session_id,
+                tracker=restart_failures,
+                error=crash_exc,
+                harness="claude-native",
+                logger=_logger,
             )
         await _supervisor_sleep(backoff_s)
         backoff_s = min(backoff_s * 2.0, _SUPERVISOR_MAX_BACKOFF_S)

--- a/omnigent/goose_native_forwarder.py
+++ b/omnigent/goose_native_forwarder.py
@@ -48,6 +48,14 @@ from pathlib import Path
 
 import httpx
 
+from omnigent._native_forwarder_liveness import (
+    PollFailureTracker,
+    RestartFailureTracker,
+    handle_poll_failure,
+    handle_supervisor_restart,
+    note_poll_success,
+    note_supervisor_healthy,
+)
 from omnigent._native_post_delivery import post_external_session_status
 from omnigent.inner.native_attachments import ATTACHMENT_MARKER_STRIP_PATTERN
 
@@ -647,6 +655,7 @@ async def forward_goose_store_to_session(
     # store before mirroring anything new. Retried in-band (not via the
     # supervisor) if the replay's idle post hits a transient server error.
     needs_replay = goose_session_id is not None and last_id > 0
+    poll_failures = PollFailureTracker()
 
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
@@ -749,13 +758,22 @@ async def forward_goose_store_to_session(
                         # Keep response_id: a late resume rejoins the same turn.
                         state.live = False
 
+                note_poll_success(poll_failures)
             except asyncio.CancelledError:
                 raise
-            except Exception:
+            except Exception as exc:
                 _logger.exception(
                     "goose forwarder poll failed; session=%s goose_session=%s",
                     session_id,
                     goose_session_id,
+                )
+                await handle_poll_failure(
+                    client=client,
+                    session_id=session_id,
+                    tracker=poll_failures,
+                    error=exc,
+                    harness="goose-native",
+                    logger=_logger,
                 )
             await asyncio.sleep(poll_interval_s)
 
@@ -792,6 +810,7 @@ async def supervise_goose_forwarder(
     :returns: Never normally returns; cancel the task to stop it.
     """
     backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+    restart_failures = RestartFailureTracker()
     while True:
         run_started_at = _supervisor_monotonic()
         crash_exc: Exception | None = None
@@ -818,6 +837,7 @@ async def supervise_goose_forwarder(
             crash_exc = exc
         if _supervisor_monotonic() - run_started_at >= _SUPERVISOR_HEALTHY_UPTIME_S:
             backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+            note_supervisor_healthy(restart_failures)
         if crash_exc is not None:
             _logger.error(
                 "goose forwarder crashed; restarting in %.1fs; session=%s bridge_dir=%s",
@@ -825,6 +845,18 @@ async def supervise_goose_forwarder(
                 session_id,
                 bridge_dir,
                 exc_info=crash_exc,
+            )
+        timeout = httpx.Timeout(_POST_TIMEOUT_S)
+        async with httpx.AsyncClient(
+            base_url=base_url, headers=headers, auth=auth, timeout=timeout
+        ) as client:
+            await handle_supervisor_restart(
+                client=client,
+                session_id=session_id,
+                tracker=restart_failures,
+                error=crash_exc,
+                harness="goose-native",
+                logger=_logger,
             )
         await _supervisor_sleep(backoff_s)
         backoff_s = min(backoff_s * 2.0, _SUPERVISOR_MAX_BACKOFF_S)

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -69,6 +69,14 @@ from pathlib import Path
 import httpx
 
 from omnigent import hermes_native_status
+from omnigent._native_forwarder_liveness import (
+    PollFailureTracker,
+    RestartFailureTracker,
+    handle_poll_failure,
+    handle_supervisor_restart,
+    note_poll_success,
+    note_supervisor_healthy,
+)
 from omnigent.inner.native_attachments import ATTACHMENT_MARKER_STRIP_PATTERN
 
 _logger = logging.getLogger(__name__)
@@ -1120,6 +1128,7 @@ async def forward_hermes_store_to_session(
     # Omnigent server so we do it at most once per forwarder lifetime.
     _external_id_synced = False
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
+    poll_failures = PollFailureTracker()
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
@@ -1441,13 +1450,22 @@ async def forward_hermes_store_to_session(
                                 bridge_dir,
                                 completed_turns,
                             )
+                note_poll_success(poll_failures)
             except asyncio.CancelledError:
                 raise
-            except Exception:
+            except Exception as exc:
                 _logger.exception(
                     "hermes forwarder poll failed; session=%s hermes_session=%s",
                     session_id,
                     hermes_session_id,
+                )
+                await handle_poll_failure(
+                    client=client,
+                    session_id=session_id,
+                    tracker=poll_failures,
+                    error=exc,
+                    harness="hermes-native",
+                    logger=_logger,
                 )
             await asyncio.sleep(poll_interval_s)
 
@@ -1485,6 +1503,7 @@ async def supervise_hermes_forwarder(
     :returns: Never normally returns; cancel the task to stop it.
     """
     backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+    restart_failures = RestartFailureTracker()
     while True:
         run_started_at = _supervisor_monotonic()
         crash_exc: Exception | None = None
@@ -1512,6 +1531,7 @@ async def supervise_hermes_forwarder(
             crash_exc = exc
         if _supervisor_monotonic() - run_started_at >= _SUPERVISOR_HEALTHY_UPTIME_S:
             backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+            note_supervisor_healthy(restart_failures)
         if crash_exc is not None:
             _logger.error(
                 "hermes forwarder crashed; restarting in %.1fs; session=%s bridge_dir=%s",
@@ -1519,6 +1539,18 @@ async def supervise_hermes_forwarder(
                 session_id,
                 bridge_dir,
                 exc_info=crash_exc,
+            )
+        timeout = httpx.Timeout(_POST_TIMEOUT_S)
+        async with httpx.AsyncClient(
+            base_url=base_url, headers=headers, auth=auth, timeout=timeout
+        ) as client:
+            await handle_supervisor_restart(
+                client=client,
+                session_id=session_id,
+                tracker=restart_failures,
+                error=crash_exc,
+                harness="hermes-native",
+                logger=_logger,
             )
         await _supervisor_sleep(backoff_s)
         backoff_s = min(backoff_s * 2.0, _SUPERVISOR_MAX_BACKOFF_S)

--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -57,6 +57,14 @@ from pathlib import Path
 
 import httpx
 
+from omnigent._native_forwarder_liveness import (
+    PollFailureTracker,
+    RestartFailureTracker,
+    handle_poll_failure,
+    handle_supervisor_restart,
+    note_poll_success,
+    note_supervisor_healthy,
+)
 from omnigent.inner.native_attachments import ATTACHMENT_MARKER_STRIP_PATTERN
 from omnigent.qwen_native_bridge import events_file_path
 
@@ -318,6 +326,7 @@ async def forward_qwen_events_to_session(
     offset = persisted.offset
     seen = _new_seen(persisted.seen_uuids)
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
+    poll_failures = PollFailureTracker()
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
@@ -335,13 +344,22 @@ async def forward_qwen_events_to_session(
                         bridge_dir,
                         _ForwardState(offset=offset, seen_uuids=list(seen)),
                     )
+                note_poll_success(poll_failures)
             except asyncio.CancelledError:
                 raise
-            except Exception:
+            except Exception as exc:
                 _logger.exception(
                     "qwen forwarder poll failed; session=%s bridge_dir=%s",
                     session_id,
                     bridge_dir,
+                )
+                await handle_poll_failure(
+                    client=client,
+                    session_id=session_id,
+                    tracker=poll_failures,
+                    error=exc,
+                    harness="qwen-native",
+                    logger=_logger,
                 )
             await asyncio.sleep(poll_interval_s)
 
@@ -377,6 +395,7 @@ async def supervise_qwen_forwarder(
     :returns: Never normally returns; cancel the task to stop it.
     """
     backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+    restart_failures = RestartFailureTracker()
     while True:
         run_started_at = _supervisor_monotonic()
         crash_exc: Exception | None = None
@@ -402,6 +421,7 @@ async def supervise_qwen_forwarder(
             crash_exc = exc
         if _supervisor_monotonic() - run_started_at >= _SUPERVISOR_HEALTHY_UPTIME_S:
             backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+            note_supervisor_healthy(restart_failures)
         if crash_exc is not None:
             _logger.error(
                 "qwen forwarder crashed; restarting in %.1fs; session=%s bridge_dir=%s",
@@ -409,6 +429,18 @@ async def supervise_qwen_forwarder(
                 session_id,
                 bridge_dir,
                 exc_info=crash_exc,
+            )
+        timeout = httpx.Timeout(_POST_TIMEOUT_S)
+        async with httpx.AsyncClient(
+            base_url=base_url, headers=headers, auth=auth, timeout=timeout
+        ) as client:
+            await handle_supervisor_restart(
+                client=client,
+                session_id=session_id,
+                tracker=restart_failures,
+                error=crash_exc,
+                harness="qwen-native",
+                logger=_logger,
             )
         await _supervisor_sleep(backoff_s)
         backoff_s = min(backoff_s * 2.0, _SUPERVISOR_MAX_BACKOFF_S)

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1461,12 +1461,15 @@ async def _run_tunnel_from_env() -> None:
         """Record real runner work for the inactivity watchdog.
 
         Called by the WebSocket tunnel frame dispatcher for non-keepalive
-        request frames.
+        request frames, and by native session-status edges so a long PTY
+        turn refreshes the idle timer.
 
         :returns: None.
         """
         nonlocal last_activity_at
         last_activity_at = loop.time()
+
+    app.state.mark_activity = _mark_activity
 
     def _last_activity() -> float:
         """Return the last real runner activity time.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -242,6 +242,13 @@ for _builder_name in (
 # Servers before 0.3.0 cannot serialize the runner's "waiting" status.
 # Unknown versions also downgrade to "running" so old servers never return 500.
 _WAITING_STATUS_MIN_SERVER_VERSION = "0.3.0"
+# A native pane ``running`` entry only pins the idle watchdog while fresh.
+# Status edges are edge-triggered (idle→running once); continuous work instead
+# refreshes the stamp via ``session.terminal.activity`` (~1s). Without a bound,
+# a SIGKILLed forwarder / frozen pane leaves ``running`` forever and the runner
+# never shuts down. 120s is well above the activity cadence and the 1s PTY idle
+# threshold, but short enough that a dead pin cannot hold billable compute open.
+_NATIVE_PANE_RUNNING_STALE_S = 120.0
 # Cached server version from the /api/version probe; ``None`` until a probe
 # succeeds. A failed probe stays ``None`` and is retried on the next
 # session-create — the GET is cheap and self-heals a transient failure.
@@ -1978,7 +1985,10 @@ def create_runner_app(
     app.state.antigravity_terminal_ensure_locks = _antigravity_terminal_ensure_locks
     _repl_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     _active_turns: dict[str, asyncio.Task[None] | None] = {}
-    _native_pane_status: dict[str, str] = {}
+    # session_id → (status, monotonic timestamp of last liveness refresh).
+    # ``running`` only pins the idle watchdog while the stamp is fresh; see
+    # :data:`_NATIVE_PANE_RUNNING_STALE_S`.
+    _native_pane_status: dict[str, tuple[str, float]] = {}
     _session_message_buffers: dict[str, list[_JsonObject]] = {}
     _ingest_next_seq: dict[str, int] = {}
     _ingest_now_serving: dict[str, int] = {}
@@ -1993,6 +2003,47 @@ def create_runner_app(
     _session_event_queues = _session_event_queues_ref
     _session_inboxes = _session_inboxes_ref
     _session_async_tasks: dict[str, dict[str, tuple[asyncio.Task[str], asyncio.Event]]] = {}
+
+    def _set_native_pane_status(session_id: str, status: str, *, now: float | None = None) -> None:
+        """Record a native pane status edge and refresh its liveness stamp.
+
+        :param session_id: Omnigent session/conversation id.
+        :param status: Status value, e.g. ``"running"`` or ``"idle"``.
+        :param now: Optional monotonic timestamp (tests inject a clock).
+        :returns: None.
+        """
+        _native_pane_status[session_id] = (
+            status,
+            time.monotonic() if now is None else now,
+        )
+
+    def _touch_native_pane_running(session_id: str, *, now: float | None = None) -> None:
+        """Refresh the liveness stamp when a running pane still has activity.
+
+        :param session_id: Omnigent session/conversation id.
+        :param now: Optional monotonic timestamp (tests inject a clock).
+        :returns: None.
+        """
+        entry = _native_pane_status.get(session_id)
+        if entry is None or entry[0] != "running":
+            return
+        _native_pane_status[session_id] = (
+            "running",
+            time.monotonic() if now is None else now,
+        )
+
+    def _has_fresh_native_pane_running(*, now: float | None = None) -> bool:
+        """Return whether any native pane is freshly ``running``.
+
+        :param now: Optional monotonic timestamp (tests inject a clock).
+        :returns: ``True`` when at least one session is ``running`` and its
+            liveness stamp is within :data:`_NATIVE_PANE_RUNNING_STALE_S`.
+        """
+        stamp = time.monotonic() if now is None else now
+        for status, seen_at in _native_pane_status.values():
+            if status == "running" and stamp - seen_at <= _NATIVE_PANE_RUNNING_STALE_S:
+                return True
+        return False
 
     def _has_active_work() -> bool:
         if _active_turns:
@@ -2011,11 +2062,17 @@ def create_runner_app(
                 return True
         # Native PTY turns clear `_active_turns` at proxy-stream end while the
         # pane is still working; the pane reaper already treats this as busy.
-        if any(status == "running" for status in _native_pane_status.values()):
+        # Bound by freshness so a stuck ``running`` entry cannot pin the
+        # runner awake forever after a silent forwarder/pane death.
+        if _has_fresh_native_pane_running():
             return True
         return False
 
     app.state.has_active_work = _has_active_work
+    # Test seams for the freshness bound.
+    app.state._set_native_pane_status = _set_native_pane_status
+    app.state._has_fresh_native_pane_running = _has_fresh_native_pane_running
+    app.state._native_pane_running_stale_s = _NATIVE_PANE_RUNNING_STALE_S
 
     def _drain_session_streams() -> None:
         for queue in list(_session_event_queues.values()):
@@ -2030,16 +2087,24 @@ def create_runner_app(
             queue = asyncio.Queue()
             _session_event_queues[session_id] = queue
         queue.put_nowait(event_body)
-        if event_body.get("type") == "session.status":
+        event_type = event_body.get("type")
+        if event_type == "session.status":
             _status_value = event_body.get("status")
             if isinstance(_status_value, str):
-                _native_pane_status[session_id] = _status_value
+                _set_native_pane_status(session_id, _status_value)
                 # Reset the runner idle timer on native status edges so a long
                 # PTY turn does not look "already timed out" the moment it
                 # settles to idle.
                 mark_activity = getattr(app.state, "mark_activity", None)
                 if callable(mark_activity):
                     mark_activity()
+        elif event_type == "session.terminal.activity":
+            # Continuous pane work does not re-emit ``running`` (edge-only);
+            # activity pulses keep the freshness stamp alive instead.
+            _touch_native_pane_running(session_id)
+            mark_activity = getattr(app.state, "mark_activity", None)
+            if callable(mark_activity):
+                mark_activity()
         _fan_out_child_delta_to_parent(session_id, event_body)
 
     def _child_preview_from_status(
@@ -6364,6 +6429,11 @@ def create_runner_app(
             delivery_ack: _SubagentDeliveryAck | None = None
             recovered_entry: _SubagentWorkEntry | None = None
             if status in ("running", "waiting", "idle", "failed"):
+                # Keep the idle-watchdog pin aligned with forwarder-observed
+                # edges without re-publishing ``session.status`` (the server
+                # already did). Terminal ``idle``/``failed`` clear a stuck
+                # ``running`` pin even when the PTY watcher never fires again.
+                _set_native_pane_status(conversation_id, status)
                 resource_registry.note_external_session_status(conversation_id, status)
                 _fan_out_child_delta_to_parent(
                     conversation_id,
@@ -8948,7 +9018,12 @@ def create_runner_app(
                 process_manager is not None and process_manager.has_active_turn(conv_id)
             ):
                 return True
-            if _native_pane_status.get(conv_id) == "running":
+            entry = _native_pane_status.get(conv_id)
+            if (
+                entry is not None
+                and entry[0] == "running"
+                and time.monotonic() - entry[1] <= _NATIVE_PANE_RUNNING_STALE_S
+            ):
                 return True
             clients = await asyncio.to_thread(_list_tmux_clients, str(pane.socket_path), "main")
             if clients:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2009,6 +2009,10 @@ def create_runner_app(
             session_ids = set(_session_start_cache) | set(_session_agent_ids)
             if any(process_manager.has_active_turn(session_id) for session_id in session_ids):
                 return True
+        # Native PTY turns clear `_active_turns` at proxy-stream end while the
+        # pane is still working; the pane reaper already treats this as busy.
+        if any(status == "running" for status in _native_pane_status.values()):
+            return True
         return False
 
     app.state.has_active_work = _has_active_work
@@ -2030,6 +2034,12 @@ def create_runner_app(
             _status_value = event_body.get("status")
             if isinstance(_status_value, str):
                 _native_pane_status[session_id] = _status_value
+                # Reset the runner idle timer on native status edges so a long
+                # PTY turn does not look "already timed out" the moment it
+                # settles to idle.
+                mark_activity = getattr(app.state, "mark_activity", None)
+                if callable(mark_activity):
+                    mark_activity()
         _fan_out_child_delta_to_parent(session_id, event_body)
 
     def _child_preview_from_status(
@@ -7357,6 +7367,11 @@ def create_runner_app(
             tmux_target=entry.instance.tmux_target,
             read_only=read_only,
             on_client_interaction=entry.instance.note_client_interaction,
+            on_pane_dead=(
+                (lambda: resource_registry.notify_pane_dead(session_id, terminal_id))
+                if resource_registry is not None
+                else None
+            ),
         )
 
     async def _require_os_env(session_id: str) -> AgentSpec | None:

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -1395,6 +1395,57 @@ class SessionResourceRegistry:
             session_id_getter=_session_id_getter,
         )
 
+    def notify_pane_dead(self, session_id: str, terminal_id: str) -> None:
+        """
+        Schedule exit handling when an attach bridge sees a definitive dead pane.
+
+        Idempotent with the idle watcher's ``on_exit`` path: the first caller to
+        claim the terminal lifecycle wins, so a clean ``/quit`` (idle memo) still
+        does not publish ``failed``, and a mid-turn crash still does.
+
+        :param session_id: Omnigent session/conversation id.
+        :param terminal_id: Opaque terminal resource id, e.g. ``"terminal_claude_main"``.
+        :returns: None.
+        """
+        if self._terminal_registry is None:
+            return
+        entry = None
+        for candidate in self._terminal_registry.list_for_conversation(session_id):
+            if terminal_resource_id(candidate.terminal_name, candidate.session_key) == terminal_id:
+                entry = candidate
+                break
+        if entry is None:
+            return
+        with self._lock:
+            lifecycle = self._terminal_lifecycles.get((session_id, terminal_id))
+        if lifecycle is None:
+            return
+
+        loop = asyncio.get_running_loop()
+
+        def _schedule() -> None:
+            task = asyncio.create_task(
+                self._handle_terminal_exit(
+                    session_id=session_id,
+                    terminal_name=entry.terminal_name,
+                    session_key=entry.session_key,
+                    lifecycle=lifecycle,
+                    instance=entry.instance,
+                )
+            )
+            self._terminal_exit_tasks.add(task)
+            self._terminal_exit_scheduled.set()
+            task.add_done_callback(self._terminal_exit_tasks.discard)
+
+        try:
+            loop.call_soon_threadsafe(_schedule)
+        except RuntimeError:
+            _logger.debug(
+                "Event loop unavailable while handling pane death: session=%s terminal=%s",
+                session_id,
+                terminal_id,
+            )
+
     async def _handle_terminal_exit(
         self,
         *,

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -397,6 +397,7 @@ async def bridge_tmux_control_to_websocket(
     tmux_target: str,
     read_only: bool,
     on_client_interaction: Callable[[], None] | None = None,
+    on_pane_dead: Callable[[], None] | None = None,
     reader_done: asyncio.Event | None = None,
     forward_done: asyncio.Event | None = None,
 ) -> None:
@@ -417,6 +418,8 @@ async def bridge_tmux_control_to_websocket(
         interaction (connect, disconnect, each input/resize frame) so the
         idle watcher can discount client-driven repaints. See the PTY bridge
         for the full rationale.
+    :param on_pane_dead: Optional callback fired when the bridge observes a
+        definitive dead pane. Same contract as the PTY bridge.
     :param reader_done: Optional test-only event set once the reader has queued
         the full backlog and the ``None`` EOF sentinel, letting a test await the
         reader draining tmux instead of sleeping. Inert (never awaited) when
@@ -676,6 +679,8 @@ async def bridge_tmux_control_to_websocket(
                 if pane_dead is True or (
                     pane_dead is None and not await _tmux_session_alive(socket_path, tmux_target)
                 ):
+                    if on_pane_dead is not None:
+                        on_pane_dead()
                     await websocket.close(
                         code=WS_CLOSE_TERMINAL_NOT_FOUND,
                         reason="terminal session ended",

--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -510,6 +510,7 @@ async def bridge_tmux_pty_to_websocket(
     tmux_target: str,
     read_only: bool,
     on_client_interaction: Callable[[], None] | None = None,
+    on_pane_dead: Callable[[], None] | None = None,
 ) -> None:
     """
     Bridge a tmux attach PTY to an already-accepted *websocket*.
@@ -538,6 +539,11 @@ async def bridge_tmux_pty_to_websocket(
         mis-reading them as agent activity. ``None`` (e.g. the
         server-direct attach path, which is out-of-process from the
         watcher) disables that attribution.
+    :param on_pane_dead: Optional callback fired when the bridge observes
+        a definitive dead pane (``#{pane_dead}=1`` or session gone). The
+        runner uses this to drive the same required-terminal exit path as
+        the idle watcher so a mid-turn crash publishes durable ``failed``
+        instead of only closing the websocket.
     """
     # Attaching is itself a client interaction: tmux resizes the window to
     # the new client, which reflows the pane. Stamp it before the bridge
@@ -668,6 +674,8 @@ async def bridge_tmux_pty_to_websocket(
                                 "tmux-attach: pane is dead; closing websocket target=%s",
                                 tmux_target,
                             )
+                            if on_pane_dead is not None:
+                                on_pane_dead()
                             with contextlib.suppress(RuntimeError):
                                 await websocket.close(
                                     code=WS_CLOSE_TERMINAL_NOT_FOUND,
@@ -732,6 +740,8 @@ async def bridge_tmux_pty_to_websocket(
                 if pane_dead is True or (
                     pane_dead is None and not await _tmux_session_alive(socket_path, tmux_target)
                 ):
+                    if on_pane_dead is not None:
+                        on_pane_dead()
                     await websocket.close(
                         code=WS_CLOSE_TERMINAL_NOT_FOUND,
                         reason="terminal session ended",

--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -7,6 +7,7 @@ import contextlib
 import dataclasses
 import json
 import logging
+import time
 import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -2222,6 +2223,124 @@ async def test_has_active_work_reports_native_pane_running() -> None:
 
     publisher(session_id, "idle")
     assert app.state.has_active_work() is False
+
+
+@pytest.mark.asyncio
+async def test_has_active_work_ignores_stale_native_pane_running() -> None:
+    """A stale ``running`` entry must not pin the idle watchdog forever.
+
+    If a forwarder is SIGKILLed or the pane freezes without a final status
+    edge, ``_native_pane_status`` can linger as ``running``. Without a
+    freshness bound that turns into a whole-runner leak (the mirror of the
+    premature-idle bug).
+
+    :returns: None.
+    """
+    app, _pm, _hc = _build_lifecycle_app()
+    session_id = "b2c3d4e5f60718293a4b5c6d7e8f90a1"
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            "/v1/sessions",
+            json={
+                "session_id": session_id,
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
+        )
+
+    assert resp.status_code == 201
+    set_status = app.state._set_native_pane_status
+    has_fresh = app.state._has_fresh_native_pane_running
+    stale_s = float(app.state._native_pane_running_stale_s)
+
+    # Fresh running pin keeps the runner alive (stamp = now).
+    set_status(session_id, "running")
+    assert app.state.has_active_work() is True
+
+    # Injected clock: past the staleness window the pin expires even though
+    # the stored status string is still ``running``.
+    now = time.monotonic()
+    set_status(session_id, "running", now=now)
+    assert has_fresh(now=now) is True
+    assert has_fresh(now=now + stale_s + 1.0) is False
+
+    # Drive has_active_work through the live clock with an already-stale stamp.
+    set_status(session_id, "running", now=now - stale_s - 1.0)
+    assert app.state.has_active_work() is False
+
+
+@pytest.mark.asyncio
+async def test_terminal_activity_refreshes_native_pane_running_freshness() -> None:
+    """Pane activity pulses keep a long ``running`` turn from going stale.
+
+    Status edges are idle→running only; continuous work refreshes liveness via
+    ``session.terminal.activity`` so a healthy multi-minute turn still pins
+    the watchdog.
+
+    :returns: None.
+    """
+    app, _pm, _hc = _build_lifecycle_app()
+    session_id = "c3d4e5f60718293a4b5c6d7e8f90a1b2"
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            "/v1/sessions",
+            json={
+                "session_id": session_id,
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
+        )
+
+    assert resp.status_code == 201
+    registry = app.state.session_resource_registry
+    status_publisher = getattr(registry, "_session_status_publisher", None)
+    activity_publisher = getattr(registry, "_terminal_activity_publisher", None)
+    assert callable(status_publisher) and callable(activity_publisher)
+
+    status_publisher(session_id, "running")
+    assert app.state.has_active_work() is True
+
+    # Age the stamp past the window, then an activity pulse must revive it.
+    set_status = app.state._set_native_pane_status
+    stale_s = float(app.state._native_pane_running_stale_s)
+    set_status(session_id, "running", now=time.monotonic() - stale_s - 1.0)
+    assert app.state.has_active_work() is False
+    activity_publisher(session_id, "terminal_claude_main")
+    assert app.state.has_active_work() is True
+
+
+@pytest.mark.asyncio
+async def test_external_session_status_failed_clears_native_pane_running_pin() -> None:
+    """Forwarder ``failed`` clears the idle-watchdog pin without a PTY idle edge.
+
+    Part A posts ``external_session_status: failed`` when the forwarder gives
+    up. That must drop the ``running`` pin even if the PTY watcher never
+    observes quiescence (SIGKILL / hung TUI with a frozen pane).
+
+    :returns: None.
+    """
+    app, _pm, _hc = _build_lifecycle_app()
+    session_id = "d4e5f60718293a4b5c6d7e8f90a1b2c3"
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            "/v1/sessions",
+            json={
+                "session_id": session_id,
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
+        )
+        assert resp.status_code == 201
+
+        app.state._set_native_pane_status(session_id, "running")
+        assert app.state.has_active_work() is True
+
+        fail_resp = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "type": "external_session_status",
+                "data": {"status": "failed", "output": "forwarder gave up"},
+            },
+        )
+        assert fail_resp.status_code == 204
+        assert app.state.has_active_work() is False
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -2189,6 +2189,42 @@ async def test_has_active_work_reports_process_manager_turns() -> None:
 
 
 @pytest.mark.asyncio
+async def test_has_active_work_reports_native_pane_running() -> None:
+    """The runner idle watchdog sees a native PTY pane marked ``running``.
+
+    Native turns clear ``_active_turns`` at proxy-stream end while the pane is
+    still working. Without counting ``_native_pane_status == "running"``, the
+    inactivity monitor would shut the runner down mid-turn (premature idle /
+    orphaned native agent).
+
+    :returns: None.
+    """
+    app, _pm, _hc = _build_lifecycle_app()
+    session_id = "a1b2c3d4e5f60718293a4b5c6d7e8f90"
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            "/v1/sessions",
+            json={
+                "session_id": session_id,
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
+        )
+
+    assert resp.status_code == 201
+    assert app.state.has_active_work() is False
+
+    registry = app.state.session_resource_registry
+    publisher = getattr(registry, "_session_status_publisher", None)
+    assert callable(publisher)
+
+    publisher(session_id, "running")
+    assert app.state.has_active_work() is True
+
+    publisher(session_id, "idle")
+    assert app.state.has_active_work() is False
+
+
+@pytest.mark.asyncio
 async def test_create_session_missing_fields() -> None:
     """``POST /v1/sessions`` with missing fields returns 400."""
     app, _pm, _hc = _build_lifecycle_app()

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -928,6 +928,35 @@ async def test_notify_pane_dead_is_idempotent_with_idle_watcher_exit(
 
 
 @pytest.mark.asyncio
+async def test_notify_pane_dead_is_noop_before_terminal_observed(tmp_path: Path) -> None:
+    """Pane-death notify before observe cannot publish a spurious failed card.
+
+    Native cold start briefly has no observed lifecycle. ``notify_pane_dead``
+    must no-op until ``observe_required_terminal`` registers the pane — the
+    attach bridge also refuses to connect until ``is_alive()`` is true, so a
+    pre-pane cold start cannot trip part B.
+
+    :param tmp_path: Temporary directory for fake terminal paths.
+    :returns: None.
+    """
+    from omnigent.entities.session_resources import terminal_resource_id
+
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    instance = make_test_terminal_instance("claude", "main", tmp_path)
+    terminal_registry._by_conversation.setdefault("conv_cold", {})[("claude", "main")] = instance
+    exits: list[TerminalExitEvent] = []
+
+    def _publish_exit(event: TerminalExitEvent) -> None:
+        exits.append(event)
+
+    registry.set_terminal_exit_publisher(_publish_exit)
+    registry.notify_pane_dead("conv_cold", terminal_resource_id("claude", "main"))
+    await asyncio.sleep(0)
+    assert exits == []
+
+
+@pytest.mark.asyncio
 async def test_required_terminal_exit_without_observed_status_is_failure(tmp_path: Path) -> None:
     """A required terminal that never reported a PTY status fails on exit.
 

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -805,6 +805,129 @@ def test_remember_exit_status_ignores_live_pane() -> None:
 
 
 @pytest.mark.asyncio
+async def test_notify_pane_dead_while_running_publishes_failure_exit(
+    tmp_path: Path,
+) -> None:
+    """Attach-bridge pane death mid-turn drives the same durable failure path.
+
+    When the websocket bridge observes ``#{pane_dead}=1`` during a running
+    turn, ``notify_pane_dead`` must schedule the required-terminal exit with
+    ``session_was_idle=False`` so the runner publishes ``failed`` and clears
+    the spinner — not only close the websocket.
+
+    :param tmp_path: Temporary directory for fake terminal paths.
+    :returns: None.
+    """
+    from omnigent.entities.session_resources import terminal_resource_id
+
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    instance = make_test_terminal_instance("claude", "main", tmp_path)
+    terminal_registry._by_conversation.setdefault("conv_pane", {})[("claude", "main")] = instance
+    exits: list[TerminalExitEvent] = []
+    exit_published = asyncio.Event()
+
+    def _publish_exit(event: TerminalExitEvent) -> None:
+        exits.append(event)
+        exit_published.set()
+
+    registry.set_terminal_exit_publisher(_publish_exit)
+    callbacks = await _observe_native_agent_terminal_and_capture(
+        registry, terminal_registry, instance, "conv_pane"
+    )
+    on_activity = callbacks["on_activity"]
+    assert callable(on_activity)
+    on_activity()
+
+    registry.notify_pane_dead("conv_pane", terminal_resource_id("claude", "main"))
+    await asyncio.wait_for(exit_published.wait(), timeout=1.0)
+
+    assert len(exits) == 1
+    assert exits[0].session_was_idle is False
+    assert exits[0].lifecycle == TerminalLifecycle.REQUIRED
+
+
+@pytest.mark.asyncio
+async def test_notify_pane_dead_while_idle_is_clean_shutdown(tmp_path: Path) -> None:
+    """Attach-bridge pane death after idle must not look like a crash.
+
+    A clean ``/quit`` goes idle first; when the pane then dies, the exit must
+    carry ``session_was_idle=True`` so the runner does not publish a spurious
+    failed card.
+
+    :param tmp_path: Temporary directory for fake terminal paths.
+    :returns: None.
+    """
+    from omnigent.entities.session_resources import terminal_resource_id
+
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    instance = make_test_terminal_instance("claude", "main", tmp_path)
+    terminal_registry._by_conversation.setdefault("conv_quit", {})[("claude", "main")] = instance
+    exits: list[TerminalExitEvent] = []
+    exit_published = asyncio.Event()
+
+    def _publish_exit(event: TerminalExitEvent) -> None:
+        exits.append(event)
+        exit_published.set()
+
+    registry.set_terminal_exit_publisher(_publish_exit)
+    callbacks = await _observe_native_agent_terminal_and_capture(
+        registry, terminal_registry, instance, "conv_quit"
+    )
+    on_activity = callbacks["on_activity"]
+    on_idle = callbacks["on_idle"]
+    assert callable(on_activity) and callable(on_idle)
+    on_activity()
+    on_idle()
+
+    registry.notify_pane_dead("conv_quit", terminal_resource_id("claude", "main"))
+    await asyncio.wait_for(exit_published.wait(), timeout=1.0)
+
+    assert len(exits) == 1
+    assert exits[0].session_was_idle is True
+
+
+@pytest.mark.asyncio
+async def test_notify_pane_dead_is_idempotent_with_idle_watcher_exit(
+    tmp_path: Path,
+) -> None:
+    """Pane-death notify and watcher ``on_exit`` must not double-publish.
+
+    :param tmp_path: Temporary directory for fake terminal paths.
+    :returns: None.
+    """
+    from omnigent.entities.session_resources import terminal_resource_id
+
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    instance = make_test_terminal_instance("claude", "main", tmp_path)
+    terminal_registry._by_conversation.setdefault("conv_once", {})[("claude", "main")] = instance
+    exits: list[TerminalExitEvent] = []
+    exit_published = asyncio.Event()
+
+    def _publish_exit(event: TerminalExitEvent) -> None:
+        exits.append(event)
+        exit_published.set()
+
+    registry.set_terminal_exit_publisher(_publish_exit)
+    callbacks = await _observe_native_agent_terminal_and_capture(
+        registry, terminal_registry, instance, "conv_once"
+    )
+    on_activity = callbacks["on_activity"]
+    on_exit = callbacks["on_exit"]
+    assert callable(on_activity) and callable(on_exit)
+    on_activity()
+
+    registry.notify_pane_dead("conv_once", terminal_resource_id("claude", "main"))
+    await asyncio.wait_for(exit_published.wait(), timeout=1.0)
+    on_exit()
+    await registry.wait_for_terminal_exit_cleanup()
+
+    assert len(exits) == 1
+
+
+@pytest.mark.asyncio
 async def test_required_terminal_exit_without_observed_status_is_failure(tmp_path: Path) -> None:
     """A required terminal that never reported a PTY status fails on exit.
 

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -1501,3 +1501,54 @@ async def test_check_pane_dead_definitive_tri_state(
     # By calling with non-existent socket/target, tmux probe fails and returns None
     result = await _check_pane_dead_definitive("/nonexistent/socket", "nonexistent")
     assert result is None, "inconclusive probe should return None"
+
+
+@pytest.mark.asyncio
+async def test_bridge_calls_on_pane_dead_when_pty_ends_on_dead_pane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PTY EOF against a definitive dead pane fires ``on_pane_dead``.
+
+    Closing the websocket alone left mid-turn chats frozen; the runner wires
+    this callback into the required-terminal exit path so durable ``failed``
+    is published.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    master_fd, slave_fd = os.openpty()
+    # Closing the slave makes the master report EOF → pty_task ends first.
+    os.close(slave_fd)
+
+    monkeypatch.setattr(
+        ws_bridge,
+        "_fork_exec_pty",
+        lambda *_a, **_k: ws_bridge._SpawnedPty(pid=999_999, master_fd=master_fd),
+    )
+    monkeypatch.setattr(os, "kill", lambda *_a, **_k: None)
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/tmux")
+
+    async def _pane_dead(*_a: object, **_k: object) -> bool:
+        return True
+
+    async def _reap(*_a: object, **_k: object) -> None:
+        return None
+
+    monkeypatch.setattr(ws_bridge, "_check_pane_dead_definitive", _pane_dead)
+    monkeypatch.setattr(ws_bridge, "_reap_tmux_attach_child", _reap)
+
+    deaths: list[int] = []
+    ws = _ParkingFakeWebSocket()
+
+    await asyncio.wait_for(
+        bridge_tmux_pty_to_websocket(
+            ws,  # type: ignore[arg-type]
+            socket_path="/nonexistent.sock",
+            tmux_target="main",
+            read_only=False,
+            on_pane_dead=lambda: deaths.append(1),
+        ),
+        timeout=5.0,
+    )
+    assert deaths == [1]
+    assert ws.close_code == ws_bridge.WS_CLOSE_TERMINAL_NOT_FOUND

--- a/tests/test_native_forwarder_liveness.py
+++ b/tests/test_native_forwarder_liveness.py
@@ -164,6 +164,50 @@ async def test_successful_poll_resets_failure_streak() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cold_start_empty_polls_do_not_escalate() -> None:
+    """Native cold-start discovery polls must not trip durable ``failed``.
+
+    A cold-starting native session commonly spends several polls discovering
+    the vendor session / waiting for the transcript file. Those iterations
+    succeed (no exception) and call :func:`note_poll_success`. Even a few
+    transient exceptions below the threshold must not POST ``failed`` — that
+    was the shape of prior spurious failed-card bugs during cold start.
+
+    :returns: None.
+    """
+    posts: list[dict[str, Any]] = []
+    tracker = PollFailureTracker()
+
+    async def _post_status(
+        _client: object,
+        *,
+        session_id: str,
+        status: str,
+        output: str | None = None,
+        **_kwargs: object,
+    ) -> None:
+        posts.append({"session_id": session_id, "status": status, "output": output})
+
+    # Simulate cold-start: a couple of transient misses, then a successful
+    # discovery poll, then more quiet successful polls — never escalate.
+    for i in range(2):
+        await handle_poll_failure(
+            client=_RecordingClient(),  # type: ignore[arg-type]
+            session_id="conv_cold",
+            tracker=tracker,
+            error=RuntimeError(f"not-ready-{i}"),
+            harness="claude-native",
+            post_status=_post_status,
+        )
+    note_poll_success(tracker)
+    for _ in range(POLL_FAILURE_THRESHOLD + 2):
+        note_poll_success(tracker)
+    assert posts == []
+    assert tracker.consecutive_failures == 0
+    assert tracker.failed_status_emitted is False
+
+
+@pytest.mark.asyncio
 async def test_supervisor_restarts_escalate_within_window() -> None:
     """M supervisor restarts inside the window POST durable ``failed``.
 

--- a/tests/test_native_forwarder_liveness.py
+++ b/tests/test_native_forwarder_liveness.py
@@ -1,0 +1,318 @@
+"""Regression tests for durable native-forwarder failure escalation.
+
+Pins that poll-loop exceptions and supervisor restart storms POST a durable
+``external_session_status: failed`` through the shared liveness helper — and
+that successful polls / healthy uptime reset the counters so transient blips
+do not produce a failed card.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from omnigent._native_forwarder_liveness import (
+    POLL_FAILURE_THRESHOLD,
+    RESTART_FAILURE_THRESHOLD,
+    PollFailureTracker,
+    RestartFailureTracker,
+    handle_poll_failure,
+    handle_supervisor_restart,
+    note_poll_success,
+    note_supervisor_healthy,
+)
+
+
+class _RecordingClient:
+    """Minimal stand-in for ``httpx.AsyncClient`` in liveness tests."""
+
+
+@pytest.mark.asyncio
+async def test_poll_failures_escalate_to_durable_failed_status() -> None:
+    """N consecutive poll failures POST ``external_session_status: failed``.
+
+    :returns: None.
+    """
+    posts: list[dict[str, Any]] = []
+    tracker = PollFailureTracker()
+
+    async def _post_status(
+        _client: object,
+        *,
+        session_id: str,
+        status: str,
+        output: str | None = None,
+        **_kwargs: object,
+    ) -> None:
+        posts.append({"session_id": session_id, "status": status, "output": output})
+
+    for i in range(POLL_FAILURE_THRESHOLD - 1):
+        posted = await handle_poll_failure(
+            client=_RecordingClient(),  # type: ignore[arg-type]
+            session_id="conv_poll",
+            tracker=tracker,
+            error=RuntimeError(f"transient-{i}"),
+            harness="claude-native",
+            post_status=_post_status,
+        )
+        assert posted is False
+        assert posts == []
+
+    posted = await handle_poll_failure(
+        client=_RecordingClient(),  # type: ignore[arg-type]
+        session_id="conv_poll",
+        tracker=tracker,
+        error=RuntimeError("transient-final"),
+        harness="claude-native",
+        post_status=_post_status,
+    )
+    assert posted is True
+    assert len(posts) == 1
+    assert posts[0]["status"] == "failed"
+    assert posts[0]["session_id"] == "conv_poll"
+    assert "claude-native" in (posts[0]["output"] or "")
+    assert f"{POLL_FAILURE_THRESHOLD} consecutive" in (posts[0]["output"] or "")
+
+    posted_again = await handle_poll_failure(
+        client=_RecordingClient(),  # type: ignore[arg-type]
+        session_id="conv_poll",
+        tracker=tracker,
+        error=RuntimeError("still-broken"),
+        harness="claude-native",
+        post_status=_post_status,
+    )
+    assert posted_again is False
+    assert len(posts) == 1
+
+
+@pytest.mark.asyncio
+async def test_permanent_poll_error_fails_immediately() -> None:
+    """A permanent poll error class escalates on the first failure.
+
+    :returns: None.
+    """
+    posts: list[dict[str, Any]] = []
+    tracker = PollFailureTracker()
+
+    async def _post_status(
+        _client: object,
+        *,
+        session_id: str,
+        status: str,
+        output: str | None = None,
+        **_kwargs: object,
+    ) -> None:
+        posts.append({"session_id": session_id, "status": status, "output": output})
+
+    posted = await handle_poll_failure(
+        client=_RecordingClient(),  # type: ignore[arg-type]
+        session_id="conv_perm",
+        tracker=tracker,
+        error=PermissionError("bridge unreadable"),
+        harness="goose-native",
+        post_status=_post_status,
+    )
+    assert posted is True
+    assert posts[0]["status"] == "failed"
+    assert "permanent" in (posts[0]["output"] or "")
+
+
+@pytest.mark.asyncio
+async def test_successful_poll_resets_failure_streak() -> None:
+    """A successful poll clears the streak so later blips do not accumulate.
+
+    :returns: None.
+    """
+    posts: list[dict[str, Any]] = []
+    tracker = PollFailureTracker()
+
+    async def _post_status(
+        _client: object,
+        *,
+        session_id: str,
+        status: str,
+        output: str | None = None,
+        **_kwargs: object,
+    ) -> None:
+        posts.append({"session_id": session_id, "status": status, "output": output})
+
+    for i in range(POLL_FAILURE_THRESHOLD - 1):
+        await handle_poll_failure(
+            client=_RecordingClient(),  # type: ignore[arg-type]
+            session_id="conv_reset",
+            tracker=tracker,
+            error=RuntimeError(f"blip-{i}"),
+            harness="qwen-native",
+            post_status=_post_status,
+        )
+    note_poll_success(tracker)
+    assert tracker.consecutive_failures == 0
+
+    await handle_poll_failure(
+        client=_RecordingClient(),  # type: ignore[arg-type]
+        session_id="conv_reset",
+        tracker=tracker,
+        error=RuntimeError("one-more"),
+        harness="qwen-native",
+        post_status=_post_status,
+    )
+    assert posts == []
+
+
+@pytest.mark.asyncio
+async def test_supervisor_restarts_escalate_within_window() -> None:
+    """M supervisor restarts inside the window POST durable ``failed``.
+
+    :returns: None.
+    """
+    posts: list[dict[str, Any]] = []
+    tracker = RestartFailureTracker()
+    now = 1000.0
+
+    async def _post_status(
+        _client: object,
+        *,
+        session_id: str,
+        status: str,
+        output: str | None = None,
+        **_kwargs: object,
+    ) -> None:
+        posts.append({"session_id": session_id, "status": status, "output": output})
+
+    for i in range(RESTART_FAILURE_THRESHOLD - 1):
+        posted = await handle_supervisor_restart(
+            client=_RecordingClient(),  # type: ignore[arg-type]
+            session_id="conv_restarts",
+            tracker=tracker,
+            error=RuntimeError(f"crash-{i}"),
+            harness="hermes-native",
+            now=now + i,
+            post_status=_post_status,
+        )
+        assert posted is False
+
+    posted = await handle_supervisor_restart(
+        client=_RecordingClient(),  # type: ignore[arg-type]
+        session_id="conv_restarts",
+        tracker=tracker,
+        error=RuntimeError("crash-final"),
+        harness="hermes-native",
+        now=now + RESTART_FAILURE_THRESHOLD,
+        post_status=_post_status,
+    )
+    assert posted is True
+    assert posts[0]["status"] == "failed"
+    assert "restarted" in (posts[0]["output"] or "")
+
+
+@pytest.mark.asyncio
+async def test_healthy_supervisor_uptime_clears_restart_budget() -> None:
+    """Healthy uptime resets restart escalation so later crashes start fresh.
+
+    :returns: None.
+    """
+    posts: list[dict[str, Any]] = []
+    tracker = RestartFailureTracker()
+
+    async def _post_status(
+        _client: object,
+        *,
+        session_id: str,
+        status: str,
+        output: str | None = None,
+        **_kwargs: object,
+    ) -> None:
+        posts.append({"session_id": session_id, "status": status, "output": output})
+
+    for i in range(RESTART_FAILURE_THRESHOLD - 1):
+        await handle_supervisor_restart(
+            client=_RecordingClient(),  # type: ignore[arg-type]
+            session_id="conv_healthy",
+            tracker=tracker,
+            error=RuntimeError(f"early-{i}"),
+            harness="claude-native",
+            now=float(i),
+            post_status=_post_status,
+        )
+    note_supervisor_healthy(tracker)
+    assert tracker.restart_at == []
+
+    await handle_supervisor_restart(
+        client=_RecordingClient(),  # type: ignore[arg-type]
+        session_id="conv_healthy",
+        tracker=tracker,
+        error=RuntimeError("later"),
+        harness="claude-native",
+        now=100.0,
+        post_status=_post_status,
+    )
+    assert posts == []
+
+
+@pytest.mark.asyncio
+async def test_qwen_forwarder_poll_exception_posts_durable_failed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A live qwen poll loop escalates via the shared helper after N failures.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary directory for the bridge dir.
+    :returns: None.
+    """
+    from omnigent import qwen_native_forwarder as fwd
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    posts: list[dict[str, Any]] = []
+
+    def _always_fail(*_args: object, **_kwargs: object) -> tuple[list[object], int]:
+        raise RuntimeError("simulated poll boom")
+
+    async def _record_failure(**kwargs: Any) -> bool:
+        return await handle_poll_failure(
+            **kwargs,
+            threshold=3,
+            post_status=_post_status,
+        )
+
+    async def _post_status(
+        _client: object,
+        *,
+        session_id: str,
+        status: str,
+        output: str | None = None,
+        **_kwargs: object,
+    ) -> None:
+        posts.append({"session_id": session_id, "status": status, "output": output})
+
+    monkeypatch.setattr(fwd, "_read_new_events", _always_fail)
+    monkeypatch.setattr(fwd, "handle_poll_failure", _record_failure)
+
+    task = asyncio.create_task(
+        fwd.forward_qwen_events_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv_qwen_fail",
+            bridge_dir=bridge_dir,
+            agent_name="qwen-native",
+            poll_interval_s=0.001,
+        )
+    )
+    try:
+        for _ in range(200):
+            if posts:
+                break
+            await asyncio.sleep(0.01)
+        assert posts, "expected durable failed status after consecutive poll failures"
+        assert posts[0]["status"] == "failed"
+        assert posts[0]["session_id"] == "conv_qwen_fail"
+        assert "qwen-native" in (posts[0]["output"] or "")
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task


### PR DESCRIPTION
## Related issue

N/A

## Summary

Native chats were freezing with no failed card because mirroring is best-effort/logged while the UI only reacts to durable `session.status` writes. This PR closes three concrete gaps:

- **A. Forwarder catch-and-continue** — Claude/Hermes/Goose/Qwen poll loops and supervisors now escalate through one shared helper (`omnigent/_native_forwarder_liveness.py`): after N consecutive poll failures (or immediately on a permanent error class) they POST `external_session_status: failed`; after M supervisor restarts in a window they do the same. Successful polls / healthy uptime reset the counters.
- **B. Pane death** — PTY/control attach bridges fire `on_pane_dead`, and the runner routes that into `SessionResourceRegistry.notify_pane_dead` → the existing required-terminal exit path (idle ⇒ clean quit; running ⇒ durable `failed` + spinner clear). Idempotent with the idle watcher.
- **C. Idle watchdog** — `_has_active_work()` now treats `_native_pane_status == "running"` as busy (same signal the pane reaper already uses), and native status edges refresh `app.state.mark_activity` so a long PTY turn does not look already-timed-out when it settles.

```mermaid
flowchart TD
  pollFail[Forwarder poll exception] --> shared[Shared liveness helper]
  restartStorm[Supervisor restart storm] --> shared
  shared -->|threshold tripped| failedPost["POST external_session_status: failed"]
  paneDead[Attach bridge pane_dead] --> notify[notify_pane_dead]
  notify --> exitPath[Required-terminal exit path]
  exitPath -->|memo idle| clean[Clean shutdown no failed card]
  exitPath -->|memo running| failedEvt["session.status failed"]
  nativeRunning["_native_pane_status running"] --> activeWork[_has_active_work true]
  activeWork --> keepAlive[Idle watchdog waits]
```

## Test Plan

- New unit/integration coverage:
  - `tests/test_native_forwarder_liveness.py` — consecutive poll failures, permanent class, streak reset, restart-window escalation, healthy reset, live qwen poll loop posts durable `failed`
  - `tests/runner/test_app_sessions_native_workflow_init.py::test_has_active_work_reports_native_pane_running` — mirrors the existing `has_active_turn` test
  - `tests/runner/test_resource_registry.py` — `notify_pane_dead` while running / idle / idempotent with watcher exit
  - `tests/terminals/test_ws_bridge.py::test_bridge_calls_on_pane_dead_when_pty_ends_on_dead_pane`
- Existing no-spurious-failure guards re-run:
  - `test_required_terminal_exit_while_idle_does_not_fail_session`
  - `test_required_terminal_exit_while_idle_is_clean_shutdown`
  - `test_notify_pane_dead_while_idle_is_clean_shutdown`
- Suites run (this branch):
  - `uv run pytest tests/runtime/harnesses tests/runner -q` → **1399 passed, 4 xfailed** in ~9m 25s
  - `uv run pytest tests/test_codex_native.py tests/test_claude_native.py tests/test_claude_native_forwarder.py tests/test_antigravity_native.py tests/test_antigravity_native_bridge.py` (+ idle guards) → **587 passed** in ~40s
- Checked `tests/harness_bench/`: no cheap probe extension needed for this failure-path change.

## Demo

N/A — behavior is failure-path / status-card surfacing; no intentional UI layout change. User-visible effect: previously frozen native chats now show a failed card when the forwarder dies or the pane crashes mid-turn; clean `/quit` and idle pane exit still do **not** show a failed card.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated regression tests assert durable `failed` is written on simulated forwarder exceptions and mid-turn pane death, and assert idle/clean-quit paths do **not** publish failed. Existing idle-exit guards remain green.

## Changelog

Native sessions that silently froze now surface a failed card when the forwarder or pane dies mid-turn