### PR TITLE
fix(release): harden finalize, cut, and homebrew against the 0.7.0-cycle failure modes

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -2,13 +2,16 @@
 # run after the prod PyPI publish succeeded and the draft notes are curated
 # (designs/RELEASE-AUTOMATION.md).
 #
-# Deterministic gates first (all fail with actionable links):
-#   * the tag is a final vX.Y.Z with an unpublished draft release,
+# Deterministic gates first (each fails with actionable links):
+#   * the tag is a final vX.Y.Z (input is normalized: `0.7.0` -> `v0.7.0`)
+#     with an unpublished draft release; a draft whose tag binding was lost
+#     to a web-UI edit (tag_name became `untagged-…`) is rebound automatically,
 #   * PyPI serves all three lockstep packages at the version (never advertise
 #     a release that isn't installable),
-#   * the auto/changelog/vX.Y.Z CHANGELOG PR isn't sitting open,
-#   * the docs sweep: no open PRs against omnigent-site's X.Y-docs staging
-#     branch (every doc staged this cycle is reviewed + merged/closed).
+#   * the auto/changelog/vX.Y.Z CHANGELOG PR isn't sitting open.
+# The docs sweep (open PRs against omnigent-site's X.Y-docs staging branch) is
+# ADVISORY only: it lists what is still unmerged but never blocks the publish —
+# docs can land after the release, any time before the docs-publish PR merges.
 #
 # The publish job binds the `publish-release` environment (one-time setup:
 # create it in repo settings with required reviewers). Approving it is the
@@ -64,16 +67,23 @@ jobs:
     outputs:
       release_id: ${{ steps.draft.outputs.release_id }}
       already_published: ${{ steps.draft.outputs.already_published }}
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Require a final vX.Y.Z tag
+        id: tag
         env:
-          TAG: ${{ inputs.tag }}
+          RAW_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
+          # Normalize the input: trim whitespace, add the leading v if omitted
+          # (`0.7.0` -> `v0.7.0`), so a bare version doesn't fail the dispatch.
+          TAG="$(printf '%s' "$RAW_TAG" | tr -d '[:space:]')"
+          case "$TAG" in v*) ;; *) TAG="v${TAG}" ;; esac
           if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::${TAG} is not a final vX.Y.Z tag — rc/dev/pre releases never finalize."
+            echo "::error::${RAW_TAG} is not a final vX.Y.Z tag — rc/dev/pre releases never finalize."
             exit 1
           fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       # Drafts are invisible to read-only tokens and unaddressable by tag
       # (the get-by-tag endpoint 404s on drafts) — resolve by listing with the
@@ -93,11 +103,32 @@ jobs:
         id: draft
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TAG: ${{ inputs.tag }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
           match="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
             --jq 'map(select(.tag_name == env.TAG)) | first // empty')"
+          if [ -z "$match" ]; then
+            # Editing a draft in the web UI can silently drop its tag binding
+            # (tag_name becomes `untagged-…` while the name stays vX.Y.Z; bit
+            # v0.5.0 and v0.7.0). Recover: match the DRAFT by name and rebind —
+            # only ever onto a tag that already exists, so publishing can never
+            # mint a new tag at main.
+            match="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+              --jq 'map(select(.draft == true and .name == env.TAG)) | first // empty')"
+            if [ -n "$match" ]; then
+              if ! gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" --jq .object.sha >/dev/null 2>&1; then
+                echo "::error::Draft named ${TAG} exists but the git tag does not — push the tag before finalizing."
+                exit 1
+              fi
+              rebind_id="$(printf '%s' "$match" | jq -r '.id')"
+              gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${rebind_id}" \
+                -f tag_name="$TAG" > /dev/null
+              match="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${rebind_id}")"
+              echo "Rebound draft ${rebind_id} to ${TAG} (tag binding was lost, usually to a web-UI edit)." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
           if [ -z "$match" ]; then
             echo "::error::No GitHub release found for ${TAG}. Did the tag push run github-release.yml?"
             exit 1
