### PR TITLE
[setup] Support Antigravity sign-in

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -1746,40 +1746,54 @@ def _prompt_install_antigravity() -> str | None:
 
 
 def _manage_antigravity_harness() -> None:
-    """Run the level-2 loop for Antigravity: set / replace / remove its Gemini key.
+    """Run the level-2 loop for Antigravity auth.
 
-    Antigravity is Gemini-native (no provider family), so this manages just its
-    API key — stored in the secret store, referenced from the ``antigravity:``
-    config block — mirroring how the other harnesses persist api keys.
+    Antigravity can authenticate either through the native ``agy`` auth service
+    (Google sign-in for ``antigravity-native``) or through a Gemini API key for
+    the in-process SDK harness. The API key is stored in the secret store and
+    referenced from the ``antigravity:`` config block.
 
-    When the optional ``google-antigravity`` SDK is missing, the drill-in first offers
-    to install it (:func:`_prompt_install_antigravity`). Unlike the CLI-backed harnesses
-    (whose drill-in *gates* on the CLI), declining here still drops into the key menu,
-    since the ``antigravity:`` key is independently storable.
+    When both the optional ``google-antigravity`` SDK and ``agy`` are missing,
+    the drill-in first offers to install the SDK
+    (:func:`_prompt_install_antigravity`). An installed ``agy`` goes straight
+    to the auth choices so SDK setup never hides the native sign-in path.
 
