### PR TITLE
feat(android): instrumented screenshot capture with Gradle-managed servers

### DIFF
--- a/web/android/app/build.gradle.kts
+++ b/web/android/app/build.gradle.kts
@@ -1,4 +1,12 @@
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.Properties
+import java.util.concurrent.TimeUnit
 
 plugins {
     alias(libs.plugins.android.application)
@@ -32,6 +40,10 @@ android {
         targetSdk = 35
         versionCode = (project.findProperty("versionCode") as? String)?.toIntOrNull() ?: 2
         versionName = "0.1.0"
+
+        // Instrumented (androidTest) runner — required for UI Automator / Espresso
+        // screenshot tests. Mirrors the androidx.test stable line pinned below.
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     signingConfigs {
@@ -106,6 +118,16 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)
+
+    // Instrumented (androidTest) screenshot tests. Run via connectedDebugAndroidTest
+    // against a device/emulator; see the `recordScreenshots` Gradle task. UI Automator
+    // is the capture mechanism (UiDevice.takeScreenshot(File)); espresso + runner/rules
+    // provide the ActivityScenario/JUnit harness.
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.test.rules)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.uiautomator)
 }
 
 // Local development helpers — these delegate to adb so they work with physical
@@ -147,4 +169,457 @@ tasks.register<Exec>("reverseProxy") {
     description = "Forward local port 8000 to the Android device/emulator (adb reverse)"
     group = "install"
     commandLine(adbPath, "reverse", "tcp:8000", "tcp:8000")
+}
+
+// ---------------------------------------------------------------------------
+// Screenshot capture (instrumented, on-device)
+//
+// `recordScreenshots` is the one-shot entry point: it verifies the Vite dev
+// server is reachable on localhost:5173, wires `adb reverse tcp:5173 tcp:5173`
+// so the device's `localhost:5173` resolves to the host (works on both emulator
+// and USB-attached physical devices — no --host 0.0.0.0 / LAN IP needed),
+// builds+installs the androidTest APK, runs the screenshot test(s), then pulls
+// the captured PNGs into app/build/screenshots/. The test itself
+// (ScreenshotTest) seeds ServerStore with http://localhost:5173 and captures
+// via UiDevice.takeScreenshot.
+//
+// Note: the app's DEFAULT_DEBUG_SERVER / `reverseProxy` task target port 8000,
+// but the actual Vite dev server is 5173 (see web/README.md). This screenshot
+// flow uses the real port and its own reverse mapping rather than coupling to
+// those stale 8000 values.
+//
+// Requires exactly one attached device. Run from web/android:
+//
+//   ./gradlew recordScreenshots
+//   open app/build/screenshots/home.png
+//
+// The Vite dev server is managed automatically: `startWebDevServer` launches it
+// (if one isn't already up) and `stopWebDevServer` tears it down. So you don't
+// need a separate `npm run dev` terminal — just run `recordScreenshots`.
+// ---------------------------------------------------------------------------
+
+/** Local Vite dev-server URL the device will reach via `adb reverse`. Must match
+ *  the URL ScreenshotTest seeds into ServerStore and the cleartext allowlist in
+ *  app/src/debug/res/xml/network_security_config.xml (localhost is permitted,
+ *  any port). 5173 is Vite's default per web/README.md. Override the port with
+ *  -PvitePort=… and host with -PviteHost=… . */
+private val screenshotVitePort =
+    (project.findProperty("vitePort") as? String)?.toIntOrNull() ?: 5173
+private val screenshotViteHost = (project.findProperty("viteHost") as? String) ?: "127.0.0.1"
+private val screenshotServerUrl = "http://localhost:$screenshotVitePort"
+private val screenshotHostPort = screenshotVitePort
+
+/** On-device path the instrumented test writes PNGs to (app external-files dir;
+ *  pulled by `recordScreenshots` before the app is uninstalled). */
+private val localScreenshotsDir =
+    layout.buildDirectory
+        .dir("screenshots")
+        .get()
+        .asFile
+
+/** The web/ project (sibling of web/android/) — where Vite lives. */
+private val webDir = rootProject.projectDir.parentFile
+
+/** The vite CLI entry launched directly via `node` (avoids spawning `npm`/
+ *  `pnpm`, whose grandchild vite process is hard to kill reliably). */
+private val viteEntry = File(webDir, "node_modules/vite/bin/vite.js")
+
+/** Backend (omnigent server) port — Vite proxies /v1 here (OMNIGENT_URL default
+ *  is http://localhost:6767 per web/vite.config.ts). Override with -PbackendPort=. */
+private val screenshotBackendPort =
+    (project.findProperty("backendPort") as? String)?.toIntOrNull() ?: 6767
+
+/** The agent YAML to pre-register so POST /v1/sessions has an agent_id. Override
+ *  with -PagentSpec=. */
+private val screenshotAgentSpec =
+    (project.findProperty("agentSpec") as? String)
+        ?: "examples/kimi_hello.yaml"
+
+/** The demo user message seeded into the session so `session.png` has content. */
+private val screenshotDemoPrompt =
+    "Can you list the files in the current directory and explain what this project does?"
+
+tasks.register<Exec>("reverseScreenshotPort") {
+    description =
+        "Forward local Vite port $screenshotHostPort to the device (adb reverse) for screenshot tests"
+    group = "verification"
+    commandLine(adbPath, "reverse", "tcp:$screenshotHostPort", "tcp:$screenshotHostPort")
+}
+
+/** Polls 127.0.0.1:$port until a TCP connection succeeds (Vite is ready) or the
+ *  timeout elapses. Vite's first build can take a few seconds. */
+private fun waitForPort(
+    host: String,
+    port: Int,
+    timeoutMs: Long,
+): Boolean {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+        try {
+            Socket().use { it.connect(InetSocketAddress(host, port), 1000) }
+            return true
+        } catch (e: Exception) {
+            Thread.sleep(250)
+        }
+    }
+    return false
+}
+
+/** The dev-server process we started (null if we reused an existing server or
+ *  haven't started one). Kept in a top-level var so `stopWebDevServer` — a
+ *  separate task in the same build — can reach it. */
+private var devServerProcess: Process? = null
+private var devServerStartedByUs = false
+
+/** The backend (omnigent server) process we started. */
+private var backendProcess: Process? = null
+private var backendTempDir: Path? = null
+
+/** The session id created by seedDemoSession (passed to the `session` screen). */
+private var seededSessionId: String? = null
+
+// Ensures web/node_modules is installed before launching Vite. Uses `npm`
+// (the repo's canonical manager per web/README.md + package-lock.json); skip
+// if node_modules already exists. Override with -PwebPackageManager=… .
+tasks.register<Exec>("installWebDeps") {
+    description = "Run npm install in web/ if node_modules is missing (prereq for the dev server)"
+    group = "verification"
+    onlyIf { !File(webDir, "node_modules").exists() }
+    val pm = (project.findProperty("webPackageManager") as? String) ?: "npm"
+    workingDir = webDir
+    commandLine(pm, "install")
+}
+
+tasks.register("startWebDevServer") {
+    description = "Start the Vite dev server (or reuse an existing one) for screenshot capture"
+    group = "verification"
+    dependsOn("installWebDeps")
+    doLast {
+        // Reuse an already-running server on the IPv4 loopback — adb reverse
+        // forwards to 127.0.0.1, so the server must be reachable there. A default
+        // `npm run dev` binds IPv6 `::1` only on macOS and would NOT be reached;
+        // in that case we start our own with --host 127.0.0.1.
+        fun alive(host: String) =
+            try {
+                Socket().use {
+                    it.connect(InetSocketAddress(host, screenshotVitePort), 1000)
+                    true
+                }
+            } catch (e: Exception) {
+                false
+            }
+        if (alive("127.0.0.1")) {
+            logger.lifecycle(
+                "recordScreenshots: reusing existing dev server on 127.0.0.1:$screenshotVitePort",
+            )
+            return@doLast
+        }
+        if (!viteEntry.exists()) {
+            throw GradleException(
+                "Vite entry not found at ${viteEntry.absolutePath}. Run `npm install` in web/ first.",
+            )
+        }
+        val pb =
+            ProcessBuilder(
+                "node",
+                viteEntry.absolutePath,
+                "--host",
+                screenshotViteHost,
+                "--port",
+                screenshotVitePort.toString(),
+            ).directory(webDir)
+                .redirectErrorStream(true)
+        // Inherit env (the Gradle daemon's PATH includes node via nvm). Pipe stdout
+        // so Vite's logs don't flood the build output; on failure we dump them.
+        devServerProcess = pb.start()
+        devServerStartedByUs = true
+        logger.lifecycle(
+            "recordScreenshots: starting Vite dev server on $screenshotViteHost:$screenshotVitePort ...",
+        )
+        if (!waitForPort(screenshotViteHost, screenshotVitePort, 60_000)) {
+            val log = devServerProcess!!.inputStream.readBytes().toString(Charsets.UTF_8)
+            devServerProcess?.destroyForcibly()
+            devServerProcess = null
+            devServerStartedByUs = false
+            throw GradleException(
+                "Vite dev server didn't become ready on $screenshotViteHost:" +
+                    "$screenshotVitePort within 60s.\n" +
+                    "Vite output:\n$log",
+            )
+        }
+        logger.lifecycle(
+            "recordScreenshots: dev server ready on $screenshotViteHost:$screenshotVitePort",
+        )
+    }
+}
+
+tasks.register("stopWebDevServer") {
+    description = "Stop the Vite dev server started by startWebDevServer (no-op if reused)"
+    group = "verification"
+    doLast {
+        val p = devServerProcess
+        if (p == null || !devServerStartedByUs) {
+            logger.lifecycle(
+                "recordScreenshots: dev server was reused or never started — nothing to stop",
+            )
+            return@doLast
+        }
+        // Kill the whole process tree: vite spawns esbuild/rollup workers as
+        // children; destroyForcibly on the parent alone orphans them.
+        p.descendants().forEach { runCatching { it.destroyForcibly() } }
+        runCatching { p.destroyForcibly() }
+        p.waitFor(3, TimeUnit.SECONDS)
+        devServerProcess = null
+        devServerStartedByUs = false
+        logger.lifecycle("recordScreenshots: dev server stopped")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Backend (omnigent server) — isolated, in a temp dir, no auth.
+//
+// `startBackendServer` launches `omnigent server` with OMNIGENT_DATA_DIR /
+// OMNIGENT_CONFIG_HOME pointed at a throwaway mktemp dir so it never touches
+// the user's real ~/.omnigent. On loopback it's single-user (no login wall).
+// Vite proxies /v1 to this backend (OMNIGENT_URL default = localhost:6767),
+// so the SPA in the WebView gets real data — populated session list + a
+// session page with content. `seedDemoSession` creates a session with a user
+// message via POST /v1/sessions; `stopBackendServer` tears it down + cleans
+// the temp dir.
+// ---------------------------------------------------------------------------
+
+tasks.register("startBackendServer") {
+    description =
+        "Start an isolated omnigent backend server (temp data dir, no auth) for real SPA data"
+    group = "verification"
+    doLast {
+        // Reuse an already-running backend on the configured port.
+        if (waitForPort("127.0.0.1", screenshotBackendPort, 0)) {
+            logger.lifecycle(
+                "recordScreenshots: reusing existing backend on 127.0.0.1:$screenshotBackendPort",
+            )
+            return@doLast
+        }
+        backendTempDir = Files.createTempDirectory("omnigent-screenshot")
+        val dataDir = backendTempDir!!.resolve("data").toFile().apply { mkdirs() }
+        val configDir = backendTempDir!!.resolve("config").toFile().apply { mkdirs() }
+        val artifactsDir = backendTempDir!!.resolve("artifacts").toFile().apply { mkdirs() }
+        val dbUri = "sqlite:///${dataDir.absolutePath}/chat.db"
+        // Resolve the agent spec relative to the repo root (parent of web/).
+        val agentSpecFile = File(rootProject.projectDir.parentFile, screenshotAgentSpec)
+        val agentArg =
+            if (agentSpecFile.exists()) {
+                listOf(
+                    "--agent",
+                    agentSpecFile.absolutePath,
+                )
+            } else {
+                emptyList()
+            }
+        val pb =
+            ProcessBuilder(
+                "omnigent",
+                "server",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                screenshotBackendPort.toString(),
+                "--database-uri",
+                dbUri,
+                "--artifact-location",
+                artifactsDir.absolutePath,
+                *agentArg.toTypedArray(),
+            ).directory(rootProject.projectDir.parentFile)
+                .redirectErrorStream(true)
+        pb.environment()["OMNIGENT_DATA_DIR"] = dataDir.absolutePath
+        pb.environment()["OMNIGENT_CONFIG_HOME"] = configDir.absolutePath
+        pb.environment()["OMNIGENT_DATABASE_URI"] = dbUri
+        backendProcess = pb.start()
+        logger.lifecycle(
+            "recordScreenshots: starting backend on 127.0.0.1:$screenshotBackendPort (data dir: $backendTempDir) ...",
+        )
+        if (!waitForPort("127.0.0.1", screenshotBackendPort, 30_000)) {
+            val log = backendProcess!!.inputStream.readBytes().toString(Charsets.UTF_8)
+            backendProcess?.destroyForcibly()
+            backendProcess = null
+            throw GradleException(
+                "Backend didn't become ready on :$screenshotBackendPort within 30s.\nOutput:\n$log",
+            )
+        }
+        logger.lifecycle("recordScreenshots: backend ready on 127.0.0.1:$screenshotBackendPort")
+    }
+}
+
+tasks.register("seedDemoSession") {
+    description =
+        "Create a session with a user message on the backend so the session screenshot has content"
+    group = "verification"
+    dependsOn("startBackendServer")
+    doLast {
+        val baseUrl = "http://127.0.0.1:$screenshotBackendPort"
+        // Find a registered agent id (the --agent flag pre-registered one).
+        val agentsJson = URI(baseUrl + "/v1/agents").toURL().readText()
+        // Agent IDs may or may not have an "ag_" prefix depending on source;
+        // just grab the first id from the list.
+        val agentId =
+            Regex(""""id":\s*"([^"]+)"""").find(agentsJson)?.groupValues?.get(1)
+                ?: throw GradleException("No agent found on the backend at $baseUrl/v1/agents")
+        // Create a session with an initial user message.
+        val body =
+            """{"agent_id":"$agentId","initial_items":[{"type":"message",""""" +
+                """"data":{"role":"user","content":[{"type":"input_text",""""" +
+                """"text":"$screenshotDemoPrompt"}]}]}}]}"""
+        val conn = (URI(baseUrl + "/v1/sessions").toURL().openConnection() as HttpURLConnection)
+        conn.requestMethod = "POST"
+        conn.setRequestProperty("Content-Type", "application/json")
+        conn.doOutput = true
+        conn.outputStream.use { it.write(body.toByteArray(Charsets.UTF_8)) }
+        val resp = conn.inputStream.bufferedReader().use { it.readText() }
+        seededSessionId = Regex(""""id":\s*"([^"]+)"""").find(resp)?.groupValues?.get(1)
+            ?: throw GradleException("Failed to create session. Response: $resp")
+        logger.lifecycle(
+            "recordScreenshots: created demo session $seededSessionId (agent=$agentId)",
+        )
+    }
+}
+
+tasks.register("stopBackendServer") {
+    description = "Stop the isolated backend server and clean its temp dir"
+    group = "verification"
+    doLast {
+        backendProcess?.let { p ->
+            p.descendants().forEach { runCatching { it.destroyForcibly() } }
+            runCatching { p.destroyForcibly() }
+            p.waitFor(3, TimeUnit.SECONDS)
+        }
+        backendProcess = null
+        backendTempDir?.let {
+            runCatching {
+                Files.walk(it).sorted(reverseOrder()).forEach { f ->
+                    runCatching { Files.deleteIfExists(f) }
+                }
+            }
+        }
+        backendTempDir = null
+        logger.lifecycle("recordScreenshots: backend stopped + temp dir cleaned")
+    }
+}
+
+/** Application id of the app under test. */
+private val screenshotAppId = "ai.omnigent.android"
+
+/** Test component (test package / instrumentation runner) for `am instrument`. */
+private val screenshotTestComponent =
+    "$screenshotAppId.test/androidx.test.runner.AndroidJUnitRunner"
+
+tasks.register("recordScreenshots") {
+    description =
+        "Capture the server-select + home + session-list + session screens into app/build/screenshots"
+    group = "verification"
+    dependsOn("installDebug")
+    dependsOn("installDebugAndroidTest")
+    dependsOn("startBackendServer")
+    dependsOn("seedDemoSession")
+    dependsOn("startWebDevServer")
+    dependsOn("reverseScreenshotPort")
+    finalizedBy("stopWebDevServer")
+    finalizedBy("stopBackendServer")
+    doLast {
+        localScreenshotsDir.mkdirs()
+        // The session id to deep-link to. Prefer the one seeded by seedDemoSession;
+        // fall back to -PsessionId=… then to a placeholder (empty session chrome).
+        val sessionId =
+            seededSessionId
+                ?: (project.findProperty("sessionId") as? String).orEmpty()
+        val screens =
+            linkedMapOf(
+                "server_select" to "",
+                "home" to "",
+                "session_list" to "",
+                "session" to sessionId,
+            )
+        val reportDir =
+            layout.buildDirectory
+                .dir("screenshots-instrumentation")
+                .get()
+                .asFile
+        reportDir.mkdirs()
+        for ((screen, sid) in screens) {
+            logger.lifecycle("recordScreenshots: capturing screen=$screen ...")
+            // Per-screen device prep: pm clear so launch routes to ConnectActivity,
+            // and pre-grant POST_NOTIFICATIONS to suppress the runtime dialog.
+            exec {
+                commandLine(adbPath, "shell", "pm", "clear", screenshotAppId)
+                isIgnoreExitValue = true
+            }
+            exec {
+                commandLine(
+                    adbPath,
+                    "shell",
+                    "pm",
+                    "grant",
+                    screenshotAppId,
+                    "android.permission.POST_NOTIFICATIONS",
+                )
+                isIgnoreExitValue = true
+            }
+            // pm clear stops the app process; give the system a moment to settle
+            // before am instrument starts a fresh one, else the instrumentation
+            // can race with the process shutdown and crash.
+            Thread.sleep(1_000)
+            // Run the single test method, parameterized by screen (+sessionId).
+            val instrumentLog = File(reportDir, "instrument-$screen.log")
+            val instrumentArgs =
+                mutableListOf(
+                    adbPath,
+                    "shell",
+                    "am",
+                    "instrument",
+                    "-w",
+                    "-r",
+                    "-e",
+                    "class",
+                    "ai.omnigent.android.ScreenshotTest",
+                    "-e",
+                    "screen",
+                    screen,
+                    "-e",
+                    "serverUrl",
+                    screenshotServerUrl,
+                )
+            if (sid.isNotEmpty()) {
+                instrumentArgs.addAll(listOf("-e", "sessionId", sid))
+            }
+            instrumentArgs.add(screenshotTestComponent)
+            exec {
+                commandLine(instrumentArgs)
+                standardOutput = instrumentLog.outputStream()
+                errorOutput = instrumentLog.outputStream()
+            }
+            val log = instrumentLog.readText()
+            val failures =
+                Regex("INSTRUMENTATION_RESULT: failures=(\\d+)")
+                    .find(log)
+                    ?.groupValues
+                    ?.get(1)
+                    ?.toIntOrNull() ?: 0
+            if (failures > 0 || !log.contains("OK (1 test)")) {
+                throw GradleException(
+                    "Screenshot test failed for screen=$screen.\nInstrumentation output:\n$log",
+                )
+            }
+            // Pull this screen's PNG while the app is still installed (am
+            // instrument, unlike connectedDebugAndroidTest, doesn't uninstall).
+            val src = "/sdcard/Android/data/$screenshotAppId/files/screenshots/$screen.png"
+            val outFile = File(localScreenshotsDir, "$screen.png")
+            exec { commandLine(adbPath, "pull", src, outFile.absolutePath) }
+            if (!outFile.exists() || outFile.length() == 0L) {
+                throw GradleException("No screenshot pulled for screen=$screen from $src.")
+            }
+            logger.lifecycle("recordScreenshots: saved ${outFile.name} (${outFile.length()} bytes)")
+        }
+        logger.lifecycle(
+            "recordScreenshots: done — ${screens.size} screenshots in ${localScreenshotsDir.absolutePath}",
+        )
+    }
 }

--- a/web/android/app/src/androidTest/java/ai/omnigent/android/ScreenshotTest.kt
+++ b/web/android/app/src/androidTest/java/ai/omnigent/android/ScreenshotTest.kt
@@ -1,0 +1,224 @@
+package ai.omnigent.android
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * Instrumented screenshot test for the WebView shell.
+ *
+ * Captures real SPA rendering inside [MainActivity]'s WebView (and the native
+ * [ConnectActivity] server-selection screen) on a device/emulator against a
+ * *live* Vite dev server. This is the only way to screenshot the product UI the
+ * shell hosts.
+ *
+ * Driven by the `recordScreenshots` Gradle task, which runs this test once per
+ * screen (passing `-e screen <name>`) and pulls each PNG into
+ * app/build/screenshots/. Screens:
+ *
+ *  - `server_select` — [ConnectActivity] (native server-entry screen). Captured
+ *    before tapping Connect, so no WebView is involved.
+ *  - `home` — the SPA landing page at `/` (new-chat composer + sidebar).
+ *  - `session_list` — the SPA home; the session list *is* the sidebar
+ *    (`AppShell`), always visible on every route. Same route as `home` (there's
+ *    no dedicated `/sessions` page); a populated list needs the omnigent
+ *    backend (proxied at :6767) to serve `/v1/sessions`.
+ *  - `session` — a chat/session page at `/c/:conversationId`. Pass a real id via
+ *    `-e sessionId=conv_...` to capture one with content; without it (or without
+ *    the backend) the session page chrome renders empty/loading.
+ *
+ * Prerequisites (enforced/handled by the `recordScreenshots` Gradle task):
+ *  1. A Vite dev server reachable at http://localhost:5173 (the task starts one
+ *     automatically if none is running, and runs `adb reverse tcp:5173`).
+ *  2. The debug network-security config permits cleartext to `localhost`
+ *     (app/src/debug/res/xml/network_security_config.xml).
+ *  3. App data is `pm clear`-ed before each screen so launch routes to
+ *    ConnectActivity, and POST_NOTIFICATIONS is pre-granted (suppresses the
+ *    runtime dialog that would cover the WebView).
+ *
+ * This is a pure UI Automator (out-of-process, black-box) test: it launches the
+ * app from the launcher, types the server URL into the real ConnectActivity
+ * field, and taps Connect. ServerStore is written in the *app* process (the
+ * production code path MainActivity reads) and the real MainActivity is brought
+ * to the foreground as the user sees it. (An instrumented test runs in its own
+ * process `ai.omnigent.android.test`; writing SharedPreferences directly, or
+ * launching via ActivityScenario, would stay in the test process and MainActivity
+ * would never foreground.)
+ *
+ * Once MainActivity is up, the test waits for the floating server-switcher pill
+ * (added after the WebView is built and loadUrl is called) as the "shell is up"
+ * signal, plus a render buffer for the web content, then captures via
+ * [UiDevice.takeScreenshot].
+ */
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class ScreenshotTest {
+    private val instrumentation get() = InstrumentationRegistry.getInstrumentation()
+    private val device get() = UiDevice.getInstance(instrumentation)
+    private val targetPackage get() = instrumentation.targetContext.packageName
+
+    /** Which screen to capture, passed via `am instrument -e screen <name>`. */
+    private val screen: String
+        get() = InstrumentationRegistry.getArguments().getString("screen") ?: "home"
+
+    /** Optional real session id for the `session` screen (-e sessionId=conv_...). */
+    private val sessionId: String?
+        get() =
+            InstrumentationRegistry
+                .getArguments()
+                .getString(
+                    "sessionId",
+                )?.takeIf { it.isNotBlank() }
+
+    /** Base server URL the device reaches via `adb reverse`. */
+    private val serverBaseUrl: String
+        get() =
+            InstrumentationRegistry
+                .getArguments()
+                .getString(
+                    "serverUrl",
+                )?.takeIf { it.isNotBlank() }
+                ?: "http://localhost:5173"
+
+    @Test
+    fun capture() {
+        device.wakeUp()
+        if (device.isScreenOn) device.pressMenu() // dismiss any keyguard guard
+
+        // Pre-grant POST_NOTIFICATIONS (API 33+) so MainActivity's runtime
+        // request doesn't surface a dialog over the WebView. App data is already
+        // pm-cleared by the Gradle task; we can't pm clear here (shared uid).
+        try {
+            instrumentation.uiAutomation.grantRuntimePermission(
+                targetPackage,
+                android.Manifest.permission.POST_NOTIFICATIONS,
+            )
+        } catch (e: Exception) {
+            // pre-33 or already granted
+        }
+
+        when (screen) {
+            "server_select" -> captureConnectActivity()
+            "session" -> captureWebView(routePath = "/c/${sessionId ?: SCREENSHOT_DEMO_SESSION_ID}")
+            "session_list" -> captureSessionList()
+            else -> captureWebView(routePath = "/") // home
+        }
+    }
+
+    /** Captures the native ConnectActivity server-selection screen (pre-connect). */
+    private fun captureConnectActivity() {
+        launchApp()
+        waitConnectField()
+        // Don't tap Connect — capture the server-entry screen as-is.
+        Thread.sleep(RENDER_BUFFER_MS)
+        capturePng("server_select.png")
+    }
+
+    /**
+     * Drives ConnectActivity: types the server URL (base + [routePath]), taps
+     * Connect, waits for the shell (switch pill), then captures the rendered
+     * SPA at that route. The SPA fully supports deep-linking (server-side SPA
+     * fallback returns index.html, react-router resolves the path), so loading
+     * base + `/c/:id` renders the session page directly.
+     */
+    private fun captureWebView(routePath: String) {
+        val serverUrl = serverBaseUrl.trimEnd('/') + routePath
+
+        launchApp()
+        waitConnectField()
+        device.findObject(By.text(FIELD_HINT))!!.text = serverUrl
+        device.findObject(By.text("Connect"))!!.click()
+
+        // If the POST_NOTIFICATIONS dialog still appeared (grant failed),
+        // dismiss it by tapping a system "Allow"-prefixed button.
+        device.wait(Until.hasObject(By.textStartsWith("Allow")), 4_000)?.let {
+            if (it) device.findObject(By.textStartsWith("Allow"))?.click()
+        }
+
+        // The floating switch pill's label is hostLabelOf(serverUrl). With a
+        // route path appended, hostLabelOf still yields "localhost:5173" (it
+        // parses host:port, ignoring the path) — so the same label works for
+        // every screen. Its presence means the WebView shell is up.
+        val switchLabel = "localhost:5173"
+        assertTrue(
+            "Server-switcher pill \"$switchLabel\" never appeared — " +
+                "is the Vite dev server up at $serverBaseUrl and is " +
+                "`adb reverse tcp:5173 tcp:5173` in place?",
+            device.wait(Until.hasObject(By.text(switchLabel)), SHELL_UP_TIMEOUT_MS),
+        )
+
+        // Render buffer for the network load + first paint of the SPA route.
+        Thread.sleep(RENDER_BUFFER_MS)
+        capturePng("$screen.png")
+    }
+
+    /**
+     * The session list is the sidebar (Conversations drawer), which on a
+     * phone-width WebView is *closed* by default. Rather than coordinate-tapping
+     * the top-left toggle (fragile, and uiautomator dump can't see inside the
+     * WebView to find it), we deep-link to `/?sidebar=open` — AppShell reads
+     * that query param and opens the sidebar drawer on mount, then strips it.
+     * This reliably renders the conversation-list drawer on any device width.
+     */
+    private fun captureSessionList() {
+        captureWebView(routePath = "/?sidebar=open")
+    }
+
+    private fun launchApp() {
+        val ctx = instrumentation.context
+        val intent =
+            ctx.packageManager.getLaunchIntentForPackage(targetPackage)
+                ?: error("No launch intent for $targetPackage")
+        intent.addFlags(
+            android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK or
+                android.content.Intent.FLAG_ACTIVITY_NEW_TASK,
+        )
+        ctx.startActivity(intent)
+    }
+
+    private fun waitConnectField() {
+        assertTrue(
+            "ConnectActivity server-url field never appeared",
+            device.wait(Until.hasObject(By.text(FIELD_HINT)), LAUNCH_TIMEOUT_MS),
+        )
+    }
+
+    private fun capturePng(name: String) {
+        val outDir = File(instrumentation.targetContext.getExternalFilesDir(null), "screenshots")
+        outDir.mkdirs()
+        val outFile = File(outDir, name)
+        val ok = device.takeScreenshot(outFile)
+        assertTrue("takeScreenshot returned false", ok)
+        assertTrue("screenshot not written to ${outFile.absolutePath}", outFile.length() > 0)
+        // The Gradle task pulls this via `adb pull` before uninstalling the app
+        // (we run via `am instrument`, not AGP's connectedDebugAndroidTest, which
+        // auto-uninstalls and would delete this dir first).
+    }
+
+    private companion object {
+        // ConnectActivity's URL-field hint (R.string.connect_hint) — unique, so
+        // we match by text rather than resource-id to avoid app-vs-test
+        // application-id ambiguity in By.res(pkg, id).
+        const val FIELD_HINT = "https://omnigent.example.com"
+
+        // Placeholder session id for the `session` screen when no real id is
+        // supplied. The SPA renders the session-page chrome and attempts to
+        // load it; without the backend it shows a loading/empty state. Pass
+        // `-e sessionId=conv_...` against a live backend for real content.
+        const val SCREENSHOT_DEMO_SESSION_ID = "screenshot-demo"
+
+        const val LAUNCH_TIMEOUT_MS = 20_000L
+        const val SHELL_UP_TIMEOUT_MS = 20_000L
+
+        // Render buffer for the network load + first paint. Tuned conservatively
+        // for a local dev server; bump if captures come back blank/loading.
+        const val RENDER_BUFFER_MS = 6_000L
+    }
+}

--- a/web/android/gradle/libs.versions.toml
+++ b/web/android/gradle/libs.versions.toml
@@ -12,6 +12,14 @@ androidxWebkit = "1.12.1"
 junit = "4.13.2"
 robolectric = "4.14.1"
 androidxTestCore = "1.6.1"
+# Instrumented (androidTest) deps. Pinned to the AGP 8.6 / compileSdk 35 toolchain;
+# androidx.test 1.6.x + espresso 3.6.x + uiautomator 2.4.0 are the last stable line
+# that doesn't force the AGP 9 / compileSdk 36 jump.
+androidxTestRunner = "1.6.2"
+androidxTestRules = "1.6.1"
+androidxTestExtJunit = "1.2.1"
+espresso = "3.6.1"
+uiautomator = "2.4.0"
 # Gradle Play Publisher. 3.x tracks the AGP 8.x / Gradle 8.9 toolchain pinned
 # above; 4.x targets the newer toolchain, so bump it with the rest, not alone.
 playPublisher = "3.12.1"
@@ -24,6 +32,11 @@ androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "a
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
+androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTestRules" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
+espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
+uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Add a `./gradlew recordScreenshots` task that captures four real-WebView screenshots of the Android shell on a device/emulator — with **zero manual setup**. Gradle starts and stops both the Vite dev server and an isolated omnigent backend automatically, seeds a real session with a user message, captures all four screens, then tears everything down.

## Screens captured (`app/build/screenshots/`)

| File | Screen |
|---|---|
| `server_select.png` | Native ConnectActivity (server-entry screen, pre-connect) |
| `home.png` | SPA landing page (sidebar closed) |
| `session_list.png` | SPA home with sidebar drawer open (`?sidebar=open`) |
| `session.png` | Session/chat page with a real seeded user message from the backend |

## How it works

**Servers managed by Gradle:**
- `startBackendServer` — launches `omnigent server` in a throwaway `mktemp` data dir (`OMNIGENT_DATA_DIR`/`CONFIG_HOME`/`DATABASE_URI` isolated from `~/.omnigent`, no-auth on loopback), pre-registers `examples/kimi_hello.yaml`. Vite proxies `/v1` here (its `OMNIGENT_URL` default = `localhost:6767`), so the SPA gets real data.
- `seedDemoSession` — `POST /v1/sessions` with an initial user message so `session.png` has real content.
- `startWebDevServer` — launches `node vite --host 127.0.0.1 --port 5173` directly (avoids spawning `npm`/`pnpm` whose grandchild vite is hard to kill), reuses an existing server if present.
- `stopWebDevServer` / `stopBackendServer` — tear down both process trees + clean the temp dir (wired as `finalizedBy`, so they run even on failure).

**Per-screen capture** (one `am instrument` run each):
- `pm clear` (so launch routes to ConnectActivity) + pre-grant `POST_NOTIFICATIONS` (suppress the runtime permission dialog that would cover the WebView).
- The test drives the real `ConnectActivity` → `MainActivity` flow via UI Automator: types the server URL (base + route path), taps Connect, waits for the floating switch pill as the "shell is up" signal, then captures via `UiDevice.takeScreenshot`.
- Uses `am instrument` (not AGP's `connectedDebugAndroidTest`, which auto-uninstalls the app and deletes the screenshot file before we can `adb pull` it).

**`session_list`** uses the `?sidebar=open` query param — `AppShell` reads it on mount to open the conversation drawer — since `uiautomator dump` can't see inside the WebView to tap the toggle button.

## Dependencies added

Pinned to the AGP 8.6 / compileSdk 35 toolchain:
- `androidx.test:runner` 1.6.2, `:rules` 1.6.1, `ext:junit` 1.2.1
- `androidx.test.espresso:espresso-core` 3.6.1
- `androidx.test.uiautomator:uiautomator` 2.4.0
- Sets `testInstrumentationRunner = AndroidJUnitRunner`

## Testing

```
$ ANDROID_SERIAL=emulator-5554 ./gradlew recordScreenshots
> Task :app:startBackendServer
recordScreenshots: backend ready on 127.0.0.1:6767
> Task :app:seedDemoSession
recordScreenshots: created demo session 8c3b76dcc... (agent=057995...)
> Task :app:startWebDevServer
recordScreenshots: dev server ready on 127.0.0.1:5173
> Task :app:recordScreenshots
recordScreenshots: saved server_select.png (70220 bytes)
recordScreenshots: saved home.png (132546 bytes)
recordScreenshots: saved session_list.png (71337 bytes)
recordScreenshots: saved session.png (161439 bytes)
recordScreenshots: done — 4 screenshots in app/build/screenshots
> Task :app:stopWebDevServer
> Task :app:stopBackendServer
BUILD SUCCESSFUL in 58s
```

All 4 screenshots verified distinct; `session.png` (161KB) is significantly larger than the no-backend version (138KB), confirming real content.

## Usage

```bash
# Requires an emulator or unlocked device on ANDROID_SERIAL
ANDROID_SERIAL=emulator-5554 ./gradlew recordScreenshots
open app/build/screenshots/*.png
```

No separate terminals needed — Gradle manages the backend + Vite entirely.
