### PR TITLE
feat(web): group archived sessions by date

### DIFF
--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -929,4 +929,37 @@ describe("SettingsPage", () => {
     expect(screen.getByTestId("archived-row")).toBeInTheDocument();
     expect(screen.getByText("Deep archive")).toBeInTheDocument();
   });
+
+  it("groups archived sessions under date headers", () => {
+    // Fix "now" to 2026-07-15T12:00:00Z so bucket boundaries are deterministic.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-07-15T12:00:00Z"));
+
+    const todaySec = new Date("2026-07-15T10:00:00Z").getTime() / 1000;
+    const yesterdaySec = new Date("2026-07-14T08:00:00Z").getTime() / 1000;
+    const fiveDaysAgoSec = new Date("2026-07-10T08:00:00Z").getTime() / 1000;
+    const twentyDaysAgoSec = new Date("2026-06-25T08:00:00Z").getTime() / 1000;
+    const oldSec = new Date("2026-03-01T08:00:00Z").getTime() / 1000;
+
+    mocks.conversations = [
+      conv("c_today", { archived: true, title: "Today chat", updated_at: todaySec }),
+      conv("c_yesterday", { archived: true, title: "Yesterday chat", updated_at: yesterdaySec }),
+      conv("c_week", { archived: true, title: "This week chat", updated_at: fiveDaysAgoSec }),
+      conv("c_month", { archived: true, title: "This month chat", updated_at: twentyDaysAgoSec }),
+      conv("c_old", { archived: true, title: "Old chat", updated_at: oldSec }),
+    ];
+    renderPage("/settings/archived");
+
+    expect(screen.getByText("Today")).toBeInTheDocument();
+    expect(screen.getByText("Yesterday")).toBeInTheDocument();
+    expect(screen.getByText("Previous 7 days")).toBeInTheDocument();
+    expect(screen.getByText("Previous 30 days")).toBeInTheDocument();
+    // March 2026 — locale-dependent label for the oldest session.
+    expect(screen.getByText(/March.*2026/)).toBeInTheDocument();
+
+    // Each session renders under its respective group.
+    expect(screen.getAllByTestId("archived-row")).toHaveLength(5);
+
+    vi.useRealTimers();
+  });
 });

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -931,35 +931,44 @@ describe("SettingsPage", () => {
   });
 
   it("groups archived sessions under date headers", () => {
-    // Fix "now" to 2026-07-15T12:00:00Z so bucket boundaries are deterministic.
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    vi.setSystemTime(new Date("2026-07-15T12:00:00Z"));
+    // Use local-time construction so bucket boundaries align with the
+    // local-time arithmetic in dateGroupLabel regardless of the test runner's
+    // timezone.
+    vi.setSystemTime(new Date(2026, 6, 15, 12, 0, 0));
 
-    const todaySec = new Date("2026-07-15T10:00:00Z").getTime() / 1000;
-    const yesterdaySec = new Date("2026-07-14T08:00:00Z").getTime() / 1000;
-    const fiveDaysAgoSec = new Date("2026-07-10T08:00:00Z").getTime() / 1000;
-    const twentyDaysAgoSec = new Date("2026-06-25T08:00:00Z").getTime() / 1000;
-    const oldSec = new Date("2026-03-01T08:00:00Z").getTime() / 1000;
+    try {
+      const todaySec = new Date(2026, 6, 15, 10, 0, 0).getTime() / 1000;
+      const yesterdaySec = new Date(2026, 6, 14, 8, 0, 0).getTime() / 1000;
+      const fiveDaysAgoSec = new Date(2026, 6, 10, 8, 0, 0).getTime() / 1000;
+      const twentyDaysAgoSec = new Date(2026, 5, 25, 8, 0, 0).getTime() / 1000;
+      const oldDate = new Date(2026, 2, 1, 8, 0, 0);
+      const oldSec = oldDate.getTime() / 1000;
 
-    mocks.conversations = [
-      conv("c_today", { archived: true, title: "Today chat", updated_at: todaySec }),
-      conv("c_yesterday", { archived: true, title: "Yesterday chat", updated_at: yesterdaySec }),
-      conv("c_week", { archived: true, title: "This week chat", updated_at: fiveDaysAgoSec }),
-      conv("c_month", { archived: true, title: "This month chat", updated_at: twentyDaysAgoSec }),
-      conv("c_old", { archived: true, title: "Old chat", updated_at: oldSec }),
-    ];
-    renderPage("/settings/archived");
+      mocks.conversations = [
+        conv("c_today", { archived: true, title: "Today chat", updated_at: todaySec }),
+        conv("c_yesterday", { archived: true, title: "Yesterday chat", updated_at: yesterdaySec }),
+        conv("c_week", { archived: true, title: "This week chat", updated_at: fiveDaysAgoSec }),
+        conv("c_month", { archived: true, title: "This month chat", updated_at: twentyDaysAgoSec }),
+        conv("c_old", { archived: true, title: "Old chat", updated_at: oldSec }),
+      ];
+      renderPage("/settings/archived");
 
-    expect(screen.getByText("Today")).toBeInTheDocument();
-    expect(screen.getByText("Yesterday")).toBeInTheDocument();
-    expect(screen.getByText("Previous 7 days")).toBeInTheDocument();
-    expect(screen.getByText("Previous 30 days")).toBeInTheDocument();
-    // March 2026 — locale-dependent label for the oldest session.
-    expect(screen.getByText(/March.*2026/)).toBeInTheDocument();
+      expect(screen.getByText("Today")).toBeInTheDocument();
+      expect(screen.getByText("Yesterday")).toBeInTheDocument();
+      expect(screen.getByText("Previous 7 days")).toBeInTheDocument();
+      expect(screen.getByText("Previous 30 days")).toBeInTheDocument();
+      // Derive the expected label the same way the component does so the
+      // assertion is locale-independent.
+      const expectedOldLabel = oldDate.toLocaleDateString(undefined, {
+        month: "long",
+        year: "numeric",
+      });
+      expect(screen.getByText(expectedOldLabel)).toBeInTheDocument();
 
-    // Each session renders under its respective group.
-    expect(screen.getAllByTestId("archived-row")).toHaveLength(5);
-
-    vi.useRealTimers();
+      expect(screen.getAllByTestId("archived-row")).toHaveLength(5);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1880,10 +1880,11 @@ function ArchivedSection() {
   );
 
   const groupedArchived = useMemo(() => {
+    const now = new Date();
     const groups: { label: string; conversations: typeof archived }[] = [];
     let currentLabel = "";
     for (const conv of archived) {
-      const label = dateGroupLabel(conv.updated_at);
+      const label = dateGroupLabel(conv.updated_at, now);
       if (label !== currentLabel) {
         currentLabel = label;
         groups.push({ label, conversations: [] });

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1825,18 +1825,23 @@ function selectValueToProject(value: string): string | undefined {
   return value.slice(PROJECT_VALUE_PREFIX.length);
 }
 
-function dateGroupLabel(timestampSec: number): string {
+function dateGroupLabel(timestampSec: number, now: Date = new Date()): string {
   const date = new Date(timestampSec * 1000);
-  const now = new Date();
   const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const startOfYesterday = new Date(startOfToday.getTime() - 86_400_000);
-  const startOf7DaysAgo = new Date(startOfToday.getTime() - 7 * 86_400_000);
-  const startOf30DaysAgo = new Date(startOfToday.getTime() - 30 * 86_400_000);
+
+  const yesterday = new Date(startOfToday);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  const sevenDaysAgo = new Date(startOfToday);
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+  const thirtyDaysAgo = new Date(startOfToday);
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
   if (date >= startOfToday) return "Today";
-  if (date >= startOfYesterday) return "Yesterday";
-  if (date >= startOf7DaysAgo) return "Previous 7 days";
-  if (date >= startOf30DaysAgo) return "Previous 30 days";
+  if (date >= yesterday) return "Yesterday";
+  if (date >= sevenDaysAgo) return "Previous 7 days";
+  if (date >= thirtyDaysAgo) return "Previous 30 days";
   return date.toLocaleDateString(undefined, { month: "long", year: "numeric" });
 }
 

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1825,6 +1825,21 @@ function selectValueToProject(value: string): string | undefined {
   return value.slice(PROJECT_VALUE_PREFIX.length);
 }
 
+function dateGroupLabel(timestampSec: number): string {
+  const date = new Date(timestampSec * 1000);
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfYesterday = new Date(startOfToday.getTime() - 86_400_000);
+  const startOf7DaysAgo = new Date(startOfToday.getTime() - 7 * 86_400_000);
+  const startOf30DaysAgo = new Date(startOfToday.getTime() - 30 * 86_400_000);
+
+  if (date >= startOfToday) return "Today";
+  if (date >= startOfYesterday) return "Yesterday";
+  if (date >= startOf7DaysAgo) return "Previous 7 days";
+  if (date >= startOf30DaysAgo) return "Previous 30 days";
+  return date.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+}
+
 function ArchivedSection() {
   // `undefined` = all projects; a name scopes the list to that project.
   const [project, setProject] = useState<string | undefined>(undefined);
@@ -1858,6 +1873,20 @@ function ArchivedSection() {
     () => (listQuery.data?.pages ?? []).flatMap((p) => p.data).filter((c) => c.archived === true),
     [listQuery.data],
   );
+
+  const groupedArchived = useMemo(() => {
+    const groups: { label: string; conversations: typeof archived }[] = [];
+    let currentLabel = "";
+    for (const conv of archived) {
+      const label = dateGroupLabel(conv.updated_at);
+      if (label !== currentLabel) {
+        currentLabel = label;
+        groups.push({ label, conversations: [] });
+      }
+      groups[groups.length - 1].conversations.push(conv);
+    }
+    return groups;
+  }, [archived]);
 
   // Keep a picked project listed even if it drops out of the option set (its
   // last archived session was just unarchived) so the trigger never shows a
@@ -1914,11 +1943,20 @@ function ArchivedSection() {
       ) : (
         <>
           {archived.length > 0 && (
-            <ul className="flex flex-col gap-0.5">
-              {archived.map((conv) => (
-                <ArchivedRow key={conv.id} conversation={conv} />
+            <div className="flex flex-col gap-4">
+              {groupedArchived.map((group) => (
+                <div key={group.label}>
+                  <h3 className="mb-1 px-3 text-xs font-medium text-muted-foreground">
+                    {group.label}
+                  </h3>
+                  <ul className="flex flex-col gap-0.5">
+                    {group.conversations.map((conv) => (
+                      <ArchivedRow key={conv.id} conversation={conv} />
+                    ))}
+                  </ul>
+                </div>
               ))}
-            </ul>
+            </div>
           )}
           {archived.length === 0 && (
             // The list fetches a mixed page (active + archived rows) and filters


### PR DESCRIPTION
## Related issue

N/A

## Summary

The archived sessions list in the settings page was a flat chronological list that became hard to scan as sessions accumulated. This groups them under date headers — **Today**, **Yesterday**, **Previous 7 days**, **Previous 30 days**, or **Month Year** (e.g. "June 2026") for older entries — making it much easier to browse.

- Added a `dateGroupLabel()` helper that buckets a timestamp into a human-readable date group
- Added a `groupedArchived` memo that partitions the sorted session list into groups by label
- Replaced the flat `<ul>` with grouped sections, each under a small muted header

## Test Plan

- Open Settings → Archived sessions
- Verify sessions are grouped under date headers (Today, Yesterday, Previous 7 days, etc.)
- Verify sessions within each group retain their existing order and row behavior (hover actions, delete, unarchive)
- Verify the project filter dropdown still works correctly with grouping
- Verify empty states still render correctly (no archived sessions, no sessions in selected project)
- Verify "Load more" pagination still works and new sessions slot into the correct date group

## Demo

<!-- Screenshot/recording to be attached -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified by running the dev server and inspecting the archived sessions page. The grouping logic is a pure function over an already-sorted list, and the rendering change is structural (wrapping existing `ArchivedRow` components under headers) with no new interactive behavior.

## Changelog

Archived sessions in Settings are now grouped by date (Today, Yesterday, Previous 7/30 days, month/year) for easier browsing.