### PR TITLE
fix(codex-native): share plugins/cache into per-session homes

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -121,6 +121,13 @@ _CODEX_HOOKS_JSON = "hooks.json"
 # shared ``~/.codex/config.toml``. This keeps model selection and cost-policy
 # enforcement isolated between concurrent sessions.
 _CODEX_HOME_COPY_FILES = ("config.toml",)
+# Directories symlinked (not copied) from the real CODEX_HOME into the
+# per-session temp home. ``plugins/cache`` is codex's content-addressed
+# (versioned) plugin store — read-only reference data that codex would
+# otherwise re-materialize tens of MB into every private home. Sharing the
+# one real cache dedupes it across sessions; codex's own writes land in the
+# shared cache exactly as they would without the private home.
+_CODEX_HOME_SYMLINK_DIRS = (Path("plugins") / "cache",)
 _CODEX_MINIMAL_CONFIG_ENV = "HARNESS_CODEX_MINIMAL_CONFIG"
 
 # Environment variables explicitly excluded from the codex subprocess even
@@ -764,6 +771,28 @@ def _populate_codex_home_config(
                 exc,
             )
             shutil.copy2(source_file, link_path)
+
+    if not minimal_config:
+        for reldir in _CODEX_HOME_SYMLINK_DIRS:
+            source_subdir = source_dir / reldir
+            if not source_subdir.is_dir():
+                continue
+            link_path = target_dir / reldir
+            if link_path.exists() or link_path.is_symlink():
+                continue
+            link_path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                link_path.symlink_to(source_subdir.resolve())
+            except OSError as exc:
+                # Symlink unsupported (some Windows configs) or a race — skip
+                # the dedupe rather than abort session boot; codex re-populates
+                # its own private cache, costing disk but staying correct.
+                logger.warning(
+                    "could not symlink %r into %s (%s); codex will repopulate it",
+                    str(reldir),
+                    target_dir,
+                    exc,
+                )
 
     for filename in _CODEX_HOME_COPY_FILES:
         source_file = source_dir / filename

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -2359,6 +2359,52 @@ def test_populate_codex_home_config_symlinks_auth_and_config(tmp_path: Path) -> 
     assert (target / "config.toml").read_text() == '[default]\nmodel = "gpt-5.4"'
 
 
+def test_populate_codex_home_config_symlinks_plugins_cache(tmp_path: Path) -> None:
+    """``plugins/cache`` is symlinked to the shared home to dedupe it.
+
+    Codex materializes tens of MB of versioned plugin data into every private
+    home; sharing the one real cache keeps each session small. Only the
+    ``cache`` subdir is shared — sibling scratch dirs stay session-local.
+    """
+    from omnigent.inner.codex_executor import _populate_codex_home_config
+
+    source = tmp_path / "real_codex_home"
+    source.mkdir()
+    (source / "auth.json").write_text('{"auth_mode": "chatgpt"}')
+    (source / "config.toml").write_text("[default]\n")
+    cache = source / "plugins" / "cache"
+    cache.mkdir(parents=True)
+    (cache / "big-plugin.bin").write_text("payload")
+    (source / "plugins" / ".remote-plugin-install-staging").mkdir()
+    target = tmp_path / "temp_codex_home"
+    target.mkdir()
+
+    _populate_codex_home_config(target, source)
+
+    link = target / "plugins" / "cache"
+    assert link.is_symlink()
+    assert (link / "big-plugin.bin").read_text() == "payload"
+    # Only cache is shared; the sibling scratch dir is not created here.
+    assert not (target / "plugins" / ".remote-plugin-install-staging").exists()
+
+
+def test_populate_codex_home_config_minimal_mode_skips_plugins_cache(tmp_path: Path) -> None:
+    """Minimal (title-sidecar) mode does not link plugins — it runs no plugins."""
+    from omnigent.inner.codex_executor import _populate_codex_home_config
+
+    source = tmp_path / "real_codex_home"
+    source.mkdir()
+    (source / "auth.json").write_text('{"auth_mode": "chatgpt"}')
+    (source / "config.toml").write_text("[default]\n")
+    (source / "plugins" / "cache").mkdir(parents=True)
+    target = tmp_path / "temp_codex_home"
+    target.mkdir()
+
+    _populate_codex_home_config(target, source, minimal_config=True)
+
+    assert not (target / "plugins" / "cache").exists()
+
+
 def test_populate_codex_home_config_minimal_mode_keeps_only_provider_routing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Related issue

n/a

## Summary

Follow-up to the codex-native disk-growth investigation. After upgrading codex to fix the `logs_2.sqlite` TRACE bloat (upstream [openai/codex#28224](https://github.com/openai/codex/issues/28224), fixed in codex ≥ 0.142.0), profiling a fresh codex-native session showed the dominant consumer had shifted:

| item | size | share of session |
|---|---|---|
| **`plugins/cache`** | **44 MB** | **65%** |
| `cache/` | 8.9 MB | 13% |
| `logs_2.sqlite` (+WAL) | ~10 MB | 15% |
| everything else | ~5 MB | 7% |

Codex materializes its versioned plugin store (`openai-curated` templates, `browser`, `presentations`, …) into `$CODEX_HOME/plugins/cache` on session start. codex-native points `CODEX_HOME` at a private per-session home, so codex re-materializes ~44 MB of **identical** plugin data into every session.

- Symlink `plugins/cache` from the shared source home into each private home, mirroring the existing skills-symlink pattern in `_populate_codex_home_config`.
- The cache is content-addressed, read-only reference data (verified byte-identical to the shared `~/.codex/plugins/cache`), so unlike `config.toml` it needs no per-session isolation.
- Sibling scratch dirs (`.remote-plugin-install-staging`, `.plugin-appserver`) stay session-local.
- Skipped in minimal (title-sidecar) mode, which runs no plugins.
- Best-effort: a symlink failure logs a warning and lets codex repopulate its own copy (correctness preserved, disk cost only).

Drops a fresh session's footprint from ~68 MB to ~15 MB. Complements the 7-day cleanup backstop (#3399) and the codex upgrade.

## Test Plan

- `python -m pytest tests/inner/test_codex_executor.py -k populate_codex_home_config` — 16 passed (2 new: symlinks `plugins/cache` + shares only `cache`; minimal mode skips it).
- `pre-commit run --files ...` — passed.
- Root cause confirmed empirically: profiled a live codex 0.145.0 codex-native session; `plugins/cache` was 44 MB and byte-identical to the shared home.

## Demo

<img width="686" height="75" alt="image" src="https://github.com/user-attachments/assets/5d1b359f-875e-4cf8-8fc3-a38971f3ae08" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by unit tests plus a live-session profile confirming the cache is shared and identical.

## Changelog

Dedupe codex-native's per-session plugin cache to reclaim disk