-    :returns: None. Side effects: may install the ``antigravity`` extra, and may write
-        the ``antigravity:`` config block and the secret store.
+    :returns: None. Side effects: may launch ``agy``, install the
+        ``antigravity`` extra, and write the ``antigravity:`` config block and
+        secret store.
     """
     from omnigent.onboarding import secrets as secret_store
     from omnigent.onboarding.antigravity_auth import (
         ANTIGRAVITY_CONFIG_KEY,
+        ANTIGRAVITY_ENV_VARS,
         ANTIGRAVITY_SECRET_NAME,
         antigravity_api_key_configured,
         antigravity_api_key_ref,
         antigravity_sdk_installed,
     )
+    from omnigent.onboarding.harness_install import (
+        harness_cli_installed,
+        harness_cli_logged_in,
+        harness_install_spec,
+        harness_login,
+    )
     from omnigent.onboarding.interactive import select
+    from omnigent.onboarding.provider_config import GEMINI_FAMILY
 
     # Offer the install once on entry (not per loop iteration); the returned status
     # seeds the menu's transient status line.
     status: str | None = None
-    if not antigravity_sdk_installed():
+    if not antigravity_sdk_installed() and not harness_cli_installed(GEMINI_FAMILY):
         status = _prompt_install_antigravity()
         if status == _SOFT_INSTALL_ABORT:
             return
     while True:
         config = _load_global_config()
-        key_set = antigravity_api_key_configured(config)
+        key_set = antigravity_api_key_configured(config) or any(
+            os.environ.get(var) for var in ANTIGRAVITY_ENV_VARS
+        )
+        agy_installed = harness_cli_installed(GEMINI_FAMILY)
+        agy_signed_in = agy_installed and harness_cli_logged_in(GEMINI_FAMILY)
 
         rows: list[_HarnessMenuRow] = [
             _HarnessMenuRow(
@@ -1789,20 +1803,47 @@ def _manage_antigravity_harness() -> None:
         ]
         if key_set:
             rows.append(_HarnessMenuRow("Remove API key", action="remove_key"))
+        if agy_installed:
+            rows.append(
+                _HarnessMenuRow(
+                    "Re-run Antigravity sign-in" if agy_signed_in else "Sign in with Antigravity",
+                    action="sign_in",
+                )
+            )
+        else:
+            spec = harness_install_spec(GEMINI_FAMILY)
+            hint = spec.install_hint if spec is not None and spec.install_hint else "install agy"
+            rows.append(_HarnessMenuRow(f"Install agy first ({hint})", action="show_install"))
         rows.append(_HarnessMenuRow("← Back", action="back"))
 
-        header = (
-            "Antigravity — Gemini API key configured"
-            if key_set
-            else "Antigravity — no Gemini API key yet"
-        )
+        auth_bits: list[str] = []
+        if agy_signed_in:
+            auth_bits.append("Antigravity sign-in ready")
+        elif agy_installed:
+            auth_bits.append("Antigravity sign-in needed")
+        else:
+            auth_bits.append("agy not installed")
+        auth_bits.append("Gemini API key configured" if key_set else "no Gemini API key")
+        header = f"Antigravity — {' · '.join(auth_bits)}"
         idx = select(header, [r.label for r in rows], clear_on_exit=True, status=status)
         if idx < 0:  # Esc / q
             return
         action = rows[idx].action
         if action == "back":
             return
-        if action == "set_key":
+        if action == "show_install":
+            spec = harness_install_spec(GEMINI_FAMILY)
+            hint = (
+                spec.install_hint if spec is not None and spec.install_hint else "curl installer"
+            )
+            status = f"Install agy manually, then re-open: {hint}"
+        elif action == "sign_in":
+            status = (
+                "✓ Antigravity sign-in ready"
+                if harness_login(GEMINI_FAMILY)
+                else "✗ Antigravity sign-in not detected"
+            )
+        elif action == "set_key":
             status = _set_antigravity_api_key()
         elif action == "remove_key":
             ref = antigravity_api_key_ref(config)
@@ -3212,6 +3253,7 @@ def _run_configure_harnesses_interactive() -> None:
     from omnigent.onboarding.interactive import select
     from omnigent.onboarding.provider_config import (
         ANTHROPIC_FAMILY,
+        GEMINI_FAMILY,
         OPENAI_FAMILY,
         PI_SURFACE,
         surface_default_provider,
@@ -3460,11 +3502,23 @@ def _run_configure_harnesses_interactive() -> None:
 
         rows.append(_family_row(PI_SURFACE))
 
-        # Antigravity — Gemini key (antigravity-sdk extra is soft, like Cursor).
+        # Antigravity — native agy sign-in OR Gemini key (SDK extra is soft, like Cursor).
         if antigravity_api_key_configured(config) or any(
             os.environ.get(v) for v in ANTIGRAVITY_ENV_VARS
         ):
             rows.append((_ANTIGRAVITY, "Antigravity", "Gemini API key", "ready", ""))
+        elif harness_cli_installed(GEMINI_FAMILY) and harness_cli_logged_in(GEMINI_FAMILY):
+            rows.append((_ANTIGRAVITY, "Antigravity", "Signed in", "ready", ""))
+        elif harness_cli_installed(GEMINI_FAMILY):
+            rows.append(
+                (
+                    _ANTIGRAVITY,
+                    "Antigravity",
+                    "Needs sign-in",
+                    "warn",
+                    "Open to sign in with Antigravity, or add a Gemini API key.",
+                ),
+            )
         elif not antigravity_sdk_installed():
             rows.append(
                 (
@@ -3482,7 +3536,7 @@ def _run_configure_harnesses_interactive() -> None:
                     "Antigravity",
                     "Not configured",
                     "warn",
-                    "Open to add the Gemini API key.",
+                    "Open to sign in with Antigravity, or add a Gemini API key.",
                 ),
             )
 

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -245,26 +245,23 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         install_hint="curl -fsSL https://cli.kiro.dev/install | bash",
         min_version=_KIRO_MIN_VERSION,
     ),
-    # The native Antigravity (agy) TUI bridge wraps the ``agy`` CLI. ``agy`` has
-    # no ``login`` / ``logout`` subcommand — the user authenticates via browser
-    # OAuth by launching ``agy`` with no arguments on first run — so login_args /
-    # logout_args stay ``None`` (``harness_login`` / ``harness_logout`` no-op for
-    # it). It DOES expose a usable status check: ``agy models`` lists models and
-    # exits 0 only when signed in (else exits non-zero with "Please sign in …"),
-    # so status_args wires it the way Codex's exit-code ``login status`` is — so
-    # ``harness_cli_logged_in`` reads a real, revocation-aware verdict from the
-    # CLI instead of guessing from a credential file. (The readiness layer still
-    # uses the subprocess-free file check ``gemini_login_detected`` for its fast
-    # path.) ``agy`` ships via a shell installer rather than npm, so ``package``
-    # is ``None`` and the manual command lives in ``install_hint`` (shown as
-    # guidance; ``install_harness_cli`` refuses to auto-run it).
+    # The native Antigravity (agy) TUI bridge wraps the ``agy`` CLI. agy's auth
+    # service is reached by launching ``agy`` itself (no login subcommand); after
+    # the browser flow completes, ``agy models`` exits 0 and provides the same
+    # revocation-aware status probe Codex gets from ``codex login status``. An
+    # empty ``login_args`` tuple intentionally means “run the binary with no
+    # arguments” in ``harness_login``. ``agy`` ships via a shell installer rather
+    # than npm, so ``package`` is ``None`` and the manual command lives in
+    # ``install_hint`` (shown as guidance; ``install_harness_cli`` refuses to
+    # auto-run it).
     GEMINI_FAMILY: HarnessInstallSpec(
         "Antigravity",
         "agy",
         package=None,
+        login_args=(),
         status_args=("models",),
         install_hint="curl -fsSL https://antigravity.google/cli/install.sh | bash",
-        auth_hint="run `agy` once and complete the browser sign-in",
+        auth_hint="run `agy` and complete the browser sign-in",
     ),
     GOOSE_KEY: HarnessInstallSpec(
         "Goose",
@@ -969,11 +966,13 @@ def harness_cli_logged_in(key: str) -> bool:
     spec = harness_install_spec(key)
     if spec is None or spec.status_args is None:
         return False
-    if shutil.which(spec.binary) is None:
+    binary = resolve_cli_binary(spec.binary) if key == GEMINI_FAMILY else shutil.which(spec.binary)
+    if binary is None:
         return False
+    argv_binary = binary if key == GEMINI_FAMILY else spec.binary
     try:
         result = subprocess.run(
-            [spec.binary, *spec.status_args],
+            [argv_binary, *spec.status_args],
             check=False,
             timeout=30,
             capture_output=True,
@@ -1002,15 +1001,16 @@ def harness_login(key: str) -> bool:
     """Run the harness CLI's interactive subscription login; return logged-in state.
 
     Lets ``configure harnesses`` be the single place to sign in: when the user