@@ -118,7 +149,7 @@ jobs:
       - name: Assert PyPI serves all three packages
         if: steps.draft.outputs.already_published != 'true'
         env:
-          TAG: ${{ inputs.tag }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
           version="${TAG#v}"
@@ -134,7 +165,7 @@ jobs:
         if: steps.draft.outputs.already_published != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ inputs.tag }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
           open_pr="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "auto/changelog/${TAG}" \
@@ -145,11 +176,14 @@ jobs:
           fi
           echo "CHANGELOG PR for ${TAG}: merged or not needed."
 
-      - name: Docs sweep — no open PRs against the X.Y-docs staging branch
+      # Advisory only: docs frequently land after the release. The list tells
+      # the coordinator what must merge into X.Y-docs before the docs-publish
+      # PR does — it never blocks the publish itself.
+      - name: Docs sweep — list open PRs against the X.Y-docs staging branch
         if: steps.draft.outputs.already_published != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TAG: ${{ inputs.tag }}
+          TAG: ${{ steps.tag.outputs.tag }}
           SITE_REPO: ${{ github.repository_owner }}/omnigent-site
         run: |
           set -euo pipefail
@@ -158,16 +192,17 @@ jobs:
           open="$(gh pr list --repo "$SITE_REPO" --base "$docs_branch" --state open \
             --json url,title --jq '.[] | "- \(.url)  \(.title)"')"
           if [ -n "$open" ]; then
+            count="$(printf '%s\n' "$open" | grep -c .)"
             {
-              echo "## Docs sweep failed for ${TAG}"
+              echo "## Docs sweep for ${TAG} — ${count} open PR(s) still target \`${docs_branch}\`"
               echo ""
-              echo "Open PRs still target \`${docs_branch}\` on ${SITE_REPO} — review and merge/close them, then re-dispatch:"
+              echo "Advisory, not blocking. Merge/close these before merging the docs-publish PR:"
               echo "$open"
             } | tee -a "$GITHUB_STEP_SUMMARY"
-            echo "::error::Open doc PRs still target ${docs_branch} — see the run summary."
-            exit 1
+            echo "::warning::${count} open doc PR(s) still target ${docs_branch} (non-blocking) — see the run summary."
+          else
+            echo "Docs sweep clean: no open PRs against ${docs_branch}." | tee -a "$GITHUB_STEP_SUMMARY"
           fi
-          echo "Docs sweep clean: no open PRs against ${docs_branch}." | tee -a "$GITHUB_STEP_SUMMARY"
 
   # Approving this environment attests "I reviewed the curated draft notes".
   publish:
@@ -189,7 +224,7 @@ jobs:
       - name: Publish the draft as Latest
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TAG: ${{ inputs.tag }}
+          TAG: ${{ needs.checks.outputs.tag }}
           RELEASE_ID: ${{ needs.checks.outputs.release_id }}
         run: |
           set -euo pipefail

--- a/.github/workflows/oss-publish-images.yml
+++ b/.github/workflows/oss-publish-images.yml
@@ -50,8 +50,10 @@ permissions:
   contents: read
 
 concurrency:
-  # Key by SHA so back-to-back merges each build; don't cancel mid-push.
-  group: oss-publish-images-${{ github.sha }}
+  # One build at a time: rc and final tags land minutes apart at a release cut,
+  # and built concurrently they race each other's layer cache cold and blow the
+  # job timeout. Serialized, the later build reuses the earlier one's layers.
+  group: oss-publish-images
   cancel-in-progress: false
 
 jobs:
@@ -67,9 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     # Multi-arch: the linux/arm64 leg cross-builds under QEMU emulation on this
     # amd64 runner, which roughly doubles the host-image build time (emulated
-    # npm/pip native steps). 30m was tight for two native amd64 builds; give the
-    # four-variant (server+host × amd64+arm64) build headroom.
-    timeout-minutes: 60
+    # npm/pip native steps). A cold-cache four-variant (server+host × amd64+
+    # arm64) build can exceed 60m, and hitting the timeout loses the release's
+    # images silently — give it real headroom.
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -657,7 +657,6 @@ jobs:
   # never re-freezes and doc-sync keeps deriving the right X.Y-docs branch.
   bump-main:
     needs: [authorize, plan, cut]
