### PR TITLE
fix(deploy): wire the project store into the Docker entrypoint

### DIFF
--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -309,6 +309,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         SqlAlchemyPermissionStore,
     )
     from omnigent.stores.policy_store.sqlalchemy_store import SqlAlchemyPolicyStore
+    from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
     from omnigent.stores.scheduled_task_store.sqlalchemy_store import (
         SqlAlchemyScheduledTaskStore,
     )
@@ -323,6 +324,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     host_store = HostStore(database_url)
     policy_store = SqlAlchemyPolicyStore(database_url)
     scheduled_task_store = SqlAlchemyScheduledTaskStore(database_url)
+    project_store = SqlAlchemyProjectStore(database_url)
     # Fail startup loud on a malformed `sandbox:` section (an operator
     # typo should not surface as a runtime 502 on the first managed
     # session); the startup catch-all below logs it.
@@ -419,6 +421,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         policy_store=policy_store,
         host_store=host_store,
         scheduled_task_store=scheduled_task_store,
+        project_store=project_store,
         auth_provider=auth_provider,
         account_store=account_store,
         # Non-secret auth settings from the config file (admins are the


### PR DESCRIPTION
## Related issue

N/A — found deploying a container-hosted server; reproduces on any Docker/compose deployment.

## Summary

Creating a project against a container-deployed server fails with `405 Method Not Allowed`.

- `create_app` mounts the projects router only when a project store is wired (`omnigent/server/app.py`, `if project_store is not None`).
- The CLI server path builds `SqlAlchemyProjectStore` and passes it (`omnigent/cli.py`).
- `deploy/docker/entrypoint.py` builds every other store but never this one, so `project_store` stays `None`, `/v1/projects` is not a route at all, and `POST` falls through to the SPA catch-all (GET-only) — which answers 405.

Net effect: the same build serves projects under `omnigent server start` and 405s in the container, even though the `projects` table is migrated and the web UI ships the feature.

This constructs `SqlAlchemyProjectStore` from the resolved database URL and passes it to `create_app`, mirroring the other stores in that function.

## Test Plan

Against a container-deployed server, before the change: `GET /v1/projects` → 404 and `POST /v1/projects` → `{"detail":"Method Not Allowed"}` (405), because the path resolves to the SPA catch-all rather than a registered route. After the change the projects router mounts and both verbs are served by it.

Also asserted directly on the entrypoint module that the store is constructed and threaded into `create_app`, and confirmed the `projects` table is present after `run_migrations` (the entrypoint already migrates before wiring stores), so the newly-mounted routes have their schema.

## Demo

N/A — non-visual (server route wiring).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually against a live container deployment (405 before, projects router mounted after). The change is store wiring inside the Docker entrypoint's app-construction function — the existing projects route/store tests cover the behaviour once the store is passed; there is no entrypoint-level test harness in the repo to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