-    picks "Claude / Codex — subscription" we drive the harness's own login
-    command (``claude auth login --claudeai`` / ``codex login``) **in the
-    foreground** (inheriting stdio so the OAuth / device-code prompts and any
-    browser URL reach the user), then confirm via :func:`harness_cli_logged_in`.
+    picks a subscription or Antigravity sign-in, we drive the harness's own
+    auth entrypoint (``claude auth login --claudeai`` / ``codex login`` / bare
+    ``agy``) **in the foreground** (inheriting stdio so OAuth / device-code
+    prompts and browser URLs reach the user), then confirm via
+    :func:`harness_cli_logged_in`.
     If the CLI is already logged in this is a no-op that returns ``True``
     immediately (no redundant re-auth).
 
-    :param key: A harness family, ``"anthropic"`` (Claude) or ``"openai"``
-        (Codex).
+    :param key: A harness family, ``"anthropic"`` (Claude), ``"openai"``
+        (Codex), or ``"gemini"`` (Antigravity).
     :returns: ``True`` when the harness CLI is logged in after the attempt
         (including the already-logged-in short-circuit); ``False`` when the key
         has no login command, the CLI binary is missing, the login process
@@ -1019,8 +1019,10 @@ def harness_login(key: str) -> bool:
     spec = harness_install_spec(key)
     if spec is None or spec.login_args is None:
         return False
-    if shutil.which(spec.binary) is None:
+    binary = resolve_cli_binary(spec.binary) if key == GEMINI_FAMILY else shutil.which(spec.binary)
+    if binary is None:
         return False
