### PR TITLE
fix(claude-native): never launch a bare family alias a gateway rejects

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -324,11 +324,23 @@ def resolve_claude_native_model_selection(
     Direct Claude logins have no provider config, so they use the canonical
     Anthropic model id.
 
+    On a provider config, a family alias whose tier has no
+    ``ANTHROPIC_DEFAULT_*_MODEL`` pin would be canonicalized by Claude Code
+    to an Anthropic id (e.g. ``claude-opus-4-8``) the gateway rejects, so it
+    resolves to the provider's default model instead.
+
     :param model: Persisted picker id, built-in alias, or concrete model id.
     :param claude_config: Resolved provider config for the terminal.
     :returns: A model identifier suitable for ``--model`` or ``/model``.
     """
     if model != _UCODE_CLAUDE_CUSTOM_TIER:
+        tier_env = _UCODE_CLAUDE_TIER_TO_ENV.get(model or "")
+        if (
+            tier_env is not None
+            and claude_config is not None
+            and not claude_config.env.get(tier_env)
+        ):
+            return claude_config.model or model
         return model
     if claude_config is not None:
         custom_model = claude_config.env.get(_ANTHROPIC_CUSTOM_MODEL_OPTION_ENV)
@@ -429,6 +441,20 @@ def claude_native_model_options(
                     )
     if options:
         return options
+    if claude_config is not None:
+        # A provider config with no tier pins routes through a gateway that
+        # rejects the subscription aliases below; offer the one model the
+        # config is known to route.
+        if not claude_config.model:
+            return []
+        return [
+            {
+                "id": claude_config.model,
+                "model": claude_config.model,
+                "displayName": claude_config.model,
+                "isDefault": True,
+            }
+        ]
     return [
         {
             "id": model_id,

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -324,10 +324,8 @@ def resolve_claude_native_model_selection(
     Direct Claude logins have no provider config, so they use the canonical
     Anthropic model id.
 
-    On a provider config, a family alias whose tier has no
-    ``ANTHROPIC_DEFAULT_*_MODEL`` pin would be canonicalized by Claude Code
-    to an Anthropic id (e.g. ``claude-opus-4-8``) the gateway rejects, so it
-    resolves to the provider's default model instead.
+    Unpinned family aliases on a provider config resolve to the provider's
+    default model — Claude Code would canonicalize them to ids gateways reject.
 
     :param model: Persisted picker id, built-in alias, or concrete model id.
     :param claude_config: Resolved provider config for the terminal.
@@ -442,19 +440,12 @@ def claude_native_model_options(
     if options:
         return options
     if claude_config is not None:
-        # A provider config with no tier pins routes through a gateway that
-        # rejects the subscription aliases below; offer the one model the
-        # config is known to route.
-        if not claude_config.model:
+        # No tier pins: the gateway rejects the subscription aliases below,
+        # so offer the one model the config is known to route.
+        model_id = claude_config.model
+        if not model_id:
             return []
-        return [
-            {
-                "id": claude_config.model,
-                "model": claude_config.model,
-                "displayName": claude_config.model,
-                "isDefault": True,
-            }
-        ]
+        return [{"id": model_id, "model": model_id, "displayName": model_id, "isDefault": True}]
     return [
         {
             "id": model_id,

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -35,6 +35,7 @@ from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import IO, TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from omnigent.onboarding.provider_config import ProviderEntry
@@ -311,6 +312,22 @@ class ClaudeNativeUcodeConfig:
     model: str | None = None
 
 
+def _serves_canonical_anthropic_ids(claude_config: ClaudeNativeUcodeConfig) -> bool:
+    """Whether the config's endpoint accepts canonical Anthropic ids and aliases.
+
+    Bedrock and custom gateways route their own model ids only; the Anthropic
+    API (and a config with no endpoint override) resolves family aliases
+    natively, so aliases must not be rewritten for it.
+    """
+    if claude_config.env.get(_ANTHROPIC_BEDROCK_BASE_URL_ENV):
+        return False
+    base_url = claude_config.env.get(_UCODE_CLAUDE_BASE_URL_ENV)
+    if not base_url:
+        return True
+    host = (urlparse(base_url).hostname or "").lower()
+    return host == "anthropic.com" or host.endswith(".anthropic.com")
+
+
 def resolve_claude_native_model_selection(
     model: str | None,
     claude_config: ClaudeNativeUcodeConfig | None,
@@ -324,8 +341,9 @@ def resolve_claude_native_model_selection(
     Direct Claude logins have no provider config, so they use the canonical
     Anthropic model id.
 
-    Unpinned family aliases on a provider config resolve to the provider's
-    default model — Claude Code would canonicalize them to ids gateways reject.
+    On a gateway/Bedrock endpoint, a family alias with no tier pin (launch env
+    or managed settings) resolves to the provider's default model — Claude
+    Code would canonicalize it to an Anthropic id the endpoint rejects.
 
     :param model: Persisted picker id, built-in alias, or concrete model id.
     :param claude_config: Resolved provider config for the terminal.
@@ -337,8 +355,11 @@ def resolve_claude_native_model_selection(
             tier_env is not None
             and claude_config is not None
             and not claude_config.env.get(tier_env)
+            and not _serves_canonical_anthropic_ids(claude_config)
         ):
-            return claude_config.model or model
+            managed = _managed_claude_model_config()
+            if managed is None or not managed.env.get(tier_env):
+                return claude_config.model or model
         return model
     if claude_config is not None:
         custom_model = claude_config.env.get(_ANTHROPIC_CUSTOM_MODEL_OPTION_ENV)
@@ -439,9 +460,9 @@ def claude_native_model_options(
                     )
     if options:
         return options
-    if claude_config is not None:
-        # No tier pins: the gateway rejects the subscription aliases below,
-        # so offer the one model the config is known to route.
+    if claude_config is not None and not _serves_canonical_anthropic_ids(claude_config):
+        # No tier pins on a gateway/Bedrock endpoint: it rejects the
+        # subscription aliases below, so offer the one model it routes.
         model_id = claude_config.model
         if not model_id:
             return []

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4792,7 +4792,7 @@ def create_runner_app(
         selected_model = model.strip()
         resolved_model = resolve_claude_native_model_selection(
             selected_model,
-            _session_claude_launch_configs.get(conv_id),
+            await _resolve_session_claude_launch_config(conv_id),
         )
         command = f"/model {resolved_model}"
         try:

--- a/tests/e2e_ui/chat/test_claude_model_picker.py
+++ b/tests/e2e_ui/chat/test_claude_model_picker.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 from urllib.parse import urlparse
 
 from playwright.sync_api import Page, Route, expect
+
+from omnigent.claude_native import ClaudeNativeUcodeConfig, claude_native_model_options
 
 _EXPECTED_ROWS = [
     ("opus", "Opus 4.10"),
@@ -39,6 +43,8 @@ def _patch_session_as_claude_native(
     session_id: str,
     model_override: str | None = None,
     catalog_state: dict[str, bool] | None = None,
+    model_options: list[dict] | None = None,
+    llm_model: str = "system.ai.claude-sonnet-5",
 ) -> list[dict]:
     """Patch the browser's session snapshot into a claude-native response.
 
@@ -52,6 +58,8 @@ def _patch_session_as_claude_native(
     :param session_id: Session id to patch, e.g. ``"conv_abc123"``.
     :param model_override: Optional session-scoped model override to expose.
     :param catalog_state: Optional mutable readiness gate for delayed options.
+    :param model_options: Catalog rows to expose; defaults to the live-alias set.
+    :param llm_model: Bound model id shown for the session.
     :returns: Captured PATCH request bodies.
     """
     latest_payload: dict | None = None
@@ -85,9 +93,10 @@ def _patch_session_as_claude_native(
             "omnigent.wrapper": "claude-code-native-ui",
         }
         payload["harness"] = "claude"
-        payload["llm_model"] = "system.ai.claude-sonnet-5"
+        payload["llm_model"] = llm_model
+        catalog = _MODEL_OPTIONS if model_options is None else model_options
         payload["model_options"] = (
-            _MODEL_OPTIONS if catalog_state is None or catalog_state["ready"] else []
+            catalog if catalog_state is None or catalog_state["ready"] else []
         )
         if model_override is not None:
             payload["model_override"] = model_override
@@ -139,6 +148,7 @@ def test_claude_native_picker_lists_only_live_databricks_models(
     expect(sonnet_row).to_have_attribute("data-active", "true")
     expect(page.locator('[role="option"][data-model-id="fable"]')).to_have_count(0)
     expect(page.locator('[role="option"][data-model-id="sonnet_5"]')).to_have_count(0)
+    _screenshot(page, "pinned-catalog-picker")
 
 
 def test_claude_native_picker_updates_after_delayed_catalog(
@@ -241,6 +251,64 @@ def test_claude_native_alias_selection_persists(
     assert patch_bodies[-1] == {"model_override": "opus"}
     # The read-only composer label reflects the new pick.
     expect(page.get_by_test_id("composer-model-effort-label")).to_contain_text("Opus 4.10")
+
+
+def _screenshot(page: Page, name: str) -> None:
+    """Save a demo screenshot when E2E_SCREENSHOT_DIR is set (local runs)."""
+    shot_dir = os.environ.get("E2E_SCREENSHOT_DIR")
+    if shot_dir:
+        page.screenshot(path=str(Path(shot_dir) / f"{name}.png"))
+
+
+def test_claude_native_unpinned_gateway_catalog_offers_only_the_routable_default(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A pin-less gateway config renders one concrete row and no alias rows.
+
+    The catalog is produced by the real ``claude_native_model_options`` for a
+    provider config with no ``ANTHROPIC_DEFAULT_*_MODEL`` pins — the setup
+    where the subscription aliases used to appear and canonicalize to
+    Anthropic ids the gateway rejects at launch.
+    """
+    base_url, session_id = seeded_session
+    default_model = "databricks-claude-sonnet-4-5"
+    catalog = claude_native_model_options(
+        ClaudeNativeUcodeConfig(
+            env={"ANTHROPIC_BASE_URL": "https://example.databricks.com/ai-gateway/anthropic"},
+            model=default_model,
+        )
+    )
+    _patch_session_as_claude_native(
+        page,
+        session_id,
+        model_options=catalog,
+        llm_model=default_model,
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # The composer label already shows the concrete routable id.
+    expect(page.get_by_test_id("composer-model-effort-label")).to_contain_text(
+        default_model, timeout=15_000
+    )
+    _screenshot(page, "unpinned-gateway-composer")
+
+    gear = page.get_by_test_id("composer-config-gear")
+    expect(gear).to_be_visible(timeout=15_000)
+    gear.click()
+    page.get_by_test_id("composer-config-model").click()
+
+    # Exactly one row: the provider's routable default, pre-selected. Picking
+    # it can only ever PATCH the concrete gateway id, which the launch
+    # resolver passes through verbatim — never a bare family alias.
+    rows = page.locator('[role="option"][data-model-id]')
+    expect(rows).to_have_count(1)
+    expect(rows.first).to_have_attribute("data-model-id", default_model)
+    expect(rows.first).to_have_attribute("data-active", "true")
+    for alias in ("fable", "opus", "sonnet", "sonnet_5", "haiku"):
+        expect(page.locator(f'[role="option"][data-model-id="{alias}"]')).to_have_count(0)
+    _screenshot(page, "unpinned-gateway-picker")
 
 
 def test_claude_native_picker_prefers_session_override_over_sticky_model(

--- a/tests/e2e_ui/chat/test_claude_model_picker.py
+++ b/tests/e2e_ui/chat/test_claude_model_picker.py
@@ -294,20 +294,17 @@ def test_claude_native_unpinned_gateway_catalog_offers_only_the_routable_default
     )
     _screenshot(page, "unpinned-gateway-composer")
 
-    gear = page.get_by_test_id("composer-config-gear")
-    expect(gear).to_be_visible(timeout=15_000)
-    gear.click()
+    page.get_by_test_id("composer-config-gear").click()
     page.get_by_test_id("composer-config-model").click()
 
-    # Exactly one row: the provider's routable default, pre-selected. Picking
+    # Exactly one row — the provider's routable default, pre-selected — so no
+    # alias row exists to canonicalize into an id the gateway rejects. Picking
     # it can only ever PATCH the concrete gateway id, which the launch
-    # resolver passes through verbatim — never a bare family alias.
+    # resolver passes through verbatim.
     rows = page.locator('[role="option"][data-model-id]')
     expect(rows).to_have_count(1)
     expect(rows.first).to_have_attribute("data-model-id", default_model)
     expect(rows.first).to_have_attribute("data-active", "true")
-    for alias in ("fable", "opus", "sonnet", "sonnet_5", "haiku"):
-        expect(page.locator(f'[role="option"][data-model-id="{alias}"]')).to_have_count(0)
     _screenshot(page, "unpinned-gateway-picker")
 
 

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -658,24 +658,16 @@ def test_unpinned_family_alias_resolves_to_the_provider_default_model() -> None:
     )
 
 
-def test_pinned_family_alias_passes_through_for_env_resolution() -> None:
-    """A pinned alias stays an alias; Claude Code resolves it via the env pin."""
-    config = claude_native.ClaudeNativeUcodeConfig(
+def test_family_alias_passes_through_when_substitution_is_not_needed() -> None:
+    """Pinned (env resolves it), direct login (Claude does), or no default (nothing to swap in)."""
+    pinned = claude_native.ClaudeNativeUcodeConfig(
         env={"ANTHROPIC_DEFAULT_OPUS_MODEL": "databricks-claude-opus-4-8"},
         model="databricks-claude-sonnet-4-5",
     )
-    assert claude_native.resolve_claude_native_model_selection("opus", config) == "opus"
-
-
-def test_family_alias_passes_through_on_direct_claude_login() -> None:
-    """Without a provider config, Claude Code resolves aliases natively."""
+    no_default = claude_native.ClaudeNativeUcodeConfig(env={"ANTHROPIC_BASE_URL": "https://x"})
+    assert claude_native.resolve_claude_native_model_selection("opus", pinned) == "opus"
     assert claude_native.resolve_claude_native_model_selection("opus", None) == "opus"
-
-
-def test_unpinned_family_alias_without_default_model_passes_through() -> None:
-    """No pin and no default model leaves nothing routable to substitute."""
-    config = claude_native.ClaudeNativeUcodeConfig(env={"ANTHROPIC_BASE_URL": "https://x"})
-    assert claude_native.resolve_claude_native_model_selection("opus", config) == "opus"
+    assert claude_native.resolve_claude_native_model_selection("opus", no_default) == "opus"
 
 
 def test_provider_config_without_pins_offers_only_the_default_model_row() -> None:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -646,8 +646,11 @@ def test_claude_native_model_options_follow_managed_claude_catalog(
     ]
 
 
-def test_unpinned_family_alias_resolves_to_the_provider_default_model() -> None:
+def test_unpinned_family_alias_resolves_to_the_provider_default_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A tier alias with no env pin cannot reach the gateway as a canonical id."""
+    monkeypatch.setattr(claude_native, "_CLAUDE_CODE_MANAGED_SETTINGS_PATHS", ())
     config = claude_native.ClaudeNativeUcodeConfig(
         env={"ANTHROPIC_BASE_URL": "https://example.databricks.com/ai-gateway/anthropic"},
         model="databricks-claude-sonnet-4-5",
@@ -656,6 +659,33 @@ def test_unpinned_family_alias_resolves_to_the_provider_default_model() -> None:
         claude_native.resolve_claude_native_model_selection("opus", config)
         == "databricks-claude-sonnet-4-5"
     )
+
+
+def test_unpinned_family_alias_passes_through_on_the_anthropic_api() -> None:
+    """The Anthropic API resolves aliases natively; never rewrite them there."""
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://api.anthropic.com"},
+        model="claude-sonnet-5",
+    )
+    assert claude_native.resolve_claude_native_model_selection("opus", config) == "opus"
+
+
+def test_managed_settings_pin_keeps_alias_passthrough_on_a_gateway(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Claude Code applies managed-settings pins, so the alias still routes."""
+    managed_settings = tmp_path / "managed-settings.json"
+    managed_settings.write_text(
+        json.dumps({"env": {"ANTHROPIC_DEFAULT_OPUS_MODEL": "databricks-claude-opus-4-8"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(claude_native, "_CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (managed_settings,))
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://example.databricks.com/ai-gateway/anthropic"},
+        model="databricks-claude-sonnet-4-5",
+    )
+    assert claude_native.resolve_claude_native_model_selection("opus", config) == "opus"
 
 
 def test_family_alias_passes_through_when_substitution_is_not_needed() -> None:
@@ -690,6 +720,17 @@ def test_provider_config_without_pins_offers_only_the_default_model_row() -> Non
         )
         == []
     )
+
+
+def test_anthropic_endpoint_config_without_pins_keeps_the_alias_rows() -> None:
+    """API-key providers on the Anthropic API keep the alias catalog Claude resolves."""
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://api.anthropic.com"},
+        model="claude-sonnet-5",
+    )
+    options = claude_native.claude_native_model_options(config)
+    assert options
+    assert all(option["model"] == option["id"] for option in options)
 
 
 def test_sonnet_5_selection_resolves_to_the_configured_custom_model() -> None:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -646,6 +646,60 @@ def test_claude_native_model_options_follow_managed_claude_catalog(
     ]
 
 
+def test_unpinned_family_alias_resolves_to_the_provider_default_model() -> None:
+    """A tier alias with no env pin cannot reach the gateway as a canonical id."""
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://example.databricks.com/ai-gateway/anthropic"},
+        model="databricks-claude-sonnet-4-5",
+    )
+    assert (
+        claude_native.resolve_claude_native_model_selection("opus", config)
+        == "databricks-claude-sonnet-4-5"
+    )
+
+
+def test_pinned_family_alias_passes_through_for_env_resolution() -> None:
+    """A pinned alias stays an alias; Claude Code resolves it via the env pin."""
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_DEFAULT_OPUS_MODEL": "databricks-claude-opus-4-8"},
+        model="databricks-claude-sonnet-4-5",
+    )
+    assert claude_native.resolve_claude_native_model_selection("opus", config) == "opus"
+
+
+def test_family_alias_passes_through_on_direct_claude_login() -> None:
+    """Without a provider config, Claude Code resolves aliases natively."""
+    assert claude_native.resolve_claude_native_model_selection("opus", None) == "opus"
+
+
+def test_unpinned_family_alias_without_default_model_passes_through() -> None:
+    """No pin and no default model leaves nothing routable to substitute."""
+    config = claude_native.ClaudeNativeUcodeConfig(env={"ANTHROPIC_BASE_URL": "https://x"})
+    assert claude_native.resolve_claude_native_model_selection("opus", config) == "opus"
+
+
+def test_provider_config_without_pins_offers_only_the_default_model_row() -> None:
+    """Gateway configs never get the subscription alias rows they cannot route."""
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://example.databricks.com/ai-gateway/anthropic"},
+        model="databricks-claude-sonnet-4-5",
+    )
+    assert claude_native.claude_native_model_options(config) == [
+        {
+            "id": "databricks-claude-sonnet-4-5",
+            "model": "databricks-claude-sonnet-4-5",
+            "displayName": "databricks-claude-sonnet-4-5",
+            "isDefault": True,
+        }
+    ]
+    assert (
+        claude_native.claude_native_model_options(
+            claude_native.ClaudeNativeUcodeConfig(env={"ANTHROPIC_BASE_URL": "https://x"})
+        )
+        == []
+    )
+
+
 def test_sonnet_5_selection_resolves_to_the_configured_custom_model() -> None:
     """The friendly Sonnet 5 row launches the provider's routable model id."""
     config = claude_native.ClaudeNativeUcodeConfig(


### PR DESCRIPTION
## Related issue

N/A — root-caused from a report of every Opus session failing at start with *"There's an issue with the selected model (claude-opus-4-8). It may not exist or you may not have access to it."*

## Summary

- A family alias (`opus`/`sonnet`/`haiku`/`fable`) selected on a provider config whose tier has no `ANTHROPIC_DEFAULT_*_MODEL` pin gets canonicalized by Claude Code to an Anthropic id (e.g. `claude-opus-4-8`) that Databricks-style gateways 404 (verified live: `claude-opus-4-8` → `404 'claude-opus-4-8' does not exist`), so the session fails at start.
- `resolve_claude_native_model_selection` now resolves an unpinned alias to the provider's default model — but only when the config routes through a gateway/Bedrock endpoint that rejects canonical ids; the Anthropic API (api.anthropic.com or no endpoint override) resolves aliases natively, so API-key providers keep alias routing. Managed-settings tier pins are respected (Claude Code applies them to the spawned process). All three consumers route through the resolver — session launch, sticky-model handoff, and in-session `/model` injection.
- `claude_native_model_options` no longer offers the static subscription alias rows to a pin-less gateway/Bedrock config (they can never route); it lists the one model the config is known to route. Direct Claude logins, Anthropic-API key providers, and managed-settings catalogs keep the alias catalog.
- The runner's `/model` handler resolves the session launch config instead of reading the in-memory cache, so alias resolution survives a runner restart.

### ELI5

The picker sometimes offered generic names like "Opus" on setups where nothing translates that name into a model the gateway understands. Claude Code then guessed the official Anthropic name, the gateway said "no such model", and the session died. Now the generic name is translated to a real, routable model id before it ever reaches Claude Code.

### Diagram

```mermaid
flowchart TD
    A["picker id 'opus'"] --> B{"tier pin (ANTHROPIC_DEFAULT_OPUS_MODEL)?"}
    B -->|pinned| C["pass alias through — Claude Code resolves via env pin"]
    B -->|unpinned, provider config| D["before: alias → canonical claude-opus-4-8 → gateway 404"]
    B -->|unpinned, provider config| E["after: resolve to provider default model → launches"]
    B -->|no provider config| F["direct Claude login — alias resolves natively"]
```

## Test Plan

- `uv run pytest tests/test_claude_native.py -q` — 156 passed (6 new regression tests: unpinned alias → gateway default, passthrough when substitution isn't needed, Anthropic-API passthrough, managed-pin passthrough, pin-less gateway catalog rows, Anthropic-API alias rows kept).
- `uv run pytest tests/runner/test_app_sessions_native_events_lifecycle.py tests/host/test_connect.py tests/server/routes/test_sessions_snapshot.py -q` — 161 passed (downstream consumers of the catalog).
- `uv run pytest tests/e2e_ui/chat/test_claude_model_picker.py --ui-skip-build -v` — 5 passed in headless chromium (4 pre-existing scenarios unchanged + 1 new: pin-less gateway catalog renders exactly one concrete routable row, no alias rows, produced by the real `claude_native_model_options`).
- Gateway probes confirming the failure mode and fix premise: bare `claude-opus-4-8` → 404; concrete `databricks-claude-*` / `system.ai.claude-*` ids → 200.

## Demo

Headless-chromium e2e screenshots (assets branch `assets/pr-3378-screenshots`, not part of this PR's diff):

**Fix — pin-less gateway config: the picker offers exactly one concrete routable row (pre-selected), no subscription aliases:**

![pin-less gateway picker shows the single routable model row](https://raw.githubusercontent.com/omnigent-ai/omnigent/dd2a2ea4b668ac97011107362953e5dbbb34bc53/pr-assets/3378/unpinned-gateway-picker.png)

**Unchanged — pinned live catalog still renders the friendly alias rows:**

![pinned catalog picker unchanged with Opus 4.10 / Sonnet 5 / Haiku 4.5 rows](https://raw.githubusercontent.com/omnigent-ai/omnigent/dd2a2ea4b668ac97011107362953e5dbbb34bc53/pr-assets/3378/pinned-catalog-picker.png)

**Composer label on the pin-less config shows the concrete gateway id the session launches with:**

![composer label shows databricks-claude-sonnet-4-5](https://raw.githubusercontent.com/omnigent-ai/omnigent/dd2a2ea4b668ac97011107362953e5dbbb34bc53/pr-assets/3378/unpinned-gateway-composer.png)

Reproduce locally:

```bash
E2E_SCREENSHOT_DIR=/tmp/shots uv run pytest tests/e2e_ui/chat/test_claude_model_picker.py --ui-skip-build -v
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the resolver guard and catalog rows; the headless-chromium e2e covers the rendered picker for pin-less and pinned catalogs.

## Changelog

Claude sessions started with a model alias (e.g. Opus) no longer fail on gateway setups that can't pin the alias — the launch resolves to a routable model id.

This pull request and its description were written by Isaac.

