### PR TITLE
chore(pnpm): approve build scripts for .github/ci-deps packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,6 +73,9 @@ overrides:
   express-rate-limit>ip-address: ^10.1.1
 
 allowBuilds:
+  '@anthropic-ai/claude-code': true
+  '@google/genai': true
   canvas: true
   electron-winstaller: true
   msw: true
+  protobufjs: true


### PR DESCRIPTION
Approves build scripts for @anthropic-ai/claude-code, @google/genai, and protobufjs so a full workspace install (and pnpm dev from root) does not fail with [ERR_PNPM_IGNORED_BUILDS].