+    argv_binary = binary if key == GEMINI_FAMILY else spec.binary
     if harness_cli_logged_in(key):
         return True
     try:
@@ -1036,7 +1038,7 @@ def harness_login(key: str) -> bool:
                 tty_fd = os.open("/dev/tty", os.O_RDWR)
             except OSError:
                 tty_fd = None
-        argv = [spec.binary, *spec.login_args]
+        argv = [argv_binary, *spec.login_args]
         try:
             if tty_fd is not None:
                 subprocess.run(

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -37,6 +37,7 @@ load-bearing behavior — it has dedicated coverage below.
 from __future__ import annotations
 
 import os
+from unittest.mock import Mock
 
 import pytest
 import tomllib
@@ -2007,6 +2008,10 @@ def test_overview_descriptions_map_to_their_rows(isolated_config, monkeypatch) -
     monkeypatch.setattr(
         "omnigent.onboarding.antigravity_auth.antigravity_sdk_installed", lambda: True
     )
+    monkeypatch.setattr(
+        "omnigent.onboarding.harness_install.harness_cli_installed",
+        lambda family: family != GEMINI_FAMILY,
+    )
     monkeypatch.setattr("omnigent.onboarding.copilot_auth.copilot_sdk_installed", lambda: True)
     monkeypatch.setattr(
         "omnigent.onboarding.opencode_auth.opencode_auth_summary",
@@ -2035,7 +2040,9 @@ def test_overview_descriptions_map_to_their_rows(isolated_config, monkeypatch) -
     assert desc_by_name["OpenCode"] == "Open to sign in (opencode auth login)."
     assert desc_by_name["Hermes"] == "Open to configure with `hermes model`."
     assert desc_by_name["Pi"] == "Open to add a credential."
-    assert desc_by_name["Antigravity"] == "Open to add the Gemini API key."
+    assert (
+        desc_by_name["Antigravity"] == "Open to sign in with Antigravity, or add a Gemini API key."
+    )
     assert desc_by_name["Qwen Code"] == "Open to set up auth (/auth or env vars)."
     assert desc_by_name["Goose"] == "Open to run `goose configure`."
     assert desc_by_name["Copilot"] == "Open to add the GitHub token."
@@ -2673,11 +2680,11 @@ def test_cursor_install_now_invokes_runner_without_index(
     assert not any("index" in part or "://" in part for part in argv)
 
 
-# ── Antigravity Gemini API-key flow ─────────────────────────────────────────
+# ── Antigravity auth flow ───────────────────────────────────────────────────
 # Antigravity (Gemini-native, no provider family) is row 7 on the overview (it
 # follows Pi) and stores its key in the secret store + the ``antigravity:``
-# config block. API-key-only menu (Set/Replace/Remove); ``isolated_config``
-# clears ambient GEMINI_API_KEY / ANTIGRAVITY_API_KEY.
+# config block. The same drill-in also exposes native ``agy`` sign-in;
+# ``isolated_config`` clears ambient GEMINI_API_KEY / ANTIGRAVITY_API_KEY.
 
 
 @pytest.fixture()
@@ -2738,6 +2745,46 @@ def test_antigravity_adopt_env_api_key_writes_env_ref(
     cfg = _config_yaml(isolated_config)
     assert cfg["antigravity"] == {"api_key_ref": "env:GEMINI_API_KEY"}
     assert secrets.load_secret("antigravity") is None
+
+
+def test_antigravity_sign_in_runs_agy_auth_service(
+    isolated_config, monkeypatch, _antigravity_sdk_present
+) -> None:
+    """Selecting Antigravity sign-in launches bare ``agy`` through harness auth."""
+    login = Mock(return_value=True)
+    monkeypatch.setattr("omnigent.onboarding.harness_install.harness_login", login)
+
+    # L1 7=Antigravity → 2=Sign in → q back → q quit.
+    result = CliRunner().invoke(
+        cli,
+        ["setup", "--no-internal-beta"],
+        input="\n".join(["7", "2", "q", "q"]) + "\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    login.assert_called_once_with(GEMINI_FAMILY)
+
+
+def test_antigravity_sign_in_skips_sdk_install_prompt(isolated_config, monkeypatch) -> None:
+    """An installed agy can sign in even when the optional SDK is absent."""
+    monkeypatch.setattr(
+        "omnigent.onboarding.antigravity_auth.antigravity_sdk_installed",
+        lambda: False,
+    )
+    prompt = Mock()
+    monkeypatch.setattr("omnigent.cli_config._prompt_install_antigravity", prompt)
+    login = Mock(return_value=True)
+    monkeypatch.setattr("omnigent.onboarding.harness_install.harness_login", login)
+
+    result = CliRunner().invoke(
+        cli,
+        ["setup", "--no-internal-beta"],
+        input="\n".join(["7", "2", "q", "q"]) + "\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    prompt.assert_not_called()
+    login.assert_called_once_with(GEMINI_FAMILY)
 
 
 def test_antigravity_remove_api_key_drops_block_and_secret(
@@ -2816,17 +2863,23 @@ def test_antigravity_set_api_key_non_aiza_declined_is_not_stored(
 
 @pytest.fixture()
 def _antigravity_sdk_absent(monkeypatch):
-    """Force ``google-antigravity`` detection to report missing.
+    """Force ``google-antigravity`` and native ``agy`` detection to report missing.
 
     Both call sites (overview row + drill-in) resolve ``antigravity_sdk_installed``
     from the source module at call time, so patching the module attribute is seen by
-    both.
+    both. The autouse harness fixture marks CLIs installed by default, so this
+    also clears only the Gemini/agy install bit to exercise the SDK-install hint
+    instead of the native sign-in row.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     """
     monkeypatch.setattr(
         "omnigent.onboarding.antigravity_auth.antigravity_sdk_installed",
         lambda: False,
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.harness_install.harness_cli_installed",
+        lambda family: family != GEMINI_FAMILY,
     )
 
 

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -153,11 +153,11 @@ def test_hermes_install_spec_has_actionable_vendor_installer() -> None:
     ]
 
 
-def test_antigravity_install_spec_status_only_no_npm() -> None:
-    """Antigravity (agy) ships via a shell installer (no npm) and has no login
-    subcommand — the user signs in by launching ``agy`` once. It DOES expose a
-    status check (``agy models``), so the spec carries ``status_args`` +
-    ``install_hint`` but no ``package`` / ``login_args`` / ``logout_args``.
+def test_antigravity_install_spec_launches_auth_service_no_npm() -> None:
+    """Antigravity (agy) ships via a shell installer (no npm) and signs in by
+    launching ``agy`` once. It also exposes a status check (``agy models``), so
+    the spec carries empty ``login_args`` plus ``status_args`` + ``install_hint``
+    but no ``package`` / ``logout_args``.
 
     Drift here (a package sneaking in, or losing ``status_args``) would make the
     setup menu offer a bogus ``npm install`` or fall back to a file-only login
@@ -170,16 +170,16 @@ def test_antigravity_install_spec_status_only_no_npm() -> None:
     assert spec.install_hint is not None
     assert "antigravity.google/cli/install.sh" in spec.install_hint
     assert spec.status_args == ("models",)
-    assert spec.login_args is None
+    assert spec.login_args == ()
     assert spec.logout_args is None
     assert spec.login_status_key is None
     assert spec.auth_hint is not None
 
 
 def test_harness_setup_hint_antigravity_surfaces_sign_in() -> None:
-    """A not-yet-signed-in agy can't be fixed by ``agy login`` (no such
-    command), so the launch hint names the installer AND the "run agy to sign
-    in" step — otherwise a user who already has agy installed gets a misleading
+    """A not-yet-signed-in agy is fixed by launching ``agy`` itself, so the
+    launch hint names the installer AND the "run agy to sign in" step —
+    otherwise a user who already has agy installed gets a misleading
     install-only hint.
     """
     hint = hi.harness_setup_hint("antigravity-native")
@@ -641,6 +641,7 @@ def test_harness_login_skips_when_already_logged_in(monkeypatch: pytest.MonkeyPa
     [
         (ANTHROPIC_FAMILY, ["claude", "auth", "login", "--claudeai"]),
         (OPENAI_FAMILY, ["codex", "login"]),
+        (GEMINI_FAMILY, ["/usr/bin/agy"]),
     ],
 )
 def test_harness_login_runs_cli_login_then_verifies(
@@ -671,6 +672,30 @@ def test_harness_login_runs_cli_login_then_verifies(
     monkeypatch.setattr(hi.subprocess, "run", _run)
     assert hi.harness_login(key) is True
     assert calls == [expected_argv]
+
+
+def test_harness_login_resolves_agy_outside_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Antigravity sign-in launches agy's resolved fallback install path."""
+    monkeypatch.setattr(hi.shutil, "which", lambda name: None)
+    monkeypatch.setattr(hi, "resolve_cli_binary", lambda name: "/home/user/.local/bin/agy")
+    monkeypatch.setattr(hi.sys.stdin, "isatty", lambda: True)
+    state = {"logged_in": False}
+    monkeypatch.setattr(
+        hi,
+        "harness_cli_logged_in",
+        lambda key: state["logged_in"],
+    )
+    calls: list[list[str]] = []
+
+    def _run(argv: list[str], **kwargs: object):
+        calls.append(argv)
+        state["logged_in"] = True
+        return subprocess.CompletedProcess(args=argv, returncode=0)
+
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+
+    assert hi.harness_login(GEMINI_FAMILY) is True
+    assert calls == [["/home/user/.local/bin/agy"]]
 
 
 def test_harness_login_wires_dev_tty_when_stdin_not_a_tty(
@@ -934,7 +959,7 @@ def test_harness_cli_logged_in_agy_uses_exit_code(
     monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
 
     def _run(argv: list[str], **k: object):
-        assert argv == ["agy", "models"]  # the status subcommand
+        assert argv == ["/usr/bin/agy", "models"]  # the status subcommand
         return subprocess.CompletedProcess(
             args=argv, returncode=returncode, stdout=stdout, stderr=""
         )


### PR DESCRIPTION
## Related issue

N/A

## Summary

`omni setup` only exposed Gemini API-key configuration for Antigravity, even though the native `agy` CLI owns a Google OAuth sign-in flow. This adds that native sign-in path alongside the existing SDK/API-key path and keeps setup status aligned with whichever credential is available.

- Launch bare `agy` from the Antigravity setup menu, then verify sign-in with `agy models`.
- Resolve `agy` from its fallback install location, so `~/.local/bin/agy` works even when it is not yet on `PATH`.
- Skip the optional SDK install prompt when `agy` is already installed, and report `Signed in` / `Needs sign-in` in the harness overview.

**ELI5:** Antigravity users can now choose “Sign in with Antigravity” and complete Google login instead of being required to paste a Gemini API key.

```mermaid
flowchart LR
    A[omni setup → Antigravity] --> B{Choose auth}
    B --> C[Gemini API key]
    B --> D[Launch agy]
    D --> E[Google OAuth]
    E --> F[Verify with agy models]
```

<img width="1320" height="462" alt="image" src="https://github.com/user-attachments/assets/873488cb-842b-4aa5-aeaa-053f86b95198" />


## Test Plan

- [x] Ran `pytest tests/onboarding/test_harness_install.py` — 123 passed.
- [x] Ran `pytest tests/onboarding/test_harness_install.py tests/cli/test_configure_models.py -k 'antigravity or harness_login'` — 25 passed.
- [x] Ran targeted Antigravity readiness and credential tests.
- [x] Ran `pre-commit run` on the staged four-file diff — all applicable hooks passed.
- [x] Ran Ruff checks on all changed Python files.

## Demo

N/A — terminal setup flow; covered through CliRunner tests.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage exercises the bare-`agy` auth launch, fallback binary resolution, SDK-prompt bypass, setup overview states, and existing Gemini API-key flows.

## Changelog

`omni setup` now supports signing in to Antigravity with Google OAuth through `agy`, alongside Gemini API keys.
