### PR TITLE
fix(android): resolve adb from SDK dir in runDebug task

### DIFF
--- a/web/android/app/build.gradle.kts
+++ b/web/android/app/build.gradle.kts
@@ -110,10 +110,19 @@ dependencies {
 
 // Local development helpers — these delegate to adb so they work with physical
 // devices or any running emulator.
+//
+// Resolve adb from the configured Android SDK directory rather than relying on
+// it being on PATH: the Gradle daemon is long-lived and may have been started
+// from an environment whose PATH doesn't include platform-tools (e.g. homebrew's
+// android-commandlinetools), which makes a bare `commandLine("adb", ...)` fail
+// with "A problem occurred starting process 'command 'adb''". AGP's own tasks
+// (installDebug, etc.) resolve adb from the SDK internally, so we do the same.
+val adbPath = android.sdkDirectory.resolve("platform-tools/adb").absolutePath
+
 tasks.register<Exec>("listDevices") {
     description = "List attached Android devices/emulators"
     group = "install"
-    commandLine("adb", "devices", "-l")
+    commandLine(adbPath, "devices", "-l")
 }
 
 tasks.register("runDebug") {
@@ -123,7 +132,7 @@ tasks.register("runDebug") {
     doLast {
         exec {
             commandLine(
-                "adb",
+                adbPath,
                 "shell",
                 "am",
                 "start",
@@ -137,5 +146,5 @@ tasks.register("runDebug") {
 tasks.register<Exec>("reverseProxy") {
     description = "Forward local port 8000 to the Android device/emulator (adb reverse)"
     group = "install"
-    commandLine("adb", "reverse", "tcp:8000", "tcp:8000")
+    commandLine(adbPath, "reverse", "tcp:8000", "tcp:8000")
 }


### PR DESCRIPTION
## Summary

`just run-android` (which runs `./gradlew installDebug runDebug`) was failing:

```
> Task :app:runDebug FAILED
> A problem occurred starting process 'command 'adb''
```

even though `installDebug` succeeded and `adb devices` works from the shell.

## Root cause

The custom `runDebug`, `listDevices`, and `reverseProxy` Exec tasks call `commandLine("adb", ...)`, relying on `adb` being on `PATH`. The **Gradle daemon** is a long-lived process that may have been started from an environment whose `PATH` doesn't include `platform-tools` (e.g. homebrew's `android-commandlinetools`), so the spawn fails with `A problem occurred starting process 'command 'adb''`.

AGP's own `installDebug` was unaffected because it resolves `adb` from the SDK directory internally — which is why the install succeeded but the launch failed.

## Fix

Resolve `adb` from `android.sdkDirectory` instead of `PATH`, mirroring what AGP does, so the custom launch tasks are independent of the daemon's `PATH`:

```kotlin
val adbPath = android.sdkDirectory.resolve("platform-tools/adb").absolutePath
```

and use `adbPath` in all three custom tasks.

## Testing

```
$ ./gradlew runDebug --offline
> Task :app:installDebug
Installed on 1 device.
> Task :app:runDebug
Starting: Intent { cmp=ai.omnigent.android/.MainActivity }
BUILD SUCCESSFUL in 1m 23s
```

Confirmed the daemon's `PATH` did not include `platform-tools`, and that the fix works against the same daemon (no restart needed).