-    if: ${{ !inputs.dry_run && needs.plan.outputs.branch_exists == 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -667,8 +666,24 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.plan.outputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          BRANCH_EXISTS: ${{ needs.plan.outputs.branch_exists }}
         run: |
           set -euo pipefail
+          # Gate in shell, not a job-level `if`: a CLI/API dispatch delivers
+          # boolean inputs as the STRING "false", which is truthy in an
+          # expression, so `!inputs.dry_run` silently skipped this job at the
+          # v0.7.0 cut. Shell string comparison is dispatch-channel-proof and
+          # logs its decision instead of vanishing from the run.
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run — not dispatching the main bump." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ "$BRANCH_EXISTS" != "false" ]; then
+            echo "Release branch pre-existed (not the first cut of this cycle) — main bump not needed." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           # A cut below main's current line (a throwaway rehearsal rc, or
           # resurrecting an old series for a backport) must not walk main's
           # version backwards.

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -15,11 +15,21 @@
 # from finalize-release.yml's App-token publish; `workflow_dispatch` covers
 # retries and catch-up (e.g. jumping the formula straight to the newest
 # version after a missed cycle).
+#
+# brew resolves resources through pip's `--uploaded-prior-to=P1D` window, so a
+# run within 24h of the PyPI upload cannot see the new sdist and used to go
+# red every release day (v0.6.0, v0.7.0). Now: runs inside that window defer
+# (green, with a warning), and the nightly `schedule` catch-up — which targets
+# the latest published release and no-ops when the formula is already
+# current — opens the tap PR once the window has passed.
 name: Update Homebrew tap
 
 on:
   release:
     types: [published]
+  schedule:
+    # Nightly catch-up for the P1D window (see header). No-ops when current.
+    - cron: "45 23 * * *"
   workflow_dispatch:
     inputs:
       tag:
@@ -31,7 +41,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: update-homebrew-${{ github.event.release.tag_name || inputs.tag }}
+  group: update-homebrew-${{ github.event.release.tag_name || inputs.tag || 'nightly' }}
   cancel-in-progress: false
 
 jobs:
@@ -46,12 +56,18 @@ jobs:
       - name: Resolve tag and finality
         id: r
         env:
+          GH_TOKEN: ${{ github.token }}
           EVENT_TAG: ${{ github.event.release.tag_name }}
           PRERELEASE: ${{ github.event.release.prerelease }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
           tag="${INPUT_TAG:-$EVENT_TAG}"
+          if [ -z "$tag" ]; then
+            # Scheduled catch-up: target the latest published final release
+            # (empty when the repo has none yet — resolves to is_final=false).
+            tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>/dev/null || echo "")"
+          fi
           is_final=true
           case "$tag" in
             v[0-9]*.[0-9]*.[0-9]*) ;;
@@ -145,12 +161,29 @@ jobs:
           path: tap
           persist-credentials: false
 
+      - name: Skip when the formula is already at this version
+        id: current
+        working-directory: tap
+        env:
+          VERSION: ${{ steps.sdist.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Nightly catch-up no-op: the stable url already points at this sdist.
+          if grep -q "omnigent-${VERSION}\.tar\.gz" Formula/omnigent.rb; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Formula already at ${VERSION} — nothing to do." | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Homebrew
+        if: steps.current.outputs.skip != 'true'
         uses: Homebrew/actions/setup-homebrew@18fcb8e3e06b4247c676c506750dc95ea7226479 # 2026-07-10
         with:
           token: ${{ github.token }}
 
       - name: Rewrite the formula's stable url/sha256
+        if: steps.current.outputs.skip != 'true'
         working-directory: tap
         env:
           SDIST_URL: ${{ steps.sdist.outputs.url }}
@@ -172,9 +205,12 @@ jobs:
           git diff --stat
 
       - name: Regenerate the pinned Python resources
+        id: regen
+        if: steps.current.outputs.skip != 'true'
         env:
           HOMEBREW_NO_AUTO_UPDATE: "1"
           HOMEBREW_NO_INSTALL_FROM_API: "1"
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # Make the checkout visible to brew as the real tap.
@@ -185,12 +221,31 @@ jobs:
           # deps (certifi/cryptography/pydantic/rpds-py and their transitive
           # cffi/pycparser) and the platform-conditional google-antigravity
           # wheel stanzas.
-          brew update-python-resources \
+          if ! brew update-python-resources \
             --exclude-packages=certifi,cryptography,pydantic,rpds-py,cffi,pycparser,google-antigravity \
-            omnigent-ai/tap/omnigent
+            omnigent-ai/tap/omnigent; then
+            # brew resolves through pip's --uploaded-prior-to=P1D window: a
+            # release <24h old is invisible and resolution ALWAYS fails. Defer
+            # to the nightly catch-up instead of going red; older releases are
+            # real failures.
+            published_at="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq .published_at 2>/dev/null || echo "")"
+            age_h=999
+            if [ -n "$published_at" ]; then
+              age_h="$(python3 -c 'import datetime, sys; d = datetime.datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00")); print(int((datetime.datetime.now(datetime.timezone.utc) - d).total_seconds() // 3600))' "$published_at")"
+            fi
+            if [ "$age_h" -lt 24 ]; then
+              echo "deferred=true" >> "$GITHUB_OUTPUT"
+              echo "::warning::Resource resolution failed with ${TAG} only ${age_h}h old — inside pip's --uploaded-prior-to=P1D window. The nightly catch-up will open the tap PR."
+              echo "Deferred to the nightly catch-up (${TAG} is ${age_h}h old, inside the 24h PyPI window)." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            exit 1
+          fi
+          echo "deferred=false" >> "$GITHUB_OUTPUT"
           brew style omnigent-ai/tap/omnigent
 
       - name: Assert the hand-maintained sections survived
+        if: steps.current.outputs.skip != 'true' && steps.regen.outputs.deferred != 'true'
         working-directory: tap
         run: |
           set -euo pipefail
@@ -214,6 +269,7 @@ jobs:
           done
 
       - name: Open or update the tap bump PR
+        if: steps.current.outputs.skip != 'true' && steps.regen.outputs.deferred != 'true'
         working-directory: tap
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/uv.lock
+++ b/uv.lock
@@ -1381,14 +1381,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", upload-time = "2026-07-23T02:52:43.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", upload-time = "2026-07-23T02:52:41.932Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Related issue

N/A — failure modes observed live while cutting v0.7.0 (and previously v0.5.0/v0.6.0).

## Summary

Fixes the four release-pipeline failure modes that required manual intervention during the v0.7.0 cut, plus the dependency advisory they exposed:

- **finalize-release.yml — docs sweep is now advisory.** It lists the open PRs still targeting the `X.Y-docs` staging branch (with a `::warning::` and run-summary table) but never blocks the publish; docs can land any time before the docs-publish PR merges. (v0.7.0 shipped with 27 doc PRs still staged.)
- **finalize-release.yml — auto-rebind untagged drafts.** Editing a draft release in the web UI can silently drop its tag binding (`tag_name` becomes `untagged-…` while the name stays `vX.Y.Z`) — this broke finalize at both v0.5.0 and v0.7.0 with a misleading "No GitHub release found". The resolve step now falls back to matching the draft by name and rebinds it, but only onto a tag that already exists, so a publish can never mint a tag at main.
- **finalize-release.yml — tag input normalized.** `0.7.0` (or stray whitespace) becomes `v0.7.0` instead of failing the first gate; the normalized tag is threaded through all later steps via step/job outputs.
- **release.yml — bump-main can no longer skip silently.** The job-level `if: !inputs.dry_run && …` is gone: a CLI/API dispatch delivers boolean inputs as the *string* `"false"`, which is truthy, so the expression skipped the job at the v0.7.0 cut and main never got its post-release bump dispatched. The gate now runs in shell, where string comparison is dispatch-channel-proof and every skip is logged to the run summary.
- **update-homebrew.yml — release-day runs defer instead of failing.** `brew update-python-resources` resolves through pip's `--uploaded-prior-to=P1D`, so any run within 24h of the PyPI upload cannot see the new sdist and went red every cycle (v0.6.0, v0.7.0). Failures now check the release age: inside the window they defer green with a warning; a new nightly `schedule` catch-up targets the latest published release, no-ops when the formula is already current, and opens the tap PR once the window has passed.
- **uv.lock — gitpython 3.1.50 → 3.1.55.** Transitive via mlflow-skinny; 8 OSV advisories against 3.1.50 (published 2026-07-23) tripped the Security Scan on every lock-touching PR (first hit: #3377). Lock-only stamp: version, sdist/wheel URLs, sha256, and upload times taken from PyPI's JSON metadata; `gitdb<5,>=4.0.1` runtime dependency unchanged, so the resolution graph is untouched.

- **oss-publish-images.yml — a release's images can no longer vanish silently.** At the v0.7.0 cut the final tag's image build was killed by its 60-minute job timeout: concurrency was keyed by SHA, so the rc1 build (21:51, 39 min) and the final build (21:57) ran concurrently and raced each other's layer cache cold — and nothing surfaced the cancellation, so `:v0.7.0` / `:latest` were never published until a manual re-run ~23h later. Runs now serialize in a single group (`cancel-in-progress: false` — the later build queues and reuses the earlier build's hot layers) and the timeout is 120m for genuinely cold builds.

**ELI5:** cutting 0.7.0 needed four manual rescues — un-wedging the draft release, hand-dispatching the version bump, retrying homebrew tomorrow, and waiving a security scan. This PR teaches the pipeline to handle all four itself.

```mermaid
flowchart LR
    A[finalize dispatch] --> B[normalize tag]
    B --> C{draft found by tag?}
    C -- no --> D[find draft by name,\nassert tag exists, rebind]
    C -- yes --> E[PyPI x3 + CHANGELOG gates]
    D --> E
    E --> F[docs sweep\nadvisory warning only]
    F --> G[publish-release approval] --> H[publish as Latest]
    H --> I[update-homebrew]
    I -- release < 24h old --> J[defer green\nnightly catch-up opens tap PR]
```

## Test Plan

- All three workflows parse (`yaml.safe_load`) and passed the repo pre-commit hooks (whitespace/newline/yaml/etc.; the `normalize-uv-lock-registry` guard run directly confirms the lock stays pypi.org-only).
- gitpython 3.1.55 URLs, sha256 digests, and upload times verified against PyPI's JSON metadata; `requires_dist` compared 3.1.50 → 3.1.55 (runtime deps identical: `gitdb<5,>=4.0.1`), so the hand-stamp cannot change resolution. This PR's lint gate (`uv sync --locked`) validates the lock. Note the Security Scan's OSV audit does NOT run here — the scan trust-gates maintainer-authored PRs — so the empirical OSV confirmation lands on the next bot-authored lock-touching PR (bot PRs are untrusted, which is why #3377 hit the scan); 3.1.55 is the highest fix version pip-audit itself listed, so no known advisory remains by construction.
- The rebind logic replays the manual recovery performed live on the v0.7.0 draft (`PATCH releases/<id> -f tag_name=v0.7.0`), which worked and published cleanly.
- The bump-main and homebrew paths only execute at release time; they will be exercised at the 0.8.0 cut. The nightly homebrew catch-up is additionally observable within a day of merge (it should no-op green while the tap is current).

## Demo

N/A — CI/workflow behavior changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Workflow-dispatch release paths have no test harness in this repo; verification is the parse/hook checks above plus this PR's lint `uv sync --locked` gate for the lock change (the OSV audit trust-skips maintainer PRs — see Test Plan). The finalize rebind mirrors the manual fix already proven on the live v0.7.0 release; the remaining paths get their first live exercise at the 0.8.0 cycle.

This pull request and its description were written by Isaac